### PR TITLE
Add opCount to fault-tolerance abort log message

### DIFF
--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -842,10 +842,14 @@ void CtranGpe::Impl::gpeThreadFn() {
                     commRemoteError));
           }
         } else if (!cmd->coll.opGroup.empty() /* skip when opGroup is empty, i.e,. we are only here for post-kernel cmd destruction/cleanup */) {
-          CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
-            FB_COMMCHECKTHROW_EX(
-                cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
-          });
+          CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
+              comm,
+              {
+                FB_COMMCHECKTHROW_EX(
+                    cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
+              },
+              static_cast<int>(cmd->coll.opGroup.front()->type),
+              cmd->coll.opGroup.front()->opCount);
         }
 
         if (cmd->persistent) {

--- a/comms/ctran/utils/AsyncError.h
+++ b/comms/ctran/utils/AsyncError.h
@@ -36,32 +36,37 @@ namespace ctran::utils {
         asyncErr, ctran::utils::Exception(e.what(), commRemoteError)); \
   }
 
-#define CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e)       \
-  do {                                                             \
-    CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);         \
-    if (comm->abortEnabled()) {                                    \
-      XLOGF(                                                       \
-          ERR,                                                     \
-          "Fault tolerance enabled; marking communicator aborted " \
-          "(rank={}, commHash={:x})",                              \
-          comm->logMetaData_.rank,                                 \
-          comm->logMetaData_.commHash);                            \
-      comm->setAbort();                                            \
-    } else {                                                       \
-      throw;                                                       \
-    }                                                              \
+#define CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e, opType, opCount) \
+  do {                                                                        \
+    CTRAN_ASYNC_ERR_HANDLE_IMPL(comm->getAsyncError(), e);                    \
+    if (comm->abortEnabled()) {                                               \
+      XLOGF(                                                                  \
+          ERR,                                                                \
+          "Fault tolerance enabled; marking communicator aborted "            \
+          "(opType={}, opCount={}) on rank {} commHash {:x}",                 \
+          opType,                                                             \
+          opCount,                                                            \
+          comm->logMetaData_.rank,                                            \
+          comm->logMetaData_.commHash);                                       \
+      comm->setAbort();                                                       \
+    } else {                                                                  \
+      throw;                                                                  \
+    }                                                                         \
   } while (0)
 
-#define CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, code)          \
-  try {                                                            \
-    code;                                                          \
-  } catch (const ctran::utils::Exception& e) {                     \
-    CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e);          \
-  } catch (const std::runtime_error& e) {                          \
-    /*TODO: replace remaining runtime_error with Exception */      \
-    /*TODO(T238821628): improve from simple commRemoteError */     \
-    CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(                   \
-        comm, ctran::utils::Exception(e.what(), commRemoteError)); \
+#define CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, code, opType, opCount) \
+  try {                                                                    \
+    code;                                                                  \
+  } catch (const ctran::utils::Exception& e) {                             \
+    CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e, opType, opCount); \
+  } catch (const std::runtime_error& e) {                                  \
+    /*TODO: replace remaining runtime_error with Exception */              \
+    /*TODO(T238821628): improve from simple commRemoteError */             \
+    CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(                           \
+        comm,                                                              \
+        ctran::utils::Exception(e.what(), commRemoteError),                \
+        opType,                                                            \
+        opCount);                                                          \
   }
 
 class AsyncError {

--- a/comms/ctran/utils/tests/AsyncErrorUT.cc
+++ b/comms/ctran/utils/tests/AsyncErrorUT.cc
@@ -70,9 +70,11 @@ TEST(AsyncErrorTest, FaultToleranceDisabled) {
       std::make_unique<CtranComm>(ctran::utils::createAbort(/*enabled=*/false));
   EXPECT_THROW(
       {
-        CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(comm, {
-          throw ::ctran::utils::Exception("UT error", commRemoteError);
-        });
+        CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
+            comm,
+            { throw ::ctran::utils::Exception("UT error", commRemoteError); },
+            -1,
+            0);
       },
       ::ctran::utils::Exception)
       << "Expected to throw exception on error";
@@ -82,6 +84,9 @@ TEST(AsyncErrorTest, FaultToleranceEnabled) {
   auto comm =
       std::make_unique<CtranComm>(ctran::utils::createAbort(/*enabled=*/true));
   CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
-      comm, { throw ::ctran::utils::Exception("UT error", commRemoteError); });
+      comm,
+      { throw ::ctran::utils::Exception("UT error", commRemoteError); },
+      -1,
+      0);
   EXPECT_TRUE(comm->testAbort());
 }


### PR DESCRIPTION
Summary: When a collective operation fails with an exception in the GPE thread, the fault-tolerance log message only included `rank` and `commHash`. This adds `opCount` to identify which collective operation failed, which is useful for debugging timeouts.

Reviewed By: arttianezhu

Differential Revision: D103798820


