### PR TITLE
Fix QP rounding logic to round up instead of down

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -99,10 +99,12 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   // assure maxNumQps_ to be a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK
   if (maxNumQps_ % NCCL_CTRAN_IB_DEVICES_PER_RANK) {
     int originalMaxNumQps = maxNumQps_;
-    maxNumQps_ = maxNumQps_ - (maxNumQps_ % NCCL_CTRAN_IB_DEVICES_PER_RANK);
+    maxNumQps_ = maxNumQps_ +
+        (NCCL_CTRAN_IB_DEVICES_PER_RANK -
+         maxNumQps_ % NCCL_CTRAN_IB_DEVICES_PER_RANK);
     CLOGF(
         WARN,
-        "CTRAN-IB: CTRAN_MAX_QPS is not a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK  ({} > {}), use {} instead",
+        "CTRAN-IB: CTRAN_MAX_QPS is not a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK  ({} < {}), rounding up to {} instead",
         originalMaxNumQps,
         NCCL_CTRAN_IB_DEVICES_PER_RANK,
         maxNumQps_);

--- a/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+class CtranIbQpConfigTest
+    : public ::testing::TestWithParam<std::tuple<int, int>> {
+ protected:
+  void SetUp() override {
+    ncclCvarInit();
+  }
+};
+
+TEST_P(CtranIbQpConfigTest, MaxNumQpsIsValidForAllConfigs) {
+  const auto [maxQps, devicesPerRank] = GetParam();
+
+  EnvRAII envMaxQps(NCCL_CTRAN_IB_MAX_QPS, maxQps);
+  EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, devicesPerRank);
+
+  std::vector<CtranIbDevice> dummyDevices(devicesPerRank, CtranIbDevice{});
+  CtranIbVirtualConn vc(
+      dummyDevices,
+      /*peerRank=*/0,
+      /*comm=*/nullptr,
+      /*pgTrafficClass=*/0,
+      /*cudaDev=*/0);
+
+  const int maxNumQps = vc.getMaxNumQp();
+  EXPECT_GE(maxNumQps, 1) << "maxNumQps must never be zero";
+  EXPECT_GE(maxNumQps, devicesPerRank)
+      << "maxNumQps must be at least devicesPerRank";
+  EXPECT_EQ(maxNumQps % devicesPerRank, 0)
+      << "maxNumQps must be an exact multiple of devicesPerRank";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QpRounding,
+    CtranIbQpConfigTest,
+    ::testing::Values(
+        std::make_tuple(1, 1),
+        std::make_tuple(16, 1),
+        std::make_tuple(1, 2),
+        std::make_tuple(2, 2),
+        std::make_tuple(3, 2),
+        std::make_tuple(5, 2),
+        std::make_tuple(1, 3),
+        std::make_tuple(4, 3),
+        std::make_tuple(1, 4),
+        std::make_tuple(3, 4),
+        std::make_tuple(5, 4),
+        std::make_tuple(128, 1),
+        std::make_tuple(128, 2),
+        std::make_tuple(129, 3)));
+
+// Exact regression test for the bug case: maxQps=1, devicesPerRank=2
+// produced maxNumQps_=0 with the old round-down logic.
+TEST(CtranIbQpConfigRegressionTest, MaxQps1DevPerRank2) {
+  ncclCvarInit();
+  EnvRAII envMaxQps(NCCL_CTRAN_IB_MAX_QPS, 1);
+  EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 2);
+
+  std::vector<CtranIbDevice> dummyDevices(2, CtranIbDevice{});
+  CtranIbVirtualConn vc(
+      dummyDevices,
+      /*peerRank=*/0,
+      /*comm=*/nullptr,
+      /*pgTrafficClass=*/0,
+      /*cudaDev=*/0);
+
+  EXPECT_EQ(vc.getMaxNumQp(), 2);
+}


### PR DESCRIPTION
Summary:
When CTRAN_MAX_QPS is not a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK,
the QP count was rounded down. This caused maxNumQps_ to become 0 when
maxQps=1 and there are 2 IB devices per rank, resulting in no QPs being
created. This led to connectVcDirect failing with 'QPs must be
initialized first' and the test hanging indefinitely.

Fix by rounding up to the next multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK
instead, ensuring at least 1 QP per device.

Reviewed By: Regina8023

Differential Revision: D104859882


