### PR TITLE
Remove rack/SU topology detection from CommStateX (#2570)

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -51,11 +51,8 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   ConnectionType connTyp = ConnectionType::NO_STATEX;
   std::vector<std::string>* configList{nullptr};
   if (comm_ && comm_->statex_) {
-    if (comm_->statex_->isSameRack(comm_->statex_->rank(), peerRank)) {
-      connTyp = ConnectionType::SAME_RACK;
-    } else if (comm_->statex_->isSameZone(comm_->statex_->rank(), peerRank)) {
+    if (comm_->statex_->isSameZone(comm_->statex_->rank(), peerRank)) {
       connTyp = ConnectionType::SAME_ZONE;
-      configList = &NCCL_CTRAN_IB_QP_CONFIG_XRACK;
     } else if (comm_->statex_->isSameDc(comm_->statex_->rank(), peerRank)) {
       connTyp = ConnectionType::SAME_DC;
       configList = &NCCL_CTRAN_IB_QP_CONFIG_XZONE;
@@ -71,7 +68,7 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   if ((configList != nullptr) && (configList->size() > 0)) {
     FB_CHECKABORT(
         configList->size() == kExpectedQpConfigLength,
-        "XRACK, XZONE, XDC QP Config strings must have exactly 4 elements");
+        "XZONE, XDC QP Config strings must have exactly 4 elements");
     qpScalingTh_ = stoul(configList->at(qpConfigIndex::QP_SCALING_THRESHOLD));
     maxNumQps_ = stoi(configList->at(qpConfigIndex::MAX_QPS));
     if (configList->at(qpConfigIndex::VC_MODE) == "spray") {
@@ -132,8 +129,6 @@ std::string CtranIbVirtualConn::connTypeName(ConnectionType connTyp) {
   switch (connTyp) {
     case ConnectionType::NO_STATEX:
       return "NO_STATEX";
-    case ConnectionType::SAME_RACK:
-      return "SAME_RACK";
     case ConnectionType::SAME_ZONE:
       return "SAME_ZONE";
     case ConnectionType::SAME_DC:
@@ -173,12 +168,11 @@ void CtranIbVirtualConn::logConnectionConfig(ConnectionType connTyp) {
       CLOGF_SUBSYS(
           INFO,
           INIT,
-          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}, sameRack {}): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
+          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
           "rank {} peerRank {} commHash {:x} commDesc {}",
           connTypeName(connTyp),
           statex->isSameDc(statex->rank(), peerRank),
           statex->isSameZone(statex->rank(), peerRank),
-          statex->isSameRack(statex->rank(), peerRank),
           maxNumQps_,
           qpScalingTh_,
           vcModeName(vcMode_),

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -148,11 +148,10 @@ class CtranIb;
 
 using ConnectionType = enum {
   NO_STATEX = 0,
-  SAME_RACK = 1,
-  SAME_ZONE = 2,
-  SAME_DC = 3,
-  DIFF_DC = 4,
-  CTRAN_EX = 5,
+  SAME_ZONE = 1,
+  SAME_DC = 2,
+  DIFF_DC = 3,
+  CTRAN_EX = 4,
 };
 
 namespace {

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -1796,10 +1796,10 @@ TEST_F(CtranIbTest, envQpConfig) {
                  zone2 = "nha1.c085", zone3 = "nha2.c080";
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
-      {0, {"rtsw098.c084.f00.nha1", dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", dc1, zone1}}, // rank-1: same zone as rank-0
-      {2, {"rtsw100.c085.f00.nha1", dc1, zone2}}, // rank-2: x-zone with rank-0
-      {3, {"rtsw101.c080.f00.nha2", dc2, zone3}} // rank-3: x-dc with rank-0
+      {0, {dc1, zone1}}, // rank-0
+      {1, {dc1, zone1}}, // rank-1: same zone as rank-0
+      {2, {dc1, zone2}}, // rank-2: x-zone with rank-0
+      {3, {dc2, zone3}} // rank-3: x-dc with rank-0
   };
   // dummy values for testing
   // {<QP Scaling Threshold>, <number of QPs>, <VC mode>}
@@ -1821,9 +1821,8 @@ TEST_F(CtranIbTest, envQpConfig) {
     topo.rank = rank;
     auto fakeHostName = "fakehost.0" + std::to_string(rank);
     std::strcpy(topo.host, fakeHostName.c_str());
-    std::strcpy(topo.rtsw, expectedTopology.at(rank)[0].c_str());
-    std::strcpy(topo.dc, expectedTopology.at(rank)[1].c_str());
-    std::strcpy(topo.zone, expectedTopology.at(rank)[2].c_str());
+    std::strcpy(topo.dc, expectedTopology.at(rank)[0].c_str());
+    std::strcpy(topo.zone, expectedTopology.at(rank)[1].c_str());
     testRankTopologies.emplace_back(topo);
   }
   // create a new statex with fake topology for testing
@@ -1897,18 +1896,14 @@ TEST_F(CtranIbTest, envQpConfig) {
 }
 
 TEST_F(CtranIbTest, ValidBeTopology) {
-  std::string kSuDomain1 = "nha1.c084.u001";
   constexpr auto dc1 = "nha1", dc2 = "nha2", zone1 = "nha1.c084",
                  zone2 = "nha1.c085", zone3 = "nha2.c080";
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
-      {0, {"rtsw098.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-1: same
-                                                              // zone as rank-0
-      {2, {"rtsw100.c085.f00.nha1", kSuDomain1, dc1, zone2}}, // rank-2: x-zone
-                                                              // with rank-0
-      {3, {"rtsw101.c080.f00.nha2", kSuDomain1, dc2, zone3}} // rank-3: x-dc
-                                                             // with rank-0
+      {0, {dc1, zone1}}, // rank-0
+      {1, {dc1, zone1}}, // rank-1: same zone as rank-0
+      {2, {dc1, zone2}}, // rank-2: x-zone with rank-0
+      {3, {dc2, zone3}} // rank-3: x-dc with rank-0
   };
 
   std::vector<ncclx::RankTopology> testRankTopologies{};
@@ -1917,10 +1912,8 @@ TEST_F(CtranIbTest, ValidBeTopology) {
     topo.rank = rank;
     auto fakeHostName = "fakehost.0" + std::to_string(rank);
     std::strcpy(topo.host, fakeHostName.c_str());
-    std::strcpy(topo.rtsw, expectedTopology.at(rank)[0].c_str());
-    std::strcpy(topo.su, expectedTopology.at(rank)[1].c_str());
-    std::strcpy(topo.dc, expectedTopology.at(rank)[2].c_str());
-    std::strcpy(topo.zone, expectedTopology.at(rank)[3].c_str());
+    std::strcpy(topo.dc, expectedTopology.at(rank)[0].c_str());
+    std::strcpy(topo.zone, expectedTopology.at(rank)[1].c_str());
     testRankTopologies.emplace_back(topo);
   }
 
@@ -1950,7 +1943,6 @@ TEST_F(CtranIbTest, ValidBeTopology) {
 }
 
 TEST_F(CtranIbTest, InvalidBeTopology) {
-  std::string kSuDomain1 = "";
   constexpr auto dc1 = "nha1", dc2 = "nha2", zone1 = "nha1.c084",
                  zone2 = "nha1.c085", zone3 = "nha2.c080";
   // set a fake topology to test QP changes for each IB VC. No rtsw or SU info
@@ -1970,7 +1962,6 @@ TEST_F(CtranIbTest, InvalidBeTopology) {
     std::strcpy(topo.host, fakeHostName.c_str());
     std::strcpy(topo.dc, expectedTopology.at(rank)[0].c_str());
     std::strcpy(topo.zone, expectedTopology.at(rank)[1].c_str());
-    std::strcpy(topo.su, kSuDomain1.c_str());
     testRankTopologies.emplace_back(topo);
   }
 

--- a/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDistUT.cc
@@ -1797,7 +1797,7 @@ TEST_F(CtranIbTest, envQpConfig) {
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {"rtsw098.c084.f00.nha1", dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", dc1, zone1}}, // rank-1: x-rack with rank-0
+      {1, {"rtsw099.c084.f00.nha1", dc1, zone1}}, // rank-1: same zone as rank-0
       {2, {"rtsw100.c085.f00.nha1", dc1, zone2}}, // rank-2: x-zone with rank-0
       {3, {"rtsw101.c080.f00.nha2", dc2, zone3}} // rank-3: x-dc with rank-0
   };
@@ -1809,7 +1809,6 @@ TEST_F(CtranIbTest, envQpConfig) {
       {"512", "8", "spray", "8"},
       {"1024", "16", "dqplb", "12"},
   };
-  EnvRAII xRackQps(NCCL_CTRAN_IB_QP_CONFIG_XRACK, kPeerTestQpConfig[1]);
   EnvRAII xZoneQps(NCCL_CTRAN_IB_QP_CONFIG_XZONE, kPeerTestQpConfig[2]);
   EnvRAII xDcQps(NCCL_CTRAN_IB_QP_CONFIG_XDC, kPeerTestQpConfig[3]);
 
@@ -1865,19 +1864,29 @@ TEST_F(CtranIbTest, envQpConfig) {
 
       CtranIb::CtranIbVcConfig_t config;
       EXPECT_EQ(ctranIb->getVcConfig(peer, config), commSuccess);
-      // Check QP Scaling Threshold
-      EXPECT_EQ(std::get<0>(config), std::stoul(kPeerTestQpConfig[peer].at(0)));
-      // Check # of QPs
-      EXPECT_EQ(std::get<1>(config), std::stoi(kPeerTestQpConfig[peer].at(1)));
-      // Check VC Mode
-      if (kPeerTestQpConfig[peer].at(2) == "spray") {
-        EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::spray);
+      if (peer == 1) {
+        // Peer 1 is in same zone (SAME_ZONE) — uses global defaults
+        EXPECT_EQ(
+            std::get<0>(config), (size_t)NCCL_CTRAN_IB_QP_SCALING_THRESHOLD);
+        EXPECT_EQ(std::get<1>(config), (int)NCCL_CTRAN_IB_MAX_QPS);
+        EXPECT_EQ(
+            std::get<2>(config),
+            (enum NCCL_CTRAN_IB_VC_MODE)NCCL_CTRAN_IB_VC_MODE);
+        EXPECT_EQ(std::get<3>(config), (int)NCCL_CTRAN_IB_QP_MAX_MSGS);
       } else {
-        EXPECT_EQ(kPeerTestQpConfig[peer].at(2), "dqplb"); // Only other option
-        EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::dqplb);
+        // Peers 2,3 use XZONE/XDC config overrides
+        EXPECT_EQ(
+            std::get<0>(config), std::stoul(kPeerTestQpConfig[peer].at(0)));
+        EXPECT_EQ(
+            std::get<1>(config), std::stoi(kPeerTestQpConfig[peer].at(1)));
+        if (kPeerTestQpConfig[peer].at(2) == "spray") {
+          EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::spray);
+        } else {
+          EXPECT_EQ(std::get<2>(config), NCCL_CTRAN_IB_VC_MODE::dqplb);
+        }
+        EXPECT_EQ(
+            std::get<3>(config), std::stoi(kPeerTestQpConfig[peer].at(3)));
       }
-      // Check # of QPs per VC
-      EXPECT_EQ(std::get<3>(config), std::stoi(kPeerTestQpConfig[peer].at(3)));
     }
   } else {
     ControlMsg msg(ControlMsgType::SYNC);
@@ -1894,8 +1903,8 @@ TEST_F(CtranIbTest, ValidBeTopology) {
   // set a fake topology to test QP changes for each IB VC
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {"rtsw098.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-0
-      {1, {"rtsw099.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-1: x-rack
-                                                              // with rank-0
+      {1, {"rtsw099.c084.f00.nha1", kSuDomain1, dc1, zone1}}, // rank-1: same
+                                                              // zone as rank-0
       {2, {"rtsw100.c085.f00.nha1", kSuDomain1, dc1, zone2}}, // rank-2: x-zone
                                                               // with rank-0
       {3, {"rtsw101.c080.f00.nha2", kSuDomain1, dc2, zone3}} // rank-3: x-dc
@@ -1948,7 +1957,7 @@ TEST_F(CtranIbTest, InvalidBeTopology) {
   // is present for the ranks
   std::unordered_map<int, std::vector<std::string>> expectedTopology = {
       {0, {dc1, zone1}}, // rank-0
-      {1, {dc1, zone1}}, // rank-1: x-rack with rank-0
+      {1, {dc1, zone1}}, // rank-1: same zone as rank-0
       {2, {dc1, zone2}}, // rank-2: x-zone with rank-0
       {3, {dc2, zone3}} // rank-3: x-dc with rank-0
   };

--- a/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
@@ -87,9 +87,17 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
     EnvRAII<decltype(NCCL_CTRAN_IB_DEVICES_PER_RANK)> devices{
         NCCL_CTRAN_IB_DEVICES_PER_RANK,
         2};
-    EnvRAII<decltype(NCCL_CTRAN_IB_QP_CONFIG_XRACK)> xRackQps{
-        NCCL_CTRAN_IB_QP_CONFIG_XRACK,
-        qpConfig};
+    // SAME_ZONE uses global defaults, so set them to dqplb mode
+    EnvRAII<decltype(NCCL_CTRAN_IB_QP_SCALING_THRESHOLD)> scalingTh{
+        NCCL_CTRAN_IB_QP_SCALING_THRESHOLD,
+        524288};
+    EnvRAII<decltype(NCCL_CTRAN_IB_MAX_QPS)> maxQps{NCCL_CTRAN_IB_MAX_QPS, 2};
+    EnvRAII<decltype(NCCL_CTRAN_IB_VC_MODE)> vcMode{
+        NCCL_CTRAN_IB_VC_MODE,
+        NCCL_CTRAN_IB_VC_MODE::dqplb};
+    EnvRAII<decltype(NCCL_CTRAN_IB_QP_MAX_MSGS)> maxMsgs{
+        NCCL_CTRAN_IB_QP_MAX_MSGS,
+        128};
     EnvRAII<decltype(NCCL_CTRAN_IB_QP_CONFIG_XZONE)> xZoneQps{
         NCCL_CTRAN_IB_QP_CONFIG_XZONE,
         qpConfig};

--- a/comms/ctran/commstate/CommStateX.cc
+++ b/comms/ctran/commstate/CommStateX.cc
@@ -117,25 +117,25 @@ void CommStateX::initRankStatesTopology(meta::comms::IBootstrap* bootstrap) {
         commDesc_,
         fmt::format("Failed to load topology from {}", NCCL_TOPO_FILE_PATH));
   } else {
+    networkTopo_ = std::move(myTopo->networkTopo);
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "Load topology for rank {} commHash {:x} commDesc {}, nRanks {}, host {}, dc {} zone {} rtsw {} scaling unit {} rackSerial {}",
+        "Load topology for rank {} commHash {:x} commDesc {}, nRanks {}, host {}, dc {} zone {} rackSerial {} networkTopo {}",
         rank_,
         commHash_,
         commDesc_,
         nRanks_,
-        myTopo->host,
-        myTopo->dc,
-        myTopo->zone,
-        myTopo->rtsw,
-        myTopo->su,
-        myTopo->rackSerial);
+        myTopo->rankTopology.host,
+        myTopo->rankTopology.dc,
+        myTopo->rankTopology.zone,
+        myTopo->rankTopology.rackSerial,
+        networkTopo_);
   }
 
   // Gather topologies across all the ranks
   std::vector<ncclx::RankTopology> allTopos(nRanks_);
-  allTopos.at(rank_) = *myTopo;
+  allTopos.at(rank_) = myTopo->rankTopology;
   auto resFuture = bootstrap->allGather(
       allTopos.data(), sizeof(ncclx::RankTopology), rank_, nRanks_);
   FB_COMMCHECKTHROW_EX(
@@ -350,8 +350,6 @@ void CommStateX::setRankStatesTopologies(
   for (int r = 0; r < static_cast<int>(rankTopologies_.size()); r++) {
     const auto& rankTopology = rankTopologies_[r];
     const std::string host(rankTopology.host);
-    const std::string rtsw(rankTopology.rtsw);
-    const std::string su(rankTopology.su);
     const std::string dc(rankTopology.dc);
     const std::string zone(rankTopology.zone);
 
@@ -371,8 +369,6 @@ void CommStateX::setRankStatesTopologies(
     state.rank = r;
     state.pid = rankTopology.pid;
     state.host = host;
-    state.rtsw = rtsw;
-    state.su = su;
     state.dc = dc;
     state.zone = zone;
     state.rackSerial = rankTopology.rackSerial;
@@ -578,11 +574,6 @@ std::string CommStateX::host(int rank) const {
   return rankStates_.at(rank).host;
 }
 
-std::string CommStateX::rtsw(int rank) const {
-  CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
-  return rankStates_.at(rank).rtsw;
-}
-
 int CommStateX::gRank(int rank) const {
   CHECK_RANKMAP_SET(commRanksToWorldRanks_);
   if (rank == -1) {
@@ -599,6 +590,10 @@ std::string CommStateX::gPid(int rank) const {
       std::to_string(rankStates_.at(rank).pid);
 }
 
+const std::string& CommStateX::networkTopo() const {
+  return networkTopo_;
+}
+
 std::string CommStateX::dc(int rank) const {
   CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
   return rankStates_.at(rank).dc;
@@ -607,11 +602,6 @@ std::string CommStateX::dc(int rank) const {
 std::string CommStateX::zone(int rank) const {
   CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
   return rankStates_.at(rank).zone;
-}
-
-std::string CommStateX::su(int rank) const {
-  CHECK_TOPO_AND_SET_RANK(rank, rank_, rankStates_);
-  return rankStates_.at(rank).su;
 }
 
 std::string_view CommStateX::deviceRack(int rank) const {
@@ -623,24 +613,6 @@ std::string_view CommStateX::deviceRack(int rank) const {
 bool CommStateX::isSameNode(int myRank, int peer) const {
   return node(peer) == node(myRank);
 }
-bool CommStateX::isSameRack(int myRank, int peer) const {
-  const auto& rtsw1 = rtsw(myRank);
-  if (!rtsw1.empty()) {
-    const auto& rtsw2 = rtsw(peer);
-    return !rtsw2.empty() && rtsw1 == rtsw2;
-  }
-
-  // Check su only if rtsw check failed. Since PXN is enabled all ranks in the
-  // same SU are 1 hop away.
-  const auto& su1 = su(myRank);
-  if (!su1.empty()) {
-    const auto& su2 = su(peer);
-    return !su2.empty() && su1 == su2;
-  }
-
-  return false;
-}
-
 bool CommStateX::isSameZone(int myRank, int peer) const {
   return zone(peer) == zone(myRank);
 }

--- a/comms/ctran/commstate/CommStateX.h
+++ b/comms/ctran/commstate/CommStateX.h
@@ -19,7 +19,7 @@ namespace ncclx {
 
 namespace {
 constexpr size_t kMaxNameLen = 64;
-}
+} // namespace
 
 // We use sizeof(T) to determine the size for bootstrapAllGather, so have to use
 // c style char[] to get accurate size
@@ -33,12 +33,6 @@ struct RankTopology {
 
   // host name e.g twshared0265.02.nha1
   char host[kMaxNameLen];
-
-  // rtsw name e.g rtsw098.c084.f00.nha1
-  char rtsw[kMaxNameLen];
-
-  // Scaling unit info for rail based networks eg. atn3.z085.u001
-  char su[kMaxNameLen];
 
   char zone[kMaxNameLen];
 
@@ -146,11 +140,9 @@ class CommStateX {
   // get host name for a given rank, default to current rank
   std::string host(int rank = -1) const;
 
-  // get rtsw/rack name for a given rank, default to current rank
-  std::string rtsw(int rank = -1) const;
-
-  // get scaling unit name for a given rank, default to current rank
-  std::string su(int rank = -1) const;
+  // get raw DEVICE_BACKEND_NETWORK_TOPOLOGY string (local rank only, for
+  // observability)
+  const std::string& networkTopo() const;
 
   // get zone name for a given rank, default to current rank
   std::string zone(int rank = -1) const;
@@ -170,9 +162,6 @@ class CommStateX {
 
   // check if two ranks are on the same node
   bool isSameNode(int myRank, int peer) const;
-
-  // check if two ranks are on the same rack/ (under the same rtsw)
-  bool isSameRack(int myRank, int peer) const;
 
   // check if two ranks are on the same zone
   bool isSameZone(int myRank, int peer) const;
@@ -208,10 +197,6 @@ class CommStateX {
     int pid{-1};
 
     std::string host;
-
-    std::string rtsw;
-
-    std::string su;
 
     std::string dc;
 
@@ -261,6 +246,10 @@ class CommStateX {
   int64_t busId_{-1};
   const uint64_t commHash_{0};
   const std::string commDesc_;
+
+  // Raw DEVICE_BACKEND_NETWORK_TOPOLOGY string for local rank (observability
+  // only)
+  std::string networkTopo_;
 
   std::vector<RankTopology> rankTopologies_{};
   // World ranks only exist in eager init when there's a default_pg

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -29,8 +29,6 @@ void parseTopologyValue(
     const std::string& filepath,
     std::string& dc,
     std::string& zone,
-    std::string& su,
-    std::string& rtsw,
     bool& isBackendTopologyValid) {
   std::vector<std::string> topologyParts;
   folly::split('/', value, topologyParts);
@@ -48,8 +46,6 @@ void parseTopologyValue(
 
   dc = std::move(topologyParts[0]);
   zone = std::move(topologyParts[1]);
-  su = std::move(topologyParts[2]);
-  rtsw = std::move(topologyParts[3]);
 
   if (zone.empty()) {
     return;
@@ -57,7 +53,7 @@ void parseTopologyValue(
   isBackendTopologyValid = true;
 }
 
-std::optional<ncclx::RankTopology> loadTopology(
+std::optional<TopologyResult> loadTopology(
     int rank,
     const std::string& filepath) {
   std::ifstream file(filepath);
@@ -65,12 +61,7 @@ std::optional<ncclx::RankTopology> loadTopology(
 
   std::string rackSerial;
 
-  // currently we don't use rtsw info yet, it's ok to have empty rtsw
-  std::string rtsw;
-
-  // Rail based topologies do not have rtsw info, we use scaling unit info
-  // instead
-  std::string dc, zone, su, host, backendNetworkTopology;
+  std::string dc, zone, host, backendNetworkTopology;
   bool isBackendTopologyValid = false;
 
   while (std::getline(file, line)) {
@@ -88,8 +79,7 @@ std::optional<ncclx::RankTopology> loadTopology(
       host = value;
     } else if (key == kNetworkTopo) {
       backendNetworkTopology = value;
-      parseTopologyValue(
-          value, filepath, dc, zone, su, rtsw, isBackendTopologyValid);
+      parseTopologyValue(value, filepath, dc, zone, isBackendTopologyValid);
     } else if (key == kDeviceRackSerial) {
       if (value.size() >= ncclx::kMaxNameLen) {
         CLOGF(
@@ -131,9 +121,7 @@ std::optional<ncclx::RankTopology> loadTopology(
   std::strncpy(topo.dc, dc.c_str(), ncclx::kMaxNameLen);
   std::strncpy(topo.zone, zone.c_str(), ncclx::kMaxNameLen);
   std::strncpy(topo.host, host.c_str(), ncclx::kMaxNameLen);
-  std::strncpy(topo.rtsw, rtsw.c_str(), ncclx::kMaxNameLen);
-  std::strncpy(topo.su, su.c_str(), ncclx::kMaxNameLen);
-  return topo;
+  return TopologyResult{topo, std::move(backendNetworkTopology)};
 }
 
 } // namespace ctran::commstate

--- a/comms/ctran/commstate/Topology.h
+++ b/comms/ctran/commstate/Topology.h
@@ -8,8 +8,13 @@
 
 namespace ctran::commstate {
 
+struct TopologyResult {
+  ncclx::RankTopology rankTopology;
+  std::string networkTopo;
+};
+
 // load RankTopology from a given filepath
-std::optional<ncclx::RankTopology> loadTopology(
+std::optional<TopologyResult> loadTopology(
     int rank,
     const std::string& filepath);
 

--- a/comms/ctran/commstate/tests/CommStateXTest.cc
+++ b/comms/ctran/commstate/tests/CommStateXTest.cc
@@ -23,12 +23,6 @@ constexpr auto kHost3 = "twshared0103.01.nha1";
 constexpr auto kDc = "nha1";
 constexpr auto kZone = "c084";
 
-constexpr auto kRtsw0 = "rtsw098.c084.f00.nha1";
-constexpr auto kRtsw1 = "rtsw099.c084.f00.nha1";
-
-constexpr auto kSuDomain1 = "nha1.c084.u001";
-constexpr auto kSuDomain2 = "nha1.c084.u002";
-
 constexpr auto kNvlFabricClusterId1 = "1";
 constexpr auto kNvlFabricClusterId2 = "2";
 constexpr int64_t kNvlFabricCliqueId1 = 1;
@@ -40,8 +34,6 @@ RankTopology createRankTopology(
     int rank,
     const std::string& dc,
     const std::string& zone,
-    const std::string& su,
-    const std::string& rtsw,
     const std::string& host,
     const std::string& rackSerial = "",
     int pid = -1) {
@@ -49,8 +41,6 @@ RankTopology createRankTopology(
   topo.rank = rank;
   topo.pid = pid;
   std::strcpy(topo.host, host.c_str());
-  std::strcpy(topo.rtsw, rtsw.c_str());
-  std::strcpy(topo.su, su.c_str());
   std::strcpy(topo.dc, dc.c_str());
   std::strcpy(topo.zone, zone.c_str());
   std::strncpy(topo.rackSerial, rackSerial.c_str(), ncclx::kMaxNameLen);
@@ -79,36 +69,26 @@ class CommStateXTest : public ::testing::Test {
 };
 
 TEST(CommStateXTest, Topology) {
-  // format dc/zone//rtsw
   std::vector<RankTopology> rankTopologies{};
-  const std::string kSu;
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
 
-  rankTopologies.emplace_back(
-      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
-  rankTopologies.emplace_back(
-      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
 
   std::unordered_map<int, std::vector<std::string_view>> expectedHostRtsws{
-      {0, {kHost0, kRtsw0, kDc, kZone}},
-      {1, {kHost0, kRtsw0, kDc, kZone}},
-      {2, {kHost1, kRtsw0, kDc, kZone}},
-      {3, {kHost1, kRtsw0, kDc, kZone}},
-      {4, {kHost2, kRtsw1, kDc, kZone}},
-      {5, {kHost2, kRtsw1, kDc, kZone}},
-      {6, {kHost3, kRtsw1, kDc, kZone}},
-      {7, {kHost3, kRtsw1, kDc, kZone}}};
+      {0, {kHost0, kDc, kZone}},
+      {1, {kHost0, kDc, kZone}},
+      {2, {kHost1, kDc, kZone}},
+      {3, {kHost1, kDc, kZone}},
+      {4, {kHost2, kDc, kZone}},
+      {5, {kHost2, kDc, kZone}},
+      {6, {kHost3, kDc, kZone}},
+      {7, {kHost3, kDc, kZone}}};
 
   auto verify = [&](CommStateX* s, int rank) {
     EXPECT_EQ(s->cudaDev(), 0);
@@ -162,11 +142,10 @@ TEST(CommStateXTest, Topology) {
         EXPECT_EQ(s->localRankToRank(i, nodeId), nodeId * 2 + i);
       }
     }
-    // host/rtsw
+    // host/dc/zone
     EXPECT_EQ(s->host(), expectedHostRtsws.at(rank).at(0));
-    EXPECT_EQ(s->rtsw(), expectedHostRtsws.at(rank).at(1));
-    EXPECT_EQ(s->dc(), expectedHostRtsws.at(rank).at(2));
-    EXPECT_EQ(s->zone(), expectedHostRtsws.at(rank).at(3));
+    EXPECT_EQ(s->dc(), expectedHostRtsws.at(rank).at(1));
+    EXPECT_EQ(s->zone(), expectedHostRtsws.at(rank).at(2));
   };
 
   // verify all ranks
@@ -187,18 +166,13 @@ TEST(CommStateXTest, Topology) {
 
 TEST(CommStateXTest, ValidEorTopology) {
   std::vector<RankTopology> rankTopologies{};
-  const std::string kRtsw;
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSuDomain1, kRtsw, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSuDomain2, kRtsw, kHost2));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost2));
 
   std::unordered_map<int, std::vector<std::string_view>> expectedTopology{
-      {0, {kHost0, kSuDomain1, kDc, kZone}}};
+      {0, {kHost0, kDc, kZone}}};
 
   int myRank = 0;
   auto commState = std::make_unique<CommStateX>(
@@ -220,19 +194,15 @@ TEST(CommStateXTest, ValidEorTopology) {
   EXPECT_EQ(commState->nNodes(), 3);
 
   EXPECT_EQ(commState->host(), expectedTopology.at(myRank).at(0));
-  EXPECT_EQ(commState->su(), expectedTopology.at(myRank).at(1));
-  EXPECT_EQ(commState->dc(), expectedTopology.at(myRank).at(2));
-  EXPECT_EQ(commState->zone(), expectedTopology.at(myRank).at(3));
+  EXPECT_EQ(commState->dc(), expectedTopology.at(myRank).at(1));
+  EXPECT_EQ(commState->zone(), expectedTopology.at(myRank).at(2));
 
   for (int peer = 1; peer < 4; ++peer) {
     if (peer == 1) {
       EXPECT_TRUE(commState->isSameNode(myRank, peer));
-      EXPECT_TRUE(commState->isSameRack(myRank, peer));
     } else if (peer == 2) {
       EXPECT_FALSE(commState->isSameNode(myRank, peer));
-      EXPECT_TRUE(commState->isSameRack(myRank, peer));
     } else if (peer == 3) {
-      EXPECT_FALSE(commState->isSameRack(myRank, peer));
       EXPECT_TRUE(commState->isSameZone(myRank, peer));
     }
   }
@@ -245,14 +215,10 @@ TEST(CommStateXTest, multiRackTest) {
   const int cudaArch = 90;
   const int64_t busId = 25;
   const uint64_t commHash = 0;
-  const std::string kRtsw;
   std::vector<RankTopology> rankTopologies{};
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0, "100"));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0, "100"));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSuDomain1, kRtsw, kHost1, "101"));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0, "100"));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0, "100"));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1, "101"));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -276,12 +242,9 @@ TEST(CommStateXTest, emptyDeviceRackReturnsFalse) {
   const int cudaArch = 90;
   const int64_t busId = 25;
   const uint64_t commHash = 0;
-  const std::string kRtsw;
   std::vector<RankTopology> rankTopologies{};
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kRtsw, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kRtsw, kHost0));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -323,24 +286,15 @@ TEST(CommStateXTest, nvlFabricTest) {
       createNvlFabricTopology(7, kNvlFabricClusterId2, kNvlFabricCliqueId1));
 
   std::vector<RankTopology> rankTopologies{};
-  const std::string kSu = "";
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
 
-  rankTopologies.emplace_back(
-      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
-  rankTopologies.emplace_back(
-      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -411,24 +365,15 @@ TEST(CommStateXTest, nvlFabricCliqueTest) {
       createNvlFabricTopology(7, kNvlFabricClusterId2, kNvlFabricCliqueId4));
 
   std::vector<RankTopology> rankTopologies{};
-  const std::string kSu = "";
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
 
-  rankTopologies.emplace_back(
-      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
-  rankTopologies.emplace_back(
-      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -475,23 +420,14 @@ TEST(CommStateXTest, nvlFabricVCliqueSizeHint) {
   }
 
   std::vector<RankTopology> rankTopologies{};
-  const std::string kSu = "";
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
-  rankTopologies.emplace_back(
-      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
 
   auto makeCommState = [&](int vCliqueSize = 0) {
     return std::make_unique<CommStateX>(
@@ -618,16 +554,13 @@ class GpidTopoTest : public ::testing::TestWithParam<TopoTestParam> {
   static constexpr uint64_t kCommHash = 0;
 
   std::vector<RankTopology> makeRankTopologies() {
-    const std::string kSu;
-    const std::array<std::pair<const char*, const char*>, kNumHosts> hostInfo =
-        {{{kHost0, kRtsw0}, {kHost1, kRtsw1}}};
+    const std::array<const char*, kNumHosts> hostInfo = {{kHost0, kHost1}};
     std::vector<RankTopology> topos;
     topos.reserve(kNRanks);
     for (int r = 0; r < kNRanks; r++) {
-      const auto& [host, rtsw] = hostInfo[r / kRanksPerHost];
+      const auto host = hostInfo[r / kRanksPerHost];
       const int pid = 1000 * (r / kRanksPerHost + 1) + r % kRanksPerHost;
-      topos.emplace_back(
-          createRankTopology(r, kDc, kZone, kSu, rtsw, host, "", pid));
+      topos.emplace_back(createRankTopology(r, kDc, kZone, host, "", pid));
     }
     return topos;
   }
@@ -728,24 +661,15 @@ TEST(CommStateXTest, TopologySetInvalidNvlFabricTopos) {
   const uint64_t commHash = 0;
 
   std::vector<RankTopology> rankTopologies{};
-  const std::string kSu;
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSu, kRtsw0, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(2, kDc, kZone, kSu, kRtsw0, kHost1));
-  rankTopologies.emplace_back(
-      createRankTopology(3, kDc, kZone, kSu, kRtsw0, kHost1));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(2, kDc, kZone, kHost1));
+  rankTopologies.emplace_back(createRankTopology(3, kDc, kZone, kHost1));
 
-  rankTopologies.emplace_back(
-      createRankTopology(4, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(5, kDc, kZone, kSu, kRtsw1, kHost2));
-  rankTopologies.emplace_back(
-      createRankTopology(6, kDc, kZone, kSu, kRtsw1, kHost3));
-  rankTopologies.emplace_back(
-      createRankTopology(7, kDc, kZone, kSu, kRtsw1, kHost3));
+  rankTopologies.emplace_back(createRankTopology(4, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(5, kDc, kZone, kHost2));
+  rankTopologies.emplace_back(createRankTopology(6, kDc, kZone, kHost3));
+  rankTopologies.emplace_back(createRankTopology(7, kDc, kZone, kHost3));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -904,18 +828,16 @@ TEST(CommStateXTest, gb300DsfTopologyNoSuNoRtsw) {
   const int cudaArch = 90;
   const int64_t busId = 25;
   const uint64_t commHash = 0;
-  const std::string kEmptySu = "";
-  const std::string kEmptyRtsw = "";
   const std::string kUco1Dc = "uco1";
   const std::string kUco1Zone = "uco1.z086";
 
   std::vector<RankTopology> rankTopologies{};
   rankTopologies.emplace_back(
-      createRankTopology(0, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost0));
+      createRankTopology(0, kUco1Dc, kUco1Zone, kHost0));
   rankTopologies.emplace_back(
-      createRankTopology(1, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost0));
+      createRankTopology(1, kUco1Dc, kUco1Zone, kHost0));
   rankTopologies.emplace_back(
-      createRankTopology(2, kUco1Dc, kUco1Zone, kEmptySu, kEmptyRtsw, kHost1));
+      createRankTopology(2, kUco1Dc, kUco1Zone, kHost1));
 
   auto commState = std::make_unique<CommStateX>(
       rank,
@@ -929,10 +851,6 @@ TEST(CommStateXTest, gb300DsfTopologyNoSuNoRtsw) {
 
   EXPECT_TRUE(commState->isSameNode(rank, 1));
   EXPECT_FALSE(commState->isSameNode(rank, 2));
-
-  // With both su and rtsw empty, isSameRack returns false for all peers
-  EXPECT_FALSE(commState->isSameRack(rank, 1));
-  EXPECT_FALSE(commState->isSameRack(rank, 2));
 
   EXPECT_TRUE(commState->isSameZone(rank, 1));
   EXPECT_TRUE(commState->isSameZone(rank, 2));
@@ -949,14 +867,10 @@ TEST(CommStateXTest, isSameDeviceRackUnknownSerial) {
   const int cudaArch = 90;
   const int64_t busId = 25;
   const uint64_t commHash = 0;
-  const std::string kEmptyRtsw;
-
   std::vector<RankTopology> rankTopologies{};
   // Both ranks have empty rackSerial
-  rankTopologies.emplace_back(
-      createRankTopology(0, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0));
-  rankTopologies.emplace_back(
-      createRankTopology(1, kDc, kZone, kSuDomain1, kEmptyRtsw, kHost0));
+  rankTopologies.emplace_back(createRankTopology(0, kDc, kZone, kHost0));
+  rankTopologies.emplace_back(createRankTopology(1, kDc, kZone, kHost0));
 
   auto commState = std::make_unique<CommStateX>(
       rank,

--- a/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
+++ b/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
@@ -15,11 +15,10 @@ TEST(TopologyTest, LoadTopologySuccess) {
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
-  EXPECT_EQ(topo->rank, 0);
-  const std::string host(topo->host);
-  const std::string rtsw(topo->rtsw);
+  EXPECT_EQ(topo->rankTopology.rank, 0);
+  const std::string host(topo->rankTopology.host);
   EXPECT_EQ(host, "rtptest021.nha1.facebook.com");
-  EXPECT_EQ(rtsw, "rtsw098.c084.f00.nha1");
+  EXPECT_EQ(topo->networkTopo, "/nha1.1D//rtsw098.c084.f00.nha1");
 }
 
 TEST(TopologyTest, LoadTopologyFailure) {
@@ -49,20 +48,17 @@ TEST(TopologyTest, RailBasedTopology) {
 
   auto topo = ctran::commstate::loadTopology(1, filepath);
   EXPECT_TRUE(topo);
-  EXPECT_EQ(topo->rank, 1);
+  EXPECT_EQ(topo->rankTopology.rank, 1);
 
-  const std::string host(topo->host);
-  const std::string dc(topo->dc);
-  const std::string zone(topo->zone);
-  const std::string su(topo->su);
-  const std::string rtsw(topo->rtsw);
+  const std::string host(topo->rankTopology.host);
+  const std::string dc(topo->rankTopology.dc);
+  const std::string zone(topo->rankTopology.zone);
 
   EXPECT_EQ(host, "testhost.rail.facebook.com");
   EXPECT_EQ(dc, "");
   EXPECT_EQ(zone, "snb1.z081");
-  EXPECT_EQ(su, "snb1.z081.u015");
-  EXPECT_EQ(rtsw, "");
-  EXPECT_STREQ(topo->rackSerial, "12345");
+  EXPECT_STREQ(topo->rankTopology.rackSerial, "12345");
+  EXPECT_EQ(topo->networkTopo, "/snb1.z081/snb1.z081.u015/");
 }
 
 TEST(TopologyTest, InvalidTopologyFormat) {
@@ -85,10 +81,7 @@ TEST(TopologyTest, BothRtswAndScalingUnit) {
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
-  const std::string su(topo->su);
-  const std::string rtsw(topo->rtsw);
-  EXPECT_EQ(su, "scaling_unit");
-  EXPECT_EQ(rtsw, "rtsw_name");
+  EXPECT_EQ(topo->networkTopo, "dc/zone/scaling_unit/rtsw_name");
 }
 
 TEST(TopologyTest, GB300DsfTopologyZoneOnly) {
@@ -100,17 +93,14 @@ TEST(TopologyTest, GB300DsfTopologyZoneOnly) {
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
-  const std::string host(topo->host);
-  const std::string dc(topo->dc);
-  const std::string zone(topo->zone);
-  const std::string su(topo->su);
-  const std::string rtsw(topo->rtsw);
+  const std::string host(topo->rankTopology.host);
+  const std::string dc(topo->rankTopology.dc);
+  const std::string zone(topo->rankTopology.zone);
   EXPECT_EQ(host, "twshared1766.40.uco1.facebook.com");
   EXPECT_EQ(dc, "uco1");
   EXPECT_EQ(zone, "uco1.z086");
-  EXPECT_EQ(su, "");
-  EXPECT_EQ(rtsw, "");
-  EXPECT_STREQ(topo->rackSerial, "12278553");
+  EXPECT_STREQ(topo->rankTopology.rackSerial, "12278553");
+  EXPECT_EQ(topo->networkTopo, "uco1/uco1.z086//");
 }
 
 TEST(TopologyTest, EmptyTopologyValue) {
@@ -123,8 +113,9 @@ TEST(TopologyTest, EmptyTopologyValue) {
   EXPECT_TRUE(topo); // Should succeed, empty topology is allowed when no
                      // backend network
 
-  const std::string host(topo->host);
+  const std::string host(topo->rankTopology.host);
   EXPECT_EQ(host, "testhost.facebook.com");
+  EXPECT_EQ(topo->networkTopo, "");
 }
 
 TEST(TopologyTest, EmptyRackSerial) {
@@ -137,12 +128,10 @@ TEST(TopologyTest, EmptyRackSerial) {
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
-  EXPECT_EQ(topo->rank, 0);
-  const std::string host(topo->host);
-  const std::string rtsw(topo->rtsw);
+  EXPECT_EQ(topo->rankTopology.rank, 0);
+  const std::string host(topo->rankTopology.host);
   EXPECT_EQ(host, "rtptest021.nha1.facebook.com");
-  EXPECT_EQ(rtsw, "rtsw098.c084.f00.nha1");
-  EXPECT_STREQ(topo->rackSerial, "");
+  EXPECT_STREQ(topo->rankTopology.rackSerial, "");
 }
 
 TEST(TopologyTest, NonNumericRackSerial) {
@@ -154,5 +143,5 @@ TEST(TopologyTest, NonNumericRackSerial) {
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   EXPECT_TRUE(topo);
-  EXPECT_STREQ(topo->rackSerial, "not_a_number");
+  EXPECT_STREQ(topo->rankTopology.rackSerial, "not_a_number");
 }

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -498,9 +498,6 @@ std::unique_ptr<CtranComm> CtranStandaloneFixture::makeCtranComm(
   std::strncpy(topo.dc, "ut_dc", ncclx::kMaxNameLen);
   std::strncpy(topo.zone, "ut_zone", ncclx::kMaxNameLen);
   std::strncpy(topo.host, "ut_host", ncclx::kMaxNameLen);
-  // we can only set one of the two, rtsw or su.
-  std::strncpy(topo.rtsw, "", ncclx::kMaxNameLen);
-  std::strncpy(topo.su, "ut_su", ncclx::kMaxNameLen);
 
   std::vector<ncclx::RankTopology> rankTopologies = {topo};
   std::vector<int> commRanksToWorldRanks = {0};

--- a/comms/utils/cvars/README.md
+++ b/comms/utils/cvars/README.md
@@ -99,8 +99,7 @@ NCCL_RAS_ENABLE - default value changed from 1 to 0 NCCL_CTRAN_IB_MAX_QPS -
 default value changed from 1 to 16 NCCL_CTRAN_IB_QP_MAX_MSGS - default value
 changed from 4 to 128 NCCL_CTRAN_IB_QP_SCALING_THRESHOLD - default value changed
 from 131072 to 524288 NCCL_CTRAN_IB_QP_CONFIG_XDC - default value changed from
-"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XRACK - default value
-changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
+"" to "1048576,16,spray,128" NCCL_CTRAN_IB_QP_CONFIG_XZONE -
 default value changed from "" to "1048576,16,spray,128" NCCL_CTRAN_IB_VC_MODE -
 default value changed from "spray" to "dqplb"
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1555,17 +1555,6 @@ cvars:
      Configure IBVCs to support either spray mode (uses extra QP for
      notifications) or dqplb mode ("normal" but all writes are WRITE_WITH_IMM)
 
- - name        : NCCL_CTRAN_IB_QP_CONFIG_XRACK
-   type        : stringlist
-   default     : "1048576,16,spray,128"
-   description : |-
-     A set of configuration for CTRAN IB over inter-rack communication:
-     <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS>
-     e.g., NCCL_CTRAN_IB_QP_CONFIG_XRACK="1048576,4,spray,6",
-     If not given, NCCLx will use values from
-     NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, NCCL_CTRAN_IB_MAX_QPS,
-     NCCL_CTRAN_IB_VC_MODE, and NCCL_CTRAN_IB_QP_MAX_MSGS respectively
-
  - name        : NCCL_CTRAN_IB_QP_CONFIG_XZONE
    type        : stringlist
    default     : "1048576,16,spray,128"
@@ -1606,7 +1595,7 @@ cvars:
      where value is a list of <QP_SCALING_THRESHOLD>,<MAX_QPS>,<VC_MODE>,<QP_MAX_MSGS><TRAFFIC_CLASS>
      e.g., NCCL_CTRAN_IB_QP_CONFIG_ALGO="alltoall:1048576,4,dqplb,128,224;sendrecv:1048576,16,spray,128,224"
      If not given, NCCLx will use the configuration specified per topology
-     (see NCCL_CTRAN_IB_QP_CONFIG_XDC, NCCL_CTRAN_IB_QP_CONFIG_XZONE, NCCL_CTRAN_IB_QP_CONFIG_XRACK),
+     (see NCCL_CTRAN_IB_QP_CONFIG_XDC, NCCL_CTRAN_IB_QP_CONFIG_XZONE),
      or the default configuration set (see NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, NCCL_CTRAN_IB_MAX_QPS,
      NCCL_CTRAN_IB_VC_MODE, and NCCL_CTRAN_IB_QP_MAX_MSGS) for all collectives.
 


### PR DESCRIPTION
Summary:

Remove `isSameRack()`, `rtsw()`, and `su()` from `CommStateX` since ctran IB no longer uses rack-level QP config (removed in the parent commit):
- Delete `isSameRack()` method, `rtsw()` and `su()` accessors, and their backing fields from `RankTopology`/`RankState`
- Remove `rtsw` and `su` parsing from `Topology.cc` — dc and zone are still parsed from `DEVICE_BACKEND_NETWORK_TOPOLOGY`
- Add `networkTopo` field to store the raw `DEVICE_BACKEND_NETWORK_TOPOLOGY` string for observability (logged at init, accessible via `networkTopo()` accessor)
- Remove profiler `Wqe::Scope::RACK` and `wqe.rtsw`/`wqe.remoteRtsw` fields
- Update all tests to remove rtsw/su assertions and add `networkTopo` coverage
- Note: `deviceRack()`/`isSameDeviceRack()`/`rackSerial` are intentionally kept — used by NVL backend for MNNVL trunk detection

Differential Revision: D105381886


