### PR TITLE
Fix AllToAllvAmd build: use send_group/recv_group instead of send/recv

### DIFF
--- a/comms/pipes/amd/collectives/AllToAllvAmd.cuh
+++ b/comms/pipes/amd/collectives/AllToAllvAmd.cuh
@@ -134,14 +134,14 @@ __device__ __forceinline__ void all_to_allv_hybrid_amd(
 
       bool is_send = (partition_id == 0);
       if (is_send) {
-        transport.p2p_nvl.send(
+        transport.p2p_nvl.send_group(
             group_per_peer,
             static_cast<char*>(const_cast<void*>(sendbuff_d)) +
                 send_info.offset,
             send_info.nbytes,
             timeout);
       } else {
-        transport.p2p_nvl.recv(
+        transport.p2p_nvl.recv_group(
             group_per_peer,
             static_cast<char*>(recvbuff_d) + recv_info.offset,
             recv_info.nbytes,


### PR DESCRIPTION
Summary: The `send()` and `recv()` methods on `P2pNvlTransportDevice` gained `active_blocks` and `max_signal_bytes` parameters before `timeout`, breaking AllToAllvAmd which passed a `Timeout` in the 4th position. Switch to `send_group()`/`recv_group()` which match the call pattern used by the NVIDIA `AllToAllv.cuh` and accept `(group, src/dst, nbytes, timeout)` directly.

Reviewed By: zhiyongww

Differential Revision: D103762164


