### PR TITLE
RMA window-based persistent alltoall

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -215,6 +215,15 @@ commResult_t ctranGet(
     CtranComm* comm,
     cudaStream_t stream);
 
+commResult_t ctranFetchAdd(
+    void* resultBuf,
+    uint64_t addVal,
+    size_t targetIndex,
+    int peer,
+    ctran::CtranWin* win,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 void ctranGroupTrackDefaultOp(CtranComm* comm);
 
 namespace ctran {

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -297,6 +297,24 @@ commResult_t AllToAllPExec(
 
 commResult_t AllToAllPDestroy(CtranPersistentRequest* request);
 
+/* Window-based alltoall using the same CE+IB algorithm as AllToAllP.
+ * Buffer metadata is sourced from CtranWin (post-exchange) instead of
+ * PersistArgs. The window must have been allocated and exchanged before init.
+ */
+commResult_t AllToAllWinInit(
+    CtranWin* win,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    CtranPersistentRequest*& request);
+
+commResult_t AllToAllWinExec(
+    const void* sendbuff,
+    const size_t count,
+    CtranPersistentRequest* request);
+
+commResult_t AllToAllWinDestroy(CtranPersistentRequest* request);
+
 // Global pointer-based memory registration (does not require a comm).
 // If forceReg is true, registration happens even in async/lazy mode.
 commResult_t globalRegisterWithPtr(

--- a/comms/ctran/algos/AllToAll/WinAllToAll.cc
+++ b/comms/ctran/algos/AllToAll/WinAllToAll.cc
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
+#include "comms/ctran/algos/AllToAll/HostTypes.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/window/CtranWin.h"
+
+using ctran::alltoallp::AlgoImpl;
+
+#define CHECK_VALID_PREQ(pReq)                                        \
+  do {                                                                \
+    if (!(pReq)) {                                                    \
+      FB_ERRORRETURN(                                                 \
+          commInvalidArgument,                                        \
+          "Null PersistentRequest passed to {}",                      \
+          __func__);                                                  \
+    }                                                                 \
+    if (pReq->type != CtranPersistentRequest::Type::ALLTOALL_P_WIN) { \
+      FB_ERRORRETURN(                                                 \
+          commInvalidArgument,                                        \
+          "Unexpected PersistentRequest type {} called into {}",      \
+          pReq->type,                                                 \
+          __func__);                                                  \
+    }                                                                 \
+  } while (0)
+
+namespace ctran {
+
+commResult_t AllToAllWinInit(
+    CtranWin* win,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream,
+    CtranPersistentRequest*& request) {
+  const auto statex = comm->statex_.get();
+  const auto nRanks = statex->nRanks();
+
+  if (win->remWinInfo.empty() ||
+      static_cast<int>(win->remWinInfo.size()) != nRanks) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Window remWinInfo not populated (size {}). "
+        "Was exchange() called?",
+        win->remWinInfo.size());
+  }
+
+  auto algo = std::make_unique<AlgoImpl>(comm, stream);
+
+  algo->pArgs.recvbuff = win->winDataPtr;
+  algo->pArgs.recvHdl = win->dataRegHdl;
+  algo->pArgs.maxRecvCount = win->dataBytes / commTypeSize(datatype);
+  algo->pArgs.datatype = datatype;
+  algo->pArgs.skipCtrlMsg = true;
+  algo->pArgs.remoteRecvBuffs.resize(nRanks);
+  algo->pArgs.remoteAccessKeys.resize(nRanks);
+  for (int r = 0; r < nRanks; r++) {
+    algo->pArgs.remoteRecvBuffs[r] = win->remWinInfo[r].dataAddr;
+    algo->pArgs.remoteAccessKeys[r] = win->remWinInfo[r].dataRkey;
+  }
+
+  request = new CtranPersistentRequest(
+      CtranPersistentRequest::Type::ALLTOALL_P_WIN, comm, stream);
+  request->algo = algo.release();
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "AllToAllWinInit: rank {} initialized request {}, "
+      "recvbuff {}, comm {} commHash {:x} [nranks={}] stream={}",
+      statex->rank(),
+      (void*)request,
+      win->winDataPtr,
+      (void*)comm,
+      statex->commHash(),
+      nRanks,
+      (void*)stream);
+
+  return commSuccess;
+}
+
+commResult_t AllToAllWinExec(
+    const void* sendbuff,
+    const size_t count,
+    CtranPersistentRequest* request) {
+  CHECK_VALID_PREQ(request);
+  auto* algo = reinterpret_cast<AlgoImpl*>(request->algo);
+  CLOGF_TRACE(
+      COLL,
+      "AllToAllWinExec: rank {} started executing request {}, sendbuff {} recvbuff {} count {}",
+      request->comm_->statex_->rank(),
+      (void*)request,
+      sendbuff,
+      (void*)algo->pArgs.recvbuff,
+      count);
+  return algo->exec(sendbuff, count);
+}
+
+commResult_t AllToAllWinDestroy(CtranPersistentRequest* request) {
+  CHECK_VALID_PREQ(request);
+
+  auto* algo = reinterpret_cast<AlgoImpl*>(request->algo);
+  delete algo;
+  request->algo = nullptr;
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "AllToAllWinDestroy: rank {} destroyed request {}",
+      request->comm_->statex_->rank(),
+      (void*)request);
+
+  return commSuccess;
+}
+
+} // namespace ctran

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -220,6 +220,7 @@ class CtranPersistentRequest {
     ALLTOALL_P,
     ALLTOALLV_DEDUP,
     ALLGATHER_P_WIN,
+    ALLTOALL_P_WIN,
   };
 
   Type type;

