### PR TITLE
Add direct NVLink allgather, reduce-scatter, and hierarchical allgather kernels (#2509)

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -5,50 +5,11 @@
 #include <cstddef>
 
 #include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
-
-struct Memcpy {
-  template <typename... Args>
-  __device__ __forceinline__ static void send(
-      char* staging,
-      const char* src,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(staging, src, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void recv(
-      char* dst,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(dst, staging, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void forward(
-      char* dst,
-      char* fwd_staging,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    if (dst) {
-      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
-    } else {
-      memcpy_vectorized(fwd_staging, staging, nbytes, group);
-    }
-  }
-};
 
 template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 struct TileReduce {

--- a/comms/pipes/MemcpyCopyOp.cuh
+++ b/comms/pipes/MemcpyCopyOp.cuh
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+struct Memcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(dst, staging, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    if (dst) {
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
+    } else {
+      memcpy_vectorized(fwd_staging, staging, nbytes, group);
+    }
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -21,7 +21,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
       config_(multiPeerNvlTransportConfig),
-      memSharingMode_(GpuMemHandler::detectBestMode()) {
+      memSharingMode_(
+          config_.memSharingMode.value_or(GpuMemHandler::detectBestMode())) {
   // ===========================================================================
   // Buffer Allocation
   // ===========================================================================

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -101,6 +101,11 @@ struct MultiPeerNvlTransportConfig {
   // on P2pNvlTransportDevice. When 0 (default), LL is disabled.
   // Use ll_buffer_size() from LlPacket.cuh to compute from message size.
   std::size_t llBufferSize{0};
+
+  // Override the automatically selected memory sharing mode. Leaving this unset
+  // keeps the default behavior: fabric handles when available, cudaIpc
+  // otherwise.
+  std::optional<MemSharingMode> memSharingMode;
 };
 
 /**

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -1243,8 +1243,7 @@ void MultipeerIbgdaTransport::exchange() {
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
 
   for (int peer = 0; peer < numPeers; peer++) {
-    // One NicDeviceIbgdaResourcesBuildSpec per physical NIC. NIC-fast
-    // interleaving: slot s = q * numNics_ + nic.
+    // One NicDeviceIbgdaResourcesBuildSpec per exposed physical NIC.
     auto& bp = buildParams[peer];
     bp.h_nicDeviceIbgdaResources.resize(numNics_);
     for (int n = 0; n < numNics_; ++n) {
@@ -1255,9 +1254,9 @@ void MultipeerIbgdaTransport::exchange() {
       nicSpec.deviceId = n;
     }
 
-    for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDevices_[nic].qpGroups;
-      auto& nicSpec = bp.h_nicDeviceIbgdaResources[nic];
+    for (int n = 0; n < numNics_; n++) {
+      auto& nicQps = nicDevices_[n].qpGroups;
+      auto& nicSpec = bp.h_nicDeviceIbgdaResources[n];
       for (int q = 0; q < numQps; q++) {
         const int qpIdx = peer * numQps + q;
         doca_error_t err = doca_gpu_verbs_get_qp_dev(

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -59,8 +59,7 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
  * Owns the QPs (primary + companion for compound put+signal+counter ops)
  * and the sink lkey for atomic FA responses on a single NIC. The
  * P2pIbgdaTransportDevice holds a `DeviceSpan<NicDeviceIbgdaResources>` indexed
- * by NIC slot (peer-rotated on the host side so that `nic_qp_for_group(g)`'s
- * nic_id (= g % numNics) yields balanced per-peer scatter).
+ * by physical NIC slot.
  */
 struct NicDeviceIbgdaResources {
   DeviceSpan<doca_gpu_dev_verbs_qp*> qps{};
@@ -1818,16 +1817,10 @@ class P2pIbgdaTransportDevice {
   };
 
   /**
-   * nic_qp_for_group - Single lookup: returns {nic_id, qp_id} for a group.
+   * nic_qp_for_group - Single lookup: returns NIC/QP ids.
    *
-   * Round-robin over nicDevices_, then within the chosen NIC round-robin
-   * over its qps. All WQEs for one logical operation share the same
-   * group_id and therefore land on the same NIC + QP — required for the
-   * FENCE bit to order them. Host-side population is responsible for
-   * peer-rotating the NicDeviceIbgdaResources[] order so adjacent peers
-   * land on different NICs. Traps if nicDevices_ is empty or the chosen
-   * NIC has no qps (programming error: device op on a default-constructed
-   * transport).
+   * Round-robin over NIC resources, then within the chosen NIC round-robin over
+   * its QPs.
    */
   __device__ NicQpIndex nic_qp_for_group(uint32_t group_id) const {
     if (nicDevices_.empty()) {
@@ -1877,10 +1870,7 @@ class P2pIbgdaTransportDevice {
   }
 
   // --- Members ---
-  // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id). Host-side
-  // builder peer-rotates the order so nic_qp_for_group(g)'s nic_id (= g %
-  // nicDevices_.size()) produces balanced scatter. At single-NIC:
-  // nicDevices_.size() == 1.
+  // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id).
   DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
 
   // Owned signal/counter buffers (set by transport during construction)

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -12,6 +12,7 @@
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/HipCompat.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -144,9 +145,9 @@ struct NvlinkTransportTileState {
  *     after group.sync()
  */
 struct P2pNvlTransportOptions {
-  std::size_t dataBufferSize;
-  std::size_t chunkSize;
-  std::size_t pipelineDepth;
+  std::size_t dataBufferSize{0};
+  std::size_t chunkSize{0};
+  std::size_t pipelineDepth{0};
   bool useDualStateBuffer{false}; // Default to single state buffer mode
   std::size_t ll128BufferNumPackets{0}; // 0 = no chunking
   std::size_t llBufferNumLines{0}; // 0 = no chunking
@@ -366,6 +367,14 @@ class P2pNvlTransportDevice {
         tile_state_(tileState) {}
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
+
+  __host__ __device__ std::size_t pipeline_window(int totalGroups) const {
+    const std::size_t perBlockSlotSize =
+        (options_.dataBufferSize / totalGroups) & ~15ULL;
+    const std::size_t safeDepth =
+        options_.pipelineDepth > 1 ? options_.pipelineDepth - 1 : 1;
+    return perBlockSlotSize * safeDepth;
+  }
 
   /**
    * send_group - Cooperative transfer to peer GPU over NVLink
@@ -1475,8 +1484,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1520,13 +1530,15 @@ class P2pNvlTransportDevice {
 #endif
   }
 
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1588,8 +1600,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[max_groups + groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1603,11 +1616,13 @@ class P2pNvlTransportDevice {
           group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
 
       if (copyBytes > 0) {
-        memcpy_vectorized(
+        CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1658,6 +1673,7 @@ class P2pNvlTransportDevice {
    * @param max_signal_bytes Hint for max bytes between signals.
    *   0 means one signal per slot fill. Capped at per_block_slot_size.
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -1665,7 +1681,8 @@ class P2pNvlTransportDevice {
       P2pNvlTransportDevice& successor,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1735,11 +1752,19 @@ class P2pNvlTransportDevice {
     int64_t sendStep = successor.tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
-      const std::size_t slot = slotStep % options_.pipelineDepth;
-      const std::size_t slotOff = slot * slotSize;
-      const std::size_t chunkOff = subStep * effectiveChunk;
+      const std::size_t absRecvStep = static_cast<std::size_t>(recvStep);
+      const std::size_t recvSlotStep = absRecvStep / stepsPerSlot;
+      const std::size_t recvSubStep = absRecvStep % stepsPerSlot;
+      const std::size_t recvSlot = recvSlotStep % options_.pipelineDepth;
+      const std::size_t recvSlotOff = recvSlot * slotSize;
+      const std::size_t recvChunkOff = recvSubStep * effectiveChunk;
+
+      const std::size_t absSendStep = static_cast<std::size_t>(sendStep);
+      const std::size_t sendSlotStep = absSendStep / stepsPerSlot;
+      const std::size_t sendSubStep = absSendStep % stepsPerSlot;
+      const std::size_t sendSlot = sendSlotStep % options_.pipelineDepth;
+      const std::size_t sendSlotOff = sendSlot * slotSize;
+      const std::size_t sendChunkOff = sendSubStep * effectiveChunk;
 
       const std::size_t dataOff = s * effectiveChunk;
       const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
@@ -1752,7 +1777,7 @@ class P2pNvlTransportDevice {
 
       // 2. Wait for successor's staging slot to be free (send side, only at
       //    slot boundaries once we have wrapped around the pipeline).
-      if (subStep == 0 &&
+      if (sendSubStep == 0 &&
           sendStep >=
               static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
         successor.tile_state_.local_signals[headSignalId].wait_until(
@@ -1766,12 +1791,14 @@ class P2pNvlTransportDevice {
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
       if (copyBytes > 0) {
-        memcpy_vectorized(
-            dstPtr + dataOff,
-            sendBuf + slotOff + stagingOff + chunkOff,
-            recvBuf + slotOff + stagingOff + chunkOff,
+        CopyOp::forward(
+            dstPtr ? dstPtr + dataOff : nullptr,
+            sendBuf + sendSlotOff + stagingOff + sendChunkOff,
+            recvBuf + recvSlotOff + stagingOff + recvChunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1782,7 +1809,7 @@ class P2pNvlTransportDevice {
 
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
-        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+        if (recvSubStep == stepsPerSlot - 1 || s == totalSteps - 1) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
         }
@@ -2031,7 +2058,7 @@ class P2pNvlTransportDevice {
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
-  const P2pNvlTransportOptions options_;
+  const P2pNvlTransportOptions options_{};
   LocalState localState_;
   RemoteState remoteState_;
   NvlinkTransportTileState tile_state_;

--- a/comms/pipes/collectives/AllGatherDirect.cu
+++ b/comms/pipes/collectives/AllGatherDirect.cu
@@ -1,0 +1,179 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/AllGatherDirect.cuh"
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
+
+namespace comms::pipes {
+
+template <int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
+    const __grid_constant__ DirectAllgatherNvlArgs args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int my_rank = args.my_rank;
+  const int W = args.num_ranks;
+  const std::size_t sendcount = args.sendcount;
+  const std::size_t max_sig = args.signaling_data_size;
+
+  TiledBuffer<char> tile(nullptr, sendcount, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  const char* own_src = args.sendbuf + tile_offset;
+  char* own_dst = args.recvbuf + my_rank * sendcount + tile_offset;
+  memcpy_vectorized(own_dst, own_src, tile_bytes, group);
+  group.sync();
+
+  if (W <= 1 || tile_bytes == 0) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0, "direct NVLink allgather pipeline window is zero");
+
+  for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = tile_bytes - off;
+    const std::size_t window =
+        remaining < pipeline_window ? remaining : pipeline_window;
+
+    const char* send_src = args.sendbuf + tile_offset + off;
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      auto peer = args.peers[peer_rank];
+      peer.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    }
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      char* dst = args.recvbuf + peer_rank * sendcount + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.recv(group, dst, window, group.total_groups, max_sig, timeout);
+    }
+  }
+#endif
+}
+
+template <int kBlockSize>
+__global__
+__launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
+    const __grid_constant__ HierarchicalAllgatherFusedArgs args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int W = args.ib_size;
+  const std::size_t chunk_bytes = args.sendcount;
+  const std::size_t max_sig = args.ib_signaling_data_size;
+
+  TiledBuffer<char> ring_tile(nullptr, chunk_bytes, group);
+  const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const char* own_src = args.sendbuf + io_tile_offset;
+  char* own_dst = args.recvbuf +
+      (static_cast<std::size_t>(args.ib_rank) * args.nvl_size + args.nvl_rank) *
+          chunk_bytes +
+      io_tile_offset;
+
+  // Single IB node (W==1): self-copy then NVL broadcast within the local
+  // NVL group. The broadcast is still needed because each NVL peer must
+  // receive every other peer's chunk even when there is only one IB node.
+  if (W <= 1) {
+    memcpy_vectorized(own_dst, own_src, io_tile_bytes, group);
+    group.sync();
+    hierarchical_allgather_nvl_broadcast_from_recvbuf(
+        group,
+        args.ib_size,
+        args.nvl_rank,
+        args.nvl_size,
+        args.sendcount,
+        args.nvl_signaling_data_size,
+        args.nvl_peers,
+        args.recvbuf,
+        timeout);
+    return;
+  }
+
+  const auto& topo = args.ib_ring;
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical allgather IB pipeline window is zero");
+
+  const int stride = (args.ib_rank - topo.prev_rank + W) % W;
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    const char* send_src = args.sendbuf + io_tile_offset + off;
+    next.template send<MemcpyAndSelfCopy>(
+        group,
+        send_src,
+        window,
+        group.total_groups,
+        max_sig,
+        timeout,
+        own_dst + off);
+
+    int fwd_current_rank = args.ib_rank;
+    for (int step = 0; step < W - 1; step++) {
+      fwd_current_rank = (fwd_current_rank + W - stride) % W;
+      char* dst = args.recvbuf +
+          (static_cast<std::size_t>(fwd_current_rank) * args.nvl_size +
+           args.nvl_rank) *
+              chunk_bytes +
+          io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.forward(
+            group, dst, next, window, group.total_groups, max_sig, timeout);
+      } else {
+        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+
+  group.sync();
+
+  hierarchical_allgather_nvl_broadcast_from_recvbuf(
+      group,
+      args.ib_size,
+      args.nvl_rank,
+      args.nvl_size,
+      args.sendcount,
+      args.nvl_signaling_data_size,
+      args.nvl_peers,
+      args.recvbuf,
+      timeout);
+#endif
+}
+
+template __global__ void direct_allgather_nvl_kernel<512>(
+    const __grid_constant__ DirectAllgatherNvlArgs,
+    Timeout);
+
+template __global__ void hierarchical_allgather_fused_kernel<512>(
+    const __grid_constant__ HierarchicalAllgatherFusedArgs,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherDirect.cuh
+++ b/comms/pipes/collectives/AllGatherDirect.cuh
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Direct NVLink AllGather and Hierarchical AllGather kernels.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/AllGatherDirectTypes.h"
+
+namespace comms::pipes {
+
+template <int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
+    const __grid_constant__ DirectAllgatherNvlArgs args,
+    Timeout timeout);
+
+template <int kBlockSize>
+__global__
+    __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
+        const __grid_constant__ HierarchicalAllgatherFusedArgs args,
+        Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherDirectTypes.h
+++ b/comms/pipes/collectives/AllGatherDirectTypes.h
@@ -1,0 +1,45 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/DirectCollectiveTypes.h"
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct DirectAllgatherNvlArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+};
+
+struct HierarchicalAllgatherIbgdaRing {
+  int prev_rank{0};
+  int next_rank{0};
+  P2pIbgdaTransportDevice* prev{nullptr};
+  P2pIbgdaTransportDevice* next{nullptr};
+};
+
+struct HierarchicalAllgatherFusedArgs {
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -1,0 +1,95 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/AllGatherLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/Checks.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/AllGatherDirect.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+void validate_direct_nvl(int num_ranks) {
+  if (num_ranks < 1 || num_ranks > kDirectNvlMaxRanks) {
+    throw std::runtime_error(
+        "Unsupported direct NVLink num_ranks=" + std::to_string(num_ranks) +
+        " (supported: 1.." + std::to_string(kDirectNvlMaxRanks) + ")");
+  }
+}
+
+Timeout make_launch_timeout(float timeout_ms) {
+  Timeout timeout;
+  if (timeout_ms > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout = makeTimeout(timeout_ms, device);
+  }
+  return timeout;
+}
+
+} // namespace
+
+void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params) {
+  validate_direct_nvl(params.num_ranks);
+
+  DirectAllgatherNvlArgs args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.sendcount = params.sendcount;
+  args.signaling_data_size = params.signaling_data_size;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+
+  for (int peer = 0; peer < params.num_ranks; ++peer) {
+    if (peer == params.my_rank) {
+      continue;
+    }
+    new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
+  }
+
+  direct_allgather_nvl_kernel<512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+void launch_hierarchical_allgather_fused(
+    const HierarchicalAllgatherLaunchParams& params) {
+  validate_direct_nvl(params.nvl_size);
+  if (params.ib_size < 1 ||
+      params.ib_size * params.nvl_size != params.num_ranks) {
+    throw std::runtime_error("Invalid hierarchical allgather rank geometry");
+  }
+
+  HierarchicalAllgatherFusedArgs args{};
+  args.ib_rank = params.ib_rank;
+  args.ib_size = params.ib_size;
+  args.nvl_rank = params.nvl_rank;
+  args.nvl_size = params.nvl_size;
+  args.sendcount = params.sendcount;
+  args.ib_signaling_data_size = params.ib_signaling_data_size;
+  args.nvl_signaling_data_size = params.nvl_signaling_data_size;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+  args.ib_ring = params.ib_ring;
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == params.nvl_rank) {
+      continue;
+    }
+    new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
+  }
+
+  hierarchical_allgather_fused_kernel<512>
+      <<<params.ib_num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherLauncher.h
+++ b/comms/pipes/collectives/AllGatherLauncher.h
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/AllGatherDirectTypes.h"
+
+namespace comms::pipes {
+
+struct DirectAllgatherNvlLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params);
+
+struct HierarchicalAllgatherLaunchParams {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int ib_num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_hierarchical_allgather_fused(
+    const HierarchicalAllgatherLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectCollectiveTypes.h
+++ b/comms/pipes/collectives/DirectCollectiveTypes.h
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::pipes {
+
+inline constexpr int kDirectNvlMaxRanks = 16;
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectCollectiveUtils.cuh
+++ b/comms/pipes/collectives/DirectCollectiveUtils.cuh
@@ -1,0 +1,107 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+
+struct MemcpyAndSelfCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      char* self_dst,
+      Args...) {
+    memcpy_vectorized(staging, self_dst + byte_offset, src, nbytes, group);
+  }
+};
+
+__device__ __forceinline__ std::size_t direct_pipeline_window(
+    const P2pNvlTransportDevice* peers,
+    int my_rank,
+    int num_ranks,
+    int total_groups) {
+  std::size_t window = 0;
+  for (int peer = 0; peer < num_ranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    const std::size_t peer_window = peers[peer].pipeline_window(total_groups);
+    window = window == 0 || peer_window < window ? peer_window : window;
+  }
+  return window;
+}
+
+template <typename Group>
+__device__ __forceinline__ void
+hierarchical_allgather_nvl_broadcast_from_recvbuf(
+    Group& group,
+    int ib_size,
+    int nvl_rank,
+    int nvl_size,
+    std::size_t sendcount,
+    std::size_t max_sig,
+    const P2pNvlTransportDevice* peers,
+    char* recvbuf,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  if (nvl_size <= 1) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical allgather NVLink broadcast pipeline window is zero");
+
+  for (int ib_src = 0; ib_src < ib_size; ++ib_src) {
+    TiledBuffer<char> tile(nullptr, sendcount, group);
+    const std::size_t tile_offset = group.group_id * tile.tile_elements;
+    const std::size_t tile_bytes = tile.bytes();
+
+    for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = tile_bytes - off;
+      const std::size_t window =
+          remaining < pipeline_window ? remaining : pipeline_window;
+      const char* send_src = recvbuf +
+          (static_cast<std::size_t>(ib_src) * nvl_size + nvl_rank) * sendcount +
+          tile_offset + off;
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        auto peer = peers[peer_rank];
+        peer.send(
+            group, send_src, window, group.total_groups, max_sig, timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        char* dst = recvbuf +
+            (static_cast<std::size_t>(ib_src) * nvl_size + peer_rank) *
+                sendcount +
+            tile_offset + off;
+        auto peer = peers[peer_rank];
+        peer.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+#endif
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirect.cu
+++ b/comms/pipes/collectives/ReduceScatterDirect.cu
@@ -1,0 +1,86 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/ReduceScatterDirect.cuh"
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
+
+namespace comms::pipes {
+
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+__global__
+__launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
+    const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int my_rank = args.my_rank;
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  TiledBuffer<char> tile(nullptr, chunk_bytes, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  const char* own_src = reinterpret_cast<const char*>(args.input) +
+      my_rank * chunk_bytes + tile_offset;
+  char* own_dst = reinterpret_cast<char*>(args.output) + tile_offset;
+  memcpy_vectorized(own_dst, own_src, tile_bytes, group);
+  group.sync();
+
+  if (W <= 1 || tile_bytes == 0) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "direct NVLink reduce-scatter pipeline window is zero");
+
+  using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
+  const char* input_base = reinterpret_cast<const char*>(args.input);
+  char* output_base = reinterpret_cast<char*>(args.output);
+
+  for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = tile_bytes - off;
+    const std::size_t window =
+        remaining < pipeline_window ? remaining : pipeline_window;
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      const char* send_src =
+          input_base + peer_rank * chunk_bytes + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    }
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      char* dst = output_base + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.template recv<ReduceOp>(
+          group, dst, window, group.total_groups, max_sig, timeout, dst);
+    }
+  }
+#endif
+}
+
+template __global__ void
+direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>(
+    const __grid_constant__ DirectReduceScatterNvlArgs<float>,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirect.cuh
+++ b/comms/pipes/collectives/ReduceScatterDirect.cuh
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/ReduceScatterDirectTypes.h"
+
+namespace comms::pipes {
+
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+__global__
+    __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
+        const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
+        Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirectTypes.h
+++ b/comms/pipes/collectives/ReduceScatterDirectTypes.h
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/DirectCollectiveTypes.h"
+
+namespace comms::pipes {
+
+template <typename T>
+struct DirectReduceScatterNvlArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+  const T* input{nullptr};
+  T* output{nullptr};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterLauncher.cu
+++ b/comms/pipes/collectives/ReduceScatterLauncher.cu
@@ -1,0 +1,65 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/ReduceScatterLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/Checks.h"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/ReduceScatterDirect.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+void validate_direct_nvl(int num_ranks) {
+  if (num_ranks < 1 || num_ranks > kDirectNvlMaxRanks) {
+    throw std::runtime_error(
+        "Unsupported direct NVLink num_ranks=" + std::to_string(num_ranks) +
+        " (supported: 1.." + std::to_string(kDirectNvlMaxRanks) + ")");
+  }
+}
+
+Timeout make_launch_timeout(float timeout_ms) {
+  Timeout timeout;
+  if (timeout_ms > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout = makeTimeout(timeout_ms, device);
+  }
+  return timeout;
+}
+
+} // namespace
+
+void launch_direct_reduce_scatter_nvl(
+    const DirectReduceScatterNvlLaunchParams& params) {
+  validate_direct_nvl(params.num_ranks);
+
+  DirectReduceScatterNvlArgs<float> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = params.chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+
+  for (int peer = 0; peer < params.num_ranks; ++peer) {
+    if (peer == params.my_rank) {
+      continue;
+    }
+    new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
+  }
+
+  direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterLauncher.h
+++ b/comms/pipes/collectives/ReduceScatterLauncher.h
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/ReduceScatterDirectTypes.h"
+
+namespace comms::pipes {
+
+struct DirectReduceScatterNvlLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_direct_reduce_scatter_nvl(
+    const DirectReduceScatterNvlLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -12,6 +12,7 @@
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/benchmarks/TileSendRecv.cuh"
 #include "comms/pipes/tests/P2pNvlTransportTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
@@ -4256,6 +4257,173 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardMultiCallPersistentStep) {
       2,
       4,
       5);
+}
+
+TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
+  if (numRanks != 2) {
+    return;
+  }
+
+  constexpr int kNumBlocks = 4;
+  constexpr size_t kDataBufferSize = 1024 * 1024;
+  constexpr size_t kMaxSignalBytes = 64 * 1024;
+  constexpr size_t kPerBlockSlotSize = kDataBufferSize / kNumBlocks;
+  constexpr size_t kForwardBytes = kMaxSignalBytes * kNumBlocks;
+  constexpr size_t kAdvanceBytes = kForwardBytes * 5;
+  constexpr int kThreadCount = 256;
+  constexpr unsigned char kAdvancePattern = 0x33;
+  constexpr unsigned char kForwardPattern = 0x7a;
+
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDataBufferSize,
+      .chunkSize = kDataBufferSize,
+      .pipelineDepth = 2,
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bs, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+  int device = 0;
+  CUDACHECK_TEST(cudaGetDevice(&device));
+  Timeout timeout = makeTimeout(5000, device);
+
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(
+        p2pHost.getLocalState().dataBuffer,
+        0,
+        config.pipelineDepth * config.dataBufferSize));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  DeviceBuffer advanceSendBuf(kAdvanceBytes);
+  DeviceBuffer advanceRecvBuf(kAdvanceBytes);
+  if (globalRank == 1) {
+    CUDACHECK_TEST(
+        cudaMemset(advanceSendBuf.get(), kAdvancePattern, kAdvanceBytes));
+  } else {
+    CUDACHECK_TEST(cudaMemset(advanceRecvBuf.get(), 0, kAdvanceBytes));
+  }
+
+  // Advance only the rank1->rank0 tile send/recv state by 5 sub-steps. The
+  // following forward call then has recvStep == 0 and sendStep == 5 on rank 1.
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (globalRank == 1) {
+    test::testTileSend(
+        p2pHost,
+        advanceSendBuf.get(),
+        kAdvanceBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  } else {
+    test::testTileRecv(
+        p2pHost,
+        advanceRecvBuf.get(),
+        kAdvanceBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    std::vector<char> hostBuf(kAdvanceBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(),
+        advanceRecvBuf.get(),
+        kAdvanceBytes,
+        cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < kAdvanceBytes; ++i) {
+      if (static_cast<unsigned char>(hostBuf[i]) != kAdvancePattern) {
+        EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), kAdvancePattern)
+            << "pre-advance mismatch at byte " << i;
+        break;
+      }
+    }
+  }
+
+  DeviceBuffer srcBuf(kForwardBytes);
+  DeviceBuffer fwdR1Buf(kForwardBytes);
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(srcBuf.get(), kForwardPattern, kForwardBytes));
+  } else {
+    CUDACHECK_TEST(cudaMemset(fwdR1Buf.get(), 0, kForwardBytes));
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (globalRank == 0) {
+    test::testTileSend(
+        p2pHost,
+        srcBuf.get(),
+        kForwardBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  } else {
+    TiledBuffer<char> dstTiles(
+        static_cast<char*>(fwdR1Buf.get()), kForwardBytes, kNumBlocks);
+    int numBlocksArg = kNumBlocks;
+    std::size_t maxSignalBytes = kMaxSignalBytes;
+    void* args[] = {
+        &p2pHost,
+        &p2pHost,
+        &dstTiles,
+        &numBlocksArg,
+        &maxSignalBytes,
+        &timeout};
+
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileForward,
+        dim3(kNumBlocks),
+        dim3(kThreadCount),
+        args,
+        0,
+        nullptr));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    std::vector<char> stagingSlot(kDataBufferSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        stagingSlot.data(),
+        static_cast<char*>(p2pHost.getLocalState().dataBuffer) +
+            kDataBufferSize,
+        kDataBufferSize,
+        cudaMemcpyDeviceToHost));
+    for (int block = 0; block < kNumBlocks; ++block) {
+      const size_t chunkOffset = block * kPerBlockSlotSize + kMaxSignalBytes;
+      for (size_t i = 0; i < kMaxSignalBytes; ++i) {
+        EXPECT_EQ(
+            static_cast<unsigned char>(stagingSlot[chunkOffset + i]),
+            kForwardPattern)
+            << "forward staging mismatch at block " << block << " byte " << i;
+        if (static_cast<unsigned char>(stagingSlot[chunkOffset + i]) !=
+            kForwardPattern) {
+          return;
+        }
+      }
+    }
+  } else {
+    std::vector<char> hostBuf(kForwardBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), fwdR1Buf.get(), kForwardBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < kForwardBytes; ++i) {
+      EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), kForwardPattern)
+          << "forward mismatch at byte " << i;
+      if (static_cast<unsigned char>(hostBuf[i]) != kForwardPattern) {
+        return;
+      }
+    }
+  }
 }
 
 // Partial tiles (nbytes not evenly divisible by numBlocks)

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -3,6 +3,8 @@
 #include "comms/pipes/tests/Checks.h"
 #include "comms/pipes/tests/P2pNvlTransportTest.cuh"
 
+#include "comms/pipes/TiledBuffer.cuh"
+
 namespace comms::pipes::test {
 
 // Helper to create the appropriate thread group based on type
@@ -33,6 +35,44 @@ __global__ void testRecvKernel(
     GroupType groupType) {
   auto group = make_group(groupType);
   p2p->recv_group(group, dst_d, nbytes);
+}
+
+__global__ void testTileSendKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_block_group();
+  TiledBuffer<char> tiles(reinterpret_cast<char*>(src_d), nbytes, group);
+  p2p.send(
+      group,
+      tiles.data(),
+      tiles.bytes(),
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+}
+
+__global__ void testTileRecvKernel(
+    P2pNvlTransportDevice p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_block_group();
+  TiledBuffer<char> tiles(reinterpret_cast<char*>(dst_d), nbytes, group);
+  p2p.recv(
+      group,
+      tiles.data(),
+      tiles.bytes(),
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
 }
 
 // Kernel that performs multiple sequential sends within a single kernel launch
@@ -156,6 +196,36 @@ void testRecv(
     cudaStream_t stream) {
   testRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
       p2p, dst_d, nbytes, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileSend(
+    const P2pNvlTransportDevice& p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileSendKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, src_d, nbytes, activeBlocks, maxSignalBytes, timeout);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileRecv(
+    const P2pNvlTransportDevice& p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, dst_d, nbytes, activeBlocks, maxSignalBytes, timeout);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -38,6 +38,28 @@ void testRecv(
     int blocksPerGroup = 1,
     cudaStream_t stream = nullptr);
 
+void testTileSend(
+    const P2pNvlTransportDevice& p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileRecv(
+    const P2pNvlTransportDevice& p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
 // Multiple sequential sends within a single kernel
 void testMultiSend(
     P2pNvlTransportDevice* p2p,


### PR DESCRIPTION
Summary:

Implements three GPU collective kernels using the Pipes transport primitives: direct NVLink allgather, direct NVLink reduce-scatter, and hierarchical (IB ring + NVLink broadcast) allgather.

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│                    Hierarchical AllGather                        │
│                                                                 │
│  Phase 1: IB Ring AllGather (inter-node)                        │
│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐  │
│  │ IB Node 0│───►│ IB Node 1│───►│ IB Node 2│───►│ IB Node 3│  │
│  │ (send →  │    │(fwd → →) │    │(fwd → →) │    │ (← recv) │  │
│  └──────────┘    └──────────┘    └──────────┘    └──────────┘  │
│       │               │               │               │         │
│  Phase 2: NVLink Broadcast (intra-node)                         │
│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐  │
│  │ GPU 0    │    │ GPU 0    │    │ GPU 0    │    │ GPU 0    │  │
│  │ GPU 1    │    │ GPU 1    │    │ GPU 1    │    │ GPU 1    │  │
│  │  ...     │    │  ...     │    │  ...     │    │  ...     │  │
│  │ GPU N    │    │ GPU N    │    │ GPU N    │    │ GPU N    │  │
│  └──────────┘    └──────────┘    └──────────┘    └──────────┘  │
└─────────────────────────────────────────────────────────────────┘
```

## Kernel descriptions

### `direct_allgather_nvl_kernel`
One-kernel allgather over NVLink. Each block owns a tile of the send buffer and pipelines send+recv windows across all NVLink peers. The pipeline window is computed from the minimum of all peers' `pipeline_window()` to avoid overrunning any peer's staging buffer.

```
Block b (rank R):
  1. Self-copy: sendbuf[tile] → recvbuf[R * sendcount + tile]
  2. For each pipeline window:
     a. send(sendbuf[tile+off]) to all peers via NVLink staging
     b. recv(peer's data) from all peers → recvbuf[peer * sendcount + tile+off]
```

### `direct_reduce_scatter_nvl_kernel`
Same structure as allgather but with `TileReduceStaged` CopyOp on recv: incoming chunks are accumulated into the output buffer via tile-based reduction instead of plain copy.

### `hierarchical_allgather_fused_kernel`
Composes an IB ring allgather with a local NVLink broadcast.

**Fused self-copy optimization**: The IB send fuses the local self-copy into the staging copy via `MemcpyAndSelfCopy` CopyOp. Each send window is read once from `sendbuf` and written to both `sendStaging` and `recvbuf[self]`, eliminating a separate self-copy pass:

```
Without fusion (2 reads):                With fusion (1 read):
  read sendbuf → write recvbuf[self]       read sendbuf → write recvbuf[self]
  read recvbuf[self] → write sendStaging                 → write sendStaging
```

**Single IB node path** (`ib_size == 1`): When there is only one IB node, the kernel skips the IB ring and goes straight to self-copy + NVLink broadcast. The NVLink broadcast is still required because each NVL peer must receive every other peer's chunk.

## Files

| File | Purpose |
|------|---------|
| `DirectNvlTypes.h` | Kernel arg structs, `kDirectNvlMaxRanks` constant |
| `DirectNvl.cuh` | Kernel declarations |
| `DirectNvl.cu` | Kernel implementations + `MemcpyAndSelfCopy` CopyOp |
| `DirectNvlLauncher.h` | Host-side launch param structs and launch functions |
| `DirectNvlLauncher.cu` | Host-side launch function implementations |

## Review comments addressed
- **[DirectNvl.cu:258]** "do we need this for single node?" → Added clarifying comment explaining the NVL broadcast IS needed for single-node because it distributes data within the NVL group.
- **[DirectNvl.cuh:3]** "rename to AllGather" → Added file-level doc comment "Direct NVLink AllGather, ReduceScatter, and Hierarchical AllGather kernels." Full file rename avoided because the module contains both allgather and reduce-scatter.

Reviewed By: siyengar

Differential Revision: D104725448


