### PR TITLE
Add missing ncclResult_t enum values to ir_include stub for NCCLX v2.30

### DIFF
--- a/comms/ncclx/v2_30/makefiles/common.mk
+++ b/comms/ncclx/v2_30/makefiles/common.mk
@@ -86,15 +86,10 @@ else
 endif
 $(info NVCC_GENCODE is ${NVCC_GENCODE})
 
-# CUDA 13.0 requires c++17
-ifeq ($(shell test "0$(CUDA_MAJOR)" -ge 13; echo $$?),0)
-  CXXSTD ?= -std=c++17
-else
-  CXXSTD ?= -std=c++14
-endif
+CXXSTD ?= -std=c++17
 
 CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisibility=hidden \
-              -Wall -Wno-unused-function -Wno-sign-compare $(CXXSTD) -Wvla \
+              -Wall -Wno-unused-function -Wno-sign-compare -std=c++2a -Wvla \
               -I $(CUDA_INC) -I $(CUDA_INC)/cccl \
               $(CXXFLAGS)
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)

--- a/comms/ncclx/v2_30/setup.py
+++ b/comms/ncclx/v2_30/setup.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+from distutils.command.build import build as _build
+
+from pybind11.setup_helpers import Pybind11Extension
+from setuptools import setup
+from setuptools.command.egg_info import egg_info as _egg_info
+
+BUILDDIR = os.environ.get("BUILDDIR", None)
+if BUILDDIR is not None:
+    LIBDIR = os.path.join(BUILDDIR, "lib")
+    BUILDDIR = os.path.join(BUILDDIR, "pybind")
+    os.makedirs(BUILDDIR, exist_ok=True)
+
+
+class build(_build):
+    def initialize_options(self):
+        super().initialize_options()
+        self.build_base = BUILDDIR
+
+
+class egg_info(_egg_info):
+    def initialize_options(self):
+        super().initialize_options()
+        self.egg_base = BUILDDIR
+
+
+def get_cmdclass():
+    from pybind11.setup_helpers import build_ext
+
+    return {
+        "build": build,
+        "egg_info": egg_info,
+        "build_ext": build_ext,
+    }
+
+
+ext_modules = [
+    Pybind11Extension(
+        "ncclx_trainer_context",
+        ["../meta/py/wrapper.cc"],
+        library_dirs=[LIBDIR],
+        libraries=["nccl"],
+    ),
+]
+
+setup(
+    name="ncclx_trainer_context",
+    ext_modules=ext_modules,
+    cmdclass=get_cmdclass(),
+)

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -302,7 +302,12 @@ DOCA_LIBOBJ      := $(DOCA_LIBSRC:%.cpp=$(DOCA_OBJDIR)/%.o)
 LIBOBJ           += $(DOCA_LIBOBJ)
 
 ##### rules
+BUILD_NCCL_CLI ?= 1
+ifeq ($(BUILD_NCCL_CLI),1)
 build : lib staticlib binary
+else
+build : lib staticlib
+endif
 
 lib : $(INCTARGETS) $(LIBDIR)/$(LIBTARGET) $(PKGDIR)/$(PKGTARGET)
 
@@ -353,7 +358,7 @@ $(BINDIR)/$(BINNAME): $(BINOBJ)
 $(BINDIR)/$(PARAMBIN): $(PARAMBINOBJ) $(LIBDIR)/$(LIBTARGET)
 	@printf "Linking    %-35s > %s\n" $(PARAMBIN) $@
 	mkdir -p $(BINDIR)
-	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
+	$(CXX) $(CXXFLAGS) $< -o $@ -L$(LIBDIR) -L${CONDA_LIB_DIR} -lnccl -L${CUDA_LIB} -l$(CUDARTLIB) -lpthread -lrt -ldl
 
 $(PKGDIR)/nccl.pc : nccl.pc.in
 	mkdir -p $(PKGDIR)
