### PR TITLE
Wire GpeProfiler into gpeThreadFn (#2615)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -8,7 +8,10 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/gpe/CtranGpeImpl.h"
+#include "comms/ctran/profiler/DefaultGpeProfilerReporter.h"
+#include "comms/ctran/profiler/GpeProfiler.h"
 #include "comms/ctran/utils/Checks.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
 using namespace ctran;
@@ -350,11 +353,31 @@ std::string KernelConfig::toString() {
   return ss.str();
 }
 
-CtranGpe::CtranGpe(int cudaDev, CtranComm* comm) {
+CtranGpe::CtranGpe(
+    int cudaDev,
+    CtranComm* comm,
+    std::unique_ptr<ctran::IGpeProfilerReporter> reporter) {
   this->pimpl = std::make_unique<Impl>();
   this->pimpl->comm = comm;
   this->pimpl->cudaDev = cudaDev;
   this->pimpl->gpe = this;
+  // The cvar is the kill-switch at this integration layer. When false,
+  // the reporter is nulled regardless of caller injection — production
+  // operators always control whether Scuba rows flow. The profiler still
+  // exists and tracks internal state so gpeProfiler_->debugString() keeps
+  // populating the abort ERR line on stderr.
+  if (!NCCL_CTRAN_GPE_PROFILING_ENABLE) {
+    reporter.reset();
+  } else if (!reporter) {
+    reporter = std::make_unique<ctran::DefaultGpeProfilerReporter>();
+  }
+  this->pimpl->gpeProfiler_ = std::make_unique<ctran::GpeProfiler>(
+      &comm->logMetaData_,
+      comm->statex_->rank(),
+      comm->statex_->commHash(),
+      NCCL_CTRAN_GPE_PROFILING_SAMPLING_WEIGHT,
+      std::move(reporter),
+      comm->getAbort());
   this->pimpl->start();
 }
 

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -20,6 +20,7 @@
 #include "comms/ctran/algos/SendRecv/Types.h"
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/gpe/CtranGpeDev.h"
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
 #include "comms/ctran/window/CtranWin.h"
 
@@ -372,7 +373,16 @@ struct fmt::formatter<KernelConfig::KernelType> : fmt::formatter<int> {
 
 class CtranGpe {
  public:
-  CtranGpe(int cudaDev, CtranComm* comm);
+  // Optional reporter injection for tests. The cvar
+  // NCCL_CTRAN_GPE_PROFILING_ENABLE gates whether any reporter is wired
+  // through to the profiler at all: when false (default), the reporter
+  // is nulled regardless of what's passed here. When true, a passed
+  // reporter is used as-is, and nullptr is replaced with the production
+  // DefaultGpeProfilerReporter (Scuba flush).
+  CtranGpe(
+      int cudaDev,
+      CtranComm* comm,
+      std::unique_ptr<ctran::IGpeProfilerReporter> reporter = nullptr);
   ~CtranGpe();
 
   // Submit device mem communication. A kernel will be launched and host side

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -705,6 +705,16 @@ void CtranGpe::Impl::terminate() {
       statex->commDesc());
 }
 
+void CtranGpe::Impl::injectGpeProfilerMetadata(CtranGpeCmd* cmd) {
+  if (cmd->coll.opGroup.empty()) {
+    return;
+  }
+  gpeProfiler_->injectMetadata({
+      .opCount = cmd->coll.opGroup.front()->opCount,
+      .opType = static_cast<int>(cmd->coll.opGroup.front()->type),
+  });
+}
+
 void CtranGpe::Impl::gpeThreadFn() {
   const auto& statex = comm->statex_;
   assert(statex != nullptr);
@@ -719,7 +729,15 @@ void CtranGpe::Impl::gpeThreadFn() {
     FB_CUDACHECKTHROW_EX(cudaSetDevice(cudaDev), comm->logMetaData_);
 
     while (1) {
+      gpeProfiler_->mark(ctran::GpeTracePoint::ITER_START);
       auto cmd = cmdDequeue();
+      injectGpeProfilerMetadata(cmd);
+      gpeProfiler_->mark(ctran::GpeTracePoint::CMD_DEQUEUE);
+
+      // Captured before SCOPE_EXIT so the lambda can safely see it after
+      // the TERMINATE branch deletes cmd + returns.
+      const bool isTerminateCmd =
+          (cmd->type == CtranGpeCmd::TypeEnum::TERMINATE);
 
       if (cmd->timeout.has_value()) {
         comm->setTimeout(cmd->timeout.value());
@@ -729,29 +747,33 @@ void CtranGpe::Impl::gpeThreadFn() {
         comm->setTimeout(*d);
       }
       SCOPE_EXIT {
-        // if comm is aborted for any reason, we mark it as aborted to avoid
-        // resetting the state.
         if (comm->testAbort()) {
-          auto abort = comm->getAbort();
-          if (abort->TimedOut()) {
-            CLOGF(
-                ERR,
-                "Communicator aborted due to timeout on rank {} commHash {:x}",
-                statex->rank(),
-                statex->commHash());
-          } else {
-            CLOGF(
-                ERR,
-                "Communicator aborted (explicit) on rank {} commHash {:x}",
-                statex->rank(),
-                statex->commHash());
-          }
+          // Preserve abort state across cancelTimeout(): an aborted comm
+          // must never flip back to not-aborted.
           comm->setAbort();
+          const std::string_view reason =
+              comm->getAbort()->TimedOut() ? "timeout" : "explicit";
+
+          // TERMINATE was marked before SCOPE_EXIT — skip the marker here.
+          if (!isTerminateCmd) {
+            gpeProfiler_->mark(ctran::GpeTracePoint::ALGO_ABORTED, reason);
+          }
+
+          const std::string_view phase = isTerminateCmd ? " now TERMINATE" : "";
+          CLOGF(
+              ERR,
+              "Communicator aborted ({}){} on rank {} commHash {:x} {}",
+              reason,
+              phase,
+              statex->rank(),
+              statex->commHash(),
+              gpeProfiler_->debugString());
         }
         comm->cancelTimeout();
       };
 
       if (cmd->type == CtranGpeCmd::TypeEnum::TERMINATE) {
+        gpeProfiler_->mark(ctran::GpeTracePoint::TERMINATE_CMD);
         CLOGF_SUBSYS(
             INFO,
             INIT,
@@ -776,6 +798,7 @@ void CtranGpe::Impl::gpeThreadFn() {
           std::this_thread::yield();
         }
       }
+      gpeProfiler_->mark(ctran::GpeTracePoint::WAIT_KERNEL);
 
       if (cmd->coll.collHandle != nullptr) {
         cmd->coll.collHandle->trigger(
@@ -854,6 +877,7 @@ void CtranGpe::Impl::gpeThreadFn() {
           cmd->coll.opGroup.clear();
         }
       }
+      gpeProfiler_->mark(ctran::GpeTracePoint::HOST_ALGO);
 
       if (kernelFlag) {
         volatile int* flag_d = kernelFlag->flag_;
@@ -877,6 +901,7 @@ void CtranGpe::Impl::gpeThreadFn() {
           // termination
           kernelFlag->setFlagPerGroup(
               comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
+          gpeProfiler_->mark(ctran::GpeTracePoint::TERMINATE_KERNEL);
         }
         // Teardown unpack queue if it was allocated for this operation (TcpDM
         // backend). Don't wait for kernel to finish, the pool manages

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -17,6 +17,8 @@
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/gpe/CtranChecksum.h"
 #include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/profiler/GpeProfiler.h"
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/ctran/utils/PinnedHostPool.h"
@@ -327,6 +329,9 @@ class CtranGpe::Impl {
   int cudaDev{-1};
   CtranGpe* gpe{nullptr};
 
+  // Used only by the GPE thread.
+  std::unique_ptr<ctran::GpeProfiler> gpeProfiler_;
+
  private:
   struct CmdQueue {
     std::queue<CtranGpeCmd*> queue;
@@ -359,6 +364,14 @@ class CtranGpe::Impl {
     locked->queue.pop();
     return cmd;
   }
+
+  // Forwards opCount/opType from the dequeued command's leading op to
+  // the GPE profiler, which uses opCount to compute this iter's
+  // sampling verdict. No-op when opGroup is empty (TERMINATE cmd or
+  // post-kernel cleanup-only cmd) since there is no meaningful op to
+  // attribute metadata to. The TERMINATE iter still gets an explicit
+  // TERMINATE_CMD tracepoint via the always-on path.
+  void injectGpeProfilerMetadata(CtranGpeCmd* cmd);
 
   static void CUDART_CB cmdCb(void* data);
   static void CUDART_CB cmdDestroy(void* data);

--- a/comms/ctran/gpe/tests/CtranGpeProfilerIntegrationUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeProfilerIntegrationUT.cc
@@ -1,0 +1,239 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/gpe/tests/CtranGpeFaultToleranceUTBase.h"
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
+#include "comms/ctran/profiler/tests/MockGpeProfilerReporter.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::fttesting {
+
+// ---------------------------------------------------------------------------
+// GpeProfiler integration tests (T270778705).
+//
+// These tests inject a MockGpeProfilerReporter through the 3-arg CtranGpe ctor
+// and assert on the per-tracepoint Scuba rows the GPE thread emits eagerly
+// from inside ctran::GpeProfiler::mark(). Per the universal in-order backfill
+// rule, ITER_START + CMD_DEQUEUE only emit when a downstream mark (sampled
+// row, ALGO_ABORTED marker, or always-on TERMINATE_CMD) triggers a
+// backfill; WAIT_KERNEL/HOST_ALGO/TERMINATE_KERNEL respect sampling;
+// ALGO_ABORTED and TERMINATE_CMD are always-on.
+// ---------------------------------------------------------------------------
+
+// NCCL_CTRAN_GPE_PROFILING_ENABLE defaults to false in production, which
+// nulls the reporter at the CtranGpe integration layer regardless of caller
+// injection. The integration tests here inject a mock reporter and would
+// see zero report() calls without flipping the cvar. SetUp/TearDown override
+// the cvar around the test body and restore it after.
+class GpeProfilerIntegrationTest : public CtranGpeFaultToleranceTestBase {
+ protected:
+  void SetUp() override {
+    SetUpInternal(/*abortEnabled=*/true);
+    savedProfilingEnable_ = NCCL_CTRAN_GPE_PROFILING_ENABLE;
+    NCCL_CTRAN_GPE_PROFILING_ENABLE = true;
+  }
+  void TearDown() override {
+    NCCL_CTRAN_GPE_PROFILING_ENABLE = savedProfilingEnable_;
+    CtranGpeFaultToleranceTestBase::TearDown();
+  }
+
+ private:
+  bool savedProfilingEnable_{false};
+};
+
+// Drives the abort path (HostDetectedTimeout style) and asserts that the
+// reporter sees the anchor pair (ITER_START + CMD_DEQUEUE) and the
+// force-emitted ALGO_ABORTED row carrying aborted=true and reason="timeout".
+TEST_F(GpeProfilerIntegrationTest, GpeProfiler_RecordsAlgoAbortedOnAbort) {
+  ASSERT_TRUE(ctranComm->abortEnabled());
+
+  auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
+  auto* mockPtr = mockReporter.get();
+
+  std::vector<::ctran::GpeProfilerReport> rows;
+  EXPECT_CALL(*mockPtr, report(::testing::_))
+      .WillRepeatedly(
+          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+
+  auto gpe = std::make_unique<CtranGpe>(
+      cudaDev, ctranComm.get(), std::move(mockReporter));
+
+  FtTestSync sync;
+  sync.setTimeout();
+  this->launchKernelFn(
+      gpe.get(),
+      (void*)CtranGpeTestFtBaseKernel,
+      stream,
+      &sync,
+      /*timeout=*/kHostAlgoFnWait - std::chrono::milliseconds(500));
+
+  // Wait for kernel + abort handling to complete.
+  tryQueryStreamFor(stream, kHostAlgoFnWait + std::chrono::milliseconds(2000));
+  ASSERT_TRUE(ctranComm->testAbort());
+
+  // Tear down gpe — ~Impl joins the GPE thread.
+  gpe.reset();
+
+  ASSERT_FALSE(rows.empty()) << "expected at least the anchor pair";
+
+  // Anchor pair always emits.
+  bool sawIterStart = false;
+  bool sawCmdDequeue = false;
+  bool sawAlgoAborted = false;
+  for (const auto& r : rows) {
+    if (r.tracePoint == ::ctran::GpeTracePoint::ITER_START) {
+      sawIterStart = true;
+      EXPECT_EQ(r.iterUs, 0UL);
+      EXPECT_EQ(r.durationUs, 0UL);
+      EXPECT_FALSE(r.aborted);
+    } else if (r.tracePoint == ::ctran::GpeTracePoint::CMD_DEQUEUE) {
+      sawCmdDequeue = true;
+      EXPECT_FALSE(r.aborted);
+    } else if (r.tracePoint == ::ctran::GpeTracePoint::ALGO_ABORTED) {
+      sawAlgoAborted = true;
+      EXPECT_TRUE(r.aborted);
+      EXPECT_EQ(r.message, std::string_view{"timeout"});
+    }
+  }
+  EXPECT_TRUE(sawIterStart);
+  EXPECT_TRUE(sawCmdDequeue);
+  EXPECT_TRUE(sawAlgoAborted);
+}
+
+// Happy-path iter at default samplingWeight=1000 with opCount=100 is NOT
+// sampled, so the user iter emits nothing (universal backfill rule — no
+// downstream emit fires, so ITER_START + CMD_DEQUEUE stay deferred and
+// WAIT_KERNEL/HOST_ALGO/TERMINATE_KERNEL drop). The trailing TERMINATE
+// iter fires its always-on TERMINATE_CMD, which backfills that iter's
+// ITER_START + CMD_DEQUEUE. So the expected emit set is exactly
+// {ITER_START, CMD_DEQUEUE, TERMINATE_CMD} — no collective-phase rows.
+TEST_F(
+    GpeProfilerIntegrationTest,
+    GpeProfiler_UnsampledHappyPathEmitsAnchorPairOnly) {
+  ASSERT_TRUE(ctranComm->abortEnabled());
+
+  auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
+  auto* mockPtr = mockReporter.get();
+
+  std::vector<::ctran::GpeProfilerReport> rows;
+  EXPECT_CALL(*mockPtr, report(::testing::_))
+      .WillRepeatedly(
+          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+
+  auto gpe = std::make_unique<CtranGpe>(
+      cudaDev, ctranComm.get(), std::move(mockReporter));
+
+  // Run a happy-path iteration (no abort).
+  FtTestSync sync;
+  this->launchKernelFn(
+      gpe.get(), (void*)CtranGpeTestFtEnabledOobTerminateKernel, stream, &sync);
+  *oobKernelTerminateFlag = true;
+  sync.signal();
+  tryQueryStreamFor(stream, kHostAlgoFnWait + std::chrono::milliseconds(1000));
+
+  gpe.reset();
+
+  EXPECT_FALSE(ctranComm->testAbort());
+  bool sawCollectivePhaseRow = false;
+  for (const auto& r : rows) {
+    EXPECT_FALSE(r.aborted);
+    switch (r.tracePoint) {
+      case ::ctran::GpeTracePoint::ITER_START:
+      case ::ctran::GpeTracePoint::CMD_DEQUEUE:
+      case ::ctran::GpeTracePoint::TERMINATE_CMD:
+        // Anchor pair (backfilled by TERMINATE_CMD) + the TERMINATE_CMD
+        // itself. All expected on a happy unsampled-then-terminate
+        // sequence.
+        break;
+      default:
+        sawCollectivePhaseRow = true;
+        break;
+    }
+  }
+  EXPECT_FALSE(sawCollectivePhaseRow)
+      << "unsampled iter should not emit WAIT_KERNEL/HOST_ALGO/TERMINATE_KERNEL/ALGO_ABORTED";
+}
+
+// TERMINATE-only sequence (no real cmds). The TERMINATE iter triggers
+// the always-on TERMINATE_CMD mark, which backfills the preceding
+// ITER_START + CMD_DEQUEUE per the universal in-order backfill rule.
+// Expected emits: exactly {ITER_START, CMD_DEQUEUE, TERMINATE_CMD}. No
+// ALGO_ABORTED.
+TEST_F(GpeProfilerIntegrationTest, GpeProfiler_TerminateIterEmitsAnchorPair) {
+  ASSERT_TRUE(ctranComm->abortEnabled());
+
+  auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
+  auto* mockPtr = mockReporter.get();
+
+  std::vector<::ctran::GpeProfilerReport> rows;
+  EXPECT_CALL(*mockPtr, report(::testing::_))
+      .WillRepeatedly(
+          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+
+  auto gpe = std::make_unique<CtranGpe>(
+      cudaDev, ctranComm.get(), std::move(mockReporter));
+
+  // No collectives submitted; immediately tear down. ~Impl enqueues a
+  // TERMINATE cmd and joins the thread.
+  gpe.reset();
+  EXPECT_FALSE(ctranComm->testAbort());
+
+  for (const auto& r : rows) {
+    EXPECT_FALSE(r.aborted);
+    EXPECT_TRUE(
+        r.tracePoint == ::ctran::GpeTracePoint::ITER_START ||
+        r.tracePoint == ::ctran::GpeTracePoint::CMD_DEQUEUE ||
+        r.tracePoint == ::ctran::GpeTracePoint::TERMINATE_CMD)
+        << "TERMINATE iter emitted unexpected tracePoint";
+  }
+}
+
+// External abort before TERMINATE: gpe is destroyed while the comm's
+// abort flag is set but no collective ran. The SCOPE_EXIT on the
+// TERMINATE iter sees testAbort() == true and logs ("now TERMINATE"
+// flavor) but must NOT stamp ALGO_ABORTED — that would land later in
+// wall-clock than the already-stamped TERMINATE_CMD. The abort flag
+// must remain set across cancelTimeout().
+TEST_F(
+    GpeProfilerIntegrationTest,
+    GpeProfiler_TerminateAfterAbortSkipsAlgoAborted) {
+  ASSERT_TRUE(ctranComm->abortEnabled());
+
+  auto mockReporter = std::make_unique<::ctran::MockGpeProfilerReporter>();
+  auto* mockPtr = mockReporter.get();
+
+  std::vector<::ctran::GpeProfilerReport> rows;
+  EXPECT_CALL(*mockPtr, report(::testing::_))
+      .WillRepeatedly(
+          [&](const ::ctran::GpeProfilerReport& r) { rows.push_back(r); });
+
+  auto gpe = std::make_unique<CtranGpe>(
+      cudaDev, ctranComm.get(), std::move(mockReporter));
+
+  // Externally abort the comm before teardown — TERMINATE will be the
+  // only cmd the GPE thread sees.
+  ctranComm->setAbort();
+  ASSERT_TRUE(ctranComm->testAbort());
+
+  gpe.reset();
+
+  // Abort state must persist across cancelTimeout().
+  EXPECT_TRUE(ctranComm->testAbort());
+
+  // No ALGO_ABORTED row — TERMINATE branch skips the marker.
+  bool sawAlgoAborted = false;
+  for (const auto& r : rows) {
+    if (r.tracePoint == ::ctran::GpeTracePoint::ALGO_ABORTED) {
+      sawAlgoAborted = true;
+    }
+    EXPECT_TRUE(
+        r.tracePoint == ::ctran::GpeTracePoint::ITER_START ||
+        r.tracePoint == ::ctran::GpeTracePoint::CMD_DEQUEUE ||
+        r.tracePoint == ::ctran::GpeTracePoint::TERMINATE_CMD)
+        << "TERMINATE-after-abort iter emitted unexpected tracePoint";
+  }
+  EXPECT_FALSE(sawAlgoAborted)
+      << "ALGO_ABORTED must be skipped on TERMINATE to avoid out-of-order stamp";
+}
+
+} // namespace ctran::fttesting

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -86,6 +86,17 @@ cvars:
       to e.g. "scuba:nccl_profiler_gpe".
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
+ - name        : NCCL_CTRAN_GPE_PROFILING_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Kill-switch for ctran::GpeProfiler's per-tracepoint Scuba flush
+     (table nccl_profiler_gpe). When false (default), CtranGpe nulls the
+     reporter regardless of caller injection — no Scuba rows are emitted.
+     The profiler still tracks per-iteration state internally so the
+     consolidated abort ERR line on stderr (gpeProfiler_->debugString())
+     keeps producing per-phase latencies. Set true to enable Scuba flush.
+
  - name        : NCCL_CTRAN_GPE_PROFILING_SAMPLING_WEIGHT
    type        : int
    default     : 1000


### PR DESCRIPTION
Summary:

Wires the GpeProfiler from D104838321 into CtranGpe::Impl so
gpeThreadFn emits per-tracepoint Scuba rows for every iteration
(sampled or aborted) and a consolidated stderr ERR line on abort.

Changes:
- CtranGpe.{h,cc}: 3-arg constructor with default
  std::unique_ptr<ctran::IGpeProfilerReporter> = nullptr. The cvar
  NCCL_CTRAN_GPE_PROFILING_ENABLE is the kill-switch at this
  integration layer — when false, the reporter is nulled regardless
  of caller injection, so the profiler tracks state for the abort
  ERR line on stderr but no Scuba rows flow. The abort handle
  (comm->getAbort()) is forwarded so the profiler can bypass
  sampling + backfill on live abort.
- CtranGpeImpl.{h,cc}: new gpeProfiler_ member and a small
  injectGpeProfilerMetadata(cmd) private helper that encapsulates
  the empty-opGroup skip rule. gpeThreadFn now has 6 mark()
  points: ITER_START, CMD_DEQUEUE, WAIT_KERNEL, HOST_ALGO,
  TERMINATE_KERNEL, plus an ALGO_ABORTED mark from the SCOPE_EXIT
  abort branch carrying "timeout" or "explicit" as the reason,
  and a TERMINATE_CMD mark on the GPE-thread exit branch.
- def_build.bzl: add gpe_profiler + i_gpe_profiler_reporter to
  CTRAN_DEPS.
- tests/BUCK: new comms_gpu_cpp_unittest target
  ctran_gpe_profiler_integration_ut owning
  CtranGpeProfilerIntegrationUT.cc (split from
  ctran_gpe_fault_tolerance_ut). Both targets share the
  ctran_gpe_fault_tolerance_ut_base header library introduced in
  the prior diff.
- tests/CtranGpeProfilerIntegrationUT.cc: integration TEST_F cases
  on top of the fixtures extracted in the prior diff, asserting
  the mock reporter sees the expected per-tracepoint rows on
  abort + sampled + terminate iters.
- nccl_cvars.yaml: new NCCL_CTRAN_GPE_PROFILING_ENABLE bool
  (default false) — documented kill-switch.

Reviewed By: saifhhasan

Differential Revision: D105578016


