### PR TITLE
Add Thrift package to analyzer .thrift files (#2411)

### DIFF
--- a/comms/analyzer/if/CommsTracingService.thrift
+++ b/comms/analyzer/if/CommsTracingService.thrift
@@ -10,8 +10,7 @@ cpp_include "<unordered_set>"
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
-@thrift.AllowLegacyMissingUris
-package;
+package "meta.com/comms/analyzer"
 
 typedef i64 GlobalRank
 typedef string CommHash

--- a/comms/analyzer/if/NCCLAnalyzerState.thrift
+++ b/comms/analyzer/if/NCCLAnalyzerState.thrift
@@ -4,8 +4,7 @@ namespace cpp2 facebook.comms.analyzer
 
 include "thrift/annotation/thrift.thrift"
 
-@thrift.AllowLegacyMissingUris
-package;
+package "meta.com/comms/analyzer"
 
 // Numerical rank identifier within a communicator.
 typedef i64 CommRank

--- a/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
+++ b/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
@@ -3,8 +3,7 @@
 include "thrift/annotation/cpp.thrift"
 include "thrift/annotation/thrift.thrift"
 
-@thrift.AllowLegacyMissingUris
-package;
+package "meta.com/comms/analyzer"
 
 cpp_include "<unordered_set>"
 


### PR DESCRIPTION
Summary:

Add `package "meta.com/comms/analyzer"` to the 3 Thrift files under `comms/analyzer/if/` that were missing it, and remove the `thrift.AllowLegacyMissingUris` annotation that was only needed because the package was empty. This resolves T262746691.

Differential Revision: D104105074


