### PR TITLE
Create function to clear the entry for test (#2500)

### DIFF
--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -338,11 +338,18 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
   auto plugins =
       std::vector<std::unique_ptr<meta::comms::colltrace::ICollTracePlugin>>{};
 
+  auto evictionMode = NCCL_COLLTRACE_ITERATION_MODE
+      ? meta::comms::colltrace::EvictionMode::Iteration
+      : meta::comms::colltrace::EvictionMode::FixedCount;
+
   auto commDumpPlugin =
       std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
           meta::comms::colltrace::CommDumpConfig{
               .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
               .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
+              .evictionMode = evictionMode,
+              .maxIterations = NCCL_COLLTRACE_RECORD_MAX_ITERATIONS,
+              .iterationUpperBound = NCCL_COLLTRACE_ITERATION_UPPER_BOUND,
           });
   plugins.push_back(std::move(commDumpPlugin));
 

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -258,7 +258,8 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
 __attribute__((visibility("default"))) ncclResult_t ncclCommDumpAll(
     std::unordered_map<
         std::string,
-        std::unordered_map<std::string, std::string>>& map) {
+        std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFieldsStr) {
   initEnv();
   auto commDumpsMaybe = ncclx::comms_monitor::CommsMonitor::commDumpAll();
   if (!commDumpsMaybe.has_value()) {

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -217,6 +217,13 @@ CommsMonitor::getTopologyByCommDesc(const std::string& commDesc) {
   return commsMonitorSingleton.try_get();
 }
 
+/*static*/ void CommsMonitor::testOnlyClearComms() {
+  auto commMonitorPtr = getInstance();
+  if (commMonitorPtr != nullptr) {
+    commMonitorPtr->commsMap_.wlock()->clear();
+  }
+}
+
 /*static*/ std::optional<CommDumpAllMap> CommsMonitor::commDumpAll() {
   if (!NCCL_COMMSMONITOR_ENABLE) {
     static bool logDumpAllUnavailable = false;

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -69,6 +69,9 @@ class CommsMonitor {
   // If any failure happened during calling this function, it will return -1.
   static int64_t getNumOfCommMonitoring();
 
+  // For testing only. Clears all registered communicators from the singleton.
+  static void testOnlyClearComms();
+
  private:
   bool registerCommImpl(ncclComm_t comm);
   bool deregisterCommImpl(ncclComm_t comm);

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -950,6 +950,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -959,8 +960,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1118,6 +1118,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -1127,8 +1128,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -1126,6 +1126,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -1135,8 +1136,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/utils/colltrace/CollRecord.cc
+++ b/comms/utils/colltrace/CollRecord.cc
@@ -110,11 +110,18 @@ bool CollTimingRecord::operator==(const CollTimingRecord& other) const {
 // CollRecord implementation
 CollRecord::CollRecord(
     uint64_t collId,
-    std::unique_ptr<ICollMetadata> ICollMetadata)
-    : collId_(collId), collMetadata_(std::move(ICollMetadata)) {}
+    std::unique_ptr<ICollMetadata> ICollMetadata,
+    int64_t iteration)
+    : collId_(collId),
+      iteration_(iteration),
+      collMetadata_(std::move(ICollMetadata)) {}
 
 uint64_t CollRecord::getCollId() const noexcept {
   return collId_;
+}
+
+int64_t CollRecord::getIteration() const noexcept {
+  return iteration_;
 }
 
 const ICollMetadata* CollRecord::getCollMetadata() const {
@@ -127,7 +134,8 @@ CollTimingRecord& CollRecord::getTimingInfo() {
 
 std::size_t CollRecord::hash() const {
   // Hash the collId and timingInfo
-  std::size_t seed = folly::hash::hash_combine(collId_, timingInfo_.hash());
+  std::size_t seed =
+      folly::hash::hash_combine(collId_, iteration_, timingInfo_.hash());
 
   // Add the hash of collMetadata if it exists
   if (collMetadata_) {
@@ -139,7 +147,8 @@ std::size_t CollRecord::hash() const {
 
 bool CollRecord::equals(const CollRecord& other) const noexcept {
   // Compare collId and timingInfo
-  if (collId_ != other.collId_ || !(timingInfo_ == other.timingInfo_)) {
+  if (collId_ != other.collId_ || iteration_ != other.iteration_ ||
+      !(timingInfo_ == other.timingInfo_)) {
     return false;
   }
 
@@ -172,6 +181,7 @@ folly::dynamic CollRecord::toDynamic() const noexcept {
   // and call it "opCount". We should switch to use collId in the future.
   result["collId"] = collId_;
   result["opCount"] = collId_;
+  result["iteration"] = iteration_;
 
   return result;
 }

--- a/comms/utils/colltrace/CollRecord.h
+++ b/comms/utils/colltrace/CollRecord.h
@@ -55,9 +55,13 @@ class ICollRecord {
 
 class CollRecord : public ICollRecord {
  public:
-  CollRecord(uint64_t collId, std::unique_ptr<ICollMetadata> ICollMetadata);
+  CollRecord(
+      uint64_t collId,
+      std::unique_ptr<ICollMetadata> ICollMetadata,
+      int64_t iteration = -1);
 
   uint64_t getCollId() const noexcept override;
+  int64_t getIteration() const noexcept;
   const ICollMetadata* getCollMetadata() const;
 
   // Timing info is the only field that we could modify after init
@@ -72,6 +76,8 @@ class CollRecord : public ICollRecord {
  private:
   uint64_t collId_; // CollTrace internal collective id. Should always increment
                     // monotonically
+  int64_t iteration_; // Step number in the training loop.
+
   std::unique_ptr<ICollMetadata>
       collMetadata_; // Using unique ptr as we might get an inherited class
   CollTimingRecord

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -20,6 +20,7 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/trainer/TrainerContext.h"
 
 namespace meta::comms::colltrace {
 
@@ -251,7 +252,8 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
   }
 
   pendingEnqueueColl_ = std::make_unique<CollTraceEvent>(
-      std::make_shared<CollRecord>(collId_.fetch_add(1), std::move(metadata)),
+      std::make_shared<CollRecord>(
+          collId_.fetch_add(1), std::move(metadata), ncclxGetIteration()),
       std::move(waitEvent));
   auto handle =
       std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
@@ -358,8 +360,8 @@ CollTrace::recordGraphCollectiveImpl(
 
   rawWaitEvent->attachRingBuffer(&*ringBuffer_);
 
-  auto collRecord =
-      std::make_shared<CollRecord>(collIdVal, std::move(metadata));
+  auto collRecord = std::make_shared<CollRecord>(
+      collIdVal, std::move(metadata), ncclxGetIteration());
   auto recordPtr = std::static_pointer_cast<ICollRecord>(collRecord);
 
   auto collEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -308,6 +308,10 @@ std::unordered_map<std::string, std::string> commDumpToMap(
   }
   map["CT_currentColls"] = folly::toJson(currentColls);
 
+  map["CT_currentIteration"] = std::to_string(dump.currentIteration);
+  map["CT_currentIterationCommTimeUs"] =
+      std::to_string(dump.currentIterationCommTimeUs);
+
   return map;
 }
 

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -160,6 +160,29 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
   evictPastColls(*lockedCollTraceDump, completedIteration);
   lockedCollTraceDump->currentColls.erase(it);
 
+  auto latencyUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                       curEvent.collRecord->getTimingInfo().getCollEndTs() -
+                       curEvent.collRecord->getTimingInfo().getCollStartTs())
+                       .count();
+  if (completedIteration > lockedCollTraceDump->currentIteration) {
+    lockedCollTraceDump->currentIteration = completedIteration;
+    lockedCollTraceDump->currentIterationCommTimeUs = latencyUs;
+  } else if (completedIteration == lockedCollTraceDump->currentIteration) {
+    lockedCollTraceDump->currentIterationCommTimeUs += latencyUs;
+  } else {
+    // Unexpected: a collective from an older iteration completed after we
+    // already moved to a newer iteration.  Log and skip the comm-time update
+    // to avoid corrupting the current iteration's accounting.
+    XLOG_FIRST_N(
+        ERR,
+        2,
+        "CommDumpPlugin: Completed iteration ",
+        completedIteration,
+        " is older than current iteration ",
+        lockedCollTraceDump->currentIteration,
+        ". Skipping comm time update.");
+  }
+
   return folly::unit;
 }
 
@@ -253,6 +276,14 @@ CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
   }
 
   return dumpCopy;
+}
+
+IterationCommTime CommDumpPlugin::getCurrentIterationCommTime() const noexcept {
+  auto locked = collTraceDump_.rlock(config_.dumpLockAcquireTimeout);
+  if (locked.isNull()) {
+    return {};
+  }
+  return {locked->currentIteration, locked->currentIterationCommTimeUs};
 }
 
 std::unordered_map<std::string, std::string> commDumpToMap(

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -155,15 +155,45 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
         commInternalError));
   }
 
+  auto completedIteration = curEvent.collRecord->getIteration();
   lockedCollTraceDump->pastCollsHeap.push(std::move(*it));
-  while (config_.pastCollSize >= 0 &&
-         static_cast<int64_t>(lockedCollTraceDump->pastCollsHeap.size()) >
-             config_.pastCollSize) {
-    lockedCollTraceDump->pastCollsHeap.pop();
-  }
+  evictPastColls(*lockedCollTraceDump, completedIteration);
   lockedCollTraceDump->currentColls.erase(it);
 
   return folly::unit;
+}
+
+void CommDumpPlugin::evictPastColls(
+    CollTraceDump& dump,
+    int64_t completedIteration) {
+  switch (config_.evictionMode) {
+    case EvictionMode::FixedCount: {
+      while (config_.pastCollSize >= 0 &&
+             static_cast<int64_t>(dump.pastCollsHeap.size()) >
+                 config_.pastCollSize) {
+        dump.pastCollsHeap.pop();
+      }
+      break;
+    }
+    case EvictionMode::Iteration: {
+      if (completedIteration > maxIterationSeen_) {
+        maxIterationSeen_ = completedIteration;
+      }
+      int64_t evictionThreshold = maxIterationSeen_ - config_.maxIterations + 1;
+      while (!dump.pastCollsHeap.empty()) {
+        const auto& oldest = dump.pastCollsHeap.top();
+        bool overHardLimit = static_cast<int64_t>(dump.pastCollsHeap.size()) >
+            config_.iterationUpperBound;
+        bool oldIteration = oldest->getIteration() < evictionThreshold;
+        if (overHardLimit || oldIteration) {
+          dump.pastCollsHeap.pop();
+        } else {
+          break;
+        }
+      }
+      break;
+    }
+  }
 }
 
 CommsMaybe<CollTraceDump> CommDumpPlugin::dump() noexcept {
@@ -251,6 +281,9 @@ std::unordered_map<std::string, std::string> commDumpToMap(
 }
 
 int64_t CommDumpPlugin::maxEventRetention() const noexcept {
+  if (config_.evictionMode == EvictionMode::Iteration) {
+    return config_.iterationUpperBound;
+  }
   return config_.pastCollSize;
 }
 
@@ -258,6 +291,7 @@ CommsMaybeVoid CommDumpPlugin::testOnlyClearColls() noexcept {
   collTraceDump_.exchange(CollTraceDump{});
   newPendingColls_ =
       folly::MPMCQueue<std::shared_ptr<CollRecord>>(config_.pendingCollSize);
+  maxIterationSeen_ = -1;
   return folly::unit;
 }
 

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -14,6 +14,11 @@
 
 namespace meta::comms::colltrace {
 
+enum class EvictionMode {
+  FixedCount, // Keep last N records (current behavior)
+  Iteration, // Keep records from current iteration, with hard upper bound
+};
+
 struct CommDumpConfig {
   // Default size of queue storing past collective communication operations.
   // The default value should be enough for debugging past collective. For slow
@@ -36,6 +41,15 @@ struct CommDumpConfig {
   // dropped if the queue is full.
   int64_t pendingCollSize{kCommDumpQueueSize};
   std::chrono::milliseconds dumpLockAcquireTimeout{kDumpLockAcquireTimeout};
+
+  EvictionMode evictionMode{EvictionMode::FixedCount};
+  // Number of recent iterations to retain when using Iteration mode.
+  // 1 = current iteration only, 2 = current + previous, etc.
+  int64_t maxIterations{1};
+  // Hard upper bound on retained past records when using Iteration mode.
+  // Prevents unbounded growth if ncclxSetIteration is never called.
+  static constexpr int64_t kDefaultIterationUpperBound{3000};
+  int64_t iterationUpperBound{kDefaultIterationUpperBound};
 };
 
 struct CollRecordGreaterCollId {
@@ -91,7 +105,10 @@ class CommDumpPlugin : public ICollTracePlugin {
   static constexpr std::string_view kCommDumpPluginName = "CommDumpPlugin";
 
  private:
+  void evictPastColls(CollTraceDump& dump, int64_t completedIteration);
+
   CommDumpConfig config_;
+  int64_t maxIterationSeen_{-1};
 
   folly::Synchronized<CollTraceDump> collTraceDump_;
 

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -70,6 +70,14 @@ struct CollTraceDump {
   std::deque<std::shared_ptr<CollRecord>> pastColls;
   std::deque<std::shared_ptr<CollRecord>> currentColls;
   std::deque<std::shared_ptr<CollRecord>> pendingColls;
+
+  int64_t currentIteration{-1};
+  int64_t currentIterationCommTimeUs{0};
+};
+
+struct IterationCommTime {
+  int64_t iteration{-1};
+  int64_t commTimeUs{0};
 };
 
 class CommDumpPlugin : public ICollTracePlugin {
@@ -96,6 +104,8 @@ class CommDumpPlugin : public ICollTracePlugin {
 
   // CommDump specific API, supposed to be called by the dump (user) thread
   CommsMaybe<CollTraceDump> dump() noexcept;
+
+  IterationCommTime getCurrentIterationCommTime() const noexcept;
 
   // For testing purpose only. This API is NOT thread safe! Clears all the
   // recorded colls. Please make sure all the previous colls are processed

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
@@ -496,3 +496,80 @@ TEST_F(CommDumpPluginIterationTest, MaxIterationsRetention) {
 TEST_F(CommDumpPluginIterationTest, MaxEventRetentionReturnsUpperBound) {
   EXPECT_EQ(plugin->maxEventRetention(), 3000);
 }
+
+// ---- Iteration comm time tracking tests ----
+
+TEST_F(CommDumpPluginTest, CommTimeDefaultValue) {
+  auto result = plugin->getCurrentIterationCommTime();
+  EXPECT_EQ(result.iteration, -1);
+  EXPECT_EQ(result.commTimeUs, 0);
+}
+
+TEST_F(CommDumpPluginTest, CommTimeAccumulation) {
+  using std::chrono::microseconds;
+  using std::chrono::system_clock;
+  auto now = system_clock::now();
+
+  auto event1 = createCollTraceEventWithIteration(1, 5);
+  event1.collRecord->getTimingInfo().setCollStartTs(now);
+  event1.collRecord->getTimingInfo().setCollEndTs(now + microseconds(100));
+
+  auto event2 = createCollTraceEventWithIteration(2, 5);
+  event2.collRecord->getTimingInfo().setCollStartTs(now);
+  event2.collRecord->getTimingInfo().setCollEndTs(now + microseconds(250));
+
+  processFullLifecycle(event1);
+  processFullLifecycle(event2);
+
+  auto result = plugin->getCurrentIterationCommTime();
+  EXPECT_EQ(result.iteration, 5);
+  EXPECT_EQ(result.commTimeUs, 350);
+}
+
+TEST_F(CommDumpPluginTest, CommTimeStaleIterationIgnored) {
+  using std::chrono::microseconds;
+  using std::chrono::system_clock;
+  auto now = system_clock::now();
+
+  // Process event from iteration 5
+  auto event1 = createCollTraceEventWithIteration(1, 5);
+  event1.collRecord->getTimingInfo().setCollStartTs(now);
+  event1.collRecord->getTimingInfo().setCollEndTs(now + microseconds(100));
+  processFullLifecycle(event1);
+
+  EXPECT_EQ(plugin->getCurrentIterationCommTime().iteration, 5);
+  EXPECT_EQ(plugin->getCurrentIterationCommTime().commTimeUs, 100);
+
+  // Process event from older iteration 3 — should be ignored
+  auto event2 = createCollTraceEventWithIteration(2, 3);
+  event2.collRecord->getTimingInfo().setCollStartTs(now);
+  event2.collRecord->getTimingInfo().setCollEndTs(now + microseconds(200));
+  processFullLifecycle(event2);
+
+  // Current iteration should still be 5 with unchanged comm time
+  auto result = plugin->getCurrentIterationCommTime();
+  EXPECT_EQ(result.iteration, 5);
+  EXPECT_EQ(result.commTimeUs, 100);
+}
+
+TEST_F(CommDumpPluginTest, CommTimeIterationRollover) {
+  using std::chrono::microseconds;
+  using std::chrono::system_clock;
+  auto now = system_clock::now();
+
+  auto event1 = createCollTraceEventWithIteration(1, 1);
+  event1.collRecord->getTimingInfo().setCollStartTs(now);
+  event1.collRecord->getTimingInfo().setCollEndTs(now + microseconds(100));
+  processFullLifecycle(event1);
+
+  EXPECT_EQ(plugin->getCurrentIterationCommTime().commTimeUs, 100);
+
+  auto event2 = createCollTraceEventWithIteration(2, 2);
+  event2.collRecord->getTimingInfo().setCollStartTs(now);
+  event2.collRecord->getTimingInfo().setCollEndTs(now + microseconds(200));
+  processFullLifecycle(event2);
+
+  auto result = plugin->getCurrentIterationCommTime();
+  EXPECT_EQ(result.iteration, 2);
+  EXPECT_EQ(result.commTimeUs, 200);
+}

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
@@ -45,12 +45,25 @@ class CommDumpPluginTest : public ::testing::Test {
 
   // Helper method to create a CollTraceEvent with a CollRecord
   CollTraceEvent createCollTraceEvent(uint64_t collId) {
+    return createCollTraceEventWithIteration(collId, -1);
+  }
+
+  CollTraceEvent createCollTraceEventWithIteration(
+      uint64_t collId,
+      int64_t iteration) {
     auto metadata = std::make_unique<MockCollMetadata>();
-    auto collRecord = std::make_shared<CollRecord>(collId, std::move(metadata));
+    auto collRecord =
+        std::make_shared<CollRecord>(collId, std::move(metadata), iteration);
 
     CollTraceEvent event;
     event.collRecord = collRecord;
     return event;
+  }
+
+  void processFullLifecycle(CollTraceEvent& event) {
+    EXPECT_VALUE(plugin->afterCollKernelScheduled(event));
+    EXPECT_VALUE(plugin->afterCollKernelStart(event));
+    EXPECT_VALUE(plugin->afterCollKernelEnd(event));
   }
 
   std::unique_ptr<CommDumpPlugin> plugin;
@@ -389,4 +402,97 @@ TEST_F(CommDumpPluginTest, ConcurrentActiveCollectives) {
   EXPECT_VALUE(dump3);
   EXPECT_TRUE(dump3.value().currentColls.empty());
   EXPECT_EQ(dump3.value().pastColls.size(), 2);
+}
+
+// ---- Iteration-based eviction tests ----
+
+class CommDumpPluginIterationTest : public CommDumpPluginTest {
+ protected:
+  void SetUp() override {
+    plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
+        .evictionMode = EvictionMode::Iteration,
+        .maxIterations = 1,
+        .iterationUpperBound = 3000,
+    });
+  }
+};
+
+TEST_F(CommDumpPluginIterationTest, EvictsOlderIterations) {
+  // Process events from iteration 1
+  auto event1 = createCollTraceEventWithIteration(1, 1);
+  auto event2 = createCollTraceEventWithIteration(2, 1);
+  processFullLifecycle(event1);
+  processFullLifecycle(event2);
+
+  auto dump1 = plugin->dump();
+  EXPECT_VALUE(dump1);
+  EXPECT_EQ(dump1.value().pastColls.size(), 2);
+
+  // Process event from iteration 2 — iteration 1 records should be evicted
+  auto event3 = createCollTraceEventWithIteration(3, 2);
+  processFullLifecycle(event3);
+
+  auto dump2 = plugin->dump();
+  EXPECT_VALUE(dump2);
+  EXPECT_EQ(dump2.value().pastColls.size(), 1);
+  EXPECT_EQ(dump2.value().pastColls.front()->getCollId(), 3);
+  EXPECT_EQ(dump2.value().pastColls.front()->getIteration(), 2);
+}
+
+TEST_F(CommDumpPluginIterationTest, RetainsCurrentIteration) {
+  auto event1 = createCollTraceEventWithIteration(1, 5);
+  auto event2 = createCollTraceEventWithIteration(2, 5);
+  auto event3 = createCollTraceEventWithIteration(3, 5);
+  processFullLifecycle(event1);
+  processFullLifecycle(event2);
+  processFullLifecycle(event3);
+
+  auto dump = plugin->dump();
+  EXPECT_VALUE(dump);
+  EXPECT_EQ(dump.value().pastColls.size(), 3);
+}
+
+TEST_F(CommDumpPluginIterationTest, HardUpperBoundEnforced) {
+  plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
+      .evictionMode = EvictionMode::Iteration,
+      .maxIterations = 1,
+      .iterationUpperBound = 5,
+  });
+
+  // All events have iteration -1 (simulating broken iteration tracking)
+  for (uint64_t i = 0; i < 10; ++i) {
+    auto event = createCollTraceEventWithIteration(i, -1);
+    processFullLifecycle(event);
+  }
+
+  auto dump = plugin->dump();
+  EXPECT_VALUE(dump);
+  EXPECT_LE(static_cast<int64_t>(dump.value().pastColls.size()), 5);
+}
+
+TEST_F(CommDumpPluginIterationTest, MaxIterationsRetention) {
+  // Configure to retain last 2 iterations
+  plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
+      .evictionMode = EvictionMode::Iteration,
+      .maxIterations = 2,
+      .iterationUpperBound = 3000,
+  });
+
+  auto event1 = createCollTraceEventWithIteration(1, 1);
+  auto event2 = createCollTraceEventWithIteration(2, 2);
+  auto event3 = createCollTraceEventWithIteration(3, 3);
+  processFullLifecycle(event1);
+  processFullLifecycle(event2);
+  processFullLifecycle(event3);
+
+  auto dump = plugin->dump();
+  EXPECT_VALUE(dump);
+  // Should retain iterations 2 and 3, evict iteration 1
+  EXPECT_EQ(dump.value().pastColls.size(), 2);
+  EXPECT_EQ(dump.value().pastColls[0]->getIteration(), 2);
+  EXPECT_EQ(dump.value().pastColls[1]->getIteration(), 3);
+}
+
+TEST_F(CommDumpPluginIterationTest, MaxEventRetentionReturnsUpperBound) {
+  EXPECT_EQ(plugin->maxEventRetention(), 3000);
 }

--- a/comms/utils/colltrace/plugins/tests/CommDumpToMapUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpToMapUT.cc
@@ -34,15 +34,19 @@ TEST_F(CommDumpToMapTest, EmptyDump) {
   auto map = commDumpToMap(dump);
 
   // Verify the map has the expected keys
-  EXPECT_EQ(map.size(), 3);
+  EXPECT_EQ(map.size(), 5);
   EXPECT_TRUE(map.find("CT_pastColls") != map.end());
   EXPECT_TRUE(map.find("CT_pendingColls") != map.end());
   EXPECT_TRUE(map.find("CT_currentColls") != map.end());
+  EXPECT_TRUE(map.find("CT_currentIteration") != map.end());
+  EXPECT_TRUE(map.find("CT_currentIterationCommTimeUs") != map.end());
 
   // Verify the values are as expected for an empty dump
   EXPECT_EQ(map["CT_pastColls"], "[]");
   EXPECT_EQ(map["CT_pendingColls"], "[]");
   EXPECT_EQ(map["CT_currentColls"], "[]");
+  EXPECT_EQ(map["CT_currentIteration"], "-1");
+  EXPECT_EQ(map["CT_currentIterationCommTimeUs"], "0");
 }
 
 // Test commDumpToMap with only pastColls
@@ -56,7 +60,7 @@ TEST_F(CommDumpToMapTest, WithPastColls) {
   auto map = commDumpToMap(dump);
 
   // Verify the map has the expected keys
-  EXPECT_EQ(map.size(), 3);
+  EXPECT_EQ(map.size(), 5);
 
   // Parse the JSON for pastColls and verify it contains the expected data
   auto pastCollsJson = folly::parseJson(map["CT_pastColls"]);
@@ -79,7 +83,7 @@ TEST_F(CommDumpToMapTest, WithCurrentColl) {
   auto map = commDumpToMap(dump);
 
   // Verify the map has the expected keys
-  EXPECT_EQ(map.size(), 3);
+  EXPECT_EQ(map.size(), 5);
 
   // Verify pastColls and pendingColls are empty
   EXPECT_EQ(map["CT_pastColls"], "[]");
@@ -103,7 +107,7 @@ TEST_F(CommDumpToMapTest, WithPendingColls) {
   auto map = commDumpToMap(dump);
 
   // Verify the map has the expected keys
-  EXPECT_EQ(map.size(), 3);
+  EXPECT_EQ(map.size(), 5);
 
   // Verify pastColls is empty and currentColl is null
   EXPECT_EQ(map["CT_pastColls"], "[]");
@@ -115,6 +119,20 @@ TEST_F(CommDumpToMapTest, WithPendingColls) {
   EXPECT_EQ(pendingCollsJson[0]["collId"], 4);
   EXPECT_EQ(pendingCollsJson[1]["collId"], 5);
   EXPECT_EQ(pendingCollsJson[2]["collId"], 6);
+}
+
+// Test commDumpToMap with iteration fields set
+TEST_F(CommDumpToMapTest, WithIterationFields) {
+  CollTraceDump dump;
+
+  dump.currentIteration = 42;
+  dump.currentIterationCommTimeUs = 12345;
+
+  auto map = commDumpToMap(dump);
+
+  EXPECT_EQ(map.size(), 5);
+  EXPECT_EQ(map["CT_currentIteration"], "42");
+  EXPECT_EQ(map["CT_currentIterationCommTimeUs"], "12345");
 }
 
 // Test commDumpToMap with all fields populated
@@ -132,10 +150,14 @@ TEST_F(CommDumpToMapTest, FullDump) {
   dump.pendingColls.push_back(createCollRecord(4));
   dump.pendingColls.push_back(createCollRecord(5));
 
+  // Set iteration fields
+  dump.currentIteration = 10;
+  dump.currentIterationCommTimeUs = 5000;
+
   auto map = commDumpToMap(dump);
 
   // Verify the map has the expected keys
-  EXPECT_EQ(map.size(), 3);
+  EXPECT_EQ(map.size(), 5);
 
   // Parse the JSON for pastColls and verify it contains the expected data
   auto pastCollsJson = folly::parseJson(map["CT_pastColls"]);
@@ -153,4 +175,8 @@ TEST_F(CommDumpToMapTest, FullDump) {
   EXPECT_EQ(pendingCollsJson.size(), 2);
   EXPECT_EQ(pendingCollsJson[0]["collId"], 4);
   EXPECT_EQ(pendingCollsJson[1]["collId"], 5);
+
+  // Verify iteration fields
+  EXPECT_EQ(map["CT_currentIteration"], "10");
+  EXPECT_EQ(map["CT_currentIterationCommTimeUs"], "5000");
 }

--- a/comms/utils/colltrace/tests/CollRecordUT.cc
+++ b/comms/utils/colltrace/tests/CollRecordUT.cc
@@ -281,4 +281,46 @@ TEST_F(CollRecordTest, NullMetadata) {
   EXPECT_FALSE(collRecord_->equals(*recordWithNullMetadata));
 }
 
+TEST_F(CollRecordTest, IterationDefaultValue) {
+  EXPECT_EQ(collRecord_->getIteration(), -1);
+}
+
+TEST_F(CollRecordTest, IterationExplicitValue) {
+  auto metadata = std::make_unique<NiceMock<MockCollMetadata>>();
+  auto record = std::make_unique<CollRecord>(1, std::move(metadata), 42);
+  EXPECT_EQ(record->getIteration(), 42);
+}
+
+TEST_F(CollRecordTest, IterationInToDynamic) {
+  auto metadata = std::make_unique<NiceMock<MockCollMetadata>>();
+  folly::dynamic emptyObj = folly::dynamic::object;
+  ON_CALL(*metadata, toDynamic()).WillByDefault(Return(emptyObj));
+  auto record = std::make_unique<CollRecord>(1, std::move(metadata), 7);
+  auto result = record->toDynamic();
+  ASSERT_TRUE(result.count("iteration"));
+  EXPECT_EQ(result["iteration"].asInt(), 7);
+}
+
+TEST_F(CollRecordTest, IterationAffectsHash) {
+  auto meta1 = std::make_unique<NiceMock<MockCollMetadata>>();
+  ON_CALL(*meta1, hash()).WillByDefault(Return(0));
+  auto meta2 = std::make_unique<NiceMock<MockCollMetadata>>();
+  ON_CALL(*meta2, hash()).WillByDefault(Return(0));
+
+  auto record1 = std::make_unique<CollRecord>(1, std::move(meta1), 10);
+  auto record2 = std::make_unique<CollRecord>(1, std::move(meta2), 20);
+  EXPECT_NE(record1->hash(), record2->hash());
+}
+
+TEST_F(CollRecordTest, IterationAffectsEquals) {
+  auto meta1 = std::make_unique<NiceMock<MockCollMetadata>>();
+  ON_CALL(*meta1, equals(_)).WillByDefault(Return(true));
+  auto meta2 = std::make_unique<NiceMock<MockCollMetadata>>();
+  ON_CALL(*meta2, equals(_)).WillByDefault(Return(true));
+
+  auto record1 = std::make_unique<CollRecord>(1, std::move(meta1), 10);
+  auto record2 = std::make_unique<CollRecord>(1, std::move(meta2), 20);
+  EXPECT_FALSE(record1->equals(*record2));
+}
+
 } // namespace

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2325,6 +2325,25 @@ cvars:
      in iteration 4 and 5).
      Set to 0 to disable recording past collectives.
 
+ - name        : NCCL_COLLTRACE_ITERATION_MODE
+   type        : bool
+   default     : false
+   description : |-
+     If true, CommDumpPlugin retains all collectives from recent training
+     iterations (set via ncclxSetIteration) instead of a fixed count.
+     The number of iterations retained is controlled by
+     NCCL_COLLTRACE_RECORD_MAX_ITERATIONS. Falls back to a hard upper bound
+     (NCCL_COLLTRACE_ITERATION_UPPER_BOUND, default 3000) if iteration
+     tracking is not active.
+
+ - name        : NCCL_COLLTRACE_ITERATION_UPPER_BOUND
+   type        : int
+   default     : 3000
+   description : |-
+     Hard upper bound on past collectives retained when
+     NCCL_COLLTRACE_ITERATION_MODE is enabled. Prevents unbounded growth
+     if ncclxSetIteration is never called.
+
  - name        : NCCL_COLLTRACE_SLOW_COLL_THRESHOLD_BY_PG
    type        : stringlist
    default     :


### PR DESCRIPTION
Summary:

Add clearCommImpl to CommsMonitor for test cleanup. Allows tests to deregister all communicators between test cases to avoid stale entries.

Reviewed By: minsii

Differential Revision: D104743659