--- a/comms/ctran/algos/RMA/Atomic.cc
+++ b/comms/ctran/algos/RMA/Atomic.cc
@@ -1,0 +1,195 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <memory>
+
+#include "Types.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/colltrace/CollTraceWrapper.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/utils/logger/LogUtils.h"
+
+using namespace ctran;
+using ::meta::comms::colltrace::CollTraceHandleTriggerState;
+
+extern __global__ void ncclKernelFetchAdd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    CtranKernelFetchAddArgs args);
+
+static commResult_t fetchAddImpl(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto comm = op->comm_;
+  auto win = op->fetchadd.win;
+  int peerRank = op->fetchadd.peerRank;
+
+  CtranAlgoRMALogger logger("fetchAdd", op->opCount, peerRank, win, comm);
+
+  if (!comm->ctran_->mapper->hasBackend(peerRank, CtranMapperBackend::IB)) {
+    CLOGF(ERR, "fetchAdd only supports IB backend for now");
+    return commInternalError;
+  }
+
+  const size_t targetOffsetBytes = op->fetchadd.targetIndex * sizeof(uint64_t);
+  void* remoteAddr = reinterpret_cast<void*>(
+      reinterpret_cast<uintptr_t>(win->remWinInfo[peerRank].dataAddr) +
+      targetOffsetBytes);
+
+  void* localMemHdl = nullptr;
+  bool localReg = false;
+  FB_COMMCHECK(comm->ctran_->mapper->searchRegHandle(
+      op->fetchadd.resultBuf, sizeof(uint64_t), &localMemHdl, &localReg));
+
+  CLOGF_TRACE(
+      COLL,
+      "fetchAddImpl: resultBuf {}, remoteAddr {} (base {} + offset {}), addVal {}",
+      op->fetchadd.resultBuf,
+      remoteAddr,
+      win->remWinInfo[peerRank].dataAddr,
+      targetOffsetBytes,
+      op->fetchadd.addVal);
+
+  auto fetchAddReq = std::make_unique<CtranMapperRequest>();
+  FB_COMMCHECK(comm->ctran_->mapper->ifetchAndAdd(
+      op->fetchadd.resultBuf,
+      remoteAddr,
+      op->fetchadd.addVal,
+      peerRank,
+      CtranMapperConfig{
+          .memHdl_ = localMemHdl,
+          .remoteAccessKey_ = win->remWinInfo[peerRank].dataRkey,
+      },
+      fetchAddReq.get()));
+
+  FB_COMMCHECK(comm->ctran_->mapper->waitRequest(fetchAddReq.get()));
+
+  if (localReg) {
+    FB_COMMCHECK(comm->ctran_->mapper->deregDynamic(localMemHdl));
+  }
+  return commSuccess;
+}
+
+commResult_t ctranFetchAdd(
+    void* resultBuf,
+    uint64_t addVal,
+    size_t targetIndex,
+    int peer,
+    CtranWin* win,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  const auto winOpCount = win->updateOpCount(peer);
+  const auto fetchAddOpCount =
+      win->updateOpCount(peer, window::OpCountType::kFetchAdd);
+  auto statex = comm->statex_.get();
+
+  CLOGF_SUBSYS(
+      INFO,
+      COLL,
+      "CTRAN-RMA ctranFetchAdd: opCount {} winOpCount {} resultBuf {} addVal {} "
+      "targetIndex {} rank {} peer {} win {} stream={}",
+      fetchAddOpCount,
+      winOpCount,
+      resultBuf,
+      addVal,
+      targetIndex,
+      statex->rank(),
+      peer,
+      (void*)win,
+      (void*)stream);
+
+  if (!win->isAtomicCapable()) {
+    CLOGF(
+        ERR,
+        "ctranFetchAdd requires an atomic_capable window (data buffer must be 8-byte aligned and size must be a multiple of 8 bytes)");
+    return commInvalidArgument;
+  }
+
+  auto remoteDataAddr =
+      reinterpret_cast<uintptr_t>(win->remWinInfo[peer].dataAddr);
+  if (remoteDataAddr % sizeof(uint64_t) != 0) {
+    CLOGF(
+        ERR,
+        "Remote window data buffer {} is not 8-byte aligned for peer {}",
+        remoteDataAddr,
+        peer);
+    return commInvalidArgument;
+  }
+
+  size_t peerWinSize = win->getDataSize(peer);
+  if (peerWinSize % sizeof(uint64_t) != 0) {
+    CLOGF(
+        ERR,
+        "Peer {}'s window size {} is not a multiple of 8 bytes, not suitable for atomic operations",
+        peer,
+        peerWinSize);
+    return commInvalidArgument;
+  }
+
+  size_t targetOffsetBytes = targetIndex * sizeof(uint64_t);
+  if ((targetOffsetBytes + sizeof(uint64_t)) > peerWinSize) {
+    CLOGF(
+        ERR,
+        "Invalid targetIndex {}: offset {} + 8 bytes exceeds peer {}'s window size {}",
+        targetIndex,
+        targetOffsetBytes,
+        peer,
+        peerWinSize);
+    return commInvalidArgument;
+  }
+
+  KernelConfig config = KernelConfig(
+      KernelConfig::KernelType::FETCHADD, stream, "FetchAdd", fetchAddOpCount);
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+
+  if (statex->node(peer) == statex->node() && win->nvlEnabled(peer)) {
+    uint64_t* remoteAddr = reinterpret_cast<uint64_t*>(
+        reinterpret_cast<uintptr_t>(win->remWinInfo[peer].dataAddr) +
+        targetOffsetBytes);
+
+    auto colltraceHandle = meta::comms::colltrace::getCollTraceHandleRMA(
+        comm, opGroup, config, true);
+    colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+
+    CtranKernelFetchAddArgs kernArgs{
+        .remoteAddr = remoteAddr,
+        .addVal = addVal,
+        .resultAddr = reinterpret_cast<uint64_t*>(resultBuf),
+    };
+    config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+
+    FB_COMMCHECK(comm->ctran_->gpe->submit(
+        std::move(opGroup),
+        fetchAddImpl,
+        config,
+        reinterpret_cast<void*>(ncclKernelFetchAdd)));
+
+    colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+    return commSuccess;
+  }
+
+  // IB path: GPE callback does the work; kernel only coordinates with GPE.
+  // Set remoteAddr to nullptr so the kernel skips the NVL atomic.
+  CtranKernelFetchAddArgs kernArgs{};
+  config.algoArgs = reinterpret_cast<void*>(&kernArgs);
+
+  struct OpElem* op =
+      new struct OpElem(OpElem::opType::FETCHADD, comm, fetchAddOpCount);
+  op->fetchadd.resultBuf = resultBuf;
+  op->fetchadd.targetIndex = targetIndex;
+  op->fetchadd.addVal = addVal;
+  op->fetchadd.peerRank = peer;
+  op->fetchadd.win = win;
+  opGroup.push_back(std::unique_ptr<struct OpElem>(op));
+
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup),
+      fetchAddImpl,
+      config,
+      reinterpret_cast<void*>(ncclKernelFetchAdd)));
+  return commSuccess;
+}

