### PR TITLE
Add basic `MultimemNvlTransport` APIs

### DIFF
--- a/comms/pipes/CudaDriverLazy.cc
+++ b/comms/pipes/CudaDriverLazy.cc
@@ -30,6 +30,14 @@ PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle =
     nullptr;
 PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange = nullptr;
+#if CUDART_VERSION >= 12010
+PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate = nullptr;
+PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice = nullptr;
+PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem = nullptr;
+PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr = nullptr;
+PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind = nullptr;
+PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity = nullptr;
+#endif
 
 namespace {
 
@@ -50,6 +58,14 @@ int load_sym(const char* name, void** ptr) {
     return -1;
   }
   return 0;
+}
+
+void load_optional_sym(const char* name, void** ptr) {
+  cudaDriverEntryPointQueryResult status;
+  auto res = cudaGetDriverEntryPoint(name, ptr, cudaEnableDefault, &status);
+  if (res != cudaSuccess || status != cudaDriverEntryPointSuccess) {
+    *ptr = nullptr;
+  }
 }
 
 void do_init() {
@@ -76,6 +92,20 @@ void do_init() {
   LOAD(cuMemGetAllocationPropertiesFromHandle);
   LOAD(cuMemRetainAllocationHandle);
   LOAD(cuMemGetAddressRange);
+
+#if CUDART_VERSION >= 12010
+#define LOAD_OPTIONAL(symbol) \
+  load_optional_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol))
+
+  LOAD_OPTIONAL(cuMulticastCreate);
+  LOAD_OPTIONAL(cuMulticastAddDevice);
+  LOAD_OPTIONAL(cuMulticastBindMem);
+  LOAD_OPTIONAL(cuMulticastBindAddr);
+  LOAD_OPTIONAL(cuMulticastUnbind);
+  LOAD_OPTIONAL(cuMulticastGetGranularity);
+
+#undef LOAD_OPTIONAL
+#endif
 
 #undef LOAD
 

--- a/comms/pipes/CudaDriverLazy.h
+++ b/comms/pipes/CudaDriverLazy.h
@@ -62,4 +62,15 @@ extern PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 extern PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle;
 extern PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange;
 
+#if CUDART_VERSION >= 12010
+// NVSwitch multicast / multimem. These symbols are optional at runtime: older
+// drivers may not expose them even when the headers are new enough.
+extern PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate;
+extern PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice;
+extern PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem;
+extern PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr;
+extern PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind;
+extern PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity;
+#endif
+
 } // namespace comms::pipes

