### PR TITLE
Remove xrack QP config from ctran IB backend

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -51,11 +51,8 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   ConnectionType connTyp = ConnectionType::NO_STATEX;
   std::vector<std::string>* configList{nullptr};
   if (comm_ && comm_->statex_) {
-    if (comm_->statex_->isSameRack(comm_->statex_->rank(), peerRank)) {
-      connTyp = ConnectionType::SAME_RACK;
-    } else if (comm_->statex_->isSameZone(comm_->statex_->rank(), peerRank)) {
+    if (comm_->statex_->isSameZone(comm_->statex_->rank(), peerRank)) {
       connTyp = ConnectionType::SAME_ZONE;
-      configList = &NCCL_CTRAN_IB_QP_CONFIG_XRACK;
     } else if (comm_->statex_->isSameDc(comm_->statex_->rank(), peerRank)) {
       connTyp = ConnectionType::SAME_DC;
       configList = &NCCL_CTRAN_IB_QP_CONFIG_XZONE;
@@ -71,7 +68,7 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   if ((configList != nullptr) && (configList->size() > 0)) {
     FB_CHECKABORT(
         configList->size() == kExpectedQpConfigLength,
-        "XRACK, XZONE, XDC QP Config strings must have exactly 4 elements");
+        "XZONE, XDC QP Config strings must have exactly 4 elements");
     qpScalingTh_ = stoul(configList->at(qpConfigIndex::QP_SCALING_THRESHOLD));
     maxNumQps_ = stoi(configList->at(qpConfigIndex::MAX_QPS));
     if (configList->at(qpConfigIndex::VC_MODE) == "spray") {
@@ -132,8 +129,6 @@ std::string CtranIbVirtualConn::connTypeName(ConnectionType connTyp) {
   switch (connTyp) {
     case ConnectionType::NO_STATEX:
       return "NO_STATEX";
-    case ConnectionType::SAME_RACK:
-      return "SAME_RACK";
     case ConnectionType::SAME_ZONE:
       return "SAME_ZONE";
     case ConnectionType::SAME_DC:
@@ -173,12 +168,11 @@ void CtranIbVirtualConn::logConnectionConfig(ConnectionType connTyp) {
       CLOGF_SUBSYS(
           INFO,
           INIT,
-          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}, sameRack {}): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
+          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
           "rank {} peerRank {} commHash {:x} commDesc {}",
           connTypeName(connTyp),
           statex->isSameDc(statex->rank(), peerRank),
           statex->isSameZone(statex->rank(), peerRank),
-          statex->isSameRack(statex->rank(), peerRank),
           maxNumQps_,
           qpScalingTh_,
           vcModeName(vcMode_),

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -148,11 +148,10 @@ class CtranIb;
 
 using ConnectionType = enum {
   NO_STATEX = 0,
-  SAME_RACK = 1,
-  SAME_ZONE = 2,
-  SAME_DC = 3,
-  DIFF_DC = 4,
-  CTRAN_EX = 5,
+  SAME_ZONE = 1,
+  SAME_DC = 2,
+  DIFF_DC = 3,
+  CTRAN_EX = 4,
 };
 
 namespace {

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -1797,7 +1797,7 @@ TEST_F(CtranIbTest, envQpConfig) {
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {"rtsw098.c084.f00.nha1", dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", dc1, zone1}}, // rank-1: x-rack with rank-0
+      {1, {"rtsw099.c084.f00.nha1", dc1, zone1}}, // rank-1: same zone as rank-0
       {2, {"rtsw100.c085.f00.nha1", dc1, zone2}}, // rank-2: x-zone with rank-0
       {3, {"rtsw101.c080.f00.nha2", dc2, zone3}} // rank-3: x-dc with rank-0
   };
@@ -1809,7 +1809,6 @@ TEST_F(CtranIbTest, envQpConfig) {
       {"512", "8", "spray", "8"},
       {"1024", "16", "dqplb", "12"},
   };
-  EnvRAII xRackQps(NCCL_CTRAN_IB_QP_CONFIG_XRACK, kPeerTestQpConfig[1]);
   EnvRAII xZoneQps(NCCL_CTRAN_IB_QP_CONFIG_XZONE, kPeerTestQpConfig[2]);
   EnvRAII xDcQps(NCCL_CTRAN_IB_QP_CONFIG_XDC, kPeerTestQpConfig[3]);
 
@@ -1865,19 +1864,29 @@ TEST_F(CtranIbTest, envQpConfig) {
 
       CtranIb::CtranIbVcConfig_t config;
       EXPECT_EQ(ctranIb->getVcConfig(peer, config), commSuccess);
-      // Check QP Scaling Threshold
-      EXPECT_EQ(std::get<0>(config), std::stoul(kPeerTestQpConfig[peer].at(0)));
-      // Check # of QPs
-      EXPECT_EQ(std::get<1>(config), std::stoi(kPeerTestQpConfig[peer].at(1)));
-      // Check VC Mode
-      if (kPeerTestQpConfig[peer].at(2) == "spray") {
-        EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::spray);
+      if (peer == 1) {
+        // Peer 1 is in same zone (SAME_ZONE) — uses global defaults
+        EXPECT_EQ(
+            std::get<0>(config), (size_t)NCCL_CTRAN_IB_QP_SCALING_THRESHOLD);
+        EXPECT_EQ(std::get<1>(config), (int)NCCL_CTRAN_IB_MAX_QPS);
+        EXPECT_EQ(
+            std::get<2>(config),
+            (enum NCCL_CTRAN_IB_VC_MODE)NCCL_CTRAN_IB_VC_MODE);
+        EXPECT_EQ(std::get<3>(config), (int)NCCL_CTRAN_IB_QP_MAX_MSGS);
       } else {
-        EXPECT_EQ(kPeerTestQpConfig[peer].at(2), "dqplb"); // Only other option
-        EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::dqplb);
+        // Peers 2,3 use XZONE/XDC config overrides
+        EXPECT_EQ(
+            std::get<0>(config), std::stoul(kPeerTestQpConfig[peer].at(0)));
+        EXPECT_EQ(
+            std::get<1>(config), std::stoi(kPeerTestQpConfig[peer].at(1)));
+        if (kPeerTestQpConfig[peer].at(2) == "spray") {
+          EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::spray);
+        } else {
+          EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::dqplb);
+        }
+        EXPECT_EQ(
+            std::get<3>(config), std::stoi(kPeerTestQpConfig[peer].at(3)));
       }
-      // Check # of QPs per VC
-      EXPECT_EQ(std::get<3>(config), std::stoi(kPeerTestQpConfig[peer].at(3)));
     }
   } else {
     ControlMsg msg(ControlMsgType::SYNC);
@@ -1894,8 +1903,8 @@ TEST_F(CtranIbTest, ValidBeTopology) {
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {"rtsw098.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-1: x-rack
-                                                              // with rank-0
+      {1, {"rtsw099.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-1: same
+                                                              // zone as rank-0
       {2, {"rtsw100.c085.f00.nha1", kSuDomain1, dc1, zone2}}, // rank-2: x-zone
                                                               // with rank-0
       {3, {"rtsw101.c080.f00.nha2", kSuDomain1, dc2, zone3}} // rank-3: x-dc
@@ -1948,7 +1957,7 @@ TEST_F(CtranIbTest, InvalidBeTopology) {
   // is present for the ranks
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {dc1, zone1}}, // rank-0
-      {1, {dc1, zone1}}, // rank-1: x-rack with rank-0
+      {1, {dc1, zone1}}, // rank-1: same zone as rank-0
       {2, {dc1, zone2}}, // rank-2: x-zone with rank-0
       {3, {dc2, zone3}} // rank-3: x-dc with rank-0
   };

--- a/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
@@ -87,9 +87,17 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
     EnvRAII<decltype(NCCL_CTRAN_IB_DEVICES_PER_RANK)> devices{
         NCCL_CTRAN_IB_DEVICES_PER_RANK,
         2};
-    EnvRAII<decltype(NCCL_CTRAN_IB_QP_CONFIG_XRACK)> xRackQps{
-        NCCL_CTRAN_IB_QP_CONFIG_XRACK,
-        qpConfig};
+    // SAME_ZONE uses global defaults, so set them to dqplb mode
+    EnvRAII<decltype(NCCL_CTRAN_IB_QP_SCALING_THRESHOLD)> scalingTh{
+        NCCL_CTRAN_IB_QP_SCALING_THRESHOLD,
+        524288};
+    EnvRAII<decltype(NCCL_CTRAN_IB_MAX_QPS)> maxQps{NCCL_CTRAN_IB_MAX_QPS, 2};
+    EnvRAII<decltype(NCCL_CTRAN_IB_VC_MODE)> vcMode{
+        NCCL_CTRAN_IB_VC_MODE,
+        NCCL_CTRAN_IB_VC_MODE::dqplb};
+    EnvRAII<decltype(NCCL_CTRAN_IB_QP_MAX_MSGS)> maxMsgs{
+        NCCL_CTRAN_IB_QP_MAX_MSGS,
+        128};
     EnvRAII<decltype(NCCL_CTRAN_IB_QP_CONFIG_XZONE)> xZoneQps{
         NCCL_CTRAN_IB_QP_CONFIG_XZONE,
         qpConfig};

--- a/comms/utils/cvars/README.md
+++ b/comms/utils/cvars/README.md
@@ -99,8 +99,7 @@ NCCL_RAS_ENABLE - default value changed from 1 to 0 NCCL_CTRAN_IB_MAX_QPS -
 default value changed from 1 to 16 NCCL_CTRAN_IB_QP_MAX_MSGS - default value
 changed from 4 to 128 NCCL_CTRAN_IB_QP_SCALING_THRESHOLD - default value changed
 from 131072 to 524288 NCCL_CTRAN_IB_QP_CONFIG_XDC - default value changed from
-"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XRACK - default value
-changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
+"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
 default value changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_VC_MODE -
 default value changed from "spray" to "dqplb"
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1555,17 +1555,6 @@ cvars:
      Configure IBVCs to support either spray mode (uses extra QP for
      notifications) or dqplb mode ("normal" but all writes are WRITE_WITH_IMM)
 
- - name        : NCCL_CTRAN_IB_QP_CONFIG_XRACK
-   type        : stringlist
-   default     : "1048576,16,spray,128"
-   description : |-
-     A set of configuration for CTRAN IB over inter-rack communication:
-     <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
-     e.g., NCCL_CTRAN_IB_QP_CONFIG_XRACK="1048576,4,spray,6",
-     If not given, NCCLx will use values from
-     NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, NCCL_CTRAN_IB_MAX_QPS,
-     NCCL_CTRAN_IB_VC_MODE, and NCCL_CTRAN_IB_QP_MAX_MSGS respectively
-
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XZONE
    type        : stringlist
    default     : "1048576,16,spray,128"
@@ -1606,7 +1595,7 @@ cvars:
      where value is a list of <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS><TRAFFIC_CLASS>
      e.g., NCCL_CTRAN_IB_QP_CONFIG_ALGO="alltoall:1048576,4,dqplb,128,224;sendrecv:1048576,16,spray,128,224"
      If not given, NCCLx will use the configuration specified per topology
-     (see NCCL_CTRAN_IB_QP_CONFIG_XDC, NCCL_CTRAN_IB_QP_CONFIG_XZONE, NCCL_CTRAN_IB_QP_CONFIG_XRACK),
+     (see NCCL_CTRAN_IB_QP_CONFIG_XDC, NCCL_CTRAN_IB_QP_CONFIG_XZONE),
      or the default configuration set (see NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, NCCL_CTRAN_IB_MAX_QPS,
      NCCL_CTRAN_IB_VC_MODE, and NCCL_CTRAN_IB_QP_MAX_MSGS) for all collectives.
 


### PR DESCRIPTION
Summary:
Remove the `NCCL_CTRAN_IB_QP_CONFIG_XRACK` cvar and `SAME_RACK` connection type from the ctran IB backend:
- Remove `SAME_RACK` from `ConnectionType` enum and renumber remaining values
- Remove `isSameRack` check from `CtranIbVc` QP config selection — same-zone peers now use global defaults instead of xrack overrides
- Remove `NCCL_CTRAN_IB_QP_CONFIG_XRACK` cvar definition from `nccl_cvars.yaml`
- Update all references in tests, benchmarks, env scripts, and documentation
- Update `CtranIbDqplbRelayDistUT` to set global defaults (same values as the old xrack config) instead of using the removed cvar
- Note: `CommStateX::isSameRack()` and profiler usage are intentionally kept — they are topology queries unrelated to QP config

Performance justification: cross-rack sendrecv benchmarks on H100 (PCI) and GB300 (LCO) show **ctran-dqplb ≥ ctran-spray > baseline** at all message sizes, with dqplb providing 20-40% improvement over spray at medium sizes. See `backends/ib/fb/docs/xrack_benchmark_results.md` for full data.

Differential Revision: D105374402


