### PR TITLE
Add missing #include <set> in CollTraceWrapper.cc

### DIFF
--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -2,6 +2,8 @@
 
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 
+#include <set>
+
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/RankUtils.h"


### PR DESCRIPTION
Summary: CollTraceWrapper.cc uses std::set but was missing #include <set>. This caused conda build failures for the nccl feedstock on the gbunified config.

Reviewed By: YulunW

Differential Revision: D104745879