--- a/comms/ctran/algos/RMA/Atomic.cu
+++ b/comms/ctran/algos/RMA/Atomic.cu
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+#else
+#include <cuda/atomic>
+#endif
+
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/RMA/Types.h"
+#include "comms/ctran/algos/common/GpeKernelDev.cuh"
+
+__global__ void ncclKernelFetchAdd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    CtranKernelFetchAddArgs args) {
+  const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
+  if (flag && gtIdx == 0) {
+    ctran::device::devLoadAbortFlags(flag, devState);
+    ctran::device::KernelStartGpe(flag);
+  }
+
+  if (gtIdx == 0 && args.remoteAddr != nullptr) {
+#if defined(__HIP_PLATFORM_AMD__)
+    // TODO: implement atomic operations for AMD GPUs.
+    __builtin_trap();
+#else
+    ::cuda::atomic_ref<uint64_t, cuda::thread_scope_system> ref{
+        *args.remoteAddr};
+    uint64_t oldVal =
+        ref.fetch_add(args.addVal, cuda::std::memory_order_relaxed);
+    if (args.resultAddr != nullptr) {
+      *args.resultAddr = oldVal;
+    }
+#endif
+  }
+
+  if (flag && gtIdx == 0) {
+    ctran::device::KernelWaitGpeTerminate(flag);
+  }
+}

