### PR TITLE
Guard folly Symbolizer behind __has_include(<dwarf.h>)

### DIFF
--- a/comms/utils/logger/NcclScubaSample.cc
+++ b/comms/utils/logger/NcclScubaSample.cc
@@ -4,7 +4,9 @@
 
 #include <sstream>
 
+#if __has_include(<dwarf.h>)
 #include <folly/debugging/symbolizer/Symbolizer.h>
+#endif
 #include <folly/json/json.h>
 
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
@@ -59,7 +61,8 @@ void NcclScubaSample::setExceptionInfo(const std::exception& ex) {
 }
 
 void NcclScubaSample::setError(const std::string& error) {
-  // Get stack trace
+  // Get stack trace (requires elfutils/libdwarf for folly Symbolizer)
+#if __has_include(<dwarf.h>)
   if (NCCL_SCUBA_STACK_TRACE_ON_ERROR_ENABLED) {
     std::stringstream ss;
     ss << folly::symbolizer::getStackTraceStr();
@@ -73,6 +76,7 @@ void NcclScubaSample::setError(const std::string& error) {
     this->stackTrace = stackTraceMangled;
     addNormVector("stack_trace", std::move(stackTraceMangled));
   }
+#endif
 
   // Set attributes locally
   this->hasException = true;


### PR DESCRIPTION
Summary:
Guard `#include <folly/debugging/symbolizer/Symbolizer.h>` and its usage in `NcclScubaSample::setError()` behind `#if __has_include(<dwarf.h>)`.

The folly Symbolizer requires `libdwarf`/`elfutils` headers (`<dwarf.h>`) which are not available in all OSS build environments. In particular, the GB200 conda env has a conflict between `libdwarf` and `zstd`. Wrapping the include and usage in `__has_include(<dwarf.h>)` guards makes the stack trace feature gracefully degrade to a no-op when dwarf headers are absent, rather than failing the build.

No behavior change for internal builds since `<dwarf.h>` is always present in the fbcode toolchain.

Split out from D98509252.

Differential Revision: D104088416


