### PR TITLE
Remove lazySetupChannels from ncclConfig, use cvar only (#2445)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -69,7 +69,6 @@ Config::Config(const ncclConfig_t* config) {
   checkPtrConflict("commDesc", config->commDesc);
   checkPtrConflict("splitGroupRanks", config->splitGroupRanks);
   checkPtrConflict("ncclAllGatherAlgo", config->ncclAllGatherAlgo);
-  checkIntConflict("lazySetupChannels", config->lazySetupChannels);
   checkIntConflict("fastInitMode", config->fastInitMode);
 
   if (conflict) {
@@ -155,13 +154,6 @@ Config::Config(const ncclConfig_t* config) {
     if (!val.empty()) {
       ncclAllGatherAlgo = val;
     }
-  }
-
-  if (config->lazySetupChannels != NCCL_CONFIG_UNDEF_INT) {
-    lazySetupChannels = config->lazySetupChannels != 0;
-  } else {
-    lazySetupChannels =
-        parseHintBool("lazySetupChannels", NCCL_LAZY_SETUP_CHANNELS);
   }
 
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -69,7 +69,6 @@ Config::Config(const ncclConfig_t* config) {
   checkPtrConflict("commDesc", config->commDesc);
   checkPtrConflict("splitGroupRanks", config->splitGroupRanks);
   checkPtrConflict("ncclAllGatherAlgo", config->ncclAllGatherAlgo);
-  checkIntConflict("lazyConnect", config->lazyConnect);
   checkIntConflict("lazySetupChannels", config->lazySetupChannels);
   checkIntConflict("fastInitMode", config->fastInitMode);
 
@@ -156,13 +155,6 @@ Config::Config(const ncclConfig_t* config) {
     if (!val.empty()) {
       ncclAllGatherAlgo = val;
     }
-  }
-
-  // booleans: flat field > hint > env default
-  if (config->lazyConnect != NCCL_CONFIG_UNDEF_INT) {
-    lazyConnect = config->lazyConnect != 0;
-  } else {
-    lazyConnect = parseHintBool("lazyConnect", NCCL_RUNTIME_CONNECT);
   }
 
   if (config->lazySetupChannels != NCCL_CONFIG_UNDEF_INT) {

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -27,7 +27,6 @@ class Config {
   std::string commDesc = "undefined";
   std::vector<int> splitGroupRanks;
   std::string ncclAllGatherAlgo = "undefined";
-  bool lazyConnect = false;
   bool lazySetupChannels = false;
   bool fastInitMode = false;
 
@@ -54,7 +53,6 @@ inline const std::vector<std::string>& knownHintKeys() {
       "commDesc",
       "splitGroupRanks",
       "ncclAllGatherAlgo",
-      "lazyConnect",
       "lazySetupChannels",
       "fastInitMode",
       "pipesNvlChunkSize",

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -27,7 +27,6 @@ class Config {
   std::string commDesc = "undefined";
   std::vector<int> splitGroupRanks;
   std::string ncclAllGatherAlgo = "undefined";
-  bool lazySetupChannels = false;
   bool fastInitMode = false;
 
   // Per-communicator MultiPeerTransport (pipes) NVL config overrides.
@@ -53,7 +52,6 @@ inline const std::vector<std::string>& knownHintKeys() {
       "commDesc",
       "splitGroupRanks",
       "ncclAllGatherAlgo",
-      "lazySetupChannels",
       "fastInitMode",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -35,7 +35,6 @@ TEST(ConfigHintsUT, HintsCreateNcclxConfig) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
   hints.set("commDesc", "test_desc");
-  hints.set("lazySetupChannels", "0");
   hints.set("fastInitMode", "1");
   hints.set("ncclAllGatherAlgo", "custom_algo");
   config.hints = &hints;
@@ -46,7 +45,6 @@ TEST(ConfigHintsUT, HintsCreateNcclxConfig) {
   ASSERT_NE(config.ncclxConfig, nullptr);
 
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, commDesc), "test_desc");
-  EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, lazySetupChannels));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, fastInitMode));
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, ncclAllGatherAlgo), "custom_algo");
 
@@ -62,7 +60,6 @@ TEST(ConfigHintsUT, PrefixedKeysMatchBareKeys) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
   hints.set("ncclx::commDesc", "test_desc");
-  hints.set("ncclx::lazySetupChannels", "0");
   hints.set("ncclx::fastInitMode", "1");
   hints.set("ncclx::ncclAllGatherAlgo", "custom_algo");
   config.hints = &hints;
@@ -73,7 +70,6 @@ TEST(ConfigHintsUT, PrefixedKeysMatchBareKeys) {
   ASSERT_NE(config.ncclxConfig, nullptr);
 
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, commDesc), "test_desc");
-  EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, lazySetupChannels));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, fastInitMode));
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, ncclAllGatherAlgo), "custom_algo");
 

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -23,7 +23,6 @@ TEST(ConfigHintsUT, NoHintsCreatesDefaults) {
   EXPECT_EQ(ncclxCfg->commDesc, "undefined");
   EXPECT_TRUE(ncclxCfg->splitGroupRanks.empty());
   EXPECT_EQ(ncclxCfg->ncclAllGatherAlgo, "undefined");
-  EXPECT_TRUE(ncclxCfg->lazyConnect);
 
   // Upstream NCCL fields should be untouched
   EXPECT_EQ(config.blocking, NCCL_CONFIG_UNDEF_INT);
@@ -36,7 +35,6 @@ TEST(ConfigHintsUT, HintsCreateNcclxConfig) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
   hints.set("commDesc", "test_desc");
-  hints.set("lazyConnect", "1");
   hints.set("lazySetupChannels", "0");
   hints.set("fastInitMode", "1");
   hints.set("ncclAllGatherAlgo", "custom_algo");
@@ -48,7 +46,6 @@ TEST(ConfigHintsUT, HintsCreateNcclxConfig) {
   ASSERT_NE(config.ncclxConfig, nullptr);
 
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, commDesc), "test_desc");
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, lazyConnect));
   EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, lazySetupChannels));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, fastInitMode));
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, ncclAllGatherAlgo), "custom_algo");
@@ -65,7 +62,6 @@ TEST(ConfigHintsUT, PrefixedKeysMatchBareKeys) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   ncclx::Hints hints;
   hints.set("ncclx::commDesc", "test_desc");
