### PR TITLE
enable winFetchAdd (#2517)

### DIFF
--- a/comms/ctran/algos/RMA/Types.h
+++ b/comms/ctran/algos/RMA/Types.h
@@ -36,3 +36,9 @@ struct CtranKernelSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
 };
+
+struct CtranKernelFetchAddArgs {
+  uint64_t* remoteAddr;
+  uint64_t addVal;
+  uint64_t* resultAddr;
+};

--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -317,6 +317,13 @@ CollectiveMetadata getCollectiveMetadata(
           .opCount = opCount,
       };
     }
+    case KernelConfig::KernelType::FETCHADD: {
+      return CollectiveMetadata{
+          .opName = "FetchAdd",
+          .algoName = kernelConfig.algoName,
+          .opCount = opCount,
+      };
+    }
     // Skip P2P kernel types. We intentionally don't use default so that
     // whenever ctran adds a new kernel type, we will get a compile error
     case KernelConfig::KernelType::SEND:

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -53,7 +53,8 @@ struct OpElem {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    FETCHADD
   } type;
   cudaStream_t stream;
 
@@ -245,6 +246,13 @@ struct OpElem {
       int peerRank;
       ctran::CtranWin* win;
     } get;
+    struct {
+      void* resultBuf;
+      size_t targetIndex;
+      uint64_t addVal;
+      int peerRank;
+      ctran::CtranWin* win;
+    } fetchadd;
   };
 
  public:
@@ -296,7 +304,8 @@ struct KernelConfig {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    FETCHADD
   } type;
   unsigned int numBlocks{1};
   unsigned int numThreads{1};

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -598,6 +598,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return atomicSetImpl(dbuf, val, peerRank, config, req);
   }
 
