### PR TITLE
Add lazy mode unit and e2e tests (#2493)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -32,10 +32,12 @@ using meta::comms::CommBackend;
 struct ctranPipesConfig {
   int64_t nvlChunkSize{-1};
   int useDualStateBuffer{-1}; // -1=cvar, 0=single, 1=dual
+  bool ibLazyConnect{false};
 
   bool operator==(const ctranPipesConfig& other) const {
     return nvlChunkSize == other.nvlChunkSize &&
-        useDualStateBuffer == other.useDualStateBuffer;
+        useDualStateBuffer == other.useDualStateBuffer &&
+        ibLazyConnect == other.ibLazyConnect;
   }
 };
 

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -107,6 +107,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       config.ibgdaConfig.rnrRetry =
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
+    config.ibgdaConfig.ibLazyConnect = pc.ibLazyConnect;
+    config.ibgdaConfig.materializePeerTimeoutMs =
+        NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
 
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -182,6 +182,8 @@ Config::Config(const ncclConfig_t* config) {
     }
   }
 
+  ibLazyConnect = parseHintBool("ibLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
+
   // vCliqueSize: hint only (no flat ncclConfig_t field)
   {
     auto val = getHintStr("vCliqueSize");

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -43,6 +43,9 @@ class Config {
   // Per-communicator IB transport config overrides.
   std::optional<int> ibSplitDataOnQps;
   std::optional<int> ibQpsPerConnection;
+
+  // Defer per-peer IBGDA state to first use (hint > CVAR).
+  bool ibLazyConnect = false;
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -59,6 +62,7 @@ inline const std::vector<std::string>& knownHintKeys() {
       "ncclBuffSize",
       "ibSplitDataOnQps",
       "ibQpsPerConnection",
+      "ibLazyConnect",
   };
   return keys;
 }

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -339,3 +339,24 @@ TEST(ConfigHintsUT, IbQpsPerConnectionDefaultUnset) {
 
   delete ncclxCfg;
 }
+
+// ----- ibLazyConnect tests -----
+
+TEST(ConfigHintsUT, LazyPeerInit_DefaultIsFalse) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_FALSE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, LazyPeerInit_HintOverrides) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("ibLazyConnect", "true");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -52,6 +52,7 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
       tconfig.pipesConfig.useDualStateBuffer =
           ncclxCfg->pipesUseDualStateBuffer.value() ? 1 : 0;
     }
+    tconfig.pipesConfig.ibLazyConnect = ncclxCfg->ibLazyConnect;
   }
   return tconfig;
 }

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -720,7 +720,7 @@ void MultiPeerTransport::build_device_handle() {
 
       case TransportType::P2P_IBGDA: {
         P2pIbgdaTransportDevice* devPtr = ibgdaTransport_
-            ? ibgdaTransport_->getP2pTransportDevice(r)
+            ? ibgdaTransport_->getP2pTransportDeviceSlot(r)
             : nullptr;
         new (&transportsHost[r]) Transport(devPtr);
         break;

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -289,6 +289,13 @@ void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
         ibgdaTransport_->materializePeer(peer);
       }
     }
+    ibgdaTransport_->connectPeers();
+  }
+}
+
+void MultiPeerTransport::connectPeers() {
+  if (ibgdaTransport_) {
+    ibgdaTransport_->connectPeers();
   }
 }
 

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -57,6 +57,7 @@ MultiPeerTransport::MultiPeerTransport(
     : myRank_(myRank),
       nRanks_(nRanks),
       deviceId_(deviceId),
+      ibLazyConnect_(config.ibgdaConfig.ibLazyConnect),
       bootstrap_(std::move(bootstrap)) {
   if (!topo.has_value()) {
     TopologyDiscovery topoDiscovery;
@@ -245,6 +246,11 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
     throw std::runtime_error(
         "MultiPeerTransport::get_device_handle() called before exchange()");
   }
+  if (ibLazyConnect_) {
+    throw std::runtime_error(
+        "get_device_handle() cannot be used with lazy mode (ibLazyConnect=true). "
+        "Use get_device_handle(peers) or getP2pTransportDevice(peerRank).");
+  }
 
   return MultiPeerDeviceHandle{
       myRank_,
@@ -257,6 +263,25 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
 
 MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
     const std::vector<int>& peers) {
+  if (!deviceHandleBuilt_) {
+    throw std::runtime_error(
+        "MultiPeerTransport::get_device_handle(peers) called before exchange()");
+  }
+  materializePeers(peers);
+  return MultiPeerDeviceHandle{
+      myRank_,
+      nRanks_,
+      {transportsGpu_, static_cast<uint32_t>(nRanks_)},
+      static_cast<int>(nvlPeerRanks_.size()),
+      static_cast<int>(ibgdaPeerRanks_.size()),
+  };
+}
+
+bool MultiPeerTransport::is_lazy_mode() const {
+  return ibLazyConnect_;
+}
+
+void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
   if (ibgdaTransport_) {
     for (int peer : peers) {
       if (peer >= 0 && peer < nRanks_ && peer != myRank_ &&
@@ -265,7 +290,6 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
       }
     }
   }
-  return get_device_handle();
 }
 
 IbgdaLocalBuffer MultiPeerTransport::localRegisterIbgdaBuffer(

--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -255,6 +255,19 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
   };
 }
 
+MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
+    const std::vector<int>& peers) {
+  if (ibgdaTransport_) {
+    for (int peer : peers) {
+      if (peer >= 0 && peer < nRanks_ && peer != myRank_ &&
+          typePerRank_[peer] == TransportType::P2P_IBGDA) {
+        ibgdaTransport_->materializePeer(peer);
+      }
+    }
+  }
+  return get_device_handle();
+}
+
 IbgdaLocalBuffer MultiPeerTransport::localRegisterIbgdaBuffer(
     void* ptr,
     size_t size) {

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -192,6 +192,15 @@ class MultiPeerTransport {
    */
   MultiPeerDeviceHandle get_device_handle() const;
 
+  /**
+   * Materialize the specified IBGDA peers, then return the device handle.
+   * Use this with lazy mode to ensure peers are ready before kernel launch.
+   *
+   * @param peers List of peer ranks to materialize
+   * @return MultiPeerDeviceHandle suitable for passing to CUDA kernels.
+   */
+  MultiPeerDeviceHandle get_device_handle(const std::vector<int>& peers);
+
   // --- IBGDA buffer registration (delegates to ibgdaTransport_) ---
 
   /**

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -188,18 +188,22 @@ class MultiPeerTransport {
 
   /**
    * @return MultiPeerDeviceHandle suitable for passing to CUDA kernels.
-   * @throws std::runtime_error if exchange() has not been called.
+   * @throws std::runtime_error if lazy mode is enabled or exchange() not
+   * called.
    */
   MultiPeerDeviceHandle get_device_handle() const;
 
   /**
    * Materialize the specified IBGDA peers, then return the device handle.
-   * Use this with lazy mode to ensure peers are ready before kernel launch.
+   * Use with lazy mode for DeviceWindow or direct Transport[] access.
    *
    * @param peers List of peer ranks to materialize
-   * @return MultiPeerDeviceHandle suitable for passing to CUDA kernels.
    */
   MultiPeerDeviceHandle get_device_handle(const std::vector<int>& peers);
+
+  bool is_lazy_mode() const;
+
+  void materializePeers(const std::vector<int>& peers);
 
   // --- IBGDA buffer registration (delegates to ibgdaTransport_) ---
 
@@ -262,6 +266,7 @@ class MultiPeerTransport {
   const int myRank_;
   const int nRanks_;
   const int deviceId_;
+  const bool ibLazyConnect_{false};
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
 
   // --- Topology (populated in constructor) ---

--- a/comms/pipes/MultiPeerTransport.h
+++ b/comms/pipes/MultiPeerTransport.h
@@ -205,6 +205,8 @@ class MultiPeerTransport {
 
   void materializePeers(const std::vector<int>& peers);
 
+  void connectPeers();
+
   // --- IBGDA buffer registration (delegates to ibgdaTransport_) ---
 
   /**

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -31,6 +31,81 @@ constexpr int kHopLimit = 255;
 // depth since they only carry WAIT + atomic operations (2 WQEs per round).
 constexpr uint32_t kCompanionQpDepth = 32;
 
+// Bootstrap tags for the two-phase bilateral exchange in materializePeer.
+constexpr int kTagQpExchange = 0;
+constexpr int kTagBufferExchange = 1;
+
+} // namespace
+
+// Wire formats for bilateral exchange in materializePeer.
+// Split into two phases: QP info first (to connect), then buffer info
+// (acts as QP-ready barrier — mirrors the eager path's two-allGather pattern).
+struct PeerQpPayload {
+  struct NicQpInfo {
+    uint8_t gid[16]{};
+    uint16_t lid{0};
+    uint32_t qpns[kMaxQpsPerPeerPerNic]{};
+  };
+  NicQpInfo nicInfo[kMaxNicsPerGpu]{};
+  int gidIndex{0};
+  int mtu{0};
+  int numNics{0};
+  int numQpsPerPeerPerNic{0};
+};
+
+struct PeerBufferPayload {
+  IbgdaBufferExchInfo recvStaging;
+  IbgdaBufferExchInfo srSignal;
+  IbgdaBufferExchInfo slotSignal;
+  IbgdaBufferExchInfo slotDiscard;
+};
+
+struct PeerBufferSizes {
+  std::size_t staging{0};
+  std::size_t srSignal{0};
+  std::size_t srCounter{0};
+  std::size_t srStepState{0};
+  std::size_t slotSignal{0};
+  std::size_t slotCounter{0};
+  std::size_t slotDiscard{0};
+
+  // Pointers into a contiguous allocation (set by layout())
+  void* sendStagingPtr{nullptr};
+  void* recvStagingPtr{nullptr};
+  void* srSignalPtr{nullptr};
+  void* srCounterPtr{nullptr};
+  void* srStepStatePtr{nullptr};
+  void* slotSignalPtr{nullptr};
+  void* slotCounterPtr{nullptr};
+  void* slotDiscardPtr{nullptr};
+
+  std::size_t total() const {
+    return staging * 2 + srSignal + srCounter + srStepState + slotSignal +
+        slotCounter + slotDiscard;
+  }
+
+  void layout(void* base) {
+    char* p = static_cast<char*>(base);
+    sendStagingPtr = p;
+    p += staging;
+    recvStagingPtr = p;
+    p += staging;
+    srSignalPtr = p;
+    p += srSignal;
+    srCounterPtr = p;
+    p += srCounter;
+    srStepStatePtr = p;
+    p += srStepState;
+    slotSignalPtr = p;
+    p += slotSignal;
+    slotCounterPtr = p;
+    p += slotCounter;
+    slotDiscardPtr = p;
+  }
+};
+
+namespace {
+
 // Convert ibv_mtu enum to doca_verbs_mtu_size enum.
 doca_verbs_mtu_size ibv_mtu_to_doca_mtu(enum ibv_mtu ibvMtu) {
   switch (ibvMtu) {
@@ -470,7 +545,8 @@ void MultipeerIbgdaTransport::createQpGroups() {
   const int totalQpsPerPeer = numNics_ * numQps;
   const int totalQpGroups = numPeers * totalQpsPerPeer;
   for (auto& nic : nicDevices_) {
-    nic.qpGroups.assign(numPeers * numQps, nullptr);
+    nic.qpGroups.resize(static_cast<size_t>(numPeers) * numQps);
+    nic.loopbackCompanionQps.resize(static_cast<size_t>(numPeers) * numQps);
   }
 
   // Verify CUDA device is still set correctly
@@ -500,79 +576,8 @@ void MultipeerIbgdaTransport::createQpGroups() {
           << " sq_nwqe=" << config_.qpDepth
           << " nic_handler=AUTO mreg_type=DEFAULT";
 
-  for (int nic = 0; nic < numNics_; nic++) {
-    doca_gpu_verbs_qp_init_attr_hl initAttr{};
-    initAttr.gpu_dev = docaGpu_;
-    initAttr.ibpd = nicDevices_[nic].ibvPd;
-    initAttr.sq_nwqe = config_.qpDepth;
-    initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
-    initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
-
-    auto& nicQps = nicDevices_[nic].qpGroups;
-    for (int peer = 0; peer < numPeers; peer++) {
-      for (int q = 0; q < numQps; q++) {
-        const int qpIdx = peer * numQps + q;
-        doca_error_t err =
-            doca_gpu_verbs_create_qp_group_hl(&initAttr, &nicQps[qpIdx]);
-        if (err != DOCA_SUCCESS) {
-          LOG(ERROR) << "MultipeerIbgdaTransport: QP group (nic=" << nic
-                     << " peer=" << peer << " q=" << q
-                     << ") creation failed: " << docaErrorToString(err)
-                     << " (code " << (int)err << ")";
-          checkDocaError(err, "Failed to create QP group");
-        }
-
-        VLOG(1) << "MultipeerIbgdaTransport: created QP group (nic=" << nic
-                << " peer=" << peer << " q=" << q << ") main_qpn="
-                << doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp)
-                << " companion_qpn="
-                << doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
-      }
-    }
-  }
-}
-
-void MultipeerIbgdaTransport::createLoopbackCompanionQps() {
-  const int numPeers = nRanks_ - 1;
-  const int numQps = config_.numQpsPerPeerPerNic;
-  // One self-loop responder companion QP per QP group, on the SAME NIC's
-  // PD as the active companion (loopback only works within a single NIC).
-  for (auto& nic : nicDevices_) {
-    nic.loopbackCompanionQps.assign(numPeers * numQps, nullptr);
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: creating "
-          << numNics_ * numPeers * numQps
-          << " loopback companion QPs with depth=" << kCompanionQpDepth;
-
-  for (int nic = 0; nic < numNics_; nic++) {
-    doca_gpu_verbs_qp_init_attr_hl initAttr{};
-    initAttr.gpu_dev = docaGpu_;
-    initAttr.ibpd = nicDevices_[nic].ibvPd;
-    initAttr.sq_nwqe = kCompanionQpDepth;
-    initAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
-    initAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
-
-    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
-    for (int peer = 0; peer < numPeers; peer++) {
-      for (int q = 0; q < numQps; q++) {
-        const int qpIdx = peer * numQps + q;
-        doca_error_t err =
-            doca_gpu_verbs_create_qp_hl(&initAttr, &nicLoopback[qpIdx]);
-        if (err != DOCA_SUCCESS) {
-          LOG(ERROR) << "MultipeerIbgdaTransport: loopback companion QP (nic="
-                     << nic << " peer=" << peer << " q=" << q
-                     << ") creation failed: " << docaErrorToString(err)
-                     << " (code " << (int)err << ")";
-          checkDocaError(err, "Failed to create loopback companion QP");
-        }
-
-        VLOG(1) << "MultipeerIbgdaTransport: created loopback companion QP "
-                   "(nic="
-                << nic << " peer=" << peer << " q=" << q
-                << ") qpn=" << doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
-      }
-    }
+  for (int peer = 0; peer < numPeers; peer++) {
+    createPeerQps(peer);
   }
 }
 
@@ -689,6 +694,132 @@ int MultipeerIbgdaTransport::peerIndexToRank(int peerIndex) const {
   return (peerIndex < myRank_) ? peerIndex : (peerIndex + 1);
 }
 
+void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  for (int nic = 0; nic < numNics_; nic++) {
+    doca_gpu_verbs_qp_init_attr_hl mainAttr{};
+    mainAttr.gpu_dev = docaGpu_;
+    mainAttr.ibpd = nicDevices_[nic].ibvPd;
+    mainAttr.sq_nwqe = config_.qpDepth;
+    mainAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
+    mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
+
+    doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
+    loopbackAttr.sq_nwqe = kCompanionQpDepth;
+
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      doca_error_t err =
+          doca_gpu_verbs_create_qp_group_hl(&mainAttr, &nicQps[qpIdx]);
+      checkDocaError(err, "Failed to create QP group");
+      err = doca_gpu_verbs_create_qp_hl(&loopbackAttr, &nicLoopback[qpIdx]);
+      checkDocaError(err, "Failed to create loopback companion QP");
+    }
+  }
+}
+
+void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  for (int nic = 0; nic < numNics_; nic++) {
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+
+    IbgdaTransportExchInfo selfInfo;
+    memcpy(selfInfo.gid, nicDevices_[nic].localGid.raw, sizeof(selfInfo.gid));
+    selfInfo.gidIndex = gidIndex_;
+    selfInfo.mtu = localMtu_;
+    ibv_port_attr portAttr{};
+    if (doca_verbs_wrapper_ibv_query_port(
+            nicDevices_[nic].ibvCtx, 1, &portAttr) == DOCA_SUCCESS) {
+      selfInfo.lid = portAttr.lid;
+    }
+
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
+      connectQp(&nicQps[qpIdx]->qp_companion, selfInfo, nic);
+      selfInfo.qpn = doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
+      connectQp(nicLoopback[qpIdx], selfInfo, nic);
+    }
+  }
+}
+
+PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
+  PeerBufferSizes sizes;
+  if (config_.sendRecv.has_value()) {
+    const auto& sr = *config_.sendRecv;
+    sizes.staging = sr.pipelineDepth * config_.dataBufferSize;
+    sizes.srSignal = 2 * sr.maxGroups * sizeof(uint64_t);
+    sizes.srCounter = sr.maxGroups * sizeof(uint64_t);
+    sizes.srStepState = 2 * sr.maxGroups * sizeof(int64_t);
+  }
+  sizes.slotSignal =
+      static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
+  sizes.slotCounter =
+      static_cast<std::size_t>(config_.numCounterSlots) * sizeof(uint64_t);
+  sizes.slotDiscard = (config_.numCounterSlots > 0) ? sizeof(uint64_t) : 0;
+  return sizes;
+}
+
+P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
+    int peerIndex) const {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  P2pIbgdaTransportBuildParams params;
+  params.h_nicDeviceIbgdaResources.resize(numNics_);
+  for (int n = 0; n < numNics_; ++n) {
+    auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
+    nicSpec.qps.resize(numQps);
+    nicSpec.companionQps.resize(numQps);
+    nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDevices_[n].sinkMr->lkey));
+    nicSpec.deviceId = n;
+  }
+
+  for (int nic = 0; nic < numNics_; nic++) {
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      doca_error_t err = doca_gpu_verbs_get_qp_dev(
+          nicQps[qpIdx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
+      checkDocaError(err, "Failed to get GPU QP handle");
+
+      err = doca_gpu_verbs_get_qp_dev(
+          nicQps[qpIdx]->qp_companion.qp_gverbs, &nicSpec.companionQps[q]);
+      checkDocaError(err, "Failed to get companion GPU QP handle");
+    }
+  }
+
+  if (config_.numSignalSlots > 0) {
+    params.remoteSignalBuf = signalRemoteViews_[peerIndex];
+    params.localSignalBuf = signalLocalViews_[peerIndex];
+    params.numSignalSlots = config_.numSignalSlots;
+  }
+  if (config_.numCounterSlots > 0) {
+    params.counterBuf = counterViews_[peerIndex];
+    params.discardSignalSlot = discardSignalRemoteViews_[peerIndex];
+    params.numCounterSlots = config_.numCounterSlots;
+  }
+  if (!sendRecvPeerBuffers_.empty()) {
+    const auto& pb = sendRecvPeerBuffers_[peerIndex];
+    params.sendRecvState = IbSendRecvState{
+        .sendStagingBuf = pb.sendStaging,
+        .recvStagingBuf = pb.remoteRecvStaging,
+        .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
+        .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
+        .localSignalBuf = pb.signal,
+        .remoteSignalBuf = pb.remoteSignal,
+        .localCounterBuf = pb.counter,
+        .stepState = pb.stepState,
+        .maxGroups = config_.sendRecv->maxGroups,
+        .pipelineDepth = config_.sendRecv->pipelineDepth,
+        .dataBufferSize = config_.dataBufferSize,
+    };
+  }
+  return params;
+}
+
 // Main class implementation
 
 MultipeerIbgdaTransport::MultipeerIbgdaTransport(
@@ -780,11 +911,24 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     // Open IB device and create PD
     openIbDevice();
 
-    // Create QP groups (main + companion with shared UAR and core_direct)
-    createQpGroups();
-
-    // Create self-loop responder companion QPs for counter loopback
-    createLoopbackCompanionQps();
+    if (!config_.ibLazyConnect) {
+      // Create QP groups (main + loopback) for all peers
+      createQpGroups();
+    } else {
+      const int numPeers = nRanks - 1;
+      for (auto& nic : nicDevices_) {
+        nic.qpGroups.resize(
+            static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
+        nic.loopbackCompanionQps.resize(
+            static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
+      }
+      signalRemoteViews_.resize(numPeers);
+      signalLocalViews_.resize(numPeers);
+      counterViews_.resize(numPeers);
+      discardSignalRemoteViews_.resize(numPeers);
+      lazyPeerBufs_.resize(numPeers);
+      peerMaterialized_.resize(numPeers, false);
+    }
 
     // Allocate and register sink buffer for atomic return values
     allocateResources();
@@ -930,6 +1074,26 @@ void MultipeerIbgdaTransport::exchange() {
   const int numPeers = nRanks_ - 1;
   const int numQps = config_.numQpsPerPeerPerNic;
 
+  if (config_.ibLazyConnect) {
+    peerTransportSize_ = getP2pIbgdaTransportDeviceSize();
+    std::size_t totalBytes = numPeers * peerTransportSize_;
+    cudaError_t err = cudaMalloc(&peerTransportsGpu_, totalBytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          "Failed to allocate lazy device transport array: " +
+          std::string(cudaGetErrorString(err)));
+    }
+    gpuAllocations_.push_back(peerTransportsGpu_);
+    err = cudaMemset(peerTransportsGpu_, 0, totalBytes);
+    if (err != cudaSuccess) {
+      throw std::runtime_error("Failed to zero lazy device transport array");
+    }
+    VLOG(1)
+        << "MultipeerIbgdaTransport: rank " << myRank_
+        << " lazy exchange complete (per-peer state deferred to materializePeer)";
+    return;
+  }
+
   // Validate rank count for allGather-based exchange
   if (nRanks_ > kMaxRanksForAllGather) {
     throw std::runtime_error(
@@ -1043,9 +1207,7 @@ void MultipeerIbgdaTransport::exchange() {
             << " slot0_qpn=" << peerExchInfo_[peerIndex].qpn;
   }
 
-  // Connect main QPs to peers — same-rail pairing: my (nic, q) for peer P
-  // talks to P's (nic, q) for me. NIC-fast interleaving: slot s = q * numNics_
-  // + nic.
+  // Connect main QPs + loopback companions for all peers
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
     const IbgdaTransportExchInfoAll& peerInfo =
         allInfo[peerIndexToRank(peerIndex)];
@@ -1064,50 +1226,8 @@ void MultipeerIbgdaTransport::exchange() {
         connectQp(&nicQps[qpIdx]->qp_main, qpPeerInfo, nic);
       }
     }
+    connectPeerLoopback(peerIndex);
   }
-
-  // Connect companion QPs as loopback pairs — each slot's companion QP
-  // must loopback within the same NIC's PD (loopback can't cross PDs).
-  {
-    std::vector<IbgdaTransportExchInfo> selfInfoPerNic(numNics_);
-    for (int n = 0; n < numNics_; ++n) {
-      memcpy(
-          selfInfoPerNic[n].gid,
-          nicDevices_[n].localGid.raw,
-          sizeof(selfInfoPerNic[n].gid));
-      selfInfoPerNic[n].gidIndex = gidIndex_;
-      selfInfoPerNic[n].mtu = localMtu_;
-      ibv_port_attr loopbackPortAttr{};
-      if (doca_verbs_wrapper_ibv_query_port(
-              nicDevices_[n].ibvCtx, 1, &loopbackPortAttr) == DOCA_SUCCESS) {
-        selfInfoPerNic[n].lid = loopbackPortAttr.lid;
-      }
-    }
-
-    for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDevices_[nic].qpGroups;
-      auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
-      for (int peer = 0; peer < numPeers; peer++) {
-        for (int q = 0; q < numQps; q++) {
-          const int qpIdx = peer * numQps + q;
-          IbgdaTransportExchInfo selfInfo = selfInfoPerNic[nic];
-
-          // Connect active companion → loopback responder
-          selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
-          connectQp(&nicQps[qpIdx]->qp_companion, selfInfo, nic);
-
-          // Connect loopback responder → active companion
-          selfInfo.qpn = doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
-          connectQp(nicLoopback[qpIdx], selfInfo, nic);
-
-          VLOG(1) << "MultipeerIbgdaTransport: connected companion QP loopback "
-                     "pair (nic="
-                  << nic << " peer=" << peer << " q=" << q << ")";
-        }
-      }
-    }
-  }
-
   // ---- Allocate transport-owned signal buffers (if configured) ----
   if (config_.numSignalSlots > 0) {
     // Signal inbox: one contiguous buffer with numSignalSlots per peer.
@@ -1238,63 +1358,10 @@ void MultipeerIbgdaTransport::exchange() {
 
   exchange_send_recv_buffers();
 
-  // Build device transports on GPU. One NicDeviceIbgdaResourcesBuildSpec
-  // per (peer, NIC) carries that NIC's QP pointers and sink lkey.
+  // Build device transports on GPU
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
-
   for (int peer = 0; peer < numPeers; peer++) {
-    // One NicDeviceIbgdaResourcesBuildSpec per exposed physical NIC.
-    auto& bp = buildParams[peer];
-    bp.h_nicDeviceIbgdaResources.resize(numNics_);
-    for (int n = 0; n < numNics_; ++n) {
-      auto& nicSpec = bp.h_nicDeviceIbgdaResources[n];
-      nicSpec.qps.resize(numQps);
-      nicSpec.companionQps.resize(numQps);
-      nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDevices_[n].sinkMr->lkey));
-      nicSpec.deviceId = n;
-    }
-
-    for (int n = 0; n < numNics_; n++) {
-      auto& nicQps = nicDevices_[n].qpGroups;
-      auto& nicSpec = bp.h_nicDeviceIbgdaResources[n];
-      for (int q = 0; q < numQps; q++) {
-        const int qpIdx = peer * numQps + q;
-        doca_error_t err = doca_gpu_verbs_get_qp_dev(
-            nicQps[qpIdx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
-        checkDocaError(err, "Failed to get GPU QP handle");
-
-        err = doca_gpu_verbs_get_qp_dev(
-            nicQps[qpIdx]->qp_companion.qp_gverbs, &nicSpec.companionQps[q]);
-        checkDocaError(err, "Failed to get companion GPU QP handle");
-      }
-    }
-
-    if (config_.numSignalSlots > 0) {
-      buildParams[peer].remoteSignalBuf = signalRemoteViews_[peer];
-      buildParams[peer].localSignalBuf = signalLocalViews_[peer];
-      buildParams[peer].numSignalSlots = config_.numSignalSlots;
-    }
-    if (config_.numCounterSlots > 0) {
-      buildParams[peer].counterBuf = counterViews_[peer];
-      buildParams[peer].discardSignalSlot = discardSignalRemoteViews_[peer];
-      buildParams[peer].numCounterSlots = config_.numCounterSlots;
-    }
-    if (!sendRecvPeerBuffers_.empty()) {
-      const auto& pb = sendRecvPeerBuffers_[peer];
-      buildParams[peer].sendRecvState = IbSendRecvState{
-          .sendStagingBuf = pb.sendStaging,
-          .recvStagingBuf = pb.remoteRecvStaging,
-          .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
-          .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
-          .localSignalBuf = pb.signal,
-          .remoteSignalBuf = pb.remoteSignal,
-          .localCounterBuf = pb.counter,
-          .stepState = pb.stepState,
-          .maxGroups = config_.sendRecv->maxGroups,
-          .pipelineDepth = config_.sendRecv->pipelineDepth,
-          .dataBufferSize = config_.dataBufferSize,
-      };
-    }
+    buildParams[peer] = buildPeerTransportParams(peer);
   }
 
   peerTransportsGpu_ =
@@ -1315,10 +1382,11 @@ MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
 }
 
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
-    int peerRank) const {
+    int peerRank) {
+  if (config_.ibLazyConnect && !isPeerMaterialized(peerRank)) {
+    materializePeer(peerRank);
+  }
   int peerIndex = rankToPeerIndex(peerRank);
-  // Use byte-level arithmetic since P2pIbgdaTransportDevice is incomplete
-  // here
   return reinterpret_cast<P2pIbgdaTransportDevice*>(
       reinterpret_cast<char*>(peerTransportsGpu_) +
       peerIndex * peerTransportSize_);
@@ -1327,6 +1395,23 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDevice(
 P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getDeviceTransportPtr()
     const {
   return peerTransportsGpu_;
+}
+
+P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
+    int peerRank) const {
+  if (config_.ibLazyConnect) {
+    LOG_FIRST_N(WARNING, 1)
+        << "MultipeerIbgdaTransport: lazy mode is enabled but "
+        << "Transport[] array is being built with unmaterialized IBGDA "
+        << "slots. Algorithms using Transport[] directly (DeviceWindow, "
+        << "AllToAllv) should disable lazy mode (ibLazyConnect=false). "
+        << "Algorithms using getP2pTransportDevice() per peer (Ring, "
+        << "SendRecv) are unaffected.";
+  }
+  int peerIndex = rankToPeerIndex(peerRank);
+  return reinterpret_cast<P2pIbgdaTransportDevice*>(
+      reinterpret_cast<char*>(peerTransportsGpu_) +
+      peerIndex * peerTransportSize_);
 }
 
 int MultipeerIbgdaTransport::numPeers() const {
@@ -1557,10 +1642,11 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
   }
 
   const int numPeers = nRanks_ - 1;
-  const std::size_t stagingPerPeer = sr.pipelineDepth * config_.dataBufferSize;
-  const std::size_t signalPerPeer = 2 * sr.maxGroups * sizeof(uint64_t);
-  const std::size_t counterPerPeer = sr.maxGroups * sizeof(uint64_t);
-  const std::size_t stepStatePerPeer = 2 * sr.maxGroups * sizeof(int64_t);
+  auto sizes = computePeerBufferSizes();
+  const auto stagingPerPeer = sizes.staging;
+  const auto signalPerPeer = sizes.srSignal;
+  const auto counterPerPeer = sizes.srCounter;
+  const auto stepStatePerPeer = sizes.srStepState;
 
   auto allocateBulk = [&](std::size_t perPeer) {
     auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
@@ -1573,33 +1659,41 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
     return buf;
   };
 
-  sendStagingBulk_ = allocateBulk(stagingPerPeer);
-  recvStagingBulk_ = allocateBulk(stagingPerPeer);
-  signalBulk_ = allocateBulk(signalPerPeer);
-  counterBulk_ = allocateBulk(counterPerPeer);
-  stepStateBulk_ = allocateBulk(stepStatePerPeer);
-
-  auto sendStagingBulkReg =
-      registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
-  recvStagingBulkReg_ =
-      registerBuffer(recvStagingBulk_->get(), stagingPerPeer * numPeers);
-  signalBulkReg_ = registerBuffer(signalBulk_->get(), signalPerPeer * numPeers);
-  auto counterBulkReg =
-      registerBuffer(counterBulk_->get(), counterPerPeer * numPeers);
-
   sendRecvPeerBuffers_.resize(numPeers);
-  for (int i = 0; i < numPeers; ++i) {
-    auto& pb = sendRecvPeerBuffers_[i];
-    pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
-    pb.recvStaging = recvStagingBulkReg_.subBuffer(i * stagingPerPeer);
-    pb.signal = signalBulkReg_.subBuffer(i * signalPerPeer);
-    pb.counter = counterBulkReg.subBuffer(i * counterPerPeer);
-    pb.stepState = reinterpret_cast<int64_t*>(
-        static_cast<char*>(stepStateBulk_->get()) + i * stepStatePerPeer);
-  }
 
-  VLOG(1) << "MultipeerIbgdaTransport: allocated tile buffers for " << numPeers
-          << " peers (staging=" << stagingPerPeer << "B per peer)";
+  if (!config_.ibLazyConnect) {
+    sendStagingBulk_ = allocateBulk(stagingPerPeer);
+    recvStagingBulk_ = allocateBulk(stagingPerPeer);
+    signalBulk_ = allocateBulk(signalPerPeer);
+    counterBulk_ = allocateBulk(counterPerPeer);
+    stepStateBulk_ = allocateBulk(stepStatePerPeer);
+
+    auto sendStagingBulkReg =
+        registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
+    recvStagingBulkReg_ =
+        registerBuffer(recvStagingBulk_->get(), stagingPerPeer * numPeers);
+    signalBulkReg_ =
+        registerBuffer(signalBulk_->get(), signalPerPeer * numPeers);
+    counterBulkReg_ =
+        registerBuffer(counterBulk_->get(), counterPerPeer * numPeers);
+
+    for (int i = 0; i < numPeers; ++i) {
+      auto& pb = sendRecvPeerBuffers_[i];
+      pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
+      pb.recvStaging = recvStagingBulkReg_.subBuffer(i * stagingPerPeer);
+      pb.signal = signalBulkReg_.subBuffer(i * signalPerPeer);
+      pb.counter = counterBulkReg_.subBuffer(i * counterPerPeer);
+      pb.stepState = reinterpret_cast<int64_t*>(
+          static_cast<char*>(stepStateBulk_->get()) + i * stepStatePerPeer);
+    }
+
+    VLOG(1) << "MultipeerIbgdaTransport: eager mode — allocated tile buffers "
+            << "for " << numPeers << " peers (staging=" << stagingPerPeer
+            << "B per peer, 5 bulks)";
+  } else {
+    VLOG(1) << "MultipeerIbgdaTransport: lazy mode — per-peer allocation "
+            << "deferred to materializePeer";
+  }
 }
 
 void MultipeerIbgdaTransport::exchange_send_recv_buffers() {
@@ -1632,6 +1726,12 @@ void MultipeerIbgdaTransport::exchange_send_recv_buffers() {
 }
 
 void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
+  for (auto& buf : lazyPeerBufs_) {
+    if (buf) {
+      deregisterBuffer(buf->get());
+      buf.reset();
+    }
+  }
   sendRecvPeerBuffers_.clear();
 
   if (sendStagingBulk_) {
@@ -1652,6 +1752,321 @@ void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
   signalBulk_.reset();
   counterBulk_.reset();
   stepStateBulk_.reset();
+}
+
+bool MultipeerIbgdaTransport::isPeerMaterialized(int peerRank) const {
+  if (peerRank == myRank_ || peerRank < 0 || peerRank >= nRanks_) {
+    throw std::invalid_argument(
+        fmt::format(
+            "isPeerMaterialized: invalid peerRank={} (myRank={}, nRanks={})",
+            peerRank,
+            myRank_,
+            nRanks_));
+  }
+  if (!config_.ibLazyConnect) {
+    return true;
+  }
+  int peerIndex = rankToPeerIndex(peerRank);
+  return peerMaterialized_[peerIndex];
+}
+
+PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
+    int peerIndex) const {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  PeerQpPayload payload{};
+  payload.gidIndex = gidIndex_;
+  payload.mtu = static_cast<int>(localMtu_);
+  payload.numNics = numNics_;
+  payload.numQpsPerPeerPerNic = numQps;
+
+  for (int n = 0; n < numNics_; ++n) {
+    memcpy(
+        payload.nicInfo[n].gid,
+        nicDevices_[n].localGid.raw,
+        sizeof(payload.nicInfo[n].gid));
+    ibv_port_attr portAttr{};
+    if (doca_verbs_wrapper_ibv_query_port(
+            nicDevices_[n].ibvCtx, 1, &portAttr) == DOCA_SUCCESS) {
+      payload.nicInfo[n].lid = portAttr.lid;
+    }
+    auto& nicQps = nicDevices_[n].qpGroups;
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      payload.nicInfo[n].qpns[q] =
+          doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp);
+    }
+  }
+  return payload;
+}
+
+void MultipeerIbgdaTransport::allocatePeerBuffers(
+    int peerIndex,
+    PeerBufferPayload& payload) {
+  auto sizes = computePeerBufferSizes();
+  const std::size_t totalPerPeer = sizes.total();
+  if (totalPerPeer == 0) {
+    return;
+  }
+
+  lazyPeerBufs_[peerIndex] =
+      std::make_unique<meta::comms::DeviceBuffer>(totalPerPeer);
+  cudaError_t cudaErr =
+      cudaMemset(lazyPeerBufs_[peerIndex]->get(), 0, totalPerPeer);
+  if (cudaErr != cudaSuccess) {
+    throw std::runtime_error("Failed to zero per-peer buffer");
+  }
+
+  auto& peerBuf = lazyPeerBufs_[peerIndex];
+  sizes.layout(peerBuf->get());
+
+  auto reg = registerBuffer(peerBuf->get(), totalPerPeer);
+
+  auto addr = reinterpret_cast<uintptr_t>(peerBuf->get());
+  auto mrIt = registeredBuffers_.upper_bound(addr);
+  CHECK(mrIt != registeredBuffers_.begin())
+      << "materializePeer: peerBuf MR not found after registerBuffer";
+  --mrIt;
+  auto& mr = mrIt->second;
+
+  if (config_.sendRecv.has_value()) {
+    auto& pb = sendRecvPeerBuffers_[peerIndex];
+    pb.sendStaging =
+        IbgdaLocalBuffer(sizes.sendStagingPtr, reg.lkey_per_device);
+    pb.recvStaging =
+        IbgdaLocalBuffer(sizes.recvStagingPtr, reg.lkey_per_device);
+    pb.signal = IbgdaLocalBuffer(sizes.srSignalPtr, reg.lkey_per_device);
+    pb.counter = IbgdaLocalBuffer(sizes.srCounterPtr, reg.lkey_per_device);
+    pb.stepState = reinterpret_cast<int64_t*>(sizes.srStepStatePtr);
+
+    payload.recvStaging.addr = reinterpret_cast<uint64_t>(sizes.recvStagingPtr);
+    payload.recvStaging.numNics = numNics_;
+    payload.srSignal.addr = reinterpret_cast<uint64_t>(sizes.srSignalPtr);
+    payload.srSignal.numNics = numNics_;
+    for (int n = 0; n < numNics_; ++n) {
+      auto rkey = HostRKey(mr.mrs[n]->rkey);
+      payload.recvStaging.rkey_per_device[n] = rkey;
+      payload.srSignal.rkey_per_device[n] = rkey;
+    }
+  }
+
+  if (config_.numSignalSlots > 0) {
+    signalLocalViews_[peerIndex] =
+        IbgdaLocalBuffer(sizes.slotSignalPtr, reg.lkey_per_device);
+    payload.slotSignal.addr = reinterpret_cast<uint64_t>(sizes.slotSignalPtr);
+    payload.slotSignal.numNics = numNics_;
+    for (int n = 0; n < numNics_; ++n) {
+      payload.slotSignal.rkey_per_device[n] = HostRKey(mr.mrs[n]->rkey);
+    }
+  }
+  if (config_.numCounterSlots > 0) {
+    counterViews_[peerIndex] =
+        IbgdaLocalBuffer(sizes.slotCounterPtr, reg.lkey_per_device);
+    payload.slotDiscard.addr = reinterpret_cast<uint64_t>(sizes.slotDiscardPtr);
+    payload.slotDiscard.numNics = numNics_;
+    for (int n = 0; n < numNics_; ++n) {
+      payload.slotDiscard.rkey_per_device[n] = HostRKey(mr.mrs[n]->rkey);
+    }
+  }
+}
+
+template <typename T>
+T MultipeerIbgdaTransport::exchangeWithPeer(
+    int peerRank,
+    const T& localPayload,
+    int tag) {
+  T remotePayload{};
+
+  auto timeoutUs = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::milliseconds(config_.materializePeerTimeoutMs));
+  auto waitFuture = [&](auto&& future, const char* op) -> int {
+    try {
+      return std::move(future).get(timeoutUs);
+    } catch (const std::exception&) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: rank {} {} with peer {} timed out ({}ms)",
+              myRank_,
+              op,
+              peerRank,
+              config_.materializePeerTimeoutMs));
+    }
+  };
+
+  // Lower rank recvs first to avoid deadlock with blocking bootstrap
+  // implementations (e.g. MpiBootstrap uses blocking MPI_Send/MPI_Recv).
+  if (myRank_ < peerRank) {
+    auto recvFuture =
+        bootstrap_->recv(&remotePayload, sizeof(T), peerRank, /*tag=*/tag);
+    int recvResult = waitFuture(std::move(recvFuture), "recv");
+    if (recvResult != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: rank {} recv from peer {} failed (error {})",
+              myRank_,
+              peerRank,
+              recvResult));
+    }
+    auto sendFuture = bootstrap_->send(
+        const_cast<T*>(&localPayload), sizeof(T), peerRank, /*tag=*/tag);
+    int sendResult = waitFuture(std::move(sendFuture), "send");
+    if (sendResult != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: rank {} send to peer {} failed (error {})",
+              myRank_,
+              peerRank,
+              sendResult));
+    }
+  } else {
+    auto sendFuture = bootstrap_->send(
+        const_cast<T*>(&localPayload), sizeof(T), peerRank, /*tag=*/tag);
+    int sendResult = waitFuture(std::move(sendFuture), "send");
+    if (sendResult != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: rank {} send to peer {} failed (error {})",
+              myRank_,
+              peerRank,
+              sendResult));
+    }
+    auto recvFuture =
+        bootstrap_->recv(&remotePayload, sizeof(T), peerRank, /*tag=*/tag);
+    int recvResult = waitFuture(std::move(recvFuture), "recv");
+    if (recvResult != 0) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: rank {} recv from peer {} failed (error {})",
+              myRank_,
+              peerRank,
+              recvResult));
+    }
+  }
+
+  return remotePayload;
+}
+
+void MultipeerIbgdaTransport::connectPeerMainQps(
+    int peerIndex,
+    const PeerQpPayload& remotePayload) {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  for (int nic = 0; nic < numNics_; nic++) {
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      IbgdaTransportExchInfo peerInfo;
+      peerInfo.qpn = remotePayload.nicInfo[nic].qpns[q];
+      memcpy(
+          peerInfo.gid, remotePayload.nicInfo[nic].gid, sizeof(peerInfo.gid));
+      peerInfo.gidIndex = remotePayload.gidIndex;
+      peerInfo.lid = remotePayload.nicInfo[nic].lid;
+      peerInfo.mtu = static_cast<ibv_mtu>(remotePayload.mtu);
+      connectQp(&nicQps[qpIdx]->qp_main, peerInfo, nic);
+    }
+  }
+}
+
+void MultipeerIbgdaTransport::applyRemoteViews(
+    int peerIndex,
+    const PeerBufferPayload& remotePayload) {
+  if (config_.sendRecv.has_value()) {
+    auto& pb = sendRecvPeerBuffers_[peerIndex];
+    pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
+    pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
+  }
+  if (config_.numSignalSlots > 0) {
+    signalRemoteViews_[peerIndex] = remotePayload.slotSignal.toRemoteBuffer();
+  }
+  if (config_.numCounterSlots > 0) {
+    discardSignalRemoteViews_[peerIndex] =
+        remotePayload.slotDiscard.toRemoteBuffer();
+  }
+}
+
+void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  for (int nic = 0; nic < numNics_; nic++) {
+    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    for (int q = 0; q < numQps; q++) {
+      const int qpIdx = peerIndex * numQps + q;
+      if (nicQps[qpIdx] != nullptr) {
+        doca_gpu_verbs_destroy_qp_group_hl(nicQps[qpIdx]);
+        nicQps[qpIdx] = nullptr;
+      }
+      if (nicLoopback[qpIdx] != nullptr) {
+        doca_gpu_verbs_destroy_qp_hl(nicLoopback[qpIdx]);
+        nicLoopback[qpIdx] = nullptr;
+      }
+    }
+  }
+  auto& buf = lazyPeerBufs_[peerIndex];
+  if (buf) {
+    deregisterBuffer(buf->get());
+    buf.reset();
+  }
+}
+
+void MultipeerIbgdaTransport::materializePeer(int peerRank) {
+  if (!config_.ibLazyConnect) {
+    return;
+  }
+  if (peerRank == myRank_ || peerRank < 0 || peerRank >= nRanks_) {
+    throw std::invalid_argument(
+        fmt::format(
+            "materializePeer: invalid peerRank={} (myRank={}, nRanks={})",
+            peerRank,
+            myRank_,
+            nRanks_));
+  }
+  int peerIndex = rankToPeerIndex(peerRank);
+  if (isPeerMaterialized(peerRank)) {
+    return;
+  }
+
+  try {
+    createPeerQps(peerIndex);
+
+    // Phase 1: exchange QP info, connect QPs
+    auto localQp = buildLocalQpPayload(peerIndex);
+    auto remoteQp = exchangeWithPeer(peerRank, localQp, kTagQpExchange);
+
+    if (remoteQp.numNics != numNics_) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: peer {} has numNics={} but local numNics={}",
+              peerRank,
+              remoteQp.numNics,
+              numNics_));
+    }
+    if (remoteQp.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
+      throw std::runtime_error(
+          fmt::format(
+              "materializePeer: peer {} has numQps={} but local numQps={}",
+              peerRank,
+              remoteQp.numQpsPerPeerPerNic,
+              config_.numQpsPerPeerPerNic));
+    }
+
+    connectPeerMainQps(peerIndex, remoteQp);
+    connectPeerLoopback(peerIndex);
+
+    // Phase 2: exchange buffer info (acts as QP-ready barrier)
+    PeerBufferPayload localBuf{};
+    allocatePeerBuffers(peerIndex, localBuf);
+    auto remoteBuf = exchangeWithPeer(peerRank, localBuf, kTagBufferExchange);
+    applyRemoteViews(peerIndex, remoteBuf);
+
+    auto params = buildPeerTransportParams(peerIndex);
+    writeDeviceTransportSlot(
+        peerTransportsGpu_, peerIndex, params, gpuAllocations_);
+    peerMaterialized_[peerIndex] = true;
+
+    VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
+            << " materialized peer " << peerRank;
+  } catch (...) {
+    cleanupPeerOnFailure(peerIndex);
+    throw;
+  }
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -1874,8 +1874,6 @@ T MultipeerIbgdaTransport::exchangeWithPeer(
     int peerRank,
     const T& localPayload,
     int tag) {
-  T remotePayload{};
-
   auto timeoutUs = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::milliseconds(config_.materializePeerTimeoutMs));
   auto waitFuture = [&](auto&& future, const char* op) -> int {
@@ -1892,56 +1890,29 @@ T MultipeerIbgdaTransport::exchangeWithPeer(
     }
   };
 
