### PR TITLE
Guard NCCL_SHRINK_ABORT for older NCCL headers

### DIFF
--- a/comms/torchcomms/nccl/NcclApi.hpp
+++ b/comms/torchcomms/nccl/NcclApi.hpp
@@ -7,6 +7,14 @@
 
 #include <nccl.h> // @manual=fbsource//third-party/nccl:nccl
 
+// NCCL_SHRINK_ABORT was introduced in NCCL 2.27 alongside ncclCommShrink.
+// Define a fallback so dependents compile against older NCCL headers; the
+// commShrink wrapper in NcclApi.cpp is itself version-guarded and returns
+// ncclInvalidUsage on older NCCL, so the value is never read at runtime.
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 27, 0) && !defined(NCCL_SHRINK_ABORT)
+#define NCCL_SHRINK_ABORT 0x01
+#endif
+
 namespace torch::comms {
 /**
  * Abstract interface for NCCL API operations.

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -10,6 +10,12 @@
 #include <glog/logging.h>
 #include <nccl.h> // @manual=//comms/ncclx:nccl
 
+// NCCL_SHRINK_ABORT was introduced in NCCL 2.27 alongside ncclCommShrink.
+// Define a fallback so dependents compile against older NCCL headers.
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 27, 0) && !defined(NCCL_SHRINK_ABORT)
+#define NCCL_SHRINK_ABORT 0x01
+#endif
+
 // NCCL Device API headers are only available in NCCLX 2.28+
 // For conda feedstock builds with older NCCLX versions, device API is disabled
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API


### PR DESCRIPTION
Summary:
`NCCL_SHRINK_ABORT` was added to `nccl.h` in NCCL **v2.27** (alongside
`ncclCommShrink`). `TorchCommNCCLReconfigure.cpp:310` and
`TorchCommNCCLXReconfigure.cpp:308` reference it unconditionally, which
breaks compilation against any pre-2.27 NCCL with:

```
fbcode/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp:310:15:
  error: use of undeclared identifier 'NCCL_SHRINK_ABORT'
```

This is the root cause of the `hpc_comms/param` Conveyor failures since
~R2200 (2026-04-30, when D103221062 landed) — every release for
`hpc_comms.param.{2.20.3, 2.21.5, 2.23, 2.24, 2.25, 2.26.2}` (x86 +
aarch64) has hit `APPLICATION_FAILURE` on this exact line. Builds for
2.27+ pass because the symbol exists. See T269175115.

This patch defines a `NCCL_SHRINK_ABORT = 0x01` fallback at the top of
each affected file when the macro isn't already defined by `nccl.h`. The
runtime path is safe because `DefaultNcclApi::commShrink` (NcclApi.cpp)
is itself version-guarded with
`#if NCCL_VERSION_CODE >= NCCL_VERSION(2,27,0)` and returns
`ncclInvalidUsage` on older NCCL — the fallback value is never actually
passed to a runtime call.

Mirrors the precedent pattern in
`fbcode/comms/rcclx/develop/projects/rccl-tests/src/common.cu`.

Reviewed By: dolpm, fduwjj

Differential Revision: D104866041