+  inline commResult_t ifetchAndAdd(
+      const void* sbuf,
+      void* dbuf,
+      uint64_t addVal,
+      int peerRank,
+      CtranMapperConfig config,
+      CtranMapperRequest* req) {
+    return ifetchAndAddImpl(sbuf, dbuf, addVal, peerRank, config, req);
+  }
+
   /* Post a Flush op to ensure data received from the network is visible from
    * all GPU threads.
    * Input arguments:
@@ -950,6 +960,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       case CtranMapperRequest::ReqType::IB_PUT:
       case CtranMapperRequest::ReqType::IB_GET:
       case CtranMapperRequest::ReqType::ATOMIC_SET:
+      case CtranMapperRequest::ReqType::FETCH_AND_ADD:
       case CtranMapperRequest::ReqType::TCPDM_PUT:
       case CtranMapperRequest::ReqType::SEND_SYNC_CTRL:
       case CtranMapperRequest::ReqType::RECV_SYNC_CTRL:
@@ -1839,6 +1850,45 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         dbuf);
     FB_COMMCHECK(this->ctranIb->iatomicSet(
         dbuf, val, peerRank, remoteAccessKey.ibKey, ibReqPtr));
+    return commSuccess;
+  }
+
+  inline commResult_t ifetchAndAddImpl(
+      const void* sbuf,
+      void* dbuf,
+      uint64_t addVal,
+      int peerRank,
+      CtranMapperConfig config,
+      CtranMapperRequest* req) {
+    const auto& remoteAccessKey = config.remoteAccessKey_;
+    if (remoteAccessKey.backend != CtranMapperBackend::IB) {
+      CLOGF(ERR, "CTRAN-MAPPER: ifetchAndAdd only supports IB backend");
+      return commInternalError;
+    }
+    if (req != nullptr) {
+      req->type = CtranMapperRequest::ReqType::FETCH_AND_ADD;
+      req->peer = peerRank;
+      req->backend = CtranMapperBackend::IB;
+      req->setConfig(config);
+    }
+    auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(config.memHdl_);
+    auto regLk = regElem->stateMnger.rlock();
+    CtranIbRequest* ibReqPtr = (req == nullptr ? nullptr : &(req->ibReq));
+    CLOGF_TRACE(
+        COLL,
+        "CTRAN-MAPPER: Post IB FETCH_AND_ADD to rank {}: addVal {} dbuf {} sbuf {}",
+        peerRank,
+        addVal,
+        dbuf,
+        sbuf);
+    FB_COMMCHECK(this->ctranIb->ifetchAndAdd(
+        sbuf,
+        dbuf,
+        addVal,
+        peerRank,
+        regElem->ibRegElem,
+        remoteAccessKey.ibKey,
+        ibReqPtr));
     return commSuccess;
   }
 

--- a/comms/ctran/mapper/CtranMapperRequest.cc
+++ b/comms/ctran/mapper/CtranMapperRequest.cc
@@ -10,7 +10,8 @@ static std::unordered_map<CtranMapperRequest::ReqType, std::string> reqTypeStr =
      {CtranMapperRequest::ReqType::SEND_SYNC_CTRL, "SEND_SYNC_CTRL"},
      {CtranMapperRequest::ReqType::RECV_SYNC_CTRL, "RECV_SYNC_CTRL"},
      {CtranMapperRequest::ReqType::IB_PUT, "IB_PUT"},
-     {CtranMapperRequest::ReqType::NVL_PUT, "NVL_PUT"}};
+     {CtranMapperRequest::ReqType::NVL_PUT, "NVL_PUT"},
+     {CtranMapperRequest::ReqType::FETCH_AND_ADD, "FETCH_AND_ADD"}};
 
 const std::string getReqTypeStr(CtranMapperRequest::ReqType type) {
   return reqTypeStr[type];

--- a/comms/ctran/mapper/CtranMapperTypes.h
+++ b/comms/ctran/mapper/CtranMapperTypes.h
@@ -109,7 +109,8 @@ class CtranMapperRequest {
     NVL_PUT,
     TCPDM_PUT,
     COPY,
-    ATOMIC_SET
+    ATOMIC_SET,
+    FETCH_AND_ADD
   };
   CtranMapperRequest() {
     CtranMapperRequest(SEND_CTRL, -1, CtranMapperBackend::IB);

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -63,6 +63,11 @@ struct CtranWin {
   // Stores signal values for sent signals, used to track progress
   std::deque<std::atomic<uint64_t>> signalVal{};
 
+  // Scratch buffer for IB fetch-and-add when caller passes nullptr resultBuf.
+  // Allocated and registered at window creation, deregistered at destruction.
+  void* atomicFetchBuf{nullptr};
+  void* atomicFetchBufMemHdl{nullptr};
+
   CtranWin(
       CtranComm* comm,
       size_t dataSize,

--- a/comms/ctran/window/Types.h
+++ b/comms/ctran/window/Types.h
@@ -16,6 +16,7 @@ enum OpCountType {
   kWaitSignal = 2,
   kSignal = 3,
   kGet = 4,
+  kFetchAdd = 5,
 };
 
 struct RemWinInfo {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -16,6 +16,7 @@
 #include "comms/pipes/window/DeviceWindow.cuh"
 #include "comms/pipes/window/HostWindow.h"
 #endif
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/logger/LogUtils.h"
 
 using ctran::window::RemWinInfo;
@@ -234,6 +235,16 @@ commResult_t CtranWin::allocate(void* userBufPtr) {
       statex->nNodes(),
       statex->nRanks(),
       statex->nLocalRanks());
+
+  if (isAtomicCapable()) {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    FB_CUDACHECK(cudaMallocHost(&atomicFetchBuf, sizeof(uint64_t)));
+    bool reg = false;
+    FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
+        atomicFetchBuf, sizeof(uint64_t), &atomicFetchBufMemHdl, &reg));
+  }
+
   return commSuccess;
 }
 
@@ -313,6 +324,15 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // HostWindow handles cleanup via RAII
   hostWindow_.reset();
 #endif
+
+  if (atomicFetchBuf != nullptr) {
+    if (atomicFetchBufMemHdl != nullptr) {
+      FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(atomicFetchBufMemHdl));
+      atomicFetchBufMemHdl = nullptr;
+    }
+    FB_CUDACHECK(cudaFreeHost(atomicFetchBuf));
+    atomicFetchBuf = nullptr;
+  }
 
   freeMem(winBasePtr);
 


### PR DESCRIPTION
Summary:


Enable winFetchAdd for ctran windows — a hardware-atomic fetch-and-add on a remote uint64_t slot, supporting both NVLink (`cuda::atomic_ref`) and IB (`IBV_WR_ATOMIC_FETCH_AND_ADD`) paths. The window must have an 8-byte aligned data buffer with size that is a multiple of 8 bytes (automatically determined at window registration via ctranWinRegister). The API uses targetIndex (`uint64_t` slot index) with alignment and bounds validation at call time.

Differential Revision: D104863733


