### PR TITLE
Guard reverse initNotify with enableBidirAg

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -982,10 +982,14 @@ inline commResult_t completeHostResourceSetup(
       CtranAlgo::TmpbufType::RING_TMP_RECV_BUF);
   args.rightRemBuf = (char*)args.rightRemBuf + offsetRingTmpRecv;
 
-  // Reverse: notifications from right on tmpRecvBufRev
-  args.rightNotify.reset(new CtranMapperNotify());
-  FB_COMMCHECK(comm->ctran_->mapper->initNotify(
-      args.rightRank, resource.tmpRecvBufRevHdl, args.rightNotify.get()));
+  // Reverse: notifications from right on tmpRecvBufRev.
+  // Only needed when bidir AG is enabled — otherwise the reverse path is
+  // unused.
+  if (args.enableBidirAg) {
+    args.rightNotify.reset(new CtranMapperNotify());
+    FB_COMMCHECK(comm->ctran_->mapper->initNotify(
+        args.rightRank, resource.tmpRecvBufRevHdl, args.rightNotify.get()));
+  }
 
   // Point leftRemBufRev to left neighbor's tmpRecvBufRev segment
   size_t offsetRingTmpRecvRev = comm->ctran_->algo->getTmpBufOffset(

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -608,28 +608,28 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   inline commResult_t
   iflush(const void* buf, const void* regHdl, CtranMapperRequest** req) {
-    if (!this->ctranIb) {
-      CLOGF(WARN, "CTRAN-MAPPER: IB backend not enabled, skip flush");
-      return commSuccess;
+    if (this->ctranIb) {
+      auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
+          const_cast<void*>(regHdl));
+      if (!regElem) {
+        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        return commSuccess;
+      }
+      auto regLk = regElem->stateMnger.rlock();
+      CtranIbRequest* ibReq = nullptr;
+      if (req) {
+        *req = new CtranMapperRequest();
+        ibReq = &((*req)->ibReq);
+      }
+      FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
+    } else if (this->ctranTcpDm) {
+      // TCPDM: flush is unnecessary — data arrives via kernel unpack.
+      // Return a pre-completed request so callers can poll normally.
+      if (req) {
+        *req = new CtranMapperRequest();
+        (*req)->setComplete();
+      }
     }
-
-    // regHdl from searchRegHandle is a RegElem*; extract the IB-level
-    // registration handle that LocalVirtualConn::iflush expects.
-    auto* regElem =
-        reinterpret_cast<ctran::regcache::RegElem*>(const_cast<void*>(regHdl));
-    if (!regElem) {
-      CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
-      return commSuccess;
-    }
-
-    auto regLk = regElem->stateMnger.rlock();
-
-    CtranIbRequest* ibReq = nullptr;
-    if (req) {
-      *req = new CtranMapperRequest();
-      ibReq = &((*req)->ibReq);
-    }
-    FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, ibReq));
     return commSuccess;
   }
 


### PR DESCRIPTION
Summary: Skip reverse path initNotify setup when bidir AG is disabled. The reverse notify is only used during bi-directional AllGather — without it, the notify is allocated but never checked, wasting resources on IB and failing on TCPDM (which requires kernElem for initNotify and will throw when it is nullptr, i.e bidir=false).

Reviewed By: saifhhasan

Differential Revision: D104324524


