### PR TITLE
route remaining wall-time stamps through PrecisionClock

### DIFF
--- a/comms/utils/colltrace/CPUWaitEvent.cc
+++ b/comms/utils/colltrace/CPUWaitEvent.cc
@@ -3,9 +3,11 @@
 #include "comms/utils/colltrace/CPUWaitEvent.h"
 #include <folly/Unit.h>
 
+#include "comms/utils/colltrace/PrecisionClock.h"
+
 namespace meta::comms::colltrace {
 
-CPUWaitEvent::CPUWaitEvent() : enqueueTime_(std::chrono::system_clock::now()) {}
+CPUWaitEvent::CPUWaitEvent() : enqueueTime_(precisionNow()) {}
 
 CommsMaybeVoid CPUWaitEvent::beforeCollKernelScheduled() noexcept {
   // No op for CPU Wait event before collective kernel scheduled
@@ -30,13 +32,13 @@ CommsMaybe<bool> CPUWaitEvent::waitCollEnd(
 
 CommsMaybeVoid CPUWaitEvent::signalCollStart() noexcept {
   startEvent_.waitSemaphore.post();
-  startEvent_.timePoint = std::chrono::system_clock::now();
+  startEvent_.timePoint = precisionNow();
   return folly::unit;
 }
 
 CommsMaybeVoid CPUWaitEvent::signalCollEnd() noexcept {
   endEvent_.waitSemaphore.post();
-  endEvent_.timePoint = std::chrono::system_clock::now();
+  endEvent_.timePoint = precisionNow();
   return folly::unit;
 }
 

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -17,6 +17,7 @@
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
+#include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace meta::comms::colltrace {
@@ -282,8 +283,7 @@ CommsMaybeVoid CollTrace::triggerEventState(
       triggerPlugins<&ICollTracePlugin::afterCollKernelScheduled>(
           plugins_, collEvent); // Trigger plugins before calling waitEvent
       EXPECT_CHECK(collEvent.waitEvent->afterCollKernelScheduled());
-      collEvent.collRecord->getTimingInfo().setCollEnqueueTs(
-          std::chrono::system_clock::now());
+      collEvent.collRecord->getTimingInfo().setCollEnqueueTs(precisionNow());
       if (pendingTraceColls_.write(std::move(pendingEnqueueColl_))) {
         return folly::unit;
         // If the write fails, pendingEnqueueColl_ will not be moved. Do a
@@ -483,7 +483,7 @@ void CollTrace::pollGraphEvents(
   // timer accumulates. Without this, graph collectives would never trigger
   // the watchdog timeout because collEventProgressing is only called on
   // discrete ring buffer events.
-  auto now = std::chrono::system_clock::now();
+  auto now = precisionNow();
   for (auto collId : progressingGraphCollectives_) {
     auto it = collIdMap_.find(collId);
     if (it != collIdMap_.end()) {
@@ -522,7 +522,7 @@ void CollTrace::pollEagerEvents(
 
     if (!started) {
       if (event->waitEvent->waitCollStart(kPollTimeout).value_or(false)) {
-        auto now = std::chrono::system_clock::now();
+        auto now = precisionNow();
         auto startTimeRes = event->waitEvent->getCollStartTime();
         auto startTs = startTimeRes.hasValue() ? startTimeRes.value() : now;
         timing.setCollStartTs(startTs);
@@ -532,24 +532,20 @@ void CollTrace::pollEagerEvents(
         // Fire progressing even before start so the watchdog plugin can
         // detect pre-start timeouts and async errors.
         actions.insert(
-            {event.get(),
-             PendingActionType::kProgressing,
-             std::chrono::system_clock::now()});
+            {event.get(), PendingActionType::kProgressing, precisionNow()});
       }
     }
 
     if (started && !ended) {
       if (event->waitEvent->waitCollEnd(kPollTimeout).value_or(false)) {
-        auto now = std::chrono::system_clock::now();
+        auto now = precisionNow();
         auto endTimeRes = event->waitEvent->getCollEndTime();
         auto endTs = endTimeRes.hasValue() ? endTimeRes.value() : now;
         timing.setCollEndTs(endTs);
         actions.insert({event.get(), PendingActionType::kEnd, endTs});
       } else {
         actions.insert(
-            {event.get(),
-             PendingActionType::kProgressing,
-             std::chrono::system_clock::now()});
+            {event.get(), PendingActionType::kProgressing, precisionNow()});
       }
     }
   }

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -10,6 +10,7 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CudaEventPool.h"
+#include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h" // @manual=fbcode//comms/utils/cvars:ncclx-cvars
 
 namespace meta::comms::colltrace {
@@ -150,7 +151,7 @@ CudaWaitPoint::getEventFinishTime() noexcept {
 }
 
 CudaWaitEvent::CudaWaitEvent(cudaStream_t stream)
-    : enqueueTime_(std::chrono::system_clock::now()),
+    : enqueueTime_(precisionNow()),
       startWaitPoint_(stream, CudaWaitPoint::WaitPointType::start),
       endWaitPoint_(stream, CudaWaitPoint::WaitPointType::end) {}
 

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -12,13 +12,12 @@
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/colltrace/PrecisionClock.h"
 
 namespace meta::comms::colltrace {
 
 GraphCudaWaitEvent::GraphCudaWaitEvent(cudaStream_t stream, uint32_t collId)
-    : stream_(stream),
-      collId_(collId),
-      enqueueTime_(std::chrono::system_clock::now()) {
+    : stream_(stream), collId_(collId), enqueueTime_(precisionNow()) {
   // Create per-collective CUDA resources using relaxed capture mode so
   // they don't interfere with the graph capture in progress.
   StreamCaptureModeGuard guard{cudaStreamCaptureModeRelaxed};


### PR DESCRIPTION
Summary:
The previous commits in this stack made the GPU %globaltimer ↔ wall-clock anchor PTP-aligned (D102069355) and bounded its drift via periodic re-anchoring (D102072779). That covered graph-mode collective timestamps. This commit completes the "everything timestamps via fbclock" picture by routing the remaining CPU-side wall-time readings in colltrace through precisionNow().

Sites swapped (system_clock::now() → precisionNow()):

- CPUWaitEvent: enqueue / signalCollStart / signalCollEnd timestamps (3 sites).
- CudaWaitEvent: per-collective enqueue timestamp (1 site). The CudaReferencePoint anchor on line 49 is intentionally NOT swapped — it has the same one-shot-anchor-then-drift problem the previous commit fixed for graph mode, and the equivalent eager-mode periodic re-anchor is the next commit.
- GraphCudaWaitEvent: per-collective enqueue timestamp (1 site).
- CollTrace: setCollEnqueueTs in triggerEventState; the "now" used for kProgressing emission in pollGraphEvents; start/end fallback timestamps and kProgressing stamps in pollEagerEvents (6 sites).

After this commit, every wall-time reading in colltrace either inherits PTP alignment from precisionNow(), or sits on top of a calibration anchor that itself uses precisionNow(). The only remaining system_clock::now() in production code is:

- CudaWaitEvent.cc:49 (CudaReferencePoint) — see next commit.
- NetworkPerfMonitor.cc {34,94,97} — those are interval-timer reads, not wall-time stamps. They should be steady_clock (PTP can step backwards, breaking interval semantics); switching them is an unrelated fix and out of scope here.
- PrecisionClock.cc itself — the documented system_clock fallback path.

BUCK changes: add //comms/utils/colltrace:precision_clock as a dep on cpu_wait_event, cuda_wait_event, graph_cuda_wait_event, and the colltrace library.

Reviewed By: YulunW, leoleovich

Differential Revision: D102074424


