### PR TITLE
Add cross-NIC PCIe flush for multi-NIC platforms

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
@@ -159,6 +159,21 @@ static commResult_t impl(
     timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
 
+    // Flush received data to ensure: (1) cross-NIC DMA visibility before
+    // next step reads it as iput source (multi-NIC platforms have no
+    // cross-device PCIe ordering guarantee), and (2) GPU-read-after-RDMA-write
+    // visibility if a GPU kernel is scheduled before CPU observes RDMA write
+    // completion.
+    {
+      CtranMapperRequest* rawFlushReq = nullptr;
+      FB_COMMCHECK(
+          comm->ctran_->mapper->iflush(recvbuff, memHdl, &rawFlushReq));
+      std::unique_ptr<CtranMapperRequest> flushReq(rawFlushReq);
+      if (flushReq) {
+        FB_COMMCHECK(comm->ctran_->mapper->waitRequest(flushReq.get()));
+      }
+    }
+
     CTRAN_PROFILER_IF(
         profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
   }

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -328,8 +328,12 @@ CtranIb::CtranIb(
     // https://ontrack.amd.com/browse/FBA-633
     enableLocalFlush_ = true;
 #else
-    // Turn on flush for NVidia GPUs older than H100
-    enableLocalFlush_ = comm->statex_->cudaArch() < 900;
+    // Turn on flush for NVidia GPUs older than H100, or when using
+    // multiple NICs with flush enabled (cross-NIC DMA writes have no PCIe
+    // ordering guarantee on ARM SoCs, requiring an explicit RDMA READ
+    // flush per device).
+    enableLocalFlush_ = comm->statex_->cudaArch() < 900 ||
+        (NCCL_CTRAN_IB_DEVICES_PER_RANK > 1 && NCCL_CTRAN_IB_MULTI_NIC_FLUSH);
 #endif
   }
   init(
@@ -347,9 +351,10 @@ CtranIb::CtranIb(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-IB: Initialized {} from comm {}",
+      "CTRAN-IB: Initialized {} from comm {} enableLocalFlush {}",
       (void*)this,
-      (void*)comm);
+      (void*)comm,
+      this->enableLocalFlush);
 }
 
 CtranIb::CtranIb(
@@ -382,12 +387,13 @@ CtranIb::CtranIb(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-IB: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {}",
+      "CTRAN-IB: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {} enableLocalFlush {}",
       (void*)this,
       rank,
       cudaDev,
       commHash,
-      commDesc);
+      commDesc,
+      this->enableLocalFlush);
 }
 
 void CtranIb::init(

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -123,7 +123,12 @@ commResult_t LocalVirtualConn::iflush(
         (void*)req);
   }
 
-  outstandingReqs_.push_back(req);
+  // Push one entry per device CQE. Only the last carries the actual req;
+  // earlier entries are nullptr so processCqe drains them without completing.
+  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    outstandingReqs_.push_back(
+        device == NCCL_CTRAN_IB_DEVICES_PER_RANK - 1 ? req : nullptr);
+  }
 
   return commSuccess;
 }
@@ -136,10 +141,13 @@ commResult_t LocalVirtualConn::processCqe(
       opcode);
 
   // Since each flush is executed by network one by one, we complete each flush
-  // as simple FIFO.
+  // as simple FIFO. With multi-NIC, each iflush posts one RDMA READ per
+  // device; only the last entry carries the request to complete.
   auto req = outstandingReqs_.front();
   outstandingReqs_.pop_front();
-  FB_COMMCHECK(req->complete());
+  if (req) {
+    FB_COMMCHECK(req->complete());
+  }
 
   return commSuccess;
 }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -613,12 +613,23 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return commSuccess;
     }
 
+    // regHdl from searchRegHandle is a RegElem*; extract the IB-level
+    // registration handle that LocalVirtualConn::iflush expects.
+    auto* regElem =
+        reinterpret_cast<ctran::regcache::RegElem*>(const_cast<void*>(regHdl));
+    if (!regElem) {
+      CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+      return commSuccess;
+    }
+
+    auto regLk = regElem->stateMnger.rlock();
+
     CtranIbRequest* ibReq = nullptr;
     if (req) {
       *req = new CtranMapperRequest();
       ibReq = &((*req)->ibReq);
     }
-    FB_COMMCHECK(this->ctranIb->iflush(buf, regHdl, ibReq));
+    FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
     return commSuccess;
   }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1518,6 +1518,16 @@ cvars:
      per CQ. For example, setting to 32768 keeps per-CQ memory at ~2MB.
      Default -1 to use the device-reported maximum.
 
