### PR TITLE
Internalize setCtranCommBase/makeCtranConfigFrom and remove dead code from MetaFactory (#2402)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -147,10 +147,6 @@ class CtranComm {
     return ctranOpCount_;
   }
 
-  // TODO: after finish refactoring remove factory method and define proper
-  // constructor
-  friend commResult_t setCtranCommBase(ncclComm* comm);
-
   // Get a pointer to the Transport array from MultiPeerTransport,
   // indexed by global rank. Returns nullptr if MultiPeerTransport is not
   // initialized.

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -90,7 +90,6 @@ class CommStateX {
 
   void initRankTopologyNolocal();
   void initRankTopologyVnode(const int nLocalRanks);
-  friend void initRankTopologyFrom(CommStateX* _CommStateX, void* _comm);
   void initRankStatesTopology(meta::comms::IBootstrap* bootstrap);
 
   /* Setters */

--- a/comms/ncclx/meta/commHash.cc
+++ b/comms/ncclx/meta/commHash.cc
@@ -4,15 +4,10 @@
 #include "comm.h"
 #include "nccl.h"
 
-#include "comms/ctran/commstate/CommStateX.h"
-
 NCCL_API(ncclResult_t, ncclCommGetUniqueHash, ncclComm_t comm, uint64_t* hash);
 ncclResult_t ncclCommGetUniqueHash(ncclComm_t comm, uint64_t* hash) {
-  NCCLCHECK(PtrCheck(comm, "CommGetUniqueHash", "comm"));
-  NCCLCHECK(PtrCheck(comm->ctranComm_.get(), "CommGetUniqueHash", "ctranComm"));
-  NCCLCHECK(
-      PtrCheck(comm->ctranComm_->statex_.get(), "CommGetUniqueHash", "statex"));
+  NCCLCHECK(CommCheck(comm, "CommGetUniqueHash", "comm"));
 
-  *hash = comm->ctranComm_->statex_->commHash();
+  *hash = comm->commHash;
   return ncclSuccess;
 }

--- a/comms/ncclx/meta/comms-monitor/tests/CommsMonitorUT.cc
+++ b/comms/ncclx/meta/comms-monitor/tests/CommsMonitorUT.cc
@@ -3,82 +3,23 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <folly/init/Init.h>
+
 #include "comm.h" // @manual
-#include "comms/ctran/Ctran.h" // @manual
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/NcclxConfig.h"
 #include "meta/comms-monitor/CommsMonitor.h" // @manual
-#include "meta/wrapper/MetaFactory.h"
-
-namespace {
-
-std::unique_ptr<ncclComm> createFakeNcclComm() {
-  auto comm = std::make_unique<ncclComm>();
-  comm->rank = 0;
-  comm->nRanks = 1;
-  comm->cudaDev = 0;
-  comm->commHash = 0xfaceb00c;
-  ncclx::Hints fakeHints({{"commDesc", "fake_comm"}});
-  comm->config.hints = &fakeHints;
-  ncclxParseCommConfig(&comm->config);
-  comm->localRank = 0;
-  comm->localRanks = 1;
-  comm->nNodes = 1;
-  comm->nChannels = 0;
-  setCtranCommBase(comm.get());
-
-  comm->ctranComm_->statex_ = std::make_unique<ncclx::CommStateX>(
-      comm->rank,
-      comm->nRanks,
-      comm->cudaDev,
-      comm->cudaArch,
-      comm->busId,
-      comm->commHash,
-      std::vector<ncclx::RankTopology>(), /* rankTopologies */
-      std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc));
-
-  return comm;
-}
-
-void initFakeChannels(ncclComm* comm) {
-  static std::list<std::vector<int>> ringStorage;
-
-  comm->nChannels = 2;
-
-  // Setup fake rings
-  ringStorage.push_back(std::vector<int>());
-  auto& ring1Storage = ringStorage.back();
-  ringStorage.push_back(std::vector<int>());
-  auto& ring2Storage = ringStorage.back();
-  ring1Storage.reserve(comm->nRanks);
-  ring2Storage.reserve(comm->nRanks);
-  for (int i = 0; i < comm->nRanks; i++) {
-    ring1Storage.emplace_back(i);
-    ring2Storage.emplace_back(comm->nRanks - i - 1);
-  }
-  comm->channels[0].ring.userRanks = ring1Storage.data();
-  comm->channels[1].ring.userRanks = ring2Storage.data();
-
-  // Set up fake trees
-  comm->channels[0].tree.up = 0;
-  comm->channels[1].tree.up = 1;
-}
-} // namespace
 
 // Need to be in the ncclx::comms_monitor scope to be the friend class
 namespace ncclx::comms_monitor {
-class CommsMonitorTest : public ::testing::Test {
+class CommsMonitorTest : public NcclxBaseTestFixture {
  public:
   void SetUp() override {
-    int deviceCount = 0;
-    cudaError_t err = cudaGetDeviceCount(&deviceCount);
-    if (err != cudaSuccess || deviceCount == 0) {
-      GTEST_SKIP() << "Skipping test because CUDA device is not available.";
-    }
-    ncclCvarInit();
-    NCCL_COMMSMONITOR_ENABLE = true;
+    NcclxBaseTestFixture::SetUp({{"NCCL_COMMSMONITOR_ENABLE", "1"}});
   }
+
   int getCommsMapSize() {
     auto commsMonitorPtr = CommsMonitor::getInstance();
     EXPECT_THAT(commsMonitorPtr, ::testing::NotNull());
@@ -95,87 +36,37 @@ class CommsMonitorTest : public ::testing::Test {
 using namespace ncclx::comms_monitor;
 
 TEST_F(CommsMonitorTest, TestRegisterComm) {
-  auto fakeComm = createFakeNcclComm();
   const auto refNum = CommsMonitor::getNumOfCommMonitoring();
-  EXPECT_TRUE(CommsMonitor::registerComm(fakeComm.get()));
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
+  // Real comm is auto-registered during init
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), refNum + 1);
 }
 
 TEST_F(CommsMonitorTest, TestRegisterDeregisterComm) {
-  auto fakeComm = createFakeNcclComm();
   const auto refNum = CommsMonitor::getNumOfCommMonitoring();
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
-  EXPECT_TRUE(CommsMonitor::registerComm(fakeComm.get()));
-  EXPECT_TRUE(CommsMonitor::deregisterComm(fakeComm.get()));
-
+  EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), refNum + 1);
+  EXPECT_TRUE(CommsMonitor::deregisterComm(comm.get()));
   EXPECT_EQ(CommsMonitor::getNumOfCommMonitoring(), refNum + 1);
 }
 
-// TODO: this test fails locally, disable it for now to unblock 2.25 rebase.
-TEST_F(CommsMonitorTest, DISABLED_TestOnlyDeregisterComm) {
-  auto fakeComm = createFakeNcclComm();
-  EXPECT_FALSE(CommsMonitor::deregisterComm(fakeComm.get()));
-}
-
 TEST_F(CommsMonitorTest, TestNcclTopoInfoFromNcclComm) {
-  auto fakeComm = createFakeNcclComm();
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
 
-  // Test with no channels initialized
-  {
-    auto topoInfo = getTopoInfoFromNcclComm(fakeComm.get());
-    EXPECT_EQ(topoInfo.nChannels(), 0);
-    EXPECT_TRUE(topoInfo.rings()->empty());
-    EXPECT_TRUE(topoInfo.treeInfos()->empty());
-  }
-
-  // Test with initialized channels
-  initFakeChannels(fakeComm.get());
-  {
-    auto topoInfo = getTopoInfoFromNcclComm(fakeComm.get());
-    EXPECT_EQ(topoInfo.nChannels(), 2);
-
-    ASSERT_EQ(topoInfo.rings()->size(), 2);
-
-    EXPECT_EQ((*topoInfo.rings())[0].size(), 1);
-    EXPECT_EQ((*topoInfo.rings())[0][0], 0);
-
-    EXPECT_EQ((*topoInfo.rings())[1].size(), 1);
-    EXPECT_EQ((*topoInfo.rings())[1][0], 0);
-
-    ASSERT_EQ(topoInfo.treeInfos()->size(), 2);
-    EXPECT_EQ((*topoInfo.treeInfos())[0].parentNode(), 0);
-    EXPECT_EQ((*topoInfo.treeInfos())[1].parentNode(), 1);
-
-    for (int i = 0; i < NCCL_MAX_TREE_ARITY; i++) {
-      EXPECT_GE((*topoInfo.treeInfos())[0].childrenNodes()[i], -1);
-      EXPECT_GE((*topoInfo.treeInfos())[1].childrenNodes()[i], -1);
-    }
-  }
+  auto topoInfo = getTopoInfoFromNcclComm(comm.get());
+  EXPECT_GE(topoInfo.nChannels(), 1);
+  ASSERT_GE(topoInfo.rings()->size(), 1);
+  ASSERT_GE(topoInfo.treeInfos()->size(), 1);
 }
 
-TEST_F(CommsMonitorTest, TestNcclTopoInfoFromNcclCommMultiRank) {
-  auto fakeComm = createFakeNcclComm();
-
-  fakeComm->nRanks = 4;
-  initFakeChannels(fakeComm.get());
-
-  auto topoInfo = getTopoInfoFromNcclComm(fakeComm.get());
-
-  EXPECT_EQ(topoInfo.nChannels(), 2);
-  ASSERT_EQ(topoInfo.rings()->size(), 2);
-
-  ASSERT_EQ((*topoInfo.rings())[0].size(), 4);
-  for (int i = 0; i < 4; i++) {
-    EXPECT_EQ((*topoInfo.rings())[0][i], i);
-  }
-
-  ASSERT_EQ((*topoInfo.rings())[1].size(), 4);
-  for (int i = 0; i < 4; i++) {
-    EXPECT_EQ((*topoInfo.rings())[1][i], 3 - i);
-  }
-
-  ASSERT_EQ(topoInfo.treeInfos()->size(), 2);
-  EXPECT_EQ((*topoInfo.treeInfos())[0].parentNode(), 0);
-  EXPECT_EQ((*topoInfo.treeInfos())[1].parentNode(), 1);
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
 }

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -1,83 +1,16 @@
 #include "meta/commstate/FactoryCommStateX.h"
 #include "checks.h"
 #include "comm.h"
+#include "comms/ctran/CtranComm.h"
 #include "comms/ctran/commstate/CommStateX.h"
-#include "comms/ctran/utils/Checks.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/hints/CommHintConfig.h" // @manual
 
-#include "bootstrap.h"
 #include "nvmlwrap.h"
 #include "transport.h"
 
 namespace ncclx {
-
-void initRankTopologyFrom(CommStateX* _CommStateX, void* _comm) {
-  auto comm = reinterpret_cast<ncclComm*>(_comm);
-  _CommStateX->rankStates_.resize(comm->nRanks);
-  _CommStateX->nodeRanks_.resize(comm->nNodes);
-  for (int r = 0; r < comm->nRanks; ++r) {
-    auto& rankState = _CommStateX->rankStates_.at(r);
-    rankState.rank = r;
-    rankState.nodeId = comm->rankToNode[r];
-    rankState.localRank = comm->rankToLocalRank[r];
-    rankState.nLocalRanks = comm->localRanks;
-    rankState.localRankToRanks.assign(
-        comm->localRankToRank, comm->localRankToRank + comm->localRanks);
-
-    // Order of global ranks never changes, thus OK to assume global rank on
-    // each node is already ordered by local rank
-    // NOTE: two GPUs on the same node may be with different nodeId because
-    // they don't have direct NVL access. To keep same nodeId in statex, we
-    // use hostHash+nodeId to make it unique
-    std::string host(
-        std::to_string(comm->peerInfo[r].hostHash) + "_" +
-        std::to_string(rankState.nodeId));
-    _CommStateX->hostToRanks_[host].emplace_back(r);
-
-    _CommStateX->nodeRanks_[rankState.nodeId].emplace_back(rankState.rank);
-  }
-}
-
-std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm) {
-  auto comm = reinterpret_cast<ncclComm*>(_comm);
-  CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
-  CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
-
-  auto _CommStateX = std::make_unique<CommStateX>(
-      comm->rank,
-      comm->nRanks,
-      comm->cudaDev,
-      comm->cudaArch,
-      comm->busId,
-      comm->commHash,
-      std::vector<RankTopology>(), /* rankTopologies */
-      std::vector<int>(), /* commRanksToWorldRanks */
-      NCCLX_CONFIG_FIELD(comm->config, commDesc),
-      comm->noLocal_,
-      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize)));
-
-  if (comm->noLocal_ ||
-      NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-    // Fake topology with nLocalRanks=1
-    _CommStateX->initRankTopologyNolocal();
-  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-    // Fake topology with
-    // nLocalRanks=NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS
-    _CommStateX->initRankTopologyVnode(
-        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-  } else {
-    initRankTopologyFrom(_CommStateX.get(), _comm);
-  }
-
-  INFO(
-      NCCL_INIT | NCCL_GRAPH,
-      "CommStateX: set rankTopology with %s%s",
-      topoNameMap[NCCL_COMM_STATE_DEBUG_TOPO].c_str(),
-      comm->noLocal_ ? " (noLocal hint)" : "");
-
-  return _CommStateX;
-}
+namespace {
 
 ncclResult_t getLocalGpuFabricInfo(
     ncclComm* ncclComm,
@@ -105,24 +38,34 @@ ncclResult_t getLocalGpuFabricInfo(
   return ncclSuccess;
 }
 
-ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
-  // Get local fabric information
+// TODO: NVL fabric topology init should be handled within ctran/statex
+// (e.g., as part of CommStateX initialization), not passed from ncclx.
+ncclResult_t initNvlFabricTopologies(
+    ncclComm* comm,
+    CommStateX* statex,
+    meta::comms::IBootstrap* bootstrap) {
   nvmlGpuFabricInfoV_t localFabricInfo;
-  NCCLCHECK(getLocalGpuFabricInfo(ncclComm, localFabricInfo));
+  NCCLCHECK(getLocalGpuFabricInfo(comm, localFabricInfo));
 
-  // Gather fabric info from all ranks
-  std::vector<nvmlGpuFabricInfoV_t> allFabricInfos(ncclComm->nRanks);
-  allFabricInfos.at(ncclComm->rank) = localFabricInfo;
+  std::vector<nvmlGpuFabricInfoV_t> allFabricInfos(comm->nRanks);
+  allFabricInfos.at(comm->rank) = localFabricInfo;
 
-  bootstrapAllGather(
-      ncclComm->bootstrap, allFabricInfos.data(), sizeof(nvmlGpuFabricInfoV_t));
+  auto resFuture = bootstrap->allGather(
+      allFabricInfos.data(),
+      sizeof(nvmlGpuFabricInfoV_t),
+      comm->rank,
+      comm->nRanks);
+  const int res = std::move(resFuture).get();
+  if (res != 0) {
+    WARN("initNvlFabricTopologies: bootstrap allGather failed with %d", res);
+    return ncclInternalError;
+  }
 
-  // Create NVL fabric topologies for all ranks
-  std::vector<ncclx::NvlFabricTopology> nvlFabricTopos;
-  nvlFabricTopos.reserve(ncclComm->nRanks);
-  for (int rank = 0; rank < ncclComm->nRanks; rank++) {
+  std::vector<NvlFabricTopology> nvlFabricTopos;
+  nvlFabricTopos.reserve(comm->nRanks);
+  for (int rank = 0; rank < comm->nRanks; rank++) {
     const auto& fabricInfo_ = allFabricInfos.at(rank);
-    ncclx::NvlFabricTopology topo;
+    NvlFabricTopology topo;
     if (fabricInfo_.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED) {
       topo.supportNvlFabric = true;
       topo.rank = rank;
@@ -134,37 +77,58 @@ ncclResult_t initNvlFabricTopologies(ncclComm* ncclComm, CtranComm* ctranComm) {
     }
     nvlFabricTopos.emplace_back(std::move(topo));
   }
-  ctranComm->statex_->setNvlFabricTopos(
-      std::move(nvlFabricTopos), std::nullopt);
+  statex->setNvlFabricTopos(std::move(nvlFabricTopos), std::nullopt);
   return ncclSuccess;
 }
 
-/**
- * Initialize CtranComm statex from NCCL communicator.
- * This function performs two main phases:
- * 1. Initialize rank states topology
- * 2. Initialize NVL fabric topologies by gathering fabric info from all ranks
- */
-ncclResult_t initCtranCommStatexFromNcclComm(
-    ncclComm* ncclComm,
-    CtranComm* ctranComm) {
-  if (!ncclComm || !ctranComm) {
-    FB_ERRORRETURN(ncclInvalidArgument, "Invalid arguments provided");
-  }
+} // namespace
+
+ncclResult_t createCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
+  auto comm = reinterpret_cast<ncclComm*>(_comm);
+  CHECKABORT(comm->rankToNode, "rankToNode is nullptr");
+  CHECKABORT(comm->localRankToRank, "localRankToRank is nullptr");
+
+  auto* bootstrap = ctranComm->bootstrap_.get();
+
+  const int vCliqueSize =
+      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
+
+  ctranComm->statex_ = std::make_unique<CommStateX>(
+      comm->rank,
+      comm->nRanks,
+      comm->cudaDev,
+      comm->cudaArch,
+      comm->busId,
+      comm->commHash,
+      std::vector<RankTopology>(), /* rankTopologies */
+      std::vector<int>(), /* commRanksToWorldRanks */
+      NCCLX_CONFIG_FIELD(comm->config, commDesc),
+      comm->noLocal_,
+      vCliqueSize);
 
   try {
-    ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
-
-    NCCLCHECK(initNvlFabricTopologies(ncclComm, ctranComm));
-
-    return ncclSuccess;
-
+    ctranComm->statex_->initRankStatesTopology(bootstrap);
   } catch (const std::exception& e) {
-    FB_ERRORRETURN(
-        ncclInternalError,
-        "Failed to initialize CtranComm statex from ncclComm: {}",
+    WARN(
+        "createCommStateXFromNcclComm: initRankStatesTopology failed: %s",
         e.what());
+    return ncclInternalError;
   }
+
+  INFO(
+      NCCL_INIT | NCCL_GRAPH,
+      "CommStateX: set rankTopology with noLocal=%d, vCliqueSize=%d, commDesc=%s, commHash=0x%lx, rank=%d, nRanks=%d, nLocalRanks=%d",
+      comm->noLocal_,
+      vCliqueSize,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
+      comm->commHash,
+      comm->rank,
+      comm->nRanks,
+      ctranComm->statex_->nLocalRanks());
+
+  NCCLCHECK(initNvlFabricTopologies(comm, ctranComm->statex_.get(), bootstrap));
+
+  return ncclSuccess;
 }
 
 ncclResult_t assignMnnvlCliqueIdBasedOnCliqueSize(int* cliqueId) {

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.h
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.h
@@ -1,21 +1,17 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include <algorithm>
 #include "comm.h"
-#include "comms/ctran/commstate/CommStateX.h"
 #include "meta/RankUtil.h"
 #include "socket.h"
 
+class CtranComm;
+
 namespace ncclx {
 
-// This Factory must be used ONLY in NCCLx code, not in CTRAN code
-// Ctran has it's own StateX factory
-std::unique_ptr<CommStateX> createCommStateXFromNcclComm(void* _comm);
-
-// This init function must be used ONLY in NCCLx code, not in CTRAN code
-// Ctran has it's own StateX factory
-ncclResult_t initCtranCommStatexFromNcclComm(
-    ncclComm* ncclComm,
-    CtranComm* ctranComm);
+// Create CommStateX from ncclComm. Initializes rank topology via bootstrap
+// allgather and sets up NVL fabric topologies. Virtual topology overrides
+// (noLocal, vnode, vClique) are applied internally.
+ncclResult_t createCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm);
 
 ncclResult_t assignMnnvlCliqueIdBasedOnCliqueSize(int* cliqueId);
 } // namespace ncclx

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <memory>
 
+#include <fmt/format.h>
 #include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -58,55 +59,18 @@ TEST_F(CommWithCtranTest, CtranDisable) {
       globalRank, numRanks, localRank, bootstrap_.get()};
 
   ASSERT_NE(nullptr, comm.get());
-  ASSERT_EQ(nullptr, comm->ctranComm_->ctran_);
-  EXPECT_FALSE(ctranInitialized(comm->ctranComm_.get()));
+  EXPECT_EQ(nullptr, comm->ctranComm_);
+  EXPECT_FALSE(ctranInitialized(nullptr));
 
-  ASSERT_NE(nullptr, comm->ctranComm_->opCount_);
-  EXPECT_EQ(comm->ctranComm_->opCount_, &comm->opCount);
-
-  ASSERT_NE(nullptr, comm->ctranComm_->statex_);
-
-  EXPECT_EQ(comm->ctranComm_->config_, makeCtranConfigFrom(comm));
-  EXPECT_EQ(comm->ctranComm_->logMetaData_, comm->logMetaData);
-
-  EXPECT_EQ(comm->ctranComm_->colltraceNew_, nullptr);
-
-  // Expect all CTran collective support to be false
-  EXPECT_FALSE(
-      ctranAllGatherSupport(comm->ctranComm_.get(), NCCL_ALLGATHER_ALGO));
-  EXPECT_FALSE(ctranAllReduceSupport(
-      comm->ctranComm_.get(), NCCL_ALLREDUCE_ALGO::ctran));
-  EXPECT_FALSE(
-      ctranBroadcastSupport(comm->ctranComm_.get(), NCCL_BROADCAST_ALGO));
-  EXPECT_FALSE(ctranReduceScatterSupport(
-      comm->ctranComm_.get(), NCCL_REDUCESCATTER_ALGO));
-  EXPECT_FALSE(ctranSendRecvSupport(0, comm->ctranComm_.get()));
+  // All CTran collective support functions should return false with nullptr
+  EXPECT_FALSE(ctranAllGatherSupport(nullptr, NCCL_ALLGATHER_ALGO));
+  EXPECT_FALSE(ctranAllReduceSupport(nullptr, NCCL_ALLREDUCE_ALGO::ctran));
+  EXPECT_FALSE(ctranBroadcastSupport(nullptr, NCCL_BROADCAST_ALGO));
+  EXPECT_FALSE(ctranReduceScatterSupport(nullptr, NCCL_REDUCESCATTER_ALGO));
+  EXPECT_FALSE(ctranSendRecvSupport(0, nullptr));
   EXPECT_FALSE(ctranAllToAllSupport(
-      1048576, commInt, comm->ctranComm_.get(), NCCL_ALLTOALL_ALGO::ctran));
-  EXPECT_FALSE(ctranAllToAllvSupport(comm->ctranComm_.get()));
-  meta::comms::Hints hints;
-
-  size_t maxSendcounts =
-      dceil(CTRAN_MIN_REGISTRATION_SIZE, commTypeSize(commInt));
-  size_t maxRecvcounts =
-      dceil(CTRAN_MIN_REGISTRATION_SIZE, commTypeSize(commInt));
-
-  auto res = ctranAllToAllvDynamicSupport(
-      comm->ctranComm_.get(), hints, maxSendcounts, maxRecvcounts, commInt);
-  EXPECT_EQ(commInvalidUsage, res);
-
-  hints.set("ncclx_alltoallv_dynamic_sendbuffs_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_recvbuffs_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_sendcounts_location", "gpu");
-  hints.set("ncclx_alltoallv_dynamic_max_sendcounts_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_max_recvcounts_location", "cpu");
-  hints.set("ncclx_alltoallv_dynamic_actual_recvcounts_location", "gpu");
-
-  maxSendcounts = CTRAN_MIN_REGISTRATION_SIZE / commTypeSize(commInt);
-  maxRecvcounts = CTRAN_MIN_REGISTRATION_SIZE / commTypeSize(commInt);
-  res = ctranAllToAllvDynamicSupport(
-      comm->ctranComm_.get(), hints, maxSendcounts, maxRecvcounts, commInt);
-  EXPECT_EQ(commInvalidUsage, res);
+      1048576, commInt, nullptr, NCCL_ALLTOALL_ALGO::ctran));
+  EXPECT_FALSE(ctranAllToAllvSupport(nullptr));
 }
 
 TEST_F(CommWithCtranTest, CtranCommInitialized) {
@@ -394,14 +358,12 @@ TEST_F(CommWithCtranTest, CommFailureWithInvalidTopology) {
         try {
           ncclx::test::createNcclComm(
               globalRank, numRanks, localRank, bootstrap_.get(), true);
-        } catch (const std::runtime_error& e) {
-          EXPECT_THAT(
-              e.what(),
-              testing::HasSubstr("Failed, NCCL error: internal error"));
+        } catch (const std::exception& e) {
+          EXPECT_THAT(e.what(), testing::HasSubstr("NCCL error"));
           throw;
         }
       },
-      std::runtime_error);
+      std::exception);
 
   // Clean up temporary files
   unlink(invalidTopoFilepath.c_str());

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -17,6 +17,7 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
+#include "meta/NcclxConfig.h" // @manual
 #include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
