### PR TITLE
Gate lsaMultimem on nvlsSupport to fix ncclDevCommCreate failure

### DIFF
--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -90,10 +90,11 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   reqs.teamRequirementsList = nullptr;
 
   // Mirror NCCL's internal gating (sym_kernels.cc): only request NVLS
-  // multicast when the LSA team has more than 2 members.  Without this
-  // check ncclDevCommCreate returns ncclInvalidArgument on topologies
-  // where multicast is unavailable (e.g. 1x2 configurations).
-  reqs.lsaMultimem = nccl_api->teamLsa(nccl_comm).nRanks > 2;
+  // multicast when hardware supports it AND the LSA team has more than
+  // 2 members.  Without both checks ncclDevCommCreate returns
+  // ncclInvalidArgument on topologies where multicast is unavailable.
+  reqs.lsaMultimem = nccl_api->multimemSupport(nccl_comm) &&
+      nccl_api->teamLsa(nccl_comm).nRanks > 2;
   reqs.barrierCount = config.barrier_count;
   reqs.lsaBarrierCount = config.barrier_count;
   reqs.railGinBarrierCount = config.barrier_count;

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -719,6 +719,19 @@ ncclResult_t DefaultNcclxApi::winGetLsaMultimemDevicePointer(
 ncclTeam_t DefaultNcclxApi::teamLsa(ncclComm_t comm) {
   return ncclTeamLsa(comm);
 }
+
+bool DefaultNcclxApi::multimemSupport(ncclComm_t comm) {
+#ifdef NCCL_COMM_PROPERTIES_INITIALIZER
+  ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
+  if (ncclCommQueryProperties(comm, &props) != ncclSuccess) {
+    return false;
+  }
+  return props.multimemSupport;
+#else
+  (void)comm;
+  return false;
+#endif
+}
 #endif // TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -401,6 +401,9 @@ class NcclxApi {
 
   // Get the LSA team info (rank count, local rank) for a communicator.
   [[nodiscard]] virtual ncclTeam_t teamLsa(ncclComm_t comm) = 0;
+
+  // Query whether the communicator supports NVLS multicast (multimem).
+  [[nodiscard]] virtual bool multimemSupport(ncclComm_t comm) = 0;
 #endif
 
 #if defined(ENABLE_PIPES)
@@ -792,6 +795,8 @@ class DefaultNcclxApi : public NcclxApi {
 #endif
 
   [[nodiscard]] ncclTeam_t teamLsa(ncclComm_t comm) override;
+
+  [[nodiscard]] bool multimemSupport(ncclComm_t comm) override;
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -138,6 +138,7 @@ void NcclxMock::setupDefaultBehaviors() {
   // easily mock SetArgPointee with ncclDevComm struct, so just return success
   ON_CALL(*this, devCommCreate(_, _, _)).WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, devCommDestroy(_, _)).WillByDefault(Return(ncclSuccess));
+  ON_CALL(*this, multimemSupport(_)).WillByDefault(Return(false));
 #endif
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -423,6 +423,8 @@ class NcclxMock : public NcclxApi {
 
   MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
 
+  MOCK_METHOD(bool, multimemSupport, (ncclComm_t comm), (override));
+
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   MOCK_METHOD(
       ncclResult_t,


### PR DESCRIPTION
Summary:
D100347840 partially mirrored NCCL's internal lsaMultimem gating by checking `ncclTeamLsa(comm).nRanks > 2`, but missed the `nvlsSupport` check. NCCL's canonical code in `sym_kernels.cc` does:

```
hasLsaMultimem = comm->nvlsSupport && ncclTeamLsa(comm).nRanks > 2
```

On machines with >2 GPUs but no NVSwitch/NVLS multicast support (common in CI), `ncclDevCommCreate` returns `ncclInvalidArgument` because `symTeamObtain` rejects the multicast request when `nvlsSupport` is false.

This was exposed when the `stable` ncclx symlink moved from v2_28 to v2_29 (ba19733efd4e, 2026-04-24).

Fix: Expose `multimemSupport(ncclComm_t)` via `NcclxApi` using the v2_29 `ncclCommQueryProperties` API, and gate `lsaMultimem` on both `multimemSupport` and `nRanks > 2`.

Reviewed By: siyengar

Differential Revision: D103785782


