### PR TITLE
Migrate non-sendrecv algo hints to per-comm config (#2608)

### DIFF
--- a/comms/ncclx/meta/algoconf/AlgoConfig.cc
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.cc
@@ -8,7 +8,6 @@
 using ncclx::GlobalHints;
 namespace {
 
-// TODO: populate the helper functions from CVAR auto-generated code
 inline const std::string algoValToStr(enum NCCL_SENDRECV_ALGO val) {
   switch (val) {
     case NCCL_SENDRECV_ALGO::ctran:
@@ -38,159 +37,16 @@ inline void algoStrToVal(const std::string& str, enum NCCL_SENDRECV_ALGO& val) {
   }
 }
 
-inline const std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
-  switch (val) {
-    case NCCL_ALLGATHER_ALGO::orig:
-      return "orig";
-    case NCCL_ALLGATHER_ALGO::ctran:
-      return "ctran";
-    case NCCL_ALLGATHER_ALGO::ctdirect:
-      return "ctdirect";
-    case NCCL_ALLGATHER_ALGO::ctring:
-      return "ctring";
-    case NCCL_ALLGATHER_ALGO::ctrd:
-      return "ctrd";
-    case NCCL_ALLGATHER_ALGO::ctsrd:
-      return "ctsrd";
-    case NCCL_ALLGATHER_ALGO::ctbrucks:
-      return "ctbrucks";
-    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      return "cthierarchical_ring";
-    case NCCL_ALLGATHER_ALGO::ctgraph:
-      return "ctgraph";
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
-      return "ctgraph_pipeline";
-    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
-      return "ctgraph_rdpipeline";
-    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
-      return "ctgraph_ring";
-    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
-      return "ctgraph_rd";
-  }
-  return "unknown";
-}
-
-inline void algoStrToVal(
-    const std::string& str,
-    enum NCCL_ALLGATHER_ALGO& val) {
-  if (str == "ctran") {
-    val = NCCL_ALLGATHER_ALGO::ctran;
-  } else if (str == "ctdirect") {
-    val = NCCL_ALLGATHER_ALGO::ctdirect;
-  } else if (str == "ctring") {
-    val = NCCL_ALLGATHER_ALGO::ctring;
-  } else if (str == "ctrd") {
-    val = NCCL_ALLGATHER_ALGO::ctrd;
-  } else if (str == "ctsrd") {
-    val = NCCL_ALLGATHER_ALGO::ctsrd;
-  } else if (str == "ctbrucks") {
-    val = NCCL_ALLGATHER_ALGO::ctbrucks;
-  } else if (str == "cthierarchical_ring") {
-    val = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
-  } else if (str == "ctgraph") {
-    val = NCCL_ALLGATHER_ALGO::ctgraph;
-  } else if (str == "ctgraph_pipeline") {
-    val = NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
-  } else if (str == "ctgraph_rdpipeline") {
-    val = NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline;
-  } else if (str == "ctgraph_ring") {
-    val = NCCL_ALLGATHER_ALGO::ctgraph_ring;
-  } else if (str == "ctgraph_rd") {
-    val = NCCL_ALLGATHER_ALGO::ctgraph_rd;
-  } else {
-    val = NCCL_ALLGATHER_ALGO::orig;
-  }
-}
-
-inline const std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
-  switch (val) {
-    case NCCL_ALLREDUCE_ALGO::orig:
-      return "orig";
-    case NCCL_ALLREDUCE_ALGO::ctran:
-      return "ctran";
-    case NCCL_ALLREDUCE_ALGO::ctdirect:
-      return "ctdirect";
-    case NCCL_ALLREDUCE_ALGO::ctring:
-      return "ctring";
-  }
-}
-
-inline void algoStrToVal(
-    const std::string& str,
-    enum NCCL_ALLREDUCE_ALGO& val) {
-  if (str == "ctran") {
-    val = NCCL_ALLREDUCE_ALGO::ctran;
-  } else if (str == "ctdirect") {
-    val = NCCL_ALLREDUCE_ALGO::ctdirect;
-  } else if (str == "ctring") {
-    val = NCCL_ALLREDUCE_ALGO::ctring;
-  } else {
-    val = NCCL_ALLREDUCE_ALGO::orig;
-  }
-}
-
-inline const std::string algoValToStr(enum NCCL_ALLTOALLV_ALGO val) {
-  switch (val) {
-    case ::NCCL_ALLTOALLV_ALGO::orig:
-      return "orig";
-    case NCCL_ALLTOALLV_ALGO::ctran:
-      return "ctran";
-    case NCCL_ALLTOALLV_ALGO::compCtran:
-      return "compCtran";
-    case NCCL_ALLTOALLV_ALGO::bsCompCtran:
-      return "bsCompCtran";
-  }
-}
-
-inline void algoStrToVal(
-    const std::string& str,
-    enum NCCL_ALLTOALLV_ALGO& val) {
-  if (str == "ctran") {
-    val = NCCL_ALLTOALLV_ALGO::ctran;
-  } else if (str == "compCtran") {
-    val = NCCL_ALLTOALLV_ALGO::compCtran;
-  } else if (str == "bsCompCtran") {
-    val = NCCL_ALLTOALLV_ALGO::bsCompCtran;
-  } else {
-    val = NCCL_ALLTOALLV_ALGO::orig;
-  }
-}
-
-inline const std::string algoValToStr(enum NCCL_RMA_ALGO val) {
-  switch (val) {
-    case NCCL_RMA_ALGO::orig:
-      return "orig";
-    case NCCL_RMA_ALGO::ctran:
-      return "ctran";
-  }
-}
-
-inline void algoStrToVal(const std::string& str, enum NCCL_RMA_ALGO& val) {
-  if (str == "ctran") {
-    val = NCCL_RMA_ALGO::ctran;
-  } else {
-    val = NCCL_RMA_ALGO::orig;
-  }
-}
-
 class AlgoConfig {
  public:
   AlgoConfig();
   ~AlgoConfig() {}
   static std::shared_ptr<AlgoConfig> getInstance();
 
-  // allow testOnlyResetAlgoConfig to reset the state for testing
   void reset();
 
   std::atomic<enum NCCL_SENDRECV_ALGO> sendrecv =
       NCCL_SENDRECV_ALGO_DEFAULTCVARVALUE;
-  std::atomic<enum NCCL_ALLGATHER_ALGO> allgather =
-      NCCL_ALLGATHER_ALGO_DEFAULTCVARVALUE;
-  std::atomic<enum NCCL_ALLREDUCE_ALGO> allreduce =
-      NCCL_ALLREDUCE_ALGO_DEFAULTCVARVALUE;
-  std::atomic<enum NCCL_ALLTOALLV_ALGO> alltoallv =
-      NCCL_ALLTOALLV_ALGO_DEFAULTCVARVALUE;
-  std::atomic<enum NCCL_RMA_ALGO> rma = NCCL_RMA_ALGO_DEFAULTCVARVALUE;
 };
 
 template <typename T>
@@ -203,41 +59,14 @@ AlgoConfig::AlgoConfig() {
 };
 
 void AlgoConfig::reset() {
-  // Ensure CVAR is initialized before initializing algo hints default values
   ncclCvarInit();
-  // Update default algo value from CVAR
   sendrecv.store(NCCL_SENDRECV_ALGO);
-  allgather.store(NCCL_ALLGATHER_ALGO);
-  allreduce.store(NCCL_ALLREDUCE_ALGO);
-  alltoallv.store(NCCL_ALLTOALLV_ALGO);
 
-  // Register algo hints
   auto hintsMngr = GlobalHints::getInstance();
   ncclx::GlobalHintEntry sendrecvEntry = {
       .setHook = setAlgo<enum NCCL_SENDRECV_ALGO>,
       .resetHook = resetAlgo<enum NCCL_SENDRECV_ALGO>};
   hintsMngr->regHintEntry("algo_sendrecv", sendrecvEntry);
-
-  ncclx::GlobalHintEntry allgatherEntry = {
-      .setHook = setAlgo<enum NCCL_ALLGATHER_ALGO>,
-      .resetHook = resetAlgo<enum NCCL_ALLGATHER_ALGO>};
-  hintsMngr->regHintEntry("algo_allgather", allgatherEntry);
-
-  ncclx::GlobalHintEntry allreduceEntry = {
-      .setHook = setAlgo<enum NCCL_ALLREDUCE_ALGO>,
-      .resetHook = resetAlgo<enum NCCL_ALLREDUCE_ALGO>};
-  hintsMngr->regHintEntry("algo_allreduce", allreduceEntry);
-
-  ncclx::GlobalHintEntry alltoallvEntry = {
-      .setHook = setAlgo<enum NCCL_ALLTOALLV_ALGO>,
-      .resetHook = resetAlgo<enum NCCL_ALLTOALLV_ALGO>};
-  hintsMngr->regHintEntry("algo_alltoallv", alltoallvEntry);
-
-  rma.store(NCCL_RMA_ALGO);
-  ncclx::GlobalHintEntry rmaEntry = {
-      .setHook = setAlgo<enum NCCL_RMA_ALGO>,
-      .resetHook = resetAlgo<enum NCCL_RMA_ALGO>};
-  hintsMngr->regHintEntry("algo_rma", rmaEntry);
 }
 
 folly::Singleton<AlgoConfig> algoConfigSingleton;
@@ -259,22 +88,6 @@ void setAlgo(
     enum NCCL_SENDRECV_ALGO val;
     algoStrToVal(valStr, val);
     algoConfig->sendrecv.store(val);
-  } else if (std::is_same<T, enum NCCL_ALLGATHER_ALGO>::value) {
-    enum NCCL_ALLGATHER_ALGO val;
-    algoStrToVal(valStr, val);
-    algoConfig->allgather.store(val);
-  } else if (std::is_same<T, enum NCCL_ALLREDUCE_ALGO>::value) {
-    enum NCCL_ALLREDUCE_ALGO val;
-    algoStrToVal(valStr, val);
-    algoConfig->allreduce.store(val);
-  } else if (std::is_same<T, enum NCCL_ALLTOALLV_ALGO>::value) {
-    enum NCCL_ALLTOALLV_ALGO val;
-    algoStrToVal(valStr, val);
-    algoConfig->alltoallv.store(val);
-  } else if (std::is_same<T, enum NCCL_RMA_ALGO>::value) {
-    enum NCCL_RMA_ALGO val;
-    algoStrToVal(valStr, val);
-    algoConfig->rma.store(val);
   }
 }
 
