### PR TITLE
periodically re-anchor GPU globaltimer ↔ wall-clock mapping

### DIFF
--- a/comms/utils/GpuClockCalibration.cc
+++ b/comms/utils/GpuClockCalibration.cc
@@ -9,9 +9,14 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "comms/utils/colltrace/PrecisionClock.h"
+#include <folly/ScopeGuard.h>
+#include <folly/logging/xlog.h>
 
-// simple fprintf-based check for host code.
+#include "comms/utils/colltrace/PrecisionClock.h"
+#include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
+
+// simple fprintf-based check for host code used at construction time, where
+// failure is unrecoverable (no calibration => no graph-mode timestamps).
 #define CUDA_CHECK_CC(cmd)             \
   do {                                 \
     auto _err = (cmd);                 \
@@ -31,18 +36,122 @@ namespace meta::comms::colltrace {
 
 std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     uint64_t gpu_ns) const {
+  auto a = anchor_.copy();
+  if (a.host_time.time_since_epoch().count() == 0) {
+    // Anchor never populated — only reachable when the constructor's initial
+    // refresh failed AND NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE was
+    // false. Returning epoch + delta yields timestamps near 1970, which is
+    // an obvious sentinel for downstream readers; warn rate-limited so the
+    // caller gets one log line per 5 s of bad readings.
+    XLOG_EVERY_MS(WARN, 5000)
+        << "GlobaltimerCalibration::toWallClock called before any successful "
+        << "refresh — returning a 1970-based sentinel timestamp";
+  }
   auto delta_ns =
-      static_cast<int64_t>(gpu_ns) - static_cast<int64_t>(device_ns);
-  return host_time + std::chrono::nanoseconds(delta_ns);
+      static_cast<int64_t>(gpu_ns) - static_cast<int64_t>(a.device_ns);
+  return a.host_time + std::chrono::nanoseconds(delta_ns);
+}
+
+GlobaltimerCalibration::GlobaltimerCalibration() {
+  CUDA_CHECK_CC(cudaHostAlloc(
+      reinterpret_cast<void**>(&mapped_ptr_),
+      sizeof(uint64_t),
+      cudaHostAllocDefault));
+  *mapped_ptr_ = 0;
+
+  // Dedicated non-blocking stream so periodic re-anchor reads do not
+  // serialize with the user's compute streams or wait on graph capture.
+  CUDA_CHECK_CC(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
+
+  // Take the initial anchor synchronously so callers see a valid mapping
+  // immediately after get() returns. A default-constructed anchor
+  // (host_time = epoch) would emit timestamps ~50+ years in the past;
+  // NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE controls whether we crash
+  // (default, preserves historical behaviour) or degrade gracefully and
+  // wait for a periodic refresh to populate the anchor.
+  if (!refresh()) {
+    if (NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE) {
+      XLOG(FATAL)
+          << "GlobaltimerCalibration: initial refresh() failed; refusing to "
+          << "expose a default anchor that would produce nonsensical timestamps "
+          << "(set NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE=0 to demote to ERROR)";
+    } else {
+      XLOG(ERR)
+          << "GlobaltimerCalibration: initial refresh() failed; anchor will "
+          << "remain at epoch until a later refresh succeeds. Graph-mode "
+          << "timestamps will be near 1970 in the meantime.";
+    }
+    return;
+  }
+  // Defensive post-condition: refresh() returning true must have populated
+  // host_time. Catches any future refactor that decouples return value from
+  // anchor write.
+  XCHECK_NE(anchor_.copy().host_time.time_since_epoch().count(), 0)
+      << "GlobaltimerCalibration: anchor host_time still epoch after initial refresh";
+}
+
+// Concurrent callers are expected (multiple CollTrace instances → multiple
+// poll threads → all calling GlobaltimerCalibration::get().refresh()). Only
+// one proceeds; others short-circuit on the in-progress flag (see body). The
+// winner has exclusive access to the CUDA stream and the pinned mapped buffer
+// (mapped_ptr_); anchor_ is folly::Synchronized so readers via toWallClock()
+// remain safe across a refresh.
+bool GlobaltimerCalibration::refresh() {
+  // Try-and-skip: if another thread is already in refresh(), short-circuit
+  // without touching the CUDA stream or pinned buffer. Multiple CollTrace
+  // instances exist per process (one per NCCL communicator), so concurrent
+  // calls from independent poll threads are expected. The in-flight refresh
+  // will publish a fresh anchor before our caller's next wakeup, so we lose
+  // nothing by skipping this beat.
+  if (refresh_in_progress_.test_and_set(std::memory_order_acquire)) {
+    return false;
+  }
+  auto cleanup = folly::makeGuard(
+      [this] { refresh_in_progress_.clear(std::memory_order_release); });
+
+  auto launch_err = launchReadGlobaltimer(stream_, mapped_ptr_);
+  if (launch_err != cudaSuccess) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << "GlobaltimerCalibration::refresh: launchReadGlobaltimer failed: "
+        << cudaGetErrorString(launch_err) << " — keeping previous anchor";
+    return false;
+  }
+  auto sync_err = cudaStreamSynchronize(stream_);
+  if (sync_err != cudaSuccess) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << "GlobaltimerCalibration::refresh: cudaStreamSynchronize failed: "
+        << cudaGetErrorString(sync_err) << " — keeping previous anchor";
+    return false;
+  }
+
+  // PTP-aligned anchor when the fbclock daemon is reachable; otherwise
+  // falls back to system_clock. Read host_time *after* the kernel completes
+  // so the host timestamp is no earlier than the device reading.
+  *anchor_.wlock() = Anchor{
+      .device_ns = *mapped_ptr_,
+      .host_time = colltrace::precisionNow(),
+  };
+  return true;
 }
 
 std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     uint32_t gpu_ticks_low32) const {
+  auto a = anchor_.copy();
+  if (a.host_time.time_since_epoch().count() == 0) {
+    // Same sentinel-warn as the uint64_t overload — reachable only when the
+    // constructor's initial refresh failed AND
+    // NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE was false. Without this
+    // check the elapsed-since-anchor math below would compute ~50+ years of
+    // nanoseconds and silently produce a bogus reconstructed timestamp.
+    XLOG_EVERY_MS(WARN, 5000)
+        << "GlobaltimerCalibration::toWallClock(uint32_t) called before any "
+        << "successful refresh — returning a 1970-based sentinel timestamp";
+  }
   auto host_now = std::chrono::system_clock::now();
-  int64_t elapsed_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(host_now - host_time)
-          .count();
-  uint64_t now_device_ns = device_ns + static_cast<uint64_t>(elapsed_ns);
+  int64_t elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                           host_now - a.host_time)
+                           .count();
+  uint64_t now_device_ns = a.device_ns + static_cast<uint64_t>(elapsed_ns);
   uint64_t now_ticks = now_device_ns >> US_TICK_TIMESTAMP_SHIFT;
 
   // Events are always written before they're read, so the delta is
