### PR TITLE
Add ncclCommRevoke, ncclCommShrink, ncclCommGrow, and abort() to rccl/rcclx backends

### DIFF
--- a/comms/torchcomms/rccl/CMakeLists.txt
+++ b/comms/torchcomms/rccl/CMakeLists.txt
@@ -31,6 +31,8 @@ target_compile_features(torchcomms_comms_rccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rccl PRIVATE
     torchcomms
+    glog::glog
+    fmt::fmt
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
     ${RCCL_SHARED_LIB}

--- a/comms/torchcomms/rccl/RcclApi.cpp
+++ b/comms/torchcomms/rccl/RcclApi.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/torchcomms/rccl/RcclApi.hpp"
 
+#include "comms/torchcomms/utils/Logging.hpp"
+
 namespace torch::comms {
 
 // DefaultRcclApi implementation
@@ -47,6 +49,18 @@ ncclResult_t DefaultRcclApi::commAbort(ncclComm_t comm) {
   return ncclCommAbort(comm);
 }
 
+ncclResult_t DefaultRcclApi::commRevoke(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+  return ncclCommRevoke(comm, 0);
+#else
+  (void)comm;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommRevoke API";
+  return ncclInvalidUsage;
+#endif
+}
+
 ncclResult_t DefaultRcclApi::commGetAsyncError(
     ncclComm_t comm,
     ncclResult_t* asyncError) {
@@ -62,6 +76,59 @@ ncclResult_t DefaultRcclApi::commSplit(
     ncclConfig_t* config) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return ncclCommSplit(comm, color, key, newcomm, config);
+}
+
+ncclResult_t DefaultRcclApi::commShrink(
+    ncclComm_t comm,
+    int* excludeRanksList,
+    int excludeRanksCount,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config,
+    int shrinkFlags) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+  return ncclCommShrink(
+      comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags);
+#else
+  (void)comm;
+  (void)excludeRanksList;
+  (void)excludeRanksCount;
+  (void)newcomm;
+  (void)config;
+  (void)shrinkFlags;
+  TC_LOG(ERROR) << "NCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommShrink API";
+  return ncclInvalidUsage;
+#endif
+}
+
+ncclResult_t DefaultRcclApi::commGetUniqueId(
+    ncclComm_t comm,
+    ncclUniqueId* uniqueId) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  (void)comm;
+  (void)uniqueId;
+  TC_LOG(ERROR)
+      << "ncclCommGetUniqueId API is not implemented in RCCL backend";
+  return ncclInvalidUsage;
+}
+
+ncclResult_t DefaultRcclApi::commGrow(
+    ncclComm_t comm,
+    int nRanks,
+    const ncclUniqueId* uniqueId,
+    int rank,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  (void)comm;
+  (void)nRanks;
+  (void)uniqueId;
+  (void)rank;
+  (void)newcomm;
+  (void)config;
+  TC_LOG(ERROR) << "ncclCommGrow API is not implemented in RCCL backend";
+  return ncclInvalidUsage;
 }
 
 ncclResult_t DefaultRcclApi::commRegister(

--- a/comms/torchcomms/rccl/RcclApi.cpp
+++ b/comms/torchcomms/rccl/RcclApi.cpp
@@ -106,11 +106,15 @@ ncclResult_t DefaultRcclApi::commGetUniqueId(
     ncclComm_t comm,
     ncclUniqueId* uniqueId) {
   std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGetUniqueId(comm, uniqueId);
+#else
   (void)comm;
   (void)uniqueId;
-  TC_LOG(ERROR)
-      << "ncclCommGetUniqueId API is not implemented in RCCL backend";
+  TC_LOG(ERROR) << "RCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGetUniqueId API";
   return ncclInvalidUsage;
+#endif
 }
 
 ncclResult_t DefaultRcclApi::commGrow(
@@ -121,14 +125,19 @@ ncclResult_t DefaultRcclApi::commGrow(
     ncclComm_t* newcomm,
     ncclConfig_t* config) {
   std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGrow(comm, nRanks, uniqueId, rank, newcomm, config);
+#else
   (void)comm;
   (void)nRanks;
   (void)uniqueId;
   (void)rank;
   (void)newcomm;
   (void)config;
-  TC_LOG(ERROR) << "ncclCommGrow API is not implemented in RCCL backend";
+  TC_LOG(ERROR) << "RCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGrow API";
   return ncclInvalidUsage;
+#endif
 }
 
 ncclResult_t DefaultRcclApi::commRegister(

--- a/comms/torchcomms/rccl/RcclApi.hpp
+++ b/comms/torchcomms/rccl/RcclApi.hpp
@@ -37,6 +37,8 @@ class RcclApi {
 
   [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commRevoke(ncclComm_t comm) = 0;
+
   [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
@@ -45,6 +47,26 @@ class RcclApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) = 0;
 
@@ -199,6 +221,8 @@ class DefaultRcclApi : public RcclApi {
 
   [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
+  [[nodiscard]] ncclResult_t commRevoke(ncclComm_t comm) override;
+
   [[nodiscard]] ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) override;
@@ -207,6 +231,26 @@ class DefaultRcclApi : public RcclApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) override;
+
+  [[nodiscard]] ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) override;
+
+  [[nodiscard]] ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) override;
+
+  [[nodiscard]] ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -6,6 +6,9 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
+#include <variant>
+#include <vector>
 
 #include <ATen/hip/HIPContext.h> // @manual=//caffe2:ATen-custom-hip
 #include <fmt/core.h>
@@ -91,6 +94,7 @@ void TorchCommRCCL::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
+  TC_LOG(INFO, this) << "Initializing TorchCommRCCL for device: " << device;
   // Initialize private members
   device_ = device;
   name_ = name;
@@ -102,7 +106,6 @@ void TorchCommRCCL::init(
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommRCCL already finalized");
   }
-  init_state_ = InitializationState::INITIALIZED;
 
   // Initialize default NCCL API implementation if not already set
   if (!rccl_api_) {
@@ -112,6 +115,14 @@ void TorchCommRCCL::init(
   // Initialize default HIP API implementation if not already set
   if (!hip_api_) {
     hip_api_ = std::make_unique<DefaultHipApi>();
+  }
+
+  if (options.enable_reconfigure) {
+    options_.enable_reconfigure = true;
+    reconfigure_store_ = options_.store;
+    TC_LOG(INFO, this)
+        << "TorchCommRCCL dynamic regime enabled, deferring initialization";
+    return;
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {
@@ -124,6 +135,15 @@ void TorchCommRCCL::init(
     }
   }
 
+  initRcclResources();
+
+  init_state_ = InitializationState::INITIALIZED;
+  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+
+  TC_LOG(INFO, this) << "TorchCommRCCL initialized for rank: " << rank_;
+}
+
+void TorchCommRCCL::initRcclResources() {
   // Set HIP device and verify it's accessible
   HIP_CHECK(
       hip_api_,
@@ -164,26 +184,33 @@ void TorchCommRCCL::init(
     stream_priority = greatestPriority;
   }
 
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->streamCreateWithPriority(
-          &internal_stream_, hipStreamNonBlocking, stream_priority),
-      fmt::format(
-          "Failed to create internal CUDA stream on device {}",
-          device_.index()));
+  // Create internal stream if not already created
+  if (!internal_stream_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->streamCreateWithPriority(
+            &internal_stream_, hipStreamNonBlocking, stream_priority),
+        fmt::format(
+            "Failed to create internal CUDA stream on device {}",
+            device_.index()));
+  }
 
   // Create dependency event for stream synchronization
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->eventCreate(&dependency_event_),
-      fmt::format(
-          "Failed to create dependency event on device {}", device_.index()));
+  if (!dependency_event_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->eventCreate(&dependency_event_),
+        fmt::format(
+            "Failed to create dependency event on device {}", device_.index()));
+  }
 
   // Allocate CUDA buffer for barrier operations
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->malloc(&barrier_buffer_, sizeof(float)),
-      "Failed to allocate barrier buffer");
+  if (!barrier_buffer_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->malloc(&barrier_buffer_, sizeof(float)),
+        "Failed to allocate barrier buffer");
+  }
 
   max_event_pool_size_ =
       options_.getHint<size_t>(kHintMaxEventPoolSize, kDefaultMaxEventPoolSize);
@@ -210,13 +237,25 @@ void TorchCommRCCL::init(
       rccl_api_->commCount(nccl_comm_, &comm_size_),
       "RCCL Count failed");
 
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
-
   // Start timeout watchdog thread
-  timeout_thread_ = std::thread(&TorchCommRCCL::timeoutWatchdog, this);
+  if (!shutdown_) {
+    timeout_thread_ = std::thread(&TorchCommRCCL::timeoutWatchdog, this);
+  }
 
   // Register comm with CachingAllocator
   attachMemoryHook();
+}
+
+// getInitHandle() and reconfigure() are implemented in
+// TorchCommRCCLReconfigure.cpp
+
+void TorchCommRCCL::abort() {
+  if (options_.enable_reconfigure) {
+    revokeRcclComm();
+  } else {
+    abortRcclComm();
+  }
+  comm_state_ = CommState::ERROR;
 }
 
 void TorchCommRCCL::finalize() {
@@ -226,6 +265,8 @@ void TorchCommRCCL::finalize() {
     throw std::runtime_error("TorchCommRCCL already finalized");
   }
   init_state_ = InitializationState::FINALIZED;
+
+  auto comm_state_on_entry = comm_state_.load();
 
   // Signal shutdown to timeout watchdog
   shutdown_ = true;
@@ -253,7 +294,9 @@ void TorchCommRCCL::finalize() {
   if (comm_state_ == CommState::TIMEOUT) {
     abortRcclComm();
     throw std::runtime_error("Work timed out during finalize");
-  } else if (comm_state_ == CommState::ERROR) {
+  } else if (
+      comm_state_ == CommState::ERROR &&
+      comm_state_on_entry != CommState::ERROR) {
     ncclResult_t asyncErr;
     RCCL_CHECK(
         rccl_api_,
@@ -331,6 +374,19 @@ void TorchCommRCCL::abortRcclComm() {
         rccl_api_->commAbort(nccl_comm_),
         "RCCL Abort failed");
     nccl_comm_ = nullptr;
+  }
+}
+
+void TorchCommRCCL::revokeRcclComm() {
+  TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
+  runAbortHooks();
+  detachMemoryHook();
+  if (nccl_comm_) {
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commRevoke(nccl_comm_),
+        "RCCL Revoke failed");
   }
 }
 

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -90,6 +90,15 @@ class TorchCommRCCL : public TorchCommBackend,
   int getRank() const override;
   int getSize() const override;
 
+  // Fault Tolerance API
+  bool supportsReconfigure() const override {
+    return true;
+  }
+  InitHandle getInitHandle() const override;
+  c10::intrusive_ptr<TorchWork> reconfigure(
+      const ReconfigureOptions& opts) override;
+  void abort() override;
+
   // Point-to-Point Operations
   c10::intrusive_ptr<TorchWork> send(
       const at::Tensor& tensor,
@@ -232,6 +241,7 @@ class TorchCommRCCL : public TorchCommBackend,
   [[nodiscard]] hipEvent_t getEvent();
   void returnEvent(hipEvent_t event);
   void abortRcclComm();
+  void revokeRcclComm();
 
   enum class CommState {
     NORMAL,
@@ -361,6 +371,7 @@ class TorchCommRCCL : public TorchCommBackend,
 
   void attachMemoryHook();
   void detachMemoryHook();
+  void initRcclResources();
 
   // Member variables
   ncclComm_t nccl_comm_{};
@@ -381,6 +392,9 @@ class TorchCommRCCL : public TorchCommBackend,
   // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
   // buffer address to the registeration handle
   std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
+
+  // Store held for reconfigure bootstrap (kept alive across reconfigure calls)
+  c10::intrusive_ptr<c10d::Store> reconfigure_store_;
 
   // RCCL API abstraction
   std::shared_ptr<RcclApi> rccl_api_;
@@ -406,6 +420,10 @@ class TorchCommRCCL : public TorchCommBackend,
 
   bool high_priority_stream_{false};
   std::string name_;
+  // UUID of the current communicator quorum, set at end of reconfigure().
+  // Embedded in getInitHandle() so findQuorum() can identify which ranks
+  // shared the same previous communicator.
+  int64_t uuid_{-1};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
@@ -86,6 +86,28 @@ struct QuorumInfo {
   size_t newMemberCount = 0;
 };
 
+int findRankInHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles,
+    const InitHandle& myHandle) {
+  return std::visit(
+      [&](const auto& h) -> int {
+        int result = -1;
+        int idx = 0;
+        for (const auto& handle : h) {
+          if (handle == myHandle) {
+            if (result >= 0) {
+              return -1;
+            }
+            result = idx;
+          }
+          idx++;
+        }
+        return result;
+      },
+      handles);
+}
+
 QuorumInfo findQuorum(
     const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
         handles) {
@@ -235,26 +257,43 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reconfigure(
         hip_api_->setDevice(device_.index()),
         fmt::format("Failed to set HIP device to {}", device_.index()));
 
-    auto store = c10::make_intrusive<c10d::PrefixStore>(
-        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
-
-    int myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
-
     ncclUniqueId uniqueId{};
-    if (myRank == 0) {
+    int myRank = findRankInHandles(opts.handles, getInitHandle());
+
+    if (new_size > 1) {
+      auto store = c10::make_intrusive<c10d::PrefixStore>(
+          fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+
+      if (myRank < 0) {
+        myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+      }
+
+      if (myRank == 0) {
+        RCCL_CHECK(
+            rccl_api_,
+            nccl_comm_,
+            rccl_api_->getUniqueId(&uniqueId),
+            "RCCL getUniqueId failed during reconfigure");
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+      } else {
+        store->wait({"unique_id"}, reconfigureTimeout);
+        auto vec = store->get("unique_id");
+        std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+      }
+    } else {
+      // Single-rank comm: no bootstrap networking needed, every rank
+      // creates a private 1-rank communicator with myRank=0.
       RCCL_CHECK(
           rccl_api_,
           nccl_comm_,
           rccl_api_->getUniqueId(&uniqueId),
           "RCCL getUniqueId failed during reconfigure");
-      std::vector<uint8_t> vec(
-          reinterpret_cast<uint8_t*>(&uniqueId),
-          reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
-      store->set("unique_id", vec);
-    } else {
-      store->wait({"unique_id"}, reconfigureTimeout);
-      auto vec = store->get("unique_id");
-      std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+      if (myRank < 0) {
+        myRank = 0;
+      }
     }
 
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;

--- a/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
@@ -60,15 +60,14 @@ struct HandleInfo {
 };
 
 HandleInfo parseHandle(const InitHandle& handle) {
-  // Format: "rccl:<rank>:<uuid>:<storeAddr>" or legacy "rccl:<rank>"
+  // Format: "rccl:<rank>:<uuid>:<storeAddr>"
   auto first = handle.find(':');
   if (first == std::string::npos) {
     return {-1, -1, ""};
   }
   auto second = handle.find(':', first + 1);
   if (second == std::string::npos) {
-    // Legacy format: "rccl:<rank>"
-    return {std::stoi(handle.substr(first + 1)), -1, ""};
+    return {-1, -1, ""};
   }
   int rank = std::stoi(handle.substr(first + 1, second - first - 1));
   auto third = handle.find(':', second + 1);
@@ -131,7 +130,7 @@ QuorumInfo findQuorum(
   QuorumInfo quorum;
   for (const auto& [uuid, ranks] : groupByUuid) {
     if (uuid < 0) {
-      continue; // Legacy / uninitialized handles
+      continue;
     }
     std::unordered_set<int> uniqueRanks(ranks.begin(), ranks.end());
     if (uniqueRanks.size() != ranks.size()) {
@@ -365,8 +364,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reconfigure(
       RCCL_CHECK(
           rccl_api_,
           current,
-          rccl_api_->commGrow(
-              current, new_size, nullptr, -1, &grown, nullptr),
+          rccl_api_->commGrow(current, new_size, nullptr, -1, &grown, nullptr),
           "RCCL commGrow failed during reconfigure");
       current = grown;
     }

--- a/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
@@ -158,10 +158,38 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reconfigure(
 
   // Clean up the existing communicator before any reconfiguration.
   if (nccl_comm_) {
+    // Check for in-flight work before deciding whether to revoke.
+    // Mirrors NCCL's workq_.garbageCollect() pattern: snapshot the queued
+    // work items (under the mutex), then query their HIP event status without
+    // holding the lock (checkStatus() calls hipEventQuery).
+    bool workInFlight = false;
+    {
+      std::vector<c10::intrusive_ptr<TorchWorkRCCL>> pendingWork;
+      {
+        std::lock_guard<std::mutex> lock(work_queues_mutex_);
+        for (auto& [stream, q] : stream_work_queues_) {
+          auto tmp = q;
+          while (!tmp.empty()) {
+            pendingWork.push_back(tmp.front());
+            tmp.pop();
+          }
+        }
+      }
+      for (auto& work : pendingWork) {
+        auto s = work->checkStatus();
+        if (s == TorchWork::WorkStatus::NOT_STARTED ||
+            s == TorchWork::WorkStatus::INPROGRESS) {
+          workInFlight = true;
+          break;
+        }
+      }
+    }
+
     // Only revoke when this rank is leaving the quorum (new joiner or fresh
-    // init). In-quorum ranks keep the comm alive for commShrink; revoking it
-    // would invalidate the comm before shrink runs.
-    if (!inQuorum) {
+    // init) AND there is work in flight that needs to be cancelled. In-quorum
+    // ranks keep the comm alive for commShrink; revoking it would invalidate
+    // the comm before shrink runs.
+    if (!inQuorum && workInFlight) {
       RCCL_CHECK_IGNORE(
           rccl_api_,
           rccl_api_->commRevoke(nccl_comm_),

--- a/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
@@ -143,22 +143,30 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCL::reconfigure(
   auto quorum = findQuorum(opts.handles);
   bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
 
-  // Identity reconfigure: quorum covers the full new world, no new members.
-  // The old comm may be unhealthy (revoked after abort()), so fall back to
-  // fresh init — same as NCCL reference.
-  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
-      quorum.newMemberCount == 0) {
+  // Fall back to fresh init when shrink/grow has no advantage:
+  // - Single-rank quorum: a 1-rank comm has no bootstrap networking, so
+  //   commGrow will fail. Must clear unconditionally (not just when
+  //   inQuorum) so all ranks take the same fresh init path.
+  // - Identity reconfigure: same world size, no membership change — old comm
+  //   may be unhealthy (e.g. revoked after abort()).
+  if (quorum.ranks.size() == 1 ||
+      (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+       quorum.newMemberCount == 0)) {
     inQuorum = false;
     quorum.ranks.clear();
   }
 
   // Clean up the existing communicator before any reconfiguration.
   if (nccl_comm_) {
-    // Revoke any in-flight work so ranks don't hang waiting for completions.
-    RCCL_CHECK_IGNORE(
-        rccl_api_,
-        rccl_api_->commRevoke(nccl_comm_),
-        "RCCL commRevoke failed during reconfigure");
+    // Only revoke when this rank is leaving the quorum (new joiner or fresh
+    // init). In-quorum ranks keep the comm alive for commShrink; revoking it
+    // would invalidate the comm before shrink runs.
+    if (!inQuorum) {
+      RCCL_CHECK_IGNORE(
+          rccl_api_,
+          rccl_api_->commRevoke(nccl_comm_),
+          "RCCL commRevoke failed during reconfigure");
+    }
 
     detachMemoryHook();
 

--- a/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLReconfigure.cpp
@@ -1,0 +1,344 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Implements TorchCommRCCL::getInitHandle() and TorchCommRCCL::reconfigure()
+// aligned with the NCCL reference in TorchCommNCCLReconfigure.cpp.
+//
+// See TorchCommRCCLXReconfigure.cpp for the full design description.
+// This file is the RCCL backend analogue.
+
+#include "comms/torchcomms/rccl/TorchCommRCCL.hpp"
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <ATen/hip/HIPContext.h> // @manual=//caffe2:ATen-custom-hip
+#include <fmt/core.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+
+#include "comms/torchcomms/utils/Logging.hpp"
+#include "comms/torchcomms/utils/StoreManager.hpp"
+#include "comms/torchcomms/utils/TracingGuard.hpp"
+#include "comms/torchcomms/utils/Utils.hpp"
+
+namespace torch::comms {
+
+// ---------------------------------------------------------------------------
+// Handle encoding / quorum logic (mirrors TorchCommNCCLReconfigure.cpp)
+// ---------------------------------------------------------------------------
+
+InitHandle TorchCommRCCL::getInitHandle() const {
+  std::string storeAddr;
+  if (reconfigure_store_) {
+    auto* tcpStore = dynamic_cast<c10d::TCPStore*>(reconfigure_store_.get());
+    if (!tcpStore) {
+      auto* prefixStore =
+          dynamic_cast<c10d::PrefixStore*>(reconfigure_store_.get());
+      if (prefixStore) {
+        tcpStore = dynamic_cast<c10d::TCPStore*>(
+            prefixStore->getUnderlyingNonPrefixStore().get());
+      }
+    }
+    if (tcpStore) {
+      storeAddr =
+          fmt::format("{}:{}", tcpStore->getHost(), tcpStore->getPort());
+    }
+  }
+  int rank = nccl_comm_ ? rank_ : static_cast<int>(query_ranksize().first);
+  return fmt::format("rccl:{}:{}:{}", rank, uuid_, storeAddr);
+}
+
+namespace {
+
+struct HandleInfo {
+  int rank;
+  int64_t uuid;
+  std::string storeAddr;
+};
+
+HandleInfo parseHandle(const InitHandle& handle) {
+  // Format: "rccl:<rank>:<uuid>:<storeAddr>" or legacy "rccl:<rank>"
+  auto first = handle.find(':');
+  if (first == std::string::npos) {
+    return {-1, -1, ""};
+  }
+  auto second = handle.find(':', first + 1);
+  if (second == std::string::npos) {
+    // Legacy format: "rccl:<rank>"
+    return {std::stoi(handle.substr(first + 1)), -1, ""};
+  }
+  int rank = std::stoi(handle.substr(first + 1, second - first - 1));
+  auto third = handle.find(':', second + 1);
+  if (third == std::string::npos) {
+    return {rank, std::stoll(handle.substr(second + 1)), ""};
+  }
+  int64_t uuid = std::stoll(handle.substr(second + 1, third - second - 1));
+  std::string storeAddr = handle.substr(third + 1);
+  return {rank, uuid, storeAddr};
+}
+
+struct QuorumInfo {
+  int64_t uuid = -1;
+  std::unordered_set<int> ranks;
+  size_t newMemberCount = 0;
+};
+
+QuorumInfo findQuorum(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles) {
+  std::unordered_map<int64_t, std::vector<int>> groupByUuid;
+  size_t totalHandles = 0;
+
+  auto processHandle = [&](const InitHandle& handle) {
+    totalHandles++;
+    auto info = parseHandle(handle);
+    groupByUuid[info.uuid].push_back(info.rank);
+  };
+
+  std::visit(
+      [&](const auto& h) {
+        for (const auto& handle : h) {
+          processHandle(handle);
+        }
+      },
+      handles);
+
+  QuorumInfo quorum;
+  for (const auto& [uuid, ranks] : groupByUuid) {
+    if (uuid < 0) {
+      continue; // Legacy / uninitialized handles
+    }
+    std::unordered_set<int> uniqueRanks(ranks.begin(), ranks.end());
+    if (uniqueRanks.size() != ranks.size()) {
+      continue; // Duplicate ranks in this uuid group — skip
+    }
+    if (uniqueRanks.size() > quorum.ranks.size()) {
+      quorum.uuid = uuid;
+      quorum.ranks = uniqueRanks;
+    }
+  }
+
+  quorum.newMemberCount = totalHandles - quorum.ranks.size();
+  return quorum;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// reconfigure()
+// ---------------------------------------------------------------------------
+
+c10::intrusive_ptr<TorchWork> TorchCommRCCL::reconfigure(
+    const ReconfigureOptions& opts) {
+  TC_LOG(INFO, this) << "TorchCommRCCL reconfigure starting";
+  TracingGuard tracingGuard(name_, comm_size_, "reconfigure", rank_);
+
+  int new_size = static_cast<int>(
+      std::visit([](const auto& h) { return h.size(); }, opts.handles));
+  auto reconfigureTimeout = opts.timeout.value_or(options_.timeout);
+
+  auto quorum = findQuorum(opts.handles);
+  bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
+
+  // Identity reconfigure: quorum covers the full new world, no new members.
+  // The old comm may be unhealthy (revoked after abort()), so fall back to
+  // fresh init — same as NCCL reference.
+  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+      quorum.newMemberCount == 0) {
+    inQuorum = false;
+    quorum.ranks.clear();
+  }
+
+  // Clean up the existing communicator before any reconfiguration.
+  if (nccl_comm_) {
+    // Revoke any in-flight work so ranks don't hang waiting for completions.
+    RCCL_CHECK_IGNORE(
+        rccl_api_,
+        rccl_api_->commRevoke(nccl_comm_),
+        "RCCL commRevoke failed during reconfigure");
+
+    detachMemoryHook();
+
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(work_queues_mutex_);
+      stream_work_queues_.clear();
+      std::queue<c10::intrusive_ptr<TorchWorkRCCL>> empty;
+      std::swap(completed_works_, empty);
+    }
+
+    if (!inQuorum) {
+      RCCL_CHECK_IGNORE(
+          rccl_api_,
+          rccl_api_->commAbort(nccl_comm_),
+          "RCCL commAbort failed during reconfigure");
+      nccl_comm_ = nullptr;
+    }
+  }
+
+  if (quorum.ranks.empty()) {
+    // -----------------------------------------------------------------------
+    // Case 1 & 2: Fresh init or identity reconfigure.
+    // -----------------------------------------------------------------------
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->setDevice(device_.index()),
+        fmt::format("Failed to set HIP device to {}", device_.index()));
+
+    auto store = c10::make_intrusive<c10d::PrefixStore>(
+        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+
+    int myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+    ncclUniqueId uniqueId{};
+    if (myRank == 0) {
+      RCCL_CHECK(
+          rccl_api_,
+          nccl_comm_,
+          rccl_api_->getUniqueId(&uniqueId),
+          "RCCL getUniqueId failed during reconfigure");
+      std::vector<uint8_t> vec(
+          reinterpret_cast<uint8_t*>(&uniqueId),
+          reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+      store->set("unique_id", vec);
+    } else {
+      store->wait({"unique_id"}, reconfigureTimeout);
+      auto vec = store->get("unique_id");
+      std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+    }
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclComm_t new_comm = nullptr;
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commInitRankConfig(
+            &new_comm, new_size, uniqueId, myRank, &config),
+        "RCCL commInitRankConfig failed during reconfigure");
+    nccl_comm_ = new_comm;
+
+    initRcclResources();
+
+  } else if (inQuorum) {
+    // -----------------------------------------------------------------------
+    // Case 3: In quorum — shrink departed ranks, then grow new members.
+    // -----------------------------------------------------------------------
+    ncclComm_t current = nccl_comm_;
+
+    if (quorum.ranks.size() < static_cast<size_t>(comm_size_)) {
+      std::vector<int> excludeRanks;
+      for (int r = 0; r < comm_size_; ++r) {
+        if (quorum.ranks.find(r) == quorum.ranks.end()) {
+          excludeRanks.push_back(r);
+        }
+      }
+
+      ncclComm_t shrunk = nullptr;
+      RCCL_CHECK(
+          rccl_api_,
+          current,
+          rccl_api_->commShrink(
+              current,
+              excludeRanks.data(),
+              static_cast<int>(excludeRanks.size()),
+              &shrunk,
+              nullptr,
+              NCCL_SHRINK_ABORT),
+          "RCCL commShrink failed during reconfigure");
+      current = shrunk;
+    }
+
+    if (quorum.newMemberCount > 0) {
+      int currentRank = 0;
+      RCCL_CHECK(
+          rccl_api_,
+          current,
+          rccl_api_->commUserRank(current, &currentRank),
+          "RCCL commUserRank failed during grow");
+
+      if (currentRank == 0) {
+        ncclUniqueId uniqueId{};
+        RCCL_CHECK(
+            rccl_api_,
+            current,
+            rccl_api_->commGetUniqueId(current, &uniqueId),
+            "RCCL commGetUniqueId failed during grow");
+
+        auto store = c10::make_intrusive<c10d::PrefixStore>(
+            fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+      }
+
+      ncclComm_t grown = nullptr;
+      RCCL_CHECK(
+          rccl_api_,
+          current,
+          rccl_api_->commGrow(
+              current, new_size, nullptr, -1, &grown, nullptr),
+          "RCCL commGrow failed during reconfigure");
+      current = grown;
+    }
+
+    nccl_comm_ = current;
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+    initRcclResources();
+
+  } else {
+    // -----------------------------------------------------------------------
+    // Case 4: New rank joining an existing quorum via commGrow.
+    // -----------------------------------------------------------------------
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    int quorumSize = static_cast<int>(quorum.ranks.size());
+    auto store = c10::make_intrusive<c10d::PrefixStore>(
+        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+    store->wait({"unique_id"}, reconfigureTimeout);
+
+    auto vec = store->get("unique_id");
+    ncclUniqueId uniqueId{};
+    std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+
+    int growRank =
+        quorumSize + static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+    ncclComm_t new_comm = nullptr;
+    RCCL_CHECK(
+        rccl_api_,
+        nccl_comm_,
+        rccl_api_->commGrow(
+            nullptr, new_size, &uniqueId, growRank, &new_comm, nullptr),
+        "RCCL commGrow failed for new rank during reconfigure");
+
+    nccl_comm_ = new_comm;
+    initRcclResources();
+  }
+
+  init_state_ = InitializationState::INITIALIZED;
+  uuid_ = opts.uuid;
+
+  TC_LOG(INFO, this) << "TorchCommRCCL reconfigure completed for rank: "
+                     << rank_;
+
+  return c10::make_intrusive<TorchWorkCompleted>();
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -239,14 +239,15 @@ void TorchCommRCCL::timeoutWatchdog() noexcept {
       break;
     }
     if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error) {
-      // Log the error and abort the process.  We cannot abort the NCCL
-      // communicator as it is not safe to call NCCL operations from
-      // multiple threads at the same time.
+        options_.abort_process_on_timeout_or_error &&
+        !options_.enable_reconfigure) {
       if (comm_state_ == CommState::TIMEOUT) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        TC_LOG(ERROR, this)
+            << "Aborting process due to timeout on rank " << rank_
+            << " - timeout watchdog detected timeout. ";
       } else if (comm_state_ == CommState::ERROR) {
-        TC_LOG(ERROR, this) << "Aborting process due to error";
+        TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
+                            << " - timeout watchdog detected operation error. ";
       }
 
       runAbortHooks();
@@ -298,8 +299,18 @@ void TorchCommRCCL::checkAndAbortIfTimedOutOrError() {
   }
 
   if (comm_state_ == CommState::TIMEOUT) {
-    abortRcclComm();
-    throw std::runtime_error("NCCL operation timed out");
+    if (options_.enable_reconfigure) {
+      revokeRcclComm();
+      throw std::runtime_error("RCCL operation timed out");
+    } else {
+      abortRcclComm();
+      if (options_.abort_process_on_timeout_or_error) {
+        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        abort();
+      } else {
+        throw std::runtime_error("RCCL operation timed out");
+      }
+    }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
     RCCL_CHECK(

--- a/comms/torchcomms/rccl/tests/unit/cpp/mocks/RcclMock.cpp
+++ b/comms/torchcomms/rccl/tests/unit/cpp/mocks/RcclMock.cpp
@@ -26,9 +26,25 @@ void RcclMock::setupDefaultBehaviors() {
   ON_CALL(*this, commDestroy(_)).WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, commAbort(_)).WillByDefault(Return(ncclSuccess));
 
+  ON_CALL(*this, commRevoke(_)).WillByDefault(Return(ncclSuccess));
+
   ON_CALL(*this, commSplit(_, _, _, _, _))
       .WillByDefault(DoAll(
           SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x4000)),
+          Return(ncclSuccess)));
+
+  ON_CALL(*this, commShrink(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x6000)),
+          Return(ncclSuccess)));
+
+  ON_CALL(*this, commGetUniqueId(_, _))
+      .WillByDefault(
+          DoAll(SetArgPointee<1>(ncclUniqueId{}), Return(ncclSuccess)));
+
+  ON_CALL(*this, commGrow(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<4>(reinterpret_cast<ncclComm_t>(0x7000)),
           Return(ncclSuccess)));
 
   ON_CALL(*this, commCount(_, _))

--- a/comms/torchcomms/rccl/tests/unit/cpp/mocks/RcclMock.hpp
+++ b/comms/torchcomms/rccl/tests/unit/cpp/mocks/RcclMock.hpp
@@ -24,12 +24,38 @@ class RcclMock : public RcclApi {
 
   MOCK_METHOD(ncclResult_t, commDestroy, (ncclComm_t comm), (override));
   MOCK_METHOD(ncclResult_t, commAbort, (ncclComm_t comm), (override));
+  MOCK_METHOD(ncclResult_t, commRevoke, (ncclComm_t comm), (override));
   MOCK_METHOD(
       ncclResult_t,
       commSplit,
       (ncclComm_t comm,
        int color,
        int key,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commShrink,
+      (ncclComm_t comm,
+       int* excludeRanksList,
+       int excludeRanksCount,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config,
+       int shrinkFlags),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commGetUniqueId,
+      (ncclComm_t comm, ncclUniqueId* uniqueId),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commGrow,
+      (ncclComm_t comm,
+       int nRanks,
+       const ncclUniqueId* uniqueId,
+       int rank,
        ncclComm_t* newcomm,
        ncclConfig_t* config),
       (override));

--- a/comms/torchcomms/rcclx/CMakeLists.txt
+++ b/comms/torchcomms/rcclx/CMakeLists.txt
@@ -33,6 +33,8 @@ target_compile_features(torchcomms_comms_rcclx PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rcclx PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rcclx PRIVATE
     torchcomms
+    glog::glog
+    fmt::fmt
     ${TORCH_LIBRARIES}
     ${TORCH_PYTHON_LIB}
     ${RCCLX_SHARED_LIB}

--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/rcclx/RcclxApi.hpp"
+#include <stdexcept>
+
+#include "comms/torchcomms/utils/Logging.hpp"
 
 namespace torch::comms {
 
@@ -47,6 +50,11 @@ ncclResult_t DefaultRcclxApi::commAbort(ncclComm_t comm) {
   return ncclCommAbort(comm);
 }
 
+ncclResult_t DefaultRcclxApi::commRevoke(ncclComm_t comm) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclCommRevoke(comm, 0);
+}
+
 ncclResult_t DefaultRcclxApi::commGetAsyncError(
     ncclComm_t comm,
     ncclResult_t* asyncError) {
@@ -62,6 +70,47 @@ ncclResult_t DefaultRcclxApi::commSplit(
     ncclConfig_t* config) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return ncclCommSplit(comm, color, key, newcomm, config);
+}
+
+ncclResult_t DefaultRcclxApi::commShrink(
+    ncclComm_t comm,
+    int* excludeRanksList,
+    int excludeRanksCount,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config,
+    int shrinkFlags) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return ncclCommShrink(
+      comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags);
+}
+
+ncclResult_t DefaultRcclxApi::commGetUniqueId(
+    ncclComm_t comm,
+    ncclUniqueId* uniqueId) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  (void)comm;
+  (void)uniqueId;
+  TC_LOG(ERROR)
+      << "ncclCommGetUniqueId API is not implemented in RCCLX backend";
+  return ncclInvalidUsage;
+}
+
+ncclResult_t DefaultRcclxApi::commGrow(
+    ncclComm_t comm,
+    int nRanks,
+    const ncclUniqueId* uniqueId,
+    int rank,
+    ncclComm_t* newcomm,
+    ncclConfig_t* config) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  (void)comm;
+  (void)nRanks;
+  (void)uniqueId;
+  (void)rank;
+  (void)newcomm;
+  (void)config;
+  TC_LOG(ERROR) << "ncclCommGrow API is not implemented in RCCLX backend";
+  return ncclInvalidUsage;
 }
 
 ncclResult_t DefaultRcclxApi::commRegister(

--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -88,11 +88,15 @@ ncclResult_t DefaultRcclxApi::commGetUniqueId(
     ncclComm_t comm,
     ncclUniqueId* uniqueId) {
   std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGetUniqueId(comm, uniqueId);
+#else
   (void)comm;
   (void)uniqueId;
-  TC_LOG(ERROR)
-      << "ncclCommGetUniqueId API is not implemented in RCCLX backend";
+  TC_LOG(ERROR) << "RCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGetUniqueId API";
   return ncclInvalidUsage;
+#endif
 }
 
 ncclResult_t DefaultRcclxApi::commGrow(
@@ -103,14 +107,19 @@ ncclResult_t DefaultRcclxApi::commGrow(
     ncclComm_t* newcomm,
     ncclConfig_t* config) {
   std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
+  return ncclCommGrow(comm, nRanks, uniqueId, rank, newcomm, config);
+#else
   (void)comm;
   (void)nRanks;
   (void)uniqueId;
   (void)rank;
   (void)newcomm;
   (void)config;
-  TC_LOG(ERROR) << "ncclCommGrow API is not implemented in RCCLX backend";
+  TC_LOG(ERROR) << "RCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommGrow API";
   return ncclInvalidUsage;
+#endif
 }
 
 ncclResult_t DefaultRcclxApi::commRegister(

--- a/comms/torchcomms/rcclx/RcclxApi.hpp
+++ b/comms/torchcomms/rcclx/RcclxApi.hpp
@@ -49,6 +49,8 @@ class RcclxApi {
 
   [[nodiscard]] virtual ncclResult_t commAbort(ncclComm_t comm) = 0;
 
+  [[nodiscard]] virtual ncclResult_t commRevoke(ncclComm_t comm) = 0;
+
   [[nodiscard]] virtual ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) = 0;
@@ -57,6 +59,26 @@ class RcclxApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) = 0;
+
+  [[nodiscard]] virtual ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) = 0;
 
@@ -284,6 +306,8 @@ class DefaultRcclxApi : public RcclxApi {
 
   [[nodiscard]] ncclResult_t commAbort(ncclComm_t comm) override;
 
+  [[nodiscard]] ncclResult_t commRevoke(ncclComm_t comm) override;
+
   [[nodiscard]] ncclResult_t commGetAsyncError(
       ncclComm_t comm,
       ncclResult_t* asyncError) override;
@@ -292,6 +316,26 @@ class DefaultRcclxApi : public RcclxApi {
       ncclComm_t comm,
       int color,
       int key,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config) override;
+
+  [[nodiscard]] ncclResult_t commShrink(
+      ncclComm_t comm,
+      int* excludeRanksList,
+      int excludeRanksCount,
+      ncclComm_t* newcomm,
+      ncclConfig_t* config,
+      int shrinkFlags) override;
+
+  [[nodiscard]] ncclResult_t commGetUniqueId(
+      ncclComm_t comm,
+      ncclUniqueId* uniqueId) override;
+
+  [[nodiscard]] ncclResult_t commGrow(
+      ncclComm_t comm,
+      int nRanks,
+      const ncclUniqueId* uniqueId,
+      int rank,
       ncclComm_t* newcomm,
       ncclConfig_t* config) override;
 

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -6,6 +6,9 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
+#include <variant>
+#include <vector>
 
 #include <ATen/hip/HIPContext.h> // @manual=//caffe2:ATen-custom-hip
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h> // @manual
@@ -104,6 +107,7 @@ void TorchCommRCCLX::init(
     at::Device device,
     const std::string& name,
     const CommOptions& options) {
+  TC_LOG(INFO, this) << "Initializing TorchCommRCCLX for device: " << device;
   // Initialize private members
   device_ = device;
   name_ = name;
@@ -115,7 +119,6 @@ void TorchCommRCCLX::init(
   } else if (init_state_ == InitializationState::FINALIZED) {
     throw std::runtime_error("TorchCommRCCLX already finalized");
   }
-  init_state_ = InitializationState::INITIALIZED;
 
   // Initialize default RCCLX API implementation if not already set
   if (!rcclx_api_) {
@@ -125,6 +128,14 @@ void TorchCommRCCLX::init(
   // Initialize default HIP API implementation if not already set
   if (!hip_api_) {
     hip_api_ = std::make_unique<DefaultHipApi>();
+  }
+
+  if (options.enable_reconfigure) {
+    options_.enable_reconfigure = true;
+    reconfigure_store_ = options_.store;
+    TC_LOG(INFO, this)
+        << "TorchCommRCCLX dynamic regime enabled, deferring initialization";
+    return;
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {
@@ -137,6 +148,15 @@ void TorchCommRCCLX::init(
     }
   }
 
+  initRcclxResources();
+
+  init_state_ = InitializationState::INITIALIZED;
+  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
+
+  TC_LOG(INFO, this) << "TorchCommRCCLX initialized for rank: " << rank_;
+}
+
+void TorchCommRCCLX::initRcclxResources() {
   // Set HIP device and verify it's accessible
   HIP_CHECK(
       hip_api_,
@@ -177,26 +197,33 @@ void TorchCommRCCLX::init(
     stream_priority = greatestPriority;
   }
 
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->streamCreateWithPriority(
-          &internal_stream_, hipStreamNonBlocking, stream_priority),
-      fmt::format(
-          "Failed to create internal CUDA stream on device {}",
-          device_.index()));
+  // Create internal stream if not already created
+  if (!internal_stream_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->streamCreateWithPriority(
+            &internal_stream_, hipStreamNonBlocking, stream_priority),
+        fmt::format(
+            "Failed to create internal CUDA stream on device {}",
+            device_.index()));
+  }
 
   // Create dependency event for stream synchronization
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->eventCreate(&dependency_event_),
-      fmt::format(
-          "Failed to create dependency event on device {}", device_.index()));
+  if (!dependency_event_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->eventCreate(&dependency_event_),
+        fmt::format(
+            "Failed to create dependency event on device {}", device_.index()));
+  }
 
   // Allocate CUDA buffer for barrier operations
-  HIP_CHECK(
-      hip_api_,
-      hip_api_->malloc(&barrier_buffer_, sizeof(float)),
-      "Failed to allocate barrier buffer");
+  if (!barrier_buffer_) {
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->malloc(&barrier_buffer_, sizeof(float)),
+        "Failed to allocate barrier buffer");
+  }
 
   max_event_pool_size_ =
       options_.getHint<size_t>(kHintMaxEventPoolSize, kDefaultMaxEventPoolSize);
@@ -223,13 +250,25 @@ void TorchCommRCCLX::init(
       rcclx_api_->commCount(nccl_comm_, &comm_size_),
       "RCCLX Count failed");
 
-  TracingGuard tracingGuard(name_, comm_size_, "init", rank_);
-
   // Start timeout watchdog thread
-  timeout_thread_ = std::thread(&TorchCommRCCLX::timeoutWatchdog, this);
+  if (!shutdown_) {
+    timeout_thread_ = std::thread(&TorchCommRCCLX::timeoutWatchdog, this);
+  }
 
   // Register comm with CachingAllocator
   attachMemoryHook();
+}
+
+// getInitHandle() and reconfigure() are implemented in
+// TorchCommRCCLXReconfigure.cpp
+
+void TorchCommRCCLX::abort() {
+  if (options_.enable_reconfigure) {
+    revokeRcclxComm();
+  } else {
+    abortRcclxComm();
+  }
+  comm_state_ = CommState::ERROR;
 }
 
 void TorchCommRCCLX::finalize() {
@@ -239,6 +278,8 @@ void TorchCommRCCLX::finalize() {
     throw std::runtime_error("TorchCommRCCLX already finalized");
   }
   init_state_ = InitializationState::FINALIZED;
+
+  auto comm_state_on_entry = comm_state_.load();
 
   // Signal shutdown to timeout watchdog
   shutdown_ = true;
@@ -266,7 +307,9 @@ void TorchCommRCCLX::finalize() {
   if (comm_state_ == CommState::TIMEOUT) {
     abortRcclxComm();
     throw std::runtime_error("Work timed out during finalize");
-  } else if (comm_state_ == CommState::ERROR) {
+  } else if (
+      comm_state_ == CommState::ERROR &&
+      comm_state_on_entry != CommState::ERROR) {
     ncclResult_t asyncErr;
     RCCLX_CHECK(
         rcclx_api_,
@@ -344,6 +387,18 @@ void TorchCommRCCLX::abortRcclxComm() {
         rcclx_api_->commAbort(nccl_comm_),
         "RCCLX Abort failed");
     nccl_comm_ = nullptr;
+  }
+}
+
+void TorchCommRCCLX::revokeRcclxComm() {
+  TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
+  runAbortHooks();
+  if (nccl_comm_) {
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commRevoke(nccl_comm_),
+        "RCCLX Revoke failed");
   }
 }
 

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -90,6 +90,15 @@ class TorchCommRCCLX : public TorchCommBackend,
   int getRank() const override;
   int getSize() const override;
 
+  // Fault Tolerance API
+  bool supportsReconfigure() const override {
+    return true;
+  }
+  InitHandle getInitHandle() const override;
+  c10::intrusive_ptr<TorchWork> reconfigure(
+      const ReconfigureOptions& opts) override;
+  void abort() override;
+
   // Point-to-Point Operations
   c10::intrusive_ptr<TorchWork> send(
       const at::Tensor& tensor,
@@ -256,6 +265,7 @@ class TorchCommRCCLX : public TorchCommBackend,
   [[nodiscard]] hipEvent_t getEvent();
   void returnEvent(hipEvent_t event);
   void abortRcclxComm();
+  void revokeRcclxComm();
 
   enum class CommState {
     NORMAL,
@@ -391,6 +401,7 @@ class TorchCommRCCLX : public TorchCommBackend,
 
   void attachMemoryHook();
   void detachMemoryHook();
+  void initRcclxResources();
 
   // Member variables
   ncclComm_t nccl_comm_{};
@@ -411,6 +422,9 @@ class TorchCommRCCLX : public TorchCommBackend,
   // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
   // buffer address to the registeration handle
   std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
+
+  // Store held for reconfigure bootstrap (kept alive across reconfigure calls)
+  c10::intrusive_ptr<c10d::Store> reconfigure_store_;
 
   // RCCLX API abstraction
   std::shared_ptr<RcclxApi> rcclx_api_;
@@ -437,6 +451,10 @@ class TorchCommRCCLX : public TorchCommBackend,
 
   bool high_priority_stream_{false};
   std::string name_;
+  // UUID of the current communicator quorum, set at end of reconfigure().
+  // Embedded in getInitHandle() so findQuorum() can identify which ranks
+  // shared the same previous communicator.
+  int64_t uuid_{-1};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
@@ -103,6 +103,28 @@ struct QuorumInfo {
   size_t newMemberCount = 0;
 };
 
+int findRankInHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles,
+    const InitHandle& myHandle) {
+  return std::visit(
+      [&](const auto& h) -> int {
+        int result = -1;
+        int idx = 0;
+        for (const auto& handle : h) {
+          if (handle == myHandle) {
+            if (result >= 0) {
+              return -1;
+            }
+            result = idx;
+          }
+          idx++;
+        }
+        return result;
+      },
+      handles);
+}
+
 QuorumInfo findQuorum(
     const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
         handles) {
@@ -256,26 +278,43 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reconfigure(
         hip_api_->setDevice(device_.index()),
         fmt::format("Failed to set HIP device to {}", device_.index()));
 
-    auto store = c10::make_intrusive<c10d::PrefixStore>(
-        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
-
-    int myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
-
     ncclUniqueId uniqueId{};
-    if (myRank == 0) {
+    int myRank = findRankInHandles(opts.handles, getInitHandle());
+
+    if (new_size > 1) {
+      auto store = c10::make_intrusive<c10d::PrefixStore>(
+          fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+
+      if (myRank < 0) {
+        myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+      }
+
+      if (myRank == 0) {
+        RCCLX_CHECK(
+            rcclx_api_,
+            nccl_comm_,
+            rcclx_api_->getUniqueId(&uniqueId),
+            "RCCLX getUniqueId failed during reconfigure");
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+      } else {
+        store->wait({"unique_id"}, reconfigureTimeout);
+        auto vec = store->get("unique_id");
+        std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+      }
+    } else {
+      // Single-rank comm: no bootstrap networking needed, every rank
+      // creates a private 1-rank communicator with myRank=0.
       RCCLX_CHECK(
           rcclx_api_,
           nccl_comm_,
           rcclx_api_->getUniqueId(&uniqueId),
           "RCCLX getUniqueId failed during reconfigure");
-      std::vector<uint8_t> vec(
-          reinterpret_cast<uint8_t*>(&uniqueId),
-          reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
-      store->set("unique_id", vec);
-    } else {
-      store->wait({"unique_id"}, reconfigureTimeout);
-      auto vec = store->get("unique_id");
-      std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+      if (myRank < 0) {
+        myRank = 0;
+      }
     }
 
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;

--- a/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
@@ -1,0 +1,368 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Implements TorchCommRCCLX::getInitHandle() and TorchCommRCCLX::reconfigure()
+// aligned with the NCCL reference in TorchCommNCCLReconfigure.cpp.
+//
+// Each rank's init handle encodes its rank, uuid, and store address from the
+// previous configuration.  findQuorum() groups handles by uuid to find the
+// largest set of ranks that share a common previous communicator.
+//
+// Cases (determined by quorum analysis):
+//
+// 1. Empty quorum (fresh init or all ranks are new): abort old comm if any,
+//    bootstrap via commInitRankConfig using the shared reconfigure_store_.
+//
+// 2. Identity reconfigure (quorum == new world size, no new members): the old
+//    comm may be unhealthy (e.g. revoked after abort()), so treat the same as
+//    case 1: abort and call commInitRankConfig.
+//
+// 3. In quorum with shrink and/or grow: call commShrink to remove departed
+//    ranks, then commGrow to add new ones.  Rank 0 of the post-shrink comm
+//    publishes the grow unique ID via a prefix store.
+//
+// 4. Not in quorum (new rank joining): wait for quorum rank 0 to publish the
+//    unique ID, then call commGrow(nullptr, ...) to join.
+
+#include "comms/torchcomms/rcclx/TorchCommRCCLX.hpp"
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <ATen/hip/HIPContext.h> // @manual=//caffe2:ATen-custom-hip
+#include <fmt/core.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual=//caffe2:torch-cpp-cpu
+
+#include "comms/torchcomms/utils/Logging.hpp"
+#include "comms/torchcomms/utils/StoreManager.hpp"
+#include "comms/torchcomms/utils/TracingGuard.hpp"
+#include "comms/torchcomms/utils/Utils.hpp"
+
+namespace torch::comms {
+
+// ---------------------------------------------------------------------------
+// Handle encoding / quorum logic (mirrors TorchCommNCCLReconfigure.cpp)
+// ---------------------------------------------------------------------------
+
+InitHandle TorchCommRCCLX::getInitHandle() const {
+  std::string storeAddr;
+  if (reconfigure_store_) {
+    auto* tcpStore = dynamic_cast<c10d::TCPStore*>(reconfigure_store_.get());
+    if (!tcpStore) {
+      auto* prefixStore =
+          dynamic_cast<c10d::PrefixStore*>(reconfigure_store_.get());
+      if (prefixStore) {
+        tcpStore = dynamic_cast<c10d::TCPStore*>(
+            prefixStore->getUnderlyingNonPrefixStore().get());
+      }
+    }
+    if (tcpStore) {
+      storeAddr =
+          fmt::format("{}:{}", tcpStore->getHost(), tcpStore->getPort());
+    }
+  }
+  int rank = nccl_comm_ ? rank_ : static_cast<int>(query_ranksize().first);
+  return fmt::format("rcclx:{}:{}:{}", rank, uuid_, storeAddr);
+}
+
+namespace {
+
+struct HandleInfo {
+  int rank;
+  int64_t uuid;
+  std::string storeAddr;
+};
+
+HandleInfo parseHandle(const InitHandle& handle) {
+  // Format: "rcclx:<rank>:<uuid>:<storeAddr>" or legacy "rcclx:<rank>"
+  auto first = handle.find(':');
+  if (first == std::string::npos) {
+    return {-1, -1, ""};
+  }
+  auto second = handle.find(':', first + 1);
+  if (second == std::string::npos) {
+    // Legacy format: "rcclx:<rank>"
+    return {std::stoi(handle.substr(first + 1)), -1, ""};
+  }
+  int rank = std::stoi(handle.substr(first + 1, second - first - 1));
+  auto third = handle.find(':', second + 1);
+  if (third == std::string::npos) {
+    return {rank, std::stoll(handle.substr(second + 1)), ""};
+  }
+  int64_t uuid = std::stoll(handle.substr(second + 1, third - second - 1));
+  std::string storeAddr = handle.substr(third + 1);
+  return {rank, uuid, storeAddr};
+}
+
+struct QuorumInfo {
+  int64_t uuid = -1;
+  std::unordered_set<int> ranks;
+  size_t newMemberCount = 0;
+};
+
+QuorumInfo findQuorum(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles) {
+  std::unordered_map<int64_t, std::vector<int>> groupByUuid;
+  size_t totalHandles = 0;
+
+  auto processHandle = [&](const InitHandle& handle) {
+    totalHandles++;
+    auto info = parseHandle(handle);
+    groupByUuid[info.uuid].push_back(info.rank);
+  };
+
+  std::visit(
+      [&](const auto& h) {
+        for (const auto& handle : h) {
+          processHandle(handle);
+        }
+      },
+      handles);
+
+  QuorumInfo quorum;
+  for (const auto& [uuid, ranks] : groupByUuid) {
+    if (uuid < 0) {
+      continue; // Legacy / uninitialized handles
+    }
+    std::unordered_set<int> uniqueRanks(ranks.begin(), ranks.end());
+    if (uniqueRanks.size() != ranks.size()) {
+      continue; // Duplicate ranks in this uuid group — skip
+    }
+    if (uniqueRanks.size() > quorum.ranks.size()) {
+      quorum.uuid = uuid;
+      quorum.ranks = uniqueRanks;
+    }
+  }
+
+  quorum.newMemberCount = totalHandles - quorum.ranks.size();
+  return quorum;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// reconfigure()
+// ---------------------------------------------------------------------------
+
+c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reconfigure(
+    const ReconfigureOptions& opts) {
+  TC_LOG(INFO, this) << "TorchCommRCCLX reconfigure starting";
+  TracingGuard tracingGuard(name_, comm_size_, "reconfigure", rank_);
+
+  int new_size = static_cast<int>(
+      std::visit([](const auto& h) { return h.size(); }, opts.handles));
+  auto reconfigureTimeout = opts.timeout.value_or(options_.timeout);
+
+  auto quorum = findQuorum(opts.handles);
+  bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
+
+  // Identity reconfigure: quorum covers the full new world, no new members.
+  // The old comm may be unhealthy (revoked after abort()), so fall back to
+  // fresh init — same as NCCL reference.
+  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+      quorum.newMemberCount == 0) {
+    inQuorum = false;
+    quorum.ranks.clear();
+  }
+
+  // Clean up the existing communicator before any reconfiguration.
+  if (nccl_comm_) {
+    // Revoke any in-flight work so ranks don't hang waiting for completions.
+    RCCLX_CHECK_IGNORE(
+        rcclx_api_,
+        rcclx_api_->commRevoke(nccl_comm_),
+        "RCCLX commRevoke failed during reconfigure");
+
+    detachMemoryHook();
+
+    if (timeout_thread_.joinable()) {
+      shutdown_ = true;
+      {
+        std::lock_guard<std::mutex> lock(timeout_mutex_);
+        timeout_cv_.notify_all();
+      }
+      timeout_thread_.join();
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(work_queues_mutex_);
+      stream_work_queues_.clear();
+      std::queue<c10::intrusive_ptr<TorchWorkRCCLX>> empty;
+      std::swap(completed_works_, empty);
+    }
+
+    if (!inQuorum) {
+      // This rank is not in the quorum (new joiner, or identity/fresh-init).
+      // Abort the old comm so we can bootstrap a fresh one.
+      RCCLX_CHECK_IGNORE(
+          rcclx_api_,
+          rcclx_api_->commAbort(nccl_comm_),
+          "RCCLX commAbort failed during reconfigure");
+      nccl_comm_ = nullptr;
+    }
+  }
+
+  if (quorum.ranks.empty()) {
+    // -----------------------------------------------------------------------
+    // Case 1 & 2: Fresh init or identity reconfigure.
+    // All ranks bootstrap a new communicator via commInitRankConfig using the
+    // shared reconfigure_store_ to exchange the unique ID.
+    // -----------------------------------------------------------------------
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->setDevice(device_.index()),
+        fmt::format("Failed to set HIP device to {}", device_.index()));
+
+    auto store = c10::make_intrusive<c10d::PrefixStore>(
+        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+
+    int myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+    ncclUniqueId uniqueId{};
+    if (myRank == 0) {
+      RCCLX_CHECK(
+          rcclx_api_,
+          nccl_comm_,
+          rcclx_api_->getUniqueId(&uniqueId),
+          "RCCLX getUniqueId failed during reconfigure");
+      std::vector<uint8_t> vec(
+          reinterpret_cast<uint8_t*>(&uniqueId),
+          reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+      store->set("unique_id", vec);
+    } else {
+      store->wait({"unique_id"}, reconfigureTimeout);
+      auto vec = store->get("unique_id");
+      std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+    }
+
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclComm_t new_comm = nullptr;
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commInitRankConfig(
+            &new_comm, new_size, uniqueId, myRank, &config),
+        "RCCLX commInitRankConfig failed during reconfigure");
+    nccl_comm_ = new_comm;
+
+    initRcclxResources();
+
+  } else if (inQuorum) {
+    // -----------------------------------------------------------------------
+    // Case 3: This rank is in the quorum — shrink departed ranks, then grow
+    //         to add new members if any.
+    // -----------------------------------------------------------------------
+    ncclComm_t current = nccl_comm_;
+
+    if (quorum.ranks.size() < static_cast<size_t>(comm_size_)) {
+      // Build the exclude list: ranks in the old comm that are NOT in quorum.
+      std::vector<int> excludeRanks;
+      for (int r = 0; r < comm_size_; ++r) {
+        if (quorum.ranks.find(r) == quorum.ranks.end()) {
+          excludeRanks.push_back(r);
+        }
+      }
+
+      ncclComm_t shrunk = nullptr;
+      RCCLX_CHECK(
+          rcclx_api_,
+          current,
+          rcclx_api_->commShrink(
+              current,
+              excludeRanks.data(),
+              static_cast<int>(excludeRanks.size()),
+              &shrunk,
+              nullptr,
+              NCCL_SHRINK_ABORT),
+          "RCCLX commShrink failed during reconfigure");
+      current = shrunk;
+    }
+
+    if (quorum.newMemberCount > 0) {
+      // Rank 0 of the post-shrink comm publishes the grow unique ID.
+      int currentRank = 0;
+      RCCLX_CHECK(
+          rcclx_api_,
+          current,
+          rcclx_api_->commUserRank(current, &currentRank),
+          "RCCLX commUserRank failed during grow");
+
+      if (currentRank == 0) {
+        ncclUniqueId uniqueId{};
+        RCCLX_CHECK(
+            rcclx_api_,
+            current,
+            rcclx_api_->commGetUniqueId(current, &uniqueId),
+            "RCCLX commGetUniqueId failed during grow");
+
+        auto store = c10::make_intrusive<c10d::PrefixStore>(
+            fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+        std::vector<uint8_t> vec(
+            reinterpret_cast<uint8_t*>(&uniqueId),
+            reinterpret_cast<uint8_t*>(&uniqueId) + sizeof(uniqueId));
+        store->set("unique_id", vec);
+      }
+
+      ncclComm_t grown = nullptr;
+      RCCLX_CHECK(
+          rcclx_api_,
+          current,
+          rcclx_api_->commGrow(
+              current, new_size, nullptr, -1, &grown, nullptr),
+          "RCCLX commGrow failed during reconfigure");
+      current = grown;
+    }
+
+    nccl_comm_ = current;
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+    initRcclxResources();
+
+  } else {
+    // -----------------------------------------------------------------------
+    // Case 4: New rank joining an existing quorum via commGrow.
+    // -----------------------------------------------------------------------
+    comm_state_ = CommState::NORMAL;
+    shutdown_ = false;
+
+    int quorumSize = static_cast<int>(quorum.ranks.size());
+    auto store = c10::make_intrusive<c10d::PrefixStore>(
+        fmt::format("{}/{}", name_, opts.uuid), reconfigure_store_);
+    store->wait({"unique_id"}, reconfigureTimeout);
+
+    auto vec = store->get("unique_id");
+    ncclUniqueId uniqueId{};
+    std::memcpy(&uniqueId, vec.data(), sizeof(ncclUniqueId));
+
+    int growRank =
+        quorumSize + static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+    ncclComm_t new_comm = nullptr;
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commGrow(
+            nullptr, new_size, &uniqueId, growRank, &new_comm, nullptr),
+        "RCCLX commGrow failed for new rank during reconfigure");
+
+    nccl_comm_ = new_comm;
+    initRcclxResources();
+  }
+
+  init_state_ = InitializationState::INITIALIZED;
+  uuid_ = opts.uuid;
+
+  TC_LOG(INFO, this) << "TorchCommRCCLX reconfigure completed for rank: "
+                     << rank_;
+
+  return c10::make_intrusive<TorchWorkCompleted>();
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
@@ -77,15 +77,14 @@ struct HandleInfo {
 };
 
 HandleInfo parseHandle(const InitHandle& handle) {
-  // Format: "rcclx:<rank>:<uuid>:<storeAddr>" or legacy "rcclx:<rank>"
+  // Format: "rcclx:<rank>:<uuid>:<storeAddr>"
   auto first = handle.find(':');
   if (first == std::string::npos) {
     return {-1, -1, ""};
   }
   auto second = handle.find(':', first + 1);
   if (second == std::string::npos) {
-    // Legacy format: "rcclx:<rank>"
-    return {std::stoi(handle.substr(first + 1)), -1, ""};
+    return {-1, -1, ""};
   }
   int rank = std::stoi(handle.substr(first + 1, second - first - 1));
   auto third = handle.find(':', second + 1);
@@ -148,7 +147,7 @@ QuorumInfo findQuorum(
   QuorumInfo quorum;
   for (const auto& [uuid, ranks] : groupByUuid) {
     if (uuid < 0) {
-      continue; // Legacy / uninitialized handles
+      continue;
     }
     std::unordered_set<int> uniqueRanks(ranks.begin(), ranks.end());
     if (uniqueRanks.size() != ranks.size()) {
@@ -389,8 +388,7 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reconfigure(
       RCCLX_CHECK(
           rcclx_api_,
           current,
-          rcclx_api_->commGrow(
-              current, new_size, nullptr, -1, &grown, nullptr),
+          rcclx_api_->commGrow(current, new_size, nullptr, -1, &grown, nullptr),
           "RCCLX commGrow failed during reconfigure");
       current = grown;
     }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
@@ -175,10 +175,38 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reconfigure(
 
   // Clean up the existing communicator before any reconfiguration.
   if (nccl_comm_) {
+    // Check for in-flight work before deciding whether to revoke.
+    // Mirrors NCCL's workq_.garbageCollect() pattern: snapshot the queued
+    // work items (under the mutex), then query their HIP event status without
+    // holding the lock (checkStatus() calls hipEventQuery).
+    bool workInFlight = false;
+    {
+      std::vector<c10::intrusive_ptr<TorchWorkRCCLX>> pendingWork;
+      {
+        std::lock_guard<std::mutex> lock(work_queues_mutex_);
+        for (auto& [stream, q] : stream_work_queues_) {
+          auto tmp = q;
+          while (!tmp.empty()) {
+            pendingWork.push_back(tmp.front());
+            tmp.pop();
+          }
+        }
+      }
+      for (auto& work : pendingWork) {
+        auto s = work->checkStatus();
+        if (s == TorchWork::WorkStatus::NOT_STARTED ||
+            s == TorchWork::WorkStatus::INPROGRESS) {
+          workInFlight = true;
+          break;
+        }
+      }
+    }
+
     // Only revoke when this rank is leaving the quorum (new joiner or fresh
-    // init). In-quorum ranks keep the comm alive for commShrink; revoking it
-    // would invalidate the comm before shrink runs.
-    if (!inQuorum) {
+    // init) AND there is work in flight that needs to be cancelled. In-quorum
+    // ranks keep the comm alive for commShrink; revoking it would invalidate
+    // the comm before shrink runs.
+    if (!inQuorum && workInFlight) {
       RCCLX_CHECK_IGNORE(
           rcclx_api_,
           rcclx_api_->commRevoke(nccl_comm_),

--- a/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXReconfigure.cpp
@@ -160,22 +160,30 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::reconfigure(
   auto quorum = findQuorum(opts.handles);
   bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
 
-  // Identity reconfigure: quorum covers the full new world, no new members.
-  // The old comm may be unhealthy (revoked after abort()), so fall back to
-  // fresh init — same as NCCL reference.
-  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
-      quorum.newMemberCount == 0) {
+  // Fall back to fresh init when shrink/grow has no advantage:
+  // - Single-rank quorum: a 1-rank comm has no bootstrap networking, so
+  //   commGrow will fail. Must clear unconditionally (not just when
+  //   inQuorum) so all ranks take the same fresh init path.
+  // - Identity reconfigure: same world size, no membership change — old comm
+  //   may be unhealthy (e.g. revoked after abort()).
+  if (quorum.ranks.size() == 1 ||
+      (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+       quorum.newMemberCount == 0)) {
     inQuorum = false;
     quorum.ranks.clear();
   }
 
   // Clean up the existing communicator before any reconfiguration.
   if (nccl_comm_) {
-    // Revoke any in-flight work so ranks don't hang waiting for completions.
-    RCCLX_CHECK_IGNORE(
-        rcclx_api_,
-        rcclx_api_->commRevoke(nccl_comm_),
-        "RCCLX commRevoke failed during reconfigure");
+    // Only revoke when this rank is leaving the quorum (new joiner or fresh
+    // init). In-quorum ranks keep the comm alive for commShrink; revoking it
+    // would invalidate the comm before shrink runs.
+    if (!inQuorum) {
+      RCCLX_CHECK_IGNORE(
+          rcclx_api_,
+          rcclx_api_->commRevoke(nccl_comm_),
+          "RCCLX commRevoke failed during reconfigure");
+    }
 
     detachMemoryHook();
 

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -239,14 +239,15 @@ void TorchCommRCCLX::timeoutWatchdog() noexcept {
       break;
     }
     if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error) {
-      // Log the error and abort the process.  We cannot abort the NCCL
-      // communicator as it is not safe to call NCCL operations from
-      // multiple threads at the same time.
+        options_.abort_process_on_timeout_or_error &&
+        !options_.enable_reconfigure) {
       if (comm_state_ == CommState::TIMEOUT) {
-        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        TC_LOG(ERROR, this)
+            << "Aborting process due to timeout on rank " << rank_
+            << " - timeout watchdog detected timeout. ";
       } else if (comm_state_ == CommState::ERROR) {
-        TC_LOG(ERROR, this) << "Aborting process due to error";
+        TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
+                            << " - timeout watchdog detected operation error. ";
       }
 
       runAbortHooks();
@@ -298,8 +299,18 @@ void TorchCommRCCLX::checkAndAbortIfTimedOutOrError() {
   }
 
   if (comm_state_ == CommState::TIMEOUT) {
-    abortRcclxComm();
-    throw std::runtime_error("NCCL operation timed out");
+    if (options_.enable_reconfigure) {
+      revokeRcclxComm();
+      throw std::runtime_error("RCCLX operation timed out");
+    } else {
+      abortRcclxComm();
+      if (options_.abort_process_on_timeout_or_error) {
+        TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        abort();
+      } else {
+        throw std::runtime_error("RCCLX operation timed out");
+      }
+    }
   } else if (comm_state_ == CommState::ERROR) {
     ncclResult_t asyncErr;
     RCCLX_CHECK(

--- a/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.cpp
+++ b/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.cpp
@@ -26,9 +26,25 @@ void RcclxMock::setupDefaultBehaviors() {
   ON_CALL(*this, commDestroy(_)).WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, commAbort(_)).WillByDefault(Return(ncclSuccess));
 
+  ON_CALL(*this, commRevoke(_)).WillByDefault(Return(ncclSuccess));
+
   ON_CALL(*this, commSplit(_, _, _, _, _))
       .WillByDefault(DoAll(
           SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x4000)),
+          Return(ncclSuccess)));
+
+  ON_CALL(*this, commShrink(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<3>(reinterpret_cast<ncclComm_t>(0x6000)),
+          Return(ncclSuccess)));
+
+  ON_CALL(*this, commGetUniqueId(_, _))
+      .WillByDefault(
+          DoAll(SetArgPointee<1>(ncclUniqueId{}), Return(ncclSuccess)));
+
+  ON_CALL(*this, commGrow(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<4>(reinterpret_cast<ncclComm_t>(0x7000)),
           Return(ncclSuccess)));
 
   ON_CALL(*this, commCount(_, _))

--- a/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.hpp
+++ b/comms/torchcomms/rcclx/tests/unit/cpp/mocks/RcclxMock.hpp
@@ -24,12 +24,38 @@ class RcclxMock : public RcclxApi {
 
   MOCK_METHOD(ncclResult_t, commDestroy, (ncclComm_t comm), (override));
   MOCK_METHOD(ncclResult_t, commAbort, (ncclComm_t comm), (override));
+  MOCK_METHOD(ncclResult_t, commRevoke, (ncclComm_t comm), (override));
   MOCK_METHOD(
       ncclResult_t,
       commSplit,
       (ncclComm_t comm,
        int color,
        int key,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commShrink,
+      (ncclComm_t comm,
+       int* excludeRanksList,
+       int excludeRanksCount,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config,
+       int shrinkFlags),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commGetUniqueId,
+      (ncclComm_t comm, ncclUniqueId* uniqueId),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commGrow,
+      (ncclComm_t comm,
+       int nRanks,
+       const ncclUniqueId* uniqueId,
+       int rank,
        ncclComm_t* newcomm,
        ncclConfig_t* config),
       (override));

--- a/comms/torchcomms/tests/integration/py/AbortTest.py
+++ b/comms/torchcomms/tests/integration/py/AbortTest.py
@@ -14,7 +14,7 @@ from torch.distributed import TCPStore
 class AbortTest(unittest.TestCase):
     """Test the abort() API for TorchComm."""
 
-    SUPPORTED_BACKENDS = {"nccl", "ncclx"}
+    SUPPORTED_BACKENDS = {"nccl", "ncclx", "rccl", "rcclx"}
 
     _shared_store = None
 

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -17,6 +17,7 @@ import unittest
 from datetime import timedelta
 
 import torch
+import torchcomms
 from torch.distributed import TCPStore
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
     skip_backend,
@@ -143,8 +144,6 @@ class ReconfigureTest(unittest.TestCase):
                 f"Backend {self.backend} supports reconfigure, skipping negative test"
             )
 
-        import torchcomms
-
         with self.assertRaises(RuntimeError) as context:
             torchcomms.new_comm(
                 self.backend,
@@ -163,29 +162,7 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
 
-        import torchcomms
-
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            "reconfigure_basic",
-            enable_reconfigure=True,
-            store=self._get_store_for_comm(),
-        )
-
-        all_handles = self._collect_handles(comm, "test_reconfigure_basic")
-        self.assertGreater(len(all_handles), 0)
-
-        print(f"[Rank {self.rank}] Collected handles: {all_handles}")
-
-        work = comm.reconfigure(
-            uuid=0,
-            init_handles=all_handles,
-            timeout=timedelta(milliseconds=30000),
-        )
-        self.assertIsNotNone(work)
-
-        work.wait()
+        comm, _ = self._create_reconfigured_comm("reconfigure_basic", 0)
 
         self.assertGreaterEqual(comm.get_rank(), 0)
         self.assertLess(comm.get_rank(), self.world_size)
@@ -200,24 +177,7 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
 
-        import torchcomms
-
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            "reconfigure_collective",
-            enable_reconfigure=True,
-            store=self._get_store_for_comm(),
-        )
-
-        all_handles = self._collect_handles(comm, "test_reconfigure_collective")
-
-        work = comm.reconfigure(
-            uuid=2,
-            init_handles=all_handles,
-            timeout=timedelta(milliseconds=30000),
-        )
-        work.wait()
+        comm, _ = self._create_reconfigured_comm("reconfigure_collective", 2)
 
         if self.world_size > 1:
             my_rank = comm.get_rank()
@@ -260,24 +220,7 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
 
-        import torchcomms
-
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            "reconfigure_allreduce",
-            enable_reconfigure=True,
-            store=self._get_store_for_comm(),
-        )
-
-        all_handles = self._collect_handles(comm, "test_reconfigure_allreduce")
-
-        work = comm.reconfigure(
-            uuid=3,
-            init_handles=all_handles,
-            timeout=timedelta(milliseconds=30000),
-        )
-        work.wait()
+        comm, _ = self._create_reconfigured_comm("reconfigure_allreduce", 3)
 
         my_rank = comm.get_rank()
         tensor = torch.ones(4, dtype=torch.float, device=self.device) * (my_rank + 1)
@@ -298,11 +241,8 @@ class ReconfigureTest(unittest.TestCase):
 
         comm.finalize()
 
-
     def _create_reconfigured_comm(self, name, uuid):
         """Helper: create a comm and perform initial reconfigure."""
-        import torchcomms
-
         comm = torchcomms.new_comm(
             self.backend,
             self.device,
@@ -322,11 +262,6 @@ class ReconfigureTest(unittest.TestCase):
 
         post_handles = self._collect_handles(comm, f"{name}_post")
         return comm, post_handles
-
-    def _reduce_op_sum(self):
-        import torchcomms
-
-        return torchcomms.ReduceOp.SUM
 
     def test_shrink_basic(self):
         """Test shrink: exclude last rank, allreduce on child comm."""
@@ -355,7 +290,7 @@ class ReconfigureTest(unittest.TestCase):
 
         my_rank = comm.get_rank()
         tensor = torch.ones(1024, dtype=torch.float, device=self.device) * (my_rank + 1)
-        comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+        comm.all_reduce(tensor, op=torchcomms.ReduceOp.SUM, async_op=False)
 
         expected = sum(range(1, new_size + 1))
         self.assertTrue(
@@ -363,43 +298,17 @@ class ReconfigureTest(unittest.TestCase):
             f"AllReduce post-shrink failed: got {tensor[0].item()}, expected {expected}",
         )
 
-        print(f"[Rank {my_rank}] Shrink {self.world_size} -> {new_size}, allreduce OK")
-        comm.finalize()
-
-    def test_shrink_multiple_collectives(self):
-        """Test multiple allreduces + broadcast on child comm after shrink."""
-        if not self._is_supported_backend():
-            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
-        if self.world_size < 3:
-            self.skipTest("Need at least 3 ranks for shrink test")
-
-        comm, all_handles = self._create_reconfigured_comm("shrink_multi", 200)
-        exclude_rank = self.world_size - 1
-
-        if self.rank == exclude_rank:
-            comm.finalize()
-            return
-
-        surviving_handles = [h for i, h in enumerate(all_handles) if i != exclude_rank]
-        work = comm.reconfigure(
-            uuid=201,
-            init_handles=surviving_handles,
-            timeout=timedelta(seconds=30),
-        )
-        work.wait()
-
-        new_size = comm.get_size()
-        my_rank = comm.get_rank()
-
+        # Exercise a few more collectives on the child comm to catch any
+        # state-tracking bugs that only surface on the second op onwards.
         for i in range(3):
             tensor = torch.ones(2048, dtype=torch.float, device=self.device) * (
                 my_rank + 1 + i
             )
-            comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+            comm.all_reduce(tensor, op=torchcomms.ReduceOp.SUM, async_op=False)
             expected = sum(range(1 + i, new_size + 1 + i))
             self.assertTrue(
                 torch.allclose(tensor, torch.full_like(tensor, expected)),
-                f"AllReduce iteration {i} failed",
+                f"AllReduce iteration {i} on shrunk comm failed",
             )
 
         tensor = torch.zeros(1024, dtype=torch.float, device=self.device)
@@ -408,10 +317,12 @@ class ReconfigureTest(unittest.TestCase):
         comm.broadcast(tensor, root=0, async_op=False)
         self.assertTrue(
             torch.allclose(tensor, torch.full_like(tensor, 42.0)),
-            "Broadcast after shrink failed",
+            "Broadcast on shrunk comm failed",
         )
 
-        print(f"[Rank {my_rank}] 3 AllReduce + 1 Broadcast on child comm OK")
+        print(
+            f"[Rank {my_rank}] Shrink {self.world_size} -> {new_size}, collectives OK"
+        )
         comm.finalize()
 
     def test_shrink_exclude_middle_rank(self):
@@ -443,7 +354,7 @@ class ReconfigureTest(unittest.TestCase):
         self.assertLess(my_rank, new_size)
 
         tensor = torch.ones(1024, dtype=torch.float, device=self.device) * (my_rank + 1)
-        comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+        comm.all_reduce(tensor, op=torchcomms.ReduceOp.SUM, async_op=False)
 
         expected = sum(range(1, new_size + 1))
         self.assertTrue(
@@ -462,8 +373,6 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
         self._skip_if_grow_not_supported()
-
-        import torchcomms
 
         comm = torchcomms.new_comm(
             self.backend,
@@ -499,8 +408,6 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
         self._skip_if_grow_not_supported()
-
-        import torchcomms
 
         comm = torchcomms.new_comm(
             self.backend,
@@ -545,22 +452,7 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
 
-        import torchcomms
-
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            "reconfigure_identity",
-            enable_reconfigure=True,
-            store=self._get_store_for_comm(),
-        )
-
-        all_handles = self._collect_handles(comm, "test_reconfigure_identity1")
-        comm.reconfigure(
-            uuid=4,
-            init_handles=all_handles,
-            timeout=timedelta(milliseconds=30000),
-        ).wait()
+        comm, _ = self._create_reconfigured_comm("reconfigure_identity", 4)
 
         all_handles = self._collect_handles(comm, "test_reconfigure_identity2")
         comm.reconfigure(
@@ -576,8 +468,6 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
         self._skip_if_grow_not_supported()
-
-        import torchcomms
 
         comm = torchcomms.new_comm(
             self.backend,
@@ -611,8 +501,6 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
         self._skip_if_grow_not_supported()
-
-        import torchcomms
 
         comm = torchcomms.new_comm(
             self.backend,
@@ -652,22 +540,7 @@ class ReconfigureTest(unittest.TestCase):
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
 
-        import torchcomms
-
-        comm = torchcomms.new_comm(
-            self.backend,
-            self.device,
-            "reconfigure_after_abort",
-            enable_reconfigure=True,
-            store=self._get_store_for_comm(),
-        )
-
-        all_handles = self._collect_handles(comm, "test_reconfigure_after_abort1")
-        comm.reconfigure(
-            uuid=10,
-            init_handles=all_handles,
-            timeout=timedelta(milliseconds=30000),
-        ).wait()
+        comm, _ = self._create_reconfigured_comm("reconfigure_after_abort", 10)
 
         comm.abort()
 

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -96,11 +96,11 @@ class ReconfigureTest(unittest.TestCase):
     def _skip_if_grow_not_supported(self):
         """Skip test if commGrow is not available.
 
-        Skips for rccl/rcclx backends which do not implement commGrow,
-        and for nccl/ncclx with NCCL < 2.29 (commGrow/commGetUniqueId unavailable).
+        For nccl/ncclx, skip when the linked NCCL version is older than 2.29.
+        For rccl/rcclx, commGrow requires RCCL >= 2.29; the version check is
+        performed in the C++ backend at compile time, so we attempt the test
+        and rely on the backend to surface an error if the API is unavailable.
         """
-        if self.backend in ("rccl", "rcclx"):
-            self.skipTest(f"Backend {self.backend} does not implement commGrow")
         if self.backend not in ("nccl", "ncclx"):
             return
         if torch.cuda.is_available():

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -27,7 +27,7 @@ from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
 class ReconfigureTest(unittest.TestCase):
     """Test class for reconfigure() fault tolerance API."""
 
-    SUPPORTED_BACKENDS = {"mccl", "gloo", "nccl", "ncclx"}
+    SUPPORTED_BACKENDS = {"mccl", "gloo", "nccl", "ncclx", "rccl", "rcclx"}
 
     _shared_store = None
 
@@ -93,8 +93,14 @@ class ReconfigureTest(unittest.TestCase):
         """Get the store to pass to new_comm for NCCL/NCCLx bootstrap."""
         return getattr(self, "store", None)
 
-    def _skip_if_nccl_too_old(self):
-        """Skip test if NCCL < 2.29 (commGrow/commGetUniqueId unavailable)."""
+    def _skip_if_grow_not_supported(self):
+        """Skip test if commGrow is not available.
+
+        Skips for rccl/rcclx backends which do not implement commGrow,
+        and for nccl/ncclx with NCCL < 2.29 (commGrow/commGetUniqueId unavailable).
+        """
+        if self.backend in ("rccl", "rcclx"):
+            self.skipTest(f"Backend {self.backend} does not implement commGrow")
         if self.backend not in ("nccl", "ncclx"):
             return
         if torch.cuda.is_available():
@@ -292,11 +298,170 @@ class ReconfigureTest(unittest.TestCase):
 
         comm.finalize()
 
+
+    def _create_reconfigured_comm(self, name, uuid):
+        """Helper: create a comm and perform initial reconfigure."""
+        import torchcomms
+
+        comm = torchcomms.new_comm(
+            self.backend,
+            self.device,
+            name,
+            enable_reconfigure=True,
+            store=self._get_store_for_comm(),
+            timeout=timedelta(seconds=120),
+        )
+
+        init_handles = self._collect_handles(comm, f"{name}_init")
+        work = comm.reconfigure(
+            uuid=uuid,
+            init_handles=init_handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+        post_handles = self._collect_handles(comm, f"{name}_post")
+        return comm, post_handles
+
+    def _reduce_op_sum(self):
+        import torchcomms
+
+        return torchcomms.ReduceOp.SUM
+
+    def test_shrink_basic(self):
+        """Test shrink: exclude last rank, allreduce on child comm."""
+        if not self._is_supported_backend():
+            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
+        if self.world_size < 3:
+            self.skipTest("Need at least 3 ranks for shrink test")
+
+        comm, all_handles = self._create_reconfigured_comm("shrink_basic", 100)
+        exclude_rank = self.world_size - 1
+
+        if self.rank == exclude_rank:
+            comm.finalize()
+            return
+
+        surviving_handles = [h for i, h in enumerate(all_handles) if i != exclude_rank]
+        work = comm.reconfigure(
+            uuid=101,
+            init_handles=surviving_handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+        new_size = comm.get_size()
+        self.assertEqual(new_size, self.world_size - 1)
+
+        my_rank = comm.get_rank()
+        tensor = torch.ones(1024, dtype=torch.float, device=self.device) * (my_rank + 1)
+        comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+
+        expected = sum(range(1, new_size + 1))
+        self.assertTrue(
+            torch.allclose(tensor, torch.full_like(tensor, expected)),
+            f"AllReduce post-shrink failed: got {tensor[0].item()}, expected {expected}",
+        )
+
+        print(f"[Rank {my_rank}] Shrink {self.world_size} -> {new_size}, allreduce OK")
+        comm.finalize()
+
+    def test_shrink_multiple_collectives(self):
+        """Test multiple allreduces + broadcast on child comm after shrink."""
+        if not self._is_supported_backend():
+            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
+        if self.world_size < 3:
+            self.skipTest("Need at least 3 ranks for shrink test")
+
+        comm, all_handles = self._create_reconfigured_comm("shrink_multi", 200)
+        exclude_rank = self.world_size - 1
+
+        if self.rank == exclude_rank:
+            comm.finalize()
+            return
+
+        surviving_handles = [h for i, h in enumerate(all_handles) if i != exclude_rank]
+        work = comm.reconfigure(
+            uuid=201,
+            init_handles=surviving_handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+        new_size = comm.get_size()
+        my_rank = comm.get_rank()
+
+        for i in range(3):
+            tensor = torch.ones(2048, dtype=torch.float, device=self.device) * (
+                my_rank + 1 + i
+            )
+            comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+            expected = sum(range(1 + i, new_size + 1 + i))
+            self.assertTrue(
+                torch.allclose(tensor, torch.full_like(tensor, expected)),
+                f"AllReduce iteration {i} failed",
+            )
+
+        tensor = torch.zeros(1024, dtype=torch.float, device=self.device)
+        if my_rank == 0:
+            tensor.fill_(42.0)
+        comm.broadcast(tensor, root=0, async_op=False)
+        self.assertTrue(
+            torch.allclose(tensor, torch.full_like(tensor, 42.0)),
+            "Broadcast after shrink failed",
+        )
+
+        print(f"[Rank {my_rank}] 3 AllReduce + 1 Broadcast on child comm OK")
+        comm.finalize()
+
+    def test_shrink_exclude_middle_rank(self):
+        """Test shrink excluding a middle rank, verify rank renumbering."""
+        if not self._is_supported_backend():
+            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
+        if self.world_size < 3:
+            self.skipTest("Need at least 3 ranks for shrink test")
+
+        comm, all_handles = self._create_reconfigured_comm("shrink_middle", 300)
+        exclude_rank = self.world_size // 2
+
+        if self.rank == exclude_rank:
+            comm.finalize()
+            return
+
+        surviving_handles = [h for i, h in enumerate(all_handles) if i != exclude_rank]
+        work = comm.reconfigure(
+            uuid=301,
+            init_handles=surviving_handles,
+            timeout=timedelta(seconds=30),
+        )
+        work.wait()
+
+        new_size = comm.get_size()
+        my_rank = comm.get_rank()
+        self.assertEqual(new_size, self.world_size - 1)
+        self.assertGreaterEqual(my_rank, 0)
+        self.assertLess(my_rank, new_size)
+
+        tensor = torch.ones(1024, dtype=torch.float, device=self.device) * (my_rank + 1)
+        comm.all_reduce(tensor, op=self._reduce_op_sum(), async_op=False)
+
+        expected = sum(range(1, new_size + 1))
+        self.assertTrue(
+            torch.allclose(tensor, torch.full_like(tensor, expected)),
+            f"AllReduce after middle-rank shrink failed",
+        )
+
+        print(
+            f"[Rank {my_rank}] Shrink excluding middle rank {exclude_rank}, "
+            f"new size={new_size}, allreduce OK"
+        )
+        comm.finalize()
+
     def test_reconfigure_scale_down_up(self):
         """Test that reconfigure works when scaling down and up."""
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
-        self._skip_if_nccl_too_old()
+        self._skip_if_grow_not_supported()
 
         import torchcomms
 
@@ -333,6 +498,7 @@ class ReconfigureTest(unittest.TestCase):
         """Test reconfigure from single rank to all ranks then allreduce."""
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
+        self._skip_if_grow_not_supported()
 
         import torchcomms
 
@@ -409,7 +575,7 @@ class ReconfigureTest(unittest.TestCase):
         """Test that reconfigure works when workers join late."""
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
-        self._skip_if_nccl_too_old()
+        self._skip_if_grow_not_supported()
 
         import torchcomms
 
@@ -444,7 +610,7 @@ class ReconfigureTest(unittest.TestCase):
         """Test that reconfigure works when there's a split brain condition."""
         if not self._is_supported_backend():
             self.skipTest(f"Backend {self.backend} does not support reconfigure()")
-        self._skip_if_nccl_too_old()
+        self._skip_if_grow_not_supported()
 
         import torchcomms
 


### PR DESCRIPTION
## Summary

Add fault-tolerance APIs (revoke, shrink, grow, abort) to the `rccl` and `rcclx` TorchComms backends, mirroring the `nccl`/`ncclx` reconfigure-based recovery path.

**What's included:**

- **`ncclCommRevoke`** – When `enable_reconfigure=true`, the timeout watchdog calls `revokeRcclComm()` / `revokeRcclxComm()` instead of aborting the process. Throws `RuntimeError` instead of `SIGABRT`, allowing recovery via `reconfigure()`.
- **`ncclCommShrink`** – `reconfigure()` diffs old membership against new handles and calls `ncclCommShrink` with `NCCL_SHRINK_ABORT`. Rank renumbering and collectives work on the child communicator.
- **`ncclCommGrow` + `ncclCommGetUniqueId`** – Now wired to the real RCCL 2.29 entry points (gated by `NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)`, matching nccl/ncclx). The reconfigure path gained a `findRankInHandles` helper and a dedicated `new_size == 1` branch that creates a private 1-rank comm without shared-store coordination, without this, `commInitRankConfig` failed with `Invalid rank requested` when every rank shrunk to size 1.
- **`abort()`** – Mirrors `TorchCommNCCL::abort()`: dispatches to revoke when `enable_reconfigure` is set, otherwise aborts.
- **finalize-after-abort fix** – `finalize()` captures `comm_state_` at entry and skips the async error throw if `abort()` already set it to `ERROR`.

## Test results (`TEST_BACKEND=rcclx`, RCCL 2.29.7, after rebase onto current `main`)

| Suite | Ranks | Nodes | Per-rank result | Failures |
|---|---:|---:|---|---:|
| AbortTest        |  32 |  4 | 1 passed, 0 skipped       | 0 |
| AbortTest        |  64 |  8 | 1 passed, 0 skipped       | 0 |
| AbortTest        | 128 | 16 | 1 passed, 0 skipped       | 0 |
| ReconfigureTest  |  32 |  4 | 11 passed, 2 skipped      | 0 |
| ReconfigureTest  |  64 |  8 | 11 passed, 2 skipped      | 0 |
| ReconfigureTest  | 128 | 16 | 11 passed, 2 skipped      | 0 |


**Passed in ReconfigureTest** (rcclx):
- core: `test_reconfigure_basic`, `test_reconfigure_identity`, `test_reconfigure_then_collective`, `test_reconfigure_then_allreduce`, `test_reconfigure_after_abort`
- grow: `test_reconfigure_scale_down_up`, `test_reconfigure_single_to_all`, `test_reconfigure_late`, `test_reconfigure_merge_split`
- shrink: `test_shrink_basic` (now also exercises the post-shrink collectives loop + broadcast previously in `test_shrink_multiple_collectives`), `test_shrink_exclude_middle_rank`

**Skipped** (by design): `test_reconfigure_unsupported_backend`, `test_enable_reconfigure_unsupported_backend` — negative tests for backends that do *not* support `reconfigure()`; rcclx is now supported, so these short-circuit on purpose.

## Repro

```bash
source ~/tc_venv/bin/activate
export LD_PRELOAD=~/rccl-sync-install/lib/librccl.so
export LD_LIBRARY_PATH=~/torchcomms-src/comms/torchcomms:~/rccl-sync-install/lib:$LD_LIBRARY_PATH
export TEST_BACKEND=rcclx MASTER_ADDR=$(hostname -s)

# 32 / 64 / 128 ranks -> adjust -n and the hostfile accordingly (8 GPUs/node).
MPIRUN="mpirun --hostfile <hostfile> -n <N> --npernode 8 \
  --mca btl_tcp_if_include eth0 \
  -x LD_PRELOAD -x MASTER_PORT -x MASTER_ADDR -x TEST_BACKEND -x PATH -x LD_LIBRARY_PATH"

MASTER_PORT=29510 $MPIRUN python3 -m pytest --import-mode=importlib comms/torchcomms/tests/integration/py/AbortTest.py -v
MASTER_PORT=29520 $MPIRUN python3 -m pytest --import-mode=importlib comms/torchcomms/tests/integration/py/ReconfigureTest.py -v
```
