### PR TITLE
Fix FakeTensorUpdater call for PyTorch nightly API change

### DIFF
--- a/comms/torchcomms/functional/passes.py
+++ b/comms/torchcomms/functional/passes.py
@@ -60,7 +60,7 @@ def reinplacement_pass(
     from torch._guards import detect_fake_mode
     from torch._inductor.virtualized import V
 
-    fake_tensor_updater = FakeTensorUpdater(gm.graph)
+    fake_tensor_updater = FakeTensorUpdater(gm)
 
     fake_mode = detect_fake_mode(
         [node.meta.get("val") for node in gm.graph.nodes if "val" in node.meta]


### PR DESCRIPTION
## Summary

PyTorch [PR #159523](https://github.com/pytorch/pytorch/pull/159523) changed `FakeTensorUpdater.__init__` to expect a `torch.fx.GraphModule` instead of a `torch.fx.Graph`. The new `__init__` calls `_get_subgraph_names(self.gm)` which does `gm.graph.find_nodes(...)` — passing a `Graph` causes `AttributeError: 'Graph' object has no attribute 'graph'`.

This PR has been a ping-pong: landed Apr 23 → reverted Apr 28 → re-landed May 7 → [reverted again May 11](https://github.com/pytorch/pytorch/commit/4d053600df). The May 11 revert should fix torchcomms once the next nightly cuts, but since it keeps bouncing, change `FakeTensorUpdater(gm.graph)` → `FakeTensorUpdater(gm)` so torchcomms works with both the old and new API.

## Test plan

- [ ] Run failing unit tests (`pytest comms/torchcomms/tests/unit/py/`) against both pre- and post-#159523 PyTorch nightlies