### PR TITLE
Implement dual-destination copy and forward_group API for P2pNvlTransportDevice

### DIFF
--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -125,6 +125,57 @@ __device__ __forceinline__ void memcpy_vectorized_aligned(
 #endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 
+/**
+ * memcpy_vectorized_aligned (dual-destination) - Fused recv-and-forward copy
+ *
+ * Reads source data once and writes to two destinations simultaneously.
+ * This halves the read bandwidth vs two separate memcpy_vectorized_aligned
+ * calls, which is critical for ring algorithm forwarding where an
+ * intermediate rank needs to copy to both its local user buffer and the
+ * successor's remote staging buffer.
+ *
+ * Same striding pattern as the single-dst version above.
+ */
+template <typename VecType, int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_aligned(
+    VecType* dst1_p,
+    VecType* dst2_p,
+    const VecType* src_p,
+    std::size_t nelems,
+    const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const std::size_t kLoopStride = group.group_size * kUnroll;
+  const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
+  VecType* __restrict__ dst1 = dst1_p;
+  VecType* __restrict__ dst2 = dst2_p;
+  const VecType* __restrict__ src = src_p;
+
+  for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
+       i += kLoopStride) {
+    VecType v[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      v[j] = src[i + j * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      dst1[i + j * group.group_size] = v[j];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      dst2[i + j * group.group_size] = v[j];
+    }
+  }
+
+  for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
+       i += group.group_size) {
+    VecType val = src[i];
+    dst1[i] = val;
+    dst2[i] = val;
+  }
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+}
+
 // AMD-optimized uint4 copy with system-coherent stores for P2P over XGMI.
 // NVIDIA NVLink provides hardware cache coherence for P2P writes, so the
 // standard memcpy_vectorized_aligned() is sufficient. AMD XGMI does not
@@ -160,6 +211,45 @@ __device__ __forceinline__ void memcpy_vectorized_aligned_sys(
 }
 #endif
 
+// AMD dual-destination copy: one destination gets system-coherent stores
+// (for NVLink remote write to successor), the other gets plain stores
+// (for local user buffer).
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+template <int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized_aligned_sys(
+    uint4* dst_local,
+    uint4* dst_remote,
+    const uint4* src,
+    std::size_t nelems,
+    const ThreadGroup& group) {
+  const std::size_t kLoopStride = group.group_size * kUnroll;
+  const std::size_t numVecsAligned = (nelems / kLoopStride) * kLoopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < numVecsAligned;
+       i += kLoopStride) {
+    uint4 v[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      v[j] = src[i + j * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      dst_local[i + j * group.group_size] = v[j];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      store_sys_u128(&dst_remote[i + j * group.group_size], &v[j]);
+    }
+  }
+
+  for (std::size_t i = numVecsAligned + group.thread_id_in_group; i < nelems;
+       i += group.group_size) {
+    dst_local[i] = src[i];
+    store_sys_u128(&dst_remote[i], &src[i]);
+  }
+}
+#endif
+
 template <int kUnroll = 8>
 __device__ __forceinline__ void memcpy_vectorized(
     char* dst,
@@ -182,6 +272,43 @@ __device__ __forceinline__ void memcpy_vectorized(
   }
 
   memcpy_vectorized_aligned<char, kUnroll>(dst, src, len, group);
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+}
+
+/**
+ * memcpy_vectorized (dual-destination) - Fused copy to two destinations.
+ *
+ * Handles alignment and dispatches to the appropriate dual-dst
+ * memcpy_vectorized_aligned variant. Reads source once, writes to both
+ * destinations.
+ */
+template <int kUnroll = 8>
+__device__ __forceinline__ void memcpy_vectorized(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t len,
+    const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  constexpr std::size_t kAlignment = sizeof(uint4);
+  if ((uintptr_t)dst1 % kAlignment == 0 && (uintptr_t)dst2 % kAlignment == 0 &&
+      (uintptr_t)src % kAlignment == 0) {
+    const std::size_t nelems = len / kAlignment;
+    uint4* __restrict__ dst1_p = reinterpret_cast<uint4*>(dst1);
+    uint4* __restrict__ dst2_p = reinterpret_cast<uint4*>(dst2);
+    const uint4* __restrict__ src_p = reinterpret_cast<const uint4*>(src);
+    memcpy_vectorized_aligned<uint4, kUnroll>(
+        dst1_p, dst2_p, src_p, nelems, group);
+    len -= nelems * kAlignment;
+    if (len == 0) {
+      return;
+    }
+    dst1 = reinterpret_cast<char*>(dst1_p + nelems);
+    dst2 = reinterpret_cast<char*>(dst2_p + nelems);
+    src = reinterpret_cast<const char*>(src_p + nelems);
+  }
+
+  memcpy_vectorized_aligned<char, kUnroll>(dst1, dst2, src, len, group);
 #endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -845,6 +845,202 @@ class P2pNvlTransportDevice {
 #endif
   }
 
