### PR TITLE
Update ncclx references from 2.27 to stable/2.29 across the codebase (#2518)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,4 +343,4 @@ Please check the directory and relevant files to verify the license.
 
 For convenience some of them are listed below:
 
-* [NCCL License](./comms/ncclx/v2_27/LICENSE.txt)
+* [NCCL License](./comms/ncclx/v2_29/LICENSE.txt)


### PR DESCRIPTION
Summary:

Change use_ncclx from "2.27" to "stable" and update NCCL_VERSION/NCCL_SUBDIR
from 2.27 to 2.29 in configs across the codebase.

Differential Revision: D104976188


