### PR TITLE
Split direct and cached RegCache range APIs

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -602,7 +602,7 @@ commResult_t CtranMapper::regMem(
   if (NCCL_CTRAN_REGISTER == NCCL_CTRAN_REGISTER::eager || forceRegist) {
     bool didRegister = false;
     auto* segment = segments.front();
-    FB_COMMCHECK(regCache->regRange(
+    FB_COMMCHECK(regCache->regRangeCached(
         segment->range.buf,
         segment->range.len,
         cudaDev,
@@ -790,12 +790,12 @@ commResult_t CtranMapper::searchRegHandle(
   // First try find whether the given <buf, len> range has been covered by an
   // existing registration so the registration can be reused.
   // If not yet registered, but all underlying segments have ben pre-registered
-  // (i.e., cached) by user, regRange will internally perform the
+  // (i.e., cached) by user, regRangeCached will internally perform the
   // registration and cache it. All logic should be handled within a single
   // global lock.
   ctran::regcache::RegElem* regHdl_ = nullptr;
   bool didRegister = false;
-  FB_COMMCHECK(regCache->regRange(
+  FB_COMMCHECK(regCache->regRangeCached(
       buf,
       len,
       cudaDev,
@@ -819,7 +819,7 @@ commResult_t CtranMapper::searchRegHandle(
     // registration with the given buf, len range. Caller is responsible for
     // immediate deregisgration after current use.
     FB_COMMCHECK(regCache->regDynamic(
-        buf, len, comm->statex_->cudaDev(), enableBackends_, &regHdl_));
+        buf, len, cudaDev, enableBackends_, &regHdl_, &logMetaData_));
     *dynamicRegist = true;
     CLOGF(
         WARN,

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -349,7 +349,7 @@ commResult_t ctran::RegCache::globalRegister(
     ctran::regcache::RegElem* regHdl = nullptr;
     CommLogData globalLogData{};
     globalLogData.commDesc = "global";
-    FB_COMMCHECK(regRange(
+    FB_COMMCHECK(regRangeCached(
         buf,
         len,
         cudaDev,
@@ -474,7 +474,7 @@ void ctran::RegCache::asyncRegThreadFn(int cudaDev) {
     // Expected behavior:
     // - If didRegister is true, meaning the buffer is registered by the
     //   asyncThread. Later GPE thread will lookup hit at
-    //   searchRegHandle->regRange.
+    //   searchRegHandle->regRangeCached.
     // - If didRegister is false and regHdl is not nullptr, meaning the buffer
     //   has already been registered by a previous async request or GPE
     //   registration.
@@ -484,7 +484,7 @@ void ctran::RegCache::asyncRegThreadFn(int cudaDev) {
     //   executes the registration request, e.g., too slow asyncReg thread.
     //   Then, asyncReg thread will also tread it as dynamic registration and
     //   skip.
-    FB_COMMCHECKTHROW_EX_NOCOMM(regRange(
+    FB_COMMCHECKTHROW_EX_NOCOMM(regRangeCached(
         cmd.buf,
         cmd.len,
         cmd.cudaDev,
@@ -619,7 +619,7 @@ void* ctran::RegCache::searchIbRegHandle(
   CommLogData logMetaData{};
   logMetaData.commDesc = "global";
 
-  auto res = regRange(
+  auto res = regRangeCached(
       ptr,
       len,
       cudaDev,
@@ -868,7 +868,7 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
   return commSuccess;
 }
 
-commResult_t ctran::RegCache::regRange(
+commResult_t ctran::RegCache::regRangeCached(
     const void* ptr,
     const size_t len,
     const int cudaDev,
@@ -1135,14 +1135,17 @@ commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   return commSuccess;
 }
 
-commResult_t ctran::RegCache::regDynamic(
+commResult_t ctran::RegCache::regRange(
     const void* ptr,
     const size_t len,
     int cudaDev,
     const std::vector<bool>& backends,
-    ctran::regcache::RegElem** regElem) {
-  auto dur = CtranMapperTimer();
+    ctran::regcache::RegElem** regElem,
+    bool ncclManaged,
+    const struct CommLogData* logMetaData,
+    const std::string& useDesc) {
   SetCudaDevRAII setCudaDev(cudaDev);
+  auto timerBegin = std::chrono::steady_clock::now();
 
   std::vector<ctran::regcache::SegmentRange> ranges;
   FB_COMMCHECK(
@@ -1161,7 +1164,8 @@ commResult_t ctran::RegCache::regDynamic(
       lenToReg,
       cudaDev,
       true /*isDynamic*/,
-      ranges.at(0).type);
+      ranges.at(0).type,
+      ncclManaged);
 
   // Registration (expensive)
   FB_COMMCHECK(newRegElem_->doRegister(backends));
@@ -1173,6 +1177,40 @@ commResult_t ctran::RegCache::regDynamic(
   regElemsMaps_.wlock()->regHdlToElemMap.emplace(
       *regElem, std::move(newRegElem_));
 
+  if (logMetaData != nullptr) {
+    meta::comms::memtrace::recordReg(
+        *logMetaData,
+        "",
+        useDesc,
+        reinterpret_cast<uintptr_t>(ranges.at(0).buf),
+        lenToReg,
+        ranges.size(),
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - timerBegin)
+            .count());
+  }
+
+  return commSuccess;
+}
+
+commResult_t ctran::RegCache::regDynamic(
+    const void* ptr,
+    const size_t len,
+    int cudaDev,
+    const std::vector<bool>& backends,
+    ctran::regcache::RegElem** regElem,
+    const struct CommLogData* logMetaData) {
+  auto dur = CtranMapperTimer();
+  FB_COMMCHECK(regRange(
+      ptr,
+      len,
+      cudaDev,
+      backends,
+      regElem,
+      false /* ncclManaged */,
+      logMetaData,
+      "dynamicRegMem"));
+
   {
     auto profilerLk = profiler.wlock();
     profilerLk->record(ctran::regcache::EventType::kDynamicRegMemEvent);
@@ -1182,7 +1220,7 @@ commResult_t ctran::RegCache::regDynamic(
   return commSuccess;
 }
 
-commResult_t ctran::RegCache::deregDynamic(ctran::regcache::RegElem* regHdl) {
+commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
   std::unique_ptr<ctran::regcache::RegElem> regElem = nullptr;
   // Global lock to update regElemsMaps_.
   // Unlock before deregistration, avoid long holding time of the lock.
@@ -1192,7 +1230,7 @@ commResult_t ctran::RegCache::deregDynamic(ctran::regcache::RegElem* regHdl) {
 
     auto it = regHdlToElemMap.find(regHdl);
     if (it == regHdlToElemMap.end()) {
-      CLOGF(ERR, "deregDynamic: regElem {} not found", (void*)regHdl);
+      CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
     // Remove regElem from global cache and return ownership to caller for any
@@ -1205,6 +1243,10 @@ commResult_t ctran::RegCache::deregDynamic(ctran::regcache::RegElem* regHdl) {
   FB_COMMCHECK(deregElem(regElem.get()));
 
   return commSuccess;
+}
+
+commResult_t ctran::RegCache::deregDynamic(ctran::regcache::RegElem* regHdl) {
+  return deregRange(regHdl);
 }
 
 // Helper function to get all segments and group them into contiguous memory

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -314,7 +314,7 @@ class RegCache {
       std::vector<regcache::Segment*>& segments,
       std::vector<void*>& segHdls);
 
-  // Thread-safe functions to register a given buffer range.
+  // Thread-safe functions to register a given cached buffer range.
   // If the buffer is already registered and cached, the pre-existing handle is
   // returned. Otherwise, it will check if all underlying memory segments of
   // this buffer are cached by user, and register the full segment range. If the
@@ -330,9 +330,9 @@ class RegCache {
   //   - logMetaData: the metadata of the communicator that registers the buffer
   //                  (logging purpose only)
   // output:
-  //   - didRegister: whether regRange registered regHdl, or just found it
+  //   - didRegister: whether regRangeCached registered regHdl, or just found it
   //   - regHdl: the registration handle
-  commResult_t regRange(
+  commResult_t regRangeCached(
       const void* ptr,
       const size_t len,
       const int cudaDev,
@@ -343,25 +343,47 @@ class RegCache {
       regcache::RegElem** regHdl,
       bool ncclManaged = false);
 
-  // Thread-safe functions to dynamically register a segment.
-  // It is similar to regRange() but is not associated with a cached segment nor
-  // allow reuse. It must be deregistered via deregDynamic().
+  // Thread-safe function to directly register a buffer range without consulting
+  // the reusable segment/regElem cache. It registers every pinned physical
+  // range covering [ptr, ptr + len) as one dynamic RegElem, does not allow
+  // lookup reuse, and must be deregistered via deregRange().
   // input:
   //   - ptr: the pointer to the buffer to be registered
   //   - len: the length of the buffer
   //   - cudaDev: the cuda device id of the buffer
   // output:
-  //   - regHdl: the dynamic registration handle
+  //   - regHdl: the direct registration handle
+  commResult_t regRange(
+      const void* ptr,
+      const size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      regcache::RegElem** regHdl,
+      bool ncclManaged = false,
+      const struct CommLogData* logMetaData = nullptr,
+      const std::string& useDesc = "dynamicRegMem");
+
+  // Thread-safe functions to dynamically register a segment. Compatibility
+  // wrapper around regRange() for existing callers. Always records the
+  // registration under "dynamicRegMem" so dynamic and window registrations stay
+  // separate in scuba.
   commResult_t regDynamic(
       const void* ptr,
       const size_t len,
       int cudaDev,
       const std::vector<bool>& backends,
-      regcache::RegElem** regHdl);
+      regcache::RegElem** regHdl,
+      const struct CommLogData* logMetaData = nullptr);
 
-  // Thread-safe functions to deregister a dynamic registration.
+  // Thread-safe function to deregister a direct range registration.
   // Unlike freeSegment(), it always deregisters since only the calling
   // communicator uses it.
+  // input:
+  //   - regHdl: the direct registration handle
+  commResult_t deregRange(regcache::RegElem* regHdl);
+
+  // Thread-safe function to deregister a dynamic registration. Compatibility
+  // wrapper around deregRange() for existing callers.
   // input:
   //   - regHdl: the dynamic registration handle
   commResult_t deregDynamic(regcache::RegElem* regHdl);
@@ -442,7 +464,8 @@ class RegCache {
 
   // Thread-safe function to search for a RegElem containing [ptr, ptr+len)
   // and return its ibRegElem. If the buffer is cached but not yet registered,
-  // it will perform registration via regRange(). Returns nullptr if not cached.
+  // it will perform registration via regRangeCached(). Returns nullptr if not
+  // cached.
   void* searchIbRegHandle(const void* ptr, size_t len, int deviceId = -1);
 
   // Thread-safe function to wait on all async registration requests to finish.
@@ -452,8 +475,9 @@ class RegCache {
   // Global API to register all cached segments. This is useful in lazy
   // registration mode where segments are cached but not immediately registered.
   // Instead of registering each segment individually via
-  // searchRegHandle/regRange, this function discovers all contiguous memory
-  // regions among the cached segments and registers each region separately.
+  // searchRegHandle/regRangeCached, this function discovers all contiguous
+  // memory regions among the cached segments and registers each region
+  // separately.
   //
   // This function does NOT assume all cached segments form a single
   // contiguous region. It finds ALL contiguous regions (which may be
@@ -480,9 +504,9 @@ class RegCache {
 
   // Deregister all non-dynamic registration elements from the global cache.
   // This removes all registrations that were created via regAll() or
-  // regRange(), but does NOT remove the cached segments themselves (they can be
-  // re-registered later). Dynamic registrations (created via regDynamic) are
-  // not affected.
+  // regRangeCached(), but does NOT remove the cached segments themselves (they
+  // can be re-registered later). Dynamic registrations (created via regRange()
+  // or regDynamic()) are not affected.
   //
   // Returns commSuccess if successful, or error code otherwise.
   static commResult_t deregAll();

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -5,11 +5,20 @@
 // ctgraph_ring, ctgraph_rd allow explicit selection. All variants are only
 // active during CUDA graph capture and fall back to baseline otherwise.
 
+#include <nccl.h>
+#include <cstring>
 #include <random>
 
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
+#include "comms/ctran/utils/Alloc.h"
+
+#define NCCLCHECK_TEST_BENCH(cmd)                                         \
+  do {                                                                    \
+    ncclResult_t r = cmd;                                                 \
+    ASSERT_EQ(r, ncclSuccess) << "NCCL error: " << ncclGetErrorString(r); \
+  } while (0)
 
 static AlgoDescriptor makeAllGatherCtgraph(
     enum NCCL_ALLGATHER_ALGO algo = NCCL_ALLGATHER_ALGO::ctgraph) {
@@ -341,6 +350,227 @@ TEST_F(CudaGraphAllGatherCtgraphDestroy, DestroyGraphCleanly) {
   ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
   ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
   ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+}
+
+// Reproduces the ctgraph_rdpipeline in-place corruption covered by
+// nccl-tests-suite `-F full_replay_check`: many distinct-slot AllGather calls
+// captured in one CUDA graph, then replayed several times on a 2-rank local
+// setup.
+TEST_F(
+    CtranCudaGraphTestBase,
+    DISABLED_CtgraphRdpipelineInPlaceMultiAgReplayPreservesAllBytes) {
+  setenv("NCCL_CTRAN_ENABLE", "1", 0);
+  setenv("NCCL_MNNVL_ENABLE", "1", 0);
+  setenv("NCCL_NVLS_ENABLE", "0", 0);
+  setenv("NCCL_P2P_DISABLE", "0", 0);
+  setenv("NCCL_NET_GDR_C2C", "1", 0);
+  setenv("NCCL_CTRAN_IB_DEVICES_PER_RANK", "1", 0);
+  setenv("NCCL_IB_HCA", "mlx5_0:1,mlx5_1:1", 0);
+  setenv("NCCL_IB_DISABLE", "0", 0);
+  setenv("NCCL_IB_GID_INDEX", "3", 0);
+  setenv("NCCL_SOCKET_IFNAME", "eth0", 0);
+  setenv("NCCL_CUMEM_ENABLE", "1", 1);
+  setenv("NCCL_ALLGATHER_ALGO", "ctgraph_rdpipeline", 1);
+
+  auto ctranCommHolder = makeCtranComm();
+  ASSERT_NE(ctranCommHolder, nullptr);
+
+  if (!ctran::allGatherPSupport(ctranCommHolder.get())) {
+    GTEST_SKIP() << "allGatherP not supported";
+  }
+  const auto statex = ctranCommHolder->statex_.get();
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP() << "Need at least 2 local ranks (NVL peers) to repro";
+  }
+  if (statex->nNodes() > 1 &&
+      (statex->nNodes() & (statex->nNodes() - 1)) != 0) {
+    GTEST_SKIP() << "ctgraph_rdpipeline requires nNodes to be a power of 2";
+  }
+
+  // Use the public NCCL API path and broadcast the ncclUniqueId through the
+  // test bootstrap.
+  ncclUniqueId ncclId;
+  if (globalRank == 0) {
+    NCCLCHECK_TEST_BENCH(ncclGetUniqueId(&ncclId));
+  }
+  std::vector<char> idBuf(numRanks * sizeof(ncclId));
+  std::memcpy(
+      idBuf.data() + globalRank * sizeof(ncclId), &ncclId, sizeof(ncclId));
+  {
+    auto rc =
+        ctranCommHolder->bootstrap_
+            ->allGather(idBuf.data(), sizeof(ncclId), globalRank, numRanks)
+            .get();
+    ASSERT_EQ(rc, 0) << "Bootstrap allGather for ncclUniqueId failed";
+  }
+  std::memcpy(&ncclId, idBuf.data(), sizeof(ncclId));
+  CUDACHECK_TEST(cudaSetDevice(localRank));
+  ncclComm_t ncclComm = nullptr;
+  ncclConfig_t ncclCfg = NCCL_CONFIG_INITIALIZER;
+  ncclCfg.commDesc = "nccl-tests-suite-benchmarking-comms";
+  NCCLCHECK_TEST_BENCH(ncclGroupStart());
+  NCCLCHECK_TEST_BENCH(ncclCommInitRankConfig(
+      &ncclComm, numRanks, ncclId, globalRank, &ncclCfg));
+  NCCLCHECK_TEST_BENCH(ncclGroupEnd());
+
+  ctranCommHolder.reset();
+
+  const int nRanks = numRanks;
+  constexpr size_t kIters = 50;
+  constexpr size_t kReplays = 5;
+  constexpr size_t typeBytes = 2;
+  constexpr size_t sendcount = 8UL * 1024 * 1024;
+  constexpr size_t sendBytesPerSlot = sendcount * typeBytes;
+  const size_t recvBytesPerSlot = sendcount * nRanks * typeBytes;
+
+  auto fillBf16 = [](void* buf, size_t count, uint16_t val) {
+    std::vector<uint16_t> h(count, val);
+    CUDACHECK_TEST(
+        cudaMemcpy(buf, h.data(), count * sizeof(uint16_t), cudaMemcpyDefault));
+  };
+  auto rankVal = [](int rank) -> uint16_t {
+    return static_cast<uint16_t>(0x4000 + rank);
+  };
+  auto slotVal = [](size_t slot, int rank) -> uint16_t {
+    return static_cast<uint16_t>((slot & 0xff) << 8) |
+        static_cast<uint16_t>(0x40 + rank);
+  };
+
+  meta::comms::CudaStream stream(cudaStreamNonBlocking);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  // Mirror the production sequence: perf OOP, datacheck OOP, perf IP, then
+  // datacheck IP. The datacheck phases use distinct slots and verify bytes.
+  auto doCapturedRun = [&](bool oop,
+                           bool sameBuffer,
+                           size_t* outBadSlots = nullptr) {
+    if (outBadSlots) {
+      *outBadSlots = 0;
+    }
+    if (sameBuffer) {
+      ctran::TestDeviceBuffer perfSend(sendBytesPerSlot);
+      ctran::TestDeviceBuffer perfRecv(recvBytesPerSlot);
+      char* sb = static_cast<char*>(perfSend.get());
+      char* rb = static_cast<char*>(perfRecv.get());
+      fillBf16(sb, sendcount, rankVal(globalRank));
+      CUDACHECK_TEST(cudaMemset(rb, 0, recvBytesPerSlot));
+      auto* myChunkRb = rb + globalRank * sendBytesPerSlot;
+      fillBf16(myChunkRb, sendcount, rankVal(globalRank));
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      cudaGraph_t g = nullptr;
+      cudaGraphExec_t ge = nullptr;
+      ASSERT_EQ(
+          cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+          cudaSuccess);
+      for (size_t i = 0; i < kIters; ++i) {
+        void* aghSrc =
+            oop ? static_cast<void*>(sb) : static_cast<void*>(myChunkRb);
+        NCCLCHECK_TEST_BENCH(ncclAllGather(
+            aghSrc, rb, sendcount, ncclBfloat16, ncclComm, stream.get()));
+      }
+      ASSERT_EQ(cudaStreamEndCapture(stream.get(), &g), cudaSuccess);
+      ASSERT_EQ(cudaGraphInstantiate(&ge, g, 0), cudaSuccess);
+      for (int r = 0; r < kReplays; ++r) {
+        ASSERT_EQ(cudaGraphLaunch(ge, stream.get()), cudaSuccess);
+      }
+      ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+      ASSERT_EQ(cudaGraphExecDestroy(ge), cudaSuccess);
+      ASSERT_EQ(cudaGraphDestroy(g), cudaSuccess);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      return;
+    }
+    {
+      const size_t bigDcSendBytes = kIters * sendBytesPerSlot;
+      const size_t bigDcRecvBytes = kIters * recvBytesPerSlot;
+      ctran::TestDeviceBuffer bigDcSend(bigDcSendBytes);
+      ctran::TestDeviceBuffer bigDcRecv(bigDcRecvBytes);
+      CUDACHECK_TEST(cudaMemset(bigDcRecv.get(), 0, bigDcRecvBytes));
+      for (size_t k = 0; k < kIters; ++k) {
+        auto* slotSend =
+            static_cast<char*>(bigDcSend.get()) + k * sendBytesPerSlot;
+        auto* slotRecv =
+            static_cast<char*>(bigDcRecv.get()) + k * recvBytesPerSlot;
+        fillBf16(slotSend, sendcount, slotVal(k, globalRank));
+        auto* slotMyChunk = slotRecv + globalRank * sendBytesPerSlot;
+        fillBf16(slotMyChunk, sendcount, slotVal(k, globalRank));
+      }
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+      cudaGraph_t g = nullptr;
+      cudaGraphExec_t ge = nullptr;
+      ASSERT_EQ(
+          cudaStreamBeginCapture(stream.get(), cudaStreamCaptureModeGlobal),
+          cudaSuccess);
+      for (size_t k = 0; k < kIters; ++k) {
+        auto* slotSend =
+            static_cast<char*>(bigDcSend.get()) + k * sendBytesPerSlot;
+        auto* slotRecv =
+            static_cast<char*>(bigDcRecv.get()) + k * recvBytesPerSlot;
+        auto* slotMyChunk = slotRecv + globalRank * sendBytesPerSlot;
+        void* aghSrc = oop ? static_cast<void*>(slotSend)
+                           : static_cast<void*>(slotMyChunk);
+        NCCLCHECK_TEST_BENCH(ncclAllGather(
+            aghSrc, slotRecv, sendcount, ncclBfloat16, ncclComm, stream.get()));
+      }
+      ASSERT_EQ(cudaStreamEndCapture(stream.get(), &g), cudaSuccess);
+      ASSERT_EQ(cudaGraphInstantiate(&ge, g, 0), cudaSuccess);
+      for (int r = 0; r < kReplays; ++r) {
+        ASSERT_EQ(cudaGraphLaunch(ge, stream.get()), cudaSuccess);
+      }
+      ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+      ASSERT_EQ(cudaGraphExecDestroy(ge), cudaSuccess);
+      ASSERT_EQ(cudaGraphDestroy(g), cudaSuccess);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      size_t badSlots = 0;
+      for (size_t k = 0; k < kIters; ++k) {
+        std::vector<uint16_t> h(sendcount * nRanks);
+        auto* slotRecv =
+            static_cast<char*>(bigDcRecv.get()) + k * recvBytesPerSlot;
+        CUDACHECK_TEST(cudaMemcpy(
+            h.data(), slotRecv, recvBytesPerSlot, cudaMemcpyDefault));
+        size_t mm = 0;
+        for (int r = 0; r < nRanks; ++r) {
+          uint16_t expected = slotVal(k, r);
+          for (size_t i = 0; i < sendcount; ++i) {
+            if (h[r * sendcount + i] != expected) {
+              ++mm;
+            }
+          }
+        }
+        if (mm > 0) {
+          ++badSlots;
+        }
+      }
+      if (outBadSlots) {
+        *outBadSlots = badSlots;
+      }
+    }
+  };
+
+  constexpr int kTotalChecks = 10;
+  size_t mmDcOOP = 0;
+  size_t mmDcIP = 0;
+  doCapturedRun(/*oop=*/true, /*sameBuffer=*/true);
+  for (int t = 0; t < kTotalChecks; ++t) {
+    size_t mm = 0;
+    doCapturedRun(/*oop=*/true, /*sameBuffer=*/false, &mm);
+    mmDcOOP += mm;
+  }
+  doCapturedRun(/*oop=*/false, /*sameBuffer=*/true);
+  for (int t = 0; t < kTotalChecks; ++t) {
+    size_t mm = 0;
+    doCapturedRun(/*oop=*/false, /*sameBuffer=*/false, &mm);
+    mmDcIP += mm;
+  }
+
+  EXPECT_EQ(mmDcIP, 0u)
+      << "ctgraph_rdpipeline in-place datacheck capture corrupted " << mmDcIP
+      << " slots' recvbufs across " << kTotalChecks << " iters";
+  EXPECT_EQ(mmDcOOP, 0u)
+      << "ctgraph_rdpipeline out-of-place datacheck warmup corrupted "
+      << mmDcOOP << " slots' recvbufs across " << kTotalChecks << " iters";
+
+  ncclCommDestroy(ncclComm);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Summary:
`RegCache::regRange` used to mean lookup-cached registration, while `regDynamic` was the only direct range-registration entry point. The window fix needs direct, caller-owned registration APIs with names that say which path uses the shared cache, so this diff splits the RegCache API names without moving any existing caller to a different lifetime model.

- The existing lookup-or-register path becomes `regRangeCached`, and current cache-backed callers move to that name.
- `regRange` becomes the direct registration primitive, and `regDynamic` remains as its compatibility wrapper.
- `deregRange` becomes the matching direct deregistration primitive, and `deregDynamic` remains as its compatibility wrapper.

Reviewed By: minsii

Differential Revision: D105590176