+  /**
+   * forward_group - Fused receive-and-forward
+   *
+   * Reads data from this transport's predecessor staging buffer and writes
+   * to two destinations simultaneously: the local user buffer (dstbuff) and
+   * the successor's remote staging buffer. This halves the read bandwidth
+   * vs sequential recv_group + send_group.
+   *
+   * PRECONDITIONS:
+   * - `this` transport is connected to the predecessor (data arrives in
+   *   this->localState_.dataBuffer)
+   * - `successor` transport is connected to the next rank (data forwarded
+   *   to successor.remoteState_.dataBuffer)
+   * - Both transports must have matching options (dataBufferSize, chunkSize,
+   *   pipelineDepth, useDualStateBuffer)
+   *
+   * @param group ThreadGroup for cooperative processing
+   * @param dstbuff Local user buffer to copy data into
+   * @param nbytes Number of bytes to forward
+   * @param successor Transport to the next rank in the ring
+   * @param timeout Timeout for polling operations
+   */
+  __device__ __forceinline__ void forward_group(
+      ThreadGroup& group,
+      void* dstbuff,
+      std::size_t nbytes,
+      P2pNvlTransportDevice& successor,
+      const Timeout& timeout = Timeout()) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (options_.dataBufferSize == 0) {
+      printf(
+          "P2pNvlTransportDevice::forward_group() requires staging buffer"
+          " (dataBufferSize > 0) at %s:%d\n",
+          __FILE__,
+          __LINE__);
+      __trap();
+    }
+    char* dst = reinterpret_cast<char*>(dstbuff);
+
+    // Predecessor's staging buffer (local read)
+    char* recvBuffer = localState_.dataBuffer;
+    ChunkState* const localReceiverStates =
+        localState_.receiverStateBuffer.data();
+
+    // Successor's staging buffer (NVLink write)
+    char* successorSendBuffer = successor.remoteState_.dataBuffer;
+    ChunkState* const successorRemoteReceiverStates =
+        successor.remoteState_.receiverStateBuffer.data();
+
+    const std::size_t totalSteps =
+        (nbytes + options_.dataBufferSize - 1) / options_.dataBufferSize;
+    const std::size_t kChunkSize = options_.chunkSize;
+    const std::size_t chunksPerStep =
+        (options_.dataBufferSize + kChunkSize - 1) / kChunkSize;
+
+    if (options_.useDualStateBuffer) {
+      // =================================================================
+      // DUAL CHUNK STATE MODE (forward = fused recv + send)
+      // =================================================================
+      // Per chunk, we need four signals:
+      // 1. localReceiverState.unready()        — prevents predecessor re-send
+      // 2. successorLocalSenderState.unready()  — prevents re-forward
+      // 3. remoteSenderState.ready_to_send()    — tells predecessor buf free
+      // 4. successorRemoteReceiverState.ready_to_recv() — tells successor
+      //    data ready
+      //
+      // Ordering: do both unready() calls first (each has group.sync() +
+      // plain write), then both release-store signals (each has
+      // group.sync() + st.release.sys.global).
+      // =================================================================
+      ChunkState* const remoteSenderStates =
+          remoteState_.senderStateBuffer.data();
+      ChunkState* const successorLocalSenderStates =
+          successor.localState_.senderStateBuffer.data();
+
+      for (std::size_t stepId = 0; stepId < totalSteps; stepId++) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
+
+        group.for_each_item_strided(numChunksThisStep, [&](uint32_t chunkIdx) {
+          const std::size_t chunkOffset = chunkIdx * kChunkSize;
+          const std::size_t chunkBytes = (chunkOffset + kChunkSize <= stepBytes)
+              ? kChunkSize
+              : stepBytes - chunkOffset;
+
+          if (chunkBytes == 0) {
+            return;
+          }
+
+          const std::size_t chunkStateIdx = stateOffset + chunkIdx;
+
+          // 1. Wait for predecessor data to be ready
+          ChunkState& localReceiverState = localReceiverStates[chunkStateIdx];
+          localReceiverState.wait_ready_to_recv(group, stepId, timeout);
+
+          // 2. Wait for successor's staging buffer to be free
+          ChunkState& successorLocalSenderState =
+              successorLocalSenderStates[chunkStateIdx];
+          successorLocalSenderState.wait_ready_to_send(group, timeout);
+
+          // 3. Dual-dst copy: predecessor staging → local user buf +
+          //    successor remote staging
+          memcpy_vectorized(
+              dst + stepOffset + chunkOffset,
+              successorSendBuffer + dataBufferOffset + chunkOffset,
+              recvBuffer + dataBufferOffset + chunkOffset,
+              chunkBytes,
+              group);
+
+          // 4. Both unready() calls (plain writes with group.sync())
+          localReceiverState.unready(group);
+          successorLocalSenderState.unready(group);
+
+          // 5. Both release-store signals (NVLink writes)
+          ChunkState& remoteSenderState = remoteSenderStates[chunkStateIdx];
+          remoteSenderState.ready_to_send(group);
+
+          ChunkState& successorRemoteReceiverState =
+              successorRemoteReceiverStates[chunkStateIdx];
+          successorRemoteReceiverState.ready_to_recv(group, stepId);
+        });
+      }
+    } else {
+      // =================================================================
+      // SINGLE CHUNK STATE MODE (fallback)
+      // =================================================================
+      ChunkState* const successorRemoteReceiverStatesOnly =
+          successor.remoteState_.receiverStateBuffer.data();
+
+      for (std::size_t stepId = 0; stepId < totalSteps; stepId++) {
+        const std::size_t pipelineIdx = stepId % options_.pipelineDepth;
+        const std::size_t dataBufferOffset =
+            pipelineIdx * options_.dataBufferSize;
+        const std::size_t stateOffset = pipelineIdx * chunksPerStep;
+
+        const std::size_t stepOffset = stepId * options_.dataBufferSize;
+        const std::size_t stepBytes =
+            (stepOffset + options_.dataBufferSize <= nbytes)
+            ? options_.dataBufferSize
+            : nbytes - stepOffset;
+        const std::size_t numChunksThisStep =
+            (stepBytes + kChunkSize - 1) / kChunkSize;
+
+        group.for_each_item_contiguous(
+            numChunksThisStep, [&](uint32_t chunkIdx) {
+              const std::size_t chunkOffset = chunkIdx * kChunkSize;
+              const std::size_t chunkBytes =
+                  (chunkOffset + kChunkSize <= stepBytes)
+                  ? kChunkSize
+                  : stepBytes - chunkOffset;
+
+              if (chunkBytes == 0) {
+                return;
+              }
+
+              const std::size_t chunkStateIdx = stateOffset + chunkIdx;
+
+              // Wait for predecessor data
+              ChunkState& localReceiverState =
+                  localReceiverStates[chunkStateIdx];
+              localReceiverState.wait_ready_to_recv(group, stepId, timeout);
+
+              // Wait for successor staging to be free (NVLink poll)
+              ChunkState& successorRemoteReceiverState =
+                  successorRemoteReceiverStatesOnly[chunkStateIdx];
+              successorRemoteReceiverState.wait_ready_to_send(group, timeout);
+
+              // Dual-dst copy
+              memcpy_vectorized(
+                  dst + stepOffset + chunkOffset,
+                  successorSendBuffer + dataBufferOffset + chunkOffset,
+                  recvBuffer + dataBufferOffset + chunkOffset,
+                  chunkBytes,
+                  group);
+
+              // ACK predecessor (buffer free)
+              localReceiverState.ready_to_send(group);
+
+              // Signal successor (data ready)
+              successorRemoteReceiverState.ready_to_recv(group, stepId);
+            });
+      }
+    }
+#endif
+  }
+
  public:
   // Getters for testing
   __host__ const LocalState& getLocalState() const {
@@ -1423,6 +1619,178 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] = step;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * forward - Independent per-group fused receive-and-forward (tile-style)
+   *
+   * Each group independently reads its own tile of data from this transport's
+   * predecessor staging buffer and writes to two destinations simultaneously:
+   * the local user buffer (dst) and the successor's remote staging buffer.
+   * This halves the read bandwidth vs sequential recv + send.
+   *
+   * Unlike forward_group(), which has all groups cooperate on the same buffer,
+   * forward() has each group work on its own partition independently using
+   * the tile_state_ signal protocol (matching send()/recv()).
+   *
+   * PRECONDITIONS:
+   * - `this` transport is connected to the predecessor (data arrives in
+   *   this->localState_.dataBuffer)
+   * - `successor` transport is connected to the next rank (data forwarded
+   *   to successor.remoteState_.dataBuffer)
+   * - Both transports must have matching options (dataBufferSize,
+   *   tile_max_groups, pipelineDepth) and consistent active_blocks /
+   *   max_signal_bytes choices across calls
+   *
+   * @param group ThreadGroup for cooperative processing (group-local)
+   * @param dst Local user buffer to copy data into
+   * @param nbytes Number of bytes to forward
+   * @param successor Transport to the next rank in the ring
+   * @param active_blocks Number of blocks calling forward concurrently.
+   *   0 means use tile_max_groups from transport config.
+   * @param max_signal_bytes Hint for max bytes between signals.
+   *   0 means one signal per slot fill. Capped at per_block_slot_size.
+   */
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      P2pNvlTransportDevice& successor,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout()) {
+#ifdef __CUDA_ARCH__
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int max_groups = tile_state_.tile_max_groups;
+    const int groupId = group.group_id;
+    const int effActive = active_blocks > 0 ? active_blocks : max_groups;
+
+    if (effActive > max_groups) {
+      printf(
+          "forward: active_blocks=%d > tile_max_groups=%d. "
+          "Signal and step_state arrays would be accessed out of bounds.\n",
+          effActive,
+          max_groups);
+      __trap();
+    }
+
+    if (groupId >= effActive) {
+      printf(
+          "forward: groupId=%d >= active_blocks=%d. "
+          "Too many groups calling forward.\n",
+          groupId,
+          effActive);
+      __trap();
+    }
+
+    char* __restrict__ dstPtr = reinterpret_cast<char*>(dst);
+    // Predecessor's staging buffer (local read)
+    char* __restrict__ recvBuf = localState_.dataBuffer;
+    // Successor's staging buffer (NVLink write)
+    char* __restrict__ sendBuf = successor.remoteState_.dataBuffer;
+
+    const std::size_t slotSize = options_.dataBufferSize;
+    const std::size_t perBlockSlotSize = (slotSize / effActive) & ~15ULL;
+    if (perBlockSlotSize == 0) {
+      printf(
+          "forward: perBlockSlotSize is 0 "
+          "(dataBufferSize=%llu, active_blocks=%d). "
+          "Increase dataBufferSize or decrease active_blocks.\n",
+          (unsigned long long)slotSize,
+          effActive);
+      __trap();
+    }
+    const std::size_t stagingOff = groupId * perBlockSlotSize;
+
+    const std::size_t chunkSize =
+        max_signal_bytes > 0 && max_signal_bytes < perBlockSlotSize
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlotSize;
+    const std::size_t effectiveChunk =
+        chunkSize > 0 ? chunkSize : perBlockSlotSize;
+
+    const std::size_t totalSteps =
+        (nbytes + effectiveChunk - 1) / effectiveChunk;
+    const std::size_t stepsPerSlot =
+        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+
+    const uint64_t tailSignalId = groupId;
+    const uint64_t headSignalId = max_groups + groupId;
+
+    // Recv side step counter (this transport: predecessor → me).
+    // Stored in step_state[max_groups + groupId], matching recv().
+    int64_t recvStep = tile_state_.step_state[max_groups + groupId];
+    // Send side step counter (successor transport: me → successor).
+    // Stored in step_state[groupId], matching send().
+    int64_t sendStep = successor.tile_state_.step_state[groupId];
+
+    for (std::size_t s = 0; s < totalSteps; ++s) {
+      const std::size_t slotStep = s / stepsPerSlot;
+      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t slot = slotStep % options_.pipelineDepth;
+      const std::size_t slotOff = slot * slotSize;
+      const std::size_t chunkOff = subStep * effectiveChunk;
+
+      const std::size_t dataOff = s * effectiveChunk;
+      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
+          ? effectiveChunk
+          : (dataOff < nbytes ? nbytes - dataOff : 0);
+
+      // 1. Wait for predecessor data to be ready (recv side, every step).
+      tile_state_.local_signals[tailSignalId].wait_until(
+          group, CmpOp::CMP_GE, static_cast<uint64_t>(recvStep + 1), timeout);
+
+      // 2. Wait for successor's staging slot to be free (send side, only at
+      //    slot boundaries once we have wrapped around the pipeline).
+      if (subStep == 0 &&
+          sendStep >=
+              static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
+        successor.tile_state_.local_signals[headSignalId].wait_until(
+            group,
+            CmpOp::CMP_GE,
+            static_cast<uint64_t>(
+                sendStep - stepsPerSlot * options_.pipelineDepth + 1),
+            timeout);
+      }
+
+      // 3. Dual-dst copy: predecessor staging → local user buf +
+      //    successor remote staging
+      if (copyBytes > 0) {
+        memcpy_vectorized(
+            dstPtr + dataOff,
+            sendBuf + slotOff + stagingOff + chunkOff,
+            recvBuf + slotOff + stagingOff + chunkOff,
+            copyBytes,
+            group);
+      }
+
+      group.sync();
+      if (group.is_leader()) {
+        // 4. Signal successor that data is ready (send semantic: every step).
+        successor.tile_state_.remote_signals[tailSignalId].signal(
+            SignalOp::SIGNAL_SET, static_cast<uint64_t>(sendStep + 1));
+
+        // 5. ACK predecessor that buffer is free (recv semantic: only at
+        //    slot boundaries).
+        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+          tile_state_.remote_signals[headSignalId].signal(
+              SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
+        }
+      }
+
+      recvStep++;
+      sendStep++;
+    }
+
+    if (group.is_leader()) {
+      tile_state_.step_state[max_groups + groupId] = recvStep;
+      successor.tile_state_.step_state[groupId] = sendStep;
     }
     group.sync();
 #endif

--- a/comms/pipes/benchmarks/CopyKernelBench.cc
+++ b/comms/pipes/benchmarks/CopyKernelBench.cc
@@ -193,6 +193,198 @@ static void d2dCopyKernel(
       folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
 }
 
+/**
+ * Benchmark P2P dual-destination copy: load src from local GPU, store to one
+ * local dst and one remote dst (GPU 0 -> GPU 0 + GPU 1)
+ */
+static void p2pDualDstCopyKernel(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  const int nRunsPerIter = 50;
+
+  const int localDev = 0;
+  const int remoteDev = 1;
+
+  // Allocate remote dst2 on GPU 1
+  CHECK_EQ(cudaSetDevice(remoteDev), cudaSuccess);
+  DeviceBuffer dst2Buffer(nBytes);
+  char* dst2Ptr = static_cast<char*>(dst2Buffer.get());
+
+  // Allocate src and local dst1 on GPU 0
+  CHECK_EQ(cudaSetDevice(localDev), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dst1Buffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dst1Ptr = static_cast<char*>(dst1Buffer.get());
+
+  float totalTimeMs = 0.0f;
+  const int nThreads = 256;
+  for (uint32_t i = 0; i < iters; ++i) {
+    bench.startTiming();
+
+    void* kernArgs[6] = {
+        (void*)&dst1Ptr,
+        (void*)&dst2Ptr,
+        (void*)&srcPtr,
+        (void*)&nBytes,
+        (void*)&nRunsPerIter,
+        (void*)&groupScope};
+    dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+    dim3 blocks{nThreads, 1, 1};
+
+    std::optional<dim3> clusterDimOpt =
+        (groupScope == SyncScope::CLUSTER && clusterSize > 1)
+        ? std::optional{dim3(clusterSize, 1, 1)}
+        : std::nullopt;
+    CHECK_EQ(
+        comms::common::launchKernel(
+            (void*)dualDstCopyKernel,
+            grid,
+            blocks,
+            kernArgs,
+            bench.stream,
+            clusterDimOpt),
+        cudaSuccess);
+
+    bench.stopTiming();
+    totalTimeMs += bench.measureTime();
+  }
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float readBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  size_t nGroups;
+  switch (groupScope) {
+    case SyncScope::BLOCK:
+      nGroups = nBlocks;
+      break;
+    case SyncScope::MULTIWARP:
+      nGroups = nBlocks * (nThreads / 128);
+      break;
+    case SyncScope::CLUSTER:
+      nGroups = nBlocks / clusterSize;
+      break;
+    case SyncScope::WARP:
+    default:
+      nGroups = nBlocks * (nThreads / 32);
+      break;
+  }
+  size_t chunkSize = nBytes / nGroups / 1024;
+
+  counters["deviceTimeUs"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["readBwGBps"] =
+      folly::UserMetric(readBwGBps, folly::UserMetric::Type::METRIC);
+  counters["nGroups"] =
+      folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
+  counters["chunkSizeKB"] =
+      folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
+}
+
+/**
+ * Benchmark P2P two-pass copy baseline in a SINGLE kernel: read src → write
+ * local dst1, then read src again → write remote dst2, all within one kernel
+ * launch. Fair comparison with dualDstCopyKernel (no kernel launch overhead
+ * difference).
+ */
+static void p2pTwoPassCopyKernel(
+    uint32_t iters,
+    size_t nBytes,
+    int nBlocks,
+    SyncScope groupScope,
+    folly::UserCounters& counters,
+    int clusterSize = 1) {
+  const int nRunsPerIter = 50;
+
+  const int localDev = 0;
+  const int remoteDev = 1;
+
+  // Allocate remote dst2 on GPU 1
+  CHECK_EQ(cudaSetDevice(remoteDev), cudaSuccess);
+  DeviceBuffer dst2Buffer(nBytes);
+  char* dst2Ptr = static_cast<char*>(dst2Buffer.get());
+
+  // Allocate src and local dst1 on GPU 0
+  CHECK_EQ(cudaSetDevice(localDev), cudaSuccess);
+  CudaBenchBase bench;
+
+  DeviceBuffer srcBuffer(nBytes);
+  DeviceBuffer dst1Buffer(nBytes);
+
+  char* srcPtr = static_cast<char*>(srcBuffer.get());
+  char* dst1Ptr = static_cast<char*>(dst1Buffer.get());
+
+  float totalTimeMs = 0.0f;
+  const int nThreads = 256;
+  for (uint32_t i = 0; i < iters; ++i) {
+    bench.startTiming();
+
+    void* kernArgs[6] = {
+        (void*)&dst1Ptr,
+        (void*)&dst2Ptr,
+        (void*)&srcPtr,
+        (void*)&nBytes,
+        (void*)&nRunsPerIter,
+        (void*)&groupScope};
+    dim3 grid{static_cast<unsigned int>(nBlocks), 1, 1};
+    dim3 blocks{nThreads, 1, 1};
+
+    std::optional<dim3> clusterDimOpt =
+        (groupScope == SyncScope::CLUSTER && clusterSize > 1)
+        ? std::optional{dim3(clusterSize, 1, 1)}
+        : std::nullopt;
+    CHECK_EQ(
+        comms::common::launchKernel(
+            (void*)twoPassCopyKernel,
+            grid,
+            blocks,
+            kernArgs,
+            bench.stream,
+            clusterDimOpt),
+        cudaSuccess);
+
+    bench.stopTiming();
+    totalTimeMs += bench.measureTime();
+  }
+
+  float avgTimeUs = (totalTimeMs / iters / nRunsPerIter) * 1000.0f;
+  float readBwGBps = (nBytes / 1e9f) / (avgTimeUs / 1e6f);
+
+  size_t nGroups;
+  switch (groupScope) {
+    case SyncScope::BLOCK:
+      nGroups = nBlocks;
+      break;
+    case SyncScope::MULTIWARP:
+      nGroups = nBlocks * (nThreads / 128);
+      break;
+    case SyncScope::CLUSTER:
+      nGroups = nBlocks / clusterSize;
+      break;
+    case SyncScope::WARP:
+    default:
+      nGroups = nBlocks * (nThreads / 32);
+      break;
+  }
+  size_t chunkSize = nBytes / nGroups / 1024;
+
+  counters["deviceTimeUs"] =
+      folly::UserMetric(avgTimeUs, folly::UserMetric::Type::METRIC);
+  counters["readBwGBps"] =
+      folly::UserMetric(readBwGBps, folly::UserMetric::Type::METRIC);
+  counters["nGroups"] =
+      folly::UserMetric(nGroups, folly::UserMetric::Type::METRIC);
+  counters["chunkSizeKB"] =
+      folly::UserMetric(chunkSize, folly::UserMetric::Type::METRIC);
+}
+
 //------------------------------------------------------------------------------
 // Benchmark Registration Helper Macros
 //------------------------------------------------------------------------------
@@ -286,6 +478,28 @@ REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(d2dCopyKernelCluster, cluster);
 
 // P2P (cross device) benchmarks - cluster groups (2 blocks per cluster)
 REGISTER_COPY_BENCH_ALL_SIZES_CLUSTER(p2pCopyKernelCluster, cluster);
+
+// P2P dual-dst (fused: local src -> local dst1 + remote dst2) vs
+// two-pass (sequential: src->local dst1, then src->remote dst2)
+// Sweep: 1MB, 2MB, 4MB, 8MB with 2, 4, 8, 16 blocks
+#define REGISTER_DUALDST_BENCH_FOR_SIZE(func, sizeMB, groupScope, suffix) \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                                         \
+      func, sizeMB##MB_1b_##suffix, sizeMB * 1024 * 1024, 1, groupScope); \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                                         \
+      func, sizeMB##MB_2b_##suffix, sizeMB * 1024 * 1024, 2, groupScope); \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                                         \
+      func, sizeMB##MB_4b_##suffix, sizeMB * 1024 * 1024, 4, groupScope); \
+  BENCHMARK_MULTI_PARAM_COUNTERS(                                         \
+      func, sizeMB##MB_8b_##suffix, sizeMB * 1024 * 1024, 8, groupScope)
+
+#define REGISTER_DUALDST_BENCH_ALL_SIZES(func, groupScope, suffix) \
+  REGISTER_DUALDST_BENCH_FOR_SIZE(func, 1, groupScope, suffix);    \
+  REGISTER_DUALDST_BENCH_FOR_SIZE(func, 2, groupScope, suffix);    \
+  REGISTER_DUALDST_BENCH_FOR_SIZE(func, 4, groupScope, suffix);    \
+  REGISTER_DUALDST_BENCH_FOR_SIZE(func, 8, groupScope, suffix)
+
+REGISTER_DUALDST_BENCH_ALL_SIZES(p2pDualDstCopyKernel, SyncScope::BLOCK, block);
+REGISTER_DUALDST_BENCH_ALL_SIZES(p2pTwoPassCopyKernel, SyncScope::BLOCK, block);
 
 } // namespace comms::pipes::benchmark
 

--- a/comms/pipes/benchmarks/CopyKernelBench.cu
+++ b/comms/pipes/benchmarks/CopyKernelBench.cu
@@ -29,4 +29,65 @@ __global__ void copyKernel(
   }
 }
 
+__global__ void dualDstCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+
+  const std::size_t bytes_per_group =
+      (nBytes + group.total_groups - 1) / group.total_groups;
+  const std::size_t start_offset =
+      static_cast<std::size_t>(group.group_id) * bytes_per_group;
+
+  const std::size_t end_offset = (start_offset + bytes_per_group < nBytes)
+      ? start_offset + bytes_per_group
+      : nBytes;
+  const std::size_t chunk_bytes =
+      (start_offset < nBytes) ? end_offset - start_offset : 0;
+
+  for (int run = 0; run < nRuns; ++run) {
+    memcpy_vectorized(
+        dst1 + start_offset,
+        dst2 + start_offset,
+        src + start_offset,
+        chunk_bytes,
+        group);
+  }
+}
+
+// Two-pass copy in a single kernel: read src twice, write to dst1 then dst2
+__global__ void twoPassCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope) {
+  auto group = make_thread_group(groupScope);
+
+  const std::size_t bytes_per_group =
+      (nBytes + group.total_groups - 1) / group.total_groups;
+  const std::size_t start_offset =
+      static_cast<std::size_t>(group.group_id) * bytes_per_group;
+
+  const std::size_t end_offset = (start_offset + bytes_per_group < nBytes)
+      ? start_offset + bytes_per_group
+      : nBytes;
+  const std::size_t chunk_bytes =
+      (start_offset < nBytes) ? end_offset - start_offset : 0;
+
+  for (int run = 0; run < nRuns; ++run) {
+    // Pass 1: src -> local dst1
+    memcpy_vectorized(
+        dst1 + start_offset, src + start_offset, chunk_bytes, group);
+    // Pass 2: src -> remote dst2
+    memcpy_vectorized(
+        dst2 + start_offset, src + start_offset, chunk_bytes, group);
+  }
+}
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/CopyKernelBench.cuh
+++ b/comms/pipes/benchmarks/CopyKernelBench.cuh
@@ -19,4 +19,22 @@ __global__ void copyKernel(
     int nRuns,
     SyncScope groupScope);
 