+ - name        : NCCL_CTRAN_IB_MULTI_NIC_FLUSH
+   type        : int
+   default     : 1
+   description : |-
+     Enable PCIe flush (RDMA READ) when using multiple NICs per rank
+     (NCCL_CTRAN_IB_DEVICES_PER_RANK > 1). On platforms where each NIC is a
+     separate PCIe requester (e.g. GB200 ARM SoC), cross-NIC DMA writes have
+     no ordering guarantee. The flush drains pending writes before the next
+     step reads the received data. Set to 0 to disable for debugging.
+
  - name        : NCCL_CTRAN_IB_DEVICES_PER_RANK
    type        : int
    default     : 1


### PR DESCRIPTION
Summary:
## Problem:
- On GB200 (ARM Grace SoC + NVLink-C2C), when using 2 NICs per rank (NCCL_CTRAN_IB_DEVICES_PER_RANK=2), multi-step forwarding algorithms like AllGather RecDbl (ctrd) produce incorrect results. The corruption manifests as partially zero data in the receive buffer.
- Root cause: each NIC is a separate PCIe requester. When NIC0 writes data to GPU HBM via RDMA (incoming), and NIC1 later reads from the same GPU HBM address for forwarding (outgoing iput), the ARM SoC does not guarantee cross-port PCIe ordering. NIC1's DMA read may return stale (zero) data that NIC0 wrote but hasn't been committed through the SoC interconnect yet.
- This differs from ncclx's proxy model where the GPU kernel acts as a coherency bridge between receive and forward — ctran's host-side algorithms bypass the GPU and have direct NIC-to-NIC data forwarding.

Cross-NIC data flow (ctrd step i receive, step i+1 forward):

(1) Incoming RDMA write (step i): Remote rank -> NIC0 -> PCIe port A -> ARM Grace SoC -> NVLink-C2C bridge -> GPU HBM. CQE delivered to host memory, waitNotify returns.

(2) Outgoing RDMA read (step i+1): NIC1 -> PCIe port B -> ARM Grace SoC -> NVLink-C2C bridge -> GPU HBM (reading same address that NIC0 wrote in step 1).

## The race:
PCIe only guarantees read-after-write ordering for the SAME requester. NIC0 and NIC1 are different PCIe requesters entering the ARM SoC through different PCIe ports. The SoC's internal interconnect may still have NIC0's write buffered (not yet committed to GPU HBM) when NIC1's read arrives through a different port. NIC1's read returns stale zeros.

## The iflush fix:
After waitNotify, issue an RDMA READ on each NIC device. Each RDMA READ forces that NIC's PCIe port to drain its pending writes through the SoC to GPU HBM. Once all per-device flushes complete, subsequent reads from any NIC will see the committed data.

## Repro:
Why nQP=2 reliably reproduces but nQP=16 (prod config) does not:
- With DEVICES_PER_RANK=2, QPs are distributed across 2 NICs. With nQP=2 (1 QP per NIC), the round-robin QP selection guarantees cross-NIC forwarding for small messages: step i receives on NIC0, step i+1 forwards via NIC1 (or vice versa).
- With nQP=16 (8 QPs per NIC, block distribution), small messages (<=4 iputs per step) all land on QP0-QP3 which are all on NIC0. No cross-NIC forwarding occurs, so no ordering violation.
- For large messages with nQP=16, chunks do span both NICs, but the longer transfer time provides implicit delay for cross-port writes to commit — hiding the race. The bug still exists in prod config and could manifest under different timing conditions.

## Fix:
- Add NCCL_CTRAN_IB_MULTI_NIC_FLUSH CVAR (default 1) to gate the fix
- Enable enableLocalFlush when DEVICES_PER_RANK > 1 and CVAR is set
- Add iflush (RDMA READ per NIC device) after waitNotify in ctrd step loop to drain cross-port PCIe writes before forwarding
- Fix CtranMapper::iflush to extract IB-level handle (ibRegElem) from mapper-level RegElem handle — the previous implementation passed the wrong handle type, which was never caught because enableLocalFlush was always false on H100+
- Fix LocalVirtualConn::processCqe to handle multiple CQEs per iflush (one per NIC device) — previously only tracked 1 outstanding request but generated DEVICES_PER_RANK CQEs, causing SIGSEGV on the second CQE

## Performance impact
ctrd, 8 ranks, 1x8 nolocal, GB200, QP=2, 2 NICs, dqplb:
- Each flush adds ~9us. In multi-step algorithm, it would add nSteps * 9us for overall collective latency (see detailed data in test plan)

Reviewed By: dsjohns2

Differential Revision: D103503273


