### PR TITLE
Remove unused EventsScubaUtil.h includes from proxy.cc and group.cc (#2416)

### DIFF
--- a/comms/ncclx/v2_30/src/group.cc
+++ b/comms/ncclx/v2_30/src/group.cc
@@ -27,7 +27,6 @@
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportProxy.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
 #include "meta/wrapper/MetaFactory.h"
 
 #define GROUP_MAX_RECLAIM_STEPS 10

--- a/comms/ncclx/v2_30/src/proxy.cc
+++ b/comms/ncclx/v2_30/src/proxy.cc
@@ -26,7 +26,6 @@
 #include <thread>
 
 #include "meta/colltrace/ProxyTraceFunc.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
 
 #define NCCL_MAX_PROXY_CONNECTIONS (NCCL_MAX_LOCAL_RANKS+1)
 


### PR DESCRIPTION
Summary:

Remove unused `#include "comms/utils/logger/EventsScubaUtil.h"` from `proxy.cc` and `group.cc`. Neither file references any Scuba symbols (EVENTS_SCUBA_UTIL_SAMPLE_GUARD, NcclScubaEvent, lapAndRecord, StickyContextGuard). The include was likely added as a blanket inclusion during a previous rebase and is dead code in both files.

Reviewed By: snarayankh

Differential Revision: D104146008


