### PR TITLE
Deprecate nolocal compiler flag for Allgather and enable real nolocal using parameterized tests

### DIFF
--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -35,11 +35,11 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
 
   ctran::test::VerifyAlgoStatsHelper algoStats_;
 
-  void SetUp() override {
+  void setUpWithEnvs(const ctran::CtranEnvs& envs = {}) {
     setenv("NCCL_CTRAN_TRANSPORT_PROFILER", "1", 0);
     setenv("NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT", "1", 0);
     algoStats_.enable();
-    ctran::CtranDistTestFixture::SetUp();
+    ctran::CtranDistTestFixture::SetUp(envs);
     ctranComm = makeCtranComm();
     segments.clear();
   }
@@ -156,19 +156,29 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   std::unique_ptr<CtranComm> ctranComm{nullptr};
 };
 
-class CtranAllgatherTestParam : public CtranAllgatherTest,
-                                public ::testing::WithParamInterface<std::tuple<
-                                    enum NCCL_ALLGATHER_ALGO,
-                                    size_t,
-                                    size_t,
-                                    TestInPlaceType,
-                                    MemAllocType,
-                                    int,
-                                    TestPairCollType>> {};
+// Param: (CtranEnvs, (algo, offset, count, inplace, memType, iter, pairColl))
+using CtranAllgatherParams = std::tuple<
+    enum NCCL_ALLGATHER_ALGO,
+    size_t,
+    size_t,
+    TestInPlaceType,
+    MemAllocType,
+    int,
+    TestPairCollType>;
+
+class CtranAllgatherTestParam
+    : public CtranAllgatherTest,
+      public ::testing::WithParamInterface<
+          std::tuple<ctran::CtranEnvs, CtranAllgatherParams>> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(std::get<0>(GetParam()));
+  }
+};
 
 TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
   const auto& [algo, offset, count, inplace, memType, iter, pairColl] =
-      GetParam();
+      std::get<1>(GetParam());
 
   // CollTrace will help check whether the specified algo is used
   EnvRAII env(NCCL_ALLGATHER_ALGO, algo);
@@ -269,7 +279,17 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
   memoryCleanUp(memType, inplace, pairColl);
 }
 