@@ -83,7 +84,10 @@ TEST_F(CommWithCtranTest, CtranCommInitialized) {
   ASSERT_NE(nullptr, ncclComm->ctranComm_);
 
   EXPECT_EQ(comm->ctranComm_->opCount_, &ncclComm->opCount);
-  EXPECT_EQ(comm->ctranComm_->config_, makeCtranConfigFrom(ncclComm));
+  EXPECT_EQ(comm->ctranComm_->config_.blocking, ncclComm->config.blocking);
+  EXPECT_EQ(
+      comm->ctranComm_->config_.commDesc,
+      NCCLX_CONFIG_FIELD(ncclComm->config, commDesc));
   EXPECT_EQ(comm->ctranComm_->logMetaData_, ncclComm->logMetaData);
   EXPECT_EQ(comm->ctranComm_->runtimeConn_, ncclComm->runtimeConn);
 }

--- a/comms/ncclx/meta/tests/FastInitTest.cc
+++ b/comms/ncclx/meta/tests/FastInitTest.cc
@@ -30,15 +30,6 @@ class FastInitTestFixture : public NcclxBaseTestFixture,
   bool enableFastInitConfig{false};
 };
 
-void printCommStateX(const ncclComm& comm) {
-  const auto statex = comm.ctranComm_->statex_.get();
-  VLOG(1) << "=== CommStateX ===";
-  VLOG(1) << "CommStateX " << &comm << ": ";
-  VLOG(1) << "rank: " << statex->rank();
-  VLOG(1) << "nRanks: " << statex->nRanks();
-  VLOG(1) << "=================";
-}
-
 void validateCtranInitialization(
     ncclComm_t comm,
     int expectedRank,
@@ -137,17 +128,6 @@ TEST_P(FastInitTestFixture, NcclCommInitWorldAndAbort) {
   NCCLCHECK_TEST(ncclCommAbort(rootComm));
 }
 
-void compareComm(const ncclComm& comm1, const ncclComm& comm2) {
-  const auto state1 = comm1.ctranComm_->statex_.get();
-  const auto state2 = comm2.ctranComm_->statex_.get();
-  EXPECT_EQ(state1->rank(), state2->rank());
-  EXPECT_EQ(state1->nRanks(), state2->nRanks());
-  EXPECT_EQ(state1->cudaDev(), state2->cudaDev());
-
-  // TODO: baseline ncclComm does not maintain commRankToWorldRank mapping
-  // populate them to support statex->gRank() API
-}
-
 TEST_P(FastInitTestFixture, NcclCommSplit) {
   ncclComm_t rootComm = nullptr;
   ncclUniqueId commId;
@@ -188,32 +168,13 @@ TEST_P(FastInitTestFixture, NcclCommSplit) {
     NCCLCHECK_TEST(ncclCommDestroy(rootComm));
     GTEST_SKIP() << "Skip test since only one node provided";
   }
+  EXPECT_EQ(statex1->rank(), globalRank / 2);
   EXPECT_EQ(statex1->nRanks(), numRanks / 2);
+  EXPECT_EQ(statex1->cudaDev(), localRank);
   EXPECT_NE(statex1->commHash(), 0);
   // distributed run strict checks
   EXPECT_EQ(statex1->nNodes(), 2);
   EXPECT_EQ(statex1->nLocalRanks(), localSize / 2);
-
-  ncclComm expectedComm;
-  expectedComm.config = NCCL_CONFIG_INITIALIZER;
-  ncclx::Hints expectedHints({{"commDesc", childCommDesc}});
-  expectedComm.config.hints = &expectedHints;
-  ncclxParseCommConfig(&expectedComm.config);
-  setCtranCommBase(&expectedComm);
-
-  expectedComm.ctranComm_->statex_ = std::make_unique<ncclx::CommStateX>(
-      globalRank / 2,
-      numRanks / 2,
-      localRank,
-      rootComm->ctranComm_->statex_->cudaArch(), // cudaArch of H100
-      25, // busId
-      0,
-      std::vector<ncclx::RankTopology>{},
-      std::vector<int>{});
-
-  printCommStateX(*childComm);
-  printCommStateX(expectedComm);
-  compareComm(*childComm, expectedComm);
 
   NCCLCHECK_TEST(ncclCommDestroy(childComm));
   NCCLCHECK_TEST(ncclCommDestroy(rootComm));

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -37,6 +37,8 @@ meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
   return ret;
 }
 
+namespace {
+
 ctranConfig makeCtranConfigFrom(ncclComm* comm) {
   struct ctranConfig tconfig = {
       .blocking = comm->config.blocking,
@@ -44,7 +46,6 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
       .ncclAllGatherAlgo =
           NCCLX_CONFIG_FIELD(comm->config, ncclAllGatherAlgo).c_str(),
   };
-  // Wire per-comm pipes NVL transport config from ncclx::Config hints
   if (comm->config.ncclxConfig != nullptr) {
     const auto* ncclxCfg =
         static_cast<ncclx::Config*>(comm->config.ncclxConfig);
@@ -57,28 +58,14 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
           ncclxCfg->pipesUseDualStateBuffer.value() ? 1 : 0;
     }
   }
-
   return tconfig;
 }
 
-// TODO: remove this factory method once we have proper CtranComm initialization
-// Initialize all fields except Ctran. Since Ctran/Bootstra/Colltrace requires
-// stateX and other fields to be initialized beforehand, we split its
-// initialization into two parts:
-// 1. Pre-initialization to enable Ctran/Bootstra/Colltrace initialization.
-// 2. Final initialization (final-init) to set up the remaining fields.
 commResult_t setCtranCommBase(ncclComm* ncclCommVal) {
   if (!ncclCommVal) {
     return commInvalidArgument;
   }
-
-  // can not call make_unique with a private constructor
-  // CtranComm has provate constructor for sagety reasons for now
-  // no one should use CtranComm constructor until refactoring is finished
-  // TODO: move to make_unique after finish refactoring and defining a proper
-  // constructor
-  ncclCommVal->ctranComm_ =
-      std::unique_ptr<CtranComm>(std::move(new CtranComm()));
+  ncclCommVal->ctranComm_ = std::make_unique<CtranComm>();
 
   const auto tconfig = makeCtranConfigFrom(ncclCommVal);
   ncclCommVal->ctranComm_->config_ = tconfig;
@@ -89,12 +76,7 @@ commResult_t setCtranCommBase(ncclComm* ncclCommVal) {
   return commSuccess;
 }
 
-CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
-  if (ncclComm && ncclComm->ctranComm_) {
-    return ncclComm->ctranComm_.get();
-  }
-  return nullptr;
-}
+} // namespace
 
 ncclResult_t createCtranComm(ncclComm* comm) {
   NCCLCHECK_COMM(setCtranCommBase(comm));

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -5,13 +5,19 @@
 #include "comm.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPHintUtils.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvDynamicHintUtils.h"
+#include "comms/ctran/interfaces/ICtran.h"
+#include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/window/WinHintUtils.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/commSpecs.h"
 #include "meta/NcclxConfig.h" // @manual
+#include "meta/commstate/FactoryCommStateX.h"
+#include "meta/ctran-integration/BaselineBootstrap.h"
 #include "meta/wrapper/MetaFactory.h"
 
 using namespace ctran;
+
+#define NCCLCHECK_COMM(call) NCCLCHECK(metaCommToNccl(call))
 
 meta::comms::Hints ncclToMetaComm(const ncclx::Hints& hints) {
   meta::comms::Hints ret;
@@ -88,4 +94,39 @@ CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
     return ncclComm->ctranComm_.get();
   }
   return nullptr;
+}
+
+ncclResult_t createCtranComm(ncclComm* comm) {
+  NCCLCHECK_COMM(setCtranCommBase(comm));
+
+  if (NCCL_USE_MEM_CACHE) {
+    comm->ctranComm_->memCache_ =
+        ncclx::memory::memCacheAllocator::getInstance();
+  }
+
+  comm->ctranComm_->bootstrap_ =
+      std::make_unique<ncclx::BaselineBootstrap>(comm);
+
+  NCCLCHECK(ncclx::createCommStateXFromNcclComm(comm, comm->ctranComm_.get()));
+
+  comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
+
+  NCCLCHECK_COMM(ctranInit(comm->ctranComm_.get()));
+
+  return ncclSuccess;
+}
+
+ncclResult_t destroyCtranComm(ncclComm* comm) {
+  if (!comm || !comm->ctranComm_) {
+    return ncclSuccess;
+  }
+  NCCLCHECK_COMM(ctranFinalize(comm->ctranComm_.get()));
+  try {
+    comm->ctranComm_->destroy();
+    comm->ctranComm_.reset();
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
+    return ncclInternalError;
+  }
+  return ncclSuccess;
 }

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -198,6 +198,15 @@ inline commDataType_t ncclToMetaComm(ncclDataType_t dataType) {
 ctranConfig makeCtranConfigFrom(ncclComm* comm);
 commResult_t setCtranCommBase(ncclComm* ncclCommVal);
 
+// Create and fully initialize CtranComm on the given ncclComm.
+// Combines: setCtranCommBase, memCache, bootstrap, CommStateX, colltrace,
+// and ctranInit into a single call.
+ncclResult_t createCtranComm(ncclComm* comm);
+
+// Finalize, destroy, and reset ctranComm_ on the given ncclComm.
+// No-op if ctranComm_ is nullptr.
+ncclResult_t destroyCtranComm(ncclComm* comm);
+
 // Public accessor returning the CtranComm* hanging off an ncclComm, or
 // nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
 CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -192,21 +192,9 @@ inline commDataType_t ncclToMetaComm(ncclDataType_t dataType) {
   }
 }
 
