### PR TITLE
Fix ncclparam link and skip ncclparam/ncclras binaries in v2_30 conda feedstock build (#2569)

### DIFF
--- a/comms/ncclx/v2_30/makefiles/common.mk
+++ b/comms/ncclx/v2_30/makefiles/common.mk
@@ -86,15 +86,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-# CUDA 13.0 requires c++17
-ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 13; echo $$?),0)
-  CXXSTD ?= -std=c++17
-else
-  CXXSTD ?= -std=c++14
-endif
+CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)

--- a/comms/ncclx/v2_30/setup.py
+++ b/comms/ncclx/v2_30/setup.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+from distutils.command.build import build as _build
+
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+from setuptools.command.egg_info import egg_info as _egg_info
+
+BUILDDIR = os.environ.get("BUILDDIR", None)
+if BUILDDIR is not None:
+    LIBDIR = os.path.join(BUILDDIR, "lib")
+    BUILDDIR = os.path.join(BUILDDIR, "pybind")
+    os.makedirs(BUILDDIR, exist_ok=True)
+
+
+class build(_build):
+    def initialize_options(self):
+        super().initialize_options()
+        self.build_base = BUILDDIR
+
+
+class egg_info(_egg_info):
+    def initialize_options(self):
+        super().initialize_options()
+        self.egg_base = BUILDDIR
+
+
+def get_cmdclass():
+    from pybind11.setup_helpers import build_ext
+
+    return {
+        "build": build,
+        "egg_info": egg_info,
+        "build_ext": build_ext,
+    }
+
+
+ext_modules = [
+    Pybind11Extension(
+        "ncclx_trainer_context",
+        ["../meta/py/wrapper.cc"],
+        library_dirs=[LIBDIR],
+        libraries=["nccl"],
+    ),
+]
+
+setup(
+    name="ncclx_trainer_context",
+    ext_modules=ext_modules,
+    cmdclass=get_cmdclass(),
+)

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -302,7 +302,12 @@ DOCA_LIBOBJ      := $(DOCA_LIBSRC:%.cpp=$(DOCA_OBJDIR)/%.o)
 LIBOBJ           += $(DOCA_LIBOBJ)
 
 ##### rules
+BUILD_NCCL_CLI ?= 1
+ifeq ($(BUILD_NCCL_CLI),1)
 build : lib staticlib binary
+else
+build : lib staticlib
+endif
 
 lib : $(INCTARGETS) $(LIBDIR)/$(LIBTARGET) $(PKGDIR)/$(PKGTARGET)
 
@@ -353,7 +358,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)
@@ -483,8 +488,10 @@ install : build
 	cp -P -v $(BUILDDIR)/lib/lib* $(PREFIX)/lib/
 	cp -P -v $(BUILDDIR)/lib/pkgconfig/* $(PREFIX)/lib/pkgconfig/
 	cp -v -r $(BUILDDIR)/include/* $(PREFIX)/include/
+ifeq ($(BUILD_NCCL_CLI),1)
 	cp -v $(BUILDDIR)/bin/ncclras $(PREFIX)/bin/
 	cp -v $(BUILDDIR)/bin/ncclparam $(PREFIX)/bin/
+endif
 
 FILESTOFORMAT := $(shell find . -name ".\#*" -prune -o \( -name "*.cc" -o -name "*.h" \) -print | grep -v -E 'ibvwrap.h|nvmlwrap.h|gdrwrap.h|nccl.h')
 # Note that formatting.mk defines a new target so in order to not overwrite the default target,

--- a/comms/ncclx/v2_30/src/version.script
+++ b/comms/ncclx/v2_30/src/version.script
@@ -1,0 +1,20 @@
+/*
+version.script controls symbol visibility, it exposes
+nccl: nccl(x)-related symbols
+cxa: Folly’s exception tracer intercepts all exceptions and uses
+    dlsym(RTLD_NEXT, "cxa...") to find the corresponding real symbols.
+    Therefore, it is necessary to expose certain cxa symbols from the libstdc++.
+    For further details, refer to the discussion in D64442615.
+*/
+{
+  global:
+      *nccl*;
+      *ctran*;
+      *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
+  /* Transitive symbols (e.g. coming from static libs) are not exported */
+  local:
+      *;
+};


### PR DESCRIPTION
Summary:

The new `ncclparam` binary introduced in NCCLX v2.30 fails to link in the conda flagship build with:

```
/usr/bin/ld: $SRC_DIR/build/lib/libnccl.so: undefined reference to `std::condition_variable::wait(std::unique_lock<std::mutex>&)GLIBCXX_3.4.30'
```

`libnccl.so` is linked with `$(LDFLAGS)`, which includes `-L${CONDA_LIB_DIR}`, so the linker picks up the conda environment's libstdc++ (recent gcc, has `GLIBCXX_3.4.30`). The new `ncclparam` rule in `v2_30/src/Makefile` omits `-L${CONDA_LIB_DIR}`, so the linker falls back to the system libstdc++ which lacks `GLIBCXX_3.4.30` and cannot resolve libnccl.so's DT_NEEDED libstdc++ symbols.

Two changes are required to unblock the conda flagship build:

1. `fbcode/comms/ncclx/v2_30/src/Makefile`: Add `-L${CONDA_LIB_DIR}` to the `ncclparam` link command so it resolves against the same libstdc++ that `libnccl.so` was built against.

2. `fbcode/conda/feedstock/nccl/build.sh`: Skip building `ncclparam`/`ncclras` binaries in the conda feedstock via sed — these CLI tools aren't needed in the conda package, and even with the Makefile fix above, dragging them through the conda link path is unnecessary.

v2.29 doesn't hit this because its only binary (`ras_client`) doesn't link against libnccl.so.

Reviewed By: zhiyongww

Differential Revision: D105249560


