### PR TITLE
Extend ncclx::Config with per-comm algo and flag fields (#2604)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -7,6 +7,7 @@
 #include "param.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/algoconf/AlgoStrConv.h"
 
 #include <algorithm>
 #include <sstream>
@@ -14,10 +15,21 @@
 #include <string>
 #include <vector>
 
+using ncclx::algoconf::algoStrToVal;
+
 namespace ncclx {
 
 Config::Config(const ncclConfig_t* config) {
   initEnv();
+
+  useCtran = NCCL_CTRAN_ENABLE;
+  usePatAvg = NCCL_REDUCESCATTER_PAT_AVG_ENABLE;
+  noLocal = false;
+  sendrecvAlgo = NCCL_SENDRECV_ALGO;
+  allgatherAlgo = NCCL_ALLGATHER_ALGO;
+  allreduceAlgo = NCCL_ALLREDUCE_ALGO;
+  alltoallvAlgo = NCCL_ALLTOALLV_ALGO;
+  rmaAlgo = NCCL_RMA_ALGO;
 
   if (!config) {
     WARN("ncclx::Config: config is null");
@@ -146,14 +158,21 @@ Config::Config(const ncclConfig_t* config) {
     }
   }
 
-  // ncclAllGatherAlgo
+  // ncclAllGatherAlgo — deprecated string field, kept for MetaFactory compat.
+  // The canonical field is allgatherAlgo (enum), parsed below with other algos.
   if (config->ncclAllGatherAlgo) {
+    WARN(
+        "ncclConfig_t.ncclAllGatherAlgo is deprecated; use ncclConfig_t.hints "
+        "with key 'allgatherAlgo' instead");
     ncclAllGatherAlgo = config->ncclAllGatherAlgo;
   } else {
     auto val = getHintStr("ncclAllGatherAlgo");
     if (!val.empty()) {
       ncclAllGatherAlgo = val;
     }
+  }
+  if (ncclAllGatherAlgo != "undefined") {
+    algoStrToVal(ncclAllGatherAlgo, allgatherAlgo);
   }
 
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {
@@ -252,6 +271,22 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+
+  useCtran = parseHintBool("useCtran", NCCL_CTRAN_ENABLE);
+  usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
+  noLocal = parseHintBool("noLocal", false);
+
+  auto parseAlgoHint = [&](const char* key, auto& field) {
+    auto val = getHintStr(key);
+    if (!val.empty()) {
+      algoStrToVal(val, field);
+    }
+  };
+  parseAlgoHint("sendrecvAlgo", sendrecvAlgo);
+  parseAlgoHint("allgatherAlgo", allgatherAlgo);
+  parseAlgoHint("allreduceAlgo", allreduceAlgo);
+  parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
+  parseAlgoHint("rmaAlgo", rmaAlgo);
 }
 
 } // namespace ncclx

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "nccl.h" // @manual
 
 namespace ncclx {
@@ -28,6 +29,16 @@ class Config {
   std::vector<int> splitGroupRanks;
   std::string ncclAllGatherAlgo = "undefined";
   bool fastInitMode = false;
+
+  bool useCtran = false;
+  bool usePatAvg = false;
+  bool noLocal = false;
+
+  enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
+  enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
+  enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
+  enum NCCL_ALLTOALLV_ALGO alltoallvAlgo = NCCL_ALLTOALLV_ALGO::orig;
+  enum NCCL_RMA_ALGO rmaAlgo = NCCL_RMA_ALGO::orig;
 
   // Per-communicator MultiPeerTransport (pipes) NVL config overrides.
   // When set, override the corresponding CVARs for this communicator.
@@ -52,16 +63,15 @@ class Config {
 // Hints::set() to warn on unrecognized keys (typo detection).
 inline const std::vector<std::string>& knownHintKeys() {
   static const std::vector<std::string> keys = {
-      "commDesc",
-      "splitGroupRanks",
-      "ncclAllGatherAlgo",
-      "fastInitMode",
-      "pipesNvlChunkSize",
-      "pipesUseDualStateBuffer",
-      "vCliqueSize",
-      "ncclBuffSize",
-      "ibSplitDataOnQps",
-      "ibQpsPerConnection",
+      "commDesc",          "splitGroupRanks",
+      "ncclAllGatherAlgo", "fastInitMode",
+      "useCtran",          "usePatAvg",
+      "noLocal",           "sendrecvAlgo",
+      "allgatherAlgo",     "allreduceAlgo",
+      "alltoallvAlgo",     "rmaAlgo",
+      "pipesNvlChunkSize", "pipesUseDualStateBuffer",
+      "vCliqueSize",       "ncclBuffSize",
+      "ibSplitDataOnQps",  "ibQpsPerConnection",
       "ibLazyConnect",
   };
   return keys;

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -1,0 +1,171 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ncclx::algoconf {
+
+inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_SENDRECV_ALGO::ctran;
+  } else if (str == "ctzcopy") {
+    val = NCCL_SENDRECV_ALGO::ctzcopy;
+  } else if (str == "ctp2p") {
+    val = NCCL_SENDRECV_ALGO::ctp2p;
+  } else if (str == "ctgraph") {
+    val = NCCL_SENDRECV_ALGO::ctgraph;
+  } else {
+    val = NCCL_SENDRECV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLGATHER_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLGATHER_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLGATHER_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLGATHER_ALGO::ctring;
+  } else if (str == "ctrd") {
+    val = NCCL_ALLGATHER_ALGO::ctrd;
+  } else if (str == "ctbrucks") {
+    val = NCCL_ALLGATHER_ALGO::ctbrucks;
+  } else if (str == "ctgraph") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph;
+  } else if (str == "ctgraph_pipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+  } else if (str == "ctgraph_rdpipeline") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline;
+  } else if (str == "ctgraph_ring") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
+  } else if (str == "ctgraph_rd") {
+    val = NCCL_ALLGATHER_ALGO::ctgraph_rd;
+  } else {
+    val = NCCL_ALLGATHER_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLREDUCE_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLREDUCE_ALGO::ctran;
+  } else if (str == "ctdirect") {
+    val = NCCL_ALLREDUCE_ALGO::ctdirect;
+  } else if (str == "ctring") {
+    val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else {
+    val = NCCL_ALLREDUCE_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(
+    const std::string& str,
+    enum NCCL_ALLTOALLV_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_ALLTOALLV_ALGO::ctran;
+  } else if (str == "compCtran") {
+    val = NCCL_ALLTOALLV_ALGO::compCtran;
+  } else if (str == "bsCompCtran") {
+    val = NCCL_ALLTOALLV_ALGO::bsCompCtran;
+  } else {
+    val = NCCL_ALLTOALLV_ALGO::orig;
+  }
+}
+
+inline void algoStrToVal(const std::string& str, enum NCCL_RMA_ALGO& val) {
+  if (str == "ctran") {
+    val = NCCL_RMA_ALGO::ctran;
+  } else {
+    val = NCCL_RMA_ALGO::orig;
+  }
+}
+
+inline std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
+  switch (val) {
+    case NCCL_SENDRECV_ALGO::orig:
+      return "orig";
+    case NCCL_SENDRECV_ALGO::ctran:
+      return "ctran";
+    case NCCL_SENDRECV_ALGO::ctzcopy:
+      return "ctzcopy";
+    case NCCL_SENDRECV_ALGO::ctp2p:
+      return "ctp2p";
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      return "ctgraph";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
+  switch (val) {
+    case NCCL_ALLGATHER_ALGO::orig:
+      return "orig";
+    case NCCL_ALLGATHER_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLGATHER_ALGO::ctring:
+      return "ctring";
+    case NCCL_ALLGATHER_ALGO::ctrd:
+      return "ctrd";
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+      return "ctbrucks";
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      return "ctgraph";
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      return "ctgraph_pipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      return "ctgraph_rdpipeline";
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      return "ctgraph_ring";
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      return "ctgraph_rd";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
+  switch (val) {
+    case NCCL_ALLREDUCE_ALGO::orig:
+      return "orig";
+    case NCCL_ALLREDUCE_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLREDUCE_ALGO::ctdirect:
+      return "ctdirect";
+    case NCCL_ALLREDUCE_ALGO::ctring:
+      return "ctring";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_ALLTOALLV_ALGO val) {
+  switch (val) {
+    case NCCL_ALLTOALLV_ALGO::orig:
+      return "orig";
+    case NCCL_ALLTOALLV_ALGO::ctran:
+      return "ctran";
+    case NCCL_ALLTOALLV_ALGO::compCtran:
+      return "compCtran";
+    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
+      return "bsCompCtran";
+  }
+  return "unknown";
+}
+
+inline std::string algoValToStr(enum NCCL_RMA_ALGO val) {
+  switch (val) {
+    case NCCL_RMA_ALGO::orig:
+      return "orig";
+    case NCCL_RMA_ALGO::ctran:
+      return "ctran";
+  }
+  return "unknown";
+}
+
+} // namespace ncclx::algoconf

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -1,0 +1,204 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "meta/algoconf/AlgoStrConv.h"
+
+using ncclx::algoconf::algoStrToVal;
+using ncclx::algoconf::algoValToStr;
+
+void checkAlgoStrToVal(enum NCCL_SENDRECV_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_SENDRECV_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_SENDRECV_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_SENDRECV_ALGO::ctzcopy:
+      str = "ctzcopy";
+      break;
+    case NCCL_SENDRECV_ALGO::ctp2p:
+      str = "ctp2p";
+      break;
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      str = "ctgraph";
+      break;
+  }
+  enum NCCL_SENDRECV_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLGATHER_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+      str = "ctdirect";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctring:
+      str = "ctring";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctrd:
+      str = "ctrd";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+      str = "ctbrucks";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      str = "ctgraph";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      str = "ctgraph_pipeline";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      str = "ctgraph_rdpipeline";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      str = "ctgraph_ring";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      str = "ctgraph_rd";
+      break;
+  }
+  enum NCCL_ALLGATHER_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLREDUCE_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctdirect:
+      str = "ctdirect";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctring:
+      str = "ctring";
+      break;
+  }
+  enum NCCL_ALLREDUCE_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLTOALLV_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLTOALLV_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLTOALLV_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLTOALLV_ALGO::compCtran:
+      str = "compCtran";
+      break;
+    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
+      str = "bsCompCtran";
+      break;
+  }
+  enum NCCL_ALLTOALLV_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_RMA_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_RMA_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_RMA_ALGO::ctran:
+      str = "ctran";
+      break;
+  }
+  enum NCCL_RMA_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+TEST(AlgoStrConvTest, SendRecvCompleteness) {
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::orig);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctzcopy);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctp2p);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctgraph);
+}
+
+TEST(AlgoStrConvTest, AllGatherCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctdirect);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctring);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctrd);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctbrucks);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_pipeline);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_ring);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_rd);
+}
+
+TEST(AlgoStrConvTest, AllReduceCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
+}
+
+TEST(AlgoStrConvTest, AllToAllVCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::compCtran);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::bsCompCtran);
+}
+
+TEST(AlgoStrConvTest, RmaCompleteness) {
+  checkAlgoStrToVal(NCCL_RMA_ALGO::orig);
+  checkAlgoStrToVal(NCCL_RMA_ALGO::ctran);
+}
+
+TEST(AlgoStrConvTest, UnknownStringFallback) {
+  enum NCCL_SENDRECV_ALGO sendrecv;
+  algoStrToVal("nonexistent", sendrecv);
+  EXPECT_EQ(sendrecv, NCCL_SENDRECV_ALGO::orig);
+
+  enum NCCL_ALLGATHER_ALGO allgather;
+  algoStrToVal("nonexistent", allgather);
+  EXPECT_EQ(allgather, NCCL_ALLGATHER_ALGO::orig);
+
+  enum NCCL_ALLREDUCE_ALGO allreduce;
+  algoStrToVal("nonexistent", allreduce);
+  EXPECT_EQ(allreduce, NCCL_ALLREDUCE_ALGO::orig);
+
+  enum NCCL_ALLTOALLV_ALGO alltoallv;
+  algoStrToVal("nonexistent", alltoallv);
+  EXPECT_EQ(alltoallv, NCCL_ALLTOALLV_ALGO::orig);
+
+  enum NCCL_RMA_ALGO rma;
+  algoStrToVal("nonexistent", rma);
+  EXPECT_EQ(rma, NCCL_RMA_ALGO::orig);
+}

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "nccl.h" // @manual
 
 #include "meta/NcclxConfig.h" // @manual
