### PR TITLE
Preserve getP2pTransportDevice contract

### DIFF
--- a/comms/pipes/MultiPeerTransport.cc
+++ b/comms/pipes/MultiPeerTransport.cc
@@ -286,7 +286,7 @@ void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
     for (int peer : peers) {
       if (peer >= 0 && peer < nRanks_ && peer != myRank_ &&
           typePerRank_[peer] == TransportType::P2P_IBGDA) {
-        ibgdaTransport_->materializePeer(peer);
+        ibgdaTransport_->queuePeerForMaterialization(peer);
       }
     }
     ibgdaTransport_->connectPeers();

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -2022,13 +2022,21 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
 }
 
 void MultipeerIbgdaTransport::materializePeer(int peerRank) {
+  queuePeerForMaterialization(peerRank);
+  connectPeers();
+}
+
+void MultipeerIbgdaTransport::queuePeerForMaterialization(int peerRank) {
   if (!config_.ibLazyConnect) {
     return;
+  }
+  if (materializationFailed_) {
+    throw std::runtime_error(kMaterializationFailedError);
   }
   if (peerRank == myRank_ || peerRank < 0 || peerRank >= nRanks_) {
     throw std::invalid_argument(
         fmt::format(
-            "materializePeer: invalid peerRank={} (myRank={}, nRanks={})",
+            "queuePeerForMaterialization: invalid peerRank={} (myRank={}, nRanks={})",
             peerRank,
             myRank_,
             nRanks_));
@@ -2101,6 +2109,7 @@ void MultipeerIbgdaTransport::connectPeers() {
   std::vector<int> peers;
   peers.swap(pendingPeers_);
   std::vector<int> touchedPeerIndexes;
+  touchedPeerIndexes.reserve(peers.size());
 
   try {
     for (int peerRank : peers) {

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -351,10 +351,24 @@ class MultipeerIbgdaTransport {
    * This method handles the rank-to-index mapping internally and provides
    * explicit peer selection without requiring CUDA headers.
    *
+   * In lazy mode, this materializes the requested peer before returning, so
+   * the returned pointer is ready for kernel use.
+   *
    * @param peerRank Global rank of the peer (must be != myRank and < nRanks)
    * @return Pointer to P2pIbgdaTransportDevice for the specified peer
    */
   P2pIbgdaTransportDevice* getP2pTransportDevice(int peerRank);
+
+  /**
+   * Lazily materialize one peer and return after its GPU device transport slot
+   * is populated. No-op in eager mode or if the peer is already materialized.
+   *
+   * For ring-style setup where all ranks need to expose multiple peers before
+   * connecting, use queuePeerForMaterialization() followed by connectPeers().
+   *
+   * @param peerRank Global rank of the peer to materialize
+   */
+  void materializePeer(int peerRank);
 
   /**
    * Queue a peer for lazy materialization. No network I/O happens here.
@@ -362,22 +376,24 @@ class MultipeerIbgdaTransport {
    *
    * No-op in eager mode or if the peer is already materialized.
    *
-   * @param peerRank Global rank of the peer to materialize
+   * @param peerRank Global rank of the peer to queue
    */
-  void materializePeer(int peerRank);
+  void queuePeerForMaterialization(int peerRank);
 
   /**
    * Connect all queued peers. In lazy mode, this MUST be called after
-   * all getP2pTransportDevice() / materializePeer() calls and BEFORE
-   * launching any kernel that uses the transport pointers.
+   * queuePeerForMaterialization() and BEFORE fetching transport pointers for
+   * kernel launch.
    *
    * Processes peers in sorted rank order to avoid deadlock for >2 ranks.
    * No-op in eager mode or if no peers are queued.
    *
    * Example:
+   *   transport->queuePeerForMaterialization(prev_rank);
+   *   transport->queuePeerForMaterialization(next_rank);
+   *   transport->connectPeers();
    *   prev = transport->getP2pTransportDevice(prev_rank);
    *   next = transport->getP2pTransportDevice(next_rank);
-   *   transport->connectPeers();  // must call before kernel launch
    *   launchKernel<<<...>>>(prev, next);
    */
   void connectPeers();

--- a/comms/pipes/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -190,10 +190,15 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       auto& rp = launch_params.rings[r];
       rp.prev_rank = rings[r].prev_rank;
       rp.next_rank = rings[r].next_rank;
-      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
-      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+      transport->queuePeerForMaterialization(rp.prev_rank);
+      transport->queuePeerForMaterialization(rp.next_rank);
     }
     transport->connectPeers();
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev = transport->getP2pTransportDevice(rp.prev_rank);
+      rp.next = transport->getP2pTransportDevice(rp.next_rank);
+    }
 
     CudaEvent start, stop;
     const int n_warmup = 5;

--- a/comms/pipes/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -197,10 +197,15 @@ class RingReduceScatterBenchmarkFixture
       auto& rp = launch_params.rings[r];
       rp.prev_rank = rings[r].prev_rank;
       rp.next_rank = rings[r].next_rank;
-      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
-      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+      transport->queuePeerForMaterialization(rp.prev_rank);
+      transport->queuePeerForMaterialization(rp.next_rank);
     }
     transport->connectPeers();
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev = transport->getP2pTransportDevice(rp.prev_rank);
+      rp.next = transport->getP2pTransportDevice(rp.next_rank);
+    }
 
     CudaEvent start, stop;
     const int n_warmup = 5;

--- a/comms/pipes/collectives/tests/RingAllGatherTest.cc
+++ b/comms/pipes/collectives/tests/RingAllGatherTest.cc
@@ -85,12 +85,15 @@ TEST_P(RingAllGatherTest, Correctness) {
     auto& ringParams = launchParams.rings[r];
     ringParams.prev_rank = rings[r].prev_rank;
     ringParams.next_rank = rings[r].next_rank;
-    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    transport->queuePeerForMaterialization(ringParams.prev_rank);
+    transport->queuePeerForMaterialization(ringParams.next_rank);
   }
-  // Lazy mode: connectPeers() must be called after all getP2pTransportDevice()
-  // calls and before launching the kernel.
   transport->connectPeers();
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+  }
 
   bootstrap->barrierAll();
   launch_ring_allgather(launchParams);

--- a/comms/pipes/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/pipes/collectives/tests/RingReduceScatterTest.cc
@@ -87,12 +87,15 @@ TEST_P(RingReduceScatterTest, Correctness) {
     auto& ringParams = launchParams.rings[r];
     ringParams.prev_rank = rings[r].prev_rank;
     ringParams.next_rank = rings[r].next_rank;
-    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    transport->queuePeerForMaterialization(ringParams.prev_rank);
+    transport->queuePeerForMaterialization(ringParams.next_rank);
   }
-  // Lazy mode: connectPeers() must be called after all getP2pTransportDevice()
-  // calls and before launching the kernel.
   transport->connectPeers();
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+  }
 
   bootstrap->barrierAll();
   launch_ring_reduce_scatter(launchParams);

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -1762,6 +1762,24 @@ TEST_F(LazyModeTestFixture, MaterializeOnAccess) {
 
     auto* devPtr = transport->getP2pTransportDevice(peerRank);
     EXPECT_NE(devPtr, nullptr);
+    EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA not available: " << e.what();
+  }
+  MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+TEST_F(LazyModeTestFixture, QueueThenConnect) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+  }
+  try {
+    auto transport = createLazyTransport();
+    int peerRank = (globalRank == 0) ? 1 : 0;
+
+    transport->queuePeerForMaterialization(peerRank);
+    EXPECT_FALSE(transport->isPeerMaterialized(peerRank));
+
     transport->connectPeers();
     EXPECT_TRUE(transport->isPeerMaterialized(peerRank));
   } catch (const std::exception& e) {


### PR DESCRIPTION
Summary: Restore the ready-on-return contract for `MultipeerIbgdaTransport::getP2pTransportDevice()` in lazy IB mode. `materializePeer()` now queues and immediately flushes the requested peer, while the new explicit `queuePeerForMaterialization()` API keeps the batched ring setup path deadlock-safe. Ring allgather/reduce-scatter setup now queues all neighbor peers, calls `connectPeers()`, then fetches ready transport pointers.

Differential Revision: D105720530


