### PR TITLE
Add asymmetric window allocation test (#2592)

### DIFF
--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -57,7 +57,10 @@ class WindowRmaTest(unittest.TestCase):
         self.rank = self.torchcomm.get_rank()
         self.num_ranks = self.torchcomm.get_size()
         self.device = self.torchcomm.get_device()
-        self.allocator = self.torchcomm.get_mem_allocator()
+        try:
+            self.allocator = self.torchcomm.get_mem_allocator()
+        except RuntimeError:
+            self.allocator = None
 
         # Probe NCCL symmetric-window support. NCCL_WIN_COLL_SYMMETRIC needs a
         # transport that can expose VMM-backed memory across ranks (NVLink
@@ -219,6 +222,56 @@ class WindowRmaTest(unittest.TestCase):
         win.tensor_deregister()
         del win
         del pool
+
+    def _new_window_lifecycle_test(self):
+        """Test full window lifecycle: create, register, verify, deregister."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        self.assertIsNotNone(win)
+
+        win.tensor_register(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _new_window_create_with_tensor_test(self):
+        """new_window(tensor) registers the tensor during creation."""
+        num_elements = 512
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _register_error_handling_test(self):
+        """Double register raises, deregister without register raises."""
+        num_elements = 256
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_register(buf)
+
+        win.tensor_deregister()
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_deregister()
+
+        del win
+        torch.cuda.synchronize()
 
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -273,6 +273,21 @@ class WindowRmaTest(unittest.TestCase):
         del win
         torch.cuda.synchronize()
 
+    def _asymmetric_window_lifecycle_test(self):
+        """Test window lifecycle with different buffer sizes per rank."""
+        num_elements = 1024 * (self.rank + 1)
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):
         """Run all tests with all parameter combinations."""


### PR DESCRIPTION
Summary:

Add _asymmetric_window_lifecycle_test helper to WindowRmaTest that uses rank-dependent buffer sizes (1024 * (rank+1) elements). This verifies that MCCL winAllocate correctly handles different sizes per rank, matching the asymmetric allocation support in the underlying CTran layer.

The MCCL NewWindowTest calls this helper directly to exercise the asymmetric path.

Reviewed By: goelayu

Differential Revision: D105590852


