### PR TITLE
Migrate memory logging call sites to memtrace

### DIFF
--- a/comms/ncclx/v2_27/src/allocator.cc
+++ b/comms/ncclx/v2_27/src/allocator.cc
@@ -7,6 +7,7 @@
 #include "comm.h"
 #include "transport.h"
 #include "group.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 NCCL_API(ncclResult_t, ncclMemAlloc, void **ptr, size_t size);
 ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
@@ -70,7 +71,7 @@ ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
     CUCHECK(cuMemAddressReserve((CUdeviceptr*)ptr, handleSize, memGran, 0, 0));
     /* Map the virtual address range to the physical allocation */
     CUCHECK(cuMemMap((CUdeviceptr)*ptr, handleSize, 0, handle, 0));
-    logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
+    meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
     /* Now allow RW access to the newly mapped memory */
     for (int i = 0; i < dcnt; ++i) {
       int p2p = 0;
@@ -91,7 +92,7 @@ fallback:
   // we want CUDA to return an error to the caller.
   // coverity[var_deref_model]
   CUDACHECKGOTO(cudaMalloc(ptr, size), ret, fail);
-  logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
+  meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
 
 exit:
   return ret;

--- a/comms/ncclx/v2_27/src/include/alloc.h
+++ b/comms/ncclx/v2_27/src/include/alloc.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 uint64_t clockNano(); // from utils.h with which we have a circular dependency
 
@@ -243,7 +243,7 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
   CUCHECK(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1));
   if (handlep) *handlep = handle;
   TRACE(NCCL_ALLOC, "CuMem Alloc Size %zu pointer %p handle %llx", size, *ptr, handle);
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
     memLogMetaData,
     callsite,
     "ncclCuMemAlloc",
@@ -265,7 +265,7 @@ static inline ncclResult_t ncclCuMemFree(void *ptr) {
   CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
   CUCHECK(cuMemRelease(handle));
   CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));
-  logMemoryEvent(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
+  meta::comms::memtrace::recordFree(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
   memLogMetaData = CommLogData{};
   return result;
 }
@@ -313,7 +313,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA malloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         memLogMetaData,
         callsite.c_str(),
         "ncclCudaMalloc",
@@ -350,7 +350,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
       memLogMetaData,
       callsite.c_str(),
       "ncclCudaCalloc",
@@ -382,7 +382,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc async %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
       memLogMetaData,
       callsite.c_str(),
       "ncclCudaCallocAsync",
@@ -434,7 +434,7 @@ ncclResult_t ncclCudaFree(T* ptr) {
   }
 finish:
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordFree(
         memLogMetaData,
         "",
         "ncclCudaFree",

--- a/comms/ncclx/v2_27/src/register/register.cc
+++ b/comms/ncclx/v2_27/src/register/register.cc
@@ -14,6 +14,7 @@
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/ctran/Ctran.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "meta/rma/ncclWin.h"
 #include "meta/algoconf/AlgoConfig.h"
@@ -158,7 +159,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-      logMemoryEvent(
+      meta::comms::memtrace::recordReg(
         comm->logMetaData,
         "",
         "ncclCommRegister",
@@ -167,8 +168,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
         0,
         std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+          .count());
   }
   return ncclSuccess;
 }
@@ -237,7 +237,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordReg(
         comm->logMetaData,
         "",
         "ncclCommDeregister",
@@ -246,8 +246,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
         0,
         std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+          .count());
   }
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_27/src/transport/nvls.cc
+++ b/comms/ncclx/v2_27/src/transport/nvls.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/ctran/memory/Utils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 #if CUDART_VERSION >= 12010
 
@@ -269,7 +270,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   CUCHECKGOTO(cuMemMap((CUdeviceptr)*ucptr, ucsize, 0, *ucHandle, 0), ret, fail2);
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ucptr, ucsize, desc, 1), ret, fail3);
   CUDACHECKGOTO(cudaMemset(*ucptr, 0, ucsize), ret, fail3);
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
     comm->logMetaData,
     "nvlsAllocateMem",
     "cuMemCreate",

--- a/comms/ncclx/v2_28/src/allocator.cc
+++ b/comms/ncclx/v2_28/src/allocator.cc
@@ -10,7 +10,7 @@
 #include "nvtx.h"
 
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 NCCL_API(ncclResult_t, ncclMemAlloc, void **ptr, size_t size);
 ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
@@ -73,7 +73,7 @@ ncclResult_t  ncclMemAlloc(void **ptr, size_t size) {
     CUCHECK(cuMemAddressReserve((CUdeviceptr*)ptr, handleSize, memGran, 0, 0));
     /* Map the virtual address range to the physical allocation */
     CUCHECK(cuMemMap((CUdeviceptr)*ptr, handleSize, 0, handle, 0));
-    logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
+    meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), handleSize);
     /* Now allow RW access to the newly mapped memory */
     for (int i = 0; i < dcnt; ++i) {
       int p2p = 0;
@@ -94,7 +94,7 @@ fallback:
   // we want CUDA to return an error to the caller.
   // coverity[var_deref_model]
   CUDACHECKGOTO(cudaMalloc(ptr, size), ret, fail);
-  logMemoryEvent(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
+  meta::comms::memtrace::recordAlloc(CommLogData{}, "", "ncclMemAlloc", reinterpret_cast<uintptr_t>(*ptr), size);
 
 exit:
   return ret;

--- a/comms/ncclx/v2_28/src/include/alloc.h
+++ b/comms/ncclx/v2_28/src/include/alloc.h
@@ -24,7 +24,7 @@
 #endif
 
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 uint64_t clockNano(); // from utils.h with which we have a circular dependency
 
@@ -243,7 +243,7 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
   CUCHECK(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1));
   if (handlep) *handlep = handle;
   TRACE(NCCL_ALLOC, "CuMem Alloc Size %zu pointer %p handle %llx", size, *ptr, handle);
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
     memLogMetaData,
     callsite,
     "ncclCuMemAlloc",
@@ -265,7 +265,7 @@ static inline ncclResult_t ncclCuMemFree(void *ptr) {
   CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
   CUCHECK(cuMemRelease(handle));
   CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));
