### PR TITLE
Merge ctran algo stats into dumpAlgoStat

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -144,6 +144,14 @@ commResult_t ctranInit(
     return commInternalError;
   }
 
+  for (const auto& opt : NCCL_COLLTRACE) {
+    if (opt == "algostat") {
+      comm->algoStats_ = std::make_unique<meta::comms::colltrace::AlgoStats>(
+          comm->statex_->commHash(), comm->statex_->commDesc());
+      break;
+    }
+  }
+
   auto res = ctranInitializePipes(comm);
   if (res != commSuccess) {
     return res;
@@ -178,13 +186,6 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
   }
   // Default points to internal opCount
   opCount_ = &ctranOpCount_;
-
-  for (const auto& opt : NCCL_COLLTRACE) {
-    if (opt == "algostat") {
-      algoStats_ = std::make_unique<meta::comms::colltrace::AlgoStats>();
-      break;
-    }
-  }
 }
 
 void CtranComm::destroy() {

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -156,6 +156,15 @@ class CtranComm {
   // disabled.
   std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
 
+  // Record a collective algorithm invocation. No-op if algoStats is disabled.
+  inline void recordAlgoStat(
+      const std::string& opName,
+      const std::string& algoName) {
+    if (algoStats_) {
+      algoStats_->record(opName, algoName);
+    }
+  }
+
   // fields are public to allow access from external code and tests
   // TODO: remove config_, it's redundant
   ctranConfig config_;
@@ -207,6 +216,9 @@ class CtranComm {
 
  private:
   friend class CtranGpe;
+  friend commResult_t ctranInit(
+      CtranComm* comm,
+      std::unique_ptr<ctran::IProfilerReporter> reporter);
   std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
   // TODO: define proper constructor to make CtranComm be independent of
   // ncclComm.

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -369,10 +369,8 @@ commResult_t CtranGpe::submit(
     const void* ncclKernel,
     std::optional<std::chrono::milliseconds> timeout,
     PreLaunchGraphPrepareFn graphPrepareFn) {
-  if (this->pimpl->comm->algoStats_) {
-    this->pimpl->comm->algoStats_->record(
-        kernelTypeToOpName(kernelConfig.type), kernelConfig.algoName);
-  }
+  this->pimpl->comm->recordAlgoStat(
+      kernelTypeToOpName(kernelConfig.type), kernelConfig.algoName);
   return this->pimpl->submit(
       CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE,
       std::move(opGroup),

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -26,6 +26,7 @@
 // TODO: Remove this guard once v2_27 is deprecated — v2_27 does not have the
 // comms/utils/colltrace:algostats dependency
 #if NCCL_MINOR >= 28
+#include "comms/ctran/CtranComm.h"
 #include "comms/utils/colltrace/AlgoStats.h"
 #endif
 
@@ -494,11 +495,27 @@ __attribute__((visibility("default"))) void dumpAlgoStat(
     std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>&
         map) {
   map.clear();
-  if (comm == nullptr || comm->algoStats == nullptr) {
+  if (comm == nullptr) {
     return;
   }
-  auto dump = comm->algoStats->dump();
-  map.swap(dump.counts);
+
+  // Dump baseline (ncclx) algo stats
+  if (comm->algoStats) {
+    auto dump = comm->algoStats->dump();
+    map.swap(dump.counts);
+  }
+
+  // Merge ctran algo stats
+  if (comm->ctranComm_) {
+    auto ctranDump = comm->ctranComm_->dumpAlgoStats();
+    if (ctranDump.has_value()) {
+      for (auto& [opName, algoMap] : ctranDump->counts) {
+        for (auto& [algoName, count] : algoMap) {
+          map[opName][algoName] += count;
+        }
+      }
+    }
+  }
 }
 
 namespace {

--- a/comms/ncclx/meta/colltrace/tests/DumpAlgoStatCtranTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/DumpAlgoStatCtranTest.cc
@@ -1,0 +1,119 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/colltrace/AlgoStats.h"
+#include "meta/colltrace/CollTraceWrapper.h"
+
+#include "comm.h"
+#include "nccl.h"
+
+using namespace meta::comms::ncclx;
+
+class DumpAlgoStatCtranTest : public NcclxBaseTestFixture {
+ protected:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_COLLTRACE", "algostat", 1);
+    NcclxBaseTestFixture::SetUp();
+    comm_.emplace(globalRank, numRanks, localRank, bootstrap_.get());
+    ASSERT_NE(comm()->ctranComm_, nullptr);
+    ASSERT_TRUE(comm()->ctranComm_->dumpAlgoStats().has_value());
+  }
+
+  ncclComm_t comm() const {
+    return comm_->get();
+  }
+
+  std::optional<ncclx::test::NcclCommRAII> comm_;
+};
+
+TEST_F(DumpAlgoStatCtranTest, CtranStatsAppearInDump) {
+  comm()->ctranComm_->recordAlgoStat("SendRecv", "CtranSendRecv");
+  comm()->ctranComm_->recordAlgoStat("SendRecv", "CtranSendRecv");
+  comm()->ctranComm_->recordAlgoStat("SendRecv", "CtranSendRecv");
+
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(comm(), map);
+
+  ASSERT_NE(map.find("SendRecv"), map.end());
+  EXPECT_EQ(map["SendRecv"]["CtranSendRecv"], 3);
+}
+
+TEST_F(DumpAlgoStatCtranTest, MergeBaselineAndCtranStats) {
+  ASSERT_NE(comm()->algoStats, nullptr);
+
+  comm()->algoStats->record("AllReduce", "Baseline_Simple_Ring_8");
+  comm()->algoStats->record("AllReduce", "Baseline_Simple_Ring_8");
+
+  comm()->ctranComm_->recordAlgoStat("AllReduce", "CTRing_NVL_8");
+  comm()->ctranComm_->recordAlgoStat("SendRecv", "CtranSendRecv");
+
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(comm(), map);
+
+  ASSERT_NE(map.find("AllReduce"), map.end());
+  EXPECT_EQ(map["AllReduce"]["Baseline_Simple_Ring_8"], 2);
+  EXPECT_EQ(map["AllReduce"]["CTRing_NVL_8"], 1);
+
+  ASSERT_NE(map.find("SendRecv"), map.end());
+  EXPECT_EQ(map["SendRecv"]["CtranSendRecv"], 1);
+}
+
+TEST_F(DumpAlgoStatCtranTest, AdditiveMergeSameAlgo) {
+  ASSERT_NE(comm()->algoStats, nullptr);
+
+  comm()->algoStats->record("AllGather", "SharedAlgo");
+  comm()->algoStats->record("AllGather", "SharedAlgo");
+
+  comm()->ctranComm_->recordAlgoStat("AllGather", "SharedAlgo");
+  comm()->ctranComm_->recordAlgoStat("AllGather", "SharedAlgo");
+  comm()->ctranComm_->recordAlgoStat("AllGather", "SharedAlgo");
+
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(comm(), map);
+
+  ASSERT_NE(map.find("AllGather"), map.end());
+  EXPECT_EQ(map["AllGather"]["SharedAlgo"], 5);
+}
+
+TEST_F(DumpAlgoStatCtranTest, NullCtranComm) {
+  ASSERT_NE(comm()->algoStats, nullptr);
+  comm()->algoStats->record("ReduceScatter", "Baseline_LL_Tree_4");
+
+  comm()->ctranComm_.reset();
+
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(comm(), map);
+
+  ASSERT_NE(map.find("ReduceScatter"), map.end());
+  EXPECT_EQ(map["ReduceScatter"]["Baseline_LL_Tree_4"], 1);
+}
+
+TEST_F(DumpAlgoStatCtranTest, NullComm) {
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(nullptr, map);
+  EXPECT_TRUE(map.empty());
+}
+
+TEST_F(DumpAlgoStatCtranTest, BothNull) {
+  comm()->algoStats.reset();
+  comm()->ctranComm_.reset();
+
+  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> map;
+  ncclx::colltrace::dumpAlgoStat(comm(), map);
+  EXPECT_TRUE(map.empty());
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
- `ncclx::colltrace::dumpAlgoStat()` previously only returned baseline (ncclx) algo stats, missing ctran algo stats entirely. This made ctran collectives invisible in nccl-tests-suite's `NCCL ALGO STAT` output.
- Move ctran `algoStats_` creation from `CtranComm` constructor to `ctranInit()`, where `statex_` is available, so `commHash` and `commDesc` are properly set on the `AlgoStats` object.
- Merge ctran stats into `dumpAlgoStat()` output via additive merge with baseline stats.
- Migrate `CtranGpe::submit()` to use `CtranComm::recordAlgoStat()` (inlined) instead of direct friend access to `algoStats_`.
- Add distributed unit test (`DumpAlgoStatCtranTest`) verifying the merge logic.

Differential Revision: D105098071


