### PR TITLE
build_ncclx: fix libdwarf discovery by creating missing conda symlinks (#2397)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -3,6 +3,32 @@
 
 set -x
 
+function ensure_conda_libdwarf_symlinks() {
+  local conda_lib_dir="${CMAKE_PREFIX_PATH}/lib"
+  local libdwarf_real=""
+  local soname=""
+
+  for candidate in "${conda_lib_dir}"/libdwarf.so "${conda_lib_dir}"/libdwarf.so.*; do
+    [[ -e "$candidate" ]] || continue
+    if [[ -f "$candidate" && ! -L "$candidate" ]]; then
+      libdwarf_real="$(basename "$candidate")"
+      break
+    fi
+  done
+
+  if [[ -z "$libdwarf_real" ]]; then
+    return
+  fi
+
+  if [[ "$libdwarf_real" != "libdwarf.so" ]]; then
+    ln -sf "$libdwarf_real" "${conda_lib_dir}/libdwarf.so"
+  fi
+  soname=$(readelf -d "${conda_lib_dir}/${libdwarf_real}" 2>/dev/null | sed -n 's/.*Library soname: \[\(.*\)\]/\1/p' | head -n 1)
+  if [[ -n "$soname" && "$soname" != "$libdwarf_real" ]]; then
+    ln -sf "$libdwarf_real" "${conda_lib_dir}/${soname}"
+  fi
+}
+
 function do_cmake_build() {
   local source_dir="$1"
   local extra_flags="$2"
@@ -182,6 +208,7 @@ function build_third_party {
         fmt
       )
       conda install "${DEPS[@]}" --yes
+      ensure_conda_libdwarf_symlinks
       build_fb_oss_library "https://github.com/facebook/folly.git" "$third_party_tag" folly
     fi
   fi


### PR DESCRIPTION
Summary:

Conda installs libdwarf with a versioned filename (e.g. `libdwarf.so.0.11.0`)
but does not always create the unversioned `libdwarf.so` symlink that
cmake / folly's FindLibDwarf expects. Add `ensure_conda_libdwarf_symlinks()`
which locates the real versioned library, creates the `libdwarf.so` symlink,
and also creates the SONAME symlink read from the ELF header. Call it right
after `conda install` and before building folly so the build reliably finds
libdwarf inside the conda environment.

Differential Revision: D103062296


