### PR TITLE
override BackendWrapper::shutdown / abort to safely close comm in destroy_process_group (#2550)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/torchcomms/BackendWrapper.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/utils/Logging.hpp"
 
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
 
@@ -587,6 +588,36 @@ bool BackendWrapper::verifyWorkTimeoutForTest(
 void BackendWrapper::setTimeout(std::chrono::milliseconds timeout) {
   options_->timeout = timeout;
 }
+void BackendWrapper::shutdown() {
+  // Idempotent: destroy_process_group iterates all backends and calls
+  // shutdown() on each, but multiple BackendWrappers can share the same
+  // underlying TorchComm (mixed cpu:gloo,cuda:nccl PGs registered through
+  // the backendType-to-wrapper dedup path). Finalize-on-already-finalized
+  // throws "TorchCommNCCL already finalized" — log and continue so destroy
+  // is always safe to call.
+  if (comm_) {
+    try {
+      comm_->finalize();
+    } catch (const std::exception& e) {
+      TC_LOG(WARNING)
+          << "BackendWrapper::shutdown: TorchComm::finalize() raised, "
+          << "treating as no-op (likely already finalized): " << e.what();
+    }
+  }
+}
+
+void BackendWrapper::abort() {
+  if (comm_) {
+    try {
+      comm_->abort();
+    } catch (const std::exception& e) {
+      TC_LOG(WARNING) << "BackendWrapper::abort: TorchComm::abort() raised, "
+                      << "treating as no-op (likely already aborted): "
+                      << e.what();
+    }
+  }
+}
+
 c10::intrusive_ptr<c10d::Backend> BackendWrapper::split(
     const c10::intrusive_ptr<c10d::Store>& /* store */,
     const std::vector<int>& ranks,

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -146,6 +146,18 @@ class BackendWrapper : public c10d::Backend {
       const std::vector<int>& ranks,
       const c10::intrusive_ptr<c10d::Backend::Options>& opts) override;
 
+  // Called by torch.distributed.destroy_process_group(). Calls
+  // TorchComm::finalize() to drain in-flight work and close the comm
+  // gracefully — without this override the inherited base no-op leaves the
+  // communicator alive and the destructor's synchronous ncclCommDestroy
+  // can deadlock against the NCCL GC thread holding Work refs.
+  void shutdown() override;
+
+  // Called by destroy_process_group when the user wants forceful teardown.
+  // Delegates to TorchComm::abort() which uses graceful revoke in
+  // reconfigurable mode and destructive abort otherwise.
+  void abort() override;
+
  private:
   std::shared_ptr<TorchComm> comm_;
   c10::intrusive_ptr<Options> options_;

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -4,6 +4,7 @@
 #include "comms/torchcomms/TorchCommFactory.hpp"
 
 #include <atomic>
+#include <limits>
 
 namespace torch::comms {
 
@@ -88,10 +89,17 @@ std::shared_ptr<TorchComm> new_comm(
 }
 
 void TorchComm::finalize() {
-  auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(op_id, FinalizePreHookArgs{});
+  // finalize is a lifecycle event, not a collective — don't consume a
+  // global op_id slot. Built-in hooks (FlightRecorder, Clog) all
+  // short-circuit on finalize, and FlightRecorder keys its ring-buffer
+  // slot off op_id. Bumping the global counter here would leave a hole
+  // in the FR's index space. Use a sentinel op_id instead so
+  // pre/post hooks still pair on the same value for finalize-aware
+  // Python custom hooks.
+  constexpr size_t kFinalizeOpId = std::numeric_limits<size_t>::max();
+  preHook(kFinalizeOpId, FinalizePreHookArgs{});
   impl_->finalize();
-  postHook(op_id, FinalizePostHookArgs{});
+  postHook(kFinalizeOpId, FinalizePostHookArgs{});
 }
 
 int TorchComm::getRank() const {

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderFinalizeOpIdTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderFinalizeOpIdTest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Regression test for the FlightRecorder gap-on-finalize bug.
+
+``TorchComm::finalize()`` previously consumed a slot from the global
+``op_id`` counter via ``GlobalOpIdGenerator::nextOpId()``, but the
+``FlightRecorderHook`` short-circuits before recording finalize. That
+left a hole in the recorder's index space and, because ``record()``
+keys its ring-buffer slot off ``op_id % max_entries_``, the next real
+collective tripped the growth-phase assertion
+``entries_.size() == idx + 1``.
+
+This test exercises the exact sequence: create comm, record a
+collective, finalize, then create a *new* comm and record another
+collective sharing the same recorder. Pre-fix, the second collective
+trips the assertion. Post-fix, both collectives are recorded with
+sequential ``op_id`` values and no gap.
+"""
+
+import json
+import os
+import unittest
+from datetime import timedelta
+
+import torch
+import torchcomms
+from torchcomms.hooks import FlightRecorderHook
+
+
+class TestFlightRecorderFinalizeOpId(unittest.TestCase):
+    backend = os.environ["TEST_BACKEND"]
+    device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+
+    def test_finalize_does_not_consume_op_id(self) -> None:
+        # ``isolated=True`` resets the global op_id generator so the
+        # comm's first op starts at 0, making the post-fix expectation
+        # below deterministic.
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+
+        # --- First comm life cycle: one collective, then finalize. ---
+        comm1 = torchcomms.new_comm(
+            backend=self.backend,
+            device=self.device,
+            name="fr_finalize_op_id_1",
+            timeout=timedelta(seconds=300),
+        )
+        recorder.register_with_comm(comm1)
+        t = torch.rand(4, device=self.device)
+        comm1.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+        comm1.finalize()
+
+        # --- Second comm life cycle: one more collective on a fresh
+        # comm sharing the same recorder. Pre-fix this is where the FR
+        # growth-phase assertion fires because finalize on comm1 bumped
+        # the global op_id counter without producing a recorder entry. ---
+        comm2 = torchcomms.new_comm(
+            backend=self.backend,
+            device=self.device,
+            name="fr_finalize_op_id_2",
+            timeout=timedelta(seconds=300),
+        )
+        recorder.register_with_comm(comm2)
+        comm2.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Two collectives recorded; finalize must not have caused a gap.
+        self.assertEqual(recorder.size(), 2)
+        dump = json.loads(recorder.dump_json())
+        op_ids = [entry["op_id"] for entry in dump["entries"]]
+        self.assertEqual(
+            len(op_ids), 2, f"expected 2 recorded ops, got entries={dump['entries']}"
+        )
+        op_ids.sort()
+        # Sequential, no gap from finalize between them.
+        self.assertEqual(
+            op_ids[1] - op_ids[0],
+            1,
+            f"finalize on comm1 must not consume an op_id slot, but got "
+            f"non-sequential op_ids={op_ids}",
+        )
+
+        comm2.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Verify ``BackendWrapper::shutdown`` and ``::abort`` close the underlying
+``TorchComm`` cleanly when ``torch.distributed.destroy_process_group()``
+is called.
+
+Two regressions guarded against:
+
+1. **Deadlock on destroy**: without a ``shutdown`` override the wrapper's
+   destructor would invoke ``ncclCommDestroy`` synchronously and could
+   deadlock against the NCCL GC thread.
+
+2. **Double-finalize raise**: a mixed ``cpu:gloo,cuda:nccl`` PG ends up
+   with two BackendWrappers sharing one underlying ``TorchComm`` (via the
+   BackendType-to-wrapper dedup). ``destroy_process_group`` calls
+   ``shutdown`` on each backend; ``TorchComm::finalize`` is not idempotent
+   and would raise ``RuntimeError: TorchCommNCCL already finalized`` on
+   the second call. The wrapper swallows the exception so destroy is safe
+   to call any number of times.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from packaging.version import InvalidVersion, Version
+from torchcomms.tests.helpers.py.test_helpers import skip_if_ncclx
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+_TORCHCOMMS_CONFIG_AVAILABLE = hasattr(dist, "config") and hasattr(
+    dist.config, "use_torchcomms"
+)
+
+_PR_182057_TORCH_VERSION = Version("2.13.0.dev20260502")
+
+
+def _torch_predates_pr_182057() -> bool:
+    try:
+        return Version(torch.__version__) < _PR_182057_TORCH_VERSION
+    except InvalidVersion:
+        # Unparsable version string — assume newer to avoid silently
+        # skipping on something we can't classify.
+        return False
+
+
+def _local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", get_rank_and_size()[0]))
+
+
+@unittest.skipUnless(
+    _TORCHCOMMS_CONFIG_AVAILABLE,
+    "dist.config.use_torchcomms not available in this PyTorch version",
+)
+@skip_if_ncclx
+class TestBackendWrapperShutdown(unittest.TestCase):
+    """Each test creates its own PG, runs a small collective, then tears
+    it down — no shared setUpClass, since the goal is to exercise the
+    init+destroy cycle itself."""
+
+    def _init_pg(self, backend: str) -> None:
+        rank, world_size = get_rank_and_size()
+        # NCCL requires a CUDA device to be bound to this rank before
+        # ``init_process_group`` so that the per-rank communicator gets
+        # the right device. Without this, all ranks default to cuda:0
+        # and NCCL bootstrap fails. ``get_device`` can return
+        # ``torch.device("cuda")`` with no index when ``TEST_DEVICE=cuda``
+        # is set, so resolve the index explicitly from LOCAL_RANK / rank.
+        device = get_device(os.environ["TEST_BACKEND"], rank)
+        if device.type == "cuda":
+            if device.index is None:
+                device = torch.device(f"cuda:{_local_rank()}")
+            torch.cuda.set_device(device)
+        dist.config.use_torchcomms = True
+        dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+        torch.set_default_device(device)
+
+    def test_destroy_after_collective_no_hang(self):
+        """A simple init → all_reduce → destroy cycle finishes without
+        hanging. Catches the original ``ncclCommDestroy`` deadlock."""
+        self._init_pg(os.environ["TEST_BACKEND"])
+        try:
+            tensor = torch.ones(8, dtype=torch.float32)
+            dist.all_reduce(tensor)
+            self.assertEqual(tensor[0].item(), float(dist.get_world_size()))
+        finally:
+            dist.destroy_process_group()
+
+    def test_mixed_backend_destroy_idempotent(self):
+        """Mixed ``cpu:gloo,cuda:nccl`` PG: ``destroy_process_group``
+        shuts down both sub-backends, which share one ``TorchComm``.
+        Without idempotent ``shutdown``, the second call raises
+        ``TorchCommNCCL already finalized``."""
+        if os.environ["TEST_BACKEND"] != "nccl":
+            self.skipTest("mixed backend test is nccl-specific")
+        if _torch_predates_pr_182057():
+            self.skipTest(
+                f"torch {torch.__version__} predates pytorch/pytorch#182057 "
+                f"({_PR_182057_TORCH_VERSION}); mixed cpu:gloo,cuda:nccl + "
+                "device_id= trips the ProcessGroup::setBackend "
+                "bound_device_id check on init"
+            )
+
+        rank, world_size = get_rank_and_size()
+        local_rank = _local_rank()
+        torch.cuda.set_device(local_rank)
+        dist.config.use_torchcomms = True
+        dist.init_process_group(
+            backend="cpu:gloo,cuda:nccl",
+            rank=rank,
+            world_size=world_size,
+            device_id=torch.device(f"cuda:{local_rank}"),
+        )
+        try:
+            torch.set_default_device(f"cuda:{local_rank}")
+            cpu_tensor = torch.ones(4, dtype=torch.float32, device="cpu")
+            cuda_tensor = torch.ones(
+                4, dtype=torch.float32, device=f"cuda:{local_rank}"
+            )
+            dist.all_reduce(cpu_tensor)
+            dist.all_reduce(cuda_tensor)
+            self.assertEqual(cpu_tensor[0].item(), float(world_size))
+            self.assertEqual(cuda_tensor[0].item(), float(world_size))
+        finally:
+            # Must not raise even though both sub-backends share the comm.
+            dist.destroy_process_group()


### PR DESCRIPTION
Summary:

Override `BackendWrapper::shutdown()` (→ `TorchComm::finalize()`) and `BackendWrapper::abort()` (→ `TorchComm::abort()`) so `torch.distributed.destroy_process_group()` no longer leaves the comm alive and the destructor cannot deadlock against the NCCL GC thread.

Both overrides wrap the call in `try { … } catch (const std::exception&)` because multiple `BackendWrapper`s can share the same underlying `TorchComm` (mixed `cpu:gloo,cuda:nccl` PGs registered through the BackendType-to-wrapper dedup). `destroy_process_group` calls `shutdown()` on each backend; calling `finalize()` twice on the same comm raises `RuntimeError: TorchCommNCCL already finalized`. The catch makes the override safe to call any number of times.

Lets vLLM drop the `if not _use_torchcomms_enabled()` guards in `vllm/distributed/parallel_state.py::GroupCoordinator.destroy()` and `destroy_distributed_environment()`.

Reviewed By: kapilsh

Differential Revision: D105224775


