### PR TITLE
Add AllGather NCCL-vs-ctran comparison benchmark with dual-communicator isolation, configurable algorithm/sizes, and per-rank max-latency timing (#2588)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -2,6 +2,8 @@
 #include <memory>
 #include <optional>
 
+#include <cuda_runtime.h>
+
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/CtranPipes.h"
@@ -120,6 +122,14 @@ std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
   return algoStats_->dump();
 }
 
+void CtranComm::recordAlgoStats(
+    const std::string& opName,
+    const std::string& algoName) {
+  if (algoStats_) {
+    algoStats_->record(opName, algoName);
+  }
+}
+
 commResult_t ctranInit(
     CtranComm* comm,
     std::unique_ptr<ctran::IProfilerReporter> reporter) {
@@ -183,6 +193,11 @@ void CtranComm::destroy() {
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.
 #if defined(ENABLE_PIPES)
+  if (hierarchicalAgReadyCounters_ != nullptr) {
+    cudaFree(hierarchicalAgReadyCounters_);
+    hierarchicalAgReadyCounters_ = nullptr;
+    hierarchicalAgReadyCounterCount_ = 0;
+  }
   // Must be destroyed before ctran_ (which owns SharedResource staging
   // buffers used as external data buffers) and before bootstrap_ (since
   // multiPeerTransport_ holds a non-owning reference to it).

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -4,9 +4,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <folly/Synchronized.h>
@@ -27,17 +29,19 @@ struct Transport;
 
 using meta::comms::CommBackend;
 
-// Per-communicator pipes NVL transport overrides.
+// Per-communicator Pipes transport overrides.
 // -1 means use CVAR default.
 struct ctranPipesConfig {
   int64_t nvlChunkSize{-1};
   int useDualStateBuffer{-1}; // -1=cvar, 0=single, 1=dual
   bool ibLazyConnect{false};
+  int64_t ibgdaDataBufferSize{-1};
 
   bool operator==(const ctranPipesConfig& other) const {
     return nvlChunkSize == other.nvlChunkSize &&
         useDualStateBuffer == other.useDualStateBuffer &&
-        ibLazyConnect == other.ibLazyConnect;
+        ibLazyConnect == other.ibLazyConnect &&
+        ibgdaDataBufferSize == other.ibgdaDataBufferSize;
   }
 };
 
@@ -158,13 +162,13 @@ class CtranComm {
   // disabled.
   std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
 
+  void recordAlgoStats(const std::string& opName, const std::string& algoName);
+
   // Record a collective algorithm invocation. No-op if algoStats is disabled.
   inline void recordAlgoStat(
       const std::string& opName,
       const std::string& algoName) {
-    if (algoStats_) {
-      algoStats_->record(opName, algoName);
-    }
+    recordAlgoStats(opName, algoName);
   }
 
   // fields are public to allow access from external code and tests
@@ -193,6 +197,8 @@ class CtranComm {
   std::unique_ptr<ncclx::CommStateX> statex_;
 #if defined(ENABLE_PIPES)
   std::unique_ptr<comms::pipes::MultiPeerTransport> multiPeerTransport_;
+  uint64_t* hierarchicalAgReadyCounters_{nullptr};
+  size_t hierarchicalAgReadyCounterCount_{0};
 #endif // defined(ENABLE_PIPES)
 
   // Deferred cleanup for CUDA graph resources. CUDA user-object destructor

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -2,6 +2,7 @@
 
 #include "comms/ctran/CtranPipes.h"
 
+#include <algorithm>
 #include <set>
 
 #include "comms/ctran/CtranComm.h"
@@ -36,8 +37,12 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.pipelineDepth =
         static_cast<size_t>(NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH);
 
+    const bool hierAgOverlapEnabled =
+        NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && comm->statex_->nLocalRanks() > 1;
+    const size_t nvlSharedDevbufSize =
+        ctranEffectiveP2pNvlSharedDevbufSize(comm->statex_->nLocalRanks());
     config.nvlConfig.dataBufferSize = static_cast<size_t>(
-        NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE / config.nvlConfig.pipelineDepth);
+        nvlSharedDevbufSize / config.nvlConfig.pipelineDepth);
 
     config.nvlConfig.chunkSize = (pc.nvlChunkSize > 0)
         ? static_cast<size_t>(pc.nvlChunkSize)
@@ -46,6 +51,11 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.nvlConfig.useDualStateBuffer = (pc.useDualStateBuffer >= 0)
         ? (pc.useDualStateBuffer == 1)
         : NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER;
+    if (hierAgOverlapEnabled) {
+      config.nvlConfig.tile_max_groups = std::max(
+          config.nvlConfig.tile_max_groups,
+          static_cast<int>(NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS));
+    }
 
     // LL128 buffer allocation for DeviceAllToAllv
     if (NCCL_CTRAN_DA2A_LL128_THRESHOLD > 0) {
@@ -83,7 +93,15 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       }
       config.ibgdaConfig.ibHca = std::move(hcaStr);
     }
-    config.ibgdaConfig.dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+    uint64_t ibgdaDataBufferSize = (pc.ibgdaDataBufferSize > 0)
+        ? static_cast<size_t>(pc.ibgdaDataBufferSize)
+        : static_cast<size_t>(NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE);
+    if (hierAgOverlapEnabled && NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE > 0) {
+      ibgdaDataBufferSize = std::max(
+          ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);
+    }
+    config.ibgdaConfig.dataBufferSize =
+        static_cast<size_t>(ibgdaDataBufferSize);
     config.ibgdaConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
       config.ibgdaConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
@@ -110,6 +128,46 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     config.ibgdaConfig.ibLazyConnect = pc.ibLazyConnect;
     config.ibgdaConfig.materializePeerTimeoutMs =
         NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
+
+    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+      config.ibgdaConfig.numQpsPerPeerPerNic =
+          static_cast<int>(NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC);
+      if (config.ibgdaConfig.dataBufferSize == 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 requires a positive "
+            "IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE "
+            "or per-communicator pipesIbgdaDataBufferSize");
+        return commInvalidArgument;
+      }
+      if (NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS <= 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS must be positive, got {}",
+            NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+        return commInvalidArgument;
+      }
+      if (NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH <= 0) {
+        CLOGF(
+            ERR,
+            "NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH must be positive, got {}",
+            NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
+        return commInvalidArgument;
+      }
+      config.ibgdaConfig.sendRecv =
+          comms::pipes::MultipeerIbgdaTransportConfig::SendRecvConfig{
+              .maxGroups =
+                  static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS),
+              .pipelineDepth =
+                  static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH),
+          };
+      CLOGF(
+          INFO,
+          "Pipes IBGDA sendRecv configured: maxGroups={}, pipelineDepth={}, dataBufferSize={}",
+          config.ibgdaConfig.sendRecv->maxGroups,
+          config.ibgdaConfig.sendRecv->pipelineDepth,
+          config.ibgdaConfig.dataBufferSize);
+    }
 
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -2,10 +2,24 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 
 class CtranComm;
 class CtranAlgo;
+
+inline size_t ctranEffectiveP2pNvlSharedDevbufSize(int nLocalRanks) {
+  uint64_t size = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  if (NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1 &&
+      NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE > 0) {
+    size = std::max(size, NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE);
+  }
+  return static_cast<size_t>(size);
+}
 
 // Create and configure MultiPeerTransport on the CtranComm.
 // exchange() is deferred to ctranInitPipesResources().

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -36,7 +36,9 @@ bool ctranAllGatherSupport(
     CtranComm* comm,
     enum NCCL_ALLGATHER_ALGO algo,
     cudaStream_t stream) {
-  if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
+  const bool pipesAlgo = algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  if (!ctranInitialized(comm) ||
+      (!pipesAlgo && !comm->ctran_->mapper->hasBackend())) {
     return false;
   }
 
@@ -56,12 +58,58 @@ bool ctranAllGatherSupport(
             allGatherAlgoName(algo));
       }
       break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+#if defined(ENABLE_PIPES)
