### PR TITLE
Extend P2pNvlTransportDevice with pipeline windowing and CopyOp hooks (#2523)

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -5,50 +5,11 @@
 #include <cstddef>
 
 #include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
-
-struct Memcpy {
-  template <typename... Args>
-  __device__ __forceinline__ static void send(
-      char* staging,
-      const char* src,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(staging, src, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void recv(
-      char* dst,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(dst, staging, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void forward(
-      char* dst,
-      char* fwd_staging,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    if (dst) {
-      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
-    } else {
-      memcpy_vectorized(fwd_staging, staging, nbytes, group);
-    }
-  }
-};
 
 template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 struct TileReduce {

--- a/comms/pipes/MemcpyCopyOp.cuh
+++ b/comms/pipes/MemcpyCopyOp.cuh
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+struct Memcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(dst, staging, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    if (dst) {
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
+    } else {
+      memcpy_vectorized(fwd_staging, staging, nbytes, group);
+    }
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -21,7 +21,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
       config_(multiPeerNvlTransportConfig),
-      memSharingMode_(GpuMemHandler::detectBestMode()) {
+      memSharingMode_(
+          config_.memSharingMode.value_or(GpuMemHandler::detectBestMode())) {
   // ===========================================================================
   // Buffer Allocation
   // ===========================================================================

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -101,6 +101,11 @@ struct MultiPeerNvlTransportConfig {
   // on P2pNvlTransportDevice. When 0 (default), LL is disabled.
   // Use ll_buffer_size() from LlPacket.cuh to compute from message size.
   std::size_t llBufferSize{0};
+
+  // Override the automatically selected memory sharing mode. Leaving this unset
+  // keeps the default behavior: fabric handles when available, cudaIpc
+  // otherwise.
+  std::optional<MemSharingMode> memSharingMode;
 };
 
 /**

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -12,6 +12,7 @@
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/HipCompat.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -144,9 +145,9 @@ struct NvlinkTransportTileState {
  *     after group.sync()
  */
 struct P2pNvlTransportOptions {
-  std::size_t dataBufferSize;
-  std::size_t chunkSize;
-  std::size_t pipelineDepth;
+  std::size_t dataBufferSize{0};
+  std::size_t chunkSize{0};
+  std::size_t pipelineDepth{0};
   bool useDualStateBuffer{false}; // Default to single state buffer mode
   std::size_t ll128BufferNumPackets{0}; // 0 = no chunking
   std::size_t llBufferNumLines{0}; // 0 = no chunking
@@ -366,6 +367,14 @@ class P2pNvlTransportDevice {
         tile_state_(tileState) {}
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
+
+  __host__ __device__ std::size_t pipeline_window(int totalGroups) const {
+    const std::size_t perBlockSlotSize =
+        (options_.dataBufferSize / totalGroups) & ~15ULL;
+    const std::size_t safeDepth =
+        options_.pipelineDepth > 1 ? options_.pipelineDepth - 1 : 1;
+    return perBlockSlotSize * safeDepth;
+  }
 
   /**
    * send_group - Cooperative transfer to peer GPU over NVLink
@@ -1475,8 +1484,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1520,13 +1530,15 @@ class P2pNvlTransportDevice {
 #endif
   }
 
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1588,8 +1600,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[max_groups + groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1603,11 +1616,13 @@ class P2pNvlTransportDevice {
           group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
 
       if (copyBytes > 0) {
-        memcpy_vectorized(
+        CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1658,6 +1673,7 @@ class P2pNvlTransportDevice {
    * @param max_signal_bytes Hint for max bytes between signals.
    *   0 means one signal per slot fill. Capped at per_block_slot_size.
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -1665,7 +1681,8 @@ class P2pNvlTransportDevice {
       P2pNvlTransportDevice& successor,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1735,11 +1752,19 @@ class P2pNvlTransportDevice {
     int64_t sendStep = successor.tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
-      const std::size_t slot = slotStep % options_.pipelineDepth;
-      const std::size_t slotOff = slot * slotSize;
-      const std::size_t chunkOff = subStep * effectiveChunk;
+      const std::size_t absRecvStep = static_cast<std::size_t>(recvStep);
+      const std::size_t recvSlotStep = absRecvStep / stepsPerSlot;
+      const std::size_t recvSubStep = absRecvStep % stepsPerSlot;
+      const std::size_t recvSlot = recvSlotStep % options_.pipelineDepth;
+      const std::size_t recvSlotOff = recvSlot * slotSize;
+      const std::size_t recvChunkOff = recvSubStep * effectiveChunk;
+
+      const std::size_t absSendStep = static_cast<std::size_t>(sendStep);
+      const std::size_t sendSlotStep = absSendStep / stepsPerSlot;
+      const std::size_t sendSubStep = absSendStep % stepsPerSlot;
+      const std::size_t sendSlot = sendSlotStep % options_.pipelineDepth;
+      const std::size_t sendSlotOff = sendSlot * slotSize;
+      const std::size_t sendChunkOff = sendSubStep * effectiveChunk;
 
       const std::size_t dataOff = s * effectiveChunk;
       const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
@@ -1752,7 +1777,7 @@ class P2pNvlTransportDevice {
 
       // 2. Wait for successor's staging slot to be free (send side, only at
       //    slot boundaries once we have wrapped around the pipeline).
-      if (subStep == 0 &&
+      if (sendSubStep == 0 &&
           sendStep >=
               static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
         successor.tile_state_.local_signals[headSignalId].wait_until(
@@ -1766,12 +1791,14 @@ class P2pNvlTransportDevice {
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
       if (copyBytes > 0) {
-        memcpy_vectorized(
-            dstPtr + dataOff,
-            sendBuf + slotOff + stagingOff + chunkOff,
-            recvBuf + slotOff + stagingOff + chunkOff,
+        CopyOp::forward(
+            dstPtr ? dstPtr + dataOff : nullptr,
+            sendBuf + sendSlotOff + stagingOff + sendChunkOff,
+            recvBuf + recvSlotOff + stagingOff + recvChunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1782,7 +1809,7 @@ class P2pNvlTransportDevice {
 
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
-        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+        if (recvSubStep == stepsPerSlot - 1 || s == totalSteps - 1) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
         }
@@ -2031,7 +2058,7 @@ class P2pNvlTransportDevice {
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
-  const P2pNvlTransportOptions options_;
+  const P2pNvlTransportOptions options_{};
   LocalState localState_;
   RemoteState remoteState_;
   NvlinkTransportTileState tile_state_;

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -12,6 +12,7 @@
 #include "comms/pipes/MultiPeerNvlTransport.h"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/benchmarks/TileSendRecv.cuh"
 #include "comms/pipes/tests/P2pNvlTransportTest.cuh"
 #include "comms/pipes/tests/Utils.cuh"
@@ -4256,6 +4257,173 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardMultiCallPersistentStep) {
       2,
       4,
       5);
+}
+
+TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
+  if (numRanks != 2) {
+    return;
+  }
+
+  constexpr int kNumBlocks = 4;
+  constexpr size_t kDataBufferSize = 1024 * 1024;
+  constexpr size_t kMaxSignalBytes = 64 * 1024;
+  constexpr size_t kPerBlockSlotSize = kDataBufferSize / kNumBlocks;
+  constexpr size_t kForwardBytes = kMaxSignalBytes * kNumBlocks;
+  constexpr size_t kAdvanceBytes = kForwardBytes * 5;
+  constexpr int kThreadCount = 256;
+  constexpr unsigned char kAdvancePattern = 0x33;
+  constexpr unsigned char kForwardPattern = 0x7a;
+
+  auto bs = std::make_shared<meta::comms::MpiBootstrap>();
+  const int peerRank = globalRank == 0 ? 1 : 0;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = kDataBufferSize,
+      .chunkSize = kDataBufferSize,
+      .pipelineDepth = 2,
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bs, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+  int device = 0;
+  CUDACHECK_TEST(cudaGetDevice(&device));
+  Timeout timeout = makeTimeout(5000, device);
+
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(
+        p2pHost.getLocalState().dataBuffer,
+        0,
+        config.pipelineDepth * config.dataBufferSize));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  DeviceBuffer advanceSendBuf(kAdvanceBytes);
+  DeviceBuffer advanceRecvBuf(kAdvanceBytes);
+  if (globalRank == 1) {
+    CUDACHECK_TEST(
+        cudaMemset(advanceSendBuf.get(), kAdvancePattern, kAdvanceBytes));
+  } else {
+    CUDACHECK_TEST(cudaMemset(advanceRecvBuf.get(), 0, kAdvanceBytes));
+  }
+
+  // Advance only the rank1->rank0 tile send/recv state by 5 sub-steps. The
+  // following forward call then has recvStep == 0 and sendStep == 5 on rank 1.
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (globalRank == 1) {
+    test::testTileSend(
+        p2pHost,
+        advanceSendBuf.get(),
+        kAdvanceBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  } else {
+    test::testTileRecv(
+        p2pHost,
+        advanceRecvBuf.get(),
+        kAdvanceBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    std::vector<char> hostBuf(kAdvanceBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(),
+        advanceRecvBuf.get(),
+        kAdvanceBytes,
+        cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < kAdvanceBytes; ++i) {
+      if (static_cast<unsigned char>(hostBuf[i]) != kAdvancePattern) {
+        EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), kAdvancePattern)
+            << "pre-advance mismatch at byte " << i;
+        break;
+      }
+    }
+  }
+
+  DeviceBuffer srcBuf(kForwardBytes);
+  DeviceBuffer fwdR1Buf(kForwardBytes);
+  if (globalRank == 0) {
+    CUDACHECK_TEST(cudaMemset(srcBuf.get(), kForwardPattern, kForwardBytes));
+  } else {
+    CUDACHECK_TEST(cudaMemset(fwdR1Buf.get(), 0, kForwardBytes));
+  }
+
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  if (globalRank == 0) {
+    test::testTileSend(
+        p2pHost,
+        srcBuf.get(),
+        kForwardBytes,
+        kNumBlocks,
+        kMaxSignalBytes,
+        timeout,
+        kNumBlocks,
+        kThreadCount);
+  } else {
+    TiledBuffer<char> dstTiles(
+        static_cast<char*>(fwdR1Buf.get()), kForwardBytes, kNumBlocks);
+    int numBlocksArg = kNumBlocks;
+    std::size_t maxSignalBytes = kMaxSignalBytes;
+    void* args[] = {
+        &p2pHost,
+        &p2pHost,
+        &dstTiles,
+        &numBlocksArg,
+        &maxSignalBytes,
+        &timeout};
+
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileForward,
+        dim3(kNumBlocks),
+        dim3(kThreadCount),
+        args,
+        0,
+        nullptr));
+  }
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+  if (globalRank == 0) {
+    std::vector<char> stagingSlot(kDataBufferSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        stagingSlot.data(),
+        static_cast<char*>(p2pHost.getLocalState().dataBuffer) +
+            kDataBufferSize,
+        kDataBufferSize,
+        cudaMemcpyDeviceToHost));
+    for (int block = 0; block < kNumBlocks; ++block) {
+      const size_t chunkOffset = block * kPerBlockSlotSize + kMaxSignalBytes;
+      for (size_t i = 0; i < kMaxSignalBytes; ++i) {
+        EXPECT_EQ(
+            static_cast<unsigned char>(stagingSlot[chunkOffset + i]),
+            kForwardPattern)
+            << "forward staging mismatch at block " << block << " byte " << i;
+        if (static_cast<unsigned char>(stagingSlot[chunkOffset + i]) !=
+            kForwardPattern) {
+          return;
+        }
+      }
+    }
+  } else {
+    std::vector<char> hostBuf(kForwardBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), fwdR1Buf.get(), kForwardBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < kForwardBytes; ++i) {
+      EXPECT_EQ(static_cast<unsigned char>(hostBuf[i]), kForwardPattern)
+          << "forward mismatch at byte " << i;
+      if (static_cast<unsigned char>(hostBuf[i]) != kForwardPattern) {
+        return;
+      }
+    }
+  }
 }
 
 // Partial tiles (nbytes not evenly divisible by numBlocks)

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -3,6 +3,8 @@
 #include "comms/pipes/tests/Checks.h"
 #include "comms/pipes/tests/P2pNvlTransportTest.cuh"
 
+#include "comms/pipes/TiledBuffer.cuh"
+
 namespace comms::pipes::test {
 
 // Helper to create the appropriate thread group based on type
@@ -33,6 +35,44 @@ __global__ void testRecvKernel(
     GroupType groupType) {
   auto group = make_group(groupType);
   p2p->recv_group(group, dst_d, nbytes);
+}
+
+__global__ void testTileSendKernel(
+    P2pNvlTransportDevice p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_block_group();
+  TiledBuffer<char> tiles(reinterpret_cast<char*>(src_d), nbytes, group);
+  p2p.send(
+      group,
+      tiles.data(),
+      tiles.bytes(),
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+}
+
+__global__ void testTileRecvKernel(
+    P2pNvlTransportDevice p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+  auto group = make_block_group();
+  TiledBuffer<char> tiles(reinterpret_cast<char*>(dst_d), nbytes, group);
+  p2p.recv(
+      group,
+      tiles.data(),
+      tiles.bytes(),
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
 }
 
 // Kernel that performs multiple sequential sends within a single kernel launch
@@ -156,6 +196,36 @@ void testRecv(
     cudaStream_t stream) {
   testRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
       p2p, dst_d, nbytes, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileSend(
+    const P2pNvlTransportDevice& p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileSendKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, src_d, nbytes, activeBlocks, maxSignalBytes, timeout);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileRecv(
+    const P2pNvlTransportDevice& p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileRecvKernel<<<numBlocks, blockSize, 0, stream>>>(
+      p2p, dst_d, nbytes, activeBlocks, maxSignalBytes, timeout);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -38,6 +38,28 @@ void testRecv(
     int blocksPerGroup = 1,
     cudaStream_t stream = nullptr);
 
+void testTileSend(
+    const P2pNvlTransportDevice& p2p,
+    void* src_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileRecv(
+    const P2pNvlTransportDevice& p2p,
+    void* dst_d,
+    size_t nbytes,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    Timeout timeout,
+    int numBlocks,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
 // Multiple sequential sends within a single kernel
 void testMultiSend(
     P2pNvlTransportDevice* p2p,


### PR DESCRIPTION
Summary:

Extends the NVLink transport device with pipeline windowing support, pluggable CopyOp template hooks, and correctness fixes needed for hierarchical collectives.

## Changes

### 1. `pipeline_window()` accessor
Returns the safe per-block data window (bytes) that a caller can send/recv/forward in one pipeline pass without overrunning the staging buffer:

```
pipeline_window = (dataBufferSize / totalGroups) & ~15  ×  (pipelineDepth - 1)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         ^^^^^^^^^^^^^^^^^^^^
                  per-block slot (16-byte aligned)         safe depth (reserve 1 slot)
```

### 2. CopyOp template on tiled `recv()` and `forward()`
Adds a `template <typename CopyOp = Memcpy, typename... Args>` parameter so callers can fuse custom logic into the copy path. The default `Memcpy` preserves existing behavior. Used by the direct NVLink reduce-scatter kernel (passes `TileReduceStaged` as CopyOp) and the hierarchical allgather (passes `MemcpyAndSelfCopy`).

### 3. Absolute step counter fix in tiled `send()`, `recv()`, `forward()`
The slot and chunk offset computation previously used the loop index `s` to derive `slotStep` and `subStep`. This is only correct when `step_state` starts at zero. When a transport is reused across multiple kernel launches (step_state > 0), the offsets must be derived from the absolute step counter. Fixed to use `static_cast<std::size_t>(step)` instead of `s`.

```
Before: slotStep = s / stepsPerSlot          ← wrong if step != s
After:  absStep  = static_cast<size_t>(step)
        slotStep = absStep / stepsPerSlot    ← correct for any initial step
```

### 4. Independent recv/send slot tracking in `forward()`
The forward path reads from the predecessor's staging buffer (recv side) and writes to the successor's staging buffer (send side). These may be at different pipeline phases. Previously both used the same `slotStep`/`subStep` derived from a single index. Now tracks `recvSlotStep`/`recvSubStep` and `sendSlotStep`/`sendSubStep` independently.

### 5. `MultiPeerNvlTransportConfig::memSharingMode` override
Adds an optional `memSharingMode` field so tests and benchmarks can force `cudaIpc` mode on platforms where fabric handles are available but undesired (e.g. single-node testing without IMEX).

### 6. Default-initialize `P2pNvlTransportOptions` fields
Value-initialize `dataBufferSize`, `chunkSize`, `pipelineDepth` to `{0}` for safe default construction.

Reviewed By: siyengar

Differential Revision: D105039177