-  hints.set("ncclx::lazyConnect", "1");
   hints.set("ncclx::lazySetupChannels", "0");
   hints.set("ncclx::fastInitMode", "1");
   hints.set("ncclx::ncclAllGatherAlgo", "custom_algo");
@@ -77,7 +73,6 @@ TEST(ConfigHintsUT, PrefixedKeysMatchBareKeys) {
   ASSERT_NE(config.ncclxConfig, nullptr);
 
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, commDesc), "test_desc");
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, lazyConnect));
   EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, lazySetupChannels));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, fastInitMode));
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, ncclAllGatherAlgo), "custom_algo");
@@ -93,36 +88,10 @@ TEST(ConfigHintsUT, PrefixedKeysMatchBareKeys) {
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }
 
-TEST(ConfigHintsUT, BoolHintFormats) {
-  // Test various truthy values
-  for (const char* trueVal :
-       {"1", "yes", "YES", "Yes", "true", "TRUE", "True", "y", "Y", "t", "T"}) {
-    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-    ncclx::Hints hints;
-    hints.set("lazyConnect", trueVal);
-    config.hints = &hints;
-    EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess) << trueVal;
-    EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, lazyConnect)) << trueVal;
-    delete static_cast<ncclx::Config*>(config.ncclxConfig);
-  }
-  // Test various falsy values
-  for (const char* falseVal :
-       {"0", "no", "NO", "No", "false", "FALSE", "False", "n", "N", "f", "F"}) {
-    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-    ncclx::Hints hints;
-    hints.set("lazyConnect", falseVal);
-    config.hints = &hints;
-    EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess) << falseVal;
-    EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, lazyConnect)) << falseVal;
-    delete static_cast<ncclx::Config*>(config.ncclxConfig);
-  }
-}
-
 TEST(ConfigHintsUT, OldFormatFlatFields) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   // Set fields via old format (directly on ncclConfig_t)
   config.commDesc = "old_desc";
