### PR TITLE
Logging: 1) ProcessGroup, CommHash; 2) InitComplete, FirstCollective Timestamp (#2473)

### DIFF
--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/group.cc
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/group.cc
@@ -589,6 +589,37 @@ static ncclResult_t groupLaunch(struct ncclAsyncJob *job_, ncclSimInfo_t* simInf
         memset(algoNeedConnect, 0, sizeof(bool) * NCCL_NUM_ALGORITHMS);
 
         CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
+
+        if (!comm->firstCollLogged && comm->initCompleteTimestamp != 0) {
+          comm->firstCollLogged = true;
+
+          // first collective timestamp
+          uint64_t firstCollectiveTimestamp = clockNano();
+          uint64_t firstCollectiveWallclock = wallClockNano();
+
+          // first collective type
+          const char* collName = "unknown";
+          struct ncclTaskColl* firstTask = comm->planner.collSorter.head;
+          if (firstTask && firstTask->func < ncclNumFuncs) {
+            static constexpr const char* ncclFuncNames[ncclNumFuncs] = {
+              "Broadcast", "Reduce", "AllGather", "ReduceScatter",
+              "AllReduce", "SendRecv", "Send", "Recv", "AllToAllPivot"
+            };
+            collName = ncclFuncNames[firstTask->func];
+          } else if (comm->planner.nTasksP2p > 0) {
+            collName = "P2P";
+          }
+
+          INFO(NCCL_INIT, "First Collective (rank %d nranks %d): commDesc %s commHash 0x%llx: "
+               "firstCollective(%s)=%.6f initComplete=%.6f delta=%.1f ms",
+               comm->rank, comm->nRanks,
+               comm->config.commDesc ? comm->config.commDesc : "N/A",
+               (unsigned long long)comm->commHash,
+               collName, firstCollectiveWallclock / 1e9,
+               comm->initCompleteWallclock / 1e9,
+               (firstCollectiveTimestamp - comm->initCompleteTimestamp) / 1e6);
+        }
+
         NCCLCHECKGOTO(ncclPrepareTasks(comm, algoNeedConnect, &needConnect, simInfo), ret, fail);
 
         if (comm->cuMemSupport && needConnect) {

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/include/comm.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/include/comm.h
@@ -566,7 +566,7 @@ struct ncclComm {
   float bandwidths[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   int maxThreads[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   uint64_t minMaxLLRange[RCCL_TUNABLE_COLLS][NCCL_NUM_PROTOCOLS - 1][RCCL_PROTOCOL_ENTRY_SIZE];
-  uint64_t minMaxChannelThresholds[RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES][3]; //for each collective, set for 5 channel-counts: 32,40,48,56,64, the two values for min/max size-threshold 
+  uint64_t minMaxChannelThresholds[RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES][3]; //for each collective, set for 5 channel-counts: 32,40,48,56,64, the two values for min/max size-threshold
 
   /* This attribute can indicate the states of communicators and return code of
   * asynchronous NCCL operations. */
@@ -689,6 +689,10 @@ struct ncclComm {
   ncclConfig_t config;
   // initState is to more conveniently reclaim resources when errors happen.
   ncclResult_t initState;
+  // init-completion timestamps
+  uint64_t initCompleteTimestamp; // clockNano() (monotonic) at Init COMPLETE, for delta measurement
+  uint64_t initCompleteWallclock; // wallClockNano() (epoch) at Init COMPLETE, for cross-host correlation
+  bool firstCollLogged; // true after first-collective diagnostic log has fired
   // flag to indicate if ncclCommFinalize() is called
   bool finalizeCalled;
   // shared structures for finalization

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/include/utils.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/include/utils.h
@@ -56,6 +56,13 @@ inline uint64_t clockNano() {
   return uint64_t(ts.tv_sec)*1000*1000*1000 + ts.tv_nsec;
 }
 
+// Wall-clock (epoch) time in nanoseconds for cross-host timestamp correlation
+inline uint64_t wallClockNano() {
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  return uint64_t(ts.tv_sec)*1000*1000*1000 + ts.tv_nsec;
+}
+
 /* get any bytes of random data from /dev/urandom, return ncclSuccess (0) if it succeeds. */
 inline ncclResult_t getRandomData(void* buffer, size_t bytes) {
   ncclResult_t ret = ncclSuccess;
@@ -558,7 +565,7 @@ T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T,next>* me) {
 size_t get_sc_page_size(void);
 
 /**
- * @brief function to get system's page size aligned memory address and buffersize 
+ * @brief function to get system's page size aligned memory address and buffersize
  *
  * Given a pointer `ptr` to a buffer of size `bufsize`, this function computes:
  *   1. A new pointer `aligned_ptr` which points to the start of the page-aligned memory region that includes `ptr`.

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/init.cc
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/init.cc
@@ -2147,6 +2147,16 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   comm->initState = ncclSuccess;
   timers[TIMER_INIT_TOTAL] = clockNano() - timers[TIMER_INIT_TOTAL];
 
+  // Timestamp logging: init completion
+  comm->initCompleteTimestamp = clockNano();
+  comm->initCompleteWallclock = wallClockNano();
+  INFO(NCCL_INIT, "Init Complete (rank %d nranks %d): commDesc %s commHash 0x%llx: "
+       "initComplete=%.6f",
+       comm->rank, comm->nRanks,
+       comm->config.commDesc ? comm->config.commDesc : "N/A",
+       (unsigned long long)comm->commHash,
+       comm->initCompleteWallclock / 1e9);
+
   // Trace this call for replay tool
   if (job->parent) {
     /* unlink child abort flag. */
@@ -2435,6 +2445,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   NCCL_CONFIG_DEFAULT(internalConfigPtr, CTAPolicy, NCCL_CONFIG_UNDEF_INT, NCCL_CTA_POLICY_DEFAULT, "CTA policy flags", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, shrinkShare, NCCL_CONFIG_UNDEF_INT, 0, "shrinkShare", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlsCTAs, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "nvlsCTAs", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, commDesc, NCCL_CONFIG_UNDEF_PTR, NULL, "Comm desc", "%s");
 
   /* assign config to communicator */
   comm->config.blocking = internalConfigPtr->blocking;
@@ -2449,6 +2460,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   comm->config.CTAPolicy = internalConfigPtr->CTAPolicy;
   comm->config.shrinkShare = internalConfigPtr->shrinkShare;
   comm->config.nvlsCTAs = internalConfigPtr->nvlsCTAs;
+  comm->config.commDesc = internalConfigPtr->commDesc;
   NCCLCHECKGOTO(envConfigOverride(comm), ret, fail);
 
 exit:

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/nccl.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/nccl.h
@@ -24,6 +24,7 @@
 #define RCCL_GATHER_SCATTER 1
 #define RCCL_ALLTOALLV 1
 #define RCCL_ALLREDUCE_WITH_BIAS 1
+#define NCCL_COMM_DESCRIPTION // enables ProcessGroupNCCL to pass pg_desc to config.commDesc
 
 
 #ifdef __cplusplus
@@ -103,6 +104,7 @@ typedef struct ncclConfig_v22700 {
   int CTAPolicy;               /*!< CTA Policy*/
   int shrinkShare;             /*!< Shrink size*/
   int nvlsCTAs;                /*!< Number of NVLS cooperative thread arrays (blocks)*/
+  const char *commDesc;        /*!< Communicator description from process group */
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -123,6 +125,7 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_INT,                            /* CTAPolicy */      \
   NCCL_CONFIG_UNDEF_INT,                            /* shrinkShare */    \
   NCCL_CONFIG_UNDEF_INT,                            /* nvlsCTAs */       \
+  NCCL_CONFIG_UNDEF_PTR,                            /* commDesc */       \
 }
 /*! @} */
 

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/nccl.h.in
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/nccl.h.in
@@ -24,6 +24,7 @@
 #define RCCL_GATHER_SCATTER 1
 #define RCCL_ALLTOALLV 1
 #define RCCL_ALLREDUCE_WITH_BIAS 1
+#define NCCL_COMM_DESCRIPTION // enables ProcessGroupNCCL to pass pg_desc to config.commDesc
 
 #ifdef __cplusplus
 extern "C" {
@@ -102,6 +103,7 @@ typedef struct ncclConfig_v22700 {
   int CTAPolicy;               /*!< CTA Policy*/
   int shrinkShare;             /*!< Shrink size*/
   int nvlsCTAs;                /*!< Number of NVLS cooperative thread arrays (blocks)*/
+  const char *commDesc;        /*!< Communicator description from process group */
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -122,6 +124,7 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_INT,                            /* CTAPolicy */      \
   NCCL_CONFIG_UNDEF_INT,                            /* shrinkShare */    \
   NCCL_CONFIG_UNDEF_INT,                            /* nvlsCTAs */       \
+  NCCL_CONFIG_UNDEF_PTR,                            /* commDesc */       \
 }
 /*! @} */
 

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/rccl.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/rccl.h
@@ -24,6 +24,7 @@
 #define RCCL_GATHER_SCATTER 1
 #define RCCL_ALLTOALLV 1
 #define RCCL_ALLREDUCE_WITH_BIAS 1
+#define NCCL_COMM_DESCRIPTION // enables ProcessGroupNCCL to pass pg_desc to config.commDesc
 
 #ifdef __cplusplus
 extern "C" {
@@ -102,6 +103,7 @@ typedef struct ncclConfig_v22700 {
   int CTAPolicy;               /*!< CTA Policy*/
   int shrinkShare;             /*!< Shrink size*/
   int nvlsCTAs;                /*!< Number of NVLS cooperative thread arrays (blocks)*/
+  const char *commDesc;        /*!< Communicator description from process group */
 } ncclConfig_t;
 
 /* Config initializer must be assigned to initialize config structure when it is created.
@@ -122,6 +124,7 @@ typedef struct ncclConfig_v22700 {
   NCCL_CONFIG_UNDEF_INT,                            /* CTAPolicy */      \
   NCCL_CONFIG_UNDEF_INT,                            /* shrinkShare */    \
   NCCL_CONFIG_UNDEF_INT,                            /* nvlsCTAs */       \
+  NCCL_CONFIG_UNDEF_PTR,                            /* commDesc */       \
 }
 /*! @} */
 


### PR DESCRIPTION
Summary:

In this diff, apply the same logging (D101023405) in rcclx-stable, and test with `rcclx-stable`

Logging enabled by env var:
- NCCL_DEBUG = INFO
- NCCL_DEBUG_SUBSYS = INIT

Reviewed By: ganesank-git

Differential Revision: D101393108
