### PR TITLE
Migrate 5 overlapping cvar globals to ncclParam accessors in `meta/` (#2563)

### DIFF
--- a/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
+++ b/comms/ncclx/meta/colltrace/tests/ProxyTraceDistTest.cc
@@ -39,6 +39,7 @@ class ProxyTraceTest : public NcclxBaseTestFixture {
         // ranks 2-3 on node_1. NCCL uses NCCL_HOSTID to determine node
         // membership, so different hostids produce different comm->node values.
         {"NCCL_HOSTID", "node_" + std::to_string(globalRank / 2)},
+        {"NCCL_PXN_DISABLE", "1"},
     });
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
@@ -419,9 +420,6 @@ TEST_F(ProxyTraceTest, QueryFinishedAllReduce) {
 
 TEST_F(ProxyTraceTest, QueryFinishedAllToAll) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
-  // disable PXN so that each proxy thread can have deterministic behavior:
-  // send and recv for the local rank with PPN remote ranks on the other node
-  NCCL_PXN_DISABLE = 1;
   // ensure we use default proxy path
   NCCL_ALLTOALL_ALGO = NCCL_ALLTOALL_ALGO::orig;
 
@@ -471,9 +469,6 @@ TEST_F(ProxyTraceTest, QueryFinishedAllToAll) {
 
 TEST_F(ProxyTraceTest, QueryFinishedSendRecv) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
-  // disable PXN so that each proxy thread can have deterministic behavior:
-  // send and recv for the local rank with PPN remote ranks on the other node
-  NCCL_PXN_DISABLE = 1;
   // ensure we use default proxy path
   NCCL_SENDRECV_ALGO = NCCL_SENDRECV_ALGO::orig;
 
@@ -583,9 +578,6 @@ TEST_F(ProxyTraceTest, QueryHangAllReduce) {
 
 TEST_F(ProxyTraceTest, QueryHangSendRecv) {
   auto traceGuard = EnvRAII(NCCL_PROXYTRACE, {"trace"});
-  // disable PXN so that each proxy thread is guaranteed to send and recv with
-  // PPN remote ranks
-  NCCL_PXN_DISABLE = 1;
   // ensure we use default proxy path
   NCCL_SENDRECV_ALGO = NCCL_SENDRECV_ALGO::orig;
 

--- a/comms/ncclx/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherTest.cc
@@ -15,6 +15,9 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+#include "meta/hints/GlobalHints.h"
+#endif
 
 using testinfra::AlgoRAII;
 
@@ -22,7 +25,17 @@ class AllGatherTest : public NcclxBaseTestFixture {
  public:
   AllGatherTest() = default;
   void SetUp() override {
-    NcclxBaseTestFixture::SetUp();
+    NcclxEnvs envs = {
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"},
+    };
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"});
+#endif
+    NcclxBaseTestFixture::SetUp(envs);
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+#endif
     this->comm = ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
 
@@ -31,6 +44,9 @@ class AllGatherTest : public NcclxBaseTestFixture {
   }
 
   void TearDown() override {
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
+#endif
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();
@@ -51,7 +67,6 @@ class AllGatherTest : public NcclxBaseTestFixture {
     }
 
     if (algo != NCCL_ALLGATHER_ALGO::orig) {
-#ifdef TEST_ENABLE_CTRAN
       if (!ctranAllGatherSupport(comm->ctranComm_.get(), algo)) {
         GTEST_SKIP() << "Ctran algorithm is not supported, skip test";
       }
@@ -62,9 +77,6 @@ class AllGatherTest : public NcclxBaseTestFixture {
         GTEST_SKIP()
             << "Ctran does not support cudaMalloc-ed buffer with nLocalRanks > 1, skip test";
       }
-#else
-      GTEST_SKIP() << "Ctran is not enabled, skip test";
-#endif
     }
 
     // Create and register buffers. If inplace, we use the same buffer for send
@@ -187,15 +199,13 @@ TEST_P(AllgatherMemtypeGraphTestParam, Test) {
   auto registFlag = false;
   constexpr size_t count = 10e6 * 8;
 
-  auto GRAPH_REGISTER_OVERRIDE = 1L;
-  // TODO: we should throw proper error in the unsupported case in baseline
-  // NCCL graph register
-  if (algo == NCCL_ALLGATHER_ALGO::orig && useCudaGraph &&
+  const char* graphRegEnv = getenv("NCCL_GRAPH_REGISTER");
+  if (graphRegEnv != nullptr && std::string(graphRegEnv) == "1" &&
       memType == kCuMemAllocDisjoint) {
-    GRAPH_REGISTER_OVERRIDE = 0L;
+    GTEST_SKIP()
+        << "kCuMemAllocDisjoint not supported with NCCL_GRAPH_REGISTER=1";
   }
 
-  auto envGuard = EnvRAII(NCCL_GRAPH_REGISTER, GRAPH_REGISTER_OVERRIDE);
   runTest(algo, false /* inplace */, registFlag, useCudaGraph, memType, count);
 }
 

--- a/comms/ncclx/meta/tests/AllReduceUniformTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceUniformTest.cc
@@ -41,7 +41,7 @@ class AllReduceUniformTest : public NcclxBaseTestFixture {
   AllReduceUniformTest() = default;
 
   void SetUp() override {
-    NcclxBaseTestFixture::SetUp();
+    NcclxBaseTestFixture::SetUp({{"NCCL_MAX_NCHANNELS", "1"}});
 
     comm = ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
@@ -115,10 +115,8 @@ class AllReduceUniformTestBF16
   void runTest(size_t tensorSize, AllReduceAlgo algoType) {
     if (algoType == AllReduceAlgo::SingleRing) {
       NCCL_ALGO = "ring";
-      NCCL_MAX_NCHANNELS = 1;
     } else if (algoType == AllReduceAlgo::SingleTree) {
       NCCL_ALGO = "tree";
-      NCCL_MAX_NCHANNELS = 1;
     } else {
       throw std::runtime_error("Invalid AllReduceAlgo");
     }

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -155,7 +155,7 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
   rootComm = createRootComm();
   ASSERT_NE(nullptr, rootComm);
   // Nothing should be connected or initialized if no collective is called
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // Algorithms should not be connected
     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       EXPECT_FALSE(rootComm->initAlgoChannels[a]);
@@ -165,7 +165,7 @@ TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
     // channels should not be initialized
     EXPECT_EQ(rootComm->nChannelsReady, 0);
   }
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // Algorithms should not be connected
     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       EXPECT_EQ(rootComm->algoConnectedChannels[a], 0);
@@ -188,14 +188,14 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceRing) {
       sendBuf, recvBuf, count, dataType, ncclSum, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
 
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // RING should be connected
     checkAlgoInitState(rootComm, NCCL_ALGO_RING);
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // RING should be connected in rootComm
     // other algorithms should not be connected if lazy connect is enabled
-    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, LAZY_CONNECT_ENABLED);
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -216,14 +216,14 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTree) {
       sendBuf, recvBuf, count, dataType, ncclSum, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
 
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // TREE should be connected
     checkAlgoInitState(rootComm, NCCL_ALGO_TREE);
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // TREE should be connected in rootComm
     // other algorithms should not be connected if lazy connect is enabled
-    checkAlgoChannelState(rootComm, NCCL_ALGO_TREE, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_ALGO_TREE, LAZY_CONNECT_ENABLED);
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -248,13 +248,13 @@ TEST_P(NcclxLazyConnectTestFixture, AllReduceTreeIncreaseChannel) {
       sendBuf, recvBuf, count, dataType, ncclSum, rootComm, stream);
   EXPECT_EQ(res, ncclSuccess);
 
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // TREE should be connected
     checkAlgoInitState(rootComm, NCCL_ALGO_TREE);
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // TREE should be connected in rootComm
-    checkAlgoChannelState(rootComm, NCCL_ALGO_TREE, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_ALGO_TREE, LAZY_CONNECT_ENABLED);
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -278,7 +278,7 @@ TEST_P(NcclxLazyConnectTestFixture, Alltoall) {
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
   auto prevNchannelsReady = rootComm->nChannelsReady;
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // Algorithms should not be connected
     checkAlgoInitState(rootComm, NCCL_NUM_ALGORITHMS);
   }
@@ -331,13 +331,13 @@ TEST_P(NcclxLazyConnectTestFixture, AlltoallAndAllGather) {
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // RING should be connected
     checkAlgoInitState(rootComm, NCCL_ALGO_RING);
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // RING should be connected in rootComm
-    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, LAZY_CONNECT_ENABLED);
   }
 
   NCCLCHECK_TEST(ncclCommDestroy(rootComm));
@@ -376,13 +376,13 @@ TEST_P(NcclxLazyConnectTestFixture, higherP2pChThanColl) {
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // RING should be connected
     checkAlgoInitState(rootComm, NCCL_ALGO_RING);
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // RING should be connected in rootComm
-    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_ALGO_RING, LAZY_CONNECT_ENABLED);
   }
 
   NCCLCHECK_TEST(ncclCommDestroy(rootComm));
@@ -407,7 +407,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
   EXPECT_EQ(res, ncclSuccess);
 
   // Allgather should be using RING
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // RING should be connected
     checkAlgoInitState(childComm, NCCL_ALGO_RING);
     // rootComm should not connect any algorithm
@@ -415,9 +415,9 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
   }
   if (NCCL_LAZY_SETUP_CHANNELS) {
     // RING should be connected in childComm
-    checkAlgoChannelState(childComm, NCCL_ALGO_RING, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(childComm, NCCL_ALGO_RING, LAZY_CONNECT_ENABLED);
     // rootComm should not connect any algorithm
-    checkAlgoChannelState(rootComm, NCCL_NUM_ALGORITHMS, NCCL_RUNTIME_CONNECT);
+    checkAlgoChannelState(rootComm, NCCL_NUM_ALGORITHMS, LAZY_CONNECT_ENABLED);
   }
 
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -455,7 +455,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 //       sendBuf, recvBuf, count, dataType, ncclSum, rootComm, stream);
 //   EXPECT_EQ(res, ncclSuccess);
 
-//   if (NCCL_RUNTIME_CONNECT) {
+//   if (LAZY_CONNECT_ENABLED) {
 //     // COLLNET would be connected, if available
 //     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
 //       if (rootComm->collNetSupport == 1 && a == NCCL_ALGO_COLLNET_DIRECT) {
@@ -469,7 +469,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 //     // COLLNET should be connected in rootComm, if available
 //     if (rootComm->collNetSupport == 1) {
 //       checkAlgoChannelState(
-//           rootComm, NCCL_ALGO_COLLNET_DIRECT, NCCL_RUNTIME_CONNECT);
+//           rootComm, NCCL_ALGO_COLLNET_DIRECT, LAZY_CONNECT_ENABLED);
 //     }
 //   }
 
@@ -517,7 +517,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 //       sendBuf, recvBuf, count, dataType, ncclSum, rootComm, stream);
 //   EXPECT_EQ(res, ncclSuccess);
 
-//   if (NCCL_RUNTIME_CONNECT) {
+//   if (LAZY_CONNECT_ENABLED) {
 //     // Selected algo would be connected
 //     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
 //       if (a == expectedAlgo) {
@@ -531,7 +531,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommAllGather) {
 //     // some channels should be initialized
 //     EXPECT_GE(rootComm->nChannelsReady, expectedNchannels);
 //     // Selected algo should be connected in rootComm
-//     checkAlgoChannelState(rootComm, expectedAlgo, NCCL_RUNTIME_CONNECT);
+//     checkAlgoChannelState(rootComm, expectedAlgo, LAZY_CONNECT_ENABLED);
 //   }
 
 //   CUDACHECK_TEST(cudaStreamSynchronize(stream));
@@ -552,7 +552,7 @@ TEST_P(NcclxLazyConnectTestFixture, ChildCommLazyConfig) {
   EXPECT_EQ(childComm->nChannelsReady, 0);
 
   // Nothing should be connected or initialized if no collective is called
-  if (NCCL_RUNTIME_CONNECT) {
+  if (LAZY_CONNECT_ENABLED) {
     // Algorithms should not be connected
     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       EXPECT_FALSE(rootComm->initAlgoChannels[a]);

--- a/comms/ncclx/meta/transport/transportConnect.cc
+++ b/comms/ncclx/meta/transport/transportConnect.cc
@@ -10,12 +10,12 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Utils.h"
 
-#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/EventsScubaUtil.h"
 #include "meta/transport/transportConnect.h"
 #include "meta/transport/transportExt.h"
 #include "meta/transport/transportProxy.h"
 #include "meta/wrapper/MetaFactory.h"
+#include "register.h"
 
 namespace ncclx {
 
@@ -52,8 +52,9 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
   NCCLCHECK(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_RING], 0));
 
   // exchange ring info in first connection, if needed
+#if NCCL_MINOR >= 29
   if (comm->algoConnectedChannels[NCCL_ALGO_RING] == 0 &&
-      (NCCL_LOCAL_REGISTER || NCCL_GRAPH_REGISTER)) {
+      (ncclParamLocalRegister() || ncclParamGraphRegister())) {
     struct RingConnInfo {
       bool useNetPXN{false};
       bool useGdr{true};
@@ -75,6 +76,7 @@ ncclResult_t transportRingConnect(struct ncclComm* comm, int nChannels) {
       }
     }
   }
+#endif
   INFO(
       NCCL_INIT,
       "commDesc: %s connected rings from channel %d to %d, use ring PXN %d GDR %d",


### PR DESCRIPTION
Summary:

v2_29 and v2_30 already migrated from cvar globals to `ncclParam*()` accessors for `NCCL_LOCAL_REGISTER`, `NCCL_GRAPH_REGISTER`, `NCCL_RUNTIME_CONNECT`, `NCCL_PXN_DISABLE`, and `NCCL_MAX_NCHANNELS`. This cleans up the remaining cvar usage in `meta/` to be consistent:

- `transportConnect.cc`: replace `NCCL_LOCAL_REGISTER || NCCL_GRAPH_REGISTER` with `ncclParamLocalRegister() || ncclParamGraphRegister()`
- `LazyConnectTest.cc`: replace runtime cvar reads `NCCL_RUNTIME_CONNECT` with compile-time `LAZY_CONNECT_ENABLED` flag (already set by BUCK in lockstep with the env var)
- `AllGatherTest.cc`: remove dead `EnvRAII(NCCL_GRAPH_REGISTER, ...)` override (was already a no-op for v2_29+ since enqueue.cc reads `ncclParamGraphRegister()`, not the cvar global)
- `ProxyTraceDistTest.cc`: move `NCCL_PXN_DISABLE=1` from per-test direct cvar writes to `NcclxEnvs` in `SetUp()` (ncclParam caches on first call, so env must be set before init)
- `AllReduceUniformTest.cc`: move `NCCL_MAX_NCHANNELS=1` from per-test direct cvar writes to `NcclxEnvs` in `SetUp()`

Reviewed By: mingrany

Differential Revision: D105348694


