### PR TITLE
Add CopyOp template parameter to P2pIbgdaTransportDevice send() and recv()

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -1,0 +1,54 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+struct Memcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(dst, staging, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv_forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    if (dst) {
+      memcpy_vectorized(dst, staging, nbytes, group);
+      group.sync();
+      memcpy_vectorized(fwd_staging, dst, nbytes, group);
+    } else {
+      memcpy_vectorized(fwd_staging, staging, nbytes, group);
+    }
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -9,6 +9,7 @@
 #include <device/doca_gpunetio_dev_verbs_counter.cuh>
 #include <device/doca_gpunetio_dev_verbs_onesided.cuh>
 
+#include "comms/pipes/CopyOp.cuh"
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/DocaVerbsUtils.cuh"
@@ -1103,21 +1104,21 @@ class P2pIbgdaTransportDevice {
    *                        perBlockSlot. 0 means one signal per perBlockSlot.
    * @param timeout         Optional timeout for wait operations.
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void send(
       ThreadGroup& group,
-      void* __restrict__ src,
+      const void* __restrict__ src,
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
-#ifndef __CUDA_ARCH__
-    (void)group;
-    (void)src;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::send() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
     if (nbytes == 0) {
       return;
     }
@@ -1200,12 +1201,14 @@ class P2pIbgdaTransportDevice {
             timeout);
       }
 
-      // (2) Cooperative memcpy: src → local sendStaging.
-      memcpy_vectorized(
+      // (2) Cooperative copy: src → local sendStaging via CopyOp.
+      CopyOp::send(
           sendRecvState_.sendStagingPtr + stagingOff,
-          static_cast<char*>(src) + dataOff,
+          static_cast<const char*>(src) + dataOff,
           bytesThis,
-          group);
+          group,
+          dataOff,
+          args...);
       group.sync();
 
       // (3) Backpressure: wait for receiver to free this sub-chunk's
@@ -1276,21 +1279,21 @@ class P2pIbgdaTransportDevice {
    *                        Must match the sender's value.
    * @param timeout         Optional timeout for wait operations.
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
-#ifndef __CUDA_ARCH__
-    (void)group;
-    (void)dst;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::recv() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
     if (nbytes == 0) {
       return;
     }
@@ -1369,12 +1372,14 @@ class P2pIbgdaTransportDevice {
           static_cast<uint64_t>(chunkStep + 1),
           timeout);
 
-      // (2) Cooperative memcpy: local recvStaging → dst.
-      memcpy_vectorized(
+      // (2) Cooperative copy: local recvStaging → dst via CopyOp.
+      CopyOp::recv(
           static_cast<char*>(dst) + dataOff,
           sendRecvState_.recvStagingPtr + stagingOff,
           bytesThis,
-          group);
+          group,
+          dataOff,
+          args...);
       group.sync();
 
       // (3) Signal SLOT_FREE to sender — per sub-chunk (symmetric with


### PR DESCRIPTION
Summary:
Introduce a CopyOp abstraction for the pipelined send/recv protocol in P2pIbgdaTransportDevice. The send() and recv() methods now accept a CopyOp template parameter (defaulting to Memcpy) and a variadic Args... pack, replacing the hardcoded memcpy_vectorized calls.

This enables custom data transformations during the staging copy step — for example, a ReduceAdd CopyOp can accumulate local data during recv() without a separate pass. The default CopyOp=Memcpy preserves exact backward compatibility with all existing callers.

**CopyOp.cuh**: Defines the Memcpy tag type with static send(), recv(), and recv_forward() methods that delegate to memcpy_vectorized.

**P2pIbgdaTransportDevice.cuh**:
- send(): `CopyOp::send(staging, src, nbytes, group, byte_offset, args...)` replaces `memcpy_vectorized(staging, src, nbytes, group)`
- recv(): `CopyOp::recv(dst, staging, nbytes, group, byte_offset, args...)` replaces `memcpy_vectorized(dst, staging, nbytes, group)`
- src parameter changed from `void*` to `const void*` for const-correctness

Differential Revision: D103888262


