### PR TITLE
Implement `TorchCommWindowMCCL::get` via MCCL `IWindow::get` (#2598)

### DIFF
--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -200,6 +200,14 @@ class WaitSignalOptions {
   WaitSignalOptions() : timeout(kNoTimeout) {}
 };
 
+class GetOptions {
+ public:
+  std::unordered_map<std::string, std::string> hints;
+  std::chrono::milliseconds timeout;
+
+  GetOptions() : timeout(kNoTimeout) {}
+};
+
 class AllGatherPInitOptions {
  public:
   std::unordered_map<std::string, std::string> hints;

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -912,6 +912,53 @@ Example:
           py::arg("timeout") = std::nullopt,
           py::call_guard<py::gil_scoped_release>())
       .def(
+          "get",
+          [](TorchCommWindow& self,
+             at::Tensor& tensor,
+             int src_rank,
+             size_t source_offset_nelems,
+             bool async_op,
+             std::optional<std::unordered_map<std::string, std::string>> hints,
+             std::optional<std::chrono::milliseconds> timeout) {
+            GetOptions opts;
+            if (hints) {
+              opts.hints = *hints;
+            }
+            if (timeout) {
+              opts.timeout = *timeout;
+            }
+            return self.get(
+                tensor, src_rank, source_offset_nelems, async_op, opts);
+          },
+          R"(
+Read data from a remote rank's window buffer into a local tensor (one-sided get).
+
+The remote rank does not participate; use ``signal``/``wait_signal`` to
+synchronize if needed.
+
+Args:
+    tensor (torch.Tensor): Local buffer to receive data into.
+    src_rank (int): Source rank to read from.
+    source_offset_nelems (int): Offset in source buffer (in elements).
+    async_op (bool): If True, returns TorchWork for async completion.
+    hints (Dict[str, str], optional): Backend-specific hints.
+    timeout (timedelta, optional): Operation timeout.
+
+Returns:
+    TorchWork: Work object for synchronization.
+
+Raises:
+    RuntimeError: If request exceeds window buffer size.
+
+      )",
+          py::arg("tensor"),
+          py::arg("src_rank"),
+          py::arg("source_offset_nelems"),
+          py::arg("async_op"),
+          py::arg("hints") = std::nullopt,
+          py::arg("timeout") = std::nullopt,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
           "get_attr",
           &TorchCommWindow::get_attr,
           R"(

--- a/comms/torchcomms/TorchCommWindow.hpp
+++ b/comms/torchcomms/TorchCommWindow.hpp
@@ -67,6 +67,15 @@ class TorchCommWindow {
       bool asyncOp,
       const WaitSignalOptions& options = {}) = 0;
 
+  virtual c10::intrusive_ptr<TorchWork> get(
+      at::Tensor& /*tensor*/,
+      int /*srcRank*/,
+      size_t /*sourceOffsetNelems*/,
+      bool /*asyncOp*/,
+      const GetOptions& /*options*/ = {}) {
+    throw std::runtime_error("get is not yet supported by this backend");
+  }
+
   virtual std::shared_ptr<TorchCommWindowAttr> get_attr(int peerRank) = 0;
 
   // ==========================================================================

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -57,7 +57,10 @@ class WindowRmaTest(unittest.TestCase):
         self.rank = self.torchcomm.get_rank()
         self.num_ranks = self.torchcomm.get_size()
         self.device = self.torchcomm.get_device()
-        self.allocator = self.torchcomm.get_mem_allocator()
+        try:
+            self.allocator = self.torchcomm.get_mem_allocator()
+        except RuntimeError:
+            self.allocator = None
 
         # Probe NCCL symmetric-window support. NCCL_WIN_COLL_SYMMETRIC needs a
         # transport that can expose VMM-backed memory across ranks (NVLink
@@ -219,6 +222,56 @@ class WindowRmaTest(unittest.TestCase):
         win.tensor_deregister()
         del win
         del pool
+
+    def _new_window_lifecycle_test(self):
+        """Test full window lifecycle: create, register, verify, deregister."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        self.assertIsNotNone(win)
+
+        win.tensor_register(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _new_window_create_with_tensor_test(self):
+        """new_window(tensor) registers the tensor during creation."""
+        num_elements = 512
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
+    def _register_error_handling_test(self):
+        """Double register raises, deregister without register raises."""
+        num_elements = 256
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_register(buf)
+
+        win.tensor_deregister()
+
+        with self.assertRaises(RuntimeError):
+            win.tensor_deregister()
+
+        del win
+        torch.cuda.synchronize()
 
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -317,6 +317,30 @@ class WindowRmaTest(unittest.TestCase):
         del win
         torch.cuda.synchronize()
 
+    def _window_signal_basic_test(self):
+        """Test that signal() returns valid work and completes (sync and async)."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        dst_rank = (self.rank + 1) % self.num_ranks
+
+        work = win.signal(dst_rank, False)
+        self.assertIsNotNone(work)
+        work.wait()
+        self.torchcomm.barrier(False)
+
+        async_work = win.signal(dst_rank, True)
+        self.assertIsNotNone(async_work)
+        async_work.wait()
+        self.torchcomm.barrier(False)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):
         """Run all tests with all parameter combinations."""

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -273,6 +273,21 @@ class WindowRmaTest(unittest.TestCase):
         del win
         torch.cuda.synchronize()
 
