### PR TITLE
Add adaptive transfer mode detection for IB backend

### DIFF
--- a/comms/ctran/algos/common/AdaptiveTransfer.h
+++ b/comms/ctran/algos/common/AdaptiveTransfer.h
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/common/AdaptiveTransferTypes.h"
+#include "comms/ctran/interfaces/ICtran.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran {
+namespace algos {
+
+// Check buffer registration status and determine transfer mode.
+//
+// This function checks RegCache to determine if a buffer is pre-registered:
+// - If registered: Sets mode to ZERO_COPY and populates memHdl
+// - If not registered: Sets mode to COPY_BASED and triggers async registration
+//   for future calls
+//
+// @param comm The CtranComm instance
+// @param buf Buffer to check
+// @param len Length of buffer in bytes
+// @param backend Backend type (IB, NVL, etc.)
+// @param direction Transfer direction (SEND or RECV)
+// @param config Output: TransferConfig populated with transfer mode for the
+//               specified direction
+// @return commSuccess on success, error code otherwise
+inline commResult_t checkAndSetTransferMode(
+    CtranComm* comm,
+    const void* buf,
+    size_t len,
+    CtranMapperBackend backend,
+    TransferDirection direction,
+    TransferConfig* config) {
+  // Get the directional config based on direction
+  DirectionalTransferConfig* dirConfig =
+      (direction == TransferDirection::SEND) ? &config->send : &config->recv;
+
+  // Only IB backend is supported in this phase
+  if (backend == CtranMapperBackend::IB) {
+    auto regCache = ctran::RegCache::getInstance();
+    if (!regCache) {
+      CLOGF(ERR, "CTRAN-ADAPTIVE: Failed to get RegCache instance");
+      return commInternalError;
+    }
+
+    // Step 1: Check if buffer is already registered (read-only lookup)
+    void* regHdl = regCache->getRegHandle(buf, len);
+
+    if (regHdl != nullptr) {
+      // Buffer is registered - use zero-copy path
+      // Store the handle directly to avoid lookup in collective
+      dirConfig->mode = TransferMode::ZERO_COPY;
+      dirConfig->memHdl = regHdl;
+      CLOGF_TRACE(
+          ALLOC,
+          "CTRAN-ADAPTIVE: Buffer {} len {} is registered, using zero-copy (direction={})",
+          buf,
+          len,
+          direction == TransferDirection::SEND ? "SEND" : "RECV");
+      return commSuccess;
+    }
+
+    // Step 2: Buffer not registered - use copy-based path
+    dirConfig->mode = TransferMode::COPY_BASED;
+    dirConfig->memHdl = nullptr;
+
+    // Step 3: Trigger async registration for future calls
+    FB_COMMCHECK(comm->ctran_->mapper->regAsync(buf, len));
+
+    CLOGF_TRACE(
+        ALLOC,
+        "CTRAN-ADAPTIVE: Buffer {} len {} not registered, using copy-based, "
+        "triggered async registration (direction={})",
+        buf,
+        len,
+        direction == TransferDirection::SEND ? "SEND" : "RECV");
+
+    return commSuccess;
+  }
+
+  // NVL and other backends: Not implemented yet, default to zero-copy
+  dirConfig->mode = TransferMode::ZERO_COPY;
+  dirConfig->memHdl = nullptr;
+  return commSuccess;
+}
+
+} // namespace algos
+} // namespace ctran