-// Those are temorarly functions to initialized ctranComm from ncclComm
-// TODO: remove this factory methods once we have proper CtranComm
-// initialization
-ctranConfig makeCtranConfigFrom(ncclComm* comm);
-commResult_t setCtranCommBase(ncclComm* ncclCommVal);
-
 // Create and fully initialize CtranComm on the given ncclComm.
-// Combines: setCtranCommBase, memCache, bootstrap, CommStateX, colltrace,
-// and ctranInit into a single call.
 ncclResult_t createCtranComm(ncclComm* comm);
 
 // Finalize, destroy, and reset ctranComm_ on the given ncclComm.
 // No-op if ctranComm_ is nullptr.
 ncclResult_t destroyCtranComm(ncclComm* comm);
-
-// Public accessor returning the CtranComm* hanging off an ncclComm, or
-// nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
-CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -39,7 +39,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -47,7 +47,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1635,24 +1635,6 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
-
-  comm->ctranComm_->memCache_ = comm->memCache;
 
   NCCLCHECKGOTO(
       metaCommToNccl(ncclx::transport::tranportProxyInit(comm, job->parent)),
@@ -1660,10 +1642,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       fail);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2322,19 +2301,12 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
   comm->logMetaData.commDesc.clear(); // free up memory associated with commDesc
   comm->logMetaData.commDesc.shrink_to_fit();
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
@@ -2581,7 +2553,9 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
     ctran::utils::setSkipDestroyCtran(skipDestroyFlag);
     if (comm->memCache) {
       comm->memCache.reset();
-      comm->ctranComm_->memCache_.reset();
+      if (comm->ctranComm_) {
+        comm->ctranComm_->memCache_.reset();
+      }
     }
   }
   if (NCCL_COMM_ABORT_SCOPE == NCCL_COMM_ABORT_SCOPE::none) {

--- a/comms/ncclx/v2_28/src/init.cc
+++ b/comms/ncclx/v2_28/src/init.cc
@@ -44,7 +44,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -52,7 +52,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1736,7 +1736,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
   }
   comm->cudaArch = cudaArch;
