### PR TITLE
Add new API for copy based send/recv

### DIFF
--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -67,6 +67,26 @@ Status CudaApi::getDevicePCIBusId(char* pciBusId, int len, int device) {
   return Ok();
 }
 
+// --- Host memory ---
+
+Result<void*> CudaApi::hostAlloc(size_t size, unsigned int flags) {
+  void* ptr = nullptr;
+  CUDA_CHECK(cudaHostAlloc(&ptr, size, flags), ErrCode::DriverError);
+  return ptr;
+}
+
+Status CudaApi::hostFree(void* ptr) {
+  CUDA_CHECK(cudaFreeHost(ptr), ErrCode::DriverError);
+  return Ok();
+}
+
+Result<void*> CudaApi::hostGetDevicePointer(void* hostPtr) {
+  void* devPtr = nullptr;
+  CUDA_CHECK(
+      cudaHostGetDevicePointer(&devPtr, hostPtr, 0), ErrCode::DriverError);
+  return devPtr;
+}
+
 // --- Memory copy ---
 
 Status CudaApi::memcpyAsync(

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -29,6 +29,14 @@ class CudaApi {
 
   virtual Status getDevicePCIBusId(char* pciBusId, int len, int device);
 
+  // --- Host memory ---
+
+  virtual Result<void*> hostAlloc(size_t size, unsigned int flags);
+
+  virtual Status hostFree(void* ptr);
+
+  virtual Result<void*> hostGetDevicePointer(void* hostPtr);
+
   // --- Memory copy ---
 
   virtual Status memcpyAsync(

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
@@ -51,6 +51,9 @@ DECLARE_CUDA_PFN(cuMemGetHandleForAddressRange, 11070);
 DECLARE_CUDA_PFN(cuMemRetainAllocationHandle, 11000);
 DECLARE_CUDA_PFN(cuMemGetAddressRange, 3020);
 
+// --- Stream memory ops ---
+DECLARE_CUDA_PFN(cuStreamWriteValue64, 11070);
+
 #undef DECLARE_CUDA_PFN
 
 std::once_flag g_initFlag;
@@ -338,6 +341,7 @@ void doInit() {
   LOAD_SYM(cuMemGetHandleForAddressRange, 11070, 1);
   LOAD_SYM(cuMemRetainAllocationHandle, 11000, 1);
   LOAD_SYM(cuMemGetAddressRange, 3020, 1);
+  LOAD_SYM(cuStreamWriteValue64, 11070, 1);
 
   // Check if cuMem is supported
   checkCuMemSupported(cudaDev);
@@ -495,6 +499,16 @@ Status CudaDriverApi::cuMemGetHandleForAddressRange(
     CUmemRangeHandleType handleType,
     unsigned long long flags) {
   CU_CALL(cuMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);
+}
+
+// --- Stream memory ops ---
+
+Status CudaDriverApi::streamWriteValue64(
+    CUstream stream,
+    CUdeviceptr addr,
+    uint64_t value,
+    unsigned int flags) {
+  CU_CALL(cuStreamWriteValue64, stream, addr, value, flags);
 }
 
 // --- supported APIs ---

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.h
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.h
@@ -97,6 +97,14 @@ class CudaDriverApi {
       CUmemRangeHandleType handleType,
       unsigned long long flags);
 
+  // --- Stream memory ops ---
+
+  virtual Status streamWriteValue64(
+      CUstream stream,
+      CUdeviceptr addr,
+      uint64_t value,
+      unsigned int flags);
+
   // --- supported APIs ---
   virtual Result<bool> isDmaBufSupported(int cudaDev);
 

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -30,6 +30,14 @@ class MockCudaApi : public CudaApi {
       (override));
 
   MOCK_METHOD(
+      Result<void*>,
+      hostAlloc,
+      (size_t size, unsigned int flags),
+      (override));
+  MOCK_METHOD(Status, hostFree, (void* ptr), (override));
+  MOCK_METHOD(Result<void*>, hostGetDevicePointer, (void* hostPtr), (override));
+
+  MOCK_METHOD(
       Status,
       memcpyAsync,
       (void* dst,

--- a/comms/uniflow/drivers/cuda/mock/MockCudaDriverApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaDriverApi.h
@@ -125,6 +125,13 @@ class MockCudaDriverApi : public CudaDriverApi {
       (CUdeviceptr * pbase, size_t* psize, CUdeviceptr dptr),
       (override));
 
+  // --- Stream memory ops ---
+  MOCK_METHOD(
+      Status,
+      streamWriteValue64,
+      (CUstream stream, CUdeviceptr addr, uint64_t value, unsigned int flags),
+      (override));
+
   // --- supported APIs ---
   MOCK_METHOD(Result<bool>, isDmaBufSupported, (int cudaDev), (override));
   MOCK_METHOD(Result<bool>, isCuMemSupported, (), (override));

--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -1,0 +1,107 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/transport/rdma/RdmaResources.h"
+
+namespace uniflow {
+
+// ---------------------------------------------------------------------------
+// NicResources
+// ---------------------------------------------------------------------------
+
+NicResources::NicResources(
+    ibv_device* device,
+    std::shared_ptr<IbvApi> api,
+    uint8_t gidIndex,
+    std::optional<uint8_t> port)
+    : ibvApi(std::move(api)) {
+  if (!ibvApi) {
+    ibvApi = std::make_shared<IbvApi>();
+  }
+
+  auto ctxResult = ibvApi->openDevice(device);
+  if (ctxResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to open device");
+  }
+  ctx = ctxResult.value();
+
+  portNum = port.value_or(0);
+  if (portNum == 0) {
+    portNum = findActivePort();
+    if (portNum == 0) {
+      throw std::runtime_error("NicResources: no active port found");
+    }
+  }
+
+  auto pdResult = ibvApi->allocPd(ctx);
+  if (pdResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to allocate PD");
+  }
+  pd = pdResult.value();
+
+  auto dmaBufResult = ibvApi->isDmaBufSupported(pd);
+  if (dmaBufResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to probe DMA-BUF support");
+  }
+  dmaBufSupported = dmaBufResult.value();
+
+  ibv_port_attr portAttr{};
+  auto portStatus = ibvApi->queryPort(ctx, portNum, &portAttr);
+  if (portStatus.hasError()) {
+    throw std::runtime_error("NicResources: failed to query port");
+  }
+  lid = portAttr.lid;
+  mtu = portAttr.active_mtu;
+  linkLayer = portAttr.link_layer;
+
+  auto gidStatus = ibvApi->queryGid(ctx, portNum, gidIndex, &gid);
+  if (gidStatus.hasError()) {
+    throw std::runtime_error("NicResources: failed to query GID");
+  }
+}
+
+NicResources::NicResources(NicResources&& other) noexcept
+    : ctx(other.ctx),
+      pd(other.pd),
+      lid(other.lid),
+      gid(other.gid),
+      mtu(other.mtu),
+      linkLayer(other.linkLayer),
+      portNum(other.portNum),
+      dmaBufSupported(other.dmaBufSupported),
+      ibvApi(std::move(other.ibvApi)) {
+  other.ctx = nullptr;
+  other.pd = nullptr;
+}
+
+NicResources::~NicResources() {
+  if (ibvApi) {
+    if (pd) {
+      ibvApi->deallocPd(pd);
+    }
+    if (ctx) {
+      ibvApi->closeDevice(ctx);
+    }
+  }
+}
+
+uint8_t NicResources::findActivePort() const {
+  ibv_device_attr devAttr{};
+  auto status = ibvApi->queryDevice(ctx, &devAttr);
+  if (status.hasError()) {
+    return 0;
+  }
+
+  for (uint8_t p = 1; p <= devAttr.phys_port_cnt; ++p) {
+    ibv_port_attr portAttr{};
+    auto portStatus = ibvApi->queryPort(ctx, p, &portAttr);
+    if (portStatus.hasError()) {
+      continue;
+    }
+    if (portAttr.state == IBV_PORT_ACTIVE) {
+      return p;
+    }
+  }
+  return 0;
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -1,0 +1,46 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/uniflow/drivers/ibverbs/IbvApi.h"
+
+namespace uniflow {
+
+/*
+ * Per-NIC RDMA resources with RAII lifetime management.
+ *
+ * Full-init constructor: opens device, allocates PD, queries port/GID.
+ * Destructor deallocates PD and closes device.
+ *
+ * Non-copyable, move-only. Shared across factory, transports, and slab pool
+ * via shared_ptr<vector<NicResources>>.
+ */
+struct NicResources {
+  ibv_context* ctx{nullptr}; /* Opened device context. */
+  ibv_pd* pd{nullptr}; /* Protection domain on this device. */
+  uint16_t lid{0}; /* Local identifier (IB fabrics). */
+  ibv_gid gid{}; /* GID for RoCE / IB with GRH. */
+  ibv_mtu mtu{IBV_MTU_4096}; /* Active MTU from port query. */
+  int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
+  uint8_t portNum{1}; /* Physical port number on the HCA. */
+  bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
+
+  NicResources(
+      ibv_device* device,
+      std::shared_ptr<IbvApi> api,
+      uint8_t gidIndex = 3,
+      std::optional<uint8_t> port = std::nullopt);
+
+  ~NicResources();
+
+  NicResources(const NicResources&) = delete;
+  NicResources& operator=(const NicResources&) = delete;
+  NicResources(NicResources&& other) noexcept;
+  NicResources& operator=(NicResources&&) = delete;
+
+ private:
+  uint8_t findActivePort() const;
+  std::shared_ptr<IbvApi> ibvApi{nullptr};
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -110,13 +110,113 @@ void RdmaTransportInfo::reset() {
 }
 
 // ---------------------------------------------------------------------------
+// NicResources
+// ---------------------------------------------------------------------------
+
+NicResources::NicResources(
+    ibv_device* device,
+    std::shared_ptr<IbvApi> api,
+    uint8_t gidIndex,
+    std::optional<uint8_t> port)
+    : ibvApi(std::move(api)) {
+  if (!ibvApi) {
+    ibvApi = std::make_shared<IbvApi>();
+  }
+
+  auto ctxResult = ibvApi->openDevice(device);
+  if (ctxResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to open device");
+  }
+  ctx = ctxResult.value();
+
+  portNum = port.value_or(0);
+  if (portNum == 0) {
+    portNum = findActivePort();
+    if (portNum == 0) {
+      throw std::runtime_error("NicResources: no active port found");
+    }
+  }
+
+  auto pdResult = ibvApi->allocPd(ctx);
+  if (pdResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to allocate PD");
+  }
+  pd = pdResult.value();
+
+  auto dmaBufResult = ibvApi->isDmaBufSupported(pd);
+  if (dmaBufResult.hasError()) {
+    throw std::runtime_error("NicResources: failed to probe DMA-BUF support");
+  }
+  dmaBufSupported = dmaBufResult.value();
+
+  ibv_port_attr portAttr{};
+  auto portStatus = ibvApi->queryPort(ctx, portNum, &portAttr);
+  if (portStatus.hasError()) {
+    throw std::runtime_error("NicResources: failed to query port");
+  }
+  lid = portAttr.lid;
+  mtu = portAttr.active_mtu;
+  linkLayer = portAttr.link_layer;
+
+  auto gidStatus = ibvApi->queryGid(ctx, portNum, gidIndex, &gid);
+  if (gidStatus.hasError()) {
+    throw std::runtime_error("NicResources: failed to query GID");
+  }
+}
+
+NicResources::NicResources(NicResources&& other) noexcept
+    : ctx(other.ctx),
+      pd(other.pd),
+      lid(other.lid),
+      gid(other.gid),
+      mtu(other.mtu),
+      linkLayer(other.linkLayer),
+      portNum(other.portNum),
+      dmaBufSupported(other.dmaBufSupported),
+      ibvApi(std::move(other.ibvApi)) {
+  other.ctx = nullptr;
+  other.pd = nullptr;
+}
+
+NicResources::~NicResources() {
+  if (ibvApi) {
+    if (pd) {
+      ibvApi->deallocPd(pd);
+    }
+    if (ctx) {
+      ibvApi->closeDevice(ctx);
+    }
+  }
+}
+
+uint8_t NicResources::findActivePort() const {
+  ibv_device_attr devAttr{};
+  auto status = ibvApi->queryDevice(ctx, &devAttr);
+  if (status.hasError()) {
+    return 0;
+  }
+
+  for (uint8_t p = 1; p <= devAttr.phys_port_cnt; ++p) {
+    ibv_port_attr portAttr{};
+    auto portStatus = ibvApi->queryPort(ctx, p, &portAttr);
+    if (portStatus.hasError()) {
+      continue;
+    }
+    if (portAttr.state == IBV_PORT_ACTIVE) {
+      return p;
+    }
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
 // RdmaTransport
 // ---------------------------------------------------------------------------
 
 RdmaTransport::RdmaTransport(
     std::shared_ptr<IbvApi> ibvApi,
     EventBase* evb,
-    std::vector<NicResources> nics,
+    std::shared_ptr<std::vector<NicResources>> nics,
     uint64_t domainId,
     RdmaTransportConfig config)
     : ibvApi_(std::move(ibvApi)),
@@ -124,12 +224,12 @@ RdmaTransport::RdmaTransport(
       nics_(std::move(nics)),
       config_(config),
       domainId_(domainId) {
-  CHECK_THROW_EXCEPTION(!nics_.empty(), std::invalid_argument);
+  CHECK_THROW_EXCEPTION(nics_ && !nics_->empty(), std::invalid_argument);
   CHECK_THROW_EXCEPTION(config_.numQps <= 255, std::invalid_argument);
-  numPendingCqe_.resize(nics_.size());
+  numPendingCqe_.resize(nics_->size());
 
   name_ = "rdma";
-  for (const auto& nic : nics_) {
+  for (const auto& nic : *nics_) {
     name_ += "_";
     name_ += nic.ctx->device->name;
   }
@@ -145,17 +245,17 @@ TransportInfo RdmaTransport::bind() {
   }
 
   info_.reset();
-  const uint32_t numNics = static_cast<uint32_t>(nics_.size());
+  const uint32_t numNics = static_cast<uint32_t>(nics_->size());
   const uint32_t numQps = config_.numQps;
 
   cqs_.reserve(numNics);
   uint32_t qpsPerNic = (numQps + numNics - 1) / numNics;
   for (uint32_t n = 0; n < numNics; ++n) {
     auto cqResult = ibvApi_->createCq(
-        nics_[n].ctx, config_.maxWr * qpsPerNic, nullptr, nullptr, 0);
+        nics_->at(n).ctx, config_.maxWr * qpsPerNic, nullptr, nullptr, 0);
     if (cqResult.hasError()) {
       UNIFLOW_LOG_ERROR(
-          "bind: failed to create CQ for NIC {}", getNicName(nics_[n]));
+          "bind: failed to create CQ for NIC {}", getNicName(nics_->at(n)));
       shutdown();
       state_ = TransportState::Error;
       return {};
@@ -191,12 +291,12 @@ TransportInfo RdmaTransport::bind() {
     initAttr.cap.max_recv_sge = config_.maxSge;
     initAttr.cap.max_inline_data = config_.maxInlineData;
 
-    auto qpResult = ibvApi_->createQp(nics_[nicIdx].pd, &initAttr);
+    auto qpResult = ibvApi_->createQp(nics_->at(nicIdx).pd, &initAttr);
     if (qpResult.hasError()) {
       UNIFLOW_LOG_ERROR(
           "bind: failed to create QP {} on NIC {}",
           i,
-          getNicName(nics_[nicIdx]));
+          getNicName(nics_->at(nicIdx)));
       shutdown();
       state_ = TransportState::Error;
       return {};
@@ -206,7 +306,7 @@ TransportInfo RdmaTransport::bind() {
     ibv_qp_attr attr{};
     attr.qp_state = IBV_QPS_INIT;
     attr.pkey_index = config_.pkeyIndex;
-    attr.port_num = nics_[nicIdx].portNum;
+    attr.port_num = nics_->at(nicIdx).portNum;
     attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
         IBV_ACCESS_LOCAL_WRITE;
 
@@ -217,7 +317,7 @@ TransportInfo RdmaTransport::bind() {
       UNIFLOW_LOG_ERROR(
           "bind: failed to transition QP {} to INIT on NIC {}",
           i,
-          getNicName(nics_[nicIdx]));
+          getNicName(nics_->at(nicIdx)));
       ibvApi_->destroyQp(qp);
       shutdown();
       state_ = TransportState::Error;
@@ -231,7 +331,7 @@ TransportInfo RdmaTransport::bind() {
     info_.qpInfos.push_back({.qpNum = qp->qp_num, .psn = psn});
   }
 
-  for (const auto& nic : nics_) {
+  for (const auto& nic : *nics_) {
     info_.nicInfos.push_back(
         {.lid = nic.lid,
          .linkLayer = static_cast<uint8_t>(nic.linkLayer),
@@ -271,14 +371,14 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     return Err(ErrCode::InvalidArgument, "QP count mismatch");
   }
 
-  const uint32_t numNics = static_cast<uint32_t>(nics_.size());
+  const uint32_t numNics = static_cast<uint32_t>(nics_->size());
   const uint32_t remoteNumNics = static_cast<uint32_t>(remote.nicInfos.size());
 
   for (uint32_t i = 0; i < config_.numQps; ++i) {
     uint32_t localNicIdx = i % numNics;
     uint32_t remoteNicIdx = i % remoteNumNics;
     const auto& remoteNic = remote.nicInfos[remoteNicIdx];
-    const auto& localNic = nics_[localNicIdx];
+    const auto& localNic = nics_->at(localNicIdx);
 
     ibv_mtu negotiatedMtu = static_cast<ibv_mtu>(
         std::min(static_cast<uint8_t>(localNic.mtu), remoteNic.mtu));
@@ -397,11 +497,11 @@ Status RdmaTransport::preprocessRequest(
         "RDMA transfer: no matching registration handle");
   }
 
-  if ((*localHandle)->numMrs() != nics_.size()) {
+  if ((*localHandle)->numMrs() != nics_->size()) {
     return Err(
         ErrCode::InvalidArgument,
         "RDMA transfer: local handle NIC count mismatch (expected " +
-            std::to_string(nics_.size()) + ", got " +
+            std::to_string(nics_->size()) + ", got " +
             std::to_string((*localHandle)->numMrs()) + ")");
   }
 
@@ -481,7 +581,7 @@ uint32_t RdmaTransport::postSend(
     std::shared_ptr<Task>& task) {
   ibv_send_wr* badWr = nullptr;
   auto st = ibvApi_->postSend(qps_[qpIdx], head, &badWr);
-  size_t nicIdx = qpIdx % nics_.size();
+  size_t nicIdx = qpIdx % nics_->size();
   if (st) {
     // All WRs posted successfully.
     ++numPendingCqe_[nicIdx];
@@ -491,7 +591,7 @@ uint32_t RdmaTransport::postSend(
   } else {
     UNIFLOW_LOG_ERROR(
         "postSend: failed on NIC {} QP {} taskId={}: {}",
-        getNicName(nics_[nicIdx]),
+        getNicName(nics_->at(nicIdx)),
         qpIdx,
         taskId,
         st.error().message());
@@ -534,7 +634,7 @@ uint32_t RdmaTransport::postSend(
       UNIFLOW_LOG_WARN(
           "postSend: partial failure on NIC {} QP {} taskId={}, consumed={}, "
           "flush WR posted successfully",
-          getNicName(nics_[nicIdx]),
+          getNicName(nics_->at(nicIdx)),
           qpIdx,
           taskId,
           consumed);
@@ -545,7 +645,7 @@ uint32_t RdmaTransport::postSend(
       UNIFLOW_LOG_ERROR(
           "postSend: flush WR also failed on NIC {} QP {} taskId={}, "
           "consumed={} WRs leaked",
-          getNicName(nics_[nicIdx]),
+          getNicName(nics_->at(nicIdx)),
           qpIdx,
           taskId,
           consumed);
@@ -1009,26 +1109,6 @@ Status RdmaTransportFactory::supported(std::shared_ptr<IbvApi> ibvApi) {
   return Ok();
 }
 
-uint8_t RdmaTransportFactory::findActivePort(ibv_context* ctx) {
-  ibv_device_attr devAttr{};
-  auto status = ibvApi_->queryDevice(ctx, &devAttr);
-  if (status.hasError()) {
-    return 0;
-  }
-
-  for (uint8_t port = 1; port <= devAttr.phys_port_cnt; ++port) {
-    ibv_port_attr portAttr{};
-    auto portStatus = ibvApi_->queryPort(ctx, port, &portAttr);
-    if (portStatus.hasError()) {
-      continue;
-    }
-    if (portAttr.state == IBV_PORT_ACTIVE) {
-      return port;
-    }
-  }
-  return 0;
-}
-
 RdmaTransportFactory::RdmaTransportFactory(
     const std::vector<std::string>& deviceNames,
     EventBase* evb,
@@ -1040,6 +1120,7 @@ RdmaTransportFactory::RdmaTransportFactory(
       ibvApi_(std::move(ibvApi)),
       cudaDriverApi_(std::move(cudaDriverApi)),
       evb_(evb),
+      nics_(std::make_shared<std::vector<NicResources>>()),
       config_(config) {
   assert(evb_ != nullptr);
   if (deviceNames.empty()) {
@@ -1072,19 +1153,7 @@ RdmaTransportFactory::RdmaTransportFactory(
   std::unique_ptr<ibv_device*[], decltype(devListDeleter)> devListGuard(
       deviceList, devListDeleter);
 
-  // TODO: Replace manual cleanup with EXIT_SCOPE macro (core/Utils.h).
-  auto cleanupNics = [this]() {
-    for (auto& nic : nics_) {
-      if (nic.pd) {
-        ibvApi_->deallocPd(nic.pd);
-      }
-      if (nic.ctx) {
-        ibvApi_->closeDevice(nic.ctx);
-      }
-    }
-    nics_.clear();
-  };
-
+  nics_->reserve(deviceNames.size());
   for (const auto& deviceName : deviceNames) {
     ibv_device* targetDevice = nullptr;
     for (int i = 0; i < numDevices; ++i) {
@@ -1096,83 +1165,16 @@ RdmaTransportFactory::RdmaTransportFactory(
     }
 
     if (!targetDevice) {
-      cleanupNics();
       throw std::runtime_error("RDMA device not found: " + deviceName);
     }
 
-    auto ctxResult = ibvApi_->openDevice(targetDevice);
-    if (ctxResult.hasError()) {
-      cleanupNics();
-      throw std::runtime_error("Failed to open RDMA device: " + deviceName);
-    }
-
-    NicResources nic;
-    nic.ctx = ctxResult.value();
-
-    // Discover port: use specified portNum, or find first active port
-    uint8_t port = portNum.value_or(0);
-    if (port == 0) {
-      port = findActivePort(nic.ctx);
-      if (port == 0) {
-        ibvApi_->closeDevice(nic.ctx);
-        cleanupNics();
-        throw std::runtime_error("No active port found on: " + deviceName);
-      }
-    }
-    nic.portNum = port;
-
-    auto pdResult = ibvApi_->allocPd(nic.ctx);
-    if (pdResult.hasError()) {
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to allocate PD on: " + deviceName);
-    }
-    nic.pd = pdResult.value();
-
-    // Probe kernel DMA-BUF support on this NIC's PD.
-    auto dmaBufSupported = ibvApi_->isDmaBufSupported(nic.pd);
-    CHECK_THROW_ERROR(dmaBufSupported);
-    nic.dmaBufSupported = dmaBufSupported.value();
-
-    ibv_port_attr portAttr{};
-    auto portStatus = ibvApi_->queryPort(nic.ctx, port, &portAttr);
-    if (portStatus.hasError()) {
-      ibvApi_->deallocPd(nic.pd);
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to query port on: " + deviceName);
-    }
-    nic.lid = portAttr.lid;
-    nic.mtu = portAttr.active_mtu;
-    nic.linkLayer = portAttr.link_layer;
-
-    auto gidStatus =
-        ibvApi_->queryGid(nic.ctx, port, config_.gidIndex, &nic.gid);
-    if (gidStatus.hasError()) {
-      ibvApi_->deallocPd(nic.pd);
-      ibvApi_->closeDevice(nic.ctx);
-      cleanupNics();
-      throw std::runtime_error("Failed to query GID on: " + deviceName);
-    }
-
-    nics_.push_back(nic);
-  }
-}
-
-RdmaTransportFactory::~RdmaTransportFactory() {
-  for (auto& nic : nics_) {
-    if (nic.pd) {
-      ibvApi_->deallocPd(nic.pd);
-    }
-    if (nic.ctx) {
-      ibvApi_->closeDevice(nic.ctx);
-    }
+    nics_->emplace_back(targetDevice, ibvApi_, config_.gidIndex, portNum);
   }
 }
 
 Result<std::unique_ptr<RegistrationHandle>>
 RdmaTransportFactory::registerSegment(Segment& segment) {
-  if (nics_.empty()) {
+  if (nics_->empty()) {
     return Err(ErrCode::InvalidArgument, "No NICs available for registration");
   }
 
@@ -1223,8 +1225,8 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   // Register with every NIC's protection domain so the region is usable
   // across all QPs regardless of which NIC they belong to.
   std::vector<ibv_mr*> mrs;
-  mrs.reserve(nics_.size());
-  for (const auto& nic : nics_) {
+  mrs.reserve(nics_->size());
+  for (const auto& nic : *nics_) {
     Result<ibv_mr*> mrResult = Err(ErrCode::NotImplemented);
     if (nic.dmaBufSupported && fdGuard.fd >= 0) {
       // GPU memory: register via DMA-BUF for GPU Direct RDMA.

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -45,11 +45,13 @@ struct RdmaTransportConfig {
 };
 
 /*
- * Per-NIC RDMA resources.
+ * Per-NIC RDMA resources with RAII lifetime management.
  *
- * Populated by RdmaTransportFactory during device initialization.
- * Ownership: the factory owns the underlying ibverbs objects (context, PD).
- * Transports borrow these resources — they must not outlive the factory.
+ * Full-init constructor: opens device, allocates PD, queries port/GID.
+ * Destructor deallocates PD and closes device.
+ *
+ * Non-copyable, move-only. Shared across factory, transports, and slab pool
+ * via shared_ptr<vector<NicResources>>.
  */
 struct NicResources {
   ibv_context* ctx{nullptr}; /* Opened device context. */
@@ -60,6 +62,23 @@ struct NicResources {
   int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
   uint8_t portNum{1}; /* Physical port number on the HCA. */
   bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
+
+  NicResources(
+      ibv_device* device,
+      std::shared_ptr<IbvApi> api,
+      uint8_t gidIndex = 3,
+      std::optional<uint8_t> port = std::nullopt);
+
+  ~NicResources();
+
+  NicResources(const NicResources&) = delete;
+  NicResources& operator=(const NicResources&) = delete;
+  NicResources(NicResources&& other) noexcept;
+  NicResources& operator=(NicResources&&) = delete;
+
+ private:
+  uint8_t findActivePort() const;
+  std::shared_ptr<IbvApi> ibvApi{nullptr};
 };
 
 /*
@@ -151,7 +170,7 @@ class RdmaTransport : public Transport {
   RdmaTransport(
       std::shared_ptr<IbvApi> ibvApi,
       EventBase* evb,
-      std::vector<NicResources> nics,
+      std::shared_ptr<std::vector<NicResources>> nics,
       uint64_t domainId,
       RdmaTransportConfig config = {});
 
@@ -369,7 +388,7 @@ class RdmaTransport : public Transport {
   EventBase* evb_{nullptr};
 
   std::string name_;
-  const std::vector<NicResources> nics_;
+  std::shared_ptr<std::vector<NicResources>> nics_;
   const RdmaTransportConfig config_;
 
   std::vector<ibv_cq*> cqs_;
@@ -462,7 +481,7 @@ class RdmaTransportFactory : public TransportFactory {
       std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr,
       std::optional<uint8_t> portNum = std::nullopt);
 
-  ~RdmaTransportFactory() override;
+  ~RdmaTransportFactory() override = default;
 
   RdmaTransportFactory(const RdmaTransportFactory&) = delete;
   RdmaTransportFactory& operator=(const RdmaTransportFactory&) = delete;
@@ -491,15 +510,12 @@ class RdmaTransportFactory : public TransportFactory {
  private:
   Status canConnect(std::span<const uint8_t> peerTopology) override;
 
-  /* Find the first active port on the device. Returns 0 on failure. */
-  uint8_t findActivePort(ibv_context* ctx);
-
   std::shared_ptr<IbvApi> ibvApi_;
   std::shared_ptr<CudaDriverApi> cudaDriverApi_;
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
   size_t pageSize_{0};
-  std::vector<NicResources> nics_;
+  std::shared_ptr<std::vector<NicResources>> nics_;
   const RdmaTransportConfig config_;
 };
 

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -156,6 +156,45 @@ TEST(RdmaTransportInfoTest, SerializeZeroQps) {
   ASSERT_EQ(result.value().nicInfos.size(), 1);
 }
 
+// --- Helpers ---
+
+NicResources makeNic(
+    ibv_device* dev,
+    ibv_context* ctx,
+    ibv_pd* pd,
+    std::shared_ptr<testing::NiceMock<MockIbvApi>> mockApi,
+    uint16_t lid = 0,
+    ibv_gid gid = {},
+    uint8_t port = 1) {
+  ON_CALL(*mockApi, openDevice(dev))
+      .WillByDefault(Return(Result<ibv_context*>(ctx)));
+  ON_CALL(*mockApi, allocPd(ctx)).WillByDefault(Return(Result<ibv_pd*>(pd)));
+  ON_CALL(*mockApi, isDmaBufSupported(pd))
+      .WillByDefault(Return(Result<bool>(false)));
+  ON_CALL(*mockApi, queryPort(ctx, port, _))
+      .WillByDefault([lid, gid](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->lid = lid;
+        attr->active_mtu = IBV_MTU_4096;
+        attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+        attr->state = IBV_PORT_ACTIVE;
+        return Ok();
+      });
+  ON_CALL(*mockApi, queryGid(ctx, port, _, _))
+      .WillByDefault([gid](ibv_context*, uint8_t, int, ibv_gid* out) {
+        *out = gid;
+        return Ok();
+      });
+  ON_CALL(*mockApi, queryDevice(ctx, _))
+      .WillByDefault([port](ibv_context*, ibv_device_attr* attr) {
+        attr->phys_port_cnt = port;
+        return Ok();
+      });
+  ON_CALL(*mockApi, deallocPd(pd)).WillByDefault(Return(Ok()));
+  ON_CALL(*mockApi, closeDevice(ctx)).WillByDefault(Return(Ok()));
+
+  return NicResources(dev, mockApi, 3, port);
+}
+
 // --- Mock-based transport tests ---
 
 class RdmaTransportTest : public ::testing::Test {
@@ -193,8 +232,9 @@ TEST_F(RdmaTransportTest, SingleNicBindCreatesQPs) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1234, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransportConfig config{.numQps = 2};
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
 
@@ -229,10 +269,11 @@ TEST_F(RdmaTransportTest, MultiNicBindDistributesQPsRoundRobin) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid0{}, gid1{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1111, .gid = gid0},
-      {.ctx = &fakeCtx1_, .pd = &fakePd1_, .lid = 0x2222, .gid = gid1},
-  };
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1111, gid0));
+  nics->push_back(
+      makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 4};
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
 
@@ -259,8 +300,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnCqFailure) {
       .WillOnce(Return(Result<ibv_cq*>(ErrCode::ResourceExhausted)));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
@@ -275,8 +316,8 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnQpFailure) {
       .WillOnce(Return(Result<ibv_qp*>(ErrCode::ResourceExhausted)));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
@@ -294,8 +335,9 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1234, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(
+      makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -321,8 +363,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -340,8 +382,8 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
 
 TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
 
   // Don't call bind() - go straight to connect()
@@ -370,8 +412,8 @@ TEST_F(RdmaTransportTest, ShutdownDestroysResources) {
   EXPECT_CALL(*mockApi_, destroyCq(&fakeCq0_)).WillOnce(Return(Ok()));
 
   ibv_gid gid{};
-  std::vector<NicResources> nics = {
-      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  auto nics = std::make_shared<std::vector<NicResources>>();
+  nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
@@ -619,8 +661,9 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
 
     ibv_gid gid{};
-    std::vector<NicResources> nics = {
-        {.ctx = &fakeCtx_, .pd = &fakePd_, .lid = 0x1234, .gid = gid}};
+    auto nics = std::make_shared<std::vector<NicResources>>();
+    nics->push_back(
+        makeNic(&fakeDev_, &fakeCtx_, &fakePd_, mockApi_, 0x1234, gid));
 
     transport_ = std::make_unique<RdmaTransport>(
         mockApi_, evbThread_->getEventBase(), nics, kLocalDomainId);


### PR DESCRIPTION
Summary:
Add CUDA host memory and stream memory operation APIs needed for the copy-based send/recv pipeline:

- **CudaApi**: `hostAlloc()`, `hostFree()`, `hostGetDevicePointer()` — wrappers around `cudaHostAlloc`, `cudaFreeHost`, and `cudaHostGetDevicePointer` for allocating host-pinned staging buffers accessible from both CPU and GPU.
- **CudaDriverApi**: `streamWriteValue64()` — wrapper around `cuStreamWriteValue64` (CUDA 11.1+) for stream-ordered tail pointer writes, enabling sub-microsecond CPU polling of VRAM-to-staging copy completion without `cudaEventQuery` overhead.
- **Mock classes**: `MockCudaApi` and `MockCudaDriverApi` updated with corresponding mock methods for unit testing.

These APIs implement the "Hybrid CE + tail pointer" VRAM synchronization approach described in the design doc (D102583465).

Differential Revision: D104125009