@@ -283,14 +96,6 @@ void resetAlgo(const std::string& key __attribute__((unused))) {
   auto algoConfig = AlgoConfig::getInstance();
   if (std::is_same<T, enum NCCL_SENDRECV_ALGO>::value) {
     algoConfig->sendrecv.store(NCCL_SENDRECV_ALGO);
-  } else if (std::is_same<T, enum NCCL_ALLGATHER_ALGO>::value) {
-    algoConfig->allgather.store(NCCL_ALLGATHER_ALGO);
-  } else if (std::is_same<T, enum NCCL_ALLREDUCE_ALGO>::value) {
-    algoConfig->allreduce.store(NCCL_ALLREDUCE_ALGO);
-  } else if (std::is_same<T, enum NCCL_ALLTOALLV_ALGO>::value) {
-    algoConfig->alltoallv.store(NCCL_ALLTOALLV_ALGO);
-  } else if (std::is_same<T, enum NCCL_RMA_ALGO>::value) {
-    algoConfig->rma.store(NCCL_RMA_ALGO);
   }
 }
 } // namespace
@@ -301,48 +106,12 @@ enum NCCL_SENDRECV_ALGO getSendRecvAlgo() {
   return algoConfig->sendrecv.load();
 }
 
-enum NCCL_ALLGATHER_ALGO getAllGatherAlgo() {
-  auto algoConfig = AlgoConfig::getInstance();
-  return algoConfig->allgather.load();
-}
-
-enum NCCL_ALLREDUCE_ALGO getAllReduceAlgo() {
-  auto algoConfig = AlgoConfig::getInstance();
-  return algoConfig->allreduce.load();
-}
-
-enum NCCL_ALLTOALLV_ALGO getAllToAllVAlgo() {
-  auto algoConfig = AlgoConfig::getInstance();
-  return algoConfig->alltoallv.load();
-}
-
-enum NCCL_RMA_ALGO getRmaAlgo() {
-  auto algoConfig = AlgoConfig::getInstance();
-  return algoConfig->rma.load();
-}
-
 std::string getAlgoHintValue(enum NCCL_SENDRECV_ALGO algo) {
-  return algoValToStr(algo);
-}
-std::string getAlgoHintValue(enum NCCL_ALLGATHER_ALGO algo) {
-  return algoValToStr(algo);
-}
-std::string getAlgoHintValue(enum NCCL_ALLREDUCE_ALGO algo) {
-  return algoValToStr(algo);
-}
-std::string getAlgoHintValue(enum NCCL_ALLTOALLV_ALGO algo) {
-  return algoValToStr(algo);
-}
-std::string getAlgoHintValue(enum NCCL_RMA_ALGO algo) {
   return algoValToStr(algo);
 }
 
 void testOnlyResetAlgoConfig() {
   auto algoConfig = AlgoConfig::getInstance();
-  // It may cause hint entry to be registered twice if this is the first time to
-  // initialize algoConfigSingleton. I.e., algoConfigSingleton will register all
-  // entries in its constructor. It should be OK as this function is called only
-  // in tests.
   algoConfig->reset();
 }
 
@@ -351,28 +120,7 @@ void testOnlySetAlgo(enum NCCL_SENDRECV_ALGO algo) {
   algoConfig->sendrecv.store(algo);
 }
 