+// Dual-destination copy: load src once, store to both dst1 and dst2
+__global__ void dualDstCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
+// Two-pass copy in single kernel: read src twice, write dst1 then dst2
+__global__ void twoPassCopyKernel(
+    char* dst1,
+    char* dst2,
+    const char* src,
+    std::size_t nBytes,
+    int nRuns,
+    SyncScope groupScope);
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/TileSendRecv.cu
+++ b/comms/pipes/benchmarks/TileSendRecv.cu
@@ -127,4 +127,51 @@ __global__ __launch_bounds__(512, 1) void p2pTileSendRecvDynamic(
   }
 }
 
+// =============================================================================
+// Tile-style fused recv+forward kernel.
+// =============================================================================
+//
+// Each block calls P2pNvlTransportDevice::forward(), which fuses a recv from
+// the predecessor staging buffer with a send to the successor staging buffer
+// (plus a local copy to the user dst). All blocks run forward (no role
+// partition); block group_id ∈ [0, numBlocks) drives the per-block tile
+// assignment and signal slots.
+//
+// In a 2-rank ring test (rank 0 ↔ rank 1):
+//   - Rank 0 launches p2pTileSendRecv (sends src → rank 1 staging,
+//     receives forwarded data ← rank 1 staging).
+//   - Rank 1 launches p2pTileForward with p2p_pred == p2p_succ ==
+//     the single transport to rank 0; forward reads from rank 0's send
+//     into local staging and writes to rank 0's recv staging.
+//
+// Signal slots are paired correctly because forward.recv uses [tail=i,
+// head=i+max_groups] on this transport, while forward.send uses
+// [tail=i, head=i+max_groups] on successor transport. When this ==
+// successor, the recv-side and send-side touch DIFFERENT halves of the
+// signal/step arrays (recv → step_state[max_groups+i]; send →
+// step_state[i]). Rank 0's send/recv similarly use distinct halves on
+// the same transport.
+
+__global__ __launch_bounds__(512, 1) void p2pTileForward(
+    P2pNvlTransportDevice p2p_pred,
+    P2pNvlTransportDevice p2p_succ,
+    TiledBuffer<char> dstTiles,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+
+  p2p_pred.forward(
+      group,
+      dstTiles.tile_data(blockId),
+      dstTiles.tile_bytes(blockId),
+      p2p_succ,
+      active_blocks,
+      max_signal_bytes,
+      timeout);
+}
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -179,4 +179,34 @@ __global__ void p2pTileSendRecvDynamic(
     bool needsBarrier,
     Timeout timeout = Timeout());
 
