### PR TITLE
Implement `TorchCommMCCL::new_window` with `tensor_register`/`tensor_deregister` (#2577)

### DIFF
--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -57,7 +57,10 @@ class WindowRmaTest(unittest.TestCase):
         self.rank = self.torchcomm.get_rank()
         self.num_ranks = self.torchcomm.get_size()
         self.device = self.torchcomm.get_device()
-        self.allocator = self.torchcomm.get_mem_allocator()
+        try:
+            self.allocator = self.torchcomm.get_mem_allocator()
+        except RuntimeError:
+            self.allocator = None
 
         # Probe NCCL symmetric-window support. NCCL_WIN_COLL_SYMMETRIC needs a
         # transport that can expose VMM-backed memory across ranks (NVLink
@@ -219,6 +222,56 @@ class WindowRmaTest(unittest.TestCase):
         win.tensor_deregister()
         del win
         del pool
+
+    def _new_window_lifecycle_test(self):
+        """Test full window lifecycle: create, register, verify, deregister."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        self.assertIsNotNone(win)
+
+        win.tensor_register(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _new_window_create_with_tensor_test(self):
+        """new_window(tensor) registers the tensor during creation."""
+        num_elements = 512
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _register_error_handling_test(self):
+        """Double register raises, deregister without register raises."""
+        num_elements = 256
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_register(buf)
+
+        win.tensor_deregister()
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_deregister()
+
+        del win
+        torch.cuda.synchronize()
 
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):


### PR DESCRIPTION
Summary:

Implements the `new_window` API on `TorchCommMCCL` by creating the `TorchCommWindowMCCL` class that wraps MCCL `IWindow`. This is the first step toward full MCCL RMA window support in TorchComms.

The implementation includes:
- `TorchCommWindowMCCL` class (`TorchCommWindowMCCL.hpp/.cpp`) extending `TorchCommWindow`
- `tensor_register()`: validates the tensor, then calls `mccl_comm_->winAllocate()` to create the underlying MCCL window with internally-allocated cuMem buffers
- `tensor_deregister()`: synchronizes all ranks via barriers, then releases the window
- `new_window()` on `TorchCommMCCL`: creates and returns a `TorchCommWindowMCCL`, optionally registering a tensor
- Remaining pure virtual methods (`put`, `signal`, `wait_signal`, `map_remote_tensor`, `get_attr`, `clone`) throw "not implemented" — these will be added in follow-up diffs

New files: `TorchCommWindowMCCL.hpp`, `TorchCommWindowMCCL.cpp`
Modified: `TorchCommMCCL.cpp`, `TorchCommMCCL.hpp`, `BUCK`, test `BUCK`

Differential Revision: D105086956