-  // Lower rank recvs first to avoid deadlock with blocking bootstrap
-  // implementations (e.g. MpiBootstrap uses blocking MPI_Send/MPI_Recv).
-  if (myRank_ < peerRank) {
-    auto recvFuture =
-        bootstrap_->recv(&remotePayload, sizeof(T), peerRank, /*tag=*/tag);
-    int recvResult = waitFuture(std::move(recvFuture), "recv");
-    if (recvResult != 0) {
-      throw std::runtime_error(
-          fmt::format(
-              "materializePeer: rank {} recv from peer {} failed (error {})",
-              myRank_,
-              peerRank,
-              recvResult));
-    }
-    auto sendFuture = bootstrap_->send(
-        const_cast<T*>(&localPayload), sizeof(T), peerRank, /*tag=*/tag);
-    int sendResult = waitFuture(std::move(sendFuture), "send");
-    if (sendResult != 0) {
-      throw std::runtime_error(
-          fmt::format(
-              "materializePeer: rank {} send to peer {} failed (error {})",
-              myRank_,
-              peerRank,
-              sendResult));
-    }
-  } else {
-    auto sendFuture = bootstrap_->send(
-        const_cast<T*>(&localPayload), sizeof(T), peerRank, /*tag=*/tag);
-    int sendResult = waitFuture(std::move(sendFuture), "send");
-    if (sendResult != 0) {
-      throw std::runtime_error(
-          fmt::format(
-              "materializePeer: rank {} send to peer {} failed (error {})",
-              myRank_,
-              peerRank,
-              sendResult));
-    }
-    auto recvFuture =
-        bootstrap_->recv(&remotePayload, sizeof(T), peerRank, /*tag=*/tag);
-    int recvResult = waitFuture(std::move(recvFuture), "recv");
-    if (recvResult != 0) {
-      throw std::runtime_error(
-          fmt::format(
-              "materializePeer: rank {} recv from peer {} failed (error {})",
-              myRank_,
-              peerRank,
-              recvResult));
-    }
+  int sendResult = waitFuture(
+      bootstrap_->send(const_cast<T*>(&localPayload), sizeof(T), peerRank, tag),
+      "send");
+  if (sendResult != 0) {
+    throw std::runtime_error(
+        fmt::format(
+            "materializePeer: rank {} send to peer {} failed (error {})",
+            myRank_,
+            peerRank,
+            sendResult));
   }
 
+  T remotePayload{};
+  int recvResult = waitFuture(
+      bootstrap_->recv(&remotePayload, sizeof(T), peerRank, tag), "recv");
+  if (recvResult != 0) {
+    throw std::runtime_error(
+        fmt::format(
+            "materializePeer: rank {} recv from peer {} failed (error {})",
+            myRank_,
+            peerRank,
+            recvResult));
+  }
   return remotePayload;
 }
 
