### PR TITLE
Add setup.py and version.script for NCCLX v2_30 (#2506)

### DIFF
--- a/comms/ncclx/v2_30/makefiles/common.mk
+++ b/comms/ncclx/v2_30/makefiles/common.mk
@@ -86,15 +86,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-# CUDA 13.0 requires c++17
-ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 13; echo $$?),0)
-  CXXSTD ?= -std=c++17
-else
-  CXXSTD ?= -std=c++14
-endif
+CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)

--- a/comms/ncclx/v2_30/setup.py
+++ b/comms/ncclx/v2_30/setup.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+from distutils.command.build import build as _build
+
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+from setuptools.command.egg_info import egg_info as _egg_info
+
+BUILDDIR = os.environ.get("BUILDDIR", None)
+if BUILDDIR is not None:
+    LIBDIR = os.path.join(BUILDDIR, "lib")
+    BUILDDIR = os.path.join(BUILDDIR, "pybind")
+    os.makedirs(BUILDDIR, exist_ok=True)
+
+
+class build(_build):
+    def initialize_options(self):
+        super().initialize_options()
+        self.build_base = BUILDDIR
+
+
+class egg_info(_egg_info):
+    def initialize_options(self):
+        super().initialize_options()
+        self.egg_base = BUILDDIR
+
+
+def get_cmdclass():
+    from pybind11.setup_helpers import build_ext
+
+    return {
+        "build": build,
+        "egg_info": egg_info,
+        "build_ext": build_ext,
+    }
+
+
+ext_modules = [
+    Pybind11Extension(
+        "ncclx_trainer_context",
+        ["../meta/py/wrapper.cc"],
+        library_dirs=[LIBDIR],
+        libraries=["nccl"],
+    ),
+]
+
+setup(
+    name="ncclx_trainer_context",
+    ext_modules=ext_modules,
+    cmdclass=get_cmdclass(),
+)

--- a/comms/ncclx/v2_30/src/version.script
+++ b/comms/ncclx/v2_30/src/version.script
@@ -1,0 +1,20 @@
+/*
+version.script controls symbol visibility, it exposes
+nccl: nccl(x)-related symbols
+cxa: Folly’s exception tracer intercepts all exceptions and uses
+    dlsym(RTLD_NEXT, "cxa...") to find the corresponding real symbols.
+    Therefore, it is necessary to expose certain cxa symbols from the libstdc++.
+    For further details, refer to the discussion in D64442615.
+*/
+{
+  global:
+      *nccl*;
+      *ctran*;
+      *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
+  /* Transitive symbols (e.g. coming from static libs) are not exported */
+  local:
+      *;
+};


### PR DESCRIPTION
Summary:

Add the NCCLX 2.30 internal build files needed for conda packaging:
- setup.py: pybind11 extension build configuration for ncclx_trainer_context (copied from v2_29 pattern)
- version.script: linker version script for symbol visibility (copied from v2_29)
- common.mk: hardcode -std=c++2a in host CXXFLAGS and unconditional CXXSTD=c++17 for NVCC, matching v2_29. Upstream NCCL 2.30 changed CXXSTD to c++14 on CUDA 12.x, but NCCLX includes folly headers (e.g. folly/functional/Invoke.h uses std::bool_constant) from .cu files which require c++17. Host .cc files need c++20 for folly xlog.h consteval.

Reviewed By: pavanbalaji

Differential Revision: D104855092