-void testOnlySetAlgo(enum NCCL_ALLGATHER_ALGO algo) {
-  auto algoConfig = AlgoConfig::getInstance();
-  algoConfig->allgather.store(algo);
-}
-
-void testOnlySetAlgo(enum NCCL_ALLREDUCE_ALGO algo) {
-  auto algoConfig = AlgoConfig::getInstance();
-  algoConfig->allreduce.store(algo);
-}
-
-void testOnlySetAlgo(enum NCCL_ALLTOALLV_ALGO algo) {
-  auto algoConfig = AlgoConfig::getInstance();
-  algoConfig->alltoallv.store(algo);
-}
-
-void testOnlySetAlgo(enum NCCL_RMA_ALGO algo) {
-  auto algoConfig = AlgoConfig::getInstance();
-  algoConfig->rma.store(algo);
-}
-
 void setupGlobalHints() {
-  // AlgoConfig constructor will register the hint entries to GlobalHints
   auto algoConfig = AlgoConfig::getInstance();
 }
 } // namespace ncclx::algoconf

--- a/comms/ncclx/meta/algoconf/AlgoConfig.h
+++ b/comms/ncclx/meta/algoconf/AlgoConfig.h
@@ -11,22 +11,10 @@ namespace ncclx::algoconf {
 void setupGlobalHints();
 
 enum NCCL_SENDRECV_ALGO getSendRecvAlgo();
-enum NCCL_ALLGATHER_ALGO getAllGatherAlgo();
-enum NCCL_ALLREDUCE_ALGO getAllReduceAlgo();
-enum NCCL_ALLTOALLV_ALGO getAllToAllVAlgo();
-enum NCCL_RMA_ALGO getRmaAlgo();
 
 std::string getAlgoHintValue(enum NCCL_SENDRECV_ALGO algo);
-std::string getAlgoHintValue(enum NCCL_ALLGATHER_ALGO algo);
-std::string getAlgoHintValue(enum NCCL_ALLREDUCE_ALGO algo);
-std::string getAlgoHintValue(enum NCCL_ALLTOALLV_ALGO algo);
-std::string getAlgoHintValue(enum NCCL_RMA_ALGO algo);
 
 void testOnlyResetAlgoConfig();
 
 void testOnlySetAlgo(enum NCCL_SENDRECV_ALGO algo);
-void testOnlySetAlgo(enum NCCL_ALLGATHER_ALGO algo);
-void testOnlySetAlgo(enum NCCL_ALLREDUCE_ALGO algo);
-void testOnlySetAlgo(enum NCCL_ALLTOALLV_ALGO algo);
-void testOnlySetAlgo(enum NCCL_RMA_ALGO algo);
 } // namespace ncclx::algoconf

--- a/comms/ncclx/meta/algoconf/tests/AlgoConfigTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoConfigTest.cc
@@ -8,10 +8,6 @@
 #include "meta/algoconf/AlgoConfig.h" // @manual
 #include "meta/hints/GlobalHints.h" // @manual
 
-using ncclx::algoconf::getAllGatherAlgo;
-using ncclx::algoconf::getAllReduceAlgo;
-using ncclx::algoconf::getAllToAllVAlgo;
-using ncclx::algoconf::getRmaAlgo;
 using ncclx::algoconf::getSendRecvAlgo;
 using ncclx::algoconf::testOnlyResetAlgoConfig;
 
@@ -73,120 +69,6 @@ TEST_F(AlgoConfigUT, SendRecvAlgoHintOverride) {
   }
 }
 