+      if (statex->nRanks() <= 1 || statex->nNodes() <= 1) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires multiple nodes, got nRanks={} nNodes={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes());
+        supported = false;
+        break;
+      }
+      if (statex->nLocalRanks() < 1 ||
+          statex->nRanks() != statex->nNodes() * statex->nLocalRanks()) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes(),
+            statex->nLocalRanks());
+        supported = false;
+        break;
+      }
+      if (!comm->multiPeerTransport_) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      supported = true;
+#else
+      supported = false;
+#endif
+      break;
     case NCCL_ALLGATHER_ALGO::ctdirect:
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
-      break;
-    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      supported = false;
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -178,10 +226,8 @@ commResult_t ctranAllGather(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      FB_ERRORRETURN(
-          commInvalidUsage,
-          "AllGather {} not registered in this build layer",
-          allGatherAlgoName(algo));
+      return ctranAllGatherHierarchicalRing(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -21,6 +21,7 @@ static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
     case NCCL_ALLGATHER_ALGO::ctsrd:
     case NCCL_ALLGATHER_ALGO::ctring:
     case NCCL_ALLGATHER_ALGO::ctbrucks:
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
     case NCCL_ALLGATHER_ALGO::ctran:
     case NCCL_ALLGATHER_ALGO::orig:
       return false;
@@ -58,6 +59,9 @@ bool ctranAllGatherSupport(
     case NCCL_ALLGATHER_ALGO::ctdirect:
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
+      break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      supported = false;
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -172,6 +176,12 @@ commResult_t ctranAllGather(
     case NCCL_ALLGATHER_ALGO::ctsrd:
       return ctranAllGatherStreamedRd(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
+
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      FB_ERRORRETURN(
+          commInvalidUsage,
+          "AllGather {} not registered in this build layer",
+          allGatherAlgoName(algo));
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -1,0 +1,408 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/colltrace/CollTraceWrapper.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/AllGatherLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+static const auto myAlgo = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+using ::meta::comms::colltrace::CollTraceHandleTriggerState;
+
+namespace {
+
+commResult_t validateHierarchicalRingParams(CtranComm* comm, int numBlocks) {
+  if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  const auto dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+  if (dataBufferSize == 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires a positive IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or per-communicator pipesIbgdaDataBufferSize",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+  if (numBlocks <= 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires positive NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS; got {}",
+        allGatherAlgoName(myAlgo),
+        numBlocks);
+    return commInvalidArgument;
+  }
+  if (numBlocks > NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} numBlocks={} exceeds NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+        allGatherAlgoName(myAlgo),
+        numBlocks,
+        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+    return commInvalidArgument;
+  }
+  if (dataBufferSize / static_cast<uint64_t>(numBlocks) < 16) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} dataBufferSize={} is too small for numBlocks={}",
+        allGatherAlgoName(myAlgo),
+        dataBufferSize,
+        numBlocks);
+    return commInvalidArgument;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  if (nRanks <= 1 || nNodes <= 1) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires multiple nodes, got nRanks={} nNodes={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks < 1 || nRanks != static_cast<int64_t>(nNodes) * nLocalRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes,
+        nLocalRanks);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks > comms::pipes::kDirectNvlMaxRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} nLocalRanks={} exceeds direct NVLink peer capacity {}",
+        allGatherAlgoName(myAlgo),
+        nLocalRanks,
+        comms::pipes::kDirectNvlMaxRanks);
+    return commInvalidArgument;
+  }
+
+  for (int node = 0; node < nNodes; ++node) {
+    for (int localRank = 0; localRank < nLocalRanks; ++localRank) {
+      const int expectedRank = node * nLocalRanks + localRank;
+      const int rank = statex->localRankToRank(localRank, node);
+      if (rank != expectedRank) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires contiguous node-major rank layout; localRankToRank({}, {})={} expected {}",
+            allGatherAlgoName(myAlgo),
+            localRank,
+            node,
+            rank,
+            expectedRank);
+        return commInvalidArgument;
+      }
+    }
+  }
+
+  if (!comm->multiPeerTransport_) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  const int myNode = statex->node();
+  const int localRank = statex->localRank();
+  auto rings = comms::pipes::make_standard_rings(nNodes, myNode, 1);
+  if (!rings.has_value()) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} cannot construct IB ring for {} nodes",
+        allGatherAlgoName(myAlgo),
+        nNodes);
+    return commInvalidArgument;
+  }
+  const auto& ibRing = (*rings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  if (!mpt->has_ibgda(prevGlobal) || !mpt->has_ibgda(nextGlobal)) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires IBGDA prev/next transports; prev {} has_ibgda={} next {} has_ibgda={}",
+        allGatherAlgoName(myAlgo),
+        prevGlobal,
+        mpt->has_ibgda(prevGlobal),
+        nextGlobal,
+        mpt->has_ibgda(nextGlobal));
+    return commInvalidArgument;
+  }
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    if (!mpt->is_nvl_peer(peerGlobal)) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires NVLink transport to local peer globalRank={} localRank={}",
+          allGatherAlgoName(myAlgo),
+          peerGlobal,
+          peerLocal);
+      return commInvalidArgument;
+    }
+  }
+
+  return commSuccess;
+}
+
+commResult_t ensureReadyCounterCapacity(
+    CtranComm* comm,
+    size_t counterCount,
+    cudaStream_t stream) {
+  if (counterCount == 0) {
+    return commSuccess;
+  }
+  if (comm->hierarchicalAgReadyCounterCount_ >= counterCount &&
+      comm->hierarchicalAgReadyCounters_ != nullptr) {
+    return commSuccess;
+  }
+
+  if (comm->hierarchicalAgReadyCounters_ != nullptr) {
+    FB_CUDACHECK(cudaFree(comm->hierarchicalAgReadyCounters_));
+    comm->hierarchicalAgReadyCounters_ = nullptr;
+    comm->hierarchicalAgReadyCounterCount_ = 0;
+  }
+
+  void* ptr = nullptr;
+  FB_CUDACHECK(cudaMalloc(&ptr, counterCount * sizeof(uint64_t)));
+  comm->hierarchicalAgReadyCounters_ = static_cast<uint64_t*>(ptr);
+  comm->hierarchicalAgReadyCounterCount_ = counterCount;
+  FB_CUDACHECK(cudaMemsetAsync(
+      comm->hierarchicalAgReadyCounters_,
+      0,
+      counterCount * sizeof(uint64_t),
+      stream));
+  return commSuccess;
+}
+
+} // namespace
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  CTRAN_COLL_INFO(
+      allGatherAlgoName(myAlgo).c_str(),
+      sendbuff,
+      recvbuff,
+      sendcount,
+      datatype,
+      -1,
+      comm,
+      stream);
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  const int localRank = statex->localRank();
+  const int node = statex->node();
+  const size_t sendBytes = sendcount * commTypeSize(datatype);
+
+  if (nRanks == 1) {
+    if (sendBytes > 0 && sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff, sendbuff, sendBytes, cudaMemcpyDefault, stream));
+    }
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+  if (sendBytes == 0) {
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+
+  const bool useOverlap = NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1;
+  const int numBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS);
+  const int nvlNumBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS);
+  FB_COMMCHECK(validateHierarchicalRingParams(comm, numBlocks));
+  if (useOverlap) {
+    if (nvlNumBlocks <= 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS; got {}",
+          allGatherAlgoName(myAlgo),
+          nvlNumBlocks);
+      return commInvalidArgument;
+    }
+    if (static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES) == 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES",
+          allGatherAlgoName(myAlgo));
+      return commInvalidArgument;
+    }
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  auto ibRings = comms::pipes::make_standard_rings(nNodes, node, 1);
+  if (!ibRings.has_value()) {
+    return commInvalidArgument;
+  }
+
+  comms::pipes::HierarchicalAllgatherLaunchParams params{};
+  params.num_ranks = nRanks;
+  params.ib_rank = node;
+  params.ib_size = nNodes;
+  params.nvl_rank = localRank;
+  params.nvl_size = nLocalRanks;
+  // Pipes allgather kernels operate on byte-addressed char buffers.
+  params.sendcount = sendBytes;
+  params.ib_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES);
+  params.nvl_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES);
+  params.sendbuf = static_cast<const char*>(sendbuff);
+  params.recvbuf = static_cast<char*>(recvbuff);
+  params.ib_num_blocks = numBlocks;
+  params.timeout_ms = NCCL_CTRAN_HIER_AG_TIMEOUT_MS;
+  params.stream = stream;
+
+  const auto& ibRing = (*ibRings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  params.ib_ring.prev_rank = ibRing.prev_rank;
+  params.ib_ring.next_rank = ibRing.next_rank;
+  params.ib_ring.prev = mpt->get_p2p_ibgda_transport_device(prevGlobal);
+  params.ib_ring.next = mpt->get_p2p_ibgda_transport_device(nextGlobal);
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    new (&params.nvl_peers[peerLocal]) comms::pipes::P2pNvlTransportDevice(
+        mpt->get_p2p_nvl_transport_device(peerGlobal));
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLGATHER,
+      stream,
+      allGatherAlgoName(myAlgo),
+      comm->ctran_->getOpCount());
+  ctranKernelSetAllGatherArgs(
+      sendbuff,
+      recvbuff,
+      datatype,
+      sendcount,
+      comm->ctran_->algo->getDevState(),
+      &config.args);
+
+  std::vector<std::unique_ptr<struct OpElem>> emptyOpGroup;
+  auto colltraceHandle =
+      meta::comms::colltrace::getCollTraceHandle(comm, emptyOpGroup, config);
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  }
+  comm->recordAlgoStats("AllGather", allGatherAlgoName(myAlgo));
+
+  if (useOverlap) {
+    comms::pipes::HierarchicalAllgatherOverlapLaunchParams overlapParams{};
+    overlapParams.num_ranks = params.num_ranks;
+    overlapParams.ib_rank = params.ib_rank;
+    overlapParams.ib_size = params.ib_size;
+    overlapParams.nvl_rank = params.nvl_rank;
+    overlapParams.nvl_size = params.nvl_size;
+    overlapParams.sendcount = params.sendcount;
+    overlapParams.ib_signaling_data_size = params.ib_signaling_data_size;
+    overlapParams.nvl_signaling_data_size = params.nvl_signaling_data_size;
+    overlapParams.chunk_bytes =
+        static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES);
+    overlapParams.ready_sequence = comm->ctran_->getOpCount() + 1;
+    overlapParams.sendbuf = params.sendbuf;
+    overlapParams.recvbuf = params.recvbuf;
+    overlapParams.ib_num_blocks = params.ib_num_blocks;
+    overlapParams.nvl_num_blocks = nvlNumBlocks;
+    overlapParams.timeout_ms = params.timeout_ms;
+    overlapParams.stream = params.stream;
+    overlapParams.ib_ring = params.ib_ring;
+    for (int peer = 0; peer < nLocalRanks; ++peer) {
+      if (peer == localRank) {
+        continue;
+      }
+      new (&overlapParams.nvl_peers[peer])
+          comms::pipes::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    const size_t totalChunks =
+        (sendBytes + overlapParams.chunk_bytes - 1) / overlapParams.chunk_bytes;
+    const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
+    FB_COMMCHECK(
+        ensureReadyCounterCapacity(comm, readyCounters, overlapParams.stream));
+    overlapParams.ready_counters = comm->hierarchicalAgReadyCounters_;
+    comms::pipes::launch_hierarchical_allgather_overlap(overlapParams);
+  } else {
+    comms::pipes::launch_hierarchical_allgather_fused(params);
+  }
+  FB_CUDACHECK(cudaGetLastError());
+
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  }
+  comm->ctran_->updateOpCount();
+
+  return commSuccess;
+}
+
+#else // !ENABLE_PIPES
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* /*sendbuff*/,
+    void* /*recvbuff*/,
+    size_t /*sendcount*/,
+    commDataType_t /*datatype*/,
+    CtranComm* /*comm*/,
+    cudaStream_t /*stream*/) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -48,6 +48,14 @@ commResult_t ctranAllGatherBrucksFF(
     CtranComm* comm,
     cudaStream_t stream);
 
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 static inline const std::string allGatherAlgoName(
     enum NCCL_ALLGATHER_ALGO algo) {
   switch (algo) {
@@ -61,6 +69,8 @@ static inline const std::string allGatherAlgoName(
       return "CtranAllGatherRing";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "CtranBrucksFF";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "CtranAllGatherHierarchicalRing";
     case NCCL_ALLGATHER_ALGO::ctran:
       return "CtranAuto";
     case NCCL_ALLGATHER_ALGO::ctgraph:

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranPipes.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/CtranAlgoConsts.h"
 #include "comms/ctran/utils/Alloc.h"
@@ -115,18 +116,21 @@ inline size_t getPerPeerChunkStatesSize() {
   static size_t size = sizeof(ChunkState) * CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS;
   return size;
 }
+
 // Helper to calculate sync and staging buffer and chunkState pointers for a
 // given peer
-std::tuple<CtranAlgoDeviceSync*, void*, void*>
-partitionDevShm(void* mappedDevShmPtr, int nLocalRanks, int pos) {
+std::tuple<CtranAlgoDeviceSync*, void*, void*> partitionDevShm(
+    void* mappedDevShmPtr,
+    int nLocalRanks,
+    int pos,
+    size_t nvlSharedDevbufSize) {
   char* regionPtr_d = reinterpret_cast<char*>(mappedDevShmPtr);
   void* bufBase_d =
       regionPtr_d + (nLocalRanks - 1) * sizeof(CtranAlgoDeviceSync);
   void* chunkStateBase_d = reinterpret_cast<char*>(bufBase_d) +
-      (nLocalRanks - 1) * NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+      (nLocalRanks - 1) * nvlSharedDevbufSize;
   void* sync = regionPtr_d + pos * sizeof(CtranAlgoDeviceSync);
-  void* buf = reinterpret_cast<char*>(bufBase_d) +
-      pos * NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  void* buf = reinterpret_cast<char*>(bufBase_d) + pos * nvlSharedDevbufSize;
   void* chunkState = reinterpret_cast<char*>(chunkStateBase_d) +
       pos * getPerPeerChunkStatesSize();
   return {reinterpret_cast<CtranAlgoDeviceSync*>(sync), buf, chunkState};
@@ -155,6 +159,8 @@ commResult_t CtranAlgo::initKernelResources() {
   scubaEvent.startAndRecord();
 
   memset(&devState_, 0, sizeof(CtranAlgoDeviceState));
+  const size_t nvlSharedDevbufSize =
+      ctranEffectiveP2pNvlSharedDevbufSize(nLocalRanks);
 
   // Initialize inter-process shared device buffer
   if (!this->sharedRes_) {
@@ -197,7 +203,7 @@ commResult_t CtranAlgo::initKernelResources() {
   // Copy basic comm info to device state for collective kernel to use
   statex->setupDev(devState_.statex);
 
-  devState_.bufSize = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE;
+  devState_.bufSize = nvlSharedDevbufSize;
   devState_.bcastBufSize = NCCL_CTRAN_BCAST_NVL_SHARED_DEVBUF_SIZE;
   devState_.enableTraceLog = NCCL_CTRAN_ENABLE_DEV_TRACE_LOG;
   devState_.enableCancellableWaits = comm_->abortEnabled();
@@ -224,14 +230,18 @@ commResult_t CtranAlgo::initKernelResources() {
         auto [localSync, localBuf, localChunkState] = partitionDevShm(
             this->sharedRes_->mappedDevShmPtrs[localRank],
             nLocalRanks,
-            localPos);
+            localPos,
+            nvlSharedDevbufSize);
         localSyncsMap[i] = localSync;
         localStagingBufsMap[i] = localBuf;
         localChunkStatesMap[i] = localChunkState;
 
         int remotePos = LOCAL_RANK_TO_DEV_REGION_POS(localRank, i);
         auto [remoteSync, remoteBuf, remoteChunkState] = partitionDevShm(
-            this->sharedRes_->mappedDevShmPtrs[i], nLocalRanks, remotePos);
+            this->sharedRes_->mappedDevShmPtrs[i],
+            nLocalRanks,
+            remotePos,
+            nvlSharedDevbufSize);
         remoteSyncsMap[i] = remoteSync;
         remoteStagingBufsMap[i] = remoteBuf;
         remoteChunkStatesMap[i] = remoteChunkState;
@@ -239,7 +249,7 @@ commResult_t CtranAlgo::initKernelResources() {
 
       // Next chunk is for bcastBuf
       peerBcastBufsMap[i] = (char*)this->sharedRes_->mappedDevShmPtrs[i] +
-          (sizeof(CtranAlgoDeviceSync) + NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE +
+          (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize +
            getPerPeerChunkStatesSize()) *
               (nLocalRanks - 1);
       CLOGF_TRACE(
@@ -273,8 +283,8 @@ commResult_t CtranAlgo::initKernelResources() {
           "initKernelResources-nvlTransports"));
 
   comms::pipes::P2pNvlTransportOptions options{
-      .dataBufferSize = NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE /
-          NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
+      .dataBufferSize =
+          nvlSharedDevbufSize / NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH,
       .chunkSize = NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE,
       .pipelineDepth = NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH};
 
@@ -317,6 +327,8 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
   this->comm_ = comm;
   int localRank = statex->localRank();
   int nLocalRanks = statex->nLocalRanks();
+  const size_t nvlSharedDevbufSize =
+      ctranEffectiveP2pNvlSharedDevbufSize(nLocalRanks);
 
   // Create local shared memory region
   // The memory region on each owner rank is divided to (localRanks -1) sets of
@@ -324,9 +336,8 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
   // as below with N localRanks.
   // |bufState_0|bufState_1|...|bufState_N-2|buf_0|buf_1|...|buf_N-2|chunkState_0|chunkState_1|...|chunkState_N-2|
   std::vector<ctran::utils::CtranIpcDesc> ipcDescs(nLocalRanks);
-  size_t shmSize =
-      (sizeof(CtranAlgoDeviceSync) + NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE +
-       getPerPeerChunkStatesSize()) *
+  size_t shmSize = (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize +
+                    getPerPeerChunkStatesSize()) *
           (nLocalRanks - 1) +
       NCCL_CTRAN_BCAST_NVL_SHARED_DEVBUF_SIZE;
 
@@ -376,8 +387,7 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
 
     void* chunkStatePtr_d = reinterpret_cast<char*>(devShmPtr) +
         (nLocalRanks - 1) *
-            (sizeof(CtranAlgoDeviceSync) +
-             NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE) +
+            (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize) +
         pos * getPerPeerChunkStatesSize();
     std::vector<ChunkState> initStates(
         CTRAN_P2P_NVL_DEVMEM_MAX_CHUNKS, ChunkState());
@@ -540,6 +550,7 @@ static const std::unordered_map<std::string, enum NCCL_ALLGATHER_ALGO>
         {"ctrd", NCCL_ALLGATHER_ALGO::ctrd},
         {"ctsrd", NCCL_ALLGATHER_ALGO::ctsrd},
         {"ctbrucks", NCCL_ALLGATHER_ALGO::ctbrucks},
+        {"cthierarchical_ring", NCCL_ALLGATHER_ALGO::cthierarchical_ring},
         {"ctgraph", NCCL_ALLGATHER_ALGO::ctgraph},
         {"ctgraph_pipeline", NCCL_ALLGATHER_ALGO::ctgraph_pipeline},
         {"ctgraph_rdpipeline", NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline},

--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -1,0 +1,443 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <nccl.h>
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+
+int gWarmupIters = 5;
+int gBenchIters = 50;
+std::string gCtranAlgo = "cthierarchical_ring";
+std::optional<size_t> gSizeBytes;
+bool gTotalSizeBytes = false;
+
+#define NCCLCHECK_TEST(cmd)                  \
+  do {                                       \
+    ncclResult_t r = cmd;                    \
+    if (r != ncclSuccess) {                  \
+      printf(                                \
+          "Failed, NCCL error %s:%d '%s'\n", \
+          __FILE__,                          \
+          __LINE__,                          \
+          ncclGetErrorString(r));            \
+      exit(EXIT_FAILURE);                    \
+    }                                        \
+  } while (0)
+
+namespace {
+
+struct Result {
+  size_t sizeBytes{};
+  double ncclGbps{};
+  double ctranGbps{};
+  double ncclLatencyUs{};
+  double ctranLatencyUs{};
+};
+
+std::string formatSize(size_t bytes) {
+  std::ostringstream out;
+  if (bytes >= 1024UL * 1024 * 1024) {
+    out << (bytes / (1024UL * 1024 * 1024)) << " GB";
+  } else if (bytes >= 1024UL * 1024) {
+    out << (bytes / (1024UL * 1024)) << " MB";
+  } else {
+    out << (bytes / 1024UL) << " KB";
+  }
+  return out.str();
+}
+
+std::vector<size_t> benchmarkSizes() {
+  if (gSizeBytes.has_value()) {
+    return {*gSizeBytes};
+  }
+  std::vector<size_t> sizes;
+  for (size_t size = 8 * 1024; size <= 1024UL * 1024 * 1024; size *= 2) {
+    sizes.push_back(size);
+  }
+  return sizes;
+}
+
+std::optional<std::string> parseFlagValue(
+    const std::string& arg,
+    const std::string& name) {
+  const std::string prefix = "--" + name + "=";
+  if (arg.rfind(prefix, 0) == 0) {
+    return arg.substr(prefix.size());
+  }
+  return std::nullopt;
+}
+
+bool parseBoolValue(const std::string& value) {
+  return value == "1" || value == "true" || value == "TRUE" || value == "yes" ||
+      value == "YES" || value == "on" || value == "ON";
+}
+
+class ScopedEnvVar {
+ public:
+  ScopedEnvVar(std::string name, std::optional<std::string> value)
+      : name_(std::move(name)) {
+    const char* oldValue = std::getenv(name_.c_str());
+    oldValue_ = oldValue ? std::optional<std::string>(oldValue) : std::nullopt;
+    if (value.has_value()) {
+      setenv(name_.c_str(), value->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ~ScopedEnvVar() {
+    if (oldValue_.has_value()) {
+      setenv(name_.c_str(), oldValue_->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+ private:
+  std::string name_;
+  std::optional<std::string> oldValue_;
+};
+
+void parseBenchmarkFlags(int* argc, char** argv) {
+  int write = 1;
+  for (int read = 1; read < *argc; ++read) {
+    const std::string arg = argv[read];
+    if (auto value = parseFlagValue(arg, "warmup_iters")) {
+      gWarmupIters = std::stoi(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "bench_iters")) {
+      gBenchIters = std::stoi(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "ctran_algo")) {
+      gCtranAlgo = *value;
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "size_bytes")) {
+      gSizeBytes = std::stoull(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "total_size_bytes")) {
+      gTotalSizeBytes = parseBoolValue(*value);
+      continue;
+    }
+    argv[write++] = argv[read];
+  }
+  *argc = write;
+}
+
+void parseBenchmarkEnv() {
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_WARMUP_ITERS")) {
+    gWarmupIters = std::stoi(value);
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_ITERS")) {
+    gBenchIters = std::stoi(value);
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_ALGO")) {
+    gCtranAlgo = value;
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_SIZE_BYTES")) {
+    gSizeBytes = std::stoull(value);
+  }
+  if (const char* value =
+          std::getenv("CTRAN_ALLGATHER_BENCH_TOTAL_SIZE_BYTES")) {
+    gTotalSizeBytes = parseBoolValue(value);
+  }
+}
+
+bool validateBenchmarkConfig() {
+  if (gWarmupIters < 0) {
+    std::cerr
+        << "--warmup_iters / CTRAN_ALLGATHER_BENCH_WARMUP_ITERS must be >= 0"
+        << std::endl;
+    return false;
+  }
+  if (gBenchIters <= 0) {
+    std::cerr << "--bench_iters / CTRAN_ALLGATHER_BENCH_ITERS must be > 0"
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+enum NCCL_ALLGATHER_ALGO parseCtranAlgo(const std::string& algo) {
+  if (algo == "cthierarchical_ring") {
+    return NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  }
+  if (algo == "ctring") {
+    return NCCL_ALLGATHER_ALGO::ctring;
+  }
+  if (algo == "ctdirect") {
+    return NCCL_ALLGATHER_ALGO::ctdirect;
+  }
+  if (algo == "ctrd") {
+    return NCCL_ALLGATHER_ALGO::ctrd;
+  }
+  if (algo == "ctbrucks") {
+    return NCCL_ALLGATHER_ALGO::ctbrucks;
+  }
+  std::cerr << "Unsupported --ctran_algo=" << algo << std::endl;
+  std::abort();
+}
+
+} // namespace
+
+class CtranAllGatherBenchmark : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 0);
+    setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "8388608", 0);
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 0);
+    setenv("NCCL_DEBUG", "WARN", 0);
+
+    ctran::CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    ctranComm_ = makeCtranComm();
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+
+    ctranAlgo_ = parseCtranAlgo(gCtranAlgo);
+    if (!ctranAllGatherSupport(ctranComm_.get(), ctranAlgo_, stream_)) {
+      GTEST_SKIP() << allGatherAlgoName(ctranAlgo_)
+                   << " is not supported on this topology";
+    }
+
+    ncclUniqueId ncclId;
+    if (globalRank == 0) {
+      NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
+    }
+    std::vector<char> idBuf(numRanks * sizeof(ncclId));
+    memcpy(idBuf.data() + globalRank * sizeof(ncclId), &ncclId, sizeof(ncclId));
+    auto rc =
+        ctranComm_->bootstrap_
+            ->allGather(idBuf.data(), sizeof(ncclId), globalRank, numRanks)
+            .get();
+    EXPECT_EQ(rc, 0) << "Bootstrap allGather for ncclUniqueId failed";
+    memcpy(&ncclId, idBuf.data(), sizeof(ncclId));
+
+    {
+      ScopedEnvVar disableCtran(
+          "NCCL_CTRAN_ENABLE", std::optional<std::string>{"0"});
+      ScopedEnvVar disablePipes(
+          "NCCL_CTRAN_USE_PIPES", std::optional<std::string>{"0"});
+      ScopedEnvVar unsetAllGatherAlgo("NCCL_ALLGATHER_ALGO", std::nullopt);
+      ncclCvarInit();
+      NCCLCHECK_TEST(
+          ncclCommInitRank(&ncclComm_, numRanks, ncclId, globalRank));
+    }
+    ncclCvarInit();
+  }
+
+  void TearDown() override {
+    if (ncclComm_ != nullptr) {
+      ncclCommDestroy(ncclComm_);
+    }
+    if (stream_ != nullptr) {
+      CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    }
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  double maxAcrossRanks(double value) {
+    std::vector<char> buf(numRanks * sizeof(double));
+    memcpy(buf.data() + globalRank * sizeof(double), &value, sizeof(double));
+    auto rc = ctranComm_->bootstrap_
+                  ->allGather(buf.data(), sizeof(double), globalRank, numRanks)
+                  .get();
+    EXPECT_EQ(rc, 0) << "Bootstrap allGather for timing failed";
+
+    double maxValue = 0.0;
+    for (int rank = 0; rank < numRanks; ++rank) {
+      double rankValue;
+      memcpy(&rankValue, buf.data() + rank * sizeof(double), sizeof(double));
+      maxValue = std::max(maxValue, rankValue);
+    }
+    return maxValue;
+  }
+
+  void barrier() {
+    auto rc = ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+    EXPECT_EQ(rc, 0) << "Bootstrap barrier failed";
+  }
+
+  double runNccl(size_t sizeBytes, void* sendbuf, void* recvbuf) {
+    CUDACHECK_TEST(cudaMemset(sendbuf, globalRank, sizeBytes));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, sizeBytes * numRanks));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    barrier();
+    for (int i = 0; i < gWarmupIters; ++i) {
+      NCCLCHECK_TEST(ncclAllGather(
+          sendbuf, recvbuf, sizeBytes, ncclChar, ncclComm_, stream_));
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    barrier();
+
+    cudaEvent_t start, stop;
+    CUDACHECK_TEST(cudaEventCreate(&start));
+    CUDACHECK_TEST(cudaEventCreate(&stop));
+    CUDACHECK_TEST(cudaEventRecord(start, stream_));
+    for (int i = 0; i < gBenchIters; ++i) {
+      NCCLCHECK_TEST(ncclAllGather(
+          sendbuf, recvbuf, sizeBytes, ncclChar, ncclComm_, stream_));
+    }
+    CUDACHECK_TEST(cudaEventRecord(stop, stream_));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    float totalMs = 0.0f;
+    CUDACHECK_TEST(cudaEventElapsedTime(&totalMs, start, stop));
+    CUDACHECK_TEST(cudaEventDestroy(start));
+    CUDACHECK_TEST(cudaEventDestroy(stop));
+    return maxAcrossRanks(totalMs / gBenchIters);
+  }
+
+  double runCtran(size_t sizeBytes, void* sendbuf, void* recvbuf) {
+    CUDACHECK_TEST(cudaMemset(sendbuf, globalRank, sizeBytes));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, sizeBytes * numRanks));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    barrier();
+    for (int i = 0; i < gWarmupIters; ++i) {
+      COMMCHECK_TEST(ctranAllGather(
+          sendbuf,
+          recvbuf,
+          sizeBytes,
+          commChar,
+          ctranComm_.get(),
+          stream_,
+          ctranAlgo_));
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    barrier();
+
+    cudaEvent_t start, stop;
+    CUDACHECK_TEST(cudaEventCreate(&start));
+    CUDACHECK_TEST(cudaEventCreate(&stop));
+    CUDACHECK_TEST(cudaEventRecord(start, stream_));
+    for (int i = 0; i < gBenchIters; ++i) {
+      COMMCHECK_TEST(ctranAllGather(
+          sendbuf,
+          recvbuf,
+          sizeBytes,
+          commChar,
+          ctranComm_.get(),
+          stream_,
+          ctranAlgo_));
+    }
+    CUDACHECK_TEST(cudaEventRecord(stop, stream_));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    float totalMs = 0.0f;
+    CUDACHECK_TEST(cudaEventElapsedTime(&totalMs, start, stop));
+    CUDACHECK_TEST(cudaEventDestroy(start));
+    CUDACHECK_TEST(cudaEventDestroy(stop));
+    return maxAcrossRanks(totalMs / gBenchIters);
+  }
+
+  void printResults(const std::vector<Result>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::cout << "\nNCCL vs ctran AllGather " << allGatherAlgoName(ctranAlgo_)
+              << "\n";
+    std::cout << std::left << std::setw(10) << "Size" << std::right
+              << std::setw(12) << "NCCL GB/s" << std::setw(13) << "Ctran GB/s"
+              << std::setw(9) << "Ratio" << std::setw(14) << "NCCL us"
+              << std::setw(14) << "Ctran us" << "\n";
+    for (const auto& result : results) {
+      const double ratio = result.ctranGbps / result.ncclGbps;
+      std::cout << std::left << std::setw(10) << formatSize(result.sizeBytes)
+                << std::right << std::fixed << std::setprecision(2)
+                << std::setw(12) << result.ncclGbps << std::setw(13)
+                << result.ctranGbps << std::setw(8) << ratio << "x"
+                << std::setprecision(1) << std::setw(14) << result.ncclLatencyUs
+                << std::setw(14) << result.ctranLatencyUs << "\n";
+    }
+    std::cout << std::flush;
+  }
+
+  void runBenchmark() {
+    const auto sizes = benchmarkSizes();
+    const auto sendSizeBytes = [&](size_t sizeBytes) {
+      if (!gTotalSizeBytes) {
+        return sizeBytes;
+      }
+      EXPECT_EQ(sizeBytes % numRanks, 0)
+          << "Total size must be divisible by numRanks";
+      return sizeBytes / numRanks;
+    };
+
+    const size_t maxSizeBytes = sendSizeBytes(sizes.back());
+    void* sendbuf = nullptr;
+    void* recvbuf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&sendbuf, maxSizeBytes));
+    CUDACHECK_TEST(cudaMalloc(&recvbuf, maxSizeBytes * numRanks));
+
+    std::vector<Result> results;
+    for (const size_t resultSizeBytes : sizes) {
+      const size_t sizeBytes = sendSizeBytes(resultSizeBytes);
+      const double ncclMs = runNccl(sizeBytes, sendbuf, recvbuf);
+      const double ctranMs = runCtran(sizeBytes, sendbuf, recvbuf);
+      const double totalBytes = gTotalSizeBytes
+          ? static_cast<double>(resultSizeBytes)
+          : static_cast<double>(sizeBytes) * numRanks;
+      results.push_back(
+          Result{
+              .sizeBytes = resultSizeBytes,
+              .ncclGbps = totalBytes / (ncclMs / 1000.0) / 1e9,
+              .ctranGbps = totalBytes / (ctranMs / 1000.0) / 1e9,
+              .ncclLatencyUs = ncclMs * 1000.0,
+              .ctranLatencyUs = ctranMs * 1000.0,
+          });
+      if (globalRank == 0) {
+        const auto& result = results.back();
+        std::cout << "Finished " << formatSize(resultSizeBytes)
+                  << ": NCCL=" << result.ncclGbps
+                  << " GB/s ctran=" << result.ctranGbps << " GB/s\n";
+      }
+    }
+
+    printResults(results);
+    CUDACHECK_TEST(cudaFree(sendbuf));
+    CUDACHECK_TEST(cudaFree(recvbuf));
+  }
+
+ private:
+  std::unique_ptr<CtranComm> ctranComm_;
+  ncclComm_t ncclComm_{nullptr};
+  cudaStream_t stream_{nullptr};
+  enum NCCL_ALLGATHER_ALGO ctranAlgo_ {
+    NCCL_ALLGATHER_ALGO::cthierarchical_ring
+  };
+};
+
+TEST_F(CtranAllGatherBenchmark, VsNccl) {
+  runBenchmark();
+}
+
+int main(int argc, char* argv[]) {
+  parseBenchmarkEnv();
+  parseBenchmarkFlags(&argc, argv);
+  if (!validateBenchmarkConfig()) {
+    return EXIT_FAILURE;
+  }
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -156,6 +156,17 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   std::unique_ptr<CtranComm> ctranComm{nullptr};
 };
 
+namespace {
+
+const ctran::CtranEnvs kHierarchicalRingEnvs = {
+    {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+    {"NCCL_CTRAN_USE_PIPES", "1"},
+    {"NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1"},
+    {"NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432"},
+};
+
+} // namespace
+
 // Param: (CtranEnvs, (algo, offset, count, inplace, memType, iter, pairColl))
 using CtranAllgatherParams = std::tuple<
     enum NCCL_ALLGATHER_ALGO,
@@ -250,12 +261,15 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
         << " on rank " << globalRank << " received from peer " << i;
   }
 
+  std::vector<CtranMapperBackend> excludedBackends{CtranMapperBackend::NVL};
+  if (algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring) {
+    excludedBackends.push_back(CtranMapperBackend::IB);
+  }
   verifyBackendsUsed(
       ctranComm->ctran_.get(),
       ctranComm->statex_.get(),
       memType,
-      // AllGatherDirect uses kernel bcast not NVL iput
-      {CtranMapperBackend::NVL});
+      excludedBackends);
   verifyGpeLeak(ctranComm->ctran_.get());
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -439,6 +453,21 @@ INSTANTIATE_TEST_SUITE_P(
             testing::Values(kTestInPlace, kTestOutOfPlace),
             testing::Values(kCuMemAllocDisjoint),
             testing::Values(5),
+            testing::Values(kTestPairNone))),
+    getTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTestHierarchicalRing,
+    CtranAllgatherTestParam,
+    ::testing::Combine(
+        ::testing::Values(kHierarchicalRingEnvs),
+        ::testing::Combine(
+            testing::Values(NCCL_ALLGATHER_ALGO::cthierarchical_ring),
+            testing::Values(0),
+            testing::Values(8192, 1),
+            testing::Values(kTestInPlace, kTestOutOfPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(1),
             testing::Values(kTestPairNone))),
     getTestName);
 

--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -181,6 +181,23 @@ Config::Config(const ncclConfig_t* config) {
           "pipesUseDualStateBuffer", NCCL_CTRAN_PIPES_USE_DUAL_STATE_BUFFER);
     }
   }
+  {
+    std::string val = getHintStr("pipesIbgdaDataBufferSize");
+    if (!val.empty()) {
+      try {
+        auto parsed = std::stoull(val);
+        if (parsed > 0) {
+          pipesIbgdaDataBufferSize = parsed;
+        } else {
+          WARN("NCCLX hint 'pipesIbgdaDataBufferSize': value must be positive");
+        }
+      } catch (const std::exception&) {
+        WARN(
+            "NCCLX hint 'pipesIbgdaDataBufferSize': invalid value '%s'",
+            val.c_str());
+      }
+    }
+  }
 
   ibLazyConnect = parseHintBool("ibLazyConnect", NCCL_CTRAN_IBGDA_LAZY_CONNECT);
 

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -33,6 +33,7 @@ class Config {
   // When set, override the corresponding CVARs for this communicator.
   std::optional<size_t> pipesNvlChunkSize;
   std::optional<bool> pipesUseDualStateBuffer;
+  std::optional<size_t> pipesIbgdaDataBufferSize;
   int vCliqueSize = 0;
 
   // Per-communicator buffer size override (Simple protocol).
@@ -56,6 +57,15 @@ inline const std::vector<std::string>& knownHintKeys() {
       "splitGroupRanks",
       "ncclAllGatherAlgo",
       "fastInitMode",
+      "useCtran",
+      "usePatAvg",
+      "noLocal",
+      "sendrecvAlgo",
+      "allgatherAlgo",
+      "allreduceAlgo",
+      "pipesIbgdaDataBufferSize",
+      "alltoallvAlgo",
+      "rmaAlgo",
       "pipesNvlChunkSize",
       "pipesUseDualStateBuffer",
       "vCliqueSize",

--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -54,6 +54,8 @@ inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctsrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "cthierarchical_ring";
     case NCCL_ALLGATHER_ALGO::ctgraph:
       return "ctgraph";
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -83,6 +85,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctsrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "cthierarchical_ring") {
+    val = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
   } else if (str == "ctgraph") {
     val = NCCL_ALLGATHER_ALGO::ctgraph;
   } else if (str == "ctgraph_pipeline") {

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -1,0 +1,179 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ncclx::algoconf {
+
+inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
+  } else if (str == "ctgraph") {
+    val = NCCL_SENDRECV_ALGO::ctgraph;
+  } else {
+    val = NCCL_SENDRECV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLGATHER_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLGATHER_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLGATHER_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLGATHER_ALGO::ctring;
+  } else if (str == "ctrd") {
+    val = NCCL_ALLGATHER_ALGO::ctrd;
+  } else if (str == "ctsrd") {
+    val = NCCL_ALLGATHER_ALGO::ctsrd;
+  } else if (str == "ctbrucks") {
+    val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "cthierarchical_ring") {
+    val = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph;
+  } else if (str == "ctgraph_pipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  } else if (str == "ctgraph_rdpipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline;
+  } else if (str == "ctgraph_ring") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
+  } else if (str == "ctgraph_rd") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rd;
+  } else {
+    val = NCCL_ALLGATHER_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLREDUCE_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLREDUCE_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLREDUCE_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else {
+    val = NCCL_ALLREDUCE_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLTOALLV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLTOALLV_ALGO::ctran;
+  } else if (str == "compCtran") {
+    val = NCCL_ALLTOALLV_ALGO::compCtran;
+  } else if (str == "bsCompCtran") {
+    val = NCCL_ALLTOALLV_ALGO::bsCompCtran;
+  } else {
+    val = NCCL_ALLTOALLV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(const std::string& str, enum NCCL_RMA_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_RMA_ALGO::ctran;
+  } else {
+    val = NCCL_RMA_ALGO::orig;
+  }
+}
+
+inline std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
+  switch (val) {
+    case NCCL_SENDRECV_ALGO::orig:
+      return "orig";
+    case NCCL_SENDRECV_ALGO::ctran:
+      return "ctran";
+    case NCCL_SENDRECV_ALGO::ctzcopy:
+      return "ctzcopy";
+    case NCCL_SENDRECV_ALGO::ctp2p:
+      return "ctp2p";
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      return "ctgraph";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
+  switch (val) {
+    case NCCL_ALLGATHER_ALGO::orig:
+      return "orig";
+    case NCCL_ALLGATHER_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLGATHER_ALGO::ctring:
+      return "ctring";
+    case NCCL_ALLGATHER_ALGO::ctrd:
+      return "ctrd";
+    case NCCL_ALLGATHER_ALGO::ctsrd:
+      return "ctsrd";
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+      return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "cthierarchical_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "ctgraph";
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      return "ctgraph_pipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      return "ctgraph_rdpipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      return "ctgraph_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return "ctgraph_rd";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
+  switch (val) {
+    case NCCL_ALLREDUCE_ALGO::orig:
+      return "orig";
+    case NCCL_ALLREDUCE_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLREDUCE_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLREDUCE_ALGO::ctring:
+      return "ctring";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLTOALLV_ALGO val) {
+  switch (val) {
+    case NCCL_ALLTOALLV_ALGO::orig:
+      return "orig";
+    case NCCL_ALLTOALLV_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLTOALLV_ALGO::compCtran:
+      return "compCtran";
+    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
+      return "bsCompCtran";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_RMA_ALGO val) {
+  switch (val) {
+    case NCCL_RMA_ALGO::orig:
+      return "orig";
+    case NCCL_RMA_ALGO::ctran:
+      return "ctran";
+  }
+  return "unknown";
+}
+
+} // namespace ncclx::algoconf

--- a/comms/ncclx/meta/wrapper/MetaFactory.cc
+++ b/comms/ncclx/meta/wrapper/MetaFactory.cc
@@ -53,6 +53,10 @@ ctranConfig makeCtranConfigFrom(ncclComm* comm) {
           ncclxCfg->pipesUseDualStateBuffer.value() ? 1 : 0;
     }
     tconfig.pipesConfig.ibLazyConnect = ncclxCfg->ibLazyConnect;
+    if (ncclxCfg->pipesIbgdaDataBufferSize.has_value()) {
+      tconfig.pipesConfig.ibgdaDataBufferSize =
+          static_cast<int64_t>(ncclxCfg->pipesIbgdaDataBufferSize.value());
+    }
   }
   return tconfig;
 }

--- a/comms/pipes/collectives/AllGatherDirect.cu
+++ b/comms/pipes/collectives/AllGatherDirect.cu
@@ -2,6 +2,7 @@
 
 #include "comms/pipes/collectives/AllGatherDirect.cuh"
 
+#include "comms/common/AtomicUtils.cuh"
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/P2pIbgdaTransportDevice.cuh"
@@ -168,12 +169,267 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
 #endif
 }
 
+namespace {
+
+__device__ __forceinline__ std::size_t ceil_div(
+    std::size_t numerator,
+    std::size_t denominator) {
+  return denominator == 0 ? 0 : (numerator + denominator - 1) / denominator;
+}
+
+__device__ __forceinline__ ThreadGroup make_sub_block_group(
+    const ThreadGroup& group,
+    uint32_t group_id,
+    uint32_t total_groups) {
+  return ThreadGroup{
+      .thread_id_in_group = group.thread_id_in_group,
+      .group_size = group.group_size,
+      .group_id = group_id,
+      .total_groups = total_groups,
+      .scope = group.scope};
+}
+
+__device__ __forceinline__ uint64_t load_ready_counter(const uint64_t* ptr) {
+  return comms::device::ld_acquire_sys_global(ptr);
+}
+
+__device__ __forceinline__ void publish_ready(
+    ThreadGroup& group,
+    uint64_t* ready_counters,
+    std::size_t idx,
+    uint64_t sequence) {
+  __threadfence();
+  group.sync();
+  if (group.is_leader()) {
+    comms::device::st_release_sys_global(ready_counters + idx, sequence);
+  }
+  group.sync();
+}
+
+__device__ __forceinline__ void wait_ready(
+    ThreadGroup& group,
+    const uint64_t* ready_counters,
+    std::size_t idx,
+    uint64_t sequence,
+    const Timeout& timeout) {
+  while (load_ready_counter(ready_counters + idx) != sequence) {
+    TIMEOUT_TRAP_IF_EXPIRED(
+        timeout,
+        group,
+        "hierarchical allgather waiting for ready counter idx=%llu sequence=%llu",
+        static_cast<unsigned long long>(idx),
+        static_cast<unsigned long long>(sequence));
+  }
+  group.sync();
+}
+
+} // namespace
+
+template <int kBlockSize>
+__global__
+__launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
+    const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto base_group = make_block_group();
+  const std::size_t chunk_bytes = args.chunk_bytes;
+  const std::size_t total_chunks = ceil_div(args.sendcount, chunk_bytes);
+  if (chunk_bytes == 0 || total_chunks == 0) {
+    return;
+  }
+
+  const bool is_ib_block = base_group.group_id < args.ib_num_blocks;
+  if (is_ib_block) {
+    auto group = make_sub_block_group(
+        base_group, base_group.group_id, args.ib_num_blocks);
+    const int W = args.ib_size;
+
+    for (std::size_t chunk = group.group_id; chunk < total_chunks;
+         chunk += group.total_groups) {
+      const std::size_t off = chunk * chunk_bytes;
+      const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+          ? chunk_bytes
+          : (args.sendcount - off);
+      const char* send_src = args.sendbuf + off;
+      char* own_dst = args.recvbuf +
+          (static_cast<std::size_t>(args.ib_rank) * args.nvl_size +
+           args.nvl_rank) *
+              args.sendcount +
+          off;
+
+      if (W <= 1) {
+        memcpy_vectorized(own_dst, send_src, bytes, group);
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+            args.ready_sequence);
+        continue;
+      }
+
+      const auto& topo = args.ib_ring;
+      auto& prev = *topo.prev;
+      auto& next = *topo.next;
+      const int stride = (args.ib_rank - topo.prev_rank + W) % W;
+      const std::size_t ib_window = next.pipeline_window(args.ib_num_blocks);
+      PIPES_DEVICE_CHECK_MSG(
+          ib_window != 0,
+          "hierarchical allgather overlap IB pipeline window is zero");
+
+      for (std::size_t chunk_off = 0; chunk_off < bytes;
+           chunk_off += ib_window) {
+        const std::size_t remaining = bytes - chunk_off;
+        const std::size_t window =
+            remaining < ib_window ? remaining : ib_window;
+
+        next.template send<MemcpyAndSelfCopy>(
+            group,
+            send_src + chunk_off,
+            window,
+            args.ib_num_blocks,
+            args.ib_signaling_data_size,
+            timeout,
+            own_dst + chunk_off);
+
+        int fwd_current_rank = args.ib_rank;
+        for (int step = 0; step < W - 1; step++) {
+          fwd_current_rank = (fwd_current_rank + W - stride) % W;
+          char* dst = args.recvbuf +
+              (static_cast<std::size_t>(fwd_current_rank) * args.nvl_size +
+               args.nvl_rank) *
+                  args.sendcount +
+              off + chunk_off;
+
+          if (step < W - 2) {
+            prev.forward(
+                group,
+                dst,
+                next,
+                window,
+                args.ib_num_blocks,
+                args.ib_signaling_data_size,
+                timeout);
+          } else {
+            prev.recv(
+                group,
+                dst,
+                window,
+                args.ib_num_blocks,
+                args.ib_signaling_data_size,
+                timeout);
+          }
+        }
+      }
+
+      publish_ready(
+          group,
+          args.ready_counters,
+          static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+          args.ready_sequence);
+
+      int fwd_ready_rank = args.ib_rank;
+      for (int step = 0; step < W - 1; step++) {
+        fwd_ready_rank = (fwd_ready_rank + W - stride) % W;
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(fwd_ready_rank) * total_chunks + chunk,
+            args.ready_sequence);
+      }
+    }
+    return;
+  }
+
+  if (args.nvl_size <= 1) {
+    return;
+  }
+
+  const uint32_t nvl_group_id = base_group.group_id - args.ib_num_blocks;
+  auto group =
+      make_sub_block_group(base_group, nvl_group_id, args.nvl_num_blocks);
+  const std::size_t total_tasks =
+      static_cast<std::size_t>(args.ib_size) * total_chunks;
+  const std::size_t nvl_window = direct_pipeline_window(
+      args.nvl_peers, args.nvl_rank, args.nvl_size, args.nvl_num_blocks);
+  PIPES_DEVICE_CHECK_MSG(
+      nvl_window != 0,
+      "hierarchical allgather overlap NVLink pipeline window is zero");
+
+  for (std::size_t task = group.group_id; task < total_tasks;
+       task += group.total_groups) {
+    const std::size_t chunk = task / static_cast<std::size_t>(args.ib_size);
+    const int ib_src =
+        static_cast<int>(task % static_cast<std::size_t>(args.ib_size));
+    const std::size_t off = chunk * chunk_bytes;
+    const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+        ? chunk_bytes
+        : (args.sendcount - off);
+
+    wait_ready(
+        group,
+        args.ready_counters,
+        static_cast<std::size_t>(ib_src) * total_chunks + chunk,
+        args.ready_sequence,
+        timeout);
+
+    const char* send_src = args.recvbuf +
+        (static_cast<std::size_t>(ib_src) * args.nvl_size + args.nvl_rank) *
+            args.sendcount +
+        off;
+    for (std::size_t chunk_off = 0; chunk_off < bytes;
+         chunk_off += nvl_window) {
+      const std::size_t remaining = bytes - chunk_off;
+      const std::size_t window =
+          remaining < nvl_window ? remaining : nvl_window;
+
+      for (int peer_rank = 0; peer_rank < args.nvl_size; ++peer_rank) {
+        if (peer_rank == args.nvl_rank) {
+          continue;
+        }
+        auto peer = args.nvl_peers[peer_rank];
+        peer.send(
+            group,
+            send_src + chunk_off,
+            window,
+            args.nvl_num_blocks,
+            args.nvl_signaling_data_size,
+            timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < args.nvl_size; ++peer_rank) {
+        if (peer_rank == args.nvl_rank) {
+          continue;
+        }
+        char* dst = args.recvbuf +
+            (static_cast<std::size_t>(ib_src) * args.nvl_size + peer_rank) *
+                args.sendcount +
+            off + chunk_off;
+        auto peer = args.nvl_peers[peer_rank];
+        peer.recv(
+            group,
+            dst,
+            window,
+            args.nvl_num_blocks,
+            args.nvl_signaling_data_size,
+            timeout);
+      }
+    }
+  }
+#endif
+}
+
 template __global__ void direct_allgather_nvl_kernel<512>(
     const __grid_constant__ DirectAllgatherNvlArgs,
     Timeout);
 
 template __global__ void hierarchical_allgather_fused_kernel<512>(
     const __grid_constant__ HierarchicalAllgatherFusedArgs,
+    Timeout);
+
+template __global__ void hierarchical_allgather_overlap_kernel<512>(
+    const __grid_constant__ HierarchicalAllgatherOverlapArgs,
     Timeout);
 
 } // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherDirect.cuh
