### PR TITLE
Plumb lazy-mode config to MultipeerIbgdaTransport (#2490)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -32,10 +32,12 @@ using meta::comms::CommBackend;
 struct ctranPipesConfig {
   int64_t nvlChunkSize{-1};
   int useDualStateBuffer{-1}; // -1=cvar, 0=single, 1=dual
+  bool ibLazyConnect{false};
 
   bool operator==(const ctranPipesConfig& other) const {
     return nvlChunkSize == other.nvlChunkSize &&
-        useDualStateBuffer == other.useDualStateBuffer;
+        useDualStateBuffer == other.useDualStateBuffer &&
+        ibLazyConnect == other.ibLazyConnect;
   }
 };
 

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -107,6 +107,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       config.ibgdaConfig.rnrRetry =
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
+    config.ibgdaConfig.ibLazyConnect = pc.ibLazyConnect;
+    config.ibgdaConfig.materializePeerTimeoutMs =
+        NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
 
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -182,6 +182,8 @@ Config::Config(const ncclConfig_t* config) {
     }
   }
 
+  ibLazyConnect = parseHintBool("ibLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
+
   // vCliqueSize: hint only (no flat ncclConfig_t field)
   {
     auto val = getHintStr("vCliqueSize");

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -43,6 +43,9 @@ class Config {
   // Per-communicator IB transport config overrides.
   std::optional<int> ibSplitDataOnQps;
   std::optional<int> ibQpsPerConnection;
+
+  // Defer per-peer IBGDA state to first use (hint > CVAR).
+  bool ibLazyConnect = false;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -59,6 +62,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ncclBuffSize",
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
+      "ibLazyConnect",
   };
   return keys;
 }

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -339,3 +339,24 @@ TEST(ConfigHintsUT, IbQpsPerConnectionDefaultUnset) {
 
   delete ncclxCfg;
 }
+
+// ----- ibLazyConnect tests -----
+
+TEST(ConfigHintsUT, LazyPeerInit_DefaultIsFalse) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, LazyPeerInit_HintOverrides) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibLazyConnect", "true");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -52,6 +52,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
       tconfig.pipesConfig.useDualStateBuffer =
           ncclxCfg->pipesUseDualStateBuffer.value() ? 1 : 0;
     }
+    tconfig.pipesConfig.ibLazyConnect = ncclxCfg->ibLazyConnect;
   }
   return tconfig;
 }

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -158,6 +158,15 @@ struct MultipeerIbgdaTransportConfig {
   // 7 means infinite retry.
   // Default is 7 (matching NCCL IbvQpUtils).
   uint8_t rnrRetry{7};
+
+  // When true, defer per-peer state (QPs, staging, signal buffers) to
+  // first use via materializePeer(). When false (default), allocate
+  // eagerly at exchange() time.
+  bool ibLazyConnect{false};
+
+  // Timeout (ms) for the bilateral exchange in materializePeer().
+  // On timeout, materializePeer throws rather than hanging.
+  uint32_t materializePeerTimeoutMs{30000};
 };
 
 /**

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1780,6 +1780,23 @@ cvars:
      Number of times to retry after receiving an RNR NAK.
      7 means infinite retry.
 
+ - name        : NCCL_CTRAN_IBGDA_LAZY_CONNECT
+   type        : bool
+   default     : false
+   description : |-
+     When true, MultipeerIbgdaTransport defers per-peer state allocation to
+     first use (lazy mode). When false (default), all per-peer state is
+     allocated eagerly at construction. Per-comm override via
+     CommOptions.hints["ncclx::ibLazyConnect"].
+
+ - name        : NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS
+   type        : uint32_t
+   default     : 30000
+   description : |-
+     Timeout (in milliseconds) for materializePeer bilateral exchange.
+     On timeout, materializePeer throws rather than hanging.
+     No per-comm override.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket


### PR DESCRIPTION
Summary:

Add two per-comm/process config knobs end-to-end:

1. lazyPeerInit (bool, per-comm overridable):
   - CVAR NCCL_CTRAN_IBGDA_LAZY_PEER_INIT (default false)
   - Per-comm override via CommOptions.hints["ncclx::lazyPeerInit"]
   - Mirrors pipesUseDualStateBuffer precedent end-to-end:
     ncclx::Config field -> NcclxConfig.cc parseHintBool ->
     MetaFactory.cc wiring -> pipesConfig -> MultipeerIbgdaTransportConfig

2. lazyBootstrapTimeoutMs (uint32_t, process-wide CVAR only):
   - CVAR NCCL_CTRAN_IBGDA_LAZY_BOOTSTRAP_TIMEOUT_MS (default 30000)
   - No per-comm override (operational tuning, not policy)
   - Direct CVAR -> CtranPipes.cc -> MultipeerIbgdaTransportConfig

No torchcomms changes; populateNcclConfig already forwards ncclx::*
hints. No ncclConfig_t schema changes per NcclxConfig.h:25.

Fields plumbed but not yet consumed by transport behavior (still no-op).
D3+ begins acting on lazyPeerInit; D4 begins using lazyBootstrapTimeoutMs.

First diff in lazy_ibgda_materialization stack.

Reviewed By: siyengar

Differential Revision: D103453628


