### PR TITLE
torchcomms: prefix CCA hook symbols per backend (#2410)

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -213,7 +213,7 @@ class TorchCommNCCL : public TorchCommBackend,
 
   // Friend access for TorchCommNCCL
   friend class TorchWorkNCCL;
-  friend class CachingAllocatorHookImpl;
+  friend class NcclCachingAllocatorHookImpl;
   friend class TorchCommWindowNCCL;
 
   // Getter for CUDA API (for friend classes)

--- a/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLCCA.cpp
@@ -5,28 +5,28 @@
 namespace torch::comms {
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(
+void ncclCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   // Forward to the singleton instance
-  CachingAllocatorHook::getInstance().regDeregMem(te);
+  NcclCachingAllocatorHook::getInstance().regDeregMem(te);
 }
 
-CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
+NcclCachingAllocatorHookImpl& NcclCachingAllocatorHook::getInstance() {
   // Use std::call_once for thread-safe singleton initialization
   // NOLINTNEXTLINE(facebook-hte-std::call_once)
   std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 
-DefaultCachingAllocatorHookImpl::DefaultCachingAllocatorHookImpl() {
+DefaultNcclCachingAllocatorHookImpl::DefaultNcclCachingAllocatorHookImpl() {
   // Setup memory registration hooks
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
   registerMemPreHook();
   c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
-      &cachingAllocatorHookFn);
+      &ncclCachingAllocatorHookFn);
 }
 
-void CachingAllocatorHookImpl::registerMemPreHook() {
+void NcclCachingAllocatorHookImpl::registerMemPreHook() {
   // We assume no mem pool and no comm has been created yet, we just loop up the
   // snapshot of the default pool for all devices.
   auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
@@ -43,7 +43,7 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   }
 }
 
-void CachingAllocatorHookImpl::regDeregMem(
+void NcclCachingAllocatorHookImpl::regDeregMem(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   std::lock_guard<std::mutex> lock(mutex_);
   bool register_mem = te.action_ ==
@@ -88,7 +88,7 @@ void CachingAllocatorHookImpl::regDeregMem(
   }
 }
 
-void CachingAllocatorHookImpl::registerComm(TorchCommNCCL* comm) {
+void NcclCachingAllocatorHookImpl::registerComm(TorchCommNCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   // Check if the communicator is already registered
@@ -106,7 +106,7 @@ void CachingAllocatorHookImpl::registerComm(TorchCommNCCL* comm) {
   registeredComms_.insert(comm);
 }
 
-void CachingAllocatorHookImpl::deregisterComm(TorchCommNCCL* comm) {
+void NcclCachingAllocatorHookImpl::deregisterComm(TorchCommNCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (!registeredComms_.contains(comm)) {
@@ -124,7 +124,7 @@ void CachingAllocatorHookImpl::deregisterComm(TorchCommNCCL* comm) {
   registeredComms_.erase(comm);
 }
 
-void CachingAllocatorHookImpl::clear() {
+void NcclCachingAllocatorHookImpl::clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& comm : registeredComms_) {
     for (const auto& [addr, mem_info] : registeredMemMap_) {
@@ -137,7 +137,7 @@ void CachingAllocatorHookImpl::clear() {
   registeredComms_.clear();
 }
 
-bool CachingAllocatorHookImpl::isCommRegistered(TorchCommNCCL* comm) {
+bool NcclCachingAllocatorHookImpl::isCommRegistered(TorchCommNCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
   return registeredComms_.contains(comm);
 }

--- a/comms/torchcomms/nccl/TorchCommNCCLCCA.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLCCA.hpp
@@ -10,9 +10,9 @@
 
 namespace torch::comms {
 
-class CachingAllocatorHookImpl {
+class NcclCachingAllocatorHookImpl {
  public:
-  virtual ~CachingAllocatorHookImpl() = default;
+  virtual ~NcclCachingAllocatorHookImpl() = default;
   virtual void regDeregMem(
       const c10::cuda::CUDACachingAllocator::TraceEntry& te);
   virtual void registerComm(TorchCommNCCL* comm);
@@ -39,46 +39,50 @@ class CachingAllocatorHookImpl {
   std::set<TorchCommNCCL*> registeredComms_;
 };
 
-class DefaultCachingAllocatorHookImpl : public CachingAllocatorHookImpl {
+class DefaultNcclCachingAllocatorHookImpl
+    : public NcclCachingAllocatorHookImpl {
  public:
-  DefaultCachingAllocatorHookImpl();
-  virtual ~DefaultCachingAllocatorHookImpl() = default;
+  DefaultNcclCachingAllocatorHookImpl();
+  virtual ~DefaultNcclCachingAllocatorHookImpl() = default;
 
   // Delete copy constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(const DefaultCachingAllocatorHookImpl&) =
-      delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      const DefaultCachingAllocatorHookImpl&) = delete;
+  DefaultNcclCachingAllocatorHookImpl(
+      const DefaultNcclCachingAllocatorHookImpl&) = delete;
+  DefaultNcclCachingAllocatorHookImpl& operator=(
+      const DefaultNcclCachingAllocatorHookImpl&) = delete;
   // Delete move constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(DefaultCachingAllocatorHookImpl&&) = delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      DefaultCachingAllocatorHookImpl&&) = delete;
+  DefaultNcclCachingAllocatorHookImpl(DefaultNcclCachingAllocatorHookImpl&&) =
+      delete;
+  DefaultNcclCachingAllocatorHookImpl& operator=(
+      DefaultNcclCachingAllocatorHookImpl&&) = delete;
 };
 
-class CachingAllocatorHook {
+class NcclCachingAllocatorHook {
  public:
   // Get the singleton instance
-  static CachingAllocatorHookImpl& getInstance();
+  static NcclCachingAllocatorHookImpl& getInstance();
 
   // only for use by tests
-  static void setInstance(std::unique_ptr<CachingAllocatorHookImpl> instance) {
+  static void setInstance(
+      std::unique_ptr<NcclCachingAllocatorHookImpl> instance) {
     instance_ = std::move(instance);
   }
 
  protected:
   static void createInstance() {
     if (!instance_) {
-      instance_ = std::make_unique<DefaultCachingAllocatorHookImpl>();
+      instance_ = std::make_unique<DefaultNcclCachingAllocatorHookImpl>();
     }
   }
 
-  inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
+  inline static std::unique_ptr<NcclCachingAllocatorHookImpl> instance_ =
+      nullptr;
   // NOLINTNEXTLINE(facebook-hte-std::once_flag)
   inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(
+void ncclCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te);
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -518,11 +518,11 @@ void TorchCommNCCL::returnEvent(cudaEvent_t event) {
 }
 
 void TorchCommNCCL::attachMemoryHook() {
-  CachingAllocatorHook::getInstance().registerComm(this);
+  NcclCachingAllocatorHook::getInstance().registerComm(this);
 }
 
 void TorchCommNCCL::detachMemoryHook() {
-  CachingAllocatorHook::getInstance().deregisterComm(this);
+  NcclCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxGlobalApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxGlobalApi.cpp
@@ -37,7 +37,7 @@ void DefaultNcclxGlobalApi::initCachingAllocatorHook() {
         ncclGetErrorString(result));
   }
   ncclCommDestroy(comm);
-  CachingAllocatorHook::getInstance();
+  NcclxCachingAllocatorHook::getInstance();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -266,7 +266,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   // Friend access for TorchCommNCCLX
   friend class TorchWorkNCCLX;
   friend class GraphEventTracker;
-  friend class CachingAllocatorHookImpl;
+  friend class NcclxCachingAllocatorHookImpl;
   template <typename B>
   friend class TorchCommWindowNCCLX;
 
@@ -351,7 +351,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   };
 
   // Global pointer-based registration that doesn't require a comm instance.
-  // Used by CachingAllocatorHook for pre-comm memory registration.
+  // Used by NcclxCachingAllocatorHook for pre-comm memory registration.
   // The caller provides the NcclxApi to use for the registration.
   static void global_register_address(
       const AddressWithLen& addr,
@@ -490,7 +490,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   void checkTensorDevice(const at::Tensor& tensor) const;
   void checkTensorsDevice(const std::vector<at::Tensor>& tensors) const;
 
-  // Initialize the CachingAllocatorHook singleton
+  // Initialize the NcclxCachingAllocatorHook singleton
   void attachMemoryHook();
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.cpp
@@ -5,28 +5,28 @@
 namespace torch::comms {
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(
+void ncclxCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   // Forward to the singleton instance
-  CachingAllocatorHook::getInstance().regDeregMem(te);
+  NcclxCachingAllocatorHook::getInstance().regDeregMem(te);
 }
 
-CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
+NcclxCachingAllocatorHookImpl& NcclxCachingAllocatorHook::getInstance() {
   // Use std::call_once for thread-safe singleton initialization
   // NOLINTNEXTLINE(facebook-hte-std::call_once)
   std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 
-DefaultCachingAllocatorHookImpl::DefaultCachingAllocatorHookImpl() {
+DefaultNcclxCachingAllocatorHookImpl::DefaultNcclxCachingAllocatorHookImpl() {
   // Setup memory registration hooks
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
   registerMemPreHook();
   c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(
-      &cachingAllocatorHookFn);
+      &ncclxCachingAllocatorHookFn);
 }
 
-void CachingAllocatorHookImpl::registerMemPreHook() {
+void NcclxCachingAllocatorHookImpl::registerMemPreHook() {
   // Register all memory that has already been allocated by querying the
   // CUDACachingAllocator snapshot directly. This captures any allocations
   // that occurred before the trace hook was attached.
@@ -47,7 +47,7 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   mem_pre_hook_registered_ = true;
 }
 
-void CachingAllocatorHookImpl::regDeregMem(
+void NcclxCachingAllocatorHookImpl::regDeregMem(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
   if (te.action_ ==
           c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC ||
@@ -73,7 +73,7 @@ void CachingAllocatorHookImpl::regDeregMem(
   }
 }
 
-bool CachingAllocatorHookImpl::isMemPreHookRegistered() {
+bool NcclxCachingAllocatorHookImpl::isMemPreHookRegistered() {
   return mem_pre_hook_registered_;
 }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXCCA.hpp
@@ -11,9 +11,9 @@
 
 namespace torch::comms {
 
-class CachingAllocatorHookImpl {
+class NcclxCachingAllocatorHookImpl {
  public:
-  virtual ~CachingAllocatorHookImpl() = default;
+  virtual ~NcclxCachingAllocatorHookImpl() = default;
   virtual void regDeregMem(
       const c10::cuda::CUDACachingAllocator::TraceEntry& te);
   virtual void registerMemPreHook();
@@ -40,46 +40,50 @@ class CachingAllocatorHookImpl {
   std::shared_ptr<NcclxApi> nccl_api_ = std::make_shared<DefaultNcclxApi>();
 };
 
-class DefaultCachingAllocatorHookImpl : public CachingAllocatorHookImpl {
+class DefaultNcclxCachingAllocatorHookImpl
+    : public NcclxCachingAllocatorHookImpl {
  public:
-  DefaultCachingAllocatorHookImpl();
-  virtual ~DefaultCachingAllocatorHookImpl() = default;
+  DefaultNcclxCachingAllocatorHookImpl();
+  virtual ~DefaultNcclxCachingAllocatorHookImpl() = default;
 
   // Delete copy constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(const DefaultCachingAllocatorHookImpl&) =
-      delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      const DefaultCachingAllocatorHookImpl&) = delete;
+  DefaultNcclxCachingAllocatorHookImpl(
+      const DefaultNcclxCachingAllocatorHookImpl&) = delete;
+  DefaultNcclxCachingAllocatorHookImpl& operator=(
+      const DefaultNcclxCachingAllocatorHookImpl&) = delete;
   // Delete move constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(DefaultCachingAllocatorHookImpl&&) = delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      DefaultCachingAllocatorHookImpl&&) = delete;
+  DefaultNcclxCachingAllocatorHookImpl(DefaultNcclxCachingAllocatorHookImpl&&) =
+      delete;
+  DefaultNcclxCachingAllocatorHookImpl& operator=(
+      DefaultNcclxCachingAllocatorHookImpl&&) = delete;
 };
 
-class CachingAllocatorHook {
+class NcclxCachingAllocatorHook {
  public:
   // Get the singleton instance
-  static CachingAllocatorHookImpl& getInstance();
+  static NcclxCachingAllocatorHookImpl& getInstance();
 
   // only for use by tests
-  static void setInstance(std::unique_ptr<CachingAllocatorHookImpl> instance) {
+  static void setInstance(
+      std::unique_ptr<NcclxCachingAllocatorHookImpl> instance) {
     instance_ = std::move(instance);
   }
 
  protected:
   static void createInstance() {
     if (!instance_) {
-      instance_ = std::make_unique<DefaultCachingAllocatorHookImpl>();
+      instance_ = std::make_unique<DefaultNcclxCachingAllocatorHookImpl>();
     }
   }
 
-  inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
+  inline static std::unique_ptr<NcclxCachingAllocatorHookImpl> instance_ =
+      nullptr;
   // NOLINTNEXTLINE(facebook-hte-std::once_flag)
   inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(
+void ncclxCachingAllocatorHookFn(
     const c10::cuda::CUDACachingAllocator::TraceEntry& te);
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -490,10 +490,10 @@ void TorchCommNCCLX::returnEvent(cudaEvent_t event) {
 }
 
 void TorchCommNCCLX::attachMemoryHook() {
-  // Initialize the CachingAllocatorHook singleton.
+  // Initialize the NcclxCachingAllocatorHook singleton.
   // This attaches the CCA trace hook and registers any pre-existing
   // allocations.
-  CachingAllocatorHook::getInstance();
+  NcclxCachingAllocatorHook::getInstance();
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/MemoryCCAHookTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/MemoryCCAHookTest.cpp
@@ -23,7 +23,7 @@ class MemoryCCAHookTest : public ::testing::Test {
   }
 
   void TearDown() override {
-    CachingAllocatorHook::setInstance(nullptr);
+    NcclxCachingAllocatorHook::setInstance(nullptr);
   }
 
   c10::cuda::CUDACachingAllocator::TraceEntry createAllocation(uintptr_t addr) {
@@ -53,19 +53,19 @@ class MemoryCCAHookTest : public ::testing::Test {
 };
 
 TEST_F(MemoryCCAHookTest, RegDeregWorksAfterAttach) {
-  // Use real CachingAllocatorHookImpl (not mock) with mock NCCL API
-  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  // Use real NcclxCachingAllocatorHookImpl (not mock) with mock NCCL API
+  auto hook = std::make_unique<NcclxCachingAllocatorHookImpl>();
   hook->setNcclApi(nccl_mock_);
-  CachingAllocatorHook::setInstance(std::move(hook));
+  NcclxCachingAllocatorHook::setInstance(std::move(hook));
 
-  EXPECT_NO_THROW(CachingAllocatorHook::getInstance());
+  EXPECT_NO_THROW(NcclxCachingAllocatorHook::getInstance());
 
   // Simulate allocation — should call globalRegisterWithPtr
   auto alloc_entry = createAllocation(0x9000);
   EXPECT_CALL(
       *nccl_mock_, globalRegisterWithPtr(reinterpret_cast<void*>(0x9000), 1024))
       .WillOnce(Return(ncclSuccess));
-  CachingAllocatorHook::getInstance().regDeregMem(alloc_entry);
+  NcclxCachingAllocatorHook::getInstance().regDeregMem(alloc_entry);
 
   // Simulate deallocation — should call globalDeregisterWithPtr
   auto dealloc_entry = createDeallocation(0x9000);
@@ -73,7 +73,7 @@ TEST_F(MemoryCCAHookTest, RegDeregWorksAfterAttach) {
       *nccl_mock_,
       globalDeregisterWithPtr(reinterpret_cast<void*>(0x9000), 1024))
       .WillOnce(Return(ncclSuccess));
-  CachingAllocatorHook::getInstance().regDeregMem(dealloc_entry);
+  NcclxCachingAllocatorHook::getInstance().regDeregMem(dealloc_entry);
 }
 
 } // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -1033,10 +1033,10 @@ TEST_F(
     CachingAllocatorHookCallsGlobalRegisterOnSegmentAlloc) {
   // Test: Verify that CCA hook calls global_register_address on SEGMENT_ALLOC
   // The mock_hook_ already has nccl_mock_ set via SetUp()
-  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  auto hook = std::make_unique<NcclxCachingAllocatorHookImpl>();
   hook->setNcclApi(nccl_mock_);
-  CachingAllocatorHook::setInstance(std::move(hook));
-  auto& allocator = CachingAllocatorHook::getInstance();
+  NcclxCachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = NcclxCachingAllocatorHook::getInstance();
 
   // Create memory allocation trace entry
   auto alloc_entry = createAllocation(0x5000);
@@ -1054,10 +1054,10 @@ TEST_F(
     TorchCommNCCLXTest,
     CachingAllocatorHookCallsGlobalDeregisterOnSegmentFree) {
   // Test: Verify that CCA hook calls global_deregister_address on SEGMENT_FREE
-  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  auto hook = std::make_unique<NcclxCachingAllocatorHookImpl>();
   hook->setNcclApi(nccl_mock_);
-  CachingAllocatorHook::setInstance(std::move(hook));
-  auto& allocator = CachingAllocatorHook::getInstance();
+  NcclxCachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = NcclxCachingAllocatorHook::getInstance();
 
   // Create memory deallocation trace entry
   auto dealloc_entry = createDeallocation(0x6000);
@@ -1078,10 +1078,10 @@ TEST_F(
   // Test: Verify error handling during global memory registration.
   // Registration is best-effort — when ctran is not enabled, it's expected to
   // fail silently with a warning log rather than throwing.
-  auto hook = std::make_unique<CachingAllocatorHookImpl>();
+  auto hook = std::make_unique<NcclxCachingAllocatorHookImpl>();
   hook->setNcclApi(nccl_mock_);
-  CachingAllocatorHook::setInstance(std::move(hook));
-  auto& allocator = CachingAllocatorHook::getInstance();
+  NcclxCachingAllocatorHook::setInstance(std::move(hook));
+  auto& allocator = NcclxCachingAllocatorHook::getInstance();
 
   // Create memory allocation trace entry
   auto alloc_entry = createAllocation(0x7000);

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.cpp
@@ -23,7 +23,7 @@ void TorchCommNCCLXTest::SetUp() {
   hook_mock->setNcclApi(nccl_mock_);
 
   mock_hook_ = hook_mock.get();
-  CachingAllocatorHook::setInstance(std::move(hook_mock));
+  NcclxCachingAllocatorHook::setInstance(std::move(hook_mock));
 
   // Create hash store for communication
   store_ = c10::make_intrusive<c10d::HashStore>();
@@ -50,7 +50,7 @@ void TorchCommNCCLXTest::TearDown() {
   unsetenv("TORCHCOMM_TIMEOUT_SECONDS");
 
   // Reset the instance to null to release the mock object
-  CachingAllocatorHook::setInstance(nullptr);
+  NcclxCachingAllocatorHook::setInstance(nullptr);
 }
 
 void TorchCommNCCLXTest::setupRankAndSize(int rank, int size) {

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchWorkNCCLXQueueTest.cpp
@@ -60,7 +60,7 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
     hook_mock->setupDefaultBehaviors();
 
     mock_hook_ = hook_mock.get();
-    CachingAllocatorHook::setInstance(std::move(hook_mock));
+    NcclxCachingAllocatorHook::setInstance(std::move(hook_mock));
 
     // Create hash store for communication
     auto store_ = c10::make_intrusive<c10d::HashStore>();
@@ -88,7 +88,7 @@ class TorchWorkNCCLXQueueCommTest : public ::testing::Test {
     // Clear the communicator
     comm_.reset();
     // Reset the instance to null to release the mock object
-    CachingAllocatorHook::setInstance(nullptr);
+    NcclxCachingAllocatorHook::setInstance(nullptr);
   }
 
   void setupRankAndSize(int rank, int size) {

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.cpp
@@ -16,8 +16,8 @@ void CachingAllocatorHookMock::setupDefaultBehaviors() {
     mem_pre_hook_registered_ = true;
   });
 
-  // Call registerMemPreHook to simulate what DefaultCachingAllocatorHookImpl
-  // constructor does
+  // Call registerMemPreHook to simulate what
+  // DefaultNcclxCachingAllocatorHookImpl constructor does
   registerMemPreHook();
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -8,12 +8,12 @@
 namespace torch::comms::test {
 
 /**
- * Mock implementation of CachingAllocatorHookImpl using Google Mock.
- * This class provides mock implementations of all CachingAllocatorHookImpl
+ * Mock implementation of NcclxCachingAllocatorHookImpl using Google Mock.
+ * This class provides mock implementations of all NcclxCachingAllocatorHookImpl
  * operations for testing purposes.
  * Note: Inherits from base interface to avoid CUDA initialization in Default.
  */
-class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
+class CachingAllocatorHookMock : public NcclxCachingAllocatorHookImpl {
  public:
   CachingAllocatorHookMock() = default;
   virtual ~CachingAllocatorHookMock() override = default;

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -202,7 +202,7 @@ class TorchCommRCCL : public TorchCommBackend,
 
   // Friend access for TorchCommRCCL
   friend class TorchWorkRCCL;
-  friend class CachingAllocatorHookImpl;
+  friend class RcclCachingAllocatorHookImpl;
 
   // Getter for CUDA API (for friend classes)
   HipApi* getHipApi() const {

--- a/comms/torchcomms/rccl/TorchCommRCCLCCA.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLCCA.cpp
@@ -6,26 +6,26 @@
 namespace torch::comms {
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(const TraceEntry& te) {
+void rcclCachingAllocatorHookFn(const TraceEntry& te) {
   // Forward to the singleton instance
-  CachingAllocatorHook::getInstance().regDeregMem(te);
+  RcclCachingAllocatorHook::getInstance().regDeregMem(te);
 }
 
-CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
+RcclCachingAllocatorHookImpl& RcclCachingAllocatorHook::getInstance() {
   // Use std::call_once for thread-safe singleton initialization
   // NOLINTNEXTLINE(facebook-hte-std::call_once)
   std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 
-DefaultCachingAllocatorHookImpl::DefaultCachingAllocatorHookImpl() {
+DefaultRcclCachingAllocatorHookImpl::DefaultRcclCachingAllocatorHookImpl() {
   // Setup memory registration hooks
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
   registerMemPreHook();
-  attachAllocatorTraceTracker(&cachingAllocatorHookFn);
+  attachAllocatorTraceTracker(&rcclCachingAllocatorHookFn);
 }
 
-void CachingAllocatorHookImpl::registerMemPreHook() {
+void RcclCachingAllocatorHookImpl::registerMemPreHook() {
   // We assume no mem pool and no comm has been created yet, we just loop up the
   // snapshot of the default pool for all devices.
   auto the_snapshot = snapshot();
@@ -42,7 +42,7 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   }
 }
 
-void CachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
+void RcclCachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
   std::lock_guard<std::mutex> lock(mutex_);
   bool register_mem = te.action_ == TraceEntry::Action::SEGMENT_ALLOC;
   bool unregister_mem = te.action_ == TraceEntry::Action::SEGMENT_FREE;
@@ -84,7 +84,7 @@ void CachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
   }
 }
 
-void CachingAllocatorHookImpl::registerComm(TorchCommRCCL* comm) {
+void RcclCachingAllocatorHookImpl::registerComm(TorchCommRCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   // Check if the communicator is already registered
@@ -102,7 +102,7 @@ void CachingAllocatorHookImpl::registerComm(TorchCommRCCL* comm) {
   registeredComms_.insert(comm);
 }
 
-void CachingAllocatorHookImpl::deregisterComm(TorchCommRCCL* comm) {
+void RcclCachingAllocatorHookImpl::deregisterComm(TorchCommRCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (registeredComms_.find(comm) == registeredComms_.end()) {
@@ -120,7 +120,7 @@ void CachingAllocatorHookImpl::deregisterComm(TorchCommRCCL* comm) {
   registeredComms_.erase(comm);
 }
 
-void CachingAllocatorHookImpl::clear() {
+void RcclCachingAllocatorHookImpl::clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& comm : registeredComms_) {
     for (const auto& [addr, mem_info] : registeredMemMap_) {
@@ -133,7 +133,7 @@ void CachingAllocatorHookImpl::clear() {
   registeredComms_.clear();
 }
 
-bool CachingAllocatorHookImpl::isCommRegistered(TorchCommRCCL* comm) {
+bool RcclCachingAllocatorHookImpl::isCommRegistered(TorchCommRCCL* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
   return registeredComms_.find(comm) != registeredComms_.end();
 }

--- a/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLCCA.hpp
@@ -18,9 +18,9 @@ using c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker;
 using c10::cuda::CUDACachingAllocator::snapshot;
 using c10::cuda::CUDACachingAllocator::TraceEntry;
 
-class CachingAllocatorHookImpl {
+class RcclCachingAllocatorHookImpl {
  public:
-  virtual ~CachingAllocatorHookImpl() = default;
+  virtual ~RcclCachingAllocatorHookImpl() = default;
   virtual void regDeregMem(const TraceEntry& te);
   virtual void registerComm(TorchCommRCCL* comm);
   virtual void deregisterComm(TorchCommRCCL* comm);
@@ -46,45 +46,49 @@ class CachingAllocatorHookImpl {
   std::set<TorchCommRCCL*> registeredComms_;
 };
 
-class DefaultCachingAllocatorHookImpl : public CachingAllocatorHookImpl {
+class DefaultRcclCachingAllocatorHookImpl
+    : public RcclCachingAllocatorHookImpl {
  public:
-  DefaultCachingAllocatorHookImpl();
-  virtual ~DefaultCachingAllocatorHookImpl() = default;
+  DefaultRcclCachingAllocatorHookImpl();
+  virtual ~DefaultRcclCachingAllocatorHookImpl() = default;
 
   // Delete copy constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(const DefaultCachingAllocatorHookImpl&) =
-      delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      const DefaultCachingAllocatorHookImpl&) = delete;
+  DefaultRcclCachingAllocatorHookImpl(
+      const DefaultRcclCachingAllocatorHookImpl&) = delete;
+  DefaultRcclCachingAllocatorHookImpl& operator=(
+      const DefaultRcclCachingAllocatorHookImpl&) = delete;
   // Delete move constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(DefaultCachingAllocatorHookImpl&&) = delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      DefaultCachingAllocatorHookImpl&&) = delete;
+  DefaultRcclCachingAllocatorHookImpl(DefaultRcclCachingAllocatorHookImpl&&) =
+      delete;
+  DefaultRcclCachingAllocatorHookImpl& operator=(
+      DefaultRcclCachingAllocatorHookImpl&&) = delete;
 };
 
-class CachingAllocatorHook {
+class RcclCachingAllocatorHook {
  public:
   // Get the singleton instance
-  static CachingAllocatorHookImpl& getInstance();
+  static RcclCachingAllocatorHookImpl& getInstance();
 
   // only for use by tests
-  static void setInstance(std::unique_ptr<CachingAllocatorHookImpl> instance) {
+  static void setInstance(
+      std::unique_ptr<RcclCachingAllocatorHookImpl> instance) {
     instance_ = std::move(instance);
   }
 
  protected:
   static void createInstance() {
     if (!instance_) {
-      instance_ = std::make_unique<DefaultCachingAllocatorHookImpl>();
+      instance_ = std::make_unique<DefaultRcclCachingAllocatorHookImpl>();
     }
   }
 
-  inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
+  inline static std::unique_ptr<RcclCachingAllocatorHookImpl> instance_ =
+      nullptr;
   // NOLINTNEXTLINE(facebook-hte-std::once_flag)
   inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(const TraceEntry& te);
+void rcclCachingAllocatorHookFn(const TraceEntry& te);
 
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -420,11 +420,11 @@ void TorchCommRCCL::returnEvent(hipEvent_t event) {
 }
 
 void TorchCommRCCL::attachMemoryHook() {
-  CachingAllocatorHook::getInstance().registerComm(this);
+  RcclCachingAllocatorHook::getInstance().registerComm(this);
 }
 
 void TorchCommRCCL::detachMemoryHook() {
-  CachingAllocatorHook::getInstance().deregisterComm(this);
+  RcclCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/rccl/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/rccl/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -9,7 +9,7 @@
 
 namespace torch::comms::test {
 
-class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
+class CachingAllocatorHookMock : public RcclCachingAllocatorHookImpl {
  public:
   MOCK_METHOD(void, regDeregMem, (const TraceEntry& entry), (override));
   MOCK_METHOD(void, registerComm, (TorchCommRCCL * comm), (override));

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -216,7 +216,7 @@ class TorchCommRCCLX : public TorchCommBackend,
 
   // Friend access for TorchCommRCCLX
   friend class TorchWorkRCCLX;
-  friend class CachingAllocatorHookImpl;
+  friend class RcclxCachingAllocatorHookImpl;
 
   // Getter for CUDA API (for friend classes)
   HipApi* getHipApi() const {

--- a/comms/torchcomms/rcclx/TorchCommRCCLXCCA.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXCCA.cpp
@@ -6,26 +6,26 @@
 namespace torch::comms {
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(const TraceEntry& te) {
+void rcclxCachingAllocatorHookFn(const TraceEntry& te) {
   // Forward to the singleton instance
-  CachingAllocatorHook::getInstance().regDeregMem(te);
+  RcclxCachingAllocatorHook::getInstance().regDeregMem(te);
 }
 
-CachingAllocatorHookImpl& CachingAllocatorHook::getInstance() {
+RcclxCachingAllocatorHookImpl& RcclxCachingAllocatorHook::getInstance() {
   // Use std::call_once for thread-safe singleton initialization
   // NOLINTNEXTLINE(facebook-hte-std::call_once)
   std::call_once(init_flag_, createInstance);
   return *instance_;
 }
 
-DefaultCachingAllocatorHookImpl::DefaultCachingAllocatorHookImpl() {
+DefaultRcclxCachingAllocatorHookImpl::DefaultRcclxCachingAllocatorHookImpl() {
   // Setup memory registration hooks
   at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
   registerMemPreHook();
-  attachAllocatorTraceTracker(&cachingAllocatorHookFn);
+  attachAllocatorTraceTracker(&rcclxCachingAllocatorHookFn);
 }
 
-void CachingAllocatorHookImpl::registerMemPreHook() {
+void RcclxCachingAllocatorHookImpl::registerMemPreHook() {
   // We assume no mem pool and no comm has been created yet, we just loop up the
   // snapshot of the default pool for all devices.
   auto the_snapshot = snapshot();
@@ -42,7 +42,7 @@ void CachingAllocatorHookImpl::registerMemPreHook() {
   }
 }
 
-void CachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
+void RcclxCachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
   std::lock_guard<std::mutex> lock(mutex_);
   bool register_mem = te.action_ == TraceEntry::Action::SEGMENT_ALLOC;
   bool unregister_mem = te.action_ == TraceEntry::Action::SEGMENT_FREE;
@@ -84,7 +84,7 @@ void CachingAllocatorHookImpl::regDeregMem(const TraceEntry& te) {
   }
 }
 
-void CachingAllocatorHookImpl::registerComm(TorchCommRCCLX* comm) {
+void RcclxCachingAllocatorHookImpl::registerComm(TorchCommRCCLX* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   // Check if the communicator is already registered
@@ -103,7 +103,7 @@ void CachingAllocatorHookImpl::registerComm(TorchCommRCCLX* comm) {
   registeredComms_.insert(comm);
 }
 
-void CachingAllocatorHookImpl::deregisterComm(TorchCommRCCLX* comm) {
+void RcclxCachingAllocatorHookImpl::deregisterComm(TorchCommRCCLX* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   if (registeredComms_.find(comm) == registeredComms_.end()) {
@@ -121,7 +121,7 @@ void CachingAllocatorHookImpl::deregisterComm(TorchCommRCCLX* comm) {
   registeredComms_.erase(comm);
 }
 
-void CachingAllocatorHookImpl::clear() {
+void RcclxCachingAllocatorHookImpl::clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto& comm : registeredComms_) {
     for (const auto& [addr, mem_info] : registeredMemMap_) {
@@ -134,7 +134,7 @@ void CachingAllocatorHookImpl::clear() {
   registeredComms_.clear();
 }
 
-bool CachingAllocatorHookImpl::isCommRegistered(TorchCommRCCLX* comm) {
+bool RcclxCachingAllocatorHookImpl::isCommRegistered(TorchCommRCCLX* comm) {
   std::lock_guard<std::mutex> lock(mutex_);
   return registeredComms_.find(comm) != registeredComms_.end();
 }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXCCA.hpp
@@ -18,9 +18,9 @@ using c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker;
 using c10::cuda::CUDACachingAllocator::snapshot;
 using c10::cuda::CUDACachingAllocator::TraceEntry;
 
-class CachingAllocatorHookImpl {
+class RcclxCachingAllocatorHookImpl {
  public:
-  virtual ~CachingAllocatorHookImpl() = default;
+  virtual ~RcclxCachingAllocatorHookImpl() = default;
   virtual void regDeregMem(const TraceEntry& te);
   virtual void registerComm(TorchCommRCCLX* comm);
   virtual void deregisterComm(TorchCommRCCLX* comm);
@@ -46,45 +46,49 @@ class CachingAllocatorHookImpl {
   std::set<TorchCommRCCLX*> registeredComms_;
 };
 
-class DefaultCachingAllocatorHookImpl : public CachingAllocatorHookImpl {
+class DefaultRcclxCachingAllocatorHookImpl
+    : public RcclxCachingAllocatorHookImpl {
  public:
-  DefaultCachingAllocatorHookImpl();
-  virtual ~DefaultCachingAllocatorHookImpl() = default;
+  DefaultRcclxCachingAllocatorHookImpl();
+  virtual ~DefaultRcclxCachingAllocatorHookImpl() = default;
 
   // Delete copy constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(const DefaultCachingAllocatorHookImpl&) =
-      delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      const DefaultCachingAllocatorHookImpl&) = delete;
+  DefaultRcclxCachingAllocatorHookImpl(
+      const DefaultRcclxCachingAllocatorHookImpl&) = delete;
+  DefaultRcclxCachingAllocatorHookImpl& operator=(
+      const DefaultRcclxCachingAllocatorHookImpl&) = delete;
   // Delete move constructor and assignment operator
-  DefaultCachingAllocatorHookImpl(DefaultCachingAllocatorHookImpl&&) = delete;
-  DefaultCachingAllocatorHookImpl& operator=(
-      DefaultCachingAllocatorHookImpl&&) = delete;
+  DefaultRcclxCachingAllocatorHookImpl(DefaultRcclxCachingAllocatorHookImpl&&) =
+      delete;
+  DefaultRcclxCachingAllocatorHookImpl& operator=(
+      DefaultRcclxCachingAllocatorHookImpl&&) = delete;
 };
 
-class CachingAllocatorHook {
+class RcclxCachingAllocatorHook {
  public:
   // Get the singleton instance
-  static CachingAllocatorHookImpl& getInstance();
+  static RcclxCachingAllocatorHookImpl& getInstance();
 
   // only for use by tests
-  static void setInstance(std::unique_ptr<CachingAllocatorHookImpl> instance) {
+  static void setInstance(
+      std::unique_ptr<RcclxCachingAllocatorHookImpl> instance) {
     instance_ = std::move(instance);
   }
 
  protected:
   static void createInstance() {
     if (!instance_) {
-      instance_ = std::make_unique<DefaultCachingAllocatorHookImpl>();
+      instance_ = std::make_unique<DefaultRcclxCachingAllocatorHookImpl>();
     }
   }
 
-  inline static std::unique_ptr<CachingAllocatorHookImpl> instance_ = nullptr;
+  inline static std::unique_ptr<RcclxCachingAllocatorHookImpl> instance_ =
+      nullptr;
   // NOLINTNEXTLINE(facebook-hte-std::once_flag)
   inline static std::once_flag init_flag_;
 };
 
 // Global function to be registered as a hook
-void cachingAllocatorHookFn(const TraceEntry& te);
+void rcclxCachingAllocatorHookFn(const TraceEntry& te);
 
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -420,11 +420,11 @@ void TorchCommRCCLX::returnEvent(hipEvent_t event) {
 }
 
 void TorchCommRCCLX::attachMemoryHook() {
-  CachingAllocatorHook::getInstance().registerComm(this);
+  RcclxCachingAllocatorHook::getInstance().registerComm(this);
 }
 
 void TorchCommRCCLX::detachMemoryHook() {
-  CachingAllocatorHook::getInstance().deregisterComm(this);
+  RcclxCachingAllocatorHook::getInstance().deregisterComm(this);
 }
 
 } // namespace torch::comms

--- a/comms/torchcomms/rcclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
+++ b/comms/torchcomms/rcclx/tests/unit/cpp/mocks/CachingAllocatorHookMock.hpp
@@ -9,7 +9,7 @@
 
 namespace torch::comms::test {
 
-class CachingAllocatorHookMock : public CachingAllocatorHookImpl {
+class CachingAllocatorHookMock : public RcclxCachingAllocatorHookImpl {
  public:
   MOCK_METHOD(void, regDeregMem, (const TraceEntry& entry), (override));
   MOCK_METHOD(void, registerComm, (TorchCommRCCLX * comm), (override));


### PR DESCRIPTION
Summary:

When multiple torchcomms backends (mccl, nccl, ncclx, rccl, rcclx) are loaded into the same process — directly or via a dlopen'd plugin — their CCA hook symbols collide because every backend declares the same generic names in the `torch::comms` namespace:

- `CachingAllocatorHookImpl`
- `DefaultCachingAllocatorHookImpl`
- `CachingAllocatorHook`
- `cachingAllocatorHookFn`

This is an ODR violation. The dynamic linker may resolve vtable entries and function calls to the wrong implementation, leading to subtle bugs or crashes. The most acute case today is MCCL + NCCLX in the same binary, but the same problem applies to any pair (e.g. NCCL + NCCLX in tests, RCCL + RCCLX on AMD hosts).

Prefix every backend's CCA hook symbols with the backend name so each set is unique:

- mccl  → `Mccl{Default,…}CachingAllocatorHook{,Impl,Fn}`
- nccl  → `Nccl{Default,…}CachingAllocatorHook{,Impl,Fn}`
- ncclx → `Ncclx{Default,…}CachingAllocatorHook{,Impl,Fn}`
- rccl  → `Rccl{Default,…}CachingAllocatorHook{,Impl,Fn}`
- rcclx → `Rcclx{Default,…}CachingAllocatorHook{,Impl,Fn}`

For mccl, also remove `virtual` from non-destructor methods (mccl has no mock subclass; tests use `setInstance` directly), since virtual methods add vtable entries that themselves participate in ODR conflicts. The other four backends keep `virtual` because their gmock-based test mocks override these methods.

The mock class names (`torch::comms::test::CachingAllocatorHookMock`) are intentionally left untouched — they only ever live inside a single per-backend test binary, so they can't collide.

Reviewed By: function47

Differential Revision: D101994183


