### PR TITLE
add user better registered buffer atomic alignment checking (#2530)

### DIFF
--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -146,6 +146,14 @@ struct CtranWin {
         bufType_ == DevMemType::kCumem;
   }
 
+  inline bool isAtomicCapable() const {
+    return atomicCapable_;
+  }
+
+  inline void setAtomicCapable(bool val) {
+    atomicCapable_ = val;
+  }
+
   // Check whether persistent allgather (allgatherP) is supported.
   // Returns true if ctran is initialized and all peers have configured
   // backends. Static variant allows checking before a window is created.
@@ -158,6 +166,9 @@ struct CtranWin {
   DevMemType bufType_{DevMemType::kCumem};
   // whether allocate window data buffer or provided by users
   bool allocDataBuf_{true};
+  // Whether this window's data buffer meets the alignment requirements
+  // for IB/NVLink atomic operations (8-byte aligned address and size).
+  bool atomicCapable_{false};
   // rank: window::OpCountType as key
   folly::Synchronized<
       std::unordered_map<std::pair<int, window::OpCountType>, uint64_t>>

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -392,6 +392,7 @@ commResult_t ctranWinAllocate(
       comm,
       size,
       locationRes == "cpu" ? DevMemType::kHostPinned : DevMemType::kCumem);
+  newWin->setAtomicCapable(true);
   FB_COMMCHECK(newWin->allocate(nullptr));
   FB_COMMCHECK(newWin->exchange());
   if (baseptr) {
@@ -444,6 +445,9 @@ commResult_t ctranWinRegister(
       // if user buffer is on host CPU, allocate kHostPinned buffer for
       // signal otherwise is on GPU device, allocate kCumem buffer for signal
       userBufType);
+  newWin->setAtomicCapable(
+      reinterpret_cast<uintptr_t>(databuf) % sizeof(uint64_t) == 0 &&
+      size % sizeof(uint64_t) == 0);
 
   FB_COMMCHECK(newWin->allocate((void*)databuf));
 


### PR DESCRIPTION
Summary:

 Auto-detect atomic capability for ctran windows data buffer. Allocated windows (`ctranWinAllocate`) are always atomic-capable since the buffer is 8-byte aligned and size is rounded up. Registered windows (`ctranWinRegister`) are atomic-capable when the user-provided buffer address and size are both 8-byte aligned. This is checked at registration time with no hint required — isAtomicCapable() exposes the result for use by atomic operations (e.g., `atomicAdd`, `fetchAdd`).

Differential Revision: D105051897


