### PR TITLE
Split CommRegisterTest into separate NCCL_LOCAL_REGISTER configurations

### DIFF
--- a/comms/ncclx/meta/tests/CommRegisterTest.cc
+++ b/comms/ncclx/meta/tests/CommRegisterTest.cc
@@ -34,9 +34,6 @@ class CommRegisterTestParam
 
 TEST_P(CommRegisterTestParam, RegularUsage) {
   const auto& [nbytes, memType, ctranRegist] = GetParam();
-  // Set NCCL_LOCAL_REGISTER before comm creation to avoid a race condition
-  // with internal threads spawned during comm init that may call getenv.
-  SysEnvRAII env2("NCCL_LOCAL_REGISTER", "0");
   ncclx::test::NcclCommRAII comm(
       globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env(NCCL_CTRAN_REGISTER, ctranRegist);
@@ -71,9 +68,6 @@ TEST_P(CommRegisterTestParam, RegularUsage) {
 }
 
 TEST_F(CommRegisterTest, InvalidHybridUsage) {
-  // Set NCCL_LOCAL_REGISTER before comm creation to avoid a race condition
-  // with internal threads spawned during comm init that may call getenv.
-  SysEnvRAII env2("NCCL_LOCAL_REGISTER", "1");
   ncclx::test::NcclCommRAII comm(
       globalRank, numRanks, localRank, bootstrap_.get());
   EnvRAII env1(NCCL_CTRAN_REGISTER, NCCL_CTRAN_REGISTER::lazy);
@@ -142,9 +136,6 @@ INSTANTIATE_TEST_SUITE_P(
     });
 
 int main(int argc, char* argv[]) {
-  // Disable NCCL_PARAM caching for NCCL_LOCAL_REGISTER so tests can
-  // dynamically toggle it between test cases via setenv/unsetenv.
-  setenv("NCCL_NO_CACHE", "NCCL_LOCAL_REGISTER", 0);
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
   folly::Init init(&argc, &argv);


### PR DESCRIPTION
Summary:
- NCCL_LOCAL_REGISTER changed from CVAR (runtime-overridable) to NCCL_PARAM (global cache, read once) in ncclx v2_28, making in-process setenv/unsetenv ineffective after first read
- The old NCCL_NO_CACHE workaround is no longer recognized in v2_28 (logged as "Unknown env NCCL_NO_CACHE")
- Split into two BUCK configurations with NCCL_LOCAL_REGISTER set as env var: `1x8` (LOCAL_REGISTER=0, runs all tests except InvalidHybridUsage) and `1x8_localreg` (LOCAL_REGISTER=1, runs only InvalidHybridUsage)
- Remove SysEnvRAII("NCCL_LOCAL_REGISTER", ...) and NCCL_NO_CACHE hack from test code since env is now set by the test launcher

Reviewed By: Regina8023

Differential Revision: D103913772


