### PR TITLE
Wire MemoryTracer into commDump via CommsMonitor (#2417)

### DIFF
--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ProcessGlobalErrorsUtil.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 #include "meta/colltrace/ProxyTrace.h"
 #include "meta/commDump.h"
 #include "meta/comms-monitor/CommsMonitor.h"
@@ -182,6 +183,14 @@ static void dumpProxyTrace(
   }
 }
 
+static void dumpMemoryTrace(
+    const std::shared_ptr<meta::comms::memtrace::MemoryTrace>& memTracer,
+    std::unordered_map<std::string, std::string>& map) {
+  if (memTracer) {
+    map["memory"] = memTracer->dump();
+  }
+}
+
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     const ncclx::comms_monitor::NcclCommMonitorInfo& info) {
   std::unordered_map<std::string, std::string> map;
@@ -198,6 +207,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
   }
   dumpProcessGlobalErrors(map);
+  dumpMemoryTrace(info.memTracer, map);
   return map;
 }
 

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -87,7 +87,9 @@ folly::Singleton<CommsMonitor, CommsMonitorSingletonTag>
       .topoInfo = getTopoInfoFromNcclComm(comm),
       .mapperTrace = mapperTrace,
       .proxyTrace = proxyTrace,
-      .newCollTrace = comm->newCollTrace};
+      .newCollTrace = comm->newCollTrace,
+      .memTracer = meta::comms::memtrace::MemoryTrace::getOrCreate(
+          comm->logMetaData.commHash)};
 }
 
 bool CommsMonitor::deregisterCommImpl(ncclComm_t comm) {

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -10,6 +10,7 @@
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::comms_monitor {
@@ -35,6 +36,10 @@ struct NcclCommMonitorInfo {
     ALIVE,
     DEAD,
   } status = CommStatus::ALIVE;
+
+  // Adopted from MemoryTrace::getOrCreate() at registerComm time.
+  // See MemoryTrace::getOrCreate() for dual ownership rationale.
+  std::shared_ptr<meta::comms::memtrace::MemoryTrace> memTracer;
 
   static NcclCommMonitorInfo fromNcclComm(ncclComm_t comm);
 };

--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -68,6 +68,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -75,6 +75,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -81,6 +81,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/utils/memtrace/tests/MemoryTraceTest.cc
+++ b/comms/utils/memtrace/tests/MemoryTraceTest.cc
@@ -78,3 +78,31 @@ TEST(MemoryTraceTest, DumpProducesValidJson) {
   EXPECT_TRUE(parsed.count("peakUsage"));
   EXPECT_GE(parsed["totalAllocated"].asInt(), 8192);
 }
+
+// Tests the commDump integration pattern: adopt a MemoryTrace by commHash,
+// record events, then dump to a string→string map (as commDump does).
+TEST(MemoryTraceTest, DumpToCommDumpMap) {
+  const uint64_t commHash = 0x5001;
+  auto trace = MemoryTrace::getOrCreate(commHash);
+
+  // Simulate ncclCommInit allocations
+  trace->recordAlloc(0xA001, 1024 * 1024);
+  trace->recordAlloc(0xA002, 512 * 1024);
+
+  // commDump reads the trace into a map
+  std::unordered_map<std::string, std::string> map;
+  map["memory"] = trace->dump();
+
+  auto parsed = folly::parseJson(map["memory"]);
+  EXPECT_EQ(parsed["totalAllocated"].asInt(), 1024 * 1024 + 512 * 1024);
+  EXPECT_EQ(parsed["currentUsage"].asInt(), 1024 * 1024 + 512 * 1024);
+  EXPECT_EQ(parsed["peakUsage"].asInt(), 1024 * 1024 + 512 * 1024);
+
+  // Simulate ncclCommDestroy: free without size (ncclCudaFree pattern)
+  trace->recordFree(0xA001, std::nullopt);
+
+  auto stats = trace->getStats();
+  EXPECT_EQ(stats.totalFreed, 1024 * 1024);
+  EXPECT_EQ(stats.currentUsage, 512 * 1024);
+  EXPECT_EQ(stats.peakUsage, 1024 * 1024 + 512 * 1024);
+}


### PR DESCRIPTION
Summary:

Wire the MemoryTracer into commDump/commDumpAll so per-comm memory stats are exposed:
- Added memTracer field (shared_ptr<MemoryTracer>) to NcclCommMonitorInfo
- Populate memTracer via MemoryTracer::getOrCreate(commHash) in fromNcclComm()
- Added dumpMemoryTrace() helper in commDump.cc that writes the "memory" key
- Called from commDumpByMonitorInfo() after dumpProcessGlobalErrors()
- Output format: {"totalAllocated":N,"totalFreed":N,"currentUsage":N,"peakUsage":N}

Reviewed By: dsjohns2

Differential Revision: D96010723


