### PR TITLE
Switch CtranTcpDmSingleton from LeakySingleton to folly::Singleton (#2504)

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -275,7 +275,7 @@ commResult_t CtranTcpDm::isend(
       size,
       handle,
       &request));
-  req.track(transport_, request);
+  req.track(transport_.get(), request);
 
   return commSuccess;
 }
@@ -367,7 +367,7 @@ commResult_t CtranTcpDm::irecvConnected(
       &request,
       unpackPool));
 
-  req.track(transport_, request);
+  req.track(transport_.get(), request);
 
   return commSuccess;
 }

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -90,7 +90,7 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool);
 
  private:
-  ::comms::tcp_devmem::TransportInterface* transport_{nullptr};
+  std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;
   ctran::bootstrap::ServerSocket listenSocket_{
       static_cast<int>(NCCL_SOCKET_RETRY_CNT)};
   std::vector<sockaddr_storage> allListenSocketAddrs_{};

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
@@ -53,26 +53,31 @@ bool CtranTcpDmSingleton::supportBondTransport() {
   return false;
 }
 
-// Use a LeakySingleton to avoid shutdown order issues where CtranMapper
-// objects may outlive the singleton's destruction phase. LeakySingleton
-// intentionally leaks the object at shutdown to prevent crashes.
-folly::LeakySingleton<::comms::tcp_devmem::TransportInterface> tcpTransportPtr(
-    []() -> ::comms::tcp_devmem::TransportInterface* {
-      if (!CtranTcpDmSingleton::supportBondTransport()) {
-        return new ::comms::tcp_devmem::Transport();
-      }
+static folly::Singleton<::comms::tcp_devmem::TransportInterface>
+tcpTransportPtr([]() -> ::comms::tcp_devmem::TransportInterface* {
+  if (!CtranTcpDmSingleton::supportBondTransport()) {
+    return new ::comms::tcp_devmem::Transport();
+  }
 
-      auto devs = CtranTcpDmSingleton::getIfNames(
-          NCCL_IB_HCA, NCCL_CTRAN_IB_DEVICES_PER_RANK);
-      if (devs.size() && devs.front().size() == 1) {
-        return new ::comms::tcp_devmem::Transport();
-      } else {
-        return new ::comms::tcp_devmem::BondTransport(devs);
-      }
-    });
+  auto devs = CtranTcpDmSingleton::getIfNames(
+      NCCL_IB_HCA, NCCL_CTRAN_IB_DEVICES_PER_RANK);
+  if (devs.size() && devs.front().size() == 1) {
+    return new ::comms::tcp_devmem::Transport();
+  } else {
+    return new ::comms::tcp_devmem::BondTransport(devs);
+  }
+});
 
-::comms::tcp_devmem::TransportInterface* CtranTcpDmSingleton::getTransport() {
-  return &folly::LeakySingleton<::comms::tcp_devmem::TransportInterface>::get();
+std::shared_ptr<::comms::tcp_devmem::TransportInterface>
+CtranTcpDmSingleton::getTransport() {
+  auto ptr =
+      folly::Singleton<::comms::tcp_devmem::TransportInterface>::try_get();
+  if (!ptr) {
+    FB_ERRORTHROW_EX_NOCOMM(
+        commInternalError,
+        "TCP-DEVMEM: TransportInterface singleton is not available");
+  }
+  return ptr;
 }
 
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h
@@ -18,7 +18,8 @@ class CtranTcpDmSingleton {
 
   static bool supportBondTransport();
 
-  static ::comms::tcp_devmem::TransportInterface* getTransport();
+  static std::shared_ptr<::comms::tcp_devmem::TransportInterface>
+  getTransport();
 };
 
 } // namespace ctran


### PR DESCRIPTION
Summary:

LeakySingleton intentionally skips destruction at process exit, which meant Transport::shutdown() was never called in the Ctran path. switch to folly::Singleton to trigger the transport cleanup.

Reviewed By: fomichev

Differential Revision: D104762243


