### PR TITLE
Drain graph-window cleanup on new window creation

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -177,7 +177,7 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
 }
 
 void CtranComm::destroy() {
-  cudagraphDeferredCleanup.runAll();
+  cudagraphDeferredCleanup.run(true /* force */);
 
   // All smart pointers are automatically de-initialized, but we want to
   // ensure they do so in a specific order. Therefore, we manually handle

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -2,14 +2,13 @@
 
 #pragma once
 
-#include <atomic>
 #include <chrono>
 #include <cstdint>
-#include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
-#include <folly/Synchronized.h>
+#include "comms/ctran/CudagraphDeferredCleanup.h"
 #include "comms/ctran/bootstrap/ICtranBootstrap.h"
 #include "comms/ctran/commstate/CommStateX.h"
 #include "comms/ctran/interfaces/ICtran.h"
@@ -195,25 +194,6 @@ class CtranComm {
   std::unique_ptr<comms::pipes::MultiPeerTransport> multiPeerTransport_;
 #endif // defined(ENABLE_PIPES)
 
-  // Deferred cleanup for CUDA graph resources. CUDA user-object destructor
-  // callbacks cannot call CUDA APIs, so cleanup is enqueued here and
-  // executed at comm destruction where CUDA APIs are safe.
-  class CudagraphDeferredCleanup {
-   public:
-    void add(std::function<void()> fn) {
-      fns_.wlock()->push_back(std::move(fn));
-    }
-    void runAll() {
-      auto fns = fns_.wlock();
-      for (auto& fn : *fns) {
-        fn();
-      }
-      fns->clear();
-    }
-
-   private:
-    folly::Synchronized<std::vector<std::function<void()>>> fns_;
-  };
   CudagraphDeferredCleanup cudagraphDeferredCleanup;
 
  private:

--- a/comms/ctran/CudagraphDeferredCleanup.cc
+++ b/comms/ctran/CudagraphDeferredCleanup.cc
@@ -1,0 +1,53 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CudagraphDeferredCleanup.h"
+
+#include <utility>
+
+#include "comms/utils/logger/LogUtils.h"
+
+void CudagraphDeferredCleanup::add(
+    std::function<void()> fn,
+    CleanupReadyFlag cleanupReady) {
+  entries_.wlock()->push_back(
+      Entry{
+          .fn = std::move(fn),
+          .cleanupReady = std::move(cleanupReady),
+      });
+}
+
+void CudagraphDeferredCleanup::run(bool force) {
+  std::vector<Entry> entriesToRun;
+  size_t forcedNotReadyCount = 0;
+  {
+    auto entries = entries_.wlock();
+    std::vector<Entry> pending;
+    pending.reserve(entries->size());
+
+    for (auto& entry : *entries) {
+      const bool hasReadinessFlag = entry.cleanupReady != nullptr;
+      const bool cleanupReady = hasReadinessFlag &&
+          entry.cleanupReady->load(std::memory_order_acquire);
+      if (cleanupReady || force) {
+        if (force && hasReadinessFlag && !cleanupReady) {
+          forcedNotReadyCount++;
+        }
+        entriesToRun.push_back(std::move(entry));
+      } else {
+        pending.push_back(std::move(entry));
+      }
+    }
+    *entries = std::move(pending);
+  }
+
+  if (forcedNotReadyCount > 0) {
+    CLOGF(
+        WARN,
+        "CTRAN-CUDAGRAPH: forced cleanup of {} resources that were not marked cleanup-ready",
+        forcedNotReadyCount);
+  }
+
+  for (auto& entry : entriesToRun) {
+    entry.fn();
+  }
+}

--- a/comms/ctran/CudagraphDeferredCleanup.h
+++ b/comms/ctran/CudagraphDeferredCleanup.h
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <folly/Synchronized.h>
+
+// Deferred cleanup for CUDA graph resources. CUDA user-object destructor
+// callbacks cannot call CUDA APIs, so cleanup is enqueued here and executed
+// later where CUDA APIs are safe.
+class CudagraphDeferredCleanup {
+ public:
+  using CleanupReadyFlag = std::shared_ptr<std::atomic<bool>>;
+
+  void add(std::function<void()> fn, CleanupReadyFlag cleanupReady = nullptr);
+
+  // Runs cleanup entries whose CUDA graph owner has been destroyed. When
+  // force=true, runs every pending entry and warns for entries with an explicit
+  // cleanup flag that was not marked before communicator destruction.
+  void run(bool force = false);
+
+ private:
+  struct Entry {
+    std::function<void()> fn;
+    CleanupReadyFlag cleanupReady;
+  };
+
+  folly::Synchronized<std::vector<Entry>> entries_;
+};

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -17,10 +17,12 @@
 //     via IB isendCtrl/irecvCtrl inside the GPE host node.
 //     Uses globalRegisterWithPtr so searchRegHandle hits the fast path.
 //
-// Cleanup: Resources are registered for deferred cleanup at capture time
-// (not at graph destruction). This ensures cleanup runs during comm
-// destruction on the main thread, regardless of when or whether the graph
-// is destroyed. Graph replay is guaranteed to finish before comm destroy.
+// Cleanup: Resources are kept alive by the graph, marked cleanup-ready by a
+// CUDA user-object callback at graph destruction, and drained later from safe
+// host-side points such as the next window creation or comm destruction.
+
+#include <atomic>
+#include <memory>
 
 #include <folly/ScopeGuard.h>
 
@@ -34,6 +36,12 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 
 namespace {
+
+void CUDART_CB markCudagraphCleanupReady(void* p) {
+  auto* ready = static_cast<std::shared_ptr<std::atomic<bool>>*>(p);
+  (*ready)->store(true, std::memory_order_release);
+  delete ready;
+}
 
 // winPersistBuffReg: register recvbuff as a window, exchange handles with
 // all peers. Both local and remote addresses must be stable across replays.
@@ -192,9 +200,24 @@ commResult_t ctranAllGatherCudagraphAware(
       break;
   }
 
-  // Success — transfer ownership to deferred cleanup
+  std::shared_ptr<std::atomic<bool>> cleanupReady;
+  ctran::utils::cudagraph::StreamCaptureInfo captureInfo;
+  FB_CUDACHECK(
+      ctran::utils::cudagraph::getStreamCaptureInfo(stream, captureInfo));
+  if (captureInfo.status == cudaStreamCaptureStatusActive) {
+    cleanupReady = std::make_shared<std::atomic<bool>>(false);
+    auto readyForCallback =
+        std::make_unique<std::shared_ptr<std::atomic<bool>>>(cleanupReady);
+    FB_COMMCHECK(
+        ctran::utils::cudagraph::retainUserObject(
+            readyForCallback.get(), markCudagraphCleanupReady, captureInfo));
+    readyForCallback.release();
+  }
+
+  // Success — transfer ownership to deferred cleanup.
   cleanupGuard.dismiss();
-  comm->cudagraphDeferredCleanup.add(std::move(cleanup));
+  comm->cudagraphDeferredCleanup.add(
+      std::move(cleanup), std::move(cleanupReady));
 
   return commSuccess;
 }

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -714,11 +714,6 @@ commResult_t CtranMapper::deregDynamic(void* regHdl) {
   return commSuccess;
 }
 
-void CtranMapper::removeFromExportCache(void* regHdl) {
-  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(regHdl);
-  exportRegCache_.wlock()->remove(regElem);
-}
-
 commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
   switch (rkey->backend) {
     case CtranMapperBackend::NVL: {
@@ -934,7 +929,9 @@ commResult_t CtranMapper::intraAllGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>* remoteIpcRegs,
+    bool trackExport) {
   const auto& statex = comm->statex_;
   const int nLocalRanks = statex->nLocalRanks();
 
@@ -944,7 +941,14 @@ commResult_t CtranMapper::intraAllGatherCtrl(
   }
 
   return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      remoteIpcRegs,
+      trackExport);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -952,14 +956,23 @@ commResult_t CtranMapper::allGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>* remoteIpcRegs,
+    bool trackExport) {
   const int nRanks = comm->statex_->nRanks();
   std::vector<int> ranks(nRanks);
   for (int i = 0; i < nRanks; i++) {
     ranks[i] = i;
   }
   return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      remoteIpcRegs,
+      trackExport);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -968,12 +981,20 @@ commResult_t CtranMapper::allGatherCtrl(
     const std::vector<int>& ranks,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>* remoteIpcRegs,
+    bool trackExport) {
+  const int nRanks = comm->statex_->nRanks();
   const int rank = comm->statex_->rank();
 
   // Skip if rank is not in the ranks list
   if (std::find(ranks.begin(), ranks.end(), rank) == ranks.end()) {
     return commSuccess;
+  }
+
+  if (remoteIpcRegs != nullptr &&
+      remoteIpcRegs->size() < static_cast<size_t>(nRanks)) {
+    remoteIpcRegs->resize(nRanks);
   }
 
   // When totalSegments > CTRAN_IPC_INLINE_SEGMENTS (2), the extra segment
@@ -1020,22 +1041,28 @@ commResult_t CtranMapper::allGatherCtrl(
 
     if (peerBackends[i] == CtranMapperBackend::NVL) {
       if (nvlSendMsg.type == ControlMsgType::UNSPECIFIED) {
-        // exportMem records in exportRegCache_ for this peer
         FB_COMMCHECK(this->exportMem(
             peerList[i],
             buf,
             hdl,
             nvlSendMsg,
             &nvlExtraSegments,
-            peerBackends[i]));
-      } else if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+            peerBackends[i],
+            trackExport));
+      } else if (trackExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         // exportMem not called for this peer, record explicitly
         exportRegCache_.wlock()->record(regElem, peerList[i]);
       }
     } else {
       if (ibSendMsg.type == ControlMsgType::UNSPECIFIED) {
         FB_COMMCHECK(this->exportMem(
-            peerList[i], buf, hdl, ibSendMsg, nullptr, peerBackends[i]));
+            peerList[i],
+            buf,
+            hdl,
+            ibSendMsg,
+            nullptr,
+            peerBackends[i],
+            trackExport));
       }
     }
   }
