### PR TITLE
Add multi-NIC TCPDM allreduce tests (2x2, 2x4)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -30,29 +30,29 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-// Key for kernel function lookup: (datatype, redOp, enableBidirAg)
-using KernelFuncKey = std::tuple<commDataType_t, commRedOp_t, bool>;
+// Key for kernel function lookup: (datatype, redOp, enableBidirAg, unpack)
+using KernelFuncKey = std::tuple<commDataType_t, commRedOp_t, bool, bool>;
 
-// Build a single (datatype, redOp, bidir) → kernel function pointer map
-// containing all template combinations. Adding a new template parameter
-// only requires updating the lambda and key, not duplicating the type list.
+// Build a single (datatype, redOp, bidir, unpack) → kernel function pointer
+// map containing all template combinations.
 auto makeKernelMap() {
   std::map<KernelFuncKey, const void*> m;
-  auto reg = [&]<typename T, bool Bidir>(commDataType_t dt) {
-    m[{dt, commSum, Bidir}] = reinterpret_cast<const void*>(
-        &ncclKernelAllReduceCtranRing<T, commSum, Bidir>);
-    m[{dt, commProd, Bidir}] = reinterpret_cast<const void*>(
-        &ncclKernelAllReduceCtranRing<T, commProd, Bidir>);
-    m[{dt, commAvg, Bidir}] = reinterpret_cast<const void*>(
-        &ncclKernelAllReduceCtranRing<T, commAvg, Bidir>);
-    m[{dt, commMax, Bidir}] = reinterpret_cast<const void*>(
-        &ncclKernelAllReduceCtranRing<T, commMax, Bidir>);
-    m[{dt, commMin, Bidir}] = reinterpret_cast<const void*>(
-        &ncclKernelAllReduceCtranRing<T, commMin, Bidir>);
+  auto reg = [&]<typename T, bool Bidir, bool Unpack>(commDataType_t dt) {
+    m[{dt, commSum, Bidir, Unpack}] = reinterpret_cast<const void*>(
+        &ncclKernelAllReduceCtranRing<T, commSum, Bidir, Unpack>);
+    m[{dt, commProd, Bidir, Unpack}] = reinterpret_cast<const void*>(
+        &ncclKernelAllReduceCtranRing<T, commProd, Bidir, Unpack>);
+    m[{dt, commAvg, Bidir, Unpack}] = reinterpret_cast<const void*>(
+        &ncclKernelAllReduceCtranRing<T, commAvg, Bidir, Unpack>);
+    m[{dt, commMax, Bidir, Unpack}] = reinterpret_cast<const void*>(
+        &ncclKernelAllReduceCtranRing<T, commMax, Bidir, Unpack>);
+    m[{dt, commMin, Bidir, Unpack}] = reinterpret_cast<const void*>(
+        &ncclKernelAllReduceCtranRing<T, commMin, Bidir, Unpack>);
   };
   auto regAll = [&]<typename T>(commDataType_t dt) {
-    reg.template operator()<T, false>(dt);
-    reg.template operator()<T, true>(dt);
+    reg.template operator()<T, false, false>(dt);
+    reg.template operator()<T, true, false>(dt);
+    reg.template operator()<T, false, true>(dt);
   };
   regAll.template operator()<int8_t>(commInt8);
   regAll.template operator()<uint8_t>(commUint8);
@@ -130,6 +130,14 @@ inline bool shouldEnableBidirAg(size_t messageBytes, GpuArch arch) {
 namespace {
 
 const auto myAlgo = NCCL_ALLREDUCE_ALGO::ctring;
+
+// Query whether the left peer (recv direction) uses TCPDM backend.
+inline bool hasTcpDmRecv(
+    const ctran::allreduce::ring::HostArgs& args,
+    const ctran::allreduce::ring::HostResource& resource) {
+  return resource.comm->ctran_->mapper->getBackend(args.leftRank) ==
+      CtranMapperBackend::TCPDM;
+}
 
 inline std::string toHexStr(void* ptr) {
   std::stringstream ss;
@@ -519,6 +527,36 @@ inline void progressRecvPostRecvBuf(
   bufSyncSResps.at(round).reset(req);
 }
 
+// Post irecv for the current round (TCPDM requires 1:1 irecv per iput).
+// Round 0, partition 0 is posted in completeHostResourceSetup.
+inline void progressRecvPostTcpDmIrecv(
+    const ctran::allreduce::ring::HostArgs& args,
+    ctran::allreduce::ring::HostResource& resource,
+    const AlgoContext& algoCtx) {
+  int round = algoCtx.opRounds[Op::kRecvTrans].post;
+  int tmpChunkId = getTmpChunkId(algoCtx, round);
+  auto chunkArg = getRoundArgs<Op::kRecvTrans>(
+      algoCtx, round, algoCtx.opRounds[Op::kRecvTrans].postStep);
+  char* chunkRecvBuf = reinterpret_cast<char*>(resource.tmpRecvBuf) +
+      tmpChunkId * algoCtx.chunkSize;
+  size_t chunkBytes = chunkArg.numel * algoCtx.typeSize;
+  resource.recvKernElem->waitNotify.recvbuff = chunkRecvBuf;
+  resource.recvKernElem->waitNotify.nbytes = chunkBytes;
+  if (round > 0 || algoCtx.partition > 0) {
+    // The TCPDM needs to call initNotify, i.e. tcpdm->irecv() in every single
+    // recv round. Reuse the initNotify mechnaisim here to post irecv().
+    // Reuse leftNotify — the ready counter guarantees the previous round's
+    // checkNotify completed before we post the next irecv.
+    FB_COMMCHECKTHROW_EX(
+        resource.comm->ctran_->mapper->initNotify(
+            args.leftRank,
+            resource.tmpRecvBufHdl,
+            resource.recvKernElem,
+            args.leftNotify.get()),
+        resource.comm->logMetaData_);
+  }
+}
+
 inline void progressSend(
     const ctran::allreduce::ring::HostArgs& args,
     ctran::allreduce::ring::HostResource& resource,
@@ -557,16 +595,35 @@ inline void progressRecv(
     AlgoContext& algoCtx,
     std::vector<std::unique_ptr<CtranMapperRequest>>& bufSyncSResps,
     std::vector<std::unique_ptr<CtranMapperRequest>>& flushResps) {
-  // Post step (no-op for IB — data arrives via RDMA put, not receiver post).
-  // Split from check step to allow future backends to insert work here.
+  // Post step: TCPDM posts irecv, IB is a no-op (data arrives via RDMA put).
+  // Serialized via ready counter (TCPDM: ready=1, IB: ready=-1 unlimited).
   if (opReadyToPost<Op::kRecvTrans>(algoCtx)) {
-    opUpdatePost<Op::kRecvTrans>(algoCtx);
+    if (hasTcpDmRecv(args, resource)) {
+      // TCPDM: don't post irecv if the target tmpRecvBuf slot is still being
+      // read by a previous round's recvRedCopy. IB doesn't need this because
+      // the sender-side bufSync gates writes until recvRedCopy completes.
+      int round = algoCtx.opRounds[Op::kRecvTrans].post;
+      bool slotFree = round < static_cast<int>(algoCtx.numChunks) ||
+          algoCtx.opRounds[Op::kRecvRedCopy].done >
+              round - static_cast<int>(algoCtx.numChunks);
+      if (slotFree) {
+        progressRecvPostTcpDmIrecv(args, resource, algoCtx);
+        opUpdatePost<Op::kRecvTrans>(algoCtx);
+      }
+    } else {
+      opUpdatePost<Op::kRecvTrans>(algoCtx);
+    }
   }
 
   // Check if data has arrived from left peer
   if (opHasPosted<Op::kRecvTrans>(algoCtx) &&
       progressRecvCheckTrans(args, resource, algoCtx)) {
     opUpdateDone<Op::kRecvTrans>(algoCtx);
+    if (hasTcpDmRecv(args, resource)) {
+      // Allow next round's irecv to post (one in flight at a time —
+      // initNotify reuses leftNotify after checkNotify completes).
+      algoCtx.opRounds[Op::kRecvTrans].ready++;
+    }
   }
 
   // Check if any received chunk is ready to flush
@@ -574,7 +631,6 @@ inline void progressRecv(
     progressRecvPostFlush(args, resource, algoCtx, flushResps);
     opUpdatePost<Op::kRecvFlush>(algoCtx);
   }
-
   // Check if any outstanding flush is done
   if (opHasPosted<Op::kRecvFlush>(algoCtx)) {
     if (progressRecvCheckFlush(args, resource, algoCtx, flushResps)) {
@@ -928,6 +984,12 @@ inline void updatePartitionCtxHost(
   } else {
     updatePartitionCtx<false>(algoCtx);
   }
+  if (hasTcpDmRecv(args, resource)) {
+    // TCPDM: serialize irecv posts (one at a time) since initNotify reuses
+    // leftNotify. IB uses ready=-1 to pre-post all rounds.
+    algoCtx.opRounds[Op::kRecvTrans].ready = 1;
+  }
+
   if (algoCtx.partition > 0) {
     // Sync with kernel to start the new partition if not the first one.
     resource.partitionSync->post(algoCtx.partition);
@@ -961,7 +1023,10 @@ inline commResult_t completeHostResourceSetup(
   // Forward: notifications from left on tmpRecvBuf
   args.leftNotify.reset(new CtranMapperNotify());
   FB_COMMCHECK(comm->ctran_->mapper->initNotify(
-      args.leftRank, resource.tmpRecvBufHdl, args.leftNotify.get()));
+      args.leftRank,
+      resource.tmpRecvBufHdl,
+      resource.recvKernElem,
+      args.leftNotify.get()));
 
   size_t offsetRingTmpRecv = comm->ctran_->algo->getTmpBufOffset(
       CtranAlgo::TmpbufType::RING_TMP_RECV_BUF);
@@ -1020,6 +1085,12 @@ static commResult_t impl(
   auto& resource = op->allreduce.hostResource;
 
   if (!resource.setupComplete) {
+    size_t msgSize = op->allreduce.count * commTypeSize(op->allreduce.datatype);
+    CtranMapperContext context(allReduceAlgoName(myAlgo), msgSize, msgSize);
+    // TCPDM uses unpackPool for irecv routing; nullptr for IB (ignored).
+    context.unpackPool = op->unpackPool;
+    comm->ctran_->mapper->setContext(std::move(context));
+
     FB_COMMCHECK(completeHostResourceSetup(comm, args, resource));
     resource.setupComplete = true;
   }
@@ -1289,18 +1360,29 @@ commResult_t ctranAllReduceRing(
   auto arch = ctran::allreduce::ring::GpuArch::Default;
   FB_COMMCHECK(getGpuArch(&arch));
 
-  // Select kernel based on bi-directional AG CVAR and message size
-  const bool enableBidirAg =
+  // Detect TCPDM backend for left peer (recv direction)
+  bool hasTcpDmRecv =
+      comm->ctran_->mapper->getBackend((rank - 1 + nRanks) % nRanks) ==
+      CtranMapperBackend::TCPDM;
+
+  bool enableBidirAg =
       ctran::allreduce::ring::shouldEnableBidirAg(messageBytes, arch);
-  auto kernelKey = KernelFuncKey{datatype, redOp, enableBidirAg};
+  // TODO: enable bidir AG for TCPDM (requires allocating a reverse
+  // recvKernElem for the reverse path's initNotify/irecv).
+  FB_CHECKTHROW_EX(
+      !(hasTcpDmRecv && enableBidirAg),
+      comm->logMetaData_,
+      "bidir AG is not yet supported with TCPDM backend");
+  auto kernelKey = KernelFuncKey{datatype, redOp, enableBidirAg, hasTcpDmRecv};
   FB_CHECKTHROW_EX(
       kernelFuncMap.contains(kernelKey),
       comm->logMetaData_,
       fmt::format(
-          "kernelFuncMap does not contain datatype {} op {} bidir {}",
+          "kernelFuncMap does not contain datatype {} op {} bidir {} unpack {}",
           datatype,
           redOp,
-          enableBidirAg));
+          enableBidirAg,
+          hasTcpDmRecv));
   const void* func = kernelFuncMap.at(kernelKey);
 
   int numBlocks = 0;
@@ -1338,9 +1420,8 @@ commResult_t ctranAllReduceRing(
 
   auto& hostResource = op->allreduce.hostResource;
   hostResource.comm = comm;
+
   std::vector<ctran::algos::GpeKernelSync*> gpeKernelSyncs;
-  // 3 forward (sendCopy, recvRedCopy, partition) + 2 reverse (revSendCopy,
-  // revRecvCopy)
   constexpr size_t kAllReduceRingNumSyncs = 5;
   FB_COMMCHECK(comm->ctran_->gpe->allocGpeKernelSyncs(
       kAllReduceRingNumSyncs, numBlocks, gpeKernelSyncs));
@@ -1386,6 +1467,18 @@ commResult_t ctranAllReduceRing(
   hostArgs.numBlocks = numBlocks;
   hostArgs.numThreads = numThreads;
   hostArgs.enableBidirAg = enableBidirAg;
+
+  if (hasTcpDmRecv) {
+    // Pre-allocate KernelElem for TCPDM initNotify on main thread.
+    // TCPDM's initNotify requires kernElem with recvbuff/nbytes for irecv.
+    FB_COMMCHECK(
+        comm->ctran_->gpe->allocKernelElems(1, 1, &hostResource.recvKernElem));
+    hostResource.recvKernElem->waitNotify.recvbuff = hostResource.tmpRecvBuf;
+    hostResource.recvKernElem->waitNotify.nbytes = hostResource.chunkSize;
+    op->allreduce.kElemStepMap[static_cast<int>(
+        ctran::allreduce::KernElemRole::kTcpDmRecv)] =
+        hostResource.recvKernElem;
+  }
   // rightRemBuf, rightRemKey, leftNotify init from gpe thread for EpochLock
 
   opGroup.push_back(std::move(op));
@@ -1420,6 +1513,12 @@ commResult_t ctranAllReduceRing(
   };
   // Used only in gpe->submit, copied as a Kernel Launch Arg.
   config.algoArgs = &kernArgs;
+
+  // TCPDM: populate SQueues so the kernel can drain scattered TCP chunks
+  if (hasTcpDmRecv) {
+    FB_COMMCHECK(comm->ctran_->mapper->prepareUnpackConsumer(
+        &kernArgs.unpack, numBlocks, opGroup, config));
+  }
 
   // TODO: delete, this is for colltrace: Find a way to make colltrace use
   // settings from above. Currently colltrace cannot fetch information from

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cuh
@@ -11,6 +11,12 @@
 #include "comms/ctran/gpe/CtranGpeDev.h"
 #include "comms/utils/commSpecs.h"
 
+#ifdef CTRAN_TCPDM_ENABLE
+#include "comms/tcp_devmem/unpack/batch_unpack_kernel.cuh"
+#include "comms/tcp_devmem/unpack/batch_unpack_kernel.h"
+#include "comms/tcp_devmem/unpack/batch_unpack_kernel_device.h"
+#endif
+
 namespace ctran::allreduce::ring {
 
 namespace {
@@ -18,6 +24,10 @@ namespace {
 using ctran::algos::GpeKernelSyncDev::checkPost;
 using ctran::algos::GpeKernelSyncDev::complete;
 using ctran::algos::GpeKernelSyncDev::waitPost;
+
+#ifdef CTRAN_TCPDM_ENABLE
+__shared__ UnpackBlockState allReduceRingUnpack;
+#endif
 
 } // namespace
 
@@ -38,19 +48,33 @@ __device__ __forceinline__ const T* getBufAtByteOffset(
       reinterpret_cast<const char*>(buf) + offset);
 }
 
-template <typename T, commRedOp_t RedOp>
+template <typename T, commRedOp_t RedOp, bool Unpack>
 __device__ __forceinline__ void _progressRecv(
     ctran::allreduce::ring::KernArgs& args,
     AlgoContext& algoCtx) {
+#ifdef CTRAN_TCPDM_ENABLE
+  if constexpr (Unpack) {
+    SQueue* sq = args.unpack.sq[blockIdx.x];
+    __shared__ int sqReady;
+    if (threadIdx.x == 0) {
+      sqReady = (sq != nullptr && !device_queue_empty(&sq->header)) ? 1 : 0;
+    }
+    __syncthreads();
+    if (sqReady) {
+      StrideInfos strideInfos{};
+      setupUnpackStrides(strideInfos, GET_ALGO_NUM(sq->header.flags));
+      unpack(
+          sq, &allReduceRingUnpack, strideInfos, &sq->header.flags, 0, false);
+    }
+  }
+#endif
+
   OpRound& opRound = algoCtx.opRounds[Op::kRecvRedCopy];
   int round = opRound.done;
   if (round >= opRound.totalRounds) {
-    // Already finished all rounds
     return;
   }
-  // Wait for host side to post the request
   if (!checkPost(args.recvRedCopySync, blockIdx.x, round)) {
-    // TODO: FT CHECK_ABORT
     return;
   }
 
@@ -304,7 +328,7 @@ __device__ __forceinline__ void updatePartitionCtxDevice(
   }
 }
 
-template <typename T, commRedOp_t RedOp, bool EnableBidirAg>
+template <typename T, commRedOp_t RedOp, bool EnableBidirAg, bool Unpack>
 __device__ void algoFn(ctran::allreduce::ring::KernArgs& args) {
   // Setup algorithm context
   AlgoContext algoCtx = {
@@ -341,7 +365,7 @@ __device__ void algoFn(ctran::allreduce::ring::KernArgs& args) {
     };
     while (notDone()) {
       _progressSend<T, RedOp>(args, algoCtx);
-      _progressRecv<T, RedOp>(args, algoCtx);
+      _progressRecv<T, RedOp, Unpack>(args, algoCtx);
       _progressRevSend<T, RedOp, EnableBidirAg>(args, algoCtx);
       _progressRevRecv<T, RedOp, EnableBidirAg>(args, algoCtx);
       KERNEL_ABORT();
@@ -354,9 +378,13 @@ __device__ void algoFn(ctran::allreduce::ring::KernArgs& args) {
 } // namespace ctran::allreduce::ring
 
 // EnableBidirAg template parameter:
+// EnableBidirAg:
 // - true: bi-directional AllGather with reverse direction (default)
 // - false: standard single-direction AG (lower register usage)
-template <typename T, commRedOp_t RedOp, bool EnableBidirAg>
+// Unpack:
+// - true: TCPDM unpack path (drain SQueues in kernel)
+// - false: IB path (no kernel-side unpack)
+template <typename T, commRedOp_t RedOp, bool EnableBidirAg, bool Unpack>
 __global__ void ncclKernelAllReduceCtranRing(
     int* flag,
     CtranAlgoDeviceState* devState,
@@ -373,7 +401,7 @@ __global__ void ncclKernelAllReduceCtranRing(
   }
 
   // Run algorithm main body
-  ctran::allreduce::ring::algoFn<T, RedOp, EnableBidirAg>(args);
+  ctran::allreduce::ring::algoFn<T, RedOp, EnableBidirAg, Unpack>(args);
 
   // This sync threads ensure that every thread in the block has completed using
   // the flag status before resetting it by thread 0 below.
@@ -386,20 +414,31 @@ __global__ void ncclKernelAllReduceCtranRing(
 }
 
 // Instantiation macro for bi-directional AG kernel
-#define DECL_CTRAN_ALLREDUCERING_KERN_BIDIR(T, RedOp)                    \
-  template __global__ void ncclKernelAllReduceCtranRing<T, RedOp, true>( \
-      int* flag,                                                         \
-      CtranAlgoDeviceState* devState,                                    \
+#define DECL_CTRAN_ALLREDUCERING_KERN_BIDIR(T, RedOp)  \
+  template __global__ void                             \
+  ncclKernelAllReduceCtranRing<T, RedOp, true, false>( \
+      int* flag,                                       \
+      CtranAlgoDeviceState* devState,                  \
       ctran::allreduce::ring::KernArgs args);
 
 // Instantiation macro for simple kernel (no bidir AG, lower register usage)
-#define DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE(T, RedOp)                    \
-  template __global__ void ncclKernelAllReduceCtranRing<T, RedOp, false>( \
-      int* flag,                                                          \
-      CtranAlgoDeviceState* devState,                                     \
+#define DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE(T, RedOp)  \
+  template __global__ void                              \
+  ncclKernelAllReduceCtranRing<T, RedOp, false, false>( \
+      int* flag,                                        \
+      CtranAlgoDeviceState* devState,                   \
       ctran::allreduce::ring::KernArgs args);
 
-// Combined macro to instantiate both kernel variants
-#define DECL_CTRAN_ALLREDUCERING_KERN(T, RedOp) \
-  DECL_CTRAN_ALLREDUCERING_KERN_BIDIR(T, RedOp) \
-  DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE(T, RedOp)
+// Instantiation macro for simple kernel with TCPDM unpack
+#define DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE_UNPACK(T, RedOp) \
+  template __global__ void                                    \
+  ncclKernelAllReduceCtranRing<T, RedOp, false, true>(        \
+      int* flag,                                              \
+      CtranAlgoDeviceState* devState,                         \
+      ctran::allreduce::ring::KernArgs args);
+
+// Combined macro to instantiate all kernel variants
+#define DECL_CTRAN_ALLREDUCERING_KERN(T, RedOp)  \
+  DECL_CTRAN_ALLREDUCERING_KERN_BIDIR(T, RedOp)  \
+  DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE(T, RedOp) \
+  DECL_CTRAN_ALLREDUCERING_KERN_SIMPLE_UNPACK(T, RedOp)

--- a/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceRingCommon.cuh
@@ -9,6 +9,13 @@
 #include "comms/ctran/utils/DevAttribute.h"
 #include "comms/utils/commSpecs.h"
 
+#ifndef CTRAN_DISABLE_TCPDM
+#define CTRAN_TCPDM_ENABLE
+#include "comms/tcp_devmem/unpack/batch_unpack_kernel.h"
+#else
+#include "comms/ctran/backends/mock/CtranTcpDmBaseMock.h"
+#endif
+
 namespace ctran::allreduce::ring {
 
 struct KernArgs {
@@ -34,6 +41,9 @@ struct KernArgs {
   ctran::algos::GpeKernelSync* revRecvCopySync;
   void* tmpSendBufRev;
   void* tmpRecvBufRev;
+
+  // TCPDM unpack support
+  SQueues unpack{};
 };
 
 // used by e.g. NanChecker and Trace
@@ -568,10 +578,13 @@ DEVICE_ATTRIBUTE void opUpdateDone(AlgoContext& algoCtx) {
 
 } // namespace ctran::allreduce::ring
 
-// EnableBidirAg template parameter:
-// - true: bi-directional AllGather with reverse direction
-// - false: standard single-direction AG (lower register usage)
-template <typename T, commRedOp_t RedOp, bool EnableBidirAg>
+// EnableBidirAg: true = bi-directional AG, false = standard AG
+// Unpack: true = TCPDM SQueue unpack, false = IB (no unpack)
+template <
+    typename T,
+    commRedOp_t RedOp,
+    bool EnableBidirAg,
+    bool Unpack = false>
 __global__ void ncclKernelAllReduceCtranRing(
     int* flag,
     CtranAlgoDeviceState* devState,

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -18,7 +18,8 @@ enum class KernElemRole {
   kIntraAllGather,
   kRemIntraReduce,
   kRemIntraBcast,
-  kRemInterReduce
+  kRemInterReduce,
+  kTcpDmRecv
 };
 
 struct KernelArgs {
@@ -85,6 +86,8 @@ struct HostArgs {
 
 struct HostResource {
   ~HostResource() {
+    // recvKernElem is freed via kElemStepMap in ~OpElem() (CtranGpe.cc).
+
     // Release GpeKernelSyncs back to pool (sets inuse=false so pool can
     // reclaim). For graph-captured ops, this runs at graph destruction time
     // via cmdDestroy -> delete cmd -> ~OpElem -> ~HostResource, preventing
@@ -119,6 +122,10 @@ struct HostResource {
   void* tmpSendBufHdl{nullptr};
   void* tmpRecvBuf{nullptr};
   void* tmpRecvBufHdl{nullptr};
+
+  // KernelElem for recv-side initNotify. Allocated only for TCPDM (carries
+  // irecv buffer/size); nullptr for IB (IB's initNotify doesn't need it).
+  KernelElem* recvKernElem{nullptr};
 
   // Reverse direction
   ctran::algos::GpeKernelSync* revSendCopySync{nullptr};

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -4,6 +4,7 @@
 #include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <mpi.h>
 #include <stdlib.h>
 #include <thread>
 
@@ -544,8 +545,25 @@ class CtranAllReduceRingTcpDmTestFp32
     setenv("NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS", "16", 1);
     setenv("NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE", "256", 1);
 
-    // GPU closest to beth0 (mlx5_4) on GRANDTETON hosts
-    setenv("CUDA_VISIBLE_DEVICES", "2", 1);
+    // Detect number of local ranks (ppn) from MPI
+    int worldSize = 1;
+    MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+    // With 2 hosts, ppn = worldSize / 2
+    int numHosts = 2;
+    int ppn = worldSize / numHosts;
+
+    // PIX-optimal GPU/NIC assignment for GRANDTETON H100:
+    //   beth3 → GPU 0, beth4 → GPU 1, beth0 → GPU 2, beth1 → GPU 3
+    if (ppn >= 4) {
+      setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3", 1);
+      setenv("TCP_DEVMEM_IFNAME", "beth3,beth4,beth0,beth1", 1);
+    } else if (ppn >= 2) {
+      setenv("CUDA_VISIBLE_DEVICES", "2,3", 1);
+      setenv("TCP_DEVMEM_IFNAME", "beth0,beth1", 1);
+    } else {
+      setenv("CUDA_VISIBLE_DEVICES", "2", 1);
+      setenv("TCP_DEVMEM_IFNAME", "beth0", 1);
+    }
 
     // TCPDM transport config
     setenv("TCP_DEVMEM_STEER_ACTIVE_OPEN", "1", 1);
@@ -558,7 +576,6 @@ class CtranAllReduceRingTcpDmTestFp32
     setenv("TCP_DEVMEM_RX_WORKERS_PER_DEV", "4", 1);
     setenv("TCP_DEVMEM_SOCKETS_PER_COMM", "4", 1);
     setenv("TCP_DEVMEM_QUEUES", "4", 1);
-    setenv("TCP_DEVMEM_IFNAME", "beth0", 1);
     setenv("TCP_DEVMEM_SKIP_AGENT", "1", 1);
     setenv("TCP_DEVMEM_SKIP_LOGGER", "1", 1);
 
@@ -570,9 +587,9 @@ class CtranAllReduceRingTcpDmTestFp32
     setenv("NCCL_SHM_DISABLE", "1", 1);
     setenv("NCCL_RAS_ENABLE", "0", 1);
 
-    // NCCL bootstrap: match SOCKET_IFNAME with CLIENT_SOCKET_IFNAME
-    setenv("NCCL_SOCKET_IFNAME", "beth0", 1);
-    setenv("NCCL_CLIENT_SOCKET_IFNAME", "beth0", 1);
+    // NCCL bootstrap on beth7 (separate from data NICs)
+    setenv("NCCL_SOCKET_IFNAME", "beth7", 1);
+    setenv("NCCL_CLIENT_SOCKET_IFNAME", "beth7", 1);
 
     // NCCL ctran: select TCPDM backend
     setenv("NCCL_CTRAN_ENABLE", "1", 1);

--- a/comms/ctran/tests/CtranDistAllReduceTest.cc
+++ b/comms/ctran/tests/CtranDistAllReduceTest.cc
@@ -151,7 +151,9 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       size_t count,
       TestInPlaceType inplace,
       commRedOp_t op,
-      MemAllocType memType) {
+      MemAllocType memType,
+      std::vector<CtranMapperBackend> excludedBackends = {
+          CtranMapperBackend::NVL}) {
     if (memType == kCuMemAllocDisjoint && !NCCL_CTRAN_IB_DMABUF_ENABLE) {
       GTEST_SKIP() << "dmabuf is not supported, skip disjoint test";
     }
@@ -218,12 +220,12 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
         lastColl["algoName"].asString(),
         testing::HasSubstr(allReduceAlgoName(algo)));
 
+    // AllReduce uses kernel reduce not NVL iput
     verifyBackendsUsed(
         ctranComm->ctran_.get(),
         ctranComm->statex_.get(),
         kMemNcclMemAlloc,
-        // AllReduce uses kernel reduce not NVL iput
-        {CtranMapperBackend::NVL});
+        excludedBackends);
     verifyGpeLeak(ctranComm->ctran_.get());
 
     for (auto& segment : segments) {
@@ -512,6 +514,115 @@ INSTANTIATE_TEST_SUITE_P(
     CtranTestBidirAgEnabled,
     CtranAllReduceRingBidirAgEnabledTestFp32,
     testingValuesBidirAg,
+    getTestName);
+
+#endif
+
+// =============================================================================
+// TCPDM backend tests for AllReduceRing
+// Requires multi-host setup with devmem-capable NICs.
+// Run with: buck test <target> -c comms.hosts=<host1>,<host2>
+// =============================================================================
+
+#ifdef CTRAN_TEST_TCPDM_BACKEND
+
+class CtranAllReduceRingTcpDmTestFp32
+    : public CtranAllReduceTest<float>,
+      public ::testing::WithParamInterface<
+          std::tuple<size_t, TestInPlaceType, commRedOp_t, MemAllocType>> {
+ public:
+  void SetUp() override {
+    if (!getenv("ENABLE_TCPDM_TEST")) {
+      GTEST_SKIP()
+          << "TCPDM test requires ENABLE_TCPDM_TEST=1 and devmem-capable hosts";
+    }
+
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    // TODO: re-enable bidir AG for TCPDM once reverse recvKernElem is allocated
+    setenv("NCCL_CTRAN_ALLREDUCE_RING_BIDIR_AG_MAX_SIZE", "0", 1);
+    // Force numBlocks/blockSize for TCPDM unpack kernel
+    setenv("NCCL_CTRAN_ALLREDUCE_RING_NUM_THREAD_BLOCKS", "16", 1);
+    setenv("NCCL_CTRAN_ALLREDUCE_RING_THREAD_BLOCK_SIZE", "256", 1);
+
+    // GPU closest to beth0 (mlx5_4) on GRANDTETON hosts
+    setenv("CUDA_VISIBLE_DEVICES", "2", 1);
+
+    // TCPDM transport config
+    setenv("TCP_DEVMEM_STEER_ACTIVE_OPEN", "1", 1);
+    setenv("TCP_DEVMEM_FIXED_IRQ_AFFINITY", "1", 1);
+    setenv("TCP_DEVMEM_FIXED_THREAD_AFFINITY", "1", 1);
+    setenv("TCP_DEVMEM_SETUP_XPS", "1", 1);
+    setenv("TCP_DEVMEM_CONGESTION_CONTROL", "dctcp", 1);
+    setenv("TCP_DEVMEM_DEBUG_TCP", "1", 1);
+    setenv("TCP_DEVMEM_TX_WORKERS_PER_DEV", "4", 1);
+    setenv("TCP_DEVMEM_RX_WORKERS_PER_DEV", "4", 1);
+    setenv("TCP_DEVMEM_SOCKETS_PER_COMM", "4", 1);
+    setenv("TCP_DEVMEM_QUEUES", "4", 1);
+    setenv("TCP_DEVMEM_IFNAME", "beth0", 1);
+    setenv("TCP_DEVMEM_SKIP_AGENT", "1", 1);
+    setenv("TCP_DEVMEM_SKIP_LOGGER", "1", 1);
+
+    // NCCL runtime: disable non-TCPDM transports
+    setenv("NCCL_COLLNET_ENABLE", "0", 1);
+    setenv("NCCL_OOB_NET_ENABLE", "0", 1);
+    setenv("NCCL_CROSS_NIC", "1", 1);
+    setenv("NCCL_PXN_DISABLE", "1", 1);
+    setenv("NCCL_SHM_DISABLE", "1", 1);
+    setenv("NCCL_RAS_ENABLE", "0", 1);
+
+    // NCCL bootstrap: match SOCKET_IFNAME with CLIENT_SOCKET_IFNAME
+    setenv("NCCL_SOCKET_IFNAME", "beth0", 1);
+    setenv("NCCL_CLIENT_SOCKET_IFNAME", "beth0", 1);
+
+    // NCCL ctran: select TCPDM backend
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_CTRAN_BACKENDS", "tcpdm", 1);
+
+    // Ctran unpack config
+    setenv("NCCL_NET", "", 1);
+    setenv("NCCL_CTRAN_UNPACK_NUM_THREAD_BLOCKS", "16", 1);
+    setenv("NCCL_P2P_NET_CHUNKSIZE", "262144", 1);
+    setenv("NCCL_BUFFSIZE", "4194304", 1);
+
+    ncclCvarInit();
+    CtranAllReduceTest::SetUp();
+  }
+};
+
+TEST_P(CtranAllReduceRingTcpDmTestFp32, AllReduceRingTcpDmFp32) {
+  const auto& [count, inplace, op, memType] = GetParam();
+  beginTest(
+      ctranAllReduceRing,
+      NCCL_ALLREDUCE_ALGO::ctring,
+      count,
+      inplace,
+      op,
+      memType,
+      {CtranMapperBackend::NVL, CtranMapperBackend::IB});
+}
+
+auto testingValuesTcpDm = ::testing::Values(
+    std::make_tuple(1, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(8, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(17, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(1024, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(8192, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(8195, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(1024 * 1024, kTestOutOfPlace, commSum, kMemNcclMemAlloc),
+    std::make_tuple(
+        1024 * 1024 + 17,
+        kTestOutOfPlace,
+        commSum,
+        kMemNcclMemAlloc),
+    std::make_tuple(8195, kTestOutOfPlace, commProd, kMemNcclMemAlloc),
+    std::make_tuple(8195, kTestOutOfPlace, commMax, kMemNcclMemAlloc),
+    std::make_tuple(8195, kTestOutOfPlace, commMin, kMemNcclMemAlloc),
+    std::make_tuple(8195, kTestOutOfPlace, commAvg, kMemNcclMemAlloc));
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTestTcpDm,
+    CtranAllReduceRingTcpDmTestFp32,
+    testingValuesTcpDm,
     getTestName);
 
 #endif


### PR DESCRIPTION
Summary:
Add 2x2 and 2x4 interleaved TCPDM allreduce test configurations.
Each rank gets its own NIC/GPU via PIX-optimal assignment:
  - 2x2: beth0,beth1 with GPU 2,3
  - 2x4: beth3,beth4,beth0,beth1 with GPU 0,1,2,3
Bootstrap uses beth7 to avoid data NIC conflicts.

Reviewed By: saifhhasan

Differential Revision: D105280367