-TEST_F(CtranAllgatherTest, OutOfPlaceAllgatherRingDynamicRegist) {
+// Envs-only parameterized fixture for tests that have no other params.
+class CtranAllgatherTestEnvFixture
+    : public CtranAllgatherTest,
+      public ::testing::WithParamInterface<ctran::CtranEnvs> {
+ protected:
+  void SetUp() override {
+    setUpWithEnvs(GetParam());
+  }
+};
+
+TEST_P(CtranAllgatherTestEnvFixture, OutOfPlaceAllgatherRingDynamicRegist) {
   size_t count = 8192;
   MemAllocType memType = kMemCudaMalloc;
 
@@ -308,107 +328,132 @@ TEST_F(CtranAllgatherTest, OutOfPlaceAllgatherRingDynamicRegist) {
   memoryCleanUp(memType, kTestOutOfPlace, kTestPairNone);
 }
 
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllgatherTest,
+    CtranAllgatherTestEnvFixture,
+    ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+    [](const testing::TestParamInfo<ctran::CtranEnvs>& info) {
+      auto s = ctran::envSuffix(info.param);
+      return s.empty() ? std::string("Default") : s;
+    });
+
 // common function to get test name from test parameter
 inline std::string getTestName(
     const testing::TestParamInfo<CtranAllgatherTestParam::ParamType>& info) {
-  return allGatherAlgoName(std::get<0>(info.param)) + "_" +
-      std::to_string(std::get<1>(info.param)) + "offset_" +
-      std::to_string(std::get<2>(info.param)) + "_" + "elements_" +
-      testInPlaceTypeToStr(std::get<3>(info.param)) + "_" +
-      testMemAllocTypeToStr(std::get<4>(info.param)) + "_" +
-      std::to_string(std::get<5>(info.param)) + "iters_" +
-      testPairCollTypeToStr(std::get<6>(info.param));
+  const auto& inner = std::get<1>(info.param);
+  return ctran::envSuffix(std::get<0>(info.param)) +
+      allGatherAlgoName(std::get<0>(inner)) + "_" +
+      std::to_string(std::get<1>(inner)) + "offset_" +
+      std::to_string(std::get<2>(inner)) + "_" + "elements_" +
+      testInPlaceTypeToStr(std::get<3>(inner)) + "_" +
+      testMemAllocTypeToStr(std::get<4>(inner)) + "_" +
+      std::to_string(std::get<5>(inner)) + "iters_" +
+      testPairCollTypeToStr(std::get<6>(inner));
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCudaMalloc,
     CtranAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(
-            NCCL_ALLGATHER_ALGO::ctdirect,
-            NCCL_ALLGATHER_ALGO::ctring,
-            NCCL_ALLGATHER_ALGO::ctrd),
-        testing::Values(0),
-        testing::Values(8192, 1),
-        testing::Values(kTestInPlace, kTestOutOfPlace),
-        testing::Values(kMemCudaMalloc),
-        testing::Values(1),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(
+                NCCL_ALLGATHER_ALGO::ctdirect,
+                NCCL_ALLGATHER_ALGO::ctring,
+                NCCL_ALLGATHER_ALGO::ctrd),
+            testing::Values(0),
+            testing::Values(8192, 1),
+            testing::Values(kTestInPlace, kTestOutOfPlace),
+            testing::Values(kMemCudaMalloc),
+            testing::Values(1),
+            testing::Values(kTestPairNone))),
     getTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCumemInPlace,
     CtranAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(
-            NCCL_ALLGATHER_ALGO::ctdirect,
-            NCCL_ALLGATHER_ALGO::ctring,
-            NCCL_ALLGATHER_ALGO::ctrd),
-        testing::Values(0),
-        testing::Values(8192, 1048576, 1048567, 1),
-        testing::Values(kTestInPlace),
-        testing::Values(kMemNcclMemAlloc),
-        testing::Values(1),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(
+                NCCL_ALLGATHER_ALGO::ctdirect,
+                NCCL_ALLGATHER_ALGO::ctring,
+                NCCL_ALLGATHER_ALGO::ctrd),
+            testing::Values(0),
+            testing::Values(8192, 1048576, 1048567, 1),
+            testing::Values(kTestInPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(1),
+            testing::Values(kTestPairNone))),
     getTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCumemOutOfPlace,
     CtranAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(
-            NCCL_ALLGATHER_ALGO::ctdirect,
-            NCCL_ALLGATHER_ALGO::ctring,
-            NCCL_ALLGATHER_ALGO::ctrd),
-        testing::Values(256),
-        testing::Values(1048567, 1),
-        testing::Values(kTestOutOfPlace),
-        testing::Values(kMemNcclMemAlloc),
-        testing::Values(1),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(
+                NCCL_ALLGATHER_ALGO::ctdirect,
+                NCCL_ALLGATHER_ALGO::ctring,
+                NCCL_ALLGATHER_ALGO::ctrd),
+            testing::Values(256),
+            testing::Values(1048567, 1),
+            testing::Values(kTestOutOfPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(1),
+            testing::Values(kTestPairNone))),
     getTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCumemPair,
     CtranAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(
-            NCCL_ALLGATHER_ALGO::ctdirect,
-            NCCL_ALLGATHER_ALGO::ctring,
-            NCCL_ALLGATHER_ALGO::ctrd),
-        testing::Values(0),
-        testing::Values(8192, 1),
-        testing::Values(kTestOutOfPlace),
-        testing::Values(kMemNcclMemAlloc),
-        testing::Values(20),
-        testing::Values(kTestPairAllReduce)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(
+                NCCL_ALLGATHER_ALGO::ctdirect,
+                NCCL_ALLGATHER_ALGO::ctring,
+                NCCL_ALLGATHER_ALGO::ctrd),
+            testing::Values(0),
+            testing::Values(8192, 1),
+            testing::Values(kTestOutOfPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(20),
+            testing::Values(kTestPairAllReduce))),
     getTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestDisjoint,
     CtranAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(NCCL_ALLGATHER_ALGO::ctdirect),
