### PR TITLE
make cuda graph capture match normal failed com behavior

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -92,6 +92,7 @@ void TorchCommNCCL::init(
   device_ = device;
   name_ = name;
   options_ = options;
+  comm_abort_requested_ = false;
 
   if (init_state_ == InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCL already initialized");
@@ -267,6 +268,10 @@ void TorchCommNCCL::finalize() {
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == TorchWorkNCCL::WorkStatus::ERROR) {
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was already aborted due to a previous error");
+    }
     ncclResult_t asyncErr;
     NCCL_CHECK(
         nccl_api_,
@@ -333,14 +338,16 @@ void TorchCommNCCL::finalize() {
 }
 
 void TorchCommNCCL::abortNcclComm() {
+  if (comm_abort_requested_.exchange(true)) {
+    return;
+  }
+
   detachMemoryHook();
-  if (nccl_comm_) {
+  ncclComm_t comm = nccl_comm_;
+  nccl_comm_ = nullptr;
+  if (comm) {
     NCCL_CHECK(
-        nccl_api_,
-        nccl_comm_,
-        nccl_api_->commAbort(nccl_comm_),
-        "NCCL Abort failed");
-    nccl_comm_ = nullptr;
+        nccl_api_, comm, nccl_api_->commAbort(comm), "NCCL Abort failed");
   }
   // Never abort the process in reconfigurable mode: callers fall back to
   // revoke + throw so the failure can be handled by reconfiguring.
@@ -349,6 +356,20 @@ void TorchCommNCCL::abortNcclComm() {
     TC_LOG(ERROR, this) << "Aborting process due to timeout";
     runAbortHooks();
     ::abort();
+  }
+}
+
+void TorchCommNCCL::abortNcclCommNoThrow() noexcept {
+  if (comm_abort_requested_.exchange(true)) {
+    return;
+  }
+
+  detachMemoryHook();
+  ncclComm_t comm = nccl_comm_;
+  nccl_comm_ = nullptr;
+  if (comm && nccl_api_) {
+    NCCL_CHECK_IGNORE(
+        nccl_api_, nccl_api_->commAbort(comm), "NCCL Abort failed");
   }
 }
 

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -286,6 +286,7 @@ class TorchCommNCCL : public TorchCommBackend,
   [[nodiscard]] cudaEvent_t getEvent();
   void returnEvent(cudaEvent_t event);
   void abortNcclComm();
+  void abortNcclCommNoThrow() noexcept;
   void revokeNcclComm();
 
   enum class CommState {
@@ -311,6 +312,11 @@ class TorchCommNCCL : public TorchCommBackend,
   // once per communicator generation, even when both the timeout watchdog and a
   // synchronous collective observe the same failure. Reset on reconfigure.
   std::atomic<bool> revoked_{false};
+  // Set once a non-reconfigurable communicator abort has been claimed for the
+  // current communicator generation. Prevents the timeout watchdog and a
+  // synchronous collective from both calling ncclCommAbort on the same comm.
+  // Reset on init/reconfigure.
+  std::atomic<bool> comm_abort_requested_{false};
 
   void register_address(const AddressWithLen& addr);
   void deregister_address(const Address& addr);
@@ -443,6 +449,10 @@ class TorchCommNCCL : public TorchCommBackend,
       const ncclComm_t comm,
       const ncclDataType_t dataType);
   void timeoutWatchdog() noexcept;
+  CommState handleFatalTransitionFromWatchdog(
+      CommState state_before,
+      CommState state_after);
+  void maybeAbortProcessFromWatchdog(CommState state);
   void checkInitialized() const;
   void checkAndAbortIfTimedOutOrError();
   void checkWorkQueue();

--- a/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
@@ -267,6 +267,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
 
     CUDA_CHECK(
         cuda_api_,
@@ -387,11 +388,13 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
     initNcclResources();
   } else {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
 
     int quorumSize = static_cast<int>(quorum.ranks.size());
     auto store = connectStore(

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -198,8 +198,8 @@ void TorchCommNCCL::checkWorkQueue() {
   }
 }
 
-// The timeout thread cannot make NCCL calls.  The only CUDA call it can make
-// it cudaEventQuery.
+// If the watchdog first observes a fatal state, clean up the communicator
+// immediately.
 void TorchCommNCCL::timeoutWatchdog() noexcept {
   TC_LOG(INFO, this) << "Timeout thread starting for rank: " << rank_;
 
@@ -223,6 +223,8 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
       }
     }
 
+    CommState state_before = comm_state_.load(std::memory_order_relaxed);
+
     // Check work objects for completion or timeout
     // Thread-safety: checkWorkQueue() calls garbageCollect() which acquires
     // work_queues_mutex_ before accessing the work queue, ensuring safe
@@ -237,22 +239,9 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
     if (shutdown_) {
       break;
     }
-    if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error &&
-        !options_.enable_reconfigure) {
-      if (comm_state_ == CommState::TIMEOUT) {
-        TC_LOG(ERROR, this)
-            << "Aborting process due to timeout on rank " << rank_
-            << " - timeout watchdog detected operation timeout";
-      } else if (comm_state_ == CommState::ERROR) {
-        TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
-                            << " - timeout watchdog detected operation error. ";
-      }
-
-      runAbortHooks();
-
-      ::abort();
-    }
+    CommState state_after = comm_state_.load(std::memory_order_relaxed);
+    state_after = handleFatalTransitionFromWatchdog(state_before, state_after);
+    maybeAbortProcessFromWatchdog(state_after);
 
     // Detect a communicator-level async error while the comm is still healthy.
     if (comm_state_ == CommState::NORMAL) {
@@ -303,6 +292,56 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
   TC_LOG(INFO, this) << "Timeout thread exiting for rank: " << rank_;
 }
 
+TorchCommNCCL::CommState TorchCommNCCL::handleFatalTransitionFromWatchdog(
+    CommState state_before,
+    CommState state_after) {
+  if (state_before != CommState::NORMAL || state_after == CommState::NORMAL) {
+    return state_after;
+  }
+
+  switch (state_after) {
+    case CommState::TIMEOUT:
+      if (options_.enable_reconfigure) {
+        revokeNcclComm();
+      } else {
+        abortNcclCommNoThrow();
+      }
+      return state_after;
+    case CommState::ERROR:
+      if (options_.enable_reconfigure) {
+        revokeNcclComm();
+      } else {
+        abortNcclCommNoThrow();
+      }
+      return comm_state_.load(std::memory_order_relaxed);
+    default:
+      return state_after;
+  }
+}
+
+void TorchCommNCCL::maybeAbortProcessFromWatchdog(CommState state) {
+  if (state == CommState::NORMAL ||
+      !options_.abort_process_on_timeout_or_error ||
+      options_.enable_reconfigure) {
+    return;
+  }
+
+  switch (state) {
+    case CommState::TIMEOUT:
+      TC_LOG(ERROR, this) << "Aborting process due to timeout on rank " << rank_
+                          << " - timeout watchdog detected operation timeout";
+      break;
+    case CommState::ERROR:
+      TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
+                          << " - timeout watchdog detected operation error. ";
+      break;
+    default:
+      return;
+  }
+  runAbortHooks();
+  ::abort();
+}
+
 void TorchCommNCCL::checkInitialized() const {
   if (init_state_ != InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCL not initialized");
@@ -310,15 +349,19 @@ void TorchCommNCCL::checkInitialized() const {
 }
 
 void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
-  // Nothing to check in graph capture mode
+  CommState state = comm_state_.load(std::memory_order_relaxed);
   if (getGraphCaptureMode()) {
-    return;
+    // In graph mode, only surface an already-latched fatal state.
+    if (state == CommState::NORMAL) {
+      return;
+    }
+  } else {
+    // First, check work queue status
+    checkWorkQueue();
+    state = comm_state_.load(std::memory_order_relaxed);
   }
 
-  // First, check work queue status
-  checkWorkQueue();
-
-  if (comm_state_ == CommState::TIMEOUT) {
+  if (state == CommState::TIMEOUT) {
     if (options_.enable_reconfigure) {
       revokeNcclComm();
       throw std::runtime_error("NCCL operation timed out");
@@ -332,7 +375,11 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
         throw std::runtime_error("NCCL operation timed out");
       }
     }
-  } else if (comm_state_ == CommState::ERROR) {
+  } else if (state == CommState::ERROR) {
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCL communicator was already aborted due to a previous error");
+    }
     ncclResult_t asyncErr;
     NCCL_CHECK(
         nccl_api_,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -238,6 +238,7 @@ void TorchCommNCCLX::init(
   device_ = device;
   name_ = name;
   options_ = options;
+  comm_abort_requested_ = false;
 
   if (init_state_ == InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCLX already initialized");
@@ -450,6 +451,10 @@ void TorchCommNCCLX::finalize() {
   } else if (work_status == TorchWorkNCCLX::WorkStatus::ERROR) {
     TC_LOG(INFO, this) << "Aborting NCCL comm due to error";
     comm_state_ = CommState::ERROR;
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCLX communicator was already aborted due to a previous error");
+    }
     ncclResult_t asyncErr;
     NCCLX_CHECK(
         nccl_api_,
@@ -519,19 +524,36 @@ void TorchCommNCCLX::finalize() {
 }
 
 void TorchCommNCCLX::abortNcclComm() {
+  if (comm_abort_requested_.exchange(true)) {
+    return;
+  }
+
   // Both runAbortHooks and detachMemoryHook must run before commAbort:
   // - Abort hooks may need to inspect the live NCCL comm for debug info.
   // - detachMemoryHook deregisters this comm from CachingAllocator so that
   //   subsequent alloc/free callbacks do not reference a destroyed comm.
   TC_LOG(INFO, this) << "Calling abort hooks before commAbort.";
   runAbortHooks();
-  if (nccl_comm_) {
+  ncclComm_t comm = nccl_comm_;
+  nccl_comm_ = nullptr;
+  if (comm) {
     NCCLX_CHECK(
-        nccl_api_,
-        nccl_comm_,
-        nccl_api_->commAbort(nccl_comm_),
-        "NCCLX Abort failed");
-    nccl_comm_ = nullptr;
+        nccl_api_, comm, nccl_api_->commAbort(comm), "NCCLX Abort failed");
+  }
+}
+
+void TorchCommNCCLX::abortNcclCommNoThrow() noexcept {
+  if (comm_abort_requested_.exchange(true)) {
+    return;
+  }
+
+  TC_LOG(INFO, this) << "Calling abort hooks before commAbort.";
+  runAbortHooks();
+  ncclComm_t comm = nccl_comm_;
+  nccl_comm_ = nullptr;
+  if (comm && nccl_api_) {
+    NCCLX_CHECK_IGNORE(
+        nccl_api_, nccl_api_->commAbort(comm), "NCCLX Abort failed");
   }
 }
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -316,6 +316,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   [[nodiscard]] cudaEvent_t getEvent();
   void returnEvent(cudaEvent_t event);
   void abortNcclComm();
+  void abortNcclCommNoThrow() noexcept;
   void revokeNcclComm();
 
   enum class CommState {
@@ -332,6 +333,11 @@ class TorchCommNCCLX : public TorchCommBackend,
   // once per communicator generation, even when both the timeout watchdog and a
   // synchronous collective observe the same failure. Reset on reconfigure.
   std::atomic<bool> revoked_{false};
+  // Set once a non-reconfigurable communicator abort has been claimed for the
+  // current communicator generation. Prevents the timeout watchdog and a
+  // synchronous collective from both calling ncclCommAbort on the same comm.
+  // Reset on init/reconfigure.
+  std::atomic<bool> comm_abort_requested_{false};
 
   cudaEvent_t
       dependency_event_{}; // Pre-allocated event for stream dependencies
@@ -488,6 +494,10 @@ class TorchCommNCCLX : public TorchCommBackend,
       const ncclComm_t comm,
       const ncclDataType_t dataType);
   void timeoutWatchdog() noexcept;
+  CommState handleFatalTransitionFromWatchdog(
+      CommState state_before,
+      CommState state_after);
+  void maybeAbortProcessFromWatchdog(CommState state);
   void checkInitialized() const;
   void initNcclxResources();
   void checkAndAbortIfTimedOutOrError();

--- a/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
@@ -264,6 +264,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
 
     CUDA_CHECK(
         cuda_api_,
@@ -384,11 +385,13 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
     initNcclxResources();
   } else {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
     revoked_ = false;
+    comm_abort_requested_ = false;
 
     CUDA_CHECK(
         cuda_api_,

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -197,8 +197,8 @@ void TorchCommNCCLX::checkGraphEvents() {
   }
 }
 
-// The timeout thread cannot make NCCL calls.  The only CUDA call it can make
-// it cudaEventQuery.
+// If the watchdog first observes a fatal state, clean up the communicator
+// immediately.
 void TorchCommNCCLX::timeoutWatchdog() noexcept {
   TC_LOG(INFO, this) << "Timeout thread starting for rank: " << rank_;
 
@@ -247,6 +247,8 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
       timeout_remaining_ms -= elapsed_ms;
     }
 
+    CommState state_before = comm_state_.load(std::memory_order_relaxed);
+
     // Check work objects for completion or timeout
     // Thread-safety: checkWorkQueue() calls garbageCollect() which acquires
     // work_queues_mutex_ before accessing the work queue, ensuring safe
@@ -276,22 +278,9 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
           static_cast<long>(configs_.graph_timeout_check_interval_ms_);
     }
 
-    if (comm_state_ != CommState::NORMAL &&
-        options_.abort_process_on_timeout_or_error &&
-        !options_.enable_reconfigure) {
-      if (comm_state_ == CommState::TIMEOUT) {
-        TC_LOG(ERROR, this)
-            << "Aborting process due to timeout on rank " << rank_
-            << " - timeout watchdog detected operation timeout";
-      } else if (comm_state_ == CommState::ERROR) {
-        TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
-                            << " - timeout watchdog detected operation error. ";
-      }
-
-      runAbortHooks();
-
-      std::abort();
-    }
+    CommState state_after = comm_state_.load(std::memory_order_relaxed);
+    state_after = handleFatalTransitionFromWatchdog(state_before, state_after);
+    maybeAbortProcessFromWatchdog(state_after);
 
     // Detect a communicator-level async error while the comm is still healthy.
     if (comm_state_ == CommState::NORMAL) {
@@ -342,6 +331,56 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
   TC_LOG(INFO, this) << "Timeout thread exiting for rank: " << rank_;
 }
 
+TorchCommNCCLX::CommState TorchCommNCCLX::handleFatalTransitionFromWatchdog(
+    CommState state_before,
+    CommState state_after) {
+  if (state_before != CommState::NORMAL || state_after == CommState::NORMAL) {
+    return state_after;
+  }
+
+  switch (state_after) {
+    case CommState::TIMEOUT:
+      if (options_.enable_reconfigure) {
+        revokeNcclComm();
+      } else {
+        abortNcclCommNoThrow();
+      }
+      return state_after;
+    case CommState::ERROR:
+      if (options_.enable_reconfigure) {
+        revokeNcclComm();
+      } else {
+        abortNcclCommNoThrow();
+      }
+      return comm_state_.load(std::memory_order_relaxed);
+    default:
+      return state_after;
+  }
+}
+
+void TorchCommNCCLX::maybeAbortProcessFromWatchdog(CommState state) {
+  if (state == CommState::NORMAL ||
+      !options_.abort_process_on_timeout_or_error ||
+      options_.enable_reconfigure) {
+    return;
+  }
+
+  switch (state) {
+    case CommState::TIMEOUT:
+      TC_LOG(ERROR, this) << "Aborting process due to timeout on rank " << rank_
+                          << " - timeout watchdog detected operation timeout";
+      break;
+    case CommState::ERROR:
+      TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
+                          << " - timeout watchdog detected operation error. ";
+      break;
+    default:
+      return;
+  }
+  runAbortHooks();
+  std::abort();
+}
+
 void TorchCommNCCLX::checkInitialized() const {
   if (init_state_ != InitializationState::INITIALIZED) {
     throw std::runtime_error("TorchCommNCCLX not initialized");
@@ -349,18 +388,18 @@ void TorchCommNCCLX::checkInitialized() const {
 }
 
 void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
-  // Nothing to check in graph capture mode
+  CommState state = comm_state_.load(std::memory_order_relaxed);
   if (getGraphCaptureMode()) {
-    return;
+    if (state == CommState::NORMAL) {
+      return;
+    }
+  } else {
+    // First, check work queue status
+    checkWorkQueue();
+    state = comm_state_.load(std::memory_order_relaxed);
   }
 
-  // First, check work queue status
-  checkWorkQueue();
-
-  // Graph timeout detection is handled by the watchdog thread at
-  // graph_timeout_check_interval_ms, so no synchronous check is needed here.
-
-  if (comm_state_ == CommState::TIMEOUT) {
+  if (state == CommState::TIMEOUT) {
     if (options_.enable_reconfigure) {
       revokeNcclComm();
       throw std::runtime_error("NCCLX operation timed out");
@@ -374,7 +413,11 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
         throw std::runtime_error("NCCLX operation timed out");
       }
     }
-  } else if (comm_state_ == CommState::ERROR) {
+  } else if (state == CommState::ERROR) {
+    if (!nccl_comm_) {
+      throw std::runtime_error(
+          "NCCLX communicator was already aborted due to a previous error");
+    }
     ncclResult_t asyncErr;
     NCCLX_CHECK(
         nccl_api_,

--- a/comms/torchcomms/tests/integration/py/TimeoutTest.py
+++ b/comms/torchcomms/tests/integration/py/TimeoutTest.py
@@ -179,6 +179,63 @@ if os.environ.get("_TORCHCOMM_RUN_GRAPH_TIMEOUT_AFTER_SUCCESS"):
     os._exit(1)
 
 
+def _run_capture_followup_after_timeout_failfast_scenario() -> None:
+    """After timeout, captured followup ops should fail fast, not hang."""
+
+    backend = os.environ.get("TEST_BACKEND", "")
+    rank, _ = get_rank_and_size()
+    device_count = torch.cuda.device_count()
+    device = torch.device("cuda", rank % device_count)
+    torch.cuda.set_device(device)
+
+    comm = torchcomms.new_comm(
+        backend,
+        device,
+        name="capture_followup_after_timeout_failfast_subprocess_comm",
+        abort_process_on_timeout_or_error=False,
+    )
+    capture_stream = torch.cuda.Stream() if rank != 0 else None
+
+    if rank == 0:
+        time.sleep(6.0)
+        os._exit(0)
+
+    comm.barrier(
+        async_op=True,
+        timeout=timedelta(milliseconds=500),
+    )
+    # The eager timeout is detected asynchronously by the watchdog, so wait
+    # until the communicator has latched the fatal state before attempting the
+    # follow-up graph capture.
+    deadline = time.monotonic() + 10.0
+    while not comm.is_aborted() and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if not comm.is_aborted():
+        raise RuntimeError("Timed out waiting for communicator to enter aborted state")
+
+    try:
+        assert capture_stream is not None
+        with torch.cuda.stream(capture_stream):
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                _wait(
+                    comm.barrier(
+                        async_op=False,
+                        timeout=timedelta(milliseconds=500),
+                    )
+                )
+        os._exit(2)
+    except RuntimeError as e:
+        if "timed out" not in str(e):
+            raise
+        os._exit(0)
+
+
+if os.environ.get("_TORCHCOMM_RUN_CAPTURE_FOLLOWUP_AFTER_TIMEOUT_FAILFAST"):
+    _run_capture_followup_after_timeout_failfast_scenario()
+    os._exit(1)
+
+
 class TestTimeout(CudaGraphTestBase, FatalStateTestMixin):
     """Tests timeout detection, abort behavior, and false timeout prevention."""
 
@@ -279,6 +336,27 @@ class TestTimeout(CudaGraphTestBase, FatalStateTestMixin):
                     expected=make_expected,
                     graph_assertions=assert_graph,
                 )
+
+    @unittest.skipIf(
+        os.getenv("TEST_BACKEND") not in ("nccl", "ncclx"),
+        f"Backend {os.getenv('TEST_BACKEND')} does not support this regression",
+    )
+    def test_capture_followup_after_timeout_fails_fast(self) -> None:
+        with self.create_comms(1):
+            pass
+
+        result = self.run_subprocess(
+            "_TORCHCOMM_RUN_CAPTURE_FOLLOWUP_AFTER_TIMEOUT_FAILFAST",
+            timeout=90,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            "Expected follow-up capture to fail fast, not hang.\n"
+            f"stdout:\n{result.stdout.decode(errors='replace')}\n"
+            f"stderr:\n{result.stderr.decode(errors='replace')}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
before, if communicator failed, normal not cuda capture ops would fail fast but cuda captured ops hangs instead of failing, this makes cuda captured ops follow same fail fast as normal path