### PR TITLE
Enable Pyrefly type checking at fbcode/comms root (#2439)

### DIFF
--- a/comms/ncclx/meta/tests/CommCudaInitMpTest.py
+++ b/comms/ncclx/meta/tests/CommCudaInitMpTest.py
@@ -66,6 +66,7 @@ class TestCudaInit(unittest.TestCase):
             print(f"\nTesting start method: {start_method}")
             ctx = mp.get_context(start_method)
             device_id = 0
+            # pyrefly: ignore [missing-attribute]
             process = ctx.Process(target=child_process_func, args=(device_id,))
 
             process.start()

--- a/comms/ncclx/v2_27/src/device/generate.py
+++ b/comms/ncclx/v2_27/src/device/generate.py
@@ -68,6 +68,7 @@ if func_pattern and func_pattern[0]:
   func_pattern = func_pattern.replace("*", "[^ ]*")
   func_pattern += "$"
   def func_filter(*fn):
+    # pyrefly: ignore [no-matching-overload]
     return None is not re.match(func_pattern, paste(" ", *fn), flags=re.IGNORECASE)
 else:
   def func_filter(coll, redop, ty, algo, proto):

--- a/comms/ncclx/v2_27/src/device/symmetric/generate.py
+++ b/comms/ncclx/v2_27/src/device/symmetric/generate.py
@@ -33,9 +33,12 @@ class Rec(object):
   def __init__(me, **kw):
     me.__dict__.update(kw)
   def __eq__(x, y):
+    # pyrefly: ignore [bad-argument-type]
     if len(x) != len(y): return False
+    # pyrefly: ignore [not-iterable]
     for k in x:
       if k not in y: return False
+      # pyrefly: ignore [bad-index]
       if x[k] != y[k]: return False
     return True
   def __hash__(me):

--- a/comms/ncclx/v2_28/src/device/generate.py
+++ b/comms/ncclx/v2_28/src/device/generate.py
@@ -72,6 +72,7 @@ if func_pattern and func_pattern[0]:
   func_pattern = func_pattern.replace("*", "[^ ]*")
   func_pattern += "$"
   def func_filter(*fn):
+    # pyrefly: ignore [no-matching-overload]
     return None is not re.match(func_pattern, paste(" ", *fn), flags=re.IGNORECASE)
 else:
   def func_filter(coll, redop, ty, algo, proto):

--- a/comms/ncclx/v2_28/src/device/symmetric/generate.py
+++ b/comms/ncclx/v2_28/src/device/symmetric/generate.py
@@ -37,9 +37,12 @@ class Rec(object):
   def __init__(me, **kw):
     me.__dict__.update(kw)
   def __eq__(x, y):
+    # pyrefly: ignore [bad-argument-type]
     if len(x) != len(y): return False
+    # pyrefly: ignore [not-iterable]
     for k in x:
       if k not in y: return False
+      # pyrefly: ignore [bad-index]
       if x[k] != y[k]: return False
     return True
   def __hash__(me):

--- a/comms/ncclx/v2_29/src/device/generate.py
+++ b/comms/ncclx/v2_29/src/device/generate.py
@@ -72,6 +72,7 @@ if func_pattern and func_pattern[0]:
   func_pattern = func_pattern.replace("*", "[^ ]*")
   func_pattern += "$"
   def func_filter(*fn):
+    # pyrefly: ignore [no-matching-overload]
     return None is not re.match(func_pattern, paste(" ", *fn), flags=re.IGNORECASE)
 else:
   def func_filter(coll, redop, ty, algo, proto):

--- a/comms/pipes/collectives/triton/alltoallv_op.py
+++ b/comms/pipes/collectives/triton/alltoallv_op.py
@@ -567,6 +567,7 @@ class AlltoallvOp:
             self.comm.barrier(False)
         # First deregister comms buffers
         if self._src_info is not None:
+            # pyrefly: ignore [missing-attribute]
             self._window.deregister_local_buffer(self._src_info)
             self._src_info = None
         if self._window is not None:
@@ -578,17 +579,23 @@ class AlltoallvOp:
 
         # Release all GPU buffers to free memory immediately.
         # Without this, Python GC may defer collection and cause OOM.
+        # pyrefly: ignore [bad-assignment]
         self.send_buf = None
+        # pyrefly: ignore [bad-assignment]
         self.recv_buf = None
+        # pyrefly: ignore [bad-assignment]
         self._local_recv_slot_offsets = None
         self._send_sizes_bytes = None
         self._send_offsets_bytes = None
         self._recv_sizes_bytes = None
+        # pyrefly: ignore [bad-assignment]
         self._total_tokens_buf = None
         self._remote_write_offsets = None
 
         # Release MemPools AFTER buffers (buffers use the pools)
+        # pyrefly: ignore [bad-assignment]
         self._send_pool = None
+        # pyrefly: ignore [bad-assignment]
         self._recv_pool = None
 
     def __enter__(self) -> "AlltoallvOp":
@@ -636,6 +643,7 @@ class AlltoallvOp:
         """
         # Use recv_pool since it's the larger allocation and will be used
         # for any internal allocations during alltoallv execution.
+        # pyrefly: ignore [bad-return]
         return self._recv_pool.id
 
     # ------------------------------------------------------------------

--- a/comms/pipes/collectives/triton/tests/autotune_sweep_ib.py
+++ b/comms/pipes/collectives/triton/tests/autotune_sweep_ib.py
@@ -71,12 +71,16 @@ class SweepConfig:
 
     def __post_init__(self) -> None:
         if self.msg_sizes is None:
+            # pyrefly: ignore [bad-assignment]
             self.msg_sizes = list(_DEFAULT_MSG_SIZES)
         if self.blocks_per_peer_values is None:
+            # pyrefly: ignore [bad-assignment]
             self.blocks_per_peer_values = list(_DEFAULT_BPP)
         if self.num_warps_values is None:
+            # pyrefly: ignore [bad-assignment]
             self.num_warps_values = list(_DEFAULT_WARPS)
         if self.chunk_size_values is None:
+            # pyrefly: ignore [bad-assignment]
             self.chunk_size_values = list(_DEFAULT_CHUNKS)
 
 
@@ -252,6 +256,7 @@ class IBAutoTuneSweep:
                 recv_offsets,
                 dst_offsets,
                 self.dev_win_ptr,
+                # pyrefly: ignore [bad-argument-type]
                 self.src_info,
                 self.rank,
                 self.num_ranks,
@@ -279,6 +284,7 @@ class IBAutoTuneSweep:
                         recv_offsets,
                         dst_offsets,
                         self.dev_win_ptr,
+                        # pyrefly: ignore [bad-argument-type]
                         self.src_info,
                         self.rank,
                         self.num_ranks,

--- a/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/benchmark_device_alltoallv_dynamic.py
@@ -161,6 +161,7 @@ class AlltoallvDynamicBenchmark:
         """Deregister send buffer so it can be modified."""
         if self.src_info is not None:
             self.window.deregister_local_buffer(self.src_info)
+            # pyrefly: ignore [bad-assignment]
             self.src_info = None
 
     def _register_src(self) -> None:
@@ -186,13 +187,17 @@ class AlltoallvDynamicBenchmark:
         self.comm.barrier(False)
         if self.src_info is not None:
             self.window.deregister_local_buffer(self.src_info)
+            # pyrefly: ignore [bad-assignment]
             self.src_info = None
         if self.window is not None:
             self.window.tensor_deregister()
+            # pyrefly: ignore [bad-assignment]
             self.window = None
 
         # 4. Clean up class-level pools LAST (after all graphs are destroyed)
+        # pyrefly: ignore [bad-assignment]
         self.recv_buf = None
+        # pyrefly: ignore [bad-assignment]
         self.send_buf = None
         self.recv_pool = None  # pyre-ignore[8]: Intentional cleanup
         self.send_pool = None  # pyre-ignore[8]: Intentional cleanup

--- a/comms/pipes/collectives/triton/tests/benchmark_tile_sendrecv.py
+++ b/comms/pipes/collectives/triton/tests/benchmark_tile_sendrecv.py
@@ -70,8 +70,9 @@ class BenchmarkConfig:
 
 
 if TRITON_AVAILABLE:
-
+    # pyrefly: ignore [unbound-name]
     @requires_torchcomms
+    # pyrefly: ignore [unbound-name]
     @triton.jit
     def tile_sendrecv_kernel(
         transport_ptr,

--- a/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_alltoallv_op_e2e.py
@@ -1391,6 +1391,7 @@ class TestOpMultiIterDifferentContentPackedGraphLoop(_OpTestBase):
                 graph_stream.synchronize()
 
                 # Clone output after this replay
+                # pyrefly: ignore [unbound-name]
                 replay_output = graph_output.clone()
 
                 # Verify packed output shape
@@ -1546,6 +1547,7 @@ class TestOpMultiIterDifferentContentPackedGraphLoopCopyIn(_OpTestBase):
                 graph_stream.synchronize()
 
                 # Clone output after this replay
+                # pyrefly: ignore [unbound-name]
                 replay_output = graph_output.clone()
 
                 # Verify packed output shape

--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic_e2e.py
@@ -136,7 +136,9 @@ class _SingleTestBase(unittest.TestCase):
         if hasattr(cls, "window") and cls.window is not None:
             cls.window.tensor_deregister()
             cls.window = None
+        # pyrefly: ignore [bad-assignment]
         cls.recv_buf = None
+        # pyrefly: ignore [bad-assignment]
         cls.send_buf = None
         cls.recv_pool = None
         cls.send_pool = None
@@ -241,7 +243,9 @@ class TestUniformSizesBasic(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -276,7 +280,9 @@ class TestLargeMessages(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -314,7 +320,9 @@ class TestMinimumMessageSize(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -350,7 +358,9 @@ class TestRepeatedCalls(_SingleTestBase):
                 recv_sizes,
                 local_recv_slot_offsets,
                 remote_write_offsets,
+                # pyrefly: ignore [bad-argument-type]
                 self.dev_win_ptr,
+                # pyrefly: ignore [bad-argument-type]
                 self.src_info,
                 self.my_rank,
                 self.world_size,
@@ -394,7 +404,9 @@ class TestNumWarps4(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -428,7 +440,9 @@ class TestNumWarps32(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -467,7 +481,9 @@ class TestBlocksPerPeer2Uniform(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -501,7 +517,9 @@ class TestBlocksPerPeer4Uniform(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -542,7 +560,9 @@ class TestBlocksPerPeer4Large(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -585,7 +605,9 @@ class TestBlocksPerPeerConsistency(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -613,7 +635,9 @@ class TestBlocksPerPeerConsistency(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -673,7 +697,9 @@ class TestRepeatedCallsMultiBlock(_SingleTestBase):
                 recv_sizes,
                 local_recv_slot_offsets,
                 remote_write_offsets,
+                # pyrefly: ignore [bad-argument-type]
                 self.dev_win_ptr,
+                # pyrefly: ignore [bad-argument-type]
                 self.src_info,
                 self.my_rank,
                 self.world_size,
@@ -725,7 +751,9 @@ class TestRepeatedCallsVaryingBlocksPerPeer(_SingleTestBase):
                 recv_sizes,
                 local_recv_slot_offsets,
                 remote_write_offsets,
+                # pyrefly: ignore [bad-argument-type]
                 self.dev_win_ptr,
+                # pyrefly: ignore [bad-argument-type]
                 self.src_info,
                 self.my_rank,
                 self.world_size,
@@ -769,7 +797,9 @@ class TestSyncBufferBasic(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,
@@ -824,7 +854,9 @@ class TestSyncBufferRepeatedCalls(_SingleTestBase):
                 recv_sizes,
                 local_recv_slot_offsets,
                 remote_write_offsets,
+                # pyrefly: ignore [bad-argument-type]
                 self.dev_win_ptr,
+                # pyrefly: ignore [bad-argument-type]
                 self.src_info,
                 self.my_rank,
                 self.world_size,
@@ -868,7 +900,9 @@ class TestSyncBufferMultiBlock(_SingleTestBase):
             recv_sizes,
             local_recv_slot_offsets,
             remote_write_offsets,
+            # pyrefly: ignore [bad-argument-type]
             self.dev_win_ptr,
+            # pyrefly: ignore [bad-argument-type]
             self.src_info,
             self.my_rank,
             self.world_size,

--- a/comms/pipes/triton/collectives/ib/put_bw_op.py
+++ b/comms/pipes/triton/collectives/ib/put_bw_op.py
@@ -143,6 +143,7 @@ class PutBwOp:
             )
 
         # Increment iteration counter for monotonic signal tracking
+        # pyrefly: ignore [unexpected-keyword]
         _increment_iteration_kernel[(1,)](self._iteration, num_warps=1)
 
     def _call_fireforget(

--- a/comms/pipes/triton/collectives/ib/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/ib/sendrecv_op.py
@@ -227,10 +227,20 @@ class SendRecvOp:
 
         # Reset coordination counters.
         _fill_kernel[(1,)](
-            self.send_coord, 0, self.pipeline_depth, BLOCK_SIZE=64, num_warps=1
+            # pyrefly: ignore [bad-argument-type, unexpected-keyword]
+            self.send_coord,
+            0,
+            self.pipeline_depth,
+            BLOCK_SIZE=64,
+            num_warps=1,
         )
         _fill_kernel[(1,)](
-            self.recv_coord, 0, self.pipeline_depth, BLOCK_SIZE=64, num_warps=1
+            # pyrefly: ignore [bad-argument-type, unexpected-keyword]
+            self.recv_coord,
+            0,
+            self.pipeline_depth,
+            BLOCK_SIZE=64,
+            num_warps=1,
         )
 
         sendrecv_cooperative_kernel[grid](
@@ -297,11 +307,16 @@ class SendRecvOp:
         self.dev_win = None
         self.window = None
         # 4: Release staging buffers and memory pool
+        # pyrefly: ignore [bad-assignment]
         self.send_staging = None
+        # pyrefly: ignore [bad-assignment]
         self.recv_staging = None
+        # pyrefly: ignore [bad-assignment]
         self._pool = None
         if not self.parallel:
+            # pyrefly: ignore [bad-assignment]
             self.send_coord = None
+            # pyrefly: ignore [bad-assignment]
             self.recv_coord = None
         # 5: Barrier after full cleanup
         self.comm.barrier(False)

--- a/comms/torchcomms/device_mesh.py
+++ b/comms/torchcomms/device_mesh.py
@@ -72,12 +72,15 @@ def _create_torchcomm_process_group(
     # Register backend
     # pyre-fixme[6]: BackendWrapper implements dist.Backend but types isn't aware
     pg._register_backend(comm.get_device(), backend_type, wrapper)
+    # pyrefly: ignore [bad-argument-type]
     pg._set_group_name(group_name)
 
     # Update global state
     dist.distributed_c10d._world.pg_map[pg] = (backend_str, dummy_store)
+    # pyrefly: ignore [unsupported-operation]
     dist.distributed_c10d._world.pg_names[pg] = group_name
     dist.distributed_c10d._world.pg_backend_config[pg] = str(backend_config)
+    # pyrefly: ignore [bad-argument-type]
     dist.distributed_c10d._register_process_group(group_name, pg)
 
     # Set up rank mapping
@@ -168,6 +171,7 @@ def init_device_mesh(
         _init_backend=False,
         _rank=global_rank,
     )
+    # pyrefly: ignore [bad-assignment]
     device_mesh._dim_group_names = group_names
 
     return device_mesh
@@ -222,6 +226,7 @@ def _flatten_with_comm(
             _rank=comm.get_rank(),
             _layout=coalesced_layout,
         )
+    # pyrefly: ignore [bad-assignment]
     flattened_device_mesh._dim_group_names = [mesh_dim_name]
 
     try:

--- a/comms/torchcomms/distwrap/collectives.py
+++ b/comms/torchcomms/distwrap/collectives.py
@@ -537,15 +537,21 @@ def batch_isend_irecv(p2p_op_list: list[Any]) -> list[dist.Work]:
         for p2p_op in p2p_op_list:
             # Handle both distwrap P2POp and torch.distributed.P2POp
             actual_op = getattr(p2p_op, "_p2p_op", p2p_op)
+            # pyrefly: ignore [missing-attribute]
             pg = get_group(actual_op.group)
             pg_info_assert_registered(pg)
+            # pyrefly: ignore [missing-attribute]
             tc = get_torchcomms_instance(pg, tensor=actual_op.tensor)
+            # pyrefly: ignore [missing-attribute]
             op_name = actual_op.op.__name__
 
             # Get group_peer, converting from global peer if needed
+            # pyrefly: ignore [missing-attribute]
             group_peer = actual_op.group_peer
             if group_peer is None:
+                # pyrefly: ignore [missing-attribute]
                 if actual_op.peer is not None:
+                    # pyrefly: ignore [bad-argument-type]
                     group_peer = get_group_rank(pg, actual_op.peer)
                 else:
                     raise ValueError(
@@ -554,8 +560,10 @@ def batch_isend_irecv(p2p_op_list: list[Any]) -> list[dist.Work]:
                     )
 
             if "send" in op_name:
+                # pyrefly: ignore [missing-attribute]
                 work = tc.send(actual_op.tensor, group_peer, True)
             elif "recv" in op_name:
+                # pyrefly: ignore [missing-attribute]
                 work = tc.recv(actual_op.tensor, group_peer, True)
             else:
                 raise ValueError(f"Unknown P2P operation: {op_name}")
@@ -563,6 +571,7 @@ def batch_isend_irecv(p2p_op_list: list[Any]) -> list[dist.Work]:
         return works
     # Unwrap distwrap P2POp objects to torch.distributed.P2POp
     unwrapped_ops = [getattr(op, "_p2p_op", op) for op in p2p_op_list]
+    # pyrefly: ignore [bad-argument-type]
     works = dist.batch_isend_irecv(unwrapped_ops)
     if works is None:
         raise AssertionError("dist.batch_isend_irecv returned None")

--- a/comms/torchcomms/distwrap/new_comm.py
+++ b/comms/torchcomms/distwrap/new_comm.py
@@ -322,6 +322,7 @@ def split_group(  # noqa: C901
                     if hasattr(pg_options, "config") and hasattr(
                         pg_options.config, "split_share"
                     ):
+                        # pyrefly: ignore [missing-attribute]
                         pg_options.config.split_share = 0
 
             # Use dist.split_group

--- a/comms/torchcomms/ncclx/tests/integration/py/AllToAllvDynamicTest.py
+++ b/comms/torchcomms/ncclx/tests/integration/py/AllToAllvDynamicTest.py
@@ -70,6 +70,7 @@ class AllToAllvDynamicDispatchTest(unittest.TestCase):
         """Set up test environment before each test."""
         # NCCLX alltoallvDynamic requires NCCL_CTRAN_ENABLE=1
         os.environ["NCCL_CTRAN_ENABLE"] = "1"
+        # pyrefly: ignore [missing-attribute]
         if self.use_ib:
             os.environ["NCCL_COMM_STATE_DEBUG_TOPO"] = "nolocal"
         self.wrapper = self.get_wrapper()

--- a/comms/torchcomms/ncclx/tests/integration/py/ProfilerKinetoOverheadTest.py
+++ b/comms/torchcomms/ncclx/tests/integration/py/ProfilerKinetoOverheadTest.py
@@ -47,6 +47,7 @@ class ProfilerKinetoOverheadTest(unittest.TestCase):
         # Finalize the TorchComm object to ensure proper cleanup
         if self.torchcomm:
             self.torchcomm.finalize()
+            # pyrefly: ignore [bad-assignment]
             self.torchcomm = None
 
     def _sanity_check_profiler_ncclx_meta(self, ncclx_meta_events):

--- a/comms/torchcomms/ncclx/tests/integration/py/ReduceScatterQuantizedTest.py
+++ b/comms/torchcomms/ncclx/tests/integration/py/ReduceScatterQuantizedTest.py
@@ -35,6 +35,7 @@ class ReduceScatterQuantizedTest(unittest.TestCase):
     def tearDown(self):
         """Clean up after each test."""
         self.torchcomm = None
+        # pyrefly: ignore [bad-assignment]
         self.wrapper = None
 
     def test_reduce_scatter_quantized_sum(self):

--- a/comms/torchcomms/objcol.py
+++ b/comms/torchcomms/objcol.py
@@ -687,6 +687,7 @@ def scatter_object_list(
     comm.broadcast(max_tensor_size, root=root, async_op=False, timeout=timeout)
 
     # Scatter actual serialized objects
+    # pyrefly: ignore [no-matching-overload]
     output_tensor = torch.empty(
         max_tensor_size.item(), dtype=torch.uint8, device=current_device
     )

--- a/comms/torchcomms/tests/integration/py/AllToAllTest.py
+++ b/comms/torchcomms/tests/integration/py/AllToAllTest.py
@@ -233,6 +233,7 @@ class AllToAllTest(unittest.TestCase):
                 tensor = torch.ones(count, **options) * int(self.rank + 1)
             elif dtype == torch.int8:
                 tensor = torch.ones(count, **options) * int(self.rank + 1)
+            # pyrefly: ignore [unbound-name]
             input_tensors.append(tensor)
 
         return input_tensors

--- a/comms/torchcomms/tests/integration/py/BatchSendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/BatchSendRecvTest.py
@@ -378,11 +378,13 @@ class BatchSendRecvTest(unittest.TestCase):
             description = f"recv rank {recv_rank} tensor {i}"
             if dtype == torch.float:
                 self.assertTrue(
+                    # pyrefly: ignore [unbound-name]
                     torch.allclose(recv_tensor.cpu(), expected),
                     f"Tensors not close enough for {description}",
                 )
             else:
                 self.assertTrue(
+                    # pyrefly: ignore [unbound-name]
                     torch.equal(recv_tensor.cpu(), expected),
                     f"Tensors not equal for {description}",
                 )

--- a/comms/torchcomms/tests/integration/py/BroadcastTest.py
+++ b/comms/torchcomms/tests/integration/py/BroadcastTest.py
@@ -175,6 +175,7 @@ class BroadcastTest(unittest.TestCase):
             for _ in range(self.num_replays):
                 # Reset tensor before each replay (non-root ranks need fresh data)
                 if self.rank != root_rank:
+                    # pyrefly: ignore [unbound-name]
                     tensor.copy_(original_tensor)
 
                 graph.replay()

--- a/comms/torchcomms/tests/integration/py/DPTPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/DPTPCommTest.py
@@ -88,6 +88,7 @@ class MLPStack(nn.Sequential):
             if isinstance(module, nn.LayerNorm):
                 continue
             if use_activation_checkpointing:
+                # pyrefly: ignore [invalid-param-spec]
                 checkpoint(module)
             fully_shard(module, mesh=dp_mesh, **fsdp_kwargs)
         fully_shard(self, mesh=dp_mesh, **fsdp_kwargs)
@@ -132,7 +133,9 @@ class DPTPCommTest(unittest.TestCase):
                 break
 
         # Create communicators using the new single-list API
+        # pyrefly: ignore [bad-argument-type]
         tp_comm = comm.split(tp_ranks, "tp")
+        # pyrefly: ignore [bad-argument-type]
         dp_comm = comm.split(dp_ranks, "dp")
 
         try:

--- a/comms/torchcomms/tests/integration/py/DeviceMeshTest.py
+++ b/comms/torchcomms/tests/integration/py/DeviceMeshTest.py
@@ -108,7 +108,9 @@ class DeviceMeshTest(unittest.TestCase):
                 break
 
         # Create communicators using the new single-list API
+        # pyrefly: ignore [bad-argument-type]
         tp_comm = comm.split(tp_ranks, "tp")
+        # pyrefly: ignore [bad-argument-type]
         dp_comm = comm.split(dp_ranks, "dp")
 
         sub_comms = {"dp": dp_comm, "tp": tp_comm}

--- a/comms/torchcomms/tests/integration/py/LazySetupChannelsTest.py
+++ b/comms/torchcomms/tests/integration/py/LazySetupChannelsTest.py
@@ -28,6 +28,7 @@ class LazySetupChannelsTest(unittest.TestCase):
 
     def tearDown(self):
         self.torchcomm_lazy = None
+        # pyrefly: ignore [bad-assignment]
         self.wrapper_lazy = None
 
     def test_lazy_setup_channels_split_allreduce(self):

--- a/comms/torchcomms/tests/integration/py/OptionsTest.py
+++ b/comms/torchcomms/tests/integration/py/OptionsTest.py
@@ -60,6 +60,7 @@ class OptionsTest(unittest.TestCase):
         """Clean up after each test."""
         # Explicitly reset the TorchComm object to ensure proper cleanup
         self.torchcomm = None
+        # pyrefly: ignore [bad-assignment]
         self.wrapper = None
 
     def test_send_recv(self):

--- a/comms/torchcomms/tests/integration/py/ProfilerTest.py
+++ b/comms/torchcomms/tests/integration/py/ProfilerTest.py
@@ -88,6 +88,7 @@ class ProfilerTestBase(unittest.TestCase):
     def tearDown(self):
         """Clean up after each test."""
         if hasattr(self, "torchcomm") and self.torchcomm:
+            # pyrefly: ignore [bad-assignment]
             self.torchcomm = None
 
     def sanity_check_profiler_meta(self, meta_events):

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -133,6 +133,7 @@ class ReconfigureTest(unittest.TestCase):
             torchcomms.new_comm(
                 self.backend,
                 self.device,
+                # pyrefly: ignore [bad-argument-type]
                 "test_reconfigure_unsupported",
                 enable_reconfigure=True,
             )
@@ -152,6 +153,7 @@ class ReconfigureTest(unittest.TestCase):
         comm = torchcomms.new_comm(
             self.backend,
             self.device,
+            # pyrefly: ignore [bad-argument-type]
             "reconfigure_basic",
             enable_reconfigure=True,
             store=self._get_store_for_comm(),
@@ -192,6 +194,7 @@ class ReconfigureTest(unittest.TestCase):
         comm = torchcomms.new_comm(
             self.backend,
             self.device,
+            # pyrefly: ignore [bad-argument-type]
             "reconfigure_unordered",
             enable_reconfigure=True,
             store=self._get_store_for_comm(),
@@ -229,6 +232,7 @@ class ReconfigureTest(unittest.TestCase):
         comm = torchcomms.new_comm(
             self.backend,
             self.device,
+            # pyrefly: ignore [bad-argument-type]
             "reconfigure_collective",
             enable_reconfigure=True,
             store=self._get_store_for_comm(),
@@ -289,6 +293,7 @@ class ReconfigureTest(unittest.TestCase):
         comm = torchcomms.new_comm(
             self.backend,
             self.device,
+            # pyrefly: ignore [bad-argument-type]
             "reconfigure_allreduce",
             enable_reconfigure=True,
             store=self._get_store_for_comm(),

--- a/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterTest.py
@@ -234,6 +234,7 @@ class ReduceScatterTest(unittest.TestCase):
                 tensor = torch.ones(count, **options) * int(r + 1)
             elif dtype == torch.int8:
                 tensor = torch.ones(count, **options) * int(r + 1)
+            # pyrefly: ignore [unbound-name]
             input_tensors.append(tensor)
 
         return input_tensors

--- a/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
+++ b/comms/torchcomms/tests/integration/py/ReduceScatterVTest.py
@@ -249,6 +249,7 @@ class ReduceScatterVTest(unittest.TestCase):
                 tensor = torch.ones(element_count, **options) * int(r + 1)
             elif dtype == torch.int8:
                 tensor = torch.ones(element_count, **options) * int(r + 1)
+            # pyrefly: ignore [unbound-name]
             input_tensors.append(tensor)
 
         return input_tensors

--- a/comms/torchcomms/tests/integration/py/ScatterTest.py
+++ b/comms/torchcomms/tests/integration/py/ScatterTest.py
@@ -262,6 +262,7 @@ class ScatterTest(unittest.TestCase):
                 tensor = torch.ones(count, **options) * int(i + 1)
             elif dtype == torch.int8:
                 tensor = torch.ones(count, **options) * int(i + 1)
+            # pyrefly: ignore [unbound-name]
             inputs.append(tensor)
 
         return inputs

--- a/comms/torchcomms/tests/integration/py/SendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/SendRecvTest.py
@@ -349,11 +349,13 @@ class SendRecvTest(unittest.TestCase):
         description = f"recv rank {recv_rank} tensor"
         if dtype == torch.float:
             self.assertTrue(
+                # pyrefly: ignore [unbound-name]
                 torch.allclose(recv_tensor.cpu(), expected),
                 f"Tensors not close enough for {description}",
             )
         else:
             self.assertTrue(
+                # pyrefly: ignore [unbound-name]
                 torch.equal(recv_tensor.cpu(), expected),
                 f"Tensors not equal for {description}",
             )

--- a/comms/torchcomms/tests/integration/py/SplitTest.py
+++ b/comms/torchcomms/tests/integration/py/SplitTest.py
@@ -95,6 +95,7 @@ class SplitTest(unittest.TestCase):
 
             # Skip empty groups
             if group not in empty_groups:
+                # pyrefly: ignore [bad-argument-type]
                 rank_groups[group].append(rank)
 
         return rank_groups

--- a/comms/torchcomms/tests/integration/py/TPCommTest.py
+++ b/comms/torchcomms/tests/integration/py/TPCommTest.py
@@ -50,6 +50,7 @@ class TPCommTest(unittest.TestCase):
             dist_param = dist_param.grad if compare_grad else dist_param
             if (
                 (not rank0_only)
+                # pyrefly: ignore [missing-attribute]
                 or (self.rank == 0)
                 or (
                     name not in ["net2.bias"]

--- a/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/py/TorchCommTestHelpers.py
@@ -348,6 +348,7 @@ class TorchCommTestWrapper:
         """Clean up resources."""
         if hasattr(self, "torchcomm") and self.torchcomm:
             self.torchcomm.finalize()
+            # pyrefly: ignore [bad-assignment]
             self.torchcomm = None
 
     def get_torchcomm(self):

--- a/comms/torchcomms/tests/unit/py/test_factory.py
+++ b/comms/torchcomms/tests/unit/py/test_factory.py
@@ -20,6 +20,7 @@ class TestFactory(unittest.TestCase):
         os.environ["RANK"] = "0"
         os.environ["TORCHCOMM_GLOO_HOSTNAME"] = "localhost"
 
+        # pyrefly: ignore [bad-argument-type]
         comm = torchcomms.new_comm("gloo", torch.device("cpu"), "my_comm")
         comm.finalize()
         backend = comm.get_backend_impl()
@@ -32,4 +33,5 @@ class TestFactory(unittest.TestCase):
 
     def test_factory_missing(self):
         with self.assertRaisesRegex(ModuleNotFoundError, "failed to find backend"):
+            # pyrefly: ignore [bad-argument-type]
             torchcomms.new_comm("invalid", torch.device("cuda"), "my_comm")

--- a/comms/utils/cvars/extractcvars.py
+++ b/comms/utils/cvars/extractcvars.py
@@ -815,20 +815,28 @@ def main():
         if cvar["type"] == "bool":
             allcvars.append(bool(cvar))
         elif cvar["type"] == "string":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(string(cvar))
         elif cvar["type"] == "stringlist":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(stringlist(cvar))
         elif cvar["type"] == "enum":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(enum(cvar))
         elif cvar["type"] == "enumlist":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(enumlist(cvar))
         elif cvar["type"] == "prefixed_stringlist":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(prefixedStringlist(cvar))
         elif cvar["type"] == "double":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(double(cvar))
         elif cvar["type"] == "dictlist":
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(dictlist(cvar))
         else:
+            # pyrefly: ignore [bad-argument-type]
             allcvars.append(numeric(cvar))
 
     append_unit_test_cvars(allcvars)


### PR DESCRIPTION
Summary:

Most comms subdirectories already have `python.set_pyrefly(True)` in their individual PACKAGE files. Pipes and torchcomms are being enabled in separate diffs (D104303944, D104303971). This sets it at the root to cover the remaining subdirectories (common, ncclx, utils, rccl) and any future additions.

Differential Revision: D104304086
