### PR TITLE
Fix naming convention and CUDA printf format in BarrierState/ChunkState

### DIFF
--- a/comms/ctran/algos/AllGather/docs/AllGatherPat.md
+++ b/comms/ctran/algos/AllGather/docs/AllGatherPat.md
@@ -1,0 +1,647 @@
+# CTPAT: AllGather PAT Algorithm (NVL x IB)
+
+This document describes the CTPAT AllGather algorithm, a rail-parallel butterfly (recursive-doubling) variant for multi-GPU-per-node topologies (H100 NVL x IB). CTPAT is implemented as a new `NCCL_ALLGATHER_P_ALGO` variant inside `AllGatherP/`, reusing the existing persistent infrastructure: `PersistArgs`, `allGatherCtrl` handle exchange, `copyToSelf`, `nvlCeBcast`, and the `PipeStart`/`PipeSync`/`PipeEnd` kernel pattern.
+
+## Motivation
+
+Existing persistent AllGatherP algorithms leave a performance gap at scale:
+
+| Algorithm | Pattern | IB Steps | Latency Scaling |
+|-----------|---------|----------|-----------------|
+| `ctdirect` | All-to-all direct puts | nNodes-1 | O(N) |
+| `ctpipeline` | Ring inter-node + NVL bcast | nNodes-1 | O(N) |
+| `ctrdpipeline` | Butterfly inter-node + NVL bcast | log₂(nNodes) | O(log N) |
+
+`ctrdpipeline` already has the right communication pattern. CTPAT is essentially `ctrdpipeline` with explicit naming as a PAT variant and a clean path for future extensions (non-power-of-two node counts, step aggregation). For v1, CTPAT is a narrow, power-of-two-only extension of `ctrdpipeline` — same execution model, same reusable machinery.
+
+### Why a New Variant Instead of Renaming ctrdpipeline
+
+The `ctrdpipeline` name describes the implementation technique (recursive doubling with pipelining). The `ctpat` name describes the algorithm family (Parallel Asynchronous Tiled), which has a broader scope:
+- v1: power-of-two butterfly (same as ctrdpipeline)
+- Future: non-power-of-two handling, step aggregation, auto-tuning
+
+Introducing `ctpat` as a separate enum value avoids overloading `ctrdpipeline` with new semantics and provides a clean opt-in for users who want the PAT-family behavior.
+
+## Architecture Decision: AllGatherP, Not AllGather
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    User / TorchComms                             │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   NCCLx collectives.cc                           │
+│            ctranAllGatherSupport() / ctranAllGather()            │
+└──────────┬──────────────────────────────────┬───────────────────┘
+           │                                  │
+           ▼                                  ▼
+┌─────────────────────┐          ┌────────────────────────────────┐
+│   AllGather/         │          │   AllGatherP/                   │
+│   (non-persistent)   │          │   (persistent: init/exec/      │
+│                      │          │    destroy lifecycle)           │
+│  • ctdirect          │          │                                │
+│  • ctring            │          │  • ctdirect                    │
+│  • ctrd              │          │  • ctpipeline (ring)           │
+│  • ctbrucks          │          │  • ctrdpipeline (butterfly)    │
+│  • ctgraph_*         │          │  • ctpat (butterfly — NEW)     │
+└──────────────────────┘          │                                │
+                                  │  Reuses: PersistArgs,          │
+                                  │  allGatherCtrl, PipeSync,      │
+                                  │  nvlCeBcast, copyToSelf        │
+                                  └────────────────────────────────┘
+```
+
+CTPAT lives in `AllGatherP/`, NOT `AllGather/`. The rationale:
+
+1. The strongest reusable machinery is in `AllGatherP/`: persistent remote buffer exchange (`PersistArgs`, `allGatherCtrl`), `pipeSync`, and the exact NVL-after-IB execution model in `RecursiveDoublingImpl.cc`.
+2. Re-implementing as an eager `AllGather/AllGatherPat.cc` would duplicate the hard part (handle exchange, PipeSync coordination, CE broadcast orchestration) and lose the fast path for replay/persistence.
+3. CUDA graph support will come through the existing `AllGatherCudagraphAware.cc` path once the `ctgraph_pipeline` execute path is updated to respect `NCCL_ALLGATHER_P_ALGO`. This is deferred from v1. While the execute path change is small, it is a behavior change in graph capture that should be validated separately.
+
+## Algorithm
+
+### Communication Pattern
+
+Rail-parallel butterfly (recursive doubling) with NVL CE broadcast:
+
+```
+H100 Node 0 (8 GPUs)                    H100 Node 1 (8 GPUs)
+┌─────────────────────────┐              ┌─────────────────────────┐
+│ G0  G1  G2  ...  G7     │              │ G0  G1  G2  ...  G7     │
+│  │   │   │        │     │              │  │   │   │        │     │
+│  └───┴───┴──┬─────┘     │              │  └───┴───┴──┬─────┘     │
+│        NVSwitch          │              │        NVSwitch          │
+│      (CE broadcast)      │              │      (CE broadcast)      │
+└────────────┬─────────────┘              └────────────┬─────────────┘
+             │                                         │
+             │  IB: rail i ←→ rail i (butterfly)       │
+             └─────────────────────────────────────────┘
+```
+
+Each GPU communicates only with its rail peer (same `localRank`) on remote nodes, using `log₂(nNodes)` butterfly steps. After each step, newly received chunks are broadcast to all local NVL peers via CE.
+
+### Prerequisites
+
+- `nNodes > 1` (multi-node)
+- `nNodes` is a power of 2 (v1 constraint; future versions may relax this)
+- `nRanks % nLocalRanks == 0`
+- All local peers NVL-reachable (except when `nLocalRanks == 1`)
+
+### Step Computation
+
+Reuses the existing functions from `RecursiveDoublingImpl.cc`:
+
+```cpp
+// Node-level distance at step i (i=0 is largest distance)
+int distNodesAtStep(int nNodes, int step) { return nNodes >> (step + 1); }
+
+// Rail-peer rank at step i
+int peerAtStep(int nodeId, int localRank, int nLocalRanks, int nNodes, int step) {
+    int dist = distNodesAtStep(nNodes, step);
+    int pos = (nodeId / dist) % 2;
+    int peerNode = pos == 0 ? nodeId + dist : nodeId - dist;
+    return peerNode * nLocalRanks + localRank;
+}
+
+// Chunk offset for j-th put at step i (anchorNode = myNode for send, peerNode for recv)
+size_t rankChunkOffset(int anchorNode, int localRank, int nLocalRanks,
+                       int nNodes, int step, int j) {
+    int stride = nNodes >> step;
+    int nodePos = j * stride + (anchorNode % stride);
+    return static_cast<size_t>(nodePos) * nLocalRanks + localRank;
+}
+```
+
+### Butterfly Communication Pattern (4 Nodes, localRank=0)
+
+```
+         Node 0       Node 1       Node 2       Node 3
+         (rank 0)     (rank 8)     (rank 16)    (rank 24)
+            │            │            │            │
+ Initial:  [A]          [B]          [C]          [D]
+            │            │            │            │
+            │            │            │            │
+ Step 0:    ├────────────────────────►│            │     dist = 2
+ (dist=2)   │◄───────────────────────┤            │     Node 0 ↔ Node 2
+            │            ├────────────────────────►│     Node 1 ↔ Node 3
+            │            │◄───────────────────────┤
+            │            │            │            │
+ After 0:  [A,C]        [B,D]        [C,A]        [D,B]
+            │            │            │            │
+            │    NVL     │    NVL     │    NVL     │    NVL
+            │   bcast    │   bcast    │   bcast    │   bcast
+            │            │            │            │
+ Step 1:    ├───────────►│            │            │     dist = 1
+ (dist=1)   │◄──────────┤            │            │     Node 0 ↔ Node 1
+            │            │            ├───────────►│     Node 2 ↔ Node 3
+            │            │            │◄──────────┤
+            │            │            │            │
+ After 1:  [A,B,C,D]    [B,A,D,C]    [C,D,A,B]    [D,C,B,A]
+            │            │            │            │
+            │    NVL     │    NVL     │    NVL     │    NVL
+            │   bcast    │   bcast    │   bcast    │   bcast
+            │            │            │            │
+ Final:    All GPUs on each node hold [A,B,C,D]
+```
+
+### Data Doubling Pattern
+
+```
+Step 0: Send 1 chunk, receive 1 chunk     (2 chunks held)
+Step 1: Send 2 chunks, receive 2 chunks   (4 chunks held)
+ ...
+Step k: Send 2^k chunks, receive 2^k chunks
+
+Data volume per step:
+  ┌─────────────────────────────────────────────────┐
+  │ Step   │ Chunks Sent │ Chunks Held │ IB Bytes   │
+  ├────────┼─────────────┼─────────────┼────────────┤
+  │   0    │     1       │     2       │  sendSize  │
+  │   1    │     2       │     4       │ 2×sendSize │
+  │   2    │     4       │     8       │ 4×sendSize │
+  │  ...   │    ...      │    ...      │    ...     │
+  │  k     │    2^k      │   2^(k+1)  │ 2^k×send   │
+  └────────┴─────────────┴─────────────┴────────────┘
+  Total IB per GPU = sendSize × (nNodes - 1)
+```
+
+After `log₂(nNodes)` steps, each GPU holds all `nNodes` chunks from its rail column. The NVL broadcasts after each step distribute received data to all local GPUs.
+
+### Example: 4 Nodes x 8 GPUs (32 ranks)
+
+GPU with localRank=0 on node 0 (rank 0):
+
+```
+Step 0 (dist=2): peer = node 2, rank 16
+  Send: chunk[0]      (anchorNode=0)
+  Recv: chunk[16]     (anchorNode=2)
+  NVL bcast: chunk[16] to GPUs 1-7 on node 0
+
+Step 1 (dist=1): peer = node 1, rank 8
+  Send: chunk[0], chunk[16]   (anchorNode=0)
+  Recv: chunk[8], chunk[24]   (anchorNode=1)
+  NVL bcast: chunk[8], chunk[24] to GPUs 1-7 on node 0
+```
+
+### Rail-Parallel Execution (All 8 GPUs)
+
+```
+Node 0                                    Node 2
+┌────────────────────────────────┐        ┌────────────────────────────────┐
+│ G0 ─── IB (rail 0) ───────────────────── G0                             │
+│ G1 ─── IB (rail 1) ───────────────────── G1                             │
+│ G2 ─── IB (rail 2) ───────────────────── G2                             │
+│ G3 ─── IB (rail 3) ───────────────────── G3                             │
+│ G4 ─── IB (rail 4) ───────────────────── G4                             │
+│ G5 ─── IB (rail 5) ───────────────────── G5                             │
+│ G6 ─── IB (rail 6) ───────────────────── G6                             │
+│ G7 ─── IB (rail 7) ───────────────────── G7                             │
+│                                │        │                                │
+│  ◄── NVSwitch (CE bcast) ──►  │        │  ◄── NVSwitch (CE bcast) ──►  │
+└────────────────────────────────┘        └────────────────────────────────┘
+
+Each GPU uses its own NIC. 8 independent IB transfers run in parallel.
+After IB completes, each GPU CE-broadcasts received data to 7 local peers.
+```
+
+## Execution Model
+
+CTPAT reuses the proven GPE + PipeSync cooperative model from `ctrdpipeline`. The implementation is a new `execPat()` method on `AlgoImpl`, alongside the existing `execDirect`, `execPipeline`, and `execRecursiveDoubling`.
+
+```
+Main Thread              GPE Thread                  CUDA Stream
+───────────              ──────────                  ───────────
+allGatherPInit()
+  → allGatherCtrl()
+  → PersistArgs populated
+
+allGatherPExec()
+  → waitInit()
+  → copyToSelf()                                     copyToSelf (CE)
+  → submit(PipeStart)   ┌─dequeue                   PipeStart (→ exits)
+                        │ initNotify() × nSteps
+  → nvlCeBcast(own)     │ RTR handshake              nvlCeBcast(own chunk)
+                        │
+                        │ Step 0:
+                        │   iput(1 chunk)
+                        │   waitNotify()
+                        │   pipeSync->post(0) ────→  PipeSync(0)
+                        │                             nvlCeBcast(step 0)
+                        │ Step 1:
+                        │   iput(2 chunks)
+                        │   waitNotify()
+                        │   pipeSync->post(1) ────→  PipeSync(1)
+                        │                             nvlCeBcast(step 1)
+                        │ ...
+                        └─GPE done                    PipeEnd (reset+barrier)
+```
+
+### PipeSync Overlap Timeline
+
+The key performance advantage: IB step `i+1` runs concurrently with NVL broadcast of step `i`.
+
+```
+Time ──────────────────────────────────────────────────────────────────────►
+
+GPE Thread:
+  ┌──────────┐ ┌──────────────┐ ┌──────────────────┐ ┌──────────────────────┐
+  │ RTR sync │ │ IB step 0    │ │ IB step 1        │ │ IB step 2            │
+  │          │ │ iput(1 chunk)│ │ iput(2 chunks)   │ │ iput(4 chunks)       │
+  │          │ │ waitNotify() │ │ waitNotify()     │ │ waitNotify()         │
+  └──────────┘ └──────┬───────┘ └──────┬───────────┘ └──────┬───────────────┘
+                      │ post(0)        │ post(1)            │ post(2)
+                      ▼                ▼                    ▼
+CUDA Stream:
+  ┌──────────┐ ┌─────────────┐ ┌──────────────────┐ ┌──────────────────────┐ ┌──────┐
+  │copyToSelf│ │nvlCeBcast   │ │PipeSync(0)       │ │PipeSync(1)           │ │Pipe  │
+  │          │ │(own chunk)  │ │  wait...          │ │  wait...             │ │Sync  │
+  │          │ │             │ │  ──► nvlCeBcast   │ │  ──► nvlCeBcast     │ │(2)   │
+  │          │ │             │ │  (step 0: 1 chunk)│ │  (step 1: 2 chunks) │ │ ...  │
+  └──────────┘ └─────────────┘ └──────────────────┘ └──────────────────────┘ └──────┘
+
+                               ◄── overlap ──► ◄────── overlap ──────►
+
+  Critical path = T_ib_0 + max(T_ib_1, T_nvl_0) + max(T_ib_2, T_nvl_1) + T_nvl_2
+```
+
+### Persistent Lifecycle Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ allGatherPInit(recvbuff, maxCount, hints, datatype, comm, stream)      │
+│                                                                         │
+│  1. Verify recvbuff is pre-registered (not dynamic)                    │
+│  2. ►► PAT eligibility check (NEW for ctpat) ◄◄                       │
+│     • nNodes > 1 && isPowerOf2(nNodes)                                 │
+│     • nRanks % nLocalRanks == 0                                        │
+│     • All local peers NVL-reachable                                    │
+│  3. Create AlgoImpl, populate PersistArgs                              │
+│  4. initResources() → allocate GpeKernelSync                          │
+│  5. Submit exchangeMemHdl to GPE thread                                │
+│     └─► GPE: allGatherCtrl() → populate remoteRecvBuffs/AccessKeys    │
+│     └─► GPE: barrier() → all ranks ready                              │
+│     └─► pArgs.initialized = true                                      │
+│  6. Return CtranPersistentRequest                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼  (can be called many times)
+┌─────────────────────────────────────────────────────────────────────────┐
+│ allGatherPExec(sendbuff, count, datatype, request)                     │
+│                                                                         │
+│  switch (NCCL_ALLGATHER_P_ALGO):                                       │
+│    ctdirect     → execDirect()                                         │
+│    ctpipeline   → execPipeline()                                       │
+│    ctrdpipeline → execRecursiveDoubling()                              │
+│    ctpat        → execPat()           ◄◄ NEW                          │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼  (once, at end of lifetime)
+┌─────────────────────────────────────────────────────────────────────────┐
+│ allGatherPDestroy(request)                                             │
+│                                                                         │
+│  1. Free GpeKernelSync (pipeSync)                                      │
+│  2. Delete AlgoImpl                                                    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### When nLocalRanks == 1
+
+NVL broadcasts are skipped. Uses blocking `ncclKernelAllGatherPPipe` kernel. The algorithm reduces to a pure IB recursive-doubling, equivalent to `ctrd` but through the persistent AllGatherP path.
+
+```
+nLocalRanks > 1 (full pipeline)          nLocalRanks == 1 (blocking)
+─────────────────────────────            ──────────────────────────
+                                         
+Stream: copyToSelf                       Stream: copyToSelf
+Stream: PipeStart ──► GPE starts         Stream: PipeBlocking ──► GPE starts
+Stream: nvlCeBcast(own)                            │
+Stream: PipeSync(0) ── waits...                    │ GPE runs ALL steps
+Stream: nvlCeBcast(step 0)                         │ (iput + waitNotify) × nSteps
+Stream: PipeSync(1) ── waits...                    │
+Stream: nvlCeBcast(step 1)                         │ No NVL broadcasts
+Stream: ...                                        │ No PipeSync
+Stream: PipeEnd (reset + barrier)                  ▼
+                                         Stream: PipeBlocking returns
+                                         Stream: continues
+```
+
+Both paths unconditionally enqueue `copyToSelf` before the GPE kernel, matching `RecursiveDoublingImpl.cc:311`.
+
+### GPE Callback Internal Flow (gpeFn)
+
+```
+gpeFn(opGroup) entry
+        │
+        ▼
+  searchRegHandle(sendBuff)
+  initNotify() for each of log₂(nNodes) peers
+        │
+        ▼
+  RTR handshake: isendCtrl + irecvCtrl × nSteps
+  waitRequest() for all recvCtrls
+        │
+        ▼
+  ┌─────────────────────────────────────────┐
+  │          Butterfly Loop                  │
+  │  for i = 0 .. nSteps-1:                 │
+  │    │                                     │
+  │    │  peer = peerAtStep(nodeId, ..., i)  │
+  │    │                                     │
+  │    │  for j = 0 .. 2^i - 1:             │
+  │    │    srcPtr = (i==0) ? sendBuff       │
+  │    │           : recvbuff[chunkIdx]      │
+  │    │    dstPtr = remoteRecvBuff[chunkIdx]│
+  │    │    iput(src → dst, notify on last)  │
+  │    │                                     │
+  │    │  waitRequest(lastPut)               │
+  │    │  waitNotify(peer)                   │
+  │    │                                     │
+  │    │  if nLocalRanks > 1:               │
+  │    │    pipeSync->post(i) ──────► stream │
+  │    │                                     │
+  └─────────────────────────────────────────┘
+        │
+        ▼
+  waitRequest(sendCtrls)
+  return commSuccess
+```
+
+### Relationship to ctrdpipeline
+
+For v1, `execPat()` is structurally identical to `execRecursiveDoubling()`. The step computation, GPE callback, and stream-side orchestration are the same. The value of introducing `ctpat` is:
+
+1. A clean enum for users to opt in to the PAT family
+2. A separate method that can diverge in future versions (non-power-of-two, step aggregation)
+3. Avoids overloading `ctrdpipeline` semantics if the planner evolves
+
+## Code Structure
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `AllGatherP/PatImpl.cc` | `execPat()` implementation — GPE callback + stream orchestration |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `AllGatherP/AlgoImpl.h` | Add `execPat()` method declaration, add `ctpat` to `algoName()` |
+| `AllGatherP/AllGatherP.cc` | Add `ctpat` case to `allGatherPExec()` dispatch switch |
+| `utils/cvars/nccl_cvars.yaml` | Add `ctpat` to `NCCL_ALLGATHER_P_ALGO` choices |
+
+**Not in v1**: Extracting step computation to a shared `RecursiveDoublingUtils.h` is deferred. The helper functions (`peerAtStep`, `rankChunkOffset`, etc.) are small — `PatImpl.cc` duplicates them in its own anonymous namespace for v1. Factoring to a shared header is a cleanup for after performance data validates the approach.
+
+### Build System
+
+BUCK: `ctran_lib` uses `glob(["**/*.cc"])` — new `.cc` files auto-included. No BUCK changes needed.
+
+CMake: `file(GLOB_RECURSE)` auto-includes. No CMake changes needed.
+
+After modifying `nccl_cvars.yaml`, regenerate:
+```bash
+NCCL_CVARS_OUTPUT_DIR=comms/utils/cvars buck2 run comms/utils/cvars:extractcvars
+```
+
+## Algorithm Selection
+
+### Selection Flow
+
+```
+User sets NCCL_ALLGATHER_P_ALGO=ctpat
+                    │
+                    ▼
+         allGatherPInit()
+                    │
+                    ├─── nNodes == 1? ──────────────► ERROR: ctpat requires multi-node
+                    │
+                    ├─── !isPowerOf2(nNodes)? ──────► ERROR: ctpat requires power-of-2 nodes
+                    │
+                    ├─── nRanks % nLocalRanks != 0? ► ERROR: uneven rank distribution
+                    │
+                    ├─── local peer not NVL? ────────► ERROR: NVL required for local peers
+                    │     (when nLocalRanks > 1)
+                    │
+                    ▼
+              Init succeeds
+              PersistArgs created
+              Handles exchanged
+                    │
+                    ▼
+         allGatherPExec()
+                    │
+         switch(NCCL_ALLGATHER_P_ALGO)
+                    │
+      ┌─────────┬───┴────┬──────────────┐
+      ▼         ▼        ▼              ▼
+  ctdirect  ctpipeline  ctrdpipeline   ctpat
+  (direct)  (ring)      (butterfly)    (butterfly)
+                                        │
+                                        ▼
+                                    execPat()
+```
+
+### Persistent Path
+
+`NCCL_ALLGATHER_P_ALGO=ctpat` selects the PAT variant in `allGatherPExec()`:
+
+```cpp
+case NCCL_ALLGATHER_P_ALGO::ctpat:
+    return algo->execPat(sendbuff, count, datatype);
+```
+
+PAT eligibility is validated in `allGatherPInit()`, not at exec time. If prerequisites are not met (non-power-of-two nNodes, missing NVL connectivity, nRanks not divisible by nLocalRanks), init returns an error with a descriptive message. This matches the existing init path where registration and persistent setup already happen (`AllGatherP.cc:155`).
+
+### CUDA Graph Path
+
+Graph support for ctpat is **deferred from v1**. The `ctgraph_pipeline` path in `AllGatherCudagraphAware.cc` currently hardcodes `NCCL_ALLGATHER_P_ALGO = ctpipeline` at line 166 inside its execute path (`allGatherWinExec`), so updating `selectCtgraphAlgo()` alone would not make graph-captured ctpat work. Enabling it requires changing the `ctgraph_pipeline` execute path to respect the `NCCL_ALLGATHER_P_ALGO` CVAR, which is a broader change best done after v1 is validated.
+
+### CVARs
+
+| CVAR | Default | Description |
+|------|---------|-------------|
+| `NCCL_ALLGATHER_P_ALGO` | ctpipeline | Add `ctpat` to existing choices |
+
+v1 uses explicit selection only (`NCCL_ALLGATHER_P_ALGO=ctpat`). There is no size-based auto-selection or fallback path — the user opts in to ctpat for their entire persistent AllGatherP lifetime. Size thresholds and auto-tuning CVARs are deferred to Phase 2 after benchmarking establishes where ctpat wins.
+
+## Performance Model
+
+### Latency
+
+With PipeSync pipelining, IB step `i+1` overlaps with NVL broadcast of step `i`:
+
+```
+T_pat = T_ib_step_0
+      + Σ_{i=1}^{nSteps-1} max(T_ib_step_i, T_nvl_step_{i-1})
+      + T_nvl_step_{nSteps-1}
+
+where:
+  T_ib_step_i  = T_ib_rtt + 2^i × sendSize / BW_ib
+  T_nvl_step_i = 2^i × (T_nvl_barrier + T_ce_copy(sendSize × (nLocalRanks-1)))
+```
+
+The butterfly sends increasing amounts per step — the final step transfers `nNodes/2 × sendSize`, which is half of all IB data. This asymmetry means the last step dominates IB time at large message sizes.
+
+### Bandwidth
+
+Total IB data per GPU = `sendSize × (nNodes - 1)`, same as ring and direct. Rail-parallel execution distributes traffic across all 8 NICs per node.
+
+### Expected Advantage over ctpipeline (Ring)
+
+| nNodes | Ring Steps | PAT Steps | Step Reduction |
+|--------|-----------|-----------|---------------|
+| 4 | 3 | 2 | 1.5x |
+| 8 | 7 | 3 | 2.3x |
+| 16 | 15 | 4 | 3.75x |
+| 64 | 63 | 6 | 10.5x |
+
+```
+IB Steps vs Node Count:
+
+Steps
+  │
+63│ ·                                                    Ring O(N)
+  │
+  │
+32│ ·
+  │
+  │
+16│ ·
+  │
+ 8│ ·
+ 7│          ·
+ 6│                                                 ×    PAT O(log N)
+ 4│     ·              ×
+ 3│ ×        ·    ×
+ 2│ ×   ×
+ 1│
+  └──────────────────────────────────────────────────
+   2    4    8    16   32                   64    nNodes
+
+  · = Ring (ctpipeline)    × = PAT (ctpat)
+```
+
+PAT wins increasingly at large node counts where `O(log N)` vs `O(N)` matters.
+
+## Implementation Plan
+
+```
+Phase 1 (v1)              Phase 2                Phase 3              Phase 4
+─────────────             ──────────             ─────────            ──────────
+┌──────────────┐   ┌──────────────────┐   ┌────────────────┐   ┌──────────────┐
+│ ctpat enum   │   │ Benchmark sweep  │   │ Non-power-of-2 │   │ Step         │
+│ + PatImpl.cc │──►│ across H100      │──►│ node count     │──►│ aggregation  │
+│ + tests      │   │ configs          │   │ support        │   │ + auto-tune  │
+│              │   │                  │   │                │   │              │
+│ Power-of-2   │   │ Crossover point  │   │ Bruck's or     │   │ PAT-style    │
+│ only         │   │ analysis         │   │ hybrid planner │   │ batching     │
+└──────────────┘   └──────────────────┘   └────────────────┘   └──────────────┘
+    │                                          │
+    │ Success bar:                             │ This is where ctpat
+    │ Match ctrdpipeline                       │ diverges from ctrdpipeline
+    │ Beat ctdirect (medium sizes)             │ in implementation
+    │ 4x8, 8x8, 16x8 H100                     │
+```
+
+### Phase 1: PAT as AllGatherP Variant (v1)
+
+Implement `ctpat` as a new `NCCL_ALLGATHER_P_ALGO` variant, structurally identical to `ctrdpipeline` with its own `execPat()` method.
+
+**Steps**:
+1. Add `ctpat` to `NCCL_ALLGATHER_P_ALGO` choices in `nccl_cvars.yaml` and regenerate
+2. Create `AllGatherP/PatImpl.cc` with `execPat()` — same GPE callback and stream orchestration as `execRecursiveDoubling`, with step helper functions duplicated in a local anonymous namespace
+3. Add `execPat()` to `AlgoImpl.h`, add `ctpat` case to `allGatherPExec()` and `algoName()`
+4. Add PAT eligibility validation in `allGatherPInit()` (power-of-two nNodes, NVL connectivity for local peers, nRanks divisible by nLocalRanks). Failing at init is cleaner than letting request creation succeed and then erroring on replay — init is where registration and persistent setup already happen
+
+**Success bar**: Match `ctrdpipeline` performance (since v1 is structurally identical), AND beat or match `ctdirect` on medium message sizes (32KB-8MB) for 4x8, 8x8, and 16x8 H100. A ctpat that is slower than ctrdpipeline is a regression, not a feature.
+
+**Deliverables**:
+- `AllGatherP/PatImpl.cc`
+- Updated `AlgoImpl.h`, `AllGatherP.cc`, `nccl_cvars.yaml`
+- Distributed tests with `nolocal` and `vnode` configurations
+- Benchmark: ctpat vs ctdirect vs ctpipeline vs ctrdpipeline
+
+### Phase 2: Benchmarking and Threshold Tuning
+
+Comprehensive benchmark sweep to establish crossover points and determine whether ctpat should become the default `NCCL_ALLGATHER_P_ALGO`.
+
+**Benchmark matrix**:
+
+| Dimension | Values |
+|-----------|--------|
+| Message size | 4KB, 16KB, 64KB, 256KB, 1MB, 4MB, 16MB, 64MB, 256MB, 1GB |
+| Node count | 2x8, 4x8, 8x8, 16x8, 64x8 |
+| Algorithms | ctpat, ctdirect, ctpipeline, ctrdpipeline |
+| Memory type | cudaMalloc, ncclMemAlloc |
+
+**Deliverables**:
+- Benchmark results with analysis
+- Recommendation on default algorithm selection
+- Size threshold tuning (if ctpat is made default for certain ranges)
+
+### Phase 3: Non-Power-of-Two Support (Future)
+
+Extend the planner to handle arbitrary node counts. Options:
+- Bruck's algorithm adaptation for non-power-of-two
+- Padding to next power-of-two with dummy nodes
+- Hybrid: power-of-two butterfly for the largest power-of-two subset, direct for remainder
+
+This is where CTPAT diverges from `ctrdpipeline` in implementation, not just naming.
+
+### Phase 4: Step Aggregation and Auto-Tuning (Future)
+
+Add PAT-style step aggregation from baseline NCCL (batching multiple butterfly steps to reduce synchronization points). Add auto-tuned pipeline depth and block count tiers based on benchmark data from Phase 2.
+
+## What is Cut from v1
+
+- ~~New eager `AllGatherPat.cc` under `AllGather/`~~ → Use AllGatherP path
+- ~~Separate `ctgraph_pat` enum~~ → Deferred; requires `ctgraph_pipeline` execute path change
+- ~~Shared `RecursiveDoublingUtils.h`~~ → Duplicate helpers locally; factor later
+- ~~Chunked staging buffers~~ → Defer to Phase 4 if benchmarks show a gap
+- ~~Large CVAR/auto-tune surface~~ → Start with fixed settings, add CVARs as needed
+- ~~Non-power-of-two handling~~ → Phase 3
+
+## Testing
+
+### Distributed Tests
+
+Extend the existing distributed AllGatherP test suite at `ctran/tests/CtranDistAllgatherPTests.cc` (wired from `ctran/tests/BUCK:162`) with ctpat test cases. If the test file grows too large, add a sibling `ctran/tests/CtranDistAllgatherPPatTests.cc` in the same directory and BUCK target.
+
+Test configurations reuse the existing patterns:
+
+```python
+# In ctran/tests/BUCK, extend ctran_dist_allgatherp or add:
+"1x8_nolocal_pat": {  # 8 "nodes" with 1 GPU each (pure IB butterfly)
+    "compiler_flags": ["-DNCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL"],
+    "nnodes": 1, "ppn": 8,
+},
+"1x8_vnode_pat": {  # Simulated multi-node with NVL
+    "compiler_flags": ["-DNCCL_COMM_STATE_DEBUG_TOPO_VNODE"],
+    "nnodes": 1, "ppn": 8,
+},
+```
+
+### Correctness Test Cases
+
+- nLocalRanks==1 (nolocal): pure IB butterfly, no NVL broadcasts
+- 2-node, 4-node, 8-node power-of-two configurations
+- Non-power-of-two nNodes: init returns error
+- In-place and out-of-place operations
+- Various datatypes and message sizes
+
+### Performance Tests
+
+Use existing `AllgatherPBench.cc` with `NCCL_ALLGATHER_P_ALGO=ctpat`:
+
+```bash
+NCCL_ALLGATHER_P_ALGO=ctpat buck2 run @fbcode//mode/opt \
+    -c hpc_comms.use_ncclx=stable \
+    //comms/ctran/benchmarks:AllgatherPBench -- \
+    --minBytes 16K --maxBytes 1G --stepFactor 2
+```
+
+### Stress Tests
+
+- Back-to-back allGatherPExec calls (persistent replay)
+- Concurrent communicators
+- Abort/timeout paths

--- a/comms/ctran/algos/AllGather/docs/AllGatherPatCopyBased.md
+++ b/comms/ctran/algos/AllGather/docs/AllGatherPatCopyBased.md
@@ -1,0 +1,723 @@
+# CTPATCOPY: Step-Local Staged AllGather PAT
+
+This document describes `ctpatcopy`, a staged-buffer variant of the AllGather PAT algorithm. It routes IB transfers through pre-registered staging buffers instead of putting directly to `recvbuff`, providing pre-registered buffer benefits and enabling future chunk-level pipelining. For v1, the staging pipeline operates at **step granularity**, reusing PipeStart/PipeSync/PipeEnd from the zero-copy `ctpat` but extending the model with a `stepDoneSync` signal (stream→GPE) to ensure staging→recvbuff copies complete before the next step. This makes v1 fully blocking per step.
+
+**Prerequisite**: [AllGatherPat.md](AllGatherPat.md) — the zero-copy `ctpat` design.
+
+## Motivation
+
+The zero-copy `ctpat` puts directly from `recvbuff` to the peer's `recvbuff`. This works well but has two limitations:
+
+1. **Registration dependency**: The user's `recvbuff` must be IB-registered (pre-registered at init or dynamically at exec). Dynamic registration is expensive (~50-200μs for large buffers). Pre-registration requires stable buffer addresses.
+
+2. **No intra-step overlap**: All `2^i` puts at step `i` complete before any NVL CE broadcast begins. With staging, future versions can pipeline individual chunks within a step — but this requires chunk-granular completion tracking that the current transport doesn't cleanly support.
+
+`ctpatcopy` addresses limitation 1 immediately and lays the groundwork for limitation 2.
+
+### What v1 Does NOT Do
+
+- **No chunk-level pipelining within a step.** v1 stages all `2^i` puts at step `i`, waits for the step to complete, then flushes, copies staging→recvbuff, and broadcasts. v1 is **fully blocking per step** — the GPE waits for the stream to finish staging→recvbuff copies via `stepDoneSync` before starting the next step. There is no inter-step IB/NVL overlap in v1.
+- **No multi-round sub-chunking.** If `sendSize > stagingBufSize`, v1 falls back to zero-copy.
+- **No auto-selection.** `ctpatcopy` is a separate `NCCL_ALLGATHER_P_ALGO` choice, not a dynamic branch inside `ctpat`.
+
+### Expected Benefits (Hypotheses — To Be Validated by Benchmarking)
+
+| Benefit | Mechanism | Expected Impact |
+|---------|-----------|-----------------|
+| No dynamic registration | Pre-registered staging buffers at init | Eliminate ~50-200μs per-call registration overhead |
+| Bounded BAR1 usage | Fixed 32MB staging vs. registering full recvbuff | Reduced memory pressure at large rank counts |
+| Foundation for chunk pipeline | Staging infrastructure in place | Future v2 can add chunk-level overlap when transport supports it |
+
+We expect `ctpatcopy` to be **close to `ctpat` performance** for pre-registered buffers, with a small per-step overhead from the extra CE copies and `cudaStreamSynchronize` (v1 is fully blocking per step, so this overhead is not hidden by overlap). We expect `ctpatcopy` to **outperform `ctpat`** when dynamic registration is in play, since the pre-registered staging eliminates the ~50-200μs per-call registration cost. The performance crossover for intra-step pipelining benefits is deferred to v2 once we have benchmark data and transport support for chunk-granular completion.
+
+## Architecture: ctpat vs ctpatcopy
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                        AllGatherP Persistent API                     │
+│                   allGatherPInit / allGatherPExec / allGatherPDestroy│
+└──────────────────────────────┬───────────────────────────────────────┘
+                               │
+              switch(NCCL_ALLGATHER_P_ALGO)
+                               │
+     ┌─────────┬───────────┬───┴──────────┬──────────────┐
+     ▼         ▼           ▼              ▼              ▼
+ ctdirect  ctpipeline  ctrdpipeline     ctpat         ctpatcopy
+ (direct)  (ring)      (butterfly)    (butterfly     (butterfly
+                                      zero-copy)    staged) ← NEW
+                                         │              │
+                                         │              │
+                                    ┌────┴────┐    ┌────┴────────────┐
+                                    │ iput    │    │ CE→staging      │
+                                    │ directly│    │ iput staging    │
+                                    │ to peer │    │ iflush          │
+                                    │ recvbuff│    │ CE staging→recv │
+                                    └─────────┘    │ nvlCeBcast      │
+                                                   │ stepDoneSync    │
+                                                   └─────────────────┘
+```
+
+## Architecture Decision: Separate Algo, Not Dynamic Branch
+
+`ctpatcopy` is a separate `NCCL_ALLGATHER_P_ALGO` enum value, NOT a dynamic branch inside `ctpat`. This avoids the init/exec divergence problem: staging buffers are allocated and exchanged at init time, so the algo choice must be fixed for the request lifetime.
+
+```
+NCCL_ALLGATHER_P_ALGO choices:
+  ctdirect       — all-to-all direct puts
+  ctpipeline     — ring + NVL CE bcast
+  ctrdpipeline   — butterfly + NVL CE bcast (zero-copy)
+  ctpat          — PAT butterfly + NVL CE bcast (zero-copy)
+  ctpatcopy      — PAT butterfly + NVL CE bcast (staged)  ← NEW
+```
+
+## Data Flow
+
+### Per-Step Flow (v1: Step Granularity)
+
+```
+SEND PATH — GPE thread, for each of 2^i chunks at step i:
+
+  recvbuff[chunk_j] ──CE copy──► tmpSendBuf[slot]
+  (step 0: sendbuff)                  │
+                                      │ IB RDMA PUT
+                                      ▼
+                                peer's tmpRecvBuf[slot]
+
+
+RECV PATH — GPE thread, after ALL 2^i puts complete + notify:
+
+  tmpRecvBuf[slot] ──iflush──► tmpRecvBuf[slot]
+
+
+STREAM SIDE — after GPE signals step completion via pipeSync:
+
+  tmpRecvBuf[slot] ──CE copy──► recvbuff[chunk_j]
+                                      │
+                                      │ NVL CE broadcast
+                                      ▼
+                                local peers' recvbuff[chunk_j]
+```
+
+### Detailed Data Flow (Step i, Node A → Node B, localRank=0)
+
+```
+NODE A (sender)                                     NODE B (receiver)
+┌────────────────────────────┐                      ┌────────────────────────────┐
+│                            │                      │                            │
+│  recvbuff (GPU)            │                      │  recvbuff (GPU)            │
+│  ┌────┬────┬────┬────┐     │                      │  ┌────┬────┬────┬────┐     │
+│  │ c0 │ c1 │ c2 │ c3 │     │                      │  │    │    │    │    │     │
+│  └─┬──┴─┬──┴─┬──┴─┬──┘     │                      │  └────┴─▲──┴─▲──┴─▲──┘     │
+│    │    │    │    │         │                      │         │    │    │         │
+│    │ ① CE copy (batch)     │                      │      ⑤ CE copy (stream)    │
+│    ▼    ▼    ▼    ▼         │                      │         │    │    │         │
+│  tmpSendBuf (GPU, 32MB)    │                      │  tmpRecvBuf (GPU, 32MB)    │
+│  ┌────┬────┬────┬────┐     │                      │  ┌────┬────┬────┬────┐     │
+│  │ c0 │ c1 │ c2 │ c3 │     │                      │  │ c0 │ c1 │ c2 │ c3 │     │
+│  └─┬──┴─┬──┴─┬──┴─┬──┘     │                      │  └─▲──┴─▲──┴─▲──┴─▲──┘     │
+│    │    │    │    │         │                      │    │    │    │    │         │
+└────┼────┼────┼────┼────────┘                      └────┼────┼────┼────┼────────┘
+     │    │    │    │                                     │    │    │    │
+     │    │    │    └──── ③ IB RDMA PUT (notify last) ───┘    │    │
+     │    │    └───────── ③ IB RDMA PUT ──────────────────────┘    │
+     │    └────────────── ③ IB RDMA PUT ───────────────────────────┘
+     └─────────────────── ③ IB RDMA PUT ──────────────────────────────┘
+
+② cudaStreamSynchronize(copyStream) — between ① and ③
+④ iflush (after all puts + notify complete) — between ③ and ⑤
+⑥ nvlCeBcast from recvbuff to local peers (after ⑤)
+⑦ StepDone kernel signals GPE (after ⑥)
+```
+
+### Between-Step Forwarding
+
+Step `i+1` reads from `recvbuff` (not staging) as its send source. This means the staging→recvbuff CE copies for step `i` must complete before step `i+1`'s GPE issues `icopy` from those positions.
+
+**The existing PipeSync is one-way** (stream waits for GPE) and does not provide a signal back to the GPE. The zero-copy `ctpat` does not need this because IB puts land directly in recvbuff. But with staging, the GPE must wait for the stream-side CE copies to finish.
+
+v1 uses a **`stepDoneSync` GpeKernelSync** for stream→GPE completion:
+
+1. GPE: after `pipeSync->post(i)`, wait on `stepDoneSync->waitComplete(i)` before starting step `i+1`
+2. Stream: after all CE copies and NVL broadcasts for step `i`, a 1-thread `StepDone` kernel signals `stepDoneSync->complete(i)`
+
+This makes each step **fully blocking**: the GPE cannot start step `i+1` until the stream finishes step `i`'s staging→recvbuff copies. This is strictly correct. The cost is that the inter-step IB/NVL overlap from zero-copy `ctpat` is lost — but since v1 is about registration benefits, not overlap, this is acceptable.
+
+```
+New kernel:
+__global__ void ncclKernelStepDone(
+    int* flag, CtranAlgoDeviceState* devState, StepDoneKernArgs args) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    GpeKernelSyncDev::complete(args.stepDoneSync, 0, args.stepId);
+}
+```
+
+**Reset between execs**: Both `pipeSync` and `stepDoneSync` must be reset at the end of each exec to prevent stale `completeFlag` values from causing early pass-through on the next persistent replay. `GpeKernelSync::waitComplete()` uses `>= step` comparison, so if `stepDoneSync` is left at a prior exec's terminal value, `waitComplete(0)` in the next exec passes immediately — breaking the staged dependency.
+
+The reset is done in the `PipeEnd` kernel, which already owns end-of-exec cleanup. `PipeEnd` is extended to reset both sync objects:
+
+```
+// Extended PipeEnd kernel for ctpatcopy:
+__global__ void ncclKernelAllGatherPPatCopyPipeEnd(
+    int* flag, CtranAlgoDeviceState* devState, PatCopyPipeEndKernArgs args) {
+    GpeKernelSyncDev::reset(args.pipeSync, 0);
+    GpeKernelSyncDev::reset(args.stepDoneSync, 0);
+    devStateLoadToShm(devState);
+    const auto localRank = statex->localRank();
+    const auto nLocalRanks = statex->nLocalRanks();
+    barrier(localRank, nLocalRanks);
+}
+```
+
+`stepDoneSync` is a stream-produced signal, so resetting it on the stream at the end of exec is the safest lifecycle point. Resetting from the GPE at the start of the next exec would be weaker because lingering stream work from the previous replay could race with the reset.
+
+This is **step-local staging**, not full staged forwarding. The staging buffers decouple IB from user buffers within each step, but forwarding still reads from `recvbuff`.
+
+## Staging Buffer Layout
+
+v1 uses **contiguous per-step** layout, not round-robin slot reuse. Since the GPE issues all puts for a step before the stream consumes any of them, every chunk within a step must occupy a distinct staging position. Reusing slots within a step would overwrite unconsumed data.
+
+```
+tmpSendBuf (32MB default):
+┌──────────────────────────────────────────────────────┐
+│  chunk 0  │  chunk 1  │  chunk 2  │  ...  │ chunk N  │
+│ sendSize  │ sendSize  │ sendSize  │       │ sendSize │
+└──────────────────────────────────────────────────────┘
+
+tmpRecvBuf (32MB default):
+┌──────────────────────────────────────────────────────┐
+│  chunk 0  │  chunk 1  │  chunk 2  │  ...  │ chunk N  │
+│ sendSize  │ sendSize  │ sendSize  │       │ sendSize │
+└──────────────────────────────────────────────────────┘
+
+maxChunksPerStep = stagingBufSize / sendSize
+```
+
+At step `i` with `2^i` chunks: chunk `j` uses offset `j * sendSize` within the staging buffer. No slot reuse within a step.
+
+**Capacity constraint**: If `2^i * sendSize > stagingBufSize` for any step, v1 falls back to zero-copy for that step (or the entire collective). The worst-case step is `i = nSteps - 1`, which needs `nNodes/2 * sendSize`. For 8 nodes with 32MB staging: `sendSize <= 8MB`. For 16 nodes: `sendSize <= 2MB`.
+
+If `sendSize > stagingBufSize / (nNodes / 2)`: v1 falls back to zero-copy.
+
+```
+Capacity constraint (32MB staging, worst-case = last step):
+
+  nNodes │ Max sendSize  │ Last step chunks │ Last step total
+  ───────┼───────────────┼──────────────────┼────────────────
+    4    │    16 MB      │        2         │     32 MB
+    8    │     8 MB      │        4         │     32 MB
+   16    │     4 MB      │        8         │     32 MB
+   32    │     2 MB      │       16         │     32 MB
+   64    │     1 MB      │       32         │     32 MB
+
+  If sendSize exceeds the limit → fall back to zero-copy (ctpat)
+```
+
+Two buffers (send + recv). One pair total — butterfly has a single peer per step. The entire staging buffer is reused across steps (step `i+1` can overwrite step `i`'s staging because the stream has consumed it by then — enforced by the step completion signal).
+
+## Execution Model
+
+v1 uses the **same PipeSync model** as zero-copy `ctpat`, with staging inserted in the GPE callback:
+
+```
+GPE Thread                                     CUDA Stream
+──────────                                     ───────────
+                                               copyToSelf (CE)
+PipeStart ───────────────────────────────────► PipeStart (releases GPE, exits)
+                                               nvlCeBcast(own chunk)
+Step 0 (1 chunk):
+  CE: sendbuff → tmpSend[s0]
+  cudaStreamSynchronize(copyStream)
+  iput(tmpSend[s0] → peer tmpRecv[s0])
+  waitRequest(lastPut)
+  waitNotify()
+  iflush(tmpRecv[s0])
+  pipeSync→post(0) ─────────────────────────► PipeSync(0)
+                                                CE: tmpRecv[s0] → recvbuff[c0]
+                                                nvlCeBcast(recvbuff[c0])
+                                                StepDone(0) ──► GPE
+  stepDoneSync→waitComplete(0)
+  (GPE blocked until stream finishes step 0)
+
+Step 1 (2 chunks):
+  CE: recvbuff → tmpSend[0..1]
+  cudaStreamSynchronize(copyStream)
+  iput(tmpSend[0] → peer tmpRecv[0])
+  iput(tmpSend[1] → peer tmpRecv[1])
+  waitRequest(lastPut)
+  waitNotify()
+  iflush(tmpRecv[0])
+  iflush(tmpRecv[1])
+  pipeSync→post(1) ─────────────────────────► PipeSync(1)
+                                                CE: tmpRecv[0] → recvbuff[c1]
+                                                CE: tmpRecv[1] → recvbuff[c2]
+                                                nvlCeBcast(recvbuff[c1])
+                                                nvlCeBcast(recvbuff[c2])
+                                                StepDone(1) ──► GPE
+  stepDoneSync→waitComplete(1)
+  (GPE blocked until stream finishes step 1)
+
+Step 2 (4 chunks):
+  CE: recvbuff → tmpSend[0..3]
+  cudaStreamSynchronize(copyStream)
+  iput × 4
+  waitNotify()
+  iflush × 4
+  pipeSync→post(2) ─────────────────────────► PipeSync(2)
+                                                CE: tmpRecv[0..3] → recvbuff
+                                                nvlCeBcast × 4
+                                                StepDone(2) ──► GPE
+ ...
+                                               PipeEnd (reset + barrier)
+```
+
+### Step-Level Timeline (Fully Blocking, 4 Nodes = 2 Steps)
+
+```
+Time ──────────────────────────────────────────────────────────────────────────────►
+
+GPE Thread:
+  ┌──────────────────────────────┐   ┌─────────────────────────────────────────────┐
+  │ Step 0 (1 chunk)             │   │ Step 1 (2 chunks)                           │
+  │ CE: src→stg                 │   │ CE: src→stg[0..1]                           │
+  │ sync(copyStream)            │   │ sync(copyStream)                            │
+  │ iput(stg→peer)              │   │ iput(stg[0]→peer), iput(stg[1]→peer)       │
+  │ waitRequest + waitNotify    │   │ waitRequest + waitNotify                    │
+  │ iflush                      │   │ iflush[0], iflush[1]                        │
+  │ pipeSync→post(0)            │   │ pipeSync→post(1)                            │
+  └──────────────────┬──────────┘   └──────────────────────────────┬──────────────┘
+                     │ blocked                                     │
+                     │ stepDoneSync                                │
+                     │ →waitComplete(0)                            ▼
+                     │                                          done
+                     ▼
+
+CUDA Stream:
+  ┌──────────┐ ┌────────────┐ ┌──────────────────────┐ ┌──────────────────────────┐
+  │copyToSelf│ │PipeStart   │ │PipeSync(0)           │ │PipeSync(1)               │
+  │          │ │(→exits)    │ │CE: stg[0]→recv[c0]   │ │CE: stg[0]→recv[c1]       │
+  │          │ │            │ │nvlCeBcast(c0)        │ │CE: stg[1]→recv[c2]       │
+  │          │ │nvlCeBcast  │ │StepDone(0)──►GPE     │ │nvlCeBcast(c1)            │
+  │          │ │(own chunk) │ │                      │ │nvlCeBcast(c2)            │
+  └──────────┘ └────────────┘ └──────────────────────┘ │StepDone(1)──►GPE         │
+                                                       └──────────────────────────┘
+                                                       ┌──────────────────────────┐
+                                                       │PatCopyPipeEnd            │
+                                                       │  reset(pipeSync)         │
+                                                       │  reset(stepDoneSync)     │
+                                                       │  barrier(localRanks)     │
+                                                       └──────────────────────────┘
+
+  ◄─── No overlap between steps: GPE blocked on stepDoneSync ───►
+```
+
+### Bidirectional Sync Flow
+
+```
+GPE Thread                          CUDA Stream
+──────────                          ───────────
+
+  pipeSync→post(i)  ──────────────►  PipeSyncKernel waits
+  (GPE→stream:                       (stream unblocked)
+   "IB done, staging                       │
+    ready to read")                        │ CE copies + NVL bcasts
+                                           │
+  stepDoneSync                             │
+  →waitComplete(i)  ◄────────────── StepDoneKernel signals
+  (stream→GPE:                      (stream→GPE:
+   GPE blocked until                 "recvbuff populated,
+   stream finishes)                   staging safe to reuse")
+         │
+         ▼
+  Start step i+1
+```
+
+### Key Differences from Zero-Copy ctpat
+
+| Aspect | ctpat (zero-copy) | ctpatcopy (staged) |
+|--------|-------------------|---------------------|
+| IB source | recvbuff/sendbuff directly | tmpSendBuf (pre-registered) |
+| IB destination | peer's recvbuff directly | peer's tmpRecvBuf |
+| After IB arrival | Data already in recvbuff | CE copy: tmpRecvBuf → recvbuff on stream |
+| iflush needed | No (ctrdpipeline doesn't use it) | Yes (IB→staging requires flush before CE reads) |
+| User buffer registration | Required for iput source | Not needed — staging is pre-registered |
+| Stream-side work per step | nvlCeBcast only | CE staging→recvbuff + nvlCeBcast |
+| Overlap model | Inter-step via PipeSync | Fully blocking per step (stepDoneSync) |
+| Sync direction | GPE→stream only | GPE→stream (pipeSync) + stream→GPE (stepDoneSync) |
+
+### When nLocalRanks == 1
+
+v1 `ctpatcopy` **requires nLocalRanks > 1**. The staged copy-back from `tmpRecvBuf` to `recvbuff` is driven by the CUDA stream after `PipeSync`, which only runs in the `nLocalRanks > 1` path. In the pure-IB case (`nLocalRanks == 1`), there is no stream-side copy-back, so step `i+1` would read stale data from `recvbuff`.
+
+For `nLocalRanks == 1`, use `ctpat` (zero-copy) instead. The eligibility check in `execPatCopy()` rejects `nLocalRanks == 1` with an error.
+
+## Buffer Management
+
+### Allocation: Per-Persistent-Request via BufManager
+
+```cpp
+// In AllGatherP/Types.h:
+namespace ctran::allgatherp {
+
+enum class StagingBufId {
+  kSendBuf,
+  kRecvBuf,
+  kNumBufs,
+};
+
+struct StagingInfo {
+  ctran::algos::bufmanager::RegBuf sendBuf;   // local send staging
+  ctran::algos::bufmanager::RegBuf recvBuf;   // local recv staging
+  std::vector<ctran::algos::bufmanager::RemRegBuf> remRecvBufs;  // peers' recv staging
+  size_t slotSize{0};
+  size_t numSlots{0};
+};
+
+// Extended Resource struct:
+struct Resource {
+  GpeKernelSync* pipeSync{nullptr};       // GPE→stream: step IB complete
+  GpeKernelSync* stepDoneSync{nullptr};   // stream→GPE: step CE copies complete
+  std::unique_ptr<BufManager<StagingBufId, StagingBufId::kNumBufs>> stagingBufMgr;
+  StagingInfo stagingInfo;
+};
+
+struct StepDoneKernArgs {
+  int stepId;
+  GpeKernelSync* stepDoneSync;
+};
+
+struct PatCopyPipeEndKernArgs {
+  GpeKernelSync* pipeSync;
+  GpeKernelSync* stepDoneSync;
+};
+}
+```
+
+### Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ allGatherPInit                                                      │
+│                                                                     │
+│  1. initResources():                                               │
+│     • allocate pipeSync (GpeKernelSync)                            │
+│     • allocate stepDoneSync (GpeKernelSync)                        │
+│     • BufManager: insert(kSendBuf, 32MB), insert(kRecvBuf, 32MB)  │
+│     • BufManager: commit() → cudaMalloc 64MB total                │
+│                                                                     │
+│  2. exchangeMemHdl (GPE thread):                                   │
+│     • allGatherCtrl(recvbuff) → populate PersistArgs               │
+│     • BufManager: exchange(peerRanks) → IB-register + exchange    │
+│     • pArgs.initialized = true                                     │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼ (called many times)
+┌─────────────────────────────────────────────────────────────────────┐
+│ allGatherPExec → execPatCopy()                                     │
+│                                                                     │
+│  GPE: CE→staging → sync → iput → waitNotify → iflush → pipeSync   │
+│  Stream: PipeSync → CE staging→recv → nvlCeBcast → StepDone       │
+│  GPE: stepDoneSync→waitComplete (blocked until stream done)        │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+                               ▼ (once)
+┌─────────────────────────────────────────────────────────────────────┐
+│ allGatherPDestroy                                                   │
+│                                                                     │
+│  1. BufManager: release() → deregister + cudaFree staging          │
+│  2. cudaFreeHost(pipeSync)                                          │
+│  3. cudaFreeHost(stepDoneSync)                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+| Phase | What Happens |
+|-------|-------------|
+| `allGatherPInit` | BufManager creates staging buffers, `commit()` allocates GPU memory |
+| `exchangeMemHdl` (GPE) | `bufManager.exchange()` IB-registers and exchanges addresses with butterfly peers |
+| `allGatherPExec` | GPE uses staging for iput; stream uses staging for CE copies |
+| `allGatherPDestroy` | `bufManager.release()` deregisters and frees staging |
+
+Only **IB registration** needed. NVL reads from `recvbuff` (already IPC-exchanged via `PersistArgs`).
+
+### Sizing
+
+| Parameter | Default | CVAR |
+|-----------|---------|------|
+| Staging buffer size | 32MB per buffer | `NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE` |
+| Total memory | 64MB (32MB send + 32MB recv) | — |
+
+When `sendSize > stagingBufSize / (nNodes / 2)`: `execPatCopy()` delegates to `execPat()` (zero-copy) rather than carrying an inline zero-copy duplicate. v1 does not support multi-round sub-chunking.
+
+## GPE Callback
+
+```cpp
+commResult_t gpeFn(opGroup) {
+    // Register sendbuff (step 0 source)
+    mapper->searchRegHandle(sendBuff, sendSize, &sendHdl, &localReg);
+
+    // Pre-init notifications and RTR for all steps
+    for (int i = 0; i < nSteps; i++) {
+        peers[i] = peerAtStep(...);
+        mapper->initNotify(peers[i], stagingInfo.recvBuf.regHdl, &notifyVec[i]);
+        mapper->isendCtrl(peers[i], &syncSreqs[i]);
+        mapper->irecvCtrl(peers[i], &syncRreqs[i]);
+    }
+    // Wait all RTR
+    for (int i = 0; i < nSteps; i++)
+        mapper->waitRequest(&syncRreqs[i]);
+
+    for (int step = 0; step < nSteps; step++) {
+        int peer = peers[step];
+        int nPuts = 1 << step;
+
+        // Batch CE copy: source → staging for all chunks in this step
+        for (int j = 0; j < nPuts; j++) {
+            size_t chunkIdx = rankChunkOffset(myNode, localRank, nLocalRanks, nNodes, step, j);
+            size_t byteOffset = chunkIdx * sendSize;
+
+            const void* src = (step == 0 && j == 0) ? sendBuff
+                            : getPtr(pArgs->recvbuff, byteOffset);
+
+            mapper->icopy(stagingInfo.sendBuf.ptr + j * sendSize,
+                          src, sendSize, copyStream);
+        }
+
+        // Sync: ensure ALL CE copies to staging are complete before IB reads
+        cudaStreamSynchronize(copyStream);
+
+        // Issue all IB puts for this step (staging is now populated)
+        for (int j = 0; j < nPuts; j++) {
+            bool isLast = (j == nPuts - 1);
+            mapper->iput(stagingInfo.sendBuf.ptr + j * sendSize,
+                         stagingInfo.remRecvBufs[step].ptr + j * sendSize,
+                         sendSize, peer,
+                         {stagingInfo.sendBuf.regHdl,
+                          stagingInfo.remRecvBufs[step].rkey,
+                          .notify_ = isLast},
+                         isLast ? &lastPutReq : nullptr);
+        }
+
+        // Wait for all puts + peer notification
+        mapper->waitRequest(&lastPutReq);
+        mapper->waitNotify(notifyVec[step].get());
+
+        // Flush all received staging
+        for (int j = 0; j < nPuts; j++) {
+            mapper->iflush(stagingInfo.recvBuf.ptr + j * sendSize,
+                           stagingInfo.recvBuf.regHdl, &flushReq);
+            mapper->waitRequest(&flushReq);
+        }
+
+        // Signal stream: step complete, staging ready for CE copies
+        if (nLocalRanks > 1) {
+            resource->pipeSync->post(step);
+        }
+
+        // Wait for stream to finish staging→recvbuff copies before next step
+        // (also waited on for the last step to ensure staging is consumed
+        //  before PipeEnd resets stepDoneSync)
+        if (nLocalRanks > 1) {
+            resource->stepDoneSync->waitComplete(step);
+        }
+    }
+}
+```
+
+The `cudaStreamSynchronize(copyStream)` is issued **once per step** (not per chunk), after all CE copies for that step's chunks are enqueued. This ensures staging is fully populated before any IB put reads from it. The cost is one sync per step (log₂(nNodes) syncs total), which is acceptable for v1.
+
+## Stream-Side
+
+```cpp
+commResult_t AlgoImpl::execPatCopy(sendbuff, count, datatype) {
+    // ... validation, same as ctpat ...
+
+    copyToSelf(comm_, sendbuff, sendSize, pArgs, stream_);
+
+    // Submit GPE
+    if (nNodes > 1) {
+        submit(opGroup, gpeFn, config, ncclKernelAllGatherPPipeStart);
+    }
+
+    if (nLocalRanks > 1) {
+        waitInit();
+        nvlCeBcast(comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_);
+
+        for (int step = 0; step < nSteps; step++) {
+            // Wait for GPE to signal step complete
+            PipeSyncKernArgs syncArgs = {.stepId = step, .pipeSync = resource_.pipeSync};
+            config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+            submit({}, nullptr, config, ncclKernelAllGatherPPipeSync);
+
+            // CE copy: staging → recvbuff for each received chunk
+            int nChunks = 1 << step;
+            int peerNode = computePeerNode(myNode, nNodes, step);
+
+            for (int j = 0; j < nChunks; j++) {
+                size_t chunkIdx = rankChunkOffset(peerNode, localRank, nLocalRanks, nNodes, step, j);
+                size_t byteOffset = chunkIdx * sendSize;
+
+                // CE copy: staging[j] → recvbuff (contiguous layout, no slot reuse)
+                cudaMemcpyAsync(
+                    getPtr(pArgs.recvbuff, byteOffset),
+                    stagingInfo.recvBuf.ptr + j * sendSize,
+                    sendSize, cudaMemcpyDefault, stream_);
+
+                bool needBarrier = (j == 0);
+                nvlCeBcast(comm_, getPtr(pArgs.recvbuff, byteOffset),
+                           sendSize, byteOffset, pArgs, stream_, needBarrier);
+            }
+
+            // Signal GPE: stream finished consuming staging for this step
+            StepDoneKernArgs doneArgs = {
+                .stepId = step, .stepDoneSync = resource_.stepDoneSync};
+            config.algoArgs = reinterpret_cast<void*>(&doneArgs);
+            submit({}, nullptr, config, ncclKernelStepDone);
+        }
+
+        PatCopyPipeEndKernArgs endArgs = {
+            .pipeSync = resource_.pipeSync,
+            .stepDoneSync = resource_.stepDoneSync};
+        config.algoArgs = reinterpret_cast<void*>(&endArgs);
+        submit({}, nullptr, config, ncclKernelAllGatherPPatCopyPipeEnd);
+    }
+}
+```
+
+Two new kernels: `ncclKernelStepDone` (stream→GPE completion signaling) and `ncclKernelAllGatherPPatCopyPipeEnd` (extended PipeEnd that resets both `pipeSync` and `stepDoneSync`). Reuses existing `PipeSync` and `PipeStart` from `ctpat`.
+
+## Code Structure
+
+### New Files
+
+| File | Description |
+|------|-------------|
+| `AllGatherP/PatCopyImpl.cc` | `execPatCopy()` + staged `gpeFn` |
+| `AllGatherP/PatCopyImpl.cu` | `ncclKernelStepDone` + `ncclKernelAllGatherPPatCopyPipeEnd` kernels |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `AllGatherP/Types.h` | Add `StagingBufId`, `StagingInfo`; extend `Resource` with BufManager |
+| `AllGatherP/AlgoImpl.h` | Add `execPatCopy()` declaration, `ctpatcopy` in `algoName()` |
+| `AllGatherP/AllGatherP.cc` | Add `ctpatcopy` dispatch; init/destroy staging in lifecycle |
+| `nccl_cvars.yaml` | Add `ctpatcopy` to `NCCL_ALLGATHER_P_ALGO`; add staging buf size CVAR |
+
+### Build System
+
+BUCK/CMake: `glob` auto-includes new `.cc` files. No build changes.
+
+## Implementation Plan
+
+### Phase 1: Staging Infrastructure + Step-Staged GPE
+
+**Steps**:
+1. Add `ctpatcopy` to `NCCL_ALLGATHER_P_ALGO` in `nccl_cvars.yaml` and regenerate
+2. Add `StagingBufId`, `StagingInfo`, `StepDoneKernArgs`, `PatCopyPipeEndKernArgs` to `Types.h`; extend `Resource` with BufManager and `stepDoneSync`
+3. Add staging allocation in `initResources()`, exchange in `exchangeMemHdl()`, release in `destroy()`
+4. Create `PatCopyImpl.cu` with `ncclKernelStepDone` and `ncclKernelAllGatherPPatCopyPipeEnd` kernels
+5. Create `PatCopyImpl.cc` with staged `gpeFn` + `execPatCopy()`
+6. Wire dispatch in `AllGatherP.cc` and `AlgoImpl.h`
+
+**Deliverables**:
+- `AllGatherP/PatCopyImpl.cc`
+- `AllGatherP/PatCopyImpl.cu`
+- Updated `Types.h`, `AlgoImpl.h`, `AllGatherP.cc`, `nccl_cvars.yaml`
+- Distributed tests: extend `ctran/tests/CtranDistAllgatherPTests.cc` with `ctpatcopy` in parameterized suite (nolocal + vnode configs)
+- Negative tests: `nLocalRanks==1` rejection, staging capacity fallback (via small `NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE`)
+
+**Gate**: All tests pass — no crash, no data corruption, no stale `stepDoneSync` on persistent replay. Phase 2 does not start until Phase 1 tests are green.
+
+### Phase 2: Benchmarking + Decision
+
+**Deliverables**:
+- Benchmark sweep on real H100 clusters (4x8, 8x8)
+- Message sizes: 64KB, 256KB, 1MB, 4MB, 16MB, 64MB, 256MB
+- Algorithms compared: `ctpatcopy` vs `ctpat` vs `ctdirect` vs `ctpipeline`
+- Two test modes: pre-registered buffers (ncclMemAlloc) and dynamic registration (cudaMalloc without commRegister)
+
+**Gate**:
+- `ctpatcopy` within **15% of `ctpat`** for pre-registered buffers across all message sizes (the staging overhead from per-step `cudaStreamSynchronize` + CE copies is the expected cost)
+- `ctpatcopy` **faster than `ctpat`** when dynamic registration is forced (the pre-registered staging eliminates ~50-200μs per-call registration cost)
+- Decision: ship `ctpatcopy` as-is, iterate on overhead, or deprioritize
+
+**Deliverables if gate passes**:
+- Recommendation on whether `ctpatcopy` should be promoted to default for specific workloads
+- Documented crossover points (which nNodes × sendSize combinations favor `ctpatcopy`)
+
+### Phase 3: Chunk-Level Pipelining (Future)
+
+**Prerequisite gate**: Transport supports clean chunk-granular completion without per-chunk `cudaStreamSynchronize`. This requires either:
+- A request-based CE copy completion API (post CE copy, poll for completion without stream sync)
+- Or a transport-owned staging path that internally manages CE→IB ordering
+
+**Scope** (once gate is met):
+- Add `chunkSync` (GPE→stream per chunk) and `consumeSync` (stream→GPE per staging slot) coordination
+- Enable intra-step overlap: IB transfer of chunk j+1 overlaps with CE copy + NVL bcast of chunk j
+- Round-robin staging slot reuse within a step (safe because chunk-granular completion tracks consumption)
+- Expected benefit: 5-54% improvement over step-granular staging at 4+ nodes (from earlier performance model)
+
+**Deliverables**:
+- Updated `PatCopyImpl.cc` with chunk-pipelined GPE callback
+- New `PipeSyncChunk` and `StagingConsumed` kernels
+- Benchmark comparison: chunk-pipelined vs step-granular vs zero-copy
+
+### What Is Cut from v1
+
+- ~~Chunk-level pipelining within a step~~ → requires transport-level completion support (Phase 3)
+- ~~Multi-round sub-chunking~~ → fall back to `execPat()` for oversized messages
+- ~~Auto-selection between zero-copy and staged~~ → separate `ctpatcopy` algo
+- ~~Per-chunk cudaStreamSynchronize~~ → too expensive; not viable
+- ~~nLocalRanks == 1 support~~ → use `ctpat` (zero-copy) instead
+
+### Milestone Summary
+
+```
+Phase 1                          Phase 2                        Phase 3
+────────                         ────────                       ────────
+┌───────────────────────┐  ┌──────────────────────┐  ┌─────────────────────────┐
+│ PatCopyImpl.cc + .cu  │  │ Benchmark sweep      │  │ Chunk-level pipelining  │
+│ + Types.h + dispatch  │  │ 4x8, 8x8 H100       │  │ chunkSync + consumeSync │
+│ + tests               │  │ 64KB → 256MB         │  │ intra-step IB/NVL      │
+│                       │  │                      │  │ overlap                │
+│ Gate:                 │  │ Gate:                 │  │                        │
+│ All tests pass        │──►│ ≤15% overhead vs     │──►│ Gate:                  │
+│ No data corruption    │  │ ctpat (pre-reg)      │  │ Transport supports     │
+│ Persistent replay     │  │ Faster than ctpat    │  │ chunk-granular         │
+│ safe (stepDoneSync    │  │ (dynamic reg)        │  │ completion             │
+│ reset verified)       │  │                      │  │                        │
+└───────────────────────┘  └──────────────────────┘  └─────────────────────────┘
+```
+
+## Testing
+
+### Correctness Tests
+
+Extend `ctran/tests/CtranDistAllgatherPTests.cc`:
+- Add `ctpatcopy` to parameterized test instantiation and `algoToStr()`
+- Power-of-2 nNodes enforcement
+- nLocalRanks==1: verify `execPatCopy()` rejects with error (ctpatcopy requires nLocalRanks > 1)
+- In-place and out-of-place
+- Large message fallback: set `NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE` to a small value (e.g., 4KB) to trigger the `execPatCopy() → execPat()` delegation path in CI without requiring enormous buffers
+
+### Performance Tests
+
+```bash
+NCCL_ALLGATHER_P_ALGO=ctpatcopy buck2 run @fbcode//mode/opt \
+    -c hpc_comms.use_ncclx=stable \
+    //comms/ctran/benchmarks:AllgatherPBench -- \
+    --algo ctpatcopy --min_bytes 64K --max_bytes 256M --bench_iters 20
+```
+
+Benchmark matrix:
+
+| Dimension | Values |
+|-----------|--------|
+| Message size | 64KB, 256KB, 1MB, 4MB, 16MB, 64MB, 256MB |
+| Node count | 2x8, 4x8, 8x8, 16x8 |
+| Algorithms | ctpatcopy, ctpat, ctdirect, ctpipeline |
+
+### Stress Tests
+
+- Back-to-back `allGatherPExec` calls (staging reuse across iterations)
+- Concurrent communicators with separate staging buffers
+- sendSize > stagingBufSize (verify fallback)

--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -11,9 +11,16 @@ class AlgoImpl {
  public:
   PersistArgs pArgs;
 
-  AlgoImpl(CtranComm* comm, cudaStream_t stream)
-      : comm_(comm), stream_(stream) {};
+  AlgoImpl(
+      CtranComm* comm,
+      cudaStream_t stream,
+      enum NCCL_ALLGATHER_P_ALGO algo)
+      : comm_(comm), stream_(stream), algo_(algo) {};
   ~AlgoImpl() {};
+
+  enum NCCL_ALLGATHER_P_ALGO pinnedAlgo() const {
+    return algo_;
+  }
 
   commResult_t initialize();
   commResult_t destroy();
@@ -69,6 +76,17 @@ class AlgoImpl {
       const size_t count,
       const commDataType_t datatype);
 
+  // Execute the copy-based PAT algorithm with staging buffers.
+  // Routes IB transfers through pre-registered staging buffers instead of
+  // putting directly to recvbuff. Step-granular staging with bidirectional
+  // sync (pipeSync GPE→stream, stepDoneSync stream→GPE).
+  // - Requires nNodes power of 2, nLocalRanks > 1, nRanks % nLocalRanks == 0.
+  // - Falls back to execPat() when sendSize exceeds staging capacity.
+  commResult_t execPatCopy(
+      const void* sendbuff,
+      const size_t count,
+      const commDataType_t datatype);
+
   static inline const std::string algoName(enum NCCL_ALLGATHER_P_ALGO algo) {
     switch (algo) {
       case NCCL_ALLGATHER_P_ALGO::ctdirect:
@@ -79,6 +97,8 @@ class AlgoImpl {
         return "CtranAllGatherPRecDbl";
       case NCCL_ALLGATHER_P_ALGO::ctpat:
         return "CtranAllGatherPPat";
+      case NCCL_ALLGATHER_P_ALGO::ctpatcopy:
+        return "CtranAllGatherPPatCopy";
       default:
         return "Unknown";
     }
@@ -100,5 +120,6 @@ class AlgoImpl {
   Resource resource_;
   CtranComm* comm_{nullptr};
   cudaStream_t stream_{nullptr};
+  enum NCCL_ALLGATHER_P_ALGO algo_;
 };
 } // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -58,6 +58,17 @@ class AlgoImpl {
       const size_t count,
       const commDataType_t datatype);
 
+  // Execute the PAT (Parallel Asynchronous Tiled) algorithm of allgatherP.
+  // Rail-parallel butterfly (recursive doubling) with NVL CE broadcast.
+  // Structurally identical to execRecursiveDoubling for v1, introduced as a
+  // separate method to allow future divergence (non-power-of-two support,
+  // step aggregation, auto-tuning).
+  // - Requires nNodes to be a power of 2 and nRanks % nLocalRanks == 0.
+  commResult_t execPat(
+      const void* sendbuff,
+      const size_t count,
+      const commDataType_t datatype);
+
   static inline const std::string algoName(enum NCCL_ALLGATHER_P_ALGO algo) {
     switch (algo) {
       case NCCL_ALLGATHER_P_ALGO::ctdirect:
@@ -66,6 +77,8 @@ class AlgoImpl {
         return "CtranAllGatherPPipeline";
       case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
         return "CtranAllGatherPRecDbl";
+      case NCCL_ALLGATHER_P_ALGO::ctpat:
+        return "CtranAllGatherPPat";
       default:
         return "Unknown";
     }

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -238,6 +238,8 @@ commResult_t allGatherPExec(
       return algo->execPipeline(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctpat:
+      return algo->execPat(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -81,7 +81,11 @@ commResult_t exchangeMemHdl(
         peerRanks.push_back(peerNode * nLocalRanks + localRank);
       }
 
-      FB_COMMCHECK(resource->stagingBufMgr->exchange(peerRanks, nRanks));
+      // Include self so allGatherCtrl doesn't skip this rank
+      std::vector<int> exchangeRanks = peerRanks;
+      exchangeRanks.push_back(statex->rank());
+      FB_COMMCHECK(
+          resource->stagingBufMgr->exchange(exchangeRanks, nRanks, true));
 
       resource->stagingBufMgr->assignRegBuf(
           ctran::algos::bufmanager::MemType::kDevice,

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -6,6 +6,9 @@
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/hints/Hints.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/utils/DevUtils.cuh"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 using ctran::algos::GpeKernelSync;
 using ctran::allgatherp::AlgoImpl;
@@ -58,6 +61,45 @@ commResult_t exchangeMemHdl(
     }
   }
 
+  // Exchange staging buffer addresses if ctpatcopy (use pinned algo, not
+  // global)
+  if (pArgs->pinnedAlgo == static_cast<int>(NCCL_ALLGATHER_P_ALGO::ctpatcopy)) {
+    auto* resource =
+        reinterpret_cast<Resource*>(op->allgatherp_init.algoResource);
+    if (resource->stagingBufMgr) {
+      const auto nLocalRanks = statex->nLocalRanks();
+      const auto nNodes = statex->nNodes();
+      const auto nodeId = statex->rank() / nLocalRanks;
+      const auto localRank = statex->localRank();
+      const auto nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+      std::vector<int> peerRanks;
+      for (int i = 0; i < nSteps; i++) {
+        const int dist = nNodes >> (i + 1);
+        const int pos = (nodeId / dist) % 2;
+        const int peerNode = pos == 0 ? nodeId + dist : nodeId - dist;
+        peerRanks.push_back(peerNode * nLocalRanks + localRank);
+      }
+
+      FB_COMMCHECK(resource->stagingBufMgr->exchange(peerRanks, nRanks));
+
+      resource->stagingBufMgr->assignRegBuf(
+          ctran::algos::bufmanager::MemType::kDevice,
+          StagingBufId::kSendBuf,
+          resource->stagingInfo.sendBuf);
+      resource->stagingBufMgr->assignRegBuf(
+          ctran::algos::bufmanager::MemType::kDevice,
+          StagingBufId::kRecvBuf,
+          resource->stagingInfo.recvBuf);
+      resource->stagingBufMgr->assignRemRegBuf(
+          ctran::algos::bufmanager::MemType::kDevice,
+          StagingBufId::kRecvBuf,
+          peerRanks,
+          resource->stagingInfo.remRecvBufs);
+      resource->stagingInfo.peerRanks = peerRanks;
+    }
+  }
+
   // Mark the remote registration as initialized, so that consequent execution
   // can schedule CE based NVL copy
   pArgs->initialized.store(true);
@@ -79,9 +121,39 @@ commResult_t AlgoImpl::initResources() {
   void* base = nullptr;
   FB_CUDACHECK(
       cudaHostAlloc(&base, sizeof(GpeKernelSync), cudaHostAllocDefault));
-
   resource_.pipeSync = reinterpret_cast<GpeKernelSync*>(base);
   new (resource_.pipeSync) GpeKernelSync(1 /* numWorkers */);
+
+  if (algo_ == NCCL_ALLGATHER_P_ALGO::ctpatcopy) {
+    void* stepDoneBase = nullptr;
+    FB_CUDACHECK(cudaHostAlloc(
+        &stepDoneBase, sizeof(GpeKernelSync), cudaHostAllocDefault));
+    resource_.stepDoneSync = reinterpret_cast<GpeKernelSync*>(stepDoneBase);
+    new (resource_.stepDoneSync) GpeKernelSync(1 /* numWorkers */);
+
+    const auto statex = comm_->statex_.get();
+    const size_t stagingBufSize =
+        NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE;
+
+    const auto commHash = statex->commHash();
+    const std::string stagingKey = "AllGatherP_PatCopy_Staging_" +
+        std::to_string(commHash) + "_" +
+        std::to_string(reinterpret_cast<uintptr_t>(this));
+    resource_.stagingBufMgr = std::make_unique<
+        ctran::algos::BufManager<StagingBufId, StagingBufId::kNumBufs>>(
+        statex, comm_->ctran_->mapper.get(), &comm_->logMetaData_, stagingKey);
+
+    resource_.stagingBufMgr->insert(
+        ctran::algos::bufmanager::MemType::kDevice,
+        StagingBufId::kSendBuf,
+        stagingBufSize);
+    resource_.stagingBufMgr->insert(
+        ctran::algos::bufmanager::MemType::kDevice,
+        StagingBufId::kRecvBuf,
+        stagingBufSize);
+    FB_COMMCHECK(resource_.stagingBufMgr->commit());
+  }
+
   return commSuccess;
 }
 
@@ -112,6 +184,7 @@ commResult_t AlgoImpl::initialize() {
   auto op = std::make_unique<OpElem>(
       OpElem::opType::ALLGATHERP_INIT, stream_, comm_, opCount);
   op->allgatherp_init.pArgs = &pArgs;
+  op->allgatherp_init.algoResource = &resource_;
   opGroup.push_back(std::move(op));
 
   FB_COMMCHECK(comm_->ctran_->gpe->submit(
@@ -124,6 +197,14 @@ commResult_t AlgoImpl::initialize() {
 };
 
 commResult_t AlgoImpl::destroy() {
+  if (resource_.stagingBufMgr) {
+    FB_COMMCHECK(resource_.stagingBufMgr->release());
+    resource_.stagingBufMgr.reset();
+  }
+  if (resource_.stepDoneSync) {
+    FB_CUDACHECK(cudaFreeHost(resource_.stepDoneSync));
+    resource_.stepDoneSync = nullptr;
+  }
   if (resource_.pipeSync) {
     FB_CUDACHECK(cudaFreeHost(resource_.pipeSync));
     resource_.pipeSync = nullptr;
@@ -160,7 +241,49 @@ commResult_t allGatherPInit(
     CtranComm* comm,
     cudaStream_t stream,
     CtranPersistentRequest*& request) {
-  AlgoImpl* algo = new AlgoImpl(comm, stream);
+  const auto pinnedAlgo = NCCL_ALLGATHER_P_ALGO;
+
+  // ctpatcopy eligibility: fail fast at init
+  if (pinnedAlgo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) {
+    const auto statex = comm->statex_.get();
+    const auto nNodes = statex->nNodes();
+    const auto nLocalRanks = statex->nLocalRanks();
+    if (nNodes <= 1) {
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGatherP ctpatcopy requires nNodes > 1, got {}",
+          nNodes);
+    }
+    if ((nNodes & (nNodes - 1)) != 0) {
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGatherP ctpatcopy requires power-of-2 nNodes, got {}",
+          nNodes);
+    }
+    if (statex->nRanks() % nLocalRanks != 0) {
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGatherP ctpatcopy requires nRanks divisible by nLocalRanks");
+    }
+    if (nLocalRanks <= 1) {
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGatherP ctpatcopy requires nLocalRanks > 1, got {}",
+          nLocalRanks);
+    }
+    auto mapper_check = comm->ctran_->mapper.get();
+    for (int lr = 0; lr < nLocalRanks; lr++) {
+      const int peer = statex->localRankToRank(lr);
+      if (peer != statex->rank() &&
+          mapper_check->getBackend(peer) != CtranMapperBackend::NVL) {
+        FB_ERRORRETURN(
+            commInvalidUsage,
+            "AllGatherP ctpatcopy requires NVL for local peers");
+      }
+    }
+  }
+
+  AlgoImpl* algo = new AlgoImpl(comm, stream, pinnedAlgo);
   if (!algo) {
     return commSystemError;
   }
@@ -194,6 +317,7 @@ commResult_t allGatherPInit(
   algo->pArgs.maxRecvCount = maxRecvCount;
   algo->pArgs.datatype = datatype;
   algo->pArgs.initialized.store(false);
+  algo->pArgs.pinnedAlgo = static_cast<int>(pinnedAlgo);
 
   // Initialize algo internal resource and schedule handle exchange on GPE
   // thread
@@ -231,7 +355,7 @@ commResult_t allGatherPExec(
         algo->pArgs.datatype);
   }
 
-  switch (NCCL_ALLGATHER_P_ALGO) {
+  switch (algo->pinnedAlgo()) {
     case NCCL_ALLGATHER_P_ALGO::ctdirect:
       return algo->execDirect(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctpipeline:
@@ -240,6 +364,8 @@ commResult_t allGatherPExec(
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctpat:
       return algo->execPat(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctpatcopy:
+      return algo->execPatCopy(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/AllGatherP/NvlDissemKernel.cu
+++ b/comms/ctran/algos/AllGatherP/NvlDissemKernel.cu
@@ -1,0 +1,84 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+__device__ __forceinline__ size_t devRankChunkOffset(
+    int anchorNode,
+    int localRank,
+    int nLocalRanks,
+    int nNodes,
+    int step,
+    int j) {
+  const int stride = nNodes >> step;
+  const int nodePos = j * stride + (anchorNode % stride);
+  return static_cast<size_t>(nodePos) * nLocalRanks + localRank;
+}
+
+namespace ctran::allgatherp {
+
+__global__ __launch_bounds__(512, 1) void ncclKernelAllGatherPNvlDissem(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    NvlDissemKernArgs args) {
+  comms::pipes::Timeout timeout(args.timeoutCycles);
+  timeout.start();
+
+  auto group = comms::pipes::make_warp_group();
+
+  // Split into send and recv halves
+  auto [partition_id, send_recv_group] = group.partition_interleaved(2);
+  // Distribute across local peers (including self)
+  auto [local_peer_idx, group_per_peer] =
+      send_recv_group.partition_interleaved(args.nLocalRanks);
+
+  if (local_peer_idx == args.localRank) {
+    // Self-copy: staging → own recvbuff
+    if (partition_id == 0) {
+      for (int j = 0; j < args.nChunks; j++) {
+        const size_t chunkIdx = devRankChunkOffset(
+            args.peerNode,
+            args.localRank,
+            args.nLocalRanks,
+            args.nNodes,
+            args.step,
+            j);
+        char* dst =
+            static_cast<char*>(args.recvbuff) + chunkIdx * args.chunkSize;
+        char* src =
+            static_cast<char*>(args.stagingRecvBuf) + j * args.chunkSize;
+        args.nvlTransportsBase[args.localRank].put_group(
+            group_per_peer, dst, src, args.chunkSize);
+      }
+    }
+  } else if (partition_id == 0) {
+    // Send: staging → peer via NVLink
+    for (int j = 0; j < args.nChunks; j++) {
+      char* src = static_cast<char*>(args.stagingRecvBuf) + j * args.chunkSize;
+      args.nvlTransportsBase[local_peer_idx].send_group(
+          group_per_peer, src, args.chunkSize, timeout);
+    }
+  } else {
+    // Recv: peer → own recvbuff via NVLink
+    for (int j = 0; j < args.nChunks; j++) {
+      const size_t chunkIdx = devRankChunkOffset(
+          args.peerNode,
+          local_peer_idx,
+          args.nLocalRanks,
+          args.nNodes,
+          args.step,
+          j);
+      char* dst = static_cast<char*>(args.recvbuff) + chunkIdx * args.chunkSize;
+      args.nvlTransportsBase[local_peer_idx].recv_group(
+          group_per_peer, dst, args.chunkSize, timeout);
+    }
+  }
+}
+
+} // namespace ctran::allgatherp
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGatherP/PatCopyImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PatCopyImpl.cc
@@ -281,6 +281,12 @@ extern __global__ void ncclKernelAllGatherPPatCopyPipeEnd(
     int* flag,
     CtranAlgoDeviceState* devState,
     PatCopyPipeEndKernArgs args);
+#if defined(ENABLE_PIPES)
+extern __global__ void ncclKernelAllGatherPNvlDissem(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    NvlDissemKernArgs args);
+#endif
 
 commResult_t AlgoImpl::execPatCopy(
     const void* sendbuff,
@@ -356,7 +362,7 @@ commResult_t AlgoImpl::execPatCopy(
   FB_COMMCHECK(
       nvlCeBcast(comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
 
-  // Per-step: PipeSync -> CE staging->recvbuff -> nvlCeBcast -> StepDone
+  // Per-step: PipeSync -> local dissemination -> StepDone
   // After GPE has posted pipeSync, any stream-side failure must publish
   // async error so the GPE's stepDoneSync poll can exit.
   auto setAsyncErrAndReturn = [this](commResult_t err) -> commResult_t {
@@ -385,6 +391,48 @@ commResult_t AlgoImpl::execPatCopy(
     const int peerNode = pos == 0 ? myNode + distNodes : myNode - distNodes;
     const int nChunks = 1 << step;
 
+#if defined(ENABLE_PIPES)
+    // Pipes-based NVL dissemination: single kernel launch with
+    // per-peer matched send/recv subgroups (AllToAllv pattern).
+    NvlDissemKernArgs dissemArgs{};
+    dissemArgs.stagingRecvBuf = resource_.stagingInfo.recvBuf.ptr;
+    dissemArgs.recvbuff = pArgs.recvbuff;
+    dissemArgs.nChunks = nChunks;
+    dissemArgs.chunkSize = sendSize;
+    dissemArgs.nLocalRanks = nLocalRanks;
+    dissemArgs.localRank = localRank;
+    dissemArgs.peerNode = peerNode;
+    dissemArgs.nNodes = nNodes;
+    dissemArgs.step = step;
+    dissemArgs.nvlTransportsBase = ctran->algo->getNvlTransportsBase();
+    {
+      int clockRateKhz = 0;
+      cudaDeviceGetAttribute(
+          &clockRateKhz, cudaDevAttrClockRate, statex->cudaDev());
+      dissemArgs.timeoutCycles =
+          static_cast<uint64_t>(clockRateKhz) * 10000; // 10 second timeout
+    }
+
+    auto dissemConfig = KernelConfig(
+        KernelConfig::KernelType::ALLGATHERP,
+        stream_,
+        AlgoImpl::algoName(myAlgo),
+        opCount);
+    dissemConfig.numBlocks = std::max(1, nLocalRanks * 4);
+    dissemConfig.numThreads = 512;
+    dissemConfig.args.devState_d = ctran->algo->getDevState();
+    dissemConfig.algoArgs = reinterpret_cast<void*>(&dissemArgs);
+
+    rc = ctran->gpe->submit(
+        {},
+        nullptr,
+        dissemConfig,
+        reinterpret_cast<void*>(ncclKernelAllGatherPNvlDissem));
+    if (rc != commSuccess) {
+      return setAsyncErrAndReturn(rc);
+    }
+#else
+    // CE fallback: staging → recvbuff copy + nvlCeBcast
     for (int j = 0; j < nChunks; j++) {
       const size_t chunkIdx =
           rankChunkOffset(peerNode, localRank, nLocalRanks, nNodes, step, j);
@@ -413,6 +461,7 @@ commResult_t AlgoImpl::execPatCopy(
         return setAsyncErrAndReturn(rc);
       }
     }
+#endif
 
     StepDoneKernArgs doneArgs = {
         .stepId = step,

--- a/comms/ctran/algos/AllGatherP/PatCopyImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PatCopyImpl.cc
@@ -1,0 +1,452 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/ScopeGuard.h>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/CommUtils.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/DevUtils.cuh"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::PersistArgs;
+using ctran::allgatherp::Resource;
+using ctran::allgatherp::StagingInfo;
+
+namespace {
+const auto myAlgo = NCCL_ALLGATHER_P_ALGO::ctpatcopy;
+
+inline int distNodesAtStep(int nNodes, int step) {
+  return nNodes >> (step + 1);
+}
+
+inline int
+peerAtStep(int nodeId, int localRank, int nLocalRanks, int nNodes, int step) {
+  const int dist = distNodesAtStep(nNodes, step);
+  const int pos = (nodeId / dist) % 2;
+  const int peerNode = pos == 0 ? nodeId + dist : nodeId - dist;
+  return peerNode * nLocalRanks + localRank;
+}
+
+inline int nodeChunkStrideAtStep(int nNodes, int step) {
+  return nNodes >> step;
+}
+
+inline size_t rankChunkOffset(
+    int anchorNode,
+    int localRank,
+    int nLocalRanks,
+    int nNodes,
+    int step,
+    int j) {
+  const int stride = nodeChunkStrideAtStep(nNodes, step);
+  const int nodePos = j * stride + (anchorNode % stride);
+  return static_cast<size_t>(nodePos) * nLocalRanks + localRank;
+}
+
+commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* resource = reinterpret_cast<Resource*>(op->allgatherP.algoResource);
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->allgatherP.pArgs);
+  const void* sendBuff = op->allgatherP.sendbuff;
+  const auto sendSize =
+      op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
+  CtranComm* comm = opGroup.front()->comm_;
+
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto nRanks = statex->nRanks();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto nNodes = statex->nNodes();
+  const auto nodeId = rank / nLocalRanks;
+  const auto nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
+  auto mapper = comm->ctran_->mapper.get();
+  auto& staging = resource->stagingInfo;
+
+  // If gpeFn fails, set async error for host-side detection.
+  // Note: if the failure occurs before pipeSync->post(step), the stream-side
+  // PipeSync kernel will hang waiting for a post that never comes. This is
+  // an inherited limitation of the PipeSync model, shared with ctrdpipeline
+  // and ctpipeline. It is not specific to ctpatcopy. A clean fix requires
+  // a cancellable device-side wait, which the current PipeSync kernel does
+  // not support (it only observes postFlag, not async error or abort when
+  // launched with flag=nullptr).
+  commResult_t gpeFnResult = commSuccess;
+  auto asyncErrGuard = folly::makeGuard([&gpeFnResult, comm]() {
+    if (gpeFnResult != commSuccess) {
+      comm->setAsyncException(
+          ctran::utils::Exception("ctpatcopy gpeFn failure", gpeFnResult));
+    }
+  });
+
+#define GPEFN_COMMCHECK(call)  \
+  do {                         \
+    commResult_t _rc = (call); \
+    if (_rc != commSuccess) {  \
+      gpeFnResult = _rc;       \
+      return _rc;              \
+    }                          \
+  } while (0)
+
+#define GPEFN_CUDACHECK(call)          \
+  do {                                 \
+    cudaError_t _err = (call);         \
+    if (_err != cudaSuccess) {         \
+      gpeFnResult = commInternalError; \
+      return commInternalError;        \
+    }                                  \
+  } while (0)
+
+  std::vector<int> peers(nSteps);
+  std::vector<std::unique_ptr<CtranMapperNotify>> notifyVec(nSteps);
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  for (int i = 0; i < nSteps; i++) {
+    peers[i] = peerAtStep(nodeId, localRank, nLocalRanks, nNodes, i);
+    notifyVec[i] = std::make_unique<CtranMapperNotify>();
+    GPEFN_COMMCHECK(mapper->initNotify(
+        peers[i], staging.recvBuf.regHdl, notifyVec[i].get()));
+  }
+
+  std::vector<CtranMapperRequest> syncSreqs(nSteps);
+  std::vector<CtranMapperRequest> syncRreqs(nSteps);
+  for (int i = 0; i < nSteps; i++) {
+    GPEFN_COMMCHECK(mapper->isendCtrl(peers[i], &syncSreqs[i]));
+    GPEFN_COMMCHECK(mapper->irecvCtrl(peers[i], &syncRreqs[i]));
+  }
+  for (int i = 0; i < nSteps; i++) {
+    GPEFN_COMMCHECK(mapper->waitRequest(&syncRreqs[i]));
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  std::unique_ptr<CtranMapperTimestamp> timestamp =
+      std::make_unique<CtranMapperTimestamp>(AlgoImpl::algoName(myAlgo));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  cudaStream_t copyStream = nullptr;
+  GPEFN_CUDACHECK(cudaStreamCreate(&copyStream));
+  auto streamGuard =
+      folly::makeGuard([copyStream]() { cudaStreamDestroy(copyStream); });
+
+  for (int step = 0; step < nSteps; step++) {
+    const int peer = peers[step];
+    const int nPuts = 1 << step;
+    timestamp->putIssued.push_back(CtranMapperTimestampPoint(peer));
+
+    // Find the peer's staging recv buf index in our exchanged list
+    int peerIdx = -1;
+    for (size_t pi = 0; pi < staging.peerRanks.size(); pi++) {
+      if (staging.peerRanks[pi] == peer) {
+        peerIdx = static_cast<int>(pi);
+        break;
+      }
+    }
+    if (peerIdx < 0) {
+      gpeFnResult = commInternalError;
+      return commInternalError;
+    }
+
+    // Batch CE copy: source → tmpSendBuf for all chunks in this step
+    for (int j = 0; j < nPuts; j++) {
+      const auto chunkIdx =
+          rankChunkOffset(nodeId, localRank, nLocalRanks, nNodes, step, j);
+      const size_t byteOffset = chunkIdx * sendSize;
+
+      const void* srcPtr = nullptr;
+      if (step == 0 && j == 0) {
+        srcPtr = sendBuff;
+      } else {
+        srcPtr = ctran::allgatherp::getPtr(pArgs->recvbuff, byteOffset);
+      }
+
+      GPEFN_COMMCHECK(mapper->icopy(
+          static_cast<char*>(staging.sendBuf.ptr) + j * sendSize,
+          srcPtr,
+          sendSize,
+          copyStream));
+    }
+
+    // Sync: ensure ALL CE copies to staging are complete before IB reads
+    GPEFN_CUDACHECK(cudaStreamSynchronize(copyStream));
+
+    // Issue all IB puts for this step (staging is now populated)
+    CtranMapperRequest lastPutReq;
+    for (int j = 0; j < nPuts; j++) {
+      const bool isLast = (j == nPuts - 1);
+      GPEFN_COMMCHECK(mapper->iput(
+          static_cast<char*>(staging.sendBuf.ptr) + j * sendSize,
+          static_cast<char*>(staging.remRecvBufs[peerIdx].ptr) + j * sendSize,
+          sendSize,
+          peer,
+          CtranMapperConfig{
+              .memHdl_ = staging.sendBuf.regHdl,
+              .remoteAccessKey_ = staging.remRecvBufs[peerIdx].rkey,
+              .notify_ = isLast},
+          isLast ? &lastPutReq : static_cast<CtranMapperRequest*>(nullptr)));
+    }
+
+    // Wait for all puts + peer notification
+    GPEFN_COMMCHECK(mapper->waitRequest(&lastPutReq));
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
+    GPEFN_COMMCHECK(mapper->waitNotify(notifyVec[step].get()));
+
+    // Flush all received staging slots
+    for (int j = 0; j < nPuts; j++) {
+      CtranMapperRequest* flushReq = nullptr;
+      GPEFN_COMMCHECK(mapper->iflush(
+          static_cast<char*>(staging.recvBuf.ptr) + j * sendSize,
+          staging.recvBuf.regHdl,
+          &flushReq));
+      GPEFN_COMMCHECK(mapper->waitRequest(flushReq));
+    }
+
+    // Signal stream: step complete, staging ready for CE copies
+    resource->pipeSync->post(step);
+
+    // Wait for stream to finish staging->recvbuff copies before next step.
+    // Poll with both abort and async error checks to avoid infinite spin
+    // if the stream fails before StepDone is enqueued.
+    while (!resource->stepDoneSync->isComplete(step)) {
+      if (comm->testAbort()) {
+        return commInternalError;
+      }
+      auto asyncResult = comm->getAsyncResult();
+      if (asyncResult != commSuccess) {
+        return asyncResult;
+      }
+    }
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  for (int i = 0; i < nSteps; i++) {
+    GPEFN_COMMCHECK(mapper->waitRequest(&syncSreqs[i]));
+  }
+
+  mapper->timestamps.push_back(std::move(timestamp));
+  mapper->reportProfiling();
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
+
+  gpeFnResult = commSuccess;
+  return commSuccess;
+}
+#undef GPEFN_COMMCHECK
+#undef GPEFN_CUDACHECK
+} // namespace
+
+namespace ctran::allgatherp {
+extern __global__ void ncclKernelAllGatherPPipeStart(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelAllGatherPPipeSync(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeSyncKernArgs args);
+extern __global__ void ncclKernelStepDone(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    StepDoneKernArgs args);
+extern __global__ void ncclKernelAllGatherPPatCopyPipeEnd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PatCopyPipeEndKernArgs args);
+
+commResult_t AlgoImpl::execPatCopy(
+    const void* sendbuff,
+    const size_t count,
+    const commDataType_t datatype) {
+  auto recvbuff = pArgs.recvbuff;
+  auto ctran = comm_->ctran_.get();
+  const auto statex = comm_->statex_.get();
+  const auto opCount = ctran->getOpCount();
+  const auto sendSize = count * commTypeSize(datatype);
+
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto myRank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nNodes = statex->nNodes();
+  const auto myNode = myRank / nLocalRanks;
+
+  // Topology eligibility validated at init time (pinned algo).
+  // Only check staging capacity here -- fall back to zero-copy if too large.
+  const int maxChunksPerStep = nNodes / 2;
+  if (sendSize * maxChunksPerStep >
+      static_cast<size_t>(NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE)) {
+    return execPat(sendbuff, count, datatype);
+  }
+
+  CTRAN_COLL_INFO(
+      AlgoImpl::algoName(myAlgo),
+      sendbuff,
+      recvbuff,
+      count,
+      datatype,
+      -1,
+      comm_,
+      stream_);
+
+  FB_COMMCHECK(waitInit());
+
+  const int nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP,
+      stream_,
+      AlgoImpl::algoName(myAlgo),
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = ctran->algo->getDevState();
+
+  // copyToSelf must be enqueued BEFORE PipeStart
+  FB_COMMCHECK(copyToSelf(comm_, sendbuff, sendSize, pArgs, stream_));
+
+  // Submit GPE with PipeStart
+  if (nNodes > 1) {
+    auto op = std::make_unique<OpElem>(
+        OpElem::opType::ALLGATHERP, stream_, comm_, opCount);
+    op->allgatherP.pArgs = &pArgs;
+    op->allgatherP.algoResource = &resource_;
+    op->allgatherP.sendbuff = sendbuff;
+    op->allgatherP.count = count;
+    op->allgatherP.datatype = datatype;
+
+    std::vector<std::unique_ptr<struct OpElem>> opGroup;
+    opGroup.push_back(std::move(op));
+
+    FB_COMMCHECK(ctran->gpe->submit(
+        std::move(opGroup),
+        gpeFn,
+        config,
+        reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
+  }
+
+  // Initial NVL broadcast of own chunk
+  FB_COMMCHECK(
+      nvlCeBcast(comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+
+  // Per-step: PipeSync -> CE staging->recvbuff -> nvlCeBcast -> StepDone
+  // After GPE has posted pipeSync, any stream-side failure must publish
+  // async error so the GPE's stepDoneSync poll can exit.
+  auto setAsyncErrAndReturn = [this](commResult_t err) -> commResult_t {
+    comm_->setAsyncException(
+        ctran::utils::Exception("ctpatcopy stream-side failure", err));
+    return err;
+  };
+
+  for (int step = 0; step < nSteps; step++) {
+    PipeSyncKernArgs syncArgs = {
+        .stepId = step,
+        .pipeSync = resource_.pipeSync,
+    };
+    config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+    auto rc = ctran->gpe->submit(
+        {},
+        nullptr,
+        config,
+        reinterpret_cast<void*>(ncclKernelAllGatherPPipeSync));
+    if (rc != commSuccess) {
+      return setAsyncErrAndReturn(rc);
+    }
+
+    const int distNodes = distNodesAtStep(nNodes, step);
+    const int pos = (myNode / distNodes) % 2;
+    const int peerNode = pos == 0 ? myNode + distNodes : myNode - distNodes;
+    const int nChunks = 1 << step;
+
+    for (int j = 0; j < nChunks; j++) {
+      const size_t chunkIdx =
+          rankChunkOffset(peerNode, localRank, nLocalRanks, nNodes, step, j);
+      const size_t byteOffset = chunkIdx * sendSize;
+
+      auto cudaErr = cudaMemcpyAsync(
+          ctran::allgatherp::getPtr(pArgs.recvbuff, byteOffset),
+          static_cast<char*>(resource_.stagingInfo.recvBuf.ptr) + j * sendSize,
+          sendSize,
+          cudaMemcpyDefault,
+          stream_);
+      if (cudaErr != cudaSuccess) {
+        return setAsyncErrAndReturn(commInternalError);
+      }
+
+      const bool needBarrier = (j == 0);
+      rc = nvlCeBcast(
+          comm_,
+          ctran::allgatherp::getPtr(pArgs.recvbuff, byteOffset),
+          sendSize,
+          byteOffset,
+          pArgs,
+          stream_,
+          needBarrier);
+      if (rc != commSuccess) {
+        return setAsyncErrAndReturn(rc);
+      }
+    }
+
+    StepDoneKernArgs doneArgs = {
+        .stepId = step,
+        .stepDoneSync = resource_.stepDoneSync,
+    };
+    config.algoArgs = reinterpret_cast<void*>(&doneArgs);
+    rc = ctran->gpe->submit(
+        {}, nullptr, config, reinterpret_cast<void*>(ncclKernelStepDone));
+    if (rc != commSuccess) {
+      return setAsyncErrAndReturn(rc);
+    }
+  }
+
+  // PipeEnd: reset both syncs + NVL barrier.
+  // This is the only safe reset point — both GPE and stream are quiesced.
+  PatCopyPipeEndKernArgs endArgs = {
+      .pipeSync = resource_.pipeSync,
+      .stepDoneSync = resource_.stepDoneSync,
+  };
+  config.algoArgs = reinterpret_cast<void*>(&endArgs);
+  FB_COMMCHECK(ctran->gpe->submit(
+      {},
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ncclKernelAllGatherPPatCopyPipeEnd)));
+
+  // Final async error check: catch GPE failures that occurred between
+  // PipeStart and now. Without this, execPatCopy could return commSuccess
+  // for a collective where the GPE side failed.
+  auto finalAsyncResult = comm_->getAsyncResult();
+  if (finalAsyncResult != commSuccess) {
+    return finalAsyncResult;
+  }
+
+  return commSuccess;
+}
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/PatCopyImpl.cu
+++ b/comms/ctran/algos/AllGatherP/PatCopyImpl.cu
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/DevCommon.cuh"
+#include "comms/ctran/algos/barrier.cuh"
+#include "comms/ctran/algos/common/GpeKernelSyncDev.cuh"
+#include "comms/ctran/gpe/CtranGpeDev.h"
+
+using namespace ctran::algos;
+namespace ctran::allgatherp {
+
+__global__ void ncclKernelStepDone(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    StepDoneKernArgs args) {
+  ctran::device::devLoadAbortFlags(flag, devState);
+  GpeKernelSyncDev::complete(args.stepDoneSync, 0, args.stepId);
+}
+
+__global__ void ncclKernelAllGatherPPatCopyPipeEnd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PatCopyPipeEndKernArgs args) {
+  GpeKernelSyncDev::reset(args.pipeSync, 0);
+  GpeKernelSyncDev::reset(args.stepDoneSync, 0);
+
+  devStateLoadToShm(devState);
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  barrier(localRank, nLocalRanks);
+}
+
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/PatImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PatImpl.cc
@@ -1,0 +1,368 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/ScopeGuard.h>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/CommUtils.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/DevUtils.cuh"
+#include "comms/ctran/utils/ExtUtils.h"
+
+using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::PersistArgs;
+using ctran::allgatherp::Resource;
+
+namespace {
+const auto myAlgo = NCCL_ALLGATHER_P_ALGO::ctpat;
+
+inline int distNodesAtStep(int nNodes, int step) {
+  return nNodes >> (step + 1);
+}
+
+inline int
+peerAtStep(int nodeId, int localRank, int nLocalRanks, int nNodes, int step) {
+  const int dist = distNodesAtStep(nNodes, step);
+  const int pos = (nodeId / dist) % 2;
+  const int peerNode = pos == 0 ? nodeId + dist : nodeId - dist;
+  return peerNode * nLocalRanks + localRank;
+}
+
+inline int nodeChunkStrideAtStep(int nNodes, int step) {
+  return nNodes >> step;
+}
+
+inline size_t rankChunkOffset(
+    int anchorNode,
+    int localRank,
+    int nLocalRanks,
+    int nNodes,
+    int step,
+    int j) {
+  const int stride = nodeChunkStrideAtStep(nNodes, step);
+  const int nodePos = j * stride + (anchorNode % stride);
+  return static_cast<size_t>(nodePos) * nLocalRanks + localRank;
+}
+
+commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* resource = reinterpret_cast<Resource*>(op->allgatherP.algoResource);
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->allgatherP.pArgs);
+  const void* sendBuff = op->allgatherP.sendbuff;
+  const auto sendSize =
+      op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
+  CtranComm* comm = opGroup.front()->comm_;
+
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto nRanks = statex->nRanks();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto nNodes = statex->nNodes();
+  const auto nodeId = rank / nLocalRanks;
+  const auto nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
+  auto mapper = comm->ctran_->mapper.get();
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::BUF_REG));
+  FB_COMMCHECK(
+      mapper->searchRegHandle(sendBuff, sendSize, &sendHdl, &localReg));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
+  auto regGuard = folly::makeGuard([sendHdl, localReg, mapper]() {
+    if (localReg) {
+      FB_COMMCHECKIGNORE(mapper->deregDynamic(sendHdl));
+    }
+  });
+
+  std::vector<int> peers(nSteps);
+  std::vector<std::unique_ptr<CtranMapperNotify>> notifyVec(nSteps);
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  for (int i = 0; i < nSteps; i++) {
+    peers[i] = peerAtStep(nodeId, localRank, nLocalRanks, nNodes, i);
+    notifyVec[i] = std::make_unique<CtranMapperNotify>();
+    FB_COMMCHECK(
+        mapper->initNotify(peers[i], pArgs->recvHdl, notifyVec[i].get()));
+  }
+
+  std::vector<CtranMapperRequest> syncSreqs(nSteps);
+  std::vector<CtranMapperRequest> syncRreqs(nSteps);
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->isendCtrl(peers[i], &syncSreqs[i]));
+    FB_COMMCHECK(mapper->irecvCtrl(peers[i], &syncRreqs[i]));
+  }
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->waitRequest(&syncRreqs[i]));
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  std::unique_ptr<CtranMapperTimestamp> timestamp =
+      std::make_unique<CtranMapperTimestamp>(AlgoImpl::algoName(myAlgo));
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  std::vector<CtranMapperRequest> lastPutReqs(nSteps);
+
+  for (int i = 0; i < nSteps; i++) {
+    const int peer = peers[i];
+    const int nPuts = 1 << i;
+    timestamp->putIssued.push_back(CtranMapperTimestampPoint(peer));
+
+    for (int j = 0; j < nPuts; j++) {
+      const auto chunkIdx =
+          rankChunkOffset(nodeId, localRank, nLocalRanks, nNodes, i, j);
+      const size_t byteOffset = chunkIdx * sendSize;
+
+      const void* srcPtr = nullptr;
+      void* srcHdl = nullptr;
+      if (i == 0) {
+        srcPtr = sendBuff;
+        srcHdl = sendHdl;
+      } else {
+        srcPtr = ctran::allgatherp::getPtr(pArgs->recvbuff, byteOffset);
+        srcHdl = pArgs->recvHdl;
+      }
+      void* dstPtr =
+          ctran::allgatherp::getPtr(pArgs->remoteRecvBuffs[peer], byteOffset);
+
+      const bool isLast = (j == nPuts - 1);
+      FB_COMMCHECK(mapper->iput(
+          srcPtr,
+          dstPtr,
+          sendSize,
+          peer,
+          CtranMapperConfig{
+              .memHdl_ = srcHdl,
+              .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
+              .notify_ = isLast},
+          isLast ? &lastPutReqs[i]
+                 : static_cast<CtranMapperRequest*>(nullptr)));
+    }
+
+    FB_COMMCHECK(mapper->waitRequest(&lastPutReqs[i]));
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
+
+    FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
+
+    if (nLocalRanks > 1) {
+      resource->pipeSync->post(i);
+    }
+  }
+
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  for (int i = 0; i < nSteps; i++) {
+    FB_COMMCHECK(mapper->waitRequest(&syncSreqs[i]));
+  }
+
+  mapper->timestamps.push_back(std::move(timestamp));
+  mapper->reportProfiling();
+
+  CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
+
+  return commSuccess;
+}
+} // namespace
+
+namespace ctran::allgatherp {
+extern __global__ void ncclKernelAllGatherPPipeStart(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelAllGatherPPipeSync(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeSyncKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipeEnd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeEndKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipe(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+
+commResult_t AlgoImpl::execPat(
+    const void* sendbuff,
+    const size_t count,
+    const commDataType_t datatype) {
+  auto recvbuff = pArgs.recvbuff;
+  auto ctran = comm_->ctran_.get();
+  const auto statex = comm_->statex_.get();
+  const auto opCount = ctran->getOpCount();
+  const auto sendSize = count * commTypeSize(datatype);
+
+  const auto nRanks = statex->nRanks();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto myRank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nNodes = statex->nNodes();
+  const auto myNode = myRank / nLocalRanks;
+
+  if (nNodes <= 1) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctpat requires nNodes > 1, got {}",
+        nNodes);
+  }
+  if ((nNodes & (nNodes - 1)) != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctpat requires nNodes ({}) to be a power of 2",
+        nNodes);
+  }
+  if (nLocalRanks > 1 && nRanks % nLocalRanks != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctpat requires nRanks ({}) to be evenly divisible by "
+        "nLocalRanks ({}), nNodes={}",
+        nRanks,
+        nLocalRanks,
+        nNodes);
+  }
+  if (nLocalRanks > 1) {
+    auto mapper = comm_->ctran_->mapper.get();
+    for (int lr = 0; lr < nLocalRanks; lr++) {
+      const int peer = statex->localRankToRank(lr);
+      if (peer != myRank &&
+          mapper->getBackend(peer) != CtranMapperBackend::NVL) {
+        FB_ERRORRETURN(
+            commInvalidUsage,
+            "AllGatherP ctpat requires NVL backend for all local peers, "
+            "peer rank {} has non-NVL backend",
+            peer);
+      }
+    }
+  }
+
+  CTRAN_COLL_INFO(
+      AlgoImpl::algoName(myAlgo),
+      sendbuff,
+      recvbuff,
+      count,
+      datatype,
+      -1,
+      comm_,
+      stream_);
+
+  if (nLocalRanks > 1) {
+    FB_COMMCHECK(waitInit());
+  }
+
+  const int nSteps = static_cast<int>(ctran::utils::log2i(nNodes));
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP,
+      stream_,
+      AlgoImpl::algoName(myAlgo),
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = ctran->algo->getDevState();
+
+  FB_COMMCHECK(copyToSelf(comm_, sendbuff, sendSize, pArgs, stream_));
+
+  if (nNodes > 1) {
+    auto op = std::make_unique<OpElem>(
+        OpElem::opType::ALLGATHERP, stream_, comm_, opCount);
+    op->allgatherP.pArgs = &pArgs;
+    op->allgatherP.algoResource = &resource_;
+    op->allgatherP.sendbuff = sendbuff;
+    op->allgatherP.count = count;
+    op->allgatherP.datatype = datatype;
+
+    std::vector<std::unique_ptr<struct OpElem>> opGroup;
+    opGroup.push_back(std::move(op));
+
+    if (nLocalRanks > 1) {
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
+    } else {
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipe)));
+    }
+  }
+
+  if (nLocalRanks > 1) {
+    FB_COMMCHECK(nvlCeBcast(
+        comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+
+    for (int i = 0; i < nSteps; i++) {
+      PipeSyncKernArgs syncArgs = {
+          .stepId = i,
+          .pipeSync = resource_.pipeSync,
+      };
+      config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+      FB_COMMCHECK(ctran->gpe->submit(
+          {},
+          nullptr,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeSync)));
+
+      const int distNodes = distNodesAtStep(nNodes, i);
+      const int pos = (myNode / distNodes) % 2;
+      const int peerNode = pos == 0 ? myNode + distNodes : myNode - distNodes;
+
+      const int stride = nodeChunkStrideAtStep(nNodes, i);
+      const int nodeOffset = peerNode % stride;
+      const int nChunks = 1 << i;
+
+      for (int j = 0; j < nChunks; j++) {
+        const int nodePos = j * stride + nodeOffset;
+        const size_t chunkIdx = static_cast<size_t>(nodePos) * nLocalRanks +
+            static_cast<size_t>(localRank);
+        const size_t byteOffset = chunkIdx * sendSize;
+        auto srcPtr = ctran::allgatherp::getPtr(pArgs.recvbuff, byteOffset);
+        const bool needBarrier = (j == 0);
+        FB_COMMCHECK(nvlCeBcast(
+            comm_, srcPtr, sendSize, byteOffset, pArgs, stream_, needBarrier));
+      }
+    }
+
+    PipeEndKernArgs endArgs = {
+        .pipeSync = resource_.pipeSync,
+    };
+    config.algoArgs = reinterpret_cast<void*>(&endArgs);
+    FB_COMMCHECK(ctran->gpe->submit(
+        {},
+        nullptr,
+        config,
+        reinterpret_cast<void*>(ncclKernelAllGatherPPipeEnd)));
+  }
+
+  return commSuccess;
+}
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -78,4 +78,26 @@ struct PatCopyPipeEndKernArgs {
   GpeKernelSync* pipeSync;
   GpeKernelSync* stepDoneSync;
 };
+
+} // namespace ctran::allgatherp
+
+namespace comms::pipes {
+class P2pNvlTransportDevice;
+}
+
+namespace ctran::allgatherp {
+
+struct NvlDissemKernArgs {
+  void* stagingRecvBuf;
+  void* recvbuff;
+  int nChunks;
+  size_t chunkSize;
+  int nLocalRanks;
+  int localRank;
+  int peerNode;
+  int nNodes;
+  int step;
+  ::comms::pipes::P2pNvlTransportDevice* nvlTransportsBase;
+  uint64_t timeoutCycles;
+};
 } // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -1,13 +1,25 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #pragma once
+#include <memory>
+#include <vector>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/utils/commSpecs.h"
+
+#if !defined(__CUDACC__)
+#include "comms/ctran/algos/common/BufManager.h"
+#endif
 
 using ctran::algos::GpeKernelSync;
 
 struct CtranMapperRemoteAccessKey;
 namespace ctran::allgatherp {
+
+enum class StagingBufId {
+  kSendBuf = 0,
+  kRecvBuf,
+  kNumBufs,
+};
 struct PersistArgs {
   void* recvbuff;
   void* recvHdl;
@@ -23,13 +35,29 @@ struct PersistArgs {
   // should wait for its completion via the initialized_ flag, before the main
   // thread can schedule copy engine copies
   std::atomic<bool> initialized{false};
+  int pinnedAlgo{0};
 };
 
+#if !defined(__CUDACC__)
+struct StagingInfo {
+  ctran::algos::bufmanager::RegBuf sendBuf;
+  ctran::algos::bufmanager::RegBuf recvBuf;
+  std::vector<ctran::algos::bufmanager::RemRegBuf> remRecvBufs;
+  std::vector<int> peerRanks;
+  size_t slotSize{0};
+  size_t numSlots{0};
+};
+#endif
+
 struct Resource {
-  // Used in the pipeline algorithm. Sync object for GPE thread to notify the
-  // wait kernel the completion of inter-node exchange, so that it can terminate
-  // and kick off CE bcast to forward the received data to the other local ranks
   GpeKernelSync* pipeSync{nullptr};
+  GpeKernelSync* stepDoneSync{nullptr};
+#if !defined(__CUDACC__)
+  std::unique_ptr<
+      ctran::algos::BufManager<StagingBufId, StagingBufId::kNumBufs>>
+      stagingBufMgr;
+  StagingInfo stagingInfo;
+#endif
 };
 
 struct PipeEndKernArgs {
@@ -39,5 +67,15 @@ struct PipeEndKernArgs {
 struct PipeSyncKernArgs {
   int stepId;
   GpeKernelSync* pipeSync;
+};
+
+struct StepDoneKernArgs {
+  int stepId;
+  GpeKernelSync* stepDoneSync;
+};
+
+struct PatCopyPipeEndKernArgs {
+  GpeKernelSync* pipeSync;
+  GpeKernelSync* stepDoneSync;
 };
 } // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -76,7 +76,7 @@ commResult_t allGatherWinInit(
         win->remWinInfo.size());
   }
 
-  auto algo = std::make_unique<AlgoImpl>(comm, stream);
+  auto algo = std::make_unique<AlgoImpl>(comm, stream, NCCL_ALLGATHER_P_ALGO);
 
   algo->pArgs.recvbuff = win->winDataPtr;
   algo->pArgs.recvHdl = win->dataRegHdl;

--- a/comms/ctran/algos/common/BufManager.cc
+++ b/comms/ctran/algos/common/BufManager.cc
@@ -93,13 +93,14 @@ commResult_t exchangeBase(
     const std::vector<int>& peerRanks,
     const int maxNumRanks,
     const ncclx::CommStateX* statex,
-    CtranMapper* mapper) {
+    CtranMapper* mapper,
+    bool epochHeld) {
   // Skip if base is not allocated
   if (base.size == 0 || !base.ptr) {
     return commSuccess;
   }
 
-  CtranMapperEpochRAII epochRAII(mapper);
+  CtranMapperEpochRAII epochRAII(epochHeld ? nullptr : mapper);
 
   // First register it locally
   FB_COMMCHECK(mapper->regMem(

--- a/comms/ctran/algos/common/BufManager.h
+++ b/comms/ctran/algos/common/BufManager.h
@@ -108,7 +108,8 @@ commResult_t exchangeBase(
     const std::vector<int>& peerRanks,
     const int maxNumRanks,
     const ncclx::CommStateX* statex,
-    CtranMapper* mapper);
+    CtranMapper* mapper,
+    bool epochHeld = false);
 }; // namespace ctran::algos::bufmanager
 
 namespace ctran::algos {
@@ -286,13 +287,16 @@ class BufManager {
   // Register the memory bases and exchange the registration with other ranks
   // specified in peerRanks. After this call, callsite can assign registered
   // buffers and remote buffers. See assignRegBuf() and assignRemRegBuf().
+  // Set epochHeld=true when the caller already holds the mapper epoch lock
+  // (e.g. when called from a GPE callback).
   inline commResult_t exchange(
       const std::vector<int>& peerRanks,
-      const int maxNumRanks) {
+      const int maxNumRanks,
+      bool epochHeld = false) {
     for (auto& base : memBases_) {
       // zero-sized base is skipped internally
-      FB_COMMCHECK(
-          exchangeBase(base, peerRanks, maxNumRanks, statex_, mapper_));
+      FB_COMMCHECK(exchangeBase(
+          base, peerRanks, maxNumRanks, statex_, mapper_, epochHeld));
     }
     isExchanged_ = true;
     return commSuccess;

--- a/comms/ctran/backends/nvl/CtranNvl.cc
+++ b/comms/ctran/backends/nvl/CtranNvl.cc
@@ -6,24 +6,46 @@
 #include "comms/ctran/backends/nvl/CtranNvl.h"
 #include "comms/ctran/backends/nvl/CtranNvlImpl.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/CudaUtils.h"
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/utils/StrUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+
+// Map a PCI bus ID to a locally visible CUDA device index.
+// Returns -1 if the bus ID does not match any visible device
+// (e.g. under CUDA_VISIBLE_DEVICES isolation).
+// Mirrors ncclx p2p.cc busIdToCudaDev().
+static int busIdToCudaDev(int64_t busId) {
+  int ndev;
+  if (cudaGetDeviceCount(&ndev) != cudaSuccess) {
+    return -1;
+  }
+  for (int i = 0; i < ndev; i++) {
+    auto devBusId = ctran::utils::BusId::makeFrom(i).toInt64();
+    if (busId == devBusId) {
+      return i;
+    }
+  }
+  return -1;
+}
 
 CtranNvl::CtranNvl(CtranComm* comm) {
   const auto statex = comm->statex_.get();
   int myRank = statex->rank();
   int myLocalRank = statex->localRank();
   int nLocalRanks = statex->nLocalRanks();
-  // Exchange device IDs used by each local rank
-  std::vector<int> peerDevs(nLocalRanks, 0);
+  // Exchange PCI bus IDs (hardware-level, process-independent) so we can
+  // correctly map peers to local CUDA device indices even under
+  // CUDA_VISIBLE_DEVICES isolation.
+  std::vector<int64_t> peerBusIds(nLocalRanks, 0);
   std::vector<std::string> supportedInraHostRanksStr;
   std::vector<std::string> nvlFabricSupportedRanksStr;
 
-  peerDevs[myLocalRank] = statex->cudaDev();
+  peerBusIds[myLocalRank] = statex->busId();
   auto resFuture = comm->bootstrap_->allGatherNvlDomain(
-      peerDevs.data(),
-      sizeof(int),
+      peerBusIds.data(),
+      sizeof(int64_t),
       myLocalRank,
       nLocalRanks,
       statex->localRankToRanks());
@@ -64,11 +86,26 @@ CtranNvl::CtranNvl(CtranComm* comm) {
             std::to_string(statex->localRankToRank(i)));
         continue;
       }
-      int canAccessPeer = 1;
-      FB_CUDACHECKTHROW_EX(
-          cudaDeviceCanAccessPeer(
-              &canAccessPeer, statex->cudaDev(), peerDevs[i]),
-          comm->logMetaData_);
+      // Map peer's bus ID to a locally visible CUDA device index.
+      // Under CUDA_VISIBLE_DEVICES isolation (e.g. torchrun), peer GPUs
+      // are not visible so this returns -1.
+      int peerLocalDev = busIdToCudaDev(peerBusIds[i]);
+      int canAccessPeer = 0;
+      if (peerLocalDev >= 0) {
+        FB_CUDACHECKTHROW_EX(
+            cudaDeviceCanAccessPeer(
+                &canAccessPeer, statex->cudaDev(), peerLocalDev),
+            comm->logMetaData_);
+      } else if (NCCL_CTRAN_ASSUME_HIDDEN_LOCAL_PEERS_NVL) {
+        canAccessPeer = 1;
+        CLOGF_SUBSYS(
+            INFO,
+            INIT,
+            "CTRAN-NVL: Peer {} (local rank {} busId {:x}) not visible locally, assuming NVL (NCCL_CTRAN_ASSUME_HIDDEN_LOCAL_PEERS_NVL=1)",
+            statex->localRankToRank(i),
+            i,
+            peerBusIds[i]);
+      }
       if (canAccessPeer) {
         this->pimpl_->nvlRankSupportMode[statex->localRankToRank(i)]
             .nvlIntraHost = true;
@@ -78,13 +115,13 @@ CtranNvl::CtranNvl(CtranComm* comm) {
         CLOGF_SUBSYS(
             INFO,
             INIT,
-            "CTRAN-NVL: Rank {} (local rank {} GPU {}) cannot access peer {} (local rank {} GPU {}), disable NVL support",
+            "CTRAN-NVL: Rank {} (local rank {} GPU {}) cannot access peer {} (local rank {} busId {:x}), disable NVL support",
             myRank,
             myLocalRank,
             statex->cudaDev(),
             statex->localRankToRank(i),
             i,
-            peerDevs[i]);
+            peerBusIds[i]);
       }
     }
   }

--- a/comms/ctran/benchmarks/AllgatherPBench.cc
+++ b/comms/ctran/benchmarks/AllgatherPBench.cc
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <unistd.h>
+
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <nccl.h>
@@ -180,16 +182,17 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
       CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     }
 
-    // Benchmark iterations with timing
+    // Benchmark iterations with timing.
+    // Sync each iteration: pipelining algos (ctpatcopy) use stream↔GPE
+    // handshake objects that must be reset between executions.
     CUDACHECK_TEST(cudaDeviceSynchronize());
     auto start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < FLAGS_bench_iters; ++i) {
       COMMCHECK_TEST(ctran::allGatherPExec(usedSendBuf, count, dt_, request));
+      CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     }
 
-    // Sync once after all iterations
-    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     auto end = std::chrono::high_resolution_clock::now();
 
     // Calculate total time and average per iteration
@@ -266,17 +269,18 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
       CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     }
 
-    // Benchmark iterations with timing
+    // Benchmark iterations with timing.
+    // Sync each iteration for consistent per-collective latency measurement
+    // matching the AllGatherP timing loop.
     CUDACHECK_TEST(cudaDeviceSynchronize());
     auto start = std::chrono::high_resolution_clock::now();
 
     for (int i = 0; i < FLAGS_bench_iters; ++i) {
       NCCLCHECK_TEST(ncclAllGather(
           usedSendBuf, recvbuf, count, ncclBfloat16, ncclComm_, stream_));
+      CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     }
 
-    // Sync once after all iterations
-    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
     auto end = std::chrono::high_resolution_clock::now();
 
     // Calculate total time and average per iteration
@@ -385,7 +389,23 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
 
     const auto statex = ctranComm_->statex_.get();
     const auto nNodes = statex->nNodes();
-    const bool pipelineSupported = nNodes > 1 && statex->nLocalRanks() > 1;
+    auto mapper = ctranComm_->ctran_->mapper.get();
+
+    // Check NVL connectivity for local peers
+    bool nvlAvailable = true;
+    if (statex->nLocalRanks() > 1) {
+      for (int lr = 0; lr < statex->nLocalRanks(); lr++) {
+        const int peer = statex->localRankToRank(lr);
+        if (peer != statex->rank() &&
+            mapper->getBackend(peer) != CtranMapperBackend::NVL) {
+          nvlAvailable = false;
+          break;
+        }
+      }
+    }
+
+    const bool pipelineSupported =
+        nNodes > 1 && statex->nLocalRanks() > 1 && nvlAvailable;
 
     // Generate size range (powers of 2)
     std::vector<size_t> sizes;
@@ -442,7 +462,9 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
       }
 
       // Benchmark AllgatherP Direct (dedicated request)
-      if (FLAGS_algo == "ctdirect" || FLAGS_algo == "all") {
+      // ctdirect uses nvlCeBcast for local peers, so skip if NVL unavailable
+      if ((FLAGS_algo == "ctdirect" || FLAGS_algo == "all") &&
+          (statex->nLocalRanks() <= 1 || nvlAvailable)) {
         EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctdirect);
         meta::comms::Hints directHints;
         CtranPersistentRequest* directRequest = nullptr;
@@ -636,6 +658,10 @@ TEST_F(AllgatherPBenchmark, BenchmarkSuite) {
 }
 
 int main(int argc, char* argv[]) {
+  // Redirect stdout to stderr so MAST/AnyBench captures gtest output.
+  // MAST only collects /logs/stderr; without this, benchmark results are lost.
+  dup2(STDERR_FILENO, STDOUT_FILENO);
+
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new CtranAllgatherPBenchTestEnv);
   folly::Init init(&argc, &argv);

--- a/comms/ctran/benchmarks/AllgatherPBench.cc
+++ b/comms/ctran/benchmarks/AllgatherPBench.cc
@@ -29,7 +29,7 @@ DEFINE_int32(bench_iters, 50, "Number of benchmark iterations (default: 20)");
 DEFINE_string(
     algo,
     "all",
-    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'ctpat', 'nccl', or 'all' (default: all)");
+    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'ctpat', 'ctpatcopy', 'nccl', or 'all' (default: all)");
 DEFINE_bool(in_place, false, "Run in-place allgather (default: false)");
 DEFINE_string(
     mem_type,
@@ -383,10 +383,9 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
     printHeader();
     printTableHeader();
 
-    // Check nNodes for pipeline support
     const auto statex = ctranComm_->statex_.get();
     const auto nNodes = statex->nNodes();
-    const bool pipelineSupported = nNodes > 1;
+    const bool pipelineSupported = nNodes > 1 && statex->nLocalRanks() > 1;
 
     // Generate size range (powers of 2)
     std::vector<size_t> sizes;
@@ -406,10 +405,10 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
     void* sendbuf = nullptr;
     void* recvbuf = nullptr;
     void *sendHdl = nullptr, *recvHdl = nullptr;
-    CtranPersistentRequest* request = nullptr;
 
     // Only allocate and initialize if running AllGatherP algorithms
     if (FLAGS_algo == "ctdirect" || FLAGS_algo == "ctpipeline" ||
+        FLAGS_algo == "ctpat" || FLAGS_algo == "ctpatcopy" ||
         FLAGS_algo == "all") {
       // Allocate and initialize buffers ONCE for max size
       sendbuf = allocateBuffer(maxSizeBytes);
@@ -427,25 +426,11 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
             ctranComm_->ctran_->commRegister(sendbuf, maxSizeBytes, &sendHdl));
       }
 
-      // Initialize AllGatherP ONCE globally with max size
-      meta::comms::Hints hints;
-      COMMCHECK_TEST(
-          ctran::allGatherPInit(
-              recvbuf,
-              maxCount * numRanks,
-              hints,
-              dt_,
-              ctranComm_.get(),
-              stream_,
-              request));
-
-      // Wait for async init to complete
-      CUDACHECK_TEST(cudaStreamSynchronize(stream_));
-      CUDACHECK_TEST(cudaDeviceSynchronize());
-      ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+      // No shared request. With pinned algos, each algo branch creates
+      // its own dedicated persistent request below.
     }
 
-    // Run benchmarks for all sizes using the same persistent request
+    // Run benchmarks for all sizes. Each algo creates its own request.
     for (size_t sizeBytes : sizes) {
       size_t count = sizeBytes / typeSize_;
 
@@ -456,27 +441,61 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
         CUDACHECK_TEST(cudaDeviceSynchronize());
       }
 
-      // Benchmark AllgatherP Direct (reuses same request)
+      // Benchmark AllgatherP Direct (dedicated request)
       if (FLAGS_algo == "ctdirect" || FLAGS_algo == "all") {
         EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctdirect);
+        meta::comms::Hints directHints;
+        CtranPersistentRequest* directRequest = nullptr;
+        COMMCHECK_TEST(
+            ctran::allGatherPInit(
+                recvbuf,
+                maxCount * numRanks,
+                directHints,
+                dt_,
+                ctranComm_.get(),
+                stream_,
+                directRequest));
+        CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+        ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+
         BenchmarkResult result = benchmarkAllgatherPWithRequest(
-            count, "AllGatherP_Direct", request, sendbuf, recvbuf);
+            count, "AllGatherP_Direct", directRequest, sendbuf, recvbuf);
         printResult(result);
+
+        COMMCHECK_TEST(ctran::allGatherPDestroy(directRequest));
+        delete directRequest;
         ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
       }
 
-      // Benchmark AllgatherP Pipeline (reuses same request)
+      // Benchmark AllgatherP Pipeline (dedicated request)
       if ((FLAGS_algo == "ctpipeline" || FLAGS_algo == "all") &&
           pipelineSupported) {
         EnvRAII algoEnv(
             NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpipeline);
+        meta::comms::Hints pipeHints;
+        CtranPersistentRequest* pipeRequest = nullptr;
+        COMMCHECK_TEST(
+            ctran::allGatherPInit(
+                recvbuf,
+                maxCount * numRanks,
+                pipeHints,
+                dt_,
+                ctranComm_.get(),
+                stream_,
+                pipeRequest));
+        CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+        ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+
         BenchmarkResult result = benchmarkAllgatherPWithRequest(
-            count, "AllGatherP_Pipeline", request, sendbuf, recvbuf);
+            count, "AllGatherP_Pipeline", pipeRequest, sendbuf, recvbuf);
         printResult(result);
+
+        COMMCHECK_TEST(ctran::allGatherPDestroy(pipeRequest));
+        delete pipeRequest;
         ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
       }
 
-      // Benchmark AllgatherP PAT (reuses same request)
+      // Benchmark AllgatherP PAT (needs its own request due to pinned algo)
       if (FLAGS_algo == "ctpat" || FLAGS_algo == "all") {
         const auto statex = ctranComm_->statex_.get();
         auto mapper = ctranComm_->ctran_->mapper.get();
@@ -495,9 +514,72 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
         }
         if (patSupported) {
           EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpat);
+          meta::comms::Hints patHints;
+          CtranPersistentRequest* patRequest = nullptr;
+          COMMCHECK_TEST(
+              ctran::allGatherPInit(
+                  recvbuf,
+                  maxCount * numRanks,
+                  patHints,
+                  dt_,
+                  ctranComm_.get(),
+                  stream_,
+                  patRequest));
+          CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+          ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+
           BenchmarkResult result = benchmarkAllgatherPWithRequest(
-              count, "AllGatherP_Pat", request, sendbuf, recvbuf);
+              count, "AllGatherP_Pat", patRequest, sendbuf, recvbuf);
           printResult(result);
+
+          COMMCHECK_TEST(ctran::allGatherPDestroy(patRequest));
+          delete patRequest;
+          ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+        }
+      }
+
+      // Benchmark AllgatherP PatCopy (needs its own request due to staging
+      // init)
+      if (FLAGS_algo == "ctpatcopy" || FLAGS_algo == "all") {
+        const auto statex = ctranComm_->statex_.get();
+        auto mapper = ctranComm_->ctran_->mapper.get();
+        bool patcopySupported = statex->nNodes() > 1 &&
+            (statex->nNodes() & (statex->nNodes() - 1)) == 0 &&
+            statex->nRanks() % statex->nLocalRanks() == 0 &&
+            statex->nLocalRanks() > 1;
+        if (patcopySupported) {
+          for (int lr = 0; lr < statex->nLocalRanks(); lr++) {
+            const int peer = statex->localRankToRank(lr);
+            if (peer != statex->rank() &&
+                mapper->getBackend(peer) != CtranMapperBackend::NVL) {
+              patcopySupported = false;
+              break;
+            }
+          }
+        }
+        if (patcopySupported) {
+          EnvRAII algoEnv(
+              NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpatcopy);
+          meta::comms::Hints pcHints;
+          CtranPersistentRequest* pcRequest = nullptr;
+          COMMCHECK_TEST(
+              ctran::allGatherPInit(
+                  recvbuf,
+                  maxCount * numRanks,
+                  pcHints,
+                  dt_,
+                  ctranComm_.get(),
+                  stream_,
+                  pcRequest));
+          CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+          ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+
+          BenchmarkResult result = benchmarkAllgatherPWithRequest(
+              count, "AllGatherP_PatCopy", pcRequest, sendbuf, recvbuf);
+          printResult(result);
+
+          COMMCHECK_TEST(ctran::allGatherPDestroy(pcRequest));
+          delete pcRequest;
           ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
         }
       }
@@ -512,16 +594,6 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
       if (globalRank == 0) {
         std::cout << std::endl;
       }
-    }
-
-    // Cleanup ONCE at the very end after all sizes
-    if (request != nullptr) {
-      COMMCHECK_TEST(ctran::allGatherPDestroy(request));
-      delete request;
-
-      CUDACHECK_TEST(cudaStreamSynchronize(stream_));
-      CUDACHECK_TEST(cudaDeviceSynchronize());
-      ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
     }
 
     // Deregister memory ONCE

--- a/comms/ctran/benchmarks/AllgatherPBench.cc
+++ b/comms/ctran/benchmarks/AllgatherPBench.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
@@ -28,7 +29,7 @@ DEFINE_int32(bench_iters, 50, "Number of benchmark iterations (default: 20)");
 DEFINE_string(
     algo,
     "all",
-    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'nccl', or 'all' (default: all)");
+    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'ctpat', 'nccl', or 'all' (default: all)");
 DEFINE_bool(in_place, false, "Run in-place allgather (default: false)");
 DEFINE_string(
     mem_type,
@@ -473,6 +474,32 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
             count, "AllGatherP_Pipeline", request, sendbuf, recvbuf);
         printResult(result);
         ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+      }
+
+      // Benchmark AllgatherP PAT (reuses same request)
+      if (FLAGS_algo == "ctpat" || FLAGS_algo == "all") {
+        const auto statex = ctranComm_->statex_.get();
+        auto mapper = ctranComm_->ctran_->mapper.get();
+        bool patSupported = statex->nNodes() > 1 &&
+            (statex->nNodes() & (statex->nNodes() - 1)) == 0 &&
+            statex->nRanks() % statex->nLocalRanks() == 0;
+        if (patSupported && statex->nLocalRanks() > 1) {
+          for (int lr = 0; lr < statex->nLocalRanks(); lr++) {
+            const int peer = statex->localRankToRank(lr);
+            if (peer != statex->rank() &&
+                mapper->getBackend(peer) != CtranMapperBackend::NVL) {
+              patSupported = false;
+              break;
+            }
+          }
+        }
+        if (patSupported) {
+          EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpat);
+          BenchmarkResult result = benchmarkAllgatherPWithRequest(
+              count, "AllGatherP_Pat", request, sendbuf, recvbuf);
+          printResult(result);
+          ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+        }
       }
 
       // Benchmark NCCL baseline

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -91,6 +91,7 @@ struct OpElem {
     struct {
       // reference to pre-initialized persistent arguments and resource
       void* pArgs;
+      void* algoResource;
       // non-null for window-based init; used by GPE callback to populate
       // pArgs from window remote info
       ctran::CtranWin* win;

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -289,6 +289,8 @@ static std::string algoToStr(enum NCCL_ALLGATHER_P_ALGO algo) {
       return "ctrdpipeline";
     case NCCL_ALLGATHER_P_ALGO::ctpat:
       return "ctpat";
+    case NCCL_ALLGATHER_P_ALGO::ctpatcopy:
+      return "ctpatcopy";
     default:
       return "unknown";
   }
@@ -305,15 +307,21 @@ TEST_P(CtranAllgatherPTestParam, Basic) {
     GTEST_SKIP() << "No IB Backend found, skip test";
   } else if (
       (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
-       algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
+       algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+       algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
       ctranComm->statex_->nNodes() > 1 &&
       (ctranComm->statex_->nNodes() & (ctranComm->statex_->nNodes() - 1)) !=
           0) {
     GTEST_SKIP() << algoStr << " requires nNodes to be a power of 2, skip test";
   } else if (
-      algo == NCCL_ALLGATHER_P_ALGO::ctpat &&
+      (algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+       algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
       ctranComm->statex_->nNodes() <= 1) {
-    GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
+    GTEST_SKIP() << algoStr << " requires nNodes > 1, skip test";
+  } else if (
+      algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy &&
+      ctranComm->statex_->nLocalRanks() <= 1) {
+    GTEST_SKIP() << "ctpatcopy requires nLocalRanks > 1, skip test";
   } else {
     run(maxSendCount, count, inplace, memType, ctranComm.get());
   }
@@ -342,13 +350,16 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasic) {
     const auto vnodeNNodes = numRanks / 4;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
     if ((algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
-         algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
+         algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
         vnodeNNodes > 1 && (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
       GTEST_SKIP() << algoStr
                    << " requires nNodes to be a power of 2, skip test";
     }
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctpat && vnodeNNodes <= 1) {
-      GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
+    if ((algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
+        vnodeNNodes <= 1) {
+      GTEST_SKIP() << algoStr << " requires nNodes > 1, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -381,13 +392,16 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasicMultiStep) {
     const auto vnodeNNodes = numRanks / 2;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
     if ((algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
-         algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
+         algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
         vnodeNNodes > 1 && (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
       GTEST_SKIP() << algoStr
                    << " requires nNodes to be a power of 2, skip test";
     }
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctpat && vnodeNNodes <= 1) {
-      GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
+    if ((algo == NCCL_ALLGATHER_P_ALGO::ctpat ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpatcopy) &&
+        vnodeNNodes <= 1) {
+      GTEST_SKIP() << algoStr << " requires nNodes > 1, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -442,7 +456,7 @@ TEST_F(CtranAllgatherPTestParam, DynamicSendRegPipeline) {
 
 TEST_F(CtranAllgatherPTest, CtpatRejectsSingleNode) {
   // ctpat requires nNodes > 1. On a single-node devgpu (nNodes == 1),
-  // allGatherPExec with ctpat should return an error.
+  // allGatherPExec with ctpat (pinned at init) should return an error.
   if (ctranComm->statex_->nNodes() > 1) {
     GTEST_SKIP() << "This test requires single-node topology (nNodes == 1)";
   }
@@ -457,6 +471,9 @@ TEST_F(CtranAllgatherPTest, CtpatRejectsSingleNode) {
   CtranPersistentRequest* request;
   const auto initMaxRecvCount =
       maxRecvCount * commTypeSize(dt) / commTypeSize(commInt8);
+
+  // Pin ctpat at init time -- it validates at exec time
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpat);
   COMMCHECK_TEST(
       ctran::allGatherPInit(
           recvbuf,
@@ -468,7 +485,6 @@ TEST_F(CtranAllgatherPTest, CtpatRejectsSingleNode) {
           request));
   ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
 
-  SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", "ctpat");
   ASSERT_EQ(
       ctran::allGatherPExec(sendbuf, count, dt, request), commInvalidUsage);
 
@@ -476,6 +492,116 @@ TEST_F(CtranAllgatherPTest, CtpatRejectsSingleNode) {
   delete request;
   COMMCHECK_TEST(ctranComm->ctran_->commDeregister(recvHdl));
   memoryCleanUp(kMemCudaMalloc);
+}
+
+TEST_F(CtranAllgatherPTest, CtpatcopyRejectsSingleNode) {
+  // ctpatcopy requires nNodes > 1 and nLocalRanks > 1.
+  // On a single-node devgpu, allGatherPInit should reject at init time.
+  if (ctranComm->statex_->nNodes() > 1) {
+    GTEST_SKIP() << "This test requires single-node topology (nNodes == 1)";
+  }
+
+  const auto count = 8192;
+  const auto maxSendCount = count;
+  const auto maxRecvCount = maxSendCount * numRanks;
+  memorySetUp(kMemCudaMalloc, count, maxRecvCount);
+
+  COMMCHECK_TEST(ctranComm->ctran_->commRegister(recvbuf, recvBytes, &recvHdl));
+  meta::comms::Hints hints;
+  CtranPersistentRequest* request = nullptr;
+  const auto initMaxRecvCount =
+      maxRecvCount * commTypeSize(dt) / commTypeSize(commInt8);
+
+  // Pin ctpatcopy at init time -- should fail at init
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpatcopy);
+  ASSERT_EQ(
+      ctran::allGatherPInit(
+          recvbuf,
+          initMaxRecvCount,
+          hints,
+          commInt8,
+          ctranComm.get(),
+          stream,
+          request),
+      commInvalidUsage);
+
+  COMMCHECK_TEST(ctranComm->ctran_->commDeregister(recvHdl));
+  memoryCleanUp(kMemCudaMalloc);
+}
+
+TEST_F(CtranAllgatherPTest, CtpatcopyStagingFallback) {
+  // When staging buffer is too small, ctpatcopy should fall back to execPat()
+  // (zero-copy). We force this by setting a tiny staging buffer size.
+  if (ctranComm->statex_->nNodes() > 1) {
+    GTEST_SKIP() << "This test requires single-node topology to verify "
+                    "fallback returns error (no multi-node support)";
+  }
+
+  const auto count = 8192;
+  const auto maxSendCount = count;
+  const auto maxRecvCount = maxSendCount * numRanks;
+  memorySetUp(kMemCudaMalloc, count, maxRecvCount);
+
+  COMMCHECK_TEST(ctranComm->ctran_->commRegister(recvbuf, recvBytes, &recvHdl));
+
+  // ctpatcopy init should fail on single-node regardless of staging size
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpatcopy);
+  SysEnvRAII stagingEnv(
+      "NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE", "4096");
+  meta::comms::Hints hints;
+  CtranPersistentRequest* request = nullptr;
+  const auto initMaxRecvCount =
+      maxRecvCount * commTypeSize(dt) / commTypeSize(commInt8);
+  ASSERT_EQ(
+      ctran::allGatherPInit(
+          recvbuf,
+          initMaxRecvCount,
+          hints,
+          commInt8,
+          ctranComm.get(),
+          stream,
+          request),
+      commInvalidUsage);
+
+  COMMCHECK_TEST(ctranComm->ctran_->commDeregister(recvHdl));
+  memoryCleanUp(kMemCudaMalloc);
+}
+
+TEST_F(CtranAllgatherPTest, CtpatcopyVnodeFallback) {
+  // Exercise the ctpatcopy -> execPat() fallback on a supported NVL x IB
+  // topology. Use vnode to simulate multi-node with nLocalRanks=4, then
+  // set a tiny staging buffer so sendSize * nNodes/2 exceeds staging
+  // capacity, forcing execPatCopy to delegate to execPat (zero-copy).
+  if (ncclIsCuMemSupported() == false) {
+    GTEST_SKIP() << "CuMem not supported";
+  }
+  if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
+    GTEST_SKIP() << "No IB Backend found";
+  }
+  if (ctranComm->statex_->nLocalRanks() % 4 != 0) {
+    GTEST_SKIP() << "Requires real nLocalRanks divisible by 4 for vnode=4";
+  }
+
+  EnvRAII vnodeEnv(
+      NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::vnode);
+  EnvRAII ppnEnv(NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS, 4);
+
+  auto testComm = makeCtranComm();
+  ASSERT_EQ(testComm->statex_->nLocalRanks(), 4);
+  const auto vnodeNNodes = testComm->statex_->nNodes();
+  if (vnodeNNodes <= 1 || (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
+    GTEST_SKIP() << "Requires power-of-2 nNodes > 1 under vnode, got "
+                 << vnodeNNodes;
+  }
+
+  // Pin ctpatcopy with tiny staging so fallback to execPat triggers
+  EnvRAII algoEnv(NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpatcopy);
+  SysEnvRAII stagingEnv(
+      "NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE", "1024");
+
+  const auto count = 8192;
+  const auto maxSendCount = count;
+  run(maxSendCount, count, kTestOutOfPlace, kMemNcclMemAlloc, testComm.get());
 }
 
 TEST_F(CtranAllgatherPTest, InvalidPreq) {
@@ -759,7 +885,8 @@ INSTANTIATE_TEST_SUITE_P(
             NCCL_ALLGATHER_P_ALGO::ctdirect,
             NCCL_ALLGATHER_P_ALGO::ctpipeline,
             NCCL_ALLGATHER_P_ALGO::ctrdpipeline,
-            NCCL_ALLGATHER_P_ALGO::ctpat)),
+            NCCL_ALLGATHER_P_ALGO::ctpat,
+            NCCL_ALLGATHER_P_ALGO::ctpatcopy)),
     getTestName);
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -287,6 +287,8 @@ static std::string algoToStr(enum NCCL_ALLGATHER_P_ALGO algo) {
       return "ctpipeline";
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return "ctrdpipeline";
+    case NCCL_ALLGATHER_P_ALGO::ctpat:
+      return "ctpat";
     default:
       return "unknown";
   }
@@ -302,12 +304,16 @@ TEST_P(CtranAllgatherPTestParam, Basic) {
   } else if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
     GTEST_SKIP() << "No IB Backend found, skip test";
   } else if (
-      algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline &&
+      (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
+       algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
       ctranComm->statex_->nNodes() > 1 &&
       (ctranComm->statex_->nNodes() & (ctranComm->statex_->nNodes() - 1)) !=
           0) {
-    GTEST_SKIP()
-        << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    GTEST_SKIP() << algoStr << " requires nNodes to be a power of 2, skip test";
+  } else if (
+      algo == NCCL_ALLGATHER_P_ALGO::ctpat &&
+      ctranComm->statex_->nNodes() <= 1) {
+    GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
   } else {
     run(maxSendCount, count, inplace, memType, ctranComm.get());
   }
@@ -335,10 +341,14 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasic) {
     ASSERT_EQ(testComm->statex_->nLocalRanks(), 4);
     const auto vnodeNNodes = numRanks / 4;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
-        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
-      GTEST_SKIP()
-          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    if ((algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
+        vnodeNNodes > 1 && (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
+      GTEST_SKIP() << algoStr
+                   << " requires nNodes to be a power of 2, skip test";
+    }
+    if (algo == NCCL_ALLGATHER_P_ALGO::ctpat && vnodeNNodes <= 1) {
+      GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -370,10 +380,14 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasicMultiStep) {
     ASSERT_EQ(testComm->statex_->nLocalRanks(), 2);
     const auto vnodeNNodes = numRanks / 2;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
-        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
-      GTEST_SKIP()
-          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    if ((algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
+         algo == NCCL_ALLGATHER_P_ALGO::ctpat) &&
+        vnodeNNodes > 1 && (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
+      GTEST_SKIP() << algoStr
+                   << " requires nNodes to be a power of 2, skip test";
+    }
+    if (algo == NCCL_ALLGATHER_P_ALGO::ctpat && vnodeNNodes <= 1) {
+      GTEST_SKIP() << "ctpat requires nNodes > 1, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -424,6 +438,44 @@ TEST_F(CtranAllgatherPTestParam, DynamicSendRegPipeline) {
         ctranComm.get(),
         false /* sendbufReg */);
   }
+}
+
+TEST_F(CtranAllgatherPTest, CtpatRejectsSingleNode) {
+  // ctpat requires nNodes > 1. On a single-node devgpu (nNodes == 1),
+  // allGatherPExec with ctpat should return an error.
+  if (ctranComm->statex_->nNodes() > 1) {
+    GTEST_SKIP() << "This test requires single-node topology (nNodes == 1)";
+  }
+
+  const auto count = 8192;
+  const auto maxSendCount = count;
+  const auto maxRecvCount = maxSendCount * numRanks;
+  memorySetUp(kMemCudaMalloc, count, maxRecvCount);
+
+  COMMCHECK_TEST(ctranComm->ctran_->commRegister(recvbuf, recvBytes, &recvHdl));
+  meta::comms::Hints hints;
+  CtranPersistentRequest* request;
+  const auto initMaxRecvCount =
+      maxRecvCount * commTypeSize(dt) / commTypeSize(commInt8);
+  COMMCHECK_TEST(
+      ctran::allGatherPInit(
+          recvbuf,
+          initMaxRecvCount,
+          hints,
+          commInt8,
+          ctranComm.get(),
+          stream,
+          request));
+  ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+  SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", "ctpat");
+  ASSERT_EQ(
+      ctran::allGatherPExec(sendbuf, count, dt, request), commInvalidUsage);
+
+  ASSERT_EQ(ctran::allGatherPDestroy(request), commSuccess);
+  delete request;
+  COMMCHECK_TEST(ctranComm->ctran_->commDeregister(recvHdl));
+  memoryCleanUp(kMemCudaMalloc);
 }
 
 TEST_F(CtranAllgatherPTest, InvalidPreq) {
@@ -706,7 +758,8 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(
             NCCL_ALLGATHER_P_ALGO::ctdirect,
             NCCL_ALLGATHER_P_ALGO::ctpipeline,
-            NCCL_ALLGATHER_P_ALGO::ctrdpipeline)),
+            NCCL_ALLGATHER_P_ALGO::ctrdpipeline,
+            NCCL_ALLGATHER_P_ALGO::ctpat)),
     getTestName);
 
 int main(int argc, char* argv[]) {

--- a/comms/pipes/BarrierState.cuh
+++ b/comms/pipes/BarrierState.cuh
@@ -129,7 +129,7 @@ struct alignas(128) BarrierState {
 };
 
 /**
- * getBarrierBufferSize - Calculate buffer size for multiple barriers
+ * get_barrier_buffer_size - Calculate buffer size for multiple barriers
  *
  * Computes the total memory needed to store 'count' BarrierState objects,
  * aligned to 128 bytes for optimal GPU memory access.
@@ -137,7 +137,7 @@ struct alignas(128) BarrierState {
  * @param count Number of barriers to allocate
  * @return Size in bytes, aligned to 128-byte boundary
  */
-__host__ __device__ __forceinline__ std::size_t getBarrierBufferSize(
+__host__ __device__ __forceinline__ std::size_t get_barrier_buffer_size(
     int count) {
   return bitops::alignUp(count * sizeof(BarrierState), 128);
 }

--- a/comms/pipes/ChunkState.cuh
+++ b/comms/pipes/ChunkState.cuh
@@ -211,9 +211,9 @@ __device__ __forceinline__ void ChunkState::wait_ready_to_recv(
     TIMEOUT_TRAP_IF_EXPIRED(
         timeout,
         group,
-        "ChunkState::wait_ready_to_recv waiting for stepId=%zu "
+        "ChunkState::wait_ready_to_recv waiting for stepId=%llu "
         "(current=%d)",
-        stepId,
+        static_cast<unsigned long long>(stepId),
         current_value);
   }
 }

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -141,7 +141,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
 
   // Conditionally allocate barrier buffer
   if (config_.p2pBarrierCount > 0) {
-    perPeerBarrierBufferSize_ = getBarrierBufferSize(config_.p2pBarrierCount);
+    perPeerBarrierBufferSize_ =
+        get_barrier_buffer_size(config_.p2pBarrierCount);
     std::size_t totalBarrierSize = perPeerBarrierBufferSize_ * (nRanks_ - 1);
     barrierBufferHandler_ = std::make_unique<GpuMemHandler>(
         bootstrap_, myRank_, nRanks_, totalBarrierSize, memSharingMode_);

--- a/comms/pipes/benchmarks/BarrierBench.cc
+++ b/comms/pipes/benchmarks/BarrierBench.cc
@@ -13,7 +13,7 @@
 #include "comms/utils/CudaRAII.h"
 
 using comms::pipes::BarrierState;
-using comms::pipes::getBarrierBufferSize;
+using comms::pipes::get_barrier_buffer_size;
 using meta::comms::DeviceBuffer;
 
 namespace comms::pipes::benchmark {
@@ -47,7 +47,7 @@ static void barrierBench(
   // For block groups: 1 Barrier per block
   // For warp groups: 8 Barriers per block (256 threads / 32 threads per warp)
   int numBarriers = useBlockGroups ? nBlocks : nBlocks * (nThreads / 32);
-  std::size_t barrierBufferSize = getBarrierBufferSize(numBarriers);
+  std::size_t barrierBufferSize = get_barrier_buffer_size(numBarriers);
 
   // Allocate barrier buffers on each GPU
   CHECK_EQ(cudaSetDevice(gpu0), cudaSuccess);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2005,7 +2005,7 @@ cvars:
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum
    default     : ctpipeline
-   choices     : ctdirect, ctpipeline, ctrdpipeline, ctpat
+   choices     : ctdirect, ctpipeline, ctrdpipeline, ctpat, ctpatcopy
    description : |-
      The algorithm to use for AllgatherP communication
      ctdirect - Ctran-based direct point-to-point algorithm
@@ -2017,6 +2017,17 @@ cvars:
      ctpat - PAT (Parallel Asynchronous Tiled) butterfly algorithm for NVL x IB.
              Rail-parallel recursive doubling across nodes with NVL CE broadcast.
              Requires nNodes to be a power of 2.
+     ctpatcopy - Copy-based PAT butterfly with staging buffers for NVL x IB.
+                 Routes IB transfers through pre-registered staging buffers.
+                 Requires nNodes power of 2 and nLocalRanks > 1.
+
+ - name        : NCCL_CTRAN_ALLGATHERP_PATCOPY_STAGING_BUF_SIZE
+   type        : int64_t
+   default     : 33554432
+   description : |-
+     Size in bytes of each staging buffer (send and recv) for the ctpatcopy
+     AllGatherP algorithm. Total staging memory is 2x this value.
+     Default is 32MB per buffer (64MB total).
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2005,7 +2005,7 @@ cvars:
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum
    default     : ctpipeline
-   choices     : ctdirect, ctpipeline, ctrdpipeline
+   choices     : ctdirect, ctpipeline, ctrdpipeline, ctpat
    description : |-
      The algorithm to use for AllgatherP communication
      ctdirect - Ctran-based direct point-to-point algorithm
@@ -2014,6 +2014,9 @@ cvars:
      ctrdpipeline - Ctran-based hybrid algorithm that does recursive doubling across
                     rails for inter-node exchange and CopyEngine based broadcast
                     within the NVLink domain. Requires nNodes to be a power of 2.
+     ctpat - PAT (Parallel Asynchronous Tiled) butterfly algorithm for NVL x IB.
+             Rail-parallel recursive doubling across nodes with NVL CE broadcast.
+             Requires nNodes to be a power of 2.
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1771,6 +1771,16 @@ cvars:
      Number of times to retry after receiving an RNR NAK.
      7 means infinite retry.
 
+ - name        : NCCL_CTRAN_ASSUME_HIDDEN_LOCAL_PEERS_NVL
+   type        : bool
+   default     : false
+   description : |-
+     When a local peer's GPU is not visible to this process (e.g. under
+     CUDA_VISIBLE_DEVICES isolation from torchrun), assume the peer is
+     NVLink-reachable. Enable this only on hosts known to have full
+     intra-node NVLink mesh (e.g. HGX H100/H200 with NVSwitch).
+     Default false: invisible peers are conservatively not marked as NVL.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket


### PR DESCRIPTION
Summary:
Pipes Guardian automated code quality fixes (3/3 LLM agreement, 0.95 confidence):

1. Rename `getBarrierBufferSize` to `get_barrier_buffer_size` to match the library's snake_case convention for all functions/methods. Updated all 3 call sites (definition, BarrierBench.cc, MultiPeerNvlTransport.cc).

2. Fix CUDA printf format mismatch in ChunkState::wait_ready_to_recv: replace `%zu` with `%llu` and add `static_cast<unsigned long long>()` for the `size_t` argument. CUDA device-side printf does not support the `z` length modifier, which can produce garbage output. This matches the correct pattern already used in BarrierState::wait.

Differential Revision: D103738398
