### PR TITLE
Fix test_device_alltoallv_dynamic skipping on non-GPU CI hosts (#2462)

### DIFF
--- a/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
+++ b/comms/pipes/collectives/triton/tests/test_device_alltoallv_dynamic.py
@@ -19,8 +19,10 @@ import torch
 from torch.utils._triton import has_triton
 
 
-TRITON_AVAILABLE = has_triton()
 CUDA_AVAILABLE = torch.cuda.is_available()
+# torchcomms.triton.fb (imported transitively by the collectives module)
+# requires CUDA at import time, so triton-only is not sufficient.
+TRITON_AVAILABLE = has_triton() and CUDA_AVAILABLE
 
 
 # =============================================================================


### PR DESCRIPTION
Summary:

The test used `has_triton()` to gate test execution, but that only checks if the triton package is importable — it returns True even on non-GPU hosts. Since the test imports `comms.pipes.collectives.triton` which transitively imports `torchcomms.triton.fb` (requires CUDA at import time), tests crashed with FATAL status on non-GPU CI hosts. The infrastructure doesn't count FATALs as failures, so the test run was reported as SUCCESS despite nothing actually passing.

Fix: require both triton AND CUDA for `TRITON_AVAILABLE`, so tests are properly skipped on non-GPU hosts.

Reviewed By: zhiyongww

Differential Revision: D104355365


