### PR TITLE
Add PLUGIN_STATS transport profiler implementation (#2560)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -31,14 +31,18 @@ Ctran::Ctran(
     : comm_(comm) {
   ctran::logging::initCtranLogging();
 
-  mapper = std::make_unique<CtranMapper>(comm_);
-  gpe = std::make_unique<CtranGpe>(comm->statex_->cudaDev(), comm_);
-
-  algo = std::make_unique<CtranAlgo>(comm, this);
-
+  // Profiler is constructed first so it can be passed into the mapper
+  // (and through to CtranTcpDm) -- CtranTcpDm registers its profiler
+  // hooks during construction, removing the need for a separate
+  // post-construction registerProfilerHooks() round-trip via the mapper.
   if (comm->config_.enableProfiler) {
     profiler = std::make_unique<ctran::Profiler>(comm, std::move(reporter));
   }
+
+  mapper = std::make_unique<CtranMapper>(comm_, profiler.get());
+  gpe = std::make_unique<CtranGpe>(comm->statex_->cudaDev(), comm_);
+
+  algo = std::make_unique<CtranAlgo>(comm, this);
 }
 
 Ctran::~Ctran() {

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -7,9 +7,13 @@
 
 namespace ctran {
 
+class Profiler;
+
 class CtranTcpDm {
  public:
-  explicit CtranTcpDm(CtranComm* comm) {}
+  explicit CtranTcpDm(
+      CtranComm* comm,
+      ctran::Profiler* /*profiler*/ = nullptr) {}
   ~CtranTcpDm() {}
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks) {

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -89,5 +89,8 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool) {
     return commInvalidUsage;
   }
+
+  void profilerStart() {}
+  void profilerEnd() {}
 };
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -117,6 +117,7 @@ void CtranTcpDm::bootstrapAccept() {
     ::comms::tcp_devmem::CommunicatorInterface* recvComm;
     COMMCHECKTHROW(transport_->accept(listenComm, &recvComm));
     COMMCHECKTHROW(transport_->closeListen(listenComm));
+    recvComm->setCommStats(&profilerCtx_.commStats);
 
     bootstrapAddRecvPeer(peerRank, recvComm);
 
@@ -166,6 +167,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
 
   ::comms::tcp_devmem::CommunicatorInterface* sendComm{};
   COMMCHECKTHROW(transport_->connect(netdev_, &handle, &sendComm));
+  sendComm->setCommStats(&profilerCtx_.commStats);
 
   bootstrapAddSendPeer(peerRank, sendComm);
 
@@ -197,6 +199,11 @@ CtranTcpDm::CtranTcpDm(
 
   transport_->open(netdev_);
 
+  profilerCtx_.cuDev = cudaDev_;
+  profilerCtx_.rank = rank_;
+  profilerCtx_.nRanks = nRanks_;
+  profilerCtx_.commHash = commHash_;
+
   bootstrapPrepare(comm->bootstrap_.get());
 
   registerProfilerHooks(profiler);
@@ -226,6 +233,14 @@ CtranTcpDm::~CtranTcpDm() {
   if (transport_.use_count() <= 2) {
     transport_->shutdown(false);
   }
+}
+
+void CtranTcpDm::profilerStart() {
+  transport_->profilerStart(profilerCtx_);
+}
+
+void CtranTcpDm::profilerEnd() {
+  transport_->profilerEnd(profilerCtx_);
 }
 
 commResult_t CtranTcpDm::preConnect(const std::unordered_set<int>& peerRanks) {
@@ -398,12 +413,10 @@ void CtranTcpDm::registerProfilerHooks(ctran::Profiler* profiler) {
   if (!profiler) {
     return;
   }
-  profiler->registerStartHook(ProfilerEvent::ALGO_TOTAL, [this]() {
-    // Transport profiler start -- to be implemented.
-  });
-  profiler->registerEndHook(ProfilerEvent::ALGO_TOTAL, [this]() {
-    // Transport profiler end -- to be implemented.
-  });
+  profiler->registerStartHook(
+      ProfilerEvent::ALGO_TOTAL, [this]() { profilerStart(); });
+  profiler->registerEndHook(
+      ProfilerEvent::ALGO_TOTAL, [this]() { profilerEnd(); });
 }
 
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/StrUtils.h"
@@ -182,7 +183,9 @@ commResult_t CtranTcpDm::bootstrapConnect(
   return res;
 }
 
-CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
+CtranTcpDm::CtranTcpDm(
+    [[maybe_unused]] CtranComm* comm,
+    ctran::Profiler* profiler) {
   transport_ = CtranTcpDmSingleton::getTransport();
 
   cudaDev_ = comm->statex_->cudaDev();
@@ -195,6 +198,8 @@ CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
   transport_->open(netdev_);
 
   bootstrapPrepare(comm->bootstrap_.get());
+
+  registerProfilerHooks(profiler);
 
   CLOGF_SUBSYS(
       INFO,
@@ -387,6 +392,18 @@ CtranTcpDm::prepareUnpackConsumer(SQueues* sqs, size_t blocks, void** pool) {
 commResult_t CtranTcpDm::teardownUnpackConsumer(void* pool) {
   COMMCHECK_TCP(transport_->teardownUnpackConsumer(netdev_, pool));
   return commSuccess;
+}
+
+void CtranTcpDm::registerProfilerHooks(ctran::Profiler* profiler) {
+  if (!profiler) {
+    return;
+  }
+  profiler->registerStartHook(ProfilerEvent::ALGO_TOTAL, [this]() {
+    // Transport profiler start -- to be implemented.
+  });
+  profiler->registerEndHook(ProfilerEvent::ALGO_TOTAL, [this]() {
+    // Transport profiler end -- to be implemented.
+  });
 }
 
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -80,6 +80,9 @@ class CtranTcpDm {
     return commSuccess;
   }
 
+  void profilerStart();
+  void profilerEnd();
+
   // irecv operations can not proceed unless the peer has been connected.
   // When there is no peer, irecv operations are queued and progress()
   // has to be called to make progress on them.
@@ -100,6 +103,7 @@ class CtranTcpDm {
   // mapper no longer needs to drive registration post-construction.
   void registerProfilerHooks(ctran::Profiler* profiler);
 
+  ::comms::tcp_devmem::ProfilerContext profilerCtx_{};
   std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;
   ctran::bootstrap::ServerSocket listenSocket_{
       static_cast<int>(NCCL_SOCKET_RETRY_CNT)};

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -14,9 +14,14 @@
 
 namespace ctran {
 
+class Profiler;
+
 class CtranTcpDm {
  public:
-  explicit CtranTcpDm(CtranComm* comm);
+  // `profiler` may be null when the comm has profiling disabled. When
+  // non-null, the transport registers its ALGO_TOTAL start/end hooks
+  // directly in the constructor.
+  explicit CtranTcpDm(CtranComm* comm, ctran::Profiler* profiler = nullptr);
   ~CtranTcpDm();
 
   commResult_t preConnect(const std::unordered_set<int>& peerRanks);
@@ -90,6 +95,11 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool);
 
  private:
+  // Called from the constructor when a non-null Profiler is supplied;
+  // attaches ALGO_TOTAL start/end hooks. Kept private now that the
+  // mapper no longer needs to drive registration post-construction.
+  void registerProfilerHooks(ctran::Profiler* profiler);
+
   std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;
   ctran::bootstrap::ServerSocket listenSocket_{
       static_cast<int>(NCCL_SOCKET_RETRY_CNT)};

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -93,7 +93,7 @@ void computePacketSlice(
 
 } // namespace
 
-CtranMapper::CtranMapper(CtranComm* comm) {
+CtranMapper::CtranMapper(CtranComm* comm, ctran::Profiler* profiler) {
   const auto statex = comm->statex_.get();
   if (NCCL_MAPPERTRACE_ENABLE) {
     this->mapperTrace = std::make_unique<ncclx::colltrace::MapperTrace>();
@@ -177,7 +177,8 @@ CtranMapper::CtranMapper(CtranComm* comm) {
     }
   }
   if (enableBackends_[CtranMapperBackend::TCPDM]) {
-    this->ctranTcpDm = std::make_unique<class ctran::CtranTcpDm>(comm);
+    this->ctranTcpDm =
+        std::make_unique<class ctran::CtranTcpDm>(comm, profiler);
     CLOGF(WARN, "CTRAN-MAPPER: TCPDM backend is enabled");
   }
 

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -47,7 +47,11 @@ const std::string getReqTypeStr(CtranMapperRequest::ReqType type);
 
 class CtranMapper : public ctran::regcache::IpcExportClient {
  public:
-  CtranMapper(CtranComm* comm);
+  // `profiler` may be null when the comm has profiling disabled. When
+  // non-null, it is forwarded to the underlying CtranTcpDm so the
+  // transport can register its hooks during construction (avoiding a
+  // separate post-construction wiring pass).
+  CtranMapper(CtranComm* comm, ctran::Profiler* profiler = nullptr);
   ~CtranMapper();
 
   // Allow caller to mapper to mark the mapper object is being destroyed.

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -47,9 +47,7 @@ void Profiler::initForEachColl(int opCount, int samplingWeight) {
   }
 }
 
-void Profiler::startEvent(
-    ProfilerEvent event,
-    const std::function<void(Profiler&)>& callback) {
+void Profiler::startEvent(ProfilerEvent event) {
   if (!shouldTrace_) {
     return;
   }
@@ -58,14 +56,12 @@ void Profiler::startEvent(
   if (event == ProfilerEvent::ALGO_CTRL) {
     readyTs_ = getTimeStamp(timers_[idx].getCheckpoint());
   }
-  if (callback) {
-    callback(*this);
+  for (const auto& hook : startHooks_[idx]) {
+    hook();
   }
 }
 
-void Profiler::endEvent(
-    ProfilerEvent event,
-    const std::function<void(Profiler&)>& callback) {
+void Profiler::endEvent(ProfilerEvent event) {
   if (!shouldTrace_) {
     return;
   }
@@ -74,8 +70,8 @@ void Profiler::endEvent(
   if (event == ProfilerEvent::ALGO_CTRL) {
     controlTs_ = getTimeStamp(timers_[idx].getCheckpoint());
   }
-  if (callback) {
-    callback(*this);
+  for (const auto& hook : endHooks_[idx]) {
+    hook();
   }
 }
 
@@ -113,6 +109,14 @@ void Profiler::reportToScuba() {
   }
 
   shouldTrace_ = false;
+}
+
+void Profiler::registerStartHook(ProfilerEvent event, EventHook hook) {
+  startHooks_[static_cast<size_t>(event)].push_back(std::move(hook));
+}
+
+void Profiler::registerEndHook(ProfilerEvent event, EventHook hook) {
+  endHooks_[static_cast<size_t>(event)].push_back(std::move(hook));
 }
 
 } // namespace ctran

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -37,6 +37,9 @@ class Profiler {
   using EventDurationArray = std::array<uint64_t, NUM_PROFILER_EVENT_TYPES>;
   using EventTimerArray =
       std::array<utils::StopWatch<Clock>, NUM_PROFILER_EVENT_TYPES>;
+  using EventHook = std::function<void()>;
+  using EventHookArray =
+      std::array<std::vector<EventHook>, NUM_PROFILER_EVENT_TYPES>;
 
  public:
   // Construct with a reporter. If nullptr, defaults to
@@ -74,15 +77,18 @@ class Profiler {
     return controlTs_;
   }
 
-  void startEvent(
-      ProfilerEvent event,
-      const std::function<void(Profiler&)>& callback = {});
+  void startEvent(ProfilerEvent event);
 
-  void endEvent(
-      ProfilerEvent event,
-      const std::function<void(Profiler&)>& callback = {});
+  void endEvent(ProfilerEvent event);
 
   void reportToScuba();
+
+  // Register a hook that fires at the start / end of the given
+  // ProfilerEvent. Multiple hooks per (event, phase) are supported and
+  // fire in registration order. Hooks should be cheap and exception-free
+  // -- they run on the hot path of every traced collective.
+  void registerStartHook(ProfilerEvent event, EventHook hook);
+  void registerEndHook(ProfilerEvent event, EventHook hook);
 
  public:
   AlgoContext algoContext{};
@@ -98,6 +104,8 @@ class Profiler {
   uint64_t readyTs_{0};
   uint64_t controlTs_{0};
   std::unique_ptr<IProfilerReporter> reporter_;
+  EventHookArray startHooks_{};
+  EventHookArray endHooks_{};
 };
 
 } // namespace ctran


### PR DESCRIPTION
Summary:

Implement per-CtranComm transport stats via profilerStart/profilerEnd. Each CtranTcpDm's Communicators write to a shared commStats accumulator. profilerStart resets commStats to zero, profilerEnd emits the accumulated values as a PLUGIN_STATS Scuba event with rank, nRanks, commHash, cuDev, send/recv count/bytes/completed/timeUs.

Reviewed By: erfan111

Differential Revision: D104862733


