### PR TITLE
copy base send/recv (#2447)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaSlabPool.h
+++ b/comms/uniflow/transport/rdma/RdmaSlabPool.h
@@ -23,29 +23,7 @@ struct RdmaSlabPoolConfig {
   size_t slabSize{512 * 1024}; // 512KB
 };
 
-class RdmaSlabPool;
-
-/// RAII wrapper for an acquired slab. Auto-releases back to pool on
-/// destruction. Movable but not copyable. Call release() for explicit early
-/// release without waiting for destruction.
-class RdmaSlab {
- public:
-  ~RdmaSlab();
-  RdmaSlab(RdmaSlab&& other) noexcept;
-  RdmaSlab& operator=(RdmaSlab&& other) noexcept;
-  RdmaSlab(const RdmaSlab&) = delete;
-  RdmaSlab& operator=(const RdmaSlab&) = delete;
-
-  uint16_t index() const {
-    return index_;
-  }
-
- private:
-  friend class RdmaSlabPool;
-  RdmaSlab(std::shared_ptr<RdmaSlabPool> pool, uint16_t index);
-  std::shared_ptr<RdmaSlabPool> pool_;
-  uint16_t index_;
-};
+class RdmaSlab;
 
 /// Factory-level shared pool of host-pinned staging buffers for copy-based
 /// send/recv. Composed from three RAII subsystems:
@@ -97,6 +75,45 @@ class RdmaSlabPool : public std::enable_shared_from_this<RdmaSlabPool> {
   std::unique_ptr<PinnedBuffer> buffer_;
   std::unique_ptr<MrSet> mrSet_;
   std::unique_ptr<SlabAllocator> allocator_;
+};
+
+/// RAII wrapper for an acquired slab. Auto-releases back to pool on
+/// destruction. Movable but not copyable. Call release() for explicit early
+/// release without waiting for destruction.
+class RdmaSlab {
+ public:
+  ~RdmaSlab();
+  RdmaSlab(RdmaSlab&& other) noexcept;
+  RdmaSlab& operator=(RdmaSlab&& other) noexcept;
+  RdmaSlab(const RdmaSlab&) = delete;
+  RdmaSlab& operator=(const RdmaSlab&) = delete;
+
+  uint16_t index() const {
+    return index_;
+  }
+
+  void* ptr() const {
+    return pool_->slabPtr(index_);
+  }
+
+  uint64_t addr() const {
+    return pool_->slabAddr(index_);
+  }
+
+  uint64_t stateDeviceAddr() const {
+    return pool_->stateDeviceAddr(index_);
+  }
+
+  std::atomic_ref<uint64_t> state() const {
+    auto* ptr = static_cast<uint64_t*>(pool_->statePtr(index_));
+    return std::atomic_ref<uint64_t>{*ptr};
+  }
+
+ private:
+  friend class RdmaSlabPool;
+  RdmaSlab(std::shared_ptr<RdmaSlabPool> pool, uint16_t index);
+  std::shared_ptr<RdmaSlabPool> pool_;
+  uint16_t index_;
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -49,7 +49,21 @@ uint64_t qpMapKey(size_t nicIdx, uint32_t qpNum) {
   return (static_cast<uint64_t>(nicIdx) << 32) | qpNum;
 }
 
+Result<std::vector<RdmaSlab>> allocateSlab(RdmaSlabPool* pool, size_t slabNum) {
+  auto slabResult = pool->acquire(static_cast<uint32_t>(slabNum));
+  if (slabResult) {
+    return slabResult;
+  }
+  return Err(ErrCode::ResourceExhausted, "no resource to allocate slab");
+}
+
 } // namespace
+
+RdmaTransport::SendRecvTransfer::SendRecvTransfer(
+    IOType opType,
+    Segment::Span data)
+    : opType(opType), data(std::move(data)) {}
+RdmaTransport::SendRecvTransfer::~SendRecvTransfer() = default;
 
 size_t RdmaTransportInfo::RegisteredBuffer::serialize(uint8_t* data) const {
   size_t offset = 0;
@@ -110,8 +124,10 @@ TransportInfo RdmaTransportInfo::serialize() const {
     offset += len;
   }
 
-  offset += ctrl.serialize(data.data() + offset);
-  offset += slab.serialize(data.data() + offset);
+  if (header.numNics > 0) {
+    offset += ctrl.serialize(data.data() + offset);
+    offset += slab.serialize(data.data() + offset);
+  }
   return data;
 }
 
@@ -168,7 +184,6 @@ Result<RdmaTransportInfo> RdmaTransportInfo::deserialize(
     offset += info.ctrl.deserialize(data.data() + offset, header.numNics);
     offset += info.slab.deserialize(data.data() + offset, header.numNics);
   }
-
   return info;
 }
 
