### PR TITLE
Remove public initRankTopologyNolocal/Vnode from CommStateX (#2412)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -38,6 +38,14 @@ namespace {
     CHECK_VALID_RANK(rank, rankStates_.size());            \
   } while (0)
 
+// Return vnode nLocalRanks from global debug CVAR, or 0 if not set.
+int getGlobalVNodeNLocalRanks() {
+  if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
+    return static_cast<int>(NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
+  }
+  return 0;
+}
+
 } // namespace
 
 CommStateX::CommStateX(
@@ -62,7 +70,8 @@ CommStateX::CommStateX(
       noLocal_(
           noLocal ||
           NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal),
-      vCliqueSize_(vCliqueSize) {
+      vCliqueSize_(
+          vCliqueSize > 0 ? vCliqueSize : getGlobalVNodeNLocalRanks()) {
   setRankStatesTopologies(std::move(rankTopologies));
   setCommRankToWorldRanks(std::move(commRanksToWorldRanks));
 }
@@ -75,24 +84,26 @@ void CommStateX::initRankTopologyNolocal() {
   for (int r = 0; r < nRanks_; ++r) {
     auto& rankState = rankStates_.at(r);
     rankState.rank = r;
+    rankState.pid = (r == rank_) ? getpid() : -1;
     rankState.nodeId = r;
     rankState.localRank = 0;
     rankState.nLocalRanks = 1;
     rankState.localRankToRanks.assign(1, r);
     const std::string nolocalHost("nolocal_node_" + std::to_string(r));
     rankState.host = nolocalHost;
-    hostToRanks_[nolocalHost].emplace_back(r);
     nodeRanks_[rankState.nodeId].emplace_back(rankState.rank);
   }
 }
 
 void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
   rankStates_.resize(nRanks_);
-  nodeRanks_.resize(nRanks_);
+  const int nNodes = (nRanks_ + nLocalRanks - 1) / nLocalRanks;
+  nodeRanks_.resize(nNodes);
   for (int r = 0; r < nRanks_; ++r) {
     auto& rankState = rankStates_.at(r);
     rankState.nLocalRanks = nLocalRanks;
     rankState.rank = r;
+    rankState.pid = (r == rank_) ? getpid() : -1;
     rankState.nodeId = r / rankState.nLocalRanks;
     rankState.localRank = r % rankState.nLocalRanks;
     rankState.localRankToRanks.assign(
@@ -103,18 +114,19 @@ void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
     const std::string vNodeHost(
         "vnode_node_" + std::to_string(rankState.nodeId));
     rankState.host = vNodeHost;
-    hostToRanks_[vNodeHost].emplace_back(r);
     nodeRanks_[rankState.nodeId].emplace_back(r);
   }
 }
 
 void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
-  if (noLocal_) {
+  if (bootstrap == nullptr) {
+    FB_CHECKTHROW_EX(
+        nRanks_ == 1,
+        rank_,
+        commHash_,
+        commDesc_,
+        "bootstrap is required for multi-rank topology initialization");
     initRankTopologyNolocal();
-    return;
-  }
-  if (vCliqueSize_ > 0) {
-    initRankTopologyVnode(vCliqueSize_);
     return;
   }
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
@@ -349,27 +361,32 @@ void CommStateX::setRankStatesTopologies(
     std::vector<RankTopology> rankTopologies) {
   rankStates_.clear();
   nodeRanks_.clear();
-  hostToRanks_.clear();
-
   rankTopologies_ = rankTopologies;
 
+  // nodeGroupMap uses a virtual grouping key for node assignment.
+  // Virtual topology overrides (nolocal, vnode, vClique) change node grouping
+  // without altering the real hostname stored in rankState.host.
+  std::unordered_map<std::string, std::vector<int>> nodeGroupMap;
+
   for (const auto& rankTopology : rankTopologies_) {
-    std::string host(rankTopology.host);
+    const std::string host(rankTopology.host);
     const std::string rtsw(rankTopology.rtsw);
     const std::string su(rankTopology.su);
     const std::string dc(rankTopology.dc);
     const std::string zone(rankTopology.zone);
 
-    if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-      host = "nolocal_node_" + std::to_string(rankTopology.rank);
-    } else if (
-        NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-      host =
-          "vnode_node_" +
-          std::to_string(
-              rankTopology.rank / NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
+    // Determine node grouping key — may differ from real host for virtual
+    // topos. noLocal_ treats each rank as its own node; vCliqueSize_ (set from
+    // either explicit vClique param or NCCL_COMM_STATE_DEBUG_TOPO=vnode) groups
+    // ranks into virtual nodes of the given size.
+    std::string nodeGroupKey = host;
+    if (noLocal_) {
+      nodeGroupKey = "nolocal_node_" + std::to_string(rankTopology.rank);
+    } else if (vCliqueSize_ > 0) {
+      nodeGroupKey =
+          "vnode_" + std::to_string(rankTopology.rank / vCliqueSize_);
     }
-    hostToRanks_[host].emplace_back(rankTopology.rank);
+    nodeGroupMap[nodeGroupKey].emplace_back(rankTopology.rank);
 
     RankState state;
     state.rank = rankTopology.rank;
@@ -393,21 +410,21 @@ void CommStateX::setRankStatesTopologies(
       }
     }
 
-    state.nodeId = hostToRanks_.size() - 1;
-    state.localRank = hostToRanks_.at(host).size() - 1;
+    state.nodeId = nodeGroupMap.size() - 1;
+    state.localRank = nodeGroupMap.at(nodeGroupKey).size() - 1;
 
     rankStates_.push_back(std::move(state));
   }
 
-  // Populate nodeRanks_ after setup hostToRanks_ so we know how many nodes
+  // Populate nodeRanks_ after the first pass so we know how many nodes
   // there are to resize nodeRanks_
-  nodeRanks_.resize(hostToRanks_.size());
+  nodeRanks_.resize(nodeGroupMap.size());
   for (const auto& state : rankStates_) {
     nodeRanks_[state.nodeId].emplace_back(state.rank);
   }
 
   for (auto& state : rankStates_) {
-    state.localRankToRanks = hostToRanks_.at(state.host);
+    state.localRankToRanks = nodeRanks_.at(state.nodeId);
     state.nLocalRanks = state.localRankToRanks.size();
   }
 
@@ -489,7 +506,7 @@ int CommStateX::nNodes() const {
     }
     return nvlDomainRanks_.size();
   } else {
-    return hostToRanks_.size();
+    return nodeRanks_.size();
   }
 }
 

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -78,44 +78,23 @@ CommStateX::CommStateX(
 
 CommStateX::~CommStateX() {}
 
-void CommStateX::initRankTopologyNolocal() {
-  rankStates_.resize(nRanks_);
-  nodeRanks_.resize(nRanks_);
-  for (int r = 0; r < nRanks_; ++r) {
-    auto& rankState = rankStates_.at(r);
-    rankState.rank = r;
-    rankState.pid = (r == rank_) ? getpid() : -1;
-    rankState.nodeId = r;
-    rankState.localRank = 0;
-    rankState.nLocalRanks = 1;
-    rankState.localRankToRanks.assign(1, r);
-    const std::string nolocalHost("nolocal_node_" + std::to_string(r));
-    rankState.host = nolocalHost;
-    nodeRanks_[rankState.nodeId].emplace_back(rankState.rank);
+void CommStateX::initSingleRankTopology() {
+  rankStates_.resize(1);
+  nodeRanks_.resize(1);
+  auto& rankState = rankStates_.at(0);
+  rankState.rank = rank_;
+  rankState.pid = getpid();
+  rankState.nodeId = 0;
+  rankState.localRank = 0;
+  rankState.nLocalRanks = 1;
+  rankState.localRankToRanks.assign(1, rank_);
+  char hostname[256] = {};
+  if (gethostname(hostname, sizeof(hostname)) == 0) {
+    rankState.host = hostname;
+  } else {
+    rankState.host = "uninitialized";
   }
-}
-
-void CommStateX::initRankTopologyVnode(const int nLocalRanks) {
-  rankStates_.resize(nRanks_);
-  const int nNodes = (nRanks_ + nLocalRanks - 1) / nLocalRanks;
-  nodeRanks_.resize(nNodes);
-  for (int r = 0; r < nRanks_; ++r) {
-    auto& rankState = rankStates_.at(r);
-    rankState.nLocalRanks = nLocalRanks;
-    rankState.rank = r;
-    rankState.pid = (r == rank_) ? getpid() : -1;
-    rankState.nodeId = r / rankState.nLocalRanks;
-    rankState.localRank = r % rankState.nLocalRanks;
-    rankState.localRankToRanks.assign(
-        rankState.nLocalRanks, rankState.nodeId * rankState.nLocalRanks);
-    for (int i = 0; i < rankState.nLocalRanks; i++) {
-      rankState.localRankToRanks[i] += i;
-    }
-    const std::string vNodeHost(
-        "vnode_node_" + std::to_string(rankState.nodeId));
-    rankState.host = vNodeHost;
-    nodeRanks_[rankState.nodeId].emplace_back(r);
-  }
+  nodeRanks_[0].emplace_back(rank_);
 }
 
 void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
@@ -126,7 +105,7 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
         commHash_,
         commDesc_,
         "bootstrap is required for multi-rank topology initialization");
-    initRankTopologyNolocal();
+    initSingleRankTopology();
     return;
   }
   auto myTopo = ctran::commstate::loadTopology(rank_, NCCL_TOPO_FILE_PATH);
@@ -368,7 +347,8 @@ void CommStateX::setRankStatesTopologies(
   // without altering the real hostname stored in rankState.host.
   std::unordered_map<std::string, std::vector<int>> nodeGroupMap;
 
-  for (const auto& rankTopology : rankTopologies_) {
+  for (int r = 0; r < static_cast<int>(rankTopologies_.size()); r++) {
+    const auto& rankTopology = rankTopologies_[r];
     const std::string host(rankTopology.host);
     const std::string rtsw(rankTopology.rtsw);
     const std::string su(rankTopology.su);
@@ -381,15 +361,14 @@ void CommStateX::setRankStatesTopologies(
     // ranks into virtual nodes of the given size.
     std::string nodeGroupKey = host;
     if (noLocal_) {
-      nodeGroupKey = "nolocal_node_" + std::to_string(rankTopology.rank);
+      nodeGroupKey = "nolocal_node_" + std::to_string(r);
     } else if (vCliqueSize_ > 0) {
-      nodeGroupKey =
-          "vnode_" + std::to_string(rankTopology.rank / vCliqueSize_);
+      nodeGroupKey = "vnode_" + std::to_string(r / vCliqueSize_);
     }
-    nodeGroupMap[nodeGroupKey].emplace_back(rankTopology.rank);
+    nodeGroupMap[nodeGroupKey].emplace_back(r);
 
     RankState state;
-    state.rank = rankTopology.rank;
+    state.rank = r;
     state.pid = rankTopology.pid;
     state.host = host;
     state.rtsw = rtsw;

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -266,12 +266,9 @@ class CommStateX {
   // and an associated communicator.
   std::vector<int> commRanksToWorldRanks_{};
 
-  // e.g map<host-name, localRankToRank>
-  // e.g map<host1: [0, 1, 2, 3], host2: [4, 5, 6, 7]>
-  std::unordered_map<std::string, std::vector<int>> hostToRanks_{};
-
-  // similar to hostToRanks_ but access by nodeId
-  // e.g vector<0: [0, 1, 2, 3], 1: [0, 1, 2, 3]>
+  // Node grouping: nodeRanks_[nodeId] = [rank0, rank1, ...]
+  // For virtual topologies (nolocal, vnode, vClique), node grouping may differ
+  // from physical host grouping.
   std::vector<std::vector<int>> nodeRanks_{};
 
   // similar to nodeRanks, but at nvlDomain level. e.g vector<0: [0, 1, 2, 3],

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -88,8 +88,6 @@ class CommStateX {
 
   std::shared_ptr<CommStateX> createCommStateXFromNcclComm(void* comm);
 
-  void initRankTopologyNolocal();
-  void initRankTopologyVnode(const int nLocalRanks);
   void initRankStatesTopology(meta::comms::IBootstrap* bootstrap);
 
   /* Setters */
@@ -196,6 +194,8 @@ class CommStateX {
   bool isSameDeviceRack(int myRank, int peer) const;
 
  private:
+  void initSingleRankTopology();
+
   /* Setters */
   void setRankStatesTopologies(std::vector<RankTopology> rankTopologies);
   void setCommRankToWorldRanks(std::vector<int> commRanksToWorldRanks);

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 
 #include "comms/ctran/commstate/CommStateX.h"
+#include "comms/ctran/tests/VerifyCommStateXUtil.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 
 namespace ncclx {
@@ -552,48 +553,113 @@ TEST(CommStateXTest, CommRankToWorldRanks) {
   EXPECT_EQ(commState->gRank(3), 7);
 }
 
-TEST(CommStateXTest, gPidTest) {
-  const int nRanks = 4;
-  const int cudaDev = 0;
-  const int cudaArch = 90;
-  const int64_t busId = 25;
-  const uint64_t commHash = 0;
-  const std::string kSu;
+// Parameterized test: verify host()/gPid() preserve real values and node
+// grouping is correct across all virtual topology modes.
+enum class TopoMode { kSystem, kNolocal, kVnode, kVClique };
 
-  std::vector<RankTopology> rankTopologies{};
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0, -1, 1000));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0, -1, 1001));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1, -1, 2000));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1, -1, 2001));
+struct TopoTestParam {
+  TopoMode mode;
+  int vCliqueSize; // only used for kVClique
+  int expectedNNodes;
+  int expectedNLocalRanks; // for rank 0
+};
 
-  for (int rank = 0; rank < nRanks; ++rank) {
-    auto commState = std::make_unique<CommStateX>(
-        rank,
-        nRanks,
-        cudaDev,
-        cudaArch,
-        busId,
-        commHash,
-        rankTopologies,
-        std::vector<int>{});
-
-    // Test gPid() for default (current) rank
-    std::string expectedGPid = std::string(rankTopologies[rank].host) + ":" +
-        std::to_string(rankTopologies[rank].pid);
-    EXPECT_EQ(commState->gPid(), expectedGPid);
-
-    // Test gPid(rank) for all ranks
-    for (int r = 0; r < nRanks; ++r) {
-      std::string expected = std::string(rankTopologies[r].host) + ":" +
-          std::to_string(rankTopologies[r].pid);
-      EXPECT_EQ(commState->gPid(r), expected);
-    }
+std::string topoTestName(const testing::TestParamInfo<TopoTestParam>& info) {
+  switch (info.param.mode) {
+    case TopoMode::kSystem:
+      return "system";
+    case TopoMode::kNolocal:
+      return "nolocal";
+    case TopoMode::kVnode:
+      return "vnode4";
+    case TopoMode::kVClique:
+      return "vclique" + std::to_string(info.param.vCliqueSize);
   }
+  return "unknown";
 }
+
+class GpidTopoTest : public ::testing::TestWithParam<TopoTestParam> {
+ protected:
+  static constexpr int kRanksPerHost = 4;
+  static constexpr int kNumHosts = 2;
+  static constexpr int kNRanks = kRanksPerHost * kNumHosts;
+  static constexpr int kCudaDev = 0;
+  static constexpr int kCudaArch = 90;
+  static constexpr int64_t kBusId = 25;
+  static constexpr uint64_t kCommHash = 0;
+
+  std::vector<RankTopology> makeRankTopologies() {
+    const std::string kSu;
+    const std::array<std::pair<const char*, const char*>, kNumHosts> hostInfo =
+        {{{kHost0, kRtsw0}, {kHost1, kRtsw1}}};
+    std::vector<RankTopology> topos;
+    topos.reserve(kNRanks);
+    for (int r = 0; r < kNRanks; r++) {
+      const auto& [host, rtsw] = hostInfo[r / kRanksPerHost];
+      const int pid = 1000 * (r / kRanksPerHost + 1) + r % kRanksPerHost;
+      topos.emplace_back(
+          createRankTopology(r, kDc, kZone, kSu, rtsw, host, -1, pid));
+    }
+    return topos;
+  }
+};
+
+TEST_P(GpidTopoTest, HostAndGpidPreserved) {
+  const auto& [mode, vCliqueSize, expectedNNodes, expectedNLocalRanks] =
+      GetParam();
+  auto rankTopologies = makeRankTopologies();
+
+  // Set CVAR for vnode mode (needs ncclx EnvRAII, not SysEnvRAII)
+  // nolocal and vClique are passed via constructor params instead.
+  std::unique_ptr<SysEnvRAII> envTopo, envPpn;
+  if (mode == TopoMode::kVnode) {
+    envTopo =
+        std::make_unique<SysEnvRAII>("NCCL_COMM_STATE_DEBUG_TOPO", "vnode");
+    envPpn = std::make_unique<SysEnvRAII>(
+        "NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS", "4");
+  }
+
+  const bool noLocal = (mode == TopoMode::kNolocal);
+  auto commState = std::make_unique<CommStateX>(
+      0,
+      kNRanks,
+      kCudaDev,
+      kCudaArch,
+      kBusId,
+      kCommHash,
+      rankTopologies,
+      std::vector<int>{},
+      "" /* commDesc */,
+      noLocal,
+      vCliqueSize);
+
+  // Node grouping matches expected virtual topology
+  EXPECT_EQ(commState->nNodes(), expectedNNodes);
+  EXPECT_EQ(commState->nLocalRanks(0), expectedNLocalRanks);
+
+  // Real hostname and gPid preserved for all ranks
+  using Helper = ctran::testing::VerifyCommStateXHelper;
+  for (int r = 0; r < kNRanks; ++r) {
+    Helper::verifyHost(commState.get(), r, rankTopologies[r].host);
+    Helper::verifyGPid(
+        commState.get(), r, rankTopologies[r].host, rankTopologies[r].pid);
+  }
+  Helper::verifyGPidUniqueness(commState.get(), kNRanks);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CommStateXTest,
+    GpidTopoTest,
+    ::testing::Values(
+        // system: 2 real hosts × 4 ranks each
+        TopoTestParam{TopoMode::kSystem, 0, 2, 4},
+        // nolocal: each rank is its own node
+        TopoTestParam{TopoMode::kNolocal, 0, 8, 1},
+        // vnode with nLocalRanks=4: 2 virtual nodes
+        TopoTestParam{TopoMode::kVnode, 0, 2, 4},
+        // vClique size=2: 4 virtual nodes of 2 ranks each
+        TopoTestParam{TopoMode::kVClique, 2, 4, 2}),
+    topoTestName);
 
 TEST(CommStateXTest, TopologySetInvalidNvlFabricTopos) {
   const int rank = 0;
@@ -663,9 +729,7 @@ TEST(CommStateXTest, nvlFabricWithNoLocal) {
       "" /* commDesc */,
       true /* noLocal */);
 
-  // noLocal is set at construction; initRankStatesTopology delegates to
-  // initRankTopologyNolocal
-  commState->initRankStatesTopology(nullptr);
+  commState->initRankTopologyNolocal();
 
   // Set up NVL fabric with 2 clusters of 4 ranks each (e.g. GB200 2-GPU trays)
   std::vector<NvlFabricTopology> nvlFabricTopologies{};

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <unistd.h>
 #include <cstdlib>
 #include <string>
 #include <vector>
@@ -661,6 +662,35 @@ INSTANTIATE_TEST_SUITE_P(
         TopoTestParam{TopoMode::kVClique, 2, 4, 2}),
     topoTestName);
 
+TEST(CommStateXTest, SingleRankTopology) {
+  auto commState = std::make_unique<CommStateX>(
+      0 /* rank */,
+      1 /* nRanks */,
+      0 /* cudaDev */,
+      90 /* cudaArch */,
+      25 /* busId */,
+      0 /* commHash */,
+      std::vector<RankTopology>{},
+      std::vector<int>{});
+
+  commState->initRankStatesTopology(nullptr);
+
+  EXPECT_EQ(commState->nRanks(), 1);
+  EXPECT_EQ(commState->nNodes(), 1);
+  EXPECT_EQ(commState->nLocalRanks(), 1);
+  EXPECT_EQ(commState->localRank(), 0);
+  EXPECT_EQ(commState->node(), 0);
+  EXPECT_FALSE(commState->host(0).empty());
+  EXPECT_FALSE(commState->gPid(0).empty());
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+  EXPECT_EQ(commState->host(0), std::string(hostname));
+  EXPECT_EQ(
+      commState->gPid(0),
+      std::string(hostname) + ":" + std::to_string(getpid()));
+}
+
 TEST(CommStateXTest, TopologySetInvalidNvlFabricTopos) {
   const int rank = 0;
   const int nRanks = 4;
@@ -715,8 +745,18 @@ TEST(CommStateXTest, nvlFabricWithNoLocal) {
   const int64_t busId = 25;
   const uint64_t commHash = 0;
 
-  // Create CommStateX with empty rank topologies (will be set by
-  // initRankTopologyNolocal)
+  // Build rank topologies with same host — noLocal=true will override
+  // to virtual per-rank nodes internally
+  std::vector<RankTopology> rankTopologies;
+  rankTopologies.reserve(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    RankTopology topo{};
+    topo.rank = r;
+    topo.pid = r;
+    std::strncpy(topo.host, "same_host", kMaxNameLen);
+    rankTopologies.push_back(topo);
+  }
+
   auto commState = std::make_unique<CommStateX>(
       rank,
       nRanks,
@@ -724,12 +764,10 @@ TEST(CommStateXTest, nvlFabricWithNoLocal) {
       cudaArch,
       busId,
       commHash,
-      std::vector<RankTopology>{},
+      rankTopologies,
       std::vector<int>{},
       "" /* commDesc */,
       true /* noLocal */);
-
-  commState->initRankTopologyNolocal();
 
   // Set up NVL fabric with 2 clusters of 4 ranks each (e.g. GB200 2-GPU trays)
   std::vector<NvlFabricTopology> nvlFabricTopologies{};
@@ -775,6 +813,18 @@ TEST(CommStateXTest, nvlFabricWithNoLocalCvar) {
   EnvRAII noLocalCvar(
       NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::nolocal);
 
+  // Build rank topologies with same host — CVAR nolocal will override
+  // to virtual per-rank nodes internally
+  std::vector<RankTopology> rankTopologies;
+  rankTopologies.reserve(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    RankTopology topo{};
+    topo.rank = r;
+    topo.pid = r;
+    std::strncpy(topo.host, "same_host", kMaxNameLen);
+    rankTopologies.push_back(topo);
+  }
+
   auto commState = std::make_unique<CommStateX>(
       rank,
       nRanks,
@@ -782,13 +832,10 @@ TEST(CommStateXTest, nvlFabricWithNoLocalCvar) {
       cudaArch,
       busId,
       commHash,
-      std::vector<RankTopology>{},
+      rankTopologies,
       std::vector<int>{},
       "" /* commDesc */,
       false /* noLocal - hint is NOT set, only CVAR */);
-
-  // initRankTopologyNolocal sets host-based nLocalRanks=1 for all ranks
-  commState->initRankTopologyNolocal();
 
   // Set up NVL fabric with 2 clusters of 4 ranks each (e.g. GB200 2-GPU trays)
   std::vector<NvlFabricTopology> nvlFabricTopologies{};

--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -160,7 +160,7 @@ TEST_P(DistRegCacheTestSuite, ExportImportMem) {
 
   std::unique_ptr<CtranIb> ctranIb;
   try {
-    ctranIb = std::make_unique<CtranIb>(comm_.get(), nullptr);
+    ctranIb = std::make_unique<CtranIb>(comm_.get(), std::nullopt);
   } catch (const std::bad_alloc&) {
     GTEST_SKIP() << "IB backend failed to allocate. Skip test";
   }

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -141,15 +141,9 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
   std::unique_ptr<meta::comms::IBootstrap> commBootstrap(
       meta::comms::createBootstrap("ctrancomm"));
 
-  // Initialize topology
-  if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-    comm->statex_->initRankTopologyNolocal();
-  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-    comm->statex_->initRankTopologyVnode(
-        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-  } else {
-    comm->statex_->initRankStatesTopology(commBootstrap.get());
-  }
+  // Always use bootstrap to get real pids. Virtual topology overrides
+  // (nolocal, vnode, vClique) are applied inside setRankStatesTopologies.
+  comm->statex_->initRankStatesTopology(commBootstrap.get());
 
   comm->bootstrap_ = std::make_unique<ctran::testing::CtranTestBootstrap>(
       std::move(commBootstrap));

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -529,21 +529,6 @@ std::unique_ptr<CtranComm> CtranStandaloneFixture::makeCtranComm(
 
 namespace {
 
-void initRankStatesTopologyWrapper(
-    ncclx::CommStateX* statex,
-    meta::comms::IBootstrap* bootstrap,
-    int nRanks) {
-  // Fake topology with nLocalRanks=1
-  if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-    statex->initRankTopologyNolocal();
-  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-    ASSERT_GE(nRanks, NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-    statex->initRankTopologyVnode(NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-  } else {
-    statex->initRankStatesTopology(std::move(bootstrap));
-  }
-}
-
 using PerRankState = CtranIntraProcessFixture::PerRankState;
 static void resetPerRankState(PerRankState& state) {
   if (state.dstBuffer != nullptr) {
@@ -601,8 +586,7 @@ void initCtranCommMultiRank(
       std::move(rankTopologies),
       std::move(commRanksToWorldRanks),
       std::string{kMultiRankCommDesc});
-  initRankStatesTopologyWrapper(
-      ctranComm->statex_.get(), ctranComm->bootstrap_.get(), nRanks);
+  ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
 
   FB_COMMCHECKTHROW_EX_NOCOMM(ctranInit(ctranComm));
 

--- a/comms/ctran/tests/CtranTestUtils.h
+++ b/comms/ctran/tests/CtranTestUtils.h
@@ -110,11 +110,7 @@ inline CtranCommWithBootstrap createCtranCommWithBootstrap(
       std::move(commRanksToWorldRanks),
       std::string{commDesc});
 
-  // For single-rank communicators (nRanks=1), use nolocal topology mode
-  // which doesn't require bootstrap communication.
-  if (nRanks == 1) {
-    ctranComm->statex_->initRankTopologyNolocal();
-  }
+  ctranComm->statex_->initRankStatesTopology(ctranComm->bootstrap_.get());
 
   FB_COMMCHECKTHROW_EX(ctranInit(ctranComm.get()), ctranComm->logMetaData_);
 

--- a/comms/ctran/tests/VerifyCommStateXUtil.cc
+++ b/comms/ctran/tests/VerifyCommStateXUtil.cc
@@ -20,31 +20,51 @@ VerifyCommStateXHelper::RankIdentity::local() {
   return id;
 }
 
+void VerifyCommStateXHelper::verifyHost(
+    const ncclx::CommStateX* statex,
+    int rank,
+    const std::string& expectedHostname) {
+  EXPECT_EQ(statex->host(rank), expectedHostname)
+      << "rank " << rank << " host mismatch";
+}
+
+void VerifyCommStateXHelper::verifyGPid(
+    const ncclx::CommStateX* statex,
+    int rank,
+    const std::string& expectedHostname,
+    int expectedPid) {
+  const std::string expectedGPid =
+      fmt::format("{}:{}", expectedHostname, expectedPid);
+  EXPECT_EQ(statex->gPid(rank), expectedGPid)
+      << "rank " << rank << " gPid mismatch";
+}
+
+void VerifyCommStateXHelper::verifyGPidUniqueness(
+    const ncclx::CommStateX* statex,
+    int nRanks) {
+  std::set<std::string> gPids;
+  for (int r = 0; r < nRanks; r++) {
+    auto [it, inserted] = gPids.insert(statex->gPid(r));
+    EXPECT_TRUE(inserted) << "gPid collision at rank " << r << ": "
+                          << statex->gPid(r);
+  }
+}
+
 void VerifyCommStateXHelper::verifyAllHosts(
     const ncclx::CommStateX* statex,
     const std::vector<RankIdentity>& allRankIds) const {
-  const int numRanks = static_cast<int>(allRankIds.size());
-  for (int r = 0; r < numRanks; r++) {
-    EXPECT_EQ(statex->host(r), std::string(allRankIds[r].hostname))
-        << "rank " << r << " host mismatch";
+  for (int r = 0; r < static_cast<int>(allRankIds.size()); r++) {
+    verifyHost(statex, r, allRankIds[r].hostname);
   }
 }
 
 void VerifyCommStateXHelper::verifyAllGPids(
     const ncclx::CommStateX* statex,
     const std::vector<RankIdentity>& allRankIds) const {
-  const int numRanks = static_cast<int>(allRankIds.size());
-  std::set<std::string> gPids;
-  for (int r = 0; r < numRanks; r++) {
-    const std::string expectedGPid =
-        fmt::format("{}:{}", allRankIds[r].hostname, allRankIds[r].pid);
-    EXPECT_EQ(statex->gPid(r), expectedGPid)
-        << "rank " << r << " gPid mismatch";
-
-    auto [it, inserted] = gPids.insert(statex->gPid(r));
-    EXPECT_TRUE(inserted) << "gPid collision at rank " << r << ": "
-                          << statex->gPid(r);
+  for (int r = 0; r < static_cast<int>(allRankIds.size()); r++) {
+    verifyGPid(statex, r, allRankIds[r].hostname, allRankIds[r].pid);
   }
+  verifyGPidUniqueness(statex, static_cast<int>(allRankIds.size()));
 }
 
 } // namespace ctran::testing

--- a/comms/ctran/tests/VerifyCommStateXUtil.h
+++ b/comms/ctran/tests/VerifyCommStateXUtil.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 
 namespace ncclx {
@@ -22,6 +23,18 @@ class VerifyCommStateXHelper {
     // Factory: populate with current process's hostname and pid
     static RankIdentity local();
   };
+
+  // Per-rank verification (no RankIdentity needed)
+  static void verifyHost(
+      const ncclx::CommStateX* statex,
+      int rank,
+      const std::string& expectedHostname);
+  static void verifyGPid(
+      const ncclx::CommStateX* statex,
+      int rank,
+      const std::string& expectedHostname,
+      int expectedPid);
+  static void verifyGPidUniqueness(const ncclx::CommStateX* statex, int nRanks);
 
   // Verify hostname matches for all ranks
   void verifyAllHosts(

--- a/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
@@ -86,7 +86,7 @@ TEST_F(CommStateXDistTest, CreateNoLocalFromNcclComm) {
   // initRankTopologyFrom fix lands
 }
 
-TEST_F(CommStateXDistTest, DISABLED_CreateVCliqueSizeFromNcclComm) {
+TEST_F(CommStateXDistTest, CreateVCliqueSizeFromNcclComm) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints({{"vCliqueSize", "2"}});
   config.hints = &hints;

--- a/comms/rcclx/develop/meta/ctran/MetaFactory.cc
+++ b/comms/rcclx/develop/meta/ctran/MetaFactory.cc
@@ -155,19 +155,7 @@ std::unique_ptr<ncclx::CommStateX> createCtranCommStateXFromNcclComm(
       std::vector<ncclx::RankTopology>(), /* rankTopologies */
       std::vector<int>() /* commRanksToWorldRanks */);
 
-  if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal) {
-    commStateX->initRankTopologyNolocal();
-  } else if (NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::vnode) {
-    FB_CHECKABORT(
-        ncclComm->nRanks >= NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS,
-        "CommStateX: NCCL_COMM_STATE_DEBUG_TOPO::vnode initialize failed because number of available ranks (%d) is less than nLocalRanks per vnode (NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS=%d).",
-        ncclComm->nRanks,
-        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-    commStateX->initRankTopologyVnode(
-        NCCL_COMM_STATE_DEBUG_TOPO_VNODE_NLOCALRANKS);
-  } else {
-    commStateX->initRankStatesTopology(ctranComm->bootstrap_.get());
-  }
+  commStateX->initRankStatesTopology(ctranComm->bootstrap_.get());
 
   INFO(
       NCCL_INIT | NCCL_GRAPH,


### PR DESCRIPTION
Summary:

After initRankStatesTopology handles all virtual topology modes internally, the public initRankTopologyNolocal/initRankTopologyVnode are no longer needed:
- Rename initRankTopologyNolocal to private initSingleRankTopology (used only as single-rank-no-bootstrap fallback inside initRankStatesTopology)
- Delete initRankTopologyVnode entirely (no internal use case)
- Update all callsites in rcclx, mccl, ctran tests, and benchmarks to use initRankStatesTopology(bootstrap)
- Delete mccl initRankTopologyNoSystem() wrapper

Reviewed By: dboyda, Scusemua

Differential Revision: D101926079


