### PR TITLE
Use NCCLCommProvider for TorchComm + NCCL symmetric memory

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -1,9 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/NCCLCommProvider.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
 
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
+#include <torch/csrc/distributed/c10d/NCCLCommProvider.hpp> // @manual=//caffe2:torch-cpp-cpu
+
+#include <utility>
 
 namespace torch::comms {
 
@@ -141,9 +145,41 @@ c10::intrusive_ptr<c10::ivalue::Future> WorkWrapper::getFuture() {
 
 BackendWrapper::BackendWrapper(std::shared_ptr<TorchComm> comm)
     : Backend(comm->getRank(), comm->getSize()),
-      comm_(comm),
-      backend_(comm->getBackendImpl()),
+      comm_(std::move(comm)),
+      backend_(comm_->getBackendImpl()),
       options_(c10::make_intrusive<Options>()) {}
+
+namespace {
+
+class NCCLBackendWrapper final : public BackendWrapper,
+                                 public c10d::NCCLCommProvider {
+ public:
+  explicit NCCLBackendWrapper(std::shared_ptr<TorchComm> comm)
+      : BackendWrapper(std::move(comm)) {}
+
+  void* getNCCLCommPtr() const override {
+    auto backend = getBackendImpl();
+    auto* provider = dynamic_cast<NCCLCommProvider*>(backend.get());
+    TORCH_CHECK(
+        provider != nullptr,
+        "TorchComm backend does not expose an NCCL communicator");
+    auto* comm = provider->getNCCLCommPtr();
+    TORCH_CHECK(
+        comm != nullptr, "TorchComm backend returned a null NCCL communicator");
+    return comm;
+  }
+};
+
+} // namespace
+
+c10::intrusive_ptr<BackendWrapper> createBackendWrapper(
+    std::shared_ptr<TorchComm> comm) {
+  auto backend = comm->getBackendImpl();
+  if (dynamic_cast<NCCLCommProvider*>(backend.get()) != nullptr) {
+    return c10::make_intrusive<NCCLBackendWrapper>(std::move(comm));
+  }
+  return c10::make_intrusive<BackendWrapper>(std::move(comm));
+}
 
 c10::intrusive_ptr<c10d::Work> BackendWrapper::broadcast(
     std::vector<at::Tensor>& tensors,
@@ -551,6 +587,10 @@ std::shared_ptr<TorchComm> BackendWrapper::getComm() const {
   return comm_;
 }
 
+std::shared_ptr<TorchCommBackend> BackendWrapper::getBackendImpl() const {
+  return backend_;
+}
+
 const std::string BackendWrapper::getBackendName() const {
   return comm_->getBackend();
 }
@@ -598,7 +638,7 @@ c10::intrusive_ptr<c10d::Backend> BackendWrapper::split(
   if (new_comm == nullptr) {
     return nullptr;
   }
-  return c10::make_intrusive<BackendWrapper>(new_comm);
+  return createBackendWrapper(new_comm);
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -146,10 +146,16 @@ class BackendWrapper : public c10d::Backend {
       const std::vector<int>& ranks,
       const c10::intrusive_ptr<c10d::Backend::Options>& opts) override;
 
+ protected:
+  std::shared_ptr<TorchCommBackend> getBackendImpl() const;
+
  private:
   std::shared_ptr<TorchComm> comm_;
   std::shared_ptr<TorchCommBackend> backend_;
   c10::intrusive_ptr<Options> options_;
 };
+
+c10::intrusive_ptr<BackendWrapper> createBackendWrapper(
+    std::shared_ptr<TorchComm> comm);
 
 } // namespace torch::comms

--- a/comms/torchcomms/NCCLCommProvider.hpp
+++ b/comms/torchcomms/NCCLCommProvider.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+namespace torch::comms {
+
+// Internal TorchComm extension point for backend implementations that can
+// expose an underlying NCCL communicator to BackendWrapper.
+class NCCLCommProvider {
+ public:
+  virtual ~NCCLCommProvider() = default;
+  virtual void* getNCCLCommPtr() const = 0;
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -2568,7 +2568,9 @@ Note:
 
   intrusive_ptr_class_<BackendWrapper, c10d::Backend>(m, "_BackendWrapper")
       .def(
-          py::init<std::shared_ptr<TorchComm>>(),
+          py::init([](std::shared_ptr<TorchComm> comm) {
+            return createBackendWrapper(std::move(comm));
+          }),
           "Create BackendWrapper around a TorchCommBackend",
           py::arg("comm"),
           py::call_guard<py::gil_scoped_release>())

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -651,6 +651,13 @@ int TorchCommNCCLX::getSize() const {
   return comm_size;
 }
 
+void* TorchCommNCCLX::getNCCLCommPtr() const {
+  checkInitialized();
+  TORCH_CHECK(
+      nccl_comm_ != nullptr, "[TorchCommNCCLX]: NCCL communicator is null");
+  return nccl_comm_;
+}
+
 std::string_view TorchCommNCCLX::getBackendName() const {
   return kBackendName;
 }

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "comms/torchcomms/NCCLCommProvider.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchCommBackend.hpp"
 #include "comms/torchcomms/TorchCommBatch.hpp"
@@ -71,6 +72,7 @@ bool isGraphTimeoutMonitoringEnabled();
 void resetGraphTimeoutMonitoringCacheForTest();
 
 class TorchCommNCCLX : public TorchCommBackend,
+                       public NCCLCommProvider,
                        public std::enable_shared_from_this<TorchCommNCCLX> {
  public:
   static constexpr std::string_view kBackendName = "ncclx";
@@ -329,6 +331,8 @@ class TorchCommNCCLX : public TorchCommBackend,
   const at::Device& getDevice() const override {
     return device_;
   }
+
+  void* getNCCLCommPtr() const override;
 
 #if defined(ENABLE_PIPES)
   // Get device-allocated transport handle for Triton/CUDA kernels.


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/182529

When the CUDA backend is a TorchComm backend (use_torchcomms=True), ProcessGroupNCCL's communicator cache is empty because TorchComm owns its own NCCL communicator. NCCLSymmetricMemory previously hard-coded ProcessGroupNCCL::getCommPtr(), which is null in this configuration and leads to ncclCommWindowRegister failures.

Introduce a lightweight c10d::NCCLCommProvider interface for c10d backends that can expose a borrowed NCCL communicator. NCCLSymmetricMemory still uses ProcessGroupNCCL directly first, then falls back to this provider interface, and fails with a clear error if neither path can provide a non-null communicator.

On the TorchComm side, TorchCommNCCLX implements a matching internal torch::comms::NCCLCommProvider hook. The generic BackendWrapper stays backend-agnostic: _BackendWrapper construction now goes through createBackendWrapper(), which returns the normal BackendWrapper for generic backends and a private NCCL-specific wrapper subclass only when the underlying TorchComm backend exposes the TorchComm NCCL provider. That NCCL-specific wrapper bridges to c10d::NCCLCommProvider without adding an NCCL method/base class to the generic BackendWrapper and without introducing a c10d -> TorchComm dependency.

Differential Revision: D103732297


