### PR TITLE
negotiate RDMA QP count (#2452)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -19,8 +19,19 @@ namespace uniflow {
 
 namespace {
 
-struct RdmaTopologyInfo {
+struct __attribute__((packed)) RdmaTopologyInfo {
   uint8_t version{kRdmaVersion};
+  uint32_t numQps{1};
+
+  static Result<RdmaTopologyInfo> deserialize(std::span<const uint8_t> data) {
+    if (data.size() != sizeof(RdmaTopologyInfo)) {
+      return Err(ErrCode::InvalidArgument, "TransportInfo payload mismatch");
+    }
+
+    RdmaTopologyInfo info;
+    std::memcpy(&info, data.data(), sizeof(RdmaTopologyInfo));
+    return info;
+  }
 };
 
 const char* getNicName(const NicResources& nic) {
@@ -125,7 +136,8 @@ RdmaTransport::RdmaTransport(
       config_(config),
       domainId_(domainId) {
   CHECK_THROW_EXCEPTION(!nics_.empty(), std::invalid_argument);
-  CHECK_THROW_EXCEPTION(config_.numQps <= 255, std::invalid_argument);
+  CHECK_THROW_EXCEPTION(
+      config_.numQps > 0 && config_.numQps <= 255, std::invalid_argument);
   numPendingCqe_.resize(nics_.size());
 
   name_ = "rdma";
@@ -145,8 +157,9 @@ TransportInfo RdmaTransport::bind() {
   }
 
   info_.reset();
-  const uint32_t numNics = static_cast<uint32_t>(nics_.size());
   const uint32_t numQps = config_.numQps;
+  const uint32_t numNics =
+      std::min(numQps, static_cast<uint32_t>(nics_.size()));
 
   cqs_.reserve(numNics);
   uint32_t qpsPerNic = (numQps + numNics - 1) / numNics;
@@ -171,7 +184,7 @@ TransportInfo RdmaTransport::bind() {
   numWrsPerQp_.resize(numQps, 0);
 
   info_.header.version = 1;
-  info_.header.numQps = static_cast<uint8_t>(numQps);
+  info_.header.numQps = numQps;
   info_.header.numNics = static_cast<uint8_t>(numNics);
   info_.header.domainId = domainId_;
   info_.qpInfos.reserve(numQps);
@@ -1292,27 +1305,30 @@ RdmaTransportFactory::importSegment(
 Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
     std::span<const uint8_t> peerTopology) {
   CHECK_EXPR(canConnect(peerTopology));
+  auto peerTopo = RdmaTopologyInfo::deserialize(peerTopology).value();
+  auto config = config_;
+  config.numQps = std::min(peerTopo.numQps, config.numQps);
   return std::make_unique<RdmaTransport>(
-      ibvApi_, evb_, nics_, domainId_, config_);
+      ibvApi_, evb_, nics_, domainId_, config);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for
 // customized cluster info
 std::vector<uint8_t> RdmaTransportFactory::getTopology() {
   std::vector<uint8_t> data(sizeof(RdmaTopologyInfo));
-  RdmaTopologyInfo info;
+  RdmaTopologyInfo info{kRdmaVersion, config_.numQps};
   std::memcpy(data.data(), &info, sizeof(info));
   return data;
 }
 
 Status RdmaTransportFactory::canConnect(std::span<const uint8_t> peerTopology) {
-  if (peerTopology.size() != sizeof(RdmaTopologyInfo)) {
-    return Err(ErrCode::InvalidArgument, "Invalid topology data");
-  }
-  RdmaTopologyInfo info;
-  std::memcpy(&info, peerTopology.data(), sizeof(info));
-  if (info.version != kRdmaVersion) {
+  auto info = RdmaTopologyInfo::deserialize(peerTopology);
+  CHECK_RETURN(info);
+  if (info->version != kRdmaVersion) {
     return Err(ErrCode::TopologyDisconnect, "Invalid topology version");
+  }
+  if (info->numQps == 0) {
+    return Err(ErrCode::TopologyDisconnect, "Invalid topology numQps");
   }
   return Ok();
 }

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -66,7 +66,7 @@ struct NicResources {
  * RDMA transport connection metadata — serialization and deserialization.
  *
  * Wire format (packed, memcpy-based):
- *   Header (11 bytes: version, numQps, numNics, domainId)
+ *   Header (version, numQps, numNics, domainId)
  *   + NicInfo[numNics]
  *   + QpInfo[numQps]
  *
@@ -76,8 +76,8 @@ struct RdmaTransportInfo {
   /* Header in the wire format. */
   struct __attribute__((packed)) Header {
     uint8_t version{kRdmaVersion};
-    uint8_t numQps{0};
     uint8_t numNics{0};
+    uint32_t numQps{0};
     uint64_t domainId{0};
   };
   /* Per-NIC addressing info in the wire format. */
@@ -146,7 +146,7 @@ class RdmaTransport : public Transport {
    * @param nics    Per-NIC resources from the factory. Must be non-empty.
    *                Borrowed — must outlive this transport.
    * @param config  Transport configuration (numQps, QP attributes, etc.).
-   *                numQps must be <= 255.
+   *                numQps must be in [1, 255].
    */
   RdmaTransport(
       std::shared_ptr<IbvApi> ibvApi,

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -181,6 +181,45 @@ class RdmaTransportTest : public ::testing::Test {
   ibv_qp fakeQp3_{};
 };
 
+TEST_F(RdmaTransportTest, ConstructorRejectsZeroQps) {
+  ibv_gid gid{};
+  std::vector<NicResources> nics = {
+      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0, .gid = gid}};
+  RdmaTransportConfig config{.numQps = 0};
+  EXPECT_THROW(
+      RdmaTransport(mockApi_, evbThread_.getEventBase(), nics, 0, config),
+      std::invalid_argument);
+}
+
+TEST_F(RdmaTransportTest, BindClampsNicsToQpCount) {
+  fakeQp0_.qp_num = 10;
+
+  EXPECT_CALL(*mockApi_, createCq(&fakeCtx0_, _, _, _, _))
+      .WillOnce(Return(Result<ibv_cq*>(&fakeCq0_)));
+  EXPECT_CALL(*mockApi_, createCq(&fakeCtx1_, _, _, _, _)).Times(0);
+  EXPECT_CALL(*mockApi_, createQp(&fakePd0_, _))
+      .WillOnce(Return(Result<ibv_qp*>(&fakeQp0_)));
+  EXPECT_CALL(*mockApi_, modifyQp(_, _, _)).WillRepeatedly(Return(Ok()));
+
+  ibv_gid gid0{}, gid1{};
+  std::vector<NicResources> nics = {
+      {.ctx = &fakeCtx0_, .pd = &fakePd0_, .lid = 0x1111, .gid = gid0},
+      {.ctx = &fakeCtx1_, .pd = &fakePd1_, .lid = 0x2222, .gid = gid1},
+  };
+  RdmaTransportConfig config{.numQps = 1};
+  RdmaTransport transport(mockApi_, evbThread_.getEventBase(), nics, 0, config);
+
+  auto data = transport.bind();
+  ASSERT_FALSE(data.empty());
+
+  auto result = RdmaTransportInfo::deserialize(data);
+  ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(result.value().header.numNics, 1);
+  EXPECT_EQ(result.value().header.numQps, 1);
+  ASSERT_EQ(result.value().nicInfos.size(), 1);
+  EXPECT_EQ(result.value().nicInfos[0].lid, 0x1111);
+}
+
 TEST_F(RdmaTransportTest, SingleNicBindCreatesQPs) {
   fakeQp0_.qp_num = 42;
   fakeQp1_.qp_num = 43;
@@ -450,6 +489,7 @@ TEST_F(RdmaTransportFactoryTest, GetTopologyReturnsNonEmpty) {
   auto topo = factory.getTopology();
   EXPECT_FALSE(topo.empty());
   EXPECT_EQ(topo[0], 1u); // version == kRdmaVersion == 1
+  EXPECT_GT(topo.size(), 1u); // topology now includes numQps
 }
 
 TEST_F(RdmaTransportFactoryTest, CreateTransportAcceptsValidTopology) {
@@ -474,20 +514,93 @@ TEST_F(RdmaTransportFactoryTest, CreateTransportRejectsWrongVersion) {
   setupSingleDevice();
   RdmaTransportFactory factory(
       {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
-  std::vector<uint8_t> badTopo = {99};
-  auto result = factory.createTransport(badTopo);
+  auto topo = factory.getTopology();
+  topo[0] = 99; // corrupt version byte
+  auto result = factory.createTransport(topo);
   EXPECT_TRUE(result.hasError());
   EXPECT_EQ(result.error().code(), ErrCode::TopologyDisconnect);
 }
 
-TEST_F(RdmaTransportFactoryTest, CreateTransportRejectsOversizedTopology) {
+TEST_F(RdmaTransportFactoryTest, CreateTransportRejectsSizeMismatch) {
   setupSingleDevice();
   RdmaTransportFactory factory(
       {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
-  std::vector<uint8_t> bigTopo = {1, 0, 0, 0};
-  auto result = factory.createTransport(bigTopo);
+  std::vector<uint8_t> badTopo = {1};
+  auto result = factory.createTransport(badTopo);
   EXPECT_TRUE(result.hasError());
   EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(RdmaTransportFactoryTest, TopologyRoundTripsWithDifferentQps) {
+  setupSingleDevice();
+  RdmaTransportConfig config{.numQps = 4};
+  RdmaTransportFactory factory(
+      {"mlx5_0"}, evbThread_.getEventBase(), config, mockApi_);
+
+  auto topo = factory.getTopology();
+  EXPECT_FALSE(topo.empty());
+
+  auto result = factory.createTransport(topo);
+  EXPECT_TRUE(result.hasValue());
+}
+
+TEST_F(RdmaTransportFactoryTest, CreateTransportRejectsZeroQpsTopology) {
+  setupSingleDevice();
+  RdmaTransportFactory factory(
+      {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
+  auto topo = factory.getTopology();
+  // Zero out everything after the version byte to set numQps = 0.
+  std::fill(topo.begin() + 1, topo.end(), 0);
+  auto result = factory.createTransport(topo);
+  EXPECT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().code(), ErrCode::TopologyDisconnect);
+}
+
+TEST_F(RdmaTransportFactoryTest, GetTopologyReflectsConfiguredQps) {
+  // Use WillRepeatedly so two factories can be constructed from the same mocks.
+  EXPECT_CALL(*mockApi_, getDeviceList(_))
+      .WillRepeatedly([this](int* numDevices) {
+        *numDevices = 1;
+        return Result<ibv_device**>(fakeDeviceList_);
+      });
+  EXPECT_CALL(*mockApi_, openDevice(&fakeDevice0_))
+      .WillRepeatedly(Return(Result<ibv_context*>(&fakeCtx0_)));
+  EXPECT_CALL(*mockApi_, getDeviceName(&fakeDevice0_))
+      .WillRepeatedly(Return(Result<const char*>("mlx5_0")));
+  EXPECT_CALL(*mockApi_, queryDevice(&fakeCtx0_, _))
+      .WillRepeatedly([](ibv_context*, ibv_device_attr* attr) {
+        attr->phys_port_cnt = 1;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, allocPd(&fakeCtx0_))
+      .WillRepeatedly(Return(Result<ibv_pd*>(&fakePd0_)));
+  EXPECT_CALL(*mockApi_, isDmaBufSupported(&fakePd0_))
+      .WillRepeatedly(Return(Result<bool>(true)));
+  EXPECT_CALL(*mockApi_, queryPort(&fakeCtx0_, 1, _))
+      .WillRepeatedly([](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->lid = 0x1234;
+        attr->active_mtu = IBV_MTU_4096;
+        attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+        attr->state = IBV_PORT_ACTIVE;
+        return Ok();
+      });
+  EXPECT_CALL(*mockApi_, queryGid(&fakeCtx0_, 1, 3, _))
+      .WillRepeatedly(Return(Ok()));
+  EXPECT_CALL(*mockApi_, freeDeviceList(_)).WillRepeatedly(Return(Ok()));
+  EXPECT_CALL(*mockApi_, deallocPd(&fakePd0_)).WillRepeatedly(Return(Ok()));
+  EXPECT_CALL(*mockApi_, closeDevice(&fakeCtx0_)).WillRepeatedly(Return(Ok()));
+
+  RdmaTransportFactory factory1(
+      {"mlx5_0"}, evbThread_.getEventBase(), {.numQps = 1}, mockApi_);
+  auto topo1 = factory1.getTopology();
+
+  RdmaTransportFactory factory4(
+      {"mlx5_0"}, evbThread_.getEventBase(), {.numQps = 4}, mockApi_);
+  auto topo4 = factory4.getTopology();
+
+  ASSERT_EQ(topo1.size(), topo4.size());
+  EXPECT_NE(topo1, topo4);
+  EXPECT_EQ(topo1[0], topo4[0]);
 }
 
 // --- supported() tests ---


### PR DESCRIPTION
Summary:

After MultiTransport intersects CPU and GPU transport factories, RDMA endpoints can still disagree on QP count because the factory config derives numQps from the local NIC selection.

CPU can select eight NICs while a GPU-local factory selects one, and the old topology only advertised the RDMA version, so bind/connect failed later with a QP count mismatch. Add one topology byte for the local QP count, validate that the peer advertises a nonzero count, and create the transport with the common/min QP count so both endpoints bind paired RC QPs without expanding the narrower endpoint. Also reject zero local numQps at construction/topology serialization.

Differential Revision: D104324880