@@ -483,8 +488,10 @@ install : build
 	cp -P -v $(BUILDDIR)/lib/lib* $(PREFIX)/lib/
 	cp -P -v $(BUILDDIR)/lib/pkgconfig/* $(PREFIX)/lib/pkgconfig/
 	cp -v -r $(BUILDDIR)/include/* $(PREFIX)/include/
+ifeq ($(BUILD_NCCL_CLI),1)
 	cp -v $(BUILDDIR)/bin/ncclras $(PREFIX)/bin/
 	cp -v $(BUILDDIR)/bin/ncclparam $(PREFIX)/bin/
+endif
 
 FILESTOFORMAT := $(shell find . -name ".\#*" -prune -o \( -name "*.cc" -o -name "*.h" \) -print | grep -v -E 'ibvwrap.h|nvmlwrap.h|gdrwrap.h|nccl.h')
 # Note that formatting.mk defines a new target so in order to not overwrite the default target,

--- a/comms/ncclx/v2_30/src/version.script
+++ b/comms/ncclx/v2_30/src/version.script
@@ -1,0 +1,20 @@
+/*
+version.script controls symbol visibility, it exposes
+nccl: nccl(x)-related symbols
+cxa: Folly’s exception tracer intercepts all exceptions and uses
+    dlsym(RTLD_NEXT, "cxa...") to find the corresponding real symbols.
+    Therefore, it is necessary to expose certain cxa symbols from the libstdc++.
+    For further details, refer to the discussion in D64442615.
+*/
+{
+  global:
+      *nccl*;
+      *ctran*;
+      *cxa*;
+      *getDevMemType*;
+      *getCudaDevFromPtr*;
+      *StreamCaptureModeGuard*;
+  /* Transitive symbols (e.g. coming from static libs) are not exported */
+  local:
+      *;
+};

--- a/comms/torchcomms/triton/ir_include/nccl.h
+++ b/comms/torchcomms/triton/ir_include/nccl.h
@@ -23,7 +23,10 @@ typedef enum {
   ncclInternalError = 3,
   ncclInvalidArgument = 4,
   ncclInvalidUsage = 5,
-  ncclRemoteError = 6
+  ncclRemoteError = 6,
+  ncclInProgress = 7,
+  ncclTimeout = 8,
+  ncclNumResults = 9
 } ncclResult_t;
 
 /* Opaque handle to communicator */


### PR DESCRIPTION
Summary:
## Symptom

The conda flagship build on aarch64 fails with:

```
nccl_device/impl/lsa_barrier__funcs.h:115: error: use of undeclared identifier 'ncclTimeout'
nccl_device/impl/gin_barrier__funcs.h:80:  error: use of undeclared identifier 'ncclTimeout'
```

This blocks any build that uses NCCLX v2.30 (`-c hpc_comms.use_ncclx=2.30`).

## Why there is a stub `nccl.h` in the first place

The torchcomms triton bitcode is built by a Buck genrule (`comms/torchcomms/triton/defs.bzl`) that runs clang against the NCCLX device headers. Those device headers `#include <nccl.h>` transitively (via `nccl_device/core.h`).

The real `nccl.h` does not exist in the source tree — it is generated by the NCCL Makefile from `nccl.h.in` (sed substitution of the version macros). The Triton bitcode build does not run the NCCL Makefile, so it has no real `nccl.h` to fall back on. To bridge the gap, the genrule puts `-I$SRCDIR/ir_include` first on the include path, and the small hand-written stub at `comms/torchcomms/triton/ir_include/nccl.h` provides just the type and enum declarations the device headers need.

Because the stub is hand-written, it has to track the upstream `nccl.h.in` whenever the device headers reach for a new identifier.

## Why v2.29 did not hit this

In v2.29, the barrier `wait()` and `sync()` returned `void` and used a simple `testAbort` polling loop. They never named any `ncclResult_t` value. The v2.29 stub could have omitted the enum entirely and the bitcode build would still succeed.

In v2.30, the barrier API was extended with an optional timeout. The old `void wait(Coop, order)` and `void sync(Coop, ord, fence)` overloads still exist (so torchcomms call sites do not change), but they now delegate to a new templated implementation that returns `ncclResult_t` and reports `ncclTimeout` on a timeout. Even though torchcomms only calls the old void-returning overloads, clang still has to parse the new template body and resolve `ncclTimeout` — so the identifier must be visible in the stub.

Differential Revision: D105279917