@@ -1158,12 +1185,15 @@ commResult_t CtranMapper::allGatherCtrl(
         }
       }
       if (!hasPending) {
+        std::unique_ptr<ctran::regcache::IpcRemRegElem>* ownedIpcReg =
+            remoteIpcRegs == nullptr ? nullptr : &(*remoteIpcRegs)[peerList[i]];
         FB_COMMCHECK(this->importMem(
             peerList[i],
             recvMsgs[i],
             &remoteBufs[peerList[i]],
             &remoteAccessKeys[peerList[i]],
-            allRecvExtraSegments[i]));
+            allRecvExtraSegments[i],
+            ownedIpcReg));
         peerImported[i] = true;
         numPeersImported++;
       }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -118,13 +118,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   commResult_t deregDynamic(void* regHdl);
 
-  /* Remove a registration handle from the export tracking cache.
-   * Used when the caller handles deregistration separately (e.g., via
-   * globalDeregisterWithPtr) and needs to prevent the mapper destructor
-   * from accessing a freed RegElem.
-   */
-  void removeFromExportCache(void* regHdl);
-
   /* Deregister an imported buffer registration from remote peer.
    * Input arguments:
    *  - rkey: the remoteAccessKey of the imported remote buffer received in
@@ -383,13 +376,20 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - remoteIpcRegs: if provided, NVL imports are not inserted into the
+   *                    shared import cache and are owned by this vector
+   *   - trackExport: whether to record NVL exports for mapper-managed remote
+   *                  release
    */
   commResult_t intraAllGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>*
