### PR TITLE
Add scribe-based consumer + watcher integration for CKS jobs (#2619)

### DIFF
--- a/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
+++ b/comms/analyzer/if/NCCLAnalyzerVerdict.thrift
@@ -68,6 +68,17 @@ enum VerdictType {
   IB_COMPLETION_ERROR = 25,
   CUDA_ERROR = 26,
   CUDA_NVLINK_UNCORRECTABLE_ERROR = 27,
+  // CKS push path: rank's process is unreachable per the producer's
+  // explicit per-rank delivery status (UNREACHABLE / TIMEOUT / etc.) in
+  // the most recent fired bucket. Distinct from STUCK verdicts because
+  // it's a positive signal from the poller, not an inference from data
+  // absence.
+  JOB_RANK_PROCESS_DEAD = 28,
+  // CKS push path: bucket fired with one or more pods missing from the
+  // expected roster. Distinguishes "OTel pipeline lag" (transient) from
+  // "pod genuinely silent" (persistent) when paired with the bucket
+  // completion timeout.
+  JOB_PODS_UNREACHABLE = 29,
 }
 
 struct SlowRankLeastCommsVerdict {


### PR DESCRIPTION
Summary:

Second half of the CKS NCCL Comms Analyzer push-path pipeline (D1 added
the producer sidecar). Wires the consumer + analyzer integration so
fired buckets from genai_puller_comm_dump flow into the existing
CommDumpPuller verdict pipeline, and so CKS MAST jobs are auto-discovered
and tracked by the Watcher.

Why a separate consumer path: the existing pull-path Watcher assumes the
analyzer initiates per-rank Thrift fetches against trainer pods over HTTP,
which is impossible on CKS (pods are not reachable from outside the
cluster). Instead the producer sidecar (D1) pushes per-pod batched
PodSnapshots to Scribe, and this diff makes the analyzer assemble those
snapshots back into the same per-rank session view it consumes today.

Components:
- CksScribeConsumer (cks/CksScribeConsumer.{h,cpp})
  Snap-aligned bucket cache keyed by capture-time bucket. A bucket fires
  on either:
    1. expected pod count delivered (fast path; typical case),
    2. firstArrivalMs + cks_bucket_completion_timeout_ms elapsed
       (slow path; one or more pods silent),
    3. per-job in-flight cap exceeded (cks_max_buckets_per_job force-fires
       oldest bucket),
    4. global in-flight cap exceeded (cks_max_total_buckets, same).
  Per-rank latest-snapshot dedup: within a single bucket, duplicate pod
  deliveries (e.g. retransmit) overwrite the prior; bucket completeness
  is judged by distinct podIds, not message count.

- TulipV2CommDumpDeserializer (cks/TulipV2CommDumpDeserializer.{h,cpp})
  Parses the JSON-wrapped LoggerRawScribeStruct produced by the sidecar
  and surfaces per-rank delivery status (OK / UNREACHABLE / THRIFT_ERROR
  / PARSE_ERROR / TIMEOUT). The wire field is i32 (logger codegen rejects
  nested enum types in struct fields); we mirror it as a typed enum on
  the consumer side so verdict logic can switch on it cleanly.

- SessionsCacheScribeReader (cks/SessionsCacheScribeReader.{h,cpp})
  SessionsCache subclass that converts one fired bucket into the
  analyzer-facing per-rank session view. Sets failedDeliveryRanks for
  ranks the producer marked non-OK (drives JOB_RANK_PROCESS_DEAD) and
  silentPodCount for pods missing from the expected roster (drives
  JOB_PODS_UNREACHABLE). warmup / fetch / parse become no-ops or
  trivial-true — the actual data move happens in buildFromBucket.

- CksMastInfo (cks/CksMastInfo.{h,cpp})
  MastInfoBase implementation for CKS jobs (job_type
  JOBSET_KUBERNETES_WORKLOAD). The pull-path MastInfo's fetch() ends
  with a per-task hostname loop that requires per-pod IP addresses, which
  CKS doesn't expose; this implementation skips that and reads only
  scheduler-side metadata (version, attempt, jobStartTime, state, host
  count, per-host GPU count) — enough for the consumer to determine
  expected pod count and freshness.

- Watcher integration
  - watcher/JobFetcher.{h,cc}: co_fetchCksJobs discovers CKS jobs from
    MAST; runs alongside the existing pull-path JobFetcher.
  - watcher/Watcher.cc: per-cycle calls CksScribeConsumer's
    popLatestFiredBucket and feeds the result through the puller.
  - CommDumpPuller.{h,cc}: PullOneJobConfig grows optional
    cks_consumer + cks_job_id fields (only set when connection_type ==
    "scribe"). Emits JOB_RANK_PROCESS_DEAD and JOB_PODS_UNREACHABLE
    verdicts based on the consumer's signal.

- Controls (watcher/CksControls.{h,cpp})
  gflags: cks_scribe_category, cks_bucket_completion_timeout_ms,
  cks_max_buckets_per_job, cks_max_total_buckets, cks_enable_topology_fetch.
  JK: ncclx/analyzer:enable_cks_consumption (whole-pipeline kill switch).

- Verdict schema (if/NCCLAnalyzerVerdict.thrift)
  Adds JOB_RANK_PROCESS_DEAD = 28 and JOB_PODS_UNREACHABLE = 29.
  Distinguished from STUCK verdicts because they're positive signals
  from the producer (rank explicitly unreachable / pod missing from
  expected roster), not inferences from data absence.

- Watcher utilities (watcher/CksWatcherUtils.{h,cc})
  Shared helpers for CKS-vs-pull-path job classification.

Reviewed By: YulunW

Differential Revision: D105367720


