### PR TITLE
Migrate non-algo config fields from CommHintConfig to per-comm ncclx::Config (#2605)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -7,6 +7,7 @@
 #include "param.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/algoconf/AlgoStrConv.h"
 
 #include <algorithm>
 #include <sstream>
@@ -14,10 +15,21 @@
 #include <string>
 #include <vector>
 
+using ncclx::algoconf::algoStrToVal;
+
 namespace ncclx {
 
 Config::Config(const ncclConfig_t* config) {
   initEnv();
+
+  useCtran = NCCL_CTRAN_ENABLE;
+  usePatAvg = NCCL_REDUCESCATTER_PAT_AVG_ENABLE;
+  noLocal = false;
+  sendrecvAlgo = NCCL_SENDRECV_ALGO;
+  allgatherAlgo = NCCL_ALLGATHER_ALGO;
+  allreduceAlgo = NCCL_ALLREDUCE_ALGO;
+  alltoallvAlgo = NCCL_ALLTOALLV_ALGO;
+  rmaAlgo = NCCL_RMA_ALGO;
 
   if (!config) {
     WARN("ncclx::Config: config is null");
@@ -146,14 +158,21 @@ Config::Config(const ncclConfig_t* config) {
     }
   }
 
-  // ncclAllGatherAlgo
+  // ncclAllGatherAlgo — deprecated string field, kept for MetaFactory compat.
+  // The canonical field is allgatherAlgo (enum), parsed below with other algos.
   if (config->ncclAllGatherAlgo) {
+    WARN(
+        "ncclConfig_t.ncclAllGatherAlgo is deprecated; use ncclConfig_t.hints "
+        "with key 'allgatherAlgo' instead");
     ncclAllGatherAlgo = config->ncclAllGatherAlgo;
   } else {
     auto val = getHintStr("ncclAllGatherAlgo");
     if (!val.empty()) {
       ncclAllGatherAlgo = val;
     }
+  }
+  if (ncclAllGatherAlgo != "undefined") {
+    algoStrToVal(ncclAllGatherAlgo, allgatherAlgo);
   }
 
   if (config->fastInitMode != NCCL_CONFIG_UNDEF_INT) {
@@ -269,6 +288,22 @@ Config::Config(const ncclConfig_t* config) {
       }
     }
   }
+
+  useCtran = parseHintBool("useCtran", NCCL_CTRAN_ENABLE);
+  usePatAvg = parseHintBool("usePatAvg", NCCL_REDUCESCATTER_PAT_AVG_ENABLE);
+  noLocal = parseHintBool("noLocal", false);
+
+  auto parseAlgoHint = [&](const char* key, auto& field) {
+    auto val = getHintStr(key);
+    if (!val.empty()) {
+      algoStrToVal(val, field);
+    }
+  };
+  parseAlgoHint("sendrecvAlgo", sendrecvAlgo);
+  parseAlgoHint("allgatherAlgo", allgatherAlgo);
+  parseAlgoHint("allreduceAlgo", allreduceAlgo);
+  parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
+  parseAlgoHint("rmaAlgo", rmaAlgo);
 }
 
 } // namespace ncclx

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "nccl.h" // @manual
 
 namespace ncclx {
@@ -28,6 +29,16 @@ class Config {
   std::vector<int> splitGroupRanks;
   std::string ncclAllGatherAlgo = "undefined";
   bool fastInitMode = false;
+
+  bool useCtran = false;
+  bool usePatAvg = false;
+  bool noLocal = false;
+
+  enum NCCL_SENDRECV_ALGO sendrecvAlgo = NCCL_SENDRECV_ALGO::orig;
+  enum NCCL_ALLGATHER_ALGO allgatherAlgo = NCCL_ALLGATHER_ALGO::orig;
+  enum NCCL_ALLREDUCE_ALGO allreduceAlgo = NCCL_ALLREDUCE_ALGO::orig;
+  enum NCCL_ALLTOALLV_ALGO alltoallvAlgo = NCCL_ALLTOALLV_ALGO::orig;
+  enum NCCL_RMA_ALGO rmaAlgo = NCCL_RMA_ALGO::orig;
 
   // Per-communicator MultiPeerTransport (pipes) NVL config overrides.
   // When set, override the corresponding CVARs for this communicator.

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -1,0 +1,212 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "meta/algoconf/AlgoStrConv.h"
+
+using ncclx::algoconf::algoStrToVal;
+using ncclx::algoconf::algoValToStr;
+
+void checkAlgoStrToVal(enum NCCL_SENDRECV_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_SENDRECV_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_SENDRECV_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_SENDRECV_ALGO::ctzcopy:
+      str = "ctzcopy";
+      break;
+    case NCCL_SENDRECV_ALGO::ctp2p:
+      str = "ctp2p";
+      break;
+    case NCCL_SENDRECV_ALGO::ctgraph:
+      str = "ctgraph";
+      break;
+  }
+  enum NCCL_SENDRECV_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLGATHER_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLGATHER_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctdirect:
+      str = "ctdirect";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctring:
+      str = "ctring";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctrd:
+      str = "ctrd";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctsrd:
+      str = "ctsrd";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctbrucks:
+      str = "ctbrucks";
+      break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      str = "cthierarchical_ring";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph:
+      str = "ctgraph";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+      str = "ctgraph_pipeline";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+      str = "ctgraph_rdpipeline";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
+      str = "ctgraph_ring";
+      break;
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+      str = "ctgraph_rd";
+      break;
+  }
+  enum NCCL_ALLGATHER_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLREDUCE_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctdirect:
+      str = "ctdirect";
+      break;
+    case NCCL_ALLREDUCE_ALGO::ctring:
+      str = "ctring";
+      break;
+  }
+  enum NCCL_ALLREDUCE_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_ALLTOALLV_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_ALLTOALLV_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_ALLTOALLV_ALGO::ctran:
+      str = "ctran";
+      break;
+    case NCCL_ALLTOALLV_ALGO::compCtran:
+      str = "compCtran";
+      break;
+    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
+      str = "bsCompCtran";
+      break;
+  }
+  enum NCCL_ALLTOALLV_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+void checkAlgoStrToVal(enum NCCL_RMA_ALGO algo) {
+  std::string str = "UNHANDLED_ENUM_VALUE";
+  switch (algo) {
+    case NCCL_RMA_ALGO::orig:
+      str = "orig";
+      break;
+    case NCCL_RMA_ALGO::ctran:
+      str = "ctran";
+      break;
+  }
+  enum NCCL_RMA_ALGO result;
+  algoStrToVal(str, result);
+  EXPECT_EQ(result, algo) << "algoStrToVal(\"" << str
+                          << "\") returned wrong value";
+  EXPECT_EQ(algoValToStr(algo), str) << "algoValToStr round-trip failed";
+}
+
+TEST(AlgoStrConvTest, SendRecvCompleteness) {
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::orig);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctzcopy);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctp2p);
+  checkAlgoStrToVal(NCCL_SENDRECV_ALGO::ctgraph);
+}
+
+TEST(AlgoStrConvTest, AllGatherCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctdirect);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctring);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctrd);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctsrd);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctbrucks);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::cthierarchical_ring);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_pipeline);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_ring);
+  checkAlgoStrToVal(NCCL_ALLGATHER_ALGO::ctgraph_rd);
+}
+
+TEST(AlgoStrConvTest, AllReduceCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
+}
+
+TEST(AlgoStrConvTest, AllToAllVCompleteness) {
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::orig);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::ctran);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::compCtran);
+  checkAlgoStrToVal(NCCL_ALLTOALLV_ALGO::bsCompCtran);
+}
+
+TEST(AlgoStrConvTest, RmaCompleteness) {
+  checkAlgoStrToVal(NCCL_RMA_ALGO::orig);
+  checkAlgoStrToVal(NCCL_RMA_ALGO::ctran);
+}
+
+TEST(AlgoStrConvTest, UnknownStringFallback) {
+  enum NCCL_SENDRECV_ALGO sendrecv;
+  algoStrToVal("nonexistent", sendrecv);
+  EXPECT_EQ(sendrecv, NCCL_SENDRECV_ALGO::orig);
+
+  enum NCCL_ALLGATHER_ALGO allgather;
+  algoStrToVal("nonexistent", allgather);
+  EXPECT_EQ(allgather, NCCL_ALLGATHER_ALGO::orig);
+
+  enum NCCL_ALLREDUCE_ALGO allreduce;
+  algoStrToVal("nonexistent", allreduce);
+  EXPECT_EQ(allreduce, NCCL_ALLREDUCE_ALGO::orig);
+
+  enum NCCL_ALLTOALLV_ALGO alltoallv;
+  algoStrToVal("nonexistent", alltoallv);
+  EXPECT_EQ(alltoallv, NCCL_ALLTOALLV_ALGO::orig);
+
+  enum NCCL_RMA_ALGO rma;
+  algoStrToVal("nonexistent", rma);
+  EXPECT_EQ(rma, NCCL_RMA_ALGO::orig);
+}

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -90,8 +90,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
 
   auto* bootstrap = ctranComm->bootstrap_.get();
 