-TEST_F(AlgoConfigUT, AllGatherAlgoHintOverride) {
-  setenv("NCCL_ALLGATHER_ALGO", "orig", 1);
-  CLOGF(WARN, "before testOnlyResetGlobalHints");
-  ncclx::testOnlyResetGlobalHints();
-  CLOGF(WARN, "after testOnlyResetGlobalHints");
-  testOnlyResetAlgoConfig();
-  CLOGF(WARN, "after testOnlyResetAlgoConfig");
-
-  const char* hintName = "algo_allgather";
-  ASSERT_EQ(getAllGatherAlgo(), NCCL_ALLGATHER_ALGO::orig);
-  CLOGF(WARN, "after getAllGatherAlgo");
-
-  // set/reset multiple times
-  std::unordered_map<enum NCCL_ALLGATHER_ALGO, const char*> overrideAlgos = {
-      {NCCL_ALLGATHER_ALGO::ctran, "ctran"},
-      {NCCL_ALLGATHER_ALGO::ctring, "ctring"},
-      {NCCL_ALLGATHER_ALGO::ctrd, "ctrd"},
-      {NCCL_ALLGATHER_ALGO::ctbrucks, "ctbrucks"},
-      {NCCL_ALLGATHER_ALGO::ctdirect, "ctdirect"},
-  };
-
-  const int iter = 10;
-  for (int i = 0; i < iter; i++) {
-    for (auto& [algo, hintVal] : overrideAlgos) {
-      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
-
-      auto getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_TRUE(getHintVal.has_value());
-      ASSERT_EQ(getHintVal.value(), hintVal);
-
-      ASSERT_EQ(getAllGatherAlgo(), algo);
-
-      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-      getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_FALSE(getHintVal.has_value());
-
-      ASSERT_EQ(getAllGatherAlgo(), NCCL_ALLGATHER_ALGO::orig);
-    }
-  }
-}
-
-TEST_F(AlgoConfigUT, AllReduceAlgoHintOverride) {
-  setenv("NCCL_ALLREDUCE_ALGO", "orig", 1);
-  ncclx::testOnlyResetGlobalHints();
-  testOnlyResetAlgoConfig();
-
-  const char* hintName = "algo_allreduce";
-  ASSERT_EQ(getAllReduceAlgo(), NCCL_ALLREDUCE_ALGO::orig);
-
-  std::unordered_map<enum NCCL_ALLREDUCE_ALGO, const char*> overrideAlgos = {
-      {NCCL_ALLREDUCE_ALGO::ctran, "ctran"},
-      {NCCL_ALLREDUCE_ALGO::ctdirect, "ctdirect"},
-      {NCCL_ALLREDUCE_ALGO::ctring, "ctring"},
-  };
-
-  const int iter = 10;
-  for (int i = 0; i < iter; i++) {
-    for (auto& [algo, hintVal] : overrideAlgos) {
-      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
-
-      auto getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_TRUE(getHintVal.has_value());
-      ASSERT_EQ(getHintVal.value(), hintVal);
-
-      ASSERT_EQ(getAllReduceAlgo(), algo);
-
-      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-      getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_FALSE(getHintVal.has_value());
-
-      ASSERT_EQ(getAllReduceAlgo(), NCCL_ALLREDUCE_ALGO::orig);
-    }
-  }
-}
-
-TEST_F(AlgoConfigUT, AlltoAllVAlgoHintOverride) {
-  setenv("NCCL_ALLTOALLV_ALGO", "orig", 1);
-  CLOGF(WARN, "before testOnlyResetGlobalHints");
-  ncclx::testOnlyResetGlobalHints();
-  CLOGF(WARN, "after testOnlyResetGlobalHints");
-  testOnlyResetAlgoConfig();
-  CLOGF(WARN, "after testOnlyResetAlgoConfig");
-
-  const char* hintName = "algo_alltoallv";
-  ASSERT_EQ(getAllToAllVAlgo(), NCCL_ALLTOALLV_ALGO::orig);
-  CLOGF(WARN, "after getAllToAllVAlgo");
-
-  // set/reset multiple times
-  std::unordered_map<enum NCCL_ALLTOALLV_ALGO, const char*> overrideAlgos = {
-      {NCCL_ALLTOALLV_ALGO::ctran, "ctran"},
-      {NCCL_ALLTOALLV_ALGO::compCtran, "compCtran"},
-      {NCCL_ALLTOALLV_ALGO::bsCompCtran, "bsCompCtran"},
-  };
-
-  const int iter = 10;
-  for (int i = 0; i < iter; i++) {
-    for (auto& [algo, hintVal] : overrideAlgos) {
-      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
-
-      auto getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_TRUE(getHintVal.has_value());
-      ASSERT_EQ(getHintVal.value(), hintVal);
-
-      ASSERT_EQ(getAllToAllVAlgo(), algo);
-
-      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-      getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_FALSE(getHintVal.has_value());
-
-      ASSERT_EQ(getAllToAllVAlgo(), NCCL_ALLTOALLV_ALGO::orig);
-    }
-  }
-}
-
 TEST_F(AlgoConfigUT, InvalidAlgoHint) {
   setenv("NCCL_SENDRECV_ALGO", "orig", 1);
   ncclx::testOnlyResetGlobalHints();
@@ -205,37 +87,4 @@ TEST_F(AlgoConfigUT, InvalidAlgoHint) {
   auto getHintVal = ncclx::getGlobalHint("algo_sendrecv");
   ASSERT_TRUE(getHintVal.has_value());
   ASSERT_EQ(getHintVal.value(), "dummy_val");
-}
-
-TEST_F(AlgoConfigUT, RmaAlgoHintOverride) {
-  setenv("NCCL_RMA_ALGO", "ctran", 1);
-  ncclx::testOnlyResetGlobalHints();
-  testOnlyResetAlgoConfig();
-
-  const char* hintName = "algo_rma";
-  ASSERT_EQ(getRmaAlgo(), NCCL_RMA_ALGO::ctran);
-
-  // set/reset multiple times
-  std::unordered_map<enum NCCL_RMA_ALGO, const char*> overrideAlgos = {
-      {NCCL_RMA_ALGO::orig, "orig"},
-  };
-
-  const int iter = 10;
-  for (int i = 0; i < iter; i++) {
-    for (auto& [algo, hintVal] : overrideAlgos) {
-      ASSERT_TRUE(ncclx::setGlobalHint(hintName, hintVal));
-
-      auto getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_TRUE(getHintVal.has_value());
-      ASSERT_EQ(getHintVal.value(), hintVal);
-
-      ASSERT_EQ(getRmaAlgo(), algo);
-
-      ASSERT_TRUE(ncclx::resetGlobalHint(hintName));
-      getHintVal = ncclx::getGlobalHint(hintName);
-      ASSERT_FALSE(getHintVal.has_value());
-
-      ASSERT_EQ(getRmaAlgo(), NCCL_RMA_ALGO::ctran);
-    }
-  }
 }

--- a/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
+++ b/comms/ncclx/meta/colltrace/tests/NewCollTraceDistTestNoLocal.cc
@@ -20,7 +20,6 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/tests/nvidia-only/CPUControlledKernel.h"
@@ -138,8 +137,14 @@ class CollTraceTest : public NcclxBaseTestFixture {
 };
 
 TEST_F(CollTraceTest, NewCollTraceAllReduce) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -165,8 +170,6 @@ TEST_F(CollTraceTest, NewCollTraceAllReduce) {
 }
 
 TEST_F(CollTraceTest, MixedCtranBaseline) {
-  auto ctranAlgoGuard =
-      testinfra::AlgoRAII(NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctring);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   // CTran has temporarily disabled NVL backend support. Set to nolocal to
   // enable test
@@ -174,8 +177,14 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
       EnvRAII(NCCL_COMM_STATE_DEBUG_TOPO, NCCL_COMM_STATE_DEBUG_TOPO::nolocal);
   auto checksumSampleRateGuard =
       EnvRAII(NCCL_CTRAN_ALLGATHER_CHECKSUM_SAMPLE_RATE, 1);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"allgatherAlgo", "ctring"}};
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   constexpr int count = 1048576;
   constexpr int nColl = 10;
