### PR TITLE
Migrate memory logging call sites to memtrace

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -20,7 +20,7 @@
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 #ifdef ENABLE_META_COMPRESSION
 #include <comms/ctran/mapper/fb/IcompressionManager.h>
@@ -681,7 +681,7 @@ commResult_t CtranMapper::deregMem(void* segHdl, const bool skipRemRelease) {
   // freed is true means all segments are deregistered
   if (freed) {
     for (auto& regElem : regElemsFreed) {
-      logMemoryEvent(
+      meta::comms::memtrace::recordReg(
           logMetaData_,
           "",
           "deregMem",
@@ -690,8 +690,7 @@ commResult_t CtranMapper::deregMem(void* segHdl, const bool skipRemRelease) {
           regElem->numSegments(),
           std::chrono::duration_cast<std::chrono::microseconds>(
               std::chrono::steady_clock::now() - timerBegin)
-              .count(),
-          true /* isRegMemEvent */);
+              .count());
     }
   }
   return commSuccess;

--- a/comms/ctran/memory/memCacheAllocator.h
+++ b/comms/ctran/memory/memCacheAllocator.h
@@ -17,7 +17,6 @@
 
 #include "comms/ctran/memory/SlabAllocator.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
 
 // Allow test class to access getFreeMemReg() method
 class memCacheAllocatorTest;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -17,7 +17,7 @@
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/commSpecs.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 static folly::Singleton<ctran::RegCache> regCacheSingleton;
 std::shared_ptr<ctran::RegCache> ctran::RegCache::getInstance() {
@@ -421,7 +421,7 @@ commResult_t ctran::RegCache::globalDeregister(
   if (totalSegmentsFreed > 0) {
     CommLogData globalLogData{};
     globalLogData.commDesc = "global";
-    logMemoryEvent(
+    meta::comms::memtrace::recordReg(
         globalLogData,
         "",
         "globalDeregister",
@@ -430,8 +430,7 @@ commResult_t ctran::RegCache::globalDeregister(
         totalSegmentsFreed,
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - timerBegin)
-            .count(),
-        true /* isRegMemEvent */);
+            .count());
   }
 
   return commSuccess;
@@ -961,7 +960,7 @@ commResult_t ctran::RegCache::regRange(
   }
 
   // Log to scuba
-  logMemoryEvent(
+  meta::comms::memtrace::recordReg(
       logMetaData,
       "",
       useDesc,
@@ -970,8 +969,7 @@ commResult_t ctran::RegCache::regRange(
       numSegmentsToReg,
       std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count(),
-      true /* isRegMemEvent */);
+          .count());
 
   profiler.wlock()->record(ctran::regcache::EventType::kRegMemEvent, dur);
   return commSuccess;
@@ -1379,7 +1377,7 @@ commResult_t ctran::RegCache::regAll() {
         0, // rank
         0 // nRanks
     };
-    logMemoryEvent(
+    meta::comms::memtrace::recordReg(
         defaultLogMetaData,
         "",
         "regAll",
@@ -1388,8 +1386,7 @@ commResult_t ctran::RegCache::regAll() {
         totalSegmentsRegistered,
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - timerBegin)
-            .count(),
-        true /* isRegMemEvent */);
+            .count());
   }
 
   CLOGF_TRACE(

--- a/comms/ctran/utils/Alloc.cc
+++ b/comms/ctran/utils/Alloc.cc
@@ -52,7 +52,7 @@ commResult_t commCuMemAlloc(
       size,
       *ptr,
       ctran::utils::toFormattableHandle(handle));
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
       logMetaData ? *logMetaData : CommLogData{},
       callsite,
       "commCuMemAlloc",
@@ -96,7 +96,7 @@ commResult_t commCuMemFree(void* ptr, const CommLogData* logMetaData) {
       size,
       ptr,
       ctran::utils::toFormattableHandle(handle));
-  logMemoryEvent(
+  meta::comms::memtrace::recordFree(
       logMetaData ? *logMetaData : CommLogData{},
       "",
       "commCuMemFree",

--- a/comms/ctran/utils/Alloc.h
+++ b/comms/ctran/utils/Alloc.h
@@ -13,7 +13,7 @@
 #include "comms/ctran/utils/DevUtils.cuh"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/logger/alloc.h"
+#include "comms/utils/memtrace/MemoryTrace.h"
 
 namespace ctran::utils {
 
@@ -102,7 +102,7 @@ finish:
       nelem * sizeof(T),
       (void*)*ptr);
   if (!getCuMemSysSupported()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         logMetaData ? *logMetaData : CommLogData{},
         callsite,
         "commCudaMalloc",
@@ -129,7 +129,7 @@ commResult_t commCudaFree(T* ptr, const CommLogData* logMetaData = nullptr) {
   }
 finish:
   if (!getCuMemSysSupported()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordFree(
         logMetaData ? *logMetaData : CommLogData{},
         "",
         "commCudaFree",
@@ -169,7 +169,7 @@ finish:
       line,
       nelem * sizeof(T),
       (void*)*ptr);
-  logMemoryEvent(
+  meta::comms::memtrace::recordAlloc(
       logMetaData ? *logMetaData : CommLogData{},
       callsite,
       "commCudaHostAlloc",
@@ -194,7 +194,7 @@ commResult_t commCudaFreeHost(
     FB_CUDACHECKGOTO(cudaFreeHost(ptr), result, finish);
   }
 finish:
-  logMemoryEvent(
+  meta::comms::memtrace::recordFree(
       logMetaData ? *logMetaData : CommLogData{},
       "",
       "commCudaFreeHost",
@@ -249,7 +249,7 @@ finish:
       nelem * sizeof(T),
       (void*)*ptr);
   if (!getCuMemSysSupported()) {
-    logMemoryEvent(
+    meta::comms::memtrace::recordAlloc(
         logMetaData ? *logMetaData : CommLogData{},
         callsite,
         "commCudaCallocAsync",


### PR DESCRIPTION
Summary:
Migrate all 9 logMemoryEvent() call sites in ctran/ to use the new memtrace API:
- comms/ctran/utils/Alloc.h: 3 sites (commCudaMalloc→recordAlloc, commCudaFree→recordFree, commCudaCallocAsync→recordAlloc)
- comms/ctran/utils/Alloc.cc: 2 sites (commCuMemAlloc→recordAlloc, commCuMemFree→recordFree)
- comms/ctran/regcache/RegCache.cc: 3 sites (globalDeregister→recordReg, memory registration→recordReg, regAll→recordReg)
- comms/ctran/mapper/CtranMapper.cc: 1 site (deregMem→recordReg)
- comms/ctran/memory/memCacheAllocator.h: removed unused logger/alloc.h include
- Updated BUCK deps: logger:alloc → memtrace:memory_tracer in utils/BUCK, def_build.bzl, memory/BUCK

Reviewed By: YulunW

Differential Revision: D96010717