+/**
+ * p2pTileForward — Tile-style fused recv+forward kernel.
+ *
+ * Each block calls P2pNvlTransportDevice::forward() to read its tile
+ * from the predecessor staging buffer (p2p_pred.localState_.dataBuffer)
+ * and dual-write it to (a) the local user dst tile and (b) the
+ * successor staging buffer (p2p_succ.remoteState_.dataBuffer).
+ *
+ * Launch with `numBlocks` total blocks (no role partition). Each block
+ * processes one tile.
+ *
+ * In a 2-rank ring test, p2p_pred == p2p_succ (the single transport
+ * between rank 0 and rank 1) — see ForwardGroup tests for pattern.
+ *
+ * @param p2p_pred   Transport to predecessor (read source staging)
+ * @param p2p_succ   Transport to successor (write target staging)
+ * @param dstTiles   Tiled view of the local output buffer
+ * @param active_blocks Number of blocks calling forward concurrently.
+ *                      0 means use tile_max_groups.
+ * @param max_signal_bytes Hint for signal granularity. 0 = per-slot signal.
+ * @param timeout    Optional timeout for signal waits
+ */
+__global__ void p2pTileForward(
+    P2pNvlTransportDevice p2p_pred,
+    P2pNvlTransportDevice p2p_succ,
+    TiledBuffer<char> dstTiles,
+    int active_blocks,
+    std::size_t max_signal_bytes = 0,
+    Timeout timeout = Timeout());
+
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -3576,6 +3576,931 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvDynamicBlockCount) {
   }
 }
 