@@ -62,34 +171,32 @@ std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
 
   int64_t delta_ns =
       static_cast<int64_t>(full_ticks << US_TICK_TIMESTAMP_SHIFT) -
-      static_cast<int64_t>(device_ns);
-  return host_time + std::chrono::nanoseconds(delta_ns);
+      static_cast<int64_t>(a.device_ns);
+  return a.host_time + std::chrono::nanoseconds(delta_ns);
 }
 
-/* static */ const GlobaltimerCalibration& GlobaltimerCalibration::get() {
-  static const GlobaltimerCalibration instance = [] {
-    GlobaltimerCalibration cal{};
+/* static */ GlobaltimerCalibration& GlobaltimerCalibration::get() {
+  // Heap-allocated and intentionally leaked: a function-local static would
+  // run ~GlobaltimerCalibration() during process exit, after CUDA has begun
+  // unloading, which segfaults under cudaErrorCudartUnloading. Matches the
+  // leak-by-design pattern used by CudaReferencePoint and PrecisionClockImpl.
+  static auto* p = new GlobaltimerCalibration();
+  return *p;
+}
 
-    uint64_t* mapped_ptr = nullptr;
-    CUDA_CHECK_CC(cudaHostAlloc(
-        reinterpret_cast<void**>(&mapped_ptr),
-        sizeof(uint64_t),
-        cudaHostAllocDefault));
-    *mapped_ptr = 0;
+GlobaltimerCalibration::GlobaltimerCalibration(
+    TestOnlyTag,
+    uint64_t device_ns,
+    std::chrono::system_clock::time_point host_time) {
+  *anchor_.wlock() = Anchor{.device_ns = device_ns, .host_time = host_time};
+}
 
-    (void)launchReadGlobaltimer(nullptr, mapped_ptr);
-    CUDA_CHECK_CC(cudaDeviceSynchronize());
-
-    cal.device_ns = *mapped_ptr;
-    // PTP-aligned anchor when fbclock daemon is reachable; otherwise
-    // falls back to system_clock. This is the single mapping that
-    // converts every graph-mode %globaltimer ns reading into wall time.
-    cal.host_time = colltrace::precisionNow();
-
-    CUDA_CHECK_CC(cudaFreeHost(mapped_ptr));
-    return cal;
-  }();
-  return instance;
+/* static */ std::unique_ptr<GlobaltimerCalibration>
+GlobaltimerCalibration::createForTest(
+    uint64_t device_ns,
+    std::chrono::system_clock::time_point host_time) {
+  return std::unique_ptr<GlobaltimerCalibration>(
+      new GlobaltimerCalibration(TestOnlyTag{}, device_ns, host_time));
 }
 
 #undef CUDA_CHECK_CC

--- a/comms/utils/GpuClockCalibration.cc
+++ b/comms/utils/GpuClockCalibration.cc
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "comms/utils/colltrace/PrecisionClock.h"
+
 // simple fprintf-based check for host code.
 #define CUDA_CHECK_CC(cmd)             \
   do {                                 \
@@ -79,7 +81,10 @@ std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     CUDA_CHECK_CC(cudaDeviceSynchronize());
 
     cal.device_ns = *mapped_ptr;
-    cal.host_time = std::chrono::system_clock::now();
+    // PTP-aligned anchor when fbclock daemon is reachable; otherwise
+    // falls back to system_clock. This is the single mapping that
+    // converts every graph-mode %globaltimer ns reading into wall time.
+    cal.host_time = colltrace::precisionNow();
 
     CUDA_CHECK_CC(cudaFreeHost(mapped_ptr));
     return cal;

--- a/comms/utils/GpuClockCalibration.h
+++ b/comms/utils/GpuClockCalibration.h
@@ -7,7 +7,11 @@
 #include <cstdint>
 
 #if not defined(__CUDACC__) and not defined(__HIPCC__)
+#include <atomic>
 #include <chrono>
+#include <memory>
+
+#include <folly/Synchronized.h>
 #endif // not defined(__CUDACC__) and not defined(__HIPCC__)
 
 // Globaltimer (ns) is reduced to ~1024ns ticks (`>> shift`) to fit in 32
@@ -18,14 +22,29 @@
 
 namespace meta::comms::colltrace {
 
-// One-time calibration point mapping globaltimer nanoseconds to system_clock.
-// Thread-safe; lazily initialized on first call.
+// Calibration anchor mapping GPU %globaltimer nanoseconds to wall-clock time.
+// The first anchor is taken lazily on first use of get(); subsequent anchors
+// are taken by callers via refresh() to bound drift between GPU oscillator
+// and PTP-aligned wall time.
+//
+// Thread-safety: toWallClock() is safe under any concurrency, including
+// concurrent with refresh(). refresh() is also safe to call from multiple
+// threads — concurrent callers race on the refresh_in_progress_ flag and
+// the loser short-circuits (returns false without touching the CUDA stream
+// or pinned buffer), so the dedicated stream and mapped buffer have
+// effectively single-caller semantics at the CUDA layer.
+//
+// WARNING: This class owns a CUDA stream and a pinned host buffer that are
+// intentionally NOT destroyed at process exit. Calling cudaStreamDestroy /
+// cudaFreeHost during static destruction races with CUDA runtime teardown
+// (cudaErrorCudartUnloading) and segfaults. The singleton in get() is
+// heap-allocated and leaked; matches CudaReferencePoint and PrecisionClockImpl.
 #if not defined(__CUDACC__) and not defined(__HIPCC__)
-struct GlobaltimerCalibration {
-  uint64_t device_ns{};
-  std::chrono::system_clock::time_point host_time;
-
-  // Convert a device globaltimer nanosecond value to a system_clock time_point.
+class GlobaltimerCalibration {
+ public:
+  // Convert a device globaltimer nanosecond reading to a wall-clock
+  // time_point using the most recent anchor. Thread-safe vs. concurrent
+  // refresh().
   std::chrono::system_clock::time_point toWallClock(uint64_t gpu_ns) const;
 
   // Convert a packed 32-bit timestamp (globaltimer_ns >> 10, i.e. ~1024ns
@@ -38,8 +57,64 @@ struct GlobaltimerCalibration {
   std::chrono::system_clock::time_point toWallClock(
       uint32_t gpu_ticks_low32) const;
 
-  // Get the process-global calibration singleton.
-  static const GlobaltimerCalibration& get();
+  // Re-read %globaltimer + precisionNow() and atomically replace the cached
+  // anchor. Cost: 1 single-thread kernel launch + 1 stream sync + 1 fbclock
+  // read on a dedicated side stream (no device-wide sync). Caller is
+  // responsible for rate-limiting; the colltrace poll thread invokes this
+  // at ~1 Hz, which keeps residual oscillator drift between anchors below
+  // 100 ns at 100 ppm. Failures are logged and the prior anchor is kept;
+  // returns true when the anchor was successfully replaced. Safe under
+  // concurrent invocation: at most one caller proceeds to touch the CUDA
+  // stream/buffer; others observe `refresh_in_progress_` already set and
+  // return false (the in-flight refresh will publish a fresh anchor before
+  // the next caller's wakeup, so no information is lost).
+  bool refresh();
+
+  // Process-global singleton.
+  static GlobaltimerCalibration& get();
+
+  // TEST-ONLY: construct a calibration with a synthetic anchor and no CUDA
+  // initialization. Used by GpuClockCalibrationTest to exercise the
+  // toWallClock math against known anchor values without a real GPU.
+  // Production code must use get() — refresh() is a no-op on a test
+  // instance because there is no CUDA stream to drive.
+  static std::unique_ptr<GlobaltimerCalibration> createForTest(
+      uint64_t device_ns,
+      std::chrono::system_clock::time_point host_time);
+
+  GlobaltimerCalibration(const GlobaltimerCalibration&) = delete;
+  GlobaltimerCalibration& operator=(const GlobaltimerCalibration&) = delete;
+  GlobaltimerCalibration(GlobaltimerCalibration&&) = delete;
+  GlobaltimerCalibration& operator=(GlobaltimerCalibration&&) = delete;
+  // Trivial: present only to satisfy clang-tidy
+  // cppcoreguidelines-special-member-functions. Never runs in practice — the
+  // singleton in get() is heap-allocated and intentionally leaked, so the
+  // cudaErrorCudartUnloading risk documented above is unchanged.
+  ~GlobaltimerCalibration() = default;
+
+ private:
+  GlobaltimerCalibration();
+
+  // Tag-dispatched ctor used by createForTest. Skips CUDA init and just
+  // populates the anchor with the provided values.
+  struct TestOnlyTag {};
+  GlobaltimerCalibration(
+      TestOnlyTag,
+      uint64_t device_ns,
+      std::chrono::system_clock::time_point host_time);
+
+  struct Anchor {
+    uint64_t device_ns{};
+    std::chrono::system_clock::time_point host_time;
+  };
+
+  folly::Synchronized<Anchor> anchor_;
+  uint64_t* mapped_ptr_ = nullptr;
+  cudaStream_t stream_ = nullptr;
+  // Serializes refresh() callers without blocking: contenders that find the
+  // flag already set short-circuit (return false) so the CUDA stream and
+  // pinned buffer are never touched by more than one thread at a time.
+  std::atomic_flag refresh_in_progress_ = ATOMIC_FLAG_INIT;
 };
 
 // Launch a single-thread kernel that writes globaltimer() to *out.

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -638,7 +638,24 @@ void CollTrace::collTraceThread(
 
   bool initialized = false;
 
+  // Periodic re-anchor of the GPU %globaltimer ↔ wall-clock mapping. Bounds
+  // residual drift between anchors to ~kReanchorInterval × oscillator-ppm
+  // (≤ ~100 ns at 1 s and 100 ppm). Only meaningful in graph mode, since the
+  // anchor is only consulted when converting ring buffer device timestamps.
+  // Gated on NCCL_COLLTRACE_PERIODIC_REANCHOR (default false) — issuing CUDA
+  // calls from this thread has been observed to hang some training jobs.
+  constexpr auto kReanchorInterval = std::chrono::seconds(1);
+  auto lastReanchor = std::chrono::steady_clock::now();
+
   while (!isThreadCancelled()) {
+    if (NCCL_COLLTRACE_PERIODIC_REANCHOR && ringBuffer_.has_value()) {
+      auto now = std::chrono::steady_clock::now();
+      if (now - lastReanchor >= kReanchorInterval) {
+        GlobaltimerCalibration::get().refresh();
+        lastReanchor = now;
+      }
+    }
+
     std::multiset<PendingAction> actions;
 
     pollGraphEvents(actions);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2391,6 +2391,34 @@ cvars:
      The default value is 10 minutes. The gloalhint from the user program takes
      precedence over this env var for the actual time colltrace will wait.
 
+ - name        : NCCL_COLLTRACE_PERIODIC_REANCHOR
+   type        : bool
+   default     : False
+   description : |-
+     When true, the colltrace poll thread periodically (~1 Hz) re-records the
+     GPU-time ↔ wall-clock anchors used by graph mode (GlobaltimerCalibration)
+     and eager mode (CudaReferencePoint) to bound drift between the GPU's
+     oscillator and PTP-aligned wall time below ~100 ns at 100 ppm. When
+     false (default), each anchor is taken once at construction and never
+     refreshed; long-running jobs accumulate ~36–360 ms/hour of drift. The
+     refresh path issues CUDA calls from the colltrace thread; this flag
+     exists so deployments that have observed CUDA-on-non-main-thread hangs
+     can disable the feature without rebuilding.
+
+ - name        : NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE
+   type        : bool
+   default     : True
+   description : |-
+     When true (default), GlobaltimerCalibration's constructor crashes via
+     XLOG(FATAL) if the initial CUDA-side anchor read fails — without a
+     valid anchor, graph-mode timestamps would map to ~50 years before the
+     UNIX epoch, which is worse than crashing. When false, the failure is
+     logged at ERROR severity, the anchor is left at its default state,
+     and the periodic refresh thread (gated on NCCL_COLLTRACE_PERIODIC_REANCHOR)
+     gets a chance to populate it later. Until refresh succeeds, graph-mode
+     timestamps will be near the UNIX epoch and a rate-limited warning is
+     emitted on each toWallClock() call.
+
  - name        : NCCL_MAPPERTRACE_COLL_RECORD_MAX
    type        : uint64_t
    default     : 20

--- a/comms/utils/tests/GpuClockCalibrationTest.cc
+++ b/comms/utils/tests/GpuClockCalibrationTest.cc
@@ -12,16 +12,6 @@ using namespace std::chrono_literals;
 
 namespace {
 
-// Build a calibration as if it were captured "right now" so that the
-// reconstruction inside toWallClock(uint32_t) — which queries
-// std::chrono::system_clock::now() internally — has a known reference.
-GlobaltimerCalibration makeCalibrationAtNow(uint64_t deviceNs) {
-  GlobaltimerCalibration cal{};
-  cal.device_ns = deviceNs;
-  cal.host_time = std::chrono::system_clock::now();
-  return cal;
-}
-
 uint32_t pack(uint64_t gpuNs) {
   return static_cast<uint32_t>(gpuNs >> US_TICK_TIMESTAMP_SHIFT);
 }
@@ -51,52 +41,53 @@ TEST(GpuClockCalibrationTest, ToWallClock64BitIdentity) {
   // The 64-bit overload is pure arithmetic on the calibration point:
   // toWallClock(device_ns) must equal host_time exactly.
   const uint64_t kDeviceNs = 5'000'000'000ULL;
-  GlobaltimerCalibration cal{};
-  cal.device_ns = kDeviceNs;
-  cal.host_time = std::chrono::system_clock::now();
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
-  EXPECT_EQ(cal.toWallClock(kDeviceNs), cal.host_time);
+  EXPECT_EQ(cal->toWallClock(kDeviceNs), kHostTime);
 }
 
 TEST(GpuClockCalibrationTest, ToWallClock64BitOffset) {
   // device_ns + 2s should map to host_time + 2s.
   const uint64_t kDeviceNs = 5'000'000'000ULL;
-  GlobaltimerCalibration cal{};
-  cal.device_ns = kDeviceNs;
-  cal.host_time = std::chrono::system_clock::now();
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
   auto wall =
-      cal.toWallClock(static_cast<uint64_t>(kDeviceNs + 2'000'000'000ULL));
-  EXPECT_EQ(wall, cal.host_time + 2s);
+      cal->toWallClock(static_cast<uint64_t>(kDeviceNs + 2'000'000'000ULL));
+  EXPECT_EQ(wall, kHostTime + 2s);
 }
 
 TEST(GpuClockCalibrationTest, ToWallClock32BitAtCalibrationPoint) {
   // Event at exactly the calibration point — packed timestamp is
   // (device_ns >> 10). Reconstruction should yield ≈ host_time.
   const uint64_t kDeviceNs = 5'000'000'000ULL;
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
-  expectClose(cal.toWallClock(pack(kDeviceNs)), cal.host_time);
+  expectClose(cal->toWallClock(pack(kDeviceNs)), kHostTime);
 }
 
 TEST(GpuClockCalibrationTest, ToWallClock32BitPastEvent) {
   // Event 1 second before the calibration point. Reconstruction should
   // yield ≈ host_time - 1s.
   const uint64_t kDeviceNs = 5'000'000'000ULL;
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
-  auto wall = cal.toWallClock(pack(kDeviceNs - 1'000'000'000ULL));
-  expectClose(wall, cal.host_time - 1s);
+  auto wall = cal->toWallClock(pack(kDeviceNs - 1'000'000'000ULL));
+  expectClose(wall, kHostTime - 1s);
 }
 
 TEST(GpuClockCalibrationTest, ToWallClock32BitFutureEvent) {
   // Event 1 second after the calibration point. Reconstruction should
   // yield ≈ host_time + 1s.
   const uint64_t kDeviceNs = 5'000'000'000ULL;
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
-  auto wall = cal.toWallClock(pack(kDeviceNs + 1'000'000'000ULL));
-  expectClose(wall, cal.host_time + 1s);
+  auto wall = cal->toWallClock(pack(kDeviceNs + 1'000'000'000ULL));
+  expectClose(wall, kHostTime + 1s);
 }
 
 TEST(GpuClockCalibrationTest, ToWallClock32BitWrapsCorrectly) {
@@ -111,10 +102,11 @@ TEST(GpuClockCalibrationTest, ToWallClock32BitWrapsCorrectly) {
   // "100ms in the future", not "~71 minutes in the past".
   const uint64_t kBaselineTicks = 0xFFFF'FFF0ULL;
   const uint64_t kDeviceNs = kBaselineTicks << US_TICK_TIMESTAMP_SHIFT;
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
-  auto wall = cal.toWallClock(pack(kDeviceNs + 100'000'000ULL)); // +100ms
-  expectClose(wall, cal.host_time + 100ms);
+  auto wall = cal->toWallClock(pack(kDeviceNs + 100'000'000ULL)); // +100ms
+  expectClose(wall, kHostTime + 100ms);
 }
 
 // Past-only bias: events spanning the full ~73 min past lookback should
@@ -125,15 +117,16 @@ TEST(GpuClockCalibrationTest, ToWallClock32BitNearWrapBoundary) {
   // Device clock past 5h so subtracting >70 minutes stays positive.
   const uint64_t kDeviceNs =
       std::chrono::duration_cast<std::chrono::nanoseconds>(5h).count();
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
   for (auto past : {70min, 71min, 72min}) {
     SCOPED_TRACE("past=" + std::to_string(past.count()) + "min");
     const int64_t pastNs =
         std::chrono::duration_cast<std::chrono::nanoseconds>(past).count();
     auto wall =
-        cal.toWallClock(pack(kDeviceNs - static_cast<uint64_t>(pastNs)));
-    expectClose(wall, cal.host_time - past);
+        cal->toWallClock(pack(kDeviceNs - static_cast<uint64_t>(pastNs)));
+    expectClose(wall, kHostTime - past);
   }
 }
 
@@ -145,16 +138,17 @@ TEST(GpuClockCalibrationTest, ToWallClock32BitNearWrapBoundary) {
 TEST(GpuClockCalibrationTest, ToWallClock32BitWrapsBeyondBoundary) {
   const uint64_t kDeviceNs =
       std::chrono::duration_cast<std::chrono::nanoseconds>(5h).count();
-  auto cal = makeCalibrationAtNow(kDeviceNs);
+  const auto kHostTime = std::chrono::system_clock::now();
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
   constexpr int64_t k74MinNs =
       std::chrono::duration_cast<std::chrono::nanoseconds>(74min).count();
   auto wall =
-      cal.toWallClock(pack(kDeviceNs - static_cast<uint64_t>(k74MinNs)));
+      cal->toWallClock(pack(kDeviceNs - static_cast<uint64_t>(k74MinNs)));
 
   constexpr auto kWrapWindow =
       std::chrono::nanoseconds(uint64_t{1} << 42); // 2^32 ticks * 1024 ns
-  expectClose(wall, cal.host_time - 74min + kWrapWindow);
+  expectClose(wall, kHostTime - 74min + kWrapWindow);
 }
 
 // Calibration captured long enough ago that (now - host_time) in ticks
@@ -167,9 +161,9 @@ TEST(GpuClockCalibrationTest, ToWallClock32BitWrapsBeyondBoundary) {
 // elapsed device_ticks since calibration will have wrapped past
 // UINT32_MAX at least once.
 TEST(GpuClockCalibrationTest, ToWallClock32BitOldCalibration) {
-  GlobaltimerCalibration cal{};
-  cal.device_ns = 1'000'000'000ULL;
-  cal.host_time = std::chrono::system_clock::now() - 2h;
+  const uint64_t kDeviceNs = 1'000'000'000ULL;
+  const auto kHostTime = std::chrono::system_clock::now() - 2h;
+  auto cal = GlobaltimerCalibration::createForTest(kDeviceNs, kHostTime);
 
   // The "current" device timestamp is device_ns + 2h. Pack it (truncate
   // to low 32 of the 1024ns ticks) and feed it to the reconstruction —
@@ -177,27 +171,27 @@ TEST(GpuClockCalibrationTest, ToWallClock32BitOldCalibration) {
   // distinguish this event from one ~71 minutes earlier.
   constexpr int64_t kTwoHoursNs =
       std::chrono::duration_cast<std::chrono::nanoseconds>(2h).count();
-  const uint64_t nowGpuNs = cal.device_ns + static_cast<uint64_t>(kTwoHoursNs);
+  const uint64_t nowGpuNs = kDeviceNs + static_cast<uint64_t>(kTwoHoursNs);
 
   expectClose(
-      cal.toWallClock(pack(nowGpuNs)), std::chrono::system_clock::now());
+      cal->toWallClock(pack(nowGpuNs)), std::chrono::system_clock::now());
 }
 
 // End-to-end smoke test against the real singleton. Confirms that
 // GlobaltimerCalibration::get() boots (kernel launches successfully,
 // captures device_ns + host_time) and that the resulting calibration
-// passes the same math invariants we tested with synthetic data.
+// passes the toWallClock invariants. Round-trip property: feeding a known
+// offset through toWallClock(uint64_t) returns the anchored host_time
+// shifted by the same offset.
 TEST(GpuClockCalibrationTest, SingletonRoundTrip) {
-  const auto& cal = GlobaltimerCalibration::get();
+  auto& cal = GlobaltimerCalibration::get();
 
-  // The 64-bit overload at the calibration point is exact.
-  EXPECT_EQ(cal.toWallClock(cal.device_ns), cal.host_time);
-
-  // The 32-bit overload at the calibration point reconstructs to ≈
-  // host_time. Slack is wider here because the singleton was captured
-  // at process start (potentially many seconds ago) so toWallClock's
-  // internal now() has drifted from cal.host_time accordingly — the
-  // reconstruction still snaps back to host_time via the signed-delta
-  // math, but rounding to ~1024ns ticks contributes a small error.
-  expectClose(cal.toWallClock(pack(cal.device_ns)), cal.host_time);
+  // Pick two device_ns values 2s apart and check the wall-time delta is
+  // also exactly 2s — that's all the math the singleton can validate
+  // without exposing its private anchor.
+  constexpr uint64_t kBase = 1'000'000'000'000ULL;
+  constexpr uint64_t kOffset = 2'000'000'000ULL;
+  auto wall0 = cal.toWallClock(kBase);
+  auto wall1 = cal.toWallClock(kBase + kOffset);
+  EXPECT_EQ(wall1 - wall0, std::chrono::nanoseconds(kOffset));
 }


### PR DESCRIPTION
Summary:
The previous commit (D102069355) fixed the *anchor* of the GPU %globaltimer ↔ wall-clock mapping by reading host time via precisionNow() (PTP-aligned when fbclock is reachable). It did not address *drift after* the anchor: %globaltimer is driven by the GPU's own oscillator, which is not slaved to PHC/PTP. At ±10–100 ppm typical oscillator tolerance, a one-shot anchor drifts ~36–360 ms per hour relative to wall time, which compounds over the lifetime of a training run and causes per-rank drift between GPUs on the same node.

This commit makes GlobaltimerCalibration stateful and re-anchorable:

- The cached (device_ns, host_time) pair is now held in a folly::Synchronized<Anchor>, with reads (toWallClock) under shared lock and writes (refresh) under exclusive lock. The original const-by-value semantics are preserved at the call site via .copy().
- A pre-allocated cudaHostAlloc'd buffer and a dedicated non-blocking cudaStream are owned by the singleton and reused across refreshes — no per-refresh allocation, no device-wide synchronize, no interference with user compute streams.
- A new public refresh() method launches the existing readGlobaltimerKernel on the side stream, syncs that stream only, and atomically swaps in the new anchor. CUDA failures in refresh are logged (rate-limited) and the previous anchor is kept — periodic refresh failure must not kill colltrace.
- The colltrace poll thread calls refresh() at most once per second (kReanchorInterval = 1s), gated on `NCCL_COLLTRACE_PERIODIC_REANCHOR && ringBuffer_.has_value()` so only graph-mode workloads with the flag enabled pay the cost. At 1 s cadence and 100 ppm, residual drift between anchors is bounded to ~100 ns.

The constructor takes the initial anchor itself (preserving the existing eager-init behavior at CollTrace ctor time), so callers see a valid mapping the moment get() returns. The new `NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE` flag controls whether initial-refresh failure crashes (default, preserves prior behavior) or degrades gracefully.

The singleton is heap-allocated and intentionally leaked (`static auto* p = new GlobaltimerCalibration(); return *p;`) — running ~GlobaltimerCalibration() at process exit would call cudaStreamDestroy / cudaFreeHost concurrently with CUDA runtime teardown and segfault under cudaErrorCudartUnloading. Matches the leak-by-design pattern already used by neighboring colltrace singletons (CudaReferencePoint, PrecisionClockImpl).

## v2 — addressed review feedback

- **New cvar `NCCL_COLLTRACE_PERIODIC_REANCHOR`** (default `False`) gates the refresh call in the colltrace poll thread. The reviewer flagged that issuing CUDA calls from a non-main thread has been observed to hang some training jobs; with the flag default-off, the feature ships dark and operators opt in after validating in conda. The same flag will be reused by D102076826 to gate the eager-mode CudaReferencePoint refresh.
- **New cvar `NCCL_COLLTRACE_FATAL_ON_CALIBRATION_FAILURE`** (default `True`) makes the initial-failure FATAL optional. When `false`, the constructor logs `XLOG(ERR)` instead of crashing, returns early without populating the anchor, and lets the periodic refresh thread (gated on the cvar above) populate it later. Until that succeeds, `toWallClock()` emits a rate-limited `XLOG_EVERY_MS(WARN, 5000)` so the bad-timestamp condition is loud but doesn't kill colltrace. Default preserves the historical FATAL behavior.
- **Added `~GlobaltimerCalibration() = default;`** to silence clang-tidy `cppcoreguidelines-special-member-functions`. The destructor never runs in practice because the singleton is heap-allocated and intentionally leaked, so the `cudaErrorCudartUnloading` risk is unchanged.

---

Reviewed By: YulunW

Differential Revision: D102072779


