### PR TITLE
pool events to avoid unpredictable side-thread cuda runtime calls (#2486)

### DIFF
--- a/comms/torchcomms/ncclx/GraphEventTracker.cpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.cpp
@@ -27,6 +27,14 @@ namespace torch::comms {
 
 GraphEventTracker::GraphEventTracker(TorchCommNCCLX* comm) : comm_(comm) {}
 
+GraphEventTracker::~GraphEventTracker() {
+  destroyAll();
+  CudaApi* api = comm_->getCudaApi();
+  for (cudaEvent_t event : event_pool_) {
+    (void)api->eventDestroy(event);
+  }
+}
+
 void GraphEventTracker::initOnGraphStart(cudaStream_t stream) {
   // No op if not in graph capture mode
   if (!comm_->getGraphCaptureMode()) {
@@ -65,9 +73,10 @@ void GraphEventTracker::maybeInitGraphState(
     return;
   }
   auto& state = it->second;
+  state.event_pool_ = &event_pool_;
+  state.counter_pool_ = &counter_pool_;
 
   CudaApi* api = comm_->getCudaApi();
-  state.api_ = api;
 
   SharedCallbackState* shared = allocateCallbackState();
   state.shared_ = shared;
@@ -314,18 +323,6 @@ GraphEventTracker::CheckResult GraphEventTracker::checkAll() {
 
 #undef EVENT_QUERY_CHECK
 
-GraphState::~GraphState() {
-  if (api_ == nullptr) {
-    return;
-  }
-
-  for (auto& [_, entries] : stream_entries) {
-    for (auto& entry : entries) {
-      entry.destroyEvents(api_);
-    }
-  }
-}
-
 void GraphEventTracker::cleanupReleasedGraphs() {
   CudaApi* api = comm_->getCudaApi();
 
@@ -351,17 +348,6 @@ void GraphEventTracker::cleanupReleasedGraphs() {
           }
         }
       }
-
-      // Recycle the counter back to the pool instead of letting
-      // ~DeviceCounter run inline. cudaFreeHost is a synchronizing call —
-      // running it here on the watchdog thread can block indefinitely if
-      // the device is busy with the next eager warmup, starving NCCL
-      // progress and causing a peer-visible deadlock. The graph has been
-      // fully destroyed (cudaGraphExecDestroy blocks until in-flight
-      // replays complete, then the user-object refcount drops to zero
-      // and our cleanupCallback fires), so no GPU work references this
-      // counter region.
-      releaseCounter(std::move(graph_state.replay_counter));
     }
 
     it = graphs_.erase(it);
@@ -379,8 +365,14 @@ cudaError_t GraphEventTracker::acquireCounter(
   return DeviceCounter::create(comm_->getCudaApi(), out);
 }
 
-void GraphEventTracker::releaseCounter(std::unique_ptr<DeviceCounter> counter) {
-  counter_pool_.push_back(std::move(counter));
+cudaError_t GraphEventTracker::acquireEvent(cudaEvent_t& out) {
+  if (!event_pool_.empty()) {
+    out = event_pool_.back();
+    event_pool_.pop_back();
+    return cudaSuccess;
+  }
+  return comm_->getCudaApi()->eventCreateWithFlags(
+      &out, cudaEventDisableTiming);
 }
 
 void GraphEventTracker::destroyAll() {

--- a/comms/torchcomms/ncclx/GraphEventTracker.hpp
+++ b/comms/torchcomms/ncclx/GraphEventTracker.hpp
@@ -24,8 +24,8 @@ class TorchWorkNCCLX;
 
 // Tracks a single graph-captured collective for timeout detection.
 struct GraphWork {
-  cudaEvent_t start_event; // OWNED — ad-hoc created, destroyed on cleanup
-  cudaEvent_t end_event; // OWNED — ad-hoc created, destroyed on cleanup
+  cudaEvent_t start_event; // OWNED — stashed in tracker event_pool_ on cleanup
+  cudaEvent_t end_event; // OWNED — stashed in tracker event_pool_ on cleanup
   std::chrono::milliseconds timeout;
   std::optional<std::chrono::steady_clock::time_point> start_completed_time;
   uint64_t last_seen_replay{0};
@@ -39,11 +39,6 @@ struct GraphWork {
 
   GraphWork(cudaEvent_t start, cudaEvent_t end, std::chrono::milliseconds t)
       : start_event(start), end_event(end), timeout(t) {}
-
-  void destroyEvents(CudaApi* api) {
-    (void)api->eventDestroy(start_event);
-    (void)api->eventDestroy(end_event);
-  }
 };
 
 // Shared state for the graph-release flag, read by the tracker's watchdog.
@@ -56,22 +51,41 @@ struct SharedCallbackState {
   std::atomic_bool released{false};
 };
 
-// Per-graph state. Owns the CUDA events / dependency tensors
-// for all captured collectives; RAII destruction for
-// automatic cleanup on erase/clear.
+// Per-graph state. Holds the CUDA events / dependency tensors
+// for all captured collectives. The destructor returns owned events to the
+// tracker's event_pool_; the counter is explicitly moved to counter_pool_
+// before destruction. This ensures neither cudaEventDestroy nor cudaFreeHost
+// runs inline on the watchdog thread.
 struct GraphState {
   // Entries grouped by stream — collectives are only ordered within a stream,
   // so per-stream grouping enables early-exit optimization in checkAll().
   std::unordered_map<cudaStream_t, std::vector<GraphWork>> stream_entries;
   SharedCallbackState* shared_{nullptr};
-  CudaApi* api_{nullptr};
   std::unique_ptr<DeviceCounter> replay_counter;
   // CPU tensors that must be kept alive for the graph's lifetime.
   // This includes CPU pointer tensors used by alltoallv_dynamic_dispatch
   // operations. These tensors are moved from work objects during graph
   // capture and remain valid until the graph is destroyed.
   std::vector<at::Tensor> cpu_tensors;
-  ~GraphState();
+  // Set by GraphEventTracker::maybeInitGraphState to point at the tracker's
+  // pools. Null for GraphState objects that were never fully initialized.
+  std::vector<cudaEvent_t>* event_pool_{nullptr};
+  std::vector<std::unique_ptr<DeviceCounter>>* counter_pool_{nullptr};
+
+  ~GraphState() {
+    if (counter_pool_ && replay_counter) {
+      counter_pool_->push_back(std::move(replay_counter));
+    }
+    if (!event_pool_) {
+      return;
+    }
+    for (auto& [_, entries] : stream_entries) {
+      for (auto& entry : entries) {
+        event_pool_->push_back(entry.start_event);
+        event_pool_->push_back(entry.end_event);
+      }
+    }
+  }
 };
 
 // Monitors graph-captured collectives for timeout/error after graph launch.
@@ -107,7 +121,7 @@ class GraphEventTracker {
   enum class CheckResult { OK, TIMEOUT, ERROR };
 
   explicit GraphEventTracker(TorchCommNCCLX* comm);
-  ~GraphEventTracker() = default;
+  ~GraphEventTracker();
 
   // Non-copyable, non-movable (contains mutex)
   GraphEventTracker(const GraphEventTracker&) = delete;
@@ -139,12 +153,17 @@ class GraphEventTracker {
   void cleanupReleasedGraphs();
 
   // Counter pool. Acquire returns a counter from the pool (resetting it to
-  // zero) or creates a new one if empty. Release returns a counter to the
-  // pool. Both must be called with mutex_ held. Pooling avoids the
-  // synchronizing cudaFreeHost in ~DeviceCounter on the watchdog thread —
-  // see cleanupReleasedGraphs() for context.
+  // zero) or creates a new one if empty. ~GraphState handles returning
+  // counters to the pool. Pooling avoids the synchronizing cudaFreeHost
+  // in ~DeviceCounter on the watchdog thread — see cleanupReleasedGraphs()
+  // for context.
   cudaError_t acquireCounter(std::unique_ptr<DeviceCounter>& out);
-  void releaseCounter(std::unique_ptr<DeviceCounter> counter);
+
+  // Event pool. Acquire returns an event from the pool, creating a new one
+  // if empty. ~GraphState handles returning events to the pool.
+  // Pooling avoids the synchronizing cudaEventDestroy on the watchdog
+  // thread — see cleanupReleasedGraphs() for context.
+  cudaError_t acquireEvent(cudaEvent_t& out);
 
   // Fire graph replay hooks for all events from the entry's last notified
   // position up to (current_replay, current_event). Events are ordered
@@ -169,6 +188,11 @@ class GraphEventTracker {
   // Guarded by mutex_. Drained at destruction (~DeviceCounter calls
   // cudaFreeHost — safe at comm shutdown when device is quiescent).
   std::vector<std::unique_ptr<DeviceCounter>> counter_pool_;
+  // Pool of CUDA events from completed graphs, deferred for destruction
+  // until ~GraphEventTracker. cudaEventDestroy is a synchronizing call —
+  // running it on the watchdog thread can deadlock with the eager warmup
+  // that follows a PAFT recapture. Guarded by mutex_.
+  std::vector<cudaEvent_t> event_pool_;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -338,8 +338,9 @@ TEST_F(GraphEventTrackerTest, ReplayCounterResetsTimer) {
   setupFinalizeExpectations(*comm);
 }
 
-// destroyAll should destroy exactly the entry-owned events. We track which
-// events are destroyed to verify precise cleanup.
+// destroyAll should stash the entry-owned events into the tracker event pool;
+// the actual cudaEventDestroy calls fire at ~GraphEventTracker (comm
+// destruction). We track destroys to verify the events are eventually freed.
 TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
@@ -377,15 +378,26 @@ TEST_F(GraphEventTrackerTest, DestroyAllCleansUpGraphEntryEvents) {
 
   comm->finalize();
 
-  EXPECT_TRUE(
-      std::find(
-          destroyed_events.begin(), destroyed_events.end(), events.start) !=
+  // After finalize, events are stashed in the tracker pool, not destroyed.
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
       destroyed_events.end())
-      << "start event was not destroyed by destroyAll";
-  EXPECT_TRUE(
-      std::find(destroyed_events.begin(), destroyed_events.end(), events.end) !=
+      << "start event must defer destruction past finalize";
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
       destroyed_events.end())
-      << "end event was not destroyed by destroyAll";
+      << "end event must defer destruction past finalize";
+
+  // ~GraphEventTracker drains the pool at comm destruction.
+  comm.reset();
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start event was not destroyed by ~GraphEventTracker";
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end event was not destroyed by ~GraphEventTracker";
 }
 
 // Verify that the cleanup callback only sets the released flag when a graph
@@ -554,18 +566,52 @@ TEST_F(GraphEventTrackerTest, CheckAllCleansUpReleasedGraphs) {
   // Invoke cleanup callback — sets released flag
   captured_cleanup_fn(captured_cleanup_data);
 
-  // checkGraphEvents calls checkAll which calls cleanupReleasedGraphs
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.start))
-      .WillOnce(Return(cudaSuccess));
-  EXPECT_CALL(*cuda_mock_, eventDestroy(events.end))
-      .WillOnce(Return(cudaSuccess));
+  // checkGraphEvents calls checkAll which calls cleanupReleasedGraphs.
+  // Events are now stashed in the tracker event pool rather than destroyed
+  // inline, so checkAll must NOT call eventDestroy on the captured events.
+  std::vector<cudaEvent_t> destroyed_events;
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          [&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          },
+          Return(cudaSuccess)));
 
   comm->checkGraphEvents();
 
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start_event must be stashed by cleanupReleasedGraphs, not destroyed";
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end_event must be stashed by cleanupReleasedGraphs, not destroyed";
+
   ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
 
-  // finalize should have nothing to clean up (already cleaned by checkAll)
-  setupFinalizeExpectations(*comm);
+  // Re-install the destroy tracker for the finalize/destroy sequence.
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          [&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          },
+          Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+  comm->finalize();
+
+  // Drain happens at comm destruction.
+  comm.reset();
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start_event not destroyed at comm destruction";
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end_event not destroyed at comm destruction";
 }
 
 TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
@@ -650,11 +696,15 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
   // Release only graph 1
   cleanup_fn_1(cleanup_data_1);
 
-  // checkAll should destroy graph 1's events but not graph 2's
-  EXPECT_CALL(*cuda_mock_, eventDestroy(start1)).WillOnce(Return(cudaSuccess));
-  EXPECT_CALL(*cuda_mock_, eventDestroy(end1)).WillOnce(Return(cudaSuccess));
-  EXPECT_CALL(*cuda_mock_, eventDestroy(start2)).Times(0);
-  EXPECT_CALL(*cuda_mock_, eventDestroy(end2)).Times(0);
+  // checkAll stashes graph 1's events in the tracker pool; graph 2 stays in
+  // graphs_ and its events are untouched. No eventDestroy fires on either.
+  std::vector<cudaEvent_t> destroyed_events;
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          [&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          },
+          Return(cudaSuccess)));
 
   ON_CALL(*cuda_mock_, eventQuery(start2))
       .WillByDefault(Return(cudaErrorNotReady));
@@ -663,10 +713,36 @@ TEST_F(GraphEventTrackerTest, MultipleGraphsOnlyReleasedOneCleanedUp) {
 
   comm->checkGraphEvents();
 
+  for (auto e : {start1, end1, start2, end2}) {
+    EXPECT_EQ(
+        std::find(destroyed_events.begin(), destroyed_events.end(), e),
+        destroyed_events.end())
+        << "event must be stashed by cleanupReleasedGraphs, not destroyed";
+  }
+
   ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
 
-  // finalize should destroy graph 2's events
-  setupFinalizeExpectations(*comm);
+  // Re-install destroy tracker, then run finalize and comm destruction.
+  // graph 2's events get stashed by destroyAll, then both graphs' events
+  // drain at ~GraphEventTracker.
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_))
+      .WillRepeatedly(DoAll(
+          [&destroyed_events](cudaEvent_t event) {
+            destroyed_events.push_back(event);
+          },
+          Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+  comm->finalize();
+  comm.reset();
+
+  for (auto e : {start1, end1, start2, end2}) {
+    EXPECT_NE(
+        std::find(destroyed_events.begin(), destroyed_events.end(), e),
+        destroyed_events.end())
+        << "event was not destroyed at comm destruction";
+  }
 }
 
 // Verify the pinned-memory counter region is reused across recaptures rather
@@ -869,6 +945,93 @@ TEST_F(GraphEventTrackerTest, CounterPoolDrainsAtFinalize) {
          "counter region";
 }
 
+// Verify that graph events captured by GraphEventTracker are destroyed at
+// comm destruction (~GraphEventTracker drains event_pool_), not earlier.
+// finalize() runs destroyAll() which only stashes; the actual cudaEventDestroy
+// calls happen when the comm itself is destroyed and the device is quiescent.
+TEST_F(GraphEventTrackerTest, EventPoolDrainsAtCommDestruction) {
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  comm->init(*device_, "test_event_pool_drains_at_destruction", options);
+
+  // Track every eventDestroy call across the full lifecycle.
+  std::vector<cudaEvent_t> destroyed_events;
+  auto trackEventDestroy = [&destroyed_events](cudaEvent_t e) {
+    destroyed_events.push_back(e);
+    return cudaSuccess;
+  };
+  ON_CALL(*cuda_mock_, eventDestroy(_)).WillByDefault(trackEventDestroy);
+
+  // -------- Capture / release a graph --------
+  void* cleanup_data = nullptr;
+  cudaHostFn_t cleanup_fn = nullptr;
+  setupGraphCaptureMocks(/*graph_id=*/100);
+  auto events = setupGraphCaptureEvents();
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          SaveArg<1>(&cleanup_data),
+          SaveArg<2>(&cleanup_fn),
+          Return(cudaSuccess)));
+
+  {
+    auto tensor = createTestTensor({10, 10});
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ASSERT_NE(cleanup_fn, nullptr);
+  cleanup_fn(cleanup_data);
+  switchToReplayMode();
+  comm->checkGraphEvents();
+
+  // Watchdog cleanup must not destroy start/end events.
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start_event destroyed during watchdog cleanup";
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end_event destroyed during watchdog cleanup";
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+  cuda_mock_->setupDefaultBehaviors();
+
+  // Manually set up finalize expectations so our tracker keeps capturing
+  // eventDestroy across both finalize() and the subsequent comm destruction.
+  // (The default setupFinalizeExpectations installs an EXPECT_CALL on
+  // eventDestroy that would shadow our ON_CALL tracker.)
+  EXPECT_CALL(*cuda_mock_, eventDestroy(_)).WillRepeatedly(trackEventDestroy);
+  EXPECT_CALL(*cuda_mock_, free(_)).WillRepeatedly(Return(cudaSuccess));
+  EXPECT_CALL(*cuda_mock_, streamDestroy(_)).WillOnce(Return(cudaSuccess));
+  EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
+  comm->finalize();
+
+  // finalize stashes events into event_pool_ but doesn't destroy them.
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start_event destroyed during finalize (must defer to ~GraphEventTracker)";
+  EXPECT_EQ(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end_event destroyed during finalize (must defer to ~GraphEventTracker)";
+
+  // Destroy the comm; ~GraphEventTracker drains event_pool_ here.
+  comm.reset();
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
+      destroyed_events.end())
+      << "start_event was not destroyed when comm was destroyed";
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
+      destroyed_events.end())
+      << "end_event was not destroyed when comm was destroyed";
+}
+
 TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
   auto comm = createMockedTorchComm();
   cuda_mock_->setupDefaultBehaviors();
@@ -905,7 +1068,8 @@ TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
 
   switchToReplayMode();
 
-  // destroyAll (via finalize) should destroy events regardless of released flag
+  // destroyAll (via finalize) stashes events into the tracker pool regardless
+  // of the released flag; the actual destruction fires at ~GraphEventTracker.
   std::vector<cudaEvent_t> destroyed_events;
   EXPECT_CALL(*cuda_mock_, eventDestroy(_))
       .WillRepeatedly(DoAll(
@@ -918,16 +1082,16 @@ TEST_F(GraphEventTrackerTest, DestroyAllIgnoresReleasedFlag) {
   EXPECT_CALL(*nccl_mock_, commDestroy(_)).WillOnce(Return(ncclSuccess));
 
   comm->finalize();
+  comm.reset();
 
-  EXPECT_TRUE(
-      std::find(
-          destroyed_events.begin(), destroyed_events.end(), events.start) !=
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.start),
       destroyed_events.end())
-      << "start event was not destroyed by destroyAll";
-  EXPECT_TRUE(
-      std::find(destroyed_events.begin(), destroyed_events.end(), events.end) !=
+      << "start event was not destroyed at comm destruction";
+  EXPECT_NE(
+      std::find(destroyed_events.begin(), destroyed_events.end(), events.end),
       destroyed_events.end())
-      << "end event was not destroyed by destroyAll";
+      << "end event was not destroyed at comm destruction";
 }
 
 TEST_F(GraphEventTrackerTest, EventResetByReplayDefeatsTimeout) {


### PR DESCRIPTION
Summary:

follow-up to https://github.com/meta-pytorch/torchcomms/pull/2407 which wasn't enough.

Reviewed By: ngimel

Differential Revision: D104340241