--- a/comms/ctran/algos/common/AdaptiveTransferTypes.h
+++ b/comms/ctran/algos/common/AdaptiveTransferTypes.h
@@ -1,0 +1,67 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#pragma once
+
+namespace ctran {
+namespace algos {
+
+// Transfer mode for adaptive data transfer mechanism.
+//
+// The adaptive transfer mechanism checks RegCache to determine if a buffer
+// is pre-registered:
+// - ZERO_COPY: Buffer is registered, use direct RDMA/NVL transfer
+// - COPY_BASED: Buffer not registered, use staging buffer with pipelining
+enum class TransferMode {
+  ZERO_COPY, // Buffer is registered, use direct RDMA/NVL transfer
+  COPY_BASED, // Buffer not registered, use staging buffer
+};
+
+// Transfer direction for adaptive transfer.
+enum class TransferDirection {
+  SEND,
+  RECV,
+};
+
+// Configuration for a single direction (send or recv) of adaptive transfer.
+//
+// This struct is populated by checkAndSetTransferMode() and used by
+// collective implementations to determine the appropriate transfer path.
+//
+// Default is ZERO_COPY to maintain backward compatibility with existing
+// code paths (NVL, TCPDM) that don't use adaptive transfer yet.
+//
+// Note: Staging buffer management is handled by each collective implementation,
+// not by this struct. Collectives should use CtranAlgo::getTmpBufInfo() to
+// get staging buffers when mode == COPY_BASED.
+struct DirectionalTransferConfig {
+  TransferMode mode{
+      TransferMode::ZERO_COPY}; // Default to zero-copy for backward compat
+  void* memHdl{nullptr}; // Memory registration handle (populated by
+                         // checkAndSetTransferMode for zero-copy)
+
+  // Returns true if zero-copy path should be used.
+  bool isZeroCopy() const {
+    return mode == TransferMode::ZERO_COPY;
+  }
+};
+
+// Configuration for adaptive transfer with separate send and recv configs.
+//
+// This struct holds transfer configurations for both directions, allowing
+// different transfer modes for send and receive operations.
+struct TransferConfig {
+  DirectionalTransferConfig send; // Configuration for send direction
+  DirectionalTransferConfig recv; // Configuration for recv direction
+
+  // Returns true if send zero-copy path should be used.
+  bool isSendZeroCopy() const {
+    return send.isZeroCopy();
+  }
+
+  // Returns true if recv zero-copy path should be used.
+  bool isRecvZeroCopy() const {
+    return recv.isZeroCopy();
+  }
+};
+
+} // namespace algos
+} // namespace ctran

