### PR TITLE
Fix high_priority_stream access across backends

### DIFF
--- a/comms/torchcomms/README.md
+++ b/comms/torchcomms/README.md
@@ -69,18 +69,19 @@ TorchComm provides the following categories of operations:
 #### Constructor
 
 ```python
-torchcomms.new_comm(backend, device, ...)
+torchcomms.new_comm(backend, device, name, ...)
 ```
 
 - **backend** (str): Communication backend to use (e.g., "ncclx")
 - **device** (torch.device): Device to use for communication
-- **options** (CommOptions, optional): Configuration options including store,
-  timeout, and other settings
+- **name** (str): Communicator name, unique within the process
+- **optional keyword arguments**: `abort_process_on_timeout_or_error`,
+  `timeout`, `is_high_priority_stream`, `store`, `enable_reconfigure`, and
+  `hints`
 
-**Note**: The store parameter is now optional and can be provided through the
-options parameter. TorchComms supports multiple bootstrap backends including
-TCPStore, and Torchrun. If no store is provided, TorchComms will automatically
-detect the environment and use the appropriate bootstrap mechanism.
+**Note**: TorchComms supports multiple bootstrap backends including TCPStore
+and Torchrun. If no store is provided, TorchComms will automatically detect the
+environment and use the appropriate bootstrap mechanism.
 
 #### Initialization Methods
 
@@ -443,18 +444,25 @@ arguments:
 
 **Backend-Specific Hints:**
 
-- **"is_high_priority_stream"**: Set to "true" to enable high priority CUDA stream
-  for NCCL operations (default: not set, equivalent to false)
+- **"is_high_priority_stream"**: Set to `"true"` or `"false"` to override the
+  high-priority stream setting for GPU backends. If both this hint and the
+  `is_high_priority_stream` communicator option are provided, the hint takes
+  precedence.
 
 #### Communicator Options
 
-The `new_comm` function accepts several optional parameters for configuration:
+The `new_comm` function accepts the following parameters for configuration:
 
 - **abort_process_on_timeout_or_error** (bool, optional): Whether to abort the
   process on timeout or error
 - **timeout** (timedelta, optional): Default timeout for operations
+- **is_high_priority_stream** (bool, optional): Whether to use a
+  high-priority stream by default for GPU backends when the
+  `is_high_priority_stream` hint is not provided
 - **store** (Store, optional): Store for communication between processes
-- **name** (str, optional): Communicator name
+- **name** (str): Communicator name
+- **enable_reconfigure** (bool, optional): Enables `reconfigure()` for fault
+  tolerance on supported backends
 - **hints** (Dict[str, str], optional): Dictionary of string hints for
   backend-specific options
 
@@ -497,7 +505,7 @@ store = torch.distributed.FileStore("/tmp/torchcomm_test", 2)
 
 # Create a communicator
 device = torch.device("cuda:0")
-comm = torchcomms.new_comm("nccl", device, store=store)
+comm = torchcomms.new_comm("nccl", device, name="example_comm", store=store)
 
 # Get rank and world size
 rank = comm.get_rank()
@@ -525,7 +533,7 @@ import torchcomms
 # Create a communicator
 store = torch.distributed.FileStore("/tmp/torchcomm_test", 2)
 device = torch.device("cuda:0")
-comm = torchcomms.new_comm("nccl", device, store=store)
+comm = torchcomms.new_comm("nccl", device, name="async_example", store=store)
 
 rank = comm.get_rank()
 world_size = comm.get_size()
@@ -558,7 +566,7 @@ import torchcomms
 
 # Create a communicator
 device = torch.device("cuda:0")
-comm = torchcomms.new_comm("ncclx", device)
+comm = torchcomms.new_comm("ncclx", device, name="cuda_graph_example")
 
 rank = comm.get_rank()
 world_size = comm.get_size()
