### PR TITLE
allow asymmetric MultiTransport factories

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -394,31 +394,34 @@ Result<std::unique_ptr<MultiTransport>> MultiTransportFactory::createTransport(
   CHECK_RETURN(parsed);
   auto& entries = parsed.value();
   if (entries.size() != factories_.size()) {
-    return Err(
-        ErrCode::InvalidArgument,
-        "transport count mismatch: local=" + std::to_string(factories_.size()) +
-            ", peer=" + std::to_string(entries.size()));
+    UNIFLOW_LOG_WARN(
+        "transport count mismatch: local={}, peer={}",
+        factories_.size(),
+        entries.size());
   }
 
   auto mt = std::make_unique<MultiTransport>(deviceId_, eventBaseThread_);
-  for (size_t i = 0; i < factories_.size(); ++i) {
-    if (entries[i].type != factories_[i]->transportType()) {
-      return Err(
-          ErrCode::TopologyDisconnect,
-          "transport type mismatch at " + std::to_string(i) +
-              ": local=" + std::to_string(factories_[i]->transportType()) +
-              ", peer=" + std::to_string(entries[i].type));
+  for (size_t i = 0, j = 0; i < entries.size() && j < factories_.size();) {
+    if (entries[i].type < factories_[j]->transportType()) {
+      ++i;
+      continue;
+    }
+    if (entries[i].type > factories_[j]->transportType()) {
+      ++j;
+      continue;
     }
 
-    auto transport = factories_[i]->createTransport(entries[i].data);
+    auto transport = factories_[j]->createTransport(entries[i].data);
     if (transport) {
       mt->addTransport(std::move(transport).value());
     } else {
       UNIFLOW_LOG_WARN(
           "Transport {} cannot be created: {}",
-          factories_[i]->transportType(),
+          factories_[j]->transportType(),
           transport.error().message());
     }
+    ++i;
+    ++j;
   }
   if (mt->transports_.empty()) {
     return Err(ErrCode::TopologyDisconnect, "no transport can be connected");

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -614,20 +614,25 @@ TEST_F(MultiTransportFactoryTest, CreateTransportRejectsEmptyTopology) {
   EXPECT_EQ(result.error().code(), ErrCode::TopologyDisconnect);
 }
 
-TEST_F(MultiTransportFactoryTest, CreateTransportRejectsFactoryCountMismatch) {
+TEST_F(MultiTransportFactoryTest, CreateTransportAllowsFactoryCountMismatch) {
   auto rdma = makeFactory(TransportType::RDMA, {0x01}, {0xAA});
   MultiTransportFactory singleMtf = makeMultiTransportFactory({rdma});
   auto topo = singleMtf.getTopology();
 
-  // Peer has two factories — count mismatch.
+  // Peer has two factories, but only RDMA overlaps with the sender.
   auto rdmaPeer = makeFactory(TransportType::RDMA, {0x01}, {0xAA});
   auto nvlinkPeer = makeFactory(TransportType::NVLink, {0x01}, {0xBB});
   MultiTransportFactory peerMtf =
       makeMultiTransportFactory({rdmaPeer, nvlinkPeer});
 
   auto result = peerMtf.createTransport(topo);
-  ASSERT_TRUE(result.hasError());
-  EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
+  ASSERT_TRUE(result.hasValue()) << result.error().message();
+  ASSERT_NE(result.value(), nullptr);
+
+  auto bindResult = result.value()->bind();
+  ASSERT_TRUE(bindResult.hasValue()) << bindResult.error().message();
+  ASSERT_FALSE(bindResult.value().empty());
+  EXPECT_EQ(1, bindResult.value().front());
 }
 
 TEST_F(MultiTransportFactoryTest, CreateTransportRejectsTransportTypeMismatch) {


### PR DESCRIPTION
Summary: CPU endpoints can expose only RDMA while GPU endpoints expose NVLink plus RDMA, so the factory should intersect transport types instead of requiring identical local and peer transport counts.

Reviewed By: tanquer

Differential Revision: D104325544