--- a/comms/ctran/algos/common/tests/AdaptiveTransferUT.cc
+++ b/comms/ctran/algos/common/tests/AdaptiveTransferUT.cc
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/algos/common/AdaptiveTransfer.h"
+#include "comms/ctran/algos/common/AdaptiveTransferTypes.h"
+#include "comms/ctran/mapper/CtranMapperTypes.h"
+#include "comms/ctran/regcache/RegCache.h"
+
+using namespace ctran::algos;
+
+class AdaptiveTransferTypesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+// Test TransferDirection enum values
+TEST_F(AdaptiveTransferTypesTest, TransferDirectionValues) {
+  EXPECT_NE(
+      static_cast<int>(TransferDirection::SEND),
+      static_cast<int>(TransferDirection::RECV));
+}
+
+// Test DirectionalTransferConfig default construction
+TEST_F(AdaptiveTransferTypesTest, DirectionalTransferConfigDefaults) {
+  DirectionalTransferConfig config;
+
+  // Default should be ZERO_COPY for backward compatibility
+  EXPECT_EQ(config.mode, TransferMode::ZERO_COPY);
+  EXPECT_EQ(config.memHdl, nullptr);
+  EXPECT_TRUE(config.isZeroCopy());
+}
+
+// Test DirectionalTransferConfig with COPY_BASED mode
+TEST_F(AdaptiveTransferTypesTest, DirectionalTransferConfigCopyBased) {
+  DirectionalTransferConfig config;
+  config.mode = TransferMode::COPY_BASED;
+
+  EXPECT_EQ(config.mode, TransferMode::COPY_BASED);
+  EXPECT_FALSE(config.isZeroCopy());
+}
+
+// Test DirectionalTransferConfig with memHdl set
+TEST_F(AdaptiveTransferTypesTest, DirectionalTransferConfigWithMemHdl) {
+  DirectionalTransferConfig config;
+  void* fakeHandle = reinterpret_cast<void*>(0x12345678);
+  config.memHdl = fakeHandle;
+
+  EXPECT_EQ(config.memHdl, fakeHandle);
+  EXPECT_TRUE(config.isZeroCopy());
+}
+
+// Test TransferConfig default construction
+TEST_F(AdaptiveTransferTypesTest, TransferConfigDefaults) {
+  TransferConfig config;
+
+  // Both send and recv should default to ZERO_COPY
+  EXPECT_TRUE(config.send.isZeroCopy());
+  EXPECT_TRUE(config.recv.isZeroCopy());
+  EXPECT_TRUE(config.isSendZeroCopy());
+  EXPECT_TRUE(config.isRecvZeroCopy());
+  EXPECT_EQ(config.send.memHdl, nullptr);
+  EXPECT_EQ(config.recv.memHdl, nullptr);
+}
+
+// Test TransferConfig with different send/recv modes
+TEST_F(AdaptiveTransferTypesTest, TransferConfigDifferentModes) {
+  TransferConfig config;
+
+  // Set send to COPY_BASED, recv stays ZERO_COPY
+  config.send.mode = TransferMode::COPY_BASED;
+
+  EXPECT_FALSE(config.isSendZeroCopy());
+  EXPECT_TRUE(config.isRecvZeroCopy());
+
+  // Set recv to COPY_BASED as well
+  config.recv.mode = TransferMode::COPY_BASED;
+
+  EXPECT_FALSE(config.isSendZeroCopy());
+  EXPECT_FALSE(config.isRecvZeroCopy());
+}
+
+// Test TransferConfig with different memHdls
+TEST_F(AdaptiveTransferTypesTest, TransferConfigDifferentMemHdls) {
+  TransferConfig config;
+  void* sendHandle = reinterpret_cast<void*>(0x11111111);
+  void* recvHandle = reinterpret_cast<void*>(0x22222222);
+
+  config.send.memHdl = sendHandle;
+  config.recv.memHdl = recvHandle;
+
+  EXPECT_EQ(config.send.memHdl, sendHandle);
+  EXPECT_EQ(config.recv.memHdl, recvHandle);
+  EXPECT_NE(config.send.memHdl, config.recv.memHdl);
+}
+
+// Test TransferMode enum values
+TEST_F(AdaptiveTransferTypesTest, TransferModeValues) {
+  EXPECT_NE(
+      static_cast<int>(TransferMode::ZERO_COPY),
+      static_cast<int>(TransferMode::COPY_BASED));
+}
+
+// Test isZeroCopy helper for both modes
+TEST_F(AdaptiveTransferTypesTest, IsZeroCopyHelper) {
+  DirectionalTransferConfig zeroCopyConfig;
+  zeroCopyConfig.mode = TransferMode::ZERO_COPY;
+  EXPECT_TRUE(zeroCopyConfig.isZeroCopy());
+
+  DirectionalTransferConfig copyBasedConfig;
+  copyBasedConfig.mode = TransferMode::COPY_BASED;
+  EXPECT_FALSE(copyBasedConfig.isZeroCopy());
+}
+
+// Test TransferConfig convenience methods match underlying config
+TEST_F(AdaptiveTransferTypesTest, TransferConfigConvenienceMethods) {
+  TransferConfig config;
+
+  // Test that convenience methods match direct access
+  EXPECT_EQ(config.isSendZeroCopy(), config.send.isZeroCopy());
+  EXPECT_EQ(config.isRecvZeroCopy(), config.recv.isZeroCopy());
+
+  config.send.mode = TransferMode::COPY_BASED;
+  EXPECT_EQ(config.isSendZeroCopy(), config.send.isZeroCopy());
+  EXPECT_EQ(config.isRecvZeroCopy(), config.recv.isZeroCopy());
+
+  config.recv.mode = TransferMode::COPY_BASED;
+  EXPECT_EQ(config.isSendZeroCopy(), config.send.isZeroCopy());
+  EXPECT_EQ(config.isRecvZeroCopy(), config.recv.isZeroCopy());
+}

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -461,7 +461,6 @@ void ctran::RegCache::asyncRegThreadFn(int cudaDev) {
           INFO, INIT, "CTranMapperRegCache asyncRegThreadFn: terminate");
       return;
     }
