### PR TITLE
Support GB300 DSF topology with empty su and rtsw (#2482)

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -648,7 +648,11 @@ bool CommStateX::isSameDc(int myRank, int peer) const {
   return dc(peer) == dc(myRank);
 }
 bool CommStateX::isSameDeviceRack(int myRank, int peer) const {
-  return deviceRack(myRank) == deviceRack(peer);
+  // Guard against unknown rackSerial (-1): without this, two ranks with
+  // missing DEVICE_RACK_SERIAL would match (-1 == -1), falsely disabling
+  // trunk P2P when NCCL_MNNVL_TRUNK_DISABLE is set.
+  auto rs = deviceRack(myRank);
+  return rs >= 0 && rs == deviceRack(peer);
 }
 bool CommStateX::isSameNvlFabric(int myRank, int peer) const {
   if (!nvlFabricEnabled_) {

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -18,11 +18,12 @@ constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL";
 // DEVICE_BACKEND_NETWORK_TOPOLOGY should be present in all T20 hosts with
 // backend network. If not found CTRAN initialization fails.
 // Ignore this field for other platform types.
-// Expected format for top of rack topology
-// e.g
-// DEVICE_BACKEND_NETWORK_TOPOLOGY=pci5/pci5.5D.z088//rtsw191.c088.f00.pci5
-// Expected format for rail based topology
+// Expected format for top of rack topology (NSF)
+// e.g DEVICE_BACKEND_NETWORK_TOPOLOGY=pci5/pci5.5D.z088//rtsw191.c088.f00.pci5
+// Expected format for rail based topology (DSF with scaling unit)
 // e.g DEVICE_BACKEND_NETWORK_TOPOLOGY=/snb1.z081/snb1.z081.u015/
+// Expected format for DSF without scaling unit (e.g. GB300 DSF at UCO1)
+// e.g DEVICE_BACKEND_NETWORK_TOPOLOGY=uco1/uco1.z086//
 void parseTopologyValue(
     const std::string& value,
     const std::string& filepath,
@@ -50,8 +51,7 @@ void parseTopologyValue(
   su = std::move(topologyParts[2]);
   rtsw = std::move(topologyParts[3]);
 
-  if ((rtsw.empty() && su.empty()) || (!rtsw.empty() && !su.empty()) ||
-      zone.empty()) {
+  if (zone.empty()) {
     return;
   }
   isBackendTopologyValid = true;

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -869,4 +869,79 @@ TEST(CommStateXTest, nvlFabricWithNoLocalCvar) {
   EXPECT_EQ(commState->nNodes(), nRanks);
 }
 
+TEST(CommStateXTest, gb300DsfTopologyNoSuNoRtsw) {
+  const int rank = 0;
+  const int nRanks = 3;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+  const std::string kEmptySu = "";
+  const std::string kEmptyRtsw = "";
+  const std::string kUco1Dc = "uco1";
+  const std::string kUco1Zone = "uco1.z086";
+
+  std::vector<RankTopology> rankTopologies{};
+  rankTopologies.emplace_back(
+      createRankTopology(0, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost0));
+  rankTopologies.emplace_back(
+      createRankTopology(1, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost0));
+  rankTopologies.emplace_back(
+      createRankTopology(2, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost1));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      rankTopologies,
+      std::vector<int>{});
+
+  EXPECT_TRUE(commState->isSameNode(rank, 1));
+  EXPECT_FALSE(commState->isSameNode(rank, 2));
+
+  // With both su and rtsw empty, isSameRack returns false for all peers
+  EXPECT_FALSE(commState->isSameRack(rank, 1));
+  EXPECT_FALSE(commState->isSameRack(rank, 2));
+
+  EXPECT_TRUE(commState->isSameZone(rank, 1));
+  EXPECT_TRUE(commState->isSameZone(rank, 2));
+
+  EXPECT_TRUE(commState->isSameDc(rank, 1));
+  EXPECT_TRUE(commState->isSameDc(rank, 2));
+}
+
+TEST(CommStateXTest, isSameDeviceRackUnknownSerial) {
+  EnvRAII env(NCCL_MNNVL_TRUNK_DISABLE, true);
+  const int rank = 0;
+  const int nRanks = 2;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+  const std::string kEmptyRtsw;
+
+  std::vector<RankTopology> rankTopologies{};
+  // Both ranks have unknown rackSerial (-1)
+  rankTopologies.emplace_back(
+      createRankTopology(0, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0, -1));
+  rankTopologies.emplace_back(
+      createRankTopology(1, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0, -1));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      rankTopologies,
+      std::vector<int>{});
+
+  // Unknown rackSerial (-1) should not match
+  EXPECT_FALSE(commState->isSameDeviceRack(rank, 1));
+}
+
 } // namespace ncclx

--- a/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
+++ b/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
@@ -84,8 +84,33 @@ TEST(TopologyTest, BothRtswAndScalingUnit) {
        << std::endl;
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
-  EXPECT_FALSE(
-      topo); // Should fail because both rtsw and scaling unit are non-empty
+  EXPECT_TRUE(topo);
+  const std::string su(topo->su);
+  const std::string rtsw(topo->rtsw);
+  EXPECT_EQ(su, "scaling_unit");
+  EXPECT_EQ(rtsw, "rtsw_name");
+}
+
+TEST(TopologyTest, GB300DsfTopologyZoneOnly) {
+  const std::string filepath = "/tmp/ut-topology.txt";
+  std::ofstream file(filepath);
+  file << "DEVICE_NAME=twshared1766.40.uco1.facebook.com" << std::endl;
+  file << "DEVICE_BACKEND_NETWORK_TOPOLOGY=uco1/uco1.z086//" << std::endl;
+  file << "DEVICE_RACK_SERIAL=12278553" << std::endl;
+
+  auto topo = ctran::commstate::loadTopology(0, filepath);
+  EXPECT_TRUE(topo);
+  const std::string host(topo->host);
+  const std::string dc(topo->dc);
+  const std::string zone(topo->zone);
+  const std::string su(topo->su);
+  const std::string rtsw(topo->rtsw);
+  EXPECT_EQ(host, "twshared1766.40.uco1.facebook.com");
+  EXPECT_EQ(dc, "uco1");
+  EXPECT_EQ(zone, "uco1.z086");
+  EXPECT_EQ(su, "");
+  EXPECT_EQ(rtsw, "");
+  EXPECT_EQ(topo->rackSerial, 12278553);
 }
 
 TEST(TopologyTest, EmptyTopologyValue) {


### PR DESCRIPTION
Summary:

GB300 DSF hosts at UCO1 have DEVICE_BACKEND_NETWORK_TOPOLOGY=uco1/uco1.z086// where both scaling_unit and rtsw are empty. This is intentional per the network design — UCO1 DSF has no scaling unit concept and no single RTSW per host. The previous parseTopologyValue validation rejected this case (XOR check required exactly one of su/rtsw), causing loadTopology to return nullopt and crashing 128-GPU jobs during rank init.

Changes:
1. Relax parseTopologyValue validation to only require non-empty zone. All topology variants (GrandTeton NSF with rtsw, GB200 NVLSO DSF with su, GB300 DSF with neither) are now accepted.
2. Fix isSameDeviceRack() to guard against rackSerial == -1 (unknown). Previously two ranks with unknown rackSerial would falsely match as "same device rack" because -1 == -1. This could cause incorrect P2P decisions when NCCL_MNNVL_TRUNK_DISABLE is enabled on platforms without DEVICE_RACK_SERIAL.
3. Add unit tests for GB300 DSF topology parsing, isSameRack behavior with empty su/rtsw, and isSameDeviceRack with unknown rackSerial.

Note: isSameRack() still returns false for all GB300 DSF peers since both su and rtsw are empty. Whether rackSerial should be used as a fallback signal depends on whether DEVICE_RACK_SERIAL indicates network locality on DSF — pending confirmation from the fabric team.

Reviewed By: minsii

Differential Revision: D104332046


