### PR TITLE
Restrict hardware stochastic rounding for B200a and B300a

### DIFF
--- a/comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh
+++ b/comms/utils/kernels/stochastic_rounding/stochastic_rounding.cuh
@@ -12,7 +12,8 @@
 
 #include <cuda_bf16.h>
 
-#if __CUDA_ARCH__ >= 1000
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
 constexpr bool kHasHardwareSR = true;
 #else
 constexpr bool kHasHardwareSR = false;
@@ -40,7 +41,8 @@ __device__ __forceinline__ bool isFinite(float val) {
 // uint32.
 __device__ __forceinline__ __nv_bfloat162
 stochastic_round_bf16x2_blackwell(float2 vals, uint32_t rand_bits) {
-#if __CUDA_ARCH__ >= 1000
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) && \
+    defined(__CUDA_ARCH_FEAT_SM100_ALL)
   // Use cvt.rs.bf16x2.f32 for vectorized stochastic rounding
   // PTX instruction: cvt.rs.bf16x2.f32 dst, src_hi, src_lo, rand;
   // - dst: 32-bit register containing 2 packed BF16 values


### PR DESCRIPTION
Summary:
Previously we only check `__CUDA_ARCH__ >= 1000` for hardware stochastic rounding. It turns out to be not enough as B200 and B300 (sm100, sm103) does not have it.
Change it to also check `__CUDA_ARCH_FEAT_SM100_ALL`, which only exists when the sm100a features exist

Differential Revision: D105076801


