### PR TITLE
Set MCCL_SCUBA_LOG_LEVEL default to NORMAL (#2537)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3201,7 +3201,7 @@ cvars:
 
  - name        : MCCL_SCUBA_LOG_LEVEL
    type        : enum
-   default     : HIGH
+   default     : NORMAL
    choices     : CRITICAL, HIGH, NORMAL, LOW
    description : |-
      Minimum log priority level for MCCL Scuba logging. Only logs at or above


### PR DESCRIPTION
Summary:

Change the default MCCL_SCUBA_LOG_LEVEL from HIGH to NORMAL so that NORMAL-priority events (COMM_REGISTER, COMM_DEREGISTER, ALGO_PROFILING) are logged to Scuba by default. This gives better observability without the volume of LOW (collective-level) logging.

Changes:
- `nccl_cvars.yaml`: Change MCCL_SCUBA_LOG_LEVEL default from HIGH to NORMAL
- `nccl_env.py`: Explicitly set MCCL_SCUBA_LOG_LEVEL=NORMAL alongside MCCL_SCUBA_ENABLED=1 in the llama4x LOGGING_ENVS

Reviewed By: yuchenhao

Differential Revision: D105080231


