### PR TITLE
requirements: move expecttest to dev reqs

### DIFF
--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -28,10 +28,9 @@ export USE_GLOO=OFF
 export USE_TRANSPORT=OFF
 export USE_SYSTEM_LIBS=1
 
-python3 -m pip install typing-extensions numpy sympy expecttest pytest parameterized
-python3 -m pip install --no-deps --pre torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir 
+python3 -m pip install --pre torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir
 
-cd torchcomms && pip install . --no-deps --no-build-isolation && cd ..
+cd torchcomms && pip install '.[dev]' --no-build-isolation && cd ..
 
 #Check Intel XPU visibility
 #Expose ZE_AFFINITY_MASK to explicitly expose the number of Intel GPUs assigned to the runner for all tests.

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -128,7 +128,8 @@ jobs:
         export DISABLED_TESTS="${{ vars.DISABLED_TESTS }}"
 
         # Install from pre-built wheel (skip build step)
-        pip install "${RUNNER_ARTIFACT_DIR}"/*.whl pytest numpy psutil parameterized pydot requests urllib3 tabulate
+        WHEEL=$(ls "${RUNNER_ARTIFACT_DIR}"/*.whl)
+        pip install "${WHEEL}[dev]"
 
         python -c "import torchcomms"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 torch
 pyyaml
 packaging
-expecttest

--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,7 @@ extras_require = {
         "lintrunner",
         "parameterized",
         "pydot",
+        "expecttest",
     ],
 }
 


### PR DESCRIPTION
```
tristanr@devvm5553 ~/v/torchcomms-0.3.0-release [1]> uv pip install --pre torch torchcomms==0.3.0 --index-url https://download.pytorch.org/whl/test/cu130 --force-reinstall
  × No solution found when resolving dependencies:
  ╰─▶ Because expecttest was not found in the package registry and torchcomms==0.3.0+cu130 depends on expecttest, we can conclude that torchcomms==0.3.0+cu130 cannot be used.
      And because only the following versions of torchcomms are available:
          torchcomms<0.3.0
          torchcomms>=0.3.0+cu130
      and you require torchcomms==0.3.0, we can conclude that your requirements are unsatisfiable.
```