-  const int vCliqueSize =
-      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
+  const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
 
   ctranComm->statex_ = std::make_unique<CommStateX>(
       comm->rank,

--- a/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
@@ -10,7 +10,6 @@
 #include "comms/ctran/tests/VerifyCommStateXUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 using ctran::testing::VerifyCommStateXHelper;
@@ -22,14 +21,9 @@ class CommStateXDistTest : public NcclxBaseTestFixture {
 
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-        ncclSuccess);
   }
 
   void TearDown() override {
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -41,8 +35,11 @@ class CommStateXDistTest : public NcclxBaseTestFixture {
 };
 
 TEST_F(CommStateXDistTest, CreateFromNcclComm) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
 
@@ -61,14 +58,11 @@ TEST_F(CommStateXDistTest, CreateFromNcclComm) {
 }
 
 TEST_F(CommStateXDistTest, CreateNoLocalFromNcclComm) {
-  // FIXME: replace with per-comm ncclx::Hints config once noLocal is
-  // supported as a per-comm hint field (global hints will be deprecated)
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}, {"noLocal", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
 
@@ -88,7 +82,7 @@ TEST_F(CommStateXDistTest, CreateNoLocalFromNcclComm) {
 
 TEST_F(CommStateXDistTest, CreateVCliqueSizeFromNcclComm) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  ncclx::Hints hints({{"vCliqueSize", "2"}});
+  ncclx::Hints hints({{"vCliqueSize", "2"}, {"useCtran", "1"}});
   config.hints = &hints;
 
   ncclx::test::NcclCommRAII comm{

--- a/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
+++ b/comms/ncclx/meta/hints/tests/ConfigHintsUT.cc
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "nccl.h" // @manual
 
 #include "meta/NcclxConfig.h" // @manual
@@ -23,6 +24,14 @@ TEST(ConfigHintsUT, NoHintsCreatesDefaults) {
   EXPECT_EQ(ncclxCfg->commDesc, "undefined");
   EXPECT_TRUE(ncclxCfg->splitGroupRanks.empty());
   EXPECT_EQ(ncclxCfg->ncclAllGatherAlgo, "undefined");
+  EXPECT_EQ(ncclxCfg->useCtran, false);
+  EXPECT_EQ(ncclxCfg->usePatAvg, false);
+  EXPECT_EQ(ncclxCfg->noLocal, false);
+  EXPECT_EQ(ncclxCfg->sendrecvAlgo, NCCL_SENDRECV_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->allgatherAlgo, NCCL_ALLGATHER_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->allreduceAlgo, NCCL_ALLREDUCE_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->alltoallvAlgo, NCCL_ALLTOALLV_ALGO::orig);
+  EXPECT_EQ(ncclxCfg->rmaAlgo, NCCL_RMA_ALGO::ctran);
 
   // Upstream NCCL fields should be untouched
   EXPECT_EQ(config.blocking, NCCL_CONFIG_UNDEF_INT);
@@ -358,5 +367,108 @@ TEST(ConfigHintsUT, LazyPeerInit_HintOverrides) {
   EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
   ASSERT_NE(config.ncclxConfig, nullptr);
   EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, ibLazyConnect));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, UseCtranHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("useCtran", "1");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, useCtran));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, UsePatAvgHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("usePatAvg", "true");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, usePatAvg));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, NoLocalHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("noLocal", "1");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_TRUE(NCCLX_CONFIG_FIELD(config, noLocal));
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AllgatherAlgoHintOverride) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("allgatherAlgo", "ctring");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, allgatherAlgo), NCCL_ALLGATHER_ALGO::ctring);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, SendrecvAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("sendrecvAlgo", "ctran");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, sendrecvAlgo), NCCL_SENDRECV_ALGO::ctran);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AllreduceAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("allreduceAlgo", "ctdirect");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, allreduceAlgo), NCCL_ALLREDUCE_ALGO::ctdirect);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, AlltoallvAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("alltoallvAlgo", "ctran");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(
+      NCCLX_CONFIG_FIELD(config, alltoallvAlgo), NCCL_ALLTOALLV_ALGO::ctran);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, RmaAlgoHint) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("rmaAlgo", "orig");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(config, rmaAlgo), NCCL_RMA_ALGO::orig);
+  delete static_cast<ncclx::Config*>(config.ncclxConfig);
+}
+
+TEST(ConfigHintsUT, InvalidAlgoHintFallsBackToDefault) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  hints.set("sendrecvAlgo", "invalid_algo");
+  config.hints = &hints;
+  EXPECT_EQ(ncclxParseCommConfig(&config), ncclSuccess);
+  ASSERT_NE(config.ncclxConfig, nullptr);
+  EXPECT_EQ(NCCLX_CONFIG_FIELD(config, sendrecvAlgo), NCCL_SENDRECV_ALGO::orig);
   delete static_cast<ncclx::Config*>(config.ncclxConfig);
 }

