### PR TITLE
Extract Memcpy CopyOp into standalone MemcpyCopyOp.cuh header (#2524)

### DIFF
--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -5,50 +5,11 @@
 #include <cstddef>
 
 #include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
-
-struct Memcpy {
-  template <typename... Args>
-  __device__ __forceinline__ static void send(
-      char* staging,
-      const char* src,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(staging, src, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void recv(
-      char* dst,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(dst, staging, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void forward(
-      char* dst,
-      char* fwd_staging,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    if (dst) {
-      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
-    } else {
-      memcpy_vectorized(fwd_staging, staging, nbytes, group);
-    }
-  }
-};
 
 template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 struct TileReduce {

--- a/comms/pipes/MemcpyCopyOp.cuh
+++ b/comms/pipes/MemcpyCopyOp.cuh
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+struct Memcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(dst, staging, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    if (dst) {
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
+    } else {
+      memcpy_vectorized(fwd_staging, staging, nbytes, group);
+    }
+  }
+};
+
+} // namespace comms::pipes


### PR DESCRIPTION
Summary:

Extracts the `Memcpy` CopyOp struct from `CopyOp.cuh` into its own `MemcpyCopyOp.cuh` header and `memcpy_copy_op` Buck target.

## Motivation

The `Memcpy` struct is a lightweight, zero-dependency CopyOp that wraps `memcpy_vectorized` for send, recv, and forward operations. It is needed by transport-layer code (`P2pNvlTransportDevice`) as a default template argument, but the transport should not depend on the heavier `CopyOp.cuh` which pulls in `Tile.cuh` and tile-based reduce operations (`TileReduce`, `TileReduceStaged`).

## Change overview

```
Before:
  CopyOp.cuh
  ├── struct Memcpy          (memcpy-based send/recv/forward)
  ├── struct TileReduce      (tile-based reduce)
  └── struct TileReduceStaged (tile-based staged reduce)

After:
  MemcpyCopyOp.cuh           ← NEW: standalone Memcpy struct
  CopyOp.cuh
  ├── #include "MemcpyCopyOp.cuh"  ← re-exports Memcpy
  ├── struct TileReduce
  └── struct TileReduceStaged
```

## Dependency graph

```
memcpy_copy_op (NEW)
  ├── :copy_utils
  └── :thread_group

copy_op (UPDATED)
  ├── :copy_utils
  ├── :memcpy_copy_op   ← NEW dep
  ├── :thread_group
  └── :tile
```

Pure refactor: the `Memcpy` struct is moved verbatim, and `CopyOp.cuh` re-includes it so all existing consumers see no change. No functional behavior change.

Reviewed By: siyengar

Differential Revision: D105039175