@@ -594,6 +602,7 @@ device = torch.device("cuda:0")
 comm = torchcomms.new_comm(
     "ncclx",
     device,
+    name="custom_options_example",
     timeout=torch.timedelta(seconds=60),
     abort_process_on_timeout_or_error=False,
     hints={

--- a/comms/torchcomms/TorchCommOptions.cpp
+++ b/comms/torchcomms/TorchCommOptions.cpp
@@ -56,6 +56,10 @@ T CommOptions::getHint(std::string_view key, const T& default_value) const {
   }
 }
 
+bool CommOptions::isHighPriorityStreamEnabled() const {
+  return getHint<bool>("is_high_priority_stream", is_high_priority_stream);
+}
+
 template bool CommOptions::getHint<bool>(std::string_view, const bool&) const;
 template size_t CommOptions::getHint<size_t>(std::string_view, const size_t&)
     const;

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -176,6 +176,8 @@ class CommOptions {
   // Returns default_value if the key is not present.
   template <typename T>
   T getHint(std::string_view key, const T& default_value) const;
+
+  bool isHighPriorityStreamEnabled() const;
 };
 
 class PutOptions {

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -124,6 +124,10 @@ PYBIND11_MODULE(_comms, m, py::mod_gil_not_used()) {
           &CommOptions::timeout,
           "Timeout for operations (milliseconds)")
       .def_readwrite(
+          "is_high_priority_stream",
+          &CommOptions::is_high_priority_stream,
+          "Whether to use a high priority stream by default")
+      .def_readwrite(
           "store",
           &CommOptions::store,
           "Store for communication between processes")
@@ -2329,6 +2333,8 @@ Args:
              std::optional<std::unordered_map<std::string, std::string>> hints,
              std::optional<std::chrono::milliseconds> timeout) {
             CommOptions opts;
+            opts.is_high_priority_stream =
+                self.getOptions().isHighPriorityStreamEnabled();
             if (hints) {
               opts.hints = *hints;
             }

--- a/comms/torchcomms/_comms.pyi
+++ b/comms/torchcomms/_comms.pyi
@@ -293,8 +293,8 @@ PostHookArgs = (
 class CommOptions:
     abort_process_on_timeout_or_error: bool
     timeout: timedelta
+    is_high_priority_stream: bool
     store: Any
-    name: str
     enable_reconfigure: bool
     hints: Dict[str, str]
     def __init__(self) -> None: ...
@@ -716,10 +716,11 @@ class TorchComm:
 def new_comm(
     backend: str,
     device: Any,
+    name: str,
     abort_process_on_timeout_or_error: bool | None = ...,
     timeout: timedelta | None = ...,
+    is_high_priority_stream: bool | None = ...,
     store: Any | None = ...,
-    name: str | None = ...,
     enable_reconfigure: bool = False,
     hints: Dict[str, str] | None = ...,
 ) -> TorchComm: ...

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -152,8 +152,7 @@ void TorchCommNCCL::initNcclResources() {
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  is_high_priority_stream_ =
-      options_.getHint<bool>(kHintIsHighPriorityStream, false);
+  is_high_priority_stream_ = options_.isHighPriorityStreamEnabled();
 
   int stream_priority = 0;
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -301,8 +301,7 @@ void TorchCommNCCLX::initNcclxResources() {
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  is_high_priority_stream_ =
-      options_.getHint<bool>(kHintIsHighPriorityStream, false);
+  is_high_priority_stream_ = options_.isHighPriorityStreamEnabled();
 
   int stream_priority = 0;
 

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -166,8 +166,7 @@ void TorchCommRCCL::initRcclResources() {
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
   // Read hints and store them
-  is_high_priority_stream_ =
-      options_.getHint<bool>(kHintIsHighPriorityStream, false);
+  is_high_priority_stream_ = options_.isHighPriorityStreamEnabled();
 
   // Create internal stream
   //

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -179,8 +179,7 @@ void TorchCommRCCLX::initRcclxResources() {
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
   // Read hints and store them
-  is_high_priority_stream_ =
-      options_.getHint<bool>(kHintIsHighPriorityStream, false);
+  is_high_priority_stream_ = options_.isHighPriorityStreamEnabled();
 
   // Create internal stream
   //

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -318,8 +318,7 @@ void TorchCommXCCL::init(
           std::to_string(device_.index()));
 
   // Read hints and store them
-  is_high_priority_stream_ =
-      options_.getHint<bool>(kHintIsHighPriorityStream, false);
+  is_high_priority_stream_ = options_.isHighPriorityStreamEnabled();
 
   // Create internal stream
   int stream_priority = 0;


### PR DESCRIPTION
`torchcomms.new_comm("nccl", device, "comm", high_priority_stream=True)` was a no op only only `hints={"high_priority_stream": "true"}` worked. 
now `high_priority_stream=True`  enables high priority streams, changed readme and stub.