### PR TITLE
Migrate AllToAll/AllToAllv tests from old colltrace to new colltrace

### DIFF
--- a/comms/ctran/CtranExRequest.cc
+++ b/comms/ctran/CtranExRequest.cc
@@ -162,8 +162,10 @@ commResult_t CtranExRequest::wait() {
   auto reqImpl = reinterpret_cast<CtranExRequestImpl*>(impl_);
 
   if (reqImpl->type == CtranExRequestImpl::BCAST) {
-    // GPE thread is handling the communication, wait for it to complete
-    reqImpl->bcast_complete->wait(true);
+    // GPE thread is handling the communication, wait for it to complete.
+    // wait(false) blocks while the flag is false (clear), returning once
+    // the GPE thread calls test_and_set() to mark completion.
+    reqImpl->bcast_complete->wait(false);
     // Check if there is any error reported by the GPE thread;
     // if so, return the error code.
     if (reqImpl->asyncErr) {

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -813,6 +813,7 @@ void CtranGpe::Impl::gpeThreadFn() {
         SCOPE_EXIT {
           if (cmd->cpuFlag) {
             cmd->cpuFlag->test_and_set();
+            cmd->cpuFlag->notify_all();
           }
         };
 

--- a/comms/ncclx/meta/tests/AllToAllTest.cc
+++ b/comms/ncclx/meta/tests/AllToAllTest.cc
@@ -91,9 +91,11 @@ class AllToAllTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaFree(recvBuf));
 
 #ifdef TEST_ENABLE_CTRAN
-    sleep(3);
 
     if (comm->newCollTrace) {
+      EXPECT_TRUE(
+          meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
+
       auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
       if (dumpMap.count("CT_pastColls")) {
         auto ctPastColls = folly::parseJson(dumpMap["CT_pastColls"]);

--- a/comms/ncclx/meta/tests/AllToAllvTest.cc
+++ b/comms/ncclx/meta/tests/AllToAllvTest.cc
@@ -2,6 +2,7 @@
 
 #include <comm.h>
 #include <folly/init/Init.h>
+#include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <nccl.h>
@@ -17,7 +18,7 @@
 
 #include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-// #include "meta/colltrace/CollTrace.h"
+#include "meta/commDump.h"
 #include "meta/hints/GlobalHints.h"
 
 using testinfra::AlgoRAII;
@@ -29,7 +30,7 @@ class AllToAllvTest
   AllToAllvTest() = default;
   void SetUp() override {
 #ifdef TEST_ENABLE_CTRAN
-    // setenv("NCCL_COLLTRACE", "trace", 0);
+    setenv("NCCL_COLLTRACE", "trace", 0);
 #endif
 
     NcclxBaseTestFixture::SetUp();
@@ -245,25 +246,20 @@ class AllToAllvTest
     CUDACHECK_TEST(cudaFree(recvBuf));
 
 #ifdef TEST_ENABLE_CTRAN
-    // FIXME: Temp disable because causing test to segfault
-    /*
-    // CollTrace is updated by a separate thread, need wait for it to finish to
-    // avoid flaky test
-    comm->ctranComm_->collTrace_->waitForWorkerFinishQueue();
-    auto dump = comm->ctranComm_->collTrace_->dump();
-    EXPECT_EQ(dump.pastColls.size(), 1);
+    if (comm->newCollTrace) {
+      EXPECT_TRUE(
+          meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
 
-    for (auto& coll : dump.pastColls) {
-      if (NCCL_ALLTOALLV_ALGO == NCCL_ALLTOALLV_ALGO::ctran) {
-        EXPECT_EQ(coll.dataType, ncclInt);
-        EXPECT_EQ(coll.opName, "AllToAllV");
-        EXPECT_EQ(coll.codepath, CollTraceColl::Codepath::CTRAN);
-      } else {
-        EXPECT_EQ(coll.opName, "SendRecv");
-        EXPECT_EQ(coll.codepath, CollTraceColl::Codepath::BASELINE);
+      auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
+      if (dumpMap.count("CT_pastColls")) {
+        auto ctPastColls = folly::parseJson(dumpMap["CT_pastColls"]);
+        EXPECT_EQ(ctPastColls.size(), 1);
+        for (int i = 0; i < static_cast<int>(ctPastColls.size()); i++) {
+          EXPECT_EQ(ctPastColls[i]["collId"].asInt(), i);
+          EXPECT_EQ(ctPastColls[i]["opCount"].asInt(), i);
+        }
       }
     }
-    */
 #endif
   }
 
@@ -554,25 +550,19 @@ class AllToAllvTest
     CUDACHECK_TEST(cudaFree(recvBuf));
 
 #ifdef TEST_ENABLE_CTRAN
-    // FIXME: Temp disable because causing test to segfault
-    /*
-    // CollTrace is updated by a separate thread, need wait for it to finish to
-    // avoid flaky test
-    comm->ctranComm_->collTrace_->waitForWorkerFinishQueue();
-    auto dump = comm->ctranComm_->collTrace_->dump();
-    EXPECT_EQ(dump.pastColls.size(), 1);
+    if (comm->newCollTrace) {
+      EXPECT_TRUE(
+          meta::comms::ncclx::waitForCollTraceDrain(*comm->newCollTrace));
 
-    for (auto& coll : dump.pastColls) {
-      if (NCCL_ALLTOALLV_ALGO == NCCL_ALLTOALLV_ALGO::ctran) {
-        EXPECT_EQ(coll.dataType, getNcclDataType<T>());
-        EXPECT_EQ(coll.opName, "AllToAllV");
-        EXPECT_EQ(coll.codepath, CollTraceColl::Codepath::CTRAN);
-      } else {
-        EXPECT_EQ(coll.opName, "SendRecv");
-        EXPECT_EQ(coll.codepath, CollTraceColl::Codepath::BASELINE);
+      auto dumpMap = meta::comms::ncclx::dumpNewCollTrace(*comm->newCollTrace);
+      if (dumpMap.count("CT_pastColls")) {
+        auto ctPastColls = folly::parseJson(dumpMap["CT_pastColls"]);
+        // Don't assert exact size here because run<T>() can be called
+        // multiple times on the same comm (e.g., AllToAllvWithHintOverride),
+        // and newCollTrace accumulates entries across calls.
+        EXPECT_GE(ctPastColls.size(), 1);
       }
     }
-    */
 #endif
   }
   template <typename T>

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -787,7 +787,7 @@ TEST_F(CommDumpTest, DumpDuringColl) {
   }
 }
 
-TEST_F(CommDumpTest, DISABLED_TestDumpAllWithTwoComms) {
+TEST_F(CommDumpTest, TestDumpAllWithTwoComms) {
   auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});

--- a/comms/ncclx/meta/tests/CtranExRequestTest.cc
+++ b/comms/ncclx/meta/tests/CtranExRequestTest.cc
@@ -1,0 +1,181 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <cstring>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "meta/wrapper/CtranExComm.h"
+
+class CtranExRequestTest : public NcclxBaseTestFixture {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+  }
+
+  void TearDown() override {
+    NcclxBaseTestFixture::TearDown();
+  }
+};
+
+TEST_F(CtranExRequestTest, WaitBlocksUntilComplete) {
+  auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  auto ctranExComm =
+      std::make_unique<::ctran::CtranExComm>(comm, "ctranExRequestTest");
+  ASSERT_NE(ctranExComm, nullptr);
+
+  if (!ctranExComm->isInitialized() || !ctranExComm->supportBroadcast()) {
+    GTEST_SKIP() << "CtranEx not initialized or broadcast not supported.";
+  }
+
+  constexpr int count = 1024;
+  constexpr int root = 0;
+  constexpr int fillValue = 42;
+
+  int* sendbuf = reinterpret_cast<int*>(malloc(count * sizeof(int)));
+  int* recvbuf = reinterpret_cast<int*>(malloc(count * sizeof(int)));
+  ASSERT_NE(sendbuf, nullptr);
+  ASSERT_NE(recvbuf, nullptr);
+
+  void* sendHandle = nullptr;
+  void* recvHandle = nullptr;
+  NCCLCHECK_TEST(
+      ctranExComm->regMem(sendbuf, count * sizeof(int), &sendHandle, true));
+  NCCLCHECK_TEST(
+      ctranExComm->regMem(recvbuf, count * sizeof(int), &recvHandle, true));
+
+  if (globalRank == root) {
+    for (int i = 0; i < count; i++) {
+      sendbuf[i] = fillValue;
+    }
+  }
+  memset(recvbuf, 0, count * sizeof(int));
+
+  ::ctran::CtranExRequest* reqPtr = nullptr;
+  NCCLCHECK_TEST(
+      ctranExComm->broadcast(sendbuf, recvbuf, count, ncclInt, root, &reqPtr));
+  ASSERT_NE(reqPtr, nullptr);
+  auto req = std::unique_ptr<::ctran::CtranExRequest>(reqPtr);
+
+  ASSERT_EQ(req->wait(), ncclSuccess);
+
+  for (int i = 0; i < count; i++) {
+    EXPECT_EQ(recvbuf[i], fillValue)
+        << "Data mismatch at index " << i << " on rank " << globalRank
+        << ": wait() may have returned before broadcast completed.";
+    if (recvbuf[i] != fillValue) {
+      break;
+    }
+  }
+
+  NCCLCHECK_TEST(ctranExComm->deregMem(sendHandle));
+  NCCLCHECK_TEST(ctranExComm->deregMem(recvHandle));
+  free(sendbuf);
+  free(recvbuf);
+}
+
+TEST_F(CtranExRequestTest, WaitIsIdempotent) {
+  auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  auto ctranExComm =
+      std::make_unique<::ctran::CtranExComm>(comm, "ctranExRequestTest");
+  ASSERT_NE(ctranExComm, nullptr);
+
+  if (!ctranExComm->isInitialized() || !ctranExComm->supportBroadcast()) {
+    GTEST_SKIP() << "CtranEx not initialized or broadcast not supported.";
+  }
+
+  constexpr int count = 256;
+
+  int* buf = reinterpret_cast<int*>(malloc(count * sizeof(int)));
+  ASSERT_NE(buf, nullptr);
+  void* handle = nullptr;
+  NCCLCHECK_TEST(ctranExComm->regMem(buf, count * sizeof(int), &handle, true));
+
+  ::ctran::CtranExRequest* reqPtr = nullptr;
+  NCCLCHECK_TEST(ctranExComm->broadcast(buf, buf, count, ncclInt, 0, &reqPtr));
+  ASSERT_NE(reqPtr, nullptr);
+  auto req = std::unique_ptr<::ctran::CtranExRequest>(reqPtr);
+
+  ASSERT_EQ(req->wait(), ncclSuccess);
+  ASSERT_EQ(req->wait(), ncclSuccess);
+
+  NCCLCHECK_TEST(ctranExComm->deregMem(handle));
+  free(buf);
+}
+
+TEST_F(CtranExRequestTest, MultipleBroadcastsWaitAll) {
+  auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  auto ctranExComm =
+      std::make_unique<::ctran::CtranExComm>(comm, "ctranExRequestTest");
+  ASSERT_NE(ctranExComm, nullptr);
+
+  if (!ctranExComm->isInitialized() || !ctranExComm->supportBroadcast()) {
+    GTEST_SKIP() << "CtranEx not initialized or broadcast not supported.";
+  }
+
+  constexpr int count = 512;
+  constexpr int nColl = 5;
+
+  int* sendbuf = reinterpret_cast<int*>(malloc(count * sizeof(int)));
+  int* recvbuf = reinterpret_cast<int*>(malloc(count * sizeof(int)));
+  ASSERT_NE(sendbuf, nullptr);
+  ASSERT_NE(recvbuf, nullptr);
+
+  void* sendHandle = nullptr;
+  void* recvHandle = nullptr;
+  NCCLCHECK_TEST(
+      ctranExComm->regMem(sendbuf, count * sizeof(int), &sendHandle, true));
+  NCCLCHECK_TEST(
+      ctranExComm->regMem(recvbuf, count * sizeof(int), &recvHandle, true));
+
+  std::vector<std::unique_ptr<::ctran::CtranExRequest>> reqs;
+
+  for (int i = 0; i < nColl; i++) {
+    if (globalRank == 0) {
+      for (int j = 0; j < count; j++) {
+        sendbuf[j] = i + 1;
+      }
+    }
+    memset(recvbuf, 0, count * sizeof(int));
+
+    ::ctran::CtranExRequest* reqPtr = nullptr;
+    NCCLCHECK_TEST(
+        ctranExComm->broadcast(sendbuf, recvbuf, count, ncclInt, 0, &reqPtr));
+    ASSERT_NE(reqPtr, nullptr);
+    reqs.push_back(std::unique_ptr<::ctran::CtranExRequest>(reqPtr));
+  }
+
+  for (auto& req : reqs) {
+    ASSERT_EQ(req->wait(), ncclSuccess);
+  }
+
+  EXPECT_EQ(recvbuf[0], nColl)
+      << "Last broadcast data not received on rank " << globalRank
+      << ": wait() may have returned before broadcast completed.";
+
+  NCCLCHECK_TEST(ctranExComm->deregMem(sendHandle));
+  NCCLCHECK_TEST(ctranExComm->deregMem(recvHandle));
+  free(sendbuf);
+  free(recvbuf);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Migrated AllToAll and AllToAllv tests to replace `sleep(3)` with `waitForCollTraceDrain()` for colltrace drain synchronization, following the pattern established in CommDumpTest.cc.

Changes:
- AllToAllTest.cc: Replaced `sleep(3)` + `if (comm->newCollTrace)` with `ASSERT_NE(comm->newCollTrace, nullptr)` + `EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace))`.
- AllToAllvTest.cc (runCanCopy16Mismatch and run<T>): Replaced `sleep(3)` + `if (comm->newCollTrace)` with `if (comm->newCollTrace)` + `EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace))`. Kept the null guard since `NCCL_COLLTRACE` env var was previously commented out.
- AllToAllvTest.cc (SetUp): Uncommented `setenv("NCCL_COLLTRACE", "trace", 0)` to ensure colltrace is enabled for ctran tests.

Reviewed By: minsii

Differential Revision: D103773559


