### PR TITLE
Add CVAR to force exact numBlocks bypassing auto-tuner

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -982,10 +982,14 @@ inline commResult_t completeHostResourceSetup(
       CtranAlgo::TmpbufType::RING_TMP_RECV_BUF);
   args.rightRemBuf = (char*)args.rightRemBuf + offsetRingTmpRecv;
 
-  // Reverse: notifications from right on tmpRecvBufRev
-  args.rightNotify.reset(new CtranMapperNotify());
-  FB_COMMCHECK(comm->ctran_->mapper->initNotify(
-      args.rightRank, resource.tmpRecvBufRevHdl, args.rightNotify.get()));
+  // Reverse: notifications from right on tmpRecvBufRev.
+  // Only needed when bidir AG is enabled — otherwise the reverse path is
+  // unused.
+  if (args.enableBidirAg) {
+    args.rightNotify.reset(new CtranMapperNotify());
+    FB_COMMCHECK(comm->ctran_->mapper->initNotify(
+        args.rightRank, resource.tmpRecvBufRevHdl, args.rightNotify.get()));
+  }
 
   // Point leftRemBufRev to left neighbor's tmpRecvBufRev segment
   size_t offsetRingTmpRecvRev = comm->ctran_->algo->getTmpBufOffset(

--- a/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRingAutoTune.cc
@@ -11,6 +11,7 @@
 #include <fmt/format.h>
 
 #include "comms/ctran/algos/CtranAlgoConsts.h"
+#include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
@@ -222,19 +223,30 @@ AutoTuneParams getAutoTunedParams(
 
   auto bp = getAutoTunedBlockParams(
       p.chunkSize, maxOccupancyNumBlocks, maxOccupancyBlockSize, arch);
-  if (NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS > 0 &&
+  if (NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS > 0) {
+    FB_CHECKTHROW_EX_NOCOMM(
+        NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS <= 0 ||
+            NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS <=
+                NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS,
+        fmt::format(
+            "NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS ({}) exceeds "
+            "MAX_NUM_THREAD_BLOCKS ({})",
+            NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS,
+            NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS));
+    bp.numBlocks = NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS;
+  } else if (
+      NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS > 0 &&
       bp.numBlocks > NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS) {
     bp.numBlocks = NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS;
   }
   if (NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE > 0) {
-    if (NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE > maxOccupancyBlockSize) {
-      throw std::invalid_argument(
-          fmt::format(
-              "NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE ({}) exceeds "
-              "max occupancy block size ({})",
-              NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE,
-              maxOccupancyBlockSize));
-    }
+    FB_CHECKTHROW_EX_NOCOMM(
+        NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE <= maxOccupancyBlockSize,
+        fmt::format(
+            "NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE ({}) exceeds "
+            "max occupancy block size ({})",
+            NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE,
+            maxOccupancyBlockSize));
     bp.blockSize = NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE;
   }
 

--- a/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
+++ b/comms/ctran/algos/AllReduce/tests/AllReduceRingAutoTuneTest.cc
@@ -11,6 +11,7 @@
 
 #include "comms/ctran/algos/AllReduce/AllReduceRingAutoTune.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
+#include "comms/ctran/utils/Exception.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 using ctran::allreduce::ring::getAutoTunedParams;
@@ -81,6 +82,18 @@ class NumBlocksOverride {
   ~NumBlocksOverride() {
     NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS =
         NCCL_CTRAN_ALLREDUCE_RING_MAX_NUM_THREAD_BLOCKS_DEFAULTCVARVALUE;
+  }
+};
+
+// RAII guard for NUM_THREAD_BLOCKS CVAR (force exact value).
+class ForceNumBlocksOverride {
+ public:
+  explicit ForceNumBlocksOverride(int v) {
+    NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS = v;
+  }
+  ~ForceNumBlocksOverride() {
+    NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS =
+        NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS_DEFAULTCVARVALUE;
   }
 };
 
@@ -943,7 +956,47 @@ TEST_F(AutoTuneCVAROverrideTest, BlockOverrides) {
     EXPECT_THROW(
         getAutoTunedParams(
             kMsg, kNRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1),
-        std::invalid_argument);
+        ctran::utils::Exception);
+  }
+}
+
+// NUM_THREAD_BLOCKS forces exact numBlocks, bypassing auto-tuner.
+TEST_F(AutoTuneCVAROverrideTest, ForceNumBlocks) {
+  MaxBDPOverride bdp(128 * MB);
+
+  // Force 16 blocks regardless of auto-tuner output.
+  {
+    ForceNumBlocksOverride fn(16);
+    auto at = getAutoTunedParams(
+        kMsg, kNRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1);
+    EXPECT_EQ(at.block.numBlocks, 16);
+  }
+
+  // Force 1 block — overrides auto-tuner's higher value.
+  {
+    ForceNumBlocksOverride fn(1);
+    auto at = getAutoTunedParams(
+        kMsg, kNRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1);
+    EXPECT_EQ(at.block.numBlocks, 1);
+  }
+
+  // Force + MAX cap: force must not exceed cap.
+  {
+    ForceNumBlocksOverride fn(16);
+    NumBlocksOverride nb(8);
+    EXPECT_THROW(
+        getAutoTunedParams(
+            kMsg, kNRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1),
+        ctran::utils::Exception);
+  }
+
+  // Force <= MAX cap: succeeds.
+  {
+    ForceNumBlocksOverride fn(4);
+    NumBlocksOverride nb(8);
+    auto at = getAutoTunedParams(
+        kMsg, kNRanks, kMaxOccNumBlocks, kMaxOccBlockSize, 1);
+    EXPECT_EQ(at.block.numBlocks, 4);
   }
 }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2914,6 +2914,16 @@ cvars:
      We might use fewer thread blocks, if we can achieve max occupancy
      with them.
 
+ - name        : NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS
+   type        : int
+   default     : 0
+   description : |-
+     Force the exact number of thread blocks for the AllReduce Ring
+     kernel, bypassing the auto-tuner. When set to > 0, the auto-tuner
+     block selection is skipped and this value is used directly.
+     Use with NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE to fully
+     override the auto-tuner.
+
  - name        : NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE
    type        : int
    default     : 0


### PR DESCRIPTION
Summary: Add NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS CVAR that forces the exact number of thread blocks for the AllReduce Ring kernel, bypassing the auto-tuner's block selection. When set to > 0, the auto-tuner is skipped and this value is used directly. Throws if it exceeds MAX_NUM_THREAD_BLOCKS (when that cap is also set).

Reviewed By: saifhhasan, arttianezhu

Differential Revision: D104324525