+          remoteIpcRegs = nullptr,
+      bool trackExport = true);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -405,6 +405,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - remoteIpcRegs: if provided, NVL imports are not inserted into the
+   *                    shared import cache and are owned by this vector
+   *   - trackExport: whether to record NVL exports for mapper-managed remote
+   *                  release
    */
   commResult_t allGatherCtrl(
       const void* buf,
@@ -412,7 +416,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<int>& ranks,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>*
+          remoteIpcRegs = nullptr,
+      bool trackExport = true);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -428,13 +435,20 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - remoteIpcRegs: if provided, NVL imports are not inserted into the
+   *                    shared import cache and are owned by this vector
+   *   - trackExport: whether to record NVL exports for mapper-managed remote
+   *                  release
    */
   commResult_t allGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>*
+          remoteIpcRegs = nullptr,
+      bool trackExport = true);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.
@@ -878,6 +892,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
   CtranSocket* ctranSockPtr();
 
+  const std::vector<bool>& enabledBackends() const {
+    return enableBackends_;
+  }
+
   // number of iput requests made for each backend
   std::vector<int> iPutCount;
   std::vector<int> iGetCount;
@@ -1107,7 +1125,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       void* hdl,
       ControlMsg& msg,
       std::vector<ctran::utils::CtranIpcSegDesc>* extraSegments,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET) {
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool trackExport = true) {
     auto regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
     // TODO: Enforce that a communicator can only export memory it registered
     // itself except the memory registered by globalRegister. Currently any comm
@@ -1143,7 +1162,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       }
 
       // Record the exported remote rank to notify at deregistration
-      if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+      if (trackExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         exportRegCache_.wlock()->record(regElem, rank);
       }
 
@@ -1178,7 +1197,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const ControlMsg& msg,
       void** buf,
       CtranMapperRemoteAccessKey* remKey,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {}) {
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      std::unique_ptr<ctran::regcache::IpcRemRegElem>* ownedIpcReg = nullptr) {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
@@ -1201,15 +1221,28 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         }
         remKey->backend = CtranMapperBackend::NVL;
         const std::string peerId = comm->statex_->gPid(rank);
-        FB_COMMCHECK(
-            ctran::IpcRegCache::getInstance()->importMem(
-                peerId,
-                msg.ipcDesc,
-                comm->statex_->cudaDev(),
-                buf,
-                &(remKey->nvlKey),
-                &this->logMetaData_,
-                extraSegments));
+        if (ownedIpcReg != nullptr) {
+          FB_COMMCHECK(
+              ctran::IpcRegCache::getInstance()->importMemUncached(
+                  peerId,
+                  msg.ipcDesc,
+                  comm->statex_->cudaDev(),
+                  buf,
+                  &(remKey->nvlKey),
+                  ownedIpcReg,
+                  &this->logMetaData_,
+                  extraSegments));
+        } else {
+          FB_COMMCHECK(
+              ctran::IpcRegCache::getInstance()->importMem(
+                  peerId,
+                  msg.ipcDesc,
+                  comm->statex_->cudaDev(),
+                  buf,
+                  &(remKey->nvlKey),
+                  &this->logMetaData_,
+                  extraSegments));
+        }
         break;
       }
       default:

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -122,6 +122,51 @@ commResult_t ctran::IpcRegCache::importMem(
   return commSuccess;
 }
 
