### PR TITLE
Add hierarchical AllGather CVARs, per-communicator IBGDA sizing, IBGDA sendrecv config, NVLink overlap buffer sizing, and algorithm registration (#2585)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -2,6 +2,8 @@
 #include <memory>
 #include <optional>
 
+#include <cuda_runtime.h>
+
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranPipes.h"
@@ -120,6 +122,14 @@ std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
   return algoStats_->dump();
 }
 
+void CtranComm::recordAlgoStats(
+    const std::string& opName,
+    const std::string& algoName) {
+  if (algoStats_) {
+    algoStats_->record(opName, algoName);
+  }
+}
+
 commResult_t ctranInit(
     CtranComm* comm,
     std::unique_ptr<ctran::IProfilerReporter> reporter) {
@@ -183,6 +193,11 @@ void CtranComm::destroy() {
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.
 #if defined(ENABLE_PIPES)
+  if (hierarchicalAgReadyCounters_ != nullptr) {
+    cudaFree(hierarchicalAgReadyCounters_);
+    hierarchicalAgReadyCounters_ = nullptr;
+    hierarchicalAgReadyCounterCount_ = 0;
+  }
   // Must be destroyed before ctran_ (which owns SharedResource staging
   // buffers used as external data buffers) and before bootstrap_ (since
   // multiPeerTransport_ holds a non-owning reference to it).

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -4,9 +4,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <folly/Synchronized.h>
@@ -27,17 +29,19 @@ struct Transport;
 
 using meta::comms::CommBackend;
 
-// Per-communicator pipes NVL transport overrides.
+// Per-communicator Pipes transport overrides.
 // -1 means use CVAR default.
 struct ctranPipesConfig {
   int64_t nvlChunkSize{-1};
   int useDualStateBuffer{-1}; // -1=cvar, 0=single, 1=dual
   bool ibLazyConnect{false};
+  int64_t ibgdaDataBufferSize{-1};
 
   bool operator==(const ctranPipesConfig& other) const {
     return nvlChunkSize == other.nvlChunkSize &&
         useDualStateBuffer == other.useDualStateBuffer &&
-        ibLazyConnect == other.ibLazyConnect;
+        ibLazyConnect == other.ibLazyConnect &&
+        ibgdaDataBufferSize == other.ibgdaDataBufferSize;
   }
 };
 
@@ -158,13 +162,13 @@ class CtranComm {
   // disabled.
   std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
 
+  void recordAlgoStats(const std::string& opName, const std::string& algoName);
+
   // Record a collective algorithm invocation. No-op if algoStats is disabled.
   inline void recordAlgoStat(
       const std::string& opName,
       const std::string& algoName) {
-    if (algoStats_) {
-      algoStats_->record(opName, algoName);
-    }
+    recordAlgoStats(opName, algoName);
   }
 
   // fields are public to allow access from external code and tests
@@ -193,6 +197,8 @@ class CtranComm {
   std::unique_ptr<ncclx::CommStateX> statex_;
 #if defined(ENABLE_PIPES)
   std::unique_ptr<comms::pipes::MultiPeerTransport> multiPeerTransport_;
+  uint64_t* hierarchicalAgReadyCounters_{nullptr};
+  size_t hierarchicalAgReadyCounterCount_{0};
 #endif // defined(ENABLE_PIPES)
 
   // Deferred cleanup for CUDA graph resources. CUDA user-object destructor

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/CtranPipes.h"
 
+#include <algorithm>
 #include <set>
 
 #include "comms/ctran/CtranComm.h"
@@ -36,8 +37,12 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.pipelineDepth =
         static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
 
+    const bool hierAgOverlapEnabled =
+        NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && comm->statex_->nLocalRanks() > 1;
+    const size_t nvlSharedDevbufSize =
+        ctranEffectiveP2pNvlSharedDevbufSize(comm->statex_->nLocalRanks());
     config.nvlConfig.dataBufferSize = static_cast<size_t>(
-        NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE / config.nvlConfig.pipelineDepth);
+        nvlSharedDevbufSize / config.nvlConfig.pipelineDepth);
 
     config.nvlConfig.chunkSize = (pc.nvlChunkSize > 0)
         ? static_cast<size_t>(pc.nvlChunkSize)
@@ -46,6 +51,11 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.useDualStateBuffer = (pc.useDualStateBuffer >= 0)
         ? (pc.useDualStateBuffer == 1)
         : NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER;
+    if (hierAgOverlapEnabled) {
+      config.nvlConfig.tile_max_groups = std::max(
+          config.nvlConfig.tile_max_groups,
+          static_cast<int>(NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS));
+    }
 
     // LL128 buffer allocation for DeviceAllToAllv
     if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {
@@ -83,7 +93,15 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       }
       config.ibgdaConfig.ibHca = std::move(hcaStr);
     }
-    config.ibgdaConfig.dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+    uint64_t ibgdaDataBufferSize = (pc.ibgdaDataBufferSize > 0)
+        ? static_cast<size_t>(pc.ibgdaDataBufferSize)
+        : static_cast<size_t>(NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE);
+    if (hierAgOverlapEnabled && NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE > 0) {
+      ibgdaDataBufferSize = std::max(
+          ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);
+    }
+    config.ibgdaConfig.dataBufferSize =
+        static_cast<size_t>(ibgdaDataBufferSize);
     config.ibgdaConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibgdaConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
@@ -110,6 +128,46 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibgdaConfig.ibLazyConnect = pc.ibLazyConnect;
     config.ibgdaConfig.materializePeerTimeoutMs =
         NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
+
+    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+      config.ibgdaConfig.numQpsPerPeerPerNic =
+          static_cast<int>(NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC);
+      if (config.ibgdaConfig.dataBufferSize == 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 requires a positive "
+            "IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE "
+            "or per-communicator pipesIbgdaDataBufferSize");
+        return commInvalidArgument;
+      }
+      if (NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS <= 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS must be positive, got {}",
+            NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+        return commInvalidArgument;
+      }
+      if (NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH <= 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH must be positive, got {}",
+            NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
+        return commInvalidArgument;
+      }
+      config.ibgdaConfig.sendRecv =
+          comms::pipes::MultipeerIbgdaTransportConfig::SendRecvConfig{
+              .maxGroups =
+                  static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS),
+              .pipelineDepth =
+                  static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH),
+          };
+      CLOGF(
+          INFO,
+          "Pipes IBGDA sendRecv configured: maxGroups={}, pipelineDepth={}, dataBufferSize={}",
+          config.ibgdaConfig.sendRecv->maxGroups,
+          config.ibgdaConfig.sendRecv->pipelineDepth,
+          config.ibgdaConfig.dataBufferSize);
+    }
 
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -2,10 +2,24 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 class CtranComm;
 class CtranAlgo;
