### PR TITLE
Fix NCCL_SOCKET_IFNAME parsing in getInterfaceAddress (#2457)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -651,27 +651,12 @@ void CtranIb::init(
 void CtranIb::bootstrapStart(
     std::optional<const SocketServerAddr*> qpServerAddr) {
   // Setup the listen socket
-  std::string* ifnamePtr = nullptr;
+  std::string resolvedIfName;
   folly::SocketAddress addrSockAddr;
   if (this->bootstrapMode == BootstrapMode::kDefaultServer) {
-    ifnamePtr = &NCCL_SOCKET_IFNAME;
-    // Validate that NCCL_SOCKET_IFNAME contains only one interface
-    if (NCCL_SOCKET_IFNAME.find(',') != std::string::npos) {
-      CLOGF(
-          WARN,
-          "CTRAN-IB: NCCL_SOCKET_IFNAME contains multiple interfaces ({}). "
-          "Only one interface should be specified.",
-          NCCL_SOCKET_IFNAME);
-      throw ::ctran::utils::Exception(
-          "CTRAN-IB: NCCL_SOCKET_IFNAME should specify only one interface",
-          commInvalidArgument,
-          this->rank,
-          this->commHash,
-          this->commDesc);
-    }
     // Use default NCCL socket ifname
     auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
-        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX);
+        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
     if (maybeAddr.hasError()) {
       CLOGF(WARN, "CTRAN-IB: No socket interfaces found");
       throw ::ctran::utils::Exception(
@@ -691,11 +676,11 @@ void CtranIb::bootstrapStart(
     auto qpServerAddrPtr = qpServerAddr.value();
     // use provided addr(i.e. ip, port, host) to initialize ctranIB
     addrSockAddr = toSocketAddress(*qpServerAddrPtr);
-    ifnamePtr = const_cast<std::string*>(&qpServerAddrPtr->ifName);
+    resolvedIfName = qpServerAddrPtr->ifName;
   }
 
   FB_SYSCHECKTHROW_EX(
-      this->listenSocket->bindAndListen(addrSockAddr, *ifnamePtr),
+      this->listenSocket->bindAndListen(addrSockAddr, resolvedIfName),
       this->rank,
       this->commHash,
       this->commDesc);
@@ -707,7 +692,7 @@ void CtranIb::bootstrapStart(
       bootstrapMode == BootstrapMode::kSpecifiedServer ? "specified"
                                                        : "self-finding",
       this->listenSocket->getListenAddress()->describe().c_str(),
-      *ifnamePtr);
+      resolvedIfName);
 
   // Exchange listen sock address among all ranks
   if (comm) {

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -311,27 +311,6 @@ TEST_P(CtranIbBootstrapParameterizedTest, BootstrapStartDefaultServer) {
   getAndValidateListenAddr(ctranIb.get());
 }
 
-// Test that NCCL_SOCKET_IFNAME with multiple interfaces (comma-separated)
-// throws an exception.
-TEST_F(CtranIbBootstrapCommonTest, MultipleInterfacesInSocketIfnameThrows) {
-  std::string originalIfname = NCCL_SOCKET_IFNAME;
-  SCOPE_EXIT {
-    NCCL_SOCKET_IFNAME = originalIfname;
-  };
-
-  NCCL_SOCKET_IFNAME = "beth0,beth1,beth2"; // > 1 interface (comma-separated)
-  auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
-  EXPECT_THROW(
-      {
-        auto ctranIb = createCtranIb(
-            /*rank=*/0,
-            CtranIb::BootstrapMode::kDefaultServer,
-            abortCtrl,
-            std::nullopt);
-      },
-      ::ctran::utils::Exception);
-}
-
 // Test that NCCL_SOCKET_IFNAME with a single interface works correctly
 TEST_F(CtranIbBootstrapCommonTest, SingleInterfaceInSocketIfnameSucceeds) {
   std::string originalIfname = NCCL_SOCKET_IFNAME;
@@ -348,11 +327,26 @@ TEST_F(CtranIbBootstrapCommonTest, SingleInterfaceInSocketIfnameSucceeds) {
   getAndValidateListenAddr(ctranIb.get());
 }
 
-// Test that empty NCCL_SOCKET_IFNAME does not trigger the multi-interface error
-// (it should fail later with "No socket interfaces found" instead)
-TEST_F(
-    CtranIbBootstrapCommonTest,
-    EmptySocketIfnameDoesNotTriggerMultiIfError) {
+// Test that NCCL_SOCKET_IFNAME with multiple comma-separated interfaces works.
+// This simulates the MAST scheduler override that expands beth0 to
+// beth0,beth1,...,beth7. The bootstrap should resolve to a single interface
+// and bind successfully (no ENODEV from SO_BINDTODEVICE).
+TEST_F(CtranIbBootstrapCommonTest, MultiInterfaceInSocketIfnameSucceeds) {
+  std::string originalIfname = NCCL_SOCKET_IFNAME;
+  SCOPE_EXIT {
+    NCCL_SOCKET_IFNAME = originalIfname;
+  };
+
+  NCCL_SOCKET_IFNAME = "lo,eth0";
+  auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+
+  auto ctranIb = createCtranIb(
+      /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
+  getAndValidateListenAddr(ctranIb.get());
+}
+
+// Test that empty NCCL_SOCKET_IFNAME fails with "No socket interfaces found"
+TEST_F(CtranIbBootstrapCommonTest, EmptySocketIfnameFailsNoInterfaces) {
   std::string originalIfname = NCCL_SOCKET_IFNAME;
   SCOPE_EXIT {
     NCCL_SOCKET_IFNAME = originalIfname;
@@ -361,17 +355,14 @@ TEST_F(
   NCCL_SOCKET_IFNAME = "";
   auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
 
-  // Empty string does not contain a comma, so the multi-interface check passes.
   try {
     auto ctranIb = createCtranIb(
         /*rank=*/0, CtranIb::BootstrapMode::kDefaultServer, abortCtrl);
-    getAndValidateListenAddr(ctranIb.get()); // Creation succeeded
+    getAndValidateListenAddr(ctranIb.get());
   } catch (const ::ctran::utils::Exception& e) {
-    // If it throws, verify it's NOT the multi-interface error
-    std::string errorMsg = e.what();
-    EXPECT_EQ(
-        errorMsg.find("should specify only one interface"), std::string::npos)
-        << "Empty NCCL_SOCKET_IFNAME should not trigger multi-interface error";
+    EXPECT_NE(
+        std::string(e.what()).find("No socket interfaces found"),
+        std::string::npos);
   }
 }
 

--- a/comms/ctran/backends/socket/CtranSocket.cc
+++ b/comms/ctran/backends/socket/CtranSocket.cc
@@ -124,8 +124,9 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
     this->preConnectPeerMap_.resize(comm->statex_->nRanks(), false);
     // only exchange listen sockets with bootstrapAllGather when using comm to
     // initialize CtranSocket
+    std::string resolvedIfName;
     auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
-        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX);
+        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
     if (maybeAddr.hasError()) {
       std::string msg = fmt::format(
           "CTRAN-SOCKET: No socket interfaces found (NCCL_SOCKET_IFNAME={}, NCCL_SOCKET_IPADDR_PREFIX={})",
@@ -140,12 +141,12 @@ void CtranSocket::init(const SocketServerAddr& serverAddr) {
           INIT,
           "CTRAN-SOCKET: socket address set to {} on interface {}",
           maybeAddr->str(),
-          NCCL_SOCKET_IFNAME);
+          resolvedIfName);
     }
 
     folly::SocketAddress ifAddrSockAddr(maybeAddr.value(), 0 /* port */);
     FB_SYSCHECKTHROW_EX(
-        listenSocket_.bindAndListen(ifAddrSockAddr, NCCL_SOCKET_IFNAME),
+        listenSocket_.bindAndListen(ifAddrSockAddr, resolvedIfName),
         ncclLogData_);
     CLOGF_SUBSYS(
         INFO,

--- a/comms/ctran/bootstrap/NcclSocketNameFilter.cc
+++ b/comms/ctran/bootstrap/NcclSocketNameFilter.cc
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "NcclSocketNameFilter.h"
+
+#include <cstring>
+
+namespace ctran::bootstrap {
+
+IfNameFilter parseIfNameSpec(const std::string& spec) {
+  IfNameFilter filter;
+  if (spec.empty()) {
+    return filter;
+  }
+
+  const char* ptr = spec.c_str();
+
+  // Check for ^ (negate) prefix
+  if (*ptr == '^') {
+    filter.negate = true;
+    ptr++;
+  }
+
+  // Check for = (exact match) prefix
+  if (*ptr == '=') {
+    filter.exactMatch = true;
+    ptr++;
+  }
+
+  // Split remaining string by commas
+  std::string remaining(ptr);
+  size_t start = 0;
+  while (start < remaining.size()) {
+    size_t comma = remaining.find(',', start);
+    std::string token;
+    if (comma == std::string::npos) {
+      token = remaining.substr(start);
+      start = remaining.size();
+    } else {
+      token = remaining.substr(start, comma - start);
+      start = comma + 1;
+    }
+    if (!token.empty()) {
+      filter.entries.push_back(std::move(token));
+    }
+  }
+
+  return filter;
+}
+
+bool matchesIfName(const IfNameFilter& filter, const char* ifaName) {
+  // Empty filter matches everything
+  if (filter.entries.empty()) {
+    return true;
+  }
+
+  bool matched = false;
+  for (const auto& entry : filter.entries) {
+    if (filter.exactMatch) {
+      if (std::strcmp(ifaName, entry.c_str()) == 0) {
+        matched = true;
+        break;
+      }
+    } else {
+      if (std::strncmp(ifaName, entry.c_str(), entry.size()) == 0) {
+        matched = true;
+        break;
+      }
+    }
+  }
+
+  return filter.negate ? !matched : matched;
+}
+
+} // namespace ctran::bootstrap

--- a/comms/ctran/bootstrap/NcclSocketNameFilter.h
+++ b/comms/ctran/bootstrap/NcclSocketNameFilter.h
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ctran::bootstrap {
+
+struct IfNameFilter {
+  std::vector<std::string> entries;
+  bool negate{false};
+  bool exactMatch{false};
+};
+
+// Parse NCCL_SOCKET_IFNAME spec string into an IfNameFilter.
+// Handles ^, =, and comma-separated lists.
+// TODO: Have callers pass IfNameFilter directly to getInterfaceAddress instead
+// of parsing inside it. The current coupling to NCCL_SOCKET_IFNAME format makes
+// it fragile when input ifname strings vary. Deferred because it impacts mccl
+// callsites too.
+IfNameFilter parseIfNameSpec(const std::string& spec);
+
+// Check if a system interface name matches the filter.
+// Empty filter (no entries) matches everything.
+bool matchesIfName(const IfNameFilter& filter, const char* ifaName);
+
+} // namespace ctran::bootstrap

--- a/comms/ctran/bootstrap/Socket.cc
+++ b/comms/ctran/bootstrap/Socket.cc
@@ -13,6 +13,7 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/logging/xlog.h>
+#include "comms/ctran/bootstrap/NcclSocketNameFilter.h"
 #include "comms/ctran/utils/Exception.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -51,8 +52,18 @@ folly::SocketAddress getSocketAdddress(int fd) {
 folly::Expected<folly::IPAddress, int> getInterfaceAddress(
     const std::string& ifName,
     const std::string& addrPrefix,
-    bool preferV6) {
+    bool preferV6,
+    std::string* resolvedIfName) {
   struct ifaddrs* ifaddrs = nullptr;
+
+  XLOGF(
+      DBG,
+      "getInterfaceAddress called with ifName=\"{}\" addrPrefix=\"{}\" preferV6={}",
+      ifName,
+      addrPrefix,
+      preferV6);
+
+  const auto ifNameFilter = parseIfNameSpec(ifName);
 
   if (getifaddrs(&ifaddrs) == -1) {
     return folly::makeUnexpected(errno);
@@ -61,45 +72,69 @@ folly::Expected<folly::IPAddress, int> getInterfaceAddress(
     freeifaddrs(ifaddrs);
   };
 
-  std::vector<folly::IPAddress> addrs;
+  std::vector<std::pair<folly::IPAddress, std::string>> addrs;
   for (auto ifa = ifaddrs; ifa != nullptr; ifa = ifa->ifa_next) {
     if (ifa->ifa_addr == nullptr) {
+      XLOGF(DBG, "  skip {}: no address", ifa->ifa_name);
       continue;
     }
-    if (strncmp(ifName.c_str(), ifa->ifa_name, ifName.size()) != 0) {
+    if (!matchesIfName(ifNameFilter, ifa->ifa_name)) {
+      XLOGF(DBG, "  skip {}: ifname filter mismatch", ifa->ifa_name);
       continue;
     }
     if (ifa->ifa_flags & IFA_F_DEPRECATED) {
-      continue; // Avoid use of deprecated addresses
+      XLOGF(DBG, "  skip {}: deprecated address", ifa->ifa_name);
+      continue;
     }
 
     auto addr = folly::IPAddress::tryFromSockAddr(ifa->ifa_addr);
-    if (addr.hasError() || addr->isLinkLocal()) {
+    if (addr.hasError()) {
+      XLOGF(DBG, "  skip {}: failed to parse address", ifa->ifa_name);
       continue;
     }
     if (addr->isLinkLocal()) {
+      XLOGF(
+          DBG, "  skip {}: link-local address {}", ifa->ifa_name, addr->str());
       continue;
     }
     if (!addrPrefix.empty() && addr->str().find(addrPrefix) != 0) {
-      continue; // Address does not match prefix
+      XLOGF(
+          DBG,
+          "  skip {}: address {} does not match prefix \"{}\"",
+          ifa->ifa_name,
+          addr->str(),
+          addrPrefix);
+      continue;
     }
-    addrs.push_back(addr.value());
+    XLOGF(DBG, "  accept {}: {}", ifa->ifa_name, addr->str());
+    addrs.emplace_back(addr.value(), std::string(ifa->ifa_name));
   }
 
   if (addrs.empty()) {
+    XLOGF(
+        WARN,
+        "getInterfaceAddress: no matching address found for ifName=\"{}\" addrPrefix=\"{}\" preferV6={}",
+        ifName,
+        addrPrefix,
+        preferV6);
     return folly::makeUnexpected(ENXIO);
   }
 
-  // Sort by type
+  // Sort by address family preference
   std::sort(
       addrs.begin(),
       addrs.end(),
-      [preferV6](const folly::IPAddress& a, const folly::IPAddress& b) {
-        return preferV6 ? (a.family() > b.family()) : (a.family() < b.family());
+      [preferV6](
+          const std::pair<folly::IPAddress, std::string>& a,
+          const std::pair<folly::IPAddress, std::string>& b) {
+        return preferV6 ? (a.first.family() > b.first.family())
+                        : (a.first.family() < b.first.family());
       });
 
-  // Return first address
-  return addrs.at(0);
+  if (resolvedIfName != nullptr) {
+    *resolvedIfName = addrs.at(0).second;
+  }
+  return addrs.at(0).first;
 }
 
 //

--- a/comms/ctran/bootstrap/Socket.h
+++ b/comms/ctran/bootstrap/Socket.h
@@ -22,7 +22,8 @@ namespace ctran::bootstrap {
 folly::Expected<folly::IPAddress, int> getInterfaceAddress(
     const std::string& ifName,
     const std::string& addrPrefix = "",
-    bool preferV6ElseV4 = true);
+    bool preferV6ElseV4 = true,
+    std::string* resolvedIfName = nullptr);
 
 /**
  * C++ wrapper over socket interface for communicating with the peer.

--- a/comms/ctran/bootstrap/tests/NcclSocketNameFilterTest.cpp
+++ b/comms/ctran/bootstrap/tests/NcclSocketNameFilterTest.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/bootstrap/NcclSocketNameFilter.h"
+
+using namespace ctran::bootstrap;
+
+// --- parseIfNameSpec tests ---
+
+TEST(IfNameFilter, ParseEmpty) {
+  auto filter = parseIfNameSpec("");
+  EXPECT_TRUE(filter.entries.empty());
+  EXPECT_FALSE(filter.negate);
+  EXPECT_FALSE(filter.exactMatch);
+}
+
+TEST(IfNameFilter, ParseSinglePrefix) {
+  auto filter = parseIfNameSpec("eth");
+  ASSERT_EQ(filter.entries.size(), 1);
+  EXPECT_EQ(filter.entries[0], "eth");
+  EXPECT_FALSE(filter.negate);
+  EXPECT_FALSE(filter.exactMatch);
+}
+
+TEST(IfNameFilter, ParseCommaSeparated) {
+  auto filter = parseIfNameSpec("beth0,beth1,beth2");
+  ASSERT_EQ(filter.entries.size(), 3);
+  EXPECT_EQ(filter.entries[0], "beth0");
+  EXPECT_EQ(filter.entries[1], "beth1");
+  EXPECT_EQ(filter.entries[2], "beth2");
+  EXPECT_FALSE(filter.negate);
+  EXPECT_FALSE(filter.exactMatch);
+}
+
+TEST(IfNameFilter, ParseNegate) {
+  auto filter = parseIfNameSpec("^docker,lo");
+  ASSERT_EQ(filter.entries.size(), 2);
+  EXPECT_EQ(filter.entries[0], "docker");
+  EXPECT_EQ(filter.entries[1], "lo");
+  EXPECT_TRUE(filter.negate);
+  EXPECT_FALSE(filter.exactMatch);
+}
+
+TEST(IfNameFilter, ParseExactMatch) {
+  auto filter = parseIfNameSpec("=eth0,eth1");
+  ASSERT_EQ(filter.entries.size(), 2);
+  EXPECT_EQ(filter.entries[0], "eth0");
+  EXPECT_EQ(filter.entries[1], "eth1");
+  EXPECT_FALSE(filter.negate);
+  EXPECT_TRUE(filter.exactMatch);
+}
+
+TEST(IfNameFilter, ParseNegateExact) {
+  auto filter = parseIfNameSpec("^=docker0");
+  ASSERT_EQ(filter.entries.size(), 1);
+  EXPECT_EQ(filter.entries[0], "docker0");
+  EXPECT_TRUE(filter.negate);
+  EXPECT_TRUE(filter.exactMatch);
+}
+
+// --- matchesIfName tests ---
+
+TEST(IfNameFilter, MatchEmptyFilter) {
+  auto filter = parseIfNameSpec("");
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_TRUE(matchesIfName(filter, "anything"));
+}
+
+TEST(IfNameFilter, MatchPrefixSingle) {
+  auto filter = parseIfNameSpec("eth");
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_TRUE(matchesIfName(filter, "eth1"));
+  EXPECT_TRUE(matchesIfName(filter, "ethernet"));
+  EXPECT_FALSE(matchesIfName(filter, "lo"));
+  EXPECT_FALSE(matchesIfName(filter, "beth0"));
+}
+
+TEST(IfNameFilter, MatchPrefixCommaSeparated) {
+  // This is the exact bug scenario:
+  // NCCL_SOCKET_IFNAME="beth0,beth1,beth2,beth3,beth4,beth5,beth6,beth7"
+  auto filter =
+      parseIfNameSpec("beth0,beth1,beth2,beth3,beth4,beth5,beth6,beth7");
+  EXPECT_TRUE(matchesIfName(filter, "beth0"));
+  EXPECT_TRUE(matchesIfName(filter, "beth1"));
+  EXPECT_TRUE(matchesIfName(filter, "beth7"));
+  EXPECT_FALSE(matchesIfName(filter, "beth8"));
+  EXPECT_FALSE(matchesIfName(filter, "eth0"));
+  EXPECT_FALSE(matchesIfName(filter, "lo"));
+}
+
+TEST(IfNameFilter, MatchExact) {
+  auto filter = parseIfNameSpec("=eth0");
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_FALSE(matchesIfName(filter, "eth0:1"));
+  EXPECT_FALSE(matchesIfName(filter, "eth00"));
+  EXPECT_FALSE(matchesIfName(filter, "eth1"));
+}
+
+TEST(IfNameFilter, MatchExactCommaSeparated) {
+  auto filter = parseIfNameSpec("=eth0,eth1");
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_TRUE(matchesIfName(filter, "eth1"));
+  EXPECT_FALSE(matchesIfName(filter, "eth2"));
+  EXPECT_FALSE(matchesIfName(filter, "eth0:1"));
+}
+
+TEST(IfNameFilter, MatchNegate) {
+  auto filter = parseIfNameSpec("^docker,lo");
+  EXPECT_FALSE(matchesIfName(filter, "docker0"));
+  EXPECT_FALSE(matchesIfName(filter, "docker1"));
+  EXPECT_FALSE(matchesIfName(filter, "lo"));
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_TRUE(matchesIfName(filter, "beth0"));
+}
+
+TEST(IfNameFilter, MatchNegateExact) {
+  auto filter = parseIfNameSpec("^=docker0");
+  EXPECT_FALSE(matchesIfName(filter, "docker0"));
+  EXPECT_TRUE(matchesIfName(filter, "docker1"));
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+}
+
+// Bare "^" with no interface names should be a no-op (matches everything)
+TEST(IfNameFilter, BarePrefixOnlyNotEffective) {
+  auto filter = parseIfNameSpec("^");
+  EXPECT_TRUE(filter.entries.empty());
+  EXPECT_TRUE(filter.negate);
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  EXPECT_TRUE(matchesIfName(filter, "lo"));
+  EXPECT_TRUE(matchesIfName(filter, "anything"));
+}
+
+// Edge case: prefix that is also a full name
+TEST(IfNameFilter, MatchPrefixFullName) {
+  auto filter = parseIfNameSpec("eth0");
+  EXPECT_TRUE(matchesIfName(filter, "eth0"));
+  // "eth0" as prefix also matches "eth0:1" or "eth0_alias"
+  EXPECT_TRUE(matchesIfName(filter, "eth0:1"));
+  EXPECT_TRUE(matchesIfName(filter, "eth0_alias"));
+  EXPECT_FALSE(matchesIfName(filter, "eth1"));
+}

--- a/comms/ctran/bootstrap/tests/SocketTest.cpp
+++ b/comms/ctran/bootstrap/tests/SocketTest.cpp
@@ -55,6 +55,58 @@ TEST(Socket, GetInterfaceAddress) {
   }
 }
 
+TEST(Socket, GetInterfaceAddressMultiInterface) {
+  const bool kPreferV6{true};
+
+  // Comma-separated list should match any of the listed interfaces
+  std::string resolvedIfName;
+  auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
+      "lo,eth0", "", kPreferV6, &resolvedIfName);
+  ASSERT_FALSE(maybeAddr.hasError())
+      << "Multi-interface ifname \"lo,eth0\" should resolve an address";
+  EXPECT_FALSE(maybeAddr->isLinkLocal());
+  EXPECT_FALSE(resolvedIfName.empty());
+  EXPECT_EQ(resolvedIfName.find(','), std::string::npos)
+      << "resolvedIfName should be a single interface, got: " << resolvedIfName;
+
+  // Negation: exclude lo, should still find eth0
+  auto maybeAddrNeg =
+      ctran::bootstrap::getInterfaceAddress("^lo", "", kPreferV6);
+  ASSERT_FALSE(maybeAddrNeg.hasError())
+      << "Negated ifname \"^lo\" should resolve via other interfaces";
+  EXPECT_NE(maybeAddrNeg->str(), "::1");
+
+  // Non-existent interface should fail
+  auto maybeAddrBad =
+      ctran::bootstrap::getInterfaceAddress("nonexistent_if", "", kPreferV6);
+  EXPECT_TRUE(maybeAddrBad.hasError());
+}
+
+TEST(Socket, BindAndListenWithMultiInterfaceIfName) {
+  const bool kPreferV6{true};
+
+  // Simulate NCCL_SOCKET_IFNAME="lo,eth0" (comma-separated from scheduler)
+  // Resolve to a single interface, then bind — should not fail with ENODEV
+  std::string resolvedIfName;
+  auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
+      "lo,eth0", "", kPreferV6, &resolvedIfName);
+  ASSERT_FALSE(maybeAddr.hasError());
+
+  ctran::bootstrap::ServerSocket server{1};
+  folly::SocketAddress addr(maybeAddr.value(), 0);
+  ASSERT_EQ(0, server.bindAndListen(addr, resolvedIfName))
+      << "bindAndListen should succeed with resolved single interface \""
+      << resolvedIfName << "\", not raw comma-separated spec";
+  EXPECT_NE(server.getFd(), -1);
+
+  // Verify binding with raw comma-separated string fails
+  ctran::bootstrap::ServerSocket server2{1};
+  EXPECT_NE(0, server2.bind(addr, "lo,eth0"))
+      << "SO_BINDTODEVICE with comma-separated ifname should fail";
+
+  EXPECT_EQ(0, server.shutdown());
+}
+
 TEST(Socket, SocketLifeCycle) {
   ctran::bootstrap::ServerSocket server{1};
   ctran::bootstrap::Socket client;

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -398,8 +398,9 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
 
   // Start the server with a callback that handles IPC requests
   // The peer sends the whole IpcReq, and we check the type to dispatch
+  std::string resolvedIfName;
   auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
-      NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX);
+      NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
   if (maybeAddr.hasError()) {
     CLOGF(WARN, "CTRAN-REGCACHE: No socket interfaces found");
     throw ::ctran::utils::Exception(
@@ -495,8 +496,9 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-REGCACHE: AsyncSocket server started at {}",
-      serverAddr_.describe());
+      "CTRAN-REGCACHE: AsyncSocket server started at {} ifname {}",
+      serverAddr_.describe(),
+      resolvedIfName);
 
   return commSuccess;
 }

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -13,6 +13,7 @@
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/logger/LogUtils.h"
 
 class RegCacheTest : public ::testing::Test {
  public:
@@ -24,6 +25,7 @@ class RegCacheTest : public ::testing::Test {
     setenv("NCCL_CTRAN_BACKENDS", "ib", 1);
     setenv("NCCL_CTRAN_REGISTER", "eager", 1);
     ncclCvarInit();
+    meta::comms::logger::initCommLogging();
 
     // Initialize CUDA library (required for cuMem operations)
     ASSERT_EQ(ctran::utils::commCudaLibraryInit(), commSuccess);


### PR DESCRIPTION
Summary:

- getInterfaceAddress() treated the entire NCCL_SOCKET_IFNAME value as a single interface name prefix, failing to match any interface when the value is comma-separated (e.g. "beth0,beth1,...,beth7")
- Root cause: `strncmp(ifName.c_str(), ifa->ifa_name, ifName.size())` used the full comma-separated string length (~55 chars) to compare against short interface names like "beth0" (5 chars), so the comma at position 5 always caused a mismatch
- Added NcclSocketNameFilter utility that parses NCCL_SOCKET_IFNAME per NCCL spec: comma-separated lists, ^ negation prefix, = exact match prefix
- Replaced the broken strncmp in getInterfaceAddress() with the new filter
- Removed the single-interface gate in CtranIb::bootstrapStart that threw on comma-separated NCCL_SOCKET_IFNAME, since getInterfaceAddress now handles multi-interface specs correctly
- Added detailed debug logging in getInterfaceAddress for each skipped/accepted interface (at DBG level, enable via xlog config)

NOTE: This DIFF fixes Ctran side functionality to match with NCCL_SOCKET_IFNAME. Separate followup is needed to avoid unwanted `NCCL_SOCKET_IFNAME` overrwiten in RL jobs

## Why this happened in RL (need seperate followup)
- `NCCL_SOCKET_IFNAME` is set to `beth0` but is overwritten to `beth0,beth1,beth2,beth3,beth4,beth5,beth6,beth7` in RL jobs. 

- Log snapshot of a failing RL job:
```
NCCL_SOCKET_IFNAME=beth0
NCCL_CLIENT_SOCKET_IFNAME=beth0
...
`=beth0,beth1,beth2,beth3,beth4,beth5,beth6,beth7
...
I0509 14:19:52.185121  9510 socket.cc:178] 8297-d1ff-14f6-0a00:9510:9510 [0][main] NCCL INFO NCCL_SOCKET_IFNAME set by environment to beth0,beth1,beth2,beth3,beth4,beth5,beth6,beth7
```

- Detailed code pointer of `TW_TASK_ASSIGNED_BE_IFNAMES` override, and comparision with pretrain job:
https://www.internalfb.com/phabricator/paste/view/P2316833293?view=markdown

Reviewed By: dsjohns2

Differential Revision: D104451701


