### PR TITLE
Remove unused ErrorStackTraceUtil.h include from cudawrap.h (#2531)

### DIFF
--- a/comms/ncclx/meta/collectives/AllReduceSparseBlock.cc
+++ b/comms/ncclx/meta/collectives/AllReduceSparseBlock.cc
@@ -5,6 +5,7 @@
 #include "enqueue.h"
 #include "nccl.h"
 
+#include "comms/ctran/utils/ErrorStackTraceUtil.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/wrapper/MetaFactory.h"
 

--- a/comms/ncclx/v2_30/src/group.cc
+++ b/comms/ncclx/v2_30/src/group.cc
@@ -27,7 +27,6 @@
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportProxy.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
 #include "meta/wrapper/MetaFactory.h"
 
 #define GROUP_MAX_RECLAIM_STEPS 10

--- a/comms/ncclx/v2_30/src/include/cudawrap.h
+++ b/comms/ncclx/v2_30/src/include/cudawrap.h
@@ -13,8 +13,6 @@
 #include "checks.h"
 #include "compiler.h"
 
-#include "comms/ctran/utils/ErrorStackTraceUtil.h"
-
 // Is cuMem API usage enabled
 extern int ncclCuMemEnable();
 extern int ncclCuMemHostEnable();

--- a/comms/ncclx/v2_30/src/proxy.cc
+++ b/comms/ncclx/v2_30/src/proxy.cc
@@ -26,7 +26,6 @@
 #include <thread>
 
 #include "meta/colltrace/ProxyTraceFunc.h"
-#include "comms/utils/logger/EventsScubaUtil.h"
 
 #define NCCL_MAX_PROXY_CONNECTIONS (NCCL_MAX_LOCAL_RANKS+1)
 

--- a/comms/ncclx/v2_30/src/register/register.cc
+++ b/comms/ncclx/v2_30/src/register/register.cc
@@ -14,6 +14,7 @@
 #include "group.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/ctran/utils/ErrorStackTraceUtil.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "comms/ctran/Ctran.h"
 #include "comms/utils/memtrace/MemoryTrace.h"


### PR DESCRIPTION
Summary:

Remove unused `#include "comms/ctran/utils/ErrorStackTraceUtil.h"` from `cudawrap.h`. Neither `cudawrap.h` nor `cudawrap.cc` references any symbol from this header. Files that use ErrorStackTraceUtil (debug.cc, register.cc) include it through other paths.

Reviewed By: snarayankh

Differential Revision: D104148079


