### PR TITLE
OSS build fixes for fmt v12 strictness and missing include

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -314,7 +314,7 @@ Result<RegisteredSegment> MultiTransportFactory::registerSegment(
       UNIFLOW_LOG_WARN(
           "Segment {} cannot be registered on transport {}: {}",
           segment.data(),
-          f->transportType(),
+          toStringView(f->transportType()),
           handle.error().message());
     }
   }

--- a/comms/uniflow/drivers/nvml/NvmlApi.cpp
+++ b/comms/uniflow/drivers/nvml/NvmlApi.cpp
@@ -7,6 +7,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <array>
 #include <mutex>
 #include <string>
 

--- a/comms/uniflow/transport/TransportType.h
+++ b/comms/uniflow/transport/TransportType.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 namespace uniflow {
 
@@ -13,5 +14,21 @@ enum TransportType : uint8_t {
   Mock, // Mock transport for testing
   NumTransportType,
 };
+
+constexpr std::string_view toStringView(TransportType t) noexcept {
+  switch (t) {
+    case TransportType::NVLink:
+      return "NVLink";
+    case TransportType::RDMA:
+      return "RDMA";
+    case TransportType::TCP:
+      return "TCP";
+    case TransportType::Mock:
+      return "Mock";
+    case TransportType::NumTransportType:
+      break;
+  }
+  return "Unknown";
+}
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -827,13 +827,13 @@ void RdmaTransport::pollCompletions(uint32_t id, bool retry) {
                 taskId,
                 numWrs,
                 wc.qp_num,
-                wc.status);
-            it->second->complete(
-                Err(ErrCode::DriverError,
-                    "RDMA WR failed: wr_id=" + std::to_string(wc.wr_id) +
-                        " taskId=" + std::to_string(taskId) +
-                        " numWrs=" + std::to_string(numWrs) +
-                        " status=" + std::to_string(wc.status)));
+                static_cast<int>(wc.status));
+            it->second->complete(Err(
+                ErrCode::DriverError,
+                "RDMA WR failed: wr_id=" + std::to_string(wc.wr_id) +
+                    " taskId=" + std::to_string(taskId) +
+                    " numWrs=" + std::to_string(numWrs) +
+                    " status=" + std::to_string(static_cast<int>(wc.status))));
           }
 
           // decrement counter


### PR DESCRIPTION
Summary:
Three small OSS build fixes that surface only in the GitHub CI environment (newer fmt/spdlog, stricter compiler hygiene). Buck's pinned toolchain hides them.

- NvmlApi.cpp: add missing `<array>` include. Buck builds get it transitively; the OSS build does not.
- RdmaTransport.cpp: cast `ibv_wc_status` to `int` at log/serialization sites. fmt v12 refuses to format unscoped enums without an explicit `formatter<T>` specialization.
- TransportType.h + MultiTransport.cpp: same fmt v12 issue for `uniflow::TransportType`. Added a `toStringView()` helper in the header so log sites pass a `std::string_view` instead of the raw enum, keeping log output human-readable.

Reviewed By: tanquer

Differential Revision: D104115052


