### PR TITLE
Fix null deref in local-only window finalize, GIN activation, and FindWindow lookup (#2484)

### DIFF
--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -47,6 +47,7 @@ static struct ncclDevCommCompat *devCommCompat[] = {
 static std::mutex ncclWindowMapMutex;
 static ncclIntruAddressMap<ncclDevrWindow, struct ncclWindow_vidmem*, &ncclDevrWindow::vidmem, &ncclDevrWindow::next> ncclWindowMap;
 static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vidmem* winDev, cudaStream_t stream);
+static ncclResult_t symLocalWindowDestroy(struct ncclComm* comm, struct ncclWindow_vidmem* winDev, cudaStream_t stream);
 
 // Complete types from src/include/dev_runtime.h
 struct ncclDevrMemory {
@@ -75,7 +76,8 @@ struct ncclDevrMemory {
 struct ncclDevrWindowSorted {
   uintptr_t userAddr;
   size_t size;
-  struct ncclDevrWindow* win;
+  struct ncclDevrWindow* win; // For local-only windows, points to ncclDevrLocalWindow via
+                              // reinterpret_cast (layout-compatible prefix). Never nullptr.
 };
 
 struct ncclDevrTeam {
@@ -198,7 +200,11 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
   while (devr->winSortedCount > 0) {
     struct ncclDevrWindow* win = devr->winSorted[0].win;
-    NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
+    if (win->winFlags & NCCL_WIN_LOCAL_ONLY) {
+      NCCLCHECKIGNORE(symLocalWindowDestroy(comm, win->vidmem, stream), ret);
+    } else {
+      NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
+    }
   }
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
@@ -905,9 +911,7 @@ static ncclResult_t symLocalWindowCreate(
     struct ncclDevrWindowSorted winSort;
     winSort.userAddr = userAddr;
     winSort.size = userSize;
-    // Note: We store nullptr for local-only windows in winSorted.win since it's a different type.
-    // This is safe because winSorted is only used for lookups, not for type-specific operations.
-    winSort.win = nullptr;
+    winSort.win = reinterpret_cast<struct ncclDevrWindow*>(win);
     listInsert(&devr->winSorted, &devr->winSortedCapacity, &devr->winSortedCount, i, winSort);
   }
 
@@ -1395,7 +1399,10 @@ ncclResult_t ncclDevrCommCreateInternal(
 
   if (ginActivated) {
     // Now update the GIN handles in all existing windows. Registration of memories happened above.
+    // Skip local-only windows: they have their own GIN registration done at creation time
+    // and do not have an ncclDevrMemory (win->memory would be invalid).
     for (int i=0; i < devr->winSortedCount; i++) {
+      if (devr->winSorted[i].win->winFlags & NCCL_WIN_LOCAL_ONLY) continue;
       struct ncclDevrWindow* win = devr->winSorted[i].win;
       struct ncclWindow_vidmem* winHost;
       NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, win->vidmem, &winHost), ret, fail_stream);
@@ -1611,7 +1618,11 @@ ncclResult_t ncclDevrFindWindow(
   uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
   int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
   if (0 < i && (userAddr - devr->winSorted[i-1].userAddr < devr->winSorted[i-1].size)) {
-    *outWin = devr->winSorted[i-1].win;
+    struct ncclDevrWindow* win = devr->winSorted[i-1].win;
+    // Filter out local-only windows: callers (ncclDevrWindowIsMultiSegment,
+    // ncclDevrWindowHasSysmemSegment, sym_kernels) treat non-null as a regular
+    // collective window and dereference win->memory without null checks.
+    *outWin = (win->winFlags & NCCL_WIN_LOCAL_ONLY) ? nullptr : win;
   } else {
     *outWin = nullptr;
   }

--- a/comms/ncclx/v2_30/src/include/dev_runtime.h
+++ b/comms/ncclx/v2_30/src/include/dev_runtime.h
@@ -32,8 +32,9 @@ struct ncclDevrWindow {
 
 // Local-only window for source buffers (non-collective registration).
 // Uses parent's PD but skips rkey allGather. Can only be used as source for put.
-// NOTE: The first 5 fields (memory through winFlags) must match ncclDevrWindow
-// layout so that winFlags can be checked to distinguish window types.
+// NOTE: The first 7 fields (memory through vidmem) must match ncclDevrWindow
+// layout. winSorted[] stores both types via reinterpret_cast; code checks
+// winFlags & NCCL_WIN_LOCAL_ONLY before accessing type-specific fields.
 struct ncclDevrLocalWindow {
   void* memory;      // nullptr for local-only windows (no ncclDevrMemory)
   void* userPtr;
@@ -45,6 +46,10 @@ struct ncclDevrLocalWindow {
   void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS];
   ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS];
 };
+static_assert(offsetof(ncclDevrWindow, winFlags) == offsetof(ncclDevrLocalWindow, winFlags),
+              "ncclDevrWindow and ncclDevrLocalWindow must have winFlags at the same offset");
+static_assert(offsetof(ncclDevrWindow, vidmem) == offsetof(ncclDevrLocalWindow, vidmem),
+              "ncclDevrWindow and ncclDevrLocalWindow must have vidmem at the same offset");
 struct ncclDevrWindowSorted;
 struct ncclDevrTeam;
 


### PR DESCRIPTION
Summary:

## Problem

NCCLX v2.30 introduced local-only windows (`NCCL_WIN_LOCAL_ONLY`) in D94285097 — non-collective, source-only GPU memory registrations that register with GIN locally (no allGather). These are tracked in the same `winSorted[]` array as regular collective windows, but `symLocalWindowCreate` stores `nullptr` in `winSorted[].win` for local-only entries (dev_runtime.cc:909).

The inline comment claims "This is safe because winSorted is only used for lookups" — this is **incorrect**. Two code paths iterate `winSorted[]` and unconditionally dereference `win`, causing null pointer segfaults:

### Crash 1: `ncclDevrFinalize` (dev_runtime.cc:199-201)

```cpp
while (devr->winSortedCount > 0) {
    struct ncclDevrWindow* win = devr->winSorted[0].win;  // nullptr
    symWindowDestroy(comm, win->vidmem, stream);           // SEGFAULT
}
```

**Trigger:** User registers a local-only window; communicator is destroyed/aborted before deregistering. This is a normal abort path — users are not required to deregister before destroy.

### Crash 2: GIN activation loop (dev_runtime.cc:1397-1405)

```cpp
for (int i=0; i < devr->winSortedCount; i++) {
    struct ncclDevrWindow* win = devr->winSorted[i].win;  // nullptr
    win->vidmem; win->memory->bigOffset;                   // SEGFAULT
}
```

**Trigger:** A local-only window exists when a subsequent `ncclDevCommCreate` call first activates GIN.

### Logic bug: `ncclDevrFindWindow` (dev_runtime.cc:1613)

Returns `nullptr` for valid local-only windows. Does not crash (callers null-check), but silently treats valid windows as "not found."

## Root Cause

`symLocalWindowCreate` stores `winSort.win = nullptr` at line 909. This violates the invariant that every `winSorted` entry has a dereferenceable window pointer.

## Fix

The two window struct types (`ncclDevrWindow`, `ncclDevrLocalWindow`) are **deliberately layout-compatible** for the first 7 fields (memory through vidmem) per dev_runtime.h:35. The `winFlags` field at offset 4 discriminates: regular windows never have `NCCL_WIN_LOCAL_ONLY`; local-only windows always do. The existing deregister path (dev_runtime.cc:1588-1593) already uses this pattern successfully.

**Change 1 — Store real pointer (dev_runtime.cc:912):** Replace `winSort.win = nullptr` with `winSort.win = reinterpret_cast<ncclDevrWindow*>(win)`. Safe under C++ common initial sequence rules; enforced by new `static_assert`s.

**Change 2 — Finalize dispatch (dev_runtime.cc:199-207):** Check `win->winFlags & NCCL_WIN_LOCAL_ONLY` and dispatch to `symLocalWindowDestroy` vs `symWindowDestroy`. Both internally call `listRemove` on `winSorted`, so the while-loop drains correctly.

**Change 3 — GIN activation skip (dev_runtime.cc:1403-1404):** Skip local-only windows with `continue`. They manage their own GIN handles via `ncclGinRegisterLocal` at creation time and have no `ncclDevrMemory` backing (`memory == nullptr`).

**Change 4 — FindWindow filter (dev_runtime.cc:1624):** Filter `NCCL_WIN_LOCAL_ONLY` out of `ncclDevrFindWindow` results: `*outWin = (win->winFlags & NCCL_WIN_LOCAL_ONLY) ? nullptr : win`. This preserves existing caller semantics — `ncclDevrWindowIsMultiSegment` (line 1630) and `ncclDevrWindowHasSysmemSegment` (line 1633) dereference `win->memory` after only a `win != NULL` check, so returning a local-only pointer (where `memory == nullptr`) would create a new crash path.

**Change 5 — Compile-time safety (dev_runtime.h:49-52):** Added `static_assert`s verifying `winFlags` and `vidmem` offsets match between `ncclDevrWindow` and `ncclDevrLocalWindow`.

## Context

- Bug introduced in D94285097 (NCCLX 2.29 rebase, local-only window feature by max7255)
- Reported as review comment on D103483114 by snarayankh
- Carries forward to D104098797 (NCCLX 2.30 squashed rebase by zwood-meta)
- Related fix attempt: D103756278 (by zwood-meta)

Reviewed By: zhiyongww

Differential Revision: D104139846


