### PR TITLE
Add NCCLX 2.30 conda build fixes for github/feedstock scripts (#2485)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -380,6 +380,12 @@ if [[ -z "${USE_SYSTEM_LIBS}" ]]; then
 else
   THIRD_PARTY_LDFLAGS+="-lglog -lgflags -lboost_context -lssl -lcrypto -lfmt"
 fi
+# Link the conda env's libstdc++ by SONAME (libstdc++.so.6) — NOT the bare
+# libstdc++.so symlink, which is from libstdcxx-devel (GCC 11.2, GLIBCXX_3.4.29)
+# while libstdc++.so.6 is from libstdcxx-ng (15.2.0, GLIBCXX_3.4.33).
+if [ -f "$CONDA_LIB_DIR/libstdc++.so.6" ]; then
+  THIRD_PARTY_LDFLAGS+=" $CONDA_LIB_DIR/libstdc++.so.6"
+fi
 
 echo "$THIRD_PARTY_LDFLAGS"
 

--- a/comms/ncclx/v2_30/makefiles/common.mk
+++ b/comms/ncclx/v2_30/makefiles/common.mk
@@ -86,15 +86,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-# CUDA 13.0 requires c++17
-ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 13; echo $$?),0)
-  CXXSTD ?= -std=c++17
-else
-  CXXSTD ?= -std=c++14
-endif
+CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)

--- a/comms/ncclx/v2_30/setup.py
+++ b/comms/ncclx/v2_30/setup.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+from distutils.command.build import build as _build
+
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+from setuptools.command.egg_info import egg_info as _egg_info
+
+BUILDDIR = os.environ.get("BUILDDIR", None)
+if BUILDDIR is not None:
+    LIBDIR = os.path.join(BUILDDIR, "lib")
+    BUILDDIR = os.path.join(BUILDDIR, "pybind")
+    os.makedirs(BUILDDIR, exist_ok=True)
+
+
+class build(_build):
+    def initialize_options(self):
+        super().initialize_options()
+        self.build_base = BUILDDIR
+
+
+class egg_info(_egg_info):
+    def initialize_options(self):
+        super().initialize_options()
+        self.egg_base = BUILDDIR
+
+
+def get_cmdclass():
+    from pybind11.setup_helpers import build_ext
+
+    return {
+        "build": build,
+        "egg_info": egg_info,
+        "build_ext": build_ext,
+    }
+
+
+ext_modules = [
+    Pybind11Extension(
+        "ncclx_trainer_context",
+        ["../meta/py/wrapper.cc"],
+        library_dirs=[LIBDIR],
+        libraries=["nccl"],
+    ),
+]
+
+setup(
+    name="ncclx_trainer_context",
+    ext_modules=ext_modules,
+    cmdclass=get_cmdclass(),
+)

--- a/comms/ncclx/v2_30/src/version.script
+++ b/comms/ncclx/v2_30/src/version.script
@@ -1,0 +1,20 @@
+/*
+version.script controls symbol visibility, it exposes
+nccl: nccl(x)-related symbols
+cxa: Folly’s exception tracer intercepts all exceptions and uses
+    dlsym(RTLD_NEXT, "cxa...") to find the corresponding real symbols.
+    Therefore, it is necessary to expose certain cxa symbols from the libstdc++.
+    For further details, refer to the discussion in D64442615.
+*/
+{
+  global:
+      *nccl*;
+      *ctran*;
+      *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
+  /* Transitive symbols (e.g. coming from static libs) are not exported */
+  local:
+      *;
+};


### PR DESCRIPTION
Summary:

Build infrastructure changes to shared scripts needed for NCCLX 2.30 conda builds. Split from the internal v2_30 file additions per reviewer request.

Changes:
- build_ncclx.sh: Link conda libstdc++.so.6 by SONAME to avoid GLIBCXX version mismatch between libstdcxx-devel (GCC 11.2) and libstdcxx-ng (15.2.0), strip non-accelerated sm_100 gencode on CUDA 12.x (2.30 added TMA kernels in tma_ptx.cuh whose PTX instructions are accelerated-only; the arch guard cannot distinguish sm_100 from sm_100a since both report __CUDA_ARCH__==1000; all B200 hardware is sm_100a so no real support is lost)
- conda feedstock nccl/build.sh: Use gcc for shared library link to avoid implicit old libstdc++, skip ncclparam/ncclras binary builds (not needed in conda package, hit same GLIBCXX mismatch)

Differential Revision: D104104496


