### PR TITLE
Re-add getCtranCommFromNcclComm accessor to MetaFactory (#2460)

### DIFF
--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -107,3 +107,10 @@ ncclResult_t destroyCtranComm(ncclComm* comm) {
   }
   return ncclSuccess;
 }
+
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm) {
+  if (ncclComm && ncclComm->ctranComm_) {
+    return ncclComm->ctranComm_.get();
+  }
+  return nullptr;
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.h
+++ b/comms/ncclx/meta/wrapper/MetaFactory.h
@@ -198,3 +198,7 @@ ncclResult_t createCtranComm(ncclComm* comm);
 // Finalize, destroy, and reset ctranComm_ on the given ncclComm.
 // No-op if ctranComm_ is nullptr.
 ncclResult_t destroyCtranComm(ncclComm* comm);
+
+// Public accessor returning the CtranComm* hanging off an ncclComm, or
+// nullptr if it isn't initialized (e.g. NCCL_CTRAN_ENABLE not set).
+CtranComm* getCtranCommFromNcclComm(ncclComm* ncclComm);


### PR DESCRIPTION
Summary:

Re-adds the per-version `getCtranCommFromNcclComm` accessor that was originally landed in D103234995 and removed in D103610807 ("Internalize setCtranCommBase/makeCtranConfigFrom and remove dead code from MetaFactory") because it had no callers at the time.

The caller is being added in D103234996 ("Wire all_gather_p directly via CtranApi"), which forward-declares this symbol from torchcomms-ncclx and links against the per-NCCLX-version impl in MetaFactory.cc. Putting the accessor back here so the linker resolves the `extern` declaration on the torchcomms side.

Same pattern as before: declaration in MetaFactory.h, single-version-friendly impl in MetaFactory.cc (which gets compiled once per NCCLX version via the existing `meta/wrapper/*.cc` glob — one symbol per `libncclx.so`, no per-version BUCK edits).

Differential Revision: D104455190


