### PR TITLE
Add cross-NIC PCIe flush to AllGatherP (ctrdpipeline + ctpipeline) (#2376)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
@@ -159,6 +159,19 @@ static commResult_t impl(
     timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
 
+    // Flush received data to ensure cross-NIC DMA visibility before next
+    // step reads it as iput source (multi-NIC platforms have no cross-device
+    // PCIe ordering guarantee). Skip last step — no forwarding after it.
+    if (i < nSteps - 1) {
+      CtranMapperRequest* rawFlushReq = nullptr;
+      FB_COMMCHECK(
+          comm->ctran_->mapper->iflush(recvbuff, memHdl, &rawFlushReq));
+      std::unique_ptr<CtranMapperRequest> flushReq(rawFlushReq);
+      if (flushReq) {
+        FB_COMMCHECK(comm->ctran_->mapper->waitRequest(flushReq.get()));
+      }
+    }
+
     CTRAN_PROFILER_IF(
         profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
   }

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -120,6 +120,18 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
     // Wait till received data from upstream peer
     FB_COMMCHECK(mapper->waitNotify(notify.get()));
 
+    // Drain cross-NIC PCIe writes — multi-NIC platforms have no cross-port
+    // ordering, so the next iput / CE bcast may otherwise read stale data.
+    {
+      CtranMapperRequest* rawFlushReq = nullptr;
+      FB_COMMCHECK(
+          mapper->iflush(pArgs->recvbuff, pArgs->recvHdl, &rawFlushReq));
+      std::unique_ptr<CtranMapperRequest> flushReq(rawFlushReq);
+      if (flushReq) {
+        FB_COMMCHECK(mapper->waitRequest(flushReq.get()));
+      }
+    }
+
     // Kick off local broadcast of the received data
     resource->pipeSync->post(step);
   }

--- a/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
@@ -201,6 +201,18 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
 
+    // Drain cross-NIC PCIe writes — multi-NIC platforms have no cross-port
+    // ordering, so the next iput / CE bcast may otherwise read stale data
+    {
+      CtranMapperRequest* rawFlushReq = nullptr;
+      FB_COMMCHECK(
+          mapper->iflush(pArgs->recvbuff, pArgs->recvHdl, &rawFlushReq));
+      std::unique_ptr<CtranMapperRequest> flushReq(rawFlushReq);
+      if (flushReq) {
+        FB_COMMCHECK(mapper->waitRequest(flushReq.get()));
+      }
+    }
+
     // Notify the stream that step `i` IB exchange is done. The stream can
     // now issue the intra-node CE broadcast for the 2^i chunks just
     // received at column `localRank`.

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -328,8 +328,12 @@ CtranIb::CtranIb(
     // https://ontrack.amd.com/browse/FBA-633
     enableLocalFlush_ = true;
 #else
-    // Turn on flush for NVidia GPUs older than H100
-    enableLocalFlush_ = comm->statex_->cudaArch() < 900;
+    // Turn on flush for NVidia GPUs older than H100, or when using
+    // multiple NICs with flush enabled (cross-NIC DMA writes have no PCIe
+    // ordering guarantee on ARM SoCs, requiring an explicit RDMA READ
+    // flush per device).
+    enableLocalFlush_ = comm->statex_->cudaArch() < 900 ||
+        (NCCL_CTRAN_IB_DEVICES_PER_RANK > 1 && NCCL_CTRAN_IB_MULTI_NIC_FLUSH);
 #endif
   }
   init(
@@ -347,9 +351,10 @@ CtranIb::CtranIb(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-IB: Initialized {} from comm {}",
+      "CTRAN-IB: Initialized {} from comm {} enableLocalFlush {}",
       (void*)this,
-      (void*)comm);
+      (void*)comm,
+      this->enableLocalFlush);
 }
 
 CtranIb::CtranIb(
@@ -382,12 +387,13 @@ CtranIb::CtranIb(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-IB: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {}",
+      "CTRAN-IB: Initialized {} from rank {} cudaDev {} commHash {:x} commDesc {} enableLocalFlush {}",
       (void*)this,
       rank,
       cudaDev,
       commHash,
-      commDesc);
+      commDesc,
+      this->enableLocalFlush);
 }
 
 void CtranIb::init(

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -123,7 +123,12 @@ commResult_t LocalVirtualConn::iflush(
         (void*)req);
   }
 
-  outstandingReqs_.push_back(req);
+  // Push one entry per device CQE. Only the last carries the actual req;
+  // earlier entries are nullptr so processCqe drains them without completing.
+  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    outstandingReqs_.push_back(
+        device == NCCL_CTRAN_IB_DEVICES_PER_RANK - 1 ? req : nullptr);
+  }
 
   return commSuccess;
 }
@@ -136,10 +141,13 @@ commResult_t LocalVirtualConn::processCqe(
       opcode);
 
   // Since each flush is executed by network one by one, we complete each flush
-  // as simple FIFO.
+  // as simple FIFO. With multi-NIC, each iflush posts one RDMA READ per
+  // device; only the last entry carries the request to complete.
   auto req = outstandingReqs_.front();
   outstandingReqs_.pop_front();
-  FB_COMMCHECK(req->complete());
+  if (req) {
+    FB_COMMCHECK(req->complete());
+  }
 
   return commSuccess;
 }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -613,12 +613,23 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return commSuccess;
     }
 
+    // regHdl from searchRegHandle is a RegElem*; extract the IB-level
+    // registration handle that LocalVirtualConn::iflush expects.
+    auto* regElem =
+        reinterpret_cast<ctran::regcache::RegElem*>(const_cast<void*>(regHdl));
+    if (!regElem || !regElem->ibRegElem) {
+      CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+      return commSuccess;
+    }
+
+    auto regLk = regElem->stateMnger.rlock();
+
     CtranIbRequest* ibReq = nullptr;
     if (req) {
       *req = new CtranMapperRequest();
       ibReq = &((*req)->ibReq);
     }
-    FB_COMMCHECK(this->ctranIb->iflush(buf, regHdl, ibReq));
+    FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
     return commSuccess;
   }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1518,6 +1518,16 @@ cvars:
      per CQ. For example, setting to 32768 keeps per-CQ memory at ~2MB.
      Default -1 to use the device-reported maximum.
 
+ - name        : NCCL_CTRAN_IB_MULTI_NIC_FLUSH
+   type        : int
+   default     : 1
+   description : |-
+     Enable PCIe flush (RDMA READ) when using multiple NICs per rank
+     (NCCL_CTRAN_IB_DEVICES_PER_RANK > 1). On platforms where each NIC is a
+     separate PCIe requester (e.g. GB200 ARM SoC), cross-NIC DMA writes have
+     no ordering guarantee. The flush drains pending writes before the next
+     step reads the received data. Set to 0 to disable for debugging.
+
  - name        : NCCL_CTRAN_IB_DEVICES_PER_RANK
    type        : int
    default     : 1


### PR DESCRIPTION
Summary:

Applies the same cross-NIC PCIe flush pattern from D103503273 to both persistent AllGatherP paths used by the cudagraph-aware variants:
- `ctrdpipeline` (used by `ctgraph_rdpipeline`) in RecursiveDoublingImpl.cc
- `ctpipeline` (used by `ctgraph_pipeline`) in PipelineImpl.cc

Reviewed By: minsii

Differential Revision: D103742328