--- a/comms/ncclx/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherTest.cc
@@ -15,9 +15,6 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-#include "meta/hints/GlobalHints.h"
-#endif
 
 using testinfra::AlgoRAII;
 
@@ -33,20 +30,19 @@ class AllGatherTest : public NcclxBaseTestFixture {
     envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"});
 #endif
     NcclxBaseTestFixture::SetUp(envs);
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
 #ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+    ncclx::Hints hints{{"noLocal", "1"}};
+    config.hints = &hints;
 #endif
     this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-#endif
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();

--- a/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
@@ -7,7 +7,6 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "meta/transport/NcclxIbNetCommConfig.h" // @manual
 #include "nccl.h" // @manual
 
@@ -15,11 +14,11 @@ class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
  public:
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    ncclConfig_t initConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints initHints{{"noLocal", "1"}};
+    initConfig.hints = &initHints;
     comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &initConfig);
     CUDACHECK_TEST(cudaStreamCreate(&stream));
     CUDACHECK_TEST(cudaMalloc(&dataBuf, sizeof(int) * dataCount));
   }
@@ -28,7 +27,6 @@ class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaFree(dataBuf));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NCCLCHECK_TEST(ncclCommDestroy(comm));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -18,7 +18,6 @@
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 #define dceil(x, y) ((x / y) + !!(x % y))
@@ -439,13 +438,9 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
-  ncclx::Hints ctranHints;
+  ncclx::Hints ctranHints{{"useCtran", "1"}};
   config.hints = &ctranHints;
 
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-      ncclSuccess);
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
     comm2 = ncclx::test::createNcclComm(
@@ -469,10 +464,8 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
   }
 
   ASSERT_TRUE(ctranInitialized(comm2->ctranComm_.get()));
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran)));
 
