### PR TITLE
AllToAllV: skip NVL kernel logic on pure IB path (ppn=1) (#2390)

### DIFF
--- a/comms/ctran/algos/AllToAll/AllToAll.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAll.cuh
@@ -116,6 +116,17 @@ __global__ void ncclKernelAllToAll(
     ctran::device::KernelStartGpe(flag);
   }
 
+  // count==0 means no work for the kernel (e.g. pure-IB path where the
+  // self-copy is issued via cudaMemcpyAsync on the host and there are no
+  // NVL sends/recvs to do). Only GPE sync remains — wait for terminate
+  // and return.
+  if (args.count == 0) {
+    if (flag && gtIdx == 0) {
+      ctran::device::KernelWaitGpeTerminate(flag);
+    }
+    return;
+  }
+
   devStateLoadToShm(devState);
 
   const T* sendbuff = reinterpret_cast<const T*>(args.sendbuff);

--- a/comms/ctran/algos/AllToAll/AllToAllImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllImpl.cc
@@ -40,6 +40,34 @@ commResult_t setupKernelConfig(
     CtranComm* comm,
     cudaStream_t stream,
     KernelConfig& config) {
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.args.collective.alltoall.sendbuff = sendbuff;
+  config.args.collective.alltoall.recvbuff = recvbuff;
+  config.args.collective.alltoall.datatype = datatype;
+  config.args.collective.alltoall.count = count;
+
+  // When no local NVL peers (ppn=1, pure IB path), the alltoall kernel's
+  // send/recv loops are empty — only self-copy and GPE sync remain. Issue
+  // the self D2D copy via cudaMemcpyAsync and signal the kernel to skip
+  // its body by zeroing count. The kernel then runs as a 1-block/1-thread
+  // stub for GPE sync, freeing SMs for overlapping compute.
+  if (comm->statex_->nLocalRanks() <= 1) {
+    int myRank = comm->statex_->rank();
+    size_t selfBytes = count * commTypeSize(datatype);
+    if (selfBytes > 0) {
+      FB_COMMCHECK(comm->ctran_->mapper->icopy(
+          static_cast<char*>(recvbuff) + selfBytes * myRank,
+          static_cast<const char*>(sendbuff) + selfBytes * myRank,
+          selfBytes,
+          stream));
+    }
+    config.args.collective.alltoall.count = 0;
+    config.numBlocks = 1;
+    config.numThreads = 1;
+    return commSuccess;
+  }
+
+  // Multi-GPU path: full multi-block alltoall kernel for NVL + self copy.
   // If first time call, query cuda recommended blockSize
   if (bestThreadBlockSize == 0) {
     int minGridSize = 0;
@@ -75,12 +103,6 @@ commResult_t setupKernelConfig(
   if (config.numBlocks % 2) {
     config.numBlocks += 1;
   }
-
-  config.args.devState_d = comm->ctran_->algo->getDevState();
-  config.args.collective.alltoall.sendbuff = sendbuff;
-  config.args.collective.alltoall.recvbuff = recvbuff;
-  config.args.collective.alltoall.datatype = datatype;
-  config.args.collective.alltoall.count = count;
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllToAll/AllToAllImpl.h
+++ b/comms/ctran/algos/AllToAll/AllToAllImpl.h
@@ -6,6 +6,12 @@
 
 namespace ctran::alltoall {
 extern void* alltoallKerns[commNumTypes];
+
+// Configure kernel launch parameters for AllToAll collectives.
+// When nLocalRanks == 1 (no NVL peers), zeros args.count so the kernel
+// short-circuits (skipping self-copy and NVL send/recv) and issues the
+// self D2D copy via cudaMemcpyAsync. Otherwise launches the full
+// multi-block alltoall kernel.
 commResult_t setupKernelConfig(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/algos/AllToAll/AllToAllP.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllP.cc
@@ -108,20 +108,17 @@ commResult_t AllToAllPDestroy(CtranPersistentRequest* request) {
 }
 
 bool AllToAllPSupport(CtranComm* comm) {
-  bool ctranSupport = false;
-  const auto statex = comm->statex_.get();
-  if (ctranInitialized(comm)) {
-    ctranSupport = true;
-    for (int rank = 0; rank < statex->nRanks(); rank++) {
-      if (comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
-        ctranSupport = false;
-        break;
-      }
-    }
-  } else {
+  if (!ctranInitialized(comm)) {
     return false;
   }
+  const auto statex = comm->statex_.get();
 
-  return ctranSupport;
+  for (int rank = 0; rank < statex->nRanks(); rank++) {
+    if (comm->ctran_->mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
+      return false;
+    }
+  }
+
+  return true;
 }
 } // namespace ctran

--- a/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllPImpl.cc
@@ -344,12 +344,12 @@ commResult_t AlgoImpl::exec(const void* sendbuff, const size_t count) {
         pArgs.maxRecvCount);
   }
 
-  // prepare kernel config for NVL copies, reuse the alltoall kernel
   KernelConfig config = KernelConfig(
       KernelConfig::KernelType::ALLTOALL, stream_, algoName(myAlgo), opCount);
   FB_COMMCHECK(
       ctran::alltoall::setupKernelConfig(
           sendbuff, recvbuff, count, datatype, comm_, stream_, config));
+
   std::vector<std::unique_ptr<struct OpElem>> opGroup;
   // Passing op only when remote peers are present
   if (comm_->statex_->nNodes() > 1) {

--- a/comms/ctran/algos/AllToAll/AllToAllv.cc
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cc
@@ -61,6 +61,39 @@ static inline commResult_t setupKernelConfig(
     cudaStream_t stream,
     KernelConfig& config) {
   const auto statex = comm->statex_.get();
+
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.args.collective.alltoallv.sendbuff = sendbuff;
+  config.args.collective.alltoallv.recvbuff = recvbuff;
+  config.args.collective.alltoallv.datatype = datatype;
+  config.args.collective.alltoallv.selfCount = sendcounts[statex->rank()];
+  config.args.collective.alltoallv.selfSendDispl = sdispls[statex->rank()];
+  config.args.collective.alltoallv.selfRecvDispl = rdispls[statex->rank()];
+
+  // When no local NVL peers (ppn=1, pure IB path), the alltoallv kernel's
+  // send/recv loops are empty — only self-copy and GPE sync remain. Issue
+  // the self D2D copy via cudaMemcpyAsync and signal the kernel to skip
+  // its body by setting sendElemsList to nullptr. The kernel then runs as
+  // a 1-block/1-thread stub for GPE sync, freeing SMs for overlapping compute.
+  if (statex->nLocalRanks() <= 1) {
+    size_t selfBytes = sendcounts[statex->rank()] * commTypeSize(datatype);
+    if (selfBytes > 0) {
+      FB_COMMCHECK(comm->ctran_->mapper->icopy(
+          static_cast<char*>(recvbuff) +
+              rdispls[statex->rank()] * commTypeSize(datatype),
+          static_cast<const char*>(sendbuff) +
+              sdispls[statex->rank()] * commTypeSize(datatype),
+          selfBytes,
+          stream));
+    }
+    config.args.collective.alltoallv.selfCount = 0;
+    config.args.collective.alltoallv.sendElemsList = nullptr;
+    config.args.collective.alltoallv.recvElemsList = nullptr;
+    config.numBlocks = 1;
+    config.numThreads = 1;
+    return commSuccess;
+  }
+
   // Unlike alltoall, we cannot automatically detect grid size because each rank
   // may see different counts; use static gridSize for now.
   config.numThreads = NCCL_CTRAN_ALLTOALLV_THREAD_BLOCK_SIZE;
@@ -77,24 +110,6 @@ static inline commResult_t setupKernelConfig(
   //   states/flags holds at most CTRAN_ALGO_MAX_THREAD_BLOCKS blocks
   if (config.numBlocks < 2 || config.numBlocks > CTRAN_ALGO_MAX_THREAD_BLOCKS) {
     config.numBlocks = CTRAN_ALGO_MAX_THREAD_BLOCKS;
-  }
-
-  config.args.devState_d = comm->ctran_->algo->getDevState();
-  config.args.collective.alltoallv.sendbuff = sendbuff;
-  config.args.collective.alltoallv.recvbuff = recvbuff;
-  config.args.collective.alltoallv.datatype = datatype;
-  config.args.collective.alltoallv.selfCount = sendcounts[statex->rank()];
-  config.args.collective.alltoallv.selfSendDispl = sdispls[statex->rank()];
-  config.args.collective.alltoallv.selfRecvDispl = rdispls[statex->rank()];
-
-  // special case of ppn=1, simply set sendElemsList and recvElemsList to
-  // nullptr, and numBlocks to 1 to let alltoallv kernel skip copies over NVLink
-  // and only do self copy
-  if (statex->nLocalRanks() == 1) {
-    config.args.collective.alltoallv.sendElemsList = nullptr;
-    config.args.collective.alltoallv.recvElemsList = nullptr;
-    config.numBlocks = 1;
-    return commSuccess;
   }
 
   // Pass number of thread block groups to kernel p2p elements

--- a/comms/ctran/algos/AllToAll/AllToAllv.cuh
+++ b/comms/ctran/algos/AllToAll/AllToAllv.cuh
@@ -146,6 +146,17 @@ __global__ void ncclKernelAllToAllv(
     ctran::device::KernelStartGpe(flag);
   }
 
+  // No work for the kernel when all three are true: no NVL sends, no NVL
+  // recvs, and no self-copy (e.g. pure-IB path where the self-copy is issued
+  // via cudaMemcpyAsync on the host). Only GPE sync remains.
+  if (args.sendElemsList == nullptr && args.recvElemsList == nullptr &&
+      args.selfCount == 0) {
+    if (flag && gtIdx == 0) {
+      ctran::device::KernelWaitGpeTerminate(flag);
+    }
+    return;
+  }
+
   devStateLoadToShm(devState);
 
   const T* sendbuff = reinterpret_cast<const T*>(args.sendbuff);

--- a/comms/ctran/algos/AllToAll/Types.h
+++ b/comms/ctran/algos/AllToAll/Types.h
@@ -26,6 +26,10 @@ namespace alltoall {
 struct KernelArgs {
   const void* sendbuff;
   void* recvbuff;
+  // count==0 signals a no-op to the kernel: skip self-copy and NVL send/recv
+  // and only perform GPE start/terminate sync. Set on the pure-IB path (no
+  // local NVL peers), where the self-copy is issued via cudaMemcpyAsync from
+  // the host.
   size_t count;
   commDataType_t datatype;
 };

--- a/comms/ctran/algos/AllToAll/Types.h
+++ b/comms/ctran/algos/AllToAll/Types.h
@@ -82,6 +82,10 @@ struct KernelArgs {
   const void* sendbuff;
   void* recvbuff;
   commDataType_t datatype;
+  // selfCount==0 && sendElemsList==nullptr && recvElemsList==nullptr signals
+  // a no-op to the kernel: skip self-copy and NVL send/recv and only perform
+  // GPE start/terminate sync. Set on the pure-IB path (no local NVL peers),
+  // where the self-copy is issued via cudaMemcpyAsync from the host.
   size_t selfCount;
   size_t selfSendDispl;
   size_t selfRecvDispl;


### PR DESCRIPTION
Summary:

When AllToAllV runs with no local NVL peers (ppn=1, pure IB path), the alltoallv kernel launches with 1 thread block that does both self-copy and GPE sync. The self-copy with a single thread block is very slow (~14ms for 1GB on 1 SM), bottlenecking overall throughput to ~31 GB/s busBW — well below the ~47 GB/s that AllToAll achieves.

Per Regina8023's review on D100525044: rather than introducing a new `rdmaOnly` flag to `KernelArgs`, we reuse the existing `sendElemsList` pointer. In `setupKernelConfig`, when `nLocalRanks <= 1`:
- Self D2D copy is issued via `mapper->icopy()` (cudaMemcpyAsync) on the host stream — full DMA bandwidth.
- The kernel is launched with 1 block / 1 thread and `sendElemsList = nullptr`.
- `ncclKernelAllToAllv` short-circuits after `KernelStartGpe` / `KernelWaitGpeTerminate` when `sendElemsList == nullptr`, skipping the self-copy and NVL send/recv (frees SMs for overlapping compute).

Multi-GPU path (`nLocalRanks > 1`) is unchanged — full multi-block alltoallv kernel for NVL + self copy.

`sendElemsList == nullptr` is a natural "no NVL work to do" signal and avoids introducing a new arg that would be misleading once copy-based IB alltoall is added (which would still need SMs).

Expected improvement: AllToAllV busBW from ~31 GB/s to ~47 GB/s for ppn=1 RDMA-only workloads (matching AllToAll performance).

Reviewed By: Regina8023

Differential Revision: D102255800


