### PR TITLE
fix RMA flaky test (#2538)

### DIFF
--- a/comms/ctran/tests/CtranDistRMATest.cc
+++ b/comms/ctran/tests/CtranDistRMATest.cc
@@ -34,6 +34,9 @@ class CtranRMATest : public ctran::CtranDistTestFixture, public CtranBaseTest {
     ASSERT_NE(ctranComm.get(), nullptr);
   }
   void TearDown() override {
+    if (ctranComm) {
+      ctran::waitForCollTraceDrain(ctranComm.get());
+    }
     ctranComm.reset();
     ctran::CtranDistTestFixture::TearDown();
     // Check that all allocated memory segments have been freed
@@ -169,7 +172,18 @@ TEST_P(MultiWindowTestParam, multiWindow) {
 class CtranRMATestParam
     : public CtranRMATest,
       public ::testing::WithParamInterface<
-          std::tuple<size_t, size_t, bool, MemAllocType, bool>> {};
+          std::tuple<size_t, size_t, bool, MemAllocType, bool>> {
+ protected:
+  void SetUp() override {
+#ifdef CTRAN_TEST_IB_ONLY_BACKEND
+    const auto ctranAllReduce = std::get<2>(GetParam());
+    if (ctranAllReduce) {
+      GTEST_SKIP() << "IB-only mode: NVL not available for ctranAllReduce";
+    }
+#endif
+    CtranRMATest::SetUp();
+  }
+};
 
 TEST_P(CtranRMATestParam, winPutWait) {
   const auto& [kNumElements, kNumIters, ctranAllReduce, bufType, userBuf] =
@@ -665,7 +679,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         // kNumElements, kNumIters, ctranAllReduce, cpuWin, userBuf
         ::testing::Values(8192, 8 * 1024 * 1024),
-        ::testing::Values(500),
+        ::testing::Values(50),
         ::testing::Values(true, false),
         ::testing::Values(
             MemAllocType::kMemCuMemAlloc,


### PR DESCRIPTION
Summary:

 Fix RMA test flakiness caused by timeout and teardown issues:

  1. Add `waitForCollTraceDrain` in `TearDown` before `ctranComm.reset()` to ensure all in-flight colltrace records are drained before the
  communicator is destroyed, preventing race conditions during teardown.

  2. Reduce `kNumIters` from 500 to 50 for `CtranRMATestParam`. 500 iterations per case caused the total execution time to exceed the default
  300s `re_timeout`, resulting in SIGTERM kills. 50 iterations is sufficient for correctness validation and still provides meaningful bandwidth
  measurements.

  3. Add early skip in `CtranRMATestParam::SetUp` for `ctranAllReduce=true` tests when `CTRAN_TEST_IB_ONLY_BACKEND` is defined. In IB-only mode
  NVL is never available, so these tests always skip — but previously they still created the expensive `CtranComm` (~1s each) before skipping in
  the test body. This eliminates ~80 unnecessary setup/teardown cycles per run, saving ~80s of execution time.

Differential Revision: D105078567


