### PR TITLE
Ring ReduceScatter collective with IBGDA transport

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -6,6 +6,7 @@
 
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
 
@@ -33,7 +34,7 @@ struct Memcpy {
   }
 
   template <typename... Args>
-  __device__ __forceinline__ static void recv_forward(
+  __device__ __forceinline__ static void forward(
       char* dst,
       char* fwd_staging,
       const char* staging,
@@ -42,9 +43,7 @@ struct Memcpy {
       std::size_t /*byte_offset*/,
       Args...) {
     if (dst) {
-      memcpy_vectorized(dst, staging, nbytes, group);
-      group.sync();
-      memcpy_vectorized(fwd_staging, dst, nbytes, group);
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
     } else {
       memcpy_vectorized(fwd_staging, staging, nbytes, group);
     }

--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -50,4 +50,77 @@ struct Memcpy {
   }
 };
 
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+struct TileReduce {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    T* dst_t = reinterpret_cast<T*>(dst);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    std::size_t nelems = nbytes / sizeof(T);
+    int ntiles = static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+
+    for (int t = 0; t < ntiles; t++) {
+      std::size_t valid =
+          min(static_cast<std::size_t>(kTileElems),
+              nelems - static_cast<std::size_t>(t) * kTileElems);
+      auto acc =
+          tile_load<T, kTileElems, kBlockSize>(staging_t, t, group, valid);
+      tile_load_accumulate<T, AccumOp, kTileElems, kBlockSize>(
+          acc, local_t, t, group, valid);
+      tile_store<T, kTileElems, kBlockSize>(dst_t, t, acc, group, valid);
+    }
+#endif
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* /*dst*/,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    T* fwd_t = reinterpret_cast<T*>(fwd_staging);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    std::size_t nelems = nbytes / sizeof(T);
+    int ntiles = static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+
+    for (int t = 0; t < ntiles; t++) {
+      std::size_t valid =
+          min(static_cast<std::size_t>(kTileElems),
+              nelems - static_cast<std::size_t>(t) * kTileElems);
+      auto acc =
+          tile_load<T, kTileElems, kBlockSize>(staging_t, t, group, valid);
+      tile_load_accumulate<T, AccumOp, kTileElems, kBlockSize>(
+          acc, local_t, t, group, valid);
+      tile_store<T, kTileElems, kBlockSize>(fwd_t, t, acc, group, valid);
+    }
+#endif
+  }
+};
+
 } // namespace comms::pipes

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -19,6 +19,8 @@
 
 namespace comms::pipes {
 
+struct Memcpy;
+
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
 // Slot-id bounds checks for the slot-index API. Catches both
@@ -1400,10 +1402,318 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
+  /**
+   * forward — receive data and forward it to the next peer in a ring.
+   *
+   * Combines recv + send in a single method, sharing the staging buffer to
+   * avoid an extra copy. The CopyOp::forward() method receives three
+   * buffers: dst (application output), fwd_staging (next peer's send staging),
+   * and staging (this transport's recv staging). This enables fused
+   * receive-reduce-forward patterns.
+   *
+   * Signal ordering invariant (critical for ring deadlock avoidance):
+   *   1. Wait DATA_READY from sender (this transport)
+   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
+   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
+   *   5. Wait SLOT_FREE from fwd transport's receiver
+   *   6. threadfence_system + RDMA put via fwd transport
+   *
+   * Step 4 before step 5 breaks the circular dependency in rings: each rank
+   * releases its predecessor's staging before waiting on its successor.
+   *
+   * Protocol compatibility with send() and recv():
+   *
+   * forward acts as a recv on "this" transport and a send on "fwd".
+   * The signal protocol is wire-compatible:
+   *
+   *   Recv side (this transport):
+   *     - Reads stepState[maxGroups + groupId] (same index as recv)
+   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
+   *       piggybacked signal on remoteSignalBuf[groupId])
+   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
+   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
+   *       groupId])
+   *
+   *   Fwd side (fwd transport):
+   *     - Reads stepState[groupId] (same index as send)
+   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
+   *       self-counter)
+   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
+   *       (matches recv's backpressure release)
+   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
+   *       + NIC_DONE on localCounterBuf[groupId]
+   *       (matches recv's DATA_READY wait)
+   *
+   * Any chain of send → forward* → recv is therefore valid: each
+   * forward consumes exactly the signals its predecessor produces
+   * and produces exactly the signals its successor expects.
+   *
+   * @param group           ThreadGroup (all threads participate).
+   * @param dst             Application destination (may be nullptr if
+   *                        CopyOp handles it, e.g. reduce-scatter).
+   * @param fwd             Forward transport (sends to next peer in ring).
+   * @param nbytes          Bytes to receive and forward.
+   * @param active_blocks   Number of block-groups sharing the slot. 0 =
+   * maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   * @param args            Extra args forwarded to CopyOp::forward.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
+    if (nbytes == 0) {
+      return;
+    }
+
+    const int groupId = group.group_id;
+
+    // --- recv side (this transport) ---
+    const int recvEffActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward recv active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            recvEffActive,
+            sendRecvState_.maxGroups,
+            groupId);
+      }
+      __trap();
+    }
+
+    const std::size_t recvPerBlockSlot =
+        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
+    if (recvPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
+      }
+      __trap();
+    }
+
+    // --- fwd side (fwd transport) ---
+    const int fwdEffActive =
+        active_blocks > 0 ? active_blocks : fwd.sendRecvState_.maxGroups;
+    if (fwdEffActive > fwd.sendRecvState_.maxGroups ||
+        groupId >= fwdEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward fwd active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            fwdEffActive,
+            fwd.sendRecvState_.maxGroups,
+            groupId);
+      }
+      __trap();
+    }
+
+    const std::size_t fwdPerBlockSlot =
+        (fwd.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
+    if (fwdPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
+      }
+      __trap();
+    }
+
+    // Chunk sizes for recv and fwd sides
+    std::size_t recvChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : recvPerBlockSlot;
+    if (recvChunkSize == 0) {
+      recvChunkSize = recvPerBlockSlot;
+    }
+    std::size_t fwdChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : fwdPerBlockSlot;
+    if (fwdChunkSize == 0) {
+      fwdChunkSize = fwdPerBlockSlot;
+    }
+
+    const std::size_t recvChunksPerSlot = recvPerBlockSlot / recvChunkSize;
+    const std::size_t fwdChunksPerSlot = fwdPerBlockSlot / fwdChunkSize;
+    const std::size_t totalRecvChunks =
+        (nbytes + recvChunkSize - 1) / recvChunkSize;
+    const std::size_t totalFwdChunks =
+        (nbytes + fwdChunkSize - 1) / fwdChunkSize;
+
+    // Step state
+    const int64_t recvBaseStep =
+        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId];
+    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
+    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const int64_t recvChunksPerSlot64 = static_cast<int64_t>(recvChunksPerSlot);
+
+    const int64_t fwdBaseStep = fwd.sendRecvState_.stepState[groupId];
+    const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
+    const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
+    const int64_t fwdChunksPerSlot64 = static_cast<int64_t>(fwdChunksPerSlot);
+    const int64_t fwdPipelineChunks =
+        static_cast<int64_t>(fwdPipelineDepth) * fwdChunksPerSlot64;
+
+    // Both sides process the same nbytes; chunk sizes must match so that
+    // the loop counter advances recv and fwd step states in lockstep.
+    if (totalRecvChunks != totalFwdChunks) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward chunk count mismatch: "
+            "recv=%llu fwd=%llu\n",
+            (unsigned long long)totalRecvChunks,
+            (unsigned long long)totalFwdChunks);
+      }
+      __trap();
+    }
+
+    for (std::size_t s = 0; s < totalRecvChunks; ++s) {
+      // --- Recv side offsets ---
+      const int64_t recvChunkStep = recvBaseStep + static_cast<int64_t>(s);
+      const int64_t recvSlotStep = recvChunkStep / recvChunksPerSlot64;
+      const int64_t recvSubStep = recvChunkStep % recvChunksPerSlot64;
+      const int recvSlot = static_cast<int>(recvSlotStep % recvPipelineDepth);
+      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+      const std::size_t recvChunkOff =
+          static_cast<std::size_t>(recvSubStep) * recvChunkSize;
+      const std::size_t recvStagingOff =
+          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+      const std::size_t dataOff = s * recvChunkSize;
+      const std::size_t bytesThis = (dataOff + recvChunkSize <= nbytes)
+          ? recvChunkSize
+          : (nbytes - dataOff);
+
+      // --- Fwd side offsets ---
+      const int64_t fwdChunkStep = fwdBaseStep + static_cast<int64_t>(s);
+      const int64_t fwdSlotStep = fwdChunkStep / fwdChunksPerSlot64;
+      const int64_t fwdSubStep = fwdChunkStep % fwdChunksPerSlot64;
+      const int fwdSlot = static_cast<int>(fwdSlotStep % fwdPipelineDepth);
+      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+      const std::size_t fwdChunkOff =
+          static_cast<std::size_t>(fwdSubStep) * fwdChunkSize;
+      const std::size_t fwdStagingOff =
+          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+
+      // (1) Wait for sender's DATA_READY.
+      wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          static_cast<uint64_t>(recvChunkStep + 1),
+          timeout);
+
+      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
+      if (fwdChunkStep >= fwdPipelineChunks) {
+        fwd.wait_counter(
+            group,
+            fwd.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            timeout);
+      }
+
+      // (3) CopyOp::forward — transform recv staging → dst + fwd staging.
+      CopyOp::forward(
+          dst ? static_cast<char*>(dst) + dataOff : nullptr,
+          fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
+          sendRecvState_.recvStagingPtr + recvStagingOff,
+          bytesThis,
+          group,
+          dataOff,
+          args...);
+      group.sync();
+
+      // (4) Signal SLOT_FREE to sender (this transport).
+      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
+      //     to break circular ring dependency.
+      signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (recvMaxGroups + groupId) * sizeof(uint64_t)),
+          1ULL);
+
+      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+      //     recvStaging).
+      if (fwdChunkStep >= fwdPipelineChunks) {
+        fwd.wait_signal(
+            group,
+            fwd.sendRecvState_.localSignalBuf.subBuffer(
+                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
+            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            timeout);
+      }
+
+      // (6) threadfence_system + RDMA put via fwd transport.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        fwd.put(
+            solo,
+            fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwd.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            bytesThis,
+            fwd.sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL,
+            fwd.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            1ULL);
+      }
+      group.sync();
+    }
+
+    // Update step state for both recv and fwd sides.
+    if (group.is_leader()) {
+      sendRecvState_.stepState[sendRecvState_.maxGroups + groupId] =
+          recvBaseStep + static_cast<int64_t>(totalRecvChunks);
+      fwd.sendRecvState_.stepState[groupId] =
+          fwdBaseStep + static_cast<int64_t>(totalRecvChunks);
+    }
+    group.sync();
+#endif
+  }
+
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
     return sendRecvState_;
+  }
+
+  /**
+   * Maximum bytes a block can send without blocking on pipeline backpressure.
+   *
+   * The staging buffer is split into pipelineDepth slots, each divided evenly
+   * across active_blocks. A block can fill all its slots before the NIC must
+   * drain any of them, so the non-blocking window is:
+   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *
+   * Callers should loop over their data in pipeline_window-sized chunks so
+   * that send()/forward() never stall waiting for a free slot.
+   *
+   * @param active_blocks  Total blocks sharing this transport (typically
+   *                       gridDim.x).
+   */
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    const std::size_t per_block_slot =
+        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
+    return per_block_slot * sendRecvState_.pipelineDepth;
   }
 
  private:

--- a/comms/pipes/benchmarks/IbgdaForward.cu
+++ b/comms/pipes/benchmarks/IbgdaForward.cu
@@ -1,0 +1,146 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/benchmarks/IbgdaForward.cuh"
+
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes::benchmark {
+
+__global__ void __launch_bounds__(512, 1) ibgda_forward_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = (my_rank == 1)
+      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      : min((my_rank == 0 ? next_transport : prev_transport)
+                ->send_recv_state()
+                .dataBufferSize,
+            totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (my_rank == 0) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, group);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else if (my_rank == 2) {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->forward(
+          group,
+          tiles.data(),
+          *next_transport,
+          tiles.bytes(),
+          numBlocks,
+          0,
+          timeout);
+    }
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_recv_send_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = (my_rank == 1)
+      ? min(prev_transport->send_recv_state().dataBufferSize, totalBytes)
+      : min((my_rank == 0 ? next_transport : prev_transport)
+                ->send_recv_state()
+                .dataBufferSize,
+            totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (my_rank == 0) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, group);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else if (my_rank == 2) {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, group);
+      prev_transport->recv(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      next_transport->send(
+          group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    }
+  }
+}
+
+void launch_ibgda_forward_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_forward_kernel<<<numBlocks, 512, 0, stream>>>(
+      prev_transport,
+      next_transport,
+      src,
+      dst,
+      nbytes,
+      numBlocks,
+      my_rank,
+      timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] forward kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+void launch_ibgda_recv_send_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_recv_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      prev_transport,
+      next_transport,
+      src,
+      dst,
+      nbytes,
+      numBlocks,
+      my_rank,
+      timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] recv_send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForward.cuh
+++ b/comms/pipes/benchmarks/IbgdaForward.cuh
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes::benchmark {
+
+/**
+ * 3-rank chain kernel using forward on rank 1.
+ * rank 0: send, rank 1: forward, rank 2: recv.
+ */
+__global__ void ibgda_forward_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout);
+
+/**
+ * 3-rank chain kernel using recv + send on rank 1 (baseline).
+ * rank 0: send, rank 1: recv then send, rank 2: recv.
+ */
+__global__ void ibgda_recv_send_kernel(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    int my_rank,
+    Timeout timeout);
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForward.h
+++ b/comms/pipes/benchmarks/IbgdaForward.h
@@ -1,0 +1,38 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::benchmark {
+
+void launch_ibgda_forward_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+void launch_ibgda_recv_send_chain(
+    P2pIbgdaTransportDevice* prev_transport,
+    P2pIbgdaTransportDevice* next_transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    int my_rank,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+} // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaForwardBenchmark.cc
+++ b/comms/pipes/benchmarks/IbgdaForwardBenchmark.cc
@@ -1,0 +1,333 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/IbgdaForward.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::BenchmarkEnvironment;
+using meta::comms::BenchmarkTestFixture;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
+
+class IbgdaForwardBenchmarkTest : public BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    cudaSetDevice(localRank);
+    cudaStreamCreate(&stream_);
+  }
+
+  void TearDown() override {
+    cudaStreamDestroy(stream_);
+    BenchmarkTestFixture::TearDown();
+  }
+
+  cudaStream_t stream_{};
+};
+
+TEST_F(IbgdaForwardBenchmarkTest, Correctness) {
+  if (worldSize != 3) {
+    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 4 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+  constexpr std::size_t kSlotSize = kDataBytes;
+  constexpr int kPipelineDepth = 2;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kDataBytes);
+  DeviceBuffer recvBuf(kDataBytes);
+
+  const uint8_t fillPattern = 0xCA;
+  cudaMemset(sendBuf.get(), fillPattern, kDataBytes);
+  cudaMemset(recvBuf.get(), 0, kDataBytes);
+  cudaDeviceSynchronize();
+
+  const int prevRank = (globalRank + worldSize - 1) % worldSize;
+  const int nextRank = (globalRank + 1) % worldSize;
+
+  P2pIbgdaTransportDevice* prevTransport =
+      (globalRank != 0) ? transport.getP2pTransportDevice(prevRank) : nullptr;
+  P2pIbgdaTransportDevice* nextTransport =
+      (globalRank != 2) ? transport.getP2pTransportDevice(nextRank) : nullptr;
+
+  bootstrap->barrierAll();
+
+  launch_ibgda_forward_chain(
+      prevTransport,
+      nextTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kDataBytes,
+      kNumBlocks,
+      globalRank,
+      stream_);
+
+  cudaError_t err = cudaStreamSynchronize(stream_);
+  ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+  bootstrap->barrierAll();
+
+  if (globalRank != 0) {
+    std::vector<uint8_t> hostBuf(kDataBytes);
+    cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost);
+
+    int errors = 0;
+    for (std::size_t i = 0; i < kDataBytes; ++i) {
+      if (hostBuf[i] != fillPattern) {
+        if (errors < 10) {
+          XLOGF(
+              ERR,
+              "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+              globalRank,
+              i,
+              fillPattern,
+              hostBuf[i]);
+        }
+        ++errors;
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                         << " byte mismatches";
+  }
+}
+
+TEST_F(IbgdaForwardBenchmarkTest, Bandwidth) {
+  if (worldSize != 3) {
+    XLOGF(INFO, "Skipping: requires exactly 3 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 2;
+  constexpr std::size_t kSlotSize = 8 * 1024 * 1024;
+  constexpr int kPipelineDepth = 2;
+  constexpr int kWarmupIters = 5;
+  constexpr int kBenchIters = 20;
+
+  std::vector<std::size_t> messageSizes;
+  for (std::size_t sz = 1ULL << 20; sz <= 1ULL << 30; sz <<= 1) {
+    messageSizes.push_back(sz);
+  }
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  std::size_t maxBytes = messageSizes.back();
+  DeviceBuffer sendBuf(maxBytes);
+  DeviceBuffer recvBuf(maxBytes);
+  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
+  cudaMemset(recvBuf.get(), 0, maxBytes);
+  cudaDeviceSynchronize();
+
+  const int prevRank = (globalRank + worldSize - 1) % worldSize;
+  const int nextRank = (globalRank + 1) % worldSize;
+
+  P2pIbgdaTransportDevice* prevTransport =
+      (globalRank != 0) ? transport.getP2pTransportDevice(prevRank) : nullptr;
+  P2pIbgdaTransportDevice* nextTransport =
+      (globalRank != 2) ? transport.getP2pTransportDevice(nextRank) : nullptr;
+
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  if (globalRank == 0) {
+    XLOGF(INFO, "");
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO, "  recv_forward vs recv+send (3-rank chain: rank0→rank1→rank2)");
+    XLOGF(
+        INFO,
+        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
+        kNumBlocks,
+        kSlotSize / (1024 * 1024),
+        kPipelineDepth);
+    XLOGF(
+        INFO,
+        "================================================================");
+    XLOGF(
+        INFO,
+        "{:>10s}  {:>14s}  {:>14s}  {:>10s}",
+        "MsgSize",
+        "recv_fwd GB/s",
+        "recv+snd GB/s",
+        "Speedup");
+    XLOGF(
+        INFO, "--------------------------------------------------------------");
+  }
+
+  for (auto nBytes : messageSizes) {
+    float recvFwdBw = 0;
+    float recvSndBw = 0;
+
+    // --- Benchmark recv_forward ---
+    {
+      bootstrap->barrierAll();
+      for (int i = 0; i < kWarmupIters; ++i) {
+        launch_ibgda_forward_chain(
+            prevTransport,
+            nextTransport,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+        cudaStreamSynchronize(stream_);
+        bootstrap->barrierAll();
+      }
+
+      bootstrap->barrierAll();
+      cudaEventRecord(start, stream_);
+      for (int i = 0; i < kBenchIters; ++i) {
+        launch_ibgda_forward_chain(
+            prevTransport,
+            nextTransport,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+      }
+      cudaEventRecord(stop, stream_);
+      cudaEventSynchronize(stop);
+      bootstrap->barrierAll();
+
+      float totalMs = 0;
+      cudaEventElapsedTime(&totalMs, start, stop);
+      recvFwdBw = (nBytes / 1e9f) / ((totalMs / kBenchIters) / 1000.0f);
+    }
+
+    // --- Benchmark recv+send ---
+    {
+      // Need fresh transport since step state has advanced
+      MultipeerIbgdaTransport transport2(
+          globalRank, worldSize, bootstrap, transportConfig);
+      transport2.exchange();
+
+      P2pIbgdaTransportDevice* prevT2 = (globalRank != 0)
+          ? transport2.getP2pTransportDevice(prevRank)
+          : nullptr;
+      P2pIbgdaTransportDevice* nextT2 = (globalRank != 2)
+          ? transport2.getP2pTransportDevice(nextRank)
+          : nullptr;
+
+      bootstrap->barrierAll();
+      for (int i = 0; i < kWarmupIters; ++i) {
+        launch_ibgda_recv_send_chain(
+            prevT2,
+            nextT2,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+        cudaStreamSynchronize(stream_);
+        bootstrap->barrierAll();
+      }
+
+      bootstrap->barrierAll();
+      cudaEventRecord(start, stream_);
+      for (int i = 0; i < kBenchIters; ++i) {
+        launch_ibgda_recv_send_chain(
+            prevT2,
+            nextT2,
+            static_cast<char*>(sendBuf.get()),
+            static_cast<char*>(recvBuf.get()),
+            nBytes,
+            kNumBlocks,
+            globalRank,
+            stream_);
+      }
+      cudaEventRecord(stop, stream_);
+      cudaEventSynchronize(stop);
+      bootstrap->barrierAll();
+
+      float totalMs = 0;
+      cudaEventElapsedTime(&totalMs, start, stop);
+      recvSndBw = (nBytes / 1e9f) / ((totalMs / kBenchIters) / 1000.0f);
+    }
+
+    if (globalRank == 0) {
+      std::string sizeStr;
+      if (nBytes >= 1ULL << 30) {
+        sizeStr = fmt::format("{}GB", nBytes >> 30);
+      } else {
+        sizeStr = fmt::format("{}MB", nBytes >> 20);
+      }
+      float speedup = (recvSndBw > 0) ? (recvFwdBw / recvSndBw) : 0;
+      XLOGF(
+          INFO,
+          "{:>10s}  {:>14.2f}  {:>14.2f}  {:>9.2f}x",
+          sizeStr,
+          recvFwdBw,
+          recvSndBw,
+          speedup);
+    }
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "================================================================");
+  }
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+}
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  if (!meta::comms::isTcpEnvironment()) {
+    ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
+  }
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/Ring.cuh
+++ b/comms/pipes/collectives/Ring.cuh
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::pipes {
+
+struct RingTopology {
+  int prev_rank{0};
+  int next_rank{0};
+  P2pIbgdaTransportDevice* prev{nullptr};
+  P2pIbgdaTransportDevice* next{nullptr};
+};
+
+template <int NumRings>
+struct RingAllgatherArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  RingTopology rings[NumRings]{};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+};
+
+template <int NumRings, typename T>
+struct RingReduceScatterArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  RingTopology rings[NumRings]{};
+  const T* input{nullptr};
+  T* output{nullptr};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgather.cu
+++ b/comms/pipes/collectives/RingAllgather.cu
@@ -1,0 +1,90 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+
+namespace comms::pipes {
+
+template <int NumRings, int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
+    const __grid_constant__ RingAllgatherArgs<NumRings> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_bytes = args.sendcount;
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_bytes = chunk_bytes / NumRings;
+  const std::size_t ring_bytes = (ring_id < NumRings - 1)
+      ? base_ring_bytes
+      : (chunk_bytes - (NumRings - 1) * base_ring_bytes);
+  const std::size_t ring_offset = ring_id * base_ring_bytes;
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+
+  // Local copy: own chunk from sendbuf to recvbuf.
+  const char* own_src = args.sendbuf + ring_offset + io_tile_offset;
+  char* own_dst =
+      args.recvbuf + my_rank * chunk_bytes + ring_offset + io_tile_offset;
+  memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
+  ring_group.sync();
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    // Step 0: Send own chunk to next.
+    char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
+        io_tile_offset + off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    // Steps 1..W-1: receive and forward (or just receive on last step).
+    int current_rank = my_rank;
+    for (int step = 0; step < W - 1; step++) {
+      current_rank = (current_rank + W - stride) % W;
+      char* dst = args.recvbuf + current_rank * chunk_bytes + ring_offset +
+          io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.forward(
+            group, dst, next, window, group.total_groups, max_sig, timeout);
+      } else {
+        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+#endif
+}
+
+// Template instantiations
+template __global__ void ring_allgather_kernel<1, 512>(
+    const __grid_constant__ RingAllgatherArgs<1>,
+    Timeout);
+template __global__ void ring_allgather_kernel<2, 512>(
+    const __grid_constant__ RingAllgatherArgs<2>,
+    Timeout);
+template __global__ void ring_allgather_kernel<4, 512>(
+    const __grid_constant__ RingAllgatherArgs<4>,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgather.cuh
+++ b/comms/pipes/collectives/RingAllgather.cuh
@@ -1,0 +1,15 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/Ring.cuh"
+
+namespace comms::pipes {
+
+template <int NumRings, int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
+    const __grid_constant__ RingAllgatherArgs<NumRings> args,
+    Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgatherLauncher.cu
+++ b/comms/pipes/collectives/RingAllgatherLauncher.cu
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/RingAllgatherLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+template <int NumRings>
+void launch_impl(const RingAllgatherLaunchParams& params, Timeout timeout) {
+  RingAllgatherArgs<NumRings> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.sendcount = params.sendcount;
+  args.signaling_data_size = params.signaling_data_size;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+
+  for (int r = 0; r < NumRings; r++) {
+    auto& src = params.rings[r];
+    args.rings[r] = RingTopology{
+        .prev_rank = src.prev_rank,
+        .next_rank = src.next_rank,
+        .prev = src.prev,
+        .next = src.next,
+    };
+  }
+
+  ring_allgather_kernel<NumRings, 512>
+      <<<params.num_blocks, 512>>>(args, timeout);
+}
+
+} // namespace
+
+void launch_ring_allgather(const RingAllgatherLaunchParams& params) {
+  Timeout timeout;
+  if (params.timeout_ms > 0) {
+    int device = 0;
+    cudaGetDevice(&device);
+    timeout = makeTimeout(params.timeout_ms, device);
+  }
+
+  switch (params.num_rings) {
+    case 1:
+      launch_impl<1>(params, timeout);
+      break;
+    case 2:
+      launch_impl<2>(params, timeout);
+      break;
+    case 4:
+      launch_impl<4>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error(
+          "Unsupported num_rings=" + std::to_string(params.num_rings) +
+          " (supported: 1, 2, 4)");
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgatherLauncher.h
+++ b/comms/pipes/collectives/RingAllgatherLauncher.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct RingAllgatherLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int num_blocks{16};
+  int num_rings{1};
+  float timeout_ms{0.0f};
+
+  struct RingParams {
+    int prev_rank{0};
+    int next_rank{0};
+    P2pIbgdaTransportDevice* prev{nullptr};
+    P2pIbgdaTransportDevice* next{nullptr};
+  };
+  static constexpr int kMaxRings = 4;
+  RingParams rings[kMaxRings]{};
+};
+
+void launch_ring_allgather(const RingAllgatherLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingReduceScatter.cu
+++ b/comms/pipes/collectives/RingReduceScatter.cu
@@ -1,0 +1,113 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
+    const __grid_constant__ RingReduceScatterArgs<NumRings, T> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_elems = chunk_elems / NumRings;
+  const std::size_t ring_elems = (ring_id < NumRings - 1)
+      ? base_ring_elems
+      : (chunk_elems - (NumRings - 1) * base_ring_elems);
+  const std::size_t ring_bytes = ring_elems * sizeof(T);
+  const std::size_t ring_offset = ring_id * base_ring_elems * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+  const char* input_base = reinterpret_cast<const char*>(args.input);
+
+  using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    int current_rank = (my_rank + W - stride) % W;
+
+    // Step 0: Send raw input chunk to next.
+    const char* send_src = input_base + current_rank * chunk_bytes +
+        ring_offset + io_tile_offset + off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    // W-1 receive steps: forward for intermediate, recv for final.
+    for (int step = 0; step < W - 1; step++) {
+      current_rank = (current_rank + W - stride) % W;
+      const char* local_input = input_base + current_rank * chunk_bytes +
+          ring_offset + io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.template forward<ReduceOp>(
+            group,
+            nullptr,
+            next,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      } else {
+        char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+            io_tile_offset + off;
+        prev.template recv<ReduceOp>(
+            group,
+            dst,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      }
+    }
+  }
+#endif
+}
+
+// Template instantiations
+template __global__ void
+ring_reduce_scatter_kernel<1, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingReduceScatterArgs<1, float>,
+    Timeout);
+template __global__ void
+ring_reduce_scatter_kernel<2, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingReduceScatterArgs<2, float>,
+    Timeout);
+template __global__ void
+ring_reduce_scatter_kernel<4, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingReduceScatterArgs<4, float>,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingReduceScatter.cuh
+++ b/comms/pipes/collectives/RingReduceScatter.cuh
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/Ring.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
+    const __grid_constant__ RingReduceScatterArgs<NumRings, T> args,
+    Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingReduceScatterLauncher.cu
+++ b/comms/pipes/collectives/RingReduceScatterLauncher.cu
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/RingReduceScatterLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+template <int NumRings>
+void launch_impl(const RingReduceScatterLaunchParams& params, Timeout timeout) {
+  RingReduceScatterArgs<NumRings, float> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = params.chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+
+  for (int r = 0; r < NumRings; r++) {
+    auto& src = params.rings[r];
+    args.rings[r] = RingTopology{
+        .prev_rank = src.prev_rank,
+        .next_rank = src.next_rank,
+        .prev = src.prev,
+        .next = src.next,
+    };
+  }
+
+  ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
+      <<<params.num_blocks, 512>>>(args, timeout);
+}
+
+} // namespace
+
+void launch_ring_reduce_scatter(const RingReduceScatterLaunchParams& params) {
+  Timeout timeout;
+  if (params.timeout_ms > 0) {
+    int device = 0;
+    cudaGetDevice(&device);
+    timeout = makeTimeout(params.timeout_ms, device);
+  }
+
+  switch (params.num_rings) {
+    case 1:
+      launch_impl<1>(params, timeout);
+      break;
+    case 2:
+      launch_impl<2>(params, timeout);
+      break;
+    case 4:
+      launch_impl<4>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error(
+          "Unsupported num_rings=" + std::to_string(params.num_rings) +
+          " (supported: 1, 2, 4)");
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingReduceScatterLauncher.h
+++ b/comms/pipes/collectives/RingReduceScatterLauncher.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct RingReduceScatterLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  int num_rings{1};
+  float timeout_ms{0.0f};
+
+  struct RingParams {
+    int prev_rank{0};
+    int next_rank{0};
+    P2pIbgdaTransportDevice* prev{nullptr};
+    P2pIbgdaTransportDevice* next{nullptr};
+  };
+  static constexpr int kMaxRings = 4;
+  RingParams rings[kMaxRings]{};
+};
+
+void launch_ring_reduce_scatter(const RingReduceScatterLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingUtils.h
+++ b/comms/pipes/collectives/RingUtils.h
@@ -1,0 +1,48 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <numeric>
+#include <optional>
+#include <vector>
+
+namespace comms::pipes {
+
+struct RingNeighbors {
+  int prev_rank;
+  int next_rank;
+};
+
+/**
+ * Return the prev/next neighbor ranks for my_rank in each of num_rings
+ * distinct rings over world_size ranks.
+ *
+ * Each ring is a Hamiltonian cycle defined by a coprime stride s:
+ * next = (my_rank + s) % world_size, prev = (my_rank - s + world_size) %
+ * world_size. Different rings use different strides so they traverse
+ * different physical network paths.
+ *
+ * Returns nullopt if fewer than num_rings coprime strides exist
+ * (the count of valid strides is Euler's totient phi(world_size)).
+ */
+inline std::optional<std::vector<RingNeighbors>>
+make_standard_rings(int world_size, int my_rank, int num_rings) {
+  std::vector<RingNeighbors> rings;
+  for (int stride = 1;
+       stride < world_size && static_cast<int>(rings.size()) < num_rings;
+       ++stride) {
+    if (std::gcd(stride, world_size) != 1) {
+      continue;
+    }
+    rings.push_back({
+        .prev_rank = (my_rank - stride + world_size) % world_size,
+        .next_rank = (my_rank + stride) % world_size,
+    });
+  }
+  if (static_cast<int>(rings.size()) < num_rings) {
+    return std::nullopt;
+  }
+  return rings;
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -1,0 +1,417 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/collectives/RingAllgatherLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+struct RingAllGatherBenchmarkConfig {
+  std::size_t sendcount;
+  int num_blocks;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct RingAllGatherBenchmarkResult {
+  std::string test_name;
+  std::size_t sendcount{};
+  std::size_t total_bytes{};
+  int num_rings{};
+  float nccl_bandwidth{};
+  float ring_bandwidth{};
+  float nccl_latency{};
+  float ring_latency{};
+  float speedup{};
+};
+
+class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const RingAllGatherBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t recvcount = config.sendcount * worldSize;
+
+    DeviceBuffer send_buf(config.sendcount);
+    DeviceBuffer recv_buf(recvcount);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclAllGather(
+          send_buf.get(),
+          recv_buf.get(),
+          config.sendcount,
+          ncclChar,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclAllGather(
+          send_buf.get(),
+          recv_buf.get(),
+          config.sendcount,
+          ncclChar,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (recvcount / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_ring_benchmark(
+      const RingAllGatherBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t recvcount = config.sendcount * worldSize;
+
+    DeviceBuffer send_buf(config.sendcount);
+    DeviceBuffer recv_buf(recvcount);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
+
+    std::unique_ptr<MultipeerIbgdaTransport> transport;
+    try {
+      MultipeerIbgdaTransportConfig transport_config{
+          .cudaDevice = localRank,
+          .dataBufferSize = config.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * config.num_rings,
+                  .pipelineDepth = config.pipeline_depth,
+              },
+          .numQpsPerPeerPerNic = config.num_qps,
+      };
+      transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transport_config);
+      transport->exchange();
+    } catch (const std::exception& e) {
+      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, config.num_rings);
+    if (!rings_opt) {
+      XLOGF(
+          ERR,
+          "Cannot construct {} distinct rings for {} ranks",
+          config.num_rings,
+          worldSize);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+    auto& rings = *rings_opt;
+
+    RingAllgatherLaunchParams launch_params{};
+    launch_params.my_rank = globalRank;
+    launch_params.num_ranks = worldSize;
+    launch_params.sendcount = config.sendcount;
+    launch_params.sendbuf = static_cast<const char*>(send_buf.get());
+    launch_params.recvbuf = static_cast<char*>(recv_buf.get());
+    launch_params.num_blocks = config.num_blocks * config.num_rings;
+    launch_params.num_rings = config.num_rings;
+
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_ring_allgather(launch_params);
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get()));
+    for (int i = 0; i < n_iter; i++) {
+      launch_ring_allgather(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get()));
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (recvcount / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(const std::vector<RingAllGatherBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    auto fmt_bytes = [](std::size_t bytes) -> std::string {
+      if (bytes >= 1024UL * 1024 * 1024) {
+        return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+      }
+      if (bytes >= 1024 * 1024) {
+        return std::to_string(bytes / (1024 * 1024)) + "MB";
+      }
+      if (bytes >= 1024) {
+        return std::to_string(bytes / 1024) + "KB";
+      }
+      return std::to_string(bytes) + "B";
+    };
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "           NCCL AllGather vs Ring AllGather (IBGDA) Benchmark\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(6) << "Rings" << std::right
+       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
+       << std::right << std::setw(10) << "Speedup" << std::right
+       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
+       << "Ring Lat\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(6) << "" << std::right << std::setw(10)
+       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
+       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "(us)\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << fmt_bytes(r.sendcount) << std::right
+         << std::setw(6) << r.num_rings << std::right << std::setw(10)
+         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
+         << std::setw(10) << std::fixed << std::setprecision(2)
+         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup << "x" << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.ring_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize << " ranks, sendcount = per-rank message size\n";
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(RingAllGatherBenchmarkFixture, VsNccl) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
+  }
+
+  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+  int kNumQps = 4;
+
+  std::vector<RingAllGatherBenchmarkConfig> configs = {
+      {.sendcount = 256 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256K_8B"},
+      {.sendcount = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "1M_16B"},
+      {.sendcount = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4M_16B"},
+      {.sendcount = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16M_16B"},
+      {.sendcount = 64 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64M_16B"},
+      {.sendcount = 128 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "128M_16B"},
+      {.sendcount = 256 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256M_32B"},
+      {.sendcount = 512UL * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "512M_32B"},
+      {.sendcount = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4M_16B_2R"},
+      {.sendcount = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16M_16B_2R"},
+      {.sendcount = 64 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64M_16B_2R"},
+      {.sendcount = 256 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256M_32B_2R"},
+  };
+
+  std::vector<RingAllGatherBenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    float nccl_lat = 0.0f;
+    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
+
+    float ring_lat = 0.0f;
+    float ring_bw = run_ring_benchmark(config, ring_lat);
+
+    if (globalRank == 0) {
+      results.push_back({
+          .test_name = config.name,
+          .sendcount = config.sendcount,
+          .total_bytes = config.sendcount * static_cast<std::size_t>(worldSize),
+          .num_rings = config.num_rings,
+          .nccl_bandwidth = nccl_bw,
+          .ring_bandwidth = ring_bw,
+          .nccl_latency = nccl_lat,
+          .ring_latency = ring_lat,
+          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -1,0 +1,419 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/collectives/RingReduceScatterLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+struct RingReduceScatterBenchmarkConfig {
+  std::size_t chunk_elements;
+  int num_blocks;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct RingReduceScatterBenchmarkResult {
+  std::string test_name;
+  std::size_t chunk_elements{};
+  std::size_t total_bytes{};
+  int num_rings{};
+  float nccl_bandwidth{};
+  float ring_bandwidth{};
+  float nccl_latency{};
+  float ring_latency{};
+  float speedup{};
+};
+
+class RingReduceScatterBenchmarkFixture
+    : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const RingReduceScatterBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_elements = config.chunk_elements * worldSize;
+    const std::size_t total_bytes = total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(config.chunk_elements * sizeof(float));
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(
+        cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclReduceScatter(
+          send_buf.get(),
+          recv_buf.get(),
+          config.chunk_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclReduceScatter(
+          send_buf.get(),
+          recv_buf.get(),
+          config.chunk_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_ring_benchmark(
+      const RingReduceScatterBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_elements = config.chunk_elements * worldSize;
+    const std::size_t total_bytes = total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(config.chunk_elements * sizeof(float));
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(
+        cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
+
+    std::unique_ptr<MultipeerIbgdaTransport> transport;
+    try {
+      MultipeerIbgdaTransportConfig transport_config{
+          .cudaDevice = localRank,
+          .dataBufferSize = config.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * config.num_rings,
+                  .pipelineDepth = config.pipeline_depth,
+              },
+          .numQpsPerPeerPerNic = config.num_qps,
+      };
+      transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transport_config);
+      transport->exchange();
+    } catch (const std::exception& e) {
+      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, config.num_rings);
+    if (!rings_opt) {
+      XLOGF(
+          ERR,
+          "Cannot construct {} distinct rings for {} ranks",
+          config.num_rings,
+          worldSize);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+    auto& rings = *rings_opt;
+
+    RingReduceScatterLaunchParams launch_params{};
+    launch_params.my_rank = globalRank;
+    launch_params.num_ranks = worldSize;
+    launch_params.chunk_elements = config.chunk_elements;
+    launch_params.input = static_cast<const float*>(send_buf.get());
+    launch_params.output = static_cast<float*>(recv_buf.get());
+    launch_params.num_blocks = config.num_blocks * config.num_rings;
+    launch_params.num_rings = config.num_rings;
+
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_ring_reduce_scatter(launch_params);
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get()));
+    for (int i = 0; i < n_iter; i++) {
+      launch_ring_reduce_scatter(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get()));
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(
+      const std::vector<RingReduceScatterBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    auto fmt_bytes = [](std::size_t bytes) -> std::string {
+      if (bytes >= 1024UL * 1024 * 1024) {
+        return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+      }
+      if (bytes >= 1024 * 1024) {
+        return std::to_string(bytes / (1024 * 1024)) + "MB";
+      }
+      if (bytes >= 1024) {
+        return std::to_string(bytes / 1024) + "KB";
+      }
+      return std::to_string(bytes) + "B";
+    };
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "         NCCL ReduceScatter vs Ring ReduceScatter (IBGDA) Benchmark\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(6) << "Rings" << std::right
+       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
+       << std::right << std::setw(10) << "Speedup" << std::right
+       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
+       << "Ring Lat\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(6) << "" << std::right << std::setw(10)
+       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
+       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "(us)\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
+         << std::setw(6) << r.num_rings << std::right << std::setw(10)
+         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
+         << std::setw(10) << std::fixed << std::setprecision(2)
+         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup << "x" << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.ring_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize << " ranks, chunk_elements = per-rank output elements\n";
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(RingReduceScatterBenchmarkFixture, VsNccl) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Ring ReduceScatter (IBGDA) vs NCCL Comparison ===\n";
+  }
+
+  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+  int kNumQps = 4;
+
+  std::vector<RingReduceScatterBenchmarkConfig> configs = {
+      {.chunk_elements = 64 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256K_8B"},
+      {.chunk_elements = 256 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "1M_16B"},
+      {.chunk_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4M_16B"},
+      {.chunk_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16M_16B"},
+      {.chunk_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64M_16B"},
+      {.chunk_elements = 32 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "128M_16B"},
+      {.chunk_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256M_32B"},
+      {.chunk_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4M_16B_2R"},
+      {.chunk_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16M_16B_2R"},
+      {.chunk_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64M_16B_2R"},
+      {.chunk_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256M_32B_2R"},
+  };
+
+  std::vector<RingReduceScatterBenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    float nccl_lat = 0.0f;
+    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
+
+    float ring_lat = 0.0f;
+    float ring_bw = run_ring_benchmark(config, ring_lat);
+
+    if (globalRank == 0) {
+      results.push_back({
+          .test_name = config.name,
+          .chunk_elements = config.chunk_elements,
+          .total_bytes = config.chunk_elements *
+              static_cast<std::size_t>(worldSize) * sizeof(float),
+          .num_rings = config.num_rings,
+          .nccl_bandwidth = nccl_bw,
+          .ring_bandwidth = ring_bw,
+          .nccl_latency = nccl_lat,
+          .ring_latency = ring_lat,
+          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/AllGatherTestHarness.h
+++ b/comms/pipes/collectives/tests/AllGatherTestHarness.h
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::pipes::test {
+
+struct AllGatherTestConfig {
+  std::size_t sendcount;
+  int num_blocks;
+  std::string name;
+};
+
+class AllGatherTestBase : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void fill_sendbuf(char* sendbuf_d, std::size_t sendcount) {
+    std::vector<char> h_send(sendcount);
+    uint8_t pattern = static_cast<uint8_t>(globalRank + 1);
+    for (std::size_t i = 0; i < sendcount; i++) {
+      h_send[i] = static_cast<char>((pattern + i) % 256);
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        sendbuf_d, h_send.data(), sendcount, cudaMemcpyHostToDevice));
+  }
+
+  void verify_allgather(const char* recvbuf_d, std::size_t sendcount) {
+    std::size_t total = sendcount * worldSize;
+    std::vector<char> h_recv(total);
+    CUDACHECK_TEST(
+        cudaMemcpy(h_recv.data(), recvbuf_d, total, cudaMemcpyDeviceToHost));
+
+    int errors = 0;
+    for (int rank = 0; rank < worldSize; rank++) {
+      uint8_t pattern = static_cast<uint8_t>(rank + 1);
+      for (std::size_t i = 0; i < sendcount; i++) {
+        char expected = static_cast<char>((pattern + i) % 256);
+        char actual = h_recv[rank * sendcount + i];
+        if (actual != expected) {
+          if (errors < 10) {
+            EXPECT_EQ(actual, expected)
+                << "Mismatch at rank=" << rank << " offset=" << i
+                << " (my_rank=" << globalRank << ")";
+          }
+          errors++;
+        }
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Total mismatches: " << errors << " out of "
+                         << total << " bytes (my_rank=" << globalRank << ")";
+  }
+};
+
+} // namespace comms::pipes::test

--- a/comms/pipes/collectives/tests/ReduceScatterTestHarness.h
+++ b/comms/pipes/collectives/tests/ReduceScatterTestHarness.h
@@ -1,0 +1,77 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::pipes::test {
+
+struct ReduceScatterTestConfig {
+  std::size_t chunk_elements;
+  int num_blocks;
+  std::string name;
+};
+
+class ReduceScatterTestBase : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void fill_input(float* input_d, std::size_t total_elements) {
+    std::vector<float> h_input(total_elements);
+    for (std::size_t i = 0; i < total_elements; i++) {
+      h_input[i] = static_cast<float>((globalRank * 7 + i) % 100) * 0.01f;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        input_d,
+        h_input.data(),
+        total_elements * sizeof(float),
+        cudaMemcpyHostToDevice));
+  }
+
+  void verify_reduce_scatter(
+      const float* output_d,
+      std::size_t chunk_elements) {
+    std::vector<float> h_output(chunk_elements);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_output.data(),
+        output_d,
+        chunk_elements * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    int errors = 0;
+    for (std::size_t i = 0; i < chunk_elements; i++) {
+      float expected = 0.0f;
+      for (int rank = 0; rank < worldSize; rank++) {
+        std::size_t global_idx = globalRank * chunk_elements + i;
+        expected += static_cast<float>((rank * 7 + global_idx) % 100) * 0.01f;
+      }
+      float actual = h_output[i];
+      if (std::abs(actual - expected) > 1e-2f) {
+        if (errors < 10) {
+          EXPECT_NEAR(actual, expected, 1e-2f)
+              << "Mismatch at offset=" << i << " (my_rank=" << globalRank
+              << ")";
+        }
+        errors++;
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Total mismatches: " << errors << " out of "
+                         << chunk_elements
+                         << " elements (my_rank=" << globalRank << ")";
+  }
+};
+
+} // namespace comms::pipes::test

--- a/comms/pipes/collectives/tests/RingAllGatherTest.cc
+++ b/comms/pipes/collectives/tests/RingAllGatherTest.cc
@@ -1,0 +1,176 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/collectives/RingAllgatherLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/AllGatherTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct RingAllGatherTestParams {
+  AllGatherTestConfig config;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<RingAllGatherTestParams>& info) {
+  return info.param.config.name;
+}
+
+class RingAllGatherTest
+    : public AllGatherTestBase,
+      public ::testing::WithParamInterface<RingAllGatherTestParams> {};
+
+TEST_P(RingAllGatherTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allgather requires at least 2 ranks";
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = params.data_buffer_size,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = config.num_blocks * params.num_rings,
+                .pipelineDepth = params.pipeline_depth,
+            },
+    };
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, transportConfig);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  DeviceBuffer sendbuf(config.sendcount);
+  DeviceBuffer recvbuf(config.sendcount * worldSize);
+  CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, config.sendcount * worldSize));
+
+  fill_sendbuf(static_cast<char*>(sendbuf.get()), config.sendcount);
+
+  auto rings_opt = make_standard_rings(worldSize, globalRank, params.num_rings);
+  ASSERT_TRUE(rings_opt.has_value())
+      << "Cannot construct " << params.num_rings << " distinct rings for "
+      << worldSize << " ranks";
+  auto& rings = *rings_opt;
+
+  RingAllgatherLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.sendcount = config.sendcount;
+  launchParams.signaling_data_size = 0;
+  launchParams.sendbuf = static_cast<const char*>(sendbuf.get());
+  launchParams.recvbuf = static_cast<char*>(recvbuf.get());
+  launchParams.num_blocks = config.num_blocks * params.num_rings;
+  launchParams.num_rings = params.num_rings;
+  launchParams.timeout_ms = 30000.0f;
+
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev_rank = rings[r].prev_rank;
+    ringParams.next_rank = rings[r].next_rank;
+    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+  }
+
+  bootstrap->barrierAll();
+  launch_ring_allgather(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allgather(static_cast<const char*>(recvbuf.get()), config.sendcount);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1,
+    RingAllGatherTest,
+    ::testing::Values(
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 64 * 1024, .num_blocks = 4, .name = "64KB_4B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 256 * 1024, .num_blocks = 8, .name = "256KB_8B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 1024 * 1024, .num_blocks = 16, .name = "1MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 2 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 16 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "16MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 8 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2,
+    RingAllGatherTest,
+    ::testing::Values(
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 256 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/pipes/collectives/tests/RingReduceScatterTest.cc
@@ -1,0 +1,185 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/collectives/RingReduceScatterLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/ReduceScatterTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct RingReduceScatterTestParams {
+  ReduceScatterTestConfig config;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<RingReduceScatterTestParams>& info) {
+  return info.param.config.name;
+}
+
+class RingReduceScatterTest
+    : public ReduceScatterTestBase,
+      public ::testing::WithParamInterface<RingReduceScatterTestParams> {};
+
+TEST_P(RingReduceScatterTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring reduce-scatter requires at least 2 ranks";
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = params.data_buffer_size,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = config.num_blocks * params.num_rings,
+                .pipelineDepth = params.pipeline_depth,
+            },
+    };
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, transportConfig);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  const std::size_t total_elements = config.chunk_elements * worldSize;
+  DeviceBuffer inputBuf(total_elements * sizeof(float));
+  DeviceBuffer outputBuf(config.chunk_elements * sizeof(float));
+  CUDACHECK_TEST(
+      cudaMemset(outputBuf.get(), 0, config.chunk_elements * sizeof(float)));
+
+  fill_input(static_cast<float*>(inputBuf.get()), total_elements);
+
+  auto rings_opt = make_standard_rings(worldSize, globalRank, params.num_rings);
+  ASSERT_TRUE(rings_opt.has_value())
+      << "Cannot construct " << params.num_rings << " distinct rings for "
+      << worldSize << " ranks";
+  auto& rings = *rings_opt;
+
+  RingReduceScatterLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.chunk_elements = config.chunk_elements;
+  launchParams.signaling_data_size = 0;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.num_blocks = config.num_blocks * params.num_rings;
+  launchParams.num_rings = params.num_rings;
+  launchParams.timeout_ms = 30000.0f;
+
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev_rank = rings[r].prev_rank;
+    ringParams.next_rank = rings[r].next_rank;
+    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+  }
+
+  bootstrap->barrierAll();
+  launch_ring_reduce_scatter(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_reduce_scatter(
+      static_cast<const float*>(outputBuf.get()), config.chunk_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1,
+    RingReduceScatterTest,
+    ::testing::Values(
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 16 * 1024,
+                 .num_blocks = 4,
+                 .name = "64KB_4B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 256 * 1024,
+                 .num_blocks = 16,
+                 .name = "1MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 2 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "16MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 8 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2,
+    RingReduceScatterTest,
+    ::testing::Values(
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/RingUtilsTest.cc
+++ b/comms/pipes/collectives/tests/RingUtilsTest.cc
@@ -1,0 +1,126 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <numeric>
+#include <set>
+
+#include "comms/pipes/collectives/RingUtils.h"
+
+namespace comms::pipes::test {
+
+TEST(MakeStandardRings, SingleRing) {
+  auto rings = make_standard_rings(8, 0, 1);
+  ASSERT_TRUE(rings.has_value());
+  ASSERT_EQ(rings->size(), 1);
+  EXPECT_EQ((*rings)[0].prev_rank, 7);
+  EXPECT_EQ((*rings)[0].next_rank, 1);
+}
+
+TEST(MakeStandardRings, NeighborsAreConsistent) {
+  int W = 8;
+  for (int num_rings = 1; num_rings <= 4; num_rings++) {
+    for (int my_rank = 0; my_rank < W; my_rank++) {
+      auto rings = make_standard_rings(W, my_rank, num_rings);
+      ASSERT_TRUE(rings.has_value());
+      for (int r = 0; r < num_rings; r++) {
+        int next = (*rings)[r].next_rank;
+        auto neighbor_rings = make_standard_rings(W, next, num_rings);
+        ASSERT_TRUE(neighbor_rings.has_value());
+        EXPECT_EQ((*neighbor_rings)[r].prev_rank, my_rank)
+            << "ring=" << r << " my_rank=" << my_rank << " next=" << next;
+      }
+    }
+  }
+}
+
+TEST(MakeStandardRings, EachRingVisitsAllRanks) {
+  int W = 8;
+  auto rings = make_standard_rings(W, 0, 4);
+  ASSERT_TRUE(rings.has_value());
+  for (int r = 0; r < 4; r++) {
+    std::set<int> visited;
+    int current = 0;
+    for (int i = 0; i < W; i++) {
+      visited.insert(current);
+      auto cur_rings = make_standard_rings(W, current, 4);
+      ASSERT_TRUE(cur_rings.has_value());
+      current = (*cur_rings)[r].next_rank;
+    }
+    EXPECT_EQ(visited.size(), static_cast<std::size_t>(W))
+        << "Ring " << r << " does not visit all ranks";
+    EXPECT_EQ(current, 0) << "Ring " << r << " does not cycle back to start";
+  }
+}
+
+TEST(MakeStandardRings, DistinctNeighborsAcrossRings) {
+  auto rings = make_standard_rings(8, 0, 4);
+  ASSERT_TRUE(rings.has_value());
+
+  std::set<int> next_ranks;
+  for (int r = 0; r < 4; r++) {
+    next_ranks.insert((*rings)[r].next_rank);
+  }
+  EXPECT_EQ(next_ranks.size(), 4) << "All rings have same next neighbor";
+}
+
+TEST(MakeStandardRings, TooManyRingsReturnsNullopt) {
+  auto rings = make_standard_rings(4, 0, 3);
+  EXPECT_FALSE(rings.has_value());
+}
+
+TEST(MakeStandardRings, MaxRingsForPowerOfTwo) {
+  auto rings = make_standard_rings(8, 0, 4);
+  ASSERT_TRUE(rings.has_value());
+  EXPECT_EQ(rings->size(), 4);
+
+  auto too_many = make_standard_rings(8, 0, 5);
+  EXPECT_FALSE(too_many.has_value());
+}
+
+TEST(MakeStandardRings, PrimeWorldSize) {
+  auto rings = make_standard_rings(7, 0, 6);
+  ASSERT_TRUE(rings.has_value());
+  EXPECT_EQ(rings->size(), 6);
+}
+
+TEST(MakeStandardRings, TwoRanksOnlyOneRing) {
+  auto rings = make_standard_rings(2, 0, 1);
+  ASSERT_TRUE(rings.has_value());
+  EXPECT_EQ(rings->size(), 1);
+  EXPECT_EQ((*rings)[0].prev_rank, 1);
+  EXPECT_EQ((*rings)[0].next_rank, 1);
+
+  auto too_many = make_standard_rings(2, 0, 2);
+  EXPECT_FALSE(too_many.has_value());
+}
+
+TEST(MakeStandardRings, IterativeRankWalkMatchesRingTraversal) {
+  int W = 8;
+  auto rings_r0 = make_standard_rings(W, 0, 4);
+  ASSERT_TRUE(rings_r0.has_value());
+
+  for (int r = 0; r < 4; r++) {
+    for (int my_rank = 0; my_rank < W; my_rank++) {
+      auto my_rings = make_standard_rings(W, my_rank, 4);
+      ASSERT_TRUE(my_rings.has_value());
+      int stride = (my_rank - (*my_rings)[r].prev_rank + W) % W;
+
+      int current = my_rank;
+      int walk_rank = my_rank;
+      for (int step = 0; step < W - 1; step++) {
+        auto cur_rings = make_standard_rings(W, current, 4);
+        ASSERT_TRUE(cur_rings.has_value());
+        current = (*cur_rings)[r].prev_rank;
+
+        walk_rank = (walk_rank + W - stride) % W;
+
+        EXPECT_EQ(walk_rank, current)
+            << "ring=" << r << " my_rank=" << my_rank << " step=" << step;
+      }
+    }
+  }
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/RecvForwardChainTest.cc
+++ b/comms/pipes/tests/RecvForwardChainTest.cc
@@ -1,0 +1,366 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/tests/RecvForwardChainTest.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::BenchmarkEnvironment;
+using meta::comms::BenchmarkTestFixture;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::tests {
+
+using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
+
+class RecvForwardChainTest : public BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> create_transport(
+      std::size_t slot_size,
+      int max_groups,
+      int pipeline_depth = 2) {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .dataBufferSize = slot_size,
+        .sendRecv =
+            SendRecvConfig{
+                .maxGroups = max_groups,
+                .pipelineDepth = pipeline_depth,
+            },
+    };
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, config);
+    transport->exchange();
+    return transport;
+  }
+
+  cudaStream_t stream_{};
+};
+
+// Chain test: rank 0 → rank 1 → ... → rank N-1
+// Each intermediate uses recv_forward with dst (copies to local buffer).
+// Verify all ranks that receive data see the correct pattern.
+TEST_F(RecvForwardChainTest, ForwardWithCopy) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xCA;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    // Build per-rank transport pointer array
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    // All ranks except rank 0 should have received the data
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          if (errors < 10) {
+            XLOGF(
+                ERR,
+                "Rank {}: byte {} expected 0x{:02X} got 0x{:02X}",
+                globalRank,
+                i,
+                fillPattern,
+                hostBuf[i]);
+          }
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Chain test with dst=nullptr for intermediates (forward-only).
+// Only the last rank should have the data.
+TEST_F(RecvForwardChainTest, ForwardOnly) {
+  if (worldSize < 3) {
+    XLOGF(INFO, "Skipping: requires >= 3 ranks for forward-only test");
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xBE;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_no_dst(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    // Only the last rank gets data
+    if (globalRank == worldSize - 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Last rank: " << errors << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// 2-rank test: send → recv (no intermediates). Validates that the protocol
+// is compatible when recv_forward is not involved — just send + recv.
+TEST_F(RecvForwardChainTest, SendRecvDirect) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 2 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0x55;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    // Chain with worldSize=2: rank 0 sends, rank 1 receives — no recv_forward
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank == 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank 1: " << errors << " byte mismatches";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Multi-section test: transfer more data than one slot to exercise pipelining.
+TEST_F(RecvForwardChainTest, MultiSection) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kSlotSize = 512 * 1024;
+  constexpr std::size_t kDataBytes = 4 * kSlotSize; // 4 sections
+  constexpr int kNumBlocks = 2;
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xDD;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches in multi-section transfer";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  auto* env = new BenchmarkEnvironment();
+  ::testing::AddGlobalTestEnvironment(env);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/RecvForwardChainTest.cu
+++ b/comms/pipes/tests/RecvForwardChainTest.cu
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes::test {
+
+// Chain kernel: rank 0 sends, intermediates recv_forward, last rank receives.
+__global__ void recv_forward_chain_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    bool use_dst) {
+  auto group = make_block_group();
+  const auto num_blocks = gridDim.x;
+
+  const std::size_t per_block = (nbytes / num_blocks) & ~15ULL;
+  const std::size_t my_off = group.group_id * per_block;
+  const std::size_t my_bytes =
+      (group.group_id == num_blocks - 1) ? (nbytes - my_off) : per_block;
+
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    // First rank: send to next
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    next.send(group, send_buf + my_off, my_bytes, num_blocks);
+  } else if (my_rank == world_size - 1) {
+    // Last rank: receive from prev
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    prev.recv(group, recv_buf + my_off, my_bytes, num_blocks);
+  } else {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    char* dst = use_dst ? (recv_buf + my_off) : nullptr;
+    prev.forward(group, dst, next, my_bytes, num_blocks);
+  }
+}
+
+void launch_recv_forward_chain(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+void launch_recv_forward_chain_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/false);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_no_dst kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/RecvForwardChainTest.h
+++ b/comms/pipes/tests/RecvForwardChainTest.h
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+} // namespace comms::pipes
+
+namespace comms::pipes::test {
+
+/**
+ * Launch a chain test kernel: rank 0 sends, intermediates recv_forward,
+ * last rank receives. Tests the full send → recv_forward → recv protocol.
+ *
+ * @param transports     Array of worldSize P2pIbgdaTransportDevice pointers
+ *                       (one per peer, indexed by rank).
+ * @param send_buf       Source data (only used by rank 0).
+ * @param recv_buf       Destination (used by all ranks; intermediates use it
+ *                       as CopyOp dst in recv_forward).
+ * @param nbytes         Total bytes to transfer per block.
+ * @param my_rank        This rank's global rank.
+ * @param world_size     Total number of ranks.
+ * @param num_blocks     CUDA grid dimension.
+ * @param stream         CUDA stream.
+ */
+void launch_recv_forward_chain(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Same as above but with dst=nullptr for intermediates (forward-only mode).
+ * Only the last rank writes to recv_buf.
+ */
+void launch_recv_forward_chain_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::test


### PR DESCRIPTION
Summary:
Add a ring-based reduce-scatter collective using the pipelined send/recv/recv_forward transport primitives with vectorized TileReduce CopyOp for element-wise floating-point reduction.

Components:
- TileReduce<T, AccumOp, kTileElems, kBlockSize> CopyOp in CopyOp.cuh: vectorized reduction using tile_load/tile_load_accumulate/tile_store from Tile.cuh, templated by accumulation operation (SumOp, MaxOp, MinOp). Replaces scalar TileReduceAdd with SIMD-style tile operations for ~1.2x improvement at mid-range sizes.
- RingReduceScatter kernel: implements the standard ring reduce-scatter algorithm where each rank sends raw input at step 0 then receives and accumulates through W-1 recv_forward/recv steps, with manual tiling and pipeline windowing. Uses transport_group with global group_id to segment staging buffers across rings, avoiding slot conflicts in multi-ring configurations.
- RingReduceScatterLauncher: host-side launcher with forward-declared CUDA types, dispatches to 1-ring or 2-ring kernel instantiations (kTileElems=16384, kBlockSize=512)
- ReduceScatterTestHarness: common test base class (analogous to AllGatherTestHarness) with fill_input and verify_reduce_scatter methods for the shared test interface
- RingReduceScatterTest: parameterized correctness tests for 1-ring (64KB-16MB) and 2-ring (256KB-4MB) configurations
- RingReduceScatterBenchmark: performance comparison against NCCL ncclReduceScatter across message sizes from 256KB to 256MB

Reviewed By: YulunW

Differential Revision: D103888258


