### PR TITLE
Wire McclGpeProfilerReporter through ctranInit gated by enableProfiler (#2616)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -27,7 +27,8 @@
 
 Ctran::Ctran(
     CtranComm* comm,
-    std::unique_ptr<ctran::IProfilerReporter> reporter)
+    std::unique_ptr<ctran::IProfilerReporter> reporter,
+    std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter)
     : comm_(comm) {
   ctran::logging::initCtranLogging();
 
@@ -40,7 +41,8 @@ Ctran::Ctran(
   }
 
   mapper = std::make_unique<CtranMapper>(comm_, profiler.get());
-  gpe = std::make_unique<CtranGpe>(comm->statex_->cudaDev(), comm_);
+  gpe = std::make_unique<CtranGpe>(
+      comm->statex_->cudaDev(), comm_, std::move(gpeReporter));
 
   algo = std::make_unique<CtranAlgo>(comm, this);
 }
@@ -138,11 +140,13 @@ void CtranComm::recordAlgoStats(
 
 commResult_t ctranInit(
     CtranComm* comm,
-    std::unique_ptr<ctran::IProfilerReporter> reporter) {
+    std::unique_ptr<ctran::IProfilerReporter> reporter,
+    std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter) {
   NcclScubaEvent initEvent(&comm->logMetaData_);
   initEvent.lapAndRecord("CtranInit START");
   try {
-    comm->ctran_ = std::make_shared<Ctran>(comm, std::move(reporter));
+    comm->ctran_ = std::make_shared<Ctran>(
+        comm, std::move(reporter), std::move(gpeReporter));
   } catch (std::exception& e) {
     CLOGF(ERR, "Ctran initialization failed: {}", e.what());
     return commInternalError;

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -25,7 +25,8 @@ class Ctran : public ICtran {
  public:
   Ctran(
       CtranComm* comm,
-      std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
+      std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr,
+      std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter = nullptr);
   ~Ctran();
 
   bool isInitialized() const override;

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -230,7 +230,8 @@ class CtranComm {
   friend class CtranGpe;
   friend commResult_t ctranInit(
       CtranComm* comm,
-      std::unique_ptr<ctran::IProfilerReporter> reporter);
+      std::unique_ptr<ctran::IProfilerReporter> reporter,
+      std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter);
   std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
   // TODO: define proper constructor to make CtranComm be independent of
   // ncclComm.

--- a/comms/ctran/interfaces/ICtran.h
+++ b/comms/ctran/interfaces/ICtran.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
 #include "comms/ctran/profiler/IProfilerReporter.h"
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -64,7 +65,8 @@ inline bool ctranIsUsed() {
 
 commResult_t ctranInit(
     CtranComm* comm,
-    std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr);
+    std::unique_ptr<ctran::IProfilerReporter> reporter = nullptr,
+    std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter = nullptr);
 // Check whether the default CTran associated with the comm is initialized.
 // If to check a dedicated CTran instance, use ctran->isInitialized() instead.
 bool ctranInitialized(CtranComm* comm);

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3195,11 +3195,15 @@ cvars:
    type        : bool
    default     : true
    description : |-
-     Enable ctran transport profiling for MCCL. When true, MCCL overrides
-     NCCL_CTRAN_TRANSPORT_PROFILER to true during init so that the ctran
-     Profiler is created and algo profiling data flows to the
-     mccl_operation_trace Scuba table via McclAlgoProfilerReporter. Set to
-     false to disable ctran profiling from the MCCL level.
+     Enable ctran transport profiling for MCCL. When true (and the rank
+     passes MCCL_FILTER_PROFILER_LOGGING_BY_RANKS), MCCL sets
+     comm_->config_.enableProfiler and injects BOTH
+     McclAlgoProfilerReporter and McclGpeProfilerReporter into
+     ctranInit. Algo rows land in mccl_operation_trace with
+     mcclop="ALGO_PROFILING"; GPE per-tracepoint rows land in the same
+     table with mcclop="GPE_PROFILING". Set to false to disable both
+     reporters from the MCCL level (CTRAN-side defaults for the GPE
+     profiler still apply per NCCL_CTRAN_GPE_PROFILING_ENABLE).
 
  - name        : MCCL_FILTER_PROFILER_LOGGING_BY_RANKS
    type        : stringlist


### PR DESCRIPTION
Summary:

Final integration diff for redirecting GPE per-tracepoint rows into
mccl_operation_trace. Plumbs an optional gpeReporter argument through
ctranInit -> Ctran -> CtranGpe, and wires MCCL to inject
McclGpeProfilerReporter alongside McclAlgoProfilerReporter using the
SAME enableProfiler gate. Algo + GPE rows now coexist in
mccl_operation_trace, disambiguated by the mcclop column
("ALGO_PROFILING" vs "GPE_PROFILING").

# What changed

- ctranInit / Ctran ctor: new optional
  std::unique_ptr<ctran::IGpeProfilerReporter> gpeReporter param
  (defaults nullptr — pre-existing 1-arg / 2-arg callers continue to
  work). Forwarded into CtranGpe's 3-arg ctor.
- CtranComm friend declaration of ctranInit updated to the new
  3-arg signature so it can still set comm->algoStats_.
- McclComm: passes BOTH reporters through ctranInit, each gated on
  comm_->config_.enableProfiler (which already folds in
  MCCL_CTRAN_TRANSPORT_PROFILER + MCCL_FILTER_PROFILER_LOGGING_BY_RANKS).
  This drops the per-emit rank check the reporter used to do — the
  rank filter is now enforced once at reporter construction (parallel
  to the algo reporter).
- comms/ctran/interfaces/BUCK: exports i_gpe_profiler_reporter so
  ICtran.h's new include resolves for downstream consumers.
- comms/mccl/BUCK: depends on mccl_gpe_profiler_reporter.
- nccl_cvars.yaml: MCCL_CTRAN_TRANSPORT_PROFILER doc updated to call
  out the new GPE reporter injection.

Reviewed By: saifhhasan

Differential Revision: D105251819


