### PR TITLE
Add CUDA graph support to LlP2pOp

### DIFF
--- a/comms/pipes/ll/triton/__init__.py
+++ b/comms/pipes/ll/triton/__init__.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Pipes Triton LL Protocol Module.
+
+Provides low-latency NVLink P2P communication using the LL (Low-Latency)
+protocol with dual-flag atomicity detection. Each LL line carries 8 bytes
+of payload in a 16-byte line format.
+
+High-level API (recommended):
+    LlP2pOp: Host-side wrapper managing buffers, window, and kernel launch.
+
+Low-level API (for custom kernels):
+    ll_send_kernel, ll_recv_kernel, ll_forward_kernel: Triton JIT kernels.
+
+Utilities:
+    ll_num_lines, ll_buffer_size, ll_total_buffer_size, can_use_ll,
+    ll_peer_index, ll_peer_buffer_offset, ll_auto_tune, ll_auto_tune_bidirectional
+"""
+
+from comms.pipes.ll.triton.auto_tune import ll_auto_tune, ll_auto_tune_bidirectional
+from comms.pipes.ll.triton.ll_ops import (
+    can_use_ll,
+    ll_buffer_size,
+    ll_forward_kernel,
+    LL_LINE_SIZE,
+    ll_num_lines,
+    LL_PAYLOAD_PER_LINE,
+    ll_peer_buffer_offset,
+    ll_peer_index,
+    LL_READY_TO_WRITE,
+    ll_recv_kernel,
+    ll_send_kernel,
+    ll_total_buffer_size,
+)
+from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
+
+
+__all__ = [
+    # High-level API
+    "LlP2pOp",
+    # Low-level kernels
+    "ll_send_kernel",
+    "ll_recv_kernel",
+    "ll_forward_kernel",
+    # Constants
+    "LL_LINE_SIZE",
+    "LL_PAYLOAD_PER_LINE",
+    "LL_READY_TO_WRITE",
+    # Utilities
+    "ll_num_lines",
+    "ll_buffer_size",
+    "ll_total_buffer_size",
+    "can_use_ll",
+    "ll_peer_index",
+    "ll_peer_buffer_offset",
+    # Auto-tuning
+    "ll_auto_tune",
+    "ll_auto_tune_bidirectional",
+]

--- a/comms/pipes/ll/triton/__init__.py
+++ b/comms/pipes/ll/triton/__init__.py
@@ -32,6 +32,7 @@ from comms.pipes.ll.triton.ll_ops import (
     LL_READY_TO_WRITE,
     ll_recv_kernel,
     ll_send_kernel,
+    ll_sendrecv_kernel,
     ll_total_buffer_size,
 )
 from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
@@ -43,6 +44,7 @@ __all__ = [
     # Low-level kernels
     "ll_send_kernel",
     "ll_recv_kernel",
+    "ll_sendrecv_kernel",
     "ll_forward_kernel",
     # Constants
     "LL_LINE_SIZE",

--- a/comms/pipes/ll/triton/auto_tune.py
+++ b/comms/pipes/ll/triton/auto_tune.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Pure-Python auto-tuning for Triton LL kernels.
+
+No torch or triton dependencies — importable by unit tests without GPU.
+"""
+
+from __future__ import annotations
+
+
+def ll_auto_tune(nbytes: int) -> dict[str, int]:
+    """Return {num_blocks, block_size} for unidirectional P2P LL.
+
+    Uses BLOCK_SIZE=32 (1 warp) for small messages to avoid cross-warp
+    tl.min() coupling in the polling loop. Scales to BLOCK_SIZE=512
+    (16 warps) for larger messages where throughput matters more.
+
+    The tuning table mirrors C++ LlAutoTune.cuh with Triton-specific
+    block_size adjustments for the cross-warp polling tradeoff.
+    """
+    if nbytes <= 256:
+        return {"num_blocks": 1, "block_size": 32}
+    if nbytes <= 2048:
+        return {"num_blocks": 1, "block_size": 512}
+    if nbytes <= 4096:
+        return {"num_blocks": 2, "block_size": 512}
+    if nbytes <= 8192:
+        return {"num_blocks": 4, "block_size": 512}
+    if nbytes <= 16384:
+        return {"num_blocks": 8, "block_size": 512}
+    if nbytes <= 32768:
+        return {"num_blocks": 16, "block_size": 512}
+    if nbytes <= 65536:
+        return {"num_blocks": 32, "block_size": 512}
+    if nbytes <= 131072:
+        return {"num_blocks": 64, "block_size": 512}
+    if nbytes <= 262144:
+        return {"num_blocks": 128, "block_size": 512}
+    return {"num_blocks": 256, "block_size": 512}
+
+
+def ll_auto_tune_bidirectional(nbytes: int) -> dict[str, int]:
+    """Return {num_blocks, block_size} for bidirectional P2P LL.
+
+    Doubles the block count vs unidirectional (capped at 1024) since
+    partition_interleaved(2) halves the warps per direction.
+    """
+    config = ll_auto_tune(nbytes)
+    return {
+        "num_blocks": min(config["num_blocks"] * 2, 1024),
+        "block_size": config["block_size"],
+    }