@@ -221,8 +230,14 @@ TEST_F(CollTraceTest, MixedCtranBaseline) {
 TEST_F(CollTraceTest, GroupedSendRecv) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -270,8 +285,14 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto ctranSRGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctran};
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -326,8 +347,14 @@ TEST_F(CollTraceTest, GroupedSendRecvCtran) {
 TEST_F(CollTraceTest, SimulatePPSendRecv) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -388,8 +415,14 @@ TEST_F(CollTraceTest, SimulateCtranPPSendRecv) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto ctranSRGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::ctran};
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -461,8 +494,14 @@ TEST_F(CollTraceTest, winPutWait) {
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
   auto recordGuard = EnvRAII{NCCL_COLLTRACE_RECORD_MAX, 1000};
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   auto statex = comm->ctranComm_->statex_.get();
   ASSERT_NE(statex, nullptr);
@@ -589,8 +628,14 @@ TEST_F(CollTraceTest, winPutWait) {
 TEST_F(CollTraceTest, DumpWithUnfinished) {
   auto wakeUpGuard = EnvRAII(NCCL_COLLTRACE_WAKEUP_INTERVAL_MS, 10L);
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -641,11 +686,15 @@ TEST_F(CollTraceTest, DumpWithUnfinished) {
 
 TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
   auto wakeUpGuard = EnvRAII(NCCL_COLLTRACE_WAKEUP_INTERVAL_MS, 10L);
-  auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::ctdirect);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"allreduceAlgo", "ctdirect"}};
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -696,8 +745,14 @@ TEST_F(CollTraceTest, DumpWithUnfinishedCtran) {
 
 TEST_F(CollTraceTest, GroupedAllReduce) {
   auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -732,8 +787,14 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
   auto ctranGuard = EnvRAII{NCCL_SENDRECV_ALGO, NCCL_SENDRECV_ALGO::orig};
   auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig);
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 10;
@@ -771,8 +832,14 @@ TEST_F(CollTraceTest, GroupedSendRecvAllReduce) {
 }
 
 TEST_F(CollTraceTest, CollTraceQueryInCapture) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  hints.set("noLocal", "1");
+#endif
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const int count = 1048576;
   const int nColl = 20;
@@ -808,8 +875,14 @@ TEST_F(CollTraceTest, CollTraceTestEnqueueMoreThanPendingQueue) {
   auto wakeUpGuard = EnvRAII(NCCL_COLLTRACE_WAKEUP_INTERVAL_MS, 10L);
   auto ctranGuard = EnvRAII(NCCL_CTRAN_ENABLE, true);
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints commHints;
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+  commHints.set("noLocal", "1");
+#endif
+  config.hints = &commHints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
 
   const auto kNumElements = 8388608;
   const auto kNumIters = CollTraceConfig::kDefaultMaxPendingQueueSize;

--- a/comms/ncclx/meta/hints/GlobalHints.h
+++ b/comms/ncclx/meta/hints/GlobalHints.h
@@ -28,11 +28,15 @@ constexpr std::array<std::string_view, 3> kHintKeysArray = {
 // {deprecated GlobalHint key, replacement per-comm ncclx::Hints key}
 using DeprecatedHintKey = std::pair<std::string_view, std::string_view>;
 
-constexpr std::array<DeprecatedHintKey, 4> kDeprecatedCommHintKeys = {{
+constexpr std::array<DeprecatedHintKey, 8> kDeprecatedCommHintKeys = {{
     {"ncclx.comm.useCtran", "useCtran"},
     {"ncclx.comm.algo_reducescatter", "usePatAvg"},
     {"ncclx.comm.nolocal", "noLocal"},
     {"ncclx.comm.vCliqueSize", "vCliqueSize"},
+    {"algo_allgather", "allgatherAlgo"},
+    {"algo_allreduce", "allreduceAlgo"},
+    {"algo_alltoallv", "alltoallvAlgo"},
+    {"algo_rma", "rmaAlgo"},
 }};
 
 using GlobalSetHintHook =

--- a/comms/ncclx/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherTest.cc
@@ -9,14 +9,13 @@
 #include <cstddef>
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-
-using testinfra::AlgoRAII;
+#include "meta/algoconf/AlgoStrConv.h"
 
 class AllGatherTest : public NcclxBaseTestFixture {
  public:
@@ -30,20 +29,13 @@ class AllGatherTest : public NcclxBaseTestFixture {
     envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"});
 #endif
     NcclxBaseTestFixture::SetUp(envs);
-    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::Hints hints{{"noLocal", "1"}};
-    config.hints = &hints;
-#endif
-    this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    ctranAlgoStats_.enable();
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();
   }
@@ -55,7 +47,17 @@ class AllGatherTest : public NcclxBaseTestFixture {
       bool useCudaGraph,
       MemAllocType memType,
       size_t count) {
-    auto algoGuard = AlgoRAII(NCCL_ALLGATHER_ALGO, algo);
+    // Create comm with per-comm hints for the allgather algorithm
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints(
+        {{"allgatherAlgo", ncclx::algoconf::algoValToStr(algo)}});
+#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
+    hints.set("noLocal", "1");
+#endif
+    config.hints = &hints;
+    ncclx::test::NcclCommRAII commRaii(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    this->comm = commRaii.get();
 
     if ((memType == kMemNcclMemAlloc || memType == kCuMemAllocDisjoint) &&
         ncclIsCuMemSupported() == false) {
@@ -145,6 +147,12 @@ class AllGatherTest : public NcclxBaseTestFixture {
 
     CUDACHECK_TEST(cudaStreamSynchronize(stream));
 
+#ifdef TEST_ENABLE_CTRAN
+    if (algo != NCCL_ALLGATHER_ALGO::orig) {
+      ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllGather", "Ctran");
+    }
+#endif
+
     // Check each received chunk
     for (int r = 0; r < numRanks; r++) {
       int expectedVal = r + 1;
@@ -170,6 +178,7 @@ class AllGatherTest : public NcclxBaseTestFixture {
  protected:
   ncclComm_t comm{};
   cudaStream_t stream{};
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 };
 
 class AllgatherTestParam : public AllGatherTest,

--- a/comms/ncclx/meta/tests/AllReduceTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceTest.cc
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <cstddef>
+#include <optional>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -11,14 +12,13 @@
 #include <comm.h>
 #include <nccl.h>
 #include "checks.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/algoconf/AlgoConfig.h"
-#include "meta/hints/GlobalHints.h"
-
-#include "meta/wrapper/MetaFactory.h"
+#include "meta/NcclxConfig.h"
+#include "meta/algoconf/AlgoStrConv.h"
 
 class AllReduceTest : public NcclxBaseTestFixture {
  public:
@@ -27,16 +27,13 @@ class AllReduceTest : public NcclxBaseTestFixture {
     // registry the user buffer as NCCL_MANAGED memory. It enable the nvl
     // intra-node connection
     NcclxBaseTestFixture::SetUp();
-
-    comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+    ctranAlgoStats_.enable();
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();
   }
@@ -94,11 +91,20 @@ class AllReduceTest : public NcclxBaseTestFixture {
 
   template <typename T>
   void run(
-      enum NCCL_ALLREDUCE_ALGO algo,
+      std::optional<enum NCCL_ALLREDUCE_ALGO> algo,
       ncclDataType_t dataType,
       bool enableDequant,
       size_t count) {
-    auto envGuard = EnvRAII(NCCL_ALLREDUCE_ALGO, algo);
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
+    if (algo.has_value()) {
+      hints.set("allreduceAlgo", ncclx::algoconf::algoValToStr(*algo));
+      config.hints = &hints;
+    }
+    ncclx::test::NcclCommRAII commRaii(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    this->comm = commRaii.get();
+
     T *sendBuf = nullptr, *recvBuf = nullptr;
 
     // create and register buffers
@@ -125,6 +131,13 @@ class AllReduceTest : public NcclxBaseTestFixture {
       ASSERT_EQ(res, ncclSuccess);
     }
     CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+#ifdef TEST_ENABLE_CTRAN
+    if (algo.has_value() && *algo == NCCL_ALLREDUCE_ALGO::ctdirect) {
+      ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllReduce", "Ctran");
+    }
+#endif
+
     // Check results
     std::vector<T> expectedVals(count);
     for (int i = 0; i < count; i++) {
@@ -146,31 +159,23 @@ class AllReduceTest : public NcclxBaseTestFixture {
   }
 
  protected:
-  ncclComm_t comm;
+  ncclComm_t comm{nullptr};
   cudaStream_t stream;
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 };
 
 class AllReduceHintOverrideTest : public AllReduceTest {};
 
 TEST_F(AllReduceHintOverrideTest, TestWithHintOverride_orig) {
-  enum NCCL_ALLREDUCE_ALGO algo = NCCL_ALLREDUCE_ALGO::orig;
-  std::string hintVal = ncclx::algoconf::getAlgoHintValue(algo);
-  ASSERT_TRUE(ncclx::setGlobalHint("algo_allreduce", hintVal.c_str()));
-  run<int>(algo, ncclInt32, false, 1024);
-  ASSERT_TRUE(ncclx::resetGlobalHint("algo_allreduce"));
+  run<int>(NCCL_ALLREDUCE_ALGO::orig, ncclInt32, false, 1024);
 }
 
 TEST_F(AllReduceHintOverrideTest, TestWithHintOverride_ctdirect) {
-  enum NCCL_ALLREDUCE_ALGO algo = NCCL_ALLREDUCE_ALGO::ctdirect;
-  std::string hintVal = ncclx::algoconf::getAlgoHintValue(algo);
-  ASSERT_TRUE(ncclx::setGlobalHint("algo_allreduce", hintVal.c_str()));
-  run<int>(algo, ncclInt32, false, 1024);
-  ASSERT_TRUE(ncclx::resetGlobalHint("algo_allreduce"));
+  run<int>(NCCL_ALLREDUCE_ALGO::ctdirect, ncclInt32, false, 1024);
 }
 
 TEST_F(AllReduceHintOverrideTest, TestWithHintOverride_null) {
-  enum NCCL_ALLREDUCE_ALGO algo = NCCL_ALLREDUCE_ALGO::ctdirect;
-  run<int>(algo, ncclInt32, false, 1024);
+  run<int>(std::nullopt, ncclInt32, false, 1024);
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ncclx/meta/tests/AllToAllvTest.cc
+++ b/comms/ncclx/meta/tests/AllToAllvTest.cc
@@ -12,16 +12,15 @@
 
 #include "checks.h"
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 
-#include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
+#include "meta/algoconf/AlgoStrConv.h"
 #include "meta/commDump.h"
-#include "meta/hints/GlobalHints.h"
-
-using testinfra::AlgoRAII;
 
 class AllToAllvTest
     : public NcclxBaseTestFixture,
@@ -34,16 +33,13 @@ class AllToAllvTest
 #endif
 
     NcclxBaseTestFixture::SetUp();
-
-    this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+    ctranAlgoStats_.enable();
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
   }
 
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
     NcclxBaseTestFixture::TearDown();
   }
@@ -675,60 +671,140 @@ class AllToAllvTest
   }
 
  protected:
-  ncclComm_t comm;
+  ncclComm_t comm{nullptr};
   cudaStream_t stream;
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 };
 
 TEST_F(AllToAllvTest, OutOfPlaceInt) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   run<int>();
 }
+
 TEST_F(AllToAllvTest, OutOfPlaceUint8) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   run<uint8_t>();
 }
+
 TEST_F(AllToAllvTest, OutOfPlaceFloat) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   run<float>();
 }
 
 #ifdef TEST_ENABLE_CTRAN
 TEST_F(AllToAllvTest, CtranInt) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, NCCL_ALLTOALLV_ALGO::ctran);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", "ctran"}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   run<int>();
+  ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
 }
 
 TEST_F(AllToAllvTest, CtranUint8) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, NCCL_ALLTOALLV_ALGO::ctran);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", "ctran"}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   run<uint8_t>();
+  ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
 }
 #endif
 
 TEST_P(AllToAllvTest, CanCopy16Mismatch) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, GetParam());
+  const auto algo = GetParam();
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", ncclx::algoconf::algoValToStr(algo)}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   runCanCopy16Mismatch();
+#ifdef TEST_ENABLE_CTRAN
+  if (algo != NCCL_ALLTOALLV_ALGO::orig) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+  }
+#endif
 }
 
 #ifdef TEST_ENABLE_CTRAN
 TEST_P(AllToAllvTest, ZeroByteSendRecv) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, GetParam());
-  runZeroByteSendRecv(GetParam() == NCCL_ALLTOALLV_ALGO::ctran);
+  const auto algo = GetParam();
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", ncclx::algoconf::algoValToStr(algo)}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  runZeroByteSendRecv(algo == NCCL_ALLTOALLV_ALGO::ctran);
+  if (algo != NCCL_ALLTOALLV_ALGO::orig) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+  }
 }
 #endif
 
 TEST_P(AllToAllvTest, ReuseSharedBuffer) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, GetParam());
