### PR TITLE
Remove aiplatform/training_components/paft/ and ftar codebase

### DIFF
--- a/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
+++ b/comms/ncclx/meta/analyzer/tests/NCCLXCommsTracingServiceHandlerTest.cc
@@ -12,7 +12,6 @@
 #include <nccl.h> // @manual
 #include <thrift/lib/cpp2/protocol/DebugProtocol.h>
 
-#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "aiplatform/tw_platform/core/MastInfo.h"
 #include "comms/analyzer/Analyzer.h"
 #include "comms/analyzer/CommDumpPuller.h"
@@ -35,6 +34,25 @@ using namespace meta::comms::analyzer;
 using namespace ncclx;
 
 namespace {
+
+struct GpuBuffer {
+  explicit GpuBuffer(size_t size) : size_(size) {
+    cudaMalloc(&ptr_, size);
+  }
+  ~GpuBuffer() {
+    cudaFree(ptr_);
+  }
+  GpuBuffer(const GpuBuffer&) = delete;
+  GpuBuffer& operator=(const GpuBuffer&) = delete;
+  void* raw() const {
+    return ptr_;
+  }
+
+ private:
+  void* ptr_ = nullptr;
+  size_t size_ = 0;
+};
+
 #define NCCLCHECK(cmd)                                                  \
   do {                                                                  \
     ncclResult_t res = cmd;                                             \
@@ -337,8 +355,8 @@ TEST_F(NcclCommsTest, AnalyzerSuccess) {
 
   // Allocate memory on the GPU
   int size = 32;
-  facebook::ftar::DynMemGpuBuffer sendBuff(size * sizeof(float));
-  facebook::ftar::DynMemGpuBuffer recvBuff(size * sizeof(float));
+  GpuBuffer sendBuff(size * sizeof(float));
+  GpuBuffer recvBuff(size * sizeof(float));
 
   // Modify GPU memory
   mccl::McclIntegrationTestUtil::modifyGPUBuffer<float>(size, sendBuff.raw());
@@ -449,8 +467,8 @@ TEST_F(NcclCommsTest, OneRankHangs) {
 
   // Allocate memory on the GPU
   int size = 32;
-  facebook::ftar::DynMemGpuBuffer sendBuff(size * sizeof(float));
-  facebook::ftar::DynMemGpuBuffer recvBuff(size * sizeof(float));
+  GpuBuffer sendBuff(size * sizeof(float));
+  GpuBuffer recvBuff(size * sizeof(float));
 
   for (int c = 0; c < 4; ++c) {
     XLOG(INFO) << "Iteration " << c;
@@ -568,8 +586,8 @@ TEST_F(NcclCommsTest, DISABLED_OneRankHangsCudaGraph) {
 
   // Allocate memory on the GPU
   int size = 32;
-  facebook::ftar::DynMemGpuBuffer sendBuff(size * sizeof(float));
-  facebook::ftar::DynMemGpuBuffer recvBuff(size * sizeof(float));
+  GpuBuffer sendBuff(size * sizeof(float));
+  GpuBuffer recvBuff(size * sizeof(float));
 
   cudaGraph_t graph;
   cudaGraphExec_t instance;

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogIbMockTest.cc
@@ -7,12 +7,31 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
-#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/testinfra/IbverbMockTestUtils.h"
+
+namespace {
+struct GpuBuffer {
+  explicit GpuBuffer(size_t size) : size_(size) {
+    cudaMalloc(&ptr_, size);
+  }
+  ~GpuBuffer() {
+    cudaFree(ptr_);
+  }
+  GpuBuffer(const GpuBuffer&) = delete;
+  GpuBuffer& operator=(const GpuBuffer&) = delete;
+  void* raw() const {
+    return ptr_;
+  }
+
+ private:
+  void* ptr_ = nullptr;
+  size_t size_ = 0;
+};
+} // namespace
 
 #define NCCLCHECK_FATAL(cmd)                                            \
   do {                                                                  \
@@ -160,8 +179,8 @@ TEST_F(CollTraceWatchdogTest, TestAsyncErrorWithIbVerbMock) {
 
   // Allocate memory on the GPU
   constexpr int size = 32;
-  facebook::ftar::DynMemGpuBuffer sendBuff(size * sizeof(float));
-  facebook::ftar::DynMemGpuBuffer recvBuff(size * sizeof(float));
+  GpuBuffer sendBuff(size * sizeof(float));
+  GpuBuffer recvBuff(size * sizeof(float));
 
   // Inject ibv failure to trigger async error
   ::meta::comms::setFailureInjection("ibv_post_send", 0, rank);

--- a/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/CollTraceWatchdogTest.cc
@@ -8,12 +8,31 @@
 #include "comm.h" // @manual
 #include "nccl.h" // @manual
 
-#include "aiplatform/training_components/paft/ftar/DynMemGpuBuffer.h"
 #include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
 #include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
 #include "comms/mccl/tests/CudaStream.h"
 #include "comms/mccl/tests/CudaTestUtil.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
+
+namespace {
+struct GpuBuffer {
+  explicit GpuBuffer(size_t size) : size_(size) {
+    cudaMalloc(&ptr_, size);
+  }
+  ~GpuBuffer() {
+    cudaFree(ptr_);
+  }
+  GpuBuffer(const GpuBuffer&) = delete;
+  GpuBuffer& operator=(const GpuBuffer&) = delete;
+  void* raw() const {
+    return ptr_;
+  }
+
+ private:
+  void* ptr_ = nullptr;
+  size_t size_ = 0;
+};
+} // namespace
 
 #define NCCLCHECK_FATAL(cmd)                                            \
   do {                                                                  \
@@ -178,8 +197,8 @@ class NcclAllReduce {
   }
 
  private:
-  facebook::ftar::DynMemGpuBuffer sendBuff_;
-  facebook::ftar::DynMemGpuBuffer recvBuff_;
+  GpuBuffer sendBuff_;
+  GpuBuffer recvBuff_;
 };
 
 TEST_F(CollTraceWatchdogTest, TestAsyncErrorFromGPE) {


### PR DESCRIPTION
Summary:
Remove the PAFT (Parallelism Aware Fault Tolerance) and FTAR implementations from `aiplatform/training_components/paft/`. The canonical FTAR code was already removed in D104589873 from `fbcode/ftar/`. This diff removes the duplicate copy under `training_components` and all dependent code.

**What is removed (242 files):**
- `paft/ftar/` — C++ FTAR library (IB transport, RDMA, ctran, cuda, coordinator, logging, benchmarks, tests)
- `paft/rejoin/` — Thrift-based rejoin service
- `paft/metrics/` — Metrics aggregation, writing, manifold storage
- `paft/tests/` — All Python and C++ tests
- `paft/paft.py`, `server.py`, `paft_pybind.cpp`, `paft_pybind.pyi`, `Quorum.cpp`, `Quorum.h`, `paft_state.py`, `mast.py`, `data_iter_wrapper.py`, `utils.py`
- `aps_models/examples/dlrm/metrics_paft.py` and its test — DLRM metrics aggregator binary
- DLRM BUCK targets: `metrics_paft` binary and `aps_models.examples.metrics_paft` fbpkg (both 3.12 and 3.14 variants)

**What is kept as stubs:**
- `paft/__init__.py` — `PAFT` ABC with `available()` returning `False`, `CommitResult` dataclass, env constants
- `paft/env.py` — Port utilities used by APF launcher (pure Python, no deps removed)
- `paft/paft_hook.py` — `paft_pre_optimizer_step_hook()` returns `True` (no-op)
- `paft/dep_utils.bzl` — `get_paft_deps()` returns empty list
- `paft/BUCK` — Slimmed to only stub targets

**External consumers updated:**
- NCCLX tests (`comms/ncclx/meta/`) — replaced `DynMemGpuBuffer` include with local RAII `GpuBuffer` struct, removed BUCK deps
- APF — continues to work via stubs (`PAFT.available()` returns `False`, hook is no-op, env.py unchanged)

Differential Revision: D105090061


