### PR TITLE
Use staged tile loads for ring ReduceScatter (#2471)

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -123,4 +123,79 @@ struct TileReduce {
   }
 };
 
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+struct TileReduceStaged {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    T* dst_t = reinterpret_cast<T*>(dst);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    std::size_t nelems = nbytes / sizeof(T);
+    int ntiles = static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+
+    for (int t = 0; t < ntiles; t++) {
+      std::size_t valid =
+          min(static_cast<std::size_t>(kTileElems),
+              nelems - static_cast<std::size_t>(t) * kTileElems);
+      auto acc =
+          tile_load<T, kTileElems, kBlockSize>(staging_t, t, group, valid);
+      auto local =
+          tile_load<T, kTileElems, kBlockSize>(local_t, t, group, valid);
+      tile_accumulate<T, AccumOp, kTileElems, kBlockSize>(acc, local);
+      tile_store<T, kTileElems, kBlockSize>(dst_t, t, acc, group, valid);
+    }
+#endif
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* /*dst*/,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    T* fwd_t = reinterpret_cast<T*>(fwd_staging);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    std::size_t nelems = nbytes / sizeof(T);
+    int ntiles = static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+
+    for (int t = 0; t < ntiles; t++) {
+      std::size_t valid =
+          min(static_cast<std::size_t>(kTileElems),
+              nelems - static_cast<std::size_t>(t) * kTileElems);
+      auto acc =
+          tile_load<T, kTileElems, kBlockSize>(staging_t, t, group, valid);
+      auto local =
+          tile_load<T, kTileElems, kBlockSize>(local_t, t, group, valid);
+      tile_accumulate<T, AccumOp, kTileElems, kBlockSize>(acc, local);
+      tile_store<T, kTileElems, kBlockSize>(fwd_t, t, acc, group, valid);
+    }
+#endif
+  }
+};
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/RingReduceScatter.cu
+++ b/comms/pipes/collectives/RingReduceScatter.cu
@@ -49,7 +49,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
   const int stride = (my_rank - topo.prev_rank + W) % W;
   const char* input_base = reinterpret_cast<const char*>(args.input);
 
-  using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+  using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
 
   for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
     const std::size_t remaining = io_tile_bytes - off;


### PR DESCRIPTION
Summary:

This changes the generic ring ReduceScatter reducer from `TileReduce` to `TileReduceStaged`.

Why this improves performance: the old helper loaded the received staging tile and then used `tile_load_accumulate()` for the local input. That couples the local load with the accumulator update, which gives the compiler less room to schedule the two memory streams independently and creates a tighter load/use dependency in the reduction path. `TileReduceStaged` keeps the same tiled algorithm but makes both operand streams explicit: `tile_load(staging)`, `tile_load(local)`, `tile_accumulate()`, then `tile_store()`. The IB path is mostly network/pipeline bound, so this is a modest improvement rather than the large NVLink win, but it consistently helps the mid-size cases.

Performance from `buck run fbcode/mode/opt fbcode//comms/pipes/collectives/benchmarks:ring_reduce_scatter_benchmark` on 8 ranks. "Before" is the old `TileReduce` path; "After" is this diff.

| Test | Size | Blocks/Rings | NCCL GB/s | Ring before | Ring after | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `256K_8B` | 2MB | 8 / 1 | 20.82 | 8.23 | 8.26 | +0.4% |
| `1M_16B` | 8MB | 16 / 1 | 41.81 | 24.88 | 25.08 | +0.8% |
| `4M_16B` | 32MB | 16 / 1 | 47.93 | 45.87 | 46.94 | +2.3% |
| `16M_16B` | 128MB | 16 / 1 | 50.69 | 49.53 | 50.97 | +2.9% |
| `64M_16B` | 512MB | 16 / 1 | 51.46 | 52.94 | 53.37 | +0.8% |
| `128M_16B` | 1GB | 16 / 1 | 52.34 | 53.52 | 53.71 | +0.4% |
| `256M_32B` | 2GB | 32 / 1 | 53.16 | 53.98 | 54.07 | +0.2% |
| `4M_16B_2R` | 32MB | 16 / 2 | 48.05 | 46.36 | 47.06 | +1.5% |
| `16M_16B_2R` | 128MB | 16 / 2 | 50.53 | 50.56 | 51.26 | +1.4% |
| `64M_16B_2R` | 512MB | 16 / 2 | 51.46 | 52.41 | 51.97 | -0.8% |
| `256M_32B_2R` | 2GB | 32 / 2 | 53.09 | 53.56 | 53.56 | +0.0% |

Reviewed By: Scusemua

Differential Revision: D104600612


