### PR TITLE
Add ctran hierarchical Pipes AllGatherP via GPE

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/CtranPipes.h"
 
+#include <algorithm>
 #include <set>
 
 #include "comms/ctran/CtranComm.h"
@@ -85,6 +86,15 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     }
     config.ibgdaConfig.dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
     config.ibgdaConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
+    config.ibgdaConfig.sendRecv =
+        comms::pipes::MultipeerIbgdaTransportConfig::SendRecvConfig{
+            .maxGroups = static_cast<int>(
+                std::max<int64_t>(1, NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS)),
+            .pipelineDepth = static_cast<int>(
+                std::max<int64_t>(1, NCCL_CTRAN_HIER_AG_IB_PIPELINE_DEPTH)),
+        };
+    config.ibgdaConfig.numQpsPerPeerPerNic = static_cast<int>(
+        std::max<int64_t>(1, NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC));
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibgdaConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
     }

--- a/comms/ctran/PLAN.md
+++ b/comms/ctran/PLAN.md
@@ -1,0 +1,758 @@
+# Ctran Hierarchical NVLink + IBGDA AllGather Integration Plan
+
+Status: architecture plan only. This document is intended to drive a later implementation pass.
+
+## Phase 1: Architecture Review
+
+### Ctran AllGather Dispatch
+
+Ctran has two AllGather surfaces:
+
+- Eager AllGather under `ctran/algos/AllGather/`.
+- Persistent/window AllGatherP under `ctran/algos/AllGatherP/`.
+
+The eager path is selected from `NCCL_ALLGATHER_ALGO` and routed through `ctranAllGather()`. The current implementation maps the generic `ctran` setting to `ctdirect` when multiple local ranks exist and to `ctring` otherwise. The supported eager algorithms are:
+
+- `ctdirect`: local NVLink broadcast plus mapper-driven inter-node puts.
+- `ctring`: host/mapper ring path, only supported when `nLocalRanks == 1`.
+- `ctrd`: host/mapper recursive doubling path, only supported when `nLocalRanks == 1`.
+- `ctbrucks`: host/mapper Brucks fast-forward path.
+- `ctgraph*`: CUDA graph-aware wrappers that eventually execute AllGatherP variants.
+
+The persistent path is selected from `NCCL_ALLGATHER_P_ALGO` and routed through `allGatherPExec()` and `allGatherWinExec()`. The current persistent choices are:
+
+- `ctdirect`
+- `ctpipeline`
+- `ctrdpipeline`
+
+The persistent path already has the right shape for the new work: it has an explicit algorithm enum, a benchmark switch in `AllgatherPBench.cc`, a window path, and CUDA graph-aware entry points.
+
+### Ctran Host-Side and Device-Side Split
+
+The current ctran AllGather implementations are mostly host/GPE orchestrated:
+
+- `AllGatherDirect` builds `KernelElem` work, performs local NVLink broadcast in a ctran kernel, and performs inter-node movement through `CtranMapper` `iput` and notify operations.
+- `AllGatherP/PipelineImpl` uses small synchronization kernels (`PipeStart`, `PipeSync`, `PipeEnd`) to coordinate GPE host work. Bulk local movement is done by CUDA copy engine NVLink copies, and inter-node movement is mapper-driven.
+- `AllGatherP/RecursiveDoublingImpl` follows the same pattern, with recursive doubling over nodes and copy engine broadcast after each remote exchange.
+
+This means ctran today does not have a single device kernel that directly combines:
+
+- self-copy into final `recvbuff`,
+- IBGDA staging,
+- IB ring forwarding,
+- NVLink local broadcast from the received rank chunk.
+
+That fusion is the core performance difference in D104725448.
+
+### GPE Launch Model
+
+`CtranGpe` can launch a kernel with or without a host-side op group. `DeviceAllToAllvPipes` is the closest existing pattern:
+
+- build a ctran-local `KernArgs`,
+- set `KernelConfig.algoArgs`,
+- submit an empty `opGroup`,
+- launch a GPE-compatible kernel signature,
+- ignore `CtranAlgoDeviceState` inside the Pipes-based kernel.
+
+For the hierarchical AllGather path, this is the right integration model. It preserves ctran stream ordering and CUDA graph behavior while avoiding mapper host work in the hot data path.
+
+Block diagram:
+
+```text
+Current ctran AllGatherP pipeline
+
+  user stream
+      |
+      v
+  GPE sync kernels
+      |
+      +--> host/GPE mapper work --> CtranMapper/CtranIb --> remote GPU memory
+      |
+      +--> CUDA copy engine NVLink copies
+      |
+      v
+  recvbuff
+
+
+Proposed hierarchical Pipes AllGatherP
+
+  user stream
+      |
+      v
+  Ctran GPE kernel launch with empty opGroup
+      |
+      v
+  one GPU kernel
+      |
+      +--> CopyOp fused self-copy: sendbuf -> IB staging and recvbuff[self]
+      +--> P2pIbgdaTransportDevice ring: inter-node forward/recv
+      +--> P2pNvlTransportDevice broadcast: intra-node/NVL fanout
+      |
+      v
+  recvbuff
+```
+
+### Ctran Pipes Integration
+
+`CtranPipes.cc` already constructs a `comms::pipes::MultiPeerTransport` when Pipes is enabled. The existing integration:
+
+- configures NVLink buffer settings,
+- configures baseline IBGDA fields such as CUDA device, GID/address family, HCA, data buffer size, QP depth, timeout, retry, TC, SL, and RNR settings,
+- reuses ctran shared NVLink staging buffers through `setExternalNvlDataBuffers()`,
+- calls `exchange()` to build device-side transport handles.
+
+`MultiPeerTransport` already exposes the host accessors needed by the hierarchical AllGather:
+
+- `get_p2p_nvl_transport_device(globalPeerRank)`
+- `get_p2p_ibgda_transport_device(globalPeerRank)`
+- `nvl_local_rank()`
+- `nvl_n_ranks()`
+- `nvl_peer_ranks()`
+- `global_to_nvl_local(globalRank)`
+- `my_rank()`
+- `n_ranks()`
+
+The gap is tuning and lifecycle: the current ctran Pipes config does not yet expose the D104 performance knobs for IBGDA send/recv state, multi-QP, block count, signal granularity, or pipeline depth.
+
+### Memory Registration and Buffer Management
+
+Ctran's existing AllGatherP init path registers the user `recvbuff` for mapper-driven remote writes and exchanges access keys. The Pipes hierarchical path does not need remote ranks to RDMA directly into user `recvbuff`; it uses IBGDA transport-owned staging rings and copies from local staging into final `recvbuff` inside the GPU kernel.
+
+Implications:
+
+- The first implementation can live inside AllGatherP and tolerate the existing persistent registration overhead, because the hot path does not need mapper writes.
+- No per-exec buffer registration or exchange should occur.
+- IBGDA `sendRecv` staging resources must be configured during `CtranPipes.cc` initialization and remain stable for the lifetime of the communicator.
+- The path must guard against overlapping hierarchical collectives on the same `MultiPeerTransport` until the send/recv state is explicitly proven channel-safe.
+
+### Copy Model: Fused Staging, Not Zero-Copy
+
+The proposed integration is copy-based and staged. It is GPU-direct and copy-fused, but it is not true end-to-end zero-copy from every sender's `sendbuf` into every receiver's final `recvbuff` slot.
+
+The intended data movement is:
+
+```text
+sendbuf[self]
+    |
+    | fused CopyOp
+    v
+IBGDA send staging  +  recvbuff[self]
+    |
+    v
+remote IBGDA staging / forward path
+    |
+    v
+recvbuff[remote rank]
+    |
+    v
+NVLink fanout within the local NVL group
+```
+
+This still removes CPU bounce buffers and host-posted data movement from the hot path. The performance bet is one GPU kernel, GPU-issued IBGDA, fused self-copy into IB staging plus final recv slot, staged IB ring forwarding, and NVLink local fanout.
+
+True zero-copy final-buffer RDMA is a separate future design. It would require final `recvbuff` registration, remote final-buffer address exchange, more complex correctness for in-place/window execution, and a different flow-control model. It should not be mixed into the first integration unless the staged design cannot meet the 128MB and 1GB targets.
+
+### Topology Awareness
+
+Ctran has local-rank and node information, and Pipes `MultiPeerTransport` discovers NVLink reachability. Today there is no ctran AllGather selector that specifically says "uniform NVLink groups plus inter-node IBGDA ring."
+
+D104 assumes a rectangular rank layout:
+
+```text
+global_rank = ib_rank * nvl_size + nvl_rank
+```
+
+The ctran integration must either:
+
+- strictly require uniform, contiguous NVLink groups in that layout, or
+- add an explicit rank remap in the kernel and launcher args.
+
+The first implementation should choose strict gating. It is safer, easier to benchmark, and prevents silent writes to the wrong allgather slots.
+
+### Pipes D104725448 Hierarchical AllGather
+
+D104725448 adds the Pipes DirectNvl path:
+
+- `pipes/collectives/DirectNvl.cu`
+- `pipes/collectives/DirectNvl.cuh`
+- `pipes/collectives/DirectNvlTypes.h`
+- `pipes/collectives/DirectNvlLauncher.*`
+
+The key device behavior is:
+
+- one CUDA kernel performs hierarchical AllGather,
+- each block group participates in an IBGDA ring across NVLink groups,
+- each IB ring step receives or forwards a chunk through `P2pIbgdaTransportDevice`,
+- local NVLink peers receive chunks through `P2pNvlTransportDevice`,
+- the self chunk is copied once into both IB send staging and final `recvbuff[self]` via `CopyOp`.
+
+The key performance mechanisms are:
+
+- `MemcpyAndSelfCopy` uses the `CopyOp` hook to perform the self-copy and IB send-staging copy in one vectorized path.
+- `P2pIbgdaTransportDevice::send/recv/forward` owns the staged ring protocol and flow control for DATA_READY, SLOT_FREE, and NIC completion state.
+- `nic_qp_for_group()` spreads block groups over the available NIC/QP pool, so block count and QPs per peer per NIC are coupled tuning parameters.
+- `pipeline_window(active_blocks)` partitions the staging window across active groups; a block count that helps 1GB can over-fragment the window and hurt 128MB.
+- fused self-copy and IB staging through `memcpy_vectorized` with dual destinations,
+- GPU-issued IBGDA WQEs,
+- per-block-group QP/NIC selection,
+- configurable IB send/recv pipeline depth,
+- configurable block count and signal granularity,
+- one-kernel overlap of self-copy, inter-node IB, and local NVLink broadcast.
+
+### Current Performance-Critical Differences
+
+Current ctran `ctpipeline`:
+
+- uses host/GPE mapper orchestration for IB,
+- uses CUDA copy engine local NVLink broadcast,
+- copies self separately,
+- has multiple phase boundaries,
+- has clear CUDA graph support through existing GPE/window paths.
+
+Pipes D104 hierarchical AllGather:
+
+- uses one GPU kernel,
+- keeps IBGDA control on device,
+- fuses self-copy with IB staging,
+- maps block groups across NICs/QPs,
+- needs stricter transport state lifecycle and rank geometry guarantees.
+
+The integration should preserve the Pipes hot path and adapt ctran around it, not translate it into mapper operations.
+
+### 128MB Performance Gap Risk
+
+D104's strongest evidence is at 1GB. The 128MB target needs separate analysis because the same tuning can lose bandwidth at smaller large-message sizes.
+
+Likely 128MB failure modes:
+
+- IBGDA pipeline startup and drain overhead becomes a larger fraction of runtime.
+- Too many blocks can over-partition each staging slot, reducing per-block contiguous copy size and increasing signal pressure.
+- IB signal granularity tuned for 1GB can be too coarse or too fine at 128MB.
+- Pipeline depth and data buffer size can waste staging capacity or add unnecessary slot-management overhead.
+- NCCL may choose a different protocol/topology at 128MB than at 1GB, so a single ctran threshold is risky.
+
+The benchmark phase must include a targeted 128MB sweep:
+
+- block count: `4, 8, 16, 32`
+- IB signal bytes: `512KB, 1MB, 2MB`
+- IBGDA pipeline depth: `1, 2, 4`
+- data buffer size: `32MB, 64MB, 128MB`
+- QPs per peer per NIC: `1, 2, 4, 8`
+- NCCL baselines: production default and fair matched configurations
+
+The production selector must be size-aware. Do not auto-select the hierarchical path for 128MB, or for any size bucket, unless that size bucket independently passes the NCCL acceptance criteria on the target topology.
+
+## Phase 2: Integration Approaches
+
+### Approach A: New AllGatherP Algorithm With GPE Wrapper Over Pipes Device Path
+
+Architecture:
+
+- Add an opt-in AllGatherP algorithm such as `cthierarchical_pipes`.
+- Dispatch from `allGatherPExec()` and `allGatherWinExec()`.
+- Build a ctran-local `KernArgs` from `CommStateX`, `PersistArgs`, and `comm->multiPeerTransport_`.
+- Submit a GPE-compatible kernel with an empty `opGroup`, following the `DeviceAllToAllvPipes` pattern.
+
+Reuse vs rewrite:
+
+- Reuse Pipes `P2pIbgdaTransportDevice`, `P2pNvlTransportDevice`, `TiledBuffer`, and `CopyOp` behavior.
+- Prefer a small shared device helper in Pipes if required so the Pipes benchmark launcher and ctran wrapper share the same kernel body.
+- Keep collective policy, dispatch, support checks, and ctran args under `fbcode/comms/ctran/`.
+
+Transport layer:
+
+- Use `MultiPeerTransport` accessors for previous/next IBGDA peers and local NVLink peers.
+- Extend `CtranPipes.cc` config to expose and set `ibgdaConfig.sendRecv`, `numQpsPerPeerPerNic`, `dataBufferSize`, pipeline depth, block count, and signaling bytes.
+- Do not route IBGDA through `CtranMapper`.
+
+Kernel strategy:
+
+- Single kernel.
+- Preserve `CopyOp` dual-destination fusion.
+- Set GPE dynamic shared memory to zero unless the wrapper needs ctran shared state.
+- Avoid default-stream launcher behavior; launch on the ctran stream through GPE.
+
+Algorithm selection:
+
+- Add an enum/cvar value under `NCCL_ALLGATHER_P_ALGO`.
+- Keep it opt-in until correctness and performance acceptance criteria are met.
+- Gate support on `ENABLE_PIPES`, `NCCL_CTRAN_USE_PIPES`, `multiPeerTransport_ != nullptr`, uniform NVLink group size, IBGDA availability for inter-group peers, and valid rank geometry.
+- Add production auto-selection only after size/topology buckets have measured wins. The first selector should be explicit opt-in; the later selector should use a benchmark-derived table rather than a single hardcoded large-message threshold.
+
+Performance hypothesis:
+
+- Best chance to match D104 performance because it preserves the one-kernel fused data path.
+- Should beat host/mapper ctran paths on large transfers by reducing CPU/GPE phase overhead and redundant memory movement.
+- Should be competitive with NCCL on GB200 when QP/NIC/block tuning matches the D104 benchmark.
+
+Risk and complexity:
+
+- Medium to high.
+- Requires careful rank geometry validation.
+- Requires send/recv state lifecycle rules to avoid overlapping collective corruption.
+- Requires transport error handling rules for the shared multi-QP pool. One QP entering an error state can poison subsequent sends to that peer until the communicator is torn down or the transport is rebuilt.
+- Requires config work in `CtranPipes.cc`.
+
+Benchmark plan:
+
+- Add `cthierarchical_pipes` to `AllgatherPBench.cc`.
+- Benchmark against `ctpipeline`, `ctrdpipeline`, and NCCL in the same process and buffer setup.
+- Benchmark NCCL both with production defaults and with fair matched settings. Do not claim NCCL superiority based only on a baseline that disables NCCL NVLS, P2P, or SHM optimizations.
+- Include CUDA graph/window execution once correctness is established.
+
+Recommendation: primary approach.
+
+### Approach B: Benchmark-Only Ctran Sidecar First
+
+Architecture:
+
+- Add a benchmark-only mode in `AllgatherPBench.cc` that builds the same hierarchical launch parameters from ctran communicator state and launches the Pipes hierarchical kernel.
+- Do not expose it through production ctran dispatch initially.
+
+Reuse vs rewrite:
+
+- Reuse the Pipes launcher or a stream-aware wrapper.
+- Reuse ctran benchmark allocation, warmup, iteration, and NCCL comparison logic.
+
+Transport layer:
+
+- Use `comm->multiPeerTransport_`.
+- Configure IBGDA send/recv resources through `CtranPipes.cc`; otherwise the benchmark will not reflect the target production path.
+
+Kernel strategy:
+
+- Prefer the same kernel wrapper intended for Approach A, but restrict call sites to benchmarks.
+
+Algorithm selection:
+
+- Benchmark flag only.
+- No production selector change.
+
+Performance hypothesis:
+
+- Fastest way to verify whether the D104 win survives ctran initialization, buffers, topology discovery, and launch context.
+
+Risk and complexity:
+
+- Low to medium.
+- Can become throwaway code if not built with the same args and config as production.
+
+Benchmark plan:
+
+- Use it as Phase 0 validation before defaulting or auto-selecting anything.
+
+Recommendation: useful as a risk-reduction step, not sufficient as the final integration.
+
+### Approach C: Eager `NCCL_ALLGATHER_ALGO` Variant
+
+Architecture:
+
+- Add a new eager algorithm such as `cthierarchical_pipes`.
+- Dispatch from `ctranAllGather()` for non-persistent calls.
+
+Reuse vs rewrite:
+
+- Reuse the same ctran GPE kernel wrapper as Approach A.
+- Reuse support checks and topology gating.
+
+Transport layer:
+
+- Same as Approach A.
+
+Kernel strategy:
+
+- Single kernel, but eager calls must build params on every execution.
+
+Algorithm selection:
+
+- Add a value under `NCCL_ALLGATHER_ALGO`.
+- Do not auto-map `ctran` to this path until the persistent path passes acceptance criteria.
+
+Performance hypothesis:
+
+- Could provide a faster non-persistent path for large messages once Approach A is validated.
+
+Risk and complexity:
+
+- Higher than Approach A because eager calls interact with dynamic counts, registrations, and existing `ctranAllGatherSupport()` behavior.
+- CUDA graph support is better handled first through the AllGatherP/window path.
+
+Benchmark plan:
+
+- Add only after Approach A reaches stable performance.
+
+Recommendation: second-stage production extension.
+
+### Approach D: Hybridize Existing `ctpipeline` or `ctdirect`
+
+Architecture:
+
+- Keep the existing ctran mapper/GPE control flow.
+- Replace one part of the data path with Pipes NVLink or IBGDA operations.
+
+Reuse vs rewrite:
+
+- Reuse some ctran orchestration.
+- Reuse only fragments of Pipes transport.
+
+Transport layer:
+
+- Mixed `CtranMapper` plus Pipes device transport.
+
+Kernel strategy:
+
+- Multi-phase.
+- Likely loses self-copy and IB staging fusion.
+
+Algorithm selection:
+
+- Could remain under `ctpipeline` or a new hybrid name.
+
+Performance hypothesis:
+
+- May improve one bottleneck but is unlikely to reproduce D104 performance.
+
+Risk and complexity:
+
+- Medium complexity with poor performance upside.
+- Creates two control planes in one algorithm.
+
+Benchmark plan:
+
+- Only investigate if Approach A fails due to an unavoidable ctran/Pipes lifecycle issue.
+
+Recommendation: fallback experiment only.
+
+### Approach E: New Ctran Mapper Backend or CtranIb Port
+
+Architecture:
+
+- Translate IBGDA into `CtranMapper` or `CtranIb` abstractions.
+
+Reuse vs rewrite:
+
+- Rewrites most of D104 transport semantics.
+- Loses direct mapping to `P2pIbgdaTransportDevice::send/recv/forward`.
+
+Transport layer:
+
+- Host-posted verbs or mapper requests instead of GPU-issued IBGDA WQEs.
+
+Kernel strategy:
+
+- Multi-phase host/device orchestration.
+
+Algorithm selection:
+
+- Could be hidden behind existing mapper selection, but would affect more than AllGather.
+
+Performance hypothesis:
+
+- Unlikely to beat NCCL because it discards the main D104 advantages.
+
+Risk and complexity:
+
+- High complexity.
+- High abstraction leakage.
+- Global transport semantics become harder to reason about.
+
+Benchmark plan:
+
+- Not recommended for this goal.
+
+Recommendation: no-go for the NCCL parity target.
+
+### Approach F: Replace or Default `ctpipeline` Immediately
+
+Architecture:
+
+- Make hierarchical Pipes AllGather the default whenever topology appears to match.
+
+Reuse vs rewrite:
+
+- Could reuse Approach A internally, but without sufficient validation.
+
+Transport layer:
+
+- Same as Approach A.
+
+Kernel strategy:
+
+- Same as Approach A.
+
+Algorithm selection:
+
+- Auto-select or replace `ctpipeline`.
+
+Performance hypothesis:
+
+- Could expose wins quickly, but also risks regressions for sizes and topologies where D104 was not proven.
+
+Risk and complexity:
+
+- High production risk.
+- Poor A/B isolation.
+
+Benchmark plan:
+
+- Not valid until Approach A has passed acceptance criteria.
+
+Recommendation: no-go until after opt-in validation.
+
+## Phase 3: Domain Expert Review
+
+### Ranking Matrix
+
+| Approach | GPU Kernel Performance | Network/RDMA Transport | Systems Architecture | Benchmark/Validation |
+| --- | --- | --- | --- | --- |
+| A. AllGatherP/GPE wrapper over Pipes device path | 1 | 1 | 1 | 1 |
+| B. Direct stream-aware Pipes launcher adapter | 2 | 2 | 2 | Not preferred |
+| C. Benchmark-only ctran sidecar | Useful, not final | Useful, not final | Useful, not final | 2 |
+| D. Hybrid existing ctpipeline/ctdirect | 3 | 3 | No-go if spliced into `ctdirect` | 4 if replacing default |
+| E. Ctran-native rewrite or mapper/IB backend | 4 or no-go | No-go | 3-4 depending shape | 3, long-term only |
+| F. Replace/default `ctpipeline` immediately | No-go | No-go | No-go | No-go |
+
+### Agent 1: GPU Kernel Performance Engineer
+
+Top pick: Approach A.
+
+Key arguments:
+
+- Preserves D104's fused self-copy and IB staging, so `sendbuf` is read once and written to both IB staging and `recvbuff[self]`.
+- Keeps Pipes block-group scheduling and multi-QP/NIC mapping intact.
+- Avoids extra shared-memory and register pressure from ctran native kernel state.
+
+Biggest risk:
+
+- `CtranPipes.cc` must configure IBGDA send/recv state, QPs per peer per NIC, data buffer size, pipeline depth, and block count. Reusing the current `multiPeerTransport_` config as-is may under-saturate IB.
+
+No-go:
+
+- Do not adapt generic `DeviceAllToAllvPipes` into an all-to-all style allgather. It destroys the hierarchical traffic pattern.
+
+### Agent 2: Network/RDMA Transport Architect
+
+Top pick: Approach A.
+
+Key arguments:
+
+- Preserves GPU-issued IBGDA WQEs, fused self-copy, and `P2pIbgdaTransportDevice::forward()` ring flow control.
+- Matches the existing ctran/Pipes seam through `CtranPipes.cc` and `MultiPeerTransport`.
+- Keeps multi-NIC/QP semantics in Pipes instead of translating them into host verbs config.
+
+Biggest risk:
+
+- `sendRecvState` is comm-wide and persistent. Ctran must prevent overlapping hierarchical collectives or incompatible knob changes without quiescence/reset.
+
+No-go:
+
+- Do not port D104 onto `ctran/backends/ib/CtranIb` host verbs.
+
+### Agent 3: Systems Software Architect
+
+Top pick: Approach A.
+
+Key arguments:
+
+- Keeps ownership clean: `CtranPipes.cc` owns transport construction, while `AllGatherP` owns algorithm selection and support checks.
+- Keeps API surface narrow with a ctran-local args struct rather than leaking Pipes internals into public ctran APIs.
+- Gives the cleanest CUDA graph story because GPE launches on the user stream with existing ordering guards.
+
+Biggest risk:
+
+- Rank geometry. The D104 layout assumption must be validated or remapped before production use.
+
+No-go:
+
+- Do not splice this into `ctdirect` mapper flow or call the D104 benchmark launcher as-is.
+
+### Agent 4: Performance Benchmarking and Validation Engineer
+
+Top pick: Approach A, with Approach C as a pre-production measurement step.
+
+Key arguments:
+
+- `AllGatherP` already has a selector, persistent state, benchmark harness, and NCCL baseline.
+- A new opt-in algorithm gives clean A/B comparisons without redefining `ctpipeline`.
+- Validation includes real ctran costs rather than only the standalone Pipes benchmark.
+
+Biggest risk:
+
+- D104 proves a tuned standalone path. The reported 1GB win may not survive production NCCL defaults, ctran registration/init behavior, or the 128MB target. Benchmarking against NCCL with NVLS, P2P, or SHM disabled is useful for controlled comparison but is not sufficient to claim production superiority.
+
+No-go:
+
+- Do not replace/default `ctpipeline` based only on standalone Pipes benchmark results.
+
+## Phase 4: Consensus Recommendation
+
+### Consensus
+
+All four reviewers prefer a ctran-owned AllGatherP integration that launches the Pipes hierarchical device path through GPE.
+
+The shared reasoning is:
+
+- keep the D104 one-kernel hot path intact,
+- keep ctran algorithm dispatch and support checks in ctran,
+- use the existing `CtranPipes.cc` transport construction seam,
+- avoid mapper/host verbs for the IBGDA data path,
+- preserve CUDA graph behavior through GPE.
+
+### Divergence
+
+The main disagreement is sequencing:
+
+- GPU and RDMA reviewers prioritize preserving the exact D104 device path first.
+- Systems review prioritizes clean API ownership and rank-geometry validation.
+- Benchmark review recommends a benchmark-only sidecar before production exposure to prove the D104 win survives ctran overhead.
+
+The final implementation order should incorporate all three concerns: first make the transport config benchmark-equivalent, then validate in `AllgatherPBench`, then expose as an opt-in AllGatherP algorithm.
+
+### Additional Review Feedback Incorporated
+
+Follow-up review agreed that the GPE empty-opGroup path is architecturally stronger than bypassing GPE. The main additions from that review are:
+
+- Treat the 128MB target as its own tuning problem, not a scaled-down version of the 1GB result.
+- Add explicit size-based dispatch and defer auto-selection until each size/topology bucket proves a win.
+- Benchmark against NCCL production defaults in addition to fair matched configurations.
+- Track multi-QP error-state propagation as part of the send/recv transport lifecycle risk.
+- Keep the implementation copy-based and fused-staged initially; do not expand scope to true zero-copy final-buffer RDMA unless the staged path cannot meet the acceptance criteria.
+
+### Final Recommendation
+
+Primary approach: implement `cthierarchical_pipes` as a new opt-in AllGatherP algorithm launched through GPE, using a ctran-local wrapper over the Pipes hierarchical device body.
+
+Proposed implementation flow:
+
+```text
+allGatherPExec / allGatherWinExec
+    |
+    v
+support check
+    |
+    +-- unsupported topology/config --> existing ctpipeline or NCCL fallback
+    |
+    v
+build HierarchicalAllGatherPipes KernArgs
+    |
+    +-- rank geometry from CommStateX / MultiPeerTransport
+    +-- NVL peer handles from get_p2p_nvl_transport_device()
+    +-- IB prev/next handles from get_p2p_ibgda_transport_device()
+    +-- tuning from ctran Pipes config/cvars
+    |
+    v
+CtranGpe::submit(empty opGroup, kernel, stream)
+    |
+    v
+GPE-compatible wrapper kernel
+    |
+    v
+shared Pipes hierarchical device body
+```
+
+Key modifications:
+
+- Add ctran config/cvars for hierarchical Pipes AllGather tuning:
+  - enabled flag,
+  - IB block count,
+  - IB signal bytes,
+  - IBGDA send/recv pipeline depth,
+  - IBGDA data buffer size,
+  - QPs per peer per NIC,
+  - size bucket threshold table or explicit opt-in override,
+  - optional HCA/NIC selection override.
+- Extend `CtranPipes.cc` to set `ibgdaConfig.sendRecv` and `numQpsPerPeerPerNic`.
+- Add strict support checks for uniform NVLink group size, IBGDA availability, rank geometry, message alignment, and max supported rank count.
+- Add a per-communicator or per-algo guard against overlapping hierarchical collectives on the same send/recv state.
+- Add transport error handling that fails closed on QP error state instead of reusing a poisoned multi-QP pool.
+- Add a ctran GPE-compatible kernel wrapper that launches on the ctran stream and does not use the default-stream Pipes launcher.
+- Keep any Pipes source changes minimal. If a Pipes refactor is required, limit it to exposing a shared device helper so ctran and the Pipes benchmark use the same implementation.
+
+### Implementation Checklist
+
+- [ ] Phase 0: Freeze assumptions and guardrails.
+  - [ ] Document exact rank geometry required by the D104 kernel.
+  - [ ] Decide the first supported topology: uniform NVLink groups with contiguous global ranks.
+  - [ ] Define fallback behavior for unsupported topology: return not supported and use existing `ctpipeline` or NCCL.
+
+- [ ] Phase 1: Make ctran Pipes transport config performance-equivalent.
+  - [ ] Add ctran config/cvars for hierarchical AllGather knobs.
+  - [ ] Set `ibgdaConfig.sendRecv.maxGroups` from the hierarchical block count.
+  - [ ] Set `ibgdaConfig.sendRecv.pipelineDepth`.
+  - [ ] Set `ibgdaConfig.numQpsPerPeerPerNic`.
+  - [ ] Set data buffer size and signal granularity defaults matching the best D104 results.
+  - [ ] Add a separate 128MB tuning profile candidate instead of assuming the 1GB profile generalizes.
+  - [ ] Validate that all ranks use identical transport config.
+  - [ ] Define fail-closed behavior for QP error state in the multi-QP pool.
+
+- [ ] Phase 2: Add benchmark-only validation hook.
+  - [ ] Add `cthierarchical_pipes` as a benchmark option in `AllgatherPBench.cc`.
+  - [ ] Build hierarchical launch args from `comm->multiPeerTransport_`.
+  - [ ] Run correctness against NCCL for `nvl_size == 1` and hierarchical cases.
+  - [ ] Measure 128MB and 1GB before adding production dispatch.
+  - [ ] Run the targeted 128MB sweep for block count, IB signal bytes, pipeline depth, data buffer size, and QPs per peer per NIC.
+  - [ ] Compare against NCCL production defaults with NVLS, P2P, and SHM enabled, plus a fair matched NCCL configuration.
+
+- [ ] Phase 3: Add AllGatherP production dispatch.
+  - [ ] Add `cthierarchical_pipes` to `NCCL_ALLGATHER_P_ALGO`.
+  - [ ] Add support checks in the AllGatherP path.
+  - [ ] Add GPE-compatible kernel wrapper and ctran-local args.
+  - [ ] Route `allGatherPExec()` to the new implementation.
+  - [ ] Route `allGatherWinExec()` to the same implementation for window execution.
+
+- [ ] Phase 4: CUDA graph compatibility.
+  - [ ] Verify capture does not allocate, exchange, register, or launch on the default stream.
+  - [ ] Add graph capture/replay correctness tests.
+  - [ ] Benchmark captured and non-captured execution separately.
+
+- [ ] Phase 5: Topology expansion.
+  - [ ] Add support for non-contiguous rank layouts only with explicit rank remap.
+  - [ ] Add fallback for IB-only topologies.
+  - [ ] Add topology detection for NVSwitch/direct NVLink differences if performance tuning differs.
+
+- [ ] Phase 6: Auto-selection.
+  - [ ] Keep opt-in until all acceptance criteria pass.
+  - [ ] Add mapper/selector auto-pick only for proven topologies and message sizes.
+  - [ ] Use a benchmark-derived size/topology table rather than a single static threshold.
+  - [ ] Keep 128MB disabled or routed to the existing path until its own confidence interval clears the NCCL target.
+  - [ ] Preserve an immediate cvar fallback to `ctpipeline`.
+
+### Acceptance Criteria
+
+Correctness:
+
+- [ ] Byte-exact match with NCCL for all supported dtypes and tested counts.
+- [ ] Correct for in-place and out-of-place modes if both are claimed supported.
+- [ ] Correct for `nvl_size == 1`, single-node NVLink-only, and multi-node hierarchical topologies.
+- [ ] Correct under CUDA graph capture and replay.
+
+Performance:
+
+- [ ] On GB200, at 128MB total input, `cthierarchical_pipes` beats NCCL allgather with bootstrap 95 percent CI lower bound greater than 1.02x.
+- [ ] On GB200, at 1GB total input, `cthierarchical_pipes` beats NCCL allgather with bootstrap 95 percent CI lower bound greater than 1.02x.
+- [ ] No production auto-selection if either 128MB or 1GB misses the NCCL target.
+- [ ] No production auto-selection for any intermediate size bucket until that bucket independently meets the NCCL target or has an explicit fallback threshold.
+- [ ] Existing `ctpipeline` and `ctrdpipeline` performance does not regress when the new path is not selected.
+
+Benchmark methodology:
+
+- [ ] Sweep message sizes from 8KB to 1GB.
+- [ ] Include 128MB and 1GB as mandatory release gates.
+- [ ] Sweep nodes, local ranks per node, blocks, QPs per peer per NIC, pipeline depth, data buffer size, and HCA selection.
+- [ ] Compare against NCCL production defaults with NVLS, P2P, and SHM enabled.
+- [ ] Also compare against a fair matched NCCL configuration for diagnosis, but do not use a handicapped NCCL-only comparison as the production acceptance claim.
+- [ ] Run a dedicated 128MB sweep across block count `4, 8, 16, 32`, IB signal bytes `512KB, 1MB, 2MB`, pipeline depth `1, 2, 4`, data buffer size `32MB, 64MB, 128MB`, and QPs per peer per NIC `1, 2, 4, 8`.
+- [ ] Use at least 5 process restarts per key configuration.
+- [ ] Use randomized run order and at least 100 measured iterations after warmup.
+- [ ] Report median, P95, coefficient of variation, and bootstrap confidence intervals.
+- [ ] Record GPU SKU, driver, CUDA, NCCL, build SHA, host list, HCA list, and full environment.
+
+### Rollback Plan
+
+- Keep `cthierarchical_pipes` opt-in until acceptance criteria pass.
+- If correctness fails, disable the enum support check and fall back to existing `ctpipeline` or NCCL.
+- If 128MB does not beat NCCL, keep the path benchmark-only or large-message opt-in; do not auto-select.
+- If 1GB does not beat NCCL, stop production integration and investigate transport config, QP/NIC mapping, and rank geometry before further rollout.
+- If CUDA graph capture fails, gate the path out of `allGatherWinExec()` while preserving non-captured opt-in testing.
+- If send/recv state collisions are observed, add stricter serialization or allocate independent transport state before enabling overlap.
+- If any QP enters error state during testing, disable auto-selection and require communicator or transport rebuild before retrying the hierarchical path.

