### PR TITLE
Default to group rank 0 for scatter/gather root in distwrap

### DIFF
--- a/comms/torchcomms/distwrap/collectives.py
+++ b/comms/torchcomms/distwrap/collectives.py
@@ -347,8 +347,9 @@ def scatter(
         # Resolve group_src for torchcomms
         if group_src is None:
             if src is None:
-                raise ValueError("Either src or group_src must be specified")
-            group_src = get_group_rank(pg, src)
+                group_src = 0
+            else:
+                group_src = get_group_rank(pg, src)
         elif src is not None:
             raise ValueError("Cannot specify both src and group_src")
 
@@ -381,8 +382,9 @@ def gather(
         # Resolve group_dst for torchcomms
         if group_dst is None:
             if dst is None:
-                raise ValueError("Either dst or group_dst must be specified")
-            group_dst = get_group_rank(pg, dst)
+                group_dst = 0
+            else:
+                group_dst = get_group_rank(pg, dst)
         elif dst is not None:
             raise ValueError("Cannot specify both dst and group_dst")
 
@@ -600,8 +602,9 @@ def gather_object(
         # Resolve group_dst for torchcomms
         if group_dst is None:
             if dst is None:
-                raise ValueError("Either dst or group_dst must be specified")
-            group_dst = get_group_rank(pg, dst)
+                group_dst = 0
+            else:
+                group_dst = get_group_rank(pg, dst)
         elif dst is not None:
             raise ValueError("Cannot specify both dst and group_dst")
 
@@ -629,8 +632,9 @@ def scatter_object_list(
         # Resolve group_src for torchcomms
         if group_src is None:
             if src is None:
-                raise ValueError("Either src or group_src must be specified")
-            group_src = get_group_rank(pg, src)
+                group_src = 0
+            else:
+                group_src = get_group_rank(pg, src)
         elif src is not None:
             raise ValueError("Cannot specify both src and group_src")
 
@@ -665,8 +669,9 @@ def broadcast_object_list(
         # Resolve group_src for torchcomms
         if group_src is None:
             if src is None:
-                raise ValueError("Either src or group_src must be specified")
-            group_src = get_group_rank(pg, src)
+                group_src = 0
+            else:
+                group_src = get_group_rank(pg, src)
         elif src is not None:
             raise ValueError("Cannot specify both src and group_src")
 

--- a/comms/torchcomms/distwrap/tests/integration/ObjectCollectivesTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ObjectCollectivesTest.py
@@ -232,6 +232,58 @@ class ObjectCollectivesTest(unittest.TestCase):
         self.assertEqual(obj_0["tuple_as_list"], [1, "two", 3.0])
         self.assertIsNone(obj_0["none_value"])
 
+    def test_gather_object_default_dst(self) -> None:
+        """Test gather_object defaults to root=0 when dst is omitted (matching c10d)."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        obj = f"data_from_rank_{rank}"
+
+        if rank == 0:
+            object_gather_list = [None] * num_ranks
+        else:
+            object_gather_list = None
+
+        dist.gather_object(obj, object_gather_list=object_gather_list)
+
+        if rank == 0:
+            if object_gather_list is None:
+                raise AssertionError("object_gather_list is None")
+            for i in range(num_ranks):
+                self.assertEqual(object_gather_list[i], f"data_from_rank_{i}")
+
+    def test_scatter_object_list_default_src(self) -> None:
+        """Test scatter_object_list defaults to root=0 when src is omitted (matching c10d)."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+
+        if rank == 0:
+            scatter_input = [f"object_for_rank_{i}" for i in range(num_ranks)]
+        else:
+            scatter_input = None
+
+        scatter_output = [None]
+
+        dist.scatter_object_list(
+            scatter_output, scatter_object_input_list=scatter_input
+        )
+
+        self.assertEqual(scatter_output[0], f"object_for_rank_{rank}")
+
+    def test_broadcast_object_list_default_src(self) -> None:
+        """Test broadcast_object_list defaults to root=0 when src is omitted (matching c10d)."""
+        rank = dist.get_rank()
+
+        if rank == 0:
+            object_list = ["broadcast_string", 42]
+        else:
+            object_list = [None, None]
+
+        dist.broadcast_object_list(object_list)
+
+        self.assertEqual(object_list[0], "broadcast_string")
+        self.assertEqual(object_list[1], 42)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/comms/torchcomms/distwrap/tests/integration/ScatterGatherTest.py
+++ b/comms/torchcomms/distwrap/tests/integration/ScatterGatherTest.py
@@ -137,6 +137,52 @@ class ScatterGatherTest(unittest.TestCase):
                 expected = torch.full_like(gathered.cpu(), i + 1)
                 torch.testing.assert_close(gathered.cpu(), expected)
 
+    def test_scatter_default_src(self) -> None:
+        """Test scatter defaults to root=0 when src is omitted (matching c10d)."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        output_tensor = torch.zeros(1024, dtype=torch.float, device=device)
+
+        if rank == 0:
+            scatter_list = [
+                torch.ones(1024, dtype=torch.float, device=device) * (i + 1)
+                for i in range(num_ranks)
+            ]
+        else:
+            scatter_list = None
+
+        dist.scatter(output_tensor, scatter_list)
+
+        expected = torch.full_like(output_tensor.cpu(), rank + 1)
+        torch.testing.assert_close(output_tensor.cpu(), expected)
+
+    def test_gather_default_dst(self) -> None:
+        """Test gather defaults to root=0 when dst is omitted (matching c10d)."""
+        rank = dist.get_rank()
+        num_ranks = dist.get_world_size()
+        device = get_device(rank)
+
+        input_tensor = torch.ones(1024, dtype=torch.float, device=device) * (rank + 1)
+
+        if rank == 0:
+            gather_list = [
+                torch.zeros(1024, dtype=torch.float, device=device)
+                for _ in range(num_ranks)
+            ]
+        else:
+            gather_list = None
+
+        dist.gather(input_tensor, gather_list)
+
+        if rank == 0:
+            if gather_list is None:
+                raise AssertionError("gather_list is None")
+            for i, gathered in enumerate(gather_list):
+                expected = torch.full_like(gathered.cpu(), i + 1)
+                torch.testing.assert_close(gathered.cpu(), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
c10d defaults to rank 0 when src/dst is omitted for `scatter`, `gather`, `gather_object`, `scatter_object_list`, and `broadcast_object_list` . `distwrap `currently raises ValueError instead , which breaks compatibility. Fixed to follow c10d parity 

Also adds integration tests for all mentioned functions. 