### PR TITLE
Match c10d device preference for mixed backend distwrap

### DIFF
--- a/comms/torchcomms/distwrap/README.md
+++ b/comms/torchcomms/distwrap/README.md
@@ -239,13 +239,16 @@ from torchcomms import distwrap as dist
 dist.all_reduce(tensor)
 ```
 
-### Object collectives use an arbitrary torchcomms instance
+### Barrier and object collectives prefer CPU when available
 
-For object-based collectives (`all_gather_object`, `gather_object`,
-`scatter_object_list`, `broadcast_object_list`), there is no tensor to infer
-the device type from. In this case, distwrap picks the first available
-torchcomms instance arbitrarily. If you have multiple backends configured
-(e.g., both CPU and GPU), the chosen backend may not be what you expect.
+For operations without a tensor to infer the device from (`barrier`,
+`all_gather_object`, `gather_object`, `scatter_object_list`,
+`broadcast_object_list`), distwrap matches c10d behavior:
+
+- If the process group has a single backend, it uses that backend.
+- If multiple backends are configured and a CPU communicator is available, it
+  prefers the CPU communicator.
+- Otherwise, it falls back to the first available communicator.
 
 ### split_group and new_window operate on all backends by default
 
@@ -265,7 +268,7 @@ subgroup = dist.split_group(
 
 ### new_window uses an arbitrary torchcomms instance by default
 
-Similar to object collectives, `new_window` picks the first available
+Unlike barrier and object collectives, `new_window` picks the first available
 torchcomms instance from the group when `backend` is not specified. Use the
 `backend` parameter to explicitly choose which backend to use:
 

--- a/comms/torchcomms/distwrap/collectives.py
+++ b/comms/torchcomms/distwrap/collectives.py
@@ -61,7 +61,8 @@ def _get_default_torchcomms_instance(pg: ProcessGroup) -> TorchComm:
     Get a default torchcomms instance for the given process group.
 
     This is used for operations that don't have a tensor to infer the device
-    from (e.g., object collectives, barrier).
+    from (e.g., object collectives, barrier). Match c10d behavior by preferring
+    the CPU communicator when multiple device backends are present.
 
     Args:
         pg: The process group.
@@ -75,7 +76,10 @@ def _get_default_torchcomms_instance(pg: ProcessGroup) -> TorchComm:
     torchcomms_instances = pg_info_get_data(pg, "torchcomms")
     if not torchcomms_instances:
         raise AssertionError(f"No torchcomms instances found for process group {pg}")
-    # Use the first available torchcomms instance
+    if len(torchcomms_instances) == 1:
+        return next(iter(torchcomms_instances.values()))
+    if "cpu" in torchcomms_instances:
+        return torchcomms_instances["cpu"]
     return next(iter(torchcomms_instances.values()))
 
 

--- a/comms/torchcomms/distwrap/tests/unit/test_distwrap.py
+++ b/comms/torchcomms/distwrap/tests/unit/test_distwrap.py
@@ -2,9 +2,12 @@
 # pyre-strict
 
 import unittest
+from typing import cast
+from unittest.mock import patch
 
 import torch.distributed
 import torchcomms.distwrap
+import torchcomms.distwrap.collectives as collectives
 
 
 class ForwardedAttributesTest(unittest.TestCase):
@@ -175,6 +178,24 @@ class AllExportsTest(unittest.TestCase):
                 hasattr(torchcomms.distwrap, name),
                 f"'{name}' in __all__ but not accessible",
             )
+
+
+class DefaultTorchcommsInstanceTest(unittest.TestCase):
+    """Tests for default communicator selection for ops without tensor inputs."""
+
+    def test_prefers_cpu_comm_when_present(self) -> None:
+        fake_pg = cast(torch.distributed.ProcessGroup, object())
+        non_cpu_comm = object()
+        cpu_comm = object()
+
+        with patch.object(
+            collectives,
+            "pg_info_get_data",
+            return_value={"cuda": non_cpu_comm, "cpu": cpu_comm},
+        ):
+            selected = collectives._get_default_torchcomms_instance(fake_pg)
+
+        self.assertIs(selected, cpu_comm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
match `c10d` by preferring the CPU for collectives in mixed device `distwrap`

**Before**
```
dist.init_process_group("cuda:ncclx,cpu:gloo", use_torchcomms=True)
tc = _get_default_torchcomms_instance(dist.group.WORLD)
print("distwrap picks:", tc.get_backend(), tc.get_device())
```
```
distwrap picks: ncclx cuda:0
gathered: [0, 1]
```
**c10d**
```
dist.init_process_group("cuda:nccl,cpu:gloo")
print("c10d picks:", c10d._get_object_coll_device(dist.group.WORLD))
```
```
c10d picks: cpu
gathered: [0, 1]
```
**After**
```
dist.init_process_group("cuda:ncclx,cpu:gloo", use_torchcomms=True)
tc = _get_default_torchcomms_instance(dist.group.WORLD)
print("distwrap picks:", tc.get_backend(), tc.get_device())
```
```
distwrap picks: gloo cpu
gathered: [0, 1]
```