### PR TITLE
Extract SignatureBuilder to hooks/common (#2392)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,9 @@ target_link_libraries(torchcomms PRIVATE glog::glog gflags::gflags fmt::fmt)
 target_link_libraries(torchcomms PRIVATE ${TORCH_LIBRARIES} nlohmann_json::nlohmann_json)
 
 # Clog Hook sources (compiled into _comms)
+# Common hooks sources
+set(TORCHCOMMS_HOOKS_COMMON_SOURCES "comms/torchcomms/hooks/common/SignatureBuilder.cpp")
+
 file(GLOB TORCHCOMMS_CLOG_SOURCES "comms/torchcomms/hooks/clog/ClogHook.cpp")
 file(GLOB TORCHCOMMS_CLOG_PYTHON_SOURCES
     "comms/torchcomms/hooks/clog/ClogHookPy.cpp")
@@ -177,6 +180,7 @@ file(GLOB TORCHCOMMS_FR_PYTHON_SOURCES "comms/torchcomms/hooks/fr/FlightRecorder
 add_library(torchcomms_comms MODULE
     ${TORCHCOMMS_PYTHON_SOURCES}
     ${HOOKS_PYTHON_SOURCES}
+    ${TORCHCOMMS_HOOKS_COMMON_SOURCES}
     ${TORCHCOMMS_CLOG_SOURCES}
     ${TORCHCOMMS_CLOG_PYTHON_SOURCES}
     ${TORCHCOMMS_FR_SOURCES}

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -85,7 +85,7 @@ std::shared_ptr<TorchComm> new_comm(
 
 void TorchComm::finalize() {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::finalize, op_id, FinalizePreHookArgs{});
+  preHook(op_id, FinalizePreHookArgs{});
   impl_->finalize();
   postHook(op_id, FinalizePostHookArgs{});
 }
@@ -128,7 +128,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::send(
     const SendOptions& options) {
   validateRank(dst, "dst");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::send, op_id, SendPreHookArgs(tensor, dst, async_op));
+  preHook(op_id, SendPreHookArgs(tensor, dst, async_op));
 
   auto work = impl_->send(tensor, dst, async_op, options);
 
@@ -144,7 +144,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::recv(
     const RecvOptions& options) {
   validateRank(src, "src");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::recv, op_id, RecvPreHookArgs(tensor, src, async_op));
+  preHook(op_id, RecvPreHookArgs(tensor, src, async_op));
 
   auto work = impl_->recv(tensor, src, async_op, options);
 
@@ -161,8 +161,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::broadcast(
     const BroadcastOptions& options) {
   validateRank(root, "root");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::broadcast, op_id, BroadcastPreHookArgs(tensor, root, async_op));
+  preHook(op_id, BroadcastPreHookArgs(tensor, root, async_op));
 
   auto work = impl_->broadcast(tensor, root, async_op, options);
 
@@ -178,8 +177,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_reduce(
     bool async_op,
     const AllReduceOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::all_reduce, op_id, AllReducePreHookArgs(tensor, op, async_op));
+  preHook(op_id, AllReducePreHookArgs(tensor, op, async_op));
 
   auto work = impl_->all_reduce(tensor, op, async_op, options);
 
@@ -197,7 +195,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce(
     const ReduceOptions& options) {
   validateRank(root, "root");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::reduce, op_id, ReducePreHookArgs(tensor, root, op, async_op));
+  preHook(op_id, ReducePreHookArgs(tensor, root, op, async_op));
 
   auto work = impl_->reduce(tensor, root, op, async_op, options);
 
@@ -212,10 +210,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather(
     bool async_op,
     const AllGatherOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::all_gather,
-      op_id,
-      AllGatherPreHookArgs(tensor, tensor_list, async_op));
+  preHook(op_id, AllGatherPreHookArgs(tensor, tensor_list, async_op));
 
   auto work = impl_->all_gather(tensor_list, tensor, async_op, options);
 
@@ -231,10 +226,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_v(
     bool async_op,
     const AllGatherOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::all_gather_v,
-      op_id,
-      AllGatherVPreHookArgs(tensor, tensor_list, async_op));
+  preHook(op_id, AllGatherVPreHookArgs(tensor, tensor_list, async_op));
 
   auto work = impl_->all_gather_v(tensor_list, tensor, async_op, options);
 
@@ -250,10 +242,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_gather_single(
     bool async_op,
     const AllGatherSingleOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::all_gather_single,
-      op_id,
-      AllGatherSinglePreHookArgs(input, output, async_op));
+  preHook(op_id, AllGatherSinglePreHookArgs(input, output, async_op));
 
   auto work = impl_->all_gather_single(output, input, async_op, options);
 
@@ -271,10 +260,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter(
     bool async_op,
     const ReduceScatterOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::reduce_scatter,
-      op_id,
-      ReduceScatterPreHookArgs(input_list, output, op, async_op));
+  preHook(op_id, ReduceScatterPreHookArgs(input_list, output, op, async_op));
 
   auto work = impl_->reduce_scatter(output, input_list, op, async_op, options);
 
@@ -292,10 +278,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_v(
     bool async_op,
     const ReduceScatterOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::reduce_scatter_v,
-      op_id,
-      ReduceScatterVPreHookArgs(input_list, output, op, async_op));
+  preHook(op_id, ReduceScatterVPreHookArgs(input_list, output, op, async_op));
 
   auto work =
       impl_->reduce_scatter_v(output, input_list, op, async_op, options);
@@ -314,10 +297,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::reduce_scatter_single(
     bool async_op,
     const ReduceScatterSingleOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::reduce_scatter_single,
-      op_id,
-      ReduceScatterSinglePreHookArgs(input, output, op, async_op));
+  preHook(op_id, ReduceScatterSinglePreHookArgs(input, output, op, async_op));
 
   auto work =
       impl_->reduce_scatter_single(output, input, op, async_op, options);
@@ -336,10 +316,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_single(
     bool async_op,
     const AllToAllSingleOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::all_to_all_single,
-      op_id,
-      AllToAllSinglePreHookArgs(input, output, async_op));
+  preHook(op_id, AllToAllSinglePreHookArgs(input, output, async_op));
 
   auto work = impl_->all_to_all_single(output, input, async_op, options);
 
@@ -359,7 +336,6 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all_v_single(
     const AllToAllvSingleOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
-      OpName::all_to_all_v_single,
       op_id,
       AllToAllVSinglePreHookArgs(
           input, output, input_split_sizes, output_split_sizes, async_op));
@@ -381,7 +357,6 @@ c10::intrusive_ptr<TorchWork> TorchComm::all_to_all(
     const AllToAllOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
-      OpName::all_to_all,
       op_id,
       AllToAllPreHookArgs(input_tensor_list, output_tensor_list, async_op));
 
@@ -398,7 +373,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::barrier(
     bool async_op,
     const BarrierOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::barrier, op_id, BarrierPreHookArgs(async_op));
+  preHook(op_id, BarrierPreHookArgs(async_op));
 
   auto work = impl_->barrier(async_op, options);
 
@@ -418,7 +393,6 @@ c10::intrusive_ptr<TorchWork> TorchComm::scatter(
   validateRank(root, "root");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
-      OpName::scatter,
       op_id,
       ScatterPreHookArgs(output_tensor, input_tensor_list, root, async_op));
 
@@ -440,7 +414,6 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather(
   validateRank(root, "root");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
   preHook(
-      OpName::gather,
       op_id,
       GatherPreHookArgs(input_tensor, output_tensor_list, root, async_op));
 
@@ -460,10 +433,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather_single(
     const GatherSingleOptions& options) {
   validateRank(root, "root");
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(
-      OpName::gather_single,
-      op_id,
-      GatherSinglePreHookArgs(input, output, root, async_op));
+  preHook(op_id, GatherSinglePreHookArgs(input, output, root, async_op));
 
   auto work = impl_->gather_single(output, input, root, async_op, options);
 
@@ -477,7 +447,7 @@ c10::intrusive_ptr<TorchWork> TorchComm::gather_single(
 std::shared_ptr<TorchCommWindow> TorchComm::new_window(
     const std::optional<at::Tensor>& tensor) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::new_window, op_id, NewWindowPreHookArgs());
+  preHook(op_id, NewWindowPreHookArgs());
   auto window = impl_->new_window(tensor);
   postHook(
       op_id, NewWindowPostHookArgs(std::weak_ptr<TorchCommWindow>(window)));
@@ -529,7 +499,7 @@ std::shared_ptr<TorchComm> TorchComm::split(
     const std::string& name,
     const CommOptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(OpName::split, op_id, SplitPreHookArgs(ranks, name));
+  preHook(op_id, SplitPreHookArgs(ranks, name));
   auto new_impl = impl_->split(ranks, name, options);
   if (new_impl == nullptr) {
     return nullptr;
@@ -583,10 +553,7 @@ c10::intrusive_ptr<TorchWork> BatchSendRecv::issue(
     bool async_op,
     const BatchP2POptions& options) {
   auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  parent_->preHook(
-      OpName::batch_op_issue,
-      op_id,
-      BatchOpIssuePreHookArgs(ops.size(), async_op));
+  parent_->preHook(op_id, BatchOpIssuePreHookArgs(ops.size(), async_op));
 
   auto work = parent_->getBackendImpl()->batch_op_issue(ops, async_op, options);
 
@@ -646,9 +613,9 @@ std::unique_ptr<RemovableHandle> TorchComm::registerGraphReplayHook(
   });
 }
 
-void TorchComm::preHook(OpName name, size_t op_id, PreHookArgs&& args) {
+void TorchComm::preHook(size_t op_id, PreHookArgs&& args) {
   for (auto& hook : preHooks_) {
-    hook.second(name, op_id, args);
+    hook.second(op_id, args);
   }
 }
 

--- a/comms/torchcomms/TorchComm.hpp
+++ b/comms/torchcomms/TorchComm.hpp
@@ -264,7 +264,7 @@ class TorchComm : public std::enable_shared_from_this<TorchComm> {
       std::shared_ptr<TorchCommBackend> impl,
       std::vector<int> ranks);
 
-  void preHook(OpName name, size_t op_id, PreHookArgs&& args);
+  void preHook(size_t op_id, PreHookArgs&& args);
   void postHook(size_t op_id, PostHookArgs&& args);
 
   // Rank validation helper

--- a/comms/torchcomms/TorchCommHooks.hpp
+++ b/comms/torchcomms/TorchCommHooks.hpp
@@ -359,8 +359,7 @@ using PreHookArgs = std::variant<
     BatchOpIssuePreHookArgs,
     FinalizePreHookArgs>;
 
-using PreHook =
-    std::function<void(OpName name, size_t op_id, const PreHookArgs& args)>;
+using PreHook = std::function<void(size_t op_id, const PreHookArgs& args)>;
 
 // -- Per-collective post-hook argument structs --
 //

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -13,6 +13,7 @@
 #include "comms/torchcomms/TorchComm.hpp"
 #include "comms/torchcomms/TorchCommFactory.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
+#include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
 // Forward declarations for hook submodule init
 void init_clog_hook_bindings(py::module_& m);
@@ -2300,10 +2301,8 @@ Raises: RuntimeError if the ranks list is non-empty and the current rank is not 
       .def(
           "register_pre_hook",
           [](TorchComm& self, const py::function& callback) {
-            auto hook = [callback](
-                            OpName name,
-                            size_t op_id,
-                            const PreHookArgs& args) {
+            auto hook = [callback](size_t op_id, const PreHookArgs& args) {
+              auto name = getOpName(args);
               py::gil_scoped_acquire acquire;
               py::object py_args = std::visit(
                   [](const auto& a) -> py::object {

--- a/comms/torchcomms/TorchWork.cpp
+++ b/comms/torchcomms/TorchWork.cpp
@@ -24,7 +24,8 @@ TorchWorkCompleted::TorchWorkCompleted() {
 }
 
 void TorchWorkCompleted::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
+  runWaitPostHooks();
 }
 
 TorchWorkThread::TorchWorkThread(std::function<void()> fn)
@@ -39,13 +40,15 @@ TorchWorkThread::TorchWorkThread(std::function<void()> fn)
       })) {}
 
 void TorchWorkThread::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   if (!future_.valid()) {
     // already waited on
+    runWaitPostHooks();
     return;
   }
   future_.get();
+  runWaitPostHooks();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -73,8 +73,8 @@ class TorchWork : public c10::intrusive_ptr_target {
   //
   // - Start hook:  fired when setStatus(INPROGRESS) is called
   // - End hook:    fired when setStatus(COMPLETED/ERROR/TIMEDOUT) is called
-  // - Wait hook:   fired when runWaitHooks() is called (backends call this
-  //                from their wait() implementation)
+  // - Wait pre hook:  fired at the start of wait(), before the sync
+  // - Wait post hook: fired at the end of wait(), after the sync
   //
   // Multiple hooks can be registered; they fire in registration order.
   // Hooks are NOT thread-safe -- register before concurrent status changes.
@@ -97,8 +97,12 @@ class TorchWork : public c10::intrusive_ptr_target {
     }
   }
 
-  void registerWorkWaitHook(WorkHook hook) {
-    wait_hooks_.push_back(std::move(hook));
+  void registerWorkWaitPreHook(WorkHook hook) {
+    wait_pre_hooks_.push_back(std::move(hook));
+  }
+
+  void registerWorkWaitPostHook(WorkHook hook) {
+    wait_post_hooks_.push_back(std::move(hook));
   }
 
   // Disable copy and move semantics
@@ -120,9 +124,15 @@ class TorchWork : public c10::intrusive_ptr_target {
     }
   }
 
-  // Backend wait() implementations should call this to fire wait hooks.
-  void runWaitHooks() {
-    for (auto& hook : wait_hooks_) {
+  // Backend wait() implementations should call these around the actual wait.
+  void runWaitPreHooks() {
+    for (auto& hook : wait_pre_hooks_) {
+      hook();
+    }
+  }
+
+  void runWaitPostHooks() {
+    for (auto& hook : wait_post_hooks_) {
       hook();
     }
   }
@@ -164,7 +174,8 @@ class TorchWork : public c10::intrusive_ptr_target {
   void release_resources() override {
     start_hooks_.clear();
     end_hooks_.clear();
-    wait_hooks_.clear();
+    wait_pre_hooks_.clear();
+    wait_post_hooks_.clear();
   }
 
   std::atomic<WorkStatus> status_{WorkStatus::NOT_STARTED};
@@ -172,7 +183,8 @@ class TorchWork : public c10::intrusive_ptr_target {
 
   std::vector<WorkHook> start_hooks_;
   std::vector<WorkHook> end_hooks_;
-  std::vector<WorkHook> wait_hooks_;
+  std::vector<WorkHook> wait_pre_hooks_;
+  std::vector<WorkHook> wait_post_hooks_;
 };
 
 class TorchWorkCompleted : public TorchWork {

--- a/comms/torchcomms/gloo/TorchWorkGloo.cpp
+++ b/comms/torchcomms/gloo/TorchWorkGloo.cpp
@@ -18,8 +18,8 @@ TorchWorkGloo::~TorchWorkGloo() {
 }
 
 void TorchWorkGloo::wait() {
-  runWaitHooks();
-  return;
+  runWaitPreHooks();
+  runWaitPostHooks();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/torchcomms/hooks/clog/ClogHook.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -91,9 +92,8 @@ void ClogHook::registerHooks(std::shared_ptr<TorchComm> comm) {
 
   int device_index = comm->getDevice().index();
   auto pre_hook_handle = comm->registerPreHook(
-      [self, comm_name, device_index](
-          OpName name, size_t op_id, const PreHookArgs& args) {
-        self->onPreHook(comm_name, device_index, name, op_id, args);
+      [self, comm_name, device_index](size_t op_id, const PreHookArgs& args) {
+        self->onPreHook(comm_name, device_index, op_id, args);
       });
 
   auto post_hook_handle = comm->registerPostHook(
@@ -332,12 +332,11 @@ WorkId ClogHook::logCollective(
 
 // -- Signature builder via std::visit --
 
-std::string ClogHook::buildSignature(OpName name, const PreHookArgs& args)
-    const {
+std::string ClogHook::buildSignature(const PreHookArgs& args) const {
+  auto op = opToString(getOpName(args));
   return std::visit(
-      [this, name](const auto& a) -> std::string {
+      [this, op](const auto& a) -> std::string {
         using T = std::decay_t<decltype(a)>;
-        auto op = opToString(name);
 
         // In-place collectives (single tensor is both input and output)
         if constexpr (std::is_same_v<T, AllReducePreHookArgs>) {
@@ -615,7 +614,6 @@ std::string ClogHook::buildSignature(OpName name, const PreHookArgs& args)
 void ClogHook::onPreHook(
     const std::string& comm_name,
     int device_index,
-    OpName name,
     size_t op_id,
     const PreHookArgs& args) {
   // Handle split specially: log the split event, not a signature.
@@ -642,7 +640,7 @@ void ClogHook::onPreHook(
     return;
   }
 
-  auto sig = buildSignature(name, args);
+  auto sig = buildSignature(args);
   if (sig.empty()) {
     return;
   }

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -5,6 +5,7 @@
 #include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <stdexcept>
 #include <variant>
@@ -69,12 +70,8 @@ ClogHook::~ClogHook() = default;
 // -- Registration --
 
 void ClogHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
-  log_file_.writeLine(
-      fmt::format(
-          "new_comm|comm={}|rank={}|world_size={}",
-          std::string(comm->getCommName()),
-          comm->getRank(),
-          comm->getSize()));
+  log_file_.writeLine(buildNewCommSignature(
+      comm->getCommName(), comm->getRank(), comm->getSize()));
   registerHooks(comm);
 }
 
@@ -123,99 +120,6 @@ double ClogHook::now() {
   auto duration = tp.time_since_epoch();
   auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
   return static_cast<double>(millis.count()) / 1000.0;
-}
-
-std::string_view ClogHook::reduceOpToString(const ReduceOp& op) {
-  switch (op.type()) {
-    case ReduceOp::RedOpType::SUM:
-      return "sum";
-    case ReduceOp::RedOpType::PRODUCT:
-      return "prod";
-    case ReduceOp::RedOpType::MIN:
-      return "min";
-    case ReduceOp::RedOpType::MAX:
-      return "max";
-    case ReduceOp::RedOpType::BAND:
-      return "band";
-    case ReduceOp::RedOpType::BOR:
-      return "bor";
-    case ReduceOp::RedOpType::BXOR:
-      return "bxor";
-    case ReduceOp::RedOpType::PREMUL_SUM:
-      return "premul_sum";
-    case ReduceOp::RedOpType::AVG:
-      return "avg";
-    default:
-      return "unknown";
-  }
-}
-
-std::string_view ClogHook::dtypeToString(at::ScalarType dtype) {
-  switch (dtype) {
-    case at::ScalarType::Float:
-      return "f32";
-    case at::ScalarType::Double:
-      return "f64";
-    case at::ScalarType::Half:
-      return "f16";
-    case at::ScalarType::BFloat16:
-      return "bf16";
-    case at::ScalarType::Int:
-      return "i32";
-    case at::ScalarType::Long:
-      return "i64";
-    case at::ScalarType::Short:
-      return "i16";
-    case at::ScalarType::Char:
-      return "i8";
-    case at::ScalarType::Byte:
-      return "u8";
-    case at::ScalarType::Bool:
-      return "bool";
-    case at::ScalarType::Float8_e4m3fn:
-      return "fp8e4m3";
-    case at::ScalarType::Float8_e5m2:
-      return "fp8e5m2";
-    default:
-      return "other";
-  }
-}
-
-std::string ClogHook::formatCounts(const std::vector<at::Tensor>& tensors) {
-  std::string result;
-  for (size_t i = 0; i < tensors.size(); ++i) {
-    if (i > 0) {
-      result += ',';
-    }
-    result += std::to_string(tensors[i].numel());
-  }
-  return result;
-}
-
-std::string ClogHook::formatCounts(const std::vector<uint64_t>& counts) {
-  std::string result;
-  for (size_t i = 0; i < counts.size(); ++i) {
-    if (i > 0) {
-      result += ',';
-    }
-    result += std::to_string(counts[i]);
-  }
-  return result;
-}
-
-std::string ClogHook::formatPtr(const void* ptr) {
-  return fmt::format("{:#x}", reinterpret_cast<uintptr_t>(ptr));
-}
-
-std::string ClogHook::formatPtrs(const std::vector<at::Tensor>& tensors) {
-  std::string result;
-  for (size_t i = 0; i < tensors.size(); ++i) {
-    if (i > 0) {
-      result += ',';
-    }
-    result += formatPtr(tensors[i].data_ptr());
-  }
-  return result;
 }
 
 // graph_id is globally unique per the CUDA spec:
@@ -291,7 +195,7 @@ WorkId ClogHook::logCollective(
     bool async_op,
     void* stream,
     uint64_t graph_id) {
-  auto sig_key = fmt::format("{}|comm={}", sig_body, comm_name);
+  auto sig_key = std::string(sig_body);
 
   auto new_corr_id = next_corr_id_.fetch_add(1, std::memory_order_relaxed);
   auto corr_id = sig_map_.findOrInsert(sig_key, new_corr_id);
@@ -330,285 +234,6 @@ WorkId ClogHook::logCollective(
   return work_id;
 }
 
-// -- Signature builder via std::visit --
-
-std::string ClogHook::buildSignature(const PreHookArgs& args) const {
-  auto op = opToString(getOpName(args));
-  return std::visit(
-      [this, op](const auto& a) -> std::string {
-        using T = std::decay_t<decltype(a)>;
-
-        // In-place collectives (single tensor is both input and output)
-        if constexpr (std::is_same_v<T, AllReducePreHookArgs>) {
-          auto count = a.tensor.numel();
-          auto dtype = dtypeToString(a.tensor.scalar_type());
-          auto red_op = reduceOpToString(a.op);
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
-              op,
-              count,
-              count,
-              dtype,
-              red_op,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, BroadcastPreHookArgs>) {
-          auto count = a.tensor.numel();
-          auto dtype = dtypeToString(a.tensor.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
-              op,
-              count,
-              count,
-              dtype,
-              a.root,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, ReducePreHookArgs>) {
-          auto count = a.tensor.numel();
-          auto dtype = dtypeToString(a.tensor.scalar_type());
-          auto red_op = reduceOpToString(a.op);
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|red_op={}|root={}|async_op={}",
-              op,
-              count,
-              count,
-              dtype,
-              red_op,
-              a.root,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
-          }
-          return sig;
-
-          // Point-to-point
-        } else if constexpr (std::is_same_v<T, SendPreHookArgs>) {
-          auto dtype = dtypeToString(a.tensor.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count=0|dtype={}|peer={}|async_op={}",
-              op,
-              a.tensor.numel(),
-              dtype,
-              a.peer,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format("|in={}", formatPtr(a.tensor.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, RecvPreHookArgs>) {
-          auto dtype = dtypeToString(a.tensor.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count=0|out_count={}|dtype={}|peer={}|async_op={}",
-              op,
-              a.tensor.numel(),
-              dtype,
-              a.peer,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format("|out={}", formatPtr(a.tensor.data_ptr()));
-          }
-          return sig;
-
-          // Distinct input/output (single tensors)
-        } else if constexpr (
-            std::is_same_v<T, AllGatherSinglePreHookArgs> ||
-            std::is_same_v<T, AllToAllSinglePreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|async_op={}",
-              op,
-              a.input.numel(),
-              a.output.numel(),
-              dtype,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::
-                                 is_same_v<T, ReduceScatterSinglePreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto red_op = reduceOpToString(a.op);
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
-              op,
-              a.input.numel(),
-              a.output.numel(),
-              dtype,
-              red_op,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, AllToAllVSinglePreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_splits={}|out_splits={}|dtype={}|async_op={}",
-              op,
-              formatCounts(a.input_split_sizes),
-              formatCounts(a.output_split_sizes),
-              dtype,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-
-          // Input tensor -> output tensor list
-        } else if constexpr (
-            std::is_same_v<T, AllGatherPreHookArgs> ||
-            std::is_same_v<T, AllGatherVPreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_counts={}|dtype={}|async_op={}",
-              op,
-              a.input.numel(),
-              formatCounts(a.output),
-              dtype,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtrs(a.output));
-          }
-          return sig;
-
-          // Input tensor list -> output tensor
-        } else if constexpr (
-            std::is_same_v<T, ReduceScatterPreHookArgs> ||
-            std::is_same_v<T, ReduceScatterVPreHookArgs>) {
-          auto dtype = dtypeToString(a.output.scalar_type());
-          auto red_op = reduceOpToString(a.op);
-          auto sig = fmt::format(
-              "{}|in_counts={}|out_count={}|dtype={}|red_op={}|async_op={}",
-              op,
-              formatCounts(a.input),
-              a.output.numel(),
-              dtype,
-              red_op,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtrs(a.input),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-
-          // Tensor lists on both sides
-        } else if constexpr (std::is_same_v<T, AllToAllPreHookArgs>) {
-          if (a.input.empty()) {
-            return std::string();
-          }
-          auto dtype = dtypeToString(a.input[0].scalar_type());
-          auto sig = fmt::format(
-              "{}|in_counts={}|out_counts={}|dtype={}|async_op={}",
-              op,
-              formatCounts(a.input),
-              formatCounts(a.output),
-              dtype,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}", formatPtrs(a.input), formatPtrs(a.output));
-          }
-          return sig;
-
-          // Scatter/gather with root
-        } else if constexpr (std::is_same_v<T, ScatterPreHookArgs>) {
-          auto dtype = dtypeToString(a.output.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_counts={}|out_count={}|dtype={}|root={}|async_op={}",
-              op,
-              formatCounts(a.input),
-              a.output.numel(),
-              dtype,
-              a.root,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtrs(a.input),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, GatherPreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_counts={}|dtype={}|root={}|async_op={}",
-              op,
-              a.input.numel(),
-              formatCounts(a.output),
-              dtype,
-              a.root,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtrs(a.output));
-          }
-          return sig;
-        } else if constexpr (std::is_same_v<T, GatherSinglePreHookArgs>) {
-          auto dtype = dtypeToString(a.input.scalar_type());
-          auto sig = fmt::format(
-              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
-              op,
-              a.input.numel(),
-              a.output.numel(),
-              dtype,
-              a.root,
-              a.async_op ? 't' : 'f');
-          if (log_buffers_) {
-            sig += fmt::format(
-                "|in={}|out={}",
-                formatPtr(a.input.data_ptr()),
-                formatPtr(a.output.data_ptr()));
-          }
-          return sig;
-
-          // Special (no tensors)
-        } else if constexpr (std::is_same_v<T, BarrierPreHookArgs>) {
-          return fmt::format("{}|async_op={}", op, a.async_op ? 't' : 'f');
-        } else if constexpr (std::is_same_v<T, BatchOpIssuePreHookArgs>) {
-          return fmt::format(
-              "{}|num_ops={}|async_op={}",
-              op,
-              a.num_ops,
-              a.async_op ? 't' : 'f');
-
-          // Communicator management (split logged separately)
-        } else if constexpr (std::is_same_v<T, SplitPreHookArgs>) {
-          return std::string();
-        } else if constexpr (std::is_same_v<T, NewWindowPreHookArgs>) {
-          return std::string();
-        } else if constexpr (std::is_same_v<T, FinalizePreHookArgs>) {
-          return std::string();
-        } else {
-          return std::string();
-        }
-      },
-      args);
-}
-
 // -- Pre-hook --
 
 void ClogHook::onPreHook(
@@ -616,34 +241,18 @@ void ClogHook::onPreHook(
     int device_index,
     size_t op_id,
     const PreHookArgs& args) {
-  // Handle split specially: log the split event, not a signature.
   if (auto* split = std::get_if<SplitPreHookArgs>(&args)) {
-    std::string ranks_str;
-    for (size_t i = 0; i < split->ranks.size(); ++i) {
-      if (i > 0) {
-        ranks_str += ',';
-      }
-      ranks_str += std::to_string(split->ranks[i]);
-    }
-    log_file_.writeLine(
-        fmt::format(
-            "split|parent={}|child={}|ranks={}",
-            comm_name,
-            split->name,
-            ranks_str));
+    log_file_.writeLine(buildSplitLine(comm_name, *split));
     return;
   }
 
-  // Skip new_window and finalize (no logging needed)
   if (std::get_if<NewWindowPreHookArgs>(&args) ||
       std::get_if<FinalizePreHookArgs>(&args)) {
     return;
   }
 
-  auto sig = buildSignature(args);
-  if (sig.empty()) {
-    return;
-  }
+  auto sig = buildSignature(comm_name, args, log_buffers_);
+  assert(!sig.empty());
 
   bool async_op = getAsyncOp(args);
   auto [stream, graph_id] = getGraphCaptureInfo(device_index);

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -727,7 +727,7 @@ void ClogHook::onPostHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "S"); });
             work->registerWorkEndHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "E"); });
-            work->registerWorkWaitHook(
+            work->registerWorkWaitPreHook(
                 [this, work_id]() { logLifecycleEvent(work_id, "W"); });
           }
         }

--- a/comms/torchcomms/hooks/clog/ClogHook.hpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.hpp
@@ -19,6 +19,7 @@
 #include "comms/torchcomms/RemovableHandle.hpp"
 #include "comms/torchcomms/TorchCommHooks.hpp"
 #include "comms/torchcomms/TorchCommTypes.hpp"
+#include "comms/torchcomms/hooks/common/SignatureBuilder.hpp"
 #include "comms/torchcomms/hooks/common/ThreadSafeLogFile.hpp"
 
 namespace torch::comms {
@@ -169,17 +170,8 @@ class ClogHook : public std::enable_shared_from_this<ClogHook> {
       size_t op_id,
       const PostHookArgs& args);
 
-  // Build signature string from typed pre-hook args via std::visit.
-  std::string buildSignature(const PreHookArgs& args) const;
-
   // -- Formatting helpers --
   static double now();
-  static std::string_view reduceOpToString(const ReduceOp& op);
-  static std::string_view dtypeToString(at::ScalarType dtype);
-  static std::string formatCounts(const std::vector<at::Tensor>& tensors);
-  static std::string formatCounts(const std::vector<uint64_t>& counts);
-  static std::string formatPtr(const void* ptr);
-  static std::string formatPtrs(const std::vector<at::Tensor>& tensors);
 
   void logEvent(uint64_t corr_id, std::string_view event);
   void

--- a/comms/torchcomms/hooks/clog/ClogHook.hpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.hpp
@@ -160,7 +160,6 @@ class ClogHook : public std::enable_shared_from_this<ClogHook> {
   void onPreHook(
       const std::string& comm_name,
       int device_index,
-      OpName name,
       size_t op_id,
       const PreHookArgs& args);
 
@@ -171,7 +170,7 @@ class ClogHook : public std::enable_shared_from_this<ClogHook> {
       const PostHookArgs& args);
 
   // Build signature string from typed pre-hook args via std::visit.
-  std::string buildSignature(OpName name, const PreHookArgs& args) const;
+  std::string buildSignature(const PreHookArgs& args) const;
 
   // -- Formatting helpers --
   static double now();

--- a/comms/torchcomms/hooks/common/OpNameHelper.hpp
+++ b/comms/torchcomms/hooks/common/OpNameHelper.hpp
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <variant>
+
+#include "comms/torchcomms/TorchCommHooks.hpp"
+
+namespace torch::comms {
+
+inline OpName getOpName(const PreHookArgs& args) {
+  if (std::get_if<SendPreHookArgs>(&args))
+    return OpName::send;
+  else if (std::get_if<RecvPreHookArgs>(&args))
+    return OpName::recv;
+  else if (std::get_if<BroadcastPreHookArgs>(&args))
+    return OpName::broadcast;
+  else if (std::get_if<AllReducePreHookArgs>(&args))
+    return OpName::all_reduce;
+  else if (std::get_if<ReducePreHookArgs>(&args))
+    return OpName::reduce;
+  else if (std::get_if<AllGatherPreHookArgs>(&args))
+    return OpName::all_gather;
+  else if (std::get_if<AllGatherVPreHookArgs>(&args))
+    return OpName::all_gather_v;
+  else if (std::get_if<AllGatherSinglePreHookArgs>(&args))
+    return OpName::all_gather_single;
+  else if (std::get_if<ReduceScatterPreHookArgs>(&args))
+    return OpName::reduce_scatter;
+  else if (std::get_if<ReduceScatterVPreHookArgs>(&args))
+    return OpName::reduce_scatter_v;
+  else if (std::get_if<ReduceScatterSinglePreHookArgs>(&args))
+    return OpName::reduce_scatter_single;
+  else if (std::get_if<AllToAllSinglePreHookArgs>(&args))
+    return OpName::all_to_all_single;
+  else if (std::get_if<AllToAllVSinglePreHookArgs>(&args))
+    return OpName::all_to_all_v_single;
+  else if (std::get_if<AllToAllPreHookArgs>(&args))
+    return OpName::all_to_all;
+  else if (std::get_if<BarrierPreHookArgs>(&args))
+    return OpName::barrier;
+  else if (std::get_if<ScatterPreHookArgs>(&args))
+    return OpName::scatter;
+  else if (std::get_if<GatherPreHookArgs>(&args))
+    return OpName::gather;
+  else if (std::get_if<GatherSinglePreHookArgs>(&args))
+    return OpName::gather_single;
+  else if (std::get_if<SplitPreHookArgs>(&args))
+    return OpName::split;
+  else if (std::get_if<NewWindowPreHookArgs>(&args))
+    return OpName::new_window;
+  else if (std::get_if<BatchOpIssuePreHookArgs>(&args))
+    return OpName::batch_op_issue;
+  else if (std::get_if<FinalizePreHookArgs>(&args))
+    return OpName::finalize;
+  __builtin_unreachable();
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/hooks/common/SignatureBuilder.cpp
+++ b/comms/torchcomms/hooks/common/SignatureBuilder.cpp
@@ -1,0 +1,391 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/torchcomms/hooks/common/SignatureBuilder.hpp"
+#include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
+
+#include <variant>
+
+#include <fmt/core.h>
+
+namespace torch::comms {
+
+std::string_view dtypeToString(at::ScalarType dtype) {
+  switch (dtype) {
+    case at::ScalarType::Float:
+      return "f32";
+    case at::ScalarType::Double:
+      return "f64";
+    case at::ScalarType::Half:
+      return "f16";
+    case at::ScalarType::BFloat16:
+      return "bf16";
+    case at::ScalarType::Int:
+      return "i32";
+    case at::ScalarType::Long:
+      return "i64";
+    case at::ScalarType::Short:
+      return "i16";
+    case at::ScalarType::Char:
+      return "i8";
+    case at::ScalarType::Byte:
+      return "u8";
+    case at::ScalarType::Bool:
+      return "bool";
+    case at::ScalarType::Float8_e4m3fn:
+      return "fp8e4m3";
+    case at::ScalarType::Float8_e5m2:
+      return "fp8e5m2";
+    default:
+      return "other";
+  }
+}
+
+std::string_view reduceOpToString(const ReduceOp& op) {
+  switch (op.type()) {
+    case ReduceOp::RedOpType::SUM:
+      return "sum";
+    case ReduceOp::RedOpType::PRODUCT:
+      return "prod";
+    case ReduceOp::RedOpType::MIN:
+      return "min";
+    case ReduceOp::RedOpType::MAX:
+      return "max";
+    case ReduceOp::RedOpType::BAND:
+      return "band";
+    case ReduceOp::RedOpType::BOR:
+      return "bor";
+    case ReduceOp::RedOpType::BXOR:
+      return "bxor";
+    case ReduceOp::RedOpType::PREMUL_SUM:
+      return "premul_sum";
+    case ReduceOp::RedOpType::AVG:
+      return "avg";
+    default:
+      return "unknown";
+  }
+}
+
+std::string formatPtr(const void* ptr) {
+  return fmt::format("{:#x}", reinterpret_cast<uintptr_t>(ptr));
+}
+
+std::string formatPtrs(const std::vector<at::Tensor>& tensors) {
+  std::string result;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += formatPtr(tensors[i].data_ptr());
+  }
+  return result;
+}
+
+std::string formatCounts(const std::vector<at::Tensor>& tensors) {
+  std::string result;
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += std::to_string(tensors[i].numel());
+  }
+  return result;
+}
+
+std::string formatCounts(const std::vector<uint64_t>& counts) {
+  std::string result;
+  for (size_t i = 0; i < counts.size(); ++i) {
+    if (i > 0) {
+      result += ',';
+    }
+    result += std::to_string(counts[i]);
+  }
+  return result;
+}
+
+std::string buildSignature(
+    std::string_view comm_name,
+    const PreHookArgs& args,
+    bool include_buffers) {
+  auto op = opToString(getOpName(args));
+  auto sig = std::visit(
+      [include_buffers, comm_name, op](const auto& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+
+        if constexpr (std::is_same_v<T, AllReducePreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, BroadcastPreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, ReducePreHookArgs>) {
+          auto count = a.tensor.numel();
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|root={}|async_op={}",
+              op,
+              count,
+              count,
+              dtype,
+              red_op,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format("|buf={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, SendPreHookArgs>) {
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count=0|dtype={}|peer={}|async_op={}",
+              op,
+              a.tensor.numel(),
+              dtype,
+              a.peer,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format("|in={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, RecvPreHookArgs>) {
+          auto dtype = dtypeToString(a.tensor.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count=0|out_count={}|dtype={}|peer={}|async_op={}",
+              op,
+              a.tensor.numel(),
+              dtype,
+              a.peer,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format("|out={}", formatPtr(a.tensor.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (
+            std::is_same_v<T, AllGatherSinglePreHookArgs> ||
+            std::is_same_v<T, AllToAllSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::
+                                 is_same_v<T, ReduceScatterSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, AllToAllVSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_splits={}|out_splits={}|dtype={}|async_op={}",
+              op,
+              formatCounts(a.input_split_sizes),
+              formatCounts(a.output_split_sizes),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (
+            std::is_same_v<T, AllGatherPreHookArgs> ||
+            std::is_same_v<T, AllGatherVPreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_counts={}|dtype={}|async_op={}",
+              op,
+              a.input.numel(),
+              formatCounts(a.output),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtrs(a.output));
+          }
+          return sig;
+        } else if constexpr (
+            std::is_same_v<T, ReduceScatterPreHookArgs> ||
+            std::is_same_v<T, ReduceScatterVPreHookArgs>) {
+          auto dtype = dtypeToString(a.output.scalar_type());
+          auto red_op = reduceOpToString(a.op);
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_count={}|dtype={}|red_op={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              a.output.numel(),
+              dtype,
+              red_op,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtrs(a.input),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, AllToAllPreHookArgs>) {
+          if (a.input.empty()) {
+            return std::string();
+          }
+          auto dtype = dtypeToString(a.input[0].scalar_type());
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_counts={}|dtype={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              formatCounts(a.output),
+              dtype,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}", formatPtrs(a.input), formatPtrs(a.output));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, ScatterPreHookArgs>) {
+          auto dtype = dtypeToString(a.output.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_counts={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              formatCounts(a.input),
+              a.output.numel(),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtrs(a.input),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, GatherPreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_counts={}|dtype={}|root={}|async_op={}",
+              op,
+              a.input.numel(),
+              formatCounts(a.output),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtrs(a.output));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, GatherSinglePreHookArgs>) {
+          auto dtype = dtypeToString(a.input.scalar_type());
+          auto sig = fmt::format(
+              "{}|in_count={}|out_count={}|dtype={}|root={}|async_op={}",
+              op,
+              a.input.numel(),
+              a.output.numel(),
+              dtype,
+              a.root,
+              a.async_op ? 't' : 'f');
+          if (include_buffers) {
+            sig += fmt::format(
+                "|in={}|out={}",
+                formatPtr(a.input.data_ptr()),
+                formatPtr(a.output.data_ptr()));
+          }
+          return sig;
+        } else if constexpr (std::is_same_v<T, BarrierPreHookArgs>) {
+          return fmt::format("{}|async_op={}", op, a.async_op ? 't' : 'f');
+        } else if constexpr (std::is_same_v<T, BatchOpIssuePreHookArgs>) {
+          return fmt::format(
+              "{}|num_ops={}|async_op={}",
+              op,
+              a.num_ops,
+              a.async_op ? 't' : 'f');
+        } else if constexpr (
+            std::is_same_v<T, SplitPreHookArgs> ||
+            std::is_same_v<T, NewWindowPreHookArgs> ||
+            std::is_same_v<T, FinalizePreHookArgs>) {
+          return std::string();
+        } else {
+          return std::string();
+        }
+      },
+      args);
+  if (!sig.empty()) {
+    sig += fmt::format("|comm={}", comm_name);
+  }
+  return sig;
+}
+
+std::string buildSplitLine(
+    std::string_view parent_name,
+    const SplitPreHookArgs& split) {
+  std::string ranks_str;
+  for (size_t i = 0; i < split.ranks.size(); ++i) {
+    if (i > 0) {
+      ranks_str += ',';
+    }
+    ranks_str += std::to_string(split.ranks[i]);
+  }
+  return fmt::format(
+      "split|parent={}|child={}|ranks={}", parent_name, split.name, ranks_str);
+}
+
+std::string
+buildNewCommSignature(std::string_view comm_name, int rank, int world_size) {
+  return fmt::format(
+      "new_comm|comm={}|rank={}|world_size={}", comm_name, rank, world_size);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/hooks/common/SignatureBuilder.hpp
+++ b/comms/torchcomms/hooks/common/SignatureBuilder.hpp
@@ -1,0 +1,31 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <ATen/ATen.h>
+#include "comms/torchcomms/TorchCommHooks.hpp"
+#include "comms/torchcomms/TorchCommTypes.hpp"
+
+namespace torch::comms {
+
+std::string_view dtypeToString(at::ScalarType dtype);
+std::string_view reduceOpToString(const ReduceOp& op);
+std::string formatPtr(const void* ptr);
+std::string formatPtrs(const std::vector<at::Tensor>& tensors);
+std::string formatCounts(const std::vector<at::Tensor>& tensors);
+std::string formatCounts(const std::vector<uint64_t>& counts);
+std::string buildSignature(
+    std::string_view comm_name,
+    const PreHookArgs& args,
+    bool include_buffers);
+std::string
+buildNewCommSignature(std::string_view comm_name, int rank, int world_size);
+std::string buildSplitLine(
+    std::string_view parent_name,
+    const SplitPreHookArgs& split);
+
+} // namespace torch::comms

--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/hooks/fr/FlightRecorder.hpp"
+#include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/WaitCounter.h>
@@ -837,9 +838,8 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
 
   // Register pre-hook - records the operation
   auto pre_hook_handle = comm->registerPreHook(
-      [self, comm_name, pg_id, pg_desc](
-          OpName name, size_t op_id, const PreHookArgs& args) {
-        self->onPreHook(comm_name, pg_id, pg_desc, name, op_id, args);
+      [self, comm_name, pg_id, pg_desc](size_t op_id, const PreHookArgs& args) {
+        self->onPreHook(comm_name, pg_id, pg_desc, op_id, args);
       });
 
   // Register post-hook - called via work callback when work completes
@@ -861,9 +861,9 @@ void FlightRecorderHook::onPreHook(
     const std::string& comm_name,
     size_t pg_id,
     const std::string& pg_desc,
-    OpName name,
     size_t op_id,
     const PreHookArgs& args) {
+  auto name = getOpName(args);
   if (!enabled_) {
     return;
   }

--- a/comms/torchcomms/hooks/fr/FlightRecorder.hpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.hpp
@@ -418,7 +418,6 @@ class FlightRecorderHook
       const std::string& comm_name,
       size_t pg_id,
       const std::string& pg_desc,
-      OpName name,
       size_t op_id,
       const PreHookArgs& args);
 

--- a/comms/torchcomms/nccl/TorchWorkNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.cpp
@@ -160,12 +160,13 @@ TorchWorkNCCL::WorkStatus TorchWorkNCCL::checkStatus() {
 }
 
 void TorchWorkNCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -192,5 +193,7 @@ void TorchWorkNCCL::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -269,12 +269,13 @@ TorchWorkNCCLX::WorkStatus TorchWorkNCCLX::checkStatus() {
 }
 
 void TorchWorkNCCLX::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -302,5 +303,7 @@ void TorchWorkNCCLX::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchWorkRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchWorkRCCL.cpp
@@ -147,12 +147,13 @@ TorchWorkRCCL::WorkStatus TorchWorkRCCL::checkStatus() {
 }
 
 void TorchWorkRCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -179,5 +180,7 @@ void TorchWorkRCCL::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchWorkRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchWorkRCCLX.cpp
@@ -143,12 +143,13 @@ TorchWorkRCCLX::WorkStatus TorchWorkRCCLX::checkStatus() {
 }
 
 void TorchWorkRCCLX::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = status();
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -175,5 +176,7 @@ void TorchWorkRCCLX::wait() {
   // complete.
   inputTensors_.clear();
   inputTensor_.reset();
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms

--- a/comms/torchcomms/tests/unit/cpp/TorchCommHooksTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommHooksTest.cpp
@@ -3,6 +3,7 @@
 #include <comms/torchcomms/TorchComm.hpp>
 #include <comms/torchcomms/TorchCommFactory.hpp>
 #include <comms/torchcomms/fake/TorchCommFake.hpp>
+#include <comms/torchcomms/hooks/common/OpNameHelper.hpp>
 #include <gtest/gtest.h>
 #include <cstdlib>
 #include <vector>
@@ -36,8 +37,8 @@ TEST_F(TorchCommHooksTest, PreAndPostHookCalledAfterRegistration) {
   int postHookCallCount = 0;
 
   auto preHandle = torchcomm->registerPreHook(
-      [&preHookCalls](OpName name, size_t, const PreHookArgs&) {
-        preHookCalls.push_back(name);
+      [&preHookCalls](size_t, const PreHookArgs& args) {
+        preHookCalls.push_back(getOpName(args));
       });
 
   auto postHandle = torchcomm->registerPostHook(
@@ -61,8 +62,8 @@ TEST_F(TorchCommHooksTest, PreAndPostHookOpIdIncreases) {
   std::vector<size_t> preOpIds;
   std::vector<size_t> postOpIds;
 
-  auto preHandle = torchcomm->registerPreHook(
-      [&preOpIds](OpName, size_t op_id, const PreHookArgs&) {
+  auto preHandle =
+      torchcomm->registerPreHook([&preOpIds](size_t op_id, const PreHookArgs&) {
         preOpIds.push_back(op_id);
       });
 
@@ -100,9 +101,7 @@ TEST_F(TorchCommHooksTest, PreAndPostHookNotCalledAfterRemoval) {
   int postHookCallCount = 0;
 
   auto preHandle = torchcomm->registerPreHook(
-      [&preHookCallCount](OpName, size_t, const PreHookArgs&) {
-        preHookCallCount++;
-      });
+      [&preHookCallCount](size_t, const PreHookArgs&) { preHookCallCount++; });
 
   auto postHandle = torchcomm->registerPostHook(
       [&postHookCallCount](size_t, const PostHookArgs&) {
@@ -135,12 +134,12 @@ TEST_F(TorchCommHooksTest, MultiplePreAndPostHooksRegistered) {
   int postHook2CallCount = 0;
 
   auto preHandle1 = torchcomm->registerPreHook(
-      [&preHook1CallCount](OpName, size_t, const PreHookArgs&) {
+      [&preHook1CallCount](size_t, const PreHookArgs&) {
         preHook1CallCount++;
       });
 
   auto preHandle2 = torchcomm->registerPreHook(
-      [&preHook2CallCount](OpName, size_t, const PreHookArgs&) {
+      [&preHook2CallCount](size_t, const PreHookArgs&) {
         preHook2CallCount++;
       });
 
@@ -174,8 +173,8 @@ TEST_F(
   std::vector<size_t> postHookOpIds;
 
   auto preHandle = torchcomm->registerPreHook(
-      [&preHookCalls](OpName name, size_t op_id, const PreHookArgs&) {
-        preHookCalls.emplace_back(name, op_id);
+      [&preHookCalls](size_t op_id, const PreHookArgs& args) {
+        preHookCalls.emplace_back(getOpName(args), op_id);
       });
 
   auto postHandle = torchcomm->registerPostHook(
@@ -217,7 +216,7 @@ TEST_F(TorchCommHooksTest, PreHookArgsContainCorrectVariantTypes) {
   std::vector<size_t> variant_indices;
 
   auto preHandle = torchcomm->registerPreHook(
-      [&variant_indices](OpName, size_t, const PreHookArgs& args) {
+      [&variant_indices](size_t, const PreHookArgs& args) {
         variant_indices.push_back(args.index());
       });
 
@@ -251,7 +250,7 @@ TEST_F(TorchCommHooksTest, PreHookAllReduceArgsAccessible) {
 
   bool hook_called = false;
   auto preHandle = torchcomm->registerPreHook(
-      [&hook_called](OpName, size_t, const PreHookArgs& args) {
+      [&hook_called](size_t, const PreHookArgs& args) {
         auto* ar = std::get_if<AllReducePreHookArgs>(&args);
         ASSERT_NE(ar, nullptr);
         EXPECT_EQ(ar->tensor.numel(), 4); // 2x2 tensor
@@ -274,17 +273,16 @@ TEST_F(TorchCommHooksTest, BatchOpIssueHooksFired) {
   size_t pre_op_id = 0;
   size_t post_op_id = 0;
 
-  torchcomm->registerPreHook(
-      [&](OpName name, size_t op_id, const PreHookArgs& args) {
-        if (name == OpName::batch_op_issue) {
-          pre_hook_called = true;
-          pre_op_id = op_id;
-          auto* ba = std::get_if<BatchOpIssuePreHookArgs>(&args);
-          ASSERT_NE(ba, nullptr);
-          EXPECT_EQ(ba->num_ops, 2);
-          EXPECT_TRUE(ba->async_op);
-        }
-      });
+  torchcomm->registerPreHook([&](size_t op_id, const PreHookArgs& args) {
+    if (getOpName(args) == OpName::batch_op_issue) {
+      pre_hook_called = true;
+      pre_op_id = op_id;
+      auto* ba = std::get_if<BatchOpIssuePreHookArgs>(&args);
+      ASSERT_NE(ba, nullptr);
+      EXPECT_EQ(ba->num_ops, 2);
+      EXPECT_TRUE(ba->async_op);
+    }
+  });
 
   torchcomm->registerPostHook([&](size_t op_id, const PostHookArgs& args) {
     if (std::get_if<BatchOpIssuePostHookArgs>(&args)) {

--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -17,7 +17,8 @@ class TestWork : public TorchWork {
   }
 
   void wait() override {
-    runWaitHooks();
+    runWaitPreHooks();
+    runWaitPostHooks();
   }
 
   // expose for testing
@@ -69,16 +70,29 @@ TEST(TorchWorkTest, EndHookFiredOnTimedOut) {
   EXPECT_EQ(end_count, 1);
 }
 
-TEST(TorchWorkTest, WaitHookFiredOnWait) {
+TEST(TorchWorkTest, WaitPreHookFiredOnWait) {
   auto work = c10::make_intrusive<TestWork>();
   int wait_count = 0;
-  work->registerWorkWaitHook([&wait_count]() { wait_count++; });
+  work->registerWorkWaitPreHook([&wait_count]() { wait_count++; });
 
   EXPECT_EQ(wait_count, 0);
   work->wait();
   EXPECT_EQ(wait_count, 1);
 
   // wait hooks fire every time wait() is called
+  work->wait();
+  EXPECT_EQ(wait_count, 2);
+}
+
+TEST(TorchWorkTest, WaitPostHookFiredOnWait) {
+  auto work = c10::make_intrusive<TestWork>();
+  int wait_count = 0;
+  work->registerWorkWaitPostHook([&wait_count]() { wait_count++; });
+
+  EXPECT_EQ(wait_count, 0);
+  work->wait();
+  EXPECT_EQ(wait_count, 1);
+
   work->wait();
   EXPECT_EQ(wait_count, 2);
 }
@@ -115,19 +129,21 @@ TEST(TorchWorkTest, EndHookNotFiredOnInProgress) {
   EXPECT_EQ(end_count, 0);
 }
 
-TEST(TorchWorkTest, AllThreeHooksFiredInLifecycle) {
+TEST(TorchWorkTest, AllHooksFiredInLifecycle) {
   auto work = c10::make_intrusive<TestWork>();
   std::vector<std::string> events;
 
   work->registerWorkStartHook([&events]() { events.push_back("start"); });
   work->registerWorkEndHook([&events]() { events.push_back("end"); });
-  work->registerWorkWaitHook([&events]() { events.push_back("wait"); });
+  work->registerWorkWaitPreHook([&events]() { events.push_back("wait_pre"); });
+  work->registerWorkWaitPostHook(
+      [&events]() { events.push_back("wait_post"); });
 
   work->setStatus(TorchWork::WorkStatus::INPROGRESS);
   work->wait();
   work->setStatus(TorchWork::WorkStatus::COMPLETED);
 
-  std::vector<std::string> expected{"start", "wait", "end"};
+  std::vector<std::string> expected{"start", "wait_pre", "wait_post", "end"};
   EXPECT_EQ(events, expected);
 }
 

--- a/comms/torchcomms/xccl/TorchWorkXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchWorkXCCL.cpp
@@ -156,12 +156,13 @@ TorchWorkXCCL::WorkStatus TorchWorkXCCL::checkStatus() {
 }
 
 void TorchWorkXCCL::wait() {
-  runWaitHooks();
+  runWaitPreHooks();
 
   // If already completed, return immediately
   WorkStatus local_state = state_;
   if (local_state == WorkStatus::COMPLETED ||
       local_state == WorkStatus::ERROR || local_state == WorkStatus::TIMEDOUT) {
+    runWaitPostHooks();
     return;
   }
 
@@ -182,5 +183,7 @@ void TorchWorkXCCL::wait() {
       comm_->getXpuApi(),
       comm_->getXpuApi()->streamWaitEvent(current_stream, end_event_, 0),
       "Failed to make stream wait for event");
+
+  runWaitPostHooks();
 }
 } // namespace torch::comms


### PR DESCRIPTION
Summary:

Move buildSignature, dtypeToString, reduceOpToString,
formatPtr, formatPtrs, and formatCounts from ClogHook into a
shared SignatureBuilder utility at hooks/common/. The
buildSignature function takes a bool include_buffers parameter
so callers can control whether buffer addresses are included
in the signature.

ClogHook now calls buildSignature(name, args, log_buffers_)
instead of its own member function.

Differential Revision: D103891512


