### PR TITLE
Change rackSerial from int to string for GCP topology support

### DIFF
--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -614,7 +614,7 @@ std::string CommStateX::su(int rank) const {
   return rankStates_.at(rank).su;
 }
 
-int CommStateX::deviceRack(int rank) const {
+std::string_view CommStateX::deviceRack(int rank) const {
   CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
   return rankStates_.at(rank).rackSerial;
 }
@@ -648,11 +648,12 @@ bool CommStateX::isSameDc(int myRank, int peer) const {
   return dc(peer) == dc(myRank);
 }
 bool CommStateX::isSameDeviceRack(int myRank, int peer) const {
-  // Guard against unknown rackSerial (-1): without this, two ranks with
-  // missing DEVICE_RACK_SERIAL would match (-1 == -1), falsely disabling
-  // trunk P2P when NCCL_MNNVL_TRUNK_DISABLE is set.
-  auto rs = deviceRack(myRank);
-  return rs >= 0 && rs == deviceRack(peer);
+  const auto myRack = deviceRack(myRank);
+  const auto peerRack = deviceRack(peer);
+  if (myRack.empty() || peerRack.empty()) {
+    return false;
+  }
+  return myRack == peerRack;
 }
 bool CommStateX::isSameNvlFabric(int myRank, int peer) const {
   if (!nvlFabricEnabled_) {

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -43,7 +44,7 @@ struct RankTopology {
 
   char dc[kMaxNameLen];
 
-  int rackSerial{-1};
+  char rackSerial[kMaxNameLen];
 };
 
 // ncclx internal structure for NVL Fabric info
@@ -157,7 +158,7 @@ class CommStateX {
   // get DataCenter name for a given rank, default to current rank
   std::string dc(int rank = -1) const;
 
-  int deviceRack(int rank) const;
+  std::string_view deviceRack(int rank = -1) const;
 
   // get globalRank for a given rank, default to current rank
   int gRank(int rank = -1) const;
@@ -224,7 +225,7 @@ class CommStateX {
 
     std::vector<int> localRankToRanks{};
 
-    int rackSerial{-1};
+    std::string rackSerial;
   };
 
   // internal state related to NVL Fabric for quick one time lookup

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -57,21 +57,13 @@ void parseTopologyValue(
   isBackendTopologyValid = true;
 }
 
-void parseRackSerial(const std::string& value, int& rackSerial) {
-  try {
-    rackSerial = folly::to<int>(value);
-  } catch (const std::exception& e) {
-    CLOGF(ERR, "Failed to parse rack serial '{}': {}", value, e.what());
-  }
-}
-
 std::optional<ncclx::RankTopology> loadTopology(
     int rank,
     const std::string& filepath) {
   std::ifstream file(filepath);
   std::string line;
 
-  int rackSerial = -1;
+  std::string rackSerial;
 
   // currently we don't use rtsw info yet, it's ok to have empty rtsw
   std::string rtsw;
@@ -99,9 +91,14 @@ std::optional<ncclx::RankTopology> loadTopology(
       parseTopologyValue(
           value, filepath, dc, zone, su, rtsw, isBackendTopologyValid);
     } else if (key == kDeviceRackSerial) {
-      // If device rack serial is not present, use default value -1
-      if (!value.empty()) {
-        parseRackSerial(value, rackSerial);
+      if (value.size() >= ncclx::kMaxNameLen) {
+        CLOGF(
+            WARN,
+            "DEVICE_RACK_SERIAL '{}' exceeds max length {}, ignoring to avoid truncation-based false matches",
+            value,
+            ncclx::kMaxNameLen);
+      } else {
+        rackSerial = value;
       }
     }
   }
@@ -118,12 +115,19 @@ std::optional<ncclx::RankTopology> loadTopology(
           "to ignore this error");
       return std::nullopt;
     }
+    if (rackSerial.empty()) {
+      CLOGF(
+          WARN,
+          "DEVICE_RACK_SERIAL not found in {}. "
+          "isSameDeviceRack() will always return false, which may affect NVL fabric topology detection",
+          filepath);
+    }
   }
 
   ncclx::RankTopology topo;
   topo.rank = rank;
   topo.pid = getpid();
-  topo.rackSerial = rackSerial;
+  std::strncpy(topo.rackSerial, rackSerial.c_str(), ncclx::kMaxNameLen);
   std::strncpy(topo.dc, dc.c_str(), ncclx::kMaxNameLen);
   std::strncpy(topo.zone, zone.c_str(), ncclx::kMaxNameLen);
   std::strncpy(topo.host, host.c_str(), ncclx::kMaxNameLen);

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -43,7 +43,7 @@ RankTopology createRankTopology(
     const std::string& su,
     const std::string& rtsw,
     const std::string& host,
-    int rackSerial = -1,
+    const std::string& rackSerial = "",
     int pid = -1) {
   RankTopology topo;
   topo.rank = rank;
@@ -53,7 +53,7 @@ RankTopology createRankTopology(
   std::strcpy(topo.su, su.c_str());
   std::strcpy(topo.dc, dc.c_str());
   std::strcpy(topo.zone, zone.c_str());
-  topo.rackSerial = rackSerial;
+  std::strncpy(topo.rackSerial, rackSerial.c_str(), ncclx::kMaxNameLen);
   return topo;
 }
 
@@ -248,11 +248,11 @@ TEST(CommStateXTest, multiRackTest) {
   const std::string kRtsw;
   std::vector<RankTopology> rankTopologies{};
   rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0, 100));
+      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0, "100"));
   rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0, 100));