+commResult_t ctran::IpcRegCache::importMemUncached(
+    const std::string& peerId,
+    const ctran::regcache::IpcDesc& ipcDesc,
+    int cudaDev,
+    void** buf,
+    struct ctran::regcache::IpcRemHandle* remKey,
+    std::unique_ptr<ctran::regcache::IpcRemRegElem>* remRegElem,
+    const struct CommLogData* logMetaData,
+    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+  if (remRegElem == nullptr) {
+    CLOGF(ERR, "CTRAN-REGCACHE: remRegElem is nullptr in importMemUncached");
+    return commInvalidArgument;
+  }
+
+  std::unique_ptr<ctran::regcache::IpcRemRegElem> reg = nullptr;
+  try {
+    reg = std::make_unique<ctran::regcache::IpcRemRegElem>(
+        ipcDesc.desc, cudaDev, logMetaData, extraSegments);
+  } catch (std::exception& e) {
+    CLOGF(
+        WARN,
+        "CTRAN-REGCACHE: failed to import uncached IPC remote registration from peer {} ipcDesc {}, error {}",
+        peerId,
+        ipcDesc.toString(),
+        e.what());
+    return ErrorStackTraceUtil::log(commInternalError);
+  }
+
+  void* basePtr = reg->ipcRemMem.getBase();
+  *buf = reinterpret_cast<char*>(basePtr) + ipcDesc.offset;
+  std::snprintf(remKey->peerId, regcache::kMaxPeerIdLen, "%s", peerId.c_str());
+  remKey->basePtr = ipcDesc.desc.base;
+  remKey->uid = ipcDesc.uid;
+  *remRegElem = std::move(reg);
+  CLOGF_TRACE(
+      COLL,
+      "CTRAN-REGCACHE: Imported uncached NVL remote mem from peer {}: buf {} (base {} offset {} uid {})",
+      peerId,
+      (void*)*buf,
+      (void*)basePtr,
+      ipcDesc.offset,
+      ipcDesc.uid);
+  return commSuccess;
+}
+
 commResult_t ctran::IpcRegCache::importRemMemImpl(
     const std::string& peerId,
     const ctran::regcache::IpcDesc& ipcDesc,

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -89,6 +90,18 @@ class IpcRegCache {
       int cudaDev,
       void** buf,
       struct ctran::regcache::IpcRemHandle* remKey,
+      const struct CommLogData* logMetaData = nullptr,
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
+
+  // Import a remote NVL memory registration without inserting it into the
+  // shared import cache. The caller owns remRegElem and controls its lifetime.
+  commResult_t importMemUncached(
+      const std::string& peerId,
+      const ctran::regcache::IpcDesc& ipcDesc,
+      int cudaDev,
+      void** buf,
+      struct ctran::regcache::IpcRemHandle* remKey,
+      std::unique_ptr<ctran::regcache::IpcRemRegElem>* remRegElem,
       const struct CommLogData* logMetaData = nullptr,
       const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
 

--- a/comms/ctran/regcache/tests/DistRegCacheUT.cc
+++ b/comms/ctran/regcache/tests/DistRegCacheUT.cc
@@ -258,6 +258,104 @@ TEST_P(DistRegCacheTestSuite, ExportImportMem) {
   }
 }
 
+TEST_F(DistRegCacheTest, ImportMemUncachedDoesNotPopulateSharedCache) {
+  auto& mapper = comm_->ctran_->mapper;
+  ASSERT_NE(mapper, nullptr);
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+
+  std::unique_ptr<CtranIb> ctranIb;
+  try {
+    ctranIb = std::make_unique<CtranIb>(comm_.get(), std::nullopt);
+  } catch (const std::bad_alloc&) {
+    GTEST_SKIP() << "IB backend failed to allocate. Skip test";
+  }
+
+  const size_t dataCount = 100;
+  const size_t dataRange = dataCount * sizeof(int);
+
+  CtranIbEpochRAII epochRAII(ctranIb.get());
+  if (globalRank == 0) {
+    const int peer = 1;
+    void* data = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&data, dataRange));
+    ASSERT_NE(data, nullptr);
+    assignChunkValue((int*)data, dataCount, (int)dataCount, (int)1);
+
+    void* segHdl = nullptr;
+    ctran::regcache::RegElem* regHdl = nullptr;
+    COMMCHECK_TEST(
+        mapper->regMem(data, dataRange, &segHdl, true, true, (void**)&regHdl));
+    ASSERT_NE(regHdl, nullptr);
+
+    ControlMsg msg(ControlMsgType::NVL_EXPORT_MEM);
+    std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+    COMMCHECK_TEST(ipcRegCache->exportMem(
+        data, regHdl->ipcRegElem, msg.ipcDesc, extraSegments));
+    COMMCHECK_TEST(ibSendCtrl(msg, peer, ctranIb));
+
+    ctranIb->waitNotify(peer);
+
+    COMMCHECK_TEST(mapper->deregMem(segHdl, true));
+    CUDACHECK_TEST(cudaFree(data));
+  } else if (globalRank == 1) {
+    const int peer = 0;
+    const auto peerId = comm_->statex_->gPid(peer);
+    ipcRegCache->clearAllRemReg();
+
+    ControlMsg msg;
+    COMMCHECK_TEST(ibRecvCtrl(msg, peer, ctranIb));
+    EXPECT_EQ(msg.type, ControlMsgType::NVL_EXPORT_MEM);
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+    void* uncachedMappedData = nullptr;
+    CtranMapperRemoteAccessKey uncachedKey{};
+    uncachedKey.backend = CtranMapperBackend::NVL;
+    std::unique_ptr<ctran::regcache::IpcRemRegElem> uncachedReg;
+    COMMCHECK_TEST(ipcRegCache->importMemUncached(
+        peerId,
+        msg.ipcDesc,
+        comm_->statex_->cudaDev(),
+        &uncachedMappedData,
+        &uncachedKey.nvlKey,
+        &uncachedReg,
+        &comm_->logMetaData_));
+    EXPECT_NE(uncachedMappedData, nullptr);
+    EXPECT_NE(uncachedReg, nullptr);
+    EXPECT_EQ(uncachedKey.nvlKey.basePtr, msg.ipcDesc.desc.base);
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+    EXPECT_EQ(
+        checkChunkValue(
+            (int*)uncachedMappedData, dataCount, (int)dataCount, (int)1),
+        0);
+
+    uncachedReg.reset();
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+    void* cachedMappedData = nullptr;
+    CtranMapperRemoteAccessKey cachedKey{};
+    cachedKey.backend = CtranMapperBackend::NVL;
+    COMMCHECK_TEST(ipcRegCache->importMem(
+        peerId,
+        msg.ipcDesc,
+        comm_->statex_->cudaDev(),
+        &cachedMappedData,
+        &cachedKey.nvlKey,
+        &comm_->logMetaData_));
+    EXPECT_NE(cachedMappedData, nullptr);
+    EXPECT_EQ(cachedKey.nvlKey.basePtr, msg.ipcDesc.desc.base);
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+    EXPECT_EQ(
+        checkChunkValue((int*)cachedMappedData, dataCount, (int)dataCount, 1),
+        0);
+    COMMCHECK_TEST(ipcRegCache->releaseRemReg(
+        peerId, msg.ipcDesc.desc.base, msg.ipcDesc.uid));
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+    COMMCHECK_TEST(ibNotify(peer, ctranIb));
+  }
+}
+
 TEST_F(DistRegCacheTest, ExportReleaseMemCb) {
   auto& mapper = comm_->ctran_->mapper;
   ASSERT_NE(mapper, nullptr);

--- a/comms/ctran/tests/CtranCommTest.cc
+++ b/comms/ctran/tests/CtranCommTest.cc
@@ -1,5 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <atomic>
+#include <memory>
+
 #include <gtest/gtest.h>
 
 #include "comms/ctran/CtranComm.h"
@@ -60,6 +63,35 @@ TEST(CtranCommTest, ctranCommConfigTest) {
   /// Explicitly create comm with false abort as first argument is unomittable
   CtranComm comm2(ctran::utils::createAbort(false));
   EXPECT_EQ(comm2.config_.backends.size(), 0);
+}
+
+TEST(CudagraphDeferredCleanupTest, RunCleansReadyResourcesBeforeForce) {
+  CudagraphDeferredCleanup cleanup;
+  auto ready = std::make_shared<std::atomic<bool>>(false);
+  auto pending = std::make_shared<std::atomic<bool>>(false);
+  int readyCleanupCount = 0;
+  int pendingCleanupCount = 0;
+  int untrackedCleanupCount = 0;
+
+  cleanup.add([&]() { readyCleanupCount++; }, ready);
+  cleanup.add([&]() { pendingCleanupCount++; }, pending);
+  cleanup.add([&]() { untrackedCleanupCount++; });
+
+  cleanup.run();
+  EXPECT_EQ(readyCleanupCount, 0);
+  EXPECT_EQ(pendingCleanupCount, 0);
+  EXPECT_EQ(untrackedCleanupCount, 0);
+
+  ready->store(true, std::memory_order_release);
+  cleanup.run();
+  EXPECT_EQ(readyCleanupCount, 1);
+  EXPECT_EQ(pendingCleanupCount, 0);
+  EXPECT_EQ(untrackedCleanupCount, 0);
+
+  cleanup.run(true /* force */);
+  EXPECT_EQ(readyCleanupCount, 1);
+  EXPECT_EQ(pendingCleanupCount, 1);
+  EXPECT_EQ(untrackedCleanupCount, 1);
 }
 
 } // namespace ctran::testing

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -13,6 +13,7 @@
 #include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 #include "comms/ctran/utils/Alloc.h"
