### PR TITLE
Add forward() to P2pIbgdaTransportDevice

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -6,6 +6,7 @@
 
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
 
@@ -33,7 +34,7 @@ struct Memcpy {
   }
 
   template <typename... Args>
-  __device__ __forceinline__ static void recv_forward(
+  __device__ __forceinline__ static void forward(
       char* dst,
       char* fwd_staging,
       const char* staging,
@@ -42,9 +43,7 @@ struct Memcpy {
       std::size_t /*byte_offset*/,
       Args...) {
     if (dst) {
-      memcpy_vectorized(dst, staging, nbytes, group);
-      group.sync();
-      memcpy_vectorized(fwd_staging, dst, nbytes, group);
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
     } else {
       memcpy_vectorized(fwd_staging, staging, nbytes, group);
     }

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -19,6 +19,8 @@
 
 namespace comms::pipes {
 
+struct Memcpy;
+
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
 // Slot-id bounds checks for the slot-index API. Catches both
@@ -1400,10 +1402,318 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
+  /**
+   * forward — receive data and forward it to the next peer in a ring.
+   *
+   * Combines recv + send in a single method, sharing the staging buffer to
+   * avoid an extra copy. The CopyOp::forward() method receives three
+   * buffers: dst (application output), fwd_staging (next peer's send staging),
+   * and staging (this transport's recv staging). This enables fused
+   * receive-reduce-forward patterns.
+   *
+   * Signal ordering invariant (critical for ring deadlock avoidance):
+   *   1. Wait DATA_READY from sender (this transport)
+   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
+   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
+   *   5. Wait SLOT_FREE from fwd transport's receiver
+   *   6. threadfence_system + RDMA put via fwd transport
+   *
+   * Step 4 before step 5 breaks the circular dependency in rings: each rank
+   * releases its predecessor's staging before waiting on its successor.
+   *
+   * Protocol compatibility with send() and recv():
+   *
+   * forward acts as a recv on "this" transport and a send on "fwd".
+   * The signal protocol is wire-compatible:
+   *
+   *   Recv side (this transport):
+   *     - Reads stepState[maxGroups + groupId] (same index as recv)
+   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
+   *       piggybacked signal on remoteSignalBuf[groupId])
+   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
+   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
+   *       groupId])
+   *
+   *   Fwd side (fwd transport):
+   *     - Reads stepState[groupId] (same index as send)
+   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
+   *       self-counter)
+   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
+   *       (matches recv's backpressure release)
+   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
+   *       + NIC_DONE on localCounterBuf[groupId]
+   *       (matches recv's DATA_READY wait)
+   *
+   * Any chain of send → forward* → recv is therefore valid: each
+   * forward consumes exactly the signals its predecessor produces
+   * and produces exactly the signals its successor expects.
+   *
+   * @param group           ThreadGroup (all threads participate).
+   * @param dst             Application destination (may be nullptr if
+   *                        CopyOp handles it, e.g. reduce-scatter).
+   * @param fwd             Forward transport (sends to next peer in ring).
+   * @param nbytes          Bytes to receive and forward.
+   * @param active_blocks   Number of block-groups sharing the slot. 0 =
+   * maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   * @param args            Extra args forwarded to CopyOp::forward.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int groupId = group.group_id;
+
+    // --- recv side (this transport) ---
+    const int recvEffActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward recv active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            recvEffActive,
+            sendRecvState_.maxGroups,
+            groupId);
+      }
+      __trap();
+    }
+
+    const std::size_t recvPerBlockSlot =
+        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
+    if (recvPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
+      }
+      __trap();
+    }
+
+    // --- fwd side (fwd transport) ---
+    const int fwdEffActive =
+        active_blocks > 0 ? active_blocks : fwd.sendRecvState_.maxGroups;
+    if (fwdEffActive > fwd.sendRecvState_.maxGroups ||
+        groupId >= fwdEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward fwd active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            fwdEffActive,
+            fwd.sendRecvState_.maxGroups,
+            groupId);
+      }
+      __trap();
+    }
+
+    const std::size_t fwdPerBlockSlot =
+        (fwd.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
+    if (fwdPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
+      }
+      __trap();
+    }
+
+    // Chunk sizes for recv and fwd sides
+    std::size_t recvChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : recvPerBlockSlot;
+    if (recvChunkSize == 0) {
+      recvChunkSize = recvPerBlockSlot;
+    }
+    std::size_t fwdChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : fwdPerBlockSlot;
+    if (fwdChunkSize == 0) {
+      fwdChunkSize = fwdPerBlockSlot;
+    }
+
+    const std::size_t recvChunksPerSlot = recvPerBlockSlot / recvChunkSize;
+    const std::size_t fwdChunksPerSlot = fwdPerBlockSlot / fwdChunkSize;
+    const std::size_t totalRecvChunks =
+        (nbytes + recvChunkSize - 1) / recvChunkSize;
+    const std::size_t totalFwdChunks =
+        (nbytes + fwdChunkSize - 1) / fwdChunkSize;
+
+    // Step state
+    const int64_t recvBaseStep =
+        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId];
+    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
+    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const int64_t recvChunksPerSlot64 = static_cast<int64_t>(recvChunksPerSlot);
+
+    const int64_t fwdBaseStep = fwd.sendRecvState_.stepState[groupId];
+    const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
+    const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
+    const int64_t fwdChunksPerSlot64 = static_cast<int64_t>(fwdChunksPerSlot);
+    const int64_t fwdPipelineChunks =
+        static_cast<int64_t>(fwdPipelineDepth) * fwdChunksPerSlot64;
+
+    // Both sides process the same nbytes; chunk sizes must match so that
+    // the loop counter advances recv and fwd step states in lockstep.
+    if (totalRecvChunks != totalFwdChunks) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward chunk count mismatch: "
+            "recv=%llu fwd=%llu\n",
+            (unsigned long long)totalRecvChunks,
+            (unsigned long long)totalFwdChunks);
+      }
+      __trap();
+    }
+
+    for (std::size_t s = 0; s < totalRecvChunks; ++s) {
+      // --- Recv side offsets ---
+      const int64_t recvChunkStep = recvBaseStep + static_cast<int64_t>(s);
+      const int64_t recvSlotStep = recvChunkStep / recvChunksPerSlot64;
+      const int64_t recvSubStep = recvChunkStep % recvChunksPerSlot64;
+      const int recvSlot = static_cast<int>(recvSlotStep % recvPipelineDepth);
+      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+      const std::size_t recvChunkOff =
+          static_cast<std::size_t>(recvSubStep) * recvChunkSize;
+      const std::size_t recvStagingOff =
+          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+      const std::size_t dataOff = s * recvChunkSize;
+      const std::size_t bytesThis = (dataOff + recvChunkSize <= nbytes)
+          ? recvChunkSize
+          : (nbytes - dataOff);
+
+      // --- Fwd side offsets ---
+      const int64_t fwdChunkStep = fwdBaseStep + static_cast<int64_t>(s);
+      const int64_t fwdSlotStep = fwdChunkStep / fwdChunksPerSlot64;
+      const int64_t fwdSubStep = fwdChunkStep % fwdChunksPerSlot64;
+      const int fwdSlot = static_cast<int>(fwdSlotStep % fwdPipelineDepth);
+      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+      const std::size_t fwdChunkOff =
+          static_cast<std::size_t>(fwdSubStep) * fwdChunkSize;
+      const std::size_t fwdStagingOff =
+          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+
+      // (1) Wait for sender's DATA_READY.
+      wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          static_cast<uint64_t>(recvChunkStep + 1),
+          timeout);
+
+      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
+      if (fwdChunkStep >= fwdPipelineChunks) {
+        fwd.wait_counter(
+            group,
+            fwd.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            timeout);
+      }
+
+      // (3) CopyOp::forward — transform recv staging → dst + fwd staging.
+      CopyOp::forward(
+          dst ? static_cast<char*>(dst) + dataOff : nullptr,
+          fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
+          sendRecvState_.recvStagingPtr + recvStagingOff,
+          bytesThis,
+          group,
+          dataOff,
+          args...);
+      group.sync();
+
+      // (4) Signal SLOT_FREE to sender (this transport).
+      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
+      //     to break circular ring dependency.
+      signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (recvMaxGroups + groupId) * sizeof(uint64_t)),
+          1ULL);
+
+      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+      //     recvStaging).
+      if (fwdChunkStep >= fwdPipelineChunks) {
+        fwd.wait_signal(
+            group,
+            fwd.sendRecvState_.localSignalBuf.subBuffer(
+                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
+            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            timeout);
+      }
+
+      // (6) threadfence_system + RDMA put via fwd transport.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        fwd.put(
+            solo,
+            fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwd.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            bytesThis,
+            fwd.sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL,
+            fwd.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL);
+      }
+      group.sync();
+    }
+
+    // Update step state for both recv and fwd sides.
+    if (group.is_leader()) {
+      sendRecvState_.stepState[sendRecvState_.maxGroups + groupId] =
+          recvBaseStep + static_cast<int64_t>(totalRecvChunks);
+      fwd.sendRecvState_.stepState[groupId] =
+          fwdBaseStep + static_cast<int64_t>(totalRecvChunks);
+    }
+    group.sync();
+#endif
+  }
+
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
     return sendRecvState_;
+  }
+
+  /**
+   * Maximum bytes a block can send without blocking on pipeline backpressure.
+   *
+   * The staging buffer is split into pipelineDepth slots, each divided evenly
+   * across active_blocks. A block can fill all its slots before the NIC must
+   * drain any of them, so the non-blocking window is:
+   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *
+   * Callers should loop over their data in pipeline_window-sized chunks so
+   * that send()/forward() never stall waiting for a free slot.
+   *
+   * @param active_blocks  Total blocks sharing this transport (typically
+   *                       gridDim.x).
+   */
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    const std::size_t per_block_slot =
+        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
+    return per_block_slot * sendRecvState_.pipelineDepth;
   }
 
  private:

--- a/comms/pipes/benchmarks/IbgdaForward.cu
+++ b/comms/pipes/benchmarks/IbgdaForward.cu
@@ -1,0 +1,146 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/benchmarks/IbgdaForward.cuh"
+
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = (my_rank == 1)
+      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      : min((my_rank == 0 ? next_transport : prev_transport)
+                ->send_recv_state()
+                .dataBufferSize,
+            totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (my_rank == 0) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, group);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else if (my_rank == 2) {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->forward(
+          group,
+          tiles.data(),
+          *next_transport,
+          tiles.bytes(),
+          numBlocks,
+          0,
+          timeout);
+    }
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = (my_rank == 1)
+      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      : min((my_rank == 0 ? next_transport : prev_transport)
+                ->send_recv_state()
+                .dataBufferSize,
+            totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (my_rank == 0) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, group);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else if (my_rank == 2) {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    }
+  }
+}
+
+void launch_ibgda_forward_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_forward_kernel<<<numBlocks, 512, 0, stream>>>(
+      prev_transport,
+      next_transport,
+      src,
+      dst,
+      nbytes,
+      numBlocks,
+      my_rank,
+      timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] forward kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void launch_ibgda_recv_send_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_recv_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      prev_transport,
+      next_transport,
+      src,
+      dst,
+      nbytes,
+      numBlocks,
+      my_rank,
+      timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] recv_send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForward.cuh
+++ b/comms/pipes/benchmarks/IbgdaForward.cuh
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes::benchmark {
+
+/**
+ * 3-rank chain kernel using forward on rank 1.
+ * rank 0: send, rank 1: forward, rank 2: recv.
+ */
+__global__ void ibgda_forward_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout);
+
+/**
+ * 3-rank chain kernel using recv + send on rank 1 (baseline).
+ * rank 0: send, rank 1: recv then send, rank 2: recv.
+ */
+__global__ void ibgda_recv_send_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForward.h
+++ b/comms/pipes/benchmarks/IbgdaForward.h
@@ -1,0 +1,38 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::benchmark {
+
+void launch_ibgda_forward_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_recv_send_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForwardBenchmark.cc
+++ b/comms/pipes/benchmarks/IbgdaForwardBenchmark.cc
@@ -1,0 +1,333 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/IbgdaForward.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::BenchmarkEnvironment;
+using meta::comms::BenchmarkTestFixture;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
+
+class IbgdaForwardBenchmarkTest : public BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    cudaSetDevice(localRank);
+    cudaStreamCreate(&stream_);
+  }
+
+  void TearDown() override {
+    cudaStreamDestroy(stream_);
+    BenchmarkTestFixture::TearDown();
+  }
+
+  cudaStream_t stream_{};
+};
+
+TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
+  if (worldSize != 3) {
+    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 4 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+  constexpr std::size_t kSlotSize = kDataBytes;
+  constexpr int kPipelineDepth = 2;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kDataBytes);
+  DeviceBuffer recvBuf(kDataBytes);
+
+  const uint8_t fillPattern = 0xCA;
+  cudaMemset(sendBuf.get(), fillPattern, kDataBytes);
+  cudaMemset(recvBuf.get(), 0, kDataBytes);
+  cudaDeviceSynchronize();
+
+  const int prevRank = (globalRank + worldSize - 1) % worldSize;
+  const int nextRank = (globalRank + 1) % worldSize;
+
+  P2pIbgdaTransportDevice* prevTransport =
+      (globalRank != 0) ? transport.getP2pTransportDevice(prevRank) : nullptr;
+  P2pIbgdaTransportDevice* nextTransport =
+      (globalRank != 2) ? transport.getP2pTransportDevice(nextRank) : nullptr;
+
+  bootstrap->barrierAll();
+
+  launch_ibgda_forward_chain(
+      prevTransport,
+      nextTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kDataBytes,
+      kNumBlocks,
+      globalRank,
+      stream_);
+
+  cudaError_t err = cudaStreamSynchronize(stream_);
+  ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+  bootstrap->barrierAll();
+
+  if (globalRank != 0) {
+    std::vector<uint8_t> hostBuf(kDataBytes);
+    cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost);
+
+    int errors = 0;
+    for (std::size_t i = 0; i < kDataBytes; ++i) {
+      if (hostBuf[i] != fillPattern) {
+        if (errors < 10) {
+          XLOGF(
+              ERR,
+              "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+              globalRank,
+              i,
+              fillPattern,
+              hostBuf[i]);
+        }
+        ++errors;
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                         << " byte mismatches";
+  }
+}
+
+TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
+  if (worldSize != 3) {
+    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 2;
+  constexpr std::size_t kSlotSize = 8 * 1024 * 1024;
+  constexpr int kPipelineDepth = 2;
+  constexpr int kWarmupIters = 5;
+  constexpr int kBenchIters = 20;
+
+  std::vector<std::size_t> messageSizes;
+  for (std::size_t sz = 1ULL << 20; sz <= 1ULL << 30; sz <<= 1) {
+    messageSizes.push_back(sz);
+  }
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  std::size_t maxBytes = messageSizes.back();
+  DeviceBuffer sendBuf(maxBytes);
+  DeviceBuffer recvBuf(maxBytes);
+  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
+  cudaMemset(recvBuf.get(), 0, maxBytes);
+  cudaDeviceSynchronize();
+
+  const int prevRank = (globalRank + worldSize - 1) % worldSize;
+  const int nextRank = (globalRank + 1) % worldSize;
+
+  P2pIbgdaTransportDevice* prevTransport =
+      (globalRank != 0) ? transport.getP2pTransportDevice(prevRank) : nullptr;
+  P2pIbgdaTransportDevice* nextTransport =
+      (globalRank != 2) ? transport.getP2pTransportDevice(nextRank) : nullptr;
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  if (globalRank == 0) {
+    XLOGF(INFO, "");
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO, "  recv_forward vs recv+send (3-rank chain: rank0→rank1→rank2)");
+    XLOGF(
+        INFO,
+        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
+        kNumBlocks,
+        kSlotSize / (1024 * 1024),
+        kPipelineDepth);
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO,
+        "{:>10s}  {:>14s}  {:>14s}  {:>10s}",
+        "MsgSize",
+        "recv_fwd GB/s",
+        "recv+snd GB/s",
+        "Speedup");
+    XLOGF(
+        INFO, "--------------------------------------------------------------");
+  }
+
+  for (auto nBytes : messageSizes) {
+    float recvFwdBw = 0;
+    float recvSndBw = 0;
+
+    // --- Benchmark recv_forward ---
+    {
+      bootstrap->barrierAll();
+      for (int i = 0; i < kWarmupIters; ++i) {
+        launch_ibgda_forward_chain(
+            prevTransport,
+            nextTransport,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+        cudaStreamSynchronize(stream_);
+        bootstrap->barrierAll();
+      }
+
+      bootstrap->barrierAll();
+      cudaEventRecord(start, stream_);
+      for (int i = 0; i < kBenchIters; ++i) {
+        launch_ibgda_forward_chain(
+            prevTransport,
+            nextTransport,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+      }
+      cudaEventRecord(stop, stream_);
+      cudaEventSynchronize(stop);
+      bootstrap->barrierAll();
+
+      float totalMs = 0;
+      cudaEventElapsedTime(&totalMs, start, stop);
+      recvFwdBw = (nBytes / 1e9f) / ((totalMs / kBenchIters) / 1000.0f);
+    }
+
+    // --- Benchmark recv+send ---
+    {
+      // Need fresh transport since step state has advanced
+      MultipeerIbgdaTransport transport2(
+          globalRank, worldSize, bootstrap, transportConfig);
+      transport2.exchange();
+
+      P2pIbgdaTransportDevice* prevT2 = (globalRank != 0)
+          ? transport2.getP2pTransportDevice(prevRank)
+          : nullptr;
+      P2pIbgdaTransportDevice* nextT2 = (globalRank != 2)
+          ? transport2.getP2pTransportDevice(nextRank)
+          : nullptr;
+
+      bootstrap->barrierAll();
+      for (int i = 0; i < kWarmupIters; ++i) {
+        launch_ibgda_recv_send_chain(
+            prevT2,
+            nextT2,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+        cudaStreamSynchronize(stream_);
+        bootstrap->barrierAll();
+      }
+
+      bootstrap->barrierAll();
+      cudaEventRecord(start, stream_);
+      for (int i = 0; i < kBenchIters; ++i) {
+        launch_ibgda_recv_send_chain(
+            prevT2,
+            nextT2,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+      }
+      cudaEventRecord(stop, stream_);
+      cudaEventSynchronize(stop);
+      bootstrap->barrierAll();
+
+      float totalMs = 0;
+      cudaEventElapsedTime(&totalMs, start, stop);
+      recvSndBw = (nBytes / 1e9f) / ((totalMs / kBenchIters) / 1000.0f);
+    }
+
+    if (globalRank == 0) {
+      std::string sizeStr;
+      if (nBytes >= 1ULL << 30) {
+        sizeStr = fmt::format("{}GB", nBytes >> 30);
+      } else {
+        sizeStr = fmt::format("{}MB", nBytes >> 20);
+      }
+      float speedup = (recvSndBw > 0) ? (recvFwdBw / recvSndBw) : 0;
+      XLOGF(
+          INFO,
+          "{:>10s}  {:>14.2f}  {:>14.2f}  {:>9.2f}x",
+          sizeStr,
+          recvFwdBw,
+          recvSndBw,
+          speedup);
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "================================================================");
+  }
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
+  }
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/RecvForwardChainTest.cc
+++ b/comms/pipes/tests/RecvForwardChainTest.cc
@@ -1,0 +1,366 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/tests/RecvForwardChainTest.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::BenchmarkEnvironment;
+using meta::comms::BenchmarkTestFixture;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::tests {
+
+using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
+
+class RecvForwardChainTest : public BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> create_transport(
+      std::size_t slot_size,
+      int max_groups,
+      int pipeline_depth = 2) {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .dataBufferSize = slot_size,
+        .sendRecv =
+            SendRecvConfig{
+                .maxGroups = max_groups,
+                .pipelineDepth = pipeline_depth,
+            },
+    };
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, config);
+    transport->exchange();
+    return transport;
+  }
+
+  cudaStream_t stream_{};
+};
+
+// Chain test: rank 0 → rank 1 → ... → rank N-1
+// Each intermediate uses recv_forward with dst (copies to local buffer).
+// Verify all ranks that receive data see the correct pattern.
+TEST_F(RecvForwardChainTest, ForwardWithCopy) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xCA;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    // Build per-rank transport pointer array
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    // All ranks except rank 0 should have received the data
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          if (errors < 10) {
+            XLOGF(
+                ERR,
+                "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+                globalRank,
+                i,
+                fillPattern,
+                hostBuf[i]);
+          }
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Chain test with dst=nullptr for intermediates (forward-only).
+// Only the last rank should have the data.
+TEST_F(RecvForwardChainTest, ForwardOnly) {
+  if (worldSize < 3) {
+    XLOGF(INFO, "Skipping: requires >= 3 ranks for forward-only test");
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xBE;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_no_dst(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    // Only the last rank gets data
+    if (globalRank == worldSize - 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Last rank: " << errors << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// 2-rank test: send → recv (no intermediates). Validates that the protocol
+// is compatible when recv_forward is not involved — just send + recv.
+TEST_F(RecvForwardChainTest, SendRecvDirect) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 2 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0x55;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    // Chain with worldSize=2: rank 0 sends, rank 1 receives — no recv_forward
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank == 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank 1: " << errors << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Multi-section test: transfer more data than one slot to exercise pipelining.
+TEST_F(RecvForwardChainTest, MultiSection) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kSlotSize = 512 * 1024;
+  constexpr std::size_t kDataBytes = 4 * kSlotSize; // 4 sections
+  constexpr int kNumBlocks = 2;
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xDD;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches in multi-section transfer";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto* env = new BenchmarkEnvironment();
+  ::testing::AddGlobalTestEnvironment(env);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/RecvForwardChainTest.cu
+++ b/comms/pipes/tests/RecvForwardChainTest.cu
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes::test {
+
+// Chain kernel: rank 0 sends, intermediates recv_forward, last rank receives.
+__global__ void recv_forward_chain_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    bool use_dst) {
+  auto group = make_block_group();
+  const auto num_blocks = gridDim.x;
+
+  const std::size_t per_block = (nbytes / num_blocks) & ~15ULL;
+  const std::size_t my_off = group.group_id * per_block;
+  const std::size_t my_bytes =
+      (group.group_id == num_blocks - 1) ? (nbytes - my_off) : per_block;
+
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    // First rank: send to next
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    next.send(group, send_buf + my_off, my_bytes, num_blocks);
+  } else if (my_rank == world_size - 1) {
+    // Last rank: receive from prev
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    prev.recv(group, recv_buf + my_off, my_bytes, num_blocks);
+  } else {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    char* dst = use_dst ? (recv_buf + my_off) : nullptr;
+    prev.forward(group, dst, next, my_bytes, num_blocks);
+  }
+}
+
+void launch_recv_forward_chain(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+void launch_recv_forward_chain_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/false);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_no_dst kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/RecvForwardChainTest.h
+++ b/comms/pipes/tests/RecvForwardChainTest.h
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::test {
+
+/**
+ * Launch a chain test kernel: rank 0 sends, intermediates recv_forward,
+ * last rank receives. Tests the full send → recv_forward → recv protocol.
+ *
+ * @param transports     Array of worldSize P2pIbgdaTransportDevice pointers
+ *                       (one per peer, indexed by rank).
+ * @param send_buf       Source data (only used by rank 0).
+ * @param recv_buf       Destination (used by all ranks; intermediates use it
+ *                       as CopyOp dst in recv_forward).
+ * @param nbytes         Total bytes to transfer per block.
+ * @param my_rank        This rank's global rank.
+ * @param world_size     Total number of ranks.
+ * @param num_blocks     CUDA grid dimension.
+ * @param stream         CUDA stream.
+ */
+void launch_recv_forward_chain(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Same as above but with dst=nullptr for intermediates (forward-only mode).
+ * Only the last rank writes to recv_buf.
+ */
+void launch_recv_forward_chain_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
Add a forward() method to P2pIbgdaTransportDevice that combines receive and forward in a single operation. This is the key primitive for ring collectives: each rank receives data from its predecessor and forwards it to its successor.

The method takes two transports: `this` (receive side) and `fwd` (forward/send side). The CopyOp::recv_forward() hook receives three buffers — dst, fwd_staging, and recv_staging — enabling fused receive-transform-forward patterns (e.g., accumulate local data during reduce-scatter forwarding).

**Signal ordering invariant** (critical for ring deadlock avoidance):
1. Wait DATA_READY from sender
2. Wait NIC_DONE on fwd sendStaging (backpressure)
3. CopyOp::recv_forward(dst, fwd_staging, recv_staging, ...)
4. Signal SLOT_FREE to sender — BEFORE step 5
5. Wait SLOT_FREE from fwd receiver
6. threadfence_system + RDMA put via fwd transport

Step 4 before step 5 breaks the circular dependency in rings: each rank releases its predecessors staging slot before blocking on its successor. Without this ordering, all ranks would deadlock waiting on each other in a cycle.

Updates Memcpy::recv_forward in CopyOp.cuh to use the dual-destination memcpy_vectorized overload from D103736411 instead of two sequential memcpy_vectorized calls, eliminating one full memory pass and a barrier. This benefits both IBGDA and NVLink forward paths.

Bug fix: forward null pointer guard — when dst=nullptr (used during intermediate ring reduce-scatter steps), the transport was computing static_cast<char*>(nullptr) + dataOff, producing a non-null garbage pointer for pipeline iterations with dataOff > 0. Fixed by guarding: dst ? static_cast<char*>(dst) + dataOff : nullptr.

Bug fix: forward step state mismatch — the fwd step state update was using totalFwdChunks but the loop iterates totalRecvChunks times. Added an assertion that chunk counts match and use totalRecvChunks consistently.

Reviewed By: zhiyongww, Scusemua

Differential Revision: D103888256