-  
+
   // init this communicator's  Logger fields
   comm->logMetaData.commId = commIdHash;
   comm->logMetaData.commHash = comm->commHash;
@@ -1763,27 +1763,9 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2483,16 +2465,9 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
 

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -43,7 +43,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "comms/ctran/commstate/CommStateX.h"
+
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/utils/Utils.h"
 #include "comms/ctran/utils/SkipDestroyUtil.h"
@@ -51,7 +51,7 @@
 #include "meta/colltrace/CollTraceWrapper.h"
 #include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/commstate/FactoryCommStateX.h"
-#include "meta/ctran-integration/BaselineBootstrap.h"
+
 #include "meta/hints/CommHintConfig.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -1933,27 +1933,9 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
    */
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceInit(comm), res, fail);
 
-  // TODO: remove all ncclx fields and leave only ctranComm_
-  // (we are working on refactoring now, when it's done only ctranComm_ must be used)
-
-  // TODO: replace this dirty init code with CtranComm constructor.
-  // There is an issue with the order of initialization. We need to initialize stateX
-  // before initializing ctran/bootstrap/calltrace. The ctran classes internally start
-  // using CtranComm while still relying on ncclComm_t. This means that when we call
-  // ctranInit/boostrap init/calltrace init/ any internal ctran calss,
-  // both comm->stateX and ctranComm_->stateX must be initialized. Consequently, we have
-  // to split the initialization of CtranComm into several parts. This must be cleaned
-  // when we develop CtranComm constuctor.
-  NCCLCHECKGOTO(metaCommToNccl(setCtranCommBase(comm)), res, fail);
-
-  comm->ctranComm_->bootstrap_ = std::make_unique<ncclx::BaselineBootstrap>(comm);
-  comm->ctranComm_->statex_ = ncclx::createCommStateXFromNcclComm(comm);
 
   if (comm->useCtran_) {
-    // TODO: move initialization to CtranComm constructor once we finish all ctran refactor
-    NCCLCHECK(ncclx::initCtranCommStatexFromNcclComm(comm, comm->ctranComm_.get()));
-    comm->ctranComm_->colltraceNew_ = comm->newCollTrace;
-    NCCLCHECKGOTO(metaCommToNccl(ctranInit(comm->ctranComm_.get())), res, fail);
+    NCCLCHECKGOTO(createCtranComm(comm), res, fail);
   }
   // --------------------- done
 
