### PR TITLE
Fix ncclTopoNeedFlush to enable flush on GB200 PATH_P2C topology (#2372)

### DIFF
--- a/comms/ncclx/v2_29/src/graph/paths.cc
+++ b/comms/ncclx/v2_29/src/graph/paths.cc
@@ -585,6 +585,14 @@ ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev,
   if (gpu->paths[NET][n].type <= PATH_PXB && gpu->paths[CPU][c].type == PATH_C2C) {
     *flush = 1;
   }
+  // [META] PATH_P2C (C2C to CPU + PCIe to NIC) also requires flush: RDMA data
+  // arrives via PCIe while the proxy tail update reaches GPU via a different path,
+  // with no cross-path ordering guarantee.
+  int netPathType = gpu->paths[NET][n].type;
+  int cpuPathType = gpu->paths[CPU][c].type;
+  if (NCCL_ENABLE_P2C_RDMA_FLUSH && netPathType == PATH_P2C && cpuPathType == PATH_C2C) {
+    *flush = 1;
+  }
   return ncclSuccess;
 }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -539,6 +539,16 @@ cvars:
    default     : 0
    description : https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-net-force-flush
 
+ - name        : NCCL_ENABLE_P2C_RDMA_FLUSH
+   type        : bool
+   default     : true
+   description : |-
+     Enable RDMA READ flush for PATH_P2C topology (C2C to CPU + PCIe to NIC)
+     on GB200. When RDMA data arrives via PCIe and the proxy tail update reaches
+     GPU via a different path (C2C), there is no cross-path ordering guarantee.
+     The flush drains pending PCIe writes before signaling the GPU kernel.
+     Set to false to disable for performance comparison.
+
  - name        : NCCL_NET_DISABLE_INTRA
    type        : int64_t
    default     : 0


### PR DESCRIPTION
Summary:

On GB200, the flush condition in ncclTopoNeedFlush excludes PATH_P2C (6) because it only checks `netPathType <= PATH_PXB (5)`. PATH_P2C represents exactly the split-path topology (RDMA data via PCIe, proxy flag via C2C) that flush is designed to protect against. Without flush, the GPU kernel may read stale RDMA data after observing the tail pointer update.

- Fix: add `|| netPathType == PATH_P2C` to the C2C flush condition
- Add investigation doc with full analysis, code pointers, and test log evidence from MAST job torchx-ctrd-qp2-gdc-ag-n8ppn1-nolocal-576

Reviewed By: jspark1105

Differential Revision: D103775295