-  // Now it should be disabled again after hint reset
+  // Now it should be disabled again after no hint
   ncclComm_t comm3 = ncclx::test::createNcclComm(
       globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm3, nullptr);

--- a/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
@@ -10,8 +10,6 @@
 #include "comm.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
-#include "meta/hints/CommHintConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 #include "transport.h"
 
@@ -35,7 +33,6 @@ class CommWithNoLocalTest : public NcclxBaseTestFixture {
   }
 
   void TearDown() override {
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 };
@@ -68,13 +65,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "noLocal");
-  ncclx::Hints noLocalHints({{"commDesc", commDescStr}});
+  ncclx::Hints noLocalHints({{"commDesc", commDescStr}, {"noLocal", "1"}});
   config.hints = &noLocalHints;
-
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
   std::optional<ncclx::test::NcclCommRAII> comm2Default;
@@ -102,9 +94,6 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   }
 
   EXPECT_TRUE(comm2->noLocal_);
-
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal)));
 
   // Now disabled again
   {
@@ -142,16 +131,11 @@ class CommWithNoLocalCollTest
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
     algoStats_.enable();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-        ncclSuccess);
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -333,14 +317,14 @@ class CommWithNoLocalCollTest
 TEST_P(CommWithNoLocalCollTest, BaselineRun) {
   const auto [noLocal, collectiveOp] = GetParam();
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}};
   if (noLocal) {
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    hints.set("noLocal", "1");
   }
