### PR TITLE
Remove ftar codebase - no longer used in production

### DIFF
--- a/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
+++ b/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
@@ -12,6 +12,7 @@
 #include <nccl.h> // @manual
 #include <thrift/lib/cpp2/protocol/DebugProtocol.h>
 
+#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "aiplatform/tw_platform/core/MastInfo.h"
 #include "comms/analyzer/Analyzer.h"
 #include "comms/analyzer/CommDumpPuller.h"
@@ -24,7 +25,6 @@
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/trainer/TrainerContext.h"
-#include "ftar/DynMemGpuBuffer.h"
 #include "meta/analyzer/NCCLXCommsTracingServiceUtil.h"
 #include "servicerouter/client/cpp2/ServiceRouter.h"
 #include "tupperware/common/client_factory/FreePortSocket.h"

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -7,12 +7,12 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
+#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
-#include "ftar/DynMemGpuBuffer.h"
 
 #define NCCLCHECK_FATAL(cmd)                                            \
   do {                                                                  \

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -8,12 +8,12 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
+#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
-#include "ftar/DynMemGpuBuffer.h"
 
 #define NCCLCHECK_FATAL(cmd)                                            \
   do {                                                                  \


### PR DESCRIPTION
Summary:
The ftar codebase is no longer being used in production. Removing the entire
fbcode/ftar/ as well as it's duplicate presence in a aiplatform/ directory to clean up dead code.

Changes:

- Removed fbcode/ftar/ (323 files)
- Updated //ftar:dyn_mem_gpu_buffer deps in comms/ncclx tests to point to
  //aiplatform/training_components/paft/ftar:dyn_mem_gpu_buffer
- Updated //ftar/coordinator/if:coordinator dep in paft/ftar/tests to point to
  //aiplatform/training_components/paft/ftar/coordinator/if:coordinator
- Updated comments and shell script paths in paft/ftar/

Reviewed By: Scusemua, arttianezhu, minsii

Differential Revision: D104589873


