### PR TITLE
Fix commGrow failure when growing from single-rank communicator (#2464) (#2464) (#2464) (#2464)

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
@@ -125,6 +125,28 @@ std::string extractStoreAddr(
   return addr;
 }
 
+int findRankInHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles,
+    const InitHandle& myHandle) {
+  return std::visit(
+      [&](const auto& h) -> int {
+        int result = -1;
+        int idx = 0;
+        for (const auto& handle : h) {
+          if (handle == myHandle) {
+            if (result >= 0) {
+              return -1;
+            }
+            result = idx;
+          }
+          idx++;
+        }
+        return result;
+      },
+      handles);
+}
+
 c10::intrusive_ptr<c10d::Store> connectStore(
     const std::string& storeAddr,
     const std::string& prefix,
@@ -183,7 +205,7 @@ c10::intrusive_ptr<c10d::Store> connectStore(
 // is aborted and nulled out.
 c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
     const ReconfigureOptions& opts) {
-  TC_LOG(INFO, this) << "TorchCommNCCL reconfigure starting 2";
+  TC_LOG(INFO, this) << "TorchCommNCCL reconfigure starting";
   TracingGuard tracingGuard(name_, comm_size_, "reconfigure", rank_);
 
   int new_size = static_cast<int>(
@@ -194,18 +216,25 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
   bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
   auto storeAddr = extractStoreAddr(opts.handles);
 
-  // Identity reconfigure (same world size, no membership change) --
-  // fall back to fresh init since the old comm may be unhealthy.
-  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
-      quorum.newMemberCount == 0) {
+  // Fall back to fresh init when shrink/grow has no advantage:
+  // - Single-rank quorum: a 1-rank comm has no bootstrap networking, so
+  //   commGrow will fail. Must clear unconditionally (not just when
+  //   inQuorum) so all ranks take the same fresh init path.
+  // - Identity reconfigure: same world size, no membership change — old comm
+  //   may be unhealthy.
+  if (quorum.ranks.size() == 1 ||
+      (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+       quorum.newMemberCount == 0)) {
     inQuorum = false;
     quorum.ranks.clear();
   }
 
   if (nccl_comm_) {
     auto workStatus = workq_.garbageCollect();
-    if (workStatus == TorchWorkNCCL::WorkStatus::NOT_STARTED ||
-        workStatus == TorchWorkNCCL::WorkStatus::INPROGRESS) {
+
+    if (!inQuorum &&
+        (workStatus == TorchWorkNCCL::WorkStatus::NOT_STARTED ||
+         workStatus == TorchWorkNCCL::WorkStatus::INPROGRESS)) {
       NCCL_CHECK_IGNORE(
           nccl_api_,
           nccl_api_->commRevoke(nccl_comm_),
@@ -244,14 +273,17 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
         fmt::format("Failed to set CUDA device to {}", device_.index()));
 
     ncclUniqueId uniqueId{};
-    int myRank = 0;
+    int myRank = findRankInHandles(opts.handles, getInitHandle());
 
     if (new_size > 1) {
       auto store = connectStore(
           storeAddr,
           fmt::format("{}/{}", name_, opts.uuid),
           reconfigureTimeout);
-      myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+      if (myRank < 0) {
+        myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+      }
 
       if (myRank == 0) {
         NCCL_CHECK(
@@ -338,6 +370,9 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
         store->set("unique_id", vec);
       }
 
+      TC_LOG(INFO, this) << "TorchCommNCCL existing commGrow: rank=" << rank_
+                         << " new_size=" << new_size;
+
       ncclComm_t grown = nullptr;
       NCCL_CHECK(
           nccl_api_,
@@ -366,6 +401,10 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
 
     int growRank =
         quorumSize + static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+    TC_LOG(INFO, this) << "TorchCommNCCL new rank commGrow: rank=" << growRank
+                       << " uniqueId=" << vec.size()
+                       << " new_size=" << new_size;
 
     ncclComm_t new_comm = nullptr;
     NCCL_CHECK(

--- a/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
@@ -125,6 +125,28 @@ std::string extractStoreAddr(
   return addr;
 }
 
+int findRankInHandles(
+    const std::variant<std::unordered_set<InitHandle>, std::vector<InitHandle>>&
+        handles,
+    const InitHandle& myHandle) {
+  return std::visit(
+      [&](const auto& h) -> int {
+        int result = -1;
+        int idx = 0;
+        for (const auto& handle : h) {
+          if (handle == myHandle) {
+            if (result >= 0) {
+              return -1;
+            }
+            result = idx;
+          }
+          idx++;
+        }
+        return result;
+      },
+      handles);
+}
+
 c10::intrusive_ptr<c10d::Store> connectStore(
     const std::string& storeAddr,
     const std::string& prefix,
@@ -194,18 +216,24 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
   bool inQuorum = nccl_comm_ && uuid_ >= 0 && uuid_ == quorum.uuid;
   auto storeAddr = extractStoreAddr(opts.handles);
 
-  // Identity reconfigure (same world size, no membership change) --
-  // fall back to fresh init since the old comm may be unhealthy.
-  if (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
-      quorum.newMemberCount == 0) {
+  // Fall back to fresh init when shrink/grow has no advantage:
+  // - Single-rank quorum: a 1-rank comm has no bootstrap networking, so
+  //   commGrow will fail. Must clear unconditionally (not just when
+  //   inQuorum) so all ranks take the same fresh init path.
+  // - Identity reconfigure: same world size, no membership change — old comm
+  //   may be unhealthy.
+  if (quorum.ranks.size() == 1 ||
+      (inQuorum && quorum.ranks.size() == static_cast<size_t>(new_size) &&
+       quorum.newMemberCount == 0)) {
     inQuorum = false;
     quorum.ranks.clear();
   }
 
   if (nccl_comm_) {
     auto workStatus = workq_.garbageCollect();
-    if (workStatus == TorchWorkNCCLX::WorkStatus::NOT_STARTED ||
-        workStatus == TorchWorkNCCLX::WorkStatus::INPROGRESS) {
+    if (!inQuorum &&
+        (workStatus == TorchWorkNCCLX::WorkStatus::NOT_STARTED ||
+         workStatus == TorchWorkNCCLX::WorkStatus::INPROGRESS)) {
       NCCLX_CHECK_IGNORE(
           nccl_api_,
           nccl_api_->commRevoke(nccl_comm_),
@@ -242,14 +270,17 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
         fmt::format("Failed to set CUDA device to {}", device_.index()));
 
     ncclUniqueId uniqueId{};
-    int myRank = 0;
+    int myRank = findRankInHandles(opts.handles, getInitHandle());
 
     if (new_size > 1) {
       auto store = connectStore(
           storeAddr,
           fmt::format("{}/{}", name_, opts.uuid),
           reconfigureTimeout);
-      myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+
+      if (myRank < 0) {
+        myRank = static_cast<int>(store->add("rank_counter", 1)) - 1;
+      }
 
       if (myRank == 0) {
         NCCLX_CHECK(

--- a/comms/torchcomms/tests/integration/py/ReconfigureTest.py
+++ b/comms/torchcomms/tests/integration/py/ReconfigureTest.py
@@ -329,6 +329,51 @@ class ReconfigureTest(unittest.TestCase):
 
         comm.finalize()
 
+    def test_reconfigure_single_to_all(self):
+        """Test reconfigure from single rank to all ranks then allreduce."""
+        if not self._is_supported_backend():
+            self.skipTest(f"Backend {self.backend} does not support reconfigure()")
+
+        import torchcomms
+
+        comm = torchcomms.new_comm(
+            self.backend,
+            self.device,
+            "reconfigure_single_to_all",
+            enable_reconfigure=True,
+            store=self._get_store_for_comm(),
+        )
+
+        comm.reconfigure(
+            uuid=3,
+            init_handles=[comm.get_init_handle()],
+            timeout=timedelta(milliseconds=30000),
+        ).wait()
+
+        all_handles = self._collect_handles(comm, "test_reconfigure_single_to_all")
+        comm.reconfigure(
+            uuid=4,
+            init_handles=all_handles,
+            timeout=timedelta(milliseconds=30000),
+        ).wait()
+
+        my_rank = comm.get_rank()
+        tensor = torch.ones(4, dtype=torch.float, device=self.device) * (my_rank + 1)
+        comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, async_op=False)
+
+        if self.device.type == "cuda":
+            torch.cuda.current_stream().synchronize()
+
+        expected_value = sum(range(1, self.world_size + 1))
+        expected = torch.ones(4, dtype=torch.float, device="cpu") * expected_value
+        self.assertTrue(
+            torch.allclose(tensor.cpu(), expected),
+            f"[Rank {my_rank}] AllReduce after single-to-all reconfigure failed: "
+            f"got {tensor.cpu()}, expected {expected}",
+        )
+
+        comm.finalize()
+
     def test_reconfigure_identity(self):
         """Test that reconfigure works when world size doesn't change."""
         if not self._is_supported_backend():


### PR DESCRIPTION
Summary:
- Single-rank NCCL/NCCLX communicators don't initialize bootstrap networking, so `commGrow` fails with an uninitialized address (family=0). Fall back to fresh init (`commInitRankConfig`) when the quorum has only 1 rank, since there are no inter-rank connections to preserve.
- Use deterministic rank assignment from handle vector position when handles are unique, falling back to the store counter when ambiguous (e.g. first init where all ranks share the same handle).
- Only `commRevoke` when `!inQuorum`, since comms reused for shrink/grow need their bootstrap state intact.


Test Plan:
- [x] All existing NCCL reconfigure integration tests pass (10 tests, 8 ran, 2 skipped)
- [x] All existing NCCLX reconfigure integration tests pass (10 tests, 8 ran, 2 skipped)
- [x] New `test_reconfigure_single_to_all` test added and passing for both NCCL and NCCLX — verifies init as single rank, grow to all ranks, then allreduce

Differential Revision: D104490473
