### PR TITLE
Add ALGO_TOTAL profiler hooks for transport stats

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -99,6 +99,18 @@ uint64_t Ctran::getCtranOpCount() const {
   return comm_->getCtranOpCount();
 }
 
+void Ctran::startEventAlgo() {
+  if (mapper) {
+    mapper->startEventAlgo();
+  }
+}
+
+void Ctran::endEventAlgo() {
+  if (mapper) {
+    mapper->endEventAlgo();
+  }
+}
+
 #if defined(ENABLE_PIPES)
 comms::pipes::Transport* CtranComm::getMultiPeerTransportsPtr() const {
   if (!multiPeerTransport_) {

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -44,6 +44,9 @@ class Ctran : public ICtran {
   uint64_t getOpCount() const override;
   uint64_t getCtranOpCount() const override;
 
+  void startEventAlgo() override;
+  void endEventAlgo() override;
+
  private:
   CtranComm* comm_{nullptr};
 };

--- a/comms/ctran/interfaces/ICtran.h
+++ b/comms/ctran/interfaces/ICtran.h
@@ -45,6 +45,11 @@ class ICtran {
   // OpCount to track calls only to Ctran collectives
   virtual uint64_t getCtranOpCount() const = 0;
 
+  // Transport profiler hooks, called at ALGO_TOTAL boundaries by the Profiler.
+  // Implementations snapshot transport stats at start, emit delta at end.
+  virtual void startEventAlgo() = 0;
+  virtual void endEventAlgo() = 0;
+
   std::unique_ptr<CtranMapper> mapper{nullptr};
   // IMPORTANT: Member destruction order matters! C++ destroys members in
   // reverse order of declaration. algo must be declared BEFORE gpe so that

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -816,6 +816,13 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return commSuccess;
   }
 
+  void startEventAlgo() {
+    // To be defined by the transports.
+  }
+  void endEventAlgo() {
+    // To be defined by the transports.
+  }
+
   /* report the Ctran profiling results
    * Input arguments:
    *   - flush: force flushing the profiling result

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/interfaces/ICtran.h"
 #include "comms/ctran/profiler/DefaultAlgoProfilerReporter.h"
 
 namespace {
@@ -57,6 +59,9 @@ void Profiler::startEvent(
   if (event == ProfilerEvent::ALGO_CTRL) {
     readyTs_ = getTimeStamp(timers_[idx].getCheckpoint());
   }
+  if (event == ProfilerEvent::ALGO_TOTAL && comm_ && comm_->ctran_) {
+    comm_->ctran_->startEventAlgo();
+  }
   if (callback) {
     callback(*this);
   }
@@ -72,6 +77,9 @@ void Profiler::endEvent(
   durations_[idx] += getDurationUs(timers_[idx].lap());
   if (event == ProfilerEvent::ALGO_CTRL) {
     controlTs_ = getTimeStamp(timers_[idx].getCheckpoint());
+  }
+  if (event == ProfilerEvent::ALGO_TOTAL && comm_ && comm_->ctran_) {
+    comm_->ctran_->endEventAlgo();
   }
   if (callback) {
     callback(*this);


### PR DESCRIPTION
Summary:
Add startEventAlgo/endEventAlgo hooks to ICtran interface, called from Profiler at ALGO_TOTAL boundaries. This enables transport plugins to snapshot per-collective stats.

Changes:
  - ICtran: virtual startEventAlgo/endEventAlgo hooks
  - Profiler.cc: call hooks at ALGO_TOTAL start/end
  - Ctran/CtranMapper: delegate to CtranTcpDm
  - CtranTcpDm: profilerStart/End calling transport, ProfilerSnapshot with comm context (rank, nRanks, commHash, cuDev)
  - interface.h: ProfilerSnapshot struct + profilerStart/profilerEnd virtual stubs on TransportInterface

 Profiler chain: Profiler::startEvent/endEvent(ALGO_TOTAL) -> Ctran::startEventAlgo/endEventAlgo -> CtranMapper -> CtranTcpDm -> Transport::profilerStart/End

Reviewed By: function47

Differential Revision: D104055263