+++ b/comms/pipes/collectives/AllGatherDirect.cuh
@@ -20,4 +20,10 @@ __global__
         const __grid_constant__ HierarchicalAllgatherFusedArgs args,
         Timeout timeout);
 
+template <int kBlockSize>
+__global__
+    __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
+        const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
+        Timeout timeout);
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherDirectTypes.h
+++ b/comms/pipes/collectives/AllGatherDirectTypes.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/collectives/DirectCollectiveTypes.h"
@@ -36,6 +37,26 @@ struct HierarchicalAllgatherFusedArgs {
   std::size_t sendcount{0};
   std::size_t ib_signaling_data_size{0};
   std::size_t nvl_signaling_data_size{0};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+struct HierarchicalAllgatherOverlapArgs {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  int ib_num_blocks{0};
+  int nvl_num_blocks{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  std::size_t chunk_bytes{0};
+  uint64_t ready_sequence{0};
+  uint64_t* ready_counters{nullptr};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -92,4 +92,54 @@ void launch_hierarchical_allgather_fused(
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
+void launch_hierarchical_allgather_overlap(
+    const HierarchicalAllgatherOverlapLaunchParams& params) {
+  validate_direct_nvl(params.nvl_size);
+  if (params.ib_size < 1 ||
+      params.ib_size * params.nvl_size != params.num_ranks) {
+    throw std::runtime_error("Invalid hierarchical allgather rank geometry");
+  }
+  if (params.ib_num_blocks < 1 || params.nvl_num_blocks < 1) {
+    throw std::runtime_error(
+        "Hierarchical overlap allgather requires positive block counts");
+  }
+  if (params.chunk_bytes == 0) {
+    throw std::runtime_error(
+        "Hierarchical overlap allgather requires positive chunk_bytes");
+  }
+  if (params.ready_counters == nullptr) {
+    throw std::runtime_error(
+        "Hierarchical overlap allgather requires ready counters");
+  }
+
+  HierarchicalAllgatherOverlapArgs args{};
+  args.num_ranks = params.num_ranks;
+  args.ib_rank = params.ib_rank;
+  args.ib_size = params.ib_size;
+  args.nvl_rank = params.nvl_rank;
+  args.nvl_size = params.nvl_size;
+  args.ib_num_blocks = params.ib_num_blocks;
+  args.nvl_num_blocks = params.nvl_num_blocks;
+  args.sendcount = params.sendcount;
+  args.ib_signaling_data_size = params.ib_signaling_data_size;
+  args.nvl_signaling_data_size = params.nvl_signaling_data_size;
+  args.chunk_bytes = params.chunk_bytes;
+  args.ready_sequence = params.ready_sequence;
+  args.ready_counters = params.ready_counters;
+  args.sendbuf = params.sendbuf;
+  args.recvbuf = params.recvbuf;
+  args.ib_ring = params.ib_ring;
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == params.nvl_rank) {
+      continue;
+    }
+    new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
+  }
+
+  hierarchical_allgather_overlap_kernel<512>
+      <<<params.ib_num_blocks + params.nvl_num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/AllGatherLauncher.h
+++ b/comms/pipes/collectives/AllGatherLauncher.h
@@ -47,4 +47,29 @@ struct HierarchicalAllgatherLaunchParams {
 void launch_hierarchical_allgather_fused(
     const HierarchicalAllgatherLaunchParams& params);
 
+struct HierarchicalAllgatherOverlapLaunchParams {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t sendcount{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  std::size_t chunk_bytes{0};
+  uint64_t ready_sequence{0};
+  uint64_t* ready_counters{nullptr};
+  const char* sendbuf{nullptr};
+  char* recvbuf{nullptr};
+  int ib_num_blocks{16};
+  int nvl_num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  HierarchicalAllgatherIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_hierarchical_allgather_overlap(
+    const HierarchicalAllgatherOverlapLaunchParams& params);
+
 } // namespace comms::pipes

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1117,6 +1117,85 @@ cvars:
      Split messages larger than NCCL_CTRAN_AG_RING_MIN_SPLIT_SIZE into this many
      messages.
 
+ - name        : NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Number of CUDA thread blocks for the cthierarchical_ring AllGather IB
+     ring phase. For 4x1 IB-only tests, this is the full hierarchical kernel
+     grid size because the NVLink fanout degenerates to nvl_size=1.
+
+ - name        : NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable the experimental overlapped cthierarchical_ring AllGather kernel.
+     When enabled, dedicated IB blocks publish chunk-ready counters and
+     dedicated NVLink blocks fan out chunks as soon as they arrive.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Number of CUDA thread blocks for the experimental overlapped
+     cthierarchical_ring AllGather NVLink fanout role.
+
+ - name        : NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES
+   type        : uint64_t
+   default     : 4194304
+   description : |-
+     Logical chunk size, in bytes, used by the experimental overlapped
+     cthierarchical_ring AllGather kernel for IB-ready notification and
+     NVLink fanout scheduling.
+
+ - name        : NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE
+   type        : uint64_t
+   default     : 33554432
+   description : |-
+     Minimum IBGDA send/recv data-buffer size to use when the experimental
+     overlapped cthierarchical_ring AllGather kernel is enabled. 0 disables
+     this algorithm-specific minimum and uses NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE
+     or the per-communicator pipesIbgdaDataBufferSize directly.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_SHARED_DEVBUF_SIZE
+   type        : uint64_t
+   default     : 67108864
+   description : |-
+     Minimum total per-peer NVLink shared device-buffer size to use when the
+     experimental overlapped cthierarchical_ring AllGather kernel is enabled.
+     This value is divided by NCCL_CTRAN_P2P_NVL_COPY_PIPELINE_DEPTH before
+     configuring each pipeline slot. 0 disables this algorithm-specific
+     minimum and uses NCCL_CTRAN_P2P_NVL_SHARED_DEVBUF_SIZE directly.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC
+   type        : int
+   default     : 4
+   description : |-
+     Number of IBGDA QP sets per peer per NIC for the cthierarchical_ring
+     AllGather algorithm.
+
+ - name        : NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Maximum bytes per signaled sub-chunk for the cthierarchical_ring IBGDA
+     send/recv phase. 0 means each block signals once per per-block staging
+     slot.
+
+ - name        : NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES
+   type        : uint64_t
+   default     : 0
+   description : |-
+     Maximum bytes per signaled sub-chunk for the cthierarchical_ring NVLink
+     fanout phase. 0 means each block signals once per per-block staging slot.
+
+ - name        : NCCL_CTRAN_HIER_AG_TIMEOUT_MS
+   type        : float
+   default     : 30000.0
+   description : |-
+     Timeout in milliseconds for the cthierarchical_ring AllGather kernel.
+     0 means no timeout.
+
 
  - name        : NCCL_CTRAN_AG_RD_RTR
    type        : bool
@@ -1776,6 +1855,31 @@ cvars:
      On timeout, materializePeer throws rather than hanging.
      No per-comm override.
 
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable send/recv staging buffers for IBGDA transport in Pipes
+     MultiPeerTransport. Required for cthierarchical_ring. When enabled,
+     allocates additional GPU memory for pipelined send/recv staging per
+     IBGDA peer. The effective IBGDA data-buffer size must be positive via
+     NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or the per-communicator
+     pipesIbgdaDataBufferSize hint.
+
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS
+   type        : int
+   default     : 128
+   description : |-
+     Maximum number of block-groups for IBGDA send/recv staging.
+     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
+
+ - name        : NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH
+   type        : int
+   default     : 2
+   description : |-
+     Pipeline depth (number of staging ring slots) for IBGDA send/recv.
+     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
+
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket
@@ -1973,7 +2077,7 @@ cvars:
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctrd, ctsrd, ctbrucks, ctgraph, ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd
+   choices     : orig, ctran, ctdirect, ctring, ctrd, ctsrd, ctbrucks, cthierarchical_ring, ctgraph, ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd
    description : |-
      The algorithm to use for Allgather communication
      orig - Copy-based ring algorithm
@@ -1982,6 +2086,7 @@ cvars:
      ctring - Ctran-based ring algorithm
      ctrd - Ctran-based recursive doubling algorithm
      ctsrd - Ctran-based streamed recursive doubling algorithm
+     cthierarchical_ring - Pipes-based hierarchical AllGather using an inter-node IBGDA ring per local rank followed by intra-node NVLink fanout; with nLocalRanks==1 it degenerates to the hierarchical kernel's IB-only phase
      ctgraph - Cudagraph-aware: auto-selects pipeline/ring/rd based on topology during graph capture
      ctgraph_pipeline - Cudagraph-aware: forces persistent pipeline algorithm (nLocalRanks>1)
      ctgraph_rdpipeline - Cudagraph-aware: forces persistent recursive-doubling pipeline algorithm (nLocalRanks>1, nNodes power of 2)


### PR DESCRIPTION
Summary:

Adds a non-persistent AllGather benchmark (`AllGatherBench.cc`) that provides head-to-head comparison of NCCL `ncclAllGather` against ctran `ctranAllGather` with `cthierarchical_ring` (or any ctran algorithm). The benchmark creates two separate communicators -- one pure NCCL baseline with ctran disabled, one ctran-enabled -- to ensure fair, isolated comparison without ctran overhead or memory allocation affecting the NCCL baseline measurements.

## Benchmark Architecture

```
SetUp:
+----------------------------------------------+
| 1. Set default env vars:                      |
|    NCCL_CTRAN_ENABLE=1                        |
|    NCCL_CTRAN_USE_PIPES=1                     |
|    NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1         |
|    NCCL_COMM_STATE_DEBUG_TOPO=nolocal         |
|                                               |
| 2. Create ctranComm (Pipes + IBGDA enabled)   |
|                                               |
| 3. Bootstrap allGather for ncclUniqueId       |
|                                               |
| 4. Create NCCL baseline comm with ctran OFF:  |
|    ScopedEnvVar("NCCL_CTRAN_ENABLE", "0")     |
|    ScopedEnvVar("NCCL_CTRAN_USE_PIPES", "0")  |
|    ncclCvarInit()  (re-read CVARs)            |
|    ncclCommInitRank()  (pure NCCL comm)       |
|                                               |
| 5. Restore ctran env vars + ncclCvarInit()    |
+----------------------------------------------+

Per-size Benchmark:
+----------------------------------------------+
| For each size in [8KB, 16KB, ..., 1GB]:       |
|                                               |
|   runNccl(size):                              |
|     memset sendbuf/recvbuf                    |
|     barrier()                                 |
|     warmup (gWarmupIters iterations)          |
|     cudaEventRecord(start)                    |
|     bench (gBenchIters iterations)            |
|     cudaEventRecord(stop)                     |
|     cudaStreamSynchronize()                   |
|     -> maxAcrossRanks(elapsed / iters)        |
|                                               |
|   runCtran(size):                             |
|     memset sendbuf/recvbuf                    |
|     barrier()                                 |
|     warmup (gWarmupIters iterations)          |
|     cudaEventRecord(start)                    |
|     bench (gBenchIters iterations)            |
|     cudaEventRecord(stop)                     |
|     cudaStreamSynchronize()                   |
|     -> maxAcrossRanks(elapsed / iters)        |
+----------------------------------------------+

Output:
+----------------------------------------------+
| Size    NCCL GB/s  Ctran GB/s  Ratio  Latency |
| 8 KB    X.XX       Y.YY        Z.ZZx  ...     |
| 16 KB   ...        ...         ...    ...     |
| ...                                           |
| 1 GB    ...        ...         ...    ...     |
+----------------------------------------------+
```

## Features

### Dual-Communicator Isolation
The NCCL baseline communicator is created while ctran is completely disabled via `ScopedEnvVar` RAII wrappers that temporarily set `NCCL_CTRAN_ENABLE=0` and `NCCL_CTRAN_USE_PIPES=0`. This prevents ctran initialization overhead, Pipes transport memory allocation, and IBGDA QP creation from affecting the NCCL baseline measurements.

### Timing Methodology
- **CUDA events**: Uses `cudaEventRecord`/`cudaEventElapsedTime` for GPU-accurate timing without host-side jitter
- **Max-latency aggregation**: Reports `max(elapsed)` across all ranks via bootstrap allGather, ensuring the slowest rank's time is reported (AllGather is complete only when the last rank finishes)
- **Warmup/measurement separation**: Configurable warmup iterations (default 5) run before timed iterations (default 50)

### Configuration Options

| Flag / Env Var | Default | Description |
|---|---|---|
| `--warmup_iters` / `CTRAN_ALLGATHER_BENCH_WARMUP_ITERS` | 5 | Warmup iterations before timing |
| `--bench_iters` / `CTRAN_ALLGATHER_BENCH_ITERS` | 50 | Timed iterations for measurement |
| `--ctran_algo` / `CTRAN_ALLGATHER_BENCH_ALGO` | `cthierarchical_ring` | ctran algorithm to benchmark (`cthierarchical_ring`, `ctring`, `ctdirect`, `ctrd`, `ctbrucks`) |
| `--size_bytes` / `CTRAN_ALLGATHER_BENCH_SIZE_BYTES` | (sweep) | Fixed per-rank send size; if unset, sweeps 8 KB through 1 GB |
| `--total_size_bytes` / `CTRAN_ALLGATHER_BENCH_TOTAL_SIZE_BYTES` | false | Treat `--size_bytes` as total AllGather output size (divided by numRanks for per-rank send) |

### Output Metrics
- **Per-rank send size** (formatted as KB/MB/GB)
- **NCCL algorithmic bandwidth** (GB/s)
- **Ctran algorithmic bandwidth** (GB/s)
- **Speedup ratio** (ctran/NCCL)
- **NCCL latency** (microseconds)
- **Ctran latency** (microseconds)

### BUCK Target
- `fbcode//comms/ctran/benchmarks:allgather_bench_4x1` -- 4 nodes x 1 GPU/node configuration with `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE=8MB`, `NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1`, `NCCL_CTRAN_USE_PIPES=1`, 1200s RE timeout

## Implementation Details

- Inherits from `ctran::CtranDistTestFixture` for MPI bootstrap, rank discovery, and `CtranComm` construction
- Uses `makeCtranComm()` for the ctran communicator (gets full Pipes + IBGDA transport setup)
- Uses `ncclCommInitRank()` for the NCCL baseline communicator (standard NCCL initialization)
- `ScopedEnvVar` RAII class saves/restores environment variables with automatic cleanup
- `parseBenchmarkFlags()` removes benchmark-specific flags before passing to GTest and folly
- `parseBenchmarkEnv()` reads environment variable overrides (lower priority than flags)
- Supports all ctran AllGather algorithms via `parseCtranAlgo()` dispatch

Reviewed By: elvinlife

Differential Revision: D105521695


