### PR TITLE
Rename MCCL ALGO_PROFILER CVARs to PROFILER for reusability

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3051,30 +3051,30 @@ cvars:
      mccl_operation_trace Scuba table via McclAlgoProfilerReporter. Set to
      false to disable ctran profiling from the MCCL level.
 
- - name        : MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS
+ - name        : MCCL_FILTER_PROFILER_LOGGING_BY_RANKS
    type        : stringlist
    default     : "0"
    description : |-
-     Comma-separated list of global ranks allowed to write algo profiler
+     Comma-separated list of global ranks allowed to write profiler
      operation data to filter logs (mccl_operation_trace). Only effective
      when MCCL_CTRAN_TRANSPORT_PROFILER is enabled (true by default),
-     which controls whether ctran algo profiling data flows to
-     mccl_operation_trace. This filter applies only to algo profiler
+     which controls whether ctran profiling data flows to
+     mccl_operation_trace. This filter applies only to profiler
      operation trace samples; other log types are not affected. When
      this list is non-empty, only the specified ranks will have their
-     algo profiler samples written; all other ranks are silently skipped.
+     profiler samples written; all other ranks are silently skipped.
      Default: "0" (only rank 0 logs). Set to an empty string to allow
      all ranks to log.
 
- - name        : MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL
+ - name        : MCCL_PROFILER_STEP_LOGGING_INTERVAL
    type        : int
    default     : 113
    description : |-
-     Controls step-based algo profiler logging at the MCCL level. When the
+     Controls step-based profiler logging at the MCCL level. When the
      training step (from AllReduceOpts kvPairs["step"]) is a multiple of this
-     interval, all allreduce algo profiler data for that step is logged,
+     interval, all allreduce profiler data for that step is logged,
      bypassing the per-op NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT filter.
-     Rank filtering (MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS) still applies.
+     Rank filtering (MCCL_FILTER_PROFILER_LOGGING_BY_RANKS) still applies.
      Set to 0 or negative to disable step-based logging.
 
  - name        : NCCL_GIN_GDAKI_NIC_HANDLER


### PR DESCRIPTION
Summary:
Rename MCCL-level CVARs that are specific to the algo profiler to be generic profiler CVARs, so they can be reused if we add more profilers in the future.

- `MCCL_FILTER_ALGO_PROFILER_LOGGING_BY_RANKS` -> `MCCL_FILTER_PROFILER_LOGGING_BY_RANKS`
- `MCCL_ALGO_PROFILER_STEP_LOGGING_INTERVAL` -> `MCCL_PROFILER_STEP_LOGGING_INTERVAL`

Updated CVAR definitions in `nccl_cvars.yaml` and all usage sites in `McclComm.cpp` and `Utils.cpp`.

Differential Revision: D105241058


