### PR TITLE
Add selective dump (#2501)

### DIFF
--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <fmt/core.h>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -24,22 +25,63 @@
 #include "meta/comms-monitor/CommsMonitor.h"
 
 using meta::comms::colltrace::CommDumpPlugin;
+using meta::comms::ncclx::DumpFieldSet;
+
+namespace {
+
+DumpFieldSet parseRequestFields(
+    const std::optional<std::string>& requestFieldsStr) {
+  if (!requestFieldsStr.has_value() || requestFieldsStr->empty()) {
+    return {};
+  }
+  DumpFieldSet fields;
+  std::istringstream ss(*requestFieldsStr);
+  std::string token;
+  while (std::getline(ss, token, ';')) {
+    if (!token.empty()) {
+      fields.insert(std::move(token));
+    }
+  }
+  return fields;
+}
+
+bool anyKeyRequested(
+    const DumpFieldSet& fields,
+    std::initializer_list<std::string_view> keys) {
+  if (fields.empty()) {
+    return true;
+  }
+  for (auto key : keys) {
+    if (fields.contains(std::string{key})) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
 
 namespace meta::comms::ncclx {
+
+bool isKeyRequested(const DumpFieldSet& fields, std::string_view key) {
+  return fields.empty() || fields.contains(std::string{key});
+}
+
 std::unordered_map<std::string, std::string> dumpNewCollTrace(
-    meta::comms::colltrace::ICollTrace& colltrace) {
+    meta::comms::colltrace::ICollTrace& colltrace,
+    const DumpFieldSet& requestFields) {
   auto commDumpPluginMaybe = colltrace.getPluginByName(
       std::string{CommDumpPlugin::kCommDumpPluginName});
   auto commDumpPluginPtr = dynamic_cast<CommDumpPlugin*>(commDumpPluginMaybe);
   if (commDumpPluginPtr == nullptr) {
     return {};
   }
+
   auto dump = commDumpPluginPtr->dump();
   if (dump.hasError()) {
     return {};
   }
-
-  return meta::comms::colltrace::commDumpToMap(dump.value());
+  return meta::comms::colltrace::commDumpToMap(dump.value(), requestFields);
 }
 
 bool waitForCollTraceDrain(
@@ -65,11 +107,16 @@ bool waitForCollTraceDrain(
 } // namespace meta::comms::ncclx
 
 using meta::comms::ncclx::dumpNewCollTrace;
+using meta::comms::ncclx::isKeyRequested;
 
 namespace {
 // NOTE: Keep in sync with scripts/lobanova/nccl/nccl_dump.thrift
 void dumpProcessGlobalErrors(
-    std::unordered_map<std::string, std::string>& map) {
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
+  if (!isKeyRequested(requestFields, "processGlobalErrors")) {
+    return;
+  }
   if (!NCCL_COMM_DUMP_ENABLE_PROCESS_GLOBAL_ERRORS) {
     return;
   }
@@ -123,26 +170,44 @@ static void dumpCommInfo(
 static void dumpCommInfo(
     const CommLogData* logMetaData,
     const ncclx::comms_monitor::CommStateInfo& stateInfo,
-    std::unordered_map<std::string, std::string>& map) {
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
   if (logMetaData != nullptr) {
-    map["commHash"] = toQuotedString(hashToHexStr(logMetaData->commHash));
-    map["rank"] = std::to_string(logMetaData->rank);
-    map["commDesc"] = toQuotedString(logMetaData->commDesc);
-    map["nRanks"] = std::to_string(logMetaData->nRanks);
+    if (isKeyRequested(requestFields, "commHash")) {
+      map["commHash"] = toQuotedString(hashToHexStr(logMetaData->commHash));
+    }
+    if (isKeyRequested(requestFields, "rank")) {
+      map["rank"] = std::to_string(logMetaData->rank);
+    }
+    if (isKeyRequested(requestFields, "commDesc")) {
+      map["commDesc"] = toQuotedString(logMetaData->commDesc);
+    }
+    if (isKeyRequested(requestFields, "nRanks")) {
+      map["nRanks"] = std::to_string(logMetaData->nRanks);
+    }
   } else {
     XLOGF(DBG2, "CommDump: logMetaData is disabled. No trace to dump");
     return;
   }
 
-  map["localRank"] = std::to_string(stateInfo.localRank);
-  map["node"] = std::to_string(stateInfo.node);
-  map["localRanks"] = std::to_string(stateInfo.nLocalRanks);
-  map["nNodes"] = std::to_string(stateInfo.nNodes);
+  if (isKeyRequested(requestFields, "localRank")) {
+    map["localRank"] = std::to_string(stateInfo.localRank);
+  }
+  if (isKeyRequested(requestFields, "node")) {
+    map["node"] = std::to_string(stateInfo.node);
+  }
+  if (isKeyRequested(requestFields, "localRanks")) {
+    map["localRanks"] = std::to_string(stateInfo.nLocalRanks);
+  }
+  if (isKeyRequested(requestFields, "nNodes")) {
+    map["nNodes"] = std::to_string(stateInfo.nNodes);
+  }
 }
 
 static void dumpMapperTrace(
     ncclx::colltrace::MapperTrace& mapperTrace,
-    std::unordered_map<std::string, std::string>& map) {
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
   auto dump = mapperTrace.dump();
 
   XLOGF(
@@ -151,21 +216,30 @@ static void dumpMapperTrace(
       dump.unfinishedRequests.size(),
       dump.currentColl != nullptr ? 1 : 0);
 
-  if (dump.currentColl != nullptr) {
-    map["MT_currentColl"] = folly::toJson(dump.currentColl->toDynamic());
-  } else {
-    map["MT_currentColl"] = "null";
+  if (isKeyRequested(requestFields, "MT_currentColl")) {
+    if (dump.currentColl != nullptr) {
+      map["MT_currentColl"] = folly::toJson(dump.currentColl->toDynamic());
+    } else {
+      map["MT_currentColl"] = "null";
+    }
   }
 
-  map["MT_unfinishedRequests"] = serializeObjects(dump.unfinishedRequests);
-  map["MT_recvNotifiedByPeer"] = mapToJson(dump.recvNotifiedByPeer);
-  map["MT_putFinishedByPeer"] = mapToJson(dump.putFinishedByPeer);
+  if (isKeyRequested(requestFields, "MT_unfinishedRequests")) {
+    map["MT_unfinishedRequests"] = serializeObjects(dump.unfinishedRequests);
+  }
+  if (isKeyRequested(requestFields, "MT_recvNotifiedByPeer")) {
+    map["MT_recvNotifiedByPeer"] = mapToJson(dump.recvNotifiedByPeer);
+  }
+  if (isKeyRequested(requestFields, "MT_putFinishedByPeer")) {
+    map["MT_putFinishedByPeer"] = mapToJson(dump.putFinishedByPeer);
+  }
 }
 
 static void dumpProxyTrace(
     const ProxyTrace* ProxyTrace,
     uint64_t commHash,
-    std::unordered_map<std::string, std::string>& map) {
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
   if (ProxyTrace) {
     auto dump = ProxyTrace->dump(commHash);
 
@@ -175,9 +249,15 @@ static void dumpProxyTrace(
         dump.pastColls.size(),
         dump.activeOps.size());
 
-    map["PT_pastColls"] = serializeObjects(dump.pastColls);
-    map["PT_activeOps"] = serializeObjects(dump.activeOps);
-    map["PT_activeColls"] = serializeObjects(dump.activeColls);
+    if (isKeyRequested(requestFields, "PT_pastColls")) {
+      map["PT_pastColls"] = serializeObjects(dump.pastColls);
+    }
+    if (isKeyRequested(requestFields, "PT_activeOps")) {
+      map["PT_activeOps"] = serializeObjects(dump.activeOps);
+    }
+    if (isKeyRequested(requestFields, "PT_activeColls")) {
+      map["PT_activeColls"] = serializeObjects(dump.activeColls);
+    }
   } else {
     XLOGF(DBG2, "CommDump: PROXYTRACE is disabled. No trace to dump");
   }
@@ -185,29 +265,65 @@ static void dumpProxyTrace(
 
 static void dumpMemoryTrace(
     const std::shared_ptr<meta::comms::memtrace::MemoryTrace>& memTracer,
-    std::unordered_map<std::string, std::string>& map) {
-  if (memTracer) {
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
+  if (memTracer && isKeyRequested(requestFields, "memory")) {
     map["memory"] = memTracer->dump();
   }
 }
 
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
-    const ncclx::comms_monitor::NcclCommMonitorInfo& info) {
+    const ncclx::comms_monitor::NcclCommMonitorInfo& info,
+    const std::unordered_set<std::string>& requestFields) {
   std::unordered_map<std::string, std::string> map;
-  dumpCommInfo(&info.logMetaData, info.stateInfo, map);
-  if (info.newCollTrace != nullptr) {
-    map.merge(dumpNewCollTrace(*info.newCollTrace));
+
+  if (anyKeyRequested(
+          requestFields,
+          {"commHash",
+           "rank",
+           "localRank",
+           "node",
+           "nRanks",
+           "localRanks",
+           "nNodes",
+           "commDesc"})) {
+    dumpCommInfo(&info.logMetaData, info.stateInfo, map, requestFields);
+  }
+
+  if (info.newCollTrace != nullptr &&
+      anyKeyRequested(
+          requestFields,
+          {"CT_pastColls",
+           "CT_currentColls",
+           "CT_pendingColls",
+           "CT_currentIteration",
+           "CT_currentIterationCommTimeUs"})) {
+    map.merge(dumpNewCollTrace(*info.newCollTrace, requestFields));
     XLOGF(DBG2, "commDumpByMonitorInfo: Dumped from colltrace");
   }
-  dumpProxyTrace(info.proxyTrace.get(), info.logMetaData.commHash, map);
 
-  if (info.mapperTrace != nullptr) {
-    dumpMapperTrace(*info.mapperTrace, map);
-  } else {
-    XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
+  if (anyKeyRequested(
+          requestFields, {"PT_pastColls", "PT_activeOps", "PT_activeColls"})) {
+    dumpProxyTrace(
+        info.proxyTrace.get(), info.logMetaData.commHash, map, requestFields);
   }
-  dumpProcessGlobalErrors(map);
-  dumpMemoryTrace(info.memTracer, map);
+
+  if (anyKeyRequested(
+          requestFields,
+          {"MT_currentColl",
+           "MT_unfinishedRequests",
+           "MT_recvNotifiedByPeer",
+           "MT_putFinishedByPeer"})) {
+    if (info.mapperTrace != nullptr) {
+      dumpMapperTrace(*info.mapperTrace, map, requestFields);
+    } else {
+      XLOGF(DBG2, "CommDump: MAPPERTRACE is disabled. No trace to dump");
+    }
+  }
+
+  dumpProcessGlobalErrors(map, requestFields);
+  dumpMemoryTrace(info.memTracer, map, requestFields);
+
   return map;
 }
 
@@ -261,7 +377,9 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDumpAll(
         std::unordered_map<std::string, std::string>>& map,
     std::optional<std::string> requestFieldsStr) {
   initEnv();
-  auto commDumpsMaybe = ncclx::comms_monitor::CommsMonitor::commDumpAll();
+  auto requestFields = parseRequestFields(requestFieldsStr);
+  auto commDumpsMaybe =
+      ncclx::comms_monitor::CommsMonitor::commDumpAll(requestFields);
   if (!commDumpsMaybe.has_value()) {
     return ncclInternalError;
   }

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -258,7 +258,8 @@ __attribute__((visibility("default"))) ncclResult_t ncclCommDump(
 __attribute__((visibility("default"))) ncclResult_t ncclCommDumpAll(
     std::unordered_map<
         std::string,
-        std::unordered_map<std::string, std::string>>& map) {
+        std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFieldsStr) {
   initEnv();
   auto commDumpsMaybe = ncclx::comms_monitor::CommsMonitor::commDumpAll();
   if (!commDumpsMaybe.has_value()) {

--- a/comms/ncclx/meta/commDump.h
+++ b/comms/ncclx/meta/commDump.h
@@ -4,12 +4,19 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "comms/utils/colltrace/CollTraceInterface.h"
 
 namespace meta::comms::ncclx {
+
+using DumpFieldSet = std::unordered_set<std::string>;
+
+bool isKeyRequested(const DumpFieldSet& fields, std::string_view key);
+
 std::unordered_map<std::string, std::string> dumpNewCollTrace(
-    meta::comms::colltrace::ICollTrace& colltrace);
+    meta::comms::colltrace::ICollTrace& colltrace,
+    const DumpFieldSet& requestFields = {});
 
 bool waitForCollTraceDrain(
     meta::comms::colltrace::ICollTrace& colltrace,

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -7,7 +7,9 @@
 #include "comms/ctran/Ctran.h" // access to incomplete type
 
 #include "comms/utils/colltrace/NetworkPerfMonitor.h"
+#include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/commDump.h"
 
 constexpr static auto kGlobalInfoDumpMapKey = "GlobalInfo";
 
@@ -110,7 +112,11 @@ bool CommsMonitor::registerCommImpl(ncclComm_t comm) {
   return true;
 }
 
-CommDumpAllMap CommsMonitor::commDumpAllImpl() {
+CommDumpAllMap CommsMonitor::commDumpAllImpl(
+    const std::unordered_set<std::string>& requestFields) {
+  using meta::comms::colltrace::CommDumpPlugin;
+  using meta::comms::ncclx::isKeyRequested;
+
   std::vector<NcclCommMonitorInfo> commInfos;
   {
     auto lockedMap = commsMap_.rlock();
@@ -125,17 +131,57 @@ CommDumpAllMap CommsMonitor::commDumpAllImpl() {
       commInfos.size());
 
   CommDumpAllMap commDumpAllMap;
-  for (const auto& commMonitorInfo : commInfos) {
-    commDumpAllMap[hashToHexStr(commMonitorInfo.logMetaData.commHash)] =
-        commDumpByMonitorInfo(commMonitorInfo);
+
+  bool onlyGlobalInfo = !requestFields.empty() &&
+      std::all_of(
+          requestFields.begin(),
+          requestFields.end(),
+          [](const std::string& key) {
+            return key.starts_with("GlobalInfo::");
+          });
+
+  if (!onlyGlobalInfo) {
+    for (const auto& commMonitorInfo : commInfos) {
+      commDumpAllMap[hashToHexStr(commMonitorInfo.logMetaData.commHash)] =
+          commDumpByMonitorInfo(commMonitorInfo, requestFields);
+    }
   }
 
   std::unordered_map<std::string, std::string> globalInfoDumpMap;
-  auto networkPerfMonitorPtr =
-      ncclx::colltrace::NetworkPerfMonitor::getInstance();
-  if (networkPerfMonitorPtr != nullptr) {
-    networkPerfMonitorPtr->reportPerfStatsAsMap(globalInfoDumpMap);
+
+  if (isKeyRequested(requestFields, "GlobalInfo::NetworkPerfInfo")) {
+    auto networkPerfMonitorPtr =
+        ncclx::colltrace::NetworkPerfMonitor::getInstance();
+    if (networkPerfMonitorPtr != nullptr) {
+      networkPerfMonitorPtr->reportPerfStatsAsMap(globalInfoDumpMap);
+    }
   }
+
+  if (isKeyRequested(requestFields, "GlobalInfo::totalCommDurPerIterationUs")) {
+    int64_t totalCommTimeUs = 0;
+    int64_t curCommIter = -1;
+    for (const auto& commInfo : commInfos) {
+      if (commInfo.newCollTrace == nullptr) {
+        continue;
+      }
+      auto* plugin =
+          dynamic_cast<CommDumpPlugin*>(commInfo.newCollTrace->getPluginByName(
+              std::string{CommDumpPlugin::kCommDumpPluginName}));
+      if (plugin == nullptr) {
+        continue;
+      }
+      auto iterTime = plugin->getCurrentIterationCommTime();
+      if (iterTime.iteration > curCommIter) {
+        curCommIter = iterTime.iteration;
+        totalCommTimeUs = iterTime.commTimeUs;
+      } else if (iterTime.iteration == curCommIter) {
+        totalCommTimeUs += iterTime.commTimeUs;
+      }
+    }
+    globalInfoDumpMap["totalCommDurPerIterationUs"] =
+        std::to_string(totalCommTimeUs);
+  }
+
   if (!globalInfoDumpMap.empty()) {
     commDumpAllMap[kGlobalInfoDumpMapKey] = globalInfoDumpMap;
   }
@@ -224,7 +270,8 @@ CommsMonitor::getTopologyByCommDesc(const std::string& commDesc) {
   }
 }
 
-/*static*/ std::optional<CommDumpAllMap> CommsMonitor::commDumpAll() {
+/*static*/ std::optional<CommDumpAllMap> CommsMonitor::commDumpAll(
+    const std::unordered_set<std::string>& requestFields) {
   if (!NCCL_COMMSMONITOR_ENABLE) {
     static bool logDumpAllUnavailable = false;
     if (!logDumpAllUnavailable) {
@@ -238,7 +285,7 @@ CommsMonitor::getTopologyByCommDesc(const std::string& commDesc) {
   if (commMonitorPtr == nullptr) {
     return std::nullopt;
   }
-  return commMonitorPtr->commDumpAllImpl();
+  return commMonitorPtr->commDumpAllImpl(requestFields);
 }
 
 /*static*/ std::optional<NcclCommMonitorInfo>

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -217,6 +217,13 @@ CommsMonitor::getTopologyByCommDesc(const std::string& commDesc) {
   return commsMonitorSingleton.try_get();
 }
 
+/*static*/ void CommsMonitor::testOnlyClearComms() {
+  auto commMonitorPtr = getInstance();
+  if (commMonitorPtr != nullptr) {
+    commMonitorPtr->commsMap_.wlock()->clear();
+  }
+}
+
 /*static*/ std::optional<CommDumpAllMap> CommsMonitor::commDumpAll() {
   if (!NCCL_COMMSMONITOR_ENABLE) {
     static bool logDumpAllUnavailable = false;

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -69,6 +69,9 @@ class CommsMonitor {
   // If any failure happened during calling this function, it will return -1.
   static int64_t getNumOfCommMonitoring();
 
+  // For testing only. Clears all registered communicators from the singleton.
+  static void testOnlyClearComms();
+
  private:
   bool registerCommImpl(ncclComm_t comm);
   bool deregisterCommImpl(ncclComm_t comm);

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_set>
 
 #include "comm.h"
 #include "device.h"
@@ -56,7 +57,8 @@ class CommsMonitor {
  public:
   static bool registerComm(ncclComm_t comm);
   static bool deregisterComm(ncclComm_t comm);
-  static std::optional<CommDumpAllMap> commDumpAll();
+  static std::optional<CommDumpAllMap> commDumpAll(
+      const std::unordered_set<std::string>& requestFields = {});
 
   static std::optional<NcclCommMonitorInfo> getCommInfoByCommPtr(
       ncclComm_t comm);
@@ -75,7 +77,8 @@ class CommsMonitor {
  private:
   bool registerCommImpl(ncclComm_t comm);
   bool deregisterCommImpl(ncclComm_t comm);
-  CommDumpAllMap commDumpAllImpl();
+  CommDumpAllMap commDumpAllImpl(
+      const std::unordered_set<std::string>& requestFields);
 
   static std::shared_ptr<CommsMonitor> getInstance();
 
@@ -86,5 +89,6 @@ class CommsMonitor {
 } // namespace ncclx::comms_monitor
 
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
-    const ncclx::comms_monitor::NcclCommMonitorInfo&
-        info); // resides in commDump.cc
+    const ncclx::comms_monitor::NcclCommMonitorInfo& info,
+    const std::unordered_set<std::string>& requestFields =
+        {}); // resides in commDump.cc

--- a/comms/ncclx/meta/design_docs/selective_field_dump.md
+++ b/comms/ncclx/meta/design_docs/selective_field_dump.md
@@ -1,0 +1,99 @@
+# Selective Field Dump via requestFields Hint
+
+## Context
+
+`ncclCommDumpAll` and `ncclCommDump` dump everything for every communicator —
+comm info, colltrace, proxy trace, mapper trace, process global errors, memory,
+and global info. This is expensive when callers only need a subset (e.g., just
+the aggregated iteration time). We add a `requestFields` hint that specifies
+which individual output keys to include. Each dump function checks which of its
+keys are requested and only produces those, minimizing overhead.
+
+## API
+
+```cpp
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>> map;
+ncclCommDumpAll(map, "CT_pastColls;rank;GlobalInfo::totalCommDurPerIterationUs");
+```
+
+From Python (via TorchComms):
+```python
+dump = comm_dump_all(request_fields="GlobalInfo::totalCommDurPerIterationUs")
+total_us = int(dump["GlobalInfo"]["totalCommDurPerIterationUs"])
+```
+
+The `requestFields` parameter is `std::optional<std::string>` (default:
+`std::nullopt`). When `std::nullopt`, all fields are dumped — fully backward
+compatible.
+
+Values are semicolon-separated key names.
+
+## Key-Level Filtering
+
+Each dump function takes `const DumpFieldSet& requestFields` and only produces
+keys that are in the set (or all keys if the set is empty). A function is
+skipped entirely if none of its keys are requested (`anyKeyRequested` check).
+
+### Per-Communicator Keys
+
+| Source function | Output keys |
+|----------------|------------|
+| `dumpCommInfo()` | commHash, rank, localRank, node, nRanks, localRanks, nNodes, commDesc |
+| `dumpNewCollTrace()` → `commDumpToMap()` | CT_pastColls, CT_currentColls, CT_pendingColls, CT_currentIteration, CT_currentIterationCommTimeUs |
+| `dumpProxyTrace()` | PT_pastColls, PT_activeOps, PT_activeColls |
+| `dumpMapperTrace()` | MT_currentColl, MT_unfinishedRequests, MT_recvNotifiedByPeer, MT_putFinishedByPeer |
+| `dumpProcessGlobalErrors()` | processGlobalErrors |
+| `dumpMemoryTrace()` | memory |
+
+### GlobalInfo Keys (in outer map under "GlobalInfo")
+
+| requestFields value | What it produces |
+|--------------------|-----------------|
+| `GlobalInfo::NetworkPerfInfo` | NetworkPerfMonitor stats |
+| `GlobalInfo::totalCommDurPerIterationUs` | Aggregated iteration comm time across all communicators |
+
+## Architecture
+
+```
+ncclCommDumpAll(map, requestFields)
+  │
+  ├─ parseRequestFields(requestFields)  // Split by ";" → unordered_set<string>
+  │                                      // std::nullopt → empty set = dump all
+  │
+  └─ CommsMonitor::commDumpAll(requestFields)
+       │
+       └─ commDumpAllImpl(requestFields)
+            │
+            ├─ per communicator:
+            │    commDumpByMonitorInfo(info, requestFields)
+            │      ├─ anyKeyRequested({commHash,rank,...})?  → dumpCommInfo(requestFields)
+            │      ├─ anyKeyRequested({CT_*})?               → dumpNewCollTrace(requestFields)
+            │      │                                           → commDumpToMap(requestFields)
+            │      ├─ anyKeyRequested({PT_*})?               → dumpProxyTrace(requestFields)
+            │      ├─ anyKeyRequested({MT_*})?               → dumpMapperTrace(requestFields)
+            │      ├─ isKeyRequested(processGlobalErrors)?   → dumpProcessGlobalErrors(requestFields)
+            │      └─ isKeyRequested(memory)?                → dumpMemoryTrace(requestFields)
+            │
+            ├─ isKeyRequested(GlobalInfo::NetworkPerfInfo)?
+            │    → NetworkPerfMonitor::reportPerfStatsAsMap()
+            │
+            └─ isKeyRequested(GlobalInfo::totalCommDurPerIterationUs)?
+                 → aggregate getCurrentIterationCommTime() across all comms
+```
+
+The `DumpFieldSet` (alias for `std::unordered_set<std::string>`) is parsed once
+at the entry point and threaded through the entire call chain. Helper functions:
+- `isKeyRequested(fields, key)` — true if set is empty or contains the key
+- `anyKeyRequested(fields, {key1, key2, ...})` — true if set is empty or
+  contains any of the keys (used to skip entire dump functions)
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `v2_27/src/nccl.h.in`, `v2_29/src/nccl.h.in`, `v2_30/src/nccl.h.in` | `ncclCommDumpAll` with `std::optional<std::string> requestFields` parameter |
+| `meta/commDump.h` | `DumpFieldSet`, `parseRequestFields()`, `isKeyRequested()`, `anyKeyRequested()` |
+| `meta/commDump.cc` | Parsing, per-key gating in all dump functions, `commDumpByMonitorInfo` |
+| `meta/comms-monitor/CommsMonitor.cc` | `commDumpAllImpl` with GlobalInfo key gating |
+| `meta/tests/CommDumpTest.cc` | Integration tests for selective dump |
+| `comms/utils/colltrace/plugins/CommDumpPlugin.cc` | `commDumpToMap(dump, requestFields)` with per-key filtering |

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -21,6 +21,7 @@
 #include "meta/NcclxConfig.h"
 #include "meta/colltrace/ProxyMock.h"
 #include "meta/commDump.h"
+#include "meta/comms-monitor/CommsMonitor.h"
 #include "meta/wrapper/CtranExComm.h"
 
 static bool VERBOSE = true;
@@ -1094,6 +1095,297 @@ TEST_F(CommDumpTest, DISABLED_DumpWhileCommsInDestruct) {
     comm_ptr.reset();
     t.join();
   }
+}
+
+TEST_F(CommDumpTest, DumpAllWithRequestFieldsCommInfoOnly) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(dumpAll, std::string{"commHash;rank;nRanks"});
+  ASSERT_EQ(res, ncclSuccess);
+  EXPECT_GE(dumpAll.size(), 1);
+
+  auto commHash = hashToHexStr(comm->commHash);
+  ASSERT_TRUE(dumpAll.count(commHash));
+  const auto& commDump = dumpAll.at(commHash);
+
+  EXPECT_EQ(commDump.count("commHash"), 1);
+  EXPECT_EQ(commDump.count("rank"), 1);
+  EXPECT_EQ(commDump.count("nRanks"), 1);
+
+  // Keys not requested should be absent
+  EXPECT_EQ(commDump.count("localRank"), 0);
+  EXPECT_EQ(commDump.count("node"), 0);
+  EXPECT_EQ(commDump.count("CT_pastColls"), 0);
+  EXPECT_EQ(commDump.count("CT_pendingColls"), 0);
+  EXPECT_EQ(commDump.count("CT_currentColls"), 0);
+  EXPECT_EQ(commDump.count("PT_pastColls"), 0);
+  EXPECT_EQ(commDump.count("PT_activeOps"), 0);
+  EXPECT_EQ(commDump.count("memory"), 0);
+}
+
+TEST_F(CommDumpTest, DumpAllWithRequestFieldsTotalCommDurPerIteration) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(
+      dumpAll, std::string{"GlobalInfo::totalCommDurPerIterationUs"});
+  ASSERT_EQ(res, ncclSuccess);
+
+  // Per-communicator maps should be empty (no fields requested)
+  auto commHash = hashToHexStr(comm->commHash);
+  if (dumpAll.count(commHash)) {
+    const auto& commDump = dumpAll.at(commHash);
+    EXPECT_EQ(commDump.count("CT_pastColls"), 0);
+    EXPECT_EQ(commDump.count("commHash"), 0);
+  }
+
+  // Aggregated result should be in GlobalInfo
+  ASSERT_TRUE(dumpAll.count("GlobalInfo"));
+  const auto& globalInfo = dumpAll.at("GlobalInfo");
+  EXPECT_EQ(globalInfo.count("totalCommDurPerIterationUs"), 1);
+}
+
+TEST_F(CommDumpTest, DumpAllWithEmptyRequestFieldsDumpsEverything) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(dumpAll);
+  ASSERT_EQ(res, ncclSuccess);
+  EXPECT_GE(dumpAll.size(), 1);
+
+  auto commHash = hashToHexStr(comm->commHash);
+  ASSERT_TRUE(dumpAll.count(commHash));
+  const auto& commDump = dumpAll.at(commHash);
+
+  EXPECT_EQ(commDump.count("commHash"), 1);
+  EXPECT_EQ(commDump.count("rank"), 1);
+  EXPECT_EQ(commDump.count("CT_pastColls"), 1);
+  EXPECT_EQ(commDump.count("CT_pendingColls"), 1);
+  EXPECT_EQ(commDump.count("CT_currentColls"), 1);
+  EXPECT_EQ(commDump.count("PT_pastColls"), 1);
+  EXPECT_EQ(commDump.count("PT_activeOps"), 1);
+}
+
+TEST_F(CommDumpTest, DumpAllGlobalInfoOnlySkipsPerCommDump) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(
+      dumpAll, std::string{"GlobalInfo::totalCommDurPerIterationUs"});
+  ASSERT_EQ(res, ncclSuccess);
+
+  // Per-communicator entries should NOT exist at all (shortcut skipped the
+  // loop)
+  auto commHash = hashToHexStr(comm->commHash);
+  EXPECT_EQ(dumpAll.count(commHash), 0)
+      << "Per-communicator dump should be skipped when only GlobalInfo keys requested";
+
+  // GlobalInfo should be present
+  ASSERT_TRUE(dumpAll.count("GlobalInfo"));
+  EXPECT_EQ(dumpAll.at("GlobalInfo").count("totalCommDurPerIterationUs"), 1);
+}
+
+TEST_F(CommDumpTest, DumpAllSingleCollTraceKey) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+  auto collRecordGuard = EnvRAII(NCCL_COLLTRACE_RECORD_MAX, -1);
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(dumpAll, std::string{"CT_pastColls"});
+  ASSERT_EQ(res, ncclSuccess);
+
+  auto commHash = hashToHexStr(comm->commHash);
+  ASSERT_TRUE(dumpAll.count(commHash));
+  const auto& commDump = dumpAll.at(commHash);
+
+  // Only CT_pastColls should be present
+  EXPECT_EQ(commDump.count("CT_pastColls"), 1);
+  EXPECT_EQ(commDump.count("CT_pendingColls"), 0);
+  EXPECT_EQ(commDump.count("CT_currentColls"), 0);
+  EXPECT_EQ(commDump.count("CT_currentIteration"), 0);
+  EXPECT_EQ(commDump.count("commHash"), 0);
+  EXPECT_EQ(commDump.count("rank"), 0);
+  EXPECT_EQ(commDump.count("PT_pastColls"), 0);
+  EXPECT_EQ(commDump.count("memory"), 0);
+}
+
+TEST_F(CommDumpTest, DumpAllMixedPerCommAndGlobalInfoKeys) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 3;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+  ASSERT_NE(comm->newCollTrace, nullptr);
+  EXPECT_TRUE(waitForCollTraceDrain(*comm->newCollTrace));
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(
+      dumpAll,
+      std::string{"rank;nRanks;GlobalInfo::totalCommDurPerIterationUs"});
+  ASSERT_EQ(res, ncclSuccess);
+
+  // Per-communicator should have only rank and nRanks
+  auto commHash = hashToHexStr(comm->commHash);
+  ASSERT_TRUE(dumpAll.count(commHash));
+  const auto& commDump = dumpAll.at(commHash);
+  EXPECT_EQ(commDump.count("rank"), 1);
+  EXPECT_EQ(commDump.count("nRanks"), 1);
+  EXPECT_EQ(commDump.count("commHash"), 0);
+  EXPECT_EQ(commDump.count("CT_pastColls"), 0);
+
+  // GlobalInfo should also be present
+  ASSERT_TRUE(dumpAll.count("GlobalInfo"));
+  EXPECT_EQ(dumpAll.at("GlobalInfo").count("totalCommDurPerIterationUs"), 1);
+}
+
+TEST_F(CommDumpTest, DumpAllProxyTraceKeyOnly) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace"});
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      dumpAll;
+  auto res = ncclCommDumpAll(dumpAll, std::string{"PT_pastColls"});
+  ASSERT_EQ(res, ncclSuccess);
+
+  auto commHash = hashToHexStr(comm->commHash);
+  ASSERT_TRUE(dumpAll.count(commHash));
+  const auto& commDump = dumpAll.at(commHash);
+
+  EXPECT_EQ(commDump.count("PT_pastColls"), 1);
+  EXPECT_EQ(commDump.count("PT_activeOps"), 0);
+  EXPECT_EQ(commDump.count("PT_activeColls"), 0);
+  EXPECT_EQ(commDump.count("commHash"), 0);
+  EXPECT_EQ(commDump.count("CT_pastColls"), 0);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ncclx/v2_27/src/nccl.h.in
+++ b/comms/ncclx/v2_27/src/nccl.h.in
@@ -950,6 +950,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -959,8 +960,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -1118,6 +1118,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -1127,8 +1128,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -1126,6 +1126,7 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #define NCCL_COMM_DUMP
 #define NCCL_COMM_DUMP_ALL
 
+#include <optional>
 #include <unordered_map>
 #include <string>
 /* Dump NCCL current internal state for a given communicator in a key-value store format.
@@ -1135,8 +1136,11 @@ ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std:
 /* Dump NCCL current internal state for all the communicators.
  * The returned map is in the format {commHash: {key: value}} where
  * {key: value} is the result of ncclCommDump in the communicator with hash commHash.
+ * requestFields: semicolon-separated list of field names to include (e.g. "rank;nRanks;CT_pastColls").
+ *   std::nullopt (default) dumps all fields.
  */
-ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map);
+ncclResult_t ncclCommDumpAll(std::unordered_map<std::string, std::unordered_map<std::string, std::string>>& map,
+    std::optional<std::string> requestFields = std::nullopt);
 
 #define NCCL_HAS_COMMS_TRACING_SERVICE_PORT
 ncclResult_t ncclCommsTracingServicePort(int& port);

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -286,31 +286,51 @@ IterationCommTime CommDumpPlugin::getCurrentIterationCommTime() const noexcept {
   return {locked->currentIteration, locked->currentIterationCommTimeUs};
 }
 
+namespace {
+bool isKeyReq(
+    const std::unordered_set<std::string>& fields,
+    std::string_view key) {
+  return fields.empty() || fields.contains(std::string{key});
+}
+} // namespace
+
 std::unordered_map<std::string, std::string> commDumpToMap(
-    const CollTraceDump& dump) {
+    const CollTraceDump& dump,
+    const std::unordered_set<std::string>& requestFields) {
   std::unordered_map<std::string, std::string> map;
 
-  auto pastColls = folly::dynamic::array();
-  for (const auto& coll : dump.pastColls) {
-    pastColls.push_back(coll->toDynamic());
+  if (isKeyReq(requestFields, "CT_pastColls")) {
+    auto pastColls = folly::dynamic::array();
+    for (const auto& coll : dump.pastColls) {
+      pastColls.push_back(coll->toDynamic());
+    }
+    map["CT_pastColls"] = folly::toJson(pastColls);
   }
-  map["CT_pastColls"] = folly::toJson(pastColls);
 
-  auto pendingColls = folly::dynamic::array();
-  for (const auto& coll : dump.pendingColls) {
-    pendingColls.push_back(coll->toDynamic());
+  if (isKeyReq(requestFields, "CT_pendingColls")) {
+    auto pendingColls = folly::dynamic::array();
+    for (const auto& coll : dump.pendingColls) {
+      pendingColls.push_back(coll->toDynamic());
+    }
+    map["CT_pendingColls"] = folly::toJson(pendingColls);
   }
-  map["CT_pendingColls"] = folly::toJson(pendingColls);
 
-  auto currentColls = folly::dynamic::array();
-  for (const auto& coll : dump.currentColls) {
-    currentColls.push_back(coll->toDynamic());
+  if (isKeyReq(requestFields, "CT_currentColls")) {
+    auto currentColls = folly::dynamic::array();
+    for (const auto& coll : dump.currentColls) {
+      currentColls.push_back(coll->toDynamic());
+    }
+    map["CT_currentColls"] = folly::toJson(currentColls);
   }
-  map["CT_currentColls"] = folly::toJson(currentColls);
 
-  map["CT_currentIteration"] = std::to_string(dump.currentIteration);
-  map["CT_currentIterationCommTimeUs"] =
-      std::to_string(dump.currentIterationCommTimeUs);
+  if (isKeyReq(requestFields, "CT_currentIteration")) {
+    map["CT_currentIteration"] = std::to_string(dump.currentIteration);
+  }
+
+  if (isKeyReq(requestFields, "CT_currentIterationCommTimeUs")) {
+    map["CT_currentIterationCommTimeUs"] =
+        std::to_string(dump.currentIterationCommTimeUs);
+  }
 
   return map;
 }

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <memory>
 #include <queue>
+#include <unordered_set>
 #include <vector>
 
 #include <folly/MPMCQueue.h>
@@ -140,6 +141,7 @@ class CommDumpPlugin : public ICollTracePlugin {
 // Helper functions for CommDumpPlugin
 
 std::unordered_map<std::string, std::string> commDumpToMap(
-    const CollTraceDump& dump);
+    const CollTraceDump& dump,
+    const std::unordered_set<std::string>& requestFields = {});
 
 } // namespace meta::comms::colltrace


### PR DESCRIPTION
Summary:

Add selective field dump to ncclCommDumpAll via a requestFields hint. Callers can specify which field groups to include (e.g. "CommInfo;IterationTime"), skipping expensive dump operations for groups not requested.

Field groups: CommInfo, CollTrace, IterationTime, ProxyTrace, MapperTrace, ProcessGlobalErrors, Memory, GlobalInfo. When only IterationTime is requested, the lightweight getCurrentIterationCommTime() path is used instead of a full CommDumpPlugin::dump(), avoiding lock contention and JSON serialization of all past records.

Key changes:
- Parse requestFields hint into DumpFieldSet at ncclCommDumpAll entry point
- Thread DumpFieldSet through CommsMonitor::commDumpAll -> commDumpAllImpl -> commDumpByMonitorInfo
- Gate each dump function call (dumpCommInfo, dumpNewCollTrace, dumpProxyTrace, etc.) on whether the group is requested
- Add isDumpFieldRequested() helper (empty set = dump all, backward compatible)
- Add integration tests in CommDumpTest.cc for CommInfo-only, IterationTime-only, and default (all fields) scenarios

Reviewed By: minsii

Differential Revision: D104743416