+#include "comms/testinfra/AlgoTestUtils.h"
 
 #define NCCLCHECK_TEST_BENCH(cmd)                                         \
   do {                                                                    \
@@ -358,7 +359,7 @@ TEST_F(CudaGraphAllGatherCtgraphDestroy, DestroyGraphCleanly) {
 // setup.
 TEST_F(
     CtranCudaGraphTestBase,
-    DISABLED_CtgraphRdpipelineInPlaceMultiAgReplayPreservesAllBytes) {
+    CtgraphRdpipelineInPlaceMultiAgReplayPreservesAllBytes) {
   setenv("NCCL_CTRAN_ENABLE", "1", 0);
   setenv("NCCL_MNNVL_ENABLE", "1", 0);
   setenv("NCCL_NVLS_ENABLE", "0", 0);
@@ -370,7 +371,8 @@ TEST_F(
   setenv("NCCL_IB_GID_INDEX", "3", 0);
   setenv("NCCL_SOCKET_IFNAME", "eth0", 0);
   setenv("NCCL_CUMEM_ENABLE", "1", 1);
-  setenv("NCCL_ALLGATHER_ALGO", "ctgraph_rdpipeline", 1);
+  testinfra::AlgoRAII algoGuard(
+      NCCL_ALLGATHER_ALGO, NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline);
 
   auto ctranCommHolder = makeCtranComm();
   ASSERT_NE(ctranCommHolder, nullptr);
@@ -547,7 +549,7 @@ TEST_F(
     }
   };
 
-  constexpr int kTotalChecks = 10;
+  constexpr int kTotalChecks = 2;
   size_t mmDcOOP = 0;
   size_t mmDcIP = 0;
   doCapturedRun(/*oop=*/true, /*sameBuffer=*/true);

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -27,6 +28,11 @@ struct WindowConfig;
 #endif
 
 namespace ctran {
+namespace regcache {
+struct IpcRemRegElem;
+} // namespace regcache
+using regcache::IpcRemRegElem;
+
 struct CtranWin {
   // TODO: remove the communicator from the window allocation.
   // We will need Ctran instead of CtranComm to allocate the window. Current
@@ -39,17 +45,18 @@ struct CtranWin {
   // Remote window info (addr, rkey, dataBytes) for all peers in this window
   std::vector<window::RemWinInfo> remWinInfo;
 
+  // Window-owned NVL imports. These bypass the shared IPC import cache and are
+  // released with this window.
+  std::vector<std::unique_ptr<IpcRemRegElem>> remoteBaseIpcRegs;
+  std::vector<std::unique_ptr<IpcRemRegElem>> remoteDataIpcRegs;
+
   // This rank's local data buffer size in bytes
   size_t dataBytes{0};
   // Signal buffer size in number of uint64_t elements per rank
   size_t signalSize{0};
-  // The ctran mapper handles for caching the allocated buffer segment
-  void* baseSegHdl{nullptr};
-  // The ctran mapper handles for caching the allocated buffer registration
+  // Window-owned local registration for the allocated signal/base buffer.
   void* baseRegHdl{nullptr};
-  // The ctran mapper handles for caching the data segment
-  void* dataSegHdl{nullptr};
-  // The ctran mapper handles for caching the data registration
+  // Window-owned local registration for the data buffer.
   void* dataRegHdl{nullptr};
   // The base pointer of allocated buffer by the window
   void* winBasePtr{nullptr};
@@ -163,6 +170,14 @@ struct CtranWin {
   }
 
  private:
+  commResult_t regMem(const void* ptr, size_t len, void** regHdl);
+  commResult_t deregMemIfNotNull(void*& regHdl);
+  commResult_t releaseRemReg(
+      std::vector<std::unique_ptr<IpcRemRegElem>>& ownedRegs,
+      CtranMapperRemoteAccessKey* rkey,
+      int peer);
+  commResult_t freeMem(void* addr);
+
   DevMemType bufType_{DevMemType::kCumem};
   // whether allocate window data buffer or provided by users
   bool allocDataBuf_{true};

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -5,10 +5,10 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CudaWrap.h"
-#include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/ctran/window/Types.h"
 #if defined(ENABLE_PIPES)
@@ -41,6 +41,70 @@ CtranWin::CtranWin(CtranComm* comm, size_t size, DevMemType bufType)
     val.store(1);
 }
 
+commResult_t CtranWin::regMem(const void* ptr, size_t len, void** regHdl) {
+  if (ptr == nullptr || len == 0) {
+    *regHdl = nullptr;
+    return commSuccess;
+  }
+
+  auto statex = comm->statex_.get();
+  auto mapper = comm->ctran_->mapper.get();
+  auto regCache = ctran::RegCache::getInstance();
+  ctran::CHECK_VALID_REGCACHE(regCache);
+
+  ctran::regcache::RegElem* regElem = nullptr;
+  FB_COMMCHECK(regCache->regRange(
+      ptr,
+      len,
+      statex->cudaDev(),
+      mapper->enabledBackends(),
+      &regElem,
+      true /* ncclManaged */,
+      &mapper->logMetaData_,
+      "windowRegMem"));
+  *regHdl = regElem;
+  return commSuccess;
+}
+
+commResult_t CtranWin::deregMemIfNotNull(void*& regHdl) {
+  if (regHdl == nullptr) {
+    return commSuccess;
+  }
+
+  auto regCache = ctran::RegCache::getInstance();
+  ctran::CHECK_VALID_REGCACHE(regCache);
+
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(regHdl);
+  FB_COMMCHECK(regCache->deregRange(regElem));
+  regHdl = nullptr;
+  return commSuccess;
+}
+
+commResult_t CtranWin::releaseRemReg(
+    std::vector<std::unique_ptr<IpcRemRegElem>>& ownedRegs,
+    CtranMapperRemoteAccessKey* rkey,
+    int peer) {
+  auto statex = comm->statex_.get();
+  if (peer == statex->rank()) {
+    return commSuccess;
+  }
+
+  if (static_cast<size_t>(peer) < ownedRegs.size() && ownedRegs[peer]) {
+    ownedRegs[peer].reset();
+  }
+
+  return commSuccess;
+}
+
+commResult_t CtranWin::freeMem(void* addr) {
+  if (isGpuMem()) {
+    FB_COMMCHECK(utils::commCuMemFree(addr));
+  } else {
+    FB_CUDACHECK(cudaFreeHost(addr));
+  }
+  return commSuccess;
+}
+
 commResult_t CtranWin::exchange() {
   auto statex = comm->statex_.get();
   const auto nRanks = statex->nRanks();
@@ -50,54 +114,24 @@ commResult_t CtranWin::exchange() {
 
   auto mapper = comm->ctran_->mapper.get();
   CtranMapperEpochRAII epochRAII(mapper);
-  // Registration via ctran mapper.
-  FB_COMMCHECK(mapper->regMem(
-      winBasePtr,
-      range_,
-      &(baseSegHdl),
-      true,
-      true, /* NCCL managed buffer */
-      &baseRegHdl));
+
+  // Window memory owns its registration. Do not insert it into the global VA
+  // lookup cache: CUDA may later reuse the same device VA for a different
+  // allocation after this window expires.
+  FB_COMMCHECK(regMem(winBasePtr, range_, &baseRegHdl));
 
   if (allocDataBuf_) {
-    dataSegHdl = baseSegHdl;
     dataRegHdl = baseRegHdl;
   } else {
-    // User-provided buffer: use globalRegisterWithPtr to cache and register
-    // multi-segment buffers (e.g., expandable segments) that mapper->regMem
-    // cannot handle (it asserts single-segment). forceReg=true ensures
-    // registration happens immediately; ncclManaged=true enables NVL IPC
-    // handle creation for cudaMalloc buffers. searchRegHandle then finds the
-    // RegElem via fast path for use in allGatherCtrl handle exchange.
-    FB_COMMCHECK(
-        ctran::globalRegisterWithPtr(
-            winDataPtr,
-            dataBytes,
-            true /* forceReg */,
-            true /* ncclManaged */));
-    bool dynamicRegist = false;
-    FB_COMMCHECK(mapper->searchRegHandle(
-        winDataPtr, dataBytes, &dataRegHdl, &dynamicRegist));
-    // globalRegisterWithPtr with forceReg=true guarantees the RegElem is
-    // already created, so searchRegHandle should find it via fast path
-    // (not dynamic registration).
-    FB_CHECKABORT(
-        !dynamicRegist,
-        "Unexpected dynamic registration for window data buffer {} len {}",
-        winDataPtr,
-        dataBytes);
+    FB_COMMCHECK(regMem(winDataPtr, dataBytes, &dataRegHdl));
   }
 
-  // Exchange each rank's data buffer size via bootstrap allGather
-  // This populates remWinInfo[r].dataBytes for all ranks
   std::vector<size_t> allRankSizes(nRanks);
   allRankSizes[myRank] = dataBytes;
   auto resFuture = comm->bootstrap_->allGather(
       allRankSizes.data(), sizeof(size_t), myRank, nRanks);
   FB_COMMCHECK(static_cast<commResult_t>(std::move(resFuture).get()));
 
-  // Handshake with other peers for registration exchange and network
-  // connection setup
   std::vector<void*> remoteBaseBufs(nRanks);
   std::vector<void*> remoteUserBufs(nRanks);
   std::vector<struct CtranMapperRemoteAccessKey> remoteBaseBufAccessKeys(
@@ -105,14 +139,27 @@ commResult_t CtranWin::exchange() {
   std::vector<struct CtranMapperRemoteAccessKey> remoteUserBufAccessKeys(
       nRanks);
 
+  remoteBaseIpcRegs.resize(nRanks);
+  remoteDataIpcRegs.resize(nRanks);
+
   FB_COMMCHECK(mapper->allGatherCtrl(
-      winBasePtr, baseRegHdl, remoteBaseBufs, remoteBaseBufAccessKeys));
+      winBasePtr,
+      baseRegHdl,
+      remoteBaseBufs,
+      remoteBaseBufAccessKeys,
+      CtranMapperBackend::UNSET,
+      &remoteBaseIpcRegs,
+      false /* trackExport */));
 
   if (!allocDataBuf_) {
-    // if data buffer is provided by user, extra round of handler exchange is
-    // needed
     FB_COMMCHECK(mapper->allGatherCtrl(
-        winDataPtr, dataRegHdl, remoteUserBufs, remoteUserBufAccessKeys));
+        winDataPtr,
+        dataRegHdl,
+        remoteUserBufs,
+        remoteUserBufAccessKeys,
+        CtranMapperBackend::UNSET,
+        &remoteDataIpcRegs,
+        false /* trackExport */));
   }
 
   for (auto r = 0; r < nRanks; r++) {
@@ -266,62 +313,46 @@ commResult_t CtranWin::free(bool skipBarrier) {
 
   auto nRanks = statex->nRanks();
 
-  // utils funcs to deregister memory
-  auto deregMemIfNotNull = [&](void* segHdl) {
-    if (segHdl != nullptr) {
-      FB_COMMCHECK(mapper->deregMem(segHdl, true /* skipRemRelease */));
-    }
-    return commSuccess;
-  };
-
-  // utils func to free memory
-  auto freeMem = [&](void* addr) {
-    if (isGpuMem()) {
-      FB_COMMCHECK(utils::commCuMemFree(addr));
-    } else {
-      FB_CUDACHECK(cudaFreeHost(addr));
-    }
-    return commSuccess;
-  };
-
-  // deregistr buffer
-  deregMemIfNotNull(baseSegHdl);
-  // deregister remote buf
+  // Release locally-imported remote signal buffers.
   for (auto i = 0; i < nRanks; ++i) {
-    if (i != statex->rank()) {
-      FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].signalRkey));
+    FB_COMMCHECK(
+        releaseRemReg(remoteBaseIpcRegs, &remWinInfo[i].signalRkey, i));
+  }
+
+  // User-provided data buffer: release locally-imported remote data buffers.
+  if (!allocDataBuf_) {
+    for (auto i = 0; i < nRanks; ++i) {
+      FB_COMMCHECK(
+          releaseRemReg(remoteDataIpcRegs, &remWinInfo[i].dataRkey, i));
     }
   }
 
-  // User-provided data buffer: deregister locally without remote IPC
-  // notifications. Remove from export cache first (so mapper destructor
-  // won't access the freed RegElem), then free segments locally, then
-  // release locally-imported remote handles.
-  if (!allocDataBuf_) {
-    mapper->removeFromExportCache(dataRegHdl);
-    FB_COMMCHECK(
-        ctran::globalDeregisterWithPtr(
-            winDataPtr, dataBytes, true /* skipRemRelease */));
-    for (auto i = 0; i < nRanks; ++i) {
-      if (i != statex->rank()) {
-        FB_COMMCHECK(mapper->deregRemReg(&remWinInfo[i].dataRkey));
-      }
-    }
+  if (dataRegHdl != baseRegHdl) {
+    FB_COMMCHECK(deregMemIfNotNull(dataRegHdl));
+  } else {
+    dataRegHdl = nullptr;
   }
+  FB_COMMCHECK(deregMemIfNotNull(baseRegHdl));
 
 #if defined(ENABLE_PIPES)
   // HostWindow handles cleanup via RAII
   hostWindow_.reset();
 #endif
 
-  freeMem(winBasePtr);
+  FB_COMMCHECK(freeMem(winBasePtr));
 
   return commSuccess;
 }
 
 bool CtranWin::nvlEnabled(int rank) const {
-  return isGpuMem() &&
-      comm->ctran_->mapper->hasBackend(rank, CtranMapperBackend::NVL);
+  if (!isGpuMem()) {
+    return false;
+  }
+  if (rank >= 0 && rank < static_cast<int>(remWinInfo.size()) &&
+      remWinInfo[rank].dataRkey.backend != CtranMapperBackend::UNSET) {
+    return remWinInfo[rank].dataRkey.backend == CtranMapperBackend::NVL;
+  }
+  return comm->ctran_->mapper->hasBackend(rank, CtranMapperBackend::NVL);
 }
 
 #if defined(ENABLE_PIPES)

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -11,6 +11,7 @@
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/ctran/window/Types.h"
+#include "comms/utils/CudaRAII.h"
 #if defined(ENABLE_PIPES)
 #include "comms/pipes/MultiPeerTransport.h"
 #include "comms/pipes/window/DeviceWindow.cuh"
@@ -400,6 +401,12 @@ commResult_t ctranWinAllocate(
     void** baseptr,
     CtranWin** win,
     const meta::comms::Hints& hints) {
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    comm->cudagraphDeferredCleanup.run();
+  }
+
   if (size < CTRAN_MIN_REGISTRATION_SIZE) {
     CLOGF_SUBSYS(
         INFO,
@@ -458,6 +465,12 @@ commResult_t ctranWinRegister(
     CtranComm* comm,
     CtranWin** win,
     const meta::comms::Hints& hints) {
+  {
+    meta::comms::StreamCaptureModeGuard captureGuard{
+        cudaStreamCaptureModeRelaxed};
+    comm->cudagraphDeferredCleanup.run();
+  }
+
   if (databuf == nullptr) {
     FB_ERRORRETURN(
         commInternalError,


### PR DESCRIPTION
Summary: Mark graph-deferred window cleanup entries ready from a CUDA user-object destructor when the captured graph is destroyed, and drain ready entries from ctranWinAllocate/ctranWinRegister before creating a new window. This keeps graph-owned window resources alive through graph lifetime without retaining already-destroyed graph windows until communicator destruction.

Differential Revision: D105041182


