### PR TITLE
Flush after RDMA receive in ctdirect AllReduce (multi-NIC) (#2396)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -69,6 +69,23 @@ static const auto myAlgo = NCCL_ALLREDUCE_ALGO::ctdirect;
     }                                                                          \
   } while (0)
 
+// Drain pending NIC PCIe writes into GPU HBM after RDMA receives complete and
+// before launching the GPU kernel that reads the just-received buffer. On
+// GB200 (split-path topology: NIC<->SoC over PCIe, CPU<->GPU over NVLink-C2C),
+// PCIe write ordering does not extend across the SoC<->C2C boundary, so the
+// CPU may observe waitNotify completion before the RDMA payload has committed
+// to HBM. Issuing an RDMA READ per device drains the PCIe write pipeline.
+// Companion to D103775295 (proxy receive path) and D103503273 (ctrd AG).
+static commResult_t flushAfterRecv(CtranComm* comm, void* buf, void* hdl) {
+  CtranMapperRequest* rawReq = nullptr;
+  FB_COMMCHECK(comm->ctran_->mapper->iflush(buf, hdl, &rawReq));
+  std::unique_ptr<CtranMapperRequest> req(rawReq);
+  if (req) {
+    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(req.get()));
+  }
+  return commSuccess;
+}
+
 static commResult_t impl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   struct OpElem* op = opGroup.front().get();
@@ -316,6 +333,10 @@ static commResult_t impl(
           FB_COMMCHECK(comm->ctran_->mapper->waitNotify(&notify));
         }
       }
+
+      // See flushAfterRecv: drain peers' RDMA WRITEs into tmpBuf before the
+      // kInterReduceScatter kernel reads it.
+      FB_COMMCHECK(flushAfterRecv(comm, tmpBuf, tmpbufRegHdl));
     }
 
     /* local reduction from tmpbuf */
@@ -368,6 +389,11 @@ static commResult_t impl(
           FB_COMMCHECK(comm->ctran_->mapper->waitNotify(&notify));
         }
       }
+
+      // See flushAfterRecv: drain peers' RDMA WRITEs into recvbuff before the
+      // kIntraAllGather kernel (Step 4) reads it for NVLink bcast.
+      FB_COMMCHECK(
+          flushAfterRecv(comm, BUFOFFSET(recvbuff, localOffset), recvHdl));
     }
     THROW_IF_ABORTED(, "ctdirect step 3: inter-node allgather");
 
@@ -490,6 +516,10 @@ static commResult_t impl(
         FB_COMMCHECK(comm->ctran_->mapper->waitNotify(&notify));
       }
     }
+
+    // See flushAfterRecv: drain peers' RDMA WRITEs into tmpBuf before the
+    // kRemInterReduce kernel reads it.
+    FB_COMMCHECK(flushAfterRecv(comm, tmpBuf, tmpbufRegHdl));
 
     /* local reduction from tmpbuf */
     elem = op->allreduce.kElemStepMap.at(


### PR DESCRIPTION
Summary:

**Scope:** This diff covers GB200 only with multiple NICs per rank (`NCCL_CTRAN_IB_DEVICES_PER_RANK > 1` + `NCCL_CTRAN_IB_MULTI_NIC_FLUSH=1`). On single-NIC GB200, the flush calls added here become CtranIb-level no-ops because D103503273's `enableLocalFlush_` gating (`cudaArch < 900 || (DEVICES_PER_RANK > 1 && MULTI_NIC_FLUSH)`) disables flush on Blackwell when there is only one NIC. Closing the GPU-read-after-RDMA race for single-NIC GB200 needs a follow-up that relaxes `enableLocalFlush_` on Blackwell regardless of NIC count; flagged for Min/Dan to weigh in.

On GB200, ctdirect's three inter-node phases each follow the pattern: peers RDMA-WRITE into my `tmpBuf` or `recvbuff` slice → CPU sees `waitNotify` → CPU launches a GPU kernel that immediately reads that buffer. With the split-path topology (NIC↔SoC over PCIe, CPU↔GPU over NVLink-C2C), PCIe write ordering does not extend across the SoC↔C2C boundary: the CPU may observe the notify before the RDMA payload has committed to HBM, so the GPU kernel can read stale data. This is the same memory-ordering gap that D103775295 closes for the ncclx proxy receive path and D103503273 closes for ctrd AllGather.

Unlike ctring AllReduce (which already calls `mapper->iflush` at lines 415 and 779 of `AllReduceRing.cc` and just needed the plumbing fixes from D103503273 to become functional), `AllReduceDirect.cc` had zero `iflush` calls — so D103503273 alone does not cover ctdirect.

Fix: introduce a small file-local `flushAfterRecv` helper that wraps the standard `iflush + waitRequest` idiom, and invoke it after each of the three inter-node `waitNotify` fan-in loops, before the dependent GPU kernel:

- Step 2 (inter-node reduce-scatter): flush `tmpBuf` before `kInterReduceScatter`.
- Step 3 (inter-node allgather): flush `recvbuff` slice before `kIntraAllGather` (Step 4).
- Step 7 (remainder inter-node allreduce): flush `tmpBuf` before `kRemInterReduce`.

One flush per phase is sufficient; `mapper->iflush` posts an RDMA READ per device (per the `CtranIbLocalVc` change in D103503273), so a single call drains every NIC's PCIe pipeline.

This stacks on D103503273.

Reviewed By: minsii

Differential Revision: D103903226