@@ -23,6 +24,14 @@ TEST(ConfigHintsUT, NoHintsCreatesDefaults) {
   EXPECT_EQ(ncclxCfg->commDesc, "undefined");
   EXPECT_TRUE(ncclxCfg->splitGroupRanks.empty());
   EXPECT_EQ(ncclxCfg->ncclAllGatherAlgo, "undefined");
+  EXPECT_EQ(ncclxCfg->useCtran, false);
+  EXPECT_EQ(ncclxCfg->usePatAvg, false);
+  EXPECT_EQ(ncclxCfg->noLocal, false);
+  EXPECT_EQ(ncclxCfg->sendrecvAlgo, NCCL_SENDRECV_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->allgatherAlgo, NCCL_ALLGATHER_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->allreduceAlgo, NCCL_ALLREDUCE_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->alltoallvAlgo, NCCL_ALLTOALLV_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->rmaAlgo, NCCL_RMA_ALGO::ctran);
 
   // Upstream NCCL fields should be untouched
   EXPECT_EQ(config.blocking, NCCL_CONFIG_UNDEF_INT);
@@ -358,5 +367,108 @@ TEST(ConfigHintsUT, LazyPeerInit_HintOverrides) {
   EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
   ASSERT_NE(config.ncclxConfig, nullptr);
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, UseCtranHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("useCtran", "1");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, useCtran));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, UsePatAvgHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("usePatAvg", "true");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, usePatAvg));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, NoLocalHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("noLocal", "1");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, noLocal));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AllgatherAlgoHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("allgatherAlgo", "ctring");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, allgatherAlgo), NCCL_ALLGATHER_ALGO::ctring);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, SendrecvAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("sendrecvAlgo", "ctran");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, sendrecvAlgo), NCCL_SENDRECV_ALGO::ctran);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AllreduceAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("allreduceAlgo", "ctdirect");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, allreduceAlgo), NCCL_ALLREDUCE_ALGO::ctdirect);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AlltoallvAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("alltoallvAlgo", "ctran");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, alltoallvAlgo), NCCL_ALLTOALLV_ALGO::ctran);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, RmaAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("rmaAlgo", "orig");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(config, rmaAlgo), NCCL_RMA_ALGO::orig);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, InvalidAlgoHintFallsBackToDefault) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("sendrecvAlgo", "invalid_algo");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(config, sendrecvAlgo), NCCL_SENDRECV_ALGO::orig);
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }


### PR DESCRIPTION
Summary:

Add 8 new per-communicator config fields to `ncclx::Config`, parsed from `ncclConfig_t.hints` with CVAR defaults:
- `useCtran` (bool, default `NCCL_CTRAN_ENABLE`)
- `usePatAvg` (bool, default `NCCL_REDUCESCATTER_PAT_AVG_ENABLE`)
- `noLocal` (bool, default false)
- `sendrecvAlgo`, `allgatherAlgo`, `allreduceAlgo`, `alltoallvAlgo`, `rmaAlgo` (enum, defaults from CVARs)

The existing `ncclAllGatherAlgo` string field is kept for backward compatibility with `MetaFactory.cc`. When the deprecated flat field `ncclConfig_t.ncclAllGatherAlgo` is used, a WARN is emitted directing users to the new `allgatherAlgo` hint key. The old hint key `ncclAllGatherAlgo` is also accepted as a fallback.

Extract `algoStrToVal`/`algoValToStr` helpers into shared header `meta/algoconf/AlgoStrConv.h` for reuse across `NcclxConfig.cc` and future `AlgoConfig.cc` cleanup.

Reviewed By: mingrany

Differential Revision: D105604044