-
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_EQ(comm->noLocal_, noLocal);
 
@@ -359,12 +343,11 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
     GTEST_SKIP() << "CtranRun only tests noLocal mode";
   }
 
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}, {"noLocal", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_TRUE(comm->noLocal_);
 

--- a/comms/ncclx/meta/tests/CommWithPatAvgTest.cc
+++ b/comms/ncclx/meta/tests/CommWithPatAvgTest.cc
@@ -9,8 +9,6 @@
 
 #include "comm.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "meta/hints/CommHintConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
@@ -24,9 +22,6 @@ class CommWithPatAvgTest : public NcclxBaseTestFixture {
   }
 
   void TearDown() override {
-    // Only reset our hint value, don't unregister all keys
-    ncclx::resetGlobalHint(
-        std::string(ncclx::HintKeys::kCommAlgoReduceScatter));
     NcclxBaseTestFixture::TearDown();
   }
 };
@@ -47,17 +42,24 @@ TEST_F(CommWithPatAvgTest, PatAvgEnableByCvar) {
   EXPECT_TRUE(comm->usePatAvg_);
 }
 
-TEST_F(CommWithPatAvgTest, PatAvgNotEnabledForOtherValues) {
+TEST_F(CommWithPatAvgTest, PatAvgNotEnabledByExplicitDisable) {
   EnvRAII cvarEnv(NCCL_REDUCESCATTER_PAT_AVG_ENABLE, false);
-
-  // Set hint to a different value
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "sum:ring"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "0"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
+  ASSERT_NE(comm.get(), nullptr);
+  EXPECT_FALSE(comm->usePatAvg_);
+}
+
+TEST_F(CommWithPatAvgTest, PatAvgNotEnabledByUnrelatedHint) {
+  EnvRAII cvarEnv(NCCL_REDUCESCATTER_PAT_AVG_ENABLE, false);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"commDesc", "unrelated_hint"}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_FALSE(comm->usePatAvg_);
 }
@@ -84,14 +86,8 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "usePatAvg");
-  ncclx::Hints patAvgHints({{"commDesc", commDescStr}});
+  ncclx::Hints patAvgHints({{"commDesc", commDescStr}, {"usePatAvg", "1"}});
   config.hints = &patAvgHints;
-
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
   std::optional<ncclx::test::NcclCommRAII> comm2Default;
@@ -119,10 +115,6 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   }
 
   EXPECT_TRUE(comm2->usePatAvg_);