--- a/comms/pipes/MultimemHandler.cc
+++ b/comms/pipes/MultimemHandler.cc
@@ -1,0 +1,706 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/MultimemHandler.h"
+
+#include "comms/pipes/CudaDriverLazy.h"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace comms::pipes {
+
+namespace {
+
+void checkCudaError(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+void checkCuError(CUresult err, const char* msg) {
+  if (err != CUDA_SUCCESS) {
+    const char* errStr = nullptr;
+    pfn_cuGetErrorString(err, &errStr);
+    throw std::runtime_error(
+        std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
+  }
+}
+
+std::size_t alignUp(std::size_t value, std::size_t alignment) {
+  if (alignment == 0) {
+    return value;
+  }
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+constexpr int kCachedMultimemSupportDevices = 8;
+constexpr std::size_t kTrialAllocSize = 2 * 1024 * 1024;
+
+enum class MultimemSupportCacheState : uint8_t {
+  kUnknown,
+  kUnsupported,
+  kSupported,
+};
+
+bool multicastDriverApisAvailable() {
+#if CUDART_VERSION < 12030
+  return false;
+#else
+  return pfn_cuMulticastCreate != nullptr &&
+      pfn_cuMulticastAddDevice != nullptr &&
+      pfn_cuMulticastBindMem != nullptr && pfn_cuMulticastUnbind != nullptr &&
+      pfn_cuMulticastGetGranularity != nullptr;
+#endif
+}
+
+bool multicastSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int multicastSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &multicastSupported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev);
+  return err == CUDA_SUCCESS && multicastSupported != 0;
+#endif
+}
+
+CUmemAllocationProp makeLocalAllocationProp(CUdevice cuDev) {
+  CUmemAllocationProp localProp = {};
+#if CUDART_VERSION >= 12030
+  localProp.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  localProp.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  localProp.location.id = cuDev;
+  localProp.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+  int rdmaSupported = 0;
+  pfn_cuDeviceGetAttribute(
+      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
+  if (rdmaSupported) {
+    localProp.allocFlags.gpuDirectRDMACapable = 1;
+  }
+#else
+  (void)cuDev;
+#endif
+  return localProp;
+}
+
+bool fabricHandleSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int fabricSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &fabricSupported,
+      CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      cuDev);
+  if (err != CUDA_SUCCESS || fabricSupported == 0) {
+    return false;
+  }
+
+  auto localProp = makeLocalAllocationProp(cuDev);
+  std::size_t granularity = 0;
+  err = pfn_cuMemGetAllocationGranularity(
+      &granularity, &localProp, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  const std::size_t allocSize = alignUp(kTrialAllocSize, granularity);
+  CUmemGenericAllocationHandle handle = 0;
+  err = pfn_cuMemCreate(&handle, allocSize, &localProp, 0);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  FabricHandle fabricHandle = {};
+  err = pfn_cuMemExportToShareableHandle(
+      &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  CUmemGenericAllocationHandle importedHandle = 0;
+  err = pfn_cuMemImportFromShareableHandle(
+      &importedHandle, &fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  pfn_cuMemRelease(importedHandle);
+  pfn_cuMemRelease(handle);
+  return true;
+#endif
+}
+
+int32_t findNvlRankForCommRank(
+    int32_t commRank,
+    const std::vector<int>& nvlRankToCommRank) {
+  for (std::size_t nvlRank = 0; nvlRank < nvlRankToCommRank.size(); ++nvlRank) {
+    if (nvlRankToCommRank[nvlRank] == commRank) {
+      return static_cast<int32_t>(nvlRank);
+    }
+  }
+  return -1;
+}
+
+bool isMultimemSupportedImpl(int cudaDevice) {
+#if CUDART_VERSION < 12030
+  return false;
+#else
+  if (cudaDevice < 0) {
+    return false;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  if (!multicastDriverApisAvailable()) {
+    return false;
+  }
+
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    return false;
+  }
+
+  if (!multicastSupported(cuDev)) {
+    return false;
+  }
+
+  return fabricHandleSupported(cuDev);
+#endif
+}
+
+} // namespace
+
+MultimemHandler::MultimemHandler(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int32_t commRank,
+    std::vector<int> nvlRankToCommRank,
+    int cudaDevice,
+    std::size_t size)
+    : bootstrap_(std::move(bootstrap)),
+      commRank_(commRank),
+      nvlRank_(findNvlRankForCommRank(commRank, nvlRankToCommRank)),
+      nvlRanks_(static_cast<int32_t>(nvlRankToCommRank.size())),
+      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
+      cudaDevice_(cudaDevice),
+      requestedSize_(size) {
+  if (nvlRanks_ <= 0) {
+    throw std::runtime_error(
+        "MultimemHandler: nvlRankToCommRank must be non-empty");
+  }
+  if (nvlRank_ < 0 || nvlRank_ >= nvlRanks_) {
+    throw std::runtime_error(
+        "MultimemHandler: commRank must appear in nvlRankToCommRank");
+  }
+  for (int rank = 0; rank < nvlRanks_; ++rank) {
+    if (nvlRankToCommRank_[rank] < 0) {
+      throw std::runtime_error(
+          "MultimemHandler: nvlRankToCommRank contains a negative rank");
+    }
+    for (int prev = 0; prev < rank; ++prev) {
+      if (nvlRankToCommRank_[prev] == nvlRankToCommRank_[rank]) {
+        throw std::runtime_error(
+            "MultimemHandler: nvlRankToCommRank contains duplicate ranks");
+      }
+    }
+  }
+  if (requestedSize_ == 0) {
+    throw std::runtime_error("MultimemHandler: size must be non-zero");
+  }
+  if (!bootstrap_) {
+    throw std::runtime_error("MultimemHandler: bootstrap must be non-null");
+  }
+  if (!isMultimemSupported(cudaDevice_)) {
+    throw std::runtime_error(
+        "MultimemHandler: multicast multimem is not supported. Requires CUDA "
+        "12.3+, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, and fabric allocation "
+        "handles.");
+  }
+}
+
+MultimemHandler::~MultimemHandler() {
+  cleanup();
+}
+
+bool MultimemHandler::isMultimemSupported(int cudaDevice) {
+  if (cudaDevice < 0) {
+    return false;
+  }
+
+  static std::array<
+      std::atomic<MultimemSupportCacheState>,
+      kCachedMultimemSupportDevices>
+      cachedResults{};
+  if (cudaDevice >= kCachedMultimemSupportDevices) {
+    return isMultimemSupportedImpl(cudaDevice);
+  }
+
+  auto& cachedResult = cachedResults[static_cast<std::size_t>(cudaDevice)];
+  const auto cachedState = cachedResult.load(std::memory_order_acquire);
+  if (cachedState != MultimemSupportCacheState::kUnknown) {
+    return cachedState == MultimemSupportCacheState::kSupported;
+  }
+
+  const bool supported = isMultimemSupportedImpl(cudaDevice);
+  cachedResult.store(
+      supported ? MultimemSupportCacheState::kSupported
+                : MultimemSupportCacheState::kUnsupported,
+      std::memory_order_release);
+  return supported;
+}
+
+void MultimemHandler::exchange() {
+  if (exchanged_) {
+    return;
+  }
+
+#if CUDART_VERSION < 12030
+  throw std::runtime_error("MultimemHandler requires CUDA 12.3+");
+#else
+  const char* failedPhase = "initializeDevice";
+  const char* completedPhase = "none";
+
+  try {
+    // Multicast setup is host-synchronous locally, but it still has ordering
+    // requirements across ranks:
+    //
+    // 1. initializeDevice() resolves cudaDevice_ to a CUdevice and builds the
+    //    access descriptor used for both mappings. The caller must have already
+    //    made cudaDevice_ current; this handler does not call cudaSetDevice().
+    //
+    // 2. computeAllocationSize() aligns the requested size to both the local
+    //    allocation granularity and the multicast granularity. The local
+    //    backing allocation and multicast object must agree on the final size.
+    //
+    // 3. create/export/exchange/import shares only the multicast object
+    //    handle. Team rank 0 owns object creation, exports a fabric handle for
+    //    it, all ranks exchange handles, and the other ranks import rank 0's
+    //    object before joining the multicast team.
+    //
+    // 4. addLocalDeviceToMulticast() registers this rank's device with the
+    //    shared object. CUDA requires every participating device to be added
+    //    before memory can be bound to the multicast object.
+    //
+    // 5. allocateLocalMemory() creates, maps, grants access to, and zeroes this
+    //    rank's local backing allocation. This handle stays private to the
+    //    rank; peers do not need it because each rank binds its own allocation.
+    //
+    // 6. The pre-bind barrier is a control-plane robustness barrier. NCCL keeps
+    //    the same barrier to avoid possible cuMulticastBindMem hangs during
+    //    uneven setup or abort paths; it is not a GPU stream synchronization.
+    //
+    // 7. bindLocalMemoryToMulticast() attaches this rank's local allocation at
+    //    offset 0 in the shared object. After all ranks bind the same range,
+    //    multimem stores to that range can be replicated by NVSwitch.
+    //
+    // 8. mapMulticastMemory() reserves and maps this rank's multicast VA, then
+    //    grants device access. Kernels use this VA for multimem instructions.
+    //
+    // 9. The post-map barrier is the "ready to use" contract for exchange():
+    //    no rank returns and launches a kernel using multimem while another
+    //    rank is still binding or mapping the multicast VA.
+    const auto device = initializeDevice();
+    cuDev_ = device.cuDev;
+    deviceInitialized_ = true;
+    completedPhase = failedPhase;
+
+    failedPhase = "computeAllocationLayout";
+    const auto layout = computeAllocationLayout(device);
+    allocatedSize_ = layout.allocatedSize;
+    completedPhase = failedPhase;
+
+    failedPhase = "createMulticastHandle";
+    createMulticastHandle(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    FabricHandle multicastFabricHandle = {};
+    if (nvlRank_ == 0) {
+      failedPhase = "exportMulticastHandle";
+      multicastFabricHandle = exportMulticastHandle();
+      completedPhase = failedPhase;
+    }
+    failedPhase = "exchangeMulticastHandle";
+    multicastFabricHandle = exchangeMulticastHandle(multicastFabricHandle);
+    completedPhase = failedPhase;
+
+    // nvlRank_ is the rank inside this NVLink multicast team. Team rank 0
+    // already owns the CUDA multicast handle it created; every other team rank
+    // imports rank 0's exchanged fabric handle.
+    if (nvlRank_ != 0) {
+      failedPhase = "importMulticastHandle";
+      importMulticastHandle(multicastFabricHandle);
+      completedPhase = failedPhase;
+    }
+
+    // Every participating rank, including rank 0, must add its local device to
+    // the shared multicast object before any rank binds memory to the object.
+    failedPhase = "addLocalDeviceToMulticast";
+    addLocalDeviceToMulticast(device.cuDev);
+    completedPhase = failedPhase;
+
+    // Only the multicast object is shared. Each rank binds its own local
+    // allocation into that object.
+    failedPhase = "allocateLocalMemory";
+    allocateLocalMemory(device, layout);
+    completedPhase = failedPhase;
+
+    // Keep all ranks out of the driver's blocking cuMulticastBindMem path
+    // until every rank has joined the multicast object and allocated its local
+    // backing memory. NCCL uses the same barrier to avoid bind hangs during
+    // uneven setup or abort paths.
+    failedPhase = "synchronizeRanks:pre-bind";
+    synchronizeRanks("pre-bind");
+    completedPhase = failedPhase;
+
+    failedPhase = "bindLocalMemoryToMulticast";
+    bindLocalMemoryToMulticast(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    failedPhase = "mapMulticastMemory";
+    mapMulticastMemory(device, layout);
+    completedPhase = failedPhase;
+
+    // exchange() returns ready-to-use pointers. This barrier prevents an early
+    // rank from launching kernels against the multicast VA while another rank
+    // is still binding or mapping that VA.
+    failedPhase = "synchronizeRanks:post-map";
+    synchronizeRanks("post-map");
+
+    exchanged_ = true;
+  } catch (const std::exception& ex) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message = std::string("MultimemHandler::exchange failed: ") +
+        ex.what() + "\n" + state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    cleanup();
+    throw std::runtime_error(message);
+  } catch (...) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message =
+        std::string(
+            "MultimemHandler::exchange failed with unknown exception\n") +
+        state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    cleanup();
+    throw std::runtime_error(message);
+  }
+#endif
+}
+
+void* MultimemHandler::getLocalDeviceMemPtr() const {
+  if (!exchanged_ || localPtr_ == 0) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before using local ptr");
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(localPtr_);
+}
+
+void* MultimemHandler::getMultimemDeviceMemPtr() const {
+  if (!exchanged_ || multicastPtr_ == 0) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before using multimem ptr");
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(multicastPtr_);
+}
+
+MultimemHandler::DeviceContext MultimemHandler::initializeDevice() const {
+  DeviceContext device;
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuDeviceGet(&device.cuDev, cudaDevice_), "cuDeviceGet failed");
+
+  device.accessDesc = {};
+  device.accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  device.accessDesc.location.id = device.cuDev;
+  device.accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+#endif
+  return device;
+}
+
+MultimemHandler::AllocationLayout MultimemHandler::computeAllocationLayout(
+    const DeviceContext& device) const {
+  AllocationLayout layout;
+#if CUDART_VERSION >= 12030
+  auto localProp = makeLocalAllocationProp(device.cuDev);
+
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &layout.localGranularity,
+          &localProp,
+          CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+      "cuMemGetAllocationGranularity failed");
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks_);
+  multicastProp.size = alignUp(requestedSize_, layout.localGranularity);
+  multicastProp.handleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  multicastProp.flags = 0;
+
+  checkCuError(
+      pfn_cuMulticastGetGranularity(
+          &layout.multicastGranularity,
+          &multicastProp,
+          CU_MULTICAST_GRANULARITY_MINIMUM),
+      "cuMulticastGetGranularity failed");
+
+  layout.allocatedSize = alignUp(
+      alignUp(requestedSize_, layout.localGranularity),
+      layout.multicastGranularity);
+#endif
+  return layout;
+}
+
+void MultimemHandler::createMulticastHandle(std::size_t allocatedSize) {
+#if CUDART_VERSION >= 12030
+  if (nvlRank_ != 0) {
+    return;
+  }
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks_);
+  multicastProp.size = allocatedSize;
+  multicastProp.handleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  multicastProp.flags = 0;
+
+  checkCuError(
+      pfn_cuMulticastCreate(&multicastHandle_, &multicastProp),
+      "cuMulticastCreate failed");
+  multicastHandleValid_ = true;
+#endif
+}
+
+FabricHandle MultimemHandler::exportMulticastHandle() {
+  FabricHandle fabricHandle = {};
+#if CUDART_VERSION >= 12030
+  if (nvlRank_ == 0) {
+    checkCuError(
+        pfn_cuMemExportToShareableHandle(
+            &fabricHandle, multicastHandle_, CU_MEM_HANDLE_TYPE_FABRIC, 0),
+        "cuMemExportToShareableHandle for multicast fabric handle failed");
+  }
+#endif
+  return fabricHandle;
+}
+
+FabricHandle MultimemHandler::exchangeMulticastHandle(
+    FabricHandle fabricHandle) {
+  std::vector<FabricHandle> allHandles(nvlRanks_, FabricHandle{});
+  allHandles[nvlRank_] = fabricHandle;
+
+  auto result = bootstrap_
+                    ->allGatherNvlDomain(
+                        allHandles.data(),
+                        sizeof(FabricHandle),
+                        nvlRank_,
+                        nvlRanks_,
+                        nvlRankToCommRank_)
+                    .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "MultimemHandler::exchangeMulticastHandle fabric allGatherNvlDomain failed");
+  }
+  return allHandles[0];
+}
+
+void MultimemHandler::importMulticastHandle(const FabricHandle& fabricHandle) {
+#if CUDART_VERSION >= 12030
+  auto importedFabricHandle = fabricHandle;
+  checkCuError(
+      pfn_cuMemImportFromShareableHandle(
+          &multicastHandle_, &importedFabricHandle, CU_MEM_HANDLE_TYPE_FABRIC),
+      "cuMemImportFromShareableHandle for multicast fabric handle failed");
+  multicastHandleValid_ = true;
+#endif
+}
+
+void MultimemHandler::addLocalDeviceToMulticast(CUdevice cuDev) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMulticastAddDevice(multicastHandle_, cuDev),
+      "cuMulticastAddDevice failed");
+#endif
+}
+
+void MultimemHandler::allocateLocalMemory(
+    const DeviceContext& device,
+    const AllocationLayout& layout) {
+#if CUDART_VERSION >= 12030
+  auto localProp = makeLocalAllocationProp(device.cuDev);
+
+  checkCuError(
+      pfn_cuMemAddressReserve(
+          &localPtr_, layout.allocatedSize, layout.localGranularity, 0, 0),
+      "cuMemAddressReserve for local multimem backing failed");
+
+  checkCuError(
+      pfn_cuMemCreate(&localAllocHandle_, layout.allocatedSize, &localProp, 0),
+      "cuMemCreate for local multimem backing failed");
+  localHandleValid_ = true;
+
+  checkCuError(
+      pfn_cuMemMap(localPtr_, layout.allocatedSize, 0, localAllocHandle_, 0),
+      "cuMemMap for local multimem backing failed");
+  localMapped_ = true;
+
+  checkCuError(
+      pfn_cuMemSetAccess(
+          localPtr_, layout.allocatedSize, &device.accessDesc, 1),
+      "cuMemSetAccess for local multimem backing failed");
+
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  auto* localPtr = reinterpret_cast<void*>(localPtr_);
+  checkCudaError(
+      cudaMemset(localPtr, 0, layout.allocatedSize),
+      "cudaMemset for local multimem backing failed");
+  checkCudaError(
+      cudaDeviceSynchronize(),
+      "cudaDeviceSynchronize after local multimem backing memset failed");
+#endif
+}
+
+void MultimemHandler::bindLocalMemoryToMulticast(std::size_t allocatedSize) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMulticastBindMem(
+          multicastHandle_, 0, localAllocHandle_, 0, allocatedSize, 0),
+      "cuMulticastBindMem failed");
+  multicastBound_ = true;
+#endif
+}
+
+void MultimemHandler::mapMulticastMemory(
+    const DeviceContext& device,
+    const AllocationLayout& layout) {
+#if CUDART_VERSION >= 12030
+  checkCuError(
+      pfn_cuMemAddressReserve(
+          &multicastPtr_,
+          layout.allocatedSize,
+          layout.multicastGranularity,
+          0,
+          0),
+      "cuMemAddressReserve for multimem VA failed");
+
+  checkCuError(
+      pfn_cuMemMap(multicastPtr_, layout.allocatedSize, 0, multicastHandle_, 0),
+      "cuMemMap for multimem VA failed");
+  multicastMapped_ = true;
+
+  checkCuError(
+      pfn_cuMemSetAccess(
+          multicastPtr_, layout.allocatedSize, &device.accessDesc, 1),
+      "cuMemSetAccess for multimem VA failed");
+#endif
+}
+
+void MultimemHandler::synchronizeRanks(const char* phase) {
+  auto barrierResult =
+      bootstrap_->barrierNvlDomain(nvlRank_, nvlRanks_, nvlRankToCommRank_)
+          .get();
+  if (barrierResult != 0) {
+    throw std::runtime_error(
+        std::string("MultimemHandler::synchronizeRanks failed during ") +
+        phase);
+  }
+}
+
+std::string MultimemHandler::describeState(
+    const char* failedPhase,
+    const char* completedPhase) const {
+  std::ostringstream out;
+  out << "MultimemHandler state:"
+      << " failedPhase=" << (failedPhase != nullptr ? failedPhase : "unknown")
+      << " completedPhase="
+      << (completedPhase != nullptr ? completedPhase : "unknown")
+      << " commRank=" << commRank_ << " nvlRank=" << nvlRank_
+      << " nvlRanks=" << nvlRanks_ << " cudaDevice=" << cudaDevice_
+      << " requestedSize=" << requestedSize_
+      << " allocatedSize=" << allocatedSize_ << " rankMap=[";
+  for (std::size_t i = 0; i < nvlRankToCommRank_.size(); ++i) {
+    if (i != 0) {
+      out << ",";
+    }
+    out << nvlRankToCommRank_[i];
+  }
+  out << "] flags={exchanged=" << exchanged_
+      << ",deviceInitialized=" << deviceInitialized_
+      << ",multicastHandleValid=" << multicastHandleValid_
+      << ",localHandleValid=" << localHandleValid_
+      << ",localMapped=" << localMapped_
+      << ",multicastBound=" << multicastBound_
+      << ",multicastMapped=" << multicastMapped_
+      << "} handles={cuDev=" << cuDev_ << ",localPtr=0x" << std::hex
+      << localPtr_ << ",multicastPtr=0x" << multicastPtr_
+      << ",localAllocHandle=0x" << localAllocHandle_ << ",multicastHandle=0x"
+      << multicastHandle_ << std::dec << "}";
+  return out.str();
+}
+
+void MultimemHandler::cleanup() {
+#if CUDART_VERSION >= 12030
+  if (!deviceInitialized_ || cuda_driver_lazy_init() != 0) {
+    return;
+  }
+
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+
+  if (multicastMapped_) {
+    pfn_cuMemUnmap(multicastPtr_, allocatedSize_);
+    pfn_cuMemAddressFree(multicastPtr_, allocatedSize_);
+    multicastPtr_ = 0;
+    multicastMapped_ = false;
+  } else if (multicastPtr_ != 0) {
+    pfn_cuMemAddressFree(multicastPtr_, allocatedSize_);
+    multicastPtr_ = 0;
+  }
+
+  if (multicastBound_ && pfn_cuMulticastUnbind != nullptr) {
+    pfn_cuMulticastUnbind(multicastHandle_, cuDev_, 0, allocatedSize_);
+    multicastBound_ = false;
+  }
+
+  if (multicastHandleValid_) {
+    pfn_cuMemRelease(multicastHandle_);
+    multicastHandle_ = 0;
+    multicastHandleValid_ = false;
+  }
+
+  if (localMapped_) {
+    pfn_cuMemUnmap(localPtr_, allocatedSize_);
+    pfn_cuMemAddressFree(localPtr_, allocatedSize_);
+    localPtr_ = 0;
+    localMapped_ = false;
+  } else if (localPtr_ != 0) {
+    pfn_cuMemAddressFree(localPtr_, allocatedSize_);
+    localPtr_ = 0;
+  }
+
+  if (localHandleValid_) {
+    pfn_cuMemRelease(localAllocHandle_);
+    localAllocHandle_ = 0;
+    localHandleValid_ = false;
+  }
+#endif
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/MultimemHandler.h
+++ b/comms/pipes/MultimemHandler.h
@@ -1,0 +1,180 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/GpuMemHandler.h"
+
+namespace comms::pipes {
+
+/**
+ * MultimemHandler - Manages one NVSwitch multicast allocation.
+ *
+ * Addressing model:
+ *
+ * Each rank owns a private local physical allocation. All ranks also join one
+ * CUDA multicast object whose offsets describe the shared multicast window.
+ * The handler exposes two device pointers on each rank:
+ *
+ * - local pointer: normal unicast VA mapped to this rank's local backing
+ *   allocation. Loads from this pointer read the data delivered to the local
+ *   rank, and ordinary stores update only the local rank.
+ * - multimem pointer: multicast VA mapped to the shared multicast object.
+ *   Device code writes this pointer with `multimem.st.*` or `multimem.red.*`
+ *   instructions when it wants NVSwitch to replicate the write.
+ *
+ * A store to the multimem pointer is replicated by NVSwitch into every rank's
+ * local backing allocation at the same object offset. For example, a multimem
+ * store to `getMultimemDeviceMemPtr() + x` becomes a local write visible at
+ * `getLocalDeviceMemPtr() + x` on every rank in the multicast team.
+ *
+ * Store path:
+ *
+ *   writer rank
+ *   multimemPtr + x
+ *        |
+ *        |  multimem.st value
+ *        v
+ *   CUDA multicast object offset x
+ *        |
+ *        +--> rank 0 localPtr + x = value
+ *        +--> rank 1 localPtr + x = value
+ *        +--> rank 2 localPtr + x = value
+ *        +--> ...
+ *
+ * A normal store to `localPtr + x` does not enter the multicast object and
+ * only updates the writer's local backing allocation.
+ *
+ * Pointer values are process-local CUDA virtual addresses. Do not compare the
+ * numeric multimem pointer value across MPI ranks or encode protocols that
+ * require it to match. The portable invariant is that the ranks map the same
+ * multicast object and interpret offsets within that object identically.
+ *
+ * `bootstrap` is the global communicator bootstrap. `commRank` is this
+ * process's rank in that global communicator. `nvlRankToCommRank` maps each
+ * NVLink-local rank to its global communicator rank. The handler derives its
+ * NVLink-local rank from the map, then exchange() uses the bootstrap's
+ * NVLink-domain collectives. Callers do not need to pre-wrap the bootstrap in
+ * an NVLink-local adapter.
+ *
+ * The caller must set the current CUDA device to `cudaDevice` before using this
+ * handler. MultimemHandler uses `cudaDevice` to query driver properties and
+ * describe allocations, but it does not call cudaSetDevice().
+ */
+class MultimemHandler {
+ public:
+  MultimemHandler(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int32_t commRank,
+      std::vector<int> nvlRankToCommRank,
+      int cudaDevice,
+      std::size_t size);
+
+  ~MultimemHandler();
+
+  MultimemHandler(const MultimemHandler&) = delete;
+  MultimemHandler& operator=(const MultimemHandler&) = delete;
+  MultimemHandler(MultimemHandler&&) = delete;
+  MultimemHandler& operator=(MultimemHandler&&) = delete;
+
+  /**
+   * Collective operation over all ranks in the multicast team.
+   *
+   * Allocates local backing memory, exchanges the multicast object handle,
+   * binds each rank's local allocation to the multicast object, and maps the
+   * multicast VA. Returns only after every rank has completed setup, so the
+   * local and multicast pointers are ready for device use.
+   */
+  void exchange();
+
+  /**
+   * Returns this rank's local backing allocation. Loads from this pointer read
+   * data delivered by multicast stores, and ordinary stores only update this
+   * rank's local backing memory.
+   */
+  void* getLocalDeviceMemPtr() const;
+
+  /**
+   * Returns this rank's multicast VA. Device code uses this pointer with
+   * `multimem.*` instructions to broadcast writes to every rank in the
+   * multicast team.
+   */
+  void* getMultimemDeviceMemPtr() const;
+
+  std::size_t getAllocatedSize() const {
+    return allocatedSize_;
+  }
+
+  /**
+   * Returns whether the current process can create CUDA multicast allocations
+   * on `cudaDevice`. The caller is expected to have already made `cudaDevice`
+   * current; this helper does not switch devices.
+   */
+  static bool isMultimemSupported(int cudaDevice);
+
+ private:
+  struct DeviceContext {
+    CUdevice cuDev{0};
+    CUmemAccessDesc accessDesc{};
+  };
+
+  struct AllocationLayout {
+    std::size_t allocatedSize{0};
+    std::size_t localGranularity{0};
+    std::size_t multicastGranularity{0};
+  };
+
+  DeviceContext initializeDevice() const;
+  AllocationLayout computeAllocationLayout(const DeviceContext& device) const;
+  void createMulticastHandle(std::size_t allocatedSize);
+  FabricHandle exportMulticastHandle();
+  FabricHandle exchangeMulticastHandle(FabricHandle fabricHandle);
+  void importMulticastHandle(const FabricHandle& fabricHandle);
+  void allocateLocalMemory(
+      const DeviceContext& device,
+      const AllocationLayout& layout);
+  void addLocalDeviceToMulticast(CUdevice cuDev);
+  void bindLocalMemoryToMulticast(std::size_t allocatedSize);
+  void mapMulticastMemory(
+      const DeviceContext& device,
+      const AllocationLayout& layout);
+  void synchronizeRanks(const char* phase);
+  std::string describeState(const char* failedPhase, const char* completedPhase)
+      const;
+  void cleanup();
+
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  const int32_t commRank_{-1};
+  const int32_t nvlRank_{-1};
+  const int32_t nvlRanks_{-1};
+  const std::vector<int> nvlRankToCommRank_;
+  const int cudaDevice_{-1};
+  const std::size_t requestedSize_{0};
+
+  bool exchanged_{false};
+  bool deviceInitialized_{false};
+  bool multicastHandleValid_{false};
+  bool localHandleValid_{false};
+  bool localMapped_{false};
+  bool multicastBound_{false};
+  bool multicastMapped_{false};
+
+  CUdevice cuDev_{0};
+  CUdeviceptr localPtr_{0};
+  CUdeviceptr multicastPtr_{0};
+  CUmemGenericAllocationHandle localAllocHandle_{0};
+  CUmemGenericAllocationHandle multicastHandle_{0};
+
+  std::size_t allocatedSize_{0};
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultimemNvlTransport.cc
+++ b/comms/pipes/MultimemNvlTransport.cc
@@ -1,0 +1,151 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/MultimemNvlTransport.h"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "comms/pipes/SignalState.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+int getCurrentCudaDevice() {
+  int cudaDevice = 0;
+  const auto err = cudaGetDevice(&cudaDevice);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("cudaGetDevice failed: ") + cudaGetErrorString(err));
+  }
+  return cudaDevice;
+}
+
+std::vector<int> identityRankMap(int nRanks) {
+  if (nRanks <= 0) {
+    return {};
+  }
+  std::vector<int> rankMap(static_cast<std::size_t>(nRanks));
+  for (int rank = 0; rank < nRanks; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+} // namespace
+
+MultimemNvlTransport::MultimemNvlTransport(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int commRank,
+    std::vector<int> nvlRankToCommRank,
+    const MultimemNvlTransportConfig& config)
+    : commRank_(commRank),
+      nvlRanks_(static_cast<int>(nvlRankToCommRank.size())),
+      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
+      cudaDevice_(getCurrentCudaDevice()),
+      config_(config) {
+  if (nvlRanks_ <= 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: nvlRankToCommRank must be non-empty");
+  }
+  bool foundCommRank = false;
+  for (int rank = 0; rank < nvlRanks_; ++rank) {
+    if (nvlRankToCommRank_[static_cast<std::size_t>(rank)] == commRank_) {
+      foundCommRank = true;
+    }
+  }
+  if (!foundCommRank) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: commRank must appear in nvlRankToCommRank");
+  }
+  if (config_.dataBufferSize == 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: dataBufferSize must be non-zero");
+  }
+  const uint64_t totalSignalCount =
+      static_cast<uint64_t>(config_.userSignalCount) +
+      static_cast<uint64_t>(config_.internalSignalCount);
+  if (totalSignalCount == 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: at least one signal slot is required");
+  }
+  if (totalSignalCount >
+      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
+  }
+
+  dataBufferHandler_ = std::make_unique<MultimemHandler>(
+      bootstrap,
+      commRank_,
+      nvlRankToCommRank_,
+      cudaDevice_,
+      config_.dataBufferSize);
+  signalBufferHandler_ = std::make_unique<MultimemHandler>(
+      std::move(bootstrap),
+      commRank_,
+      nvlRankToCommRank_,
+      cudaDevice_,
+      getSignalBufferSize(static_cast<int>(totalSignalCount)));
+}
+
+MultimemNvlTransport::MultimemNvlTransport(
+    int nvlRank,
+    int nvlRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultimemNvlTransportConfig& config)
+    : MultimemNvlTransport(
+          std::move(bootstrap),
+          nvlRank,
+          identityRankMap(nvlRanks),
+          config) {}
+
+void MultimemNvlTransport::exchange() {
+  if (exchanged_) {
+    return;
+  }
+  dataBufferHandler_->exchange();
+  signalBufferHandler_->exchange();
+  exchanged_ = true;
+}
+
+MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
+  if (!exchanged_) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: exchange() must complete before device use");
+  }
+
+  auto* localSignals =
+      static_cast<SignalState*>(signalBufferHandler_->getLocalDeviceMemPtr());
+  auto* multimemSignals = static_cast<SignalState*>(
+      signalBufferHandler_->getMultimemDeviceMemPtr());
+  const auto userSignalCount = config_.userSignalCount;
+  const auto internalSignalCount = config_.internalSignalCount;
+
+  return MultimemNvlTransportDevice{
+      .localData =
+          static_cast<char*>(dataBufferHandler_->getLocalDeviceMemPtr()),
+      .multimemData =
+          static_cast<char*>(dataBufferHandler_->getMultimemDeviceMemPtr()),
+      .userLocalSignals =
+          DeviceSpan<SignalState>(localSignals, userSignalCount),
+      .userMultimemSignals =
+          DeviceSpan<SignalState>(multimemSignals, userSignalCount),
+      .internalLocalSignals = DeviceSpan<SignalState>(
+          localSignals + userSignalCount, internalSignalCount),
+      .internalMultimemSignals = DeviceSpan<SignalState>(
+          multimemSignals + userSignalCount, internalSignalCount),
+      .dataBufferSize = config_.dataBufferSize,
+  };
+}
+
+std::size_t MultimemNvlTransport::getAllocatedDataBufferSize() const {
+  return dataBufferHandler_->getAllocatedSize();
+}
+
+std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {
+  return signalBufferHandler_->getAllocatedSize();
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/MultimemNvlTransport.h
+++ b/comms/pipes/MultimemNvlTransport.h
@@ -1,0 +1,98 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/MultimemHandler.h"
+#include "comms/pipes/MultimemNvlTransportDevice.cuh"
+
+namespace comms::pipes {
+
+struct MultimemNvlTransportConfig {
+  // Size in bytes of the multicast staging data window.
+  std::size_t dataBufferSize{0};
+
+  // Signal slots exposed through signal(), read_signal(), and
+  // wait_signal_until().
+  uint32_t userSignalCount{1};
+
+  // Signal slots reserved for transport-internal protocols. These are not
+  // addressable through the public signal API.
+  uint32_t internalSignalCount{0};
+};
+
+/**
+ * Host-side owner for a copy-based NVL multimem transport.
+ *
+ * This transport is group-scoped rather than peer-scoped: every rank in the
+ * NVL team maps the same multicast object and a private local backing VA.
+ * Writers use `multimemData` to broadcast into every rank's `localData` at the
+ * same offset; readers consume from their local backing memory after observing
+ * a signal. The numeric `multimemData` pointer is a process-local CUDA VA and
+ * is not part of the cross-rank protocol.
+ *
+ * The caller must set the current CUDA device before construction. The
+ * transport records that device ordinal and passes it to MultimemHandler; it
+ * does not switch CUDA devices internally.
+ *
+ * `bootstrap` is the global communicator bootstrap. `commRank` is this
+ * process's rank in that global communicator. `nvlRankToCommRank` maps each
+ * NVLink-local rank to its global communicator rank; the transport uses
+ * NVLink-domain bootstrap collectives internally.
+ */
+class MultimemNvlTransport {
+ public:
+  MultimemNvlTransport(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int commRank,
+      std::vector<int> nvlRankToCommRank,
+      const MultimemNvlTransportConfig& config);
+
+  // Compatibility constructor for callers that already wrapped `bootstrap` in
+  // an NVLink-local adapter. Prefer the global-bootstrap constructor above for
+  // new code.
+  MultimemNvlTransport(
+      int nvlRank,
+      int nvlRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultimemNvlTransportConfig& config);
+
+  ~MultimemNvlTransport() = default;
+
+  MultimemNvlTransport(const MultimemNvlTransport&) = delete;
+  MultimemNvlTransport& operator=(const MultimemNvlTransport&) = delete;
+  MultimemNvlTransport(MultimemNvlTransport&&) = delete;
+  MultimemNvlTransport& operator=(MultimemNvlTransport&&) = delete;
+
+  void exchange();
+
+  MultimemNvlTransportDevice getDeviceTransport() const;
+
+  std::size_t getAllocatedDataBufferSize() const;
+  std::size_t getAllocatedSignalBufferSize() const;
+
+  // Mirrors NCCL/NVLS enablement: multicast must be supported on cudaDevice
+  // and useful only for teams larger than two ranks. The caller should already
+  // have made cudaDevice current.
+  static bool isEligible(int nRanks, int cudaDevice) {
+    return nRanks > 2 && MultimemHandler::isMultimemSupported(cudaDevice);
+  }
+
+ private:
+  const int commRank_{-1};
+  const int nvlRanks_{-1};
+  const std::vector<int> nvlRankToCommRank_;
+  const int cudaDevice_{-1};
+  const MultimemNvlTransportConfig config_;
+  bool exchanged_{false};
+
+  std::unique_ptr<MultimemHandler> dataBufferHandler_;
+  std::unique_ptr<MultimemHandler> signalBufferHandler_;
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/MultimemNvlTransportDevice.cuh
+++ b/comms/pipes/MultimemNvlTransportDevice.cuh
@@ -1,0 +1,397 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/pipes/DeviceSpan.cuh"
+#include "comms/pipes/SignalState.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+
+namespace detail {
+
+__device__ __forceinline__ uint8_t load_u8_unaligned(const char* src) {
+  return *reinterpret_cast<const uint8_t*>(src);
+}
+
+__device__ __forceinline__ uint16_t load_u16_unaligned(const char* src) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(src);
+  return static_cast<uint16_t>(bytes[0]) |
+      (static_cast<uint16_t>(bytes[1]) << 8);
+}
+
+__device__ __forceinline__ uint32_t load_u32_unaligned(const char* src) {
+  const auto* bytes = reinterpret_cast<const uint8_t*>(src);
+  return static_cast<uint32_t>(bytes[0]) |
+      (static_cast<uint32_t>(bytes[1]) << 8) |
+      (static_cast<uint32_t>(bytes[2]) << 16) |
+      (static_cast<uint32_t>(bytes[3]) << 24);
+}
+
+__device__ __forceinline__ uint64_t load_u64_unaligned(const char* src) {
+  return static_cast<uint64_t>(load_u32_unaligned(src)) |
+      (static_cast<uint64_t>(load_u32_unaligned(src + 4)) << 32);
+}
+
+__device__ __forceinline__ uint4 load_u4_unaligned(const char* src) {
+  return uint4{
+      load_u32_unaligned(src),
+      load_u32_unaligned(src + 4),
+      load_u32_unaligned(src + 8),
+      load_u32_unaligned(src + 12)};
+}
+
+// PTX exposes multimem stores for 4/8/16-byte widths. NCCL-style byte-tail
+// paths use regular global byte/halfword stores on the multimem VA.
+__device__ __forceinline__ void multimem_store_u8(uint8_t* dst, uint8_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("st.global.b8 [%0], %1;"
+               :
+               : "l"(dst), "r"(static_cast<uint32_t>(v))
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u16(uint16_t* dst, uint16_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("st.global.b16 [%0], %1;" : : "l"(dst), "h"(v) : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u32(uint32_t* dst, uint32_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.b32 [%0], %1;"
+               :
+               : "l"(dst), "r"(v)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_u64(uint64_t* dst, uint64_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.b64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_release_sys_u64(
+    uint64_t* dst,
+    uint64_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.release.sys.global.u64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#else
+  comms::device::st_release_sys_global(dst, v);
+#endif
+}
+
+__device__ __forceinline__ void multimem_red_release_sys_add_u64(
+    uint64_t* dst,
+    uint64_t v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.red.release.sys.global.add.u64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#else
+  comms::device::atomic_fetch_add_release_sys_global(dst, v);
+#endif
+}
+
+__device__ __forceinline__ void multimem_store_v4_u32(uint4* dst, uint4 v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};"
+               :
+               : "l"(dst), "r"(v.x), "r"(v.y), "r"(v.z), "r"(v.w)
+               : "memory");
+#else
+  *dst = v;
+#endif
+}
+
+template <int kUnroll>
+__device__ __forceinline__ void strided_multimem_store_aligned(
+    ThreadGroup& group,
+    uint4* dstVec,
+    const uint4* srcVec,
+    std::size_t vecCount) {
+  static_assert(kUnroll > 0);
+  constexpr std::size_t unroll = static_cast<std::size_t>(kUnroll);
+  const std::size_t loopStride =
+      static_cast<std::size_t>(group.group_size) * unroll;
+  const std::size_t alignedVecCount = (vecCount / loopStride) * loopStride;
+
+  for (std::size_t i = group.thread_id_in_group; i < alignedVecCount;
+       i += loopStride) {
+    uint4 vals[kUnroll];
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      vals[j] = srcVec[i + static_cast<std::size_t>(j) * group.group_size];
+    }
+#pragma unroll
+    for (int j = 0; j < kUnroll; ++j) {
+      const std::size_t offset =
+          i + static_cast<std::size_t>(j) * group.group_size;
+      multimem_store_v4_u32(dstVec + offset, vals[j]);
+    }
+  }
+
+  for (std::size_t i = alignedVecCount + group.thread_id_in_group; i < vecCount;
+       i += group.group_size) {
+    multimem_store_v4_u32(dstVec + i, srcVec[i]);
+  }
+}
+
+__device__ __forceinline__ void
+multimem_store_bytes(char* dst, const char* src, std::size_t bytes) {
+  while (bytes > 0) {
+    const auto dstAddr = reinterpret_cast<uintptr_t>(dst);
+    if (bytes >= sizeof(uint4) && (dstAddr & 0xF) == 0) {
+      multimem_store_v4_u32(
+          reinterpret_cast<uint4*>(dst), load_u4_unaligned(src));
+      dst += sizeof(uint4);
+      src += sizeof(uint4);
+      bytes -= sizeof(uint4);
+    } else if (bytes >= sizeof(uint64_t) && (dstAddr & 0x7) == 0) {
+      multimem_store_u64(
+          reinterpret_cast<uint64_t*>(dst), load_u64_unaligned(src));
+      dst += sizeof(uint64_t);
+      src += sizeof(uint64_t);
+      bytes -= sizeof(uint64_t);
+    } else if (bytes >= sizeof(uint32_t) && (dstAddr & 0x3) == 0) {
+      multimem_store_u32(
+          reinterpret_cast<uint32_t*>(dst), load_u32_unaligned(src));
+      dst += sizeof(uint32_t);
+      src += sizeof(uint32_t);
+      bytes -= sizeof(uint32_t);
+    } else if (bytes >= sizeof(uint16_t) && (dstAddr & 0x1) == 0) {
+      multimem_store_u16(
+          reinterpret_cast<uint16_t*>(dst), load_u16_unaligned(src));
+      dst += sizeof(uint16_t);
+      src += sizeof(uint16_t);
+      bytes -= sizeof(uint16_t);
+    } else {
+      multimem_store_u8(
+          reinterpret_cast<uint8_t*>(dst), load_u8_unaligned(src));
+      ++dst;
+      ++src;
+      --bytes;
+    }
+  }
+}
+
+__device__ __forceinline__ void strided_multimem_store_unaligned(
+    ThreadGroup& group,
+    char* dst,
+    const char* src,
+    std::size_t bytes) {
+  constexpr std::size_t kChunkBytes = sizeof(uint4);
+  for (std::size_t offset =
+           static_cast<std::size_t>(group.thread_id_in_group) * kChunkBytes;
+       offset < bytes;
+       offset += static_cast<std::size_t>(group.group_size) * kChunkBytes) {
+    const std::size_t remaining = bytes - offset;
+    multimem_store_bytes(
+        dst + offset,
+        src + offset,
+        remaining < kChunkBytes ? remaining : kChunkBytes);
+  }
+}
+
+} // namespace detail
+
+/**
+ * Device-side handle for one multicast staging window.
+ *
+ * `multimemData` and multimem signal spans are multicast VAs. Writes through
+ * `store()` preserve multicast semantics; `localData` and local signal spans
+ * are this rank's backing memory after multicast replication.
+ */
+struct MultimemNvlTransportDevice {
+  char* localData{nullptr};
+  char* multimemData{nullptr};
+  DeviceSpan<SignalState> userLocalSignals{};
+  DeviceSpan<SignalState> userMultimemSignals{};
+  DeviceSpan<SignalState> internalLocalSignals{};
+  DeviceSpan<SignalState> internalMultimemSignals{};
+  std::size_t dataBufferSize{0};
+
+  __device__ __forceinline__ char* local_data_at(std::size_t offset) const {
+    return localData + offset;
+  }
+
+  __device__ __forceinline__ char* multimem_data_at(std::size_t offset) const {
+    return multimemData + offset;
+  }
+
+  template <int kUnroll = 1>
+  __device__ __forceinline__ void store(
+      ThreadGroup& group,
+      std::size_t dst_offset,
+      const void* src,
+      std::size_t bytes) const {
+    static_assert(kUnroll > 0);
+    auto* dst = multimem_data_at(dst_offset);
+    const auto srcAddr = reinterpret_cast<uintptr_t>(src);
+    const auto dstAddr = reinterpret_cast<uintptr_t>(dst);
+
+    if (((srcAddr | dstAddr) & 0xF) == 0) {
+      const std::size_t alignedBytes = bytes & ~static_cast<std::size_t>(0xF);
+      auto* srcVec = reinterpret_cast<const uint4*>(src);
+      auto* dstVec = reinterpret_cast<uint4*>(dst);
+      const std::size_t vecCount = alignedBytes / sizeof(uint4);
+      detail::strided_multimem_store_aligned<kUnroll>(
+          group, dstVec, srcVec, vecCount);
+      if (alignedBytes != bytes) {
+        detail::strided_multimem_store_unaligned(
+            group,
+            dst + alignedBytes,
+            static_cast<const char*>(src) + alignedBytes,
+            bytes - alignedBytes);
+      }
+    } else {
+      detail::strided_multimem_store_unaligned(
+          group, dst, static_cast<const char*>(src), bytes);
+    }
+  }
+
+  __device__ __forceinline__ void signal(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      SignalOp op,
+      uint64_t value) const {
+    signal_at(group, user_multimem_signal_ptr(signal_id), op, value);
+  }
+
+  __device__ __forceinline__ uint64_t read_signal(uint64_t signal_id) const {
+    return user_local_signal_at(signal_id)->load();
+  }
+
+  __device__ __forceinline__ void wait_signal_until(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      CmpOp op,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    user_local_signal_at(signal_id)->wait_until(group, op, expected, timeout);
+  }
+
+  __device__ __forceinline__ void signal_internal(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      SignalOp op,
+      uint64_t value) const {
+    signal_at(group, internal_multimem_signal_ptr(signal_id), op, value);
+  }
+
+  __device__ __forceinline__ uint64_t
+  read_internal_signal(uint64_t signal_id) const {
+    return internal_local_signal_at(signal_id)->load();
+  }
+
+  __device__ __forceinline__ void wait_internal_signal_until(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      CmpOp op,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    internal_local_signal_at(signal_id)->wait_until(
+        group, op, expected, timeout);
+  }
+
+  __device__ __forceinline__ void multicast_signal_set(
+      ThreadGroup& group,
+      uint32_t signalIndex,
+      uint64_t value) const {
+    signal(group, signalIndex, SignalOp::SIGNAL_SET, value);
+  }
+
+  __device__ __forceinline__ void wait_local_signal(
+      ThreadGroup& group,
+      uint32_t signalIndex,
+      CmpOp op,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    wait_signal_until(group, signalIndex, op, expected, timeout);
+  }
+
+ private:
+  __device__ __forceinline__ SignalState* signal_ptr_at(
+      DeviceSpan<SignalState> signals,
+      uint64_t signal_id,
+      const char* kind) const {
+#if defined(__CUDA_ARCH__)
+    if (signal_id >= signals.size()) {
+      printf(
+          "MultimemNvlTransportDevice: %s signal_id=%llu out of range "
+          "(count=%u)\n",
+          kind,
+          static_cast<unsigned long long>(signal_id),
+          static_cast<unsigned>(signals.size()));
+      __trap();
+    }
+#endif
+    return signals.data() + signal_id;
+  }
+
+  __device__ __forceinline__ SignalState* user_local_signal_at(
+      uint64_t signal_id) const {
+    return signal_ptr_at(userLocalSignals, signal_id, "user local");
+  }
+
+  __device__ __forceinline__ SignalState* user_multimem_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr_at(userMultimemSignals, signal_id, "user multimem");
+  }
+
+  __device__ __forceinline__ SignalState* internal_local_signal_at(
+      uint64_t signal_id) const {
+    return signal_ptr_at(internalLocalSignals, signal_id, "internal local");
+  }
+
+  __device__ __forceinline__ SignalState* internal_multimem_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr_at(
+        internalMultimemSignals, signal_id, "internal multimem");
+  }
+
+  __device__ __forceinline__ void signal_at(
+      ThreadGroup& group,
+      SignalState* signal,
+      SignalOp op,
+      uint64_t value) const {
+    comms::device::fence_acq_rel_sys();
+    group.sync();
+    if (group.is_leader()) {
+      switch (op) {
+        case SignalOp::SIGNAL_SET:
+          detail::multimem_store_release_sys_u64(&signal->signal_, value);
+          break;
+        case SignalOp::SIGNAL_ADD:
+          detail::multimem_red_release_sys_add_u64(&signal->signal_, value);
+          break;
+      }
+    }
+  }
+};
+
+} // namespace comms::pipes

--- a/comms/pipes/tests/MultimemHandlerTest.cc
+++ b/comms/pipes/tests/MultimemHandlerTest.cc
@@ -1,0 +1,161 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultimemHandler.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::pipes::tests {
+
+class MultimemHandlerTestFixture : public ::testing::Test,
+                                   public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::vector<int> reverseRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = size - 1 - rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+bool allRanksMultimemSupported(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> supported(static_cast<std::size_t>(nRanks));
+  supported[static_cast<std::size_t>(rank)] =
+      MultimemHandler::isMultimemSupported(cudaDevice) ? 1 : 0;
+  auto supportRc =
+      bootstrap->allGather(supported.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(supportRc, 0);
+  if (supportRc != 0) {
+    return false;
+  }
+  bool allRanksSupported = true;
+  for (const auto value : supported) {
+    allRanksSupported = allRanksSupported && value != 0;
+  }
+  return allRanksSupported;
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSetsUpStableMappings) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  MultimemHandler handler(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      localRank,
+      kRequestedBytes);
+  EXPECT_THROW(handler.getLocalDeviceMemPtr(), std::runtime_error);
+  EXPECT_THROW(handler.getMultimemDeviceMemPtr(), std::runtime_error);
+
+  handler.exchange();
+
+  auto* localPtr = handler.getLocalDeviceMemPtr();
+  auto* multimemPtr = handler.getMultimemDeviceMemPtr();
+
+  EXPECT_NE(localPtr, nullptr);
+  EXPECT_NE(multimemPtr, nullptr);
+  EXPECT_NE(localPtr, multimemPtr);
+  EXPECT_EQ(localPtr, handler.getLocalDeviceMemPtr());
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  std::vector<std::uintptr_t> multimemAddrs(static_cast<std::size_t>(numRanks));
+  multimemAddrs[static_cast<std::size_t>(globalRank)] =
+      reinterpret_cast<std::uintptr_t>(multimemPtr);
+  auto rc = bootstrap
+                ->allGather(
+                    multimemAddrs.data(),
+                    sizeof(std::uintptr_t),
+                    globalRank,
+                    numRanks)
+                .get();
+  ASSERT_EQ(rc, 0);
+  for (int rank = 0; rank < numRanks; ++rank) {
+    EXPECT_NE(multimemAddrs[static_cast<std::size_t>(rank)], 0);
+  }
+
+  handler.exchange();
+  EXPECT_EQ(localPtr, handler.getLocalDeviceMemPtr());
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSupportsNonIdentityRankMap) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_non_identity_rank_map_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  MultimemHandler handler(
+      bootstrap,
+      globalRank,
+      reverseRankMap(numRanks),
+      localRank,
+      kRequestedBytes);
+  handler.exchange();
+
+  EXPECT_NE(handler.getLocalDeviceMemPtr(), nullptr);
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/MultimemHandlerValidationTest.cc
+++ b/comms/pipes/tests/MultimemHandlerValidationTest.cc
@@ -1,0 +1,96 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/pipes/MultimemHandler.h"
+
+namespace comms::pipes::tests {
+
+namespace {
+
+class FakeBootstrap : public meta::comms::IBootstrap {
+ public:
+  folly::SemiFuture<int> allGather(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> send(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> recv(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+};
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap() {
+  return std::make_shared<FakeBootstrap>();
+}
+
+template <typename Fn>
+void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
+  try {
+    std::forward<Fn>(fn)();
+    FAIL() << "expected std::runtime_error containing " << expected;
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected), std::string::npos)
+        << ex.what();
+  }
+}
+
+} // namespace
+
+TEST(MultimemHandlerValidationTest, RejectsEmptyRankMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {}, 0, 4096); },
+      "nvlRankToCommRank must be non-empty");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsMissingCommRank) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 7, {0, 1, 2}, 0, 4096); },
+      "commRank must appear in nvlRankToCommRank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNegativeRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0, -1}, 0, 4096); },
+      "contains a negative rank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsDuplicateRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0, 0}, 0, 4096); },
+      "contains duplicate ranks");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsZeroSize) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(makeBootstrap(), 0, {0}, 0, 0); },
+      "size must be non-zero");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNullBootstrap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, 0, {0}, 0, 4096); },
+      "bootstrap must be non-null");
+}
+
+TEST(MultimemHandlerValidationTest, NegativeCudaDeviceIsUnsupported) {
+  EXPECT_FALSE(MultimemHandler::isMultimemSupported(-1));
+}
+
+} // namespace comms::pipes::tests

