### PR TITLE
Add GpeProfiler interface + DefaultGpeProfilerReporter + mock

### DIFF
--- a/comms/ctran/profiler/DefaultGpeProfilerReporter.cc
+++ b/comms/ctran/profiler/DefaultGpeProfilerReporter.cc
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/DefaultGpeProfilerReporter.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "comms/utils/logger/EventMgr.h"
+#include "comms/utils/logger/ScubaLogger.h"
+
+namespace ctran {
+
+void DefaultGpeProfilerReporter::report(const GpeProfilerReport& report) {
+  // Copy message string_view into std::string here; the
+  // CtranProfilerGpeEvent owns it for the async Scuba flush.
+  // rank and commHash are added by the CommEvent base class via
+  // logMetaData — do NOT pass them explicitly here (would duplicate
+  // the Scuba columns).
+  NcclScubaEvent scubaEvent(
+      std::make_unique<CtranProfilerGpeEvent>(
+          report.logMetaData,
+          "ctranProfilerGpeV1",
+          report.opCount,
+          report.opType,
+          std::string(tracePointName(report.tracePoint)),
+          report.iterUs,
+          report.durationUs,
+          report.aborted,
+          std::string(report.message)));
+  scubaEvent.record();
+}
+
+} // namespace ctran

--- a/comms/ctran/profiler/DefaultGpeProfilerReporter.h
+++ b/comms/ctran/profiler/DefaultGpeProfilerReporter.h
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
+
+namespace ctran {
+
+// Default reporter that logs per-tracepoint GPE thread profiler rows to a
+// scuba table.
+class DefaultGpeProfilerReporter : public IGpeProfilerReporter {
+ public:
+  ~DefaultGpeProfilerReporter() override = default;
+  void report(const GpeProfilerReport& report) override;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/GpeProfilerReport.h
+++ b/comms/ctran/profiler/GpeProfilerReport.h
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+struct CommLogData;
+
+namespace ctran {
+
+// One of the GPE thread's instrumented tracepoints. Stamped by
+// gpeThreadFn at the corresponding boundary.
+enum class GpeTracePoint : int {
+  ITER_START, // Top of the GPE main loop iter (anchor; always emits).
+  CMD_DEQUEUE, // cmdDequeue returned + injectMetadata ran (always emits).
+  WAIT_KERNEL, // KERNEL_STARTED observed (kernel started executing).
+  HOST_ALGO, // cmd->coll.func returned (or skip-aborted bookkeeping done).
+  TERMINATE_KERNEL, // setFlagPerGroup() returned (HOST_ABORT or TERMINATE).
+  ALGO_ABORTED, // markAborted() called from SCOPE_EXIT (abort-only; forced).
+  // TERMINATE_CMD intentionally last (just before NUM_TRACE_POINTS): it
+  // only co-occurs with ITER_START + CMD_DEQUEUE in TERMINATE iters, so
+  // its placement at the end avoids creating a stamp gap in the middle
+  // of the enum that would skip slots in debugString's adjacent-pair
+  // walk.
+  TERMINATE_CMD, // Dequeued cmd is TERMINATE; gpeThread is about to exit
+                 // (always emits, bypasses sampling).
+  NUM_TRACE_POINTS,
+};
+
+// Stable string names for the tracepoints, used as the Scuba
+// `trace_point` column value.
+constexpr std::string_view tracePointName(GpeTracePoint p) {
+  switch (p) {
+    case GpeTracePoint::ITER_START:
+      return "iter_start";
+    case GpeTracePoint::CMD_DEQUEUE:
+      return "cmd_dequeue";
+    case GpeTracePoint::WAIT_KERNEL:
+      return "wait_kernel";
+    case GpeTracePoint::HOST_ALGO:
+      return "host_algo";
+    case GpeTracePoint::TERMINATE_KERNEL:
+      return "terminate_kernel";
+    case GpeTracePoint::ALGO_ABORTED:
+      return "algo_aborted";
+    case GpeTracePoint::TERMINATE_CMD:
+      return "terminate_cmd";
+    case GpeTracePoint::NUM_TRACE_POINTS:
+      return "<invalid>";
+  }
+  return "<invalid>";
+}
+
+// One Scuba row per stamped tracepoint, written eagerly at mark() time.
+// iterUs is microseconds since the iteration's ITER_START (so ITER_START
+// itself always has iterUs == 0). durationUs is microseconds since the
+// previous stamped tracepoint in the same iter (0 for ITER_START).
+// `aborted` and `message` are populated only on the ALGO_ABORTED row;
+// `message` carries the abort reason ("timeout" / "explicit" /
+// "abnormal_exit") and lands in the Scuba "Message" column.
+struct GpeProfilerReport {
+  const CommLogData* logMetaData{nullptr};
+  uint64_t opCount{0};
+  int opType{-1};
+  GpeTracePoint tracePoint{GpeTracePoint::ITER_START};
+  uint64_t iterUs{0};
+  uint64_t durationUs{0};
+  bool aborted{false};
+  std::string_view message{};
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/IGpeProfilerReporter.h
+++ b/comms/ctran/profiler/IGpeProfilerReporter.h
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+
+namespace ctran {
+
+// Sink for one report row. Production impl writes to Scuba; tests use
+// gmock-based MockGpeProfilerReporter to capture and assert.
+class IGpeProfilerReporter {
+ public:
+  virtual ~IGpeProfilerReporter() = default;
+  virtual void report(const GpeProfilerReport& report) = 0;
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/tests/DefaultGpeProfilerReporterTest.cc
+++ b/comms/ctran/profiler/tests/DefaultGpeProfilerReporterTest.cc
@@ -1,0 +1,110 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/DefaultGpeProfilerReporter.h"
+
+#include <folly/portability/GTest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+
+namespace ctran {
+
+namespace {
+
+constexpr uint64_t kCommId = 11111;
+constexpr uint64_t kCommHash = 22222;
+constexpr int kRank = 3;
+constexpr int kNRanks = 8;
+const char* kCommDesc = "test_pg:0";
+
+CommLogData makeCommLogData() {
+  return CommLogData{kCommId, kCommHash, kCommDesc, kRank, kNRanks};
+}
+
+GpeProfilerReport makeReport(
+    GpeTracePoint p = GpeTracePoint::HOST_ALGO,
+    bool aborted = false,
+    std::string_view message = std::string_view{}) {
+  GpeProfilerReport r;
+  r.opCount = 42;
+  r.opType = 7;
+  r.tracePoint = p;
+  r.iterUs = 1234;
+  r.durationUs = 567;
+  r.aborted = aborted;
+  r.message = message;
+  return r;
+}
+
+class DefaultGpeProfilerReporterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Wire SCUBA_*_ptr globals so getTablePtrFromEvent() does not throw on
+    // dispatch. Lazy lookup of the backing scuba table may still warn
+    // (test env doesn't register dataset) but addSample is a no-op when
+    // table_ stays null — report() must return cleanly either way.
+    DataTableWrapper::init();
+  }
+  void TearDown() override {
+    DataTableWrapper::shutdown();
+  }
+};
+
+// Happy-path report with all fields set must dispatch via the Scuba layer
+// without throwing or crashing.
+TEST_F(DefaultGpeProfilerReporterTest, ReportRunsCleanlyForSampledRow) {
+  DefaultGpeProfilerReporter reporter;
+  const auto md = makeCommLogData();
+  auto report = makeReport();
+  report.logMetaData = &md;
+
+  EXPECT_NO_THROW(reporter.report(report));
+}
+
+// Aborted-row dispatch: aborted=true + non-empty message. Verify the
+// reporter does not throw on the marker path.
+TEST_F(DefaultGpeProfilerReporterTest, ReportAbortedRowRunsCleanly) {
+  DefaultGpeProfilerReporter reporter;
+  const auto md = makeCommLogData();
+  auto report = makeReport(
+      GpeTracePoint::ALGO_ABORTED,
+      /*aborted=*/true,
+      std::string_view{"timeout"});
+  report.logMetaData = &md;
+
+  EXPECT_NO_THROW(reporter.report(report));
+}
+
+// nullptr logMetaData: the reporter forwards logMetaData straight into
+// CtranProfilerGpeEvent, which uses CommEvent's nullptr-tolerant ctor
+// (defaults rank/commHash/commDesc). Must not crash.
+TEST_F(DefaultGpeProfilerReporterTest, ReportTolerantOfNullLogMetaData) {
+  DefaultGpeProfilerReporter reporter;
+  auto report = makeReport();
+  report.logMetaData = nullptr;
+
+  EXPECT_NO_THROW(reporter.report(report));
+}
+
+// Each GpeTracePoint enum value must dispatch without throwing — the
+// reporter calls tracePointName(p) and the switch must cover every case
+// (a missing case would either fall through to "<invalid>" or trigger UB
+// depending on compiler).
+TEST_F(DefaultGpeProfilerReporterTest, ReportCoversEveryTracePoint) {
+  DefaultGpeProfilerReporter reporter;
+  const auto md = makeCommLogData();
+  for (int i = 0; i < static_cast<int>(GpeTracePoint::NUM_TRACE_POINTS); ++i) {
+    auto report = makeReport(static_cast<GpeTracePoint>(i));
+    report.logMetaData = &md;
+    EXPECT_NO_THROW(reporter.report(report))
+        << "tracePoint enum value " << i << " threw";
+  }
+}
+
+} // namespace
+} // namespace ctran

--- a/comms/ctran/profiler/tests/MockGpeProfilerReporter.h
+++ b/comms/ctran/profiler/tests/MockGpeProfilerReporter.h
@@ -1,0 +1,18 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
+
+namespace ctran {
+
+// GMock reporter for verifying GpeProfiler report() calls in tests.
+class MockGpeProfilerReporter : public IGpeProfilerReporter {
+ public:
+  MOCK_METHOD(void, report, (const GpeProfilerReport& report), (override));
+};
+
+} // namespace ctran

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -74,6 +74,15 @@ cvars:
       all data is logged to scuba table nccl_profiler_algo.
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
+ - name        : NCCL_CTRAN_GPE_PROFILING_LOGGING
+   type        : string
+   default     : "scuba:nccl_profiler_gpe"
+   description : |-
+      File location for logging per-tracepoint GPE thread profiler rows
+      emitted by ctran::GpeProfiler. By default, all data is logged to
+      scuba table nccl_profiler_gpe.
+      (the same format with NCCL_COMM_EVENT_LOGGING)
+
  - name        : NCCL_MEMORY_EVENT_LOGGING
    type        : string
    default     : ""

--- a/comms/utils/logger/DataTableWrapper.cc
+++ b/comms/utils/logger/DataTableWrapper.cc
@@ -15,6 +15,7 @@ constexpr std::string_view k_nccl_memory_logging = "nccl_memory_logging";
 constexpr std::string_view k_nccl_profiler_slow_rank =
     "nccl_profiler_slow_rank";
 constexpr std::string_view k_nccl_profiler_algo = "nccl_profiler_algo";
+constexpr std::string_view k_nccl_profiler_gpe = "nccl_profiler_gpe";
 constexpr std::string_view k_nccl_structured_logging =
     "nccl_structured_logging";
 constexpr std::string_view k_nccl_slow_coll = "nccl_slow_coll";
@@ -69,6 +70,7 @@ std::vector<std::pair<std::string_view, std::string_view>> getAllTableNames() {
       {k_nccl_memory_logging, NCCL_MEMORY_EVENT_LOGGING},
       {k_nccl_profiler_slow_rank, NCCL_SLOW_RANK_LOGGING},
       {k_nccl_profiler_algo, NCCL_CTRAN_ALGO_PROFILING_LOGGING},
+      {k_nccl_profiler_gpe, NCCL_CTRAN_GPE_PROFILING_LOGGING},
       {k_nccl_structured_logging, NCCL_COMM_EVENT_LOGGING},
       {k_nccl_slow_coll, NCCL_SLOW_COLL_LOGGING},
       {k_nccl_collective_stats, NCCL_COLL_STATS_LOGGING},
@@ -116,6 +118,7 @@ DEFINE_scuba_table(nccl_error_logging);
 DEFINE_scuba_table(nccl_memory_logging);
 DEFINE_scuba_table(nccl_profiler_slow_rank);
 DEFINE_scuba_table(nccl_profiler_algo);
+DEFINE_scuba_table(nccl_profiler_gpe);
 DEFINE_scuba_table(nccl_structured_logging);
 DEFINE_scuba_table(nccl_slow_coll);
 DEFINE_scuba_table(nccl_collective_stats);
@@ -128,6 +131,7 @@ void DataTableWrapper::init() {
   INIT_scuba_table(nccl_memory_logging);
   INIT_scuba_table(nccl_profiler_slow_rank);
   INIT_scuba_table(nccl_profiler_algo);
+  INIT_scuba_table(nccl_profiler_gpe);
   INIT_scuba_table(nccl_structured_logging);
   INIT_scuba_table(nccl_slow_coll);
   INIT_scuba_table(nccl_collective_stats);
@@ -141,6 +145,7 @@ void DataTableWrapper::shutdown() {
   SHUTDOWN_scuba_table(nccl_memory_logging);
   SHUTDOWN_scuba_table(nccl_profiler_slow_rank);
   SHUTDOWN_scuba_table(nccl_profiler_algo);
+  SHUTDOWN_scuba_table(nccl_profiler_gpe);
   SHUTDOWN_scuba_table(nccl_structured_logging);
   SHUTDOWN_scuba_table(nccl_slow_coll);
   SHUTDOWN_scuba_table(nccl_collective_stats);

--- a/comms/utils/logger/DataTableWrapper.h
+++ b/comms/utils/logger/DataTableWrapper.h
@@ -77,12 +77,14 @@ DECLARE_scuba_table(nccl_error_logging);
 DECLARE_scuba_table(nccl_memory_logging);
 DECLARE_scuba_table(nccl_profiler_slow_rank);
 DECLARE_scuba_table(nccl_profiler_algo);
+DECLARE_scuba_table(nccl_profiler_gpe);
 DECLARE_scuba_table(nccl_structured_logging);
 DECLARE_scuba_table(nccl_slow_coll);
 DECLARE_scuba_table(nccl_collective_stats);
 
 #define SCUBA_nccl_structured_logging (*SCUBA_nccl_structured_logging_ptr)
 #define SCUBA_nccl_profiler_algo (*SCUBA_nccl_profiler_algo_ptr)
+#define SCUBA_nccl_profiler_gpe (*SCUBA_nccl_profiler_gpe_ptr)
 #define SCUBA_nccl_profiler_slow_rank (*SCUBA_nccl_profiler_slow_rank_ptr)
 #define SCUBA_nccl_memory_logging (*SCUBA_nccl_memory_logging_ptr)
 #define SCUBA_nccl_error_logging (*SCUBA_nccl_error_logging_ptr)

--- a/comms/utils/logger/EventMgr.cc
+++ b/comms/utils/logger/EventMgr.cc
@@ -118,6 +118,22 @@ NcclScubaSample CtranProfilerAlgoEvent::toSample() {
   return sample;
 }
 
+NcclScubaSample CtranProfilerGpeEvent::toSample() {
+  auto sample = CommEvent::toSample();
+  sample.addNormal("type", "CtranProfilerGpeEvent");
+  // NOTE: rank and commHash are added by CommEvent::toSample() above,
+  // sourced from logMetaData. Do NOT re-add here.
+  sample.addInt("opCount", opCount_);
+  sample.addInt("opType", opType_);
+  sample.addNormal("tracePoint", tracePoint_);
+  sample.addInt("iterUs", iterUs_);
+  sample.addInt("durationUs", durationUs_);
+  sample.addInt("aborted", aborted_ ? 1 : 0);
+  sample.addNormal("message", message_);
+  sample.addInt("iteration", iteration_);
+  return sample;
+}
+
 NcclScubaSample NetworkPerfMonitorEvent::toSample() {
   auto sample = CommEvent::toSample();
   sample.addNormal("type", "NetworkPerfMonitorEvent");

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -25,6 +25,7 @@ enum class LoggerEventType {
   CtranProfilerEventType,
   CtranProfilerSlowRankModuleEventType,
   CtranProfilerAlgoEventType,
+  CtranProfilerGpeEventType,
   CommdumpEventType,
   TerminateEventType,
 };
@@ -341,6 +342,60 @@ class CtranProfilerAlgoEvent : public CtranProfilerEvent {
   uint64_t controlTs;
   uint64_t timeFromDataToCollEndUs;
   uint64_t collectiveDurationUs;
+};
+
+// Per-tracepoint Scuba row emitted by ctran::GpeProfiler for each
+// instrumented phase boundary in CtranGpe::Impl::gpeThreadFn.
+// Iteration-level fields (aborted, abortReason, opCount, opType)
+// are repeated on every row from the same iteration.
+class CtranProfilerGpeEvent : public CommEvent {
+ public:
+  CtranProfilerGpeEvent();
+  // rank and commHash are intentionally NOT taken here — they're added by
+  // the CommEvent base class via logMetaData (see CommEvent::toSample()
+  // adding "rank" and "commHash"). Re-adding them here would produce
+  // duplicate Scuba columns and break the local sibling convention used
+  // by CtranProfilerEvent / CtranProfilerAlgoEvent / NetworkPerfMonitorEvent.
+  CtranProfilerGpeEvent(
+      const struct CommLogData* logMetaData,
+      const std::string& stage,
+      const uint64_t opCount,
+      const int opType,
+      const std::string& tracePoint,
+      const uint64_t iterUs,
+      const uint64_t durationUs,
+      const bool aborted,
+      const std::string& message)
+      : CommEvent(logMetaData, stage, ""),
+        opCount_(opCount),
+        opType_(opType),
+        tracePoint_(tracePoint),
+        iterUs_(iterUs),
+        durationUs_(durationUs),
+        aborted_(aborted),
+        message_(message) {
+    iteration_ = ncclxGetIteration();
+  }
+
+  ~CtranProfilerGpeEvent() override = default;
+
+  LoggerEventType getEventType() override {
+    return LoggerEventType::CtranProfilerGpeEventType;
+  }
+  void setTimerDelta(double /*delta*/) override {}
+  NcclScubaSample toSample() override;
+
+ private:
+  const uint64_t opCount_;
+  const int opType_;
+  const std::string tracePoint_;
+  const uint64_t iterUs_;
+  const uint64_t durationUs_;
+  const bool aborted_;
+  const std::string message_;
+  // training step. If not set by trainer, it is always -1. Also see
+  // ncclxGetIteration().
+  int64_t iteration_{-1};
 };
 
 class NetworkPerfMonitorEvent : public CommEvent {

--- a/comms/utils/logger/ScubaLogger.cc
+++ b/comms/utils/logger/ScubaLogger.cc
@@ -20,6 +20,8 @@ DataTableWrapper* getTablePtrFromEvent(LoggerEventType event) {
       return SCUBA_nccl_profiler_slow_rank_ptr.get();
     case LoggerEventType::CtranProfilerAlgoEventType:
       return SCUBA_nccl_profiler_algo_ptr.get();
+    case LoggerEventType::CtranProfilerGpeEventType:
+      return SCUBA_nccl_profiler_gpe_ptr.get();
     case LoggerEventType::CommEventType:
       return SCUBA_nccl_structured_logging_ptr.get();
     default:

--- a/comms/utils/logger/tests/CtranProfilerGpeEventTest.cc
+++ b/comms/utils/logger/tests/CtranProfilerGpeEventTest.cc
@@ -1,0 +1,139 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/EventMgr.h"
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/DataTableWrapper.h"
+#include "comms/utils/logger/ScubaLogger.h"
+#include "comms/utils/trainer/TrainerContext.h"
+
+namespace {
+
+constexpr uint64_t kCommId = 11111;
+constexpr uint64_t kCommHash = 22222;
+constexpr int kRank = 3;
+constexpr int kNRanks = 8;
+constexpr const char* kCommDesc = "test_pg:0";
+
+constexpr uint64_t kOpCount = 42;
+constexpr int kOpType = 7;
+const std::string kTracePoint = "host_algo";
+constexpr uint64_t kIterUs = 1234;
+constexpr uint64_t kDurationUs = 567;
+constexpr bool kAborted = true;
+const std::string kMessage = "timeout";
+constexpr int64_t kIteration = 99;
+
+CommLogData makeCommLogData() {
+  return CommLogData{kCommId, kCommHash, kCommDesc, kRank, kNRanks};
+}
+
+std::unique_ptr<CtranProfilerGpeEvent> makeGpeEvent(
+    const CommLogData* logMetaData) {
+  return std::make_unique<CtranProfilerGpeEvent>(
+      logMetaData,
+      /*stage=*/"ctranProfilerGpeV1",
+      kOpCount,
+      kOpType,
+      kTracePoint,
+      kIterUs,
+      kDurationUs,
+      kAborted,
+      kMessage);
+}
+
+} // namespace
+
+// Construct a CtranProfilerGpeEvent and verify every GPE-specific column
+// added by its toSample() is present and round-trips through JSON.
+TEST(CtranProfilerGpeEventTest, ToSamplePopulatesAllNewColumns) {
+  ncclxSetIteration(kIteration);
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["type"].asString(), "CtranProfilerGpeEvent");
+  EXPECT_EQ(json["int"]["opCount"].asInt(), static_cast<int64_t>(kOpCount));
+  EXPECT_EQ(json["int"]["opType"].asInt(), kOpType);
+  EXPECT_EQ(json["normal"]["tracePoint"].asString(), kTracePoint);
+  EXPECT_EQ(json["int"]["iterUs"].asInt(), static_cast<int64_t>(kIterUs));
+  EXPECT_EQ(
+      json["int"]["durationUs"].asInt(), static_cast<int64_t>(kDurationUs));
+  EXPECT_EQ(json["int"]["aborted"].asInt(), kAborted ? 1 : 0);
+  EXPECT_EQ(json["normal"]["message"].asString(), kMessage);
+  EXPECT_EQ(json["int"]["iteration"].asInt(), kIteration);
+}
+
+// CommEvent base-class columns (commId, commHash, commDesc, rank, nranks)
+// must be populated from the injected CommLogData. The GPE subclass must
+// NOT re-add them with conflicting values.
+TEST(CtranProfilerGpeEventTest, ToSampleBaseColumnsFromCommLogData) {
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["int"]["commId"].asInt(), static_cast<int64_t>(kCommId));
+  EXPECT_EQ(json["int"]["commHash"].asInt(), static_cast<int64_t>(kCommHash));
+  EXPECT_EQ(json["normal"]["commDesc"].asString(), kCommDesc);
+  EXPECT_EQ(json["int"]["rank"].asInt(), kRank);
+  EXPECT_EQ(json["int"]["nranks"].asInt(), kNRanks);
+}
+
+// Aborted=false / empty message path: aborted column reads 0, message is
+// the empty string.
+TEST(CtranProfilerGpeEventTest, ToSampleNonAbortedRow) {
+  const auto md = makeCommLogData();
+  auto event = std::make_unique<CtranProfilerGpeEvent>(
+      &md,
+      /*stage=*/"ctranProfilerGpeV1",
+      kOpCount,
+      kOpType,
+      std::string("cmd_dequeue"),
+      kIterUs,
+      kDurationUs,
+      /*aborted=*/false,
+      /*message=*/"");
+
+  auto sample = event->toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["int"]["aborted"].asInt(), 0);
+  EXPECT_EQ(json["normal"]["message"].asString(), "");
+  EXPECT_EQ(json["normal"]["tracePoint"].asString(), "cmd_dequeue");
+}
+
+// getEventType() must return the GPE variant so ScubaLogger's dispatch
+// routes the event to nccl_profiler_gpe (and not to the algo or another
+// sibling table).
+TEST(CtranProfilerGpeEventTest, GetEventTypeIsGpeVariant) {
+  const auto md = makeCommLogData();
+  auto event = makeGpeEvent(&md);
+  EXPECT_EQ(event->getEventType(), LoggerEventType::CtranProfilerGpeEventType);
+}
+
+// ScubaLogger's getTablePtrFromEvent() must route the GPE event type to
+// the wrapper added in this diff (SCUBA_nccl_profiler_gpe_ptr). Without
+// the correct routing, GPE rows would land in algo (or worse, throw on
+// the default branch).
+TEST(CtranProfilerGpeEventTest, ScubaDispatchTargetsGpeTablePtr) {
+  DataTableWrapper::init();
+  ASSERT_NE(SCUBA_nccl_profiler_gpe_ptr, nullptr);
+  EXPECT_EQ(
+      getTablePtrFromEvent(LoggerEventType::CtranProfilerGpeEventType),
+      SCUBA_nccl_profiler_gpe_ptr.get());
+  // Algo path must not return the GPE pointer (sanity check).
+  EXPECT_NE(
+      getTablePtrFromEvent(LoggerEventType::CtranProfilerAlgoEventType),
+      SCUBA_nccl_profiler_gpe_ptr.get());
+  // shutdown must be safe with no addSample calls (lazy table_ stays
+  // null; the SHUTDOWN_scuba_table macro guards on table_).
+  DataTableWrapper::shutdown();
+}


### PR DESCRIPTION
Summary:
Public reporter API + production sink + test mock for the new
per-tracepoint GpeProfiler. Follows the canonical layout already
established at comms/ctran/profiler/ (mirrors the existing 3 Algo
targets: algo_profiler_report, i_profiler_reporter,
default_algo_profiler_reporter).

# New files (under comms/ctran/profiler/)
- GpeProfilerReport.h: enum class GpeTracePoint (7 tracepoints
  including TERMINATE_CMD at the end) + struct GpeProfilerReport.
  Mirrors AlgoProfilerReport.h.
- IGpeProfilerReporter.h: abstract reporter interface.
  Mirrors IProfilerReporter.h.
- DefaultGpeProfilerReporter.{h,cc}: production reporter that
  builds CtranProfilerGpeEvent and emits to Scuba dataset
  ctranProfilerGpeV1. Mirrors DefaultAlgoProfilerReporter.{h,cc}.
- tests/MockGpeProfilerReporter.h: gmock impl.
- tests/DefaultGpeProfilerReporterTest.cc (new): UT for the
  production reporter — verifies report() dispatches cleanly across
  all GpeTracePoint enum values and for both happy/aborted/null
  metadata inputs. Sibling DefaultAlgoProfilerReporter has no UT
  today; this is the first direct test of either Default reporter.

# BUCK targets added
- 3 new ctran_cpp_library targets in comms/ctran/profiler/BUCK:
  gpe_profiler_report, i_gpe_profiler_reporter,
  default_gpe_profiler_reporter (mirroring the 3 sibling Algo
  targets 1:1).
- 2 new targets in comms/ctran/profiler/tests/BUCK:
  mock_gpe_profiler_reporter (mirrors mock_algo_profiler_reporter)
  + default_gpe_profiler_reporter_test.

Depends on the Scuba infrastructure landed in the prior diff.

Differential Revision: D104837560


