### PR TITLE
Centralize glog init in TorchCommBackend ctor

### DIFF
--- a/comms/torchcomms/TorchCommBackend.cpp
+++ b/comms/torchcomms/TorchCommBackend.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/TorchCommBackend.hpp"
+
+#include <glog/logging.h>
+
+#include <cstdlib>
+
+// Google glog's api does not have an external function that allows one to check
+// if glog is initialized or not. It does have an internal function - so we are
+// declaring it here. This is a hack but has been used by a bunch of others too
+// (e.g. Torch).
+// Copied from https://fburl.com/code/tu9hg6gf
+namespace google::glog_internal_namespace_ {
+bool IsGoogleLoggingInitialized();
+} // namespace google::glog_internal_namespace_
+
+namespace torch::comms {
+
+void TorchCommBackend::ensureLoggingInit() {
+  // This trick can only be used on UNIX platforms.
+  if (::google::glog_internal_namespace_::IsGoogleLoggingInitialized()) {
+    return;
+  }
+  ::google::InitGoogleLogging("torchcomm");
+  // Default to stderr for torchrun-style runs but let users override
+  // via standard glog env vars (GLOG_logtostderr, GLOG_log_dir, etc.).
+  if (std::getenv("GLOG_log_dir") == nullptr &&
+      std::getenv("GLOG_logtostderr") == nullptr &&
+      std::getenv("GLOG_alsologtostderr") == nullptr) {
+    FLAGS_logtostderr = true;
+  }
+
+  // This will trigger a kernel panic on GB200 NVIDIA driver
+  // temporarily disable signal handler until NVIDIA releases the new driver
+  // in late Jan.
+#if !defined(__aarch64__)
+  ::google::InstallFailureSignalHandler();
+#endif
+}
+
+TorchCommBackend::TorchCommBackend() {
+  ensureLoggingInit();
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/TorchCommBackend.hpp
+++ b/comms/torchcomms/TorchCommBackend.hpp
@@ -31,7 +31,14 @@ inline constexpr const char* TORCHCOMM_BACKEND_ABI_VERSION = "1.2";
  */
 class TorchCommBackend {
  public:
+  TorchCommBackend();
   virtual ~TorchCommBackend() = default;
+
+  // Initialize glog for torchcomms if it hasn't been initialized yet.
+  // Idempotent and safe to call from any entry point. Invoked from the
+  // base-class ctor and from TorchCommFactory::get() so logging is ready
+  // before any TC_LOG site runs.
+  static void ensureLoggingInit();
 
   // Initialize the communication backend
   virtual void init(

--- a/comms/torchcomms/TorchCommFactory.cpp
+++ b/comms/torchcomms/TorchCommFactory.cpp
@@ -242,6 +242,7 @@ void TorchCommFactory::register_allocator_factory(
 }
 
 TorchCommFactory& TorchCommFactory::get() {
+  TorchCommBackend::ensureLoggingInit();
   static TorchCommFactory instance;
   return instance;
 }

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -205,8 +205,6 @@ void TorchCommNCCL::initNcclResources() {
       nccl_api_->commUserRank(nccl_comm_, &rank_),
       "NCCL User Rank failed");
 
-  tryTorchCommLoggingInit("torchcomm");
-
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -368,8 +368,6 @@ void TorchCommNCCLX::initNcclxResources() {
       nccl_api_->commUserRank(nccl_comm_, &rank_),
       "NCCLX User Rank failed");
 
-  tryTorchCommLoggingInit("torchcomm");
-
   NCCLX_CHECK(
       nccl_api_,
       nccl_comm_,

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -229,8 +229,6 @@ void TorchCommRCCL::initRcclResources() {
       rccl_api_->commUserRank(nccl_comm_, &rank_),
       "RCCL User Rank failed");
 
-  tryTorchCommLoggingInit("torchcomm");
-
   RCCL_CHECK(
       rccl_api_,
       nccl_comm_,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -242,8 +242,6 @@ void TorchCommRCCLX::initRcclxResources() {
       rcclx_api_->commUserRank(nccl_comm_, &rank_),
       "RCCLX User Rank failed");
 
-  tryTorchCommLoggingInit("torchcomm");
-
   RCCLX_CHECK(
       rcclx_api_,
       nccl_comm_,

--- a/comms/torchcomms/utils/Logging.hpp
+++ b/comms/torchcomms/utils/Logging.hpp
@@ -33,29 +33,7 @@ inline std::string getRankPrefix(torch::comms::TorchCommBackend* comm) {
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__), \
       TC_LOG_WITH_PREFIX_BUILDER(__VA_ARGS__, getDefaultCommunicator()))
 
-// Google glog's api does not have an external function that allows one to check
-// if glog is initialized or not. It does have an internal function - so we are
-// declaring it here. This is a hack but has been used by a bunch of others too
-// (e.g. Torch).
-// Copied from https://fburl.com/code/tu9hg6gf
-namespace google::glog_internal_namespace_ {
-bool IsGoogleLoggingInitialized();
-} // namespace google::glog_internal_namespace_
-
 namespace {
-
-[[maybe_unused]] void tryTorchCommLoggingInit(std::string_view name) {
-  // This trick can only be used on UNIX platforms
-  if (!::google::glog_internal_namespace_::IsGoogleLoggingInitialized()) {
-    ::google::InitGoogleLogging(name.data());
-    // This will trigger a kernel panic on GB200 NVIDIA driver
-    // temporarily disable signal handler until NVIDIA releases the new driver
-    // in late Jan.
-#if !defined(__aarch64__)
-    ::google::InstallFailureSignalHandler();
-#endif
-  }
-}
 
 [[maybe_unused]] torch::comms::TorchCommBackend* getDefaultCommunicator() {
   static torch::comms::TorchCommBackend* defaultCommunicator = nullptr;

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -370,8 +370,6 @@ void TorchCommXCCL::init(
       xccl_api_->commUserRank(xccl_comm_, &rank_),
       "XCCL commUserRank failed");
 
-  tryTorchCommLoggingInit("torchcomm");
-
   xccl_api_->setVersionInfo();
   backend_version_ = std::to_string(xccl_api_->getVersion());
 


### PR DESCRIPTION
Move `tryTorchCommLoggingInit()` out of each backend's `init()` and into a single `TorchCommBackend::ensureLoggingInit()` called from the base-class constructor and `TorchCommFactory::get()`. The five backends (`NCCL`, `NCCLX`, `RCCL`, `RCCLX`, `XCCL`) and future backends no longer have to call it, and logging is guaranteed to be initialized before any `TC_LOG` site runs (including the factory's own "Loading backend library" log).

Also default `FLAGS_logtostderr=true` when no `GLOG_*` env var is set, so torchrun-style runs see logs on stderr instead of files in `/tmp`. Users can still override via `GLOG_log_dir`, `GLOG_logtostderr`, or `GLOG_alsologtostderr`.