+
+inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
+  uint64_t size = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  if (NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1 &&
+      NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE > 0) {
+    size = std::max(size, NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE);
+  }
+  return static_cast<size_t>(size);
+}
 
 // Create and configure MultiPeerTransport on the CtranComm.
 // exchange() is deferred to ctranInitPipesResources().

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -21,6 +21,7 @@ static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
     case NCCL_ALLGATHER_ALGO::ctsrd:
     case NCCL_ALLGATHER_ALGO::ctring:
     case NCCL_ALLGATHER_ALGO::ctbrucks:
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
     case NCCL_ALLGATHER_ALGO::ctran:
     case NCCL_ALLGATHER_ALGO::orig:
       return false;
@@ -58,6 +59,9 @@ bool ctranAllGatherSupport(
     case NCCL_ALLGATHER_ALGO::ctdirect:
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
+      break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      supported = false;
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -172,6 +176,12 @@ commResult_t ctranAllGather(
     case NCCL_ALLGATHER_ALGO::ctsrd:
       return ctranAllGatherStreamedRd(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
+
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGather {} not registered in this build layer",
+          allGatherAlgoName(algo));
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranPipes.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -115,18 +116,21 @@ inline size_t getPerPeerChunkStatesSize() {
   static size_t size = sizeof(ChunkState) * CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS;
   return size;
 }
+
 // Helper to calculate sync and staging buffer and chunkState pointers for a
 // given peer
-std::tuple<CtranAlgoDeviceSync*, void*, void*>
-partitionDevShm(void* mappedDevShmPtr, int nLocalRanks, int pos) {
+std::tuple<CtranAlgoDeviceSync*, void*, void*> partitionDevShm(
+    void* mappedDevShmPtr,
+    int nLocalRanks,
+    int pos,
+    size_t nvlSharedDevbufSize) {
   char* regionPtr_d = reinterpret_cast<char*>(mappedDevShmPtr);
   void* bufBase_d =
       regionPtr_d + (nLocalRanks - 1) * sizeof(CtranAlgoDeviceSync);
   void* chunkStateBase_d = reinterpret_cast<char*>(bufBase_d) +
-      (nLocalRanks - 1) * NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+      (nLocalRanks - 1) * nvlSharedDevbufSize;
   void* sync = regionPtr_d + pos * sizeof(CtranAlgoDeviceSync);
-  void* buf = reinterpret_cast<char*>(bufBase_d) +
-      pos * NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  void* buf = reinterpret_cast<char*>(bufBase_d) + pos * nvlSharedDevbufSize;
   void* chunkState = reinterpret_cast<char*>(chunkStateBase_d) +
       pos * getPerPeerChunkStatesSize();
   return {reinterpret_cast<CtranAlgoDeviceSync*>(sync), buf, chunkState};
@@ -155,6 +159,8 @@ commResult_t CtranAlgo::initKernelResources() {
   scubaEvent.startAndRecord();
 
   memset(&devState_, 0, sizeof(CtranAlgoDeviceState));
+  const size_t nvlSharedDevbufSize =
+      ctranEffectiveP2pNvlSharedDevbufSize(nLocalRanks);
 
   // Initialize inter-process shared device buffer
   if (!this->sharedRes_) {
@@ -197,7 +203,7 @@ commResult_t CtranAlgo::initKernelResources() {
   // Copy basic comm info to device state for collective kernel to use
   statex->setupDev(devState_.statex);
 
-  devState_.bufSize = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  devState_.bufSize = nvlSharedDevbufSize;
   devState_.bcastBufSize = NCCL_CTRAN_BCAST_NVL_SHARED_DEVBUF_SIZE;
   devState_.enableTraceLog = NCCL_CTRAN_ENABLE_DEV_TRACE_LOG;
   devState_.enableCancellableWaits = comm_->abortEnabled();
@@ -224,14 +230,18 @@ commResult_t CtranAlgo::initKernelResources() {
         auto [localSync, localBuf, localChunkState] = partitionDevShm(
             this->sharedRes_->mappedDevShmPtrs[localRank],
             nLocalRanks,
-            localPos);
+            localPos,
+            nvlSharedDevbufSize);
         localSyncsMap[i] = localSync;
         localStagingBufsMap[i] = localBuf;
         localChunkStatesMap[i] = localChunkState;
 
         int remotePos = LOCAL_RANK_TO_DEV_REGION_POS(localRank, i);
         auto [remoteSync, remoteBuf, remoteChunkState] = partitionDevShm(
-            this->sharedRes_->mappedDevShmPtrs[i], nLocalRanks, remotePos);
+            this->sharedRes_->mappedDevShmPtrs[i],
+            nLocalRanks,
+            remotePos,
+            nvlSharedDevbufSize);
         remoteSyncsMap[i] = remoteSync;
         remoteStagingBufsMap[i] = remoteBuf;
         remoteChunkStatesMap[i] = remoteChunkState;
@@ -239,7 +249,7 @@ commResult_t CtranAlgo::initKernelResources() {
 
       // Next chunk is for bcastBuf
       peerBcastBufsMap[i] = (char*)this->sharedRes_->mappedDevShmPtrs[i] +
-          (sizeof(CtranAlgoDeviceSync) + NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE +
+          (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize +
            getPerPeerChunkStatesSize()) *
               (nLocalRanks - 1);
       CLOGF_TRACE(
@@ -273,8 +283,8 @@ commResult_t CtranAlgo::initKernelResources() {
           "initKernelResources-nvlTransports"));
 
   comms::pipes::P2pNvlTransportOptions options{
-      .dataBufferSize = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE /
-          NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
+      .dataBufferSize =
+          nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
       .chunkSize = NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE,
       .pipelineDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH};
 
@@ -317,6 +327,8 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
   this->comm_ = comm;
   int localRank = statex->localRank();
   int nLocalRanks = statex->nLocalRanks();
+  const size_t nvlSharedDevbufSize =
+      ctranEffectiveP2pNvlSharedDevbufSize(nLocalRanks);
 
   // Create local shared memory region
   // The memory region on each owner rank is divided to (localRanks -1) sets of
@@ -324,9 +336,8 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
   // as below with N localRanks.
   // |bufState_0|bufState_1|...|bufState_N-2|buf_0|buf_1|...|buf_N-2|chunkState_0|chunkState_1|...|chunkState_N-2|
   std::vector<ctran::utils::CtranIpcDesc> ipcDescs(nLocalRanks);
-  size_t shmSize =
-      (sizeof(CtranAlgoDeviceSync) + NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE +
-       getPerPeerChunkStatesSize()) *
+  size_t shmSize = (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize +
+                    getPerPeerChunkStatesSize()) *
           (nLocalRanks - 1) +
       NCCL_CTRAN_BCAST_NVL_SHARED_DEVBUF_SIZE;
 
@@ -376,8 +387,7 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
 
     void* chunkStatePtr_d = reinterpret_cast<char*>(devShmPtr) +
         (nLocalRanks - 1) *
-            (sizeof(CtranAlgoDeviceSync) +
-             NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE) +
+            (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize) +
         pos * getPerPeerChunkStatesSize();
     std::vector<ChunkState> initStates(
         CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS, ChunkState());
@@ -540,6 +550,7 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctrd", NCCL_ALLGATHER_ALGO::ctrd},
         {"ctsrd", NCCL_ALLGATHER_ALGO::ctsrd},
         {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
+        {"cthierarchical_ring", NCCL_ALLGATHER_ALGO::cthierarchical_ring},
         {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph},
         {"ctgraph_pipeline", NCCL_ALLGATHER_ALGO::ctgraph_pipeline},
         {"ctgraph_rdpipeline", NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline},

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -181,6 +181,23 @@ Config::Config(const ncclConfig_t* config) {
           "pipesUseDualStateBuffer", NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER);
     }
   }
+  {
+    std::string val = getHintStr("pipesIbgdaDataBufferSize");
+    if (!val.empty()) {
+      try {
+        auto parsed = std::stoull(val);
+        if (parsed > 0) {
+          pipesIbgdaDataBufferSize = parsed;
+        } else {
+          WARN("NCCLX hint 'pipesIbgdaDataBufferSize': value must be positive");
+        }
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'pipesIbgdaDataBufferSize': invalid value '%s'",
+            val.c_str());
+      }
+    }
+  }
 
   ibLazyConnect = parseHintBool("ibLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
 

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -33,6 +33,7 @@ class Config {
   // When set, override the corresponding CVARs for this communicator.
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
+  std::optional<size_t> pipesIbgdaDataBufferSize;
   int vCliqueSize = 0;
 
   // Per-communicator buffer size override (Simple protocol).
@@ -56,6 +57,15 @@ inline const std::vector<std::string>& knownHintKeys() {
       "splitGroupRanks",
       "ncclAllGatherAlgo",
       "fastInitMode",
+      "useCtran",
+      "usePatAvg",
+      "noLocal",
+      "sendrecvAlgo",
+      "allgatherAlgo",
+      "allreduceAlgo",
+      "pipesIbgdaDataBufferSize",
+      "alltoallvAlgo",
+      "rmaAlgo",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
       "vCliqueSize",

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -54,6 +54,8 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctsrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "cthierarchical_ring";
     case NCCL_ALLGATHER_ALGO::ctgraph:
       return "ctgraph";
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -83,6 +85,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctsrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "cthierarchical_ring") {
+    val = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
   } else if (str == "ctgraph") {
     val = NCCL_ALLGATHER_ALGO::ctgraph;
   } else if (str == "ctgraph_pipeline") {

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -1,0 +1,179 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ncclx::algoconf {
+
+inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
+  } else if (str == "ctgraph") {
+    val = NCCL_SENDRECV_ALGO::ctgraph;
+  } else {
+    val = NCCL_SENDRECV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLGATHER_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLGATHER_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLGATHER_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLGATHER_ALGO::ctring;
+  } else if (str == "ctrd") {
+    val = NCCL_ALLGATHER_ALGO::ctrd;
+  } else if (str == "ctsrd") {
+    val = NCCL_ALLGATHER_ALGO::ctsrd;
+  } else if (str == "ctbrucks") {
+    val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "cthierarchical_ring") {
+    val = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph;
+  } else if (str == "ctgraph_pipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  } else if (str == "ctgraph_rdpipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline;
+  } else if (str == "ctgraph_ring") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
+  } else if (str == "ctgraph_rd") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rd;
+  } else {
+    val = NCCL_ALLGATHER_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLREDUCE_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLREDUCE_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLREDUCE_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else {
+    val = NCCL_ALLREDUCE_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLTOALLV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLTOALLV_ALGO::ctran;
+  } else if (str == "compCtran") {
+    val = NCCL_ALLTOALLV_ALGO::compCtran;
+  } else if (str == "bsCompCtran") {
+    val = NCCL_ALLTOALLV_ALGO::bsCompCtran;
+  } else {
+    val = NCCL_ALLTOALLV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(const std::string& str, enum NCCL_RMA_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_RMA_ALGO::ctran;
+  } else {
+    val = NCCL_RMA_ALGO::orig;
+  }
+}
+
+inline std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
+  switch (val) {
+    case NCCL_SENDRECV_ALGO::orig:
+      return "orig";
+    case NCCL_SENDRECV_ALGO::ctran:
+      return "ctran";
+    case NCCL_SENDRECV_ALGO::ctzcopy:
+      return "ctzcopy";
+    case NCCL_SENDRECV_ALGO::ctp2p:
+      return "ctp2p";
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      return "ctgraph";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
+  switch (val) {
+    case NCCL_ALLGATHER_ALGO::orig:
+      return "orig";
+    case NCCL_ALLGATHER_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLGATHER_ALGO::ctring:
+      return "ctring";
+    case NCCL_ALLGATHER_ALGO::ctrd:
+      return "ctrd";
+    case NCCL_ALLGATHER_ALGO::ctsrd:
+      return "ctsrd";
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+      return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "cthierarchical_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "ctgraph";
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      return "ctgraph_pipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      return "ctgraph_rdpipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      return "ctgraph_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return "ctgraph_rd";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
+  switch (val) {
+    case NCCL_ALLREDUCE_ALGO::orig:
+      return "orig";
+    case NCCL_ALLREDUCE_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLREDUCE_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLREDUCE_ALGO::ctring:
+      return "ctring";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLTOALLV_ALGO val) {
+  switch (val) {
+    case NCCL_ALLTOALLV_ALGO::orig:
+      return "orig";
+    case NCCL_ALLTOALLV_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLTOALLV_ALGO::compCtran:
+      return "compCtran";
+    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
+      return "bsCompCtran";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_RMA_ALGO val) {
+  switch (val) {
+    case NCCL_RMA_ALGO::orig:
+      return "orig";
+    case NCCL_RMA_ALGO::ctran:
+      return "ctran";
+  }
+  return "unknown";
+}
+
+} // namespace ncclx::algoconf

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -53,6 +53,10 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
           ncclxCfg->pipesUseDualStateBuffer.value() ? 1 : 0;
     }
     tconfig.pipesConfig.ibLazyConnect = ncclxCfg->ibLazyConnect;
+    if (ncclxCfg->pipesIbgdaDataBufferSize.has_value()) {
+      tconfig.pipesConfig.ibgdaDataBufferSize =
+          static_cast<int64_t>(ncclxCfg->pipesIbgdaDataBufferSize.value());
+    }
   }
   return tconfig;
 }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1117,6 +1117,85 @@ cvars:
      Split messages larger than NCCL_CTRAN_AG_RING_MIN_SPLIT_SIZE into this many
      messages.
 
+ - name        : NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Number of CUDA thread blocks for the cthierarchical_ring AllGather IB
+     ring phase. For 4x1 IB-only tests, this is the full hierarchical kernel
+     grid size because the NVLink fanout degenerates to nvl_size=1.
+
+ - name        : NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable the experimental overlapped cthierarchical_ring AllGather kernel.
+     When enabled, dedicated IB blocks publish chunk-ready counters and
+     dedicated NVLink blocks fan out chunks as soon as they arrive.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Number of CUDA thread blocks for the experimental overlapped
+     cthierarchical_ring AllGather NVLink fanout role.
+
+ - name        : NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES
+   type        : uint64_t
+   default     : 4194304
+   description : |-
+     Logical chunk size, in bytes, used by the experimental overlapped
+     cthierarchical_ring AllGather kernel for IB-ready notification and
+     NVLink fanout scheduling.
+
+ - name        : NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE
+   type        : uint64_t
+   default     : 33554432
+   description : |-
+     Minimum IBGDA send/recv data-buffer size to use when the experimental
+     overlapped cthierarchical_ring AllGather kernel is enabled. 0 disables
+     this algorithm-specific minimum and uses NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE
+     or the per-communicator pipesIbgdaDataBufferSize directly.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE
+   type        : uint64_t
+   default     : 67108864
+   description : |-
+     Minimum total per-peer NVLink shared device-buffer size to use when the
+     experimental overlapped cthierarchical_ring AllGather kernel is enabled.
+     This value is divided by NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH before
+     configuring each pipeline slot. 0 disables this algorithm-specific
+     minimum and uses NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE directly.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC
+   type        : int
+   default     : 4
+   description : |-
+     Number of IBGDA QP sets per peer per NIC for the cthierarchical_ring
+     AllGather algorithm.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Maximum bytes per signaled sub-chunk for the cthierarchical_ring IBGDA
+     send/recv phase. 0 means each block signals once per per-block staging
+     slot.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Maximum bytes per signaled sub-chunk for the cthierarchical_ring NVLink
+     fanout phase. 0 means each block signals once per per-block staging slot.
+
+ - name        : NCCL_CTRAN_HIER_AG_TIMEOUT_MS
+   type        : float
+   default     : 30000.0
+   description : |-
+     Timeout in milliseconds for the cthierarchical_ring AllGather kernel.
+     0 means no timeout.
+
 
  - name        : NCCL_CTRAN_AG_RD_RTR
    type        : bool
@@ -1776,6 +1855,31 @@ cvars:
      On timeout, materializePeer throws rather than hanging.
      No per-comm override.
 
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable send/recv staging buffers for IBGDA transport in Pipes
+     MultiPeerTransport. Required for cthierarchical_ring. When enabled,
+     allocates additional GPU memory for pipelined send/recv staging per
+     IBGDA peer. The effective IBGDA data-buffer size must be positive via
+     NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or the per-communicator
+     pipesIbgdaDataBufferSize hint.
+
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS
+   type        : int
+   default     : 128
+   description : |-
+     Maximum number of block-groups for IBGDA send/recv staging.
+     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
+
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH
+   type        : int
+   default     : 2
+   description : |-
+     Pipeline depth (number of staging ring slots) for IBGDA send/recv.
+     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket
@@ -1973,7 +2077,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctsrd, ctbrucks, ctgraph, ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctsrd, ctbrucks, cthierarchical_ring, ctgraph, ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -1982,6 +2086,7 @@ cvars:
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
      ctsrd - Ctran-based streamed recursive doubling algorithm
+     cthierarchical_ring - Pipes-based hierarchical AllGather using an inter-node IBGDA ring per local rank followed by intra-node NVLink fanout; with nLocalRanks==1 it degenerates to the hierarchical kernel's IB-only phase
      ctgraph - Cudagraph-aware: auto-selects pipeline/ring/rd based on topology during graph capture
      ctgraph_pipeline - Cudagraph-aware: forces persistent pipeline algorithm (nLocalRanks>1)
      ctgraph_rdpipeline - Cudagraph-aware: forces persistent recursive-doubling pipeline algorithm (nLocalRanks>1, nNodes power of 2)


### PR DESCRIPTION
Summary:

Adds the configuration surface, resource allocation, and plumbing required by the no-GPE hierarchical AllGather path (`NCCL_ALLGATHER_ALGO=cthierarchical_ring`). This diff establishes the control plane -- CVARs, per-communicator overrides, transport configuration, device scratch, and algorithm enum registration -- without adding the kernel or entry point (those follow in D105521698 and D105521696).

## Changes Overview

```
Configuration and Resource Flow:

nccl_cvars.yaml ----------> Generated CVAR headers
    |                            |
    | 15 new CVARs               |
    v                            v
NcclxConfig.h/cc ---> MetaFactory.cc ---> ctranPipesConfig
    |                                       |
    | pipesIbgdaDataBufferSize              |
    | (per-communicator override)           |
    v                                       v
CtranPipes.cc                          CtranComm.h
    |                                   |
    | * IBGDA sendrecv config           | * hierarchicalAgReadyCounters_
    | * NVLink devbuf overlap sizing    | * hierarchicalAgReadyCounterCount_
    | * IBGDA data buffer sizing        | * recordAlgoStats()
    | * tile_max_groups update          |
    v                                   v
MultipeerIbgdaTransportConfig      CtranAlgo.cc / AlgoConfig.cc
                                       |
                                       | * "cthierarchical_ring" enum
                                       | * string <-> enum mapping
                                       | * NVLink shared devbuf
                                       |   parameterization
                                       v
                                   Ctran.cc
                                       |
                                       | * cudaFree ready counters
                                       |   in destructor
```

## Detailed Changes

### 1. CVARs (`nccl_cvars.yaml`) -- 15 new configuration variables

**IB tuning:**
- `NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS` (default 16) -- CUDA thread blocks for the IB ring phase
- `NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES` (default 0) -- bytes per signaled sub-chunk for IB
- `NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC` (default 4) -- IBGDA QP sets per peer per NIC

**Overlap kernel:**
- `NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE` (default false) -- master switch for the overlapped kernel
- `NCCL_CTRAN_HIER_AG_OVERLAP_IB_NUM_BLOCKS` (default 8) -- IB blocks when overlap is active
- `NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES` (default 4 MB) -- logical chunk size for IB-ready notification and NVLink scheduling
- `NCCL_CTRAN_HIER_AG_OVERLAP_IB_SIGNAL_BYTES` (default 1 MB) -- IB signal granularity in overlap mode

**NVLink tuning:**
- `NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS` (default 16) -- CUDA thread blocks for NVLink fanout
- `NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES` (default 0) -- bytes per signaled sub-chunk for NVLink
- `NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE` (default 64 MB) -- minimum NVLink shared device buffer for overlap mode

**Resource sizing:**
- `NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE` (default 32 MB) -- minimum IBGDA data buffer for overlap mode
- `NCCL_CTRAN_HIER_AG_TIMEOUT_MS` (default 30000) -- kernel-level timeout in milliseconds

**IBGDA sendrecv infrastructure:**
- `NCCL_CTRAN_IBGDA_SENDRECV_ENABLE` (default false) -- enables send/recv staging buffers for IBGDA transport
- `NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS` (default 128) -- maximum block-groups for send/recv staging
- `NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH` (default 2) -- pipeline depth for send/recv staging

### 2. Per-communicator IBGDA Data Buffer Override (`NcclxConfig.h/cc`, `MetaFactory.cc`, `CtranComm.h`)

- Adds `pipesIbgdaDataBufferSize` to `NcclxConfig` (parsed from hints), `ctranPipesConfig` (with `operator==` update), and `MetaFactory` plumbing
- Follows the same pattern as the existing `pipesNvlChunkSize` and `pipesUseDualStateBuffer` overrides
- Enables per-communicator IBGDA sizing for targeted experiments without affecting other communicators

### 3. IBGDA Sendrecv Configuration (`CtranPipes.cc`)

When `NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1`:
- Validates that the effective IBGDA data buffer size is positive
- Validates that `NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS` and `NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH` are positive
- Configures `MultipeerIbgdaTransportConfig::SendRecvConfig` with `maxGroups` and `pipelineDepth`
- Sets `numQpsPerPeerPerNic` from the hierarchical AG CVAR
- Logs the effective sendrecv configuration at INFO level

### 4. NVLink Shared Devbuf Sizing for Overlap (`CtranPipes.cc`, `CtranAlgo.cc`)

When `NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE=1` and `nLocalRanks > 1`:
- Uses `max(base_size, NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE)` for NVLink shared device buffers
- Introduces `getEffectiveP2pNvlSharedDevbufSize()` helper to centralize the effective size computation
- Parameterizes all previously-hardcoded `NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE` references in `CtranAlgo.cc` (`partitionDevShm()`, `initKernelResources()`, `initSharedRes()`)
- Updates `tile_max_groups` to accommodate hierarchical kernel NVLink block count

### 5. Ready Counter Lifecycle (`CtranComm.h`, `Ctran.cc`)

- Adds `hierarchicalAgReadyCounters_` (`uint64_t*`) and `hierarchicalAgReadyCounterCount_` to `CtranComm` for device-side ready counter scratch
- Adds `cudaFree` cleanup in `CtranComm` destructor
- Adds `recordAlgoStats()` public method as a non-inline wrapper, consolidating the algo stat recording path

### 6. Algorithm Registration (`CtranAlgo.cc`, `AlgoConfig.cc`)

- Adds `cthierarchical_ring` to the `NCCL_ALLGATHER_ALGO` enum choices in `nccl_cvars.yaml`
- Adds bidirectional string-to-enum mapping in `AlgoConfig.cc` (`allGatherAlgoToString`, `allGatherAlgoFromString`)
- Adds enum entry to the algorithm dispatch map in `CtranAlgo.cc`

### 7. IBGDA Data Buffer Sizing with Overlap (`CtranPipes.cc`)

When overlap is enabled, applies `max(effective_ibgda_size, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE)` to ensure the IBGDA transport has sufficient staging for the hierarchical kernel's pipeline depth requirements.

Reviewed By: elvinlife

Differential Revision: D105521697


