### PR TITLE
Add `MultimemHandler` for CUDA multicast allocations

### DIFF
--- a/comms/pipes/CudaDriverLazy.cc
+++ b/comms/pipes/CudaDriverLazy.cc
@@ -30,6 +30,14 @@ PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle =
     nullptr;
 PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange = nullptr;
+#if CUDART_VERSION >= 12010
+PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate = nullptr;
+PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice = nullptr;
+PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem = nullptr;
+PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr = nullptr;
+PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind = nullptr;
+PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity = nullptr;
+#endif
 
 namespace {
 
@@ -50,6 +58,14 @@ int load_sym(const char* name, void** ptr) {
     return -1;
   }
   return 0;
+}
+
+void load_optional_sym(const char* name, void** ptr) {
+  cudaDriverEntryPointQueryResult status;
+  auto res = cudaGetDriverEntryPoint(name, ptr, cudaEnableDefault, &status);
+  if (res != cudaSuccess || status != cudaDriverEntryPointSuccess) {
+    *ptr = nullptr;
+  }
 }
 
 void do_init() {
@@ -76,6 +92,20 @@ void do_init() {
   LOAD(cuMemGetAllocationPropertiesFromHandle);
   LOAD(cuMemRetainAllocationHandle);
   LOAD(cuMemGetAddressRange);
+
+#if CUDART_VERSION >= 12010
+#define LOAD_OPTIONAL(symbol) \
+  load_optional_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol))
+
+  LOAD_OPTIONAL(cuMulticastCreate);
+  LOAD_OPTIONAL(cuMulticastAddDevice);
+  LOAD_OPTIONAL(cuMulticastBindMem);
+  LOAD_OPTIONAL(cuMulticastBindAddr);
+  LOAD_OPTIONAL(cuMulticastUnbind);
+  LOAD_OPTIONAL(cuMulticastGetGranularity);
+
+#undef LOAD_OPTIONAL
+#endif
 
 #undef LOAD
 

--- a/comms/pipes/CudaDriverLazy.h
+++ b/comms/pipes/CudaDriverLazy.h
@@ -62,4 +62,15 @@ extern PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 extern PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle;
 extern PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange;
 
+#if CUDART_VERSION >= 12010
+// NVSwitch multicast / multimem. These symbols are optional at runtime: older
+// drivers may not expose them even when the headers are new enough.
+extern PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate;
+extern PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice;
+extern PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem;
+extern PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr;
+extern PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind;
+extern PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity;
+#endif
+
 } // namespace comms::pipes

