### PR TITLE
Remove duplicate NCCL_NAMED_THREAD_START macro definition in debug.h (#2477)

### DIFF
--- a/comms/ncclx/meta/transport/transportProxy.cc
+++ b/comms/ncclx/meta/transport/transportProxy.cc
@@ -62,8 +62,17 @@ commResult_t tranportProxyShutdown(struct ncclComm* comm) {
 }
 
 TransportProxy::TransportProxy(struct ncclComm* comm) : parentComm_(comm) {
-  NCCLCHECKIGNORE(
-      ncclCuMemHostAlloc((void**)&syncPoolPtr_, nullptr, kDefaultSyncPoolSize));
+  ncclResult_t allocRes =
+      ncclCuMemHostAlloc((void**)&syncPoolPtr_, nullptr, kDefaultSyncPoolSize);
+  if (allocRes != ncclSuccess && allocRes != ncclInProgress) {
+    WARN_WITH_SCUBA(
+        "%s:%s:%d -> %d (%s)",
+        __FILE__,
+        __func__,
+        __LINE__,
+        allocRes,
+        ncclCodeToString(allocRes));
+  }
   size_t nFlags = kDefaultSyncPoolSize / sizeof(uint64_t);
   for (int elemOffset = 0; elemOffset < nFlags; elemOffset++) {
     syncFlagPool_.push_back(syncPoolPtr_ + elemOffset);
@@ -101,7 +110,16 @@ void TransportProxy::shutdown() {
   if (syncPoolPtr_) {
     activeOps_.clear();
     syncFlagPool_.clear();
-    NCCLCHECKIGNORE(ncclCuMemHostFree((void*)syncPoolPtr_));
+    ncclResult_t freeRes = ncclCuMemHostFree((void*)syncPoolPtr_);
+    if (freeRes != ncclSuccess && freeRes != ncclInProgress) {
+      WARN_WITH_SCUBA(
+          "%s:%s:%d -> %d (%s)",
+          __FILE__,
+          __func__,
+          __LINE__,
+          freeRes,
+          ncclCodeToString(freeRes));
+    }
   }
   initialized_ = false;
 }

--- a/comms/ncclx/v2_30/src/ce_coll.cc
+++ b/comms/ncclx/v2_30/src/ce_coll.cc
@@ -71,9 +71,9 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
 
   // Clean up CE resources - continue cleanup even on errors to avoid leaks
   // Note: both functions handle null safely
-  NCCLCHECKIGNORE(ncclCommWindowDeregister(comm, comm->ceColl.ceSyncWin ? comm->ceColl.ceSyncWin->vidmem : nullptr));
-  NCCLCHECKIGNORE(ncclMemFree(comm->ceColl.baseUCSymReadyPtr));
-  NCCLCHECKIGNORE(ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager));
+  NCCLCHECKIGNORE(ncclCommWindowDeregister(comm, comm->ceColl.ceSyncWin ? comm->ceColl.ceSyncWin->vidmem : nullptr), ret);
+  NCCLCHECKIGNORE(ncclMemFree(comm->ceColl.baseUCSymReadyPtr), ret);
+  NCCLCHECKIGNORE(ncclCudaFree(comm->ceColl.ceSeqNumDev, comm->memManager), ret);
 
   comm->ceColl.ceSeqNumDev = nullptr;
   comm->ceColl.baseUCSymReadyPtr = nullptr;

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -184,6 +184,7 @@ static void symTeamDestroyAll(struct ncclComm* comm); // Further down
 ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream;
+  ncclResult_t ret = ncclSuccess;
   if (devr->bigSize == 0) return ncclSuccess;
 
   while (!ncclIntruQueueEmpty(&devr->regTaskQueue)) {
@@ -197,7 +198,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
   while (devr->winSortedCount > 0) {
     struct ncclDevrWindow* win = devr->winSorted[0].win;
-    NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream));
+    NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
   }
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
@@ -227,7 +228,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   ncclSpaceDestruct(&devr->bigSpace);
   free(devr->lsaRankList);
   free(devr->winSorted);
-  return ncclSuccess;
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/comms/ncclx/v2_30/src/include/checks.h
+++ b/comms/ncclx/v2_30/src/include/checks.h
@@ -269,20 +269,21 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
   } \
 } while (false)
 