@@ -2018,10 +1989,19 @@ void MultipeerIbgdaTransport::materializePeer(int peerRank) {
             myRank_,
             nRanks_));
   }
-  int peerIndex = rankToPeerIndex(peerRank);
   if (isPeerMaterialized(peerRank)) {
     return;
   }
+  for (int p : pendingPeers_) {
+    if (p == peerRank) {
+      return;
+    }
+  }
+  pendingPeers_.push_back(peerRank);
+}
+
+void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
+  int peerIndex = rankToPeerIndex(peerRank);
 
   try {
     createPeerQps(peerIndex);
@@ -2033,7 +2013,7 @@ void MultipeerIbgdaTransport::materializePeer(int peerRank) {
     if (remoteQp.numNics != numNics_) {
       throw std::runtime_error(
           fmt::format(
-              "materializePeer: peer {} has numNics={} but local numNics={}",
+              "materializePeer: peer {} numNics={} vs local {}",
               peerRank,
               remoteQp.numNics,
               numNics_));
@@ -2041,7 +2021,7 @@ void MultipeerIbgdaTransport::materializePeer(int peerRank) {
     if (remoteQp.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
       throw std::runtime_error(
           fmt::format(
-              "materializePeer: peer {} has numQps={} but local numQps={}",
+              "materializePeer: peer {} numQps={} vs local {}",
               peerRank,
               remoteQp.numQpsPerPeerPerNic,
               config_.numQpsPerPeerPerNic));
@@ -2067,6 +2047,17 @@ void MultipeerIbgdaTransport::materializePeer(int peerRank) {
     cleanupPeerOnFailure(peerIndex);
     throw;
   }
+}
+
+void MultipeerIbgdaTransport::connectPeers() {
+  if (pendingPeers_.empty()) {
+    return;
+  }
+  std::sort(pendingPeers_.begin(), pendingPeers_.end());
+  for (int peerRank : pendingPeers_) {
+    doMaterializePeer(peerRank);
+  }
+  pendingPeers_.clear();
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -357,17 +357,30 @@ class MultipeerIbgdaTransport {
   P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank);
 
   /**
-   * Lazily allocate per-peer staging buffers and build the GPU device
-   * transport slot. No-op in eager mode or if the peer is already
-   * materialized. Both ranks must call materializePeer() for each other
-   * concurrently (or within the timeout window).
+   * Queue a peer for lazy materialization. No network I/O happens here.
+   * Call connectPeers() to complete all queued peers.
    *
-   * NOT thread-safe. Callers must not invoke this concurrently for
-   * the same or different peers.
+   * No-op in eager mode or if the peer is already materialized.
    *
    * @param peerRank Global rank of the peer to materialize
    */
   void materializePeer(int peerRank);
+
+  /**
+   * Connect all queued peers. In lazy mode, this MUST be called after
+   * all getP2pTransportDevice() / materializePeer() calls and BEFORE
+   * launching any kernel that uses the transport pointers.
+   *
+   * Processes peers in sorted rank order to avoid deadlock for >2 ranks.
+   * No-op in eager mode or if no peers are queued.
+   *
+   * Example:
+   *   prev = transport->getP2pTransportDevice(prev_rank);
+   *   next = transport->getP2pTransportDevice(next_rank);
+   *   transport->connectPeers();  // must call before kernel launch
+   *   launchKernel<<<...>>>(prev, next);
+   */
+  void connectPeers();
 
   /**
    * Check whether a peer's staging buffers have been allocated and its
@@ -500,7 +513,8 @@ class MultipeerIbgdaTransport {
 
   PeerBufferSizes computePeerBufferSizes() const;
 
-  // materializePeer decomposition
+  void doMaterializePeer(int peerRank);
+
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
   void allocatePeerBuffers(int peerIndex, PeerBufferPayload& payload);
   template <typename T>
@@ -624,6 +638,9 @@ class MultipeerIbgdaTransport {
 
   // Lazy mode: set to true after writeDeviceTransportSlot completes.
   std::vector<bool> peerMaterialized_;
+
+  // Queued peers awaiting connectPeers().
+  std::vector<int> pendingPeers_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -23,6 +23,10 @@
 namespace comms::pipes {
 class P2pIbgdaTransportDevice;
 struct MultipeerIbgdaDeviceTransport;
+struct P2pIbgdaTransportBuildParams;
+struct PeerQpPayload;
+struct PeerBufferPayload;
+struct PeerBufferSizes;
 } // namespace comms::pipes
 
 namespace comms::pipes {
@@ -350,7 +354,30 @@ class MultipeerIbgdaTransport {
    * @param peerRank Global rank of the peer (must be != myRank and < nRanks)
    * @return Pointer to P2pIbgdaTransportDevice for the specified peer
    */
-  P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank) const;
+  P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank);
+
+  /**
+   * Lazily allocate per-peer staging buffers and build the GPU device
+   * transport slot. No-op in eager mode or if the peer is already
+   * materialized. Both ranks must call materializePeer() for each other
+   * concurrently (or within the timeout window).
+   *
+   * NOT thread-safe. Callers must not invoke this concurrently for
+   * the same or different peers.
+   *
+   * @param peerRank Global rank of the peer to materialize
+   */
+  void materializePeer(int peerRank);
+
+  /**
+   * Check whether a peer's staging buffers have been allocated and its
+   * GPU device transport slot populated. In eager mode, returns true for
+   * all valid peers after exchange().
+   *
+   * @param peerRank Global rank of the peer
+   * @return true if the peer is ready for kernel use
+   */
+  bool isPeerMaterialized(int peerRank) const;
 
   /**
    * getDeviceTransportPtr - Get pointer to device transport array
@@ -362,6 +389,16 @@ class MultipeerIbgdaTransport {
    * @return Pointer to P2pIbgdaTransportDevice array in GPU memory
    */
   P2pIbgdaTransportDevice* getDeviceTransportPtr() const;
+
+  /**
+   * Return the GPU pointer for a peer's device transport slot without
+   * triggering lazy materialization. The slot may be zeroed if the peer
+   * has not been materialized yet.
+   *
+   * @param peerRank Global rank of the peer
+   * @return Pointer to P2pIbgdaTransportDevice slot (may be zeroed)
+   */
+  P2pIbgdaTransportDevice* getP2pTransportDeviceSlot(int peerRank) const;
 
   /**
    * Get number of peers (nRanks - 1)
@@ -442,7 +479,6 @@ class MultipeerIbgdaTransport {
   void allocateResources();
   void registerMemory();
   void createQpGroups();
-  void createLoopbackCompanionQps();
   void allocate_send_recv_buffers();
   void exchange_send_recv_buffers();
   void cleanup_send_recv_buffers();
@@ -456,6 +492,22 @@ class MultipeerIbgdaTransport {
       int nic);
   int rankToPeerIndex(int rank) const;
   int peerIndexToRank(int peerIndex) const;
+
+  // Per-peer helpers shared by eager exchange() and lazy materializePeer()
+  void createPeerQps(int peerIndex);
+  void connectPeerLoopback(int peerIndex);
+  P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
+
+  PeerBufferSizes computePeerBufferSizes() const;
+
+  // materializePeer decomposition
+  PeerQpPayload buildLocalQpPayload(int peerIndex) const;
+  void allocatePeerBuffers(int peerIndex, PeerBufferPayload& payload);
+  template <typename T>
+  T exchangeWithPeer(int peerRank, const T& localPayload, int tag);
+  void connectPeerMainQps(int peerIndex, const PeerQpPayload& remotePayload);
+  void applyRemoteViews(int peerIndex, const PeerBufferPayload& remotePayload);
+  void cleanupPeerOnFailure(int peerIndex);
 
   // Rank information
   const int myRank_{-1};
@@ -532,19 +584,18 @@ class MultipeerIbgdaTransport {
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Transport-owned signal buffers (allocated if numSignalSlots > 0)
+  // Slot-index signal/counter/discard buffers.
+  // Eager mode: bulk-allocated in exchange(). Null in lazy mode.
   void* signalInboxGpu_{nullptr};
+  void* counterGpu_{nullptr};
+  void* discardSignalGpu_{nullptr};
+  // Per-peer views into signal/counter/discard (populated by both modes).
   std::vector<IbgdaRemoteBuffer> signalRemoteViews_;
   std::vector<IbgdaLocalBuffer> signalLocalViews_;
-
-  // Transport-owned counter buffers (allocated if numCounterSlots > 0)
-  void* counterGpu_{nullptr};
   std::vector<IbgdaLocalBuffer> counterViews_;
-
-  void* discardSignalGpu_{nullptr};
   std::vector<IbgdaRemoteBuffer> discardSignalRemoteViews_;
 
-  // Send/recv buffers (allocated when maxGroups > 0)
+  // Per-peer send/recv buffer views (populated by both modes).
   struct SendRecvPeerBuffers {
     IbgdaLocalBuffer sendStaging;
     IbgdaLocalBuffer recvStaging;
@@ -556,14 +607,23 @@ class MultipeerIbgdaTransport {
   };
   std::vector<SendRecvPeerBuffers> sendRecvPeerBuffers_;
 
+  // Eager mode: bulk allocations for all peers. Null in lazy mode.
   std::unique_ptr<meta::comms::DeviceBuffer> sendStagingBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> recvStagingBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> signalBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> counterBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> stepStateBulk_;
-
   IbgdaLocalBuffer recvStagingBulkReg_;
   IbgdaLocalBuffer signalBulkReg_;
+  IbgdaLocalBuffer counterBulkReg_;
+
+  // Lazy mode: per-peer contiguous allocation (staging + signal + counter +
+  // stepState + slot-index). Null for unmaterialized peers. Empty in eager
+  // mode.
+  std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
+
+  // Lazy mode: set to true after writeDeviceTransportSlot completes.
+  std::vector<bool> peerMaterialized_;
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -158,6 +158,15 @@ struct MultipeerIbgdaTransportConfig {
   // 7 means infinite retry.
   // Default is 7 (matching NCCL IbvQpUtils).
   uint8_t rnrRetry{7};
+
+  // When true, defer per-peer state (QPs, staging, signal buffers) to
+  // first use via materializePeer(). When false (default), allocate
+  // eagerly at exchange() time.
+  bool ibLazyConnect{false};
+
+  // Timeout (ms) for the bilateral exchange in materializePeer().
+  // On timeout, materializePeer throws rather than hanging.
+  uint32_t materializePeerTimeoutMs{30000};
 };
 
 /**

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cu
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cu
@@ -144,6 +144,85 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
   return gpuPtr;
 }
 
+void writeDeviceTransportSlot(
+    P2pIbgdaTransportDevice* deviceArray,
+    int peerIndex,
+    const P2pIbgdaTransportBuildParams& params,
+    std::vector<void*>& outGpuAllocations) {
+  CHECK(!params.h_nicDeviceIbgdaResources.empty())
+      << "writeDeviceTransportSlot needs >= 1 NIC";
+  int numNics = static_cast<int>(params.h_nicDeviceIbgdaResources.size());
+  int qpsPerNic =
+      static_cast<int>(params.h_nicDeviceIbgdaResources[0].qps.size());
+  constexpr int kQpKindsPerNic = 2;
+
+  std::size_t qpsPerPeer =
+      static_cast<std::size_t>(kQpKindsPerNic) * numNics * qpsPerNic;
+  std::size_t qpBytes = qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
+  doca_gpu_dev_verbs_qp** d_qps = nullptr;
+  cudaError_t err = cudaMalloc(&d_qps, qpBytes);
+  CHECK(err == cudaSuccess) << "Failed to allocate per-peer GPU QP array: "
+                            << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_qps);
+
+  std::vector<doca_gpu_dev_verbs_qp*> h_qps;
+  h_qps.reserve(qpsPerPeer);
+  for (int n = 0; n < numNics; ++n) {
+    const auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
+    h_qps.insert(h_qps.end(), nicSpec.qps.begin(), nicSpec.qps.end());
+    h_qps.insert(
+        h_qps.end(), nicSpec.companionQps.begin(), nicSpec.companionQps.end());
+  }
+  err = cudaMemcpy(d_qps, h_qps.data(), qpBytes, cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess)
+      << "Failed to copy per-peer QP array to GPU: " << cudaGetErrorString(err);
+
+  std::size_t nicBytes = numNics * sizeof(NicDeviceIbgdaResources);
+  NicDeviceIbgdaResources* d_nicResources = nullptr;
+  err = cudaMalloc(&d_nicResources, nicBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to allocate per-peer NicDeviceIbgdaResources: "
+      << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_nicResources);
+
+  std::vector<NicDeviceIbgdaResources> h_nicResources;
+  h_nicResources.reserve(numNics);
+  for (int n = 0; n < numNics; ++n) {
+    auto* d_mainQps = d_qps + (n * kQpKindsPerNic * qpsPerNic);
+    auto* d_companionQps = d_mainQps + qpsPerNic;
+    h_nicResources.push_back(
+        NicDeviceIbgdaResources{
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, qpsPerNic),
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_companionQps, qpsPerNic),
+            params.h_nicDeviceIbgdaResources[n].sinkLkey,
+            params.h_nicDeviceIbgdaResources[n].deviceId,
+        });
+  }
+  err = cudaMemcpy(
+      d_nicResources, h_nicResources.data(), nicBytes, cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess)
+      << "Failed to copy per-peer NicDeviceIbgdaResources to GPU: "
+      << cudaGetErrorString(err);
+
+  P2pIbgdaTransportDevice hostTransport(
+      DeviceSpan<NicDeviceIbgdaResources>(d_nicResources, numNics),
+      params.remoteSignalBuf,
+      params.localSignalBuf,
+      params.counterBuf,
+      params.numSignalSlots,
+      params.numCounterSlots,
+      params.discardSignalSlot,
+      params.sendRecvState);
+
+  err = cudaMemcpy(
+      deviceArray + peerIndex,
+      &hostTransport,
+      sizeof(P2pIbgdaTransportDevice),
+      cudaMemcpyHostToDevice);
+  CHECK(err == cudaSuccess) << "Failed to copy per-peer device transport slot: "
+                            << cudaGetErrorString(err);
+}
+
 std::size_t getP2pIbgdaTransportDeviceSize() {
   return sizeof(P2pIbgdaTransportDevice);
 }

--- a/comms/pipes/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/pipes/MultipeerIbgdaTransportCuda.cuh
@@ -75,6 +75,15 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
     std::vector<void*>& outGpuAllocations);
 
 /**
+ * Write a single P2pIbgdaTransportDevice into the pre-allocated array.
+ */
+void writeDeviceTransportSlot(
+    P2pIbgdaTransportDevice* deviceArray,
+    int peerIndex,
+    const P2pIbgdaTransportBuildParams& params,
+    std::vector<void*>& outGpuAllocations);
+
+/**
  * Get size of P2pIbgdaTransportDevice struct.
  */
 std::size_t getP2pIbgdaTransportDeviceSize();

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -1825,8 +1825,9 @@ class P2pIbgdaTransportDevice {
   __device__ NicQpIndex nic_qp_for_group(uint32_t group_id) const {
     if (nicDevices_.empty()) {
       printf(
-          "P2pIbgdaTransportDevice: nicDevices_ is empty at "
-          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          "P2pIbgdaTransportDevice: transport not initialized "
+          "(peer not materialized? call get_device_handle(peers) first) "
+          "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
           __FILE__,
           __LINE__,
           blockIdx.x,

--- a/comms/pipes/collectives/tests/RingAllGatherTest.cc
+++ b/comms/pipes/collectives/tests/RingAllGatherTest.cc
@@ -19,6 +19,7 @@ struct RingAllGatherTestParams {
   int num_rings;
   std::size_t data_buffer_size;
   int pipeline_depth;
+  bool ibLazyConnect{false};
 };
 
 std::string param_name(
@@ -48,6 +49,7 @@ TEST_P(RingAllGatherTest, Correctness) {
                 .maxGroups = config.num_blocks * params.num_rings,
                 .pipelineDepth = params.pipeline_depth,
             },
+        .ibLazyConnect = params.ibLazyConnect,
     };
     transport = std::make_unique<MultipeerIbgdaTransport>(
         globalRank, worldSize, bootstrap, transportConfig);
@@ -86,6 +88,9 @@ TEST_P(RingAllGatherTest, Correctness) {
     ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
     ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
   }
+  // Lazy mode: connectPeers() must be called after all getP2pTransportDevice()
+  // calls and before launching the kernel.
+  transport->connectPeers();
 
   bootstrap->barrierAll();
   launch_ring_allgather(launchParams);
@@ -161,6 +166,22 @@ INSTANTIATE_TEST_SUITE_P(
             .num_rings = 2,
             .data_buffer_size = 4 * 1024 * 1024,
             .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    LazyMode,
+    RingAllGatherTest,
+    ::testing::Values(
+        RingAllGatherTestParams{
+            .config =
+                {.sendcount = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_lazy"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+            .ibLazyConnect = true,
         }),
     param_name);
 

--- a/comms/pipes/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/pipes/collectives/tests/RingReduceScatterTest.cc
@@ -19,6 +19,7 @@ struct RingReduceScatterTestParams {
   int num_rings;
   std::size_t data_buffer_size;
   int pipeline_depth;
+  bool ibLazyConnect{false};
 };
 
 std::string param_name(
@@ -48,6 +49,7 @@ TEST_P(RingReduceScatterTest, Correctness) {
                 .maxGroups = config.num_blocks * params.num_rings,
                 .pipelineDepth = params.pipeline_depth,
             },
+        .ibLazyConnect = params.ibLazyConnect,
     };
     transport = std::make_unique<MultipeerIbgdaTransport>(
         globalRank, worldSize, bootstrap, transportConfig);
@@ -88,6 +90,9 @@ TEST_P(RingReduceScatterTest, Correctness) {
     ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
     ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
   }
+  // Lazy mode: connectPeers() must be called after all getP2pTransportDevice()
+  // calls and before launching the kernel.
+  transport->connectPeers();
 
   bootstrap->barrierAll();
   launch_ring_reduce_scatter(launchParams);
@@ -170,6 +175,22 @@ INSTANTIATE_TEST_SUITE_P(
             .num_rings = 2,
             .data_buffer_size = 4 * 1024 * 1024,
             .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    LazyMode,
+    RingReduceScatterTest,
+    ::testing::Values(
+        RingReduceScatterTestParams{
+            .config =
+                {.chunk_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_lazy"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+            .ibLazyConnect = true,
         }),
     param_name);
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -1723,6 +1723,79 @@ TEST_F(MultipeerIbgdaTransportTestFixture, MultiNicAggregateBandwidth) {
   XLOGF(INFO, "Rank {}: MultiNicAggregateBandwidth test completed", globalRank);
 }
 
+// =============================================================================
+// Lazy Mode Tests
+// =============================================================================
+
+class LazyModeTestFixture : public MpiBaseTestFixture {
+ protected:
+  void SetUp() override {
+    MpiBaseTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> createLazyTransport() {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .numSignalSlots = 1,
+        .numCounterSlots = 1,
+        .ibLazyConnect = true,
+        .materializePeerTimeoutMs = 10000,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+    return transport;
+  }
+};
+
+TEST_F(LazyModeTestFixture, MaterializeOnAccess) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  try {
+    auto transport = createLazyTransport();
+    int peerRank = (globalRank == 0) ? 1 : 0;
+
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
+    auto* devPtr = transport->getP2pTransportDevice(peerRank);
+    EXPECT_NE(devPtr, nullptr);
+    transport->connectPeers();
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(LazyModeTestFixture, EagerModeAllPeersMaterialized) {
+  if (numRanks < 2) {
+    GTEST_SKIP() << "Requires at least 2 ranks";
+  }
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .ibLazyConnect = false,
+    };
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    for (int peer = 0; peer < numRanks; peer++) {
+      if (peer == globalRank) {
+        continue;
+      }
+      EXPECT_TRUE(transport->isPeerMaterialized(peer));
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
 } // namespace comms::pipes::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -486,4 +486,9 @@ DeviceWindow HostWindow::getDeviceWindow() const {
   return dw;
 }
 
+DeviceWindow HostWindow::getDeviceWindow(const std::vector<int>& peers) {
+  transport_.get_device_handle(peers);
+  return getDeviceWindow();
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/window/HostWindow.cc
+++ b/comms/pipes/window/HostWindow.cc
@@ -398,19 +398,15 @@ void HostWindow::uploadRegistrationsToDevice() {
   }
 }
 
-DeviceWindow HostWindow::getDeviceWindow() const {
-  if (!exchanged_) {
-    throw std::runtime_error(
-        "HostWindow::getDeviceWindow() called before exchange()");
-  }
-
+DeviceWindow HostWindow::buildDeviceWindowImpl(
+    MultiPeerDeviceHandle handle) const {
   int nNvlPeers = static_cast<int>(nvlPeerRanks_.size());
   int nIbgdaPeers = static_cast<int>(ibgdaPeerRanks_.size());
 
   // DeviceSpan has deleted copy-assignment, so we use placement new
   // for all DeviceSpan-typed members.
   DeviceWindow dw;
-  new (&dw.handle_) MultiPeerDeviceHandle(transport_.get_device_handle());
+  new (&dw.handle_) MultiPeerDeviceHandle(handle);
   dw.nNvlPeers_ = nNvlPeers;
   dw.nIbgdaPeers_ = nIbgdaPeers;
 
@@ -476,8 +472,7 @@ DeviceWindow HostWindow::getDeviceWindow() const {
         nIbgdaPeers);
   }
 
-  // Window buffer NVL peer pointers (for offset-based put/put_signal).
-  // IBGDA uses remoteBufferRegistry_ (the window buffer is the exchanged buf).
+  // Window buffer NVL peer pointers (for offset-based put/put_signal)
   if (userNvlPeerPtrsDevice_ && nNvlPeers > 0) {
     new (&dw.windowNvlPeerPtrs_) DeviceSpan<void*>(
         static_cast<void**>(userNvlPeerPtrsDevice_->get()), nNvlPeers);
@@ -486,9 +481,12 @@ DeviceWindow HostWindow::getDeviceWindow() const {
   return dw;
 }
 
+DeviceWindow HostWindow::getDeviceWindow() const {
+  return buildDeviceWindowImpl(transport_.get_device_handle());
+}
+
 DeviceWindow HostWindow::getDeviceWindow(const std::vector<int>& peers) {
-  transport_.get_device_handle(peers);
-  return getDeviceWindow();
+  return buildDeviceWindowImpl(transport_.get_device_handle(peers));
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -16,6 +16,7 @@ namespace comms::pipes {
 // Forward declarations
 class DeviceWindow;
 class MultiPeerTransport;
+struct MultiPeerDeviceHandle;
 class P2pIbgdaTransportDevice;
 struct LocalBufferRegistration;
 struct RemoteBufferRegistration;
@@ -119,14 +120,25 @@ class HostWindow {
    *
    * Must be called after exchange() and after all registerLocalBuffer()
    * and registerAndExchangeBuffer() calls.
+   *
+   * @throws std::runtime_error if lazy mode is enabled (ibLazyConnect=true).
+   *   Use getDeviceWindow(peers) instead.
    */
   DeviceWindow getDeviceWindow() const;
 
   /**
-   * Materialize the specified IBGDA peers, then return the DeviceWindow.
-   * Use with lazy mode to ensure peers are ready before kernel launch.
+   * getDeviceWindow (lazy mode) - Materialize specific IBGDA peers,
+   * then return the DeviceWindow.
    *
-   * @param peers List of peer ranks to materialize
+   * Call this instead of getDeviceWindow() when lazy mode is enabled.
+   * Materializes the listed peers (QPs, buffers, bilateral exchange)
+   * before building the DeviceWindow. Unmaterialized peers remain as
+   * zeroed transport slots — the kernel must only access materialized
+   * peers.
+   *
+   * No-op for non-IBGDA peers or in eager mode.
+   *
+   * @param peers List of global peer ranks to materialize
    */
   DeviceWindow getDeviceWindow(const std::vector<int>& peers);
 
@@ -208,6 +220,7 @@ class HostWindow {
   void* get_nvlink_address(int peer, std::size_t offset = 0) const;
 
  private:
+  DeviceWindow buildDeviceWindowImpl(MultiPeerDeviceHandle handle) const;
   void uploadRegistrationsToDevice();
 
   // Transport reference (non-owning, must outlive this object)

--- a/comms/pipes/window/HostWindow.h
+++ b/comms/pipes/window/HostWindow.h
@@ -122,6 +122,14 @@ class HostWindow {
    */
   DeviceWindow getDeviceWindow() const;
 
+  /**
+   * Materialize the specified IBGDA peers, then return the DeviceWindow.
+   * Use with lazy mode to ensure peers are ready before kernel launch.
+   *
+   * @param peers List of peer ranks to materialize
+   */
+  DeviceWindow getDeviceWindow(const std::vector<int>& peers);
+
   // --- Buffer registration for generic put/put_signal ---
 
   /**

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1780,6 +1780,23 @@ cvars:
      Number of times to retry after receiving an RNR NAK.
      7 means infinite retry.
 
+ - name        : NCCL_CTRAN_IBGDA_LAZY_CONNECT
+   type        : bool
+   default     : false
+   description : |-
+     When true, MultipeerIbgdaTransport defers per-peer state allocation to
+     first use (lazy mode). When false (default), all per-peer state is
+     allocated eagerly at construction. Per-comm override via
+     CommOptions.hints["ncclx::ibLazyConnect"].
+
+ - name        : NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS
+   type        : uint32_t
+   default     : 30000
+   description : |-
+     Timeout (in milliseconds) for materializePeer bilateral exchange.
+     On timeout, materializePeer throws rather than hanging.
+     No per-comm override.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket


### PR DESCRIPTION
Summary:

Add lazy mode tests:
- MaterializeOnAccess: peers unmaterialized after exchange, materialized after getP2pTransportDevice
- EagerModeAllPeersMaterialized: lazyPeerInit=false behaves identically
- RingReduceScatter with lazyPeerInit=true: end-to-end RDMA data correctness verification

All tests pass on H100 with mpirun -np 2.

Differential Revision: D104753214


