### PR TITLE
Replace timing-based sleep with pinned flag in cudaMemcpyAsync deadlock reproducer (#2470)

### DIFF
--- a/comms/ctran/issues/repro_cuda_ctx_lock/memcpyasync_blocked.cu
+++ b/comms/ctran/issues/repro_cuda_ctx_lock/memcpyasync_blocked.cu
@@ -42,6 +42,11 @@ int main() {
   int* d;
   cudaMalloc(&d, sizeof(int));
 
+  // Pinned host buffer for the value sent via cudaMemcpyAsync.
+  int* h_zero;
+  cudaHostAlloc((void**)&h_zero, sizeof(int), cudaHostAllocDefault);
+  *h_zero = 0;
+
   // Get busyKernel running on the GPU. The first launch also lazy-loads its
   // module, but the GPU is idle so it's fast.
   busyKernel<<<1, 1, 0, sA>>>(20'000'000'000LL);
@@ -55,9 +60,8 @@ int main() {
   // child's memcpy blocks on the same lock.
   std::thread b([&] {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    int v = 0;
     auto t = std::chrono::steady_clock::now();
-    cudaMemcpyAsync(d, &v, sizeof(int), cudaMemcpyHostToDevice, sB);
+    cudaMemcpyAsync(d, h_zero, sizeof(int), cudaMemcpyHostToDevice, sB);
     std::printf("[B] cudaMemcpyAsync returned in   %.3fs\n", secs(t));
   });
 

--- a/comms/ctran/issues/repro_cuda_ctx_lock/memcpyasync_deadlock.cu
+++ b/comms/ctran/issues/repro_cuda_ctx_lock/memcpyasync_deadlock.cu
@@ -41,7 +41,7 @@
 #include <cstdlib>
 #include <thread>
 
-__global__ void persistentKernel(volatile int* shutdown);
+__global__ void persistentKernel(volatile int* shutdown, volatile int* started);
 __global__ void firstTimeKernel();
 
 static double secs(std::chrono::steady_clock::time_point t) {
@@ -58,6 +58,16 @@ int main() {
   cudaMalloc(&d_shutdown, sizeof(int));
   cudaMemset(d_shutdown, 0, sizeof(int));
 
+  // Pinned host buffer for the shutdown value sent via cudaMemcpyAsync.
+  int* h_one;
+  cudaHostAlloc((void**)&h_one, sizeof(int), cudaHostAllocDefault);
+  *h_one = 1;
+
+  // Pinned flag: persistentKernel writes 1 when it starts on the GPU.
+  volatile int* h_started;
+  cudaHostAlloc((void**)&h_started, sizeof(int), cudaHostAllocDefault);
+  *h_started = 0;
+
   // Force line-buffered stdout so prints are visible even if the process
   // is force-exited from the watchdog before stdio buffers get flushed.
   setvbuf(stdout, nullptr, _IOLBF, 0);
@@ -71,17 +81,25 @@ int main() {
   }).detach();
 
   // 1. Launch persistent kernel. It will spin until *d_shutdown != 0.
-  persistentKernel<<<1, 1, 0, sA>>>(d_shutdown);
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  persistentKernel<<<1, 1, 0, sA>>>(d_shutdown, (int*)h_started);
+
+  // Wait until kernel has ACTUALLY started on the GPU — no timing ambiguity.
+  while (*h_started == 0) {
+    std::this_thread::yield();
+  }
+  std::printf("persistentKernel confirmed running on GPU.\n");
 
   // 2. Spawn child thread to deliver the shutdown signal via
   //    cudaMemcpyAsync. In LAZY mode this call blocks on the primary
   //    context lock and never reaches the GPU.
   std::thread b([&] {
+    // Sleep so the main thread has time to enter firstTimeKernel<<<>>>'s
+    // cuLibraryLoadData (which grabs the context lock). Without this,
+    // cudaMemcpyAsync could run first, deliver shutdown=1, and the
+    // deadlock wouldn't reproduce.
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    int one = 1;
     auto t = std::chrono::steady_clock::now();
-    cudaMemcpyAsync(d_shutdown, &one, sizeof(int), cudaMemcpyHostToDevice, sB);
+    cudaMemcpyAsync(d_shutdown, h_one, sizeof(int), cudaMemcpyHostToDevice, sB);
     std::printf(
         "[B] cudaMemcpyAsync (shutdown=1) returned in %.3fs\n", secs(t));
   });

--- a/comms/ctran/issues/repro_cuda_ctx_lock/persistent_kernel.cu
+++ b/comms/ctran/issues/repro_cuda_ctx_lock/persistent_kernel.cu
@@ -1,7 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // SPDX-License-Identifier: Apache-2.0
 
-__global__ void persistentKernel(volatile int* shutdown) {
+__global__ void persistentKernel(
+    volatile int* shutdown,
+    volatile int* started) {
+  if (threadIdx.x == 0) {
+    *started = 1;
+    __threadfence_system();
+  }
+  __syncthreads();
   while (*shutdown == 0) {
   }
 }


### PR DESCRIPTION
Summary:

Improvements to the CUDA primary context lock deadlock reproducer from D103085310:

1. **Pinned start flag**: Replace the 50ms sleep that waits for persistentKernel to start with a pinned host flag (`h_started`) that the kernel writes to when it begins executing on the GPU. The host spins on this flag before proceeding, eliminating all timing ambiguity about kernel launch ordering. This proves persistentKernel is confirmed running on the GPU before firstTimeKernel or cudaMemcpyAsync are called, ruling out any argument that firstTimeKernel could grab the context lock before persistentKernel.

2. **Memory fence in kernel**: Thread 0 writes the started flag and issues `__threadfence_system()` to ensure host visibility, followed by `__syncthreads()` so all threads wait before entering the shutdown polling loop.

3. **Pinned host buffers for cudaMemcpyAsync sources**: Replace pageable stack variables (`int one = 1`, `int v = 0`) with `cudaHostAlloc`-allocated pinned buffers for the cudaMemcpyAsync source operands. This avoids any ambiguity about pageable memory staging behavior.

The child thread retains a 50ms sleep to ensure the main thread enters `cuLibraryLoadData` (grabbing the context lock) before cudaMemcpyAsync attempts to acquire it.

Reviewed By: dsjohns2

Differential Revision: D104450915


