### PR TITLE
return work from alltoallv_dynamic_combine in distwrap

### DIFF
--- a/comms/torchcomms/distwrap/collectives_extension.py
+++ b/comms/torchcomms/distwrap/collectives_extension.py
@@ -100,7 +100,7 @@ def alltoallv_dynamic_combine(
     D: int,
     group: ProcessGroup | None = None,
     async_op: bool = False,
-) -> None:
+) -> Any:
     if not torchcomms_is_enabled():
         raise AssertionError(
             "alltoallv_dynamic_combine requires torchcomms to be enabled"
@@ -117,7 +117,7 @@ def alltoallv_dynamic_combine(
         )
 
     ncclx_backend = tc.get_backend_impl()
-    ncclx_backend.alltoallv_dynamic_combine(
+    return ncclx_backend.alltoallv_dynamic_combine(
         output_tensor,
         input_tensor,
         input_split_sizes,


### PR DESCRIPTION
when `async_op=True` `distwrap.alltoallv_dynamic_combine` was returning None in this wrapper.

```
work = torchcomms.distwrap.alltoallv_dynamic_combine(..., async_op=True)
print(work)   # before: None, after: TorchWork
work.wait()   # before: AttributeError on None; after: works
```
