### PR TITLE
Log training step from kvPairs hints + add step_count Scuba column

### DIFF
--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -35,7 +35,8 @@ Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
 Profiler::~Profiler() = default;
 
 void Profiler::initForEachColl(int opCount, int samplingWeight) {
-  shouldTrace_ = samplingWeight > 0 && (opCount % samplingWeight) == 0;
+  shouldTrace_ =
+      forceTrace_ || (samplingWeight > 0 && (opCount % samplingWeight) == 0);
   if (shouldTrace_) {
     opCount_ = opCount;
     durations_.fill(0);

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -49,6 +49,10 @@ class Profiler {
   // This should be called at the beginning of the collective
   void initForEachColl(int opCount, int samplingWeight);
 
+  void setForceTrace(bool force) {
+    forceTrace_ = force;
+  }
+
   bool shouldTrace() const {
     return shouldTrace_;
   }
@@ -86,6 +90,7 @@ class Profiler {
   AlgoProfilerReport buildReport() const;
   CtranComm* comm_{nullptr};
   bool shouldTrace_{false};
+  bool forceTrace_{false};
   uint64_t opCount_{std::numeric_limits<uint64_t>::max()};
   EventDurationArray durations_{};
   EventTimerArray timers_{};

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -61,6 +61,27 @@ TEST_F(ProfilerTest, testInitForEachColl) {
   EXPECT_NE(profiler_->getOpCount(), opCount);
 }
 
+TEST_F(ProfilerTest, testForceTraceOverridesSamplingWeight) {
+  // Without forceTrace, opCount=101 with weight=20 should not trace
+  profiler_->initForEachColl(101, 20);
+  EXPECT_FALSE(profiler_->shouldTrace());
+
+  // With forceTrace, same opCount/weight should trace
+  profiler_->setForceTrace(true);
+  profiler_->initForEachColl(101, 20);
+  EXPECT_TRUE(profiler_->shouldTrace());
+  EXPECT_EQ(getOpCount(), 101);
+
+  // forceTrace persists until caller clears it
+  profiler_->initForEachColl(102, 20);
+  EXPECT_TRUE(profiler_->shouldTrace());
+
+  // Caller clears forceTrace
+  profiler_->setForceTrace(false);
+  profiler_->initForEachColl(101, 20);
+  EXPECT_FALSE(profiler_->shouldTrace());
+}
+
 TEST_F(ProfilerTest, testDefaultReporterType) {
   // Default constructor should use default reporter (no crash on reportToScuba)
   auto profiler = std::make_unique<ctran::Profiler>(comm_);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2995,6 +2995,17 @@ cvars:
      Default: "0" (only rank 0 logs). Set to an empty string to allow
      all ranks to log.
 
+ - name        : MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL
+   type        : int
+   default     : 10
+   description : |-
+     Controls step-based algo profiler logging at the MCCL level. When the
+     training step (from AllReduceOpts kvPairs["step"]) is a multiple of this
+     interval, all allreduce algo profiler data for that step is logged,
+     bypassing the per-op NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT filter.
+     Rank filtering (MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS) still applies.
+     Set to 0 or negative to disable step-based logging.
+
  - name        : NCCL_GIN_GDAKI_NIC_HANDLER
    type        : int
    default     : 0


### PR DESCRIPTION
Summary:
Consume the training step from `AllReduceOpts.kvPairs["step"]` (populated by the parent diff D103889721) in two places on the MCCL side:

1. `McclComm::allReduce` — log the step alongside opCount at INFO via `CLOGF`, so per-allreduce logs can be correlated with the training step.
2. `McclOperationTraceGuard` AllReduce constructor — extract the step into `McclOperationMetadata.stepCount` and emit it as a new `step_count` int column in the `mccl_operation_trace` Scuba table.

Changes:
- `McclComm.cpp`: Read `step` from `opts.kvPairs` and log it with opCount in the per-allreduce INFO line
- `ImplTest.cpp`: Add `AllReduceForwardsKvPairs` unit test verifying the adapter forwards `kvPairs` from the public `allReduce` call down to the underlying MCCL `IComm::allReduce`
- `McclOperationTraceTypes.h`: Add `stepCount` field to `McclOperationMetadata` (sentinel: -1 means not set)
- `McclOperationTraceData.{h,cpp}`: Add `stepCount` field + builder setter, serialize as `step_count` Scuba column in `toSample()`
- `McclOperationTraceGuard.cpp`: Extract step from `opts.kvPairs` in AllReduce ctor, wire it through `populateSample()`
- `McclOperationTraceDataTest.cpp`: Add toSample/builder coverage for `step_count`

Differential Revision: D103909210