@@ -187,6 +202,7 @@ void RdmaTransportInfo::reset() {
 RdmaTransport::RdmaTransport(
     std::shared_ptr<IbvApi> ibvApi,
     std::shared_ptr<CudaApi> cudaApi,
+    std::shared_ptr<CudaDriverApi> cudaDriverApi,
     EventBase* evb,
     std::shared_ptr<std::vector<NicResources>> nics,
     uint64_t domainId,
@@ -194,6 +210,7 @@ RdmaTransport::RdmaTransport(
     std::shared_ptr<RdmaSlabPool> slabPool)
     : ibvApi_(std::move(ibvApi)),
       cudaApi_(std::move(cudaApi)),
+      cudaDriverApi_(std::move(cudaDriverApi)),
       evb_(evb),
       nicsHandle_(std::move(nics)),
       config_(config),
@@ -228,6 +245,7 @@ TransportInfo RdmaTransport::bind() {
   const uint32_t numQps = config_.numQps;
   const uint32_t numNics = nics_.size();
   numPendingCqe_.resize(nics_.size());
+  slotPendingCqe_.resize(config_.pipelineDepth);
 
   // Allocate and register ctrl buffer for send/recv pipeline flow control.
   // Layout: [CTS: D entries][Notify: D * Q entries], all atomic<uint32_t>.
@@ -361,13 +379,16 @@ TransportInfo RdmaTransport::bind() {
   }
 
   if (slabPool_) {
+    info_.header.slabSize = static_cast<uint32_t>(slabPool_->slabSize());
     info_.slab.addr = slabPool_->slabAddr(0);
-    info_.slab.length = static_cast<uint32_t>(slabPool_->slabSize());
+    info_.slab.length =
+        info_.header.slabSize * static_cast<uint32_t>(slabPool_->numSlabs());
     info_.slab.rkeys.resize(numNics);
     for (uint8_t n = 0; n < numNics; ++n) {
       info_.slab.rkeys[n] = slabPool_->slabRkey(n);
     }
   } else {
+    info_.header.slabSize = 0;
     info_.slab.addr = 0;
     info_.slab.length = 0;
     info_.slab.rkeys.resize(numNics, 0);
@@ -402,6 +423,14 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
         remote.header.numQps);
     state_ = TransportState::Error;
     return Err(ErrCode::InvalidArgument, "QP count mismatch");
+  }
+  if (remote.header.slabSize != info_.header.slabSize) {
+    UNIFLOW_LOG_WARN(
+        "connect: slab size mismatch (local={}, remote={})",
+        info_.header.slabSize,
+        remote.header.slabSize);
+    remote.header.slabSize = info_.header.slabSize =
+        std::min(remote.header.slabSize, info_.header.slabSize);
   }
 
   const uint32_t numNics = static_cast<uint32_t>(nics_.size());
@@ -483,13 +512,13 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
 std::future<Status> RdmaTransport::put(
     std::span<const TransferRequest> requests,
     const RequestOptions& options) {
-  return rdmaTransfer(requests, IBV_WR_RDMA_WRITE, options);
+  return rdmaPutGetTransfer(requests, IBV_WR_RDMA_WRITE, options);
 }
 
 std::future<Status> RdmaTransport::get(
     std::span<const TransferRequest> requests,
     const RequestOptions& options) {
-  return rdmaTransfer(requests, IBV_WR_RDMA_READ, options);
+  return rdmaPutGetTransfer(requests, IBV_WR_RDMA_READ, options);
 }
 
 // ---------------------------------------------------------------------------
@@ -614,7 +643,8 @@ uint32_t RdmaTransport::postSend(
     ibv_send_wr* head,
     uint32_t count,
     uint32_t taskId,
-    std::shared_ptr<Task>& task) {
+    Task& task,
+    std::optional<uint16_t> slot) {
   ibv_send_wr* badWr = nullptr;
   auto st = ibvApi_->postSend(qps_[qpIdx], head, &badWr);
   size_t nicIdx = qpIdx % nics_.size();
@@ -622,7 +652,10 @@ uint32_t RdmaTransport::postSend(
     // All WRs posted successfully.
     ++numPendingCqe_[nicIdx];
     numWrsPerQp_[qpIdx] += count;
-    task->posted(count);
+    if (slot) {
+      ++slotPendingCqe_[slot.value()];
+    }
+    task.posted(count);
     return count;
   } else {
     UNIFLOW_LOG_ERROR(
@@ -647,18 +680,23 @@ uint32_t RdmaTransport::postSend(
     // Why this works:
     //   - RC guarantees in-order completion.
     //   - The flush WR will complete after all consumed unsignaled WRs.
-    //   - Its CQE carries wr_id encoding (consumed + 1) in the lower 32 bits.
-    //   - pollCompletions decrements numWrsPerQp_ by that count.
+    //   - Its CQE carries wr_id with flushCount encoded in the layout that
+    //     pollCompletions expects for this task type:
+    //       non-copy-op: lower 32 bits = flushCount
+    //       copy-op:     lower 32 bits = (flushCount << 16) | slot
+    //   - pollCompletions decrements numWrsPerQp_ by flushCount.
     //
-    // Counter invariant:
-    //   numWrsPerQp_ += (consumed + 1)   [here]
-    //   numWrsPerQp_ -= (consumed + 1)   [in pollCompletions when flush CQE
-    //   arrives] Net effect: 0. No counter leak.
+    // Counter invariant (numWrsPerQp_):
+    //   += flushCount [here]  /  -= flushCount [pollCompletions]
+    // Counter invariant (slotPendingCqe_, copy-op only):
+    //   += 1 [here]  /  -= 1 [pollCompletions]
     uint32_t flushCount = consumed + 1;
+    uint32_t wrInfo =
+        slot.has_value() ? (flushCount << 16 | slot.value()) : flushCount;
 
     ibv_sge flushSge{};
     ibv_send_wr flushWr{};
-    flushWr.wr_id = (static_cast<uint64_t>(taskId) << 32) | flushCount;
+    flushWr.wr_id = (static_cast<uint64_t>(taskId) << 32) | wrInfo;
     flushWr.next = nullptr;
     flushWr.sg_list = &flushSge;
     flushWr.num_sge = 0;
@@ -676,7 +714,10 @@ uint32_t RdmaTransport::postSend(
           consumed);
       ++numPendingCqe_[nicIdx];
       numWrsPerQp_[qpIdx] += flushCount;
-      task->posted(flushCount);
+      if (slot) {
+        ++slotPendingCqe_[slot.value()];
+      }
+      task.posted(flushCount);
     } else {
       UNIFLOW_LOG_ERROR(
           "postSend: flush WR also failed on NIC {} QP {} taskId={}, "
@@ -689,37 +730,30 @@ uint32_t RdmaTransport::postSend(
     }
   }
 
-  task->recordCompletion(st.error());
+  task.recordCompletion(st.error());
   return 0; // Signal to caller that posting failed.
 }
 
-Result<uint32_t> RdmaTransport::spray(
-    std::vector<SendWr>& wrs,
-    size_t& idx,
-    uint32_t taskId,
-    std::shared_ptr<Task>& task) {
-  const uint32_t numQps = static_cast<uint32_t>(qps_.size());
-  const uint32_t remaining = static_cast<uint32_t>(wrs.size() - idx);
-
-  // Calculate available capacity per QP.
+uint32_t RdmaTransport::getQpAvail(std::vector<uint32_t>& qpAvail) {
   uint32_t totalAvail = 0;
   const uint32_t kMaxWr = config_.maxWr;
-  std::vector<uint32_t> qpAvail(numQps);
-  for (uint32_t q = 0; q < numQps; ++q) {
+  for (size_t q = 0; q < qpAvail.size(); ++q) {
     qpAvail[q] = kMaxWr - numWrsPerQp_[q];
     totalAvail += qpAvail[q];
   }
+  return totalAvail;
+}
 
-  if (totalAvail == 0) {
-    return 0; // All QPs full — caller should poll and retry.
-  }
-
+uint32_t RdmaTransport::assignToQps(
+    const uint32_t remaining,
+    const uint32_t totalAvail,
+    std::vector<uint32_t>& qpAvail,
+    std::vector<uint32_t>& qpAssigned) {
   // Weighted distribution: assign chunks to each QP proportional
   // to its available capacity. Ensures QPs with more room get more work,
   // avoiding head-of-line blocking on a full QP.
-  std::vector<uint32_t> qpAssigned(numQps, 0);
   uint32_t totalAssigned = 0;
-  for (uint32_t q = 0; q < numQps && totalAssigned < remaining; ++q) {
+  for (size_t q = 0; q < qpAvail.size() && totalAssigned < remaining; ++q) {
     if (qpAvail[q] == 0) {
       continue;
     }
@@ -734,7 +768,8 @@ Result<uint32_t> RdmaTransport::spray(
   const uint32_t targetAssigned = std::min(remaining, totalAvail);
   while (totalAssigned < targetAssigned) {
     bool progressed = false;
-    for (uint32_t q = 0; q < numQps && totalAssigned < targetAssigned; ++q) {
+    for (size_t q = 0; q < qpAvail.size() && totalAssigned < targetAssigned;
+         ++q) {
       if (qpAssigned[q] >= qpAvail[q]) {
         continue;
       }
@@ -746,6 +781,30 @@ Result<uint32_t> RdmaTransport::spray(
       break;
     }
   }
+  return totalAssigned;
+}
+
+Result<uint32_t> RdmaTransport::spray(
+    std::vector<SendWr>& wrs,
+    size_t& idx,
+    uint32_t taskId,
+    Task& task) {
+  const uint32_t numQps = static_cast<uint32_t>(qps_.size());
+  const uint32_t remaining = static_cast<uint32_t>(wrs.size() - idx);
+
+  // Calculate available capacity per QP.
+  std::vector<uint32_t> qpAvail(numQps);
+  uint32_t totalAvail = getQpAvail(qpAvail);
+
+  if (totalAvail == 0) {
+    return 0; // All QPs full — caller should poll and retry.
+  }
+
+  // Weighted distribution: assign chunks to each QP proportional
+  // to its available capacity. Ensures QPs with more room get more work,
+  // avoiding head-of-line blocking on a full QP.
+  std::vector<uint32_t> qpAssigned(numQps, 0);
+  assignToQps(remaining, totalAvail, qpAvail, qpAssigned);
 
   // Post assigned chunks to each QP.
   uint32_t totalPosted = 0;
@@ -804,7 +863,7 @@ size_t RdmaTransport::admissionBudgetWrs() const {
   return std::max<size_t>(1, totalCapacity / 2);
 }
 
-bool RdmaTransport::canStartTransfer(const PendingTransfer& transfer) const {
+bool RdmaTransport::canStartTransfer(const PutGetTransfer& transfer) const {
   if (transfer.idx != 0) {
     return true;
   }
@@ -832,47 +891,13 @@ void RdmaTransport::ioLooper() noexcept {
   pollCompletions();
 
   // Phase 2 — Post: walk pendingTransfers_ front-to-back.
-  while (!pendingTransfers_.empty()) {
+  bool tryNext = true;
+  while (!pendingTransfers_.empty() && tryNext) {
     auto& entry = pendingTransfers_.front();
-
-    if (state_ != TransportState::Connected) {
-      entry.task->recordCompletion(
-          Err(ErrCode::TransportError, "RDMA transport is broken"));
-      pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
-      pendingTransfers_.pop_front();
-      continue;
-    }
-
-    if (entry.idx >= entry.sendWrs->size()) {
-      entry.task->postFinished();
-      pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
-      pendingTransfers_.pop_front();
-      continue;
-    }
-
-    if (!canStartTransfer(entry)) {
-      break;
-    }
-
-    auto postResult =
-        spray(*entry.sendWrs, entry.idx, entry.taskId, entry.task);
-    if (postResult.hasError()) {
-      UNIFLOW_LOG_ERROR("ioLooper: taskId={} spray failed", entry.taskId);
-      pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
-      pendingTransfers_.pop_front();
-      continue;
-    }
-
-    if (entry.idx >= entry.sendWrs->size()) {
-      UNIFLOW_LOG_DEBUG(
-          "ioLooper: taskId={} all {} chunks posted",
-          entry.taskId,
-          entry.sendWrs->size());
-      entry.task->postFinished();
-      pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
-      pendingTransfers_.pop_front();
+    if (entry.putGetTransfer) {
+      tryNext = putGetIoProcess(*entry.putGetTransfer);
     } else {
-      break;
+      tryNext = sendRecvIoProcess(*entry.sendRecvTransfer);
     }
   }
 
@@ -908,11 +933,56 @@ void RdmaTransport::ioLooper() noexcept {
   }
 }
 
+bool RdmaTransport::putGetIoProcess(PutGetTransfer& entry) noexcept {
+  if (state_ != TransportState::Connected) {
+    entry.task->recordCompletion(
+        Err(ErrCode::TransportError, "RDMA transport is broken"));
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  }
+
+  if (entry.idx >= entry.sendWrs->size()) {
+    entry.task->postFinished();
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  }
+
+  if (!canStartTransfer(entry)) {
+    return false;
+  }
+
+  auto postResult = spray(*entry.sendWrs, entry.idx, entry.taskId, *entry.task);
+  if (postResult.hasError()) {
+    // postSend failed on a QP. Task is already errored and
+    // postFinished. Don't post more — just let the poll chain
+    // drain CQEs from earlier successful QPs and the flush WR.
+    UNIFLOW_LOG_ERROR("ioLooper: taskId={} spray failed", entry.taskId);
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  }
+
+  if (entry.idx >= entry.sendWrs->size()) {
+    UNIFLOW_LOG_DEBUG(
+        "ioLooper: taskId={} all {} chunks posted",
+        entry.taskId,
+        entry.sendWrs->size());
+    entry.task->postFinished();
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  } else {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Transfer dispatch (caller thread → EventBase thread)
 // ---------------------------------------------------------------------------
 
-std::future<Status> RdmaTransport::rdmaTransfer(
+std::future<Status> RdmaTransport::rdmaPutGetTransfer(
     std::span<const TransferRequest> requests,
     ibv_wr_opcode opcode,
     const RequestOptions& /*options*/) {
@@ -927,29 +997,100 @@ std::future<Status> RdmaTransport::rdmaTransfer(
   auto wrsResult = buildSendWrs(requests, opcode);
   if (wrsResult.hasError()) {
     UNIFLOW_LOG_ERROR(
-        "rdmaTransfer: buildSendWrs failed: {}", wrsResult.error().message());
+        "rdmaPutGetTransfer: buildSendWrs failed: {}",
+        wrsResult.error().message());
     return make_ready_future<Status>(std::move(wrsResult).error());
   }
   auto reqWrs = std::move(wrsResult).value();
   assert(!reqWrs->empty());
   UNIFLOW_LOG_DEBUG(
-      "rdmaTransfer: {} requests, {} chunks, opcode={}",
+      "rdmaPutGetTransfer: {} requests, {} chunks, opcode={}",
       requests.size(),
       reqWrs->size(),
       static_cast<int>(opcode));
 
-  auto task = std::make_shared<Task>();
+  IOType type = opcode == IBV_WR_RDMA_WRITE ? IOType::Put : IOType::Get;
+  auto task = std::make_shared<Task>(type);
   auto future = task->get_future();
+  auto transfer = std::make_unique<PutGetTransfer>();
+  transfer->sendWrs = std::move(reqWrs);
+  transfer->task = task;
 
   evb_->dispatch([this,
                   task = std::move(task),
-                  reqWrs = std::move(reqWrs)]() mutable noexcept {
+                  transfer = std::move(transfer)]() mutable noexcept {
     uint32_t taskId = nextTaskId_++;
     UNIFLOW_LOG_DEBUG(
-        "rdmaTransfer: taskId={} dispatched to EventBase", taskId);
-    inflightTasks_[taskId] = task;
+        "rdmaPutGetTransfer: taskId={} dispatched to EventBase", taskId);
+    inflightTasks_[taskId] = std::move(task);
+    transfer->taskId = taskId;
     pendingTransfers_.push_back(
-        {taskId, std::move(reqWrs), /*idx=*/0, std::move(task)});
+        {.putGetTransfer = std::move(transfer), .sendRecvTransfer = nullptr});
+
+    if (!ioLooperScheduled_) {
+      ioLooperScheduled_ = true;
+      evb_->dispatch([this]() noexcept { ioLooper(); });
+    }
+  });
+
+  return future;
+}
+
+std::future<Status> RdmaTransport::rdmaSendRecvTransfer(
+    IOType ioType,
+    Segment::Span data,
+    const RequestOptions& options) {
+  if (data.size() == 0) {
+    return make_ready_future(Ok());
+  }
+
+  auto slabSize = info_.header.slabSize;
+  if (!slabPool_ || slabSize == 0) {
+    return make_ready_future<Status>(
+        Err(ErrCode::ResourceExhausted, "no slab pool"));
+  }
+
+  if (data.memType() == MemoryType::VRAM && !options.stream.has_value()) {
+    return make_ready_future<Status>(
+        Err(ErrCode::InvalidArgument,
+            "VRAM transfer requires an explicit CUDA stream"));
+  }
+
+  auto task = std::make_shared<Task>(ioType);
+  auto future = task->get_future();
+  auto transfer = std::make_unique<SendRecvTransfer>(ioType, std::move(data));
+  if (options.stream.has_value()) {
+    transfer->stream = static_cast<cudaStream_t>(options.stream.value());
+  }
+  transfer->totalSteps = (transfer->data.size() + slabSize - 1) / slabSize;
+  const uint16_t depth = static_cast<uint16_t>(std::min(
+      {static_cast<uint64_t>(config_.pipelineDepth),
+       transfer->totalSteps,
+       slabPool_->numSlabs()}));
+
+  auto slabResult = allocateSlab(slabPool_.get(), depth);
+  if (!slabResult) {
+    return make_ready_future<Status>(std::move(slabResult).error());
+  }
+  transfer->localSlabs = std::move(slabResult.value());
+  transfer->task = task;
+
+  evb_->dispatch([this,
+                  task = std::move(task),
+                  transfer = std::move(transfer)]() mutable noexcept {
+    uint32_t taskId = nextTaskId_++;
+    transfer->taskId = taskId;
+    inflightTasks_[taskId] = std::move(task);
+    UNIFLOW_LOG_DEBUG(
+        "{}: taskId={} totalSteps={} depth={} slabSize={} dispatched to EventBase",
+        transfer->opType == IOType::Send ? "send" : "recv",
+        transfer->taskId,
+        transfer->totalSteps,
+        transfer->localSlabs.size(),
+        info_.slabSize);
+
+    pendingTransfers_.push_back(
+        {.putGetTransfer = nullptr, .sendRecvTransfer = std::move(transfer)});
 
     if (!ioLooperScheduled_) {
       ioLooperScheduled_ = true;
@@ -964,13 +1105,14 @@ std::future<Status> RdmaTransport::rdmaTransfer(
 // Completion polling (EventBase thread)
 // ---------------------------------------------------------------------------
 
-void RdmaTransport::pollCompletions() {
+Status RdmaTransport::pollCompletions() {
   constexpr int kNumBatch = 16;
 
   // Cap total CQEs per call to ensure fairness with other transports
   // sharing the same EventBase.
   const uint64_t maxCqes = config_.maxWr * qps_.size();
   uint64_t totalDrained = 0;
+  Status res = Ok();
 
   // Round-robin: poll one batch from each CQ per round, repeat until
   // CQs are empty or the cap is reached.
@@ -993,43 +1135,62 @@ void RdmaTransport::pollCompletions() {
           task->recordCompletion(
               Err(ErrCode::TransportError, "RDMA transport is broken"));
         }
-        return;
+        return pollResult.error();
       }
 
       int n = pollResult.value();
       totalDrained += static_cast<uint64_t>(n);
       for (const auto& wc : std::span(wcs).subspan(0, n)) {
         uint32_t taskId = static_cast<uint32_t>(wc.wr_id >> 32);
-        uint32_t numWrs = static_cast<uint32_t>(wc.wr_id & 0xffffffff);
-
-        if (numWrs > 0) {
-          --numPendingCqe_[i];
-        }
-
-        if (auto qp = qpNumToIdx_.find(qpMapKey(i, wc.qp_num));
-            qp != qpNumToIdx_.end()) {
-          numWrsPerQp_[qp->second] -= numWrs;
-        }
+        uint32_t wrInfo = static_cast<uint32_t>(wc.wr_id & 0xffffffff);
 
         if (auto it = inflightTasks_.find(taskId); it != inflightTasks_.end()) {
+          bool isCopyOp = it->second->type() == IOType::Send ||
+              it->second->type() == IOType::Recv;
+          uint32_t numWrs = isCopyOp ? (wrInfo >> 16) : wrInfo;
+
+          if (numWrs > 0) {
+            --numPendingCqe_[i];
+          }
+
+          if (auto qp = qpNumToIdx_.find(qpMapKey(i, wc.qp_num));
+              qp != qpNumToIdx_.end()) {
+            numWrsPerQp_[qp->second] -= numWrs;
+          }
+
+          if (isCopyOp) {
+            uint32_t slot = wrInfo & 0xffff;
+            --slotPendingCqe_[slot];
+          }
+
           if (wc.status != IBV_WC_SUCCESS) {
-            UNIFLOW_LOG_ERROR(
-                "pollCompletions: WC error wr_id={} taskId={} numWrs={} "
+            auto msg = fmt::format(
+                "RDMA WR failed: wr_id={} taskId={} wrInfo={} "
                 "qp_num={} status={}",
                 wc.wr_id,
                 taskId,
-                numWrs,
+                wrInfo,
                 wc.qp_num,
                 static_cast<int>(wc.status));
-            it->second->recordCompletion(Err(
-                ErrCode::DriverError,
-                "RDMA WR failed: wr_id=" + std::to_string(wc.wr_id) +
-                    " taskId=" + std::to_string(taskId) +
-                    " numWrs=" + std::to_string(numWrs) +
-                    " status=" + std::to_string(static_cast<int>(wc.status))));
+            UNIFLOW_LOG_ERROR(msg);
+            res = Err(ErrCode::DriverError, std::move(msg));
+            it->second->recordCompletion(res.error());
           }
 
           it->second->recordCompletion(numWrs);
+
+        } else {
+          auto msg = fmt::format(
+              "pollCompletions: cannot find task for taskId={} wrInfo={}",
+              taskId,
+              wrInfo);
+          UNIFLOW_LOG_ERROR(msg);
+          res = Err(ErrCode::TransportError, std::move(msg));
+          state_ = TransportState::Error;
+          for (auto& [_, task] : inflightTasks_) {
+            task->recordCompletion(res.error());
+          }
+          return res;
         }
       }
     }
@@ -1037,6 +1198,7 @@ void RdmaTransport::pollCompletions() {
       break;
     }
   }
+  return res;
 }
 
 std::future<Status> RdmaTransport::send(
@@ -1050,9 +1212,7 @@ std::future<Status> RdmaTransport::send(
 std::future<Status> RdmaTransport::send(
     Segment::Span src,
     const RequestOptions& options) {
-  std::promise<Status> promise;
-  promise.set_value(ErrCode::NotImplemented);
-  return promise.get_future();
+  return rdmaSendRecvTransfer(IOType::Send, src, options);
 }
 
 std::future<Status> RdmaTransport::recv(
@@ -1066,9 +1226,432 @@ std::future<Status> RdmaTransport::recv(
 std::future<Status> RdmaTransport::recv(
     Segment::Span dst,
     const RequestOptions& options) {
-  std::promise<Status> promise;
-  promise.set_value(ErrCode::NotImplemented);
-  return promise.get_future();
+  return rdmaSendRecvTransfer(IOType::Recv, dst, options);
+}
+
+// ---------------------------------------------------------------------------
+// Unified IO processing loop (EventBase thread)
+// ---------------------------------------------------------------------------
+
+bool RdmaTransport::sendRecvIoProcess(SendRecvTransfer& entry) noexcept {
+  if (state_ != TransportState::Connected) {
+    entry.task->recordCompletion(
+        Err(ErrCode::TransportError, "RDMA transport is broken"));
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  }
+
+  size_t before = pendingTransfers_.size();
+  Status res = Ok();
+  if (entry.opType == IOType::Send) {
+    res = sendProgress(entry);
+  } else {
+    res = recvProgress(entry);
+  }
+
+  if (res.hasError()) {
+    entry.task->recordCompletion(std::move(res).error());
+    pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
+    pendingTransfers_.pop_front();
+    return true;
+  }
+
+  return pendingTransfers_.size() < before;
+}
+
+// ---------------------------------------------------------------------------
+// Send pipeline
+// ---------------------------------------------------------------------------
+
+Status RdmaTransport::sendProgress(SendRecvTransfer& transfer) {
+  const uint32_t depth = static_cast<uint32_t>(transfer.localSlabs.size());
+  const size_t slabSize = info_.header.slabSize;
+
+  if (transfer.done < transfer.totalSteps) {
+    sendCopyProgress(transfer, depth, slabSize);
+    CHECK_EXPR(sendTransmitProgress(transfer, depth, slabSize));
+    CHECK_EXPR(pollCompletions());
+  }
+
+  // Advance done cursor for completed slots.
+  while (transfer.done < transfer.notified) {
+    uint32_t doneSlot = transfer.done % depth;
+    if (slotPendingCqe_[doneSlot] == 0) {
+      ++transfer.done;
+    } else {
+      break;
+    }
+  }
+
+  if (transfer.done >= transfer.totalSteps) {
+    UNIFLOW_LOG_DEBUG("sendProgress: taskId={} completed", transfer.taskId);
+    transfer.task->postFinished();
+    pendingCompletions_.push_back({transfer.taskId, std::move(transfer.task)});
+    pendingTransfers_.pop_front();
+  }
+  return Ok();
+}
+
+void RdmaTransport::sendCopyProgress(
+    SendRecvTransfer& transfer,
+    uint32_t depth,
+    size_t slabSize) {
+  if (transfer.copied >= transfer.totalSteps ||
+      transfer.copied >= transfer.done + depth) {
+    return;
+  }
+
+  const auto& span = transfer.data;
+  uint32_t slot = transfer.copied % depth;
+  size_t offset = transfer.copied * slabSize;
+  size_t len = std::min(slabSize, span.size() - offset);
+  void* dst = transfer.localSlabs[slot].ptr();
+  const void* src = static_cast<const char*>(span.data()) + offset;
+
+  if (span.memType() == MemoryType::VRAM) {
+    auto stream = transfer.stream.value();
+    CudaDeviceGuard guard(*cudaApi_, span.deviceId());
+    cudaApi_->memcpyAsync(dst, src, len, cudaMemcpyDeviceToHost, stream);
+    cudaDriverApi_->streamWriteValue64(
+        stream,
+        static_cast<CUdeviceptr>(transfer.localSlabs[slot].stateDeviceAddr()),
+        1,
+        CU_STREAM_WRITE_VALUE_DEFAULT);
+  } else {
+    std::memcpy(dst, src, len);
+  }
+
+  ++transfer.copied;
+}
+
+Status RdmaTransport::sendTransmitProgress(
+    SendRecvTransfer& transfer,
+    uint32_t depth,
+    size_t slabSize) {
+  if (transfer.notified >= transfer.copied) {
+    return Ok();
+  }
+
+  auto& span = transfer.data;
+  uint32_t slot = transfer.notified % depth;
+  auto& slab = transfer.localSlabs[slot];
+  auto state = slab.state();
+
+  if (span.memType() == MemoryType::VRAM &&
+      state.load(std::memory_order_acquire) == 0) {
+    return Ok();
+  }
+
+  uint32_t remoteSlabIdx = ctrlCts(slot).load(std::memory_order_acquire);
+  if (remoteSlabIdx == kSlabIdxInvalid) {
+    return Ok();
+  }
+
+  size_t offset = transfer.notified * slabSize;
+  size_t len = std::min(slabSize, span.size() - offset);
+  uint16_t remoteSlab = static_cast<uint16_t>(remoteSlabIdx);
+
+  auto res =
+      postSlabTransfer(transfer, slab, remoteSlab, len, slot, transfer.taskId);
+  if (res.hasError()) {
+    return std::move(res).error();
+  } else if (res.value() == 0) {
+    return Ok();
+  }
+
+  if (span.memType() == MemoryType::VRAM) {
+    state.store(0, std::memory_order_release);
+  }
+  ctrlCts(slot).store(kSlabIdxInvalid, std::memory_order_release);
+  ++transfer.notified;
+  return Ok();
+}
+
+Result<size_t> RdmaTransport::postSlabTransfer(
+    SendRecvTransfer& transfer,
+    RdmaSlab& localSlab,
+    uint16_t remoteSlab,
+    size_t len,
+    uint32_t slot,
+    uint32_t taskId) {
+  const uint32_t numQps = config_.numQps;
+  const size_t chunkSize = config_.chunkSize;
+  const uint32_t numChunks =
+      static_cast<uint32_t>((len + chunkSize - 1) / chunkSize);
+  const uint32_t numWrs = numChunks + numQps;
+
+  std::vector<uint32_t> qpAvail(numQps);
+  uint32_t totalAvail = getQpAvail(qpAvail);
+
+  if (totalAvail < numWrs) {
+    return 0;
+  }
+
+  std::vector<uint32_t> qpAssigned(numQps, 0);
+  uint32_t totalAssigned = assignToQps(numWrs, totalAvail, qpAvail, qpAssigned);
+
+  if (totalAssigned < numWrs) {
+    return 0;
+  }
+
+  uint64_t localBase = localSlab.addr();
+  uint64_t remoteBase = remoteSlabBuffer_.addr +
+      static_cast<size_t>(remoteSlab) * info_.header.slabSize;
+
+  size_t chunkIdx = 0;
+  for (uint32_t q = 0; q < numQps; ++q) {
+    if (qpAssigned[q] == 0) {
+      continue;
+    }
+    uint32_t localNicIdx = q % nics_.size();
+    uint32_t remoteNicIdx = q % remoteSlabBuffer_.rkeys.size();
+    struct WrPair {
+      ibv_send_wr wr{};
+      ibv_sge sge{};
+    };
+    const uint32_t dataWrCount = qpAssigned[q] - 1;
+    std::vector<WrPair> wrs(qpAssigned[q]);
+    uint32_t postedLen = 0;
+    uint32_t postedWrCount = 0;
+    for (; postedWrCount < dataWrCount; ++postedWrCount, ++chunkIdx) {
+      size_t off = chunkIdx * chunkSize;
+      if (off >= len) {
+        break;
+      }
+      size_t length = std::min(chunkSize, len - off);
+      auto& wr = wrs[postedWrCount];
+
+      wr.sge.addr = localBase + off;
+      wr.sge.length = static_cast<uint32_t>(length);
+      wr.sge.lkey = slabPool_->slabLkey(localNicIdx);
+
+      wr.wr.sg_list = &wr.sge;
+      wr.wr.num_sge = 1;
+      wr.wr.opcode = IBV_WR_RDMA_WRITE;
+      wr.wr.send_flags = 0;
+      wr.wr.wr.rdma.remote_addr = remoteBase + off;
+      wr.wr.wr.rdma.rkey = remoteSlabBuffer_.rkeys[remoteNicIdx];
+      wr.wr.next = &wrs[postedWrCount + 1].wr;
+      postedLen += static_cast<uint32_t>(length);
+    }
+
+    auto& notifyWr = wrs[postedWrCount++];
+    notifyWr.sge.addr = reinterpret_cast<uint64_t>(&postedLen);
+    notifyWr.sge.length = sizeof(uint32_t);
+    notifyWr.sge.lkey = 0;
+
+    notifyWr.wr.sg_list = &notifyWr.sge;
+    notifyWr.wr.num_sge = 1;
+    notifyWr.wr.opcode = IBV_WR_RDMA_WRITE;
+    notifyWr.wr.send_flags = IBV_SEND_INLINE;
+    notifyWr.wr.wr.rdma.remote_addr = remoteCtrlNotifyAddr(slot, q);
+    notifyWr.wr.wr.rdma.rkey = remoteCtrlBuffer_.rkeys[remoteNicIdx];
+    notifyWr.wr.next = nullptr;
+
+    notifyWr.wr.wr_id = (static_cast<uint64_t>(taskId) << 32) |
+        (static_cast<uint32_t>(postedWrCount) << 16) | (slot & 0xFFFF);
+    notifyWr.wr.send_flags |= IBV_SEND_SIGNALED;
+
+    uint32_t posted = postSend(
+        q, &wrs.front().wr, postedWrCount, taskId, *transfer.task, slot);
+    if (posted == 0) {
+      state_ = TransportState::Error;
+      return Err(ErrCode::DriverError, "postSend failed");
+    }
+  }
+
+  return len;
+}
+
+// ---------------------------------------------------------------------------
+// Recv pipeline
+// ---------------------------------------------------------------------------
+
+Status RdmaTransport::recvProgress(SendRecvTransfer& transfer) {
+  const uint32_t depth = static_cast<uint32_t>(transfer.localSlabs.size());
+  const size_t slabSize = info_.header.slabSize;
+
+  // post initial CTS entries so sender knows which remote slabs to write to.
+  while (transfer.initStep <
+         std::min(static_cast<uint64_t>(depth), transfer.totalSteps)) {
+    auto res = postCts(
+        transfer.initStep,
+        transfer.localSlabs[transfer.initStep].index(),
+        transfer.taskId,
+        *transfer.task);
+    if (res.hasError()) {
+      return std::move(res).error();
+    }
+    // No wr space to post cts
+    if (!res.value()) {
+      return Ok();
+    }
+    ++transfer.initStep;
+  }
+
+  if (transfer.done < transfer.totalSteps) {
+    recvNotifyProgress(transfer, depth, slabSize);
+    recvCopyProgress(transfer, depth, slabSize);
+    CHECK_EXPR(recvDoneProgress(transfer, depth));
+    CHECK_EXPR(pollCompletions());
+  }
+
+  if (transfer.done >= transfer.totalSteps) {
+    UNIFLOW_LOG_DEBUG("recvProgress: taskId={} completed", transfer.taskId);
+    transfer.task->postFinished();
+    pendingCompletions_.push_back({transfer.taskId, std::move(transfer.task)});
+    pendingTransfers_.pop_front();
+  }
+  return Ok();
+}
+
+void RdmaTransport::recvNotifyProgress(
+    SendRecvTransfer& transfer,
+    uint32_t depth,
+    size_t slabSize) {
+  if (transfer.notified >= transfer.totalSteps ||
+      transfer.notified >= transfer.done + depth) {
+    return;
+  }
+
+  const uint32_t numQps = config_.numQps;
+  uint32_t slot = transfer.notified % depth;
+  uint32_t length = 0;
+  for (uint32_t q = 0; q < numQps; ++q) {
+    uint32_t notify = ctrlNotify(slot, q).load(std::memory_order_acquire);
+    if (notify != kSlabIdxInvalid) {
+      length += notify;
+    }
+  }
+
+  size_t offset = transfer.notified * slabSize;
+  if (length < std::min(slabSize, transfer.data.size() - offset)) {
+    return;
+  }
+
+  for (uint32_t q = 0; q < numQps; ++q) {
+    ctrlNotify(slot, q).store(kSlabIdxInvalid, std::memory_order_release);
+  }
+  ++transfer.notified;
+}
+
+void RdmaTransport::recvCopyProgress(
+    SendRecvTransfer& transfer,
+    uint32_t depth,
+    size_t slabSize) {
+  if (transfer.copied >= transfer.notified) {
+    return;
+  }
+
+  uint32_t slot = transfer.copied % depth;
+  auto& slab = transfer.localSlabs[slot];
+  auto& span = transfer.data;
+  size_t offset = transfer.copied * slabSize;
+  size_t len = std::min(slabSize, span.size() - offset);
+  void* dst = static_cast<char*>(span.mutable_data()) + offset;
+  const void* src = slab.ptr();
+
+  if (span.memType() == MemoryType::VRAM) {
+    auto stream = transfer.stream.value();
+    CudaDeviceGuard guard(*cudaApi_, span.deviceId());
+    cudaApi_->memcpyAsync(dst, src, len, cudaMemcpyHostToDevice, stream);
+    cudaDriverApi_->streamWriteValue64(
+        stream,
+        static_cast<CUdeviceptr>(slab.stateDeviceAddr()),
+        1,
+        CU_STREAM_WRITE_VALUE_DEFAULT);
+  } else {
+    std::memcpy(dst, src, len);
+  }
+
+  ++transfer.copied;
+}
+
+Status RdmaTransport::recvDoneProgress(
+    SendRecvTransfer& transfer,
+    uint32_t depth) {
+  if (transfer.done >= transfer.copied) {
+    return Ok();
+  }
+
+  uint32_t slot = transfer.done % depth;
+
+  // Wait for the previous CTS CQE before recycling this slot. This also
+  // guarantees all CTS CQEs are drained by completion: the last D steps
+  // skip postCts (nextStep >= totalSteps) but still hit this check.
+  if (slotPendingCqe_[slot] != 0) {
+    return Ok();
+  }
+
+  auto& slab = transfer.localSlabs[slot];
+  auto& span = transfer.data;
+  auto state = slab.state();
+
+  if (span.memType() == MemoryType::VRAM) {
+    if (state.load(std::memory_order_acquire) == 0) {
+      return Ok();
+    }
+  }
+
+  uint64_t nextStep = transfer.done + depth;
+  if (nextStep < transfer.totalSteps) {
+    auto res = postCts(slot, slab.index(), transfer.taskId, *transfer.task);
+    if (res.hasError()) {
+      return std::move(res).error();
+    }
+    // No wr space to post cts
+    if (!res.value()) {
+      return Ok();
+    }
+  }
+
+  if (span.memType() == MemoryType::VRAM) {
+    state.store(0, std::memory_order_release);
+  }
+
+  ++transfer.done;
+  return Ok();
+}
+
+Result<bool> RdmaTransport::postCts(
+    uint32_t slot,
+    uint16_t slabIdx,
+    uint32_t taskId,
+    Task& task) {
+  uint32_t qpIdx = 0;
+  for (; qpIdx < config_.numQps; ++qpIdx) {
+    if (numWrsPerQp_[qpIdx] < config_.maxWr) {
+      break;
+    }
+  }
+
+  if (qpIdx == config_.numQps) {
+    return false;
+  }
+  uint32_t nicIdx = qpIdx % nics_.size();
+
+  uint32_t ctsPayload = slabIdx;
+  ibv_sge sge{};
+  sge.addr = reinterpret_cast<uint64_t>(&ctsPayload);
+  sge.length = sizeof(uint32_t);
+  sge.lkey = 0;
+
+  ibv_send_wr wr{};
+  wr.wr_id =
+      (static_cast<uint64_t>(taskId) << 32) | (1u << 16) | (slot & 0xFFFF);
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = IBV_SEND_SIGNALED | IBV_SEND_INLINE;
+  wr.wr.rdma.remote_addr = remoteCtrlCtsAddr(slot);
+  wr.wr.rdma.rkey = remoteCtrlBuffer_.rkeys[nicIdx];
+  wr.next = nullptr;
+
+  if (postSend(qpIdx, &wr, 1, taskId, task, slot) == 0) {
+    return Err(ErrCode::TransportError, "postCts failed");
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -1436,7 +2019,14 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
   auto config = config_;
   config.numQps = std::min(peerTopo.numQps, config.numQps);
   return std::make_unique<RdmaTransport>(
-      ibvApi_, cudaApi_, evb_, nicsHandle_, domainId_, config, nullptr);
+      ibvApi_,
+      cudaApi_,
+      cudaDriverApi_,
+      evb_,
+      nicsHandle_,
+      domainId_,
+      config,
+      nullptr);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -23,6 +23,7 @@ constexpr uint8_t kRdmaVersion{1};
 // Forward declarations.
 class RdmaRegistrationHandle;
 class RdmaRemoteRegistrationHandle;
+class RdmaSlab;
 class RdmaSlabPool;
 
 /*
@@ -73,6 +74,7 @@ struct RdmaTransportInfo {
     uint8_t numNics{0};
     uint32_t numQps{0};
     uint64_t domainId{0};
+    uint32_t slabSize{0};
   };
   /* Per-NIC addressing info in the wire format. */
   struct __attribute__((packed)) NicInfo {
@@ -166,6 +168,7 @@ class RdmaTransport : public Transport {
   RdmaTransport(
       std::shared_ptr<IbvApi> ibvApi,
       std::shared_ptr<CudaApi> cudaApi,
+      std::shared_ptr<CudaDriverApi> cudaDriverApi,
       EventBase* evb,
       std::shared_ptr<std::vector<NicResources>> nics,
       uint64_t domainId,
@@ -254,11 +257,21 @@ class RdmaTransport : public Transport {
   void shutdown() override;
 
  private:
+  // --- Private methods ---
+
+  enum class IOType {
+    Put,
+    Get,
+    Send,
+    Recv,
+  };
+
   /// Tracks completion of a batch of RDMA work requests from a single
-  /// rdmaTransfer() call. All fields are accessed only on the EventBase
-  /// thread, so no synchronization is needed.
+  /// call. All fields are accessed only on the EventBase thread, so no
+  /// synchronization is needed.
   class Task {
    public:
+    explicit Task(IOType type) : type_(type) {}
     std::future<Status> get_future() {
       return promise_.get_future();
     }
@@ -280,6 +293,10 @@ class RdmaTransport : public Transport {
         return;
       }
       remainingWrs_ -= numWrs.value();
+    }
+
+    IOType type() const {
+      return type_;
     }
 
     bool isDone() const {
@@ -306,10 +323,11 @@ class RdmaTransport : public Transport {
     }
 
    private:
+    IOType type_{};
     bool fulfilled_{false};
     bool postFinished_{false};
     uint32_t remainingWrs_{0};
-    std::optional<Status> error_;
+    std::optional<Err> error_;
     std::promise<Status> promise_;
   };
 
@@ -324,11 +342,35 @@ class RdmaTransport : public Transport {
     const RdmaRemoteRegistrationHandle* remoteHandle{nullptr};
   };
 
-  struct PendingTransfer {
-    uint32_t taskId;
+  struct PutGetTransfer {
+    uint32_t taskId{};
     std::unique_ptr<std::vector<SendWr>> sendWrs;
     size_t idx{0};
     std::shared_ptr<Task> task;
+  };
+
+  struct SendRecvTransfer {
+    explicit SendRecvTransfer(IOType opType, Segment::Span data);
+    ~SendRecvTransfer();
+
+    IOType opType;
+    Segment::Span data;
+    uint32_t taskId{};
+    std::optional<cudaStream_t> stream;
+    uint32_t initStep{0};
+    uint64_t totalSteps{0};
+
+    uint64_t copied{0};
+    uint64_t notified{0};
+    uint64_t done{0};
+
+    std::vector<RdmaSlab> localSlabs;
+    std::shared_ptr<Task> task;
+  };
+
+  struct PendingTransfer {
+    std::unique_ptr<PutGetTransfer> putGetTransfer{nullptr};
+    std::unique_ptr<SendRecvTransfer> sendRecvTransfer{nullptr};
   };
 
   struct PendingCompletion {
@@ -354,14 +396,30 @@ class RdmaTransport : public Transport {
   // --- EventBase thread methods ---
 
   /// Entry point: dispatches buildSendWrs result to EventBase for posting.
-  std::future<Status> rdmaTransfer(
+  std::future<Status> rdmaPutGetTransfer(
       std::span<const TransferRequest> requests,
       ibv_wr_opcode opcode,
+      const RequestOptions& options);
+
+  std::future<Status> rdmaSendRecvTransfer(
+      IOType ioType,
+      Segment::Span data,
       const RequestOptions& options);
 
   /// Unified IO processing loop. Runs exclusively on EventBase thread.
   /// Posts WRs from pendingTransfers_, polls CQs, fulfills promises in order.
   void ioLooper() noexcept;
+
+  bool putGetIoProcess(PutGetTransfer& entry) noexcept;
+  bool sendRecvIoProcess(SendRecvTransfer& entry) noexcept;
+
+  uint32_t getQpAvail(std::vector<uint32_t>& qpAvail);
+
+  uint32_t assignToQps(
+      const uint32_t remaining,
+      const uint32_t totalAvail,
+      std::vector<uint32_t>& qpAvail,
+      std::vector<uint32_t>& qpAssigned);
 
   /// Distributes SendWrs across QPs proportional to available capacity
   /// and posts them.
@@ -376,15 +434,12 @@ class RdmaTransport : public Transport {
   /// Correctness invariant: numWrsPerQp_[q] is incremented by exactly
   /// the number of WRs that will generate CQEs (directly or via flush),
   /// ensuring pollCompletions will decrement it back to zero.
-  Result<uint32_t> spray(
-      std::vector<SendWr>& wrs,
-      size_t& idx,
-      uint32_t taskId,
-      std::shared_ptr<Task>& task);
+  Result<uint32_t>
+  spray(std::vector<SendWr>& wrs, size_t& idx, uint32_t taskId, Task& task);
 
   /// Returns whether a pending transfer may begin posting without exceeding
   /// the transport's conservative SQ admission budget.
-  bool canStartTransfer(const PendingTransfer& transfer) const;
+  bool canStartTransfer(const PutGetTransfer& transfer) const;
 
   /// Conservative global WR budget used to admit complete transfers. A single
   /// transfer larger than this budget may still start when no other WRs are
@@ -412,10 +467,13 @@ class RdmaTransport : public Transport {
       ibv_send_wr* head,
       uint32_t count,
       uint32_t taskId,
-      std::shared_ptr<Task>& task);
+      Task& task,
+      std::optional<uint16_t> slot = std::nullopt);
 
   /// Polls all CQs and routes completions to their tasks via inflightTasks_.
-  void pollCompletions();
+  Status pollCompletions();
+
+  // --- Copy-based send/recv pipeline (cursor model) ---
 
   /// Ctrl buffer helpers.
   std::atomic_ref<uint32_t> ctrlCts(uint16_t slotIdx);
@@ -424,8 +482,39 @@ class RdmaTransport : public Transport {
   uint64_t remoteCtrlNotifyAddr(uint16_t slotIdx, uint32_t qpIdx) const;
   size_t ctrlBufferSize() const;
 
+  // --- Send pipeline ---
+
+  Status sendProgress(SendRecvTransfer& transfer);
+  void
+  sendCopyProgress(SendRecvTransfer& transfer, uint32_t depth, size_t slabSize);
+  Status sendTransmitProgress(
+      SendRecvTransfer& transfer,
+      uint32_t depth,
+      size_t slabSize);
+  Result<size_t> postSlabTransfer(
+      SendRecvTransfer& transfer,
+      RdmaSlab& localSlab,
+      uint16_t remoteSlab,
+      size_t len,
+      uint32_t slot,
+      uint32_t taskId);
+
+  // --- Recv pipeline ---
+
+  Status recvProgress(SendRecvTransfer& transfer);
+  void recvNotifyProgress(
+      SendRecvTransfer& transfer,
+      uint32_t depth,
+      size_t slabSize);
+  void
+  recvCopyProgress(SendRecvTransfer& transfer, uint32_t depth, size_t slabSize);
+  Status recvDoneProgress(SendRecvTransfer& transfer, uint32_t depth);
+  Result<bool>
+  postCts(uint32_t slot, uint16_t slabIdx, uint32_t taskId, Task& task);
+
   const std::shared_ptr<IbvApi> ibvApi_;
   const std::shared_ptr<CudaApi> cudaApi_;
+  std::shared_ptr<CudaDriverApi> cudaDriverApi_;
   EventBase* evb_{nullptr};
 
   std::string name_;
@@ -446,7 +535,10 @@ class RdmaTransport : public Transport {
   uint32_t nextTaskId_{0};
 
   /// Number of pending CQEs for each nic. Accessed only on EventBase thread.
-  std::vector<int> numPendingCqe_{0};
+  std::vector<int> numPendingCqe_;
+
+  /// Number of pending CQEs for each slot. Accessed only on EventBase thread.
+  std::vector<int> slotPendingCqe_;
 
   /// Transfers awaiting WR posting. Accessed only on EventBase.
   std::deque<PendingTransfer> pendingTransfers_;

--- a/comms/uniflow/transport/rdma/tests/integration/SingleHostTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/integration/SingleHostTest.cpp
@@ -4,14 +4,17 @@
 /// Requires at least 2 RDMA NICs. GPU tests require CUDA devices.
 /// Uses two transport instances on different NICs within the same process.
 
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
+#include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
 #include <cstring>
+#include <random>
 
 #include <gtest/gtest.h>
 
@@ -44,6 +47,7 @@ class SingleHostTest : public ::testing::Test {
  protected:
   void SetUp() override {
     ibvApi_ = std::make_shared<IbvApi>();
+    cudaDriverApi_ = std::make_shared<CudaDriverApi>();
     auto initStatus = ibvApi_->init();
     ASSERT_FALSE(initStatus.hasError())
         << "Failed to init IbvApi: " << initStatus.error().message();
@@ -114,6 +118,7 @@ class SingleHostTest : public ::testing::Test {
   }
 
   std::shared_ptr<IbvApi> ibvApi_;
+  std::shared_ptr<CudaDriverApi> cudaDriverApi_;
   ibv_device** deviceList_{nullptr};
   int numDevices_{0};
   std::vector<std::string> deviceNames_;
@@ -182,14 +187,12 @@ TEST_F(SingleHostTest, RepeatedRegisterDeregister) {
 // --- VRAM registration integration tests ---
 
 TEST_F(SingleHostTest, VramRegistrationWithCudaMalloc) {
-  auto cudaDriverApi = std::make_shared<CudaDriverApi>();
-
   RdmaTransportFactory factory(
       {deviceNames_[0]},
       evbThread_->getEventBase(),
       {},
       ibvApi_,
-      cudaDriverApi);
+      cudaDriverApi_);
 
   // Allocate GPU memory via cudaMalloc (page-aligned by default).
   constexpr size_t kSize = 1 << 20; // 1 MiB
@@ -222,14 +225,12 @@ TEST_F(SingleHostTest, VramRegistrationWithCudaMalloc) {
 }
 
 TEST_F(SingleHostTest, VramRegistrationWithMultiNics) {
-  auto cudaDriverApi = std::make_shared<CudaDriverApi>();
-
   RdmaTransportFactory factory(
       {deviceNames_[0], deviceNames_[1]},
       evbThread_->getEventBase(),
       {},
       ibvApi_,
-      cudaDriverApi);
+      cudaDriverApi_);
 
   // Allocate GPU memory via cudaMalloc (page-aligned by default).
   constexpr size_t kSize = 1 << 20; // 1 MiB
@@ -263,13 +264,12 @@ TEST_F(SingleHostTest, VramRegistrationWithMultiNics) {
 }
 
 TEST_F(SingleHostTest, VramRegistrationWithUnalignedAddress) {
-  auto cudaDriverApi = std::make_shared<CudaDriverApi>();
   RdmaTransportFactory factory(
       {deviceNames_[0]},
       evbThread_->getEventBase(),
       {},
       ibvApi_,
-      cudaDriverApi);
+      cudaDriverApi_);
 
   // Allocate a large GPU buffer and offset into it to create a
   // non-page-aligned address. cudaMalloc returns page-aligned memory,
@@ -644,6 +644,198 @@ INSTANTIATE_TEST_SUITE_P(
         TransferParam{12 * 1024 * 1024 + 12 * 1024, 1, "12MB12KB_x1"},
         TransferParam{12 * 1024 * 1024 + 12 * 1024, 4, "12MB12KB_x4"}),
     transferParamName);
+
+// --- DRAM send/recv tests ---
+
+struct SendRecvParam {
+  size_t bufSize;
+  std::string name;
+};
+
+std::string sendRecvParamName(
+    const ::testing::TestParamInfo<SendRecvParam>& info) {
+  return info.param.name;
+}
+
+class DramSendRecvTest : public SingleHostTest,
+                         public ::testing::WithParamInterface<SendRecvParam> {
+ protected:
+  struct SendRecvPair {
+    std::unique_ptr<ScopedEventBaseThread> evbThread0;
+    std::unique_ptr<ScopedEventBaseThread> evbThread1;
+    std::shared_ptr<RdmaSlabPool> slabPool0;
+    std::shared_ptr<RdmaSlabPool> slabPool1;
+    std::unique_ptr<RdmaTransport> transport0;
+    std::unique_ptr<RdmaTransport> transport1;
+  };
+
+  SendRecvPair connectSendRecvPair() {
+    SendRecvPair pair;
+    pair.evbThread0 = std::make_unique<ScopedEventBaseThread>();
+    pair.evbThread1 = std::make_unique<ScopedEventBaseThread>();
+    auto ibv = ibvApi_;
+    auto cudaApi = std::make_shared<CudaApi>();
+    auto cudaDriverApi = std::make_shared<CudaDriverApi>();
+
+    int nic1Idx = numDevices_ > 3 ? 3 : numDevices_ - 1;
+    auto nics0 = std::make_shared<std::vector<NicResources>>();
+    nics0->reserve(1);
+    nics0->emplace_back(deviceList_[0], ibv);
+
+    auto nics1 = std::make_shared<std::vector<NicResources>>();
+    nics1->reserve(1);
+    nics1->emplace_back(deviceList_[nic1Idx], ibv);
+
+    RdmaSlabPoolConfig poolConfig{.slabNum = 8, .slabSize = 512 * 1024};
+    pair.slabPool0 =
+        std::make_shared<RdmaSlabPool>(poolConfig, cudaApi, ibv, nics0);
+    pair.slabPool1 =
+        std::make_shared<RdmaSlabPool>(poolConfig, cudaApi, ibv, nics1);
+
+    std::mt19937_64 rng{std::random_device{}()};
+    uint64_t domain0 = rng();
+    uint64_t domain1 = rng();
+
+    RdmaTransportConfig config{.pipelineDepth = 8};
+    pair.transport0 = std::make_unique<RdmaTransport>(
+        ibv,
+        cudaApi,
+        cudaDriverApi,
+        pair.evbThread0->getEventBase(),
+        nics0,
+        domain0,
+        config,
+        pair.slabPool0);
+    pair.transport1 = std::make_unique<RdmaTransport>(
+        ibv,
+        cudaApi,
+        cudaDriverApi,
+        pair.evbThread1->getEventBase(),
+        nics1,
+        domain1,
+        config,
+        pair.slabPool1);
+
+    auto info0 = pair.transport0->bind();
+    auto info1 = pair.transport1->bind();
+    EXPECT_FALSE(info0.empty());
+    EXPECT_FALSE(info1.empty());
+
+    auto st0 = pair.transport0->connect(info1);
+    auto st1 = pair.transport1->connect(info0);
+    EXPECT_TRUE(st0) << st0.error().message();
+    EXPECT_TRUE(st1) << st1.error().message();
+
+    return pair;
+  }
+};
+
+TEST_P(DramSendRecvTest, SendRecv) {
+  const auto& param = GetParam();
+  const size_t bufSize = param.bufSize;
+
+  auto pair = connectSendRecvPair();
+
+  std::vector<char> sendBuf(bufSize);
+  std::vector<char> recvBuf(bufSize, 0);
+  for (size_t i = 0; i < bufSize; ++i) {
+    sendBuf[i] = static_cast<char>(i & 0xFF);
+  }
+
+  Segment sendSeg(sendBuf.data(), bufSize, MemoryType::DRAM);
+  Segment recvSeg(recvBuf.data(), bufSize, MemoryType::DRAM);
+
+  auto recvFuture = pair.transport1->recv(recvSeg.span());
+  auto sendFuture = pair.transport0->send(sendSeg.span());
+
+  auto sendStatus = sendFuture.get();
+  ASSERT_FALSE(sendStatus.hasError())
+      << "send failed: " << sendStatus.error().message();
+
+  auto recvResult = recvFuture.get();
+  ASSERT_TRUE(recvResult.hasValue())
+      << "recv failed: " << recvResult.error().message();
+
+  EXPECT_EQ(std::memcmp(sendBuf.data(), recvBuf.data(), bufSize), 0)
+      << "Data mismatch";
+
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DramSendRecv,
+    DramSendRecvTest,
+    ::testing::Values(
+        SendRecvParam{4096, "4KB"},
+        SendRecvParam{512 * 1024, "512KB"},
+        SendRecvParam{2 * 1024 * 1024 + 1234, "2MB_unaligned"},
+        SendRecvParam{100 * 1024 * 1024, "100MB"}),
+    sendRecvParamName);
+
+// --- VRAM send/recv tests ---
+
+class VramSendRecvTest : public DramSendRecvTest {};
+
+TEST_P(VramSendRecvTest, SendRecv) {
+  int deviceCount = 0;
+  if (cudaGetDeviceCount(&deviceCount) != cudaSuccess || deviceCount < 2) {
+    GTEST_SKIP() << "Need at least 2 CUDA device, found " << deviceCount;
+  }
+
+  const auto& param = GetParam();
+  const size_t bufSize = param.bufSize;
+
+  auto pair = connectSendRecvPair();
+
+  CudaBuffer sendGpu(bufSize, 0);
+  CudaBuffer recvGpu(bufSize, 1);
+  ASSERT_NE(sendGpu.ptr, nullptr) << "cudaMalloc failed for send buffer";
+  ASSERT_NE(recvGpu.ptr, nullptr) << "cudaMalloc failed for recv buffer";
+
+  std::vector<char> staging(bufSize);
+  for (size_t i = 0; i < bufSize; ++i) {
+    staging[i] = static_cast<char>(i & 0xFF);
+  }
+  cudaSetDevice(0);
+  cudaMemcpy(sendGpu.ptr, staging.data(), bufSize, cudaMemcpyHostToDevice);
+  cudaSetDevice(1);
+  cudaMemset(recvGpu.ptr, 0, bufSize);
+  cudaDeviceSynchronize();
+
+  Segment sendSeg(sendGpu.ptr, bufSize, MemoryType::VRAM, 0);
+  Segment recvSeg(recvGpu.ptr, bufSize, MemoryType::VRAM, 1);
+
+  auto recvFuture = pair.transport1->recv(recvSeg.span(), {.stream = nullptr});
+  auto sendFuture = pair.transport0->send(sendSeg.span(), {.stream = nullptr});
+
+  auto sendStatus = sendFuture.get();
+  ASSERT_FALSE(sendStatus.hasError())
+      << "send failed: " << sendStatus.error().message();
+
+  auto recvResult = recvFuture.get();
+  ASSERT_TRUE(recvResult.hasValue())
+      << "recv failed: " << recvResult.error().message();
+
+  std::vector<char> verify(bufSize, 0);
+  cudaSetDevice(1);
+  cudaMemcpy(verify.data(), recvGpu.ptr, bufSize, cudaMemcpyDeviceToHost);
+  EXPECT_EQ(std::memcmp(staging.data(), verify.data(), bufSize), 0)
+      << "Data mismatch";
+
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    VramSendRecv,
+    VramSendRecvTest,
+    ::testing::Values(
+        SendRecvParam{4096, "4KB"},
+        SendRecvParam{512 * 1024, "512KB"},
+        SendRecvParam{2 * 1024 * 1024 + 1234, "2MB_unaligned"},
+        SendRecvParam{100 * 1024 * 1024, "100MB"}),
+    sendRecvParamName);
 
 } // namespace uniflow
 

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -255,7 +255,13 @@ TEST_F(RdmaTransportTest, ConstructorRejectsZeroQps) {
   RdmaTransportConfig config{.numQps = 0};
   EXPECT_THROW(
       RdmaTransport(
-          mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config),
+          mockApi_,
+          mockCudaApi_,
+          nullptr,
+          evbThread_.getEventBase(),
+          nics,
+          0,
+          config),
       std::invalid_argument);
 }
 
@@ -277,7 +283,13 @@ TEST_F(RdmaTransportTest, BindClampsNicsToQpCount) {
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 1};
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
+      mockApi_,
+      mockCudaApi_,
+      nullptr,
+      evbThread_.getEventBase(),
+      nics,
+      0,
+      config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -307,7 +319,13 @@ TEST_F(RdmaTransportTest, SingleNicBindCreatesQPs) {
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransportConfig config{.numQps = 2};
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
+      mockApi_,
+      mockCudaApi_,
+      nullptr,
+      evbThread_.getEventBase(),
+      nics,
+      0,
+      config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -347,7 +365,13 @@ TEST_F(RdmaTransportTest, MultiNicBindDistributesQPsRoundRobin) {
       makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 4};
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0, config);
+      mockApi_,
+      mockCudaApi_,
+      nullptr,
+      evbThread_.getEventBase(),
+      nics,
+      0,
+      config);
 
   auto data = transport.bind();
   ASSERT_FALSE(data.empty());
@@ -375,7 +399,7 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnCqFailure) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
   EXPECT_TRUE(data.empty());
@@ -392,7 +416,7 @@ TEST_F(RdmaTransportTest, BindReturnsEmptyOnQpFailure) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
 
   auto data = transport.bind();
   EXPECT_TRUE(data.empty());
@@ -413,7 +437,7 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   nics->push_back(
       makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0x1234, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
@@ -443,7 +467,7 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
@@ -465,7 +489,7 @@ TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
 
   // Don't call bind() - go straight to connect()
   RdmaTransportInfo remoteInfo;
@@ -498,7 +522,7 @@ TEST_F(RdmaTransportTest, ShutdownDestroysResources) {
   auto nics = std::make_shared<std::vector<NicResources>>();
   nics->push_back(makeNic(&fakeDev0_, &fakeCtx0_, &fakePd0_, mockApi_, 0, gid));
   RdmaTransport transport(
-      mockApi_, mockCudaApi_, evbThread_.getEventBase(), nics, 0);
+      mockApi_, mockCudaApi_, nullptr, evbThread_.getEventBase(), nics, 0);
   transport.bind();
 
   transport.shutdown();
@@ -841,6 +865,7 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     transport_ = std::make_unique<RdmaTransport>(
         mockApi_,
         mockCudaApi_,
+        nullptr,
         evbThread_->getEventBase(),
         nics,
         kLocalDomainId,
@@ -1154,6 +1179,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   RdmaTransport transport(
       mockApi_,
       mockCudaApi_,
+      nullptr,
       evbThread_.getEventBase(),
       nics,
       kLocalDomainId,


### PR DESCRIPTION
Summary:

Implement the full copy-based send/recv pipeline for RDMA transport, enabling `send(Segment::Span)` / `recv(Segment::Span)` for both DRAM and VRAM user buffers without prior segment registration.

The pipeline uses a cursor model with three shared cursors (`copied`, `notified`, `done`) that advance independently to overlap memcpy, RDMA WRITE, and completion processing:

**Send pipeline** (`sendProgress` → `sendCopyProgress` → `sendTransmitProgress`):
1. Copy user buffer → local staging slab (memcpy for DRAM, `cudaMemcpyAsync` D2H + `cuStreamWriteValue64` for VRAM)
2. Poll CTS ring for receiver-allocated remote slab index
3. Post RDMA WRITE from local slab to remote slab, then RDMA WRITE notify entry
4. Reap CQEs and recycle the local slab for the next chunk

**Recv pipeline** (`recvProgress` → `recvNotifyProgress` → `recvCopyProgress` → `recvDoneProgress`):
1. Post CTS entries with locally acquired slab indices
2. Poll notify ring for per-slab completion from sender
3. Copy staging slab → user buffer (memcpy for DRAM, `cudaMemcpyAsync` H2D for VRAM)
4. Release slab and post next CTS entry

Additional changes:
- **`processCqes` refactor**: extracted from `pollCompletions` to support both legacy put/get task tracking and new pipeline CQE routing. Pipeline CQEs use a shifted `wr_id` encoding (`taskId << 32 | numWrs << 16 | slot`) for per-slot CQE counting.
- **`startPipeline` template**: common entry point for send/recv that validates state, creates `Pipeline`, queues behind pending requests for ordering, acquires slabs, and dispatches to the caller-provided `onReady` callback.
- **Slab size negotiation in `connect()`**: if local and remote slab sizes differ, both sides use `min(local, remote)`.
- **SlabPool flags**: added `cudaHostAllocPortable` for cross-device VRAM copy compatibility.

Reviewed By: saifhhasan

Differential Revision: D104125049