+    def _asymmetric_window_lifecycle_test(self):
+        """Test window lifecycle with different buffer sizes per rank."""
+        num_elements = 1024 * (self.rank + 1)
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+
+        expected_size = num_elements * buf.element_size()
+        self.assertEqual(win.get_size(), expected_size)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):
         """Run all tests with all parameter combinations."""

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -288,6 +288,35 @@ class WindowRmaTest(unittest.TestCase):
         del win
         torch.cuda.synchronize()
 
+    def _window_put_basic_test(self):
+        """Test that put() returns valid work and completes (sync and async)."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+        self.assertEqual(win.get_size(), num_elements * buf.element_size())
+
+        input_tensor = (
+            torch.ones(num_elements, dtype=torch.float32, device=self.device)
+            * self.rank
+        )
+        dst_rank = (self.rank + 1) % self.num_ranks
+
+        work = win.put(input_tensor, dst_rank, 0, False)
+        self.assertIsNotNone(work)
+        work.wait()
+        self.torchcomm.barrier(False)
+
+        async_work = win.put(input_tensor, dst_rank, 0, True)
+        self.assertIsNotNone(async_work)
+        async_work.wait()
+        self.torchcomm.barrier(False)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):
         """Run all tests with all parameter combinations."""

--- a/comms/torchcomms/tests/integration/py/WindowRmaTest.py
+++ b/comms/torchcomms/tests/integration/py/WindowRmaTest.py
@@ -341,6 +341,33 @@ class WindowRmaTest(unittest.TestCase):
         del win
         torch.cuda.synchronize()
 
+    def _window_get_basic_test(self):
+        """Test that get() returns valid work and completes (sync and async)."""
+        num_elements = 1024
+        buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+        recv_buf = torch.zeros(num_elements, dtype=torch.float32, device=self.device)
+
+        win = self.torchcomm.new_window()
+        win.tensor_register(buf)
+        self.assertEqual(win.get_size(), num_elements * buf.element_size())
+        self.torchcomm.barrier(False)
+
+        src_rank = (self.rank - 1 + self.num_ranks) % self.num_ranks
+
+        work = win.get(recv_buf, src_rank, 0, False)
+        self.assertIsNotNone(work)
+        work.wait()
+        self.torchcomm.barrier(False)
+
+        async_work = win.get(recv_buf, src_rank, 0, True)
+        self.assertIsNotNone(async_work)
+        async_work.wait()
+        self.torchcomm.barrier(False)
+
+        win.tensor_deregister()
+        del win
+        torch.cuda.synchronize()
+
     @unittest.skipIf(_rma_skip, _rma_skip_reason)
     def test_all_tests(self):
         """Run all tests with all parameter combinations."""


### PR DESCRIPTION
Summary:

Implements `get()` on `TorchCommWindowMCCL` by delegating to MCCL `IWindow::get()`. This reads data from a remote rank's window buffer into a local tensor — the reverse direction of `put`.

Also adds:
- `GetOptions` class in `TorchCommOptions.hpp` (follows existing `PutOptions`/`SignalOptions` pattern)
- `get()` virtual method on `TorchCommWindow` base class with a default throw, so existing backends (NCCLX, HCCL, Gloo) continue to compile unchanged

Differential Revision: D105596912


