### PR TITLE
Fix garbageCollectLocked status overwrite across streams

### DIFF
--- a/comms/torchcomms/nccl/TorchWorkNCCLQueue.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCLQueue.cpp
@@ -20,7 +20,9 @@ TorchWorkNCCL::WorkStatus TorchWorkNCCLQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkNCCL::WorkStatus status = work->checkStatus();
-      last_status = status;
+      if (status != TorchWorkNCCL::WorkStatus::COMPLETED) {
+        last_status = status;
+      }
 
       if (status == TorchWorkNCCL::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue

--- a/comms/torchcomms/nccl/TorchWorkNCCLQueue.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCLQueue.cpp
@@ -20,9 +20,6 @@ TorchWorkNCCL::WorkStatus TorchWorkNCCLQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkNCCL::WorkStatus status = work->checkStatus();
-      if (status != TorchWorkNCCL::WorkStatus::COMPLETED) {
-        last_status = status;
-      }
 
       if (status == TorchWorkNCCL::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue
@@ -35,6 +32,7 @@ TorchWorkNCCL::WorkStatus TorchWorkNCCLQueue::garbageCollectLocked() {
         return status;
       } else {
         // NOT_STARTED or INPROGRESS - stop processing this queue
+        last_status = status;
         break;
       }
     }

--- a/comms/torchcomms/ncclx/TorchWorkNCCLXQueue.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLXQueue.cpp
@@ -21,7 +21,9 @@ TorchWorkNCCLX::WorkStatus TorchWorkNCCLXQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkNCCLX::WorkStatus status = work->checkStatus();
-      last_status = status;
+      if (status != TorchWorkNCCLX::WorkStatus::COMPLETED) {
+        last_status = status;
+      }
 
       if (status == TorchWorkNCCLX::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue

--- a/comms/torchcomms/ncclx/TorchWorkNCCLXQueue.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLXQueue.cpp
@@ -21,9 +21,6 @@ TorchWorkNCCLX::WorkStatus TorchWorkNCCLXQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkNCCLX::WorkStatus status = work->checkStatus();
-      if (status != TorchWorkNCCLX::WorkStatus::COMPLETED) {
-        last_status = status;
-      }
 
       if (status == TorchWorkNCCLX::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue
@@ -36,6 +33,7 @@ TorchWorkNCCLX::WorkStatus TorchWorkNCCLXQueue::garbageCollectLocked() {
         return status;
       } else {
         // NOT_STARTED or INPROGRESS - stop processing this queue
+        last_status = status;
         break;
       }
     }

--- a/comms/torchcomms/xccl/TorchWorkXCCLQueue.cpp
+++ b/comms/torchcomms/xccl/TorchWorkXCCLQueue.cpp
@@ -18,7 +18,9 @@ TorchWorkXCCL::WorkStatus TorchWorkXCCLQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkXCCL::WorkStatus status = work->checkStatus();
-      last_status = status;
+      if (status != TorchWorkXCCL::WorkStatus::COMPLETED) {
+        last_status = status;
+      }
 
       if (status == TorchWorkXCCL::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue

--- a/comms/torchcomms/xccl/TorchWorkXCCLQueue.cpp
+++ b/comms/torchcomms/xccl/TorchWorkXCCLQueue.cpp
@@ -18,9 +18,6 @@ TorchWorkXCCL::WorkStatus TorchWorkXCCLQueue::garbageCollectLocked() {
 
       // Use the checkStatus function to determine the work status
       TorchWorkXCCL::WorkStatus status = work->checkStatus();
-      if (status != TorchWorkXCCL::WorkStatus::COMPLETED) {
-        last_status = status;
-      }
 
       if (status == TorchWorkXCCL::WorkStatus::COMPLETED) {
         // Work is completed, remove it from the work queue
@@ -33,6 +30,7 @@ TorchWorkXCCL::WorkStatus TorchWorkXCCLQueue::garbageCollectLocked() {
         return status;
       } else {
         // NOT_STARTED or INPROGRESS - stop processing this queue
+        last_status = status;
         break;
       }
     }


### PR DESCRIPTION
`garbageCollectLocked` iterates multiple stream queues and blindly overwrites `last_status` on every stream, when a completed stream is visited after pending stream, last_status is completed when its not completed. fixed that for nccl, ncclx, xccl. rcc, rcclx use different design.