--- a/comms/pipes/MultimemHandler.cc
+++ b/comms/pipes/MultimemHandler.cc
@@ -1,0 +1,706 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/MultimemHandler.h"
+
+#include "comms/pipes/CudaDriverLazy.h"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace comms::pipes {
+
+namespace {
+
+void checkCudaError(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+void checkCuError(CUresult err, const char* msg) {
+  if (err != CUDA_SUCCESS) {
+    const char* errStr = nullptr;
+    pfn_cuGetErrorString(err, &errStr);
+    throw std::runtime_error(
+        std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
+  }
+}
+
+std::size_t alignUp(std::size_t value, std::size_t alignment) {
+  if (alignment == 0) {
+    return value;
+  }
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+constexpr int kCachedMultimemSupportDevices = 8;
+constexpr std::size_t kTrialAllocSize = 2 * 1024 * 1024;
+
+enum class MultimemSupportCacheState : uint8_t {
+  kUnknown,
+  kUnsupported,
+  kSupported,
+};
+
+bool multicastDriverApisAvailable() {
+#if CUDART_VERSION < 12030
+  return false;
+#else
+  return pfn_cuMulticastCreate != nullptr &&
+      pfn_cuMulticastAddDevice != nullptr &&
+      pfn_cuMulticastBindMem != nullptr && pfn_cuMulticastUnbind != nullptr &&
+      pfn_cuMulticastGetGranularity != nullptr;
+#endif
+}
+
+bool multicastSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int multicastSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &multicastSupported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev);
+  return err == CUDA_SUCCESS && multicastSupported != 0;
+#endif
+}
+
+CUmemAllocationProp makeLocalAllocationProp(CUdevice cuDev) {
+  CUmemAllocationProp localProp = {};
+#if CUDART_VERSION >= 12030
+  localProp.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  localProp.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  localProp.location.id = cuDev;
+  localProp.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+  int rdmaSupported = 0;
+  pfn_cuDeviceGetAttribute(
+      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
+  if (rdmaSupported) {
+    localProp.allocFlags.gpuDirectRDMACapable = 1;
+  }
+#else
+  (void)cuDev;
+#endif
+  return localProp;
+}
+
+bool fabricHandleSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int fabricSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &fabricSupported,
+      CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      cuDev);
+  if (err != CUDA_SUCCESS || fabricSupported == 0) {
+    return false;
+  }
+
+  auto localProp = makeLocalAllocationProp(cuDev);
+  std::size_t granularity = 0;
+  err = pfn_cuMemGetAllocationGranularity(
+      &granularity, &localProp, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  const std::size_t allocSize = alignUp(kTrialAllocSize, granularity);
+  CUmemGenericAllocationHandle handle = 0;
+  err = pfn_cuMemCreate(&handle, allocSize, &localProp, 0);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  FabricHandle fabricHandle = {};
+  err = pfn_cuMemExportToShareableHandle(
+      &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  CUmemGenericAllocationHandle importedHandle = 0;
+  err = pfn_cuMemImportFromShareableHandle(
+      &importedHandle, &fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  pfn_cuMemRelease(importedHandle);
+  pfn_cuMemRelease(handle);
+  return true;
+#endif
+}
+
+int32_t findNvlRankForCommRank(
+    int32_t commRank,
+    const std::vector<int>& nvlRankToCommRank) {
+  for (std::size_t nvlRank = 0; nvlRank < nvlRankToCommRank.size(); ++nvlRank) {
+    if (nvlRankToCommRank[nvlRank] == commRank) {
+      return static_cast<int32_t>(nvlRank);
+    }
+  }
+  return -1;
+}
+
+bool isMultimemSupportedImpl(int cudaDevice) {
+#if CUDART_VERSION < 12030
+  return false;
+#else
+  if (cudaDevice < 0) {
+    return false;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  if (!multicastDriverApisAvailable()) {
+    return false;
+  }
+
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    return false;
+  }
+
+  if (!multicastSupported(cuDev)) {
+    return false;
+  }
+
+  return fabricHandleSupported(cuDev);
+#endif
+}
+
+} // namespace
+
+MultimemHandler::MultimemHandler(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int32_t commRank,
+    std::vector<int> nvlRankToCommRank,
+    int cudaDevice,
+    std::size_t size)
+    : bootstrap_(std::move(bootstrap)),
+      commRank_(commRank),
+      nvlRank_(findNvlRankForCommRank(commRank, nvlRankToCommRank)),
+      nvlRanks_(static_cast<int32_t>(nvlRankToCommRank.size())),
+      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
+      cudaDevice_(cudaDevice),
+      requestedSize_(size) {
+  if (nvlRanks_ <= 0) {
+    throw std::runtime_error(
+        "MultimemHandler: nvlRankToCommRank must be non-empty");
+  }
+  if (nvlRank_ < 0 || nvlRank_ >= nvlRanks_) {
+    throw std::runtime_error(
+        "MultimemHandler: commRank must appear in nvlRankToCommRank");
+  }
+  for (int rank = 0; rank < nvlRanks_; ++rank) {
+    if (nvlRankToCommRank_[rank] < 0) {
+      throw std::runtime_error(
+          "MultimemHandler: nvlRankToCommRank contains a negative rank");
+    }
+    for (int prev = 0; prev < rank; ++prev) {
+      if (nvlRankToCommRank_[prev] == nvlRankToCommRank_[rank]) {
+        throw std::runtime_error(
+            "MultimemHandler: nvlRankToCommRank contains duplicate ranks");
+      }
+    }
+  }
+  if (requestedSize_ == 0) {
+    throw std::runtime_error("MultimemHandler: size must be non-zero");
+  }
+  if (!bootstrap_) {
+    throw std::runtime_error("MultimemHandler: bootstrap must be non-null");
+  }
+  if (!isMultimemSupported(cudaDevice_)) {
+    throw std::runtime_error(
+        "MultimemHandler: multicast multimem is not supported. Requires CUDA "
+        "12.3+, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, and fabric allocation "
+        "handles.");
+  }
+}
+
+MultimemHandler::~MultimemHandler() {
+  cleanup();
+}
+
+bool MultimemHandler::isMultimemSupported(int cudaDevice) {
+  if (cudaDevice < 0) {
+    return false;
+  }
+
+  static std::array<
+      std::atomic<MultimemSupportCacheState>,
+      kCachedMultimemSupportDevices>
+      cachedResults{};
+  if (cudaDevice >= kCachedMultimemSupportDevices) {
+    return isMultimemSupportedImpl(cudaDevice);
+  }
+
+  auto& cachedResult = cachedResults[static_cast<std::size_t>(cudaDevice)];
+  const auto cachedState = cachedResult.load(std::memory_order_acquire);
+  if (cachedState != MultimemSupportCacheState::kUnknown) {
+    return cachedState == MultimemSupportCacheState::kSupported;
+  }
+
+  const bool supported = isMultimemSupportedImpl(cudaDevice);
+  cachedResult.store(
+      supported ? MultimemSupportCacheState::kSupported
+                : MultimemSupportCacheState::kUnsupported,
+      std::memory_order_release);
+  return supported;
+}
+
+void MultimemHandler::exchange() {
+  if (exchanged_) {
+    return;
+  }
+
+#if CUDART_VERSION < 12030
+  throw std::runtime_error("MultimemHandler requires CUDA 12.3+");
+#else
+  const char* failedPhase = "initializeDevice";
+  const char* completedPhase = "none";
+
+  try {
+    // Multicast setup is host-synchronous locally, but it still has ordering
+    // requirements across ranks:
+    //
+    // 1. initializeDevice() resolves cudaDevice_ to a CUdevice and builds the
+    //    access descriptor used for both mappings. The caller must have already
+    //    made cudaDevice_ current; this handler does not call cudaSetDevice().
+    //
+    // 2. computeAllocationSize() aligns the requested size to both the local
+    //    allocation granularity and the multicast granularity. The local
+    //    backing allocation and multicast object must agree on the final size.
+    //
+    // 3. create/export/exchange/import shares only the multicast object
+    //    handle. Team rank 0 owns object creation, exports a fabric handle for
+    //    it, all ranks exchange handles, and the other ranks import rank 0's
+    //    object before joining the multicast team.
+    //
+    // 4. addLocalDeviceToMulticast() registers this rank's device with the
+    //    shared object. CUDA requires every participating device to be added
+    //    before memory can be bound to the multicast object.
+    //
+    // 5. allocateLocalMemory() creates, maps, grants access to, and zeroes this
+    //    rank's local backing allocation. This handle stays private to the
+    //    rank; peers do not need it because each rank binds its own allocation.
+    //
+    // 6. The pre-bind barrier is a control-plane robustness barrier. NCCL keeps
+    //    the same barrier to avoid possible cuMulticastBindMem hangs during
+    //    uneven setup or abort paths; it is not a GPU stream synchronization.
+    //
+    // 7. bindLocalMemoryToMulticast() attaches this rank's local allocation at
+    //    offset 0 in the shared object. After all ranks bind the same range,
+    //    multimem stores to that range can be replicated by NVSwitch.
+    //
+    // 8. mapMulticastMemory() reserves and maps this rank's multicast VA, then
+    //    grants device access. Kernels use this VA for multimem instructions.
+    //
+    // 9. The post-map barrier is the "ready to use" contract for exchange():
+    //    no rank returns and launches a kernel using multimem while another
+    //    rank is still binding or mapping the multicast VA.
+    const auto device = initializeDevice();
+    cuDev_ = device.cuDev;
+    deviceInitialized_ = true;
+    completedPhase = failedPhase;
+
+    failedPhase = "computeAllocationLayout";
+    const auto layout = computeAllocationLayout(device);
+    allocatedSize_ = layout.allocatedSize;
+    completedPhase = failedPhase;
+
+    failedPhase = "createMulticastHandle";
+    createMulticastHandle(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    FabricHandle multicastFabricHandle = {};
+    if (nvlRank_ == 0) {
+      failedPhase = "exportMulticastHandle";
+      multicastFabricHandle = exportMulticastHandle();
+      completedPhase = failedPhase;
+    }
+    failedPhase = "exchangeMulticastHandle";
+    multicastFabricHandle = exchangeMulticastHandle(multicastFabricHandle);
+    completedPhase = failedPhase;
+
+    // nvlRank_ is the rank inside this NVLink multicast team. Team rank 0
+    // already owns the CUDA multicast handle it created; every other team rank
+    // imports rank 0's exchanged fabric handle.
+    if (nvlRank_ != 0) {
+      failedPhase = "importMulticastHandle";
+      importMulticastHandle(multicastFabricHandle);
+      completedPhase = failedPhase;
+    }
+
+    // Every participating rank, including rank 0, must add its local device to
+    // the shared multicast object before any rank binds memory to the object.
+    failedPhase = "addLocalDeviceToMulticast";
+    addLocalDeviceToMulticast(device.cuDev);
+    completedPhase = failedPhase;
+
+    // Only the multicast object is shared. Each rank binds its own local
+    // allocation into that object.
+    failedPhase = "allocateLocalMemory";
+    allocateLocalMemory(device, layout);
+    completedPhase = failedPhase;
+
+    // Keep all ranks out of the driver's blocking cuMulticastBindMem path
+    // until every rank has joined the multicast object and allocated its local
+    // backing memory. NCCL uses the same barrier to avoid bind hangs during
+    // uneven setup or abort paths.
+    failedPhase = "synchronizeRanks:pre-bind";
+    synchronizeRanks("pre-bind");
+    completedPhase = failedPhase;
+
+    failedPhase = "bindLocalMemoryToMulticast";
+    bindLocalMemoryToMulticast(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    failedPhase = "mapMulticastMemory";
+    mapMulticastMemory(device, layout);
+    completedPhase = failedPhase;
+
+    // exchange() returns ready-to-use pointers. This barrier prevents an early
+    // rank from launching kernels against the multicast VA while another rank
+    // is still binding or mapping that VA.
+    failedPhase = "synchronizeRanks:post-map";
+    synchronizeRanks("post-map");
+
+    exchanged_ = true;
+  } catch (const std::exception& ex) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message = std::string("MultimemHandler::exchange failed: ") +
+        ex.what() + "\n" + state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    cleanup();
+    throw std::runtime_error(message);
+  } catch (...) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message =
+        std::string(
+            "MultimemHandler::exchange failed with unknown exception\n") +
+        state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    cleanup();
+    throw std::runtime_error(message);
+  }
+#endif
+}
+
+void* MultimemHandler::getLocalDeviceMemPtr() const {
+  if (!exchanged_ || localPtr_ == 0) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before using local ptr");
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(localPtr_);
+}
+
+void* MultimemHandler::getMultimemDeviceMemPtr() const {
+  if (!exchanged_ || multicastPtr_ == 0) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before using multimem ptr");
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(multicastPtr_);
+}
+
+MultimemHandler::DeviceContext MultimemHandler::initializeDevice() const {
+  DeviceContext device;
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuDeviceGet(&device.cuDev, cudaDevice_), "cuDeviceGet failed");
+
+  device.accessDesc = {};
+  device.accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  device.accessDesc.location.id = device.cuDev;
+  device.accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+#endif
+  return device;
+}
+
+MultimemHandler::AllocationLayout MultimemHandler::computeAllocationLayout(
+    const DeviceContext& device) const {
+  AllocationLayout layout;
+#if CUDART_VERSION >= 12030
+  auto localProp = makeLocalAllocationProp(device.cuDev);
+
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &layout.localGranularity,
+          &localProp,
+          CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+      "cuMemGetAllocationGranularity failed");
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks_);
+  multicastProp.size = alignUp(requestedSize_, layout.localGranularity);
+  multicastProp.handleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  multicastProp.flags = 0;
+
+  checkCuError(
+      pfn_cuMulticastGetGranularity(
+          &layout.multicastGranularity,
+          &multicastProp,
+          CU_MULTICAST_GRANULARITY_MINIMUM),
+      "cuMulticastGetGranularity failed");
+
+  layout.allocatedSize = alignUp(
+      alignUp(requestedSize_, layout.localGranularity),
+      layout.multicastGranularity);
+#endif
+  return layout;
+}
+
+void MultimemHandler::createMulticastHandle(std::size_t allocatedSize) {
+#if CUDART_VERSION >= 12030
+  if (nvlRank_ != 0) {
+    return;
+  }
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks_);
+  multicastProp.size = allocatedSize;
+  multicastProp.handleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  multicastProp.flags = 0;
+
+  checkCuError(
+      pfn_cuMulticastCreate(&multicastHandle_, &multicastProp),
+      "cuMulticastCreate failed");
+  multicastHandleValid_ = true;
+#endif
+}
+
+FabricHandle MultimemHandler::exportMulticastHandle() {
+  FabricHandle fabricHandle = {};
+#if CUDART_VERSION >= 12030
+  if (nvlRank_ == 0) {
+    checkCuError(
+        pfn_cuMemExportToShareableHandle(
+            &fabricHandle, multicastHandle_, CU_MEM_HANDLE_TYPE_FABRIC, 0),
+        "cuMemExportToShareableHandle for multicast fabric handle failed");
+  }
+#endif
+  return fabricHandle;
+}
+
+FabricHandle MultimemHandler::exchangeMulticastHandle(
+    FabricHandle fabricHandle) {
+  std::vector<FabricHandle> allHandles(nvlRanks_, FabricHandle{});
+  allHandles[nvlRank_] = fabricHandle;
+
+  auto result = bootstrap_
+                    ->allGatherNvlDomain(
+                        allHandles.data(),
+                        sizeof(FabricHandle),
+                        nvlRank_,
+                        nvlRanks_,
+                        nvlRankToCommRank_)
+                    .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "MultimemHandler::exchangeMulticastHandle fabric allGatherNvlDomain failed");
+  }
+  return allHandles[0];
+}
+
+void MultimemHandler::importMulticastHandle(const FabricHandle& fabricHandle) {
+#if CUDART_VERSION >= 12030
+  auto importedFabricHandle = fabricHandle;
+  checkCuError(
+      pfn_cuMemImportFromShareableHandle(
+          &multicastHandle_, &importedFabricHandle, CU_MEM_HANDLE_TYPE_FABRIC),
+      "cuMemImportFromShareableHandle for multicast fabric handle failed");
+  multicastHandleValid_ = true;
+#endif
+}
+
+void MultimemHandler::addLocalDeviceToMulticast(CUdevice cuDev) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMulticastAddDevice(multicastHandle_, cuDev),
+      "cuMulticastAddDevice failed");
+#endif
+}
+
+void MultimemHandler::allocateLocalMemory(
+    const DeviceContext& device,
+    const AllocationLayout& layout) {
+#if CUDART_VERSION >= 12030
+  auto localProp = makeLocalAllocationProp(device.cuDev);
+
+  checkCuError(
+      pfn_cuMemAddressReserve(
+          &localPtr_, layout.allocatedSize, layout.localGranularity, 0, 0),
+      "cuMemAddressReserve for local multimem backing failed");
+
+  checkCuError(
+      pfn_cuMemCreate(&localAllocHandle_, layout.allocatedSize, &localProp, 0),
+      "cuMemCreate for local multimem backing failed");
+  localHandleValid_ = true;
+
+  checkCuError(
+      pfn_cuMemMap(localPtr_, layout.allocatedSize, 0, localAllocHandle_, 0),
+      "cuMemMap for local multimem backing failed");
+  localMapped_ = true;
+
+  checkCuError(
+      pfn_cuMemSetAccess(
+          localPtr_, layout.allocatedSize, &device.accessDesc, 1),
+      "cuMemSetAccess for local multimem backing failed");
+
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  auto* localPtr = reinterpret_cast<void*>(localPtr_);
+  checkCudaError(
+      cudaMemset(localPtr, 0, layout.allocatedSize),
+      "cudaMemset for local multimem backing failed");
+  checkCudaError(
+      cudaDeviceSynchronize(),
+      "cudaDeviceSynchronize after local multimem backing memset failed");
+#endif
+}
+
+void MultimemHandler::bindLocalMemoryToMulticast(std::size_t allocatedSize) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMulticastBindMem(
+          multicastHandle_, 0, localAllocHandle_, 0, allocatedSize, 0),
+      "cuMulticastBindMem failed");
+  multicastBound_ = true;
+#endif
+}
+
+void MultimemHandler::mapMulticastMemory(
+    const DeviceContext& device,
+    const AllocationLayout& layout) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMemAddressReserve(
+          &multicastPtr_,
+          layout.allocatedSize,
+          layout.multicastGranularity,
+          0,
+          0),
+      "cuMemAddressReserve for multimem VA failed");
+
+  checkCuError(
+      pfn_cuMemMap(multicastPtr_, layout.allocatedSize, 0, multicastHandle_, 0),
+      "cuMemMap for multimem VA failed");
+  multicastMapped_ = true;
+
+  checkCuError(
+      pfn_cuMemSetAccess(
+          multicastPtr_, layout.allocatedSize, &device.accessDesc, 1),
+      "cuMemSetAccess for multimem VA failed");
+#endif
+}
+
+void MultimemHandler::synchronizeRanks(const char* phase) {
+  auto barrierResult =
+      bootstrap_->barrierNvlDomain(nvlRank_, nvlRanks_, nvlRankToCommRank_)
+          .get();
+  if (barrierResult != 0) {
+    throw std::runtime_error(
+        std::string("MultimemHandler::synchronizeRanks failed during ") +
+        phase);
+  }
+}
+
+std::string MultimemHandler::describeState(
+    const char* failedPhase,
+    const char* completedPhase) const {
+  std::ostringstream out;
+  out << "MultimemHandler state:"
+      << " failedPhase=" << (failedPhase != nullptr ? failedPhase : "unknown")
+      << " completedPhase="
+      << (completedPhase != nullptr ? completedPhase : "unknown")
+      << " commRank=" << commRank_ << " nvlRank=" << nvlRank_
+      << " nvlRanks=" << nvlRanks_ << " cudaDevice=" << cudaDevice_
+      << " requestedSize=" << requestedSize_
+      << " allocatedSize=" << allocatedSize_ << " rankMap=[";
+  for (std::size_t i = 0; i < nvlRankToCommRank_.size(); ++i) {
+    if (i != 0) {
+      out << ",";
+    }
+    out << nvlRankToCommRank_[i];
+  }
+  out << "] flags={exchanged=" << exchanged_
+      << ",deviceInitialized=" << deviceInitialized_
+      << ",multicastHandleValid=" << multicastHandleValid_
+      << ",localHandleValid=" << localHandleValid_
+      << ",localMapped=" << localMapped_
+      << ",multicastBound=" << multicastBound_
+      << ",multicastMapped=" << multicastMapped_
+      << "} handles={cuDev=" << cuDev_ << ",localPtr=0x" << std::hex
+      << localPtr_ << ",multicastPtr=0x" << multicastPtr_
+      << ",localAllocHandle=0x" << localAllocHandle_ << ",multicastHandle=0x"
+      << multicastHandle_ << std::dec << "}";
+  return out.str();
+}
+
+void MultimemHandler::cleanup() {
+#if CUDART_VERSION >= 12030
+  if (!deviceInitialized_ || cuda_driver_lazy_init() != 0) {
+    return;
+  }
+
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+
+  if (multicastMapped_) {
+    pfn_cuMemUnmap(multicastPtr_, allocatedSize_);
+    pfn_cuMemAddressFree(multicastPtr_, allocatedSize_);
+    multicastPtr_ = 0;
+    multicastMapped_ = false;
+  } else if (multicastPtr_ != 0) {
+    pfn_cuMemAddressFree(multicastPtr_, allocatedSize_);
+    multicastPtr_ = 0;
+  }
+
+  if (multicastBound_ && pfn_cuMulticastUnbind != nullptr) {
+    pfn_cuMulticastUnbind(multicastHandle_, cuDev_, 0, allocatedSize_);
+    multicastBound_ = false;
+  }
+
+  if (multicastHandleValid_) {
+    pfn_cuMemRelease(multicastHandle_);
+    multicastHandle_ = 0;
+    multicastHandleValid_ = false;
+  }
+
+  if (localMapped_) {
+    pfn_cuMemUnmap(localPtr_, allocatedSize_);
+    pfn_cuMemAddressFree(localPtr_, allocatedSize_);
+    localPtr_ = 0;
+    localMapped_ = false;
+  } else if (localPtr_ != 0) {
+    pfn_cuMemAddressFree(localPtr_, allocatedSize_);
+    localPtr_ = 0;
+  }
+
+  if (localHandleValid_) {
+    pfn_cuMemRelease(localAllocHandle_);
+    localAllocHandle_ = 0;
+    localHandleValid_ = false;
+  }
+#endif
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/MultimemHandler.h
+++ b/comms/pipes/MultimemHandler.h
@@ -1,0 +1,180 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/GpuMemHandler.h"
+
+namespace comms::pipes {
+
+/**
+ * MultimemHandler - Manages one NVSwitch multicast allocation.
+ *
+ * Addressing model:
+ *
+ * Each rank owns a private local physical allocation. All ranks also join one
+ * CUDA multicast object whose offsets describe the shared multicast window.
+ * The handler exposes two device pointers on each rank:
+ *
+ * - local pointer: normal unicast VA mapped to this rank's local backing
+ *   allocation. Loads from this pointer read the data delivered to the local
+ *   rank, and ordinary stores update only the local rank.
+ * - multimem pointer: multicast VA mapped to the shared multicast object.
+ *   Device code writes this pointer with `multimem.st.*` or `multimem.red.*`
+ *   instructions when it wants NVSwitch to replicate the write.
+ *
+ * A store to the multimem pointer is replicated by NVSwitch into every rank's
+ * local backing allocation at the same object offset. For example, a multimem
+ * store to `getMultimemDeviceMemPtr() + x` becomes a local write visible at
+ * `getLocalDeviceMemPtr() + x` on every rank in the multicast team.
+ *
+ * Store path:
+ *
+ *   writer rank
+ *   multimemPtr + x
+ *        |
+ *        |  multimem.st value
+ *        v
+ *   CUDA multicast object offset x
+ *        |
+ *        +--> rank 0 localPtr + x = value
+ *        +--> rank 1 localPtr + x = value
+ *        +--> rank 2 localPtr + x = value
+ *        +--> ...
+ *
+ * A normal store to `localPtr + x` does not enter the multicast object and
+ * only updates the writer's local backing allocation.
+ *
+ * Pointer values are process-local CUDA virtual addresses. Do not compare the
+ * numeric multimem pointer value across MPI ranks or encode protocols that
+ * require it to match. The portable invariant is that the ranks map the same
+ * multicast object and interpret offsets within that object identically.
+ *
+ * `bootstrap` is the global communicator bootstrap. `commRank` is this
+ * process's rank in that global communicator. `nvlRankToCommRank` maps each
+ * NVLink-local rank to its global communicator rank. The handler derives its
+ * NVLink-local rank from the map, then exchange() uses the bootstrap's
+ * NVLink-domain collectives. Callers do not need to pre-wrap the bootstrap in
+ * an NVLink-local adapter.
+ *
+ * The caller must set the current CUDA device to `cudaDevice` before using this
+ * handler. MultimemHandler uses `cudaDevice` to query driver properties and
+ * describe allocations, but it does not call cudaSetDevice().
+ */
+class MultimemHandler {
+ public:
+  MultimemHandler(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int32_t commRank,
+      std::vector<int> nvlRankToCommRank,
+      int cudaDevice,
+      std::size_t size);
+
+  ~MultimemHandler();
+
+  MultimemHandler(const MultimemHandler&) = delete;
+  MultimemHandler& operator=(const MultimemHandler&) = delete;
+  MultimemHandler(MultimemHandler&&) = delete;
+  MultimemHandler& operator=(MultimemHandler&&) = delete;
+
+  /**
+   * Collective operation over all ranks in the multicast team.
+   *
+   * Allocates local backing memory, exchanges the multicast object handle,
+   * binds each rank's local allocation to the multicast object, and maps the
+   * multicast VA. Returns only after every rank has completed setup, so the
+   * local and multicast pointers are ready for device use.
+   */
+  void exchange();
+
+  /**
+   * Returns this rank's local backing allocation. Loads from this pointer read
+   * data delivered by multicast stores, and ordinary stores only update this
+   * rank's local backing memory.
+   */
+  void* getLocalDeviceMemPtr() const;
+
+  /**
+   * Returns this rank's multicast VA. Device code uses this pointer with
+   * `multimem.*` instructions to broadcast writes to every rank in the
+   * multicast team.
+   */
+  void* getMultimemDeviceMemPtr() const;
+
+  std::size_t getAllocatedSize() const {
+    return allocatedSize_;
+  }
+
+  /**
+   * Returns whether the current process can create CUDA multicast allocations
+   * on `cudaDevice`. The caller is expected to have already made `cudaDevice`
+   * current; this helper does not switch devices.
+   */
+  static bool isMultimemSupported(int cudaDevice);
+
+ private:
+  struct DeviceContext {
+    CUdevice cuDev{0};
+    CUmemAccessDesc accessDesc{};
+  };
+
+  struct AllocationLayout {
+    std::size_t allocatedSize{0};
+    std::size_t localGranularity{0};
+    std::size_t multicastGranularity{0};
+  };
+
+  DeviceContext initializeDevice() const;
+  AllocationLayout computeAllocationLayout(const DeviceContext& device) const;
+  void createMulticastHandle(std::size_t allocatedSize);
+  FabricHandle exportMulticastHandle();
+  FabricHandle exchangeMulticastHandle(FabricHandle fabricHandle);
+  void importMulticastHandle(const FabricHandle& fabricHandle);
+  void allocateLocalMemory(
+      const DeviceContext& device,
+      const AllocationLayout& layout);
+  void addLocalDeviceToMulticast(CUdevice cuDev);
+  void bindLocalMemoryToMulticast(std::size_t allocatedSize);
+  void mapMulticastMemory(
+      const DeviceContext& device,
+      const AllocationLayout& layout);
+  void synchronizeRanks(const char* phase);
+  std::string describeState(const char* failedPhase, const char* completedPhase)
+      const;
+  void cleanup();
+
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  const int32_t commRank_{-1};
+  const int32_t nvlRank_{-1};
+  const int32_t nvlRanks_{-1};
+  const std::vector<int> nvlRankToCommRank_;
+  const int cudaDevice_{-1};
+  const std::size_t requestedSize_{0};
+
+  bool exchanged_{false};
+  bool deviceInitialized_{false};
+  bool multicastHandleValid_{false};
+  bool localHandleValid_{false};
+  bool localMapped_{false};
+  bool multicastBound_{false};
+  bool multicastMapped_{false};
+
+  CUdevice cuDev_{0};
+  CUdeviceptr localPtr_{0};
+  CUdeviceptr multicastPtr_{0};
+  CUmemGenericAllocationHandle localAllocHandle_{0};
+  CUmemGenericAllocationHandle multicastHandle_{0};
+
+  std::size_t allocatedSize_{0};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/MultimemHandlerTest.cc
+++ b/comms/pipes/tests/MultimemHandlerTest.cc
@@ -1,0 +1,161 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultimemHandler.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::tests {
+
+class MultimemHandlerTestFixture : public ::testing::Test,
+                                   public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::vector<int> reverseRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = size - 1 - rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+bool allRanksMultimemSupported(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> supported(static_cast<std::size_t>(nRanks));
+  supported[static_cast<std::size_t>(rank)] =
+      MultimemHandler::isMultimemSupported(cudaDevice) ? 1 : 0;
+  auto supportRc =
+      bootstrap->allGather(supported.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(supportRc, 0);
+  if (supportRc != 0) {
+    return false;
+  }
+  bool allRanksSupported = true;
+  for (const auto value : supported) {
+    allRanksSupported = allRanksSupported && value != 0;
+  }
+  return allRanksSupported;
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSetsUpStableMappings) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  MultimemHandler handler(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      localRank,
+      kRequestedBytes);
+  EXPECT_THROW(handler.getLocalDeviceMemPtr(), std::runtime_error);
+  EXPECT_THROW(handler.getMultimemDeviceMemPtr(), std::runtime_error);
+
+  handler.exchange();
+
+  auto* localPtr = handler.getLocalDeviceMemPtr();
+  auto* multimemPtr = handler.getMultimemDeviceMemPtr();
+
+  EXPECT_NE(localPtr, nullptr);
+  EXPECT_NE(multimemPtr, nullptr);
+  EXPECT_NE(localPtr, multimemPtr);
+  EXPECT_EQ(localPtr, handler.getLocalDeviceMemPtr());
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  std::vector<std::uintptr_t> multimemAddrs(static_cast<std::size_t>(numRanks));
+  multimemAddrs[static_cast<std::size_t>(globalRank)] =
+      reinterpret_cast<std::uintptr_t>(multimemPtr);
+  auto rc = bootstrap
+                ->allGather(
+                    multimemAddrs.data(),
+                    sizeof(std::uintptr_t),
+                    globalRank,
+                    numRanks)
+                .get();
+  ASSERT_EQ(rc, 0);
+  for (int rank = 0; rank < numRanks; ++rank) {
+    EXPECT_NE(multimemAddrs[static_cast<std::size_t>(rank)], 0);
+  }
+
+  handler.exchange();
+  EXPECT_EQ(localPtr, handler.getLocalDeviceMemPtr());
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSupportsNonIdentityRankMap) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_non_identity_rank_map_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  MultimemHandler handler(
+      bootstrap,
+      globalRank,
+      reverseRankMap(numRanks),
+      localRank,
+      kRequestedBytes);
+  handler.exchange();
+
+  EXPECT_NE(handler.getLocalDeviceMemPtr(), nullptr);
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/MultimemHandlerValidationTest.cc
+++ b/comms/pipes/tests/MultimemHandlerValidationTest.cc
@@ -1,0 +1,96 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/MultimemHandler.h"
+
+namespace comms::pipes::tests {
+
+namespace {
+
+class FakeBootstrap : public meta::comms::IBootstrap {
+ public:
+  folly::SemiFuture<int> allGather(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> send(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> recv(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+};
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap() {
+  return std::make_shared<FakeBootstrap>();
+}
+
+template <typename Fn>
+void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
+  try {
+    std::forward<Fn>(fn)();
+    FAIL() << "expected std::runtime_error containing " << expected;
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected), std::string::npos)
+        << ex.what();
+  }
+}
+
+} // namespace
+
+TEST(MultimemHandlerValidationTest, RejectsEmptyRankMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {}, 0, 4096); },
+      "nvlRankToCommRank must be non-empty");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsMissingCommRank) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 7, {0, 1, 2}, 0, 4096); },
+      "commRank must appear in nvlRankToCommRank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNegativeRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0, -1}, 0, 4096); },
+      "contains a negative rank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsDuplicateRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0, 0}, 0, 4096); },
+      "contains duplicate ranks");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsZeroSize) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0}, 0, 0); },
+      "size must be non-zero");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNullBootstrap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, 0, {0}, 0, 4096); },
+      "bootstrap must be non-null");
+}
+
+TEST(MultimemHandlerValidationTest, NegativeCudaDeviceIsUnsupported) {
+  EXPECT_FALSE(MultimemHandler::isMultimemSupported(-1));
+}
+
+} // namespace comms::pipes::tests


### PR DESCRIPTION
Summary: Add `MultimemHandler` for one NVLink-domain CUDA multicast allocation. Each participating rank owns a private local backing allocation, while the team shares one CUDA multicast object whose offsets define the multicast window. Team rank 0 creates the multicast object and exchanges its fabric handle through the global bootstrap NVLink-domain collectives; every other team rank imports that handle, every rank adds its local device, allocates local memory, binds its local allocation at the same object offset, then maps a process-local multicast VA. Kernels read delivered data through `getLocalDeviceMemPtr()` and write `getMultimemDeviceMemPtr()` with `multimem.*` instructions to replicate stores to the same offset in every rank local backing allocation. `exchange()` is a host-side setup protocol with two explicit NVLink-domain barriers: a pre-bind barrier matching NCCL practice to keep ranks out of uneven `cuMulticastBindMem` paths, and a post-map barrier that is the ready-to-launch contract before any rank uses the multicast VA.

Differential Revision: D105264759