-  config.lazyConnect = 1;
   config.fastInitMode = 2;
 
   EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
@@ -131,25 +100,9 @@ TEST(ConfigHintsUT, OldFormatFlatFields) {
   ASSERT_NE(config.ncclxConfig, nullptr);
 
   EXPECT_EQ(NCCLX_CONFIG_FIELD(config, commDesc), "old_desc");
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, lazyConnect));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, fastInitMode));
 
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
-}
-
-TEST(ConfigHintsUT, ConflictReturnsError) {
-  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  // Set lazyConnect in old format
-  config.lazyConnect = 1;
-  // Also set it in hints (new format)
-  ncclx::Hints hints;
-  hints.set("lazyConnect", "0");
-  config.hints = &hints;
-
-  EXPECT_EQ(ncclxParseCommConfig(&config), ncclInvalidArgument);
-
-  // ncclxConfig should NOT have been created
-  EXPECT_EQ(config.ncclxConfig, (void*)NCCL_CONFIG_UNDEF_PTR);
 }
 
 TEST(ConfigHintsUT, DoubleParseReturnsError) {

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -14,6 +14,7 @@
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/hints/GlobalHints.h"
 
 class NcclxLazyConnectTestFixture
     : public NcclxBaseTestFixture,
@@ -25,6 +26,24 @@ class NcclxLazyConnectTestFixture
   void* recvBuf{nullptr};
   ncclDataType_t dataType{ncclBfloat16};
 
+  bool isNoLocal() const {
+    for (const auto& [key, val] : GetParam()) {
+      if (key == "NCCL_NOLOCAL" && val == "1") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  ncclComm_t createRootComm() {
+    if (isNoLocal()) {
+      ncclx::setGlobalHint(
+          std::string(ncclx::HintKeys::kCommNoLocal).c_str(), "1");
+    }
+    return ncclx::test::createNcclComm(
+        globalRank, numRanks, localRank, bootstrap_.get());
+  }
+
  protected:
   void SetUp() override {
     NcclxBaseTestFixture::SetUp(GetParam());
@@ -32,6 +51,9 @@ class NcclxLazyConnectTestFixture
   }
 
   void TearDown() override {
+    if (isNoLocal()) {
+      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+    }
     if (sendBuf) {
       CUDACHECK_TEST(cudaFree(sendBuf));
       sendBuf = nullptr;
@@ -130,8 +152,7 @@ class NcclxLazyConnectTestFixture
 };
 
 TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
   // Nothing should be connected or initialized if no collective is called
   if (NCCL_RUNTIME_CONNECT) {
@@ -154,9 +175,9 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
-  EnvRAII algo(NCCL_ALGO, std::string("RING"));
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  SysEnvRAII algo("NCCL_ALGO", "RING");
+  EnvRAII<std::string> algoEnv(NCCL_ALGO, std::string("RING"));
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -173,8 +194,7 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // RING should be connected in rootComm
-    // other algorithms should not be connected if NCCL_RUNTIME_CONNECT is
-    // enabled
+    // other algorithms should not be connected if lazy connect is enabled
     checkAlgoChannelState(rootComm, NCCL_ALGO_RING, NCCL_RUNTIME_CONNECT);
   }
 
@@ -183,9 +203,9 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
-  EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  SysEnvRAII algo("NCCL_ALGO", "TREE");
+  EnvRAII<std::string> algoEnv(NCCL_ALGO, std::string("TREE"));
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 10; // 1K elements
@@ -202,8 +222,7 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // TREE should be connected in rootComm
-    // other algorithms should not be connected if NCCL_RUNTIME_CONNECT is
-    // enabled
+    // other algorithms should not be connected if lazy connect is enabled
     checkAlgoChannelState(rootComm, NCCL_ALGO_TREE, NCCL_RUNTIME_CONNECT);
   }
 
@@ -212,9 +231,9 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
-  EnvRAII algo(NCCL_ALGO, std::string("TREE"));
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  SysEnvRAII algo("NCCL_ALGO", "TREE");
+  EnvRAII<std::string> algoEnv(NCCL_ALGO, std::string("TREE"));
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   size_t smallCount = 1 << 10; // 1K elements
@@ -243,8 +262,7 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -294,8 +312,7 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   size_t count = 1 << 20; // 1M BF16 elements
@@ -329,11 +346,14 @@ TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
 // test that p2p channels higher than collective channels
 // expected behavior is that all channels should initialized
 TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
-  EnvRAII p2pMinCh(NCCL_MIN_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
-  EnvRAII p2pMaxCh(NCCL_MAX_P2P_NCHANNELS, (int64_t)MAXCHANNELS);
+  SysEnvRAII p2pMinCh("NCCL_MIN_P2P_NCHANNELS", std::to_string(MAXCHANNELS));
+  SysEnvRAII p2pMaxCh("NCCL_MAX_P2P_NCHANNELS", std::to_string(MAXCHANNELS));
+  EnvRAII<int64_t> p2pMinChEnv(
+      NCCL_MIN_P2P_NCHANNELS, static_cast<int64_t>(MAXCHANNELS));
+  EnvRAII<int64_t> p2pMaxChEnv(
+      NCCL_MAX_P2P_NCHANNELS, static_cast<int64_t>(MAXCHANNELS));
 
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
   // p2p channels should be higher than collective channels
   EXPECT_GE(rootComm->p2pnChannels, rootComm->collChannels);
@@ -369,8 +389,7 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
 
   ncclComm_t childComm;
@@ -465,7 +484,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 //   present,
 //   // fallback path will be tested.
 //   // TODO: use a mock tuner plugin to test the logic
-//   EnvRAII algo(NCCL_ALGO, std::string("TREE"));
+//   SysEnvRAII algo("NCCL_ALGO", "TREE");
 //   EnvRAII tuner(NCCL_TUNER_PLUGIN, std::string(""));
 //   NCCLCHECK_TEST(
 //       ncclCommInitRankConfig(&rootComm, numRanks, ncclUid, globalRank,
@@ -520,22 +539,16 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 // }
 
 TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
-  rootComm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
-  // split/duplicate a communicator always enable lazy connect and setup
-  // channels
   ncclComm_t childComm = nullptr;
   ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-  ncclx::Hints lazyHints({{"lazyConnect", "1"}, {"lazySetupChannels", "1"}});
+  ncclx::Hints lazyHints({{"lazySetupChannels", "1"}});
   childCommConfig.hints = &lazyHints;
   NCCLCHECK_TEST(
       ncclCommSplit(rootComm, 0, globalRank, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
 
-  // child comm should always have lazy connect and setup channels enabled and
-  // not allocate any channels
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazyConnect));
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazySetupChannels));
   for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     EXPECT_FALSE(childComm->initAlgoChannels[a]);
@@ -558,8 +571,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
 }
 
 TEST_P(NcclxLazyConnectTestFixture, coalescedAllReduce) {
-  comm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+  comm = createRootComm();
   ASSERT_NE(nullptr, comm);
 
   size_t count = 1 << 10; // 1K elements
@@ -580,44 +592,38 @@ TEST_P(NcclxLazyConnectTestFixture, coalescedAllReduce) {
   NCCLCHECK_TEST(ncclCommDestroy(comm));
 }
 
+// NCCL_RUNTIME_CONNECT is set by BUCK launcher (env var per binary), not by
+// test params. Use LAZY_CONNECT_ENABLED to select the param set that matches.
+#if LAZY_CONNECT_ENABLED
 INSTANTIATE_TEST_SUITE_P(
     MyTestSuite,
     NcclxLazyConnectTestFixture,
     testing::Values(
-        NcclxEnvs({{"NCCL_RUNTIME_CONNECT", "1"}}),
+        NcclxEnvs({}),
+        NcclxEnvs({{"NCCL_LAZY_SETUP_CHANNELS", "1"}}),
         NcclxEnvs({
-            {"NCCL_RUNTIME_CONNECT", "1"},
-            {"NCCL_LAZY_SETUP_CHANNELS", "1"},
-        }),
-        NcclxEnvs({
-            {"NCCL_RUNTIME_CONNECT", "0"},
-            {"NCCL_LAZY_SETUP_CHANNELS", "1"},
-        }),
-        NcclxEnvs({
-            {"NCCL_RUNTIME_CONNECT", "1"},
             {"NCCL_LAZY_SETUP_CHANNELS", "1"},
             {"NCCL_MEM_USE_SLAB_ALLOCATOR", "1"},
         }),
         NcclxEnvs({
-            {"NCCL_RUNTIME_CONNECT", "1"},
             {"NCCL_LAZY_SETUP_CHANNELS", "1"},
             {"NCCL_MEM_USE_SLAB_ALLOCATOR", "1"},
             {"NCCL_USE_TRANSPORT_EXT", "1"},
         }),
         NcclxEnvs({
-            {"NCCL_RUNTIME_CONNECT", "1"},
             {"NCCL_LAZY_SETUP_CHANNELS", "1"},
             {"NCCL_USE_TRANSPORT_PROXY", "shared"},
             {"NCCL_CHANNEL_METADATA_LOCATION", "host"},
+        }),
+        NcclxEnvs({{"NCCL_NOLOCAL", "1"}}),
+        NcclxEnvs({
+            {"NCCL_LAZY_SETUP_CHANNELS", "1"},
+            {"NCCL_NOLOCAL", "1"},
         })),
     [](const testing::TestParamInfo<NcclxLazyConnectTestFixture::ParamType>&
            info) {
-      // generate test-name for a given NcclxEnvs
-      std::string name = "";
+      std::string name;
       for (const auto& [key, val] : info.param) {
-        if (key == "NCCL_RUNTIME_CONNECT" && val == "1") {
-          name += "lazy_connect_";
-        }
         if (key == "NCCL_LAZY_SETUP_CHANNELS" && val == "1") {
           name += "setupChannels_";
         }
@@ -630,9 +636,23 @@ INSTANTIATE_TEST_SUITE_P(
         if (key == "NCCL_USE_TRANSPORT_PROXY" && val != "none") {
           name += "proxy_" + val + "_";
         }
+        if (key == "NCCL_NOLOCAL" && val == "1") {
+          name += "nolocal_";
+        }
+      }
+      if (name.empty()) {
+        name = "baseline";
       }
       return name;
     });
+#else
+INSTANTIATE_TEST_SUITE_P(
+    MyTestSuite,
+    NcclxLazyConnectTestFixture,
+    testing::Values(NcclxEnvs({{"NCCL_LAZY_SETUP_CHANNELS", "1"}})),
+    [](const testing::TestParamInfo<NcclxLazyConnectTestFixture::ParamType>&
+           info) { return std::string("setupChannels"); });
+#endif
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -543,13 +543,9 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
   ASSERT_NE(nullptr, rootComm);
   ncclComm_t childComm = nullptr;
   ncclConfig_t childCommConfig = NCCL_CONFIG_INITIALIZER;
-  ncclx::Hints lazyHints({{"lazySetupChannels", "1"}});
-  childCommConfig.hints = &lazyHints;
   NCCLCHECK_TEST(
       ncclCommSplit(rootComm, 0, globalRank, &childComm, &childCommConfig));
   ASSERT_NE(nullptr, childComm);
-
-  EXPECT_TRUE(NCCLX_CONFIG_FIELD(childComm->config, lazySetupChannels));
   for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     EXPECT_FALSE(childComm->initAlgoChannels[a]);
   }

--- a/comms/ncclx/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/meta/wrapper/CtranExComm.cc
@@ -42,7 +42,6 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
   ncclx::Hints hints(
       {{"commDesc", commDesc},
        {"splitGroupRanks", ranksStr},
-       {"lazyConnect", "1"},
        {"lazySetupChannels", "1"}});
   config.hints = &hints;
 

--- a/comms/ncclx/meta/wrapper/CtranExComm.cc
+++ b/comms/ncclx/meta/wrapper/CtranExComm.cc
@@ -39,10 +39,10 @@ CtranExComm::CtranExComm(const ncclComm_t comm, const std::string& commDesc) {
     }
     ranksStr += std::to_string(globalRanks[i]);
   }
-  ncclx::Hints hints(
-      {{"commDesc", commDesc},
-       {"splitGroupRanks", ranksStr},
-       {"lazySetupChannels", "1"}});
+  ncclx::Hints hints({
+      {"commDesc", commDesc},
+      {"splitGroupRanks", ranksStr},
+  });
   config.hints = &hints;
 
   // if parent comm is non-blocking, ncclCommSplit will be non-blocking

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -844,7 +844,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
+  comm->lazySetupChannels = comm->cuMemSupport && NCCL_LAZY_SETUP_CHANNELS;
   // Check for runtime connect support
   comm->runtimeConn = comm->cuMemSupport && NCCL_RUNTIME_CONNECT;
 

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -846,7 +846,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Check for lazy channel setup support
   comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
   // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
+  comm->runtimeConn = comm->cuMemSupport && NCCL_RUNTIME_CONNECT;
 
   if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
     WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -140,8 +140,6 @@ typedef struct ncclConfig_v22700 {
   // control allgather algo at comm level
   const char* ncclAllGatherAlgo{nullptr};
 
-  // control the lazy connect features
-  int lazyConnect{NCCL_CONFIG_UNDEF_INT};
   int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
 
   // control the fast init features
@@ -180,7 +178,6 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -140,8 +140,6 @@ typedef struct ncclConfig_v22700 {
   // control allgather algo at comm level
   const char* ncclAllGatherAlgo{nullptr};
 
-  int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
-
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
 
@@ -178,7 +176,6 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */            \

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1120,12 +1120,6 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   // Check for lazy channel setup support
   comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
-  // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
-
-  if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
-    WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
-  }
 
   // Check for MNNVL support
   NCCLCHECKGOTO(ncclGetUserP2pLevel(&p2pLevel), ret, fail);
@@ -1504,6 +1498,10 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
 
   comm->runtimeConn = comm->cuMemSupport && ncclParamRuntimeConnect();
+
+  if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
+    WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
+  }
 
   if (comm->lazySetupChannels) {
     INFO(

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1119,7 +1119,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
+  comm->lazySetupChannels = comm->cuMemSupport && NCCL_LAZY_SETUP_CHANNELS;
 
   // Check for MNNVL support
   NCCLCHECKGOTO(ncclGetUserP2pLevel(&p2pLevel), ret, fail);

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -163,8 +163,6 @@ typedef struct ncclConfig_v22800 {
   // control allgather algo at comm level
   const char* ncclAllGatherAlgo{nullptr};
 
-  int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
-
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
 
@@ -205,7 +203,6 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */            \

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -163,8 +163,6 @@ typedef struct ncclConfig_v22800 {
   // control allgather algo at comm level
   const char* ncclAllGatherAlgo{nullptr};
 
-  // control the lazy connect features
-  int lazyConnect{NCCL_CONFIG_UNDEF_INT};
   int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
 
   // control the fast init features
@@ -207,7 +205,6 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                  \

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -1155,7 +1155,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_ALLGATHER] = clockNano() - timers[TIMER_INIT_ALLGATHER];
 
   // Check for lazy channel setup support
-  comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
+  comm->lazySetupChannels = comm->cuMemSupport && NCCL_LAZY_SETUP_CHANNELS;
 
   // Check for MNNVL support
   NCCLCHECKGOTO(ncclGetUserP2pLevel(&p2pLevel), ret, fail);

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -1156,12 +1156,6 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   // Check for lazy channel setup support
   comm->lazySetupChannels = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels);
-  // Check for runtime connect support
-  comm->runtimeConn = comm->cuMemSupport && NCCLX_CONFIG_FIELD(comm->config, lazyConnect);
-
-  if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
-    WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
-  }
 
   // Check for MNNVL support
   NCCLCHECKGOTO(ncclGetUserP2pLevel(&p2pLevel), ret, fail);
@@ -1643,6 +1637,10 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
 
   comm->runtimeConn = comm->cuMemSupport && ncclParamRuntimeConnect();
+
+  if (comm->runtimeConn == 0 && comm->lazySetupChannels == 1) {
+    WARN("NCCL_RUNTIME_CONNECT is disabled but NCCL_LAZY_SETUP_CHANNELS is enabled, full lazy connect features will still be used");
+  }
 
   if (comm->lazySetupChannels) {
     INFO(

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -166,7 +166,6 @@ typedef struct ncclConfig_v22800 {
   const char* ncclAllGatherAlgo{nullptr};
 
   // control the lazy connect features
-  int lazyConnect{NCCL_CONFIG_UNDEF_INT};
   int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
 
   // control the fast init features
@@ -210,7 +209,6 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazyConnect */           \
   NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                 \

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -165,9 +165,6 @@ typedef struct ncclConfig_v22800 {
   // control allgather algo at comm level
   const char* ncclAllGatherAlgo{nullptr};
 
-  // control the lazy connect features
-  int lazySetupChannels{NCCL_CONFIG_UNDEF_INT};
-
   // control the fast init features
   int fastInitMode{NCCL_CONFIG_UNDEF_INT};
 
@@ -209,7 +206,6 @@ typedef struct ncclConfig_v22800 {
   NCCL_CONFIG_UNDEF_PTR,                    /* splitGroupRanks */       \
   NCCL_CONFIG_UNDEF_INT,                    /* splitGroupSize */        \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclAllGatherAlgo */     \
-  NCCL_CONFIG_UNDEF_INT,                    /* lazySetupChannels */     \
   NCCL_CONFIG_UNDEF_INT,                    /* fastInitMode */          \
   NCCL_CONFIG_UNDEF_PTR,                    /* hints */                 \
   NCCL_CONFIG_UNDEF_PTR,                    /* ncclxConfig */           \

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -345,6 +345,8 @@ cvars:
    default     : -1
    description : https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-comm-blocking
 
+ # TODO: Delete NCCL_RUNTIME_CONNECT once v2.27 and v2.28 are removed.
+ # v2.29 uses ncclParam + per-comm hints instead.
  - name        : NCCL_RUNTIME_CONNECT
    type        : int64_t
    default     : 1


### PR DESCRIPTION
Summary:

Remove lazySetupChannels from ncclConfig_t and ncclx::Config. NCCL_LAZY_SETUP_CHANNELS is now controlled exclusively via cvar (env var), with no per-comm override.

- Remove lazySetupChannels field from ncclx::Config and ncclConfig_t (all 3 versions)
- Remove lazySetupChannels hint key, conflict check, and parsing in NcclxConfig.cc
- Replace NCCLX_CONFIG_FIELD(comm->config, lazySetupChannels) with NCCL_LAZY_SETUP_CHANNELS cvar in init.cc (all 3 versions)
- Remove lazySetupChannels hint from CtranExComm.cc comm split and LazyConnectTest.cc ChildCommLazyConfig
- Remove lazySetupChannels from ConfigHintsUT test assertions

Reviewed By: pavanbalaji, MogicianWu

Differential Revision: D104327919


