### PR TITLE
Add MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL CVAR for step-based algo profiler logging (#2434)

### DIFF
--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -35,7 +35,8 @@ Profiler::Profiler(CtranComm* comm, std::unique_ptr<IProfilerReporter> reporter)
 Profiler::~Profiler() = default;
 
 void Profiler::initForEachColl(int opCount, int samplingWeight) {
-  shouldTrace_ = samplingWeight > 0 && (opCount % samplingWeight) == 0;
+  shouldTrace_ =
+      forceTrace_ || (samplingWeight > 0 && (opCount % samplingWeight) == 0);
   if (shouldTrace_) {
     opCount_ = opCount;
     durations_.fill(0);

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 
 #include "comms/ctran/CtranComm.h"
@@ -49,6 +50,10 @@ class Profiler {
   // This should be called at the beginning of the collective
   void initForEachColl(int opCount, int samplingWeight);
 
+  void setForceTrace(bool force) {
+    forceTrace_ = force;
+  }
+
   bool shouldTrace() const {
     return shouldTrace_;
   }
@@ -86,6 +91,7 @@ class Profiler {
   AlgoProfilerReport buildReport() const;
   CtranComm* comm_{nullptr};
   bool shouldTrace_{false};
+  std::atomic<bool> forceTrace_{false};
   uint64_t opCount_{std::numeric_limits<uint64_t>::max()};
   EventDurationArray durations_{};
   EventTimerArray timers_{};

--- a/comms/ctran/profiler/tests/ProfilerTest.cc
+++ b/comms/ctran/profiler/tests/ProfilerTest.cc
@@ -61,6 +61,27 @@ TEST_F(ProfilerTest, testInitForEachColl) {
   EXPECT_NE(profiler_->getOpCount(), opCount);
 }
 
+TEST_F(ProfilerTest, testForceTraceOverridesSamplingWeight) {
+  // Without forceTrace, opCount=101 with weight=20 should not trace
+  profiler_->initForEachColl(101, 20);
+  EXPECT_FALSE(profiler_->shouldTrace());
+
+  // With forceTrace, same opCount/weight should trace
+  profiler_->setForceTrace(true);
+  profiler_->initForEachColl(101, 20);
+  EXPECT_TRUE(profiler_->shouldTrace());
+  EXPECT_EQ(getOpCount(), 101);
+
+  // forceTrace persists until caller clears it
+  profiler_->initForEachColl(102, 20);
+  EXPECT_TRUE(profiler_->shouldTrace());
+
+  // Caller clears forceTrace
+  profiler_->setForceTrace(false);
+  profiler_->initForEachColl(101, 20);
+  EXPECT_FALSE(profiler_->shouldTrace());
+}
+
 TEST_F(ProfilerTest, testDefaultReporterType) {
   // Default constructor should use default reporter (no crash on reportToScuba)
   auto profiler = std::make_unique<ctran::Profiler>(comm_);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3038,6 +3038,17 @@ cvars:
      Default: "0" (only rank 0 logs). Set to an empty string to allow
      all ranks to log.
 
+ - name        : MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL
+   type        : int
+   default     : 113
+   description : |-
+     Controls step-based algo profiler logging at the MCCL level. When the
+     training step (from AllReduceOpts kvPairs["step"]) is a multiple of this
+     interval, all allreduce algo profiler data for that step is logged,
+     bypassing the per-op NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT filter.
+     Rank filtering (MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS) still applies.
+     Set to 0 or negative to disable step-based logging.
+
  - name        : NCCL_GIN_GDAKI_NIC_HANDLER
    type        : int
    default     : 0


### PR DESCRIPTION
Summary:

Add a new CVAR MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL (default 10) that forces algo profiler logging for all allreduces when the training step is a multiple of the interval. This bypasses the per-op NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT sampling filter while still respecting rank filtering (MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS).

Three-layer filtering for algo profiler data:
1. Rank filter (existing): profiler is null for non-allowed ranks
2. Weight-based sampling (existing): opCount % weight == 0
3. Step-based override (NEW): if step % interval == 0, force-trace all allreduces for that step

Adds setForceTrace(bool) to ctran Profiler, caller-managed (MCCL sets it every allReduce call, true or false).

Reviewed By: saifhhasan

Differential Revision: D104283581


