### PR TITLE
Migrate memory logging call sites to memtrace (#2418)

### DIFF
--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/ProcessGlobalErrorsUtil.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 #include "meta/colltrace/ProxyTrace.h"
 #include "meta/commDump.h"
 #include "meta/comms-monitor/CommsMonitor.h"
@@ -182,6 +183,14 @@ static void dumpProxyTrace(
   }
 }
 
+static void dumpMemoryTrace(
+    const std::shared_ptr<meta::comms::memtrace::MemoryTrace>& memTracer,
+    std::unordered_map<std::string, std::string>& map) {
+  if (memTracer) {
+    map["memory"] = memTracer->dump();
+  }
+}
+
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     const ncclx::comms_monitor::NcclCommMonitorInfo& info) {
   std::unordered_map<std::string, std::string> map;
@@ -198,6 +207,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
   }
   dumpProcessGlobalErrors(map);
+  dumpMemoryTrace(info.memTracer, map);
   return map;
 }
 

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -87,7 +87,9 @@ folly::Singleton<CommsMonitor, CommsMonitorSingletonTag>
       .topoInfo = getTopoInfoFromNcclComm(comm),
       .mapperTrace = mapperTrace,
       .proxyTrace = proxyTrace,
-      .newCollTrace = comm->newCollTrace};
+      .newCollTrace = comm->newCollTrace,
+      .memTracer = meta::comms::memtrace::MemoryTrace::getOrCreate(
+          comm->logMetaData.commHash)};
 }
 
 bool CommsMonitor::deregisterCommImpl(ncclComm_t comm) {

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -10,6 +10,7 @@
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 #include "meta/colltrace/ProxyTrace.h"
 
 namespace ncclx::comms_monitor {
@@ -35,6 +36,10 @@ struct NcclCommMonitorInfo {
     ALIVE,
     DEAD,
   } status = CommStatus::ALIVE;
+
+  // Adopted from MemoryTrace::getOrCreate() at registerComm time.
+  // See MemoryTrace::getOrCreate() for dual ownership rationale.
+  std::shared_ptr<meta::comms::memtrace::MemoryTrace> memTracer;
 
   static NcclCommMonitorInfo fromNcclComm(ncclComm_t comm);
 };

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -21,20 +21,21 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/utils/logger/tests/MockScubaTable.h"
 
-#include "LoggerUtil.h"
+#include "VerifyTopoUtil.h"
 #include "comm.h" // @manual
-#include "comms/ncclx/meta/tests/VerifyTopoUtil.h"
+#include "comms/ncclx/meta/logger/tests/LoggerUtil.h"
 #include "debug.h" // @manual
+#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h" // @manual
 
-class MemoryLoggingTestFixture
-    : public NcclxBaseTestFixture,
-      public ::testing::WithParamInterface<NcclxEnvs> {
+class MemoryTraceTestFixture : public NcclxBaseTestFixture,
+                               public ::testing::WithParamInterface<NcclxEnvs> {
  public:
-  MemoryLoggingTestFixture() = default;
+  MemoryTraceTestFixture() = default;
   void SetUp() override {
     ctran::utils::commCudaLibraryInit();
     setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_MEMTRACE_ENABLE", "1", 1);
     setenv("NCCL_MEMORY_EVENT_LOGGING", "pipe:nccl_memory_logging", 1);
     NcclxBaseTestFixture::SetUp(GetParam());
     setenv("RANK", std::to_string(this->globalRank).c_str(), 1);
@@ -213,13 +214,45 @@ class MemoryLoggingTestFixture
   }
 
  protected:
+  void runNcclInternalBufferLogTest();
+  void runUserBufferLoggingTest();
+
   cudaStream_t stream;
   void* sendBuf{nullptr};
   void* recvBuf{nullptr};
   bool mockPassthru{true};
 };
 
-TEST_P(MemoryLoggingTestFixture, ncclInternalBufferLogTest) {
+class MemoryTraceNolocalTestFixture : public MemoryTraceTestFixture {
+ public:
+  void SetUp() override {
+    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+    MemoryTraceTestFixture::SetUp();
+  }
+
+  void TearDown() override {
+    MemoryTraceTestFixture::TearDown();
+    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+  }
+};
+
+TEST_P(MemoryTraceTestFixture, ncclInternalBufferLogTest) {
+  runNcclInternalBufferLogTest();
+}
+
+TEST_P(MemoryTraceTestFixture, userBufferLoggingTest) {
+  runUserBufferLoggingTest();
+}
+
+TEST_P(MemoryTraceNolocalTestFixture, ncclInternalBufferLogTest) {
+  runNcclInternalBufferLogTest();
+}
+
+TEST_P(MemoryTraceNolocalTestFixture, userBufferLoggingTest) {
+  runUserBufferLoggingTest();
+}
+
+void MemoryTraceTestFixture::runNcclInternalBufferLogTest() {
   folly::test::TemporaryDirectory tmpDir;
   auto scubaLogDirGuard =
       EnvRAII(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
@@ -319,7 +352,7 @@ TEST_P(MemoryLoggingTestFixture, ncclInternalBufferLogTest) {
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
-TEST_P(MemoryLoggingTestFixture, userBufferLoggingTest) {
+void MemoryTraceTestFixture::runUserBufferLoggingTest() {
   folly::test::TemporaryDirectory tmpDir;
   auto scubaLogDirGuard =
       EnvRAII(NCCL_SCUBA_LOG_FILE_PREFIX, tmpDir.path().string());
@@ -385,18 +418,14 @@ TEST_P(MemoryLoggingTestFixture, userBufferLoggingTest) {
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    MyTestSuite,
-    MemoryLoggingTestFixture,
-    testing::Values(
-        // Baseline
-        NcclxEnvs({{"NCCL_USE_MEM_CACHE", "0"}}),
-        // MemOpt + lazy setup channels
-        NcclxEnvs(
-            {{"NCCL_USE_MEM_CACHE", "1"}, {"NCCL_LAZY_SETUP_CHANNELS", "1"}})),
-    [](const testing::TestParamInfo<MemoryLoggingTestFixture::ParamType>&
-           info) {
-      // generate test-name for a given NcclxEnvs
+// Base env params shared by both suites
+const auto kBaseEnvParams = testing::Values(
+    NcclxEnvs({{"NCCL_USE_MEM_CACHE", "0"}}),
+    NcclxEnvs(
+        {{"NCCL_USE_MEM_CACHE", "1"}, {"NCCL_LAZY_SETUP_CHANNELS", "1"}}));
+
+auto kTestNameGen =
+    [](const testing::TestParamInfo<MemoryTraceTestFixture::ParamType>& info) {
       std::string name;
       for (const auto& [key, val] : info.param) {
         if (key == "NCCL_USE_MEM_CACHE") {
@@ -404,7 +433,19 @@ INSTANTIATE_TEST_SUITE_P(
         }
       }
       return name;
-    });
+    };
+
+INSTANTIATE_TEST_SUITE_P(
+    Default,
+    MemoryTraceTestFixture,
+    kBaseEnvParams,
+    kTestNameGen);
+
+INSTANTIATE_TEST_SUITE_P(
+    Nolocal,
+    MemoryTraceNolocalTestFixture,
+    kBaseEnvParams,
+    kTestNameGen);
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -68,6 +68,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/ncclx/v2_28/src/Makefile
+++ b/comms/ncclx/v2_28/src/Makefile
@@ -75,6 +75,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -81,6 +81,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/trainer/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/logger/*.cc)
 ## Common Utils shared between comm libraries
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
+## Memory tracing
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)

--- a/comms/ncclx/v2_29/src/allocator.cc
+++ b/comms/ncclx/v2_29/src/allocator.cc
@@ -12,7 +12,7 @@
 #include "utils.h"
 
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 NCCL_API(ncclResult_t, ncclMemAlloc, void **ptr, size_t size);
 ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
@@ -80,7 +80,7 @@ ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
     CUCHECK(cuMemAddressReserve((CUdeviceptr*)ptr, handleSize, memGran, 0, 0));
     /* Map the virtual address range to the physical allocation */
     CUCHECK(cuMemMap((CUdeviceptr)*ptr, handleSize, 0, handle, 0));
-    logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
+    meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
     /* Now allow RW access to the newly mapped memory */
     for (int i = 0; i < dcnt; ++i) {
       int p2p = 0;
@@ -101,7 +101,7 @@ fallback:
   // we want CUDA to return an error to the caller.
   // coverity[var_deref_model]
   CUDACHECKGOTO(cudaMalloc(ptr, size), ret, fail);
-  logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
+  meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
 
 exit:
   return ret;

--- a/comms/ncclx/v2_29/src/include/alloc.h
+++ b/comms/ncclx/v2_29/src/include/alloc.h
@@ -28,7 +28,7 @@ struct ncclComm;
 #endif
 
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 uint64_t clockNano(); // from utils.h with which we have a circular dependency
 
@@ -293,12 +293,12 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
   if (manager != nullptr) {
     ncclMemTrack(manager, *ptr, size, handle, type, memType);
   }
-  logMemoryEvent(
-    memLogMetaData,
-    callsite,
-    "ncclCuMemAlloc",
-    reinterpret_cast<uintptr_t>(*ptr),
-    size);
+  meta::comms::memtrace::recordAlloc(
+      memLogMetaData,
+      callsite,
+      "ncclCuMemAlloc",
+      reinterpret_cast<uintptr_t>(*ptr),
+      size);
   memLogMetaData = CommLogData{};
   return result;
 }
@@ -315,7 +315,7 @@ static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manag
     CUCHECK(cuMemGetAddressRange(NULL, &segmentSize, (CUdeviceptr)ptr + totalSize));
     TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle 0x%llx segment %d numSegments %d", segmentSize, ptr, handle, segment, numSegments);
     CUCHECK(cuMemUnmap((CUdeviceptr)ptr + totalSize, segmentSize));
-  logMemoryEvent(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
+  meta::comms::memtrace::recordFree(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
   memLogMetaData = CommLogData{};
     CUCHECK(cuMemRelease(handle));
     totalSize += segmentSize;
@@ -406,7 +406,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA malloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p memType %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, memType);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         memLogMetaData,
         callsite.c_str(),
         "ncclCudaMalloc",
@@ -444,12 +444,12 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Calloc Size %ld pointer %p memType %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, memType);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
-      memLogMetaData,
-      callsite.c_str(),
-      "ncclCudaCalloc",
-      reinterpret_cast<uintptr_t>(*ptr),
-      nelem * ncclSizeOfT<T>());
+    meta::comms::memtrace::recordAlloc(
+        memLogMetaData,
+        callsite.c_str(),
+        "ncclCudaCalloc",
+        reinterpret_cast<uintptr_t>(*ptr),
+        nelem * ncclSizeOfT<T>());
     memLogMetaData = CommLogData{};
   }
   return result;
@@ -477,7 +477,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc async %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda CallocAsync Size %ld pointer %p memType %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, memType);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         memLogMetaData,
         callsite,
         "ncclCudaCallocAsync",
@@ -550,7 +550,7 @@ ncclResult_t ncclCudaFree(T* ptr, struct ncclMemManager* manager, int numSegment
   }
 finish:
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordFree(
         memLogMetaData,
         "",
         "ncclCudaFree",

--- a/comms/ncclx/v2_29/src/register/register.cc
+++ b/comms/ncclx/v2_29/src/register/register.cc
@@ -16,6 +16,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "comms/ctran/Ctran.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 // conflict with ctran, disable for now.
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);
@@ -149,17 +150,16 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-      logMemoryEvent(
-        comm->logMetaData,
-        "",
-        "ncclCommRegister",
-        reinterpret_cast<uintptr_t>(*handle),
-        size,
-        0,
-        std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+      meta::comms::memtrace::recordReg(
+          comm->logMetaData,
+          "",
+          "ncclCommRegister",
+          reinterpret_cast<uintptr_t>(*handle),
+          size,
+          0,
+          std::chrono::duration_cast<std::chrono::microseconds>(
+              std::chrono::steady_clock::now() - timerBegin)
+              .count());
   }
   return ncclSuccess;
 }
@@ -234,7 +234,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordReg(
         comm->logMetaData,
         "",
         "ncclCommDeregister",
@@ -242,9 +242,8 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
         0,
         0,
         std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+            std::chrono::steady_clock::now() - timerBegin)
+            .count());
   }
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_29/src/transport/nvls.cc
+++ b/comms/ncclx/v2_29/src/transport/nvls.cc
@@ -19,6 +19,7 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/ctran/memory/Utils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 #if CUDART_VERSION >= 12010
 
@@ -277,12 +278,12 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   CUDACHECKGOTO(cudaMemset(*ucptr, 0, ucsize), ret, fail3);
   // Track NVLS buffer as persistent memory
   NCCLCHECKGOTO(ncclMemTrack(comm->memManager, *ucptr, ucsize, *ucHandle, ncclCuMemHandleType, ncclMemPersist), ret, fail3);
-  logMemoryEvent(
-    comm->logMetaData,
-    "nvlsAllocateMem",
-    "cuMemCreate",
-    reinterpret_cast<uintptr_t>(*ucptr),
-    size);
+  meta::comms::memtrace::recordAlloc(
+      comm->logMetaData,
+      "nvlsAllocateMem",
+      "cuMemCreate",
+      reinterpret_cast<uintptr_t>(*ucptr),
+      size);
 
   // intra-node barrier to mitigate the possible hang in cuMulticastBindMem during abort
   NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, comm->localRankToRank[0]), ret, fail3);

--- a/comms/utils/memtrace/tests/MemoryTraceTest.cc
+++ b/comms/utils/memtrace/tests/MemoryTraceTest.cc
@@ -78,3 +78,31 @@ TEST(MemoryTraceTest, DumpProducesValidJson) {
   EXPECT_TRUE(parsed.count("peakUsage"));
   EXPECT_GE(parsed["totalAllocated"].asInt(), 8192);
 }
+
+// Tests the commDump integration pattern: adopt a MemoryTrace by commHash,
+// record events, then dump to a string→string map (as commDump does).
+TEST(MemoryTraceTest, DumpToCommDumpMap) {
+  const uint64_t commHash = 0x5001;
+  auto trace = MemoryTrace::getOrCreate(commHash);
+
+  // Simulate ncclCommInit allocations
+  trace->recordAlloc(0xA001, 1024 * 1024);
+  trace->recordAlloc(0xA002, 512 * 1024);
+
+  // commDump reads the trace into a map
+  std::unordered_map<std::string, std::string> map;
+  map["memory"] = trace->dump();
+
+  auto parsed = folly::parseJson(map["memory"]);
+  EXPECT_EQ(parsed["totalAllocated"].asInt(), 1024 * 1024 + 512 * 1024);
+  EXPECT_EQ(parsed["currentUsage"].asInt(), 1024 * 1024 + 512 * 1024);
+  EXPECT_EQ(parsed["peakUsage"].asInt(), 1024 * 1024 + 512 * 1024);
+
+  // Simulate ncclCommDestroy: free without size (ncclCudaFree pattern)
+  trace->recordFree(0xA001, std::nullopt);
+
+  auto stats = trace->getStats();
+  EXPECT_EQ(stats.totalFreed, 1024 * 1024);
+  EXPECT_EQ(stats.currentUsage, 512 * 1024);
+  EXPECT_EQ(stats.peakUsage, 1024 * 1024 + 512 * 1024);
+}


### PR DESCRIPTION
Summary:

Migrate ncclx v2.29 memory logging call sites from the old logMemoryEvent() API to the new meta::comms::memtrace API:
- Replace logMemoryEvent() calls with recordAlloc(), recordFree(), and recordReg() in allocator.cc, alloc.h, register.cc, and nvls.cc
- Remove the isRegMemEvent bool parameter — recordReg() handles registration events by design
- Add #include "comms/utils/memtrace/MemoryTrace.h" in register.cc and nvls.cc (alloc.h already had the old header)
- Enable NCCL_MEMTRACE_ENABLE=1 in test setup
- Rename and relocate test: MemoryLoggingTest.cc → MemoryTraceDistTest.cc (meta/logger/tests/ → meta/tests/), class MemoryLoggingTestFixture → MemoryTraceTestFixture
- Extract logger_util header-only library in meta/logger/tests/BUCK for cross-directory reuse
- Add memtrace dep to v2_29 def_build.bzl and src/Makefile
- Split test into two suites: Default (system topology) and Nolocal (kCommNoLocal hint, exercises NET/IB transport paths on 1x8)
- Reduce test config from 2x8 to 1x8 — nolocal suite covers cross-node transport coverage without requiring multi-node

Reviewed By: dsjohns2

Differential Revision: D104130635
