### PR TITLE
Notify every CTRAN multi-put RDMA step (#2564)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -133,7 +133,12 @@ static commResult_t impl(
         comm->ctran_->mapper->isendCtrl(recvbuff, memHdl, srcPeer, &sendReq));
     isendReq[i] = std::unique_ptr<CtranMapperRequest>(sendReq);
 
-    // Initialize notify to receive notification from peer that's sending to us
+    // This algorithm uses one notify as a phase marker for each half-step:
+    // first-half completion releases the next step's first-half send, and
+    // second-half completion releases the step loop. CtranMapperNotify counts
+    // per-peer arrivals, but it does not identify which chunk or phase
+    // generated a notification. A notify-all conversion needs a way to preserve
+    // those phase boundaries, so this path keeps the existing notify markers.
     notifyVec[i] = std::make_unique<CtranMapperNotify>();
     FB_COMMCHECK(comm->ctran_->mapper->initNotify(
         srcPeer, memHdl, notifyVec.at(i).get()));

--- a/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
+++ b/comms/ctran/algos/AllGather/AllGatherRecDbl.cc
@@ -36,7 +36,8 @@ static commResult_t impl(
   std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(nSteps);
   std::vector<std::unique_ptr<CtranMapperRequest>> irecvReq(nSteps);
   std::vector<std::unique_ptr<CtranMapperRequest>> isendReq(nSteps);
-  std::vector<std::unique_ptr<CtranMapperRequest>> iputReq(nSteps);
+  std::vector<CtranMapperRequest> iputReqs(nRanks - 1);
+  size_t iputReqIdx = 0;
   std::vector<std::unique_ptr<CtranMapperNotify>> notifyVec(nSteps);
   std::unique_ptr<CtranMapperTimestamp> timestamp =
       std::unique_ptr<CtranMapperTimestamp>(
@@ -88,8 +89,8 @@ static commResult_t impl(
 
     // Initialize notify to receive notification from peer
     notifyVec[i] = std::make_unique<CtranMapperNotify>();
-    FB_COMMCHECK(
-        comm->ctran_->mapper->initNotify(peer, memHdl, notifyVec[i].get()));
+    FB_COMMCHECK(comm->ctran_->mapper->initNotify(
+        peer, memHdl, notifyVec[i].get(), 1 << i));
   }
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
@@ -120,43 +121,21 @@ static commResult_t impl(
 
     for (size_t j = 0; j < (1 << i); j++) {
       size_t putOffset = j * (nRanks / (1 << i)) + rank % (nRanks / (1 << i));
-      // Only need to block on the final put
-      bool notify = j == (1 << i) - 1;
-
-      if (notify) {
-        CtranMapperRequest* putReqPtr = nullptr;
-        FB_COMMCHECK(comm->ctran_->mapper->iput(
-            (char*)recvbuff + putOffset * sendSize,
-            (char*)remoteRecvBuffs[i] + putOffset * sendSize,
-            sendSize,
-            peer,
-            CtranMapperConfig{
-                .memHdl_ = memHdl,
-                .remoteAccessKey_ = remoteAccessKeys[i],
-                .notify_ = notify},
-            &putReqPtr));
-        iputReq[i] = std::unique_ptr<CtranMapperRequest>(putReqPtr);
-      } else {
-        FB_COMMCHECK(comm->ctran_->mapper->iput(
-            (char*)recvbuff + putOffset * sendSize,
-            (char*)remoteRecvBuffs[i] + putOffset * sendSize,
-            sendSize,
-            peer,
-            CtranMapperConfig{
-                .memHdl_ = memHdl,
-                .remoteAccessKey_ = remoteAccessKeys[i],
-                .notify_ = notify},
-            static_cast<CtranMapperRequest*>(nullptr)));
-      }
+      FB_COMMCHECK(comm->ctran_->mapper->iput(
+          (char*)recvbuff + putOffset * sendSize,
+          (char*)remoteRecvBuffs[i] + putOffset * sendSize,
+          sendSize,
+          peer,
+          CtranMapperConfig{
+              .memHdl_ = memHdl,
+              .remoteAccessKey_ = remoteAccessKeys[i],
+              .notify_ = true},
+          &iputReqs.at(iputReqIdx++)));
       // Capture duration started from first put
       if (j == 0) {
         timestamp->putIssued.push_back(CtranMapperTimestampPoint(peer));
       }
     }
-    // Wait for signal from receives
-    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(iputReq[i].get()));
-    // Capture duration ended at last put when it is completed
-    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
 
     // Flush received data to ensure: (1) cross-NIC DMA visibility before
@@ -176,6 +155,13 @@ static commResult_t impl(
 
     CTRAN_PROFILER_IF(
         profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+  }
+
+  for (size_t k = 0; k < iputReqIdx; k++) {
+    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(&iputReqs[k]));
+  }
+  for (const auto peer : peers) {
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
   }
 
   for (int i = 0; i < nSteps; i++) {

--- a/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
@@ -122,8 +122,8 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   for (int i = 0; i < nSteps; i++) {
     peers[i] = peerAtStep(nodeId, localRank, nLocalRanks, nNodes, i);
     notifyVec[i] = std::make_unique<CtranMapperNotify>();
-    FB_COMMCHECK(
-        mapper->initNotify(peers[i], pArgs->recvHdl, notifyVec[i].get()));
+    FB_COMMCHECK(mapper->initNotify(
+        peers[i], pArgs->recvHdl, notifyVec[i].get(), 1 << i));
   }
 
   // Exchange a ready-to-receive handshake with every rail peer before
@@ -149,8 +149,8 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
 
-  // Last-put request per step, used to wait for local completion.
-  std::vector<CtranMapperRequest> lastPutReqs(nSteps);
+  std::vector<CtranMapperRequest> iputReqs(nNodes - 1);
+  size_t iputReqIdx = 0;
 
   for (int i = 0; i < nSteps; i++) {
     const int peer = peers[i];
@@ -182,7 +182,6 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
       void* dstPtr =
           ctran::allgatherp::getPtr(pArgs->remoteRecvBuffs[peer], byteOffset);
 
-      const bool isLast = (j == nPuts - 1);
       FB_COMMCHECK(mapper->iput(
           srcPtr,
           dstPtr,
@@ -191,13 +190,9 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
           CtranMapperConfig{
               .memHdl_ = srcHdl,
               .remoteAccessKey_ = pArgs->remoteAccessKeys[peer],
-              .notify_ = isLast},
-          isLast ? &lastPutReqs[i]
-                 : static_cast<CtranMapperRequest*>(nullptr)));
+              .notify_ = true},
+          &iputReqs.at(iputReqIdx++)));
     }