--- a/comms/ctran/algos/RMA/Types.h
+++ b/comms/ctran/algos/RMA/Types.h
@@ -36,3 +36,9 @@ struct CtranKernelSignalArgs {
   uint64_t* signalAddr;
   uint64_t signalVal;
 };
+
+struct CtranKernelFetchAddArgs {
+  uint64_t* remoteAddr;
+  uint64_t addVal;
+  uint64_t* resultAddr;
+};

--- a/comms/ctran/colltrace/CollTraceWrapper.cc
+++ b/comms/ctran/colltrace/CollTraceWrapper.cc
@@ -317,6 +317,13 @@ CollectiveMetadata getCollectiveMetadata(
           .opCount = opCount,
       };
     }
+    case KernelConfig::KernelType::FETCHADD: {
+      return CollectiveMetadata{
+          .opName = "FetchAdd",
+          .algoName = kernelConfig.algoName,
+          .opCount = opCount,
+      };
+    }
     // Skip P2P kernel types. We intentionally don't use default so that
     // whenever ctran adds a new kernel type, we will get a compile error
     case KernelConfig::KernelType::SEND:

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -53,7 +53,8 @@ struct OpElem {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    FETCHADD
   } type;
   cudaStream_t stream;
 
@@ -245,6 +246,13 @@ struct OpElem {
       int peerRank;
       ctran::CtranWin* win;
     } get;
+    struct {
+      void* resultBuf;
+      size_t targetIndex;
+      uint64_t addVal;
+      int peerRank;
+      ctran::CtranWin* win;
+    } fetchadd;
   };
 
  public:
@@ -296,7 +304,8 @@ struct KernelConfig {
     PUTSIGNAL,
     WAITSIGNAL,
     SIGNAL,
-    GET
+    GET,
+    FETCHADD
   } type;
   unsigned int numBlocks{1};
   unsigned int numThreads{1};

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -598,6 +598,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return atomicSetImpl(dbuf, val, peerRank, config, req);
   }
 