--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -58,6 +58,14 @@ class AlgoImpl {
       const size_t count,
       const commDataType_t datatype);
 
+  // Execute the Pipes hierarchical NVLink + IBGDA algorithm.
+  // This is an opt-in path that launches a single device-side staged
+  // allgather kernel through GPE with an empty host op group.
+  commResult_t execHierarchicalPipes(
+      const void* sendbuff,
+      const size_t count,
+      const commDataType_t datatype);
+
   static inline const std::string algoName(enum NCCL_ALLGATHER_P_ALGO algo) {
     switch (algo) {
       case NCCL_ALLGATHER_P_ALGO::ctdirect:
@@ -66,6 +74,8 @@ class AlgoImpl {
         return "CtranAllGatherPPipeline";
       case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
         return "CtranAllGatherPRecDbl";
+      case NCCL_ALLGATHER_P_ALGO::cthierarchical_pipes:
+        return "CtranAllGatherPHierarchicalPipes";
       default:
         return "Unknown";
     }

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -238,6 +238,8 @@ commResult_t allGatherPExec(
       return algo->execPipeline(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::cthierarchical_pipes:
+      return algo->execHierarchicalPipes(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/AllGatherP/HierarchicalPipes.cu
+++ b/comms/ctran/algos/AllGatherP/HierarchicalPipes.cu
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllGatherP/HierarchicalPipes.cuh"
+
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+
+namespace {
+
+struct MemcpyAndSelfCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      std::size_t byte_offset,
+      char* self_dst,
+      Args...) {
+    comms::pipes::memcpy_vectorized(
+        staging, self_dst + byte_offset, src, nbytes, group);
+  }
+};
+
+__device__ __forceinline__ std::size_t direct_pipeline_window(
+    const comms::pipes::P2pNvlTransportDevice* peers,
+    int my_rank,
+    int num_ranks,
+    int total_groups) {
+  std::size_t window = 0;
+  for (int peer = 0; peer < num_ranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    const std::size_t peer_window = peers[peer].pipeline_window(total_groups);
+    window = window == 0 || peer_window < window ? peer_window : window;
+  }
+  return window;
+}
+
+template <typename Group>
+__device__ __forceinline__ void
+hierarchical_allgather_nvl_broadcast_from_recvbuf(
+    Group& group,
+    int ib_size,
+    int nvl_rank,
+    int nvl_size,
+    std::size_t sendcount,
+    std::size_t max_sig,
+    const comms::pipes::P2pNvlTransportDevice* peers,
+    char* recvbuf,
+    comms::pipes::Timeout timeout) {
+  if (nvl_size <= 1) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "ctran hierarchical allgather NVLink broadcast pipeline window is zero");
+
+  for (int ib_src = 0; ib_src < ib_size; ++ib_src) {
+    comms::pipes::TiledBuffer<char> tile(nullptr, sendcount, group);
+    const std::size_t tile_offset = group.group_id * tile.tile_elements;
+    const std::size_t tile_bytes = tile.bytes();
+
+    for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = tile_bytes - off;
+      const std::size_t window =
+          remaining < pipeline_window ? remaining : pipeline_window;
+      const char* send_src = recvbuf +
+          (static_cast<std::size_t>(ib_src) * nvl_size + nvl_rank) * sendcount +
+          tile_offset + off;
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        auto peer = peers[peer_rank];
+        peer.send(
+            group, send_src, window, group.total_groups, max_sig, timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        char* dst = recvbuf +
+            (static_cast<std::size_t>(ib_src) * nvl_size + peer_rank) *
+                sendcount +
+            tile_offset + off;
+        auto peer = peers[peer_rank];
+        peer.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+}
+
+} // namespace
+
+__global__
+__launch_bounds__(ctran::allgatherp::hierarchical_pipes::kBlockSize, 1) void ncclKernelAllGatherPHierarchicalPipes(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allgatherp::hierarchical_pipes::KernArgs kernArgs) {
+#ifdef __CUDA_ARCH__
+  const auto& args = kernArgs.args;
+  auto timeout = kernArgs.timeout;
+  timeout.start();
+
+  auto group = comms::pipes::make_block_group();
+  const int W = args.ib_size;
+  const std::size_t chunk_bytes = args.sendcount;
+  const std::size_t max_sig = args.ib_signaling_data_size;
+
+  comms::pipes::TiledBuffer<char> ring_tile(nullptr, chunk_bytes, group);
+  const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const char* own_src = args.sendbuf + io_tile_offset;
+  char* own_dst = args.recvbuf +
+      (static_cast<std::size_t>(args.ib_rank) * args.nvl_size + args.nvl_rank) *
+          chunk_bytes +
+      io_tile_offset;
+
+  if (W <= 1) {
+    comms::pipes::memcpy_vectorized(own_dst, own_src, io_tile_bytes, group);
+    group.sync();
+    hierarchical_allgather_nvl_broadcast_from_recvbuf(
+        group,
+        args.ib_size,
+        args.nvl_rank,
+        args.nvl_size,
+        args.sendcount,
+        args.nvl_signaling_data_size,
+        args.nvl_peers,
+        args.recvbuf,
+        timeout);
+    return;
+  }
+
+  const auto& topo = args.ib_ring;
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "ctran hierarchical allgather IB pipeline window is zero");
+
+  const int stride = (args.ib_rank - topo.prev_rank + W) % W;
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        remaining < pipeline_window ? remaining : pipeline_window;
+
+    const char* send_src = args.sendbuf + io_tile_offset + off;
+    next.template send<MemcpyAndSelfCopy>(
+        group,
+        send_src,
+        window,
+        group.total_groups,
+        max_sig,
+        timeout,
+        own_dst + off);
+
+    int fwd_current_rank = args.ib_rank;
+    for (int step = 0; step < W - 1; step++) {
+      fwd_current_rank = (fwd_current_rank + W - stride) % W;
+      char* dst = args.recvbuf +
+          (static_cast<std::size_t>(fwd_current_rank) * args.nvl_size +
+           args.nvl_rank) *
+              chunk_bytes +
+          io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.forward(
+            group, dst, next, window, group.total_groups, max_sig, timeout);
+      } else {
+        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+
+  group.sync();
+
+  hierarchical_allgather_nvl_broadcast_from_recvbuf(
+      group,
+      args.ib_size,
+      args.nvl_rank,
+      args.nvl_size,
+      args.sendcount,
+      args.nvl_signaling_data_size,
+      args.nvl_peers,
+      args.recvbuf,
+      timeout);
+#endif
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGatherP/HierarchicalPipes.cuh
+++ b/comms/ctran/algos/AllGatherP/HierarchicalPipes.cuh
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/DirectNvlTypes.h"
+
+namespace ctran::allgatherp::hierarchical_pipes {
+
+inline constexpr int kBlockSize = 512;
+
+struct KernArgs {
+  comms::pipes::HierarchicalAllgatherFusedArgs args{};
+  comms::pipes::Timeout timeout{};
+};
+
+} // namespace ctran::allgatherp::hierarchical_pipes
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGatherP/HierarchicalPipesImpl.cc
+++ b/comms/ctran/algos/AllGatherP/HierarchicalPipesImpl.cc
@@ -1,0 +1,215 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+#if defined(ENABLE_PIPES)
+
+#include <algorithm>
+#include <new>
+
+#include "comms/ctran/algos/AllGatherP/HierarchicalPipes.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/DirectNvlTypes.h"
+
+extern __global__ void ncclKernelAllGatherPHierarchicalPipes(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allgatherp::hierarchical_pipes::KernArgs args);
+
+namespace {
+
+constexpr const char* kAlgoName = "CtranAllGatherPHierarchicalPipes";
+
+commResult_t validateAndFillRankGeometry(
+    CtranComm* comm,
+    comms::pipes::HierarchicalAllgatherFusedArgs& args) {
+  auto* statex = comm->statex_.get();
+  auto* transport = comm->multiPeerTransport_.get();
+  if (transport == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "cthierarchical_pipes requires NCCL_CTRAN_USE_PIPES=1");
+  }
+
+  const int globalRank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const int nvlSize = transport->nvl_n_ranks();
+  const int nvlRank = transport->nvl_local_rank();
+  if (nvlSize < 1 || nvlSize > comms::pipes::kDirectNvlMaxRanks) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "cthierarchical_pipes requires 1 <= nvl_size <= {} but got {}",
+        comms::pipes::kDirectNvlMaxRanks,
+        nvlSize);
+  }
+  if (nRanks % nvlSize != 0) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "cthierarchical_pipes requires rectangular rank geometry: nRanks {} "
+        "must be divisible by nvl_size {}",
+        nRanks,
+        nvlSize);
+  }
+  if (globalRank % nvlSize != nvlRank) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "cthierarchical_pipes requires contiguous rank geometry: rank {} "
+        "nvl_size {} implies nvl_rank {}, but pipes reports {}",
+        globalRank,
+        nvlSize,
+        globalRank % nvlSize,
+        nvlRank);
+  }
+
+  const int ibSize = nRanks / nvlSize;
+  const int ibRank = globalRank / nvlSize;
+  for (int peer = 0; peer < nvlSize; ++peer) {
+    const int peerGlobal = ibRank * nvlSize + peer;
+    try {
+      if (transport->global_to_nvl_local(peerGlobal) != peer) {
+        FB_ERRORRETURN(
+            commInvalidArgument,
+            "cthierarchical_pipes requires NVL local rank {} to map to "
+            "global rank {}",
+            peer,
+            peerGlobal);
+      }
+    } catch (const std::exception& e) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "cthierarchical_pipes rank geometry validation failed for global "
+          "rank {}: {}",
+          peerGlobal,
+          e.what());
+    }
+  }
+
+  args.ib_rank = ibRank;
+  args.ib_size = ibSize;
+  args.nvl_rank = nvlRank;
+  args.nvl_size = nvlSize;
+  return commSuccess;
+}
+
+commResult_t fillTransportArgs(
+    CtranComm* comm,
+    comms::pipes::HierarchicalAllgatherFusedArgs& args) {
+  auto* transport = comm->multiPeerTransport_.get();
+  if (transport == nullptr) {
+    return ErrorStackTraceUtil::log(commInvalidArgument);
+  }
+
+  const int ibRank = args.ib_rank;
+  const int ibSize = args.ib_size;
+  const int nvlRank = args.nvl_rank;
+  const int nvlSize = args.nvl_size;
+
+  if (ibSize > 1) {
+    const int prevIbRank = (ibRank - 1 + ibSize) % ibSize;
+    const int nextIbRank = (ibRank + 1) % ibSize;
+    const int prevGlobal = prevIbRank * nvlSize + nvlRank;
+    const int nextGlobal = nextIbRank * nvlSize + nvlRank;
+    if (!transport->has_ibgda(prevGlobal) ||
+        !transport->has_ibgda(nextGlobal)) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "cthierarchical_pipes requires IBGDA prev/next peers. "
+          "prevGlobal={} has_ibgda={} nextGlobal={} has_ibgda={}",
+          prevGlobal,
+          transport->has_ibgda(prevGlobal),
+          nextGlobal,
+          transport->has_ibgda(nextGlobal));
+    }
+    args.ib_ring.prev_rank = prevIbRank;
+    args.ib_ring.next_rank = nextIbRank;
+    args.ib_ring.prev = transport->get_p2p_ibgda_transport_device(prevGlobal);
+    args.ib_ring.next = transport->get_p2p_ibgda_transport_device(nextGlobal);
+    if (args.ib_ring.prev == nullptr || args.ib_ring.next == nullptr) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "cthierarchical_pipes received null IBGDA transport handle");
+    }
+  }
+
+  for (int peer = 0; peer < nvlSize; ++peer) {
+    if (peer == nvlRank) {
+      continue;
+    }
+    const int peerGlobal = args.ib_rank * nvlSize + peer;
+    if (!transport->is_nvl_peer(peerGlobal)) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "cthierarchical_pipes requires global rank {} to be an NVL peer",
+          peerGlobal);
+    }
+    new (&args.nvl_peers[peer]) comms::pipes::P2pNvlTransportDevice(
+        transport->get_p2p_nvl_transport_device(peerGlobal));
+  }
+
+  return commSuccess;
+}
+
+} // namespace
+
+#endif // ENABLE_PIPES
+
+namespace ctran::allgatherp {
+
+commResult_t AlgoImpl::execHierarchicalPipes(
+    const void* sendbuff,
+    const size_t count,
+    const commDataType_t datatype) {
+#if defined(ENABLE_PIPES)
+  FB_COMMCHECK(waitInit());
+
+  const size_t typeSize = commTypeSize(datatype);
+  hierarchical_pipes::KernArgs kernArgs{};
+  auto& args = kernArgs.args;
+  FB_COMMCHECK(validateAndFillRankGeometry(comm_, args));
+  args.sendcount = count * typeSize;
+  args.ib_signaling_data_size = NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES;
+  args.nvl_signaling_data_size = NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES;
+  args.sendbuf = static_cast<const char*>(sendbuff);
+  args.recvbuf = static_cast<char*>(pArgs.recvbuff);
+  FB_COMMCHECK(fillTransportArgs(comm_, args));
+  if (NCCL_CTRAN_HIER_AG_TIMEOUT_MS > 0) {
+    int device = 0;
+    FB_CUDACHECK(cudaGetDevice(&device));
+    kernArgs.timeout = comms::pipes::makeTimeout(
+        static_cast<uint32_t>(NCCL_CTRAN_HIER_AG_TIMEOUT_MS), device);
+  }
+
+  const auto opCount = comm_->ctran_->getOpCount();
+  CTRAN_COLL_INFO(
+      kAlgoName, sendbuff, pArgs.recvbuff, count, datatype, -1, comm_, stream_);
+
+  KernelConfig config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP, stream_, kAlgoName, opCount);
+  config.numBlocks = static_cast<unsigned int>(
+      std::max<int64_t>(1, NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS));
+  config.numThreads = hierarchical_pipes::kBlockSize;
+  config.dynamicSharedMemBytes = 1;
+  config.args.devState_d = comm_->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  FB_COMMCHECK(comm_->ctran_->gpe->submit(
+      std::move(opGroup),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ncclKernelAllGatherPHierarchicalPipes)));
+  return commSuccess;
+#else
+  (void)sendbuff;
+  (void)count;
+  (void)datatype;
+  return ErrorStackTraceUtil::log(commInvalidArgument);
+#endif
+}
+
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -130,6 +130,8 @@ commResult_t allGatherWinExec(
       return algo->execPipeline(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::cthierarchical_pipes:
+      return algo->execHierarchicalPipes(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/benchmarks/AllgatherPBench.cc
+++ b/comms/ctran/benchmarks/AllgatherPBench.cc
@@ -28,7 +28,8 @@ DEFINE_int32(bench_iters, 50, "Number of benchmark iterations (default: 20)");
 DEFINE_string(
     algo,
     "all",
-    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'nccl', or 'all' (default: all)");
+    "Algorithm to benchmark: 'ctdirect', 'ctpipeline', 'ctrdpipeline', "
+    "'cthierarchical_pipes', 'nccl', or 'all' (default: all)");
 DEFINE_bool(in_place, false, "Run in-place allgather (default: false)");
 DEFINE_string(
     mem_type,
@@ -386,6 +387,20 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
     const auto statex = ctranComm_->statex_.get();
     const auto nNodes = statex->nNodes();
     const bool pipelineSupported = nNodes > 1;
+#if defined(ENABLE_PIPES)
+    const bool hierarchicalPipesSupported =
+        ctranComm_->multiPeerTransport_ != nullptr;
+#else
+    const bool hierarchicalPipesSupported = false;
+#endif
+    const bool runCtranAlgo = FLAGS_algo == "ctdirect" ||
+        FLAGS_algo == "ctpipeline" || FLAGS_algo == "ctrdpipeline" ||
+        FLAGS_algo == "cthierarchical_pipes" || FLAGS_algo == "all";
+
+    EXPECT_TRUE(
+        FLAGS_algo != "cthierarchical_pipes" || hierarchicalPipesSupported)
+        << "cthierarchical_pipes requires ENABLE_PIPES and "
+           "NCCL_CTRAN_USE_PIPES=1";
 
     // Generate size range (powers of 2)
     std::vector<size_t> sizes;
@@ -408,8 +423,7 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
     CtranPersistentRequest* request = nullptr;
 
     // Only allocate and initialize if running AllGatherP algorithms
-    if (FLAGS_algo == "ctdirect" || FLAGS_algo == "ctpipeline" ||
-        FLAGS_algo == "all") {
+    if (runCtranAlgo) {
       // Allocate and initialize buffers ONCE for max size
       sendbuf = allocateBuffer(maxSizeBytes);
       recvbuf = allocateBuffer(maxRecvBytes);
@@ -471,6 +485,28 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
             NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpipeline);
         BenchmarkResult result = benchmarkAllgatherPWithRequest(
             count, "AllGatherP_Pipeline", request, sendbuf, recvbuf);
+        printResult(result);
+        ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+      }
+
+      // Benchmark AllgatherP Recursive Doubling Pipeline (reuses same request)
+      if ((FLAGS_algo == "ctrdpipeline" || FLAGS_algo == "all") &&
+          pipelineSupported) {
+        EnvRAII algoEnv(
+            NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctrdpipeline);
+        BenchmarkResult result = benchmarkAllgatherPWithRequest(
+            count, "AllGatherP_RecDblPipeline", request, sendbuf, recvbuf);
+        printResult(result);
+        ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+      }
+
+      // Benchmark AllgatherP hierarchical Pipes path (reuses same request)
+      if ((FLAGS_algo == "cthierarchical_pipes" || FLAGS_algo == "all") &&
+          hierarchicalPipesSupported) {
+        EnvRAII algoEnv(
+            NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::cthierarchical_pipes);
+        BenchmarkResult result = benchmarkAllgatherPWithRequest(
+            count, "AllGatherP_HierarchicalPipes", request, sendbuf, recvbuf);
         printResult(result);
         ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
       }

--- a/comms/pipes/CopyOp.cuh
+++ b/comms/pipes/CopyOp.cuh
@@ -5,50 +5,11 @@
 #include <cstddef>
 
 #include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Tile.cuh"
 
 namespace comms::pipes {
-
-struct Memcpy {
-  template <typename... Args>
-  __device__ __forceinline__ static void send(
-      char* staging,
-      const char* src,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(staging, src, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void recv(
-      char* dst,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    memcpy_vectorized(dst, staging, nbytes, group);
-  }
-
-  template <typename... Args>
-  __device__ __forceinline__ static void forward(
-      char* dst,
-      char* fwd_staging,
-      const char* staging,
-      std::size_t nbytes,
-      ThreadGroup& group,
-      std::size_t /*byte_offset*/,
-      Args...) {
-    if (dst) {
-      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
-    } else {
-      memcpy_vectorized(fwd_staging, staging, nbytes, group);
-    }
-  }
-};
 
 template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
 struct TileReduce {

--- a/comms/pipes/MemcpyCopyOp.cuh
+++ b/comms/pipes/MemcpyCopyOp.cuh
@@ -1,0 +1,52 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+
+namespace comms::pipes {
+
+struct Memcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(dst, staging, nbytes, group);
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    if (dst) {
+      memcpy_vectorized(dst, fwd_staging, staging, nbytes, group);
+    } else {
+      memcpy_vectorized(fwd_staging, staging, nbytes, group);
+    }
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultiPeerNvlTransport.cc
+++ b/comms/pipes/MultiPeerNvlTransport.cc
@@ -20,7 +20,8 @@ MultiPeerNvlTransport::MultiPeerNvlTransport(
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
       config_(multiPeerNvlTransportConfig),
-      memSharingMode_(GpuMemHandler::detectBestMode()) {
+      memSharingMode_(
+          config_.memSharingMode.value_or(GpuMemHandler::detectBestMode())) {
   // ===========================================================================
   // Buffer Allocation
   // ===========================================================================

--- a/comms/pipes/MultiPeerNvlTransport.h
+++ b/comms/pipes/MultiPeerNvlTransport.h
@@ -95,6 +95,11 @@ struct MultiPeerNvlTransportConfig {
   // 0 (default), LL128 is disabled. Use ll128_buffer_size() from
   // Ll128Packet.cuh to compute from message size.
   std::size_t ll128BufferSize{0};
+
+  // Override the automatically selected memory sharing mode. Leaving this unset
+  // keeps the default behavior: fabric handles when available, cudaIpc
+  // otherwise.
+  std::optional<MemSharingMode> memSharingMode;
 };
 
 /**

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -1243,8 +1243,7 @@ void MultipeerIbgdaTransport::exchange() {
   std::vector<P2pIbgdaTransportBuildParams> buildParams(numPeers);
 
   for (int peer = 0; peer < numPeers; peer++) {
-    // One NicDeviceIbgdaResourcesBuildSpec per physical NIC. NIC-fast
-    // interleaving: slot s = q * numNics_ + nic.
+    // One NicDeviceIbgdaResourcesBuildSpec per exposed physical NIC.
     auto& bp = buildParams[peer];
     bp.h_nicDeviceIbgdaResources.resize(numNics_);
     for (int n = 0; n < numNics_; ++n) {
@@ -1255,9 +1254,9 @@ void MultipeerIbgdaTransport::exchange() {
       nicSpec.deviceId = n;
     }
 
-    for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDevices_[nic].qpGroups;
-      auto& nicSpec = bp.h_nicDeviceIbgdaResources[nic];
+    for (int n = 0; n < numNics_; n++) {
+      auto& nicQps = nicDevices_[n].qpGroups;
+      auto& nicSpec = bp.h_nicDeviceIbgdaResources[n];
       for (int q = 0; q < numQps; q++) {
         const int qpIdx = peer * numQps + q;
         doca_error_t err = doca_gpu_verbs_get_qp_dev(

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -59,8 +59,7 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
  * Owns the QPs (primary + companion for compound put+signal+counter ops)
  * and the sink lkey for atomic FA responses on a single NIC. The
  * P2pIbgdaTransportDevice holds a `DeviceSpan<NicDeviceIbgdaResources>` indexed
- * by NIC slot (peer-rotated on the host side so that `nic_qp_for_group(g)`'s
- * nic_id (= g % numNics) yields balanced per-peer scatter).
+ * by physical NIC slot.
  */
 struct NicDeviceIbgdaResources {
   DeviceSpan<doca_gpu_dev_verbs_qp*> qps{};
@@ -1818,16 +1817,10 @@ class P2pIbgdaTransportDevice {
   };
 
   /**
-   * nic_qp_for_group - Single lookup: returns {nic_id, qp_id} for a group.
+   * nic_qp_for_group - Single lookup: returns NIC/QP ids.
    *
-   * Round-robin over nicDevices_, then within the chosen NIC round-robin
-   * over its qps. All WQEs for one logical operation share the same
-   * group_id and therefore land on the same NIC + QP — required for the
-   * FENCE bit to order them. Host-side population is responsible for
-   * peer-rotating the NicDeviceIbgdaResources[] order so adjacent peers
-   * land on different NICs. Traps if nicDevices_ is empty or the chosen
-   * NIC has no qps (programming error: device op on a default-constructed
-   * transport).
+   * Round-robin over NIC resources, then within the chosen NIC round-robin over
+   * its QPs.
    */
   __device__ NicQpIndex nic_qp_for_group(uint32_t group_id) const {
     if (nicDevices_.empty()) {
@@ -1877,10 +1870,7 @@ class P2pIbgdaTransportDevice {
   }
 
   // --- Members ---
-  // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id). Host-side
-  // builder peer-rotates the order so nic_qp_for_group(g)'s nic_id (= g %
-  // nicDevices_.size()) produces balanced scatter. At single-NIC:
-  // nicDevices_.size() == 1.
+  // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id).
   DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
 
   // Owned signal/counter buffers (set by transport during construction)

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -12,6 +12,7 @@
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/DeviceSpan.cuh"
 #include "comms/pipes/HipCompat.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/SignalState.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/Timeout.cuh"
@@ -141,9 +142,9 @@ struct NvlinkTransportTileState {
  *     after group.sync()
  */
 struct P2pNvlTransportOptions {
-  std::size_t dataBufferSize;
-  std::size_t chunkSize;
-  std::size_t pipelineDepth;
+  std::size_t dataBufferSize{0};
+  std::size_t chunkSize{0};
+  std::size_t pipelineDepth{0};
   bool useDualStateBuffer{false}; // Default to single state buffer mode
   std::size_t ll128BufferNumPackets{0}; // 0 = no chunking
 };
@@ -362,6 +363,14 @@ class P2pNvlTransportDevice {
         tile_state_(tileState) {}
 
   __host__ __device__ ~P2pNvlTransportDevice() = default;
+
+  __host__ __device__ std::size_t pipeline_window(int totalGroups) const {
+    const std::size_t perBlockSlotSize =
+        (options_.dataBufferSize / totalGroups) & ~15ULL;
+    const std::size_t safeDepth =
+        options_.pipelineDepth > 1 ? options_.pipelineDepth - 1 : 1;
+    return perBlockSlotSize * safeDepth;
+  }
 
   /**
    * send_group - Cooperative transfer to peer GPU over NVLink
@@ -1471,8 +1480,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1516,13 +1526,15 @@ class P2pNvlTransportDevice {
 #endif
   }
 
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1584,8 +1596,9 @@ class P2pNvlTransportDevice {
     int64_t step = tile_state_.step_state[max_groups + groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
+      const std::size_t absStep = static_cast<std::size_t>(step);
+      const std::size_t slotStep = absStep / stepsPerSlot;
+      const std::size_t subStep = absStep % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1599,11 +1612,13 @@ class P2pNvlTransportDevice {
           group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
 
       if (copyBytes > 0) {
-        memcpy_vectorized(
+        CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1654,6 +1669,7 @@ class P2pNvlTransportDevice {
    * @param max_signal_bytes Hint for max bytes between signals.
    *   0 means one signal per slot fill. Capped at per_block_slot_size.
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void forward(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -1661,7 +1677,8 @@ class P2pNvlTransportDevice {
       P2pNvlTransportDevice& successor,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #ifdef __CUDA_ARCH__
     if (nbytes == 0) {
       return;
@@ -1731,11 +1748,19 @@ class P2pNvlTransportDevice {
     int64_t sendStep = successor.tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t slotStep = s / stepsPerSlot;
-      const std::size_t subStep = s % stepsPerSlot;
-      const std::size_t slot = slotStep % options_.pipelineDepth;
-      const std::size_t slotOff = slot * slotSize;
-      const std::size_t chunkOff = subStep * effectiveChunk;
+      const std::size_t absRecvStep = static_cast<std::size_t>(recvStep);
+      const std::size_t recvSlotStep = absRecvStep / stepsPerSlot;
+      const std::size_t recvSubStep = absRecvStep % stepsPerSlot;
+      const std::size_t recvSlot = recvSlotStep % options_.pipelineDepth;
+      const std::size_t recvSlotOff = recvSlot * slotSize;
+      const std::size_t recvChunkOff = recvSubStep * effectiveChunk;
+
+      const std::size_t absSendStep = static_cast<std::size_t>(sendStep);
+      const std::size_t sendSlotStep = absSendStep / stepsPerSlot;
+      const std::size_t sendSubStep = absSendStep % stepsPerSlot;
+      const std::size_t sendSlot = sendSlotStep % options_.pipelineDepth;
+      const std::size_t sendSlotOff = sendSlot * slotSize;
+      const std::size_t sendChunkOff = sendSubStep * effectiveChunk;
 
       const std::size_t dataOff = s * effectiveChunk;
       const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
@@ -1748,7 +1773,7 @@ class P2pNvlTransportDevice {
 
       // 2. Wait for successor's staging slot to be free (send side, only at
       //    slot boundaries once we have wrapped around the pipeline).
-      if (subStep == 0 &&
+      if (sendSubStep == 0 &&
           sendStep >=
               static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
         successor.tile_state_.local_signals[headSignalId].wait_until(
@@ -1762,12 +1787,14 @@ class P2pNvlTransportDevice {
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
       if (copyBytes > 0) {
-        memcpy_vectorized(
-            dstPtr + dataOff,
-            sendBuf + slotOff + stagingOff + chunkOff,
-            recvBuf + slotOff + stagingOff + chunkOff,
+        CopyOp::forward(
+            dstPtr ? dstPtr + dataOff : nullptr,
+            sendBuf + sendSlotOff + stagingOff + sendChunkOff,
+            recvBuf + recvSlotOff + stagingOff + recvChunkOff,
             copyBytes,
-            group);
+            group,
+            dataOff,
+            args...);
       }
 
       group.sync();
@@ -1778,7 +1805,7 @@ class P2pNvlTransportDevice {
 
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
-        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+        if (recvSubStep == stepsPerSlot - 1 || s == totalSteps - 1) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
         }
@@ -1814,7 +1841,7 @@ class P2pNvlTransportDevice {
  private:
   const int myRank_{-1};
   const int peerRank_{-1};
-  const P2pNvlTransportOptions options_;
+  const P2pNvlTransportOptions options_{};
   LocalState localState_;
   RemoteState remoteState_;
   NvlinkTransportTileState tile_state_;

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -694,11 +694,13 @@ class P2pNvlTransportDevice {
    *                                   copy data to dst
    *                                   state = -1 ────────▶ [sender unblocks]
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv_group(
       ThreadGroup& group,
       void* dstbuff,
       std::size_t nbytes,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
@@ -775,12 +777,13 @@ class P2pNvlTransportDevice {
           ChunkState& localReceiverState = localReceiverStates[chunkStateIdx];
           localReceiverState.wait_ready_to_recv(group, stepId, timeout);
 
-          // Copy data from local buffer
-          memcpy_vectorized(
+          CopyOp::recv(
               dst + stepOffset + chunkOffset,
               recvBuffer + dataBufferOffset + chunkOffset,
               chunkBytes,
-              group);
+              group,
+              stepOffset + chunkOffset,
+              args...);
 
           // Sync #1 + plain write: barrier all threads, then leader
           // writes UNREADY to local receiverState (see send_group()
@@ -839,12 +842,13 @@ class P2pNvlTransportDevice {
                   localReceiverStates[chunkStateIdx];
               localReceiverState.wait_ready_to_recv(group, stepId, timeout);
 
-              // Copy data from local buffer
-              memcpy_vectorized(
+              CopyOp::recv(
                   dst + stepOffset + chunkOffset,
                   recvBuffer + dataBufferOffset + chunkOffset,
                   chunkBytes,
-                  group);
+                  group,
+                  stepOffset + chunkOffset,
+                  args...);
 
               // Signal LOCAL receiverStateBuffer with READY_TO_SEND
               localReceiverState.ready_to_send(group);
@@ -876,12 +880,14 @@ class P2pNvlTransportDevice {
    * @param successor Transport to the next rank in the ring
    * @param timeout Timeout for polling operations
    */
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void forward_group(
       ThreadGroup& group,
       void* dstbuff,
       std::size_t nbytes,
       P2pNvlTransportDevice& successor,
-      const Timeout& timeout = Timeout()) {
+      [[maybe_unused]] const Timeout& timeout = Timeout(),
+      [[maybe_unused]] Args... args) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (options_.dataBufferSize == 0) {
       printf(
@@ -964,14 +970,14 @@ class P2pNvlTransportDevice {
               successorLocalSenderStates[chunkStateIdx];
           successorLocalSenderState.wait_ready_to_send(group, timeout);
 
-          // 3. Dual-dst copy: predecessor staging → local user buf +
-          //    successor remote staging
-          memcpy_vectorized(
-              dst + stepOffset + chunkOffset,
+          CopyOp::forward(
+              dst ? dst + stepOffset + chunkOffset : nullptr,
               successorSendBuffer + dataBufferOffset + chunkOffset,
               recvBuffer + dataBufferOffset + chunkOffset,
               chunkBytes,
-              group);
+              group,
+              stepOffset + chunkOffset,
+              args...);
 
           // 4. Both unready() calls (plain writes with group.sync())
           localReceiverState.unready(group);
@@ -1031,13 +1037,14 @@ class P2pNvlTransportDevice {
                   successorRemoteReceiverStatesOnly[chunkStateIdx];
               successorRemoteReceiverState.wait_ready_to_send(group, timeout);
 
-              // Dual-dst copy
-              memcpy_vectorized(
-                  dst + stepOffset + chunkOffset,
+              CopyOp::forward(
+                  dst ? dst + stepOffset + chunkOffset : nullptr,
                   successorSendBuffer + dataBufferOffset + chunkOffset,
                   recvBuffer + dataBufferOffset + chunkOffset,
                   chunkBytes,
-                  group);
+                  group,
+                  stepOffset + chunkOffset,
+                  args...);
 
               // ACK predecessor (buffer free)
               localReceiverState.ready_to_send(group);

--- a/comms/pipes/collectives/DirectNvl.cu
+++ b/comms/pipes/collectives/DirectNvl.cu
@@ -1,0 +1,346 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/DirectNvl.cuh"
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+struct MemcpyAndSelfCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      char* self_dst,
+      Args...) {
+    memcpy_vectorized(staging, self_dst + byte_offset, src, nbytes, group);
+  }
+};
+
+__device__ __forceinline__ std::size_t direct_pipeline_window(
+    const P2pNvlTransportDevice* peers,
+    int my_rank,
+    int num_ranks,
+    int total_groups) {
+  std::size_t window = 0;
+  for (int peer = 0; peer < num_ranks; ++peer) {
+    if (peer == my_rank) {
+      continue;
+    }
+    const std::size_t peer_window = peers[peer].pipeline_window(total_groups);
+    window = window == 0 || peer_window < window ? peer_window : window;
+  }
+  return window;
+}
+
+} // namespace
+
+template <int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
+    const __grid_constant__ DirectAllgatherNvlArgs args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int my_rank = args.my_rank;
+  const int W = args.num_ranks;
+  const std::size_t sendcount = args.sendcount;
+  const std::size_t max_sig = args.signaling_data_size;
+
+  TiledBuffer<char> tile(nullptr, sendcount, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  const char* own_src = args.sendbuf + tile_offset;
+  char* own_dst = args.recvbuf + my_rank * sendcount + tile_offset;
+  memcpy_vectorized(own_dst, own_src, tile_bytes, group);
+  group.sync();
+
+  if (W <= 1 || tile_bytes == 0) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0, "direct NVLink allgather pipeline window is zero");
+
+  for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = tile_bytes - off;
+    const std::size_t window =
+        remaining < pipeline_window ? remaining : pipeline_window;
+
+    const char* send_src = args.sendbuf + tile_offset + off;
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      auto peer = args.peers[peer_rank];
+      peer.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    }
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      char* dst = args.recvbuf + peer_rank * sendcount + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.recv(group, dst, window, group.total_groups, max_sig, timeout);
+    }
+  }
+#endif
+}
+
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+__global__
+__launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
+    const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int my_rank = args.my_rank;
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  TiledBuffer<char> tile(nullptr, chunk_bytes, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  const char* own_src = reinterpret_cast<const char*>(args.input) +
+      my_rank * chunk_bytes + tile_offset;
+  char* own_dst = reinterpret_cast<char*>(args.output) + tile_offset;
+  memcpy_vectorized(own_dst, own_src, tile_bytes, group);
+  group.sync();
+
+  if (W <= 1 || tile_bytes == 0) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(args.peers, my_rank, W, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "direct NVLink reduce-scatter pipeline window is zero");
+
+  using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
+  const char* input_base = reinterpret_cast<const char*>(args.input);
+  char* output_base = reinterpret_cast<char*>(args.output);
+
+  for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = tile_bytes - off;
+    const std::size_t window =
+        remaining < pipeline_window ? remaining : pipeline_window;
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      const char* send_src =
+          input_base + peer_rank * chunk_bytes + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    }
+
+    for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
+      if (peer_rank == my_rank) {
+        continue;
+      }
+      char* dst = output_base + tile_offset + off;
+      auto peer = args.peers[peer_rank];
+      peer.template recv<ReduceOp>(
+          group, dst, window, group.total_groups, max_sig, timeout, dst);
+    }
+  }
+#endif
+}
+
+template <typename Group>
+__device__ __forceinline__ void
+hierarchical_allgather_nvl_broadcast_from_recvbuf(
+    Group& group,
+    int ib_size,
+    int nvl_rank,
+    int nvl_size,
+    std::size_t sendcount,
+    std::size_t max_sig,
+    const P2pNvlTransportDevice* peers,
+    char* recvbuf,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  if (nvl_size <= 1) {
+    return;
+  }
+
+  const std::size_t pipeline_window =
+      direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical allgather NVLink broadcast pipeline window is zero");
+
+  for (int ib_src = 0; ib_src < ib_size; ++ib_src) {
+    TiledBuffer<char> tile(nullptr, sendcount, group);
+    const std::size_t tile_offset = group.group_id * tile.tile_elements;
+    const std::size_t tile_bytes = tile.bytes();
+
+    for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = tile_bytes - off;
+      const std::size_t window =
+          remaining < pipeline_window ? remaining : pipeline_window;
+      const char* send_src = recvbuf +
+          (static_cast<std::size_t>(ib_src) * nvl_size + nvl_rank) * sendcount +
+          tile_offset + off;
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        auto peer = peers[peer_rank];
+        peer.send(
+            group, send_src, window, group.total_groups, max_sig, timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        char* dst = recvbuf +
+            (static_cast<std::size_t>(ib_src) * nvl_size + peer_rank) *
+                sendcount +
+            tile_offset + off;
+        auto peer = peers[peer_rank];
+        peer.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+#endif
+}
+
+template <int kBlockSize>
+__global__
+__launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
+    const __grid_constant__ HierarchicalAllgatherFusedArgs args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  const int W = args.ib_size;
+  const std::size_t chunk_bytes = args.sendcount;
+  const std::size_t max_sig = args.ib_signaling_data_size;
+
+  TiledBuffer<char> ring_tile(nullptr, chunk_bytes, group);
+  const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const char* own_src = args.sendbuf + io_tile_offset;
+  char* own_dst = args.recvbuf +
+      (static_cast<std::size_t>(args.ib_rank) * args.nvl_size + args.nvl_rank) *
+          chunk_bytes +
+      io_tile_offset;
+
+  // Single IB node (W==1): self-copy then NVL broadcast within the local
+  // NVL group. The broadcast is still needed because each NVL peer must
+  // receive every other peer's chunk even when there is only one IB node.
+  if (W <= 1) {
+    memcpy_vectorized(own_dst, own_src, io_tile_bytes, group);
+    group.sync();
+    hierarchical_allgather_nvl_broadcast_from_recvbuf(
+        group,
+        args.ib_size,
+        args.nvl_rank,
+        args.nvl_size,
+        args.sendcount,
+        args.nvl_signaling_data_size,
+        args.nvl_peers,
+        args.recvbuf,
+        timeout);
+    return;
+  }
+
+  const auto& topo = args.ib_ring;
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical allgather IB pipeline window is zero");
+
+  const int stride = (args.ib_rank - topo.prev_rank + W) % W;
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    const char* send_src = args.sendbuf + io_tile_offset + off;
+    next.template send<MemcpyAndSelfCopy>(
+        group,
+        send_src,
+        window,
+        group.total_groups,
+        max_sig,
+        timeout,
+        own_dst + off);
+
+    int fwd_current_rank = args.ib_rank;
+    for (int step = 0; step < W - 1; step++) {
+      fwd_current_rank = (fwd_current_rank + W - stride) % W;
+      char* dst = args.recvbuf +
+          (static_cast<std::size_t>(fwd_current_rank) * args.nvl_size +
+           args.nvl_rank) *
+              chunk_bytes +
+          io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.forward(
+            group, dst, next, window, group.total_groups, max_sig, timeout);
+      } else {
+        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+
+  group.sync();
+
+  hierarchical_allgather_nvl_broadcast_from_recvbuf(
+      group,
+      args.ib_size,
+      args.nvl_rank,
+      args.nvl_size,
+      args.sendcount,
+      args.nvl_signaling_data_size,
+      args.nvl_peers,
+      args.recvbuf,
+      timeout);
+#endif
+}
+
+template __global__ void direct_allgather_nvl_kernel<512>(
+    const __grid_constant__ DirectAllgatherNvlArgs,
+    Timeout);
+
+template __global__ void
+direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>(
+    const __grid_constant__ DirectReduceScatterNvlArgs<float>,
+    Timeout);
+
+template __global__ void hierarchical_allgather_fused_kernel<512>(
+    const __grid_constant__ HierarchicalAllgatherFusedArgs,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectNvl.cuh
+++ b/comms/pipes/collectives/DirectNvl.cuh
@@ -1,0 +1,29 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Direct NVLink AllGather, ReduceScatter, and Hierarchical AllGather kernels.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/DirectNvlTypes.h"
+
+namespace comms::pipes {
+
+template <int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
+    const __grid_constant__ DirectAllgatherNvlArgs args,
+    Timeout timeout);
+
+template <typename T, typename AccumOp, int kTileElems, int kBlockSize>
+__global__
+    __launch_bounds__(kBlockSize, 1) void direct_reduce_scatter_nvl_kernel(
+        const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
+        Timeout timeout);
+
+template <int kBlockSize>
+__global__
+    __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
+        const __grid_constant__ HierarchicalAllgatherFusedArgs args,
+        Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectNvlLauncher.cu
+++ b/comms/pipes/collectives/DirectNvlLauncher.cu
@@ -1,0 +1,121 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/DirectNvlLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/Checks.h"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/DirectNvl.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+void validate_direct_nvl(int num_ranks) {
+  if (num_ranks < 1 || num_ranks > kDirectNvlMaxRanks) {
+    throw std::runtime_error(
+        "Unsupported direct NVLink num_ranks=" + std::to_string(num_ranks) +
+        " (supported: 1.." + std::to_string(kDirectNvlMaxRanks) + ")");
+  }
+}
+
+Timeout make_launch_timeout(float timeout_ms) {
+  Timeout timeout;
+  if (timeout_ms > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout = makeTimeout(timeout_ms, device);
+  }
+  return timeout;
+}
+
+} // namespace
+
+void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params) {
+  validate_direct_nvl(params.num_ranks);
+
+  DirectAllgatherNvlArgs args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.sendcount = params.sendcount;
+  args.signaling_data_size = params.signaling_data_size;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+
+  for (int peer = 0; peer < params.num_ranks; ++peer) {
+    if (peer == params.my_rank) {
+      continue;
+    }
+    new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
+  }
+
+  direct_allgather_nvl_kernel<512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+void launch_direct_reduce_scatter_nvl(
+    const DirectReduceScatterNvlLaunchParams& params) {
+  validate_direct_nvl(params.num_ranks);
+
+  DirectReduceScatterNvlArgs<float> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = params.chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+
+  for (int peer = 0; peer < params.num_ranks; ++peer) {
+    if (peer == params.my_rank) {
+      continue;
+    }
+    new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
+  }
+
+  direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+void launch_hierarchical_allgather_fused(
+    const HierarchicalAllgatherLaunchParams& params) {
+  validate_direct_nvl(params.nvl_size);
+  if (params.ib_size < 1 ||
+      params.ib_size * params.nvl_size != params.num_ranks) {
+    throw std::runtime_error("Invalid hierarchical allgather rank geometry");
+  }
+
+  HierarchicalAllgatherFusedArgs args{};
+  args.ib_rank = params.ib_rank;
+  args.ib_size = params.ib_size;
+  args.nvl_rank = params.nvl_rank;
+  args.nvl_size = params.nvl_size;
+  args.sendcount = params.sendcount;
+  args.ib_signaling_data_size = params.ib_signaling_data_size;
+  args.nvl_signaling_data_size = params.nvl_signaling_data_size;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+  args.ib_ring = params.ib_ring;
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == params.nvl_rank) {
+      continue;
+    }
+    new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
+  }
+
+  hierarchical_allgather_fused_kernel<512>
+      <<<params.ib_num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectNvlLauncher.h
+++ b/comms/pipes/collectives/DirectNvlLauncher.h
@@ -1,0 +1,66 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/DirectNvlTypes.h"
+
+namespace comms::pipes {
+
+struct DirectAllgatherNvlLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params);
+
+struct DirectReduceScatterNvlLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_direct_reduce_scatter_nvl(
+    const DirectReduceScatterNvlLaunchParams& params);
+
+struct HierarchicalAllgatherLaunchParams {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int ib_num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_hierarchical_allgather_fused(
+    const HierarchicalAllgatherLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/DirectNvlTypes.h
+++ b/comms/pipes/collectives/DirectNvlTypes.h
@@ -1,0 +1,57 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+inline constexpr int kDirectNvlMaxRanks = 16;
+
+struct DirectAllgatherNvlArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t sendcount{0};
+  std::size_t signaling_data_size{0};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+};
+
+template <typename T>
+struct DirectReduceScatterNvlArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  P2pNvlTransportDevice peers[kDirectNvlMaxRanks]{};
+  const T* input{nullptr};
+  T* output{nullptr};
+};
+
+struct HierarchicalAllgatherIbgdaRing {
+  int prev_rank{0};
+  int next_rank{0};
+  P2pIbgdaTransportDevice* prev{nullptr};
+  P2pIbgdaTransportDevice* next{nullptr};
+};
+
+struct HierarchicalAllgatherFusedArgs {
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -1,0 +1,668 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <memory>
+#include <new>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/pipes/collectives/DirectNvlLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+constexpr int kBenchmarkNumBlocks = 8;
+constexpr int kBenchmarkIbLinks = 4;
+constexpr std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+constexpr int kPipelineDepth = 2;
+constexpr std::size_t kDefaultIbSignalBytes = 1024 * 1024;
+
+std::string format_size(std::size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+  }
+  if (bytes >= 1024 * 1024) {
+    return std::to_string(bytes / (1024 * 1024)) + "MB";
+  }
+  if (bytes >= 1024) {
+    return std::to_string(bytes / 1024) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+std::vector<std::size_t> benchmark_sizes() {
+  return {
+      8 * 1024,
+      16 * 1024,
+      32 * 1024,
+      64 * 1024,
+      128 * 1024,
+      256 * 1024,
+      512 * 1024,
+      1024 * 1024,
+      2 * 1024 * 1024,
+      4 * 1024 * 1024,
+      8 * 1024 * 1024,
+      16 * 1024 * 1024,
+      32 * 1024 * 1024,
+      64 * 1024 * 1024,
+      128 * 1024 * 1024,
+      256 * 1024 * 1024,
+      512UL * 1024 * 1024,
+      1024UL * 1024 * 1024,
+  };
+}
+
+std::vector<std::size_t> configured_benchmark_sizes() {
+  const char* only_bytes = std::getenv("HIER_AG_BENCH_ONLY_BYTES");
+  if (only_bytes != nullptr) {
+    return {std::strtoull(only_bytes, nullptr, 10)};
+  }
+  return benchmark_sizes();
+}
+
+int benchmark_num_blocks() {
+  const char* num_blocks = std::getenv("HIER_AG_BENCH_NUM_BLOCKS");
+  if (num_blocks != nullptr) {
+    return static_cast<int>(std::strtol(num_blocks, nullptr, 10));
+  }
+  return kBenchmarkNumBlocks;
+}
+
+int benchmark_nvl_size(int world_size) {
+  const char* nvl_size = std::getenv("HIER_AG_BENCH_NVL_SIZE");
+  if (nvl_size != nullptr) {
+    return static_cast<int>(std::strtol(nvl_size, nullptr, 10));
+  }
+  return world_size % 4 == 0 ? 4 : world_size;
+}
+
+int benchmark_ib_links() {
+  const char* ib_links = std::getenv("HIER_AG_BENCH_IB_LINKS");
+  if (ib_links != nullptr) {
+    return static_cast<int>(std::strtol(ib_links, nullptr, 10));
+  }
+  return kBenchmarkIbLinks;
+}
+
+std::size_t benchmark_data_buffer_size() {
+  const char* data_buffer_size = std::getenv("HIER_AG_BENCH_DATA_BUFFER_SIZE");
+  if (data_buffer_size != nullptr) {
+    return std::strtoull(data_buffer_size, nullptr, 10);
+  }
+  return kDataBufferSize;
+}
+
+int benchmark_pipeline_depth() {
+  const char* pipeline_depth = std::getenv("HIER_AG_BENCH_PIPELINE_DEPTH");
+  if (pipeline_depth != nullptr) {
+    return static_cast<int>(std::strtol(pipeline_depth, nullptr, 10));
+  }
+  return kPipelineDepth;
+}
+
+std::string benchmark_ib_hca() {
+  const char* ib_hca = std::getenv("HIER_AG_BENCH_IB_HCA");
+  if (ib_hca != nullptr) {
+    return ib_hca;
+  }
+  return "";
+}
+
+bool env_flag_enabled(const char* name, bool default_value) {
+  const char* value = std::getenv(name);
+  if (value == nullptr) {
+    return default_value;
+  }
+  return std::strtol(value, nullptr, 10) != 0;
+}
+
+bool benchmark_nccl_disable_p2p() {
+  return env_flag_enabled("HIER_AG_BENCH_NCCL_P2P_DISABLE", true);
+}
+
+bool benchmark_nccl_disable_shm() {
+  return env_flag_enabled("HIER_AG_BENCH_NCCL_SHM_DISABLE", true);
+}
+
+bool benchmark_skip_nccl() {
+  return env_flag_enabled("HIER_AG_BENCH_SKIP_NCCL", false);
+}
+
+std::size_t benchmark_nvl_signal_bytes() {
+  const char* signal_bytes = std::getenv("HIER_AG_BENCH_NVL_SIGNAL_BYTES");
+  if (signal_bytes != nullptr) {
+    return std::strtoull(signal_bytes, nullptr, 10);
+  }
+  return 0;
+}
+
+std::size_t benchmark_ib_signal_bytes(
+    std::size_t data_buffer_size,
+    int num_blocks) {
+  const char* signal_bytes = std::getenv("HIER_AG_BENCH_IB_SIGNAL_BYTES");
+  if (signal_bytes != nullptr) {
+    return std::strtoull(signal_bytes, nullptr, 10);
+  }
+  const std::size_t per_block_slot =
+      (data_buffer_size / static_cast<std::size_t>(num_blocks)) & ~15ULL;
+  return std::min(per_block_slot, kDefaultIbSignalBytes);
+}
+
+struct HierarchicalAllGatherBenchmarkConfig {
+  std::size_t total_bytes;
+  std::size_t sendcount;
+  std::size_t ib_signaling_data_size;
+  std::size_t nvl_signaling_data_size;
+  int num_blocks;
+  int ib_links;
+  int ib_size;
+  int nvl_size;
+  std::string ib_hca;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct HierarchicalAllGatherBenchmarkResult {
+  std::string test_name;
+  std::size_t sendcount{};
+  std::size_t total_bytes{};
+  int num_blocks{};
+  int ib_links{};
+  int ib_nics{};
+  std::size_t ib_signaling_data_size{};
+  std::size_t data_buffer_size{};
+  int pipeline_depth{};
+  int ib_size{};
+  int nvl_size{};
+  float nccl_bandwidth{};
+  float hierarchical_bandwidth{};
+  float nccl_latency{};
+  float hierarchical_latency{};
+  float speedup{};
+  bool nccl_p2p_disabled{};
+  bool nccl_shm_disabled{};
+};
+
+class HierarchicalAllGatherBenchmarkFixture
+    : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_ALGO", "Ring", 1);
+    setenv("NCCL_PROTO", "Simple", 1);
+    setenv("NCCL_NVLS_ENABLE", "0", 1);
+    setenv("NCCL_P2P_DISABLE", benchmark_nccl_disable_p2p() ? "1" : "0", 1);
+    setenv("NCCL_SHM_DISABLE", benchmark_nccl_disable_shm() ? "1" : "0", 1);
+    const std::string ib_hca = benchmark_ib_hca();
+    if (!ib_hca.empty()) {
+      setenv("NCCL_IB_HCA", ib_hca.c_str(), 1);
+    }
+    const std::string num_blocks = std::to_string(benchmark_num_blocks());
+    setenv("NCCL_MIN_NCHANNELS", num_blocks.c_str(), 1);
+    setenv("NCCL_MAX_NCHANNELS", num_blocks.c_str(), 1);
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+    if (!benchmark_skip_nccl()) {
+      NCCL_CHECK_VOID(
+          ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    }
+  }
+
+  void TearDown() override {
+    if (nccl_comm_ != nullptr) {
+      NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    }
+    if (stream_ != nullptr) {
+      CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    }
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const HierarchicalAllGatherBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t recvcount = config.sendcount * worldSize;
+
+    DeviceBuffer send_buf(config.sendcount);
+    DeviceBuffer recv_buf(recvcount);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
+
+    CudaEvent start, stop;
+    const bool full_bench = std::getenv("HIER_AG_BENCH_FULL") != nullptr;
+    const int n_warmup = full_bench ? 5 : 2;
+    const int n_iter = full_bench ? 100 : 10;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclAllGather(
+          send_buf.get(),
+          recv_buf.get(),
+          config.sendcount,
+          ncclChar,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclAllGather(
+          send_buf.get(),
+          recv_buf.get(),
+          config.sendcount,
+          ncclChar,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (recvcount / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_hierarchical_benchmark(
+      const HierarchicalAllGatherBenchmarkConfig& config,
+      int& ib_nics,
+      float& latency_us) {
+    const std::size_t recvcount = config.sendcount * worldSize;
+    const int nvl_rank = globalRank % config.nvl_size;
+    const int ib_rank = globalRank / config.nvl_size;
+
+    DeviceBuffer send_buf(config.sendcount);
+    DeviceBuffer recv_buf(recvcount);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
+
+    std::unique_ptr<MultipeerIbgdaTransport> ib_transport;
+    try {
+      MultipeerIbgdaTransportConfig transport_config{
+          .cudaDevice = localRank,
+          .dataBufferSize = config.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks,
+                  .pipelineDepth = config.pipeline_depth,
+              },
+          .numQpsPerPeerPerNic = config.num_qps,
+      };
+      transport_config.ibHca = config.ib_hca;
+      ib_transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transport_config);
+      ib_transport->exchange();
+      ib_nics = ib_transport->numNics();
+    } catch (const std::exception& e) {
+      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    std::unique_ptr<MultiPeerNvlTransport> nvl_transport;
+    if (config.nvl_size > 1) {
+      try {
+        std::vector<int> nvl_rank_to_global(config.nvl_size);
+        for (int peer = 0; peer < config.nvl_size; ++peer) {
+          nvl_rank_to_global[peer] = ib_rank * config.nvl_size + peer;
+        }
+        auto nvl_bootstrap = std::make_shared<NvlBootstrapAdapter>(
+            bootstrap, std::move(nvl_rank_to_global));
+        MultiPeerNvlTransportConfig transport_config{
+            .dataBufferSize = config.data_buffer_size,
+            .chunkSize = config.data_buffer_size,
+            .pipelineDepth = static_cast<std::size_t>(config.pipeline_depth),
+            .p2pSignalCount = static_cast<std::size_t>(config.num_blocks),
+            .tile_max_groups = config.num_blocks,
+            .memSharingMode = MemSharingMode::kCudaIpc,
+        };
+        nvl_transport = std::make_unique<MultiPeerNvlTransport>(
+            nvl_rank, config.nvl_size, nvl_bootstrap, transport_config);
+        nvl_transport->exchange();
+      } catch (const std::exception& e) {
+        XLOGF(ERR, "NVLink transport not available: {}", e.what());
+        latency_us = 0.0f;
+        return 0.0f;
+      }
+    }
+
+    HierarchicalAllgatherLaunchParams launch_params{};
+    launch_params.num_ranks = worldSize;
+    launch_params.ib_rank = ib_rank;
+    launch_params.ib_size = config.ib_size;
+    launch_params.nvl_rank = nvl_rank;
+    launch_params.nvl_size = config.nvl_size;
+    launch_params.sendcount = config.sendcount;
+    launch_params.ib_signaling_data_size = config.ib_signaling_data_size;
+    launch_params.nvl_signaling_data_size = config.nvl_signaling_data_size;
+    launch_params.sendbuf = static_cast<const char*>(send_buf.get());
+    launch_params.recvbuf = static_cast<char*>(recv_buf.get());
+    launch_params.ib_num_blocks = config.num_blocks;
+    launch_params.timeout_ms = 30000.0f;
+    launch_params.stream = stream_;
+
+    if (config.ib_size > 1) {
+      auto ib_rings_opt = make_standard_rings(config.ib_size, ib_rank, 1);
+      if (!ib_rings_opt) {
+        XLOGF(ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
+        latency_us = 0.0f;
+        return 0.0f;
+      }
+      const auto& ib_ring = (*ib_rings_opt)[0];
+      const int prev_global = ib_ring.prev_rank * config.nvl_size + nvl_rank;
+      const int next_global = ib_ring.next_rank * config.nvl_size + nvl_rank;
+      launch_params.ib_ring.prev_rank = ib_ring.prev_rank;
+      launch_params.ib_ring.next_rank = ib_ring.next_rank;
+      launch_params.ib_ring.prev =
+          ib_transport->getP2pTransportDevice(prev_global);
+      launch_params.ib_ring.next =
+          ib_transport->getP2pTransportDevice(next_global);
+    }
+
+    for (int peer = 0; peer < config.nvl_size; ++peer) {
+      if (peer == nvl_rank) {
+        continue;
+      }
+      new (&launch_params.nvl_peers[peer])
+          P2pNvlTransportDevice(nvl_transport->getP2pTransportDevice(peer));
+    }
+
+    CudaEvent start, stop;
+    const bool full_bench = std::getenv("HIER_AG_BENCH_FULL") != nullptr;
+    const int n_warmup = full_bench ? 5 : 2;
+    const int n_iter = full_bench ? 100 : 10;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_hierarchical_allgather_fused(launch_params);
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      launch_hierarchical_allgather_fused(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (recvcount / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(
+      const std::vector<HierarchicalAllGatherBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "      NCCL AllGather vs Hierarchical AllGather (IB Ring + NVLink AG)\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(10) << "Chunk" << std::right
+       << std::setw(8) << "Blocks" << std::right << std::setw(6) << "IB"
+       << std::right << std::setw(6) << "NVL" << std::right << std::setw(8)
+       << "IBNics" << std::right << std::setw(9) << "IBLinks" << std::right
+       << std::setw(10) << "IBSig" << std::right << std::setw(10) << "DBuf"
+       << std::right << std::setw(7) << "Pipe" << std::right << std::setw(12)
+       << "NCCL Alg" << std::right << std::setw(12) << "Hier Alg" << std::right
+       << std::setw(10) << "Speedup" << std::right << std::setw(12)
+       << "NCCL Lat" << std::right << std::setw(12) << "Hier Lat\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(10) << "" << std::right << std::setw(8) << ""
+       << std::right << std::setw(6) << "" << std::right << std::setw(6) << ""
+       << std::right << std::setw(8) << "" << std::right << std::setw(9)
+       << "(QPs/NIC)" << std::right << std::setw(10) << "" << std::right
+       << std::setw(10) << "" << std::right << std::setw(7) << "" << std::right
+       << std::setw(12) << "(GB/s)" << std::right << std::setw(12) << "(GB/s)"
+       << std::right << std::setw(10) << "" << std::right << std::setw(12)
+       << "(us)" << std::right << std::setw(12) << "(us)\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << format_size(r.total_bytes) << std::right
+         << std::setw(10) << format_size(r.sendcount) << std::right
+         << std::setw(8) << r.num_blocks << std::right << std::setw(6)
+         << r.ib_size << std::right << std::setw(6) << r.nvl_size << std::right
+         << std::setw(8) << r.ib_nics << std::right << std::setw(9)
+         << r.ib_links << std::right << std::setw(10)
+         << (r.ib_signaling_data_size == 0
+                 ? "auto"
+                 : format_size(r.ib_signaling_data_size))
+         << std::right << std::setw(10) << format_size(r.data_buffer_size)
+         << std::right << std::setw(7) << r.pipeline_depth << std::right
+         << std::setw(12) << std::fixed << std::setprecision(2)
+         << r.nccl_bandwidth << std::right << std::setw(12) << std::fixed
+         << std::setprecision(2) << r.hierarchical_bandwidth << std::right
+         << std::setw(9) << std::fixed << std::setprecision(2) << r.speedup
+         << "x" << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.nccl_latency << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.hierarchical_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize
+       << " ranks, size = total input bytes, chunk = per-rank send bytes\n";
+    ss << "Algorithmic bandwidth = total input bytes / latency, not NIC wire bandwidth\n";
+    if (!results.empty()) {
+      ss << "NCCL baseline: Ring/Simple, NVLS disabled, channels matched to blocks, P2P_DISABLE="
+         << (results.front().nccl_p2p_disabled ? "1" : "0")
+         << ", SHM_DISABLE=" << (results.front().nccl_shm_disabled ? "1" : "0")
+         << "\n";
+    }
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(HierarchicalAllGatherBenchmarkFixture, VsNccl) {
+  const int nvl_size = benchmark_nvl_size(worldSize);
+  if (nvl_size <= 0 || nvl_size > kDirectNvlMaxRanks ||
+      worldSize % nvl_size != 0) {
+    XLOGF(
+        ERR,
+        "Invalid HIER_AG_BENCH_NVL_SIZE={} for worldSize={}",
+        nvl_size,
+        worldSize);
+    std::abort();
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "\n=== Hierarchical AllGather vs NCCL Comparison (IB groups={}, NVL groups={}) ===\n",
+        worldSize / nvl_size,
+        nvl_size);
+  }
+
+  std::vector<HierarchicalAllGatherBenchmarkConfig> configs;
+  const int num_blocks = benchmark_num_blocks();
+  const int ib_links = benchmark_ib_links();
+  const std::size_t data_buffer_size = benchmark_data_buffer_size();
+  const int pipeline_depth = benchmark_pipeline_depth();
+  const std::string ib_hca = benchmark_ib_hca();
+  if (ib_links <= 0) {
+    XLOGF(ERR, "Invalid HIER_AG_BENCH_IB_LINKS={}", ib_links);
+    std::abort();
+  }
+  if (data_buffer_size == 0) {
+    XLOG(ERR, "Invalid HIER_AG_BENCH_DATA_BUFFER_SIZE=0");
+    std::abort();
+  }
+  if (pipeline_depth <= 0) {
+    XLOGF(ERR, "Invalid HIER_AG_BENCH_PIPELINE_DEPTH={}", pipeline_depth);
+    std::abort();
+  }
+  const std::size_t ib_signal_bytes =
+      benchmark_ib_signal_bytes(data_buffer_size, num_blocks);
+  const std::size_t nvl_signal_bytes = benchmark_nvl_signal_bytes();
+  const bool nccl_p2p_disabled = benchmark_nccl_disable_p2p();
+  const bool nccl_shm_disabled = benchmark_nccl_disable_shm();
+  const bool skip_nccl = benchmark_skip_nccl();
+  for (std::size_t total_bytes : configured_benchmark_sizes()) {
+    if (total_bytes % static_cast<std::size_t>(worldSize) != 0) {
+      XLOGF(
+          ERR,
+          "AllGather size {} is not divisible by {} ranks",
+          total_bytes,
+          worldSize);
+      std::abort();
+    }
+    configs.push_back({
+        .total_bytes = total_bytes,
+        .sendcount = total_bytes / static_cast<std::size_t>(worldSize),
+        .ib_signaling_data_size = ib_signal_bytes,
+        .nvl_signaling_data_size = nvl_signal_bytes,
+        .num_blocks = num_blocks,
+        .ib_links = ib_links,
+        .ib_size = worldSize / nvl_size,
+        .nvl_size = nvl_size,
+        .ib_hca = ib_hca,
+        .data_buffer_size = data_buffer_size,
+        .pipeline_depth = pipeline_depth,
+        .num_qps = ib_links,
+        .name =
+            format_size(total_bytes) + "_" + std::to_string(num_blocks) + "B",
+    });
+  }
+
+  std::vector<HierarchicalAllGatherBenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    if (globalRank == 0) {
+      XLOGF(
+          INFO,
+          "Running hierarchical AllGather {}: size={}, chunk={}, blocks={}, ib_size={}, nvl_size={}, ib_links_per_nic={}, ib_signal_bytes={}, nvl_signal_bytes={}",
+          config.name,
+          format_size(config.total_bytes),
+          format_size(config.sendcount),
+          config.num_blocks,
+          config.ib_size,
+          config.nvl_size,
+          config.ib_links,
+          config.ib_signaling_data_size,
+          config.nvl_signaling_data_size);
+    }
+
+    float nccl_lat = 0.0f;
+    float nccl_bw = 0.0f;
+    if (!skip_nccl) {
+      nccl_bw = run_nccl_benchmark(config, nccl_lat);
+    }
+
+    float hierarchical_lat = 0.0f;
+    int ib_nics = 0;
+    float hierarchical_bw =
+        run_hierarchical_benchmark(config, ib_nics, hierarchical_lat);
+
+    if (globalRank == 0) {
+      XLOGF(
+          INFO,
+          "AllGather {} result: NCCL={:.2f} GB/s ({:.1f} us), Hier={:.2f} GB/s ({:.1f} us), Hier/NCCL={:.2f}x",
+          config.name,
+          nccl_bw,
+          nccl_lat,
+          hierarchical_bw,
+          hierarchical_lat,
+          (nccl_bw > 0) ? hierarchical_bw / nccl_bw : 0.0f);
+      results.push_back({
+          .test_name = config.name,
+          .sendcount = config.sendcount,
+          .total_bytes = config.total_bytes,
+          .num_blocks = config.num_blocks,
+          .ib_links = config.ib_links,
+          .ib_nics = ib_nics,
+          .ib_signaling_data_size = config.ib_signaling_data_size,
+          .data_buffer_size = config.data_buffer_size,
+          .pipeline_depth = config.pipeline_depth,
+          .ib_size = config.ib_size,
+          .nvl_size = config.nvl_size,
+          .nccl_bandwidth = nccl_bw,
+          .hierarchical_bandwidth = hierarchical_bw,
+          .nccl_latency = nccl_lat,
+          .hierarchical_latency = hierarchical_lat,
+          .speedup = (nccl_bw > 0) ? hierarchical_bw / nccl_bw : 0.0f,
+          .nccl_p2p_disabled = nccl_p2p_disabled,
+          .nccl_shm_disabled = nccl_shm_disabled,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/DirectNvlTest.cc
+++ b/comms/pipes/collectives/tests/DirectNvlTest.cc
@@ -1,0 +1,195 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/collectives/DirectNvlLauncher.h"
+#include "comms/pipes/collectives/tests/AllGatherTestHarness.h"
+#include "comms/pipes/collectives/tests/ReduceScatterTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct DirectNvlTestParams {
+  std::size_t bytes{0};
+  int num_blocks{8};
+  std::string name;
+};
+
+auto param_name = [](const ::testing::TestParamInfo<DirectNvlTestParams>& p) {
+  return p.param.name;
+};
+
+std::unique_ptr<MultiPeerNvlTransport> make_nvl_transport(
+    int globalRank,
+    int worldSize,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    std::size_t dataBufferSize,
+    int numBlocks) {
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = dataBufferSize,
+      .chunkSize = dataBufferSize,
+      .pipelineDepth = 2,
+      .p2pSignalCount = static_cast<std::size_t>(numBlocks),
+      .tile_max_groups = numBlocks,
+      .memSharingMode = MemSharingMode::kCudaIpc,
+  };
+  auto transport = std::make_unique<MultiPeerNvlTransport>(
+      globalRank, worldSize, bootstrap, config);
+  transport->exchange();
+  return transport;
+}
+
+class DirectAllGatherNvlTest
+    : public AllGatherTestBase,
+      public ::testing::WithParamInterface<DirectNvlTestParams> {};
+
+class DirectReduceScatterNvlTest
+    : public ReduceScatterTestBase,
+      public ::testing::WithParamInterface<DirectNvlTestParams> {};
+
+TEST_P(DirectAllGatherNvlTest, Correctness) {
+  const auto& params = GetParam();
+
+  if (worldSize < 2 || worldSize > kDirectNvlMaxRanks) {
+    GTEST_SKIP() << "Direct NVLink allgather requires 2.." << kDirectNvlMaxRanks
+                 << " ranks";
+  }
+
+  std::unique_ptr<MultiPeerNvlTransport> transport;
+  try {
+    transport = make_nvl_transport(
+        globalRank, worldSize, bootstrap, 1024 * 1024, params.num_blocks);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "NVLink transport not available: " << e.what();
+  }
+
+  DeviceBuffer sendbuf(params.bytes);
+  DeviceBuffer recvbuf(params.bytes * worldSize);
+  CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, params.bytes * worldSize));
+
+  fill_sendbuf(static_cast<char*>(sendbuf.get()), params.bytes);
+
+  DirectAllgatherNvlLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.sendcount = params.bytes;
+  launchParams.signaling_data_size = 0;
+  launchParams.sendbuf = static_cast<const char*>(sendbuf.get());
+  launchParams.recvbuf = static_cast<char*>(recvbuf.get());
+  launchParams.num_blocks = params.num_blocks;
+  launchParams.timeout_ms = 30000.0f;
+
+  for (int peer = 0; peer < worldSize; ++peer) {
+    if (peer == globalRank) {
+      continue;
+    }
+    new (&launchParams.peers[peer])
+        P2pNvlTransportDevice(transport->getP2pTransportDevice(peer));
+  }
+
+  bootstrap->barrierAll();
+  launch_direct_allgather_nvl(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allgather(static_cast<const char*>(recvbuf.get()), params.bytes);
+}
+
+TEST_P(DirectReduceScatterNvlTest, Correctness) {
+  const auto& params = GetParam();
+
+  if (worldSize < 2 || worldSize > kDirectNvlMaxRanks) {
+    GTEST_SKIP() << "Direct NVLink reduce-scatter requires 2.."
+                 << kDirectNvlMaxRanks << " ranks";
+  }
+
+  std::unique_ptr<MultiPeerNvlTransport> transport;
+  try {
+    transport = make_nvl_transport(
+        globalRank, worldSize, bootstrap, 1024 * 1024, params.num_blocks);
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "NVLink transport not available: " << e.what();
+  }
+
+  const std::size_t chunk_elements = params.bytes / sizeof(float);
+  const std::size_t total_elements = chunk_elements * worldSize;
+  DeviceBuffer inputBuf(total_elements * sizeof(float));
+  DeviceBuffer outputBuf(params.bytes);
+  CUDACHECK_TEST(cudaMemset(outputBuf.get(), 0, params.bytes));
+
+  fill_input(static_cast<float*>(inputBuf.get()), total_elements);
+
+  DirectReduceScatterNvlLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.chunk_elements = chunk_elements;
+  launchParams.signaling_data_size = 0;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.num_blocks = params.num_blocks;
+  launchParams.timeout_ms = 30000.0f;
+
+  for (int peer = 0; peer < worldSize; ++peer) {
+    if (peer == globalRank) {
+      continue;
+    }
+    new (&launchParams.peers[peer])
+        P2pNvlTransportDevice(transport->getP2pTransportDevice(peer));
+  }
+
+  bootstrap->barrierAll();
+  launch_direct_reduce_scatter_nvl(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_reduce_scatter(
+      static_cast<const float*>(outputBuf.get()), chunk_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Direct,
+    DirectAllGatherNvlTest,
+    ::testing::Values(
+        DirectNvlTestParams{
+            .bytes = 64 * 1024,
+            .num_blocks = 4,
+            .name = "64KB_4B"},
+        DirectNvlTestParams{
+            .bytes = 1024 * 1024,
+            .num_blocks = 8,
+            .name = "1MB_8B"}),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Direct,
+    DirectReduceScatterNvlTest,
+    ::testing::Values(
+        DirectNvlTestParams{
+            .bytes = 64 * 1024,
+            .num_blocks = 4,
+            .name = "64KB_4B"},
+        DirectNvlTestParams{
+            .bytes = 1024 * 1024,
+            .num_blocks = 8,
+            .name = "1MB_8B"}),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/HierarchicalAllGatherTest.cc
+++ b/comms/pipes/collectives/tests/HierarchicalAllGatherTest.cc
@@ -1,0 +1,134 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+
+#include <memory>
+#include <new>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/pipes/collectives/DirectNvlLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/AllGatherTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+class HierarchicalAllGatherTest : public AllGatherTestBase {};
+
+TEST_F(HierarchicalAllGatherTest, Correctness) {
+  constexpr int kNvlSize = 2;
+  constexpr int kIbSize = 2;
+  constexpr std::size_t kSendcount = 64 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  if (worldSize != kNvlSize * kIbSize) {
+    GTEST_SKIP() << "Hierarchical test expects " << kNvlSize * kIbSize
+                 << " ranks";
+  }
+
+  const int ibRank = globalRank / kNvlSize;
+  const int nvlRank = globalRank % kNvlSize;
+
+  std::unique_ptr<MultipeerIbgdaTransport> ibTransport;
+  try {
+    MultipeerIbgdaTransportConfig ibConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = 1024 * 1024,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = kNumBlocks,
+                .pipelineDepth = 2,
+            },
+    };
+    ibTransport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, ibConfig);
+    ibTransport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
+  try {
+    MultiPeerNvlTransportConfig nvlConfig{
+        .dataBufferSize = 1024 * 1024,
+        .chunkSize = 1024 * 1024,
+        .pipelineDepth = 2,
+        .p2pSignalCount = static_cast<std::size_t>(kNumBlocks),
+        .tile_max_groups = kNumBlocks,
+        .memSharingMode = MemSharingMode::kCudaIpc,
+    };
+    std::vector<int> nvlRankToGlobal(kNvlSize);
+    for (int peer = 0; peer < kNvlSize; ++peer) {
+      nvlRankToGlobal[peer] = ibRank * kNvlSize + peer;
+    }
+    auto nvlBootstrap = std::make_shared<NvlBootstrapAdapter>(
+        bootstrap, std::move(nvlRankToGlobal));
+    nvlTransport = std::make_unique<MultiPeerNvlTransport>(
+        nvlRank, kNvlSize, nvlBootstrap, nvlConfig);
+    nvlTransport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "NVLink transport not available: " << e.what();
+  }
+
+  DeviceBuffer sendbuf(kSendcount);
+  DeviceBuffer recvbuf(kSendcount * worldSize);
+  CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, kSendcount * worldSize));
+
+  fill_sendbuf(static_cast<char*>(sendbuf.get()), kSendcount);
+
+  auto ibRingsOpt = make_standard_rings(kIbSize, ibRank, 1);
+  ASSERT_TRUE(ibRingsOpt.has_value());
+  const auto& ibRings = *ibRingsOpt;
+
+  HierarchicalAllgatherLaunchParams launchParams{};
+  launchParams.num_ranks = worldSize;
+  launchParams.ib_rank = ibRank;
+  launchParams.ib_size = kIbSize;
+  launchParams.nvl_rank = nvlRank;
+  launchParams.nvl_size = kNvlSize;
+  launchParams.sendcount = kSendcount;
+  launchParams.sendbuf = static_cast<const char*>(sendbuf.get());
+  launchParams.recvbuf = static_cast<char*>(recvbuf.get());
+  launchParams.ib_num_blocks = kNumBlocks;
+  launchParams.timeout_ms = 30000.0f;
+
+  const auto& ibRing = ibRings[0];
+  const int prevGlobal = ibRing.prev_rank * kNvlSize + nvlRank;
+  const int nextGlobal = ibRing.next_rank * kNvlSize + nvlRank;
+  launchParams.ib_ring.prev_rank = ibRing.prev_rank;
+  launchParams.ib_ring.next_rank = ibRing.next_rank;
+  launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
+  launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
+
+  for (int peer = 0; peer < kNvlSize; ++peer) {
+    if (peer == nvlRank) {
+      continue;
+    }
+    new (&launchParams.nvl_peers[peer])
+        P2pNvlTransportDevice(nvlTransport->getP2pTransportDevice(peer));
+  }
+
+  bootstrap->barrierAll();
+  launch_hierarchical_allgather_fused(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allgather(static_cast<const char*>(recvbuf.get()), kSendcount);
+}
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2014,7 +2014,7 @@ cvars:
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum
    default     : ctpipeline
-   choices     : ctdirect, ctpipeline, ctrdpipeline
+   choices     : ctdirect, ctpipeline, ctrdpipeline, cthierarchical_pipes
    description : |-
      The algorithm to use for AllgatherP communication
      ctdirect - Ctran-based direct point-to-point algorithm
@@ -2023,6 +2023,50 @@ cvars:
      ctrdpipeline - Ctran-based hybrid algorithm that does recursive doubling across
                     rails for inter-node exchange and CopyEngine based broadcast
                     within the NVLink domain. Requires nNodes to be a power of 2.
+     cthierarchical_pipes - Ctran/Pipes hierarchical NVLink + IBGDA
+                            allgather path.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS
+   type        : int64_t
+   default     : 16
+   description : |-
+     Number of CUDA block groups used by ctran hierarchical Pipes AllGather
+     for the inter-node IBGDA ring.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_PIPELINE_DEPTH
+   type        : int64_t
+   default     : 2
+   description : |-
+     Number of send/recv staging slots allocated for ctran hierarchical Pipes
+     AllGather IBGDA send/recv.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC
+   type        : int64_t
+   default     : 4
+   description : |-
+     Number of IBGDA QP sets per peer per NIC for ctran hierarchical Pipes
+     AllGather.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 1048576
+   description : |-
+     Maximum bytes covered by one IBGDA signal in ctran hierarchical Pipes
+     AllGather.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 1048576
+   description : |-
+     Maximum bytes covered by one NVLink signal in ctran hierarchical Pipes
+     AllGather.
+
+ - name        : NCCL_CTRAN_HIER_AG_TIMEOUT_MS
+   type        : uint64_t
+   default     : 30000
+   description : |-
+     GPU-side timeout in milliseconds for ctran hierarchical Pipes AllGather
+     transport waits. Set to 0 to disable timeout.
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:
Integrate an opt-in NCCL_ALLGATHER_P_ALGO::cthierarchical_pipes path that reuses the Pipes hierarchical NVLink + IBGDA device protocol from ctran AllGatherP and launches it through GPE with an empty op group, matching the DeviceAllToAllvPipes lifecycle pattern while keeping ctran stream ordering and CUDA graph-compatible launch ownership.

Add a GPE wrapper kernel and host-side AllGatherP implementation that validates contiguous rank geometry, fills Pipes NVL/IBGDA transport args, wires timeout/signaling parameters, and supports the one-kernel staged allgather with fused self-copy into IB staging.

Expose transport tuning cvars for block count, pipeline depth, QPs per peer per NIC, IB/NVL signal bytes, and timeout; plumb the send/recv transport config into CtranPipes and add build deps for the reused Pipes device components.

Extend the AllgatherP benchmark to run the hierarchical path and recursive-doubling path explicitly, and add a 4x1 benchmark configuration.

Differential Revision: D104948958


