### PR TITLE
Add `AlgoHook` registration on `Profiler` for transport stats

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -35,6 +35,7 @@ Ctran::Ctran(
 
   if (comm->config_.enableProfiler) {
     profiler = std::make_unique<ctran::Profiler>(comm, std::move(reporter));
+    mapper->registerProfilerHooks(profiler.get());
   }
 }
 

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -7,6 +7,8 @@
 
 namespace ctran {
 
+class Profiler;
+
 class CtranTcpDm {
  public:
   explicit CtranTcpDm(CtranComm* comm) {}
@@ -85,5 +87,7 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool) {
     return commInvalidUsage;
   }
+
+  void registerProfilerHooks(ctran::Profiler*) {}
 };
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
+#include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/utils/StrUtils.h"
@@ -381,6 +382,18 @@ CtranTcpDm::prepareUnpackConsumer(SQueues* sqs, size_t blocks, void** pool) {
 commResult_t CtranTcpDm::teardownUnpackConsumer(void* pool) {
   COMMCHECK_TCP(transport_->teardownUnpackConsumer(netdev_, pool));
   return commSuccess;
+}
+
+void CtranTcpDm::registerProfilerHooks(ctran::Profiler* profiler) {
+  if (!profiler) {
+    return;
+  }
+  profiler->registerAlgoStartHook([this]() {
+    // Transport profiler start — to be implemented.
+  });
+  profiler->registerAlgoEndHook([this]() {
+    // Transport profiler end — to be implemented.
+  });
 }
 
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -14,6 +14,8 @@
 
 namespace ctran {
 
+class Profiler;
+
 class CtranTcpDm {
  public:
   explicit CtranTcpDm(CtranComm* comm);
@@ -88,6 +90,8 @@ class CtranTcpDm {
   // Return GPU kernel consumer queues to the pool.
   // pool: the pool returned by prepareUnpackConsumer.
   commResult_t teardownUnpackConsumer(void* pool);
+
+  void registerProfilerHooks(ctran::Profiler* profiler);
 
  private:
   std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -816,6 +816,12 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return commSuccess;
   }
 
+  void registerProfilerHooks(ctran::Profiler* profiler) {
+    if (ctranTcpDm) {
+      ctranTcpDm->registerProfilerHooks(profiler);
+    }
+  }
+
   /* report the Ctran profiling results
    * Input arguments:
    *   - flush: force flushing the profiling result

--- a/comms/ctran/profiler/Profiler.cc
+++ b/comms/ctran/profiler/Profiler.cc
@@ -58,6 +58,9 @@ void Profiler::startEvent(
   if (event == ProfilerEvent::ALGO_CTRL) {
     readyTs_ = getTimeStamp(timers_[idx].getCheckpoint());
   }
+  if (event == ProfilerEvent::ALGO_TOTAL && algoStartHook_) {
+    algoStartHook_();
+  }
   if (callback) {
     callback(*this);
   }
@@ -73,6 +76,9 @@ void Profiler::endEvent(
   durations_[idx] += getDurationUs(timers_[idx].lap());
   if (event == ProfilerEvent::ALGO_CTRL) {
     controlTs_ = getTimeStamp(timers_[idx].getCheckpoint());
+  }
+  if (event == ProfilerEvent::ALGO_TOTAL && algoEndHook_) {
+    algoEndHook_();
   }
   if (callback) {
     callback(*this);
@@ -113,6 +119,14 @@ void Profiler::reportToScuba() {
   }
 
   shouldTrace_ = false;
+}
+
+void Profiler::registerAlgoStartHook(AlgoHook hook) {
+  algoStartHook_ = std::move(hook);
+}
+
+void Profiler::registerAlgoEndHook(AlgoHook hook) {
+  algoEndHook_ = std::move(hook);
 }
 
 } // namespace ctran

--- a/comms/ctran/profiler/Profiler.h
+++ b/comms/ctran/profiler/Profiler.h
@@ -37,6 +37,7 @@ class Profiler {
   using EventDurationArray = std::array<uint64_t, NUM_PROFILER_EVENT_TYPES>;
   using EventTimerArray =
       std::array<utils::StopWatch<Clock>, NUM_PROFILER_EVENT_TYPES>;
+  using AlgoHook = std::function<void()>;
 
  public:
   // Construct with a reporter. If nullptr, defaults to
@@ -84,6 +85,9 @@ class Profiler {
 
   void reportToScuba();
 
+  void registerAlgoStartHook(AlgoHook hook);
+  void registerAlgoEndHook(AlgoHook hook);
+
  public:
   AlgoContext algoContext{};
 
@@ -98,6 +102,8 @@ class Profiler {
   uint64_t readyTs_{0};
   uint64_t controlTs_{0};
   std::unique_ptr<IProfilerReporter> reporter_;
+  AlgoHook algoStartHook_;
+  AlgoHook algoEndHook_;
 };
 
 } // namespace ctran


### PR DESCRIPTION
Summary:
Re-implement the ALGO_TOTAL profiler hooks from D104055263 (accidentally reverted by D105391303) using a direct hook registration pattern instead of the old `ICtran -> Ctran -> CtranMapper -> CtranTcpDm` virtual call chain.

Transports now register callbacks directly on the `Profiler` via `registerAlgoStartHook`/`registerAlgoEndHook`.

Changes:
- `Profiler.h/.cc`: add `AlgoHook` type alias, `registerAlgoStartHook`/`registerAlgoEndHook` methods, invoke hooks at `ALGO_TOTAL` boundaries in `startEvent`/`endEvent`
- `CtranTcpDm.h/.cc`: add `registerProfilerHooks(Profiler*)` which registers `profilerStart`/`profilerEnd` lambdas
- `CtranMapper.h`: inline `registerProfilerHooks` forwarding to `ctranTcpDm`
- `Ctran.cc`: call `mapper->registerProfilerHooks(profiler.get())` after both mapper and profiler are constructed

Differential Revision: D105705147