-  logMemoryEvent(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
+  meta::comms::memtrace::recordFree(memLogMetaData, "", "ncclCuMemFree", reinterpret_cast<uintptr_t>(ptr));
   memLogMetaData = CommLogData{};
   return result;
 }
@@ -313,7 +313,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA malloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         memLogMetaData,
         callsite.c_str(),
         "ncclCudaMalloc",
@@ -350,7 +350,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
       memLogMetaData,
       callsite.c_str(),
       "ncclCudaCalloc",
@@ -382,7 +382,7 @@ finish:
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc async %ld bytes", nelem*ncclSizeOfT<T>());
   INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         memLogMetaData,
         callsite,
         "ncclCudaCallocAsync",
@@ -434,7 +434,7 @@ ncclResult_t ncclCudaFree(T* ptr) {
   }
 finish:
   if (!ncclCuMemEnable()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordFree(
         memLogMetaData,
         "",
         "ncclCudaFree",

--- a/comms/ncclx/v2_28/src/register/register.cc
+++ b/comms/ncclx/v2_28/src/register/register.cc
@@ -15,6 +15,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "comms/ctran/Ctran.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 // conflict with ctran, disable for now.
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);
@@ -148,7 +149,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-      logMemoryEvent(
+      meta::comms::memtrace::recordReg(
         comm->logMetaData,
         "",
         "ncclCommRegister",
@@ -157,8 +158,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, vo
         0,
         std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+          .count());
   }
   return ncclSuccess;
 }
@@ -233,7 +233,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
       comm->logMetaData.commHash,
       comm->logMetaData.commDesc.c_str());
   if (NCCL_COMM_REGISTER_LOG_ENABLE) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordReg(
         comm->logMetaData,
         "",
         "ncclCommDeregister",
@@ -242,8 +242,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
         0,
         std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-          true /* isRegMemEvent */);
+          .count());
   }
   return ncclSuccess;
 }

--- a/comms/ncclx/v2_28/src/transport/nvls.cc
+++ b/comms/ncclx/v2_28/src/transport/nvls.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/logger/Logger.h"
 #include "comms/ctran/memory/Utils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 #if CUDART_VERSION >= 12010
 
@@ -273,7 +274,7 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   CUCHECKGOTO(cuMemMap((CUdeviceptr)*ucptr, ucsize, 0, *ucHandle, 0), ret, fail2);
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ucptr, ucsize, desc, 1), ret, fail3);
   CUDACHECKGOTO(cudaMemset(*ucptr, 0, ucsize), ret, fail3);
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
     comm->logMetaData,
     "nvlsAllocateMem",
     "cuMemCreate",

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -81,6 +81,14 @@ cvars:
       File location for logging memory related events.
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
+ - name        : NCCL_MEMTRACE_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable memory tracing for all NCCLX memory allocations, frees, and
+     registrations. When enabled, memory events are logged to Scuba and
+     tracked per-communicator for commDump reporting.
+
  - name        : NCCL_SLOW_COLL_LOGGING
    type        : string
    default     : "pipe:nccl_slow_coll"

--- a/comms/utils/memtrace/MemoryTrace.cc
+++ b/comms/utils/memtrace/MemoryTrace.cc
@@ -80,8 +80,12 @@ void recordAlloc(
     int64_t bytes,
     std::optional<int> numSegments,
     std::optional<int64_t> durationUs) {
+  if (!NCCL_MEMTRACE_ENABLE) {
+    return;
+  }
   logMemoryEvent(
       logMetaData, callsite, use, addr, bytes, numSegments, durationUs);
+  MemoryTrace::getOrCreate(logMetaData.commHash)->recordAlloc(addr, bytes);
 }
 
 void recordFree(
@@ -90,7 +94,11 @@ void recordFree(
     const std::string& use,
     uintptr_t addr,
     std::optional<int64_t> bytes) {
+  if (!NCCL_MEMTRACE_ENABLE) {
+    return;
+  }
   logMemoryEvent(logMetaData, callsite, use, addr, bytes);
+  MemoryTrace::getOrCreate(logMetaData.commHash)->recordFree(addr, bytes);
 }
 
 void recordReg(
@@ -101,6 +109,9 @@ void recordReg(
     std::optional<int64_t> bytes,
     std::optional<int> numSegments,
     std::optional<int64_t> durationUs) {
+  if (!NCCL_MEMTRACE_ENABLE) {
+    return;
+  }
   logMemoryEvent(
       logMetaData,
       callsite,


### PR DESCRIPTION
Summary:
Migrate all 11 logMemoryEvent call sites in v2_27 ncclx to use memtrace::recordAlloc/recordFree/recordReg, mirroring v2_29/v2_28 migrations:
- alloc.h: 6 sites (4 recordAlloc, 2 recordFree)
- allocator.cc: 2 sites (recordAlloc)
- register.cc: 2 sites (recordReg)
- nvls.cc: 1 site (recordAlloc)
- Replace fbcode//comms/utils/logger:alloc dep with fbcode//comms/utils/memtrace:memory_tracer in v2_27 def_build.bzl

Reviewed By: YulunW

Differential Revision: D96010724