--- a/comms/pipes/tests/MultimemNvlTransportTest.cc
+++ b/comms/pipes/tests/MultimemNvlTransportTest.cc
@@ -1,0 +1,215 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultimemHandler.h"
+#include "comms/pipes/MultimemNvlTransport.h"
+#include "comms/pipes/tests/MultimemNvlTransportTest.cuh"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::tests {
+
+class MultimemNvlTransportTestFixture : public ::testing::Test,
+                                        public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+bool allRanksMultimemEligible(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> eligible(static_cast<std::size_t>(nRanks));
+  eligible[static_cast<std::size_t>(rank)] =
+      MultimemNvlTransport::isEligible(nRanks, cudaDevice) ? 1 : 0;
+  auto rc =
+      bootstrap->allGather(eligible.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(rc, 0);
+  if (rc != 0) {
+    return false;
+  }
+  for (const auto value : eligible) {
+    if (value == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void verifyMultimemSegments(
+    char* localData,
+    std::size_t bytesPerRank,
+    int nRanks) {
+  std::vector<uint8_t> host(bytesPerRank * static_cast<std::size_t>(nRanks));
+  CUDACHECK_TEST(
+      cudaMemcpy(host.data(), localData, host.size(), cudaMemcpyDeviceToHost));
+
+  for (int rank = 0; rank < nRanks; ++rank) {
+    const auto expected = static_cast<uint8_t>(0x40 + rank);
+    const std::size_t offset = static_cast<std::size_t>(rank) * bytesPerRank;
+    for (std::size_t i = 0; i < bytesPerRank; ++i) {
+      ASSERT_EQ(host[offset + i], expected) << "rank=" << rank << " byte=" << i;
+    }
+  }
+}
+
+test::MultimemNvlTransportTestResult runStoreSignalKernel(
+    MultimemNvlTransportDevice deviceTransport,
+    int rank,
+    int nRanks,
+    std::size_t bytesPerRank) {
+  DeviceBuffer src(bytesPerRank);
+  DeviceBuffer result(sizeof(test::MultimemNvlTransportTestResult));
+  CUDACHECK_TEST(cudaMemset(src.get(), 0x40 + rank, bytesPerRank));
+  CUDACHECK_TEST(cudaMemset(
+      result.get(), 0, sizeof(test::MultimemNvlTransportTestResult)));
+
+  test::launchMultimemStoreSignalTest(
+      deviceTransport,
+      static_cast<const char*>(src.get()),
+      bytesPerRank,
+      rank,
+      nRanks,
+      static_cast<test::MultimemNvlTransportTestResult*>(result.get()));
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  test::MultimemNvlTransportTestResult hostResult;
+  CUDACHECK_TEST(cudaMemcpy(
+      &hostResult,
+      result.get(),
+      sizeof(test::MultimemNvlTransportTestResult),
+      cudaMemcpyDeviceToHost));
+  return hostResult;
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    EligibilityRequiresSupportAndThreeRanks) {
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(1, localRank));
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(2, localRank));
+  EXPECT_EQ(
+      MultimemNvlTransport::isEligible(3, localRank),
+      MultimemHandler::isMultimemSupported(localRank));
+}
+
+TEST_F(MultimemNvlTransportTestFixture, StridedStoreHelperBroadcasts) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_strided_store_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kBytesPerRank = 4096;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      MultimemNvlTransportConfig{
+          .dataBufferSize = kBytesPerRank * static_cast<std::size_t>(numRanks),
+          .userSignalCount = 1,
+      });
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  DeviceBuffer src(kBytesPerRank);
+  CUDACHECK_TEST(cudaMemset(src.get(), 0x40 + globalRank, kBytesPerRank));
+  test::launchStridedMultimemStoreTest(
+      deviceTransport,
+      static_cast<const char*>(src.get()),
+      kBytesPerRank,
+      globalRank,
+      numRanks);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  verifyMultimemSegments(deviceTransport.localData, kBytesPerRank, numRanks);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemNvlTransportTestFixture, StoreSignalAddAndReadSignal) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kBytesPerRank = 4096;
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      MultimemNvlTransportConfig{
+          .dataBufferSize = kBytesPerRank * static_cast<std::size_t>(numRanks),
+          .userSignalCount = 2,
+          .internalSignalCount = 3,
+      });
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  EXPECT_EQ(deviceTransport.userLocalSignals.size(), 2);
+  EXPECT_EQ(deviceTransport.userMultimemSignals.size(), 2);
+  EXPECT_EQ(deviceTransport.internalLocalSignals.size(), 3);
+  EXPECT_EQ(deviceTransport.internalMultimemSignals.size(), 3);
+  EXPECT_EQ(
+      deviceTransport.internalLocalSignals.data(),
+      deviceTransport.userLocalSignals.data() + 2);
+  EXPECT_EQ(
+      deviceTransport.internalMultimemSignals.data(),
+      deviceTransport.userMultimemSignals.data() + 2);
+
+  const auto result = runStoreSignalKernel(
+      deviceTransport, globalRank, numRanks, kBytesPerRank);
+  EXPECT_EQ(result.user_add_signal_value, static_cast<uint64_t>(numRanks));
+  EXPECT_EQ(result.user_set_signal_value, 0x1234);
+  EXPECT_EQ(result.internal_add_signal_value, static_cast<uint64_t>(numRanks));
+  EXPECT_EQ(result.internal_set_signal_value, 0x5678);
+  EXPECT_EQ(result.user_signal_count, 2);
+  EXPECT_EQ(result.internal_signal_count, 3);
+  EXPECT_EQ(
+      result.internal_signal_addr,
+      result.user_signal_addr + 2 * sizeof(SignalState));
+
+  verifyMultimemSegments(deviceTransport.localData, kBytesPerRank, numRanks);
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/tests/MultimemNvlTransportTest.cu
+++ b/comms/pipes/tests/MultimemNvlTransportTest.cu
@@ -1,0 +1,133 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/tests/MultimemNvlTransportTest.cuh"
+
+#include "comms/pipes/tests/Checks.h"
+
+namespace comms::pipes::test {
+
+namespace {
+
+constexpr uint64_t kUserSetSignalValue = 0x1234;
+constexpr uint64_t kInternalSetSignalValue = 0x5678;
+
+__global__ void multimemStoreSignalKernel(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks,
+    MultimemNvlTransportTestResult* result) {
+  auto group = make_block_group();
+
+  const std::size_t dst_offset =
+      static_cast<std::size_t>(rank) * bytes_per_rank;
+  transport.store<4>(group, dst_offset, src, bytes_per_rank);
+  transport.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+  transport.signal_internal(group, 0, SignalOp::SIGNAL_ADD, 1);
+  if (transport.userLocalSignals.size() > 1) {
+    transport.signal(group, 1, SignalOp::SIGNAL_SET, kUserSetSignalValue);
+  }
+  if (transport.internalLocalSignals.size() > 1) {
+    transport.signal_internal(
+        group, 1, SignalOp::SIGNAL_SET, kInternalSetSignalValue);
+  }
+  transport.wait_signal_until(group, 0, CmpOp::CMP_GE, nRanks);
+  transport.wait_internal_signal_until(group, 0, CmpOp::CMP_GE, nRanks);
+  if (transport.userLocalSignals.size() > 1) {
+    transport.wait_signal_until(group, 1, CmpOp::CMP_EQ, kUserSetSignalValue);
+  }
+  if (transport.internalLocalSignals.size() > 1) {
+    transport.wait_internal_signal_until(
+        group, 1, CmpOp::CMP_EQ, kInternalSetSignalValue);
+  }
+
+  if (group.is_leader()) {
+    result->user_add_signal_value = transport.read_signal(0);
+    result->internal_add_signal_value = transport.read_internal_signal(0);
+    if (transport.userLocalSignals.size() > 1) {
+      result->user_set_signal_value = transport.read_signal(1);
+    }
+    if (transport.internalLocalSignals.size() > 1) {
+      result->internal_set_signal_value = transport.read_internal_signal(1);
+    }
+    result->user_signal_addr =
+        reinterpret_cast<uintptr_t>(transport.userLocalSignals.data());
+    result->internal_signal_addr =
+        reinterpret_cast<uintptr_t>(transport.internalLocalSignals.data());
+    result->user_signal_count = transport.userLocalSignals.size();
+    result->internal_signal_count = transport.internalLocalSignals.size();
+  }
+}
+
+__global__ void stridedMultimemStoreKernel(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks) {
+  auto group = make_block_group();
+
+  const std::size_t dst_offset =
+      static_cast<std::size_t>(rank) * bytes_per_rank;
+  auto* dstVec =
+      reinterpret_cast<uint4*>(transport.multimem_data_at(dst_offset));
+  auto* srcVec = reinterpret_cast<const uint4*>(src);
+  detail::strided_multimem_store_aligned<2>(
+      group, dstVec, srcVec, bytes_per_rank / sizeof(uint4));
+  transport.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+  transport.wait_signal_until(group, 0, CmpOp::CMP_GE, nRanks);
+}
+
+__global__ void multimemRawStoreKernel(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t dst_offset,
+    std::size_t bytes,
+    int nRanks) {
+  auto group = make_block_group();
+  transport.store<4>(group, dst_offset, src, bytes);
+  transport.signal(group, 0, SignalOp::SIGNAL_ADD, 1);
+  transport.wait_signal_until(group, 0, CmpOp::CMP_GE, nRanks);
+}
+
+} // namespace
+
+void launchMultimemStoreSignalTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks,
+    MultimemNvlTransportTestResult* result,
+    cudaStream_t stream) {
+  multimemStoreSignalKernel<<<1, 256, 0, stream>>>(
+      transport, src, bytes_per_rank, rank, nRanks, result);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchStridedMultimemStoreTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks,
+    cudaStream_t stream) {
+  stridedMultimemStoreKernel<<<1, 256, 0, stream>>>(
+      transport, src, bytes_per_rank, rank, nRanks);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchMultimemRawStoreTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t dst_offset,
+    std::size_t bytes,
+    int nRanks,
+    cudaStream_t stream) {
+  multimemRawStoreKernel<<<1, 256, 0, stream>>>(
+      transport, src, dst_offset, bytes, nRanks);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultimemNvlTransportTest.cuh
+++ b/comms/pipes/tests/MultimemNvlTransportTest.cuh
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/pipes/MultimemNvlTransportDevice.cuh"
+
+namespace comms::pipes::test {
+
+struct MultimemNvlTransportTestResult {
+  uint64_t user_add_signal_value{0};
+  uint64_t user_set_signal_value{0};
+  uint64_t internal_add_signal_value{0};
+  uint64_t internal_set_signal_value{0};
+  uintptr_t user_signal_addr{0};
+  uintptr_t internal_signal_addr{0};
+  uint32_t user_signal_count{0};
+  uint32_t internal_signal_count{0};
+};
+
+void launchMultimemStoreSignalTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks,
+    MultimemNvlTransportTestResult* result,
+    cudaStream_t stream = nullptr);
+
+void launchStridedMultimemStoreTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t bytes_per_rank,
+    int rank,
+    int nRanks,
+    cudaStream_t stream = nullptr);
+
+void launchMultimemRawStoreTest(
+    MultimemNvlTransportDevice transport,
+    const char* src,
+    std::size_t dst_offset,
+    std::size_t bytes,
+    int nRanks,
+    cudaStream_t stream = nullptr);
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/MultimemNvlTransportUnalignedTest.cc
+++ b/comms/pipes/tests/MultimemNvlTransportUnalignedTest.cc
@@ -1,0 +1,205 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultimemNvlTransport.h"
+#include "comms/pipes/tests/MultimemNvlTransportTest.cuh"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::tests {
+
+class MultimemNvlTransportUnalignedTestFixture
+    : public ::testing::Test,
+      public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+bool allRanksMultimemEligible(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> eligible(static_cast<std::size_t>(nRanks));
+  eligible[static_cast<std::size_t>(rank)] =
+      MultimemNvlTransport::isEligible(nRanks, cudaDevice) ? 1 : 0;
+  auto rc =
+      bootstrap->allGather(eligible.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(rc, 0);
+  if (rc != 0) {
+    return false;
+  }
+  for (const auto value : eligible) {
+    if (value == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+uint8_t expectedByte(int rank, std::size_t byte) {
+  return static_cast<uint8_t>((rank * 17 + byte * 3 + 5) & 0xFF);
+}
+
+TEST_F(
+    MultimemNvlTransportUnalignedTestFixture,
+    StoreSupportsUnalignedSrcDstAndSize) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_unaligned_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kStoreBytes = 257;
+  constexpr std::size_t kRankStride = kStoreBytes;
+  constexpr std::size_t kDstSkew = 1;
+  const std::size_t dataBufferSize =
+      kDstSkew + kRankStride * static_cast<std::size_t>(numRanks);
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      MultimemNvlTransportConfig{
+          .dataBufferSize = dataBufferSize,
+          .userSignalCount = 1,
+      });
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  std::vector<uint8_t> hostSrc(kStoreBytes + 1, 0xA5);
+  for (std::size_t byte = 0; byte < kStoreBytes; ++byte) {
+    hostSrc[byte + 1] = expectedByte(globalRank, byte);
+  }
+  DeviceBuffer src(hostSrc.size());
+  CUDACHECK_TEST(cudaMemcpy(
+      src.get(), hostSrc.data(), hostSrc.size(), cudaMemcpyHostToDevice));
+
+  const std::size_t dstOffset =
+      kDstSkew + static_cast<std::size_t>(globalRank) * kRankStride;
+  test::launchMultimemRawStoreTest(
+      deviceTransport,
+      static_cast<const char*>(src.get()) + 1,
+      dstOffset,
+      kStoreBytes,
+      numRanks);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<uint8_t> hostDst(dataBufferSize);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(),
+      deviceTransport.localData,
+      hostDst.size(),
+      cudaMemcpyDeviceToHost));
+
+  for (int rank = 0; rank < numRanks; ++rank) {
+    const std::size_t rankOffset =
+        kDstSkew + static_cast<std::size_t>(rank) * kRankStride;
+    for (std::size_t byte = 0; byte < kStoreBytes; ++byte) {
+      ASSERT_EQ(hostDst[rankOffset + byte], expectedByte(rank, byte))
+          << "rank=" << rank << " byte=" << byte;
+    }
+  }
+}
+
+TEST_F(
+    MultimemNvlTransportUnalignedTestFixture,
+    StoreUsesAlignedBulkForAlignedSrcDstAndUnalignedSize) {
+  auto bootstrap =
+      makeBootstrap("multimem_nvl_transport_aligned_bulk_tail_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kStoreBytes = 257;
+  constexpr std::size_t kRankStride = 272;
+  const std::size_t dataBufferSize =
+      kRankStride * static_cast<std::size_t>(numRanks);
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      MultimemNvlTransportConfig{
+          .dataBufferSize = dataBufferSize,
+          .userSignalCount = 1,
+      });
+  transport.exchange();
+  const auto deviceTransport = transport.getDeviceTransport();
+
+  std::vector<uint8_t> hostSrc(kStoreBytes);
+  for (std::size_t byte = 0; byte < kStoreBytes; ++byte) {
+    hostSrc[byte] = expectedByte(globalRank, byte);
+  }
+  DeviceBuffer src(hostSrc.size());
+  CUDACHECK_TEST(cudaMemcpy(
+      src.get(), hostSrc.data(), hostSrc.size(), cudaMemcpyHostToDevice));
+
+  const std::size_t dstOffset =
+      static_cast<std::size_t>(globalRank) * kRankStride;
+  test::launchMultimemRawStoreTest(
+      deviceTransport,
+      static_cast<const char*>(src.get()),
+      dstOffset,
+      kStoreBytes,
+      numRanks);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<uint8_t> hostDst(dataBufferSize);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(),
+      deviceTransport.localData,
+      hostDst.size(),
+      cudaMemcpyDeviceToHost));
+
+  for (int rank = 0; rank < numRanks; ++rank) {
+    const std::size_t rankOffset = static_cast<std::size_t>(rank) * kRankStride;
+    for (std::size_t byte = 0; byte < kStoreBytes; ++byte) {
+      ASSERT_EQ(hostDst[rankOffset + byte], expectedByte(rank, byte))
+          << "rank=" << rank << " byte=" << byte;
+    }
+  }
+}
+
+} // namespace comms::pipes::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary: Add the host and device `MultimemNvlTransport` API on top of `MultimemHandler`. The host wrapper owns separate multicast data and signal windows, exposes a device handle containing local and multicast data pointers plus separate user/internal signal spans, and can be constructed either from a global bootstrap plus `nvlRankToCommRank` or via the compatibility NVLink-local constructor. The device API provides `store<kUnroll>()`, `signal()`, `signal_internal()`, `read_signal()`, `read_internal_signal()`, and wait helpers. `store<kUnroll>()` keeps the 16-byte clean case on the aligned `uint4` multimem fast path; when `src` and `dst` are 16-byte aligned but `bytes` has a tail, it copies the aligned bulk with `strided_multimem_store_aligned<kUnroll>()` and sends only the remainder through `strided_multimem_store_unaligned()`. Fully unaligned source/destination/size inputs use the unaligned fallback, which loads source bytes safely and emits the widest destination-aligned store available, including 1/2-byte tail stores for exact byte coverage. Signals use multimem set/add operations and keep user-visible signal slots separate from transport-internal signal slots. Add distributed coverage for eligibility, aligned store/signal flow, direct aligned helper use, user/internal signal separation, unaligned source/destination/size stores, and aligned-bulk-plus-tail stores.

Differential Revision: D105279160