@@ -2760,16 +2742,9 @@ static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
   /*
    * NCCLX - Resource Cleanup
    */
-  NCCLCHECKGOTO(metaCommToNccl(ctranFinalize(comm->ctranComm_.get())), ret, fail);
   NCCLCHECKGOTO(meta::comms::ncclx::newCollTraceDestroy(comm), ret, fail);
 
-  try {
-    comm->ctranComm_->destroy();
-    comm->ctranComm_.reset();
-  } catch (std::exception& e) {
-    CLOGF(ERR, "CtranComm destruction failed: {}", e.what());
-    goto fail;
-  }
+  NCCLCHECKGOTO(destroyCtranComm(comm), ret, fail);
 
   TRACE(NCCL_INIT, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
 


### PR DESCRIPTION
Summary:

Clean up MetaFactory.cc/h public surface after createCtranComm/destroyCtranComm consolidation:
- Move `setCtranCommBase` and `makeCtranConfigFrom` into anonymous namespace in MetaFactory.cc — they are now internal to `createCtranComm` and not needed externally
- Delete `getCtranCommFromNcclComm` (zero callers, dead code)
- Remove vestigial `friend commResult_t setCtranCommBase(ncclComm*)` from CtranComm.h — CtranComm constructor and all fields are already public, no friend needed
- Replace `std::unique_ptr<CtranComm>(std::move(new CtranComm()))` with `std::make_unique<CtranComm>()` in setCtranCommBase
- CommWithCtranTest: replace `makeCtranConfigFrom(ncclComm)` assertion with direct field checks on `config_.blocking` and `config_.commDesc`
- FastInitTest: replace `expectedComm` + `compareComm` pattern with direct inline assertions on `childComm->ctranComm_->statex_`; delete unused `printCommStateX` and `compareComm` functions
- CommsMonitorUT: convert from fake ncclComm with `setCtranCommBase` to real single-rank comm via `NcclCommRAII`; convert from `ncclx_meta_unittest` to `ncclx_meta_distributed_unittest` with 1x1 config

Differential Revision: D103610807


