### PR TITLE
add flush support to poll thread (#2573)

### DIFF
--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -126,8 +126,17 @@ CollTrace::CollTrace(
 }
 
 CollTrace::~CollTrace() {
-  // Set the cancellation flag
-  threadShouldStop_.test_and_set();
+  // Set the cancellation flag under the flush mutex so waitFlush()
+  // can't miss the state change between its predicate check and wait.
+  {
+    std::lock_guard lock(flushState_.mutex);
+    threadShouldStop_.test_and_set();
+  }
+  flushState_.cv.notify_all();
+  // Wake the poll thread if it is blocking on the MPMC queue so it sees
+  // the cancellation flag promptly instead of waiting for the full
+  // maxCheckCancelInterval.
+  pendingTraceColls_.writeIfNotFull(nullptr);
   // Invalidate all eager handles.
   for (auto& [_, handle] : eventToHandleMap_) {
     handle->invalidate();
@@ -391,6 +400,33 @@ CollTrace::recordGraphCollectiveImpl(
   return handle;
 }
 
+uint64_t CollTrace::requestFlush() noexcept {
+  auto gen = flushState_.requested.fetch_add(1, std::memory_order_acq_rel) + 1;
+  // Best-effort sentinel to wake the poll thread. If the queue is full,
+  // the thread has plenty of work and will see the updated generation
+  // on its next iteration.
+  pendingTraceColls_.writeIfNotFull(nullptr);
+  return gen;
+}
+
+void CollTrace::waitFlush(uint64_t gen) noexcept {
+  std::unique_lock lock(flushState_.mutex);
+  flushState_.cv.wait(lock, [&] {
+    return flushState_.completed.load(std::memory_order_acquire) >= gen ||
+        isThreadCancelled();
+  });
+}
+
+void CollTrace::ackFlush(uint64_t gen) noexcept {
+  if (gen > flushState_.completed.load(std::memory_order_relaxed)) {
+    {
+      std::lock_guard lock(flushState_.mutex);
+      flushState_.completed.store(gen, std::memory_order_release);
+    }
+    flushState_.cv.notify_all();
+  }
+}
+
 bool CollTrace::isThreadCancelled() const noexcept {
   return threadShouldStop_.test(std::memory_order_relaxed);
 }
@@ -506,8 +542,6 @@ void CollTrace::pollEagerEvents(
     std::unique_ptr<CollTraceEvent> event;
     while (pendingTraceColls_.read(event)) {
       if (event == nullptr) {
-        XLOG_FIRST_N(
-            ERR, 2, logPrefix_, ": Got null event from pendingTrace queue");
         continue;
       }
       eagerEvents_.push_back(std::move(event));
@@ -670,21 +704,25 @@ void CollTrace::collTraceThread(
       }
     }
 
+    auto flushGen = flushState_.requested.load(std::memory_order_acquire);
     std::multiset<PendingAction> actions;
 
     pollGraphEvents(actions);
     pollEagerEvents(actions);
     processCompletedEvents(actions);
 
+    ackFlush(flushGen);
+
     if (!initialized) {
       threadStarted_.count_down();
       initialized = true;
     }
 
-    if (actions.empty()) {
-      // No active events. Block on the MPMC queue so incoming eager events
-      // wake the thread immediately instead of sleeping for the full
-      // interval. Graph events are polled at the top of the next iteration.
+    if (actions.empty() &&
+        flushState_.requested.load(std::memory_order_acquire) == flushGen) {
+      // No active events and no new flush request arrived during this cycle.
+      // Block on the MPMC queue so incoming eager events wake the thread
+      // immediately instead of sleeping for the full interval.
       std::unique_ptr<CollTraceEvent> event;
       auto deadline =
           std::chrono::steady_clock::now() + config_.maxCheckCancelInterval;

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -109,6 +109,9 @@ class CollTrace : public ICollTrace {
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept override;
 
+  uint64_t requestFlush() noexcept override;
+  void waitFlush(uint64_t gen) noexcept override;
+
  private:
   // Internal impl for graph-captured collectives, called when
   // recordCollective detects a GraphCudaWaitEvent.
@@ -122,6 +125,7 @@ class CollTrace : public ICollTrace {
    * cancellation.
    ***************************************************************************/
   bool isThreadCancelled() const noexcept;
+  void ackFlush(uint64_t gen) noexcept;
 
   void collTraceThread(
       const std::function<CommsMaybeVoid(void)>& threadSetupFunc);
@@ -203,6 +207,16 @@ class CollTrace : public ICollTrace {
   // Eager events being polled by the colltrace thread. Only accessed from
   // the colltrace thread — no mutex needed.
   std::vector<std::unique_ptr<CollTraceEvent>> eagerEvents_;
+
+  // Flush synchronization: requestFlush() increments requested and pushes
+  // a nullptr sentinel to wake the poll thread. The poll thread stores the
+  // requested value into completed after draining, then notifies via cv.
+  struct FlushState {
+    std::atomic<uint64_t> requested{0};
+    std::atomic<uint64_t> completed{0};
+    std::mutex mutex;
+    std::condition_variable cv;
+  } flushState_;
 
   std::atomic_flag threadShouldStop_;
   // Signaled by the poll thread after its first loop iteration completes.

--- a/comms/utils/colltrace/CollTraceInterface.h
+++ b/comms/utils/colltrace/CollTraceInterface.h
@@ -28,6 +28,20 @@ class ICollTrace {
   virtual CommsMaybeVoid triggerEventState(
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept = 0;
+
+  // Request the poll thread to drain all pending events and return a
+  // generation token. gen=0 is reserved as the no-op default; real
+  // implementations start at 1 (via fetch_add(1)+1).
+  virtual uint64_t requestFlush() noexcept {
+    return 0;
+  }
+
+  // Block until the poll thread has completed the flush identified by gen.
+  // Returns when completed >= gen OR the thread is cancelled. Callers
+  // cannot distinguish the two — if the flush must have completed (e.g.
+  // before dumping), check isThreadCancelled() separately.
+  // MUST NOT be called from the poll thread (e.g. from a plugin callback).
+  virtual void waitFlush(uint64_t /*gen*/) noexcept {}
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -684,3 +684,156 @@ TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaStreamDestroy(stream);
 }
+
+// ---------------------------------------------------------------------------
+// Flush tests — verify that requestFlush/waitFlush forces the poll thread
+// to read the ring buffer, processing graph replay events that would
+// otherwise sit unread until the next poll interval.
+// ---------------------------------------------------------------------------
+
+class GraphColltraceFlushTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamCreate(&stream_);
+
+    cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
+    meta::comms::colltrace::GlobaltimerCalibration::get();
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf1_, kWorkBytes);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf2_, kWorkBytes);
+
+    auto dumpPlugin = std::make_unique<CommDumpPlugin>(
+        meta::comms::colltrace::CommDumpConfig{.pastCollSize = 100});
+    dumpPlugin_ = dumpPlugin.get();
+
+    auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
+    plugins.push_back(std::move(dumpPlugin));
+    CommLogData logData{};
+    colltrace_ = std::make_shared<CollTrace>(
+        CollTraceConfig{
+            // Long interval so the poll thread sleeps between cycles.
+            // Ring buffer entries sit unread until flush wakes the thread.
+            .maxCheckCancelInterval = std::chrono::milliseconds{100000}},
+        logData,
+        []() -> meta::comms::CommsMaybeVoid {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaSetDevice(0);
+          auto mode = cudaStreamCaptureModeThreadLocal;
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaThreadExchangeStreamCaptureMode(&mode);
+          return folly::unit;
+        },
+        std::move(plugins));
+  }
+
+  void TearDown() override {
+    colltrace_.reset();
+    if (buf2_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf2_);
+    }
+    if (buf1_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf1_);
+    }
+    if (stream_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  cudaGraph_t captureSerial(uint32_t numColls) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      cudaMemcpyAsync(
+          buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, stream_);
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    return graph;
+  }
+
+  static constexpr size_t kWorkBytes = 64 * 1024;
+  cudaStream_t stream_{nullptr};
+  float* buf1_{nullptr};
+  float* buf2_{nullptr};
+  std::optional<EnvRAII<bool>> cvarGuard_;
+  std::shared_ptr<CollTrace> colltrace_;
+  CommDumpPlugin* dumpPlugin_{nullptr};
+};
+
+TEST_F(GraphColltraceFlushTest, DumpWithoutFlushMissesEvents) {
+  constexpr uint32_t kNumColls = 5;
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // GPU has written ring buffer entries, but the poll thread is sleeping
+  // (10s interval). Dump without flush should show no completed events.
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), 0)
+      << "Without flush, ring buffer entries should not be processed yet";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+TEST_F(GraphColltraceFlushTest, FlushDrainsRingBuffer) {
+  constexpr uint32_t kNumColls = 5;
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // Flush wakes the poll thread, which reads the ring buffer and
+  // processes all graph replay events through the plugin pipeline.
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), kNumColls)
+      << "After flush, all graph replay events should appear in pastColls";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}


### PR DESCRIPTION
Summary:

we will need this to ensure that all events from the prev. training step have been extracted from the ring buffer.

Reviewed By: YulunW

Differential Revision: D105359760