+  const auto algo = GetParam();
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", ncclx::algoconf::algoValToStr(algo)}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   runReuseSharedBuffer();
+#ifdef TEST_ENABLE_CTRAN
+  if (algo != NCCL_ALLTOALLV_ALGO::orig) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+  }
+#endif
 }
 
 TEST_P(AllToAllvTest, SparseAlltoallvInt) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, GetParam());
+  const auto algo = GetParam();
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", ncclx::algoconf::algoValToStr(algo)}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   runSparseAlltoallv<int>(true /*registFlag*/);
+#ifdef TEST_ENABLE_CTRAN
+  if (algo != NCCL_ALLTOALLV_ALGO::orig) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+  }
+#endif
 }
 
 TEST_P(AllToAllvTest, SparseAlltoallvUint8) {
-  auto envGuard = AlgoRAII(NCCL_ALLTOALLV_ALGO, GetParam());
+  const auto algo = GetParam();
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"alltoallvAlgo", ncclx::algoconf::algoValToStr(algo)}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
   runSparseAlltoallv<uint8_t>(true /*registFlag*/);
+#ifdef TEST_ENABLE_CTRAN
+  if (algo != NCCL_ALLTOALLV_ALGO::orig) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+  }
+#endif
 }
 
 TEST_F(AllToAllvTest, InvalidSendbuf) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   constexpr int count = 1048576;
   int* buf = nullptr;
   CUDACHECK_TEST(cudaMalloc(&buf, count * this->numRanks * sizeof(int)));
@@ -755,6 +831,9 @@ TEST_F(AllToAllvTest, InvalidSendbuf) {
 }
 
 TEST_F(AllToAllvTest, InvalidRecvbuf) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   constexpr int count = 1048576;
   int* buf = nullptr;
   CUDACHECK_TEST(cudaMalloc(&buf, count * this->numRanks * sizeof(int)));
@@ -781,6 +860,9 @@ TEST_F(AllToAllvTest, InvalidRecvbuf) {
 }
 
 TEST_F(AllToAllvTest, InvalidInPlace) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   constexpr int count = 1048576;
   int* buf = nullptr;
   CUDACHECK_TEST(cudaMalloc(&buf, count * this->numRanks * sizeof(int)));
@@ -807,6 +889,9 @@ TEST_F(AllToAllvTest, InvalidInPlace) {
 }
 
 TEST_F(AllToAllvTest, ValidInPlace) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
   // prepare alltoallv arguments
   std::vector<size_t> sendCounts(this->numRanks, 0);
   std::vector<size_t> sendDispls(this->numRanks, 0);