+      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0, "100"));
   rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSuDomain1, kRtsw, kHost1, 101));
+      createRankTopology(2, kDc, kZone, kSuDomain1, kRtsw, kHost1, "101"));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -266,6 +266,34 @@ TEST(CommStateXTest, multiRackTest) {
 
   EXPECT_TRUE(commState->isSameDeviceRack(rank, 1));
   EXPECT_FALSE(commState->isSameDeviceRack(rank, 2));
+}
+
+TEST(CommStateXTest, emptyDeviceRackReturnsFalse) {
+  EnvRAII env(NCCL_MNNVL_TRUNK_DISABLE, true);
+  const int rank = 0;
+  const int nRanks = 2;
+  const int cudaDev = 0;
+  const int cudaArch = 90;
+  const int64_t busId = 25;
+  const uint64_t commHash = 0;
+  const std::string kRtsw;
+  std::vector<RankTopology> rankTopologies{};
+  rankTopologies.emplace_back(
+      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0));
+  rankTopologies.emplace_back(
+      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0));
+
+  auto commState = std::make_unique<CommStateX>(
+      rank,
+      nRanks,
+      cudaDev,
+      cudaArch,
+      busId,
+      commHash,
+      rankTopologies,
+      std::vector<int>{});
+
+  EXPECT_FALSE(commState->isSameDeviceRack(rank, 1));
 }
 
 TEST(CommStateXTest, nvlFabricTest) {
@@ -599,7 +627,7 @@ class GpidTopoTest : public ::testing::TestWithParam<TopoTestParam> {
       const auto& [host, rtsw] = hostInfo[r / kRanksPerHost];
       const int pid = 1000 * (r / kRanksPerHost + 1) + r % kRanksPerHost;
       topos.emplace_back(
-          createRankTopology(r, kDc, kZone, kSu, rtsw, host, -1, pid));
+          createRankTopology(r, kDc, kZone, kSu, rtsw, host, "", pid));
     }
     return topos;
   }
@@ -924,11 +952,11 @@ TEST(CommStateXTest, isSameDeviceRackUnknownSerial) {
   const std::string kEmptyRtsw;
 
   std::vector<RankTopology> rankTopologies{};
-  // Both ranks have unknown rackSerial (-1)
+  // Both ranks have empty rackSerial
   rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0, -1));
+      createRankTopology(0, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0));
   rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0, -1));
+      createRankTopology(1, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -940,7 +968,7 @@ TEST(CommStateXTest, isSameDeviceRackUnknownSerial) {
       rankTopologies,
       std::vector<int>{});
 
-  // Unknown rackSerial (-1) should not match
+  // Empty rackSerial should not match
   EXPECT_FALSE(commState->isSameDeviceRack(rank, 1));
 }
 

--- a/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
+++ b/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
@@ -62,7 +62,7 @@ TEST(TopologyTest, RailBasedTopology) {
   EXPECT_EQ(zone, "snb1.z081");
   EXPECT_EQ(su, "snb1.z081.u015");
   EXPECT_EQ(rtsw, "");
-  EXPECT_EQ(topo->rackSerial, 12345);
+  EXPECT_STREQ(topo->rackSerial, "12345");
 }
 
 TEST(TopologyTest, InvalidTopologyFormat) {
@@ -110,7 +110,7 @@ TEST(TopologyTest, GB300DsfTopologyZoneOnly) {
   EXPECT_EQ(zone, "uco1.z086");
   EXPECT_EQ(su, "");
   EXPECT_EQ(rtsw, "");
-  EXPECT_EQ(topo->rackSerial, 12278553);
+  EXPECT_STREQ(topo->rackSerial, "12278553");
 }
 
 TEST(TopologyTest, EmptyTopologyValue) {
@@ -142,17 +142,17 @@ TEST(TopologyTest, EmptyRackSerial) {
   const std::string rtsw(topo->rtsw);
   EXPECT_EQ(host, "rtptest021.nha1.facebook.com");
   EXPECT_EQ(rtsw, "rtsw098.c084.f00.nha1");
-  EXPECT_EQ(topo->rackSerial, -1);
+  EXPECT_STREQ(topo->rackSerial, "");
 }
 
-TEST(TopologyTest, InvalidRackSerialFormat) {
+TEST(TopologyTest, NonNumericRackSerial) {
   const std::string filepath = "/tmp/ut-topology.txt";
   std::ofstream file(filepath);
   file << "DEVICE_NAME=testhost.facebook.com" << std::endl;
   file << "DEVICE_BACKEND_NETWORK_TOPOLOGY=/zone//rtsw001" << std::endl;
   file << "DEVICE_RACK_SERIAL=not_a_number" << std::endl;
 
-  // This should throw an exception during folly::to<int> conversion
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
+  EXPECT_STREQ(topo->rackSerial, "not_a_number");
 }


### PR DESCRIPTION
Summary:
- GCP GB300 hosts have alphanumeric DEVICE_RACK_SERIAL (e.g. C1507842765072) that cannot be parsed as int, causing ERR log noise and losing rack identity
- Change rackSerial from int to char[kMaxNameLen] in RankTopology (POD, exchanged via allGather) and std::string in RankState
- isSameDeviceRack() now returns false when either rank has empty rackSerial, preventing false positive matches when serial is missing
- Add WARN log in loadTopology when DEVICE_RACK_SERIAL is missing or exceeds kMaxNameLen
- Add GCP GB300 fbwhoami test with real data file under fb/ (internal only)
- Add emptyDeviceRackReturnsFalse test for the new empty-rack guard

Differential Revision: D105042596


