### PR TITLE
Fix PRODUCT skip threshold in test_c10d_torchcomms

### DIFF
--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -44,8 +44,11 @@ class TestC10dTorchCommsBasic(unittest.TestCase):
         return dist.get_rank() + 1
 
     def _skip_if_product_overflows(self, op):
-        if op == dist.ReduceOp.PRODUCT and dist.get_world_size() > 34:
-            self.skipTest("PRODUCT reduction overflows float32 for world_size > 34")
+        if op == dist.ReduceOp.PRODUCT and dist.get_world_size() > 12:
+            self.skipTest(
+                f"world_size={dist.get_world_size()} > 12: PRODUCT is world_size! "
+                "and only up to 12! is exactly representable in float32"
+            )
 
     def _expected_reduce_result(self, op):
         """Return the expected scalar result for a rank+1 input reduced across all ranks."""


### PR DESCRIPTION
The previous threshold (`world_size > 34`) targeted `float32` overflow, but `PRODUCT` fails the exactness check well before that: `world_size!` is only exactly representable in `float32` up to `12!`. From `13!` onward the expected Python int result and the `float32` reduction differ causing `assertEqual` to spuriously fail. Lower the threshold to 12 and update the skip message.