### PR TITLE
Dedup rackSerial parsing across v2_27/v2_29/v2_30 and fix GCP CHECK-crash (#2555)

### DIFF
--- a/comms/ncclx/meta/DeviceRackSerial.cc
+++ b/comms/ncclx/meta/DeviceRackSerial.cc
@@ -1,0 +1,42 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "meta/DeviceRackSerial.h"
+
+#include <cstring>
+#include <fstream>
+#include <string>
+
+namespace ncclx {
+
+namespace {
+constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL";
+} // namespace
+
+bool loadRackSerial(const std::string& filepath, char* out, size_t maxLen) {
+  std::ifstream file(filepath);
+  if (!file.is_open()) {
+    return false;
+  }
+
+  std::string line;
+  while (std::getline(file, line)) {
+    size_t pos = line.find('=');
+    if (pos == std::string::npos) {
+      continue;
+    }
+    const auto key = line.substr(0, pos);
+    if (key != kDeviceRackSerial) {
+      continue;
+    }
+    const auto value = line.substr(pos + 1);
+    if (value.empty() || value.size() >= maxLen) {
+      return false;
+    }
+    std::strncpy(out, value.c_str(), maxLen);
+    out[maxLen - 1] = '\0';
+    return true;
+  }
+  return false;
+}
+
+} // namespace ncclx

--- a/comms/ncclx/meta/DeviceRackSerial.h
+++ b/comms/ncclx/meta/DeviceRackSerial.h
@@ -1,0 +1,18 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#pragma once
+
+#include <cstring>
+#include <string>
+
+namespace ncclx {
+
+// Load DEVICE_RACK_SERIAL from a topology file into a caller-provided buffer.
+// Returns true if found and fits within maxLen, false otherwise.
+bool loadRackSerial(const std::string& filepath, char* out, size_t maxLen);
+
+// Returns true only if both serials are non-empty and equal.
+inline bool isSameRackSerial(const char* a, const char* b) {
+  return a[0] != '\0' && b[0] != '\0' && std::strcmp(a, b) == 0;
+}
+
+} // namespace ncclx

--- a/comms/ncclx/meta/baseline_modification_docs/device_rack_serial.md
+++ b/comms/ncclx/meta/baseline_modification_docs/device_rack_serial.md
@@ -1,0 +1,91 @@
+# Device Rack Serial: Baseline Modifications
+
+## Background
+
+`NCCL_MNNVL_TRUNK_DISABLE` is a Meta-custom feature that disables multi-NVLink trunk connections and instead uses `DEVICE_RACK_SERIAL` (read from the topology file at `NCCL_TOPO_FILE_PATH`) to decide P2P connectivity — ranks on the same rack get P2P enabled, ranks on different racks do not. This feature was originally added to all three NCCLX versions (v2_27, v2_29, v2_30) with the following baseline modifications:
+
+- `transport.h`: Added `int rackSerial` field to `ncclPeerInfo`
+- `init.cc`: Added `ncclxGetDeviceRackSerial()` to parse `DEVICE_RACK_SERIAL` from the topology file as an integer via `folly::tryTo<int>()`
+- `paths.cc`: Added a block in `ncclTopoCheckP2p()` to compare `rackSerial` values and set `*p2p` accordingly
+
+Each version had its own copy of `ncclxGetDeviceRackSerial()` with identical logic.
+
+## Bug Fixes
+
+GCP GB300 hosts have alphanumeric `DEVICE_RACK_SERIAL` values (e.g. `C1507842765072`). The original `folly::tryTo<int>()` conversion crashed with a `CHECK(maybeRackSerial.hasValue())` failure on these hosts. This diff fixes the crash by switching `rackSerial` from `int` to `char[]` (string-based), and deduplicates the three copies of parsing logic into a shared `meta/DeviceRackSerial.h/cc`.
+
+## Versions Affected
+
+v2_27, v2_29, v2_30
+
+## Baseline Files Modified
+
+### 1. `src/include/transport.h` — rackSerial type change
+
+**Change**: Added `constexpr auto kMaxRackSerialLen = 63` and changed `ncclPeerInfo.rackSerial` from `int` to `char[kMaxRackSerialLen+1]`.
+
+```cpp
+constexpr auto kMaxRackSerialLen = 63; // [META] for DeviceRackSerial string support
+// ...
+struct ncclPeerInfo {
+  // ...
+  char rackSerial[kMaxRackSerialLen+1]; // [META] string-based rack serial (was int)
+};
+```
+
+**Why in baseline**: `ncclPeerInfo` is a core NCCL struct exchanged between ranks during init. The field type must match across all ranks for correct bootstrapping.
+
+### 2. `src/init.cc` — Rack serial loading
+
+**Change**: Removed the per-version `ncclxGetDeviceRackSerial()` function (which used `folly::tryTo<int>()` and crashed on alphanumeric serials). Replaced with a call to shared `ncclx::loadRackSerial()` that stores the value as a string.
+
+```cpp
+// [META] Load rack serial for MNNVL trunk disable (string-based, supports alphanumeric serials)
+if(NCCL_MNNVL_TRUNK_DISABLE) {
+  if (ncclx::loadRackSerial(NCCL_TOPO_FILE_PATH, info->rackSerial, sizeof(info->rackSerial))) {
+    INFO(NCCL_INIT, "Loaded rack serial: %s", info->rackSerial);
+  } else {
+    WARN("No rack serial information available, skipping rack serial check");
+  }
+}
+```
+
+**Why in baseline**: `fillInfo()` populates `ncclPeerInfo` during communicator init. The rack serial must be loaded here so it is available for the P2P path decision in `paths.cc`.
+
+### 3. `src/graph/paths.cc` — Rack serial comparison
+
+**Change**: Updated the `NCCL_MNNVL_TRUNK_DISABLE` block to use string-based comparison via `ncclx::isSameRackSerial()` instead of integer equality. Changed format specifiers from `%d` to `%s`. Block is tagged with `[META]` comment.
+
+```cpp
+// [META] Check if multi-NVLink P2P is disabled and handle rack serial matching
+if (NCCL_MNNVL_TRUNK_DISABLE && mnnvl) {
+  if (comm->peerInfo[rank1].rackSerial[0] != '\0' && comm->peerInfo[rank2].rackSerial[0] != '\0') {
+    *p2p = ncclx::isSameRackSerial(comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+  } else {
+    WARN("No rack serial information available, skipping rack serial check");
+  }
+}
+```
+
+**Why in baseline**: `ncclTopoCheckP2p()` is the core P2P path decision function. The rack serial comparison must happen here alongside other P2P topology checks.
+
+## NCCLX meta/ Files (not baseline)
+
+| File | Purpose |
+|------|---------|
+| `meta/DeviceRackSerial.h` | `loadRackSerial()` and `isSameRackSerial()` declarations |
+| `meta/DeviceRackSerial.cc` | `loadRackSerial()` implementation — parses `DEVICE_RACK_SERIAL` from topology file as string |
+| `meta/tests/DeviceRackSerialTest.cc` | Unit tests for load/compare functions |
+
+## Build Integration
+
+Each version's `def_build.bzl` and `src/Makefile` include `meta/DeviceRackSerial.cc` in the source list for both buck and conda builds.
+
+## Revert Checklist
+
+To remove rack serial support from the baseline:
+
+1. `src/include/transport.h`: Revert `rackSerial` from `char[]` to `int`; remove `kMaxRackSerialLen`
+2. `src/init.cc`: Remove `meta/DeviceRackSerial.h` include; remove `loadRackSerial()` call block; restore original `ncclxGetDeviceRackSerial()` if integer-only serials are acceptable
+3. `src/graph/paths.cc`: Remove `meta/DeviceRackSerial.h` include; revert to integer comparison (`==`); revert format specifiers from `%s` to `%d`; remove `[META]` tag
+4. `def_build.bzl` / `src/Makefile`: Remove `meta/DeviceRackSerial.cc` from source lists

--- a/comms/ncclx/meta/tests/DeviceRackSerialTest.cc
+++ b/comms/ncclx/meta/tests/DeviceRackSerialTest.cc
@@ -1,0 +1,83 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "meta/DeviceRackSerial.h"
+#include "transport.h"
+
+#include <gtest/gtest.h>
+#include <fstream>
+
+using ncclx::isSameRackSerial;
+using ncclx::loadRackSerial;
+
+TEST(DeviceRackSerialTest, LoadNumericSerial) {
+  const std::string filepath = "/tmp/ut-rack-serial.txt";
+  std::ofstream file(filepath);
+  file << "DEVICE_NAME=testhost.facebook.com" << std::endl;
+  file << "DEVICE_RACK_SERIAL=50022944" << std::endl;
+  file.close();
+
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_TRUE(loadRackSerial(filepath, buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "50022944");
+}
+
+TEST(DeviceRackSerialTest, LoadAlphanumericSerial) {
+  const std::string filepath = "/tmp/ut-rack-serial.txt";
+  std::ofstream file(filepath);
+  file << "DEVICE_RACK_SERIAL=C1507842765072" << std::endl;
+  file.close();
+
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_TRUE(loadRackSerial(filepath, buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "C1507842765072");
+}
+
+TEST(DeviceRackSerialTest, MissingSerial) {
+  const std::string filepath = "/tmp/ut-rack-serial.txt";
+  std::ofstream file(filepath);
+  file << "DEVICE_NAME=testhost.facebook.com" << std::endl;
+  file.close();
+
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_FALSE(loadRackSerial(filepath, buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "");
+}
+
+TEST(DeviceRackSerialTest, EmptySerial) {
+  const std::string filepath = "/tmp/ut-rack-serial.txt";
+  std::ofstream file(filepath);
+  file << "DEVICE_RACK_SERIAL=" << std::endl;
+  file.close();
+
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_FALSE(loadRackSerial(filepath, buf, sizeof(buf)));
+}
+
+TEST(DeviceRackSerialTest, SerialExceedsMaxLen) {
+  const std::string filepath = "/tmp/ut-rack-serial.txt";
+  std::ofstream file(filepath);
+  std::string longSerial(kMaxRackSerialLen + 1, 'A');
+  file << "DEVICE_RACK_SERIAL=" << longSerial << std::endl;
+  file.close();
+
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_FALSE(loadRackSerial(filepath, buf, sizeof(buf)));
+}
+
+TEST(DeviceRackSerialTest, FileNotFound) {
+  char buf[kMaxRackSerialLen + 1] = {};
+  EXPECT_FALSE(loadRackSerial("/tmp/nonexistent_file_12345", buf, sizeof(buf)));
+}
+
+TEST(DeviceRackSerialTest, IsSameRackSerialBothNonEmpty) {
+  EXPECT_TRUE(isSameRackSerial("50022944", "50022944"));
+  EXPECT_FALSE(isSameRackSerial("50022944", "50022945"));
+  EXPECT_TRUE(isSameRackSerial("C1507842765072", "C1507842765072"));
+  EXPECT_FALSE(isSameRackSerial("C1507842765072", "C9999999999999"));
+}
+
+TEST(DeviceRackSerialTest, IsSameRackSerialEmptyReturnsFalse) {
+  EXPECT_FALSE(isSameRackSerial("", "50022944"));
+  EXPECT_FALSE(isSameRackSerial("50022944", ""));
+  EXPECT_FALSE(isSameRackSerial("", ""));
+}

--- a/comms/ncclx/v2_27/src/Makefile
+++ b/comms/ncclx/v2_27/src/Makefile
@@ -43,6 +43,7 @@ LIBSRCFILES := \
 
 LIBSRCFILES += $(wildcard ${NCCLDIR}/meta/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commDump.cc)
+LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/DeviceRackSerial.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/NcclxConfig.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commHash.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/RankUtil.cc)

--- a/comms/ncclx/v2_27/src/graph/paths.cc
+++ b/comms/ncclx/v2_27/src/graph/paths.cc
@@ -11,6 +11,7 @@
 #include "net.h"
 #include "channel.h"
 #include "transport.h"
+#include "meta/DeviceRackSerial.h"
 #include "device.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -315,15 +316,13 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   if (path->type <= p2pLevel) {
     *p2p = 1;
   }
-  // Check if multi-NVLink P2P is disabled and handle rack serial matching
+  // [META] Check if multi-NVLink P2P is disabled and handle rack serial matching
   if (NCCL_MNNVL_TRUNK_DISABLE && mnnvl) {
     INFO(NCCL_GRAPH, "NCCL_MNNVL_TRUNK_DISABLE enabled");
-    
-    // Only check rack serials if comm and rackSerials are available
-    if (comm->peerInfo[rank1].rackSerial && comm->peerInfo[rank2].rackSerial) {
-      *p2p = (comm->peerInfo[rank1].rackSerial == comm->peerInfo[rank2].rackSerial);
-      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %d rackSerial2: %d", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
 
+    if (comm->peerInfo[rank1].rackSerial[0] != '\0' && comm->peerInfo[rank2].rackSerial[0] != '\0') {
+      *p2p = ncclx::isSameRackSerial(comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %s rackSerial2: %s", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
     } else {
       WARN("No rack serial information available, skipping rack serial check");
     }

--- a/comms/ncclx/v2_27/src/include/transport.h
+++ b/comms/ncclx/v2_27/src/include/transport.h
@@ -25,6 +25,7 @@
 #include "bootstrap.h"
 
 constexpr auto kMaxHostNameLen = 127; // Extra byte for NUL
+constexpr auto kMaxRackSerialLen = 63; // [META] for DeviceRackSerial string support
 
 extern struct ncclTransport p2pTransport;
 extern struct ncclTransport shmTransport;
@@ -55,7 +56,7 @@ struct ncclPeerInfo {
   int cuMemSupport;
   int version;
   char hostname[kMaxHostNameLen+1];
-  int rackSerial;
+  char rackSerial[kMaxRackSerialLen+1]; // [META] string-based rack serial (was int)
 };
 
 // [META]: increase size from 256 to 288 to accommodate for NCCLX's new fields

--- a/comms/ncclx/v2_27/src/init.cc
+++ b/comms/ncclx/v2_27/src/init.cc
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nccl.h"
+#include "meta/DeviceRackSerial.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "channel.h"
 #include "nvmlwrap.h"
@@ -594,53 +595,6 @@ static void showVersion() {
   }
 }
 
-static constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL"; /* key in topology file */
-static ncclResult_t ncclxGetDeviceRackSerial(ncclComm* comm, int* rackSerial) {
-  if (comm == nullptr) {
-    WARN("Invalid state or comm pointer");
-    return ncclInvalidArgument;
-  }
-
-  std::ifstream file(NCCL_TOPO_FILE_PATH);
-  if (!file.is_open()) {
-    WARN("Failed to open topology file: %s", NCCL_TOPO_FILE_PATH.c_str());
-    return ncclSystemError;
-  }
-
-  std::string rackSerialStr;
-  std::string line;
-  bool found = false;
-
-  while (std::getline(file, line)) {
-    size_t pos = line.find('=');
-    if (pos == std::string::npos) {
-      continue;
-    }
-
-    std::string key = line.substr(0, pos);
-    std::string value = line.substr(pos + 1);
-
-    if (key == kDeviceRackSerial) {
-      if (!value.empty()) {
-        rackSerialStr = std::move(value);
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (!found) {
-    INFO(NCCL_INIT, "No rack serial found in topology file");
-  }
-
-  auto maybeRackSerial = folly::tryTo<int>(rackSerialStr);
-  CHECK(maybeRackSerial.hasValue());
-  *rackSerial = maybeRackSerial.value();
-
-  file.close();
-  return ncclSuccess;
-}
-
 static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, uint64_t commHash) {
   cudaDeviceProp prop;
   info->rank = comm->rank;
@@ -695,8 +649,13 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
            info->busId,
            ((long *)&info->fabricInfo.clusterUuid)[0], ((long *)&info->fabricInfo.clusterUuid)[1],
            info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+      // [META] Load rack serial for MNNVL trunk disable (string-based, supports alphanumeric serials)
       if(NCCL_MNNVL_TRUNK_DISABLE) {
-        NCCLCHECK(ncclxGetDeviceRackSerial(comm, &info->rackSerial));
+        if (ncclx::loadRackSerial(NCCL_TOPO_FILE_PATH, info->rackSerial, sizeof(info->rackSerial))) {
+          INFO(NCCL_INIT, "Loaded rack serial: %s", info->rackSerial);
+        } else {
+          WARN("No rack serial information available, skipping rack serial check");
+        }
       }
     }
   }

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -56,6 +56,7 @@ LIBSRCFILES := \
 
 LIBSRCFILES += $(wildcard ${NCCLDIR}/meta/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commDump.cc)
+LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/DeviceRackSerial.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/NcclxConfig.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commHash.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/RankUtil.cc)

--- a/comms/ncclx/v2_29/src/graph/paths.cc
+++ b/comms/ncclx/v2_29/src/graph/paths.cc
@@ -13,6 +13,7 @@
 #include "net.h"
 #include "channel.h"
 #include "transport.h"
+#include "meta/DeviceRackSerial.h"
 #include "device.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -373,15 +374,13 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   // Compute the PCI distance and compare with the p2pLevel.
   if (path->type <= p2pLevel) *p2p = 1;
 
-  // Check if multi-NVLink P2P is disabled and handle rack serial matching
+  // [META] Check if multi-NVLink P2P is disabled and handle rack serial matching
   if (NCCL_MNNVL_TRUNK_DISABLE && mnnvl) {
     INFO(NCCL_GRAPH, "NCCL_MNNVL_TRUNK_DISABLE enabled");
 
-    // Only check rack serials if comm and rackSerials are available
-    if (comm->peerInfo[rank1].rackSerial && comm->peerInfo[rank2].rackSerial) {
-      *p2p = (comm->peerInfo[rank1].rackSerial == comm->peerInfo[rank2].rackSerial);
-      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %d rackSerial2: %d", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
-
+    if (comm->peerInfo[rank1].rackSerial[0] != '\0' && comm->peerInfo[rank2].rackSerial[0] != '\0') {
+      *p2p = ncclx::isSameRackSerial(comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %s rackSerial2: %s", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
     } else {
       WARN("No rack serial information available, skipping rack serial check");
     }

--- a/comms/ncclx/v2_29/src/include/transport.h
+++ b/comms/ncclx/v2_29/src/include/transport.h
@@ -22,6 +22,7 @@
 #define TRANSPORT_PROFILER 4
 
 constexpr auto kMaxHostNameLen = 127; // Extra byte for NULL
+constexpr auto kMaxRackSerialLen = 63; // [META] for DeviceRackSerial string support
 
 #include "proxy.h"
 #include "comm.h"
@@ -62,7 +63,7 @@ struct ncclPeerInfo {
   bool rmaPluginAvailable;
   bool cuMemGdrSupport;
   char hostname[kMaxHostNameLen+1];
-  int rackSerial;
+  char rackSerial[kMaxRackSerialLen+1]; // [META] string-based rack serial (was int)
 };
 
 // [META]: increase size from 256 to 288 to accommodate for NCCLX's new fields

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "nccl.h"
+#include "meta/DeviceRackSerial.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxPerCommConfig.h" // @manual
 #include "channel.h"
@@ -718,53 +719,6 @@ static void showVersion() {
   INFO(NCCL_ALL,"%s", ncclGetGitVersion());
 }
 
-static constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL"; /* key in topology file */
-static ncclResult_t ncclxGetDeviceRackSerial(ncclComm* comm, int* rackSerial) {
-  if (comm == nullptr) {
-    WARN("Invalid state or comm pointer");
-    return ncclInvalidArgument;
-  }
-
-  std::ifstream file(NCCL_TOPO_FILE_PATH);
-  if (!file.is_open()) {
-    WARN("Failed to open topology file: %s", NCCL_TOPO_FILE_PATH.c_str());
-    return ncclSystemError;
-  }
-
-  std::string rackSerialStr;
-  std::string line;
-  bool found = false;
-
-  while (std::getline(file, line)) {
-    size_t pos = line.find('=');
-    if (pos == std::string::npos) {
-      continue;
-    }
-
-    std::string key = line.substr(0, pos);
-    std::string value = line.substr(pos + 1);
-
-    if (key == kDeviceRackSerial) {
-      if (!value.empty()) {
-        rackSerialStr = std::move(value);
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (!found) {
-    INFO(NCCL_INIT, "No rack serial found in topology file");
-  }
-
-  auto maybeRackSerial = folly::tryTo<int>(rackSerialStr);
-  CHECK(maybeRackSerial.hasValue());
-  *rackSerial = maybeRackSerial.value();
-
-  file.close();
-  return ncclSuccess;
-}
-
 NCCL_PARAM(MNNVLUUID, "MNNVL_UUID", -1);
 NCCL_PARAM(MNNVLCliqueId, "MNNVL_CLIQUE_ID", -1);
 
@@ -836,8 +790,13 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
            info->busId,
            uuid0, uuid1,
            info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+      // [META] Load rack serial for MNNVL trunk disable (string-based, supports alphanumeric serials)
       if(NCCL_MNNVL_TRUNK_DISABLE) {
-        NCCLCHECK(ncclxGetDeviceRackSerial(comm, &info->rackSerial));
+        if (ncclx::loadRackSerial(NCCL_TOPO_FILE_PATH, info->rackSerial, sizeof(info->rackSerial))) {
+          INFO(NCCL_INIT, "Loaded rack serial: %s", info->rackSerial);
+        } else {
+          WARN("No rack serial information available, skipping rack serial check");
+        }
       }
     }
   }

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -64,6 +64,7 @@ LIBSRCFILES := \
 
 LIBSRCFILES += $(wildcard ${NCCLDIR}/meta/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commDump.cc)
+LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/DeviceRackSerial.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/NcclxConfig.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/commHash.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/RankUtil.cc)

--- a/comms/ncclx/v2_30/src/graph/paths.cc
+++ b/comms/ncclx/v2_30/src/graph/paths.cc
@@ -13,6 +13,7 @@
 #include "net.h"
 #include "channel.h"
 #include "transport.h"
+#include "meta/DeviceRackSerial.h"
 #include "device.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -388,15 +389,13 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   // Compute the PCI distance and compare with the p2pLevel.
   if (path->type <= p2pLevel) *p2p = 1;
 
-  // Check if multi-NVLink P2P is disabled and handle rack serial matching
+  // [META] Check if multi-NVLink P2P is disabled and handle rack serial matching
   if (NCCL_MNNVL_TRUNK_DISABLE && mnnvl) {
     INFO(NCCL_GRAPH, "NCCL_MNNVL_TRUNK_DISABLE enabled");
 
-    // Only check rack serials if comm and rackSerials are available
-    if (comm->peerInfo[rank1].rackSerial && comm->peerInfo[rank2].rackSerial) {
-      *p2p = (comm->peerInfo[rank1].rackSerial == comm->peerInfo[rank2].rackSerial);
-      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %d rackSerial2: %d", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
-
+    if (comm->peerInfo[rank1].rackSerial[0] != '\0' && comm->peerInfo[rank2].rackSerial[0] != '\0') {
+      *p2p = ncclx::isSameRackSerial(comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
+      INFO(NCCL_GRAPH, "P2P is set to %d based on rack serial match/unmatch rank1: %d rank2: %d rackSerial1: %s rackSerial2: %s", *p2p, rank1, rank2, comm->peerInfo[rank1].rackSerial, comm->peerInfo[rank2].rackSerial);
     } else {
       WARN("No rack serial information available, skipping rack serial check");
     }

--- a/comms/ncclx/v2_30/src/include/transport.h
+++ b/comms/ncclx/v2_30/src/include/transport.h
@@ -22,6 +22,7 @@
 #define TRANSPORT_PROFILER 4
 
 constexpr auto kMaxHostNameLen = 127; // Extra byte for NULL
+constexpr auto kMaxRackSerialLen = 63; // [META] for DeviceRackSerial string support
 
 #include "proxy.h"
 #include "comm.h"
@@ -63,7 +64,7 @@ struct ncclPeerInfo {
   bool rmaPluginAvailable;
   bool cuMemGdrSupport;
   char hostname[kMaxHostNameLen+1];
-  int rackSerial;
+  char rackSerial[kMaxRackSerialLen+1]; // [META] string-based rack serial (was int)
 };
 
 // [META]: increase size from 256 to 288 to accommodate for NCCLX's new fields

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "nccl.h"
+#include "meta/DeviceRackSerial.h"
 #include "meta/NcclxConfig.h" // @manual
 #include "meta/NcclxPerCommConfig.h" // @manual
 #include "channel.h"
@@ -740,53 +741,6 @@ static void showVersion() {
   INFO(NCCL_ALL,"%s", ncclGetGitVersion());
 }
 
-static constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL"; /* key in topology file */
-static ncclResult_t ncclxGetDeviceRackSerial(ncclComm* comm, int* rackSerial) {
-  if (comm == nullptr) {
-    WARN("Invalid state or comm pointer");
-    return ncclInvalidArgument;
-  }
-
-  std::ifstream file(NCCL_TOPO_FILE_PATH);
-  if (!file.is_open()) {
-    WARN("Failed to open topology file: %s", NCCL_TOPO_FILE_PATH.c_str());
-    return ncclSystemError;
-  }
-
-  std::string rackSerialStr;
-  std::string line;
-  bool found = false;
-
-  while (std::getline(file, line)) {
-    size_t pos = line.find('=');
-    if (pos == std::string::npos) {
-      continue;
-    }
-
-    std::string key = line.substr(0, pos);
-    std::string value = line.substr(pos + 1);
-
-    if (key == kDeviceRackSerial) {
-      if (!value.empty()) {
-        rackSerialStr = std::move(value);
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (!found) {
-    INFO(NCCL_INIT, "No rack serial found in topology file");
-  }
-
-  auto maybeRackSerial = folly::tryTo<int>(rackSerialStr);
-  CHECK(maybeRackSerial.hasValue());
-  *rackSerial = maybeRackSerial.value();
-
-  file.close();
-  return ncclSuccess;
-}
-
 NCCL_PARAM(MNNVLUUID, "MNNVL_UUID", -1);
 NCCL_PARAM(MNNVLCliqueId, "MNNVL_CLIQUE_ID", -1);
 NCCL_PARAM(MNNVLCrossClique, "MNNVL_CROSS_CLIQUE", 0);
@@ -864,8 +818,13 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
            info->busId,
            uuid0, uuid1,
            info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+      // [META] Load rack serial for MNNVL trunk disable (string-based, supports alphanumeric serials)
       if(NCCL_MNNVL_TRUNK_DISABLE) {
-        NCCLCHECK(ncclxGetDeviceRackSerial(comm, &info->rackSerial));
+        if (ncclx::loadRackSerial(NCCL_TOPO_FILE_PATH, info->rackSerial, sizeof(info->rackSerial))) {
+          INFO(NCCL_INIT, "Loaded rack serial: %s", info->rackSerial);
+        } else {
+          WARN("No rack serial information available, skipping rack serial check");
+        }
       }
     }
   }


### PR DESCRIPTION
Summary:

- GCP GB300 hosts have alphanumeric `DEVICE_RACK_SERIAL` (e.g. `C1507842765072`) that caused `CHECK(maybeRackSerial.hasValue())` crash in `ncclxGetDeviceRackSerial` when `NCCL_MNNVL_TRUNK_DISABLE=1`
- Add shared `ncclx/meta/DeviceRackSerial.h/cc` with `loadRackSerial()` (string-based, no int conversion) and `isSameRackSerial()` (returns false when either serial is empty)
- Change `ncclPeerInfo.rackSerial` from `int` to `char[kMaxRackSerialLen+1]` across all three NCCLX versions
- Remove duplicated `ncclxGetDeviceRackSerial()` from v2_27/v2_29/v2_30 init.cc, replace with shared `loadRackSerial`
- Update paths.cc in all versions to use `isSameRackSerial()` for string comparison
- WARN when rack serial is missing (required field for NCCL_MNNVL_TRUNK_DISABLE), INFO log the value on success
- Update def_build.bzl and src/Makefile in all versions for both buck and conda builds

Reviewed By: mingrany

Differential Revision: D105113608