-// Report failure but clear error and continue
-#define NCCLCHECKIGNORE(call)                          \
-  do {                                                 \
-    ncclResult_t RES = call;                           \
-    if (RES != ncclSuccess && RES != ncclInProgress) { \
-      WARN_WITH_SCUBA(                                 \
-          "%s:%s:%d -> %d (%s)",                       \
-          __FILE__,                                    \
-          __func__,                                    \
-          __LINE__,                                    \
-          RES,                                         \
-          ncclCodeToString(RES));                      \
-    }                                                  \
-  } while (0)
+// Report failure but continue - useful for cleanup paths where we want to
+// attempt all cleanup steps. Preserves the first error in RES.
+#define NCCLCHECKIGNORE(call, RES) do {                \
+  ncclResult_t TMPRES = call;                          \
+  if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
+    WARN_WITH_SCUBA(                                   \
+        "%s:%s:%d -> %d (%s)",                         \
+        __FILE__,                                      \
+        __func__,                                      \
+        __LINE__,                                      \
+        TMPRES,                                        \
+        ncclCodeToString(TMPRES));                     \
+    if (RES == ncclSuccess) RES = TMPRES;              \
+  }                                                    \
+} while (0)
 
 // Common thread creation implementation with error handling
 #define STDTHREADCREATE_IMPL(var, func, error_action, ...) do { \

--- a/comms/ncclx/v2_30/src/include/debug.h
+++ b/comms/ncclx/v2_30/src/include/debug.h
@@ -103,17 +103,7 @@ void ncclSetMyThreadLoggingName(std::string_view name);
         "[NCCL THREAD] Starting %s thread at %s", \
         threadName,                               \
         __func__);                                \
-  } while (0);
-
-#define NCCL_NAMED_THREAD_START(threadName)       \
-  do {                                            \
-    ncclSetMyThreadLoggingName(threadName);       \
-    INFO(                                         \
-        NCCL_INIT,                                \
-        "[NCCL THREAD] Starting %s thread at %s", \
-        threadName,                               \
-        __func__);                                \
-  } while (0);
+  } while (0)
 
 #define NCCL_NAMED_THREAD_START_EXT(threadName, rank, commHash, commDesc)              \
   do {                                                                                 \

--- a/comms/ncclx/v2_30/src/misc/socket.cc
+++ b/comms/ncclx/v2_30/src/misc/socket.cc
@@ -562,7 +562,7 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
       WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
           ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
 
-      WARN("You might set TORCH_NCCL_BCAST_UNIQUEID=0 to enable fast init feature, in ncclx 2.29 you will have ncclSocketInit errors. "
+      WARN("You might set TORCH_NCCL_BCAST_UNIQUEID=0 to enable fast init feature, in ncclx 2.30 you will have ncclSocketInit errors. "
            "We have deprecated NCCL_FASTINIT_MODE; set NCCL_FASTINIT_MODE=none and TORCH_NCCL_BCAST_UNIQUEID=1 to bootstrap NCCL");
       ret = ncclInternalError;
       goto exit;

--- a/comms/ncclx/v2_30/src/transport/nvls.cc
+++ b/comms/ncclx/v2_30/src/transport/nvls.cc
@@ -17,9 +17,6 @@
 #include "register_inline.h"
 
 #include "comms/utils/logger/Logger.h"
-#include "comms/ctran/memory/Utils.h"
-#include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/memtrace/MemoryTrace.h"
 
 #if CUDART_VERSION >= 12010
 


### PR DESCRIPTION
Summary:

`NCCL_NAMED_THREAD_START` was defined identically twice (lines 98-106 and 108-116) — a copy-paste bug carried forward from v2.29. The second definition silently overwrites the first (no compiler error since they're identical), but it's dead code and confusing for reviewers.

Also fixed trailing semicolon inside the do-while macro body (`while (0);` → `while (0)`) — the caller should provide the semicolon per standard macro hygiene.

Resolves T269796125.

Reviewed By: zhiyongww

Differential Revision: D104152190