@@ -828,13 +913,27 @@ TEST_F(AllToAllvTest, ValidInPlace) {
 }
 
 TEST_F(AllToAllvTest, AllToAllvWithHintOverride) {
-  AlgoRAII algoEnv(NCCL_ALLTOALLV_ALGO, NCCL_ALLTOALLV_ALGO::orig);
+  // Run with ctran algo via per-comm hint
+  {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints{{"alltoallvAlgo", "ctran"}};
+    config.hints = &hints;
+    ncclx::test::NcclCommRAII commRaii(
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+    this->comm = commRaii.get();
+    run<int>();
+#ifdef TEST_ENABLE_CTRAN
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllToAll", "Ctran");
+#endif
+  }
 
-  ASSERT_TRUE(ncclx::setGlobalHint("algo_alltoallv", "ctran"));
-  run<int>();
-
-  ASSERT_TRUE(ncclx::resetGlobalHint("algo_alltoallv"));
-  run<int>();
+  // Run with default algo (no hint override)
+  {
+    ncclx::test::NcclCommRAII commRaii(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    this->comm = commRaii.get();
+    run<int>();
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/comms/ncclx/meta/tests/RMATest.cc
+++ b/comms/ncclx/meta/tests/RMATest.cc
@@ -8,13 +8,13 @@
 #include <nccl.h>
 #include <cstddef>
 #include "comm.h"
+#include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "comms/testinfra/AlgoTestUtils.h"
 #include "comms/testinfra/TestUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-
-using testinfra::AlgoRAII;
+#include "meta/NcclxConfig.h"
+#include "meta/algoconf/AlgoStrConv.h"
 
 // In v2.29+, RMA functions moved to ncclx:: namespace.
 // Bring them into scope so the same code compiles across versions.
@@ -32,16 +32,12 @@ class RMATest : public NcclxBaseTestFixture {
  protected:
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-
-    this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
-    ASSERT_NE(this->comm, nullptr);
+    ctranAlgoStats_.enable();
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
   void TearDown() override {
-    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();
   }
@@ -79,9 +75,15 @@ class RMATest : public NcclxBaseTestFixture {
   ncclComm_t comm{nullptr};
   cudaStream_t stream{};
   std::vector<TestMemSegment> segments;
+  ctran::test::VerifyAlgoStatsHelper ctranAlgoStats_;
 };
 
 TEST_F(RMATest, winPutOnly) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
   const size_t kNumElements = 8192;
   const size_t kNumIters = 10;
 
@@ -153,10 +155,16 @@ TEST_P(RMATestParam, winPut) {
   const auto& [kNumElements, ctranAllReduce, bufType] = GetParam();
   const size_t kNumIters = 10;
 
-  auto envGuard = AlgoRAII(
-      NCCL_ALLREDUCE_ALGO,
-      ctranAllReduce ? NCCL_ALLREDUCE_ALGO::ctdirect
-                     : NCCL_ALLREDUCE_ALGO::orig);
+  auto allreduceAlgoVal = ctranAllReduce ? NCCL_ALLREDUCE_ALGO::ctdirect
+                                         : NCCL_ALLREDUCE_ALGO::orig;
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allreduceAlgo", ncclx::algoconf::algoValToStr(allreduceAlgoVal)}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
 
   cudaStream_t put_stream, wait_stream;
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&put_stream, cudaStreamNonBlocking));
@@ -220,6 +228,12 @@ TEST_P(RMATestParam, winPut) {
   CUDACHECK_TEST(cudaStreamSynchronize(put_stream));
   CUDACHECK_TEST(cudaStreamSynchronize(wait_stream));
 
+#ifdef TEST_ENABLE_CTRAN
+  if (ctranAllReduce) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllReduce", "Ctran");
+  }
+#endif
+
   auto res = ncclCommWindowDeregister(comm, win);
   EXPECT_EQ(res, ncclSuccess);
 
@@ -237,10 +251,16 @@ TEST_P(RMATestParam, winGet) {
   const auto& [kNumElements, ctranAllReduce, bufType] = GetParam();
   const size_t kNumIters = 10;
 
-  auto envGuard = AlgoRAII(
-      NCCL_ALLREDUCE_ALGO,
-      ctranAllReduce ? NCCL_ALLREDUCE_ALGO::ctdirect
-                     : NCCL_ALLREDUCE_ALGO::orig);
+  auto allreduceAlgoVal = ctranAllReduce ? NCCL_ALLREDUCE_ALGO::ctdirect
+                                         : NCCL_ALLREDUCE_ALGO::orig;
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints(
+      {{"allreduceAlgo", ncclx::algoconf::algoValToStr(allreduceAlgoVal)}});
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
 
   cudaStream_t get_stream;
   CUDACHECK_TEST(cudaStreamCreateWithFlags(&get_stream, cudaStreamNonBlocking));
@@ -288,7 +308,15 @@ TEST_P(RMATestParam, winGet) {
     NCCLCHECK_TEST(ncclAllReduce(
         arBuf, arBuf, kNumElements, ncclInt32, ncclSum, comm, get_stream));
   }
+
   CUDACHECK_TEST(cudaStreamSynchronize(get_stream));
+
+#ifdef TEST_ENABLE_CTRAN
+  if (ctranAllReduce) {
+    ctranAlgoStats_.verify(comm->ctranComm_.get(), "AllReduce", "Ctran");
+  }
+#endif
+
   this->barrier(comm, stream);
 
   size_t errs = checkChunkValue(
@@ -335,6 +363,11 @@ class MultiWindowTestParam
       public ::testing::WithParamInterface<std::tuple<size_t, size_t>> {};
 
 TEST_P(MultiWindowTestParam, multiWindow) {
+  ncclx::test::NcclCommRAII commRaii(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  this->comm = commRaii.get();
+  ASSERT_NE(this->comm, nullptr);
+
   const auto& [kMaxNumElements, kNumIters] = GetParam();
   EXPECT_GE(kMaxNumElements, 1);
   EXPECT_GE(kNumIters, 1);

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -12,6 +12,7 @@
 #include "nvtx_payload_schemas.h"
 
 #include "comms/ctran/Ctran.h"
+#include "meta/NcclxConfig.h"
 #include "meta/algoconf/AlgoConfig.h"
 #include "meta/collectives/PatAvgHelper.h"
 #include "comms/ctran/utils/Checks.h"
@@ -100,7 +101,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
 
-  auto algo = ncclx::algoconf::getAllGatherAlgo();
+  auto algo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
 
   if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
@@ -131,7 +132,7 @@ NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
 
-  auto algo = ncclx::algoconf::getAllReduceAlgo();
+  auto algo = NCCLX_CONFIG_FIELD(comm->config, allreduceAlgo);
 
   // [NCCLX] Redirect to CTRAN if enabled and applicable
   if (algo != NCCL_ALLREDUCE_ALGO::orig && ctranAllReduceSupport(comm->ctranComm_.get(), algo)) {
@@ -446,7 +447,7 @@ ncclResult_t ncclAllToAllv(
         recvbuff);
   }
 
-  if ((ncclx::algoconf::getAllToAllVAlgo() == NCCL_ALLTOALLV_ALGO::ctran) &&
+  if ((NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo) == NCCL_ALLTOALLV_ALGO::ctran) &&
       ctranAllToAllvSupport(comm->ctranComm_.get())) {
     return metaCommToNccl(ctranAllToAllv(
         sendbuff,

--- a/comms/ncclx/v2_29/src/dev_runtime.cc
+++ b/comms/ncclx/v2_29/src/dev_runtime.cc
@@ -15,7 +15,7 @@
 #include "group.h"
 #include "gin/gin_host.h"
 #include "meta/rma/ncclWin.h"
-#include "meta/algoconf/AlgoConfig.h"
+#include "meta/NcclxConfig.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "nccl_device.h"
@@ -1234,7 +1234,7 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
     // NCCL_WIN_DEVICE_API flag bypasses CTRAN and forces NCCL orig path.
     // This is needed for device API (GIN support) which only exists in the orig path.
     bool forceOrigPath = (winFlags & NCCL_WIN_DEVICE_API) != 0;
-    if(!forceOrigPath && ncclx::algoconf::getRmaAlgo() != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
+    if(!forceOrigPath && NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
       if (!ncclGetCuMemSysSupported()) {
         FB_ERRORRETURN(ncclInternalError, "ncclWin requires CUMEM support.");
       }
@@ -1306,7 +1306,7 @@ fail:
 NCCL_API(ncclResult_t, ncclCommWindowDeregister, ncclComm_t comm, ncclWindow_t win);
 ncclResult_t ncclCommWindowDeregister(struct ncclComm* comm, struct ncclWindow_vidmem* winDev) {
 
-  if(ncclx::algoconf::getRmaAlgo() != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
+  if(NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
     ncclWin* ncclWinPtr = ncclWinMap().find(winDev);
     // If window is found in CTRAN map, deregister via CTRAN path.
     // If not found (e.g., registered with NCCL_WIN_DEVICE_API), fall through

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -12,6 +12,7 @@
 #include "nvtx_payload_schemas.h"
 
 #include "comms/ctran/Ctran.h"
+#include "meta/NcclxConfig.h"
 #include "meta/algoconf/AlgoConfig.h"
 #include "meta/collectives/PatAvgHelper.h"
 #include "comms/ctran/utils/Checks.h"
@@ -100,7 +101,7 @@ ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcoun
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
     NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype)));
 
-  auto algo = ncclx::algoconf::getAllGatherAlgo();
+  auto algo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
 
   if (algo != NCCL_ALLGATHER_ALGO::orig && ctranAllGatherSupport(comm->ctranComm_.get(), algo, stream)) {
     return metaCommToNccl(ctranAllGather(
@@ -131,7 +132,7 @@ NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
 
-  auto algo = ncclx::algoconf::getAllReduceAlgo();
+  auto algo = NCCLX_CONFIG_FIELD(comm->config, allreduceAlgo);
 
   // [NCCLX] Redirect to CTRAN if enabled and applicable
   if (algo != NCCL_ALLREDUCE_ALGO::orig && ctranAllReduceSupport(comm->ctranComm_.get(), algo)) {
@@ -446,7 +447,7 @@ ncclResult_t ncclAllToAllv(
         recvbuff);
   }
 
-  if ((ncclx::algoconf::getAllToAllVAlgo() == NCCL_ALLTOALLV_ALGO::ctran) &&
+  if ((NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo) == NCCL_ALLTOALLV_ALGO::ctran) &&
       ctranAllToAllvSupport(comm->ctranComm_.get())) {
     return metaCommToNccl(ctranAllToAllv(
         sendbuff,

--- a/comms/ncclx/v2_30/src/dev_runtime.cc
+++ b/comms/ncclx/v2_30/src/dev_runtime.cc
@@ -17,7 +17,7 @@
 #include "group.h"
 #include "gin/gin_host.h"
 #include "meta/rma/ncclWin.h"
-#include "meta/algoconf/AlgoConfig.h"
+#include "meta/NcclxConfig.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/wrapper/MetaFactory.h"
 #include "nccl_device.h"
@@ -1470,7 +1470,7 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, nc
     // NCCL_WIN_DEVICE_API flag bypasses CTRAN and forces NCCL orig path.
     // This is needed for device API (GIN support) which only exists in the orig path.
     bool forceOrigPath = (winFlags & NCCL_WIN_DEVICE_API) != 0;
-    if(!forceOrigPath && ncclx::algoconf::getRmaAlgo() != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
+    if(!forceOrigPath && NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
       if (!ncclGetCuMemSysSupported()) {
         FB_ERRORRETURN(ncclInternalError, "ncclWin requires CUMEM support.");
       }
@@ -1542,7 +1542,7 @@ fail:
 NCCL_API(ncclResult_t, ncclCommWindowDeregister, ncclComm_t comm, ncclWindow_t win);
 ncclResult_t ncclCommWindowDeregister(struct ncclComm* comm, struct ncclWindow_vidmem* winDev) {
 
-  if(ncclx::algoconf::getRmaAlgo() != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
+  if(NCCLX_CONFIG_FIELD(comm->config, rmaAlgo) != NCCL_RMA_ALGO::orig && ctranInitialized(comm->ctranComm_.get())){
     ncclWin* ncclWinPtr = ncclWinMap().find(winDev);
     // If window is found in CTRAN map, deregister via CTRAN path.
     // If not found (e.g., registered with NCCL_WIN_DEVICE_API), fall through


### PR DESCRIPTION
Summary:

- Replace `ncclx::algoconf::getAllGatherAlgo()`, `getAllReduceAlgo()`, `getAllToAllVAlgo()`, `getRmaAlgo()` with `NCCLX_CONFIG_FIELD(comm->config, field)` in `collectives.cc` (v2_27/v2_29/v2_30), `dev_runtime.cc` (v2_29/v2_30), and `register.cc` (v2_27)
- Strip `AlgoConfig` singleton to sendrecv-only: remove 4 non-sendrecv atomics, GlobalHints hook registrations (`algo_allgather`, `algo_allreduce`, `algo_alltoallv`, `algo_rma`), getters, `testOnlySetAlgo` overloads, `getAlgoHintValue` overloads, and duplicate `algoStrToVal`/`algoValToStr` functions (already in `AlgoStrConv.h`)
- Add 4 algo keys to `kDeprecatedCommHintKeys` in `GlobalHints.h` so `setGlobalHint("algo_allgather", ...)` logs deprecation warning directing to per-comm `ncclx::Hints`
- Migrate 5 test files from `AlgoRAII`/`setGlobalHint` to per-comm hints via `NcclCommRAII` with `ncclx::Hints`, and add `ctran::test::VerifyAlgoStatsHelper` to verify correct ctran algo path is taken
- Remove 4 non-sendrecv tests from `AlgoConfigTest.cc`

SendRecv algo remains on the global `AlgoConfig` singleton — deferred to a follow-up commit due to `ctranGroupEndHook` in `group.cc` requiring ctran-level changes.

Reviewed By: mingrany

Differential Revision: D105604048


