### PR TITLE
Remove unused imports and fix lint warnings

### DIFF
--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
@@ -29,10 +29,6 @@ from torch.distributed.flight_recorder.components.types import (
 )
 from torchcomms.hooks import FlightRecorderHook
 from torchcomms.objcol import all_gather_object
-from torchcomms.tests.integration.py.TorchCommTestHelpers import (
-    get_rank_and_size,
-    skip_backend,
-)
 
 
 class TestFlightRecorderHook(unittest.TestCase):

--- a/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dTorchCommTest.py
@@ -3,7 +3,6 @@ import unittest
 
 import torch
 import torch.distributed as dist
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,


### PR DESCRIPTION
Summary:
Remove unused imports flagged by FLAKE8 F401:
- FlightRecorderTest.py: get_rank_and_size, skip_backend
- C10dTorchCommTest.py: instantiate_device_type_tests

Rename unused loop variable (FLAKE8 B007):
- test_e2e.py: replay -> _replay

Differential Revision: D104257849