+  inline commResult_t ifetchAndAdd(
+      const void* sbuf,
+      void* dbuf,
+      uint64_t addVal,
+      int peerRank,
+      CtranMapperConfig config,
+      CtranMapperRequest* req) {
+    return ifetchAndAddImpl(sbuf, dbuf, addVal, peerRank, config, req);
+  }
+
   /* Post a Flush op to ensure data received from the network is visible from
    * all GPU threads.
    * Input arguments:
@@ -950,6 +960,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       case CtranMapperRequest::ReqType::IB_PUT:
       case CtranMapperRequest::ReqType::IB_GET:
       case CtranMapperRequest::ReqType::ATOMIC_SET:
+      case CtranMapperRequest::ReqType::FETCH_AND_ADD:
       case CtranMapperRequest::ReqType::TCPDM_PUT:
       case CtranMapperRequest::ReqType::SEND_SYNC_CTRL:
       case CtranMapperRequest::ReqType::RECV_SYNC_CTRL:
@@ -1839,6 +1850,45 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         dbuf);
     FB_COMMCHECK(this->ctranIb->iatomicSet(
         dbuf, val, peerRank, remoteAccessKey.ibKey, ibReqPtr));
+    return commSuccess;
+  }
+
+  inline commResult_t ifetchAndAddImpl(
+      const void* sbuf,
+      void* dbuf,
+      uint64_t addVal,
+      int peerRank,
+      CtranMapperConfig config,
+      CtranMapperRequest* req) {
+    const auto& remoteAccessKey = config.remoteAccessKey_;
+    if (remoteAccessKey.backend != CtranMapperBackend::IB) {
+      CLOGF(ERR, "CTRAN-MAPPER: ifetchAndAdd only supports IB backend");
+      return commInternalError;
+    }
+    if (req != nullptr) {
+      req->type = CtranMapperRequest::ReqType::FETCH_AND_ADD;
+      req->peer = peerRank;
+      req->backend = CtranMapperBackend::IB;
+      req->setConfig(config);
+    }
+    auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(config.memHdl_);
+    auto regLk = regElem->stateMnger.rlock();
+    CtranIbRequest* ibReqPtr = (req == nullptr ? nullptr : &(req->ibReq));
+    CLOGF_TRACE(
+        COLL,
+        "CTRAN-MAPPER: Post IB FETCH_AND_ADD to rank {}: addVal {} dbuf {} sbuf {}",
+        peerRank,
+        addVal,
+        dbuf,
+        sbuf);
+    FB_COMMCHECK(this->ctranIb->ifetchAndAdd(
+        sbuf,
+        dbuf,
+        addVal,
+        peerRank,
+        regElem->ibRegElem,
+        remoteAccessKey.ibKey,
+        ibReqPtr));
     return commSuccess;
   }
 

--- a/comms/ctran/mapper/CtranMapperRequest.cc
+++ b/comms/ctran/mapper/CtranMapperRequest.cc
@@ -10,7 +10,8 @@ static std::unordered_map<CtranMapperRequest::ReqType, std::string> reqTypeStr =
      {CtranMapperRequest::ReqType::SEND_SYNC_CTRL, "SEND_SYNC_CTRL"},
      {CtranMapperRequest::ReqType::RECV_SYNC_CTRL, "RECV_SYNC_CTRL"},
      {CtranMapperRequest::ReqType::IB_PUT, "IB_PUT"},
-     {CtranMapperRequest::ReqType::NVL_PUT, "NVL_PUT"}};
+     {CtranMapperRequest::ReqType::NVL_PUT, "NVL_PUT"},
+     {CtranMapperRequest::ReqType::FETCH_AND_ADD, "FETCH_AND_ADD"}};
 
 const std::string getReqTypeStr(CtranMapperRequest::ReqType type) {
   return reqTypeStr[type];

--- a/comms/ctran/mapper/CtranMapperTypes.h
+++ b/comms/ctran/mapper/CtranMapperTypes.h
@@ -109,7 +109,8 @@ class CtranMapperRequest {
     NVL_PUT,
     TCPDM_PUT,
     COPY,
-    ATOMIC_SET
+    ATOMIC_SET,
+    FETCH_AND_ADD
   };
   CtranMapperRequest() {
     CtranMapperRequest(SEND_CTRL, -1, CtranMapperBackend::IB);

--- a/comms/ctran/tests/CtranDistAlltoAllPTest.cc
+++ b/comms/ctran/tests/CtranDistAlltoAllPTest.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/colltrace/CollTraceWrapper.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/window/CtranWin.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -191,6 +192,63 @@ class ctranAllToAllPTest : public ctran::CtranDistTestFixture,
   int numTimesRunExec{7};
   size_t bufNbytes{0};
 };
+
+TEST_F(ctranAllToAllPTest, WinAllToAll) {
+  if (!ctran::CtranWin::allToAllWinSupported(ctranComm.get())) {
+    GTEST_SKIP() << "allToAllWin not supported on this topology";
+  }
+
+  const size_t bufNbytes = maxRecvCount * sizeof(int);
+
+  void* winBase = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&winBase, bufNbytes));
+  ctran::CtranWin* win = nullptr;
+  ASSERT_EQ(
+      ctranWinRegister(winBase, bufNbytes, ctranComm.get(), &win), commSuccess);
+
+  sendBuf = (int*)createDataBuf(bufNbytes, true);
+
+  CtranPersistentRequest* pRequest = nullptr;
+  ASSERT_EQ(
+      ctran::AllToAllWinInit(
+          win, commInt, ctranComm.get(), testStream, pRequest),
+      commSuccess);
+  ASSERT_NE(pRequest, nullptr);
+
+  for (int x = 0; x < numTimesRunExec; x++) {
+    generateDistRandomExpValue();
+    generateDistRandomCount(/*small_msg*/ x == 0);
+
+    for (int i = 0; i < numRanks; ++i) {
+      assignChunkValue<int>(
+          sendBuf + count * i, count, expectedVal + globalRank * 100 + i + 1);
+    }
+    CUDACHECK_TEST(cudaMemsetAsync(winBase, 0, bufNbytes, testStream));
+
+    ASSERT_EQ(ctran::AllToAllWinExec(sendBuf, count, pRequest), commSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+    int* recvbuff = (int*)winBase;
+    for (int i = 0; i < numRanks; ++i) {
+      int errs = checkChunkValue<int>(
+          recvbuff + count * i, count, expectedVal + i * 100 + globalRank + 1);
+      EXPECT_EQ(errs, 0) << "rank " << globalRank << " checked chunk " << i
+                         << " at " << recvbuff + count * i << " with " << errs
+                         << " errors";
+    }
+  }
+
+  verifyGpeLeak(ctranComm->ctran_.get());
+
+  auto destroyRes = ctran::AllToAllWinDestroy(pRequest);
+  ASSERT_EQ(destroyRes, commSuccess);
+  delete pRequest;
+
+  releaseDataBuf(sendBuf, bufNbytes, true);
+  sendBuf = nullptr;
+  ASSERT_EQ(ctranWinFree(win), commSuccess);
+  CUDACHECK_TEST(cudaFree(winBase));
+}
 
 class ctranAllToAllPTestParam
     : public ctranAllToAllPTest,