-
-    FB_COMMCHECK(mapper->waitRequest(&lastPutReqs[i]));
-    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
 
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
 
@@ -219,6 +214,13 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
     if (nLocalRanks > 1) {
       resource->pipeSync->post(i);
     }
+  }
+
+  for (size_t k = 0; k < iputReqIdx; k++) {
+    FB_COMMCHECK(mapper->waitRequest(&iputReqs[k]));
+  }
+  for (const auto peer : peers) {
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
   }
 
   CTRAN_PROFILER_IF(

--- a/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
+++ b/comms/ctran/algos/ReduceScatter/ReduceScatterRHD.cc
@@ -35,8 +35,8 @@ static commResult_t impl(
   std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(nSteps);
   std::vector<std::unique_ptr<CtranMapperRequest>> irecvReq(nSteps);
   std::vector<std::unique_ptr<CtranMapperRequest>> isendReq(nSteps);
-  // these are the final iput requests per step for which we will need to wait
-  std::vector<std::unique_ptr<CtranMapperRequest>> iputReq(nSteps);
+  std::vector<CtranMapperRequest> iputReqs(nRanks - 1);
+  size_t iputReqIdx = 0;
   std::vector<std::unique_ptr<CtranMapperNotify>> notifyVec(nSteps);
   CtranAlgoLogger logger(reduceScatterAlgoName(myAlgo), op->opCount, comm);
   std::unique_ptr<CtranMapperTimestamp> timestamp =
@@ -96,17 +96,17 @@ static commResult_t impl(
 
     // Initialize notify to receive notification from peer
     notifyVec[i] = std::make_unique<CtranMapperNotify>();
-    FB_COMMCHECK(
-        comm->ctran_->mapper->initNotify(peer, tmpHdl, notifyVec[i].get()));
+    FB_COMMCHECK(comm->ctran_->mapper->initNotify(
+        peer, tmpHdl, notifyVec[i].get(), nRanks >> (i + 1)));
 
     // Block until we have handle for this peer
     FB_COMMCHECK(comm->ctran_->mapper->waitRequest(irecvReq[i].get()));
     timestamp->recvCtrl.push_back(CtranMapperTimestampPoint(peer));
+    const size_t stepReqStart = iputReqIdx;
     for (size_t j = 0; j < (nRanks >> (i + 1)); j++) {
       bool lastChunkPerStep = (j == (nRanks >> (i + 1)) - 1) ? 1 : 0;
       size_t sendBufOffset = j * (2 << i) + peer % (2 << i);
       size_t tmpBufOffset = j * 2 + (peer >> i) % 2;
-      CtranMapperRequest* putReqPtr = nullptr;
 
       // Put to peer
       // Only first step needs to put from sendbuff, remaining steps just
@@ -124,43 +124,28 @@ static commResult_t impl(
           sendBufOffset,
           tmpBufOffset,
           lastChunkPerStep);
-      if (lastChunkPerStep) {
-        FB_COMMCHECK(comm->ctran_->mapper->iput(
-            putSrc,
-            (char*)remoteTmpBuffs[i] + j * recvSize,
-            recvSize,
-            peer,
-            CtranMapperConfig{
-                .memHdl_ = putHdl,
-                .remoteAccessKey_ = remoteAccessKeys[i],
-                .notify_ = lastChunkPerStep ? true : false},
-            &putReqPtr));
-      } else {
-        FB_COMMCHECK(comm->ctran_->mapper->iput(
-            putSrc,
-            (char*)remoteTmpBuffs[i] + j * recvSize,
-            recvSize,
-            peer,
-            CtranMapperConfig{
-                .memHdl_ = putHdl,
-                .remoteAccessKey_ = remoteAccessKeys[i],
-                .notify_ = lastChunkPerStep ? true : false},
-            static_cast<CtranMapperRequest*>(nullptr)));
-      }
+      FB_COMMCHECK(comm->ctran_->mapper->iput(
+          putSrc,
+          (char*)remoteTmpBuffs[i] + j * recvSize,
+          recvSize,
+          peer,
+          CtranMapperConfig{
+              .memHdl_ = putHdl,
+              .remoteAccessKey_ = remoteAccessKeys[i],
+              .notify_ = true},
+          &iputReqs.at(iputReqIdx++)));
       // Capture duration started from first put
       if (j == 0) {
         timestamp->putIssued.push_back(CtranMapperTimestampPoint(peer));
       }
-      if (lastChunkPerStep) {
-        iputReq[i] = std::unique_ptr<CtranMapperRequest>(putReqPtr);
-        // Local reduce will update tmpRedBuf, let's ensure the previous put has
-        // finished so tmpRedBuf can be updated
-        CLOGF_TRACE(
-            COLL, "rank {} peer {} iputReq: {}", rank, peer, (void*)putReqPtr);
-        FB_COMMCHECK(comm->ctran_->mapper->waitRequest(iputReq[i].get()));
-        timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
-      }
     }
+    // Local reduce can overwrite tmpRedBuf, so all sends from this step must
+    // reach local completion before reducing into it again.
+    for (size_t k = stepReqStart; k < iputReqIdx; k++) {
+      FB_COMMCHECK(comm->ctran_->mapper->waitRequest(&iputReqs[k]));
+    }
+    timestamp->putComplete.push_back(CtranMapperTimestampPoint(peer));
+
     // make sure send from peer is completed
     FB_COMMCHECK(comm->ctran_->mapper->waitNotify(notifyVec[i].get()));
 

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -1208,11 +1208,10 @@ class CtranIbVirtualConn {
     // with its notify bit set; on fast path, we don't need to track this, as
     // all writes are from same qp and are ordered.
     //
-    // Every write that is posted by the sender has a sequential sequence
-    // number starting at 0. This sequence number is written into the bits of
-    // the immediate data masked by kSeqNumMask. If a given write is the final
-    // write of a PUT with remote notify, the kNotifyBit of the immediate is
-    // also set.
+    // Every WRITE_WITH_IMM posted on this DQPLB notify path has a sequential
+    // sequence number starting at 0. This sequence number is written into the
+    // bits of the immediate data masked by kSeqNumMask. If a given write is
+    // the final write of a PUT, the kNotifyBit of the immediate is also set.
     //
     // If sequence # N has its notify bit set, we need to wait until all
     // sequence numbers <= N have been received. We do this in the following
@@ -1321,15 +1320,18 @@ class CtranIbVirtualConn {
         reinterpret_cast<uint64_t>(put->dbuf) + put->offset;
     sendPutWr_.wr.rdma.rkey = put->rkeys[device];
 
-    // RDMA_WRITE if in spray mode, or dqplb mode without notify
+    // Use plain RDMA_WRITE when the caller does not request receiver-side
+    // notification. Spray mode also uses plain writes; when spray notify is
+    // requested, burnDownPuts() sends a separate notifyQP message after the
+    // sender observes data completion.
     if (put->vcMode == NCCL_CTRAN_IB_VC_MODE::spray || !put->notify) {
       sendPutWr_.opcode = ibverbx::IBV_WR_RDMA_WRITE;
     } else {
-      // When in dqplb mode with notify, we need track when all packets have
-      // been received on the receiver side. Because packets may be issued
-      // through different QPs, we use RDMA_WRITE_WITH_IMM + per-packet seqNum
-      // to track all packets belonging to the Put on receiver side, and use
-      // notify bit to mark the seqNum of final write.
+      // DQPLB notify must track receiver-side arrival across QPs. Because
+      // packets may be issued through different QPs, each write uses
+      // RDMA_WRITE_WITH_IMM with a per-packet sequence number. The final write
+      // of the PUT sets the notify bit so the receiver can release waitNotify()
+      // only after all lower sequence numbers have arrived.
       // Also see writeImmRcvd() for receiver side logic.
       sendPutWr_.opcode = ibverbx::IBV_WR_RDMA_WRITE_WITH_IMM;
       sendPutWr_.imm_data = sndNxt_;


### PR DESCRIPTION
Summary:

Fix CTRAN algorithms that issue multiple RDMA PUTs to the same peer by initializing notifiers with the number of PUT completions the receiver must observe and setting `.notify_ = true` on every PUT in those groups. Under DQPLB VC mode, the final PUT notification can arrive before earlier no-notify writes on other QPs/NICs are receiver-visible, so waiting for only the final notify is not sufficient before forwarding or reducing received data.

Also give every PUT in these multi-PUT paths a mapper request and wait those requests explicitly. Allgather paths wait sender-side PUT completions at algorithm end; ReduceScatterRHD still waits per step because the following local reduce can overwrite tmpRedBuf used as the PUT source.

The allgather changes are straightforward, just updating to waitNotify for all puts and moving waitRequests to the end since we don't update the buffer. We can't move waitrequest to the end for reduce scatter though.

Reviewed By: minsii

Differential Revision: D105338519


