### PR TITLE
Add Scuba dataset nccl_profiler_gpe + CtranProfilerGpeEvent (#2611)

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -74,6 +74,18 @@ cvars:
       all data is logged to scuba table nccl_profiler_algo.
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
+ - name        : NCCL_CTRAN_GPE_PROFILING_LOGGING
+   type        : string
+   default     : ""
+   description : |-
+      File location for logging per-tracepoint GPE thread profiler rows
+      emitted by ctran::GpeProfiler via the DefaultGpeProfilerReporter.
+      Disabled by default (empty). MCCL injects its own
+      McclGpeProfilerReporter that writes directly to mccl_operation_trace
+      and bypasses this cvar; NCCLx consumers can opt in by setting this
+      to e.g. "scuba:nccl_profiler_gpe".
+      (the same format with NCCL_COMM_EVENT_LOGGING)
+
  - name        : NCCL_MEMORY_EVENT_LOGGING
    type        : string
    default     : ""

--- a/comms/utils/logger/DataTableWrapper.cc
+++ b/comms/utils/logger/DataTableWrapper.cc
@@ -15,6 +15,7 @@ constexpr std::string_view k_nccl_memory_logging = "nccl_memory_logging";
 constexpr std::string_view k_nccl_profiler_slow_rank =
     "nccl_profiler_slow_rank";
 constexpr std::string_view k_nccl_profiler_algo = "nccl_profiler_algo";
+constexpr std::string_view k_nccl_profiler_gpe = "nccl_profiler_gpe";
 constexpr std::string_view k_nccl_structured_logging =
     "nccl_structured_logging";
 constexpr std::string_view k_nccl_slow_coll = "nccl_slow_coll";
@@ -69,6 +70,7 @@ std::vector<std::pair<std::string_view, std::string_view>> getAllTableNames() {
       {k_nccl_memory_logging, NCCL_MEMORY_EVENT_LOGGING},
       {k_nccl_profiler_slow_rank, NCCL_SLOW_RANK_LOGGING},
       {k_nccl_profiler_algo, NCCL_CTRAN_ALGO_PROFILING_LOGGING},
+      {k_nccl_profiler_gpe, NCCL_CTRAN_GPE_PROFILING_LOGGING},
       {k_nccl_structured_logging, NCCL_COMM_EVENT_LOGGING},
       {k_nccl_slow_coll, NCCL_SLOW_COLL_LOGGING},
       {k_nccl_collective_stats, NCCL_COLL_STATS_LOGGING},
@@ -116,6 +118,7 @@ DEFINE_scuba_table(nccl_error_logging);
 DEFINE_scuba_table(nccl_memory_logging);
 DEFINE_scuba_table(nccl_profiler_slow_rank);
 DEFINE_scuba_table(nccl_profiler_algo);
+DEFINE_scuba_table(nccl_profiler_gpe);
 DEFINE_scuba_table(nccl_structured_logging);
 DEFINE_scuba_table(nccl_slow_coll);
 DEFINE_scuba_table(nccl_collective_stats);
@@ -128,6 +131,7 @@ void DataTableWrapper::init() {
   INIT_scuba_table(nccl_memory_logging);
   INIT_scuba_table(nccl_profiler_slow_rank);
   INIT_scuba_table(nccl_profiler_algo);
+  INIT_scuba_table(nccl_profiler_gpe);
   INIT_scuba_table(nccl_structured_logging);
   INIT_scuba_table(nccl_slow_coll);
   INIT_scuba_table(nccl_collective_stats);
@@ -141,6 +145,7 @@ void DataTableWrapper::shutdown() {
   SHUTDOWN_scuba_table(nccl_memory_logging);
   SHUTDOWN_scuba_table(nccl_profiler_slow_rank);
   SHUTDOWN_scuba_table(nccl_profiler_algo);
+  SHUTDOWN_scuba_table(nccl_profiler_gpe);
   SHUTDOWN_scuba_table(nccl_structured_logging);
   SHUTDOWN_scuba_table(nccl_slow_coll);
   SHUTDOWN_scuba_table(nccl_collective_stats);

--- a/comms/utils/logger/DataTableWrapper.h
+++ b/comms/utils/logger/DataTableWrapper.h
@@ -77,12 +77,14 @@ DECLARE_scuba_table(nccl_error_logging);
 DECLARE_scuba_table(nccl_memory_logging);
 DECLARE_scuba_table(nccl_profiler_slow_rank);
 DECLARE_scuba_table(nccl_profiler_algo);
+DECLARE_scuba_table(nccl_profiler_gpe);
 DECLARE_scuba_table(nccl_structured_logging);
 DECLARE_scuba_table(nccl_slow_coll);
 DECLARE_scuba_table(nccl_collective_stats);
 
 #define SCUBA_nccl_structured_logging (*SCUBA_nccl_structured_logging_ptr)
 #define SCUBA_nccl_profiler_algo (*SCUBA_nccl_profiler_algo_ptr)
+#define SCUBA_nccl_profiler_gpe (*SCUBA_nccl_profiler_gpe_ptr)
 #define SCUBA_nccl_profiler_slow_rank (*SCUBA_nccl_profiler_slow_rank_ptr)
 #define SCUBA_nccl_memory_logging (*SCUBA_nccl_memory_logging_ptr)
 #define SCUBA_nccl_error_logging (*SCUBA_nccl_error_logging_ptr)

--- a/comms/utils/logger/EventMgr.cc
+++ b/comms/utils/logger/EventMgr.cc
@@ -118,6 +118,22 @@ NcclScubaSample CtranProfilerAlgoEvent::toSample() {
   return sample;
 }
 
+NcclScubaSample CtranProfilerGpeEvent::toSample() {
+  auto sample = CommEvent::toSample();
+  sample.addNormal("type", "CtranProfilerGpeEvent");
+  // NOTE: rank and commHash are added by CommEvent::toSample() above,
+  // sourced from logMetaData. Do NOT re-add here.
+  sample.addInt("opCount", opCount_);
+  sample.addInt("opType", opType_);
+  sample.addNormal("tracePoint", tracePoint_);
+  sample.addInt("iterUs", iterUs_);
+  sample.addInt("durationUs", durationUs_);
+  sample.addInt("aborted", aborted_ ? 1 : 0);
+  sample.addNormal("message", message_);
+  sample.addInt("iteration", iteration_);
+  return sample;
+}
+
 NcclScubaSample NetworkPerfMonitorEvent::toSample() {
   auto sample = CommEvent::toSample();
   sample.addNormal("type", "NetworkPerfMonitorEvent");

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -25,6 +25,7 @@ enum class LoggerEventType {
   CtranProfilerEventType,
   CtranProfilerSlowRankModuleEventType,
   CtranProfilerAlgoEventType,
+  CtranProfilerGpeEventType,
   CommdumpEventType,
   TerminateEventType,
 };
@@ -341,6 +342,61 @@ class CtranProfilerAlgoEvent : public CtranProfilerEvent {
   uint64_t controlTs;
   uint64_t timeFromDataToCollEndUs;
   uint64_t collectiveDurationUs;
+};
+
+// Per-tracepoint Scuba row emitted by ctran::GpeProfiler for each
+// instrumented phase boundary in CtranGpe::Impl::gpeThreadFn.
+// Iteration-level fields (aborted, abortReason, opCount, opType)
+// are repeated on every row from the same iteration.
+class CtranProfilerGpeEvent : public CommEvent {
+ public:
+  CtranProfilerGpeEvent() = delete;
+  // rank and commHash are intentionally NOT taken here — they're added by
+  // the CommEvent base class via logMetaData (see CommEvent::toSample()
+  // adding "rank" and "commHash"). Re-adding them here would produce
+  // duplicate Scuba columns and break the local sibling convention used
+  // by CtranProfilerEvent / CtranProfilerAlgoEvent / NetworkPerfMonitorEvent.
+  CtranProfilerGpeEvent(
+      const struct CommLogData* logMetaData,
+      const std::string& stage,
+      const uint64_t opCount,
+      const int opType,
+      const std::string& tracePoint,
+      const uint64_t iterUs,
+      const uint64_t durationUs,
+      const bool aborted,
+      const std::string& message)
+      : CommEvent(logMetaData, stage, ""),
+        opCount_(opCount),
+        opType_(opType),
+        tracePoint_(tracePoint),
+        iterUs_(iterUs),
+        durationUs_(durationUs),
+        aborted_(aborted),
+        message_(message) {
+    iteration_ = ncclxGetIteration();
+  }
+
+  ~CtranProfilerGpeEvent() override = default;
+
+  LoggerEventType getEventType() override {
+    return LoggerEventType::CtranProfilerGpeEventType;
+  }
+  void setTimerDelta(double /*delta*/) override {}
+  void setTimestamp() override {}
+  NcclScubaSample toSample() override;
+
+ private:
+  const uint64_t opCount_;
+  const int opType_;
+  const std::string tracePoint_;
+  const uint64_t iterUs_;
+  const uint64_t durationUs_;
+  const bool aborted_;
+  const std::string message_;
+  // training step. If not set by trainer, it is always -1. Also see
+  // ncclxGetIteration().
+  int64_t iteration_{-1};
 };
 
 class NetworkPerfMonitorEvent : public CommEvent {

--- a/comms/utils/logger/ScubaLogger.cc
+++ b/comms/utils/logger/ScubaLogger.cc
@@ -20,6 +20,8 @@ DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
       return SCUBA_nccl_profiler_slow_rank_ptr.get();
     case LoggerEventType::CtranProfilerAlgoEventType:
       return SCUBA_nccl_profiler_algo_ptr.get();
+    case LoggerEventType::CtranProfilerGpeEventType:
+      return SCUBA_nccl_profiler_gpe_ptr.get();
     case LoggerEventType::CommEventType:
       return SCUBA_nccl_structured_logging_ptr.get();
     default:

--- a/comms/utils/logger/tests/CtranProfilerGpeEventTest.cc
+++ b/comms/utils/logger/tests/CtranProfilerGpeEventTest.cc
@@ -1,0 +1,139 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/EventMgr.h"
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/ScubaLogger.h"
+#include "comms/utils/trainer/TrainerContext.h"
+
+namespace {
+
+constexpr uint64_t kCommId = 11111;
+constexpr uint64_t kCommHash = 22222;
+constexpr int kRank = 3;
+constexpr int kNRanks = 8;
+constexpr const char* kCommDesc = "test_pg:0";
+
+constexpr uint64_t kOpCount = 42;
+constexpr int kOpType = 7;
+const std::string kTracePoint = "host_algo";
+constexpr uint64_t kIterUs = 1234;
+constexpr uint64_t kDurationUs = 567;
+constexpr bool kAborted = true;
+const std::string kMessage = "timeout";
+constexpr int64_t kIteration = 99;
+
+CommLogData makeCommLogData() {
+  return CommLogData{kCommId, kCommHash, kCommDesc, kRank, kNRanks};
+}
+
+std::unique_ptr<CtranProfilerGpeEvent> makeGpeEvent(
+    const CommLogData* logMetaData) {
+  return std::make_unique<CtranProfilerGpeEvent>(
+      logMetaData,
+      /*stage=*/"ctranProfilerGpeV1",
+      kOpCount,
+      kOpType,
+      kTracePoint,
+      kIterUs,
+      kDurationUs,
+      kAborted,
+      kMessage);
+}
+
+} // namespace
+
+// Construct a CtranProfilerGpeEvent and verify every GPE-specific column
+// added by its toSample() is present and round-trips through JSON.
+TEST(CtranProfilerGpeEventTest, ToSamplePopulatesAllNewColumns) {
+  ncclxSetIteration(kIteration);
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["type"].asString(), "CtranProfilerGpeEvent");
+  EXPECT_EQ(json["int"]["opCount"].asInt(), static_cast<int64_t>(kOpCount));
+  EXPECT_EQ(json["int"]["opType"].asInt(), kOpType);
+  EXPECT_EQ(json["normal"]["tracePoint"].asString(), kTracePoint);
+  EXPECT_EQ(json["int"]["iterUs"].asInt(), static_cast<int64_t>(kIterUs));
+  EXPECT_EQ(
+      json["int"]["durationUs"].asInt(), static_cast<int64_t>(kDurationUs));
+  EXPECT_EQ(json["int"]["aborted"].asInt(), kAborted ? 1 : 0);
+  EXPECT_EQ(json["normal"]["message"].asString(), kMessage);
+  EXPECT_EQ(json["int"]["iteration"].asInt(), kIteration);
+}
+
+// CommEvent base-class columns (commId, commHash, commDesc, rank, nranks)
+// must be populated from the injected CommLogData. The GPE subclass must
+// NOT re-add them with conflicting values.
+TEST(CtranProfilerGpeEventTest, ToSampleBaseColumnsFromCommLogData) {
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["int"]["commId"].asInt(), static_cast<int64_t>(kCommId));
+  EXPECT_EQ(json["int"]["commHash"].asInt(), static_cast<int64_t>(kCommHash));
+  EXPECT_EQ(json["normal"]["commDesc"].asString(), kCommDesc);
+  EXPECT_EQ(json["int"]["rank"].asInt(), kRank);
+  EXPECT_EQ(json["int"]["nranks"].asInt(), kNRanks);
+}
+
+// Aborted=false / empty message path: aborted column reads 0, message is
+// the empty string.
+TEST(CtranProfilerGpeEventTest, ToSampleNonAbortedRow) {
+  const auto md = makeCommLogData();
+  auto event = std::make_unique<CtranProfilerGpeEvent>(
+      &md,
+      /*stage=*/"ctranProfilerGpeV1",
+      kOpCount,
+      kOpType,
+      std::string("cmd_dequeue"),
+      kIterUs,
+      kDurationUs,
+      /*aborted=*/false,
+      /*message=*/"");
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["int"]["aborted"].asInt(), 0);
+  EXPECT_EQ(json["normal"]["message"].asString(), "");
+  EXPECT_EQ(json["normal"]["tracePoint"].asString(), "cmd_dequeue");
+}
+
+// getEventType() must return the GPE variant so ScubaLogger's dispatch
+// routes the event to nccl_profiler_gpe (and not to the algo or another
+// sibling table).
+TEST(CtranProfilerGpeEventTest, GetEventTypeIsGpeVariant) {
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+  EXPECT_EQ(event->getEventType(), LoggerEventType::CtranProfilerGpeEventType);
+}
+
+// ScubaLogger's getTablePtrFromEvent() must route the GPE event type to
+// the wrapper added in this diff (SCUBA_nccl_profiler_gpe_ptr). Without
+// the correct routing, GPE rows would land in algo (or worse, throw on
+// the default branch).
+TEST(CtranProfilerGpeEventTest, ScubaDispatchTargetsGpeTablePtr) {
+  DataTableWrapper::init();
+  ASSERT_NE(SCUBA_nccl_profiler_gpe_ptr, nullptr);
+  EXPECT_EQ(
+      getTablePtrFromEvent(LoggerEventType::CtranProfilerGpeEventType),
+      SCUBA_nccl_profiler_gpe_ptr.get());
+  // Algo path must not return the GPE pointer (sanity check).
+  EXPECT_NE(
+      getTablePtrFromEvent(LoggerEventType::CtranProfilerAlgoEventType),
+      SCUBA_nccl_profiler_gpe_ptr.get());
+  // shutdown must be safe with no addSample calls (lazy table_ stays
+  // null; the SHUTDOWN_scuba_table macro guards on table_).
+  DataTableWrapper::shutdown();
+}


### PR DESCRIPTION
Summary:

Adds the new Scuba table and event class for per-tracepoint
GpeProfiler reports. No callers yet — pure infrastructure.

# Changes
- comms/utils/cvars/nccl_cvars.yaml: new cvar
  NCCL_CTRAN_GPE_PROFILING_LOGGING (string, default
  "scuba:nccl_profiler_gpe"). Mirrors NCCL_CTRAN_ALGO_PROFILING_LOGGING.
- comms/utils/logger/EventMgr.{h,cc}: new LoggerEventType entry
  CtranProfilerGpeEventType + new class CtranProfilerGpeEvent
  (mirrors CtranProfilerAlgoEvent).
- comms/utils/logger/ScubaLogger.cc: new dispatch case for the
  new event type.
- comms/utils/logger/DataTableWrapper.{h,cc}: new
  DECLARE/DEFINE/INIT/SHUTDOWN of nccl_profiler_gpe table
  (mirrors nccl_profiler_algo).
- comms/utils/logger/tests/CtranProfilerGpeEventTest.cc (new): UT
  for the new event class + dispatch wiring (sibling
  CtranProfilerAlgoEvent has no UT today; this is the first direct
  test of either profiler event class).

The Scuba dataset itself (ctranProfilerGpeV1) is a separate
Configerator change, landing independently. Without it, this code
runs cleanly but consumer queries return empty.

Reviewed By: saifhhasan

Differential Revision: D104837120