--- a/comms/ctran/tests/CtranDistRMATest.cc
+++ b/comms/ctran/tests/CtranDistRMATest.cc
@@ -673,6 +673,164 @@ TEST_P(RMATestSignalParam, winSignalWait) {
   CUDACHECK_TEST(cudaStreamDestroy(wait_stream));
 }
 
+class RMAAtomicTestParam
+    : public CtranRMATest,
+      public ::testing::WithParamInterface<std::tuple<size_t, MemAllocType>> {};
+
+// Basic fetchAdd: each rank atomically increments a counter on the next peer.
+// Verifies both the final counter value and that fetched old values are
+// monotonically increasing (single writer per slot).
+TEST_P(RMAAtomicTestParam, winFetchAdd) {
+  const auto& [kNumIters, bufType] = GetParam();
+  const bool userBuf = true;
+
+  auto statex = ctranComm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+  EXPECT_EQ(statex->nRanks(), this->numRanks);
+
+  cudaStream_t atomic_stream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&atomic_stream, cudaStreamNonBlocking));
+
+  const auto rank = statex->rank();
+  const auto numRanks = statex->nRanks();
+
+  // Allocate window with one uint64_t counter per rank
+  size_t sizeBytes = numRanks * sizeof(uint64_t);
+  meta::comms::Hints hints;
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  createWin(userBuf, bufType, &winBase, &win, sizeBytes, hints);
+
+  CUDACHECK_TEST(cudaMemset(winBase, 0, sizeBytes));
+  barrier();
+
+  // Collect fetched old values to verify monotonicity
+  uint64_t* resultBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&resultBuf, kNumIters * sizeof(uint64_t)));
+
+  int nextPeer = (rank + 1) % numRanks;
+
+  // Each rank does kNumIters fetchAdd(1) on the next peer's counter[rank]
+  for (size_t iter = 0; iter < kNumIters; iter++) {
+    COMMCHECK_TEST(ctranFetchAdd(
+        resultBuf + iter,
+        1,
+        rank,
+        nextPeer,
+        win,
+        ctranComm.get(),
+        atomic_stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(atomic_stream));
+  barrier();
+
+  // Verify final counter value on local window
+  int prevPeer = (rank + numRanks - 1) % numRanks;
+  uint64_t hostVal = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &hostVal,
+      reinterpret_cast<uint64_t*>(winBase) + prevPeer,
+      sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(hostVal, kNumIters)
+      << "Rank " << rank << ": counter at slot[" << prevPeer << "] expected "
+      << kNumIters << " got " << hostVal;
+
+  // Verify fetched old values are monotonically increasing: 0, 1, 2, ...
+  // Since this rank is the only writer to slot[rank] on nextPeer, the
+  // returned sequence must be consecutive.
+  std::vector<uint64_t> hostResults(kNumIters);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostResults.data(),
+      resultBuf,
+      kNumIters * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  for (size_t i = 0; i < kNumIters; i++) {
+    EXPECT_EQ(hostResults[i], i)
+        << "Rank " << rank << ": fetchAdd iter " << i << " returned "
+        << hostResults[i] << " expected " << i;
+  }
+
+  CUDACHECK_TEST(cudaFree(resultBuf));
+  auto res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+  freeWinBuf(userBuf, winBase, sizeBytes, bufType);
+  CUDACHECK_TEST(cudaStreamDestroy(atomic_stream));
+}
+
+// Multi-rank contention: all ranks atomically add to a single counter on
+// rank 0's window at slot[0]. Verifies the final counter equals
+// (numRanks - 1) * kNumIters.
+TEST_P(RMAAtomicTestParam, winFetchAddContention) {
+  const auto& [kNumIters, bufType] = GetParam();
+  const bool userBuf = true;
+
+  auto statex = ctranComm->statex_.get();
+  ASSERT_NE(statex, nullptr);
+  EXPECT_EQ(statex->nRanks(), this->numRanks);
+
+  cudaStream_t atomic_stream;
+  CUDACHECK_TEST(
+      cudaStreamCreateWithFlags(&atomic_stream, cudaStreamNonBlocking));
+
+  const auto rank = statex->rank();
+  const auto numRanks = statex->nRanks();
+
+  size_t sizeBytes = sizeof(uint64_t);
+  CtranWin* win = nullptr;
+  void* winBase = nullptr;
+  createWin(userBuf, bufType, &winBase, &win, sizeBytes, {});
+
+  CUDACHECK_TEST(cudaMemset(winBase, 0, sizeBytes));
+  barrier();
+
+  uint64_t* resultBuf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&resultBuf, sizeof(uint64_t)));
+
+  // All non-zero ranks atomically add to rank 0's counter
+  if (rank != 0) {
+    for (size_t iter = 0; iter < kNumIters; iter++) {
+      COMMCHECK_TEST(ctranFetchAdd(
+          resultBuf, 1, 0, 0, win, ctranComm.get(), atomic_stream));
+    }
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(atomic_stream));
+  barrier();
+
+  // Rank 0 verifies the final value
+  if (rank == 0) {
+    uint64_t hostVal = 0;
+    CUDACHECK_TEST(cudaMemcpy(
+        &hostVal, winBase, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    uint64_t expected = static_cast<uint64_t>(numRanks - 1) * kNumIters;
+    EXPECT_EQ(hostVal, expected) << "Rank 0: contention counter expected "
+                                 << expected << " got " << hostVal;
+  }
+
+  CUDACHECK_TEST(cudaFree(resultBuf));
+  auto res = ctranWinFree(win);
+  EXPECT_EQ(res, commSuccess);
+  freeWinBuf(userBuf, winBase, sizeBytes, bufType);
+  CUDACHECK_TEST(cudaStreamDestroy(atomic_stream));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RMAAtomicTestInstance,
+    RMAAtomicTestParam,
+    ::testing::Combine(
+        ::testing::Values(10, 100),
+        ::testing::Values(
+            MemAllocType::kMemCuMemAlloc,
+            MemAllocType::kMemCudaMalloc)),
+    [](const ::testing::TestParamInfo<RMAAtomicTestParam::ParamType>& info) {
+      const auto kNumIters = std::get<0>(info.param);
+      const auto bufType = std::get<1>(info.param);
+      std::string name = fmt::format(
+          "numIters{}_{}", kNumIters, testMemAllocTypeToStr(bufType));
+      return name;
+    });
+
 INSTANTIATE_TEST_SUITE_P(
     RMATestInstance,
     CtranRMATestParam,

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -162,6 +162,11 @@ struct CtranWin {
     return allGatherPSupported(comm);
   }
 
+  static bool allToAllWinSupported(CtranComm* comm);
+  bool allToAllWinSupported() const {
+    return allToAllWinSupported(comm);
+  }
+
  private:
   DevMemType bufType_{DevMemType::kCumem};
   // whether allocate window data buffer or provided by users

--- a/comms/ctran/window/Types.h
+++ b/comms/ctran/window/Types.h
@@ -16,6 +16,7 @@ enum OpCountType {
   kWaitSignal = 2,
   kSignal = 3,
   kGet = 4,
+  kFetchAdd = 5,
 };
 
 struct RemWinInfo {

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -172,6 +172,10 @@ bool CtranWin::allGatherPSupported(CtranComm* comm) {
   return true;
 }
 
+bool CtranWin::allToAllWinSupported(CtranComm* comm) {
+  return allGatherPSupported(comm);
+}
+
 commResult_t CtranWin::allocate(void* userBufPtr) {
   auto statex = comm->statex_.get();
   const auto myRank = statex->rank();

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -130,6 +130,7 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/Barrier.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/Checksum.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/PutSignal.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/Get.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/Atomic.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/DevShmState.cu
 SRCS += all_reduce_sparse_block.cu
 

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -135,6 +135,7 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/Barrier.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/Checksum.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/PutSignal.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/Get.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/RMA/Atomic.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/DevShmState.cu
 SRCS += all_reduce_sparse_block.cu
 


### PR DESCRIPTION
Summary:
Implements a window-based AllToAll (AllToAllWinInit/Exec/Destroy) that reuses the existing AllToAllPImpl algorithm by sourcing buffer metadata (remote addresses, access keys, registration handles) from CtranWin post-exchange instead of PersistArgs. This avoids duplicating the CE+IB data-movement logic and keeps the window-based path consistent with the persistent AllToAll.

Key changes:
```
  - WinAllToAll.cc: Populates AlgoImpl::pArgs from win->remWinInfo and sets skipCtrlMsg=true (the window already exchanged
  handles), then delegates to algo->exec()
  - CtranWin: Adds allToAllWinSupported() (delegates to allGatherPSupported — same topology requirements)
  - CtranDistAlltoAllPTest.cc: Adds WinAllToAll test that allocates a window via ctranWinRegister, runs multiple exec
  iterations with random counts, and verifies per-chunk correctness
```

Differential Revision: D97861423