+// =============================================================================
+// forward_group() Tests - 2-rank ring topology
+// =============================================================================
+// Topology: Rank 0 → Rank 1 → Rank 0
+// - Rank 0: send_group to rank 1, recv_group from rank 1 (concurrent streams)
+// - Rank 1: forward_group with pred==succ==same device (reads from localState_
+//   staging where rank 0 wrote, writes to remoteState_ staging for rank 0's
+//   recv)
+// Uses a single transport between ranks — send uses remoteState_, recv uses
+// localState_, so both directions coexist without conflict.
+
+void runForwardGroupTest(
+    int globalRank,
+    int numRanks,
+    int localRank,
+    size_t nbytes,
+    size_t dataBufferSize,
+    size_t chunkSize,
+    size_t pipelineDepth,
+    bool useDualStateBuffer,
+    int numBlocks = 4,
+    int blockSize = 128,
+    size_t dstOffset = 0) {
+  if (numRanks != 2) {
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  // Single transport between rank 0 and rank 1 — supports bidirectional
+  // communication. send_group uses remoteState_, recv_group uses localState_,
+  // so both directions can coexist on the same device without conflict.
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = chunkSize,
+      .pipelineDepth = pipelineDepth,
+      .useDualStateBuffer = useDualStateBuffer,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+
+  // Build host-side device handle
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  // Copy to device memory
+  DeviceBuffer devP2p(sizeof(P2pNvlTransportDevice));
+  CUDACHECK_TEST(cudaMemcpy(
+      devP2p.get(),
+      &p2pHost,
+      sizeof(P2pNvlTransportDevice),
+      cudaMemcpyHostToDevice));
+
+  auto* p2pDev = static_cast<P2pNvlTransportDevice*>(devP2p.get());
+
+  const size_t numInts = nbytes / sizeof(int);
+  const int testValue = 77;
+
+  DeviceBuffer srcBuffer(nbytes);
+  DeviceBuffer dstRank0(nbytes); // rank 0's recv buffer
+  // Rank 1's local forward output, padded to support unaligned dstOffset.
+  DeviceBuffer dstRank1(nbytes + dstOffset);
+
+  auto* src_d = static_cast<int*>(srcBuffer.get());
+  auto* recvR0_d = static_cast<int*>(dstRank0.get());
+
+  if (globalRank == 0) {
+    // Fill source buffer
+    test::fillBuffer(src_d, testValue, numInts);
+    CUDACHECK_TEST(cudaMemset(recvR0_d, 0, nbytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Launch send and recv concurrently on different streams to avoid
+    // pipeline deadlock when totalSteps > pipelineDepth
+    cudaStream_t sendStream, recvStream;
+    CUDACHECK_TEST(cudaStreamCreate(&sendStream));
+    CUDACHECK_TEST(cudaStreamCreate(&recvStream));
+
+    // Send to rank 1 (writes to remoteState_.dataBuffer)
+    test::testSend(
+        p2pDev,
+        src_d,
+        nbytes,
+        numBlocks,
+        blockSize,
+        test::GroupType::WARP,
+        1,
+        sendStream);
+    // Recv from rank 1 (reads from localState_.dataBuffer — no conflict)
+    test::testRecv(
+        p2pDev,
+        recvR0_d,
+        nbytes,
+        numBlocks,
+        blockSize,
+        test::GroupType::WARP,
+        1,
+        recvStream);
+
+    CUDACHECK_TEST(cudaStreamSynchronize(sendStream));
+    CUDACHECK_TEST(cudaStreamSynchronize(recvStream));
+
+    CUDACHECK_TEST(cudaStreamDestroy(sendStream));
+    CUDACHECK_TEST(cudaStreamDestroy(recvStream));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify rank 0 received correct data
+    std::vector<int> hostBuffer(numInts);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuffer.data(), recvR0_d, nbytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < numInts; i++) {
+      EXPECT_EQ(hostBuffer[i], testValue)
+          << "Rank 0 recv: Mismatch at index " << i
+          << " (dstOffset=" << dstOffset << ")";
+      if (hostBuffer[i] != testValue) {
+        break;
+      }
+    }
+  } else {
+    // Rank 1: forward (pred == succ == same device, reads localState_ staging
+    // and writes to remoteState_ staging). Zero entire padded buffer so we
+    // can verify both prefix safety and payload correctness.
+    CUDACHECK_TEST(cudaMemset(dstRank1.get(), 0, nbytes + dstOffset));
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Apply byte-level dstOffset to the user-facing dst pointer.
+    char* dstPtr = static_cast<char*>(dstRank1.get()) + dstOffset;
+    test::testForward(p2pDev, p2pDev, dstPtr, nbytes, numBlocks, blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Read entire padded buffer to verify both prefix safety and payload.
+    std::vector<unsigned char> hostBuf(nbytes + dstOffset);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(),
+        dstRank1.get(),
+        nbytes + dstOffset,
+        cudaMemcpyDeviceToHost));
+
+    // Prefix bytes [0, dstOffset) must be untouched (still 0).
+    for (size_t i = 0; i < dstOffset; i++) {
+      EXPECT_EQ(hostBuf[i], 0u) << "Rank 1 prefix clobbered at byte " << i
+                                << " (dstOffset=" << dstOffset << ")";
+      if (hostBuf[i] != 0u) {
+        return;
+      }
+    }
+    // Payload bytes [dstOffset, dstOffset + nbytes) must match the byte
+    // pattern of testValue (a repeated int). Build expected bytes from the
+    // same int fill pattern so byte-level offsets work for any dstOffset.
+    std::vector<int> expectedInts(numInts, testValue);
+    const auto* expectedBytes =
+        reinterpret_cast<const unsigned char*>(expectedInts.data());
+    for (size_t i = 0; i < nbytes; i++) {
+      EXPECT_EQ(hostBuf[dstOffset + i], expectedBytes[i])
+          << "Rank 1 forward dst: Mismatch at byte " << i
+          << " (nbytes=" << nbytes << ", dstOffset=" << dstOffset << ")";
+      if (hostBuf[dstOffset + i] != expectedBytes[i]) {
+        return;
+      }
+    }
+  }
+}
+
+TEST_F(P2pNvlTransportTestFixture, ForwardGroupSingleState) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(localRank));
+
+  // Basic test: 4MB transfer, 1MB staging, 1KB chunks
+  runForwardGroupTest(
+      globalRank,
+      numRanks,
+      localRank,
+      4 * 1024 * 1024, // nbytes
+      1024 * 1024, // dataBufferSize
+      1024, // chunkSize
+      4, // pipelineDepth
+      false); // useDualStateBuffer
+
+  XLOGF(INFO, "Rank {}: ForwardGroupSingleState completed", globalRank);
+}
+
+TEST_F(P2pNvlTransportTestFixture, ForwardGroupDualState) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  CUDACHECK_TEST(cudaSetDevice(localRank));
+
+  // Basic test: 4MB transfer, 1MB staging, 1KB chunks
+  runForwardGroupTest(
+      globalRank,
+      numRanks,
+      localRank,
+      4 * 1024 * 1024, // nbytes
+      1024 * 1024, // dataBufferSize
+      1024, // chunkSize
+      4, // pipelineDepth
+      true); // useDualStateBuffer
+
+  XLOGF(INFO, "Rank {}: ForwardGroupDualState completed", globalRank);
+}
+
+// Parameterized forward_group test with various sizes
+struct ForwardGroupParams {
+  size_t nbytes;
+  size_t dataBufferSize;
+  size_t chunkSize;
+  size_t pipelineDepth;
+  bool useDualStateBuffer;
+  std::string name;
+};
+
+class ForwardGroupTestFixture
+    : public MpiBaseTestFixture,
+      public ::testing::WithParamInterface<ForwardGroupParams> {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+};
+
+TEST_P(ForwardGroupTestFixture, ForwardGroup) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const auto& params = GetParam();
+  XLOGF(
+      INFO,
+      "Running forward_group test: {} (nbytes={}, dualState={})",
+      params.name,
+      params.nbytes,
+      params.useDualStateBuffer);
+
+  runForwardGroupTest(
+      globalRank,
+      numRanks,
+      localRank,
+      params.nbytes,
+      params.dataBufferSize,
+      params.chunkSize,
+      params.pipelineDepth,
+      params.useDualStateBuffer);
+
+  XLOGF(
+      INFO,
+      "Rank {}: Forward group test '{}' completed",
+      globalRank,
+      params.name);
+}
+
+std::string forwardGroupParamName(
+    const ::testing::TestParamInfo<ForwardGroupParams>& info) {
+  return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ForwardGroupVariations,
+    ForwardGroupTestFixture,
+    ::testing::Values(
+        // Single state buffer mode
+        ForwardGroupParams{
+            .nbytes = 512,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = false,
+            .name = "Small_512B_SingleState"},
+        ForwardGroupParams{
+            .nbytes = 16 * 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = false,
+            .name = "MultiStep_16KB_SingleState"},
+        ForwardGroupParams{
+            .nbytes = 4 * 1024 * 1024,
+            .dataBufferSize = 1024 * 1024,
+            .chunkSize = 4096,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = false,
+            .name = "Large_4MB_SingleState"},
+        ForwardGroupParams{
+            .nbytes = 64 * 1024 * 1024,
+            .dataBufferSize = 8 * 1024 * 1024,
+            .chunkSize = 512 * 1024,
+            .pipelineDepth = 2,
+            .useDualStateBuffer = false,
+            .name = "VeryLarge_64MB_SingleState"},
+        // Dual state buffer mode
+        ForwardGroupParams{
+            .nbytes = 512,
+            .dataBufferSize = 4096,
+            .chunkSize = 1024,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = true,
+            .name = "Small_512B_DualState"},
+        ForwardGroupParams{
+            .nbytes = 16 * 1024,
+            .dataBufferSize = 4096,
+            .chunkSize = 256,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = true,
+            .name = "MultiStep_16KB_DualState"},
+        ForwardGroupParams{
+            .nbytes = 4 * 1024 * 1024,
+            .dataBufferSize = 1024 * 1024,
+            .chunkSize = 4096,
+            .pipelineDepth = 4,
+            .useDualStateBuffer = true,
+            .name = "Large_4MB_DualState"},
+        ForwardGroupParams{
+            .nbytes = 64 * 1024 * 1024,
+            .dataBufferSize = 8 * 1024 * 1024,
+            .chunkSize = 512 * 1024,
+            .pipelineDepth = 2,
+            .useDualStateBuffer = true,
+            .name = "VeryLarge_64MB_DualState"}),
+    forwardGroupParamName);
+
+// =============================================================================
+// Tile-style forward() tests — 2-rank ring topology
+// =============================================================================
+// Topology: Rank 0 ──send──▶ Rank 1 ──forward──▶ Rank 0
+// - Rank 0 launches p2pTileSendRecv (concurrent send + recv on a single
+//   transport, partitioned into 2 * numSendBlocks total blocks).
+// - Rank 1 launches p2pTileForward with p2p_pred == p2p_succ == the single
+//   transport to rank 0; each of numSendBlocks blocks calls forward(),
+//   reading rank 0's incoming data from local staging and dual-writing to
+//   rank 1's local output and rank 0's recv staging.
+//
+// Signal/step slot disjointness:
+//   On EACH transport, sender slots are [0, max_groups) and receiver slots
+//   are [max_groups, 2 * max_groups). Rank 0's send/recv use disjoint
+//   halves; rank 1's forward.recv uses the receiver half on `this` while
+//   forward.send uses the sender half on `successor` — with this == succ
+//   they still touch disjoint halves.
+//
+// Verification: Rank 0's recv buffer and Rank 1's local forward output
+// should both equal the original send pattern.
+
+// Helper: run a single tile forward round and verify both ranks' data.
+// dstOffset shifts rank 1's local forward output buffer to test unaligned
+// user-buffer addresses (the staging buffers are always cudaMalloc-aligned,
+// so this is the only user-facing pointer we can misalign).
+static void runTileForwardTest(
+    int globalRank,
+    int numRanks,
+    const std::shared_ptr<meta::comms::MpiBootstrap>& bootstrap,
+    size_t nBytes,
+    size_t dataBufferSize,
+    size_t chunkSize,
+    size_t pipelineDepth,
+    int numSendBlocks,
+    int nIters = 1,
+    int threadCount = 256,
+    size_t dstOffset = 0) {
+  if (numRanks != 2) {
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = chunkSize,
+      .pipelineDepth = pipelineDepth,
+  };
+
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  Timeout timeout;
+
+  for (int iter = 0; iter < nIters; iter++) {
+    const int pattern = 0x10 + iter * 0x20;
+
+    DeviceBuffer srcBuf(nBytes); // rank 0 source
+    DeviceBuffer recvR0Buf(nBytes); // rank 0 recv (forwarded back)
+    // Allocate rank 1's forward output with extra padding for dstOffset.
+    DeviceBuffer fwdR1Buf(nBytes + dstOffset);
+
+    if (globalRank == 0) {
+      CUDACHECK_TEST(cudaMemset(srcBuf.get(), pattern, nBytes));
+      CUDACHECK_TEST(cudaMemset(recvR0Buf.get(), 0, nBytes));
+    } else {
+      CUDACHECK_TEST(cudaMemset(fwdR1Buf.get(), 0, nBytes + dstOffset));
+    }
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      // Rank 0: tile send src + tile recv into recvR0 (single kernel,
+      // 2 * numSendBlocks total blocks via role partition).
+      comms::pipes::TiledBuffer<char> sendTiles(
+          static_cast<char*>(srcBuf.get()), nBytes, numSendBlocks);
+      comms::pipes::TiledBuffer<char> recvTiles(
+          static_cast<char*>(recvR0Buf.get()), nBytes, numSendBlocks);
+      int numBlocksArg = numSendBlocks;
+      std::size_t maxSignalBytes = 0;
+      void* args[] = {
+          &p2pHost,
+          &sendTiles,
+          &recvTiles,
+          &numBlocksArg,
+          &maxSignalBytes,
+          &timeout};
+
+      CUDACHECK_TEST(cudaLaunchKernel(
+          (void*)comms::pipes::benchmark::p2pTileSendRecv,
+          dim3(numSendBlocks * 2),
+          dim3(threadCount),
+          args,
+          0,
+          nullptr));
+    } else {
+      // Rank 1: tile forward through single transport (pred == succ).
+      // Apply dstOffset to the user-facing output buffer.
+      char* dstPtr = static_cast<char*>(fwdR1Buf.get()) + dstOffset;
+      comms::pipes::TiledBuffer<char> dstTiles(dstPtr, nBytes, numSendBlocks);
+      int numBlocksArg = numSendBlocks;
+      std::size_t maxSignalBytes = 0;
+      void* args[] = {
+          &p2pHost,
+          &p2pHost,
+          &dstTiles,
+          &numBlocksArg,
+          &maxSignalBytes,
+          &timeout};
+
+      CUDACHECK_TEST(cudaLaunchKernel(
+          (void*)comms::pipes::benchmark::p2pTileForward,
+          dim3(numSendBlocks),
+          dim3(threadCount),
+          args,
+          0,
+          nullptr));
+    }
+
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    // Verify rank 0's recv data matches the original send pattern.
+    if (globalRank == 0) {
+      std::vector<char> hostBuf(nBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvR0Buf.get(), nBytes, cudaMemcpyDeviceToHost));
+      for (size_t i = 0; i < nBytes; i++) {
+        EXPECT_EQ(
+            static_cast<unsigned char>(hostBuf[i]),
+            static_cast<unsigned char>(pattern))
+            << "Iter " << iter << " (rank 0 recv): Mismatch at byte " << i
+            << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
+            << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+            << ", pd=" << pipelineDepth << ", dstOffset=" << dstOffset << ")";
+        if (static_cast<unsigned char>(hostBuf[i]) !=
+            static_cast<unsigned char>(pattern)) {
+          return; // stop on first failure
+        }
+      }
+    } else {
+      // Read the entire padded buffer so we can also check the prefix bytes
+      // (before dstOffset) were not clobbered.
+      std::vector<char> hostBuf(nBytes + dstOffset);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(),
+          fwdR1Buf.get(),
+          nBytes + dstOffset,
+          cudaMemcpyDeviceToHost));
+      // Bytes before the offset should still be zero.
+      for (size_t i = 0; i < dstOffset; i++) {
+        EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), 0u)
+            << "Iter " << iter << " (rank 1 prefix clobbered): byte " << i
+            << " (dstOffset=" << dstOffset << ")";
+        if (static_cast<unsigned char>(hostBuf[i]) != 0u) {
+          return;
+        }
+      }
+      // Payload bytes at [dstOffset, dstOffset + nBytes) should equal pattern.
+      for (size_t i = 0; i < nBytes; i++) {
+        EXPECT_EQ(
+            static_cast<unsigned char>(hostBuf[dstOffset + i]),
+            static_cast<unsigned char>(pattern))
+            << "Iter " << iter << " (rank 1 forward dst): Mismatch at byte "
+            << i << " (nBytes=" << nBytes << ", blocks=" << numSendBlocks
+            << ", slot=" << dataBufferSize << ", chunk=" << chunkSize
+            << ", pd=" << pipelineDepth << ", dstOffset=" << dstOffset << ")";
+        if (static_cast<unsigned char>(hostBuf[dstOffset + i]) !=
+            static_cast<unsigned char>(pattern)) {
+          return;
+        }
+      }
+    }
+  }
+}
+
+// Basic single-call test
+TEST_F(P2pNvlTransportTestFixture, TileForwardBasic) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  // 8MB transfer, 8MB slot (single-step), 4 blocks
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+}
+
+// Various message sizes
+TEST_F(P2pNvlTransportTestFixture, TileForwardMessageSizes) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  // Small
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      4096,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      65536,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  // Medium
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      1 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      8,
+      1);
+  // Large (multi-step)
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      64 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+}
+
+// Signal granularity (chunkSize < slotSize → multiple sub-step signals)
+TEST_F(P2pNvlTransportTestFixture, TileForwardSignalGranularity) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 32 * 1024 * 1024;
+
+  // Per-slot signaling
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      nBytes,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      16,
+      1);
+  // Sub-slot signaling
+  runTileForwardTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 2, 16, 1);
+  runTileForwardTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 1024 * 1024, 2, 16, 1);
+}
+
+// Different block counts
+TEST_F(P2pNvlTransportTestFixture, TileForwardBlockCounts) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 16 * 1024 * 1024;
+
+  for (int blocks : {1, 2, 4, 8, 16, 32}) {
+    runTileForwardTest(
+        globalRank,
+        numRanks,
+        bs,
+        nBytes,
+        8 * 1024 * 1024,
+        8 * 1024 * 1024,
+        2,
+        blocks,
+        1);
+  }
+}
+
+// Pipeline depth variations
+TEST_F(P2pNvlTransportTestFixture, TileForwardPipelineDepth) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const size_t nBytes = 32 * 1024 * 1024;
+
+  runTileForwardTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 2, 16, 1);
+  runTileForwardTest(
+      globalRank, numRanks, bs, nBytes, 8 * 1024 * 1024, 128 * 1024, 4, 16, 1);
+}
+
+// Multi-call: persistent step state across iterations
+TEST_F(P2pNvlTransportTestFixture, TileForwardMultiCallPersistentStep) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      5);
+  // Many sub-step signals per call
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      128 * 1024,
+      2,
+      4,
+      5);
+}
+
+// Partial tiles (nbytes not evenly divisible by numBlocks)
+TEST_F(P2pNvlTransportTestFixture, TileForwardPartialTiles) {
+  if (numRanks != 2) {
+    return;
+  }
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      1000000,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      7 * 1024 * 1024 + 12345,
+      8 * 1024 * 1024,
+      8 * 1024 * 1024,
+      2,
+      4,
+      1);
+}
+
+// =============================================================================
+// Unaligned dstbuff tests for forward_group() and tile forward()
+// =============================================================================
+// The staging buffers (localState_/remoteState_.dataBuffer) are always
+// 256-byte aligned (cudaMalloc), so the only user-facing pointer that can
+// be misaligned is `dstbuff` (the local user output buffer on rank 1, where
+// the dual-dst memcpy writes its second destination).
+//
+// These tests offset rank 1's dstbuff by various byte amounts to exercise
+// memcpy_vectorized's unaligned path in the forward() implementation.
+// They reuse runForwardGroupTest / runTileForwardTest with the dstOffset
+// parameter — no duplicate helpers.
+
+// Parameterized test fixture for forward_group / tile forward unaligned dst
+struct ForwardUnalignedParams {
+  size_t dstOffset; // bytes added to dst pointer (0 = aligned)
+  size_t nbytes;
+  bool useDualStateBuffer;
+  std::string name;
+};
+
+class ForwardGroupUnalignedTestFixture
+    : public MpiBaseTestFixture,
+      public ::testing::WithParamInterface<ForwardUnalignedParams> {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+};
+
+TEST_P(ForwardGroupUnalignedTestFixture, ForwardGroup) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const auto& params = GetParam();
+  XLOGF(
+      INFO,
+      "Running forward_group unaligned test: {} (nbytes={}, dstOffset={}, dualState={})",
+      params.name,
+      params.nbytes,
+      params.dstOffset,
+      params.useDualStateBuffer);
+
+  // Use a smallish staging buffer + chunk so multi-step + sub-step paths are
+  // exercised even at modest message sizes.
+  runForwardGroupTest(
+      globalRank,
+      numRanks,
+      localRank,
+      params.nbytes,
+      /*dataBufferSize=*/256 * 1024,
+      /*chunkSize=*/4096,
+      /*pipelineDepth=*/4,
+      params.useDualStateBuffer,
+      /*numBlocks=*/4,
+      /*blockSize=*/128,
+      params.dstOffset);
+}
+
+std::string forwardUnalignedParamName(
+    const ::testing::TestParamInfo<ForwardUnalignedParams>& info) {
+  return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ForwardGroupUnalignedVariations,
+    ForwardGroupUnalignedTestFixture,
+    ::testing::Values(
+        // Baseline aligned (offset 0) for sanity
+        ForwardUnalignedParams{
+            .dstOffset = 0,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Aligned_64KB_SingleState"},
+        // Various small misalignments (single state)
+        ForwardUnalignedParams{
+            .dstOffset = 1,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off1_64KB_SingleState"},
+        ForwardUnalignedParams{
+            .dstOffset = 7,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off7_64KB_SingleState"},
+        ForwardUnalignedParams{
+            .dstOffset = 8,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off8_64KB_SingleState"},
+        ForwardUnalignedParams{
+            .dstOffset = 15,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off15_64KB_SingleState"},
+        // Larger transfer with misalignment (multi-step pipeline)
+        ForwardUnalignedParams{
+            .dstOffset = 3,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off3_4MB_SingleState"},
+        ForwardUnalignedParams{
+            .dstOffset = 13,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off13_4MB_SingleState"},
+        // Unaligned size + unaligned offset
+        ForwardUnalignedParams{
+            .dstOffset = 5,
+            .nbytes = 1000003,
+            .useDualStateBuffer = false,
+            .name = "Off5_OddSize_SingleState"},
+        // Dual state mode with misalignment
+        ForwardUnalignedParams{
+            .dstOffset = 1,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = true,
+            .name = "Off1_64KB_DualState"},
+        ForwardUnalignedParams{
+            .dstOffset = 7,
+            .nbytes = 64 * 1024,
+            .useDualStateBuffer = true,
+            .name = "Off7_64KB_DualState"},
+        ForwardUnalignedParams{
+            .dstOffset = 13,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = true,
+            .name = "Off13_4MB_DualState"}),
+    forwardUnalignedParamName);
+
+// Tile forward unaligned: reuse runTileForwardTest's dstOffset parameter.
+class TileForwardUnalignedTestFixture
+    : public MpiBaseTestFixture,
+      public ::testing::WithParamInterface<ForwardUnalignedParams> {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+};
+
+TEST_P(TileForwardUnalignedTestFixture, TileForward) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const auto& params = GetParam();
+  XLOGF(
+      INFO,
+      "Running tile forward unaligned test: {} (nbytes={}, dstOffset={})",
+      params.name,
+      params.nbytes,
+      params.dstOffset);
+
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  // Tile API doesn't use useDualStateBuffer; use a multi-step config so the
+  // unaligned dst is exercised across many steps and chunks.
+  runTileForwardTest(
+      globalRank,
+      numRanks,
+      bs,
+      params.nbytes,
+      /*dataBufferSize=*/8 * 1024 * 1024,
+      /*chunkSize=*/128 * 1024,
+      /*pipelineDepth=*/2,
+      /*numSendBlocks=*/4,
+      /*nIters=*/1,
+      /*threadCount=*/256,
+      params.dstOffset);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TileForwardUnalignedVariations,
+    TileForwardUnalignedTestFixture,
+    ::testing::Values(
+        // Baseline aligned
+        ForwardUnalignedParams{
+            .dstOffset = 0,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Aligned_4MB"},
+        // Various misalignments
+        ForwardUnalignedParams{
+            .dstOffset = 1,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off1_4MB"},
+        ForwardUnalignedParams{
+            .dstOffset = 7,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off7_4MB"},
+        ForwardUnalignedParams{
+            .dstOffset = 8,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off8_4MB"},
+        ForwardUnalignedParams{
+            .dstOffset = 15,
+            .nbytes = 4 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off15_4MB"},
+        // Larger transfer with misalignment
+        ForwardUnalignedParams{
+            .dstOffset = 3,
+            .nbytes = 16 * 1024 * 1024,
+            .useDualStateBuffer = false,
+            .name = "Off3_16MB"},
+        // Unaligned size + unaligned offset
+        ForwardUnalignedParams{
+            .dstOffset = 5,
+            .nbytes = 1000003,
+            .useDualStateBuffer = false,
+            .name = "Off5_OddSize"}),
+    forwardUnalignedParamName);
+
 } // namespace comms::pipes::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -246,6 +246,34 @@ void testWeightedRecvSend(
 }
 
 // =============================================================================
+// forward_group() test kernel and wrapper
+// =============================================================================
+
+__global__ void testForwardKernel(
+    P2pNvlTransportDevice* pred,
+    P2pNvlTransportDevice* succ,
+    void* dst_d,
+    size_t nbytes,
+    GroupType groupType) {
+  auto group = make_group(groupType);
+  pred->forward_group(group, dst_d, nbytes, *succ);
+}
+
+void testForward(
+    P2pNvlTransportDevice* pred,
+    P2pNvlTransportDevice* succ,
+    void* dst_d,
+    size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType,
+    cudaStream_t stream) {
+  testForwardKernel<<<numBlocks, blockSize, 0, stream>>>(
+      pred, succ, dst_d, nbytes, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
 // write() test kernel and wrapper
 // =============================================================================
 

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -120,6 +120,18 @@ void testPutWithSignal(
     int blockSize,
     GroupType groupType = GroupType::WARP);
 
+// forward_group: fused recv-and-forward (reads from predecessor staging buffer,
+// writes to local dst and successor's remote staging buffer simultaneously)
+void testForward(
+    P2pNvlTransportDevice* pred,
+    P2pNvlTransportDevice* succ,
+    void* dst_d,
+    size_t nbytes,
+    int numBlocks,
+    int blockSize,
+    GroupType groupType = GroupType::WARP,
+    cudaStream_t stream = nullptr);
+
 // Test wait() - one-sided wait for peer to write to dst_d and signal
 void testWait(
     P2pNvlTransportDevice* p2p,


### PR DESCRIPTION
Summary:
Adds a fused receive-and-forward primitive (forward_group) to P2pNvlTransportDevice that reads data once from a predecessor's staging buffer and writes simultaneously to a local user buffer and a successor's remote staging buffer. This halves the read bandwidth compared to sequential recv_group + send_group. Used by ring-like algorithms and any topology where a GPU receives data and then forwards it to the next peer.

Changes:
- CopyUtils.cuh: Dual-destination memcpy_vectorized overloads — read source once, write to two destinations in a single pass
- P2pNvlTransportDevice.cuh: forward_group() method supporting both single-state and dual-state chunk modes with correct pipeline signaling
- CopyKernelBench: Microbenchmark showing 10% speedup from fused dual-dst copy vs two-pass (peak 206 GB/s vs 188 GB/s on H100)
- P2pNvlTransportTest: Correctness tests covering small/large transfers, single/dual state modes

Reviewed By: siyengar

Differential Revision: D103736411