-
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter)));
 
   // Now disabled again
   {

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -14,7 +14,6 @@
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/hints/GlobalHints.h"
 
 class NcclxLazyConnectTestFixture
     : public NcclxBaseTestFixture,
@@ -37,8 +36,11 @@ class NcclxLazyConnectTestFixture
 
   ncclComm_t createRootComm() {
     if (isNoLocal()) {
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommNoLocal).c_str(), "1");
+      ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+      ncclx::Hints hints{{"noLocal", "1"}};
+      config.hints = &hints;
+      return ncclx::test::createNcclComm(
+          globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
     }
     return ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
@@ -51,9 +53,6 @@ class NcclxLazyConnectTestFixture
   }
 
   void TearDown() override {
-    if (isNoLocal()) {
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-    }
     if (sendBuf) {
       CUDACHECK_TEST(cudaFree(sendBuf));
       sendBuf = nullptr;

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -25,7 +25,6 @@
 #include "comm.h" // @manual
 #include "comms/ncclx/meta/logger/tests/LoggerUtil.h"
 #include "debug.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h" // @manual
 
 class MemoryTraceTestFixture : public NcclxBaseTestFixture,
@@ -221,18 +220,14 @@ class MemoryTraceTestFixture : public NcclxBaseTestFixture,
   void* sendBuf{nullptr};
   void* recvBuf{nullptr};
   bool mockPassthru{true};
+  bool noLocal_{false};
 };
 
 class MemoryTraceNolocalTestFixture : public MemoryTraceTestFixture {
  public:
   void SetUp() override {
-    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+    noLocal_ = true;
     MemoryTraceTestFixture::SetUp();
-  }
-
-  void TearDown() override {
-    MemoryTraceTestFixture::TearDown();
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
   }
 };
 
@@ -263,8 +258,14 @@ void MemoryTraceTestFixture::runNcclInternalBufferLogTest() {
   // First comm creation as well as first kernel launch has some extra memory
   // usage (https://fburl.com/code/rxjvjads), use second comm
   // creation/collective for testing
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  if (noLocal_) {
+    hints.set("noLocal", "1");
+  }
+  config.hints = &hints;
   comm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
   std::cout << "Rank " << this->globalRank << " finished init, run AR"
             << std::endl;
   size_t count = 1 << 10; // 1K elements
@@ -365,8 +366,14 @@ void MemoryTraceTestFixture::runUserBufferLoggingTest() {
 
   auto logFileName = initLogger();
   EXPECT_EQ(NCCL_COMM_WORLD, nullptr);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  if (noLocal_) {
+    hints.set("noLocal", "1");
+  }
+  config.hints = &hints;
   comm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
   /* mapper registration logic */
   void *buf = nullptr, *segHdl = nullptr;

--- a/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
@@ -21,7 +21,6 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/collectives/PatAvgHelper.h"
-#include "meta/hints/GlobalHints.h" // @manual
 #include "meta/wrapper/DataTypeStrUtils.h"
 
 /**
@@ -46,9 +45,6 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    // Reset global hint to avoid affecting subsequent tests
-    ncclx::resetGlobalHint(
-        std::string(ncclx::HintKeys::kCommAlgoReduceScatter));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -76,10 +72,12 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
       std::optional<std::string> expectedAlgo = std::nullopt,
       std::optional<std::string> unexpectedAlgo = std::nullopt,
       std::optional<double> tolerance = std::nullopt) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints{{"usePatAvg", usePatAvg ? "1" : "0"}};
+    config.hints = &hints;
     ncclx::test::NcclCommRAII commGuard{
-        globalRank, numRanks, localRank, bootstrap_.get()};
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
     ncclComm_t comm = commGuard.get();
-    comm->usePatAvg_ = usePatAvg;
 
     const size_t count = 8000;
     const size_t allocSize = count * numRanks * sizeof(T);
@@ -132,14 +130,11 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
  * so user ops continue through normal algorithm selection.
  */
 TEST_F(ReduceScatterPatSelectTest, UserPreMulSumNotConvertedToPatAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -193,14 +188,11 @@ TEST_F(ReduceScatterPatSelectTest, UserPreMulSumNotConvertedToPatAvg) {
  * and produces correct results (sum / nRanks).
  */
 TEST_F(ReduceScatterPatSelectTest, BuiltInAvgWithPatAvgWorks) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -360,14 +352,11 @@ INSTANTIATE_TEST_SUITE_P(
  * This is a negative test - it validates that the proper error is returned.
  */
 TEST_F(ReduceScatterPatSelectTest, GroupedReduceScatterPatAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -477,14 +466,11 @@ TEST_F(ReduceScatterPatSelectTest, UsePatAvgCvarControl) {
  * 2. Other collectives (AllReduce with ncclAvg) - not affected
  */
 TEST_F(ReduceScatterPatSelectTest, UsePatAvgOnlyAffectsReduceScatterAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 

--- a/comms/ncclx/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/meta/tests/SendRecvTest.cc
@@ -27,13 +27,14 @@ class SendRecvTest : public NcclxBaseTestFixture {
     setenv("NCCL_CTRAN_ENABLE", "1", 1);
     NcclxBaseTestFixture::SetUp();
     ctranAlgoStats_.enable();
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
 #ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    hints.set("noLocal", "1");
 #endif
+    config.hints = &hints;
     this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -42,9 +43,6 @@ class SendRecvTest : public NcclxBaseTestFixture {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-#endif
     NcclxBaseTestFixture::TearDown();
   }
 

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -2425,10 +2425,10 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
-  // Ctran can be enabled either globally via CVAR or per-communicator using hint
-  comm->useCtran_ = ncclx::commUseCtran();
-  comm->usePatAvg_ = ncclx::commUsePatAvg();
-  comm->noLocal_ = ncclx::commNoLocal();
+  // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
+  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
@@ -3148,10 +3148,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
-    // Ctran can be enabled either globally via CVAR or per-communicator using hint
-    childComm->useCtran_ = ncclx::commUseCtran();
-    childComm->usePatAvg_ = ncclx::commUsePatAvg();
-    childComm->noLocal_ = ncclx::commNoLocal();
+    // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
+    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2585,10 +2585,10 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
-  // Ctran can be enabled either globally via CVAR or per-communicator using hint
-  comm->useCtran_ = ncclx::commUseCtran();
-  comm->usePatAvg_ = ncclx::commUsePatAvg();
-  comm->noLocal_ = ncclx::commNoLocal();
+  // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
+  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
@@ -3309,10 +3309,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
-    // Ctran can be enabled either globally via CVAR or per-communicator using hint
-    childComm->useCtran_ = ncclx::commUseCtran();
-    childComm->usePatAvg_ = ncclx::commUsePatAvg();
-    childComm->noLocal_ = ncclx::commNoLocal();
+    // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
+    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),


### PR DESCRIPTION
Summary:

Migrate `useCtran`, `usePatAvg`, `noLocal`, `vCliqueSize` from process-wide `CommHintConfig` singletons and GlobalHints to per-comm `ncclx::Config` fields:

- Replace `ncclx::commUseCtran()`, `commUsePatAvg()`, `commNoLocal()` in `init.cc` (CommInit + CommSplit) with `NCCLX_CONFIG_FIELD` reads from the parsed per-comm config, across v2_27, v2_29, v2_30
- Simplify `commVCliqueSize()` wrapper in `FactoryCommStateX.cc` to direct `NCCLX_CONFIG_FIELD` read, removing the GlobalHint override path
- Migrate 9 test files from `setGlobalHint(kCommUseCtran/kCommNoLocal/kCommAlgoReduceScatter)` to per-comm `ncclx::Hints` passed at comm creation time, eliminating `resetGlobalHint` cleanup in TearDown
- Add `[META:PER_COMM_CONFIG]` labels at all modified `init.cc` sites for rebase tracking

The old `CommHintConfig` functions and GlobalHint keys still exist (removed in a follow-up commit). After this change, no production or test code calls them for `useCtran`, `usePatAvg`, `noLocal`, or `vCliqueSize`.

Reviewed By: mingrany

Differential Revision: D105604047