-        testing::Values(0, 256),
-        testing::Values(1048568, 1),
-        testing::Values(kTestInPlace, kTestOutOfPlace),
-        testing::Values(kCuMemAllocDisjoint),
-        testing::Values(5),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(NCCL_ALLGATHER_ALGO::ctdirect),
+            testing::Values(0, 256),
+            testing::Values(1048568, 1),
+            testing::Values(kTestInPlace, kTestOutOfPlace),
+            testing::Values(kCuMemAllocDisjoint),
+            testing::Values(5),
+            testing::Values(kTestPairNone))),
     getTestName);
+
+// Param: (CtranEnvs, (offset, count, inplace, iter, pairColl))
+using CtranSocketAllgatherParams =
+    std::tuple<size_t, size_t, TestInPlaceType, int, TestPairCollType>;
 
 class CtranSocketAllgatherTestParam
     : public CtranAllgatherTest,
       public ::testing::WithParamInterface<
-          std::tuple<size_t, size_t, TestInPlaceType, int, TestPairCollType>> {
+          std::tuple<ctran::CtranEnvs, CtranSocketAllgatherParams>> {
   void SetUp() override {
     EnvRAII env1(
         NCCL_CTRAN_BACKENDS,
         std::vector<enum NCCL_CTRAN_BACKENDS>{
             NCCL_CTRAN_BACKENDS::socket, NCCL_CTRAN_BACKENDS::nvl});
-    CtranAllgatherTest::SetUp();
+    setUpWithEnvs(std::get<0>(GetParam()));
 
-    if (enableNolocal || localSize < numRanks) {
+    if (ctran::isNolocalTopo() || localSize < numRanks) {
       GTEST_SKIP()
           << "Ctran Socket + NVL backend require intra-node only environment. Skip test";
     }
@@ -416,7 +461,8 @@ class CtranSocketAllgatherTestParam
 };
 
 TEST_P(CtranSocketAllgatherTestParam, AllgatherAlgo) {
-  const auto& [offset, count, inplace, iter, pairColl] = GetParam();
+  const auto& [offset, count, inplace, iter, pairColl] =
+      std::get<1>(GetParam());
   enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctdirect;
 
   // CollTrace will help check whether the specified algo is used
@@ -501,33 +547,39 @@ TEST_P(CtranSocketAllgatherTestParam, AllgatherAlgo) {
 inline std::string getSocketTestName(
     const testing::TestParamInfo<CtranSocketAllgatherTestParam::ParamType>&
         info) {
-  return std::to_string(std::get<0>(info.param)) + "offset_" +
-      std::to_string(std::get<1>(info.param)) + "_" + "elements_" +
-      testInPlaceTypeToStr(std::get<2>(info.param)) + "_" + "socket_" +
-      std::to_string(std::get<3>(info.param)) + "iters_" +
-      testPairCollTypeToStr(std::get<4>(info.param));
+  const auto& inner = std::get<1>(info.param);
+  return ctran::envSuffix(std::get<0>(info.param)) +
+      std::to_string(std::get<0>(inner)) + "offset_" +
+      std::to_string(std::get<1>(inner)) + "_" + "elements_" +
+      testInPlaceTypeToStr(std::get<2>(inner)) + "_" + "socket_" +
+      std::to_string(std::get<3>(inner)) + "iters_" +
+      testPairCollTypeToStr(std::get<4>(inner));
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCumemInPlace,
     CtranSocketAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(0),
-        testing::Values(8192, 1048576, 1048567, 1),
-        testing::Values(kTestInPlace),
-        testing::Values(1),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(0),
+            testing::Values(8192, 1048576, 1048567, 1),
+            testing::Values(kTestInPlace),
+            testing::Values(1),
+            testing::Values(kTestPairNone))),
     getSocketTestName);
 
 INSTANTIATE_TEST_SUITE_P(
     CtranTestCumemOutOfPlace,
     CtranSocketAllgatherTestParam,
     ::testing::Combine(
-        testing::Values(256),
-        testing::Values(1048567, 1),
-        testing::Values(kTestOutOfPlace),
-        testing::Values(1),
-        testing::Values(kTestPairNone)),
+        ::testing::Values(ctran::kDefaultEnvs, ctran::kNolocalEnvs),
+        ::testing::Combine(
+            testing::Values(256),
+            testing::Values(1048567, 1),
+            testing::Values(kTestOutOfPlace),
+            testing::Values(1),
+            testing::Values(kTestPairNone))),
     getSocketTestName);
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.cc
@@ -2,6 +2,8 @@
 
 #include "VerifyAlgoStatsUtil.h"
 
+#include <cstdlib>
+
 #include <fmt/core.h>
 #include <gtest/gtest.h>
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -10,11 +12,29 @@ namespace ctran::test {
 
 VerifyAlgoStatsHelper::~VerifyAlgoStatsHelper() {
   if (enabled_) {
+    if (oldEnvValue_) {
+      setenv("NCCL_COLLTRACE", oldEnvValue_->c_str(), 1);
+    } else {
+      unsetenv("NCCL_COLLTRACE");
+    }
     NCCL_COLLTRACE = oldColltrace_;
   }
 }
 
 void VerifyAlgoStatsHelper::enable() {
+  // Override at both layers:
+  //  - setenv so the value survives any later ncclCvarInit() re-read
+  //    (e.g. via ncclMemAlloc -> initEnv -> ncclCvarInit).
+  //  - NCCL_COLLTRACE cvar so the value is visible immediately, regardless of
+  //    whether ncclCvarInit() has already run.
+  auto old = std::getenv("NCCL_COLLTRACE");
+  if (old != nullptr) {
+    oldEnvValue_ = old;
+    std::string newValue = std::string(old) + ",algostat";
+    setenv("NCCL_COLLTRACE", newValue.c_str(), 1);
+  } else {
+    setenv("NCCL_COLLTRACE", "algostat", 1);
+  }
   oldColltrace_ = NCCL_COLLTRACE;
   NCCL_COLLTRACE.push_back("algostat");
   enabled_ = true;

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
+#include <vector>
 #include "comms/ctran/CtranComm.h"
 
 namespace ctran::test {
@@ -13,6 +15,9 @@ class VerifyAlgoStatsHelper {
   ~VerifyAlgoStatsHelper();
 
   // Enable AlgoStats tracing. Must be called before CtranComm creation.
+  // Overrides NCCL_COLLTRACE via both setenv (so the value survives any
+  // subsequent ncclCvarInit() re-read) and the in-memory cvar (so the value is
+  // visible immediately, regardless of call ordering).
   void enable();
 
   void verify(
@@ -29,6 +34,7 @@ class VerifyAlgoStatsHelper {
 
  private:
   bool enabled_{false};
+  std::optional<std::string> oldEnvValue_;
   std::vector<std::string> oldColltrace_;
 };
 


### PR DESCRIPTION
Summary:
Following the pattern from D102049572, migrate CtranDistAllgatherTests from the not-working
compile-time `-DNCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL` flag to runtime env-var-based
test parameterization, and deprecate the corresponding nolocal BUCK configurations.

**Source migration (CtranDistAllgatherTests.cc):**
- Convert `CtranAllgatherTest::SetUp()` override into a reusable
  `setUpWithEnvs(const ctran::CtranEnvs& envs = {})` helper that forwards envs
  to `CtranDistTestFixture::SetUp(envs)`.
- Convert `CtranAllgatherTestParam` and `CtranSocketAllgatherTestParam` to use
  `::testing::Combine` of `(CtranEnvs, inner params)`, with both
  `kDefaultEnvs` and `kNolocalEnvs` exercised in a single binary.
- Replace `enableNolocal` member with runtime `ctran::isNolocalTopo()` (getenv-based).
- Convert `TEST_F(CtranAllgatherTest, OutOfPlaceAllgatherRingDynamicRegist)` into
  `TEST_P(CtranAllgatherTestEnvFixture, ...)` with envs-only parameterization
  so the new `setUpWithEnvs` helper is invoked.
- Update `getTestName` and `getSocketTestName` to prefix the test name with
  `ctran::envSuffix(envs)`.

**BUCK changes:**
- Remove `1x8_nolocal_init_none` and `1x8_nolocal_init_ring_hybrid` configurations
  since nolocal is now covered by test parameterization.
- Bump `re_timeout` to 500 for the remaining configurations since each binary
  now runs both default and nolocal variants.

Reviewed By: minsii

Differential Revision: D103762821