--- a/comms/pipes/ll/triton/ll_ops.py
+++ b/comms/pipes/ll/triton/ll_ops.py
@@ -1,0 +1,621 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Triton LL protocol implementation for Pipes.
+
+Provides low-latency NVLink P2P communication using the LL (Low-Latency)
+protocol with dual-flag atomicity detection. Each LL line is 16 bytes:
+{data1: u32, flag1: u32, data2: u32, flag2: u32}, carrying 8 bytes of
+payload per line.
+
+Core components:
+  - Inline PTX primitives for acquire/release loads/stores
+  - ll_send_kernel: Send data to peer's LL buffer via NVLink
+  - ll_recv_kernel: Receive data from local LL buffer
+  - ll_forward_kernel: Forward data through an intermediate rank
+  - GIN-safe utility kernels for buffer initialization and iteration tracking
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import triton  # @manual
+import triton.language as tl  # @manual
+
+try:
+    from torchcomms.triton.fb import get_nvlink_address, requires_torchcomms
+except ImportError:
+    get_nvlink_address = None
+
+    def requires_torchcomms(fn):  # type: ignore[no-redef]
+        return fn
+
+
+if TYPE_CHECKING:
+    pass
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+LL_LINE_SIZE = 16
+LL_PAYLOAD_PER_LINE = 8
+LL_READY_TO_WRITE = 0xFFFFFFFF
+LL_MEMSET_INIT_BYTE = 0xFF
+# Masks for extracting fields from uint64 words in the v2.u64 representation.
+# word = {data (low 32b), flag (high 32b)}
+LL_FLAG_MASK = 0xFFFFFFFF00000000
+LL_DATA_MASK = 0x00000000FFFFFFFF
+
+# =============================================================================
+# Utility Functions (pure Python, no torch/triton deps at call time)
+# =============================================================================
+
+
+def ll_num_lines(nbytes: int) -> int:
+    """Number of LL lines needed for a payload of nbytes."""
+    if nbytes == 0:
+        return 0
+    return (nbytes + LL_PAYLOAD_PER_LINE - 1) // LL_PAYLOAD_PER_LINE
+
+
+def ll_buffer_size(max_message_size: int) -> int:
+    """LL buffer size in bytes for a single peer's region."""
+    return ll_num_lines(max_message_size) * LL_LINE_SIZE
+
+
+def ll_total_buffer_size(max_message_size: int, world_size: int) -> int:
+    """Total LL buffer size across all peers (world_size - 1 regions)."""
+    return ll_buffer_size(max_message_size) * (world_size - 1)
+
+
+def can_use_ll(nbytes: int) -> bool:
+    """Check if payload size is valid for LL (must be 8-byte multiple)."""
+    if nbytes == 0:
+        return True
+    return nbytes % LL_PAYLOAD_PER_LINE == 0
+
+
+def ll_peer_index(target_rank: int, self_rank: int) -> int:
+    """Index of target_rank in self_rank's peer list (skipping self).
+
+    Maps a rank to its 0-based position among (world_size - 1) peers,
+    as seen from self_rank's perspective. Matches the C++ pattern in
+    DeviceWindow.cuh:rank_to_peer_index().
+
+    Example (world_size=4, self_rank=1):
+      target_rank=0 -> index 0
+      target_rank=2 -> index 1
+      target_rank=3 -> index 2
+    """
+    return target_rank if target_rank < self_rank else target_rank - 1
+
+
+def ll_peer_buffer_offset(target_rank: int, self_rank: int, per_peer_size: int) -> int:
+    """Byte offset for target_rank's region within self_rank's LL buffer.
+
+    Each rank's LL buffer is partitioned into (world_size - 1) regions,
+    one per peer. This returns the byte offset to the region where
+    target_rank's data lives in self_rank's buffer.
+
+    For send: ll_peer_buffer_offset(my_rank, peer, size) -- "my region in peer's buf"
+    For recv: ll_peer_buffer_offset(peer, my_rank, size) -- "peer's region in my buf"
+    """
+    return ll_peer_index(target_rank, self_rank) * per_peer_size
+
+
+# =============================================================================
+# Inline PTX Primitives
+# =============================================================================
+
+
+@triton.jit
+def _acquire_load_v2_u64(addr):
+    """Load an LL line (16B) as two uint64 words with system-scope acquire.
+
+    Emits ld.acquire.sys.v2.u64 (without .global -- PTX infers the state
+    space from the pointer, matching NCCL LL's validated pattern:
+    ld.acquire.sys.v4.u32). Acquire ordering ensures subsequent reads see
+    the sender's writes that were released before the flag store.
+    """
+    return tl.inline_asm_elementwise(
+        "ld.acquire.sys.v2.u64 {$0, $1}, [$2];",
+        "=l,=l,l",
+        args=[addr],
+        dtype=(tl.uint64, tl.uint64),
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _release_store_v2_u64(addr, word0, word1):
+    """Store an LL line (16B) from two uint64 words with system-scope release.
+
+    Emits st.release.sys.v2.u64 (without .global -- matching CCCL's
+    validated pattern: st.release.gpu.v2.u64). Release ordering ensures
+    all prior writes (data packing) are visible before the flag becomes
+    visible to the receiver.
+    """
+    tl.inline_asm_elementwise(
+        "st.release.sys.v2.u64 [$1], {$2, $3};",
+        "=r,l,l,l",
+        args=[addr, word0, word1],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _read_globaltimer():
+    """Read the GPU global timer in nanoseconds for timeout detection.
+
+    Uses %globaltimer (not %clock64) because it returns wall-clock
+    nanoseconds, making timeout values directly interpretable without
+    per-device clock rate conversion.
+    """
+    return tl.inline_asm_elementwise(
+        "mov.u64 $0, %globaltimer;",
+        "=l",
+        args=[],
+        dtype=tl.uint64,
+        is_pure=False,
+        pack=1,
+    )
+
+
+# =============================================================================
+# Kernel Helpers
+# =============================================================================
+
+
+@triton.jit
+def _compute_line_params(
+    line_idx, buffer_num_lines, aligned_buf_lines, BLOCK_SIZE: tl.constexpr
+):
+    """Compute buffer index and flag value for a set of LL lines."""
+    if buffer_num_lines > 0:
+        buf_idx = line_idx % aligned_buf_lines
+        flag_value = tl.cast(1 + (line_idx // aligned_buf_lines), tl.int32)
+    else:
+        buf_idx = line_idx
+        flag_value = tl.full([BLOCK_SIZE], 1, dtype=tl.int32)
+    return buf_idx, flag_value
+
+
+@triton.jit
+def _poll_ll_flags(addr, expected_flag, mask):
+    """Poll an LL line until both flags match expected_flag.
+
+    @return (word0, word1) from the final successful load.
+    """
+    word0, word1 = _acquire_load_v2_u64(addr)
+    flag1 = (word0 >> 32).to(tl.uint32)
+    flag2 = (word1 >> 32).to(tl.uint32)
+    ready = (flag1 == expected_flag) & (flag2 == expected_flag)
+    ready = tl.where(mask, ready, True)
+    all_ready = tl.min(ready.to(tl.int32))
+
+    while all_ready == 0:
+        word0, word1 = _acquire_load_v2_u64(addr)
+        flag1 = (word0 >> 32).to(tl.uint32)
+        flag2 = (word1 >> 32).to(tl.uint32)
+        ready = (flag1 == expected_flag) & (flag2 == expected_flag)
+        ready = tl.where(mask, ready, True)
+        all_ready = tl.min(ready.to(tl.int32))
+
+    return word0, word1
+
+
+# =============================================================================
+# GIN-Safe Utility Kernels
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def _fill_ll_buffer_kernel(buf_ptr_i32, fill_value_i32, N: tl.constexpr):
+    """GIN-safe kernel to fill LL buffer with a 32-bit pattern.
+
+    buf_ptr_i32 is the LL buffer pointer cast to int32*. N is the number
+    of int32 elements to fill (total_bytes // 4). Each program fills one
+    int32 element. Launch with grid=(N,).
+
+    To initialize all flags to LL_READY_TO_WRITE (0xFFFFFFFF), pass
+    fill_value_i32 = -1 (which is 0xFFFFFFFF in two's complement int32).
+    """
+    idx = tl.program_id(0)
+    if idx < N:
+        tl.store(buf_ptr_i32 + idx, fill_value_i32)
+
+
+# =============================================================================
+# Iteration Tracking (CUDA graph compatible)
+# =============================================================================
+
+_ITERATION_TENSOR_CACHE: dict = {}
+
+
+def _get_iteration_tensor(device: torch.device, world_size: int) -> torch.Tensor:
+    """Return a cached int64 scalar tensor for iteration counting.
+
+    Keyed by (device, world_size) to prevent corruption when multiple
+    communicators with different world_size values share the same GPU.
+
+    MUST be called BEFORE GIN activation.
+    """
+    key = (device, world_size)
+    if key not in _ITERATION_TENSOR_CACHE:
+        _ITERATION_TENSOR_CACHE[key] = torch.zeros(1, dtype=torch.int64, device=device)
+    return _ITERATION_TENSOR_CACHE[key]
+
+
+@requires_torchcomms
+@triton.jit
+def _increment_iteration_kernel(iteration_ptr):
+    """Increment the iteration counter by 1. GIN-safe, CUDA graph capturable."""
+    if tl.program_id(0) == 0:
+        old_val = tl.load(iteration_ptr)
+        tl.store(iteration_ptr, old_val + 1)
+
+
+# =============================================================================
+# LL Send/Recv Loop Helpers (shared by standalone and fused kernels)
+# =============================================================================
+
+
+@triton.jit
+def _ll_send_loop(
+    pid,
+    num_blocks,
+    src_ptr,
+    remote_base,
+    nbytes,
+    buffer_num_lines,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Send loop body: poll for READY_TO_WRITE, pack data, release-store.
+
+    @param pid: Block index within the send direction (0-based).
+    @param num_blocks: Number of blocks in the send direction.
+    """
+    total_lines = nbytes // 8
+
+    if buffer_num_lines > 0:
+        active_blocks = tl.minimum(buffer_num_lines // BLOCK_SIZE, num_blocks)
+    else:
+        active_blocks = num_blocks
+
+    if pid >= active_blocks:
+        return
+
+    if buffer_num_lines > 0:
+        stride = active_blocks * BLOCK_SIZE
+        aligned_buf_lines = (buffer_num_lines // stride) * stride
+    else:
+        aligned_buf_lines = 0
+
+    line_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    ready_flag = tl.full([BLOCK_SIZE], LL_READY_TO_WRITE, dtype=tl.uint32)
+
+    num_steps = (total_lines + active_blocks * BLOCK_SIZE - 1) // (
+        active_blocks * BLOCK_SIZE
+    )
+    step = 0
+    while step < num_steps:
+        line_idx = line_offsets + step * active_blocks * BLOCK_SIZE
+        mask = line_idx < total_lines
+
+        buf_idx, flag_value = _compute_line_params(
+            line_idx, buffer_num_lines, aligned_buf_lines, BLOCK_SIZE
+        )
+
+        remote_addr = remote_base + buf_idx * 16
+
+        _poll_ll_flags(remote_addr, ready_flag, mask)
+
+        src_offset = line_idx * 8
+        data1 = (
+            tl.load(src_ptr + src_offset // 4, mask=mask, other=0)
+            .to(tl.uint32)
+            .to(tl.uint64)
+        )
+        data2 = (
+            tl.load(src_ptr + src_offset // 4 + 1, mask=mask, other=0)
+            .to(tl.uint32)
+            .to(tl.uint64)
+        )
+
+        flag_u64 = flag_value.to(tl.uint64)
+        out_word0 = data1 | (flag_u64 << 32)
+        out_word1 = data2 | (flag_u64 << 32)
+
+        _release_store_v2_u64(remote_addr, out_word0, out_word1)
+
+        step += 1
+
+
+@triton.jit
+def _ll_recv_loop(
+    pid,
+    num_blocks,
+    dst_ptr,
+    local_base,
+    nbytes,
+    buffer_num_lines,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Recv loop body: poll for flag, extract data, ACK with READY_TO_WRITE.
+
+    @param pid: Block index within the recv direction (0-based).
+    @param num_blocks: Number of blocks in the recv direction.
+    """
+    total_lines = nbytes // 8
+
+    if buffer_num_lines > 0:
+        active_blocks = tl.minimum(buffer_num_lines // BLOCK_SIZE, num_blocks)
+    else:
+        active_blocks = num_blocks
+
+    if pid >= active_blocks:
+        return
+
+    if buffer_num_lines > 0:
+        stride = active_blocks * BLOCK_SIZE
+        aligned_buf_lines = (buffer_num_lines // stride) * stride
+    else:
+        aligned_buf_lines = 0
+
+    line_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    ack_word = tl.full([BLOCK_SIZE], LL_READY_TO_WRITE, dtype=tl.uint64) << 32
+
+    num_steps = (total_lines + active_blocks * BLOCK_SIZE - 1) // (
+        active_blocks * BLOCK_SIZE
+    )
+    step = 0
+    while step < num_steps:
+        line_idx = line_offsets + step * active_blocks * BLOCK_SIZE
+        mask = line_idx < total_lines
+
+        buf_idx, flag_value = _compute_line_params(
+            line_idx, buffer_num_lines, aligned_buf_lines, BLOCK_SIZE
+        )
+
+        local_addr = local_base + buf_idx * 16
+        expected_flag = flag_value.to(tl.uint32)
+
+        word0, word1 = _poll_ll_flags(local_addr, expected_flag, mask)
+
+        data1 = (word0 & LL_DATA_MASK).to(tl.uint32)
+        data2 = (word1 & LL_DATA_MASK).to(tl.uint32)
+
+        dst_offset = line_idx * 8
+        tl.store(dst_ptr + dst_offset // 4, data1, mask=mask)
+        tl.store(dst_ptr + dst_offset // 4 + 1, data2, mask=mask)
+
+        _release_store_v2_u64(local_addr, ack_word, ack_word)
+
+        step += 1
+
+
+# =============================================================================
+# LL Send Kernel (standalone)
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def ll_send_kernel(
+    src_ptr,
+    win,
+    peer: tl.constexpr,
+    peer_buf_offset,
+    nbytes,
+    buffer_num_lines,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Send data to peer's LL buffer via NVLink."""
+    pid = tl.program_id(0)
+    num_blocks = tl.num_programs(0)
+    remote_base = get_nvlink_address(win, peer) + peer_buf_offset
+    _ll_send_loop(
+        pid,
+        num_blocks,
+        src_ptr,
+        remote_base,
+        nbytes,
+        buffer_num_lines,
+        BLOCK_SIZE,
+    )
+
+
+# =============================================================================
+# LL Recv Kernel (standalone)
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def ll_recv_kernel(
+    dst_ptr,
+    ll_buf_ptr,
+    peer_buf_offset,
+    nbytes,
+    buffer_num_lines,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Receive data from local LL buffer."""
+    pid = tl.program_id(0)
+    num_blocks = tl.num_programs(0)
+    local_base = ll_buf_ptr + peer_buf_offset
+    _ll_recv_loop(
+        pid,
+        num_blocks,
+        dst_ptr,
+        local_base,
+        nbytes,
+        buffer_num_lines,
+        BLOCK_SIZE,
+    )
+
+
+# =============================================================================
+# LL Fused SendRecv Kernel
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def ll_sendrecv_kernel(
+    src_ptr,
+    dst_ptr,
+    win,
+    peer: tl.constexpr,
+    send_peer_buf_offset,
+    recv_peer_buf_offset,
+    ll_buf_ptr,
+    nbytes,
+    buffer_num_lines,
+    num_blocks_per_dir,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Fused send+recv in a single kernel launch.
+
+    Grid: (2 * num_blocks_per_dir,). The first num_blocks_per_dir blocks
+    execute the send path; the remaining execute the recv path. Both ranks
+    must call this simultaneously.
+
+    num_blocks_per_dir is a runtime parameter (not constexpr) to avoid
+    Triton recompiling the kernel for every unique block count. Only
+    BLOCK_SIZE is constexpr (required for tl.arange/tl.full).
+    """
+    pid = tl.program_id(0)
+
+    if pid < num_blocks_per_dir:
+        remote_base = get_nvlink_address(win, peer) + send_peer_buf_offset
+        _ll_send_loop(
+            pid,
+            num_blocks_per_dir,
+            src_ptr,
+            remote_base,
+            nbytes,
+            buffer_num_lines,
+            BLOCK_SIZE,
+        )
+    else:
+        recv_pid = pid - num_blocks_per_dir
+        local_base = ll_buf_ptr + recv_peer_buf_offset
+        _ll_recv_loop(
+            recv_pid,
+            num_blocks_per_dir,
+            dst_ptr,
+            local_base,
+            nbytes,
+            buffer_num_lines,
+            BLOCK_SIZE,
+        )
+
+
+# =============================================================================
+# LL Forward Kernel
+# =============================================================================
+
+
+@requires_torchcomms
+@triton.jit
+def ll_forward_kernel(
+    dst_ptr,
+    ll_buf_ptr,
+    predecessor_buf_offset,
+    win,
+    successor_peer: tl.constexpr,
+    successor_buf_offset,
+    nbytes,
+    buffer_num_lines,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Forward data from predecessor to successor, copying to local output.
+
+    @param dst_ptr: Local output buffer
+    @param ll_buf_ptr: Local LL buffer base pointer
+    @param predecessor_buf_offset: Offset to predecessor's region in local LL buf
+    @param win: TorchComms device window handle
+    @param successor_peer: Successor rank to forward to (constexpr)
+    @param successor_buf_offset: Offset to this rank's region in successor's LL buf
+    @param nbytes: Total payload bytes (must be multiple of 8)
+    @param buffer_num_lines: LL buffer size in lines per peer (0 = unbounded)
+    @param BLOCK_SIZE: Lines per block (constexpr)
+
+    """
+    pid = tl.program_id(0)
+    num_blocks = tl.num_programs(0)
+    total_lines = nbytes // 8
+
+    if buffer_num_lines > 0:
+        active_blocks = tl.minimum(buffer_num_lines // BLOCK_SIZE, num_blocks)
+    else:
+        active_blocks = num_blocks
+
+    if pid >= active_blocks:
+        return
+
+    local_base = ll_buf_ptr + predecessor_buf_offset
+    remote_base = get_nvlink_address(win, successor_peer) + successor_buf_offset
+
+    if buffer_num_lines > 0:
+        stride = active_blocks * BLOCK_SIZE
+        aligned_buf_lines = (buffer_num_lines // stride) * stride
+    else:
+        stride = 0
+        aligned_buf_lines = 0
+
+    line_offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    ack_word = tl.full([BLOCK_SIZE], LL_READY_TO_WRITE, dtype=tl.uint64) << 32
+    ready_flag = tl.full([BLOCK_SIZE], LL_READY_TO_WRITE, dtype=tl.uint32)
+
+    num_steps = (total_lines + active_blocks * BLOCK_SIZE - 1) // (
+        active_blocks * BLOCK_SIZE
+    )
+    step = 0
+    while step < num_steps:
+        line_idx = line_offsets + step * active_blocks * BLOCK_SIZE
+        mask = line_idx < total_lines
+
+        buf_idx, flag_value = _compute_line_params(
+            line_idx, buffer_num_lines, aligned_buf_lines, BLOCK_SIZE
+        )
+
+        local_addr = local_base + buf_idx * 16
+        remote_addr = remote_base + buf_idx * 16
+        expected_flag = flag_value.to(tl.uint32)
+
+        # Phase 1: Poll local LL buffer for data from predecessor
+        word0, word1 = _poll_ll_flags(local_addr, expected_flag, mask)
+
+        # Extract data from predecessor's line
+        data1 = (word0 & LL_DATA_MASK).to(tl.uint64)
+        data2 = (word1 & LL_DATA_MASK).to(tl.uint64)
+
+        # Phase 2: Poll successor's remote LL buffer for READY_TO_WRITE
+        _poll_ll_flags(remote_addr, ready_flag, mask)
+
+        # Phase 3: Forward to successor, copy to local output, ACK predecessor
+        flag_u64 = flag_value.to(tl.uint64)
+        fwd_word0 = data1 | (flag_u64 << 32)
+        fwd_word1 = data2 | (flag_u64 << 32)
+
+        _release_store_v2_u64(remote_addr, fwd_word0, fwd_word1)
+
+        dst_offset = line_idx * 8
+        tl.store(dst_ptr + dst_offset // 4, data1.to(tl.uint32), mask=mask)
+        tl.store(dst_ptr + dst_offset // 4 + 1, data2.to(tl.uint32), mask=mask)
+
+        _release_store_v2_u64(local_addr, ack_word, ack_word)
+
+        step += 1

--- a/comms/pipes/ll/triton/ll_p2p_op.py
+++ b/comms/pipes/ll/triton/ll_p2p_op.py
@@ -1,0 +1,302 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Host-side wrapper for Triton LL P2P send/recv over NVLink.
+
+Manages LL buffer allocation, window registration, NVLink connectivity
+verification, and kernel launch. Designed as a building block that
+collectives (e.g., AllToAllv) can compose, but also usable standalone
+for P2P testing and benchmarking.
+
+Public API:
+  - ``LlP2pOp``: Stateful op for repeated LL send/recv/forward calls.
+
+Usage::
+
+    op = LlP2pOp(comm, max_nbytes=65536, device=torch.device("cuda:0"))
+    with op:
+        op.send(peer=1, src_tensor=src, nbytes=1024)
+        op.recv(peer=1, dst_tensor=dst, nbytes=1024)
+"""
+
+from __future__ import annotations
+
+import torch
+from comms.pipes.ll.triton.auto_tune import ll_auto_tune
+from comms.pipes.ll.triton.ll_ops import (
+    ll_buffer_size,
+    ll_forward_kernel,
+    ll_peer_buffer_offset,
+    ll_recv_kernel,
+    ll_send_kernel,
+    ll_sendrecv_kernel,
+    ll_total_buffer_size,
+)
+
+
+class LlP2pOp:
+    """Host-side wrapper for LL P2P send/recv over NVLink.
+
+    Manages LL buffer allocation, window registration, and kernel launch.
+    Supports up to 72 NVLink ranks (GB200). CUDA graph compatible via
+    GPU-resident iteration counter.
+
+    Args:
+        comm: TorchComm communicator instance.
+        max_nbytes: Maximum payload size in bytes per P2P operation.
+        device: CUDA device for buffer allocation.
+        buffer_num_lines: LL buffer size in lines per peer for chunked mode.
+            0 (default) means unbounded (buffer sized to max_nbytes).
+        timeout_ns: Reserved for future timeout support (currently unused).
+    """
+
+    def __init__(
+        self,
+        comm,
+        max_nbytes: int,
+        device: torch.device,
+        buffer_num_lines: int = 0,
+        timeout_ns: int = 10_000_000_000,
+    ) -> None:
+        self._comm = comm
+        self._max_nbytes = max_nbytes
+        self._device = device
+        self._buffer_num_lines = buffer_num_lines
+        self._timeout_ns = timeout_ns
+
+        self._rank = comm.get_rank()
+        self._world_size = comm.get_size()
+        self._backend = comm.get_backend()
+
+        self._per_peer_size = ll_buffer_size(max_nbytes)
+        self._total_ll_size = ll_total_buffer_size(max_nbytes, self._world_size)
+
+        self._window = None
+        self._dev_win_ptr = None
+        self._ll_buf = None
+        self._ll_pool = None
+        self._torn_down = False
+
+    def setup(self) -> None:
+        """Allocate LL buffer, register window, verify NVLink connectivity.
+
+        This is a collective operation -- all ranks must call setup().
+        Must be called before any send/recv/forward operations.
+        """
+        from comms.pipes.collectives.triton.utils import alloc_comms_buffer
+
+        # Allocate LL buffer (BEFORE GIN activation)
+        self._ll_buf, self._ll_pool = alloc_comms_buffer(
+            self._total_ll_size,
+            torch.uint8,
+            self._device,
+            self._backend,
+        )
+
+        # Initialize all flags to READY_TO_WRITE (0xFF bytes)
+        self._ll_buf.fill_(255)
+
+        # Window setup (COLLECTIVE)
+        self._comm.barrier(False)
+        self._window = self._comm.new_window()
+        self._window.tensor_register(self._ll_buf)
+        self._comm.barrier(False)
+        torch.cuda.synchronize()
+
+        # Activate GIN (signal_count=1 is safe minimum; LL uses inline flags)
+        self._dev_win_ptr = self._window.get_device_window(
+            signal_count=1,
+            counter_count=0,
+            barrier_count=0,
+        )
+
+    def send(
+        self, peer: int, src_tensor: torch.Tensor, nbytes: int | None = None
+    ) -> None:
+        """Send data to peer via LL protocol over NVLink.
+
+        Args:
+            peer: Destination peer rank.
+            src_tensor: Source data tensor (must be 8-byte aligned, contiguous).
+            nbytes: Payload bytes to send. If None, uses src_tensor.nbytes.
+                Must be a multiple of 8.
+        """
+        if nbytes is None:
+            nbytes = src_tensor.nbytes
+
+        config = ll_auto_tune(nbytes)
+        grid = (config["num_blocks"],)
+
+        peer_buf_offset = ll_peer_buffer_offset(
+            target_rank=self._rank,
+            self_rank=peer,
+            per_peer_size=self._per_peer_size,
+        )
+
+        ll_send_kernel[grid](
+            src_tensor,
+            self._dev_win_ptr,
+            peer,
+            peer_buf_offset,
+            nbytes,
+            self._buffer_num_lines,
+            BLOCK_SIZE=config["block_size"],
+            num_warps=config["block_size"] // 32,
+        )
+
+    def recv(
+        self, peer: int, dst_tensor: torch.Tensor, nbytes: int | None = None
+    ) -> None:
+        """Receive data from peer via LL protocol.
+
+        Args:
+            peer: Source peer rank.
+            dst_tensor: Destination data tensor (must be 8-byte aligned, contiguous).
+            nbytes: Payload bytes to receive. If None, uses dst_tensor.nbytes.
+                Must be a multiple of 8.
+        """
+        if nbytes is None:
+            nbytes = dst_tensor.nbytes
+
+        config = ll_auto_tune(nbytes)
+        grid = (config["num_blocks"],)
+
+        peer_buf_offset = ll_peer_buffer_offset(
+            target_rank=peer,
+            self_rank=self._rank,
+            per_peer_size=self._per_peer_size,
+        )
+
+        ll_recv_kernel[grid](
+            dst_tensor,
+            self._ll_buf,
+            peer_buf_offset,
+            nbytes,
+            self._buffer_num_lines,
+            BLOCK_SIZE=config["block_size"],
+            num_warps=config["block_size"] // 32,
+        )
+
+    def forward(
+        self,
+        predecessor: int,
+        successor: int,
+        dst_tensor: torch.Tensor,
+        nbytes: int | None = None,
+    ) -> None:
+        """Forward data from predecessor to successor, copying locally.
+
+        Args:
+            predecessor: Rank that sent the data (read from local LL buffer).
+            successor: Rank to forward to (write to successor's LL buffer).
+            dst_tensor: Local output tensor for the forwarded data.
+            nbytes: Payload bytes. If None, uses dst_tensor.nbytes.
+        """
+        if nbytes is None:
+            nbytes = dst_tensor.nbytes
+
+        config = ll_auto_tune(nbytes)
+        grid = (config["num_blocks"],)
+
+        predecessor_buf_offset = ll_peer_buffer_offset(
+            target_rank=predecessor,
+            self_rank=self._rank,
+            per_peer_size=self._per_peer_size,
+        )
+        successor_buf_offset = ll_peer_buffer_offset(
+            target_rank=self._rank,
+            self_rank=successor,
+            per_peer_size=self._per_peer_size,
+        )
+
+        ll_forward_kernel[grid](
+            dst_tensor,
+            self._ll_buf,
+            predecessor_buf_offset,
+            self._dev_win_ptr,
+            successor,
+            successor_buf_offset,
+            nbytes,
+            self._buffer_num_lines,
+            BLOCK_SIZE=config["block_size"],
+            num_warps=config["block_size"] // 32,
+        )
+
+    def sendrecv(
+        self,
+        peer: int,
+        src_tensor: torch.Tensor,
+        dst_tensor: torch.Tensor,
+        nbytes: int | None = None,
+    ) -> None:
+        """Fused send+recv in a single kernel launch.
+
+        Both ranks must call sendrecv simultaneously. Each rank sends
+        src_tensor to peer and receives into dst_tensor from peer.
+
+        Args:
+            peer: Peer rank to exchange with.
+            src_tensor: Source data to send.
+            dst_tensor: Destination buffer for received data.
+            nbytes: Payload bytes. If None, uses src_tensor.nbytes.
+        """
+        if nbytes is None:
+            nbytes = src_tensor.nbytes
+
+        config = ll_auto_tune(nbytes)
+        num_blocks_per_dir = config["num_blocks"]
+        grid = (num_blocks_per_dir * 2,)
+
+        send_peer_buf_offset = ll_peer_buffer_offset(
+            target_rank=self._rank,
+            self_rank=peer,
+            per_peer_size=self._per_peer_size,
+        )
+        recv_peer_buf_offset = ll_peer_buffer_offset(
+            target_rank=peer,
+            self_rank=self._rank,
+            per_peer_size=self._per_peer_size,
+        )
+
+        ll_sendrecv_kernel[grid](
+            src_tensor,
+            dst_tensor,
+            self._dev_win_ptr,
+            peer,
+            send_peer_buf_offset,
+            recv_peer_buf_offset,
+            self._ll_buf,
+            nbytes,
+            self._buffer_num_lines,
+            num_blocks_per_dir,
+            BLOCK_SIZE=config["block_size"],
+            num_warps=config["block_size"] // 32,
+        )
+
+    def teardown(self) -> None:
+        """Release resources. Must be called by all ranks (collective).
+
+        Safe to call multiple times.
+        """
+        if self._torn_down:
+            return
+
+        if self._window is not None:
+            self._window.tensor_deregister()
+
+        self._dev_win_ptr = None
+        self._window = None
+        self._ll_buf = None
+        self._ll_pool = None
+
+        self._comm.barrier(False)
+        self._torn_down = True
+
+    def __enter__(self):
+        self.setup()
+        return self
+
+    def __exit__(self, *exc):
+        self.teardown()
+        return False

--- a/comms/pipes/ll/triton/ll_p2p_op.py
+++ b/comms/pipes/ll/triton/ll_p2p_op.py
@@ -18,6 +18,30 @@ Usage::
     with op:
         op.send(peer=1, src_tensor=src, nbytes=1024)
         op.recv(peer=1, dst_tensor=dst, nbytes=1024)
+
+CUDA Graph Support
+------------------
+LlP2pOp is CUDA graph compatible. The LL flag handshake protocol
+handles cross-rank synchronization internally, so ``graph.replay()``
+works without any special wrapper.
+
+CUDA Graph Usage Example::
+
+    op = LlP2pOp(comm, max_nbytes=4096, device=device)
+    with op:
+        # 1. Warmup (compiles Triton kernels, outside graph capture)
+        op.send(peer=1, src_tensor=src, nbytes=1024)
+        torch.cuda.synchronize()
+
+        # 2. Capture graph using op's memory pool
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):
+            op.send(peer=1, src_tensor=src, nbytes=1024)
+
+        # 3. Replay with different content per iteration
+        for i in range(num_iterations):
+            src.copy_(iteration_data[i])
+            graph.replay()
 """
 
 from __future__ import annotations
@@ -273,6 +297,20 @@ class LlP2pOp:
             BLOCK_SIZE=config["block_size"],
             num_warps=config["block_size"] // 32,
         )
+
+    def get_graph_pool_id(self) -> tuple[int, int]:
+        """Return the memory pool ID for CUDA graph capture.
+
+        Pass this to ``torch.cuda.graph(graph, pool=...)`` to ensure
+        allocations during capture use the same transport-compatible pool
+        as the LL buffer.
+
+        Buffer registration (``setup()``) must occur BEFORE graph capture.
+
+        Returns:
+            tuple[int, int]: The CUDA memory pool handle.
+        """
+        return self._ll_pool.id  # type: ignore[return-value]
 
     def teardown(self) -> None:
         """Release resources. Must be called by all ranks (collective).

--- a/comms/pipes/ll/triton/tests/__init__.py
+++ b/comms/pipes/ll/triton/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.

--- a/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
+++ b/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
@@ -1,0 +1,155 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Benchmark for Triton LL P2P send/recv over NVLink.
+
+Sweeps message sizes from 8B to 256KB, measuring unidirectional and
+bidirectional bandwidth (GB/s) and latency (us).
+
+Usage:
+    buck2 run @fbcode//mode/opt \
+        -c hpc_comms.use_ncclx=stable \
+        //comms/pipes/ll/triton/tests:benchmark_ll_p2p
+
+    # With GPU offset (e.g., use GPUs 2 and 3):
+    buck2 run ... :benchmark_ll_p2p -- --gpu-offset 2
+
+    # Bidirectional mode:
+    buck2 run ... :benchmark_ll_p2p -- --bidirectional
+"""
+
+import os
+import socket
+import sys
+
+os.environ.setdefault("NCCL_GIN_ENABLE", "1")
+os.environ.setdefault("NCCL_GIN_TYPE", "-1")
+
+import torch
+import torch.multiprocessing as mp
+import torchcomms
+from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def format_size(nbytes):
+    if nbytes >= 1024 * 1024:
+        return f"{nbytes / (1024**2):.0f}MB"
+    if nbytes >= 1024:
+        return f"{nbytes / 1024:.0f}KB"
+    return f"{nbytes}B"
+
+
+MSG_SIZES = [8, 64, 256, 1024, 4096, 16384, 65536, 131072, 262144]
+
+WARMUP_ITERS = 20
+TIMED_ITERS = 200
+
+
+def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
+    gpu_id = local_rank + gpu_offset
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(gpu_id)
+    os.environ["WORLD_SIZE"] = "2"
+
+    peer_rank = 1 - local_rank
+    torch.cuda.set_device(gpu_id)
+
+    comm = torchcomms.new_comm(
+        "ncclx",
+        torch.device(f"cuda:{gpu_id}"),
+        name="ll_p2p_bench",
+    )
+
+    max_nbytes = max(MSG_SIZES)
+    op = LlP2pOp(
+        comm=comm,
+        max_nbytes=max_nbytes,
+        device=torch.device(f"cuda:{gpu_id}"),
+    )
+    op.setup()
+
+    mode_str = "Bidirectional" if bidirectional else "Unidirectional"
+    if local_rank == 0:
+        print(f"Triton LL P2P Benchmark ({mode_str}, 2 GPUs)")
+        print(f"GPU {gpu_id} <-> GPU {gpu_id + 1 - 2 * local_rank}")
+        print()
+        print(f"{'Size':<10} | {'Latency (us)':<14} | {'BW (GB/s)':<12} | {'Iters':<6}")
+        print("-" * 56)
+
+    for nbytes in MSG_SIZES:
+        num_elements = nbytes // 4  # int32
+        src = torch.randn(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+        dst = torch.zeros(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+
+        # Warmup
+        for _ in range(WARMUP_ITERS):
+            if bidirectional:
+                op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+                op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+            else:
+                if local_rank == 0:
+                    op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+                else:
+                    op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        # Fewer iterations for larger messages
+        iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start_event.record()
+        for _ in range(iters):
+            if bidirectional:
+                op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+                op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+            else:
+                if local_rank == 0:
+                    op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+                else:
+                    op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+        end_event.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start_event.elapsed_time(end_event)
+        avg_us = (elapsed_ms * 1000.0) / iters
+        bw_gbps = (nbytes / (1024**3)) / (avg_us / 1_000_000.0)
+
+        if local_rank == 0:
+            print(
+                f"{format_size(nbytes):<10} | {avg_us:<14.2f} | "
+                f"{bw_gbps:<12.4f} | {iters:<6}"
+            )
+
+        del src, dst
+
+    op.teardown()
+    comm.finalize()
+
+
+if __name__ == "__main__":
+    bidirectional = "--bidirectional" in sys.argv
+    gpu_offset = 0
+    for i, a in enumerate(sys.argv):
+        if a == "--gpu-offset" and i + 1 < len(sys.argv):
+            gpu_offset = int(sys.argv[i + 1])
+
+    port = find_free_port()
+    mp.spawn(
+        run_benchmark_worker,
+        args=(port, bidirectional, gpu_offset),
+        nprocs=2,
+        join=True,
+    )

--- a/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
+++ b/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
@@ -52,7 +52,107 @@ WARMUP_ITERS = 20
 TIMED_ITERS = 200
 
 
-def run_benchmark_worker(local_rank, master_port, bidirectional, fused, gpu_offset):
+def _do_ops(op, local_rank, peer_rank, fused, bidirectional, src, dst, nbytes):
+    if fused:
+        op.sendrecv(peer=peer_rank, src_tensor=src, dst_tensor=dst, nbytes=nbytes)
+    elif bidirectional:
+        op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+        op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+    else:
+        if local_rank == 0:
+            op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
+        else:
+            op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
+
+
+def _bench_eager(op, comm, local_rank, peer_rank, gpu_id, fused, bidirectional):
+    results = {}
+    for nbytes in MSG_SIZES:
+        num_elements = nbytes // 4
+        src = torch.randn(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+        dst = torch.zeros(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+
+        for _ in range(WARMUP_ITERS):
+            _do_ops(op, local_rank, peer_rank, fused, bidirectional, src, dst, nbytes)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+
+        comm.barrier(False)
+        start_ev.record()
+        for _ in range(iters):
+            _do_ops(op, local_rank, peer_rank, fused, bidirectional, src, dst, nbytes)
+        end_ev.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start_ev.elapsed_time(end_ev)
+        results[nbytes] = (elapsed_ms * 1000.0) / iters
+        del src, dst
+    return results
+
+
+def _bench_graph(op, comm, local_rank, peer_rank, gpu_id, fused, bidirectional):
+    results = {}
+    for nbytes in MSG_SIZES:
+        num_elements = nbytes // 4
+        src = torch.randn(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+        dst = torch.zeros(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
+
+        for _ in range(WARMUP_ITERS):
+            _do_ops(op, local_rank, peer_rank, fused, bidirectional, src, dst, nbytes)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
+
+        graph_stream = torch.cuda.Stream()
+        with torch.cuda.stream(graph_stream):
+            graph = torch.cuda.CUDAGraph()
+            # pyre-fixme[6]: pool handle type
+            with torch.cuda.graph(graph, pool=op.get_graph_pool_id()):  # type: ignore[arg-type]
+                for _ in range(iters):
+                    _do_ops(
+                        op,
+                        local_rank,
+                        peer_rank,
+                        fused,
+                        bidirectional,
+                        src,
+                        dst,
+                        nbytes,
+                    )
+
+        with torch.cuda.stream(graph_stream):
+            for _ in range(WARMUP_ITERS):
+                graph.replay()
+        torch.cuda.synchronize()
+        comm.barrier(False)
+
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(graph_stream):
+            start_ev.record()
+            graph.replay()
+            end_ev.record()
+        torch.cuda.synchronize()
+
+        elapsed_ms = start_ev.elapsed_time(end_ev)
+        results[nbytes] = (elapsed_ms * 1000.0) / iters
+        del src, dst, graph
+    return results
+
+
+def run_benchmark_worker(
+    local_rank,
+    master_port,
+    bidirectional,
+    fused,
+    cuda_graph,
+    gpu_offset,
+):
     gpu_id = local_rank + gpu_offset
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(master_port)
@@ -83,12 +183,7 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, fused, gpu_offs
         mode_str = "Bidirectional"
     else:
         mode_str = "Unidirectional"
-    # Pre-warm Triton JIT compilation for all BLOCK_SIZE variants before the
-    # timed benchmark loop. Auto-tune uses BLOCK_SIZE=32 for small messages
-    # (<=256B) and BLOCK_SIZE=512 for larger ones. Each unique BLOCK_SIZE
-    # (a tl.constexpr) triggers a separate Triton compilation that can take
-    # 30+ seconds. Both ranks must finish compiling before the fused kernel
-    # can run, so we pre-warm with sync+barrier after each variant.
+
     for prewarm_nbytes in [8, 1024]:
         prewarm_elements = prewarm_nbytes // 4
         prewarm_src = torch.randn(
@@ -97,92 +192,85 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, fused, gpu_offs
         prewarm_dst = torch.zeros(
             prewarm_elements, dtype=torch.float32, device=f"cuda:{gpu_id}"
         )
-        if fused:
-            op.sendrecv(
-                peer=peer_rank,
-                src_tensor=prewarm_src,
-                dst_tensor=prewarm_dst,
-                nbytes=prewarm_nbytes,
-            )
-        elif bidirectional:
-            op.send(peer=peer_rank, src_tensor=prewarm_src, nbytes=prewarm_nbytes)
-            op.recv(peer=peer_rank, dst_tensor=prewarm_dst, nbytes=prewarm_nbytes)
-        else:
-            if local_rank == 0:
-                op.send(peer=peer_rank, src_tensor=prewarm_src, nbytes=prewarm_nbytes)
-            else:
-                op.recv(peer=peer_rank, dst_tensor=prewarm_dst, nbytes=prewarm_nbytes)
+        _do_ops(
+            op,
+            local_rank,
+            peer_rank,
+            fused,
+            bidirectional,
+            prewarm_src,
+            prewarm_dst,
+            prewarm_nbytes,
+        )
         torch.cuda.synchronize()
         comm.barrier(False)
         del prewarm_src, prewarm_dst
 
+    eager_results = _bench_eager(
+        op,
+        comm,
+        local_rank,
+        peer_rank,
+        gpu_id,
+        fused,
+        bidirectional,
+    )
+
+    if cuda_graph:
+        graph_results = _bench_graph(
+            op,
+            comm,
+            local_rank,
+            peer_rank,
+            gpu_id,
+            fused,
+            bidirectional,
+        )
+
     if local_rank == 0:
-        print(f"Triton LL P2P Benchmark ({mode_str}, 2 GPUs)", flush=True)
+        if cuda_graph:
+            print(
+                f"Triton LL P2P Benchmark ({mode_str} + CUDA Graph, 2 GPUs)",
+                flush=True,
+            )
+        else:
+            print(f"Triton LL P2P Benchmark ({mode_str}, 2 GPUs)", flush=True)
         print(f"GPU {gpu_id} <-> GPU {gpu_id + 1 - 2 * local_rank}", flush=True)
         print(flush=True)
-        print(
-            f"{'Size':<10} | {'Latency (us)':<14} | {'BW (GB/s)':<12} | {'Iters':<6}",
-            flush=True,
-        )
-        print("-" * 56, flush=True)
 
-    for nbytes in MSG_SIZES:
-        num_elements = nbytes // 4  # int32
-        src = torch.randn(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
-        dst = torch.zeros(num_elements, dtype=torch.float32, device=f"cuda:{gpu_id}")
-
-        # Warmup
-        for _ in range(WARMUP_ITERS):
-            if fused:
-                op.sendrecv(
-                    peer=peer_rank, src_tensor=src, dst_tensor=dst, nbytes=nbytes
-                )
-            elif bidirectional:
-                op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
-                op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
-            else:
-                if local_rank == 0:
-                    op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
-                else:
-                    op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
-        torch.cuda.synchronize()
-        comm.barrier(False)
-
-        # Fewer iterations for larger messages
-        iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
-
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-
-        comm.barrier(False)
-        start_event.record()
-        for _ in range(iters):
-            if fused:
-                op.sendrecv(
-                    peer=peer_rank, src_tensor=src, dst_tensor=dst, nbytes=nbytes
-                )
-            elif bidirectional:
-                op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
-                op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
-            else:
-                if local_rank == 0:
-                    op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
-                else:
-                    op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
-        end_event.record()
-        torch.cuda.synchronize()
-
-        elapsed_ms = start_event.elapsed_time(end_event)
-        avg_us = (elapsed_ms * 1000.0) / iters
-        bw_gbps = (nbytes / (1024**3)) / (avg_us / 1_000_000.0)
-
-        if local_rank == 0:
+        if cuda_graph:
             print(
-                f"{format_size(nbytes):<10} | {avg_us:<14.2f} | "
-                f"{bw_gbps:<12.4f} | {iters:<6}"
+                f"{'Size':<10} | {'Eager (us)':<14} | {'Graph (us)':<14} | "
+                f"{'Speedup':<8} | {'Iters':<6}",
+                flush=True,
             )
-
-        del src, dst
+            print("-" * 68, flush=True)
+            for nbytes in MSG_SIZES:
+                iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
+                eager_us = eager_results[nbytes]
+                graph_us = graph_results[nbytes]
+                speedup = eager_us / graph_us if graph_us > 0 else 0.0
+                print(
+                    f"{format_size(nbytes):<10} | {eager_us:<14.2f} | "
+                    f"{graph_us:<14.2f} | {speedup:<8.2f}x | {iters:<6}",
+                    flush=True,
+                )
+        else:
+            print(
+                f"{'Size':<10} | {'Latency (us)':<14} | "
+                f"{'BW (GB/s)':<12} | {'Iters':<6}",
+                flush=True,
+            )
+            print("-" * 56, flush=True)
+            for nbytes in MSG_SIZES:
+                iters = TIMED_ITERS if nbytes <= 16384 else TIMED_ITERS // 2
+                avg_us = eager_results[nbytes]
+                bw_gbps = (nbytes / (1024**3)) / (avg_us / 1_000_000.0)
+                print(
+                    f"{format_size(nbytes):<10} | {avg_us:<14.2f} | "
+                    f"{bw_gbps:<12.4f} | {iters:<6}",
+                    flush=True,
+                )
 
     op.teardown()
     comm.finalize()
@@ -191,6 +279,7 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, fused, gpu_offs
 if __name__ == "__main__":
     bidirectional = "--bidirectional" in sys.argv
     fused = "--fused" in sys.argv
+    cuda_graph = "--cuda-graph" in sys.argv
     gpu_offset = 0
     for i, a in enumerate(sys.argv):
         if a == "--gpu-offset" and i + 1 < len(sys.argv):
@@ -199,7 +288,7 @@ if __name__ == "__main__":
     port = find_free_port()
     mp.spawn(
         run_benchmark_worker,
-        args=(port, bidirectional, fused, gpu_offset),
+        args=(port, bidirectional, fused, cuda_graph, gpu_offset),
         nprocs=2,
         join=True,
     )

--- a/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
+++ b/comms/pipes/ll/triton/tests/benchmark_ll_p2p.py
@@ -52,7 +52,7 @@ WARMUP_ITERS = 20
 TIMED_ITERS = 200
 
 
-def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
+def run_benchmark_worker(local_rank, master_port, bidirectional, fused, gpu_offset):
     gpu_id = local_rank + gpu_offset
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(master_port)
@@ -77,13 +77,54 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
     )
     op.setup()
 
-    mode_str = "Bidirectional" if bidirectional else "Unidirectional"
+    if fused:
+        mode_str = "Fused SendRecv"
+    elif bidirectional:
+        mode_str = "Bidirectional"
+    else:
+        mode_str = "Unidirectional"
+    # Pre-warm Triton JIT compilation for all BLOCK_SIZE variants before the
+    # timed benchmark loop. Auto-tune uses BLOCK_SIZE=32 for small messages
+    # (<=256B) and BLOCK_SIZE=512 for larger ones. Each unique BLOCK_SIZE
+    # (a tl.constexpr) triggers a separate Triton compilation that can take
+    # 30+ seconds. Both ranks must finish compiling before the fused kernel
+    # can run, so we pre-warm with sync+barrier after each variant.
+    for prewarm_nbytes in [8, 1024]:
+        prewarm_elements = prewarm_nbytes // 4
+        prewarm_src = torch.randn(
+            prewarm_elements, dtype=torch.float32, device=f"cuda:{gpu_id}"
+        )
+        prewarm_dst = torch.zeros(
+            prewarm_elements, dtype=torch.float32, device=f"cuda:{gpu_id}"
+        )
+        if fused:
+            op.sendrecv(
+                peer=peer_rank,
+                src_tensor=prewarm_src,
+                dst_tensor=prewarm_dst,
+                nbytes=prewarm_nbytes,
+            )
+        elif bidirectional:
+            op.send(peer=peer_rank, src_tensor=prewarm_src, nbytes=prewarm_nbytes)
+            op.recv(peer=peer_rank, dst_tensor=prewarm_dst, nbytes=prewarm_nbytes)
+        else:
+            if local_rank == 0:
+                op.send(peer=peer_rank, src_tensor=prewarm_src, nbytes=prewarm_nbytes)
+            else:
+                op.recv(peer=peer_rank, dst_tensor=prewarm_dst, nbytes=prewarm_nbytes)
+        torch.cuda.synchronize()
+        comm.barrier(False)
+        del prewarm_src, prewarm_dst
+
     if local_rank == 0:
-        print(f"Triton LL P2P Benchmark ({mode_str}, 2 GPUs)")
-        print(f"GPU {gpu_id} <-> GPU {gpu_id + 1 - 2 * local_rank}")
-        print()
-        print(f"{'Size':<10} | {'Latency (us)':<14} | {'BW (GB/s)':<12} | {'Iters':<6}")
-        print("-" * 56)
+        print(f"Triton LL P2P Benchmark ({mode_str}, 2 GPUs)", flush=True)
+        print(f"GPU {gpu_id} <-> GPU {gpu_id + 1 - 2 * local_rank}", flush=True)
+        print(flush=True)
+        print(
+            f"{'Size':<10} | {'Latency (us)':<14} | {'BW (GB/s)':<12} | {'Iters':<6}",
+            flush=True,
+        )
+        print("-" * 56, flush=True)
 
     for nbytes in MSG_SIZES:
         num_elements = nbytes // 4  # int32
@@ -92,7 +133,11 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
 
         # Warmup
         for _ in range(WARMUP_ITERS):
-            if bidirectional:
+            if fused:
+                op.sendrecv(
+                    peer=peer_rank, src_tensor=src, dst_tensor=dst, nbytes=nbytes
+                )
+            elif bidirectional:
                 op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
                 op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
             else:
@@ -112,7 +157,11 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
         comm.barrier(False)
         start_event.record()
         for _ in range(iters):
-            if bidirectional:
+            if fused:
+                op.sendrecv(
+                    peer=peer_rank, src_tensor=src, dst_tensor=dst, nbytes=nbytes
+                )
+            elif bidirectional:
                 op.send(peer=peer_rank, src_tensor=src, nbytes=nbytes)
                 op.recv(peer=peer_rank, dst_tensor=dst, nbytes=nbytes)
             else:
@@ -141,6 +190,7 @@ def run_benchmark_worker(local_rank, master_port, bidirectional, gpu_offset):
 
 if __name__ == "__main__":
     bidirectional = "--bidirectional" in sys.argv
+    fused = "--fused" in sys.argv
     gpu_offset = 0
     for i, a in enumerate(sys.argv):
         if a == "--gpu-offset" and i + 1 < len(sys.argv):
@@ -149,7 +199,7 @@ if __name__ == "__main__":
     port = find_free_port()
     mp.spawn(
         run_benchmark_worker,
-        args=(port, bidirectional, gpu_offset),
+        args=(port, bidirectional, fused, gpu_offset),
         nprocs=2,
         join=True,
     )

--- a/comms/pipes/ll/triton/tests/test_ll_ops.py
+++ b/comms/pipes/ll/triton/tests/test_ll_ops.py
@@ -1,0 +1,201 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+Unit tests for Triton LL constants, utility functions, and auto-tuning.
+
+No GPU required — tests pure-Python logic only.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from comms.pipes.ll.triton.ll_ops import (
+    can_use_ll,
+    ll_buffer_size,
+    LL_DATA_MASK,
+    LL_FLAG_MASK,
+    LL_LINE_SIZE,
+    LL_MEMSET_INIT_BYTE,
+    ll_num_lines,
+    LL_PAYLOAD_PER_LINE,
+    ll_peer_buffer_offset,
+    ll_peer_index,
+    LL_READY_TO_WRITE,
+    ll_total_buffer_size,
+)
+
+
+class TestLlConstants(unittest.TestCase):
+    def test_line_size(self) -> None:
+        self.assertEqual(LL_LINE_SIZE, 16)
+
+    def test_payload_per_line(self) -> None:
+        self.assertEqual(LL_PAYLOAD_PER_LINE, 8)
+
+    def test_ready_to_write(self) -> None:
+        self.assertEqual(LL_READY_TO_WRITE, 0xFFFFFFFF)
+
+    def test_memset_init_byte(self) -> None:
+        self.assertEqual(LL_MEMSET_INIT_BYTE, 0xFF)
+
+    def test_flag_mask(self) -> None:
+        self.assertEqual(LL_FLAG_MASK, 0xFFFFFFFF00000000)
+
+    def test_data_mask(self) -> None:
+        self.assertEqual(LL_DATA_MASK, 0x00000000FFFFFFFF)
+
+    def test_masks_are_complementary(self) -> None:
+        self.assertEqual(LL_FLAG_MASK | LL_DATA_MASK, 0xFFFFFFFFFFFFFFFF)
+        self.assertEqual(LL_FLAG_MASK & LL_DATA_MASK, 0)
+
+
+class TestLlNumLines(unittest.TestCase):
+    def test_zero_bytes(self) -> None:
+        self.assertEqual(ll_num_lines(0), 0)
+
+    def test_one_byte(self) -> None:
+        self.assertEqual(ll_num_lines(1), 1)
+
+    def test_seven_bytes(self) -> None:
+        self.assertEqual(ll_num_lines(7), 1)
+
+    def test_exact_one_line(self) -> None:
+        self.assertEqual(ll_num_lines(8), 1)
+
+    def test_nine_bytes(self) -> None:
+        self.assertEqual(ll_num_lines(9), 2)
+
+    def test_exact_two_lines(self) -> None:
+        self.assertEqual(ll_num_lines(16), 2)
+
+    def test_hundred_bytes(self) -> None:
+        self.assertEqual(ll_num_lines(100), 13)
+
+
+class TestLlBufferSize(unittest.TestCase):
+    def test_zero(self) -> None:
+        self.assertEqual(ll_buffer_size(0), 0)
+
+    def test_one_line(self) -> None:
+        self.assertEqual(ll_buffer_size(8), 16)
+
+    def test_two_lines(self) -> None:
+        self.assertEqual(ll_buffer_size(16), 32)
+
+    def test_partial_line(self) -> None:
+        self.assertEqual(ll_buffer_size(9), 32)
+
+    def test_large(self) -> None:
+        self.assertEqual(ll_buffer_size(1024), ll_num_lines(1024) * 16)
+
+
+class TestLlTotalBufferSize(unittest.TestCase):
+    def test_two_ranks(self) -> None:
+        self.assertEqual(ll_total_buffer_size(8, 2), 16)
+
+    def test_eight_ranks(self) -> None:
+        self.assertEqual(ll_total_buffer_size(8, 8), 16 * 7)
+
+    def test_gb200_max_ranks(self) -> None:
+        per_peer = ll_buffer_size(65536)
+        self.assertEqual(ll_total_buffer_size(65536, 72), per_peer * 71)
+
+
+class TestCanUseLl(unittest.TestCase):
+    def test_zero(self) -> None:
+        self.assertTrue(can_use_ll(0))
+
+    def test_valid_multiples(self) -> None:
+        self.assertTrue(can_use_ll(8))
+        self.assertTrue(can_use_ll(16))
+        self.assertTrue(can_use_ll(1024))
+
+    def test_invalid_non_multiples(self) -> None:
+        self.assertFalse(can_use_ll(1))
+        self.assertFalse(can_use_ll(7))
+        self.assertFalse(can_use_ll(15))
+        self.assertFalse(can_use_ll(100))
+
+
+class TestLlPeerIndex(unittest.TestCase):
+    def test_peer_below_self(self) -> None:
+        self.assertEqual(ll_peer_index(target_rank=0, self_rank=1), 0)
+        self.assertEqual(ll_peer_index(target_rank=0, self_rank=3), 0)
+        self.assertEqual(ll_peer_index(target_rank=2, self_rank=3), 2)
+
+    def test_peer_above_self(self) -> None:
+        self.assertEqual(ll_peer_index(target_rank=2, self_rank=1), 1)
+        self.assertEqual(ll_peer_index(target_rank=3, self_rank=1), 2)
+        self.assertEqual(ll_peer_index(target_rank=7, self_rank=0), 6)
+
+    def test_world_size_4_from_rank_1(self) -> None:
+        self.assertEqual(ll_peer_index(0, 1), 0)
+        self.assertEqual(ll_peer_index(2, 1), 1)
+        self.assertEqual(ll_peer_index(3, 1), 2)
+
+    def test_contiguous_indices(self) -> None:
+        world_size = 8
+        self_rank = 3
+        indices = [
+            ll_peer_index(r, self_rank) for r in range(world_size) if r != self_rank
+        ]
+        self.assertEqual(indices, list(range(world_size - 1)))
+
+
+class TestLlPeerBufferOffset(unittest.TestCase):
+    def test_first_peer(self) -> None:
+        self.assertEqual(
+            ll_peer_buffer_offset(target_rank=0, self_rank=1, per_peer_size=256),
+            0,
+        )
+
+    def test_second_peer(self) -> None:
+        self.assertEqual(
+            ll_peer_buffer_offset(target_rank=2, self_rank=1, per_peer_size=256),
+            256,
+        )
+
+    def test_send_recv_symmetry(self) -> None:
+        per_peer_size = 128
+        my_rank = 1
+        peer = 3
+        send_offset = ll_peer_buffer_offset(my_rank, peer, per_peer_size)
+        recv_offset = ll_peer_buffer_offset(peer, my_rank, per_peer_size)
+        self.assertNotEqual(send_offset, recv_offset)
+        self.assertEqual(send_offset, ll_peer_index(my_rank, peer) * per_peer_size)
+        self.assertEqual(recv_offset, ll_peer_index(peer, my_rank) * per_peer_size)
+
+    def test_offsets_partition_buffer(self) -> None:
+        # All peer offsets from a given self_rank must be distinct, aligned to
+        # per_peer_size, and exactly cover [0, (world_size-1)*per_peer_size).
+        world_size = 8
+        self_rank = 3
+        per_peer_size = 256
+        offsets = [
+            ll_peer_buffer_offset(r, self_rank, per_peer_size)
+            for r in range(world_size)
+            if r != self_rank
+        ]
+        self.assertEqual(len(set(offsets)), world_size - 1)
+        for off in offsets:
+            self.assertEqual(off % per_peer_size, 0)
+        self.assertEqual(
+            sorted(offsets),
+            [i * per_peer_size for i in range(world_size - 1)],
+        )
+
+    def test_offsets_within_total_buffer(self) -> None:
+        # Each region [offset, offset + per_peer_size) must fit within the
+        # total LL buffer allocated for the rank.
+        world_size = 4
+        self_rank = 2
+        per_peer_size = ll_buffer_size(64)
+        total = ll_total_buffer_size(64, world_size)
+        for r in range(world_size):
+            if r == self_rank:
+                continue
+            off = ll_peer_buffer_offset(r, self_rank, per_peer_size)
+            self.assertGreaterEqual(off, 0)
+            self.assertLessEqual(off + per_peer_size, total)

--- a/comms/pipes/ll/triton/tests/test_ll_ops.py
+++ b/comms/pipes/ll/triton/tests/test_ll_ops.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import unittest
 
+from comms.pipes.ll.triton.auto_tune import ll_auto_tune, ll_auto_tune_bidirectional
 from comms.pipes.ll.triton.ll_ops import (
     can_use_ll,
     ll_buffer_size,
@@ -199,3 +200,51 @@ class TestLlPeerBufferOffset(unittest.TestCase):
             off = ll_peer_buffer_offset(r, self_rank, per_peer_size)
             self.assertGreaterEqual(off, 0)
             self.assertLessEqual(off + per_peer_size, total)
+
+
+class TestLlAutoTune(unittest.TestCase):
+    def test_small_message_uses_single_warp(self) -> None:
+        config = ll_auto_tune(64)
+        self.assertEqual(config["block_size"], 32)
+        self.assertEqual(config["num_blocks"], 1)
+
+    def test_boundary_256(self) -> None:
+        config = ll_auto_tune(256)
+        self.assertEqual(config["block_size"], 32)
+
+    def test_medium_message(self) -> None:
+        config = ll_auto_tune(1024)
+        self.assertEqual(config["block_size"], 512)
+        self.assertEqual(config["num_blocks"], 1)
+
+    def test_large_message(self) -> None:
+        config = ll_auto_tune(65536)
+        self.assertEqual(config["block_size"], 512)
+        self.assertEqual(config["num_blocks"], 32)
+
+    def test_returns_valid_keys(self) -> None:
+        config = ll_auto_tune(8)
+        self.assertIn("num_blocks", config)
+        self.assertIn("block_size", config)
+
+    def test_monotonically_increasing_blocks(self) -> None:
+        sizes = [8, 256, 512, 1024, 4096, 16384, 65536, 262144]
+        block_counts = [ll_auto_tune(s)["num_blocks"] for s in sizes]
+        for i in range(1, len(block_counts)):
+            self.assertGreaterEqual(block_counts[i], block_counts[i - 1])
+
+    def test_very_large_message(self) -> None:
+        config = ll_auto_tune(1024 * 1024)
+        self.assertEqual(config["num_blocks"], 256)
+
+
+class TestLlAutoTuneBidirectional(unittest.TestCase):
+    def test_doubles_blocks(self) -> None:
+        uni = ll_auto_tune(16384)
+        bidi = ll_auto_tune_bidirectional(16384)
+        self.assertEqual(bidi["num_blocks"], uni["num_blocks"] * 2)
+        self.assertEqual(bidi["block_size"], uni["block_size"])
+
+    def test_capped_at_1024(self) -> None:
+        bidi = ll_auto_tune_bidirectional(1024 * 1024)
+        self.assertLessEqual(bidi["num_blocks"], 1024)

--- a/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
+++ b/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
@@ -1,0 +1,369 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Confidential and proprietary.
+# pyre-unsafe
+"""
+End-to-end integration tests for Triton LL P2P send/recv/forward.
+
+Requires 8 NVLink-connected GPUs. Run with:
+    buck2 test -c nccl.enable_pipes=false \
+        -c fbcode.enable_gpu_sections=true \
+        -c fbcode.platform010_cuda_version=12.8 \
+        -c fbcode.nvcc_arch=h100a \
+        -c hpc_comms.use_ncclx=stable \
+        //comms/pipes/ll/triton/tests:test_ll_p2p_e2e
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import time
+import unittest
+
+import torch
+from torch.utils._triton import has_triton
+from torchcomms.tests.integration.py.TorchCommTestHelpers import TorchCommTestWrapper
+
+
+TRITON_AVAILABLE = has_triton()
+RUN_DEVICE_API_TEST = os.environ.get("RUN_DEVICE_API_TEST", "false").lower() == "true"
+
+
+def _skip_if_not_ready() -> bool:
+    return TRITON_AVAILABLE and torch.cuda.is_available() and RUN_DEVICE_API_TEST
+
+
+class LlP2pTestBase(unittest.TestCase):
+    """Base class that sets up LlP2pOp once per test class."""
+
+    wrapper = None
+    op = None
+    MAX_NBYTES = 65536
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _skip_if_not_ready():
+            raise unittest.SkipTest("E2E test environment not ready")
+        from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
+
+        torch.cuda.synchronize()
+        cls.wrapper = TorchCommTestWrapper()
+        cls.torchcomm = cls.wrapper.get_torchcomm()
+        cls.rank = cls.torchcomm.get_rank()
+        cls.world_size = cls.torchcomm.get_size()
+        cls.device = cls.torchcomm.get_device()
+
+        cls.op = LlP2pOp(
+            comm=cls.torchcomm,
+            max_nbytes=cls.MAX_NBYTES,
+            device=cls.device,
+        )
+        cls.op.setup()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.op is not None:
+            cls.op.teardown()
+            cls.op = None
+        cls.torchcomm = None
+        cls.wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+
+class TestBasicSendRecv(LlP2pTestBase):
+    """Basic send/recv at various message sizes."""
+
+    def _run_send_recv(self, nbytes: int) -> None:
+        num_elements = nbytes // 4  # int32
+        peer = 1 if self.rank == 0 else 0
+
+        if self.rank == 0:
+            src = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            torch.cuda.synchronize()
+        elif self.rank == 1:
+            src = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+            torch.cuda.synchronize()
+
+            expected = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg=f"Rank {self.rank}: Data mismatch for {nbytes}B send/recv",
+            )
+        else:
+            return
+
+    def test_8b(self) -> None:
+        self._run_send_recv(8)
+
+    def test_64b(self) -> None:
+        self._run_send_recv(64)
+
+    def test_256b(self) -> None:
+        self._run_send_recv(256)
+
+    def test_1kb(self) -> None:
+        self._run_send_recv(1024)
+
+    def test_4kb(self) -> None:
+        self._run_send_recv(4096)
+
+    def test_16kb(self) -> None:
+        self._run_send_recv(16384)
+
+    def test_64kb(self) -> None:
+        self._run_send_recv(65536)
+
+
+class TestBidirectional(LlP2pTestBase):
+    """Both rank 0 and rank 1 send/recv simultaneously."""
+
+    def test_bidirectional_1kb(self) -> None:
+        if self.rank > 1:
+            return
+
+        nbytes = 1024
+        num_elements = nbytes // 4
+        peer = 1 if self.rank == 0 else 0
+
+        src = torch.full(
+            (num_elements,),
+            self.rank + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+
+        self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+        self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+        torch.cuda.synchronize()
+
+        expected = torch.full(
+            (num_elements,),
+            peer + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.testing.assert_close(
+            dst,
+            expected,
+            msg=f"Rank {self.rank}: Bidirectional data mismatch",
+        )
+
+
+class TestMultiStep(LlP2pTestBase):
+    """Multiple consecutive send/recv on the same buffer (ABA prevention)."""
+
+    def test_10_steps(self) -> None:
+        if self.rank > 1:
+            return
+
+        nbytes = 256
+        num_elements = nbytes // 4
+        peer = 1 if self.rank == 0 else 0
+
+        for step in range(10):
+            fill_value = (self.rank + 1) * 100 + step
+
+            if self.rank == 0:
+                src = torch.full(
+                    (num_elements,),
+                    fill_value,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            else:
+                dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+                self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+                torch.cuda.synchronize()
+
+                expected_value = (peer + 1) * 100 + step
+                expected = torch.full(
+                    (num_elements,),
+                    expected_value,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                torch.testing.assert_close(
+                    dst,
+                    expected,
+                    msg=f"Rank {self.rank}: Multi-step mismatch at step {step}",
+                )
+
+
+class TestVaryingData(LlP2pTestBase):
+    """Different data patterns to catch corruption."""
+
+    def _send_recv_pattern(self, src_data: torch.Tensor) -> None:
+        nbytes = src_data.nbytes
+        peer = 1 if self.rank == 0 else 0
+
+        if self.rank == 0:
+            self.op.send(peer=peer, src_tensor=src_data, nbytes=nbytes)
+        elif self.rank == 1:
+            dst = torch.zeros_like(src_data)
+            self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(dst, src_data.to(self.device))
+        else:
+            return
+
+    def test_all_zeros(self) -> None:
+        self._send_recv_pattern(torch.zeros(64, dtype=torch.int32, device=self.device))
+
+    def test_all_ones(self) -> None:
+        self._send_recv_pattern(torch.ones(64, dtype=torch.int32, device=self.device))
+
+    def test_sequential(self) -> None:
+        self._send_recv_pattern(
+            torch.arange(128, dtype=torch.int32, device=self.device)
+        )
+
+    def test_large_values(self) -> None:
+        self._send_recv_pattern(
+            torch.full((64,), 0x7FFFFFFF, dtype=torch.int32, device=self.device)
+        )
+
+
+class TestZeroBytes(LlP2pTestBase):
+    """Edge case: zero-byte send/recv should be a no-op."""
+
+    def test_zero_bytes(self) -> None:
+        if self.rank > 1:
+            return
+
+        peer = 1 if self.rank == 0 else 0
+        src = torch.empty(0, dtype=torch.int32, device=self.device)
+        dst = torch.empty(0, dtype=torch.int32, device=self.device)
+
+        if self.rank == 0:
+            self.op.send(peer=peer, src_tensor=src, nbytes=0)
+        else:
+            self.op.recv(peer=peer, dst_tensor=dst, nbytes=0)
+
+        torch.cuda.synchronize()
+
+
+class TestMultiPeer(LlP2pTestBase):
+    """Rank 0 sends to all other ranks simultaneously."""
+
+    def test_multi_peer_1kb(self) -> None:
+        nbytes = 1024
+        num_elements = nbytes // 4
+
+        if self.rank == 0:
+            for peer in range(1, self.world_size):
+                src = torch.full(
+                    (num_elements,),
+                    peer * 10,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            torch.cuda.synchronize()
+        else:
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            self.op.recv(peer=0, dst_tensor=dst, nbytes=nbytes)
+            torch.cuda.synchronize()
+
+            expected = torch.full(
+                (num_elements,),
+                self.rank * 10,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg=f"Rank {self.rank}: Multi-peer data mismatch",
+            )
+
+
+@unittest.skipUnless(
+    _skip_if_not_ready(),
+    "Forward test requires E2E environment",
+)
+class TestForward(unittest.TestCase):
+    """Forward test: rank 0 -> rank 1 -> rank 2 pipeline."""
+
+    wrapper = None
+    op = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
+
+        torch.cuda.synchronize()
+        cls.wrapper = TorchCommTestWrapper()
+        cls.torchcomm = cls.wrapper.get_torchcomm()
+        cls.rank = cls.torchcomm.get_rank()
+        cls.world_size = cls.torchcomm.get_size()
+        cls.device = cls.torchcomm.get_device()
+
+        if cls.world_size < 3:
+            raise unittest.SkipTest("Forward test requires at least 3 GPUs")
+
+        cls.op = LlP2pOp(
+            comm=cls.torchcomm,
+            max_nbytes=4096,
+            device=cls.device,
+        )
+        cls.op.setup()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.op is not None:
+            cls.op.teardown()
+            cls.op = None
+        cls.torchcomm = None
+        cls.wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+    def test_forward_1kb(self) -> None:
+        nbytes = 1024
+        num_elements = nbytes // 4
+
+        if self.rank == 0:
+            src = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            self.op.send(peer=1, src_tensor=src, nbytes=nbytes)
+            torch.cuda.synchronize()
+
+        elif self.rank == 1:
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            self.op.forward(
+                predecessor=0,
+                successor=2,
+                dst_tensor=dst,
+                nbytes=nbytes,
+            )
+            torch.cuda.synchronize()
+
+            expected = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg="Rank 1: Forward local copy mismatch",
+            )
+
+        elif self.rank == 2:
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+            self.op.recv(peer=1, dst_tensor=dst, nbytes=nbytes)
+            torch.cuda.synchronize()
+
+            expected = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg="Rank 2: Forward receive mismatch",
+            )
+        else:
+            return

--- a/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
+++ b/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
@@ -429,3 +429,144 @@ class TestFusedSendRecv(LlP2pTestBase):
                 expected,
                 msg=f"Rank {self.rank}: Fused sendrecv mismatch at {nbytes}B",
             )
+
+
+@unittest.skipUnless(
+    _skip_if_not_ready(),
+    "CUDA graph test requires E2E environment",
+)
+class TestCudaGraph(unittest.TestCase):
+    """CUDA graph capture + replay correctness for LL P2P."""
+
+    wrapper = None
+    op = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from comms.pipes.ll.triton.ll_p2p_op import LlP2pOp
+
+        torch.cuda.synchronize()
+        cls.wrapper = TorchCommTestWrapper()
+        cls.torchcomm = cls.wrapper.get_torchcomm()
+        cls.rank = cls.torchcomm.get_rank()
+        cls.world_size = cls.torchcomm.get_size()
+        cls.device = cls.torchcomm.get_device()
+
+        cls.op = LlP2pOp(
+            comm=cls.torchcomm,
+            max_nbytes=4096,
+            device=cls.device,
+        )
+        cls.op.setup()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.op is not None:
+            cls.op.teardown()
+            cls.op = None
+        cls.torchcomm = None
+        cls.wrapper = None
+        gc.collect()
+        torch.cuda.synchronize()
+        time.sleep(2)
+
+    def test_graph_replay_3x(self) -> None:
+        """Capture one send/recv, replay 3 times with different data."""
+        if self.rank > 1:
+            return
+
+        nbytes = 1024
+        num_elements = nbytes // 4
+        peer = 1 if self.rank == 0 else 0
+
+        src = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+        dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+
+        # Warmup
+        for _ in range(5):
+            if self.rank == 0:
+                self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            else:
+                self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+
+        # Capture
+        graph = torch.cuda.CUDAGraph()
+        # pyre-fixme[6]: pool handle type
+        with torch.cuda.graph(graph, pool=self.op.get_graph_pool_id()):  # type: ignore[arg-type]
+            if self.rank == 0:
+                self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            else:
+                self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+
+        # Replay 3 times with different data
+        for replay_idx in range(3):
+            fill_value = (self.rank + 1) * 100 + replay_idx
+            src.fill_(fill_value)
+            dst.fill_(0)
+
+            graph.replay()
+            torch.cuda.synchronize()
+
+            if self.rank == 1:
+                expected_value = (peer + 1) * 100 + replay_idx
+                expected = torch.full(
+                    (num_elements,),
+                    expected_value,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                torch.testing.assert_close(
+                    dst,
+                    expected,
+                    msg=f"Rank {self.rank}: Graph replay {replay_idx} data mismatch",
+                )
+
+        del graph
+
+    def test_graph_batch_5_iters(self) -> None:
+        """Capture 5 consecutive send/recv in one graph, replay once."""
+        if self.rank > 1:
+            return
+
+        nbytes = 1024
+        num_elements = nbytes // 4
+        peer = 1 if self.rank == 0 else 0
+
+        src = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+        dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+
+        # Warmup
+        for _ in range(5):
+            if self.rank == 0:
+                self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+            else:
+                self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+        torch.cuda.synchronize()
+        self.torchcomm.barrier(False)
+
+        # Capture 5 iterations
+        graph = torch.cuda.CUDAGraph()
+        # pyre-fixme[6]: pool handle type
+        with torch.cuda.graph(graph, pool=self.op.get_graph_pool_id()):  # type: ignore[arg-type]
+            for _ in range(5):
+                if self.rank == 0:
+                    self.op.send(peer=peer, src_tensor=src, nbytes=nbytes)
+                else:
+                    self.op.recv(peer=peer, dst_tensor=dst, nbytes=nbytes)
+
+        # Replay
+        dst.fill_(0)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        if self.rank == 1:
+            expected = torch.arange(num_elements, dtype=torch.int32, device=self.device)
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg="Rank 1: Graph batch 5-iter data mismatch",
+            )
+
+        del graph

--- a/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
+++ b/comms/pipes/ll/triton/tests/test_ll_p2p_e2e.py
@@ -367,3 +367,65 @@ class TestForward(unittest.TestCase):
             )
         else:
             return
+
+
+class TestFusedSendRecv(LlP2pTestBase):
+    """Fused sendrecv correctness tests."""
+
+    def test_bidirectional_1kb(self) -> None:
+        if self.rank > 1:
+            return
+
+        nbytes = 1024
+        num_elements = nbytes // 4
+        peer = 1 if self.rank == 0 else 0
+
+        src = torch.full(
+            (num_elements,),
+            self.rank + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+
+        self.op.sendrecv(peer=peer, src_tensor=src, dst_tensor=dst, nbytes=nbytes)
+        torch.cuda.synchronize()
+
+        expected = torch.full(
+            (num_elements,),
+            peer + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.testing.assert_close(
+            dst,
+            expected,
+            msg=f"Rank {self.rank}: Fused sendrecv data mismatch",
+        )
+
+    def test_multiple_sizes(self) -> None:
+        if self.rank > 1:
+            return
+
+        peer = 1 if self.rank == 0 else 0
+
+        for nbytes in [8, 64, 256, 1024, 16384, 65536]:
+            num_elements = nbytes // 4
+            src = (
+                torch.arange(num_elements, dtype=torch.int32, device=self.device)
+                + self.rank * 1000
+            )
+            dst = torch.zeros(num_elements, dtype=torch.int32, device=self.device)
+
+            self.op.sendrecv(peer=peer, src_tensor=src, dst_tensor=dst, nbytes=nbytes)
+            torch.cuda.synchronize()
+
+            expected = (
+                torch.arange(num_elements, dtype=torch.int32, device=self.device)
+                + peer * 1000
+            )
+            torch.testing.assert_close(
+                dst,
+                expected,
+                msg=f"Rank {self.rank}: Fused sendrecv mismatch at {nbytes}B",
+            )


### PR DESCRIPTION
Summary:
Adds CUDA graph capture/replay support to `LlP2pOp`, eliminating Python/Triton dispatch overhead (~15us per call) for repeated LL P2P operations.

Profiling shows the Triton LL kernel takes only 5.76us on the GPU, but end-to-end latency is ~21us due to host-side overhead (Python dispatch + CUDA launch API). CUDA graph capture records the kernel launch sequence once and replays it from the GPU, bypassing all host dispatch.

**`LlP2pOp.get_graph_pool_id()`**: Returns the LL buffer's memory pool handle for `torch.cuda.graph(pool=...)`, following the AlltoallvOp pattern. The LL protocol's flag-based handshake (READY_TO_WRITE / flag=1 cycle) is naturally graph-safe — no iteration counter or sync_buffer mechanism needed.

**Benchmark `--cuda-graph` mode**: Runs both eager and graph sweeps side-by-side, printing a comparison table with speedup. Both ranks capture their respective operations into separate graphs. Cross-rank synchronization during capture is handled by barrier + sync after warmup.

**E2E tests**: `TestCudaGraph` with two test methods:
- `test_graph_replay_3x`: Captures one send/recv, replays 3 times with different src data, verifies correctness on each replay. Validates flag handshake resets across replays.
- `test_graph_batch_5_iters`: Captures 5 consecutive send/recv iterations in one graph, replays once. Validates flag handshake within a batched graph.

Differential Revision: D104424449


