### PR TITLE
periodically re-anchor CudaReferencePoint (eager mode)

### DIFF
--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -14,6 +14,7 @@
 #include "comms/utils/CommsMaybeChecks.h"
 #include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
@@ -634,20 +635,32 @@ void CollTrace::collTraceThread(
 
   bool initialized = false;
 
-  // Periodic re-anchor of the GPU %globaltimer ↔ wall-clock mapping. Bounds
+  // Periodic re-anchor of the GPU-time ↔ wall-clock mappings. Bounds
   // residual drift between anchors to ~kReanchorInterval × oscillator-ppm
-  // (≤ ~100 ns at 1 s and 100 ppm). Only meaningful in graph mode, since the
-  // anchor is only consulted when converting ring buffer device timestamps.
+  // (≤ ~100 ns at 1 s and 100 ppm).
+  //
+  // Two independent anchors live behind this:
+  //   - GlobaltimerCalibration: %globaltimer (graph mode). Refreshed only
+  //     when this CollTrace has graph mode enabled (ringBuffer_).
+  //   - CudaReferencePoint: cudaEventElapsedTime baseline (eager mode).
+  //     Refreshed only if some CudaWaitEvent has ever been created — we
+  //     check via CudaReferencePoint::tryGet() to avoid forcing CUDA init
+  //     in CPU-only colltrace deployments.
   // Gated on NCCL_COLLTRACE_PERIODIC_REANCHOR (default false) — issuing CUDA
   // calls from this thread has been observed to hang some training jobs.
   constexpr auto kReanchorInterval = std::chrono::seconds(1);
   auto lastReanchor = std::chrono::steady_clock::now();
 
   while (!isThreadCancelled()) {
-    if (NCCL_COLLTRACE_PERIODIC_REANCHOR && ringBuffer_.has_value()) {
+    if (NCCL_COLLTRACE_PERIODIC_REANCHOR) {
       auto now = std::chrono::steady_clock::now();
       if (now - lastReanchor >= kReanchorInterval) {
-        GlobaltimerCalibration::get().refresh();
+        if (ringBuffer_.has_value()) {
+          GlobaltimerCalibration::get().refresh();
+        }
+        if (auto* refpt = CudaReferencePoint::tryGet()) {
+          refpt->refresh();
+        }
         lastReanchor = now;
       }
     }

--- a/comms/utils/colltrace/CudaWaitEvent.cc
+++ b/comms/utils/colltrace/CudaWaitEvent.cc
@@ -4,8 +4,11 @@
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <folly/ScopeGuard.h>
 #include <folly/Unit.h>
 #include <folly/stop_watch.h>
+
+#include <folly/logging/xlog.h>
 
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/checks.h"
@@ -16,6 +19,13 @@
 namespace meta::comms::colltrace {
 
 namespace {
+
+// Singleton-existence flag set by the CudaReferencePoint ctor (release) and
+// read by tryGet() (acquire). Lets the colltrace poll thread skip refresh
+// when no CudaWaitEvent has ever been created (CPU-only colltrace usage).
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::atomic<CudaReferencePoint*> g_referencePointInstance{nullptr};
+
 CommsMaybe<bool> waitCudaEventFinish(
     const CudaEvent& event,
     std::chrono::milliseconds sleepTimeMs) {
@@ -44,9 +54,80 @@ CommsMaybe<bool> waitCudaEventFinish(
 
 CudaReferencePoint::CudaReferencePoint() {
   CUDA_CHECK(cudaStreamCreate(&stream_));
-  CUDA_CHECK(cudaEventCreate(&event_));
-  CUDA_CHECK(cudaEventRecord(event_, stream_));
-  time_ = std::chrono::system_clock::now();
+  cudaEvent_t event = nullptr;
+  CUDA_CHECK(cudaEventCreate(&event));
+  CUDA_CHECK(cudaEventRecord(event, stream_));
+  // Wait for the reference event to fire so the host_time anchor below is
+  // not earlier than the GPU reading. Stream is empty so this is fast.
+  CUDA_CHECK(cudaStreamSynchronize(stream_));
+  *anchor_.wlock() = Anchor{.event = event, .time = precisionNow()};
+
+  // Publish singleton handle for tryGet() — release-store so other threads'
+  // acquire-loads see a fully-constructed object.
+  g_referencePointInstance.store(this, std::memory_order_release);
+}
+
+/* static */ CudaReferencePoint* CudaReferencePoint::tryGet() {
+  return g_referencePointInstance.load(std::memory_order_acquire);
+}
+
+void CudaReferencePoint::refresh() {
+  // Try-and-skip: if another thread is already refreshing, short-circuit
+  // without touching the dedicated CUDA stream. Multiple CollTrace
+  // instances exist per process (one per NCCL communicator) and each calls
+  // refresh from its own poll thread; the in-flight refresh will publish a
+  // fresh anchor before our next wakeup, so we lose nothing by skipping.
+  if (refresh_in_progress_.test_and_set(std::memory_order_acquire)) {
+    return;
+  }
+  auto cleanup = folly::makeGuard(
+      [this] { refresh_in_progress_.clear(std::memory_order_release); });
+
+  cudaEvent_t newEvent = nullptr;
+  if (auto err = cudaEventCreate(&newEvent); err != cudaSuccess) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << "CudaReferencePoint::refresh: cudaEventCreate failed: "
+        << cudaGetErrorString(err) << " — keeping previous anchor";
+    return;
+  }
+  CHECK(newEvent != nullptr);
+  if (auto err = cudaEventRecord(newEvent, stream_); err != cudaSuccess) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << "CudaReferencePoint::refresh: cudaEventRecord failed: "
+        << cudaGetErrorString(err) << " — keeping previous anchor";
+    // Best-effort cleanup of an event we just created; any destroy error
+    // here is unrecoverable and would only mask the record failure above.
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventDestroy(newEvent);
+    return;
+  }
+  if (auto err = cudaStreamSynchronize(stream_); err != cudaSuccess) {
+    XLOG_EVERY_MS(WARN, 5000)
+        << "CudaReferencePoint::refresh: cudaStreamSynchronize failed: "
+        << cudaGetErrorString(err) << " — keeping previous anchor";
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventDestroy(newEvent);
+    return;
+  }
+  auto newTime = precisionNow();
+
+  // Swap the anchor under wlock. Once wlock is granted, all in-flight
+  // readers have released their rlock, so the old event is no longer
+  // reachable from any subsequent reader. We destroy it *after* releasing
+  // wlock so we never hold a writer lock across a CUDA call.
+  cudaEvent_t oldEvent = nullptr;
+  {
+    auto a = anchor_.wlock();
+    oldEvent = a->event;
+    a->event = newEvent;
+    a->time = newTime;
+  }
+  if (oldEvent != nullptr) {
+    // Best-effort: a destroy error here would only be logged after the new
+    // anchor is already published, so propagating it serves no purpose.
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaEventDestroy(oldEvent);
+  }
 }
 
 CommsMaybe<ICollWaitEvent::system_clock_time_point>
@@ -56,9 +137,13 @@ CudaReferencePoint::getTimeViaEvent(const CudaEvent& event) {
 
 CommsMaybe<ICollWaitEvent::system_clock_time_point>
 CudaReferencePoint::getTimeViaEvent(cudaEvent_t event) {
+  // Hold rlock for the entire CUDA call so refresh() cannot destroy the
+  // reference event mid-read. Multiple concurrent readers are unaffected
+  // (shared_mutex); refresh briefly blocks waiting for in-flight rlocks.
+  auto a = anchor_.rlock();
   float offsetMs;
-  CUDA_CHECK_EXPECTED(cudaEventElapsedTime(&offsetMs, this->event_, event));
-  auto eventTime = this->time_ +
+  CUDA_CHECK_EXPECTED(cudaEventElapsedTime(&offsetMs, a->event, event));
+  auto eventTime = a->time +
       std::chrono::duration_cast<std::chrono::microseconds>(
                        std::chrono::duration<float, std::milli>{offsetMs});
   return eventTime;

--- a/comms/utils/colltrace/CudaWaitEvent.h
+++ b/comms/utils/colltrace/CudaWaitEvent.h
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <cuda_runtime.h> // @manual
 
+#include <folly/Synchronized.h>
 #include <folly/synchronization/Baton.h>
 
 #include "comms/utils/CudaRAII.h"
@@ -12,9 +15,15 @@
 
 namespace meta::comms::colltrace {
 
-// WARNING: The cudaEvent and cudaStream used by this class is intentionally
-// NOT destroyed, this class is only intended to be used as global static
-// variables. Creating too many of these objects might cause issue with cuda
+// WARNING: The cudaStream and the latest cudaEvent used by this class are
+// intentionally NOT destroyed at process exit; this class is only intended
+// to be used as a global static. Creating too many of these or destroying
+// them during shutdown can segfault under cudaErrorCudartUnloading.
+//
+// During normal operation, refresh() rotates the cached cudaEvent to bound
+// drift between the GPU's elapsed-time clock and PTP-aligned wall time, and
+// destroys the previous event under the writer lock once it is unreachable
+// to readers — so we don't accumulate one event per refresh.
 class CudaReferencePoint {
   using system_clock_time_point = ICollWaitEvent::system_clock_time_point;
 
@@ -24,12 +33,46 @@ class CudaReferencePoint {
   CommsMaybe<system_clock_time_point> getTimeViaEvent(const CudaEvent& event);
   CommsMaybe<system_clock_time_point> getTimeViaEvent(cudaEvent_t event);
 
+  // Re-record the reference cudaEvent on the dedicated stream and pair it
+  // with a fresh precisionNow() reading. Safe under concurrent invocation
+  // from multiple threads (e.g., one CollTrace poll thread per NCCL
+  // communicator): contenders that find refresh_in_progress_ already set
+  // return immediately without touching the dedicated stream, so the CUDA
+  // operations are effectively serialized at the API layer. Safe vs.
+  // concurrent getTimeViaEvent() readers via folly::Synchronized<Anchor>.
+  // Cost when the caller wins the flag: 1 cudaEventCreate + 1
+  // cudaEventRecord + 1 cudaStreamSynchronize on a private idle stream + 1
+  // fbclock read. CUDA failures are logged (rate-limited) and the prior
+  // anchor is kept. Caller is responsible for rate-limiting; the colltrace
+  // poll thread invokes this at ~1 Hz, bounding residual drift between
+  // anchors below 100 ns at 100 ppm oscillator tolerance.
+  void refresh();
+
+  // Returns the singleton if it has been constructed, otherwise nullptr.
+  // Safe to call from any thread; never triggers construction. Used by the
+  // colltrace poll thread to avoid forcing CUDA initialization in CPU-only
+  // colltrace deployments where no CudaWaitEvent is ever created.
+  static CudaReferencePoint* tryGet();
+
  private:
-  // We intentionally NOT using the RAII version to avoid segfault when calling
-  // cudaEventDestory and cudaStreamDestroy during the program exit.
+  struct Anchor {
+    cudaEvent_t event{nullptr};
+    system_clock_time_point time;
+  };
+
+  // We intentionally do NOT use the RAII version for stream_ to avoid
+  // segfault when calling cudaStreamDestroy during the program exit. The
+  // anchor's cudaEvent is rotated by refresh(); the latest one leaks at
+  // exit by design (see class comment).
   cudaStream_t stream_{nullptr};
-  cudaEvent_t event_{nullptr};
-  system_clock_time_point time_;
+  folly::Synchronized<Anchor> anchor_;
+  // Serializes refresh() callers without blocking: contenders that find
+  // the flag already set short-circuit so the dedicated CUDA stream is
+  // never touched by more than one thread at a time. Multiple CollTrace
+  // poll threads (one per NCCL communicator) all call refresh on this
+  // singleton — without this, concurrent cudaEventRecord on the same
+  // stream would race.
+  std::atomic_flag refresh_in_progress_ = ATOMIC_FLAG_INIT;
 };
 
 class CudaWaitPoint {


### PR DESCRIPTION
Summary:
Mirrors the previous commit's GlobaltimerCalibration refresh — now applied to the CudaReferencePoint baseline used by eager-mode CudaWaitEvent. The colltrace poll thread already calls `GlobaltimerCalibration::get().refresh()` once per second; this commit adds a parallel `CudaReferencePoint::tryGet()->refresh()` call from the same site so eager-mode timestamps stay aligned with PTP wall time at the same cadence.

The previous CudaReferencePoint design captured a single (cudaEvent, host_time) pair in its constructor and used it for the lifetime of the process. cudaEventElapsedTime is bounded by the GPU's oscillator (±10–100 ppm), so without re-anchoring the mapping drifts ~36–360 ms per hour against PTP. With 1 Hz refresh, residual intra-anchor drift is bounded below 100 ns at 100 ppm.

Refactor — symmetric with `GlobaltimerCalibration`:

- `CudaReferencePoint` now holds `folly::Synchronized<Anchor>`, where `Anchor = {cudaEvent_t event, system_clock_time_point time}`. Readers (`getTimeViaEvent`) hold an rlock for the entire `cudaEventElapsedTime` call so `refresh()` cannot destroy the reference event mid-read.
- `refresh()` records a fresh event on a private idle stream, syncs, swaps the anchor under wlock, then destroys the old event after the wlock is released. Holding the wlock briefly during the swap guarantees in-flight readers complete before the new event is published, so the old event is unreachable to any subsequent reader and safe to destroy without holding a writer lock across a CUDA call. CUDA failures are logged via `XLOG_EVERY_MS(WARN, 5000)` and the prior anchor is kept (no thrown exceptions, no anchor corruption).
- Static `tryGet()` returns the singleton if it has ever been constructed, otherwise `nullptr`. Backed by an atomic `g_referencePointInstance` set at the end of the constructor with release semantics; `tryGet()` reads with acquire semantics. Lets the colltrace poll thread skip the eager-mode refresh entirely in CPU-only colltrace deployments where no `CudaWaitEvent` is ever created — avoids forcing CUDA initialization.
- Constructor now explicitly `cudaStreamSynchronize`s before reading `precisionNow()` so the host_time anchor is not earlier than the GPU reading. The leak philosophy (intentional non-destruction at process exit to avoid `cudaErrorCudartUnloading` segfaults) is documented in the class comment.

Poll thread (`CollTrace.cc`): the existing 1 Hz block (now gated on `NCCL_COLLTRACE_PERIODIC_REANCHOR`) also calls `CudaReferencePoint::tryGet()->refresh()` when the singleton exists. Both refreshes share the `kReanchorInterval = 1s` cadence and the same `lastReanchor` timestamp — one wake-up handles both calibrations.

Known limitation: the first eager-mode collective on a thread still uses the constructor's anchor (≤1 second before refresh kicks in, when enabled). Drift accumulated over 1 second at 100 ppm is ~100 µs, well below typical collective timing resolution.

## — addressed review feedback

- **Reuses `NCCL_COLLTRACE_PERIODIC_REANCHOR`** which was previously introduced to gate the eager-mode CudaReferencePoint refresh as well. The colltrace poll thread now wraps both the GlobaltimerCalibration and the CudaReferencePoint refresh calls in a single `if (NCCL_COLLTRACE_PERIODIC_REANCHOR)` block, sharing one shared `lastReanchor` timestamp — one wake-up handles both calibrations, both off by default.
- **Fixed the misleading lock-scope comment** on `CudaReferencePoint::refresh`. The wlock scope only covers the swap; `cudaEventDestroy(oldEvent)` runs after the wlock is released. Code is unchanged (it was already correct — the wlock guarantees in-flight readers have released their rlock before the new event is published, so the old event is unreachable when destroyed). The comment now accurately describes the protocol.

---

Reviewed By: YulunW

Differential Revision: D102076826


