### PR TITLE
use PrecisionClock for GPU globaltimer→wall-time anchor

### DIFF
--- a/comms/utils/GpuClockCalibration.cc
+++ b/comms/utils/GpuClockCalibration.cc
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "comms/utils/colltrace/PrecisionClock.h"
+
 // simple fprintf-based check for host code.
 #define CUDA_CHECK_CC(cmd)             \
   do {                                 \
@@ -79,7 +81,10 @@ std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     CUDA_CHECK_CC(cudaDeviceSynchronize());
 
     cal.device_ns = *mapped_ptr;
-    cal.host_time = std::chrono::system_clock::now();
+    // PTP-aligned anchor when fbclock daemon is reachable; otherwise
+    // falls back to system_clock. This is the single mapping that
+    // converts every graph-mode %globaltimer ns reading into wall time.
+    cal.host_time = colltrace::precisionNow();
 
     CUDA_CHECK_CC(cudaFreeHost(mapped_ptr));
     return cal;


### PR DESCRIPTION
Summary:
GpuClockCalibration::get() runs once per process and pairs a GPU %globaltimer reading with a host wall-time reading; that pair is then used to convert every graph-mode collective's start/end timestamps into std::chrono::system_clock::time_point. Today the host side is std::chrono::system_clock::now(), so cross-rank graph timing disagrees by however much the local realtime clocks disagree (milliseconds across a fleet).

This commit swaps that single host-side reading to precisionNow(). When fbclock is reachable, the anchor lands at PTP-aligned wall time and every downstream timestamp inherits that alignment — no other graph-side change required. When fbclock is unreachable or NCCL_USE_PTP=0, behavior is identical to before (system_clock).

The change is one line plus an include; the dep on //comms/utils/colltrace:precision_clock is added to //comms/utils:gpu_clock_calibration.

Known limitation — anchor drift

This commit only fixes the anchor; it does not address drift after the anchor is taken. GPU %globaltimer is driven by the GPU's own oscillator, which is not slaved to PHC/PTP. Typical oscillator tolerance is ±10–100 ppm, which translates to ~36–360 ms of drift per hour relative to wall time, and accumulates further over the lifetime of a training run. Per-GPU oscillators also drift independently, so two ranks on the same node can disagree by tens of milliseconds after a few hours even with PTP-aligned anchors.

In other words, this commit makes the t=0 reference correct across the fleet, but the slope (rate) of GPU time vs. wall time is still the GPU's own. The follow-up commit in this stack adds periodic re-anchoring on the colltrace poll thread to bound the residual drift between re-anchors to the sub-millisecond range.

Reviewed By: YulunW

Differential Revision: D102069355