-
     FB_CHECKABORT(
         cmd.buf && cmd.len > 0 && cmd.cudaDev >= 0,
         "Invalid buffer registration request: buf {} len {} cudaDev {}",
@@ -591,6 +590,12 @@ bool ctran::RegCache::isRegistered(const void* ptr, const size_t len) {
   // Find range in regElemsMaps
   auto regHdl = searchRegElem(ptr, len);
   return regHdl != nullptr;
+}
+
+void* ctran::RegCache::getRegHandle(const void* ptr, const size_t len) {
+  // Return the regHdl (RegElem*) cast to void* - this is the handle format
+  // used by mapper functions like iput/isendCtrl
+  return static_cast<void*>(searchRegElem(ptr, len));
 }
 
 void* ctran::RegCache::searchIbRegHandle(

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -434,6 +434,12 @@ class RegCache {
   // Thread-safe function to check if a given <ptr, len> range is registered.
   bool isRegistered(const void* ptr, const size_t len);
 
+  // Thread-safe function to get the registration handle for a given <ptr, len>
+  // range. Returns RegElem* as void* if registered; returns nullptr if not.
+  // The returned handle can be used directly with mapper functions like
+  // iput/isendCtrl.
+  void* getRegHandle(const void* ptr, const size_t len);
+
   // Thread-safe function to search for a RegElem containing [ptr, ptr+len)
   // and return its ibRegElem. If the buffer is cached but not yet registered,
   // it will perform registration via regRange(). Returns nullptr if not cached.

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1382,6 +1382,56 @@ TEST(IpcRemHandleTest, CorruptedDestroyDoesNotCrash) {
   handle->~IpcRemHandle();
 }
 
+// Test getRegHandle returns nullptr for unregistered buffer and valid handle
+// after registration
+TEST_F(RegCacheTest, GetRegHandleReturnsHandleForRegisteredBuffer) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // getRegHandle should return nullptr for uncached buffer
+  EXPECT_EQ(regCache->getRegHandle(buf, bufSize), nullptr);
+
+  // Cache the segment
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  EXPECT_EQ(segments.size(), 1);
+
+  // Cached but not yet registered - getRegHandle should still return nullptr
+  EXPECT_EQ(regCache->getRegHandle(buf, bufSize), nullptr);
+
+  // Register via regAll
+  EXPECT_EQ(ctran::RegCache::regAll(), commSuccess);
+
+  // Now getRegHandle should return a valid handle
+  void* regHdl = regCache->getRegHandle(buf, bufSize);
+  EXPECT_NE(regHdl, nullptr);
+
+  // isRegistered should agree
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Deregister
+  EXPECT_EQ(ctran::RegCache::deregAll(), commSuccess);
+
+  // After deregistration, getRegHandle should return nullptr again
+  EXPECT_EQ(regCache->getRegHandle(buf, bufSize), nullptr);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  // Clean up
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);


### PR DESCRIPTION
Summary:
Implement the foundation for automatic zero-copy vs copy-based transfer mode selection in Ctran.

This diff introduces an adaptive transfer mechanism that checks RegCache to determine if a buffer is pre-registered:
- If registered: Uses zero-copy path and returns the registration handle
- If not registered: Uses copy-based (staging buffer) path and triggers async registration for future calls

Key changes:
- Add `AdaptiveTransferTypes.h`: Defines `TransferMode` enum (ZERO_COPY/COPY_BASED), `TransferDirection` (SEND/RECV), and config structs (`DirectionalTransferConfig`, `TransferConfig`) for managing transfer modes per direction
- Add `AdaptiveTransfer.h`: Implements `checkAndSetTransferMode()` that queries RegCache and sets the appropriate transfer mode for IB backend
- Add `RegCache::getRegHandle()` to return `void*` (registration handle) if registered, allowing callers to reuse the handle directly with mapper functions like `iput/isendCtrl`

For non-IB backends (NVL, etc.), the implementation defaults to zero-copy as adaptive transfer is not yet implemented for those backends.

The tests are basic getter/setter tests for the type structs, as the actual cache behavior and registration logic are already covered by RegCache tests.

## Next diffs:
1. Adopt IB auto-switch for SendRecv

Reviewed By: minsii

Differential Revision: D92237011


