### PR TITLE
clone-on-start graph replay with frozen records (#2574)

### DIFF
--- a/comms/utils/colltrace/CollRecord.cc
+++ b/comms/utils/colltrace/CollRecord.cc
@@ -110,7 +110,7 @@ bool CollTimingRecord::operator==(const CollTimingRecord& other) const {
 // CollRecord implementation
 CollRecord::CollRecord(
     uint64_t collId,
-    std::unique_ptr<ICollMetadata> ICollMetadata,
+    std::shared_ptr<ICollMetadata> ICollMetadata,
     int64_t iteration)
     : collId_(collId),
       iteration_(iteration),
@@ -124,8 +124,8 @@ int64_t CollRecord::getIteration() const noexcept {
   return iteration_;
 }
 
-const ICollMetadata* CollRecord::getCollMetadata() const {
-  return collMetadata_.get();
+const std::shared_ptr<ICollMetadata>& CollRecord::getCollMetadata() const {
+  return collMetadata_;
 }
 
 CollTimingRecord& CollRecord::getTimingInfo() {

--- a/comms/utils/colltrace/CollRecord.h
+++ b/comms/utils/colltrace/CollRecord.h
@@ -57,12 +57,12 @@ class CollRecord : public ICollRecord {
  public:
   CollRecord(
       uint64_t collId,
-      std::unique_ptr<ICollMetadata> ICollMetadata,
+      std::shared_ptr<ICollMetadata> ICollMetadata,
       int64_t iteration = -1);
 
   uint64_t getCollId() const noexcept override;
   int64_t getIteration() const noexcept;
-  const ICollMetadata* getCollMetadata() const;
+  const std::shared_ptr<ICollMetadata>& getCollMetadata() const;
 
   // Timing info is the only field that we could modify after init
   CollTimingRecord& getTimingInfo();
@@ -74,13 +74,9 @@ class CollRecord : public ICollRecord {
   bool operator==(const CollRecord& other) const;
 
  private:
-  uint64_t collId_; // CollTrace internal collective id. Should always increment
-                    // monotonically
-  int64_t iteration_; // Step number in the training loop.
-
-  std::unique_ptr<ICollMetadata>
-      collMetadata_; // Using unique ptr as we might get an inherited class
-  CollTimingRecord
-      timingInfo_; // This is the only field that might get changed after init
+  uint64_t collId_;
+  int64_t iteration_;
+  std::shared_ptr<ICollMetadata> collMetadata_;
+  CollTimingRecord timingInfo_;
 };
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -126,8 +126,17 @@ CollTrace::CollTrace(
 }
 
 CollTrace::~CollTrace() {
-  // Set the cancellation flag
-  threadShouldStop_.test_and_set();
+  // Set the cancellation flag under the flush mutex so waitFlush()
+  // can't miss the state change between its predicate check and wait.
+  {
+    std::lock_guard lock(flushState_.mutex);
+    threadShouldStop_.test_and_set();
+  }
+  flushState_.cv.notify_all();
+  // Wake the poll thread if it is blocking on the MPMC queue so it sees
+  // the cancellation flag promptly instead of waiting for the full
+  // maxCheckCancelInterval.
+  pendingTraceColls_.writeIfNotFull(nullptr);
   // Invalidate all eager handles.
   for (auto& [_, handle] : eventToHandleMap_) {
     handle->invalidate();
@@ -391,6 +400,33 @@ CollTrace::recordGraphCollectiveImpl(
   return handle;
 }
 
+uint64_t CollTrace::requestFlush() noexcept {
+  auto gen = flushState_.requested.fetch_add(1, std::memory_order_acq_rel) + 1;
+  // Best-effort sentinel to wake the poll thread. If the queue is full,
+  // the thread has plenty of work and will see the updated generation
+  // on its next iteration.
+  pendingTraceColls_.writeIfNotFull(nullptr);
+  return gen;
+}
+
+void CollTrace::waitFlush(uint64_t gen) noexcept {
+  std::unique_lock lock(flushState_.mutex);
+  flushState_.cv.wait(lock, [&] {
+    return flushState_.completed.load(std::memory_order_acquire) >= gen ||
+        isThreadCancelled();
+  });
+}
+
+void CollTrace::ackFlush(uint64_t gen) noexcept {
+  if (gen > flushState_.completed.load(std::memory_order_relaxed)) {
+    {
+      std::lock_guard lock(flushState_.mutex);
+      flushState_.completed.store(gen, std::memory_order_release);
+    }
+    flushState_.cv.notify_all();
+  }
+}
+
 bool CollTrace::isThreadCancelled() const noexcept {
   return threadShouldStop_.test(std::memory_order_relaxed);
 }
@@ -506,8 +542,6 @@ void CollTrace::pollEagerEvents(
     std::unique_ptr<CollTraceEvent> event;
     while (pendingTraceColls_.read(event)) {
       if (event == nullptr) {
-        XLOG_FIRST_N(
-            ERR, 2, logPrefix_, ": Got null event from pendingTrace queue");
         continue;
       }
       eagerEvents_.push_back(std::move(event));
@@ -670,21 +704,25 @@ void CollTrace::collTraceThread(
       }
     }
 
+    auto flushGen = flushState_.requested.load(std::memory_order_acquire);
     std::multiset<PendingAction> actions;
 
     pollGraphEvents(actions);
     pollEagerEvents(actions);
     processCompletedEvents(actions);
 
+    ackFlush(flushGen);
+
     if (!initialized) {
       threadStarted_.count_down();
       initialized = true;
     }
 
-    if (actions.empty()) {
-      // No active events. Block on the MPMC queue so incoming eager events
-      // wake the thread immediately instead of sleeping for the full
-      // interval. Graph events are polled at the top of the next iteration.
+    if (actions.empty() &&
+        flushState_.requested.load(std::memory_order_acquire) == flushGen) {
+      // No active events and no new flush request arrived during this cycle.
+      // Block on the MPMC queue so incoming eager events wake the thread
+      // immediately instead of sleeping for the full interval.
       std::unique_ptr<CollTraceEvent> event;
       auto deadline =
           std::chrono::steady_clock::now() + config_.maxCheckCancelInterval;

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -453,6 +453,7 @@ void CollTrace::pollGraphEvents(
           }
           collIdMap_.erase(collId);
           progressingGraphCollectives_.erase(collId);
+          inFlightReplays_.erase(collId);
         }
         return true;
       }
@@ -489,10 +490,12 @@ void CollTrace::pollGraphEvents(
         auto timestamp = cal.toWallClock(entry.timestamp);
 
         if (isStartEvent) {
-          // if we see a new start event before we observed this collectives
-          // last end, the end event was likely overwritten (ring too small).
-          // the watchdog detects this via the changed start timestamp and
-          // resets its timer automatically but we should log it anyway
+          // Graph replays are sequential on the stream, so seeing a second
+          // start before the matching end means the prior end was dropped
+          // by ring buffer overflow. The previous in-flight clone will be
+          // discarded below without a kEnd action — this is the expected
+          // data-loss path (warned here; the watchdog detects the changed
+          // start timestamp and resets its timer automatically).
           if (auto [_, inserted] = progressingGraphCollectives_.insert(collId);
               !inserted) {
             XLOG_EVERY_MS(WARN, 5000)
@@ -500,17 +503,49 @@ void CollTrace::pollGraphEvents(
                 << " saw a new start event before the previous end event"
                    " — the end event was likely overwritten (ring too small)";
           }
-          collEntry.event->collRecord->getTimingInfo().setCollStartTs(
-              timestamp);
+
+          // Graph replays produce a fresh CollRecord with its own collId
+          // (distinct from the template) so that each replay is independently
+          // tracked through the plugin pipeline. The template's metadata is
+          // shared (must remain immutable post-construction).
+          auto& prev = collEntry.event->collRecord;
+
+          auto frozenRecord = std::make_shared<CollRecord>(
+              collId_.fetch_add(1),
+              prev->getCollMetadata(),
+              prev->getIteration());
+          frozenRecord->getTimingInfo().setCollEnqueueTs(timestamp);
+          frozenRecord->getTimingInfo().setCollStartTs(timestamp);
+
+          auto replayEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{
+              .collRecord = std::move(frozenRecord),
+              .waitEvent = nullptr,
+          });
+          auto* replayPtr = replayEvent.get();
+          if (auto replayIt = inFlightReplays_.find(collId);
+              replayIt != inFlightReplays_.end()) {
+            graphReplayEvents_.push_back(std::move(replayIt->second));
+            replayIt->second = std::move(replayEvent);
+          } else {
+            inFlightReplays_[collId] = std::move(replayEvent);
+          }
           actions.insert(
-              {collEntry.event.get(),
-               PendingActionType::kScheduleAndStart,
-               timestamp});
+              {replayPtr, PendingActionType::kScheduleAndStart, timestamp});
         } else /* isEndEvent */ {
-          collEntry.event->collRecord->getTimingInfo().setCollEndTs(timestamp);
           progressingGraphCollectives_.erase(collId);
-          actions.insert(
-              {collEntry.event.get(), PendingActionType::kEnd, timestamp});
+
+          if (auto replayIt = inFlightReplays_.find(collId);
+              replayIt != inFlightReplays_.end()) {
+            auto* replayPtr = replayIt->second.get();
+            replayPtr->collRecord->getTimingInfo().setCollEndTs(timestamp);
+            actions.insert({replayPtr, PendingActionType::kEnd, timestamp});
+            graphReplayEvents_.push_back(std::move(replayIt->second));
+            inFlightReplays_.erase(replayIt);
+          } else {
+            XLOG_EVERY_MS(WARN, 5000)
+                << logPrefix_ << ": graph collective " << collId
+                << " end event without matching start — dropped";
+          }
         }
       },
       /*timeout=*/config_.maxCheckCancelInterval);
@@ -521,16 +556,15 @@ void CollTrace::pollGraphEvents(
         << " graph replay timestamp(s) (overwritten)";
   }
 
-  // Emit kProgressing for every pending start so the watchdog plugin's
-  // timer accumulates. Without this, graph collectives would never trigger
-  // the watchdog timeout because collEventProgressing is only called on
-  // discrete ring buffer events.
+  // Emit kProgressing for every in-flight clone so the watchdog plugin's
+  // timer accumulates. We use inFlightReplays_ (the cloned events) rather
+  // than collIdMap_ (the templates) so that progressing fires against the
+  // actual replay record with correct timing.
   auto now = precisionNow();
   for (auto collId : progressingGraphCollectives_) {
-    auto it = collIdMap_.find(collId);
-    if (it != collIdMap_.end()) {
-      actions.insert(
-          {it->second->event.get(), PendingActionType::kProgressing, now});
+    auto it = inFlightReplays_.find(collId);
+    if (it != inFlightReplays_.end()) {
+      actions.insert({it->second.get(), PendingActionType::kProgressing, now});
     }
   }
 }
@@ -635,6 +669,8 @@ void CollTrace::processCompletedEvents(
       }
     }
   }
+
+  graphReplayEvents_.clear();
 
   // clean up completed eager events...
   static constexpr auto kEpoch = ICollWaitEvent::system_clock_time_point{};

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -109,6 +109,9 @@ class CollTrace : public ICollTrace {
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept override;
 
+  uint64_t requestFlush() noexcept override;
+  void waitFlush(uint64_t gen) noexcept override;
+
  private:
   // Internal impl for graph-captured collectives, called when
   // recordCollective detects a GraphCudaWaitEvent.
@@ -122,6 +125,7 @@ class CollTrace : public ICollTrace {
    * cancellation.
    ***************************************************************************/
   bool isThreadCancelled() const noexcept;
+  void ackFlush(uint64_t gen) noexcept;
 
   void collTraceThread(
       const std::function<CommsMaybeVoid(void)>& threadSetupFunc);
@@ -203,6 +207,16 @@ class CollTrace : public ICollTrace {
   // Eager events being polled by the colltrace thread. Only accessed from
   // the colltrace thread — no mutex needed.
   std::vector<std::unique_ptr<CollTraceEvent>> eagerEvents_;
+
+  // Flush synchronization: requestFlush() increments requested and pushes
+  // a nullptr sentinel to wake the poll thread. The poll thread stores the
+  // requested value into completed after draining, then notifies via cv.
+  struct FlushState {
+    std::atomic<uint64_t> requested{0};
+    std::atomic<uint64_t> completed{0};
+    std::mutex mutex;
+    std::condition_variable cv;
+  } flushState_;
 
   std::atomic_flag threadShouldStop_;
   // Signaled by the poll thread after its first loop iteration completes.

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -203,6 +203,18 @@ class CollTrace : public ICollTrace {
   // Used to emit periodic kProgressing actions so the watchdog plugin can
   // detect hung graph collectives.
   std::unordered_set<uint32_t> progressingGraphCollectives_;
+  // Completed graph replay events whose kEnd has been processed. Cleared
+  // at the end of processCompletedEvents once plugins have taken ownership
+  // of the CollRecord shared_ptr.
+  std::vector<std::unique_ptr<CollTraceEvent>> graphReplayEvents_;
+
+  // Maps collId → in-flight replayEvent for collectives whose start event
+  // has been processed but end event hasn't arrived yet. The clone is
+  // created at start time so its startTs is captured immediately and
+  // can't be clobbered by a subsequent start for the same collId.
+  // Owns the CollTraceEvent so it survives across poll cycles.
+  std::unordered_map<uint32_t, std::unique_ptr<CollTraceEvent>>
+      inFlightReplays_;
 
   // Eager events being polled by the colltrace thread. Only accessed from
   // the colltrace thread — no mutex needed.

--- a/comms/utils/colltrace/CollTraceInterface.h
+++ b/comms/utils/colltrace/CollTraceInterface.h
@@ -28,6 +28,20 @@ class ICollTrace {
   virtual CommsMaybeVoid triggerEventState(
       CollTraceEvent& collEvent,
       CollTraceHandleTriggerState state) noexcept = 0;
+
+  // Request the poll thread to drain all pending events and return a
+  // generation token. gen=0 is reserved as the no-op default; real
+  // implementations start at 1 (via fetch_add(1)+1).
+  virtual uint64_t requestFlush() noexcept {
+    return 0;
+  }
+
+  // Block until the poll thread has completed the flush identified by gen.
+  // Returns when completed >= gen OR the thread is cancelled. Callers
+  // cannot distinguish the two — if the flush must have completed (e.g.
+  // before dumping), check isThreadCancelled() separately.
+  // MUST NOT be called from the poll thread (e.g. from a plugin callback).
+  virtual void waitFlush(uint64_t /*gen*/) noexcept {}
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/tests/CollRecordUT.cc
+++ b/comms/utils/colltrace/tests/CollRecordUT.cc
@@ -165,7 +165,7 @@ class CollRecordTest : public Test {
 TEST_F(CollRecordTest, ConstructorAndGetters) {
   // Check that the getters return the expected values
   EXPECT_EQ(collRecord_->getCollId(), 123);
-  EXPECT_EQ(collRecord_->getCollMetadata(), mockMetadata_);
+  EXPECT_EQ(collRecord_->getCollMetadata().get(), mockMetadata_);
 
   // Check that the timing info is accessible and has the expected values
   EXPECT_EQ(
@@ -261,7 +261,7 @@ TEST_F(CollRecordTest, NullMetadata) {
   auto recordWithNullMetadata = std::make_unique<CollRecord>(123, nullptr);
 
   // Should not crash when accessing metadata
-  EXPECT_EQ(recordWithNullMetadata->getCollMetadata(), nullptr);
+  EXPECT_EQ(recordWithNullMetadata->getCollMetadata().get(), nullptr);
 
   // Should be able to calculate hash
   std::size_t hash = recordWithNullMetadata->hash();

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -269,8 +269,6 @@ TEST_F(GraphColltraceProgressingTest, DetectsInFlightCollective) {
   ASSERT_NE(cg.instance, nullptr);
   ASSERT_EQ(cg.collIds.size(), kNumColls);
 
-  std::set<int64_t> validCollIds(cg.collIds.begin(), cg.collIds.end());
-
   // Replay once — 150ms total (3 × 50ms), giving the poll thread plenty
   // of time to observe in-flight entries.
   ASSERT_EQ(cudaGraphLaunch(cg.instance, stream_), cudaSuccess);
@@ -283,21 +281,16 @@ TEST_F(GraphColltraceProgressingTest, DetectsInFlightCollective) {
   auto progressedIds = progressPlugin_->getProgressedCollIds();
 
   // With 50ms per collective and 1ms poll interval, the poll thread
-  // should observe at least one in-flight collective.
+  // should observe at least one in-flight collective. Clone-on-start
+  // assigns new collIds to replay events, so we check count.
   EXPECT_FALSE(progressedIds.empty())
       << "Expected collEventProgressing to fire for at least one collective";
-
-  // Every reported collId must be from our captured set.
-  for (auto id : progressedIds) {
-    EXPECT_TRUE(validCollIds.count(id) > 0)
-        << "collEventProgressing reported unknown collId " << id;
-  }
 
   EXPECT_GT(progressPlugin_->progressCount(), 0);
 
   // After sync, all collectives should have completed.
   auto completedIds = progressPlugin_->getCompletedCollIds();
-  EXPECT_EQ(completedIds, validCollIds)
+  EXPECT_EQ(completedIds.size(), kNumColls)
       << "All collectives should be marked completed after stream sync";
 }
 
@@ -373,8 +366,6 @@ TEST_F(GraphColltraceProgressingTest, DetectsMultipleInFlightCollectives) {
       cudaSuccess);
   ASSERT_EQ(cg.collIds.size(), kNumColls);
 
-  std::set<int64_t> validCollIds(cg.collIds.begin(), cg.collIds.end());
-
   // Replay — all 3 collectives run concurrently with 100ms sleeps.
   // The poll thread (1ms interval) has ~100ms to observe all 3 as
   // simultaneously in-flight.
@@ -387,21 +378,18 @@ TEST_F(GraphColltraceProgressingTest, DetectsMultipleInFlightCollectives) {
   auto progressedIds = progressPlugin_->getProgressedCollIds();
 
   // All 3 collectives should have been observed as in-flight since
-  // they run concurrently for 100ms.
+  // they run concurrently for 100ms. Clone-on-start assigns new
+  // collIds to replay events, so we check count rather than matching
+  // capture-time ids.
   EXPECT_EQ(progressedIds.size(), kNumColls)
-      << "Expected all " << kNumColls
+      << "Expected exactly " << kNumColls
       << " concurrent collectives to be detected as in-flight";
-
-  for (auto id : progressedIds) {
-    EXPECT_TRUE(validCollIds.count(id) > 0)
-        << "collEventProgressing reported unknown collId " << id;
-  }
 
   EXPECT_GT(progressPlugin_->progressCount(), 0);
 
   // After sync, all collectives should have completed.
   auto completedIds = progressPlugin_->getCompletedCollIds();
-  EXPECT_EQ(completedIds, validCollIds)
+  EXPECT_EQ(completedIds.size(), kNumColls)
       << "All concurrent collectives should be marked completed after stream sync";
 
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -684,3 +684,156 @@ TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaStreamDestroy(stream);
 }
+
+// ---------------------------------------------------------------------------
+// Flush tests — verify that requestFlush/waitFlush forces the poll thread
+// to read the ring buffer, processing graph replay events that would
+// otherwise sit unread until the next poll interval.
+// ---------------------------------------------------------------------------
+
+class GraphColltraceFlushTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamCreate(&stream_);
+
+    cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
+    meta::comms::colltrace::GlobaltimerCalibration::get();
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf1_, kWorkBytes);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaMalloc(&buf2_, kWorkBytes);
+
+    auto dumpPlugin = std::make_unique<CommDumpPlugin>(
+        meta::comms::colltrace::CommDumpConfig{.pastCollSize = 100});
+    dumpPlugin_ = dumpPlugin.get();
+
+    auto plugins = std::vector<std::unique_ptr<ICollTracePlugin>>{};
+    plugins.push_back(std::move(dumpPlugin));
+    CommLogData logData{};
+    colltrace_ = std::make_shared<CollTrace>(
+        CollTraceConfig{
+            // Long interval so the poll thread sleeps between cycles.
+            // Ring buffer entries sit unread until flush wakes the thread.
+            .maxCheckCancelInterval = std::chrono::milliseconds{100000}},
+        logData,
+        []() -> meta::comms::CommsMaybeVoid {
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaSetDevice(0);
+          auto mode = cudaStreamCaptureModeThreadLocal;
+          // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+          cudaThreadExchangeStreamCaptureMode(&mode);
+          return folly::unit;
+        },
+        std::move(plugins));
+  }
+
+  void TearDown() override {
+    colltrace_.reset();
+    if (buf2_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf2_);
+    }
+    if (buf1_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFree(buf1_);
+    }
+    if (stream_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  cudaGraph_t captureSerial(uint32_t numColls) {
+    cudaGraph_t graph;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal);
+    for (uint32_t c = 0; c < numColls; ++c) {
+      auto metadata = std::make_unique<BenchMetadata>();
+      auto waitEvent = std::make_unique<GraphCudaWaitEvent>(stream_);
+      auto handle =
+          colltrace_
+              ->recordCollective(std::move(metadata), std::move(waitEvent))
+              .value();
+      handle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+      cudaMemcpyAsync(
+          buf2_, buf1_, kWorkBytes, cudaMemcpyDeviceToDevice, stream_);
+      handle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamEndCapture(stream_, &graph);
+    return graph;
+  }
+
+  static constexpr size_t kWorkBytes = 64 * 1024;
+  cudaStream_t stream_{nullptr};
+  float* buf1_{nullptr};
+  float* buf2_{nullptr};
+  std::optional<EnvRAII<bool>> cvarGuard_;
+  std::shared_ptr<CollTrace> colltrace_;
+  CommDumpPlugin* dumpPlugin_{nullptr};
+};
+
+TEST_F(GraphColltraceFlushTest, DumpWithoutFlushMissesEvents) {
+  constexpr uint32_t kNumColls = 5;
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // GPU has written ring buffer entries, but the poll thread is sleeping
+  // (10s interval). Dump without flush should show no completed events.
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), 0)
+      << "Without flush, ring buffer entries should not be processed yet";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+TEST_F(GraphColltraceFlushTest, FlushDrainsRingBuffer) {
+  constexpr uint32_t kNumColls = 5;
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  // Flush wakes the poll thread, which reads the ring buffer and
+  // processes all graph replay events through the plugin pipeline.
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dumpResult = dumpPlugin_->dump();
+  ASSERT_TRUE(dumpResult.hasValue());
+  EXPECT_EQ(static_cast<int>(dumpResult.value().pastColls.size()), kNumColls)
+      << "After flush, all graph replay events should appear in pastColls";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -18,6 +18,7 @@
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
+#include "comms/utils/trainer/TrainerContext.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
@@ -836,4 +837,127 @@ TEST_F(GraphColltraceFlushTest, FlushDrainsRingBuffer) {
   cudaGraphExecDestroy(instance);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphDestroy(graph);
+}
+
+// Replay a graph multiple times and verify each replay produces valid
+// timing (non-zero duration, enqueueTs == startTs for graph clones).
+TEST_F(GraphColltraceTopologyTest, ReplayTimingValid) {
+  constexpr uint32_t kNumColls = 2;
+  constexpr int kNumReplays = 3;
+
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  auto* plugin = dynamic_cast<CommDumpPlugin*>(colltrace_->getPluginByName(
+      std::string{CommDumpPlugin::kCommDumpPluginName}));
+  ASSERT_NE(plugin, nullptr);
+
+  for (int r = 0; r < kNumReplays; ++r) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  colltrace_->waitFlush(colltrace_->requestFlush());
+
+  auto dump = plugin->dump();
+  ASSERT_TRUE(dump.hasValue());
+  EXPECT_GE(
+      static_cast<int>(dump.value().pastColls.size()),
+      static_cast<int>(kNumColls * kNumReplays));
+
+  for (const auto& coll : dump.value().pastColls) {
+    auto startTs = coll->getTimingInfo().getCollStartTs();
+    auto endTs = coll->getTimingInfo().getCollEndTs();
+    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
+            .count();
+    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
+                      << " has non-positive duration";
+    EXPECT_GE(endTs, startTs);
+    EXPECT_EQ(enqueueTs, startTs)
+        << "Graph clone enqueueTs should equal startTs";
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+// Reproduces the production bug where pastColls entries had corrupted
+// timing because the clone was shared between pastColls and the next
+// replay's collEntry. Run multiple replays without flushing between
+// them (the production pattern), then flush once and verify that all
+// retained pastColls entries have enqueueTs == startTs. With the old
+// shared-record approach, the next replay's start event would overwrite
+// startTs while leaving enqueueTs stale.
+TEST_F(GraphColltraceTopologyTest, ReplayTimingConsistency) {
+  constexpr uint32_t kNumColls = 5;
+  constexpr int kNumReplays = 10;
+
+  ncclxSetIteration(0);
+  auto graph = captureSerial(kNumColls);
+  ASSERT_NE(graph, nullptr);
+
+  cudaGraphExec_t instance;
+  ASSERT_EQ(
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  auto* plugin = dynamic_cast<CommDumpPlugin*>(colltrace_->getPluginByName(
+      std::string{CommDumpPlugin::kCommDumpPluginName}));
+  ASSERT_NE(plugin, nullptr);
+
+  // Run all replays back-to-back WITHOUT flushing — this is the
+  // production pattern where comm_dump_all is called once per step
+  // but collectives from the previous step are still in pastColls.
+  for (int step = 0; step < kNumReplays; ++step) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  auto gen = colltrace_->requestFlush();
+  colltrace_->waitFlush(gen);
+
+  auto dump = plugin->dump();
+  ASSERT_TRUE(dump.hasValue());
+
+  int checked = 0;
+  for (const auto& coll : dump.value().pastColls) {
+    auto startTs = coll->getTimingInfo().getCollStartTs();
+    auto endTs = coll->getTimingInfo().getCollEndTs();
+    auto enqueueTs = coll->getTimingInfo().getCollEnqueueTs();
+    auto dur =
+        std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
+            .count();
+    auto iter = coll->getIteration();
+
+    EXPECT_GT(dur, 0) << "iter=" << iter << " collId=" << coll->getCollId()
+                      << " has non-positive duration " << dur << "us";
+    EXPECT_GE(endTs, startTs) << "iter=" << iter << ": endTs < startTs";
+    EXPECT_EQ(enqueueTs, startTs)
+        << "iter=" << iter << " collId=" << coll->getCollId()
+        << ": enqueueTs != startTs — pastColls entry was mutated"
+           " by a subsequent replay's start event";
+
+    checked++;
+  }
+
+  EXPECT_GT(checked, 0) << "pastColls should not be empty after " << kNumReplays
+                        << " replays";
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+
+  ncclxSetIteration(-1);
 }


### PR DESCRIPTION
Summary:

Each graph replay creates an independent frozen CollRecord at start-event
time, stored in inFlightReplays_ until the matching end event arrives.
This prevents stale template timestamps from corrupting pastColls entries
when multiple graphs replay per step (e.g., gradient accumulation with
multiple microbatches replaying the fwd_bwd graph). Also supports setting iteration s.t., we can keep track of the number of replays.

Reviewed By: YulunW

Differential Revision: D105355392


