### PR TITLE
Split CtranIb into VcState / Bootstrap / ExternalBootstrap helpers

### DIFF
--- a/comms/ctran/backends/ib/BootstrapExternal.cc
+++ b/comms/ctran/backends/ib/BootstrapExternal.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/backends/ib/BootstrapExternal.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/backends/ib/VcState.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::ib {
+
+BootstrapExternal::BootstrapExternal(
+    VcState& vcState,
+    std::vector<CtranIbDevice>& devices,
+    CtranComm* comm,
+    int cudaDev,
+    uint64_t commHash,
+    const std::string& commDesc,
+    const CommLogData& logData,
+    uint32_t trafficClass)
+    : vcState_(vcState),
+      devices_(devices),
+      comm_(comm),
+      cudaDev_(cudaDev),
+      commHash_(commHash),
+      commDesc_(commDesc),
+      logData_(logData),
+      trafficClass_(trafficClass) {}
+
+std::string BootstrapExternal::getLocalVcId(const int peerRank) {
+  auto vc = std::make_shared<CtranIbVirtualConn>(
+      devices_, peerRank, comm_, trafficClass_, cudaDev_);
+
+  std::string localBusCard;
+  {
+    const std::lock_guard<std::mutex> lock(vc->mutex);
+    localBusCard.resize(vc->getBusCardSize());
+    FB_COMMCHECKTHROW_EX(vc->getLocalBusCard(localBusCard.data()), logData_);
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, inserted] = pendingVcs_.emplace(peerRank, std::move(vc));
+    FB_CHECKABORT(
+        inserted,
+        "BootstrapExternal::getLocalVcId called twice for the same peerRank without a matching connectVc");
+  }
+
+  return localBusCard;
+}
+
+commResult_t BootstrapExternal::connectVc(
+    const std::string& remoteVcIdentifier,
+    const int peerRank) {
+  std::shared_ptr<CtranIbVirtualConn> vc;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = pendingVcs_.find(peerRank);
+    if (it == pendingVcs_.end()) {
+      CLOGF(
+          ERR,
+          "CTRAN-IB: BootstrapExternal::connectVc called for peerRank {} before "
+          "getLocalVcId. commHash {:x}, commDesc {}",
+          peerRank,
+          commHash_,
+          commDesc_);
+      return commInternalError;
+    }
+    vc = std::move(it->second);
+    pendingVcs_.erase(it);
+  }
+
+  return vcState_.setupAndPublishVc(
+      std::move(vc), remoteVcIdentifier, peerRank);
+}
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/BootstrapExternal.h
+++ b/comms/ctran/backends/ib/BootstrapExternal.h
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Owner-managed external bootstrap surface for CtranIb. The whole external
+// path (BootstrapMode::kExternal + BootstrapExternal class + RdmaTransport
+// caller) is scheduled for deletion once RdmaTransport moves off it.
+#ifndef CTRAN_IB_BOOTSTRAP_EXTERNAL_H_
+#define CTRAN_IB_BOOTSTRAP_EXTERNAL_H_
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/utils/commSpecs.h"
+
+class CtranComm;
+class CtranIbVirtualConn;
+
+namespace ctran::ib {
+
+class VcState;
+
+// BootstrapExternal is the callsite-managed handshake driver used when
+// CtranIb is constructed with BootstrapMode::kExternal. The caller (today
+// only RdmaTransport) ships the local bus card returned by getLocalVcId()
+// to the peer over its own channel, then drives the two-step handshake by
+// calling connectVc() with the remote bus card.
+//
+// Lifetime: held by std::unique_ptr<BootstrapExternal> externalBootstrap_
+// on CtranIb. Allocated only when bootstrapMode == kExternal. Must be
+// destroyed before VcState (connectVc() publishes into vcState_).
+class BootstrapExternal {
+ public:
+  BootstrapExternal(
+      VcState& vcState,
+      std::vector<CtranIbDevice>& devices,
+      CtranComm* comm,
+      int cudaDev,
+      uint64_t commHash,
+      const std::string& commDesc,
+      const CommLogData& logData,
+      uint32_t trafficClass);
+  ~BootstrapExternal() = default;
+
+  BootstrapExternal(const BootstrapExternal&) = delete;
+  BootstrapExternal& operator=(const BootstrapExternal&) = delete;
+  BootstrapExternal(BootstrapExternal&&) = delete;
+  BootstrapExternal& operator=(BootstrapExternal&&) = delete;
+
+  // Create a fresh VC for the given peer, stash it in pendingVcs_, and
+  // return the serialized local bus card for the caller to ship to the
+  // peer. Must be paired with a subsequent connectVc() for the same
+  // peerRank.
+  std::string getLocalVcId(int peerRank);
+
+  // Complete the handshake for a peer previously prepared with
+  // getLocalVcId(): pop the pending VC, run setupVc() with the remote
+  // bus card, and publish it into vcState_.
+  commResult_t connectVc(const std::string& remoteVcIdentifier, int peerRank);
+
+ private:
+  VcState& vcState_;
+  std::vector<CtranIbDevice>& devices_;
+  CtranComm* comm_{nullptr};
+  int cudaDev_{-1};
+  uint64_t commHash_{0};
+  std::string commDesc_;
+  const CommLogData& logData_;
+  uint32_t trafficClass_{0};
+
+  // VCs created by getLocalVcId() awaiting a matching connectVc() call.
+  std::unordered_map<int, std::shared_ptr<CtranIbVirtualConn>> pendingVcs_;
+  std::mutex mutex_;
+};
+
+} // namespace ctran::ib
+
+#endif // CTRAN_IB_BOOTSTRAP_EXTERNAL_H_

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -1,0 +1,342 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/backends/ib/BootstrapInternal.h"
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <folly/ScopeGuard.h>
+#include <folly/SocketAddress.h>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/backends/ib/VcState.h"
+#include "comms/ctran/bootstrap/Socket.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/Debug.h"
+#include "comms/ctran/utils/Exception.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+#include "comms/utils/logger/ScubaLogger.h"
+
+namespace {
+const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
+
+const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
+} // namespace
+
+// TODO: We may want to retry if err is ECONNRESET,
+// ETIMEDOUT, or ECONNRESET. For other errors, we
+// may still want to throw an ctran::utils::Exception,
+// like what would happen if FT is disabled (via
+// the FB_SYSCHECKTHROW_EX macro).
+#define HANDLE_SOCKET_ERROR(cmd, self)                                       \
+  if (!self->abortCtrl_->Enabled()) {                                        \
+    FB_SYSCHECKTHROW_EX(cmd, self->rank_, self->commHash_, self->commDesc_); \
+  } else {                                                                   \
+    int errCode = cmd;                                                       \
+    if (errCode || self->abortCtrl_->Test()) {                               \
+      CLOGF(ERR, "Socket error encountered: {}. Aborting.", errCode);        \
+      self->abortCtrl_->Set(); /* Ensure remote is notified */               \
+      break;                                                                 \
+    }                                                                        \
+  }
+
+namespace ctran::ib {
+
+Bootstrap::Bootstrap(
+    VcState& vcState,
+    std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory,
+    std::shared_ptr<::ctran::utils::Abort> abortCtrl,
+    const CommLogData& logData,
+    CtranComm* comm,
+    std::vector<CtranIbDevice>& devices,
+    uint32_t trafficClass,
+    int cudaDev,
+    int rank,
+    uint64_t commHash,
+    const std::string& commDesc)
+    : vcState_(vcState),
+      socketFactory_(std::move(socketFactory)),
+      abortCtrl_(std::move(abortCtrl)),
+      logData_(logData),
+      comm_(comm),
+      devices_(devices),
+      trafficClass_(trafficClass),
+      cudaDev_(cudaDev),
+      rank_(rank),
+      commHash_(commHash),
+      commDesc_(commDesc) {
+  listenSocket_ = socketFactory_->createServerSocket(
+      static_cast<int>(NCCL_SOCKET_RETRY_CNT), abortCtrl_);
+}
+
+Bootstrap::~Bootstrap() {
+  // Idempotent: explicit shutdown from CtranIb::~CtranIb runs first, but
+  // we call shutdown() again here as a safety net.
+  shutdown();
+}
+
+void Bootstrap::shutdown() {
+  if (std::exchange(shutdownCalled_, true)) {
+    return;
+  }
+  if (listenSocket_) {
+    listenSocket_->shutdown();
+  }
+  if (listenThread_.joinable()) {
+    listenThread_.join();
+  }
+}
+
+folly::Expected<folly::SocketAddress, int> Bootstrap::getListenAddress() const {
+  return listenSocket_->getListenAddress();
+}
+
+void Bootstrap::start(std::optional<const SocketServerAddr*> qpServerAddr) {
+  // Setup the listen socket
+  std::string resolvedIfName;
+  folly::SocketAddress addrSockAddr;
+  if (!qpServerAddr.has_value()) {
+    // Use default NCCL socket ifname
+    auto maybeAddr = ::ctran::bootstrap::getInterfaceAddress(
+        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
+    if (maybeAddr.hasError()) {
+      CLOGF(WARN, "CTRAN-IB: No socket interfaces found");
+      throw ::ctran::utils::Exception(
+          "CTRAN-IB : No socket interfaces found",
+          commSystemError,
+          rank_,
+          commHash_,
+          commDesc_);
+    }
+
+    addrSockAddr = folly::SocketAddress(maybeAddr.value(), 0 /* port */);
+  } else {
+    auto qpServerAddrPtr = qpServerAddr.value();
+    // use provided addr(i.e. ip, port, host) to initialize ctranIB
+    addrSockAddr = toSocketAddress(*qpServerAddrPtr);
+    resolvedIfName = qpServerAddrPtr->ifName;
+  }
+
+  FB_SYSCHECKTHROW_EX(
+      listenSocket_->bindAndListen(addrSockAddr, resolvedIfName),
+      rank_,
+      commHash_,
+      commDesc_);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: Rank {} created listen socket with {} listenAddr {} ifname {}",
+      rank_,
+      qpServerAddr.has_value() ? "specified" : "self-finding",
+      listenSocket_->getListenAddress()->describe().c_str(),
+      resolvedIfName);
+
+  // Exchange listen sock address among all ranks
+  if (comm_) {
+    allListenSocketAddrs_.resize(comm_->statex_->nRanks());
+    auto maybeListenAddr = listenSocket_->getListenAddress();
+    if (maybeListenAddr.hasError()) {
+      FB_SYSCHECKTHROW_EX(maybeListenAddr.error(), rank_, commHash_, commDesc_);
+    }
+    maybeListenAddr->getAddress(&allListenSocketAddrs_[rank_]);
+
+    auto resFuture = comm_->bootstrap_->allGather(
+        allListenSocketAddrs_.data(),
+        sizeof(allListenSocketAddrs_.at(0)),
+        comm_->statex_->rank(),
+        comm_->statex_->nRanks());
+    FB_COMMCHECKTHROW_EX(
+        static_cast<commResult_t>(std::move(resFuture).get()), logData_);
+  }
+
+  listenThread_ = std::thread{acceptLoop, this};
+}
+
+commResult_t Bootstrap::connect(
+    int peerRank,
+    std::optional<const SocketServerAddr*> peerAddr) {
+  folly::SocketAddress peerSockAddr;
+  const std::string* clientIfName;
+  // When peer server address is passed, connect to it directly.
+  // Otherwise, use the pre-exchanged listen socket address which requires an
+  // associated communicator.
+  if (peerAddr.has_value()) {
+    auto peerAddrPtr = peerAddr.value();
+    peerSockAddr = toSocketAddress(*peerAddrPtr);
+    // always use the same ifname as remote server
+    clientIfName = &peerAddrPtr->ifName;
+  } else {
+    FB_CHECKABORT(
+        allListenSocketAddrs_.size() > 0,
+        "Peer address is not specified, but pre-exchanged listen sockets is empty. It indicates a COMM internal bug.");
+    peerSockAddr = toSocketAddress(allListenSocketAddrs_[peerRank]);
+    clientIfName = &NCCL_CLIENT_SOCKET_IFNAME;
+  }
+
+  NcclScubaEvent scubaEvent(kCtranIbLogEventName, &logData_);
+  scubaEvent.startAndRecord();
+  SCOPE_EXIT {
+    scubaEvent.stopAndRecord();
+  };
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: Establishing connection: commHash {:x}, commDesc {}, rank {}, peer {}, peer listenAddr {} clientIfName {}",
+      commHash_,
+      commDesc_,
+      rank_,
+      peerRank,
+      peerSockAddr.describe(),
+      *clientIfName);
+
+  // Send SETUP command to remote listenThread
+  std::unique_ptr<::ctran::bootstrap::ISocket> sock =
+      socketFactory_->createClientSocket(abortCtrl_);
+  FB_SYSCHECKRETURN(
+      sock->connect(
+          peerSockAddr,
+          *clientIfName,
+          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
+          NCCL_SOCKET_RETRY_CNT),
+      commRemoteError);
+  FB_SYSCHECKRETURN(
+      sock->send(&kBootstrapMagic, sizeof(uint64_t)), commRemoteError);
+  FB_SYSCHECKRETURN(sock->send(&rank_, sizeof(int)), commRemoteError);
+  return exchangeAndPublish(std::move(sock), /*isServer=*/false, peerRank);
+}
+
+commResult_t Bootstrap::exchangeAndPublish(
+    std::unique_ptr<::ctran::bootstrap::ISocket> sock,
+    bool isServer,
+    int peerRank) {
+  if (peerRank < 0 || (comm_ && peerRank >= comm_->statex_->nRanks())) {
+    CLOGF(
+        ERR,
+        "invalid peerRank ({}) < 0 or >= nRanks {}",
+        peerRank,
+        comm_ ? comm_->statex_->nRanks() : -1);
+    return commInternalError;
+  }
+
+  // Create a new VC for the peer
+  auto vc = std::make_shared<CtranIbVirtualConn>(
+      devices_, peerRank, comm_, trafficClass_, cudaDev_);
+
+  std::string localBusCard, remoteBusCard;
+  {
+    // No need to lock since VC is not yet exposed to local rank. Lock to
+    // simply follow VC thread-safety semantics.
+    const std::lock_guard<std::mutex> lock(vc->mutex);
+
+    /* exchange business cards */
+    std::size_t size = vc->getBusCardSize();
+    localBusCard.resize(size);
+    remoteBusCard.resize(size);
+    FB_COMMCHECK(vc->getLocalBusCard(localBusCard.data()));
+    if (isServer) {
+      FB_SYSCHECKRETURN(
+          sock->recv(remoteBusCard.data(), size), commRemoteError);
+      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
+    } else {
+      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
+      FB_SYSCHECKRETURN(
+          sock->recv(remoteBusCard.data(), size), commRemoteError);
+    }
+  }
+
+  FB_COMMCHECK(
+      vcState_.setupAndPublishVc(std::move(vc), remoteBusCard, peerRank));
+
+  // Ack that the connection is fully established.
+  // Ensure remote rank don't use the VC before local setupVc and
+  // vcStateMaps update.
+  int ack{0};
+  if (isServer) {
+    FB_SYSCHECKRETURN(sock->send(&ack, sizeof(int)), commRemoteError);
+    FB_SYSCHECKRETURN(sock->recv(&ack, sizeof(int)), commRemoteError);
+  } else {
+    FB_SYSCHECKRETURN(sock->recv(&ack, sizeof(int)), commRemoteError);
+    FB_SYSCHECKRETURN(sock->send(&ack, sizeof(int)), commRemoteError);
+  }
+  return commSuccess;
+}
+
+void Bootstrap::acceptLoop(Bootstrap* self) {
+  // Set cudaDev for logging
+  FB_CUDACHECKTHROW_EX(
+      cudaSetDevice(self->cudaDev_),
+      self->rank_,
+      self->commHash_,
+      self->commDesc_);
+  commNamedThreadStart(
+      "CTranIbListen",
+      self->rank_,
+      self->commHash_,
+      self->commDesc_.c_str(),
+      __func__);
+  while (1) {
+    // Accept a connection from a peer. Socket will automatically closed when
+    // it'll go out of scope (part of its destructor).
+    auto maybeSocket = self->listenSocket_->acceptSocket();
+    if (maybeSocket.hasError()) {
+      if (self->listenSocket_->hasShutDown()) {
+        break; // listen socket is closed or the CtranIb instance was aborted
+      }
+      HANDLE_SOCKET_ERROR(maybeSocket.error(), self);
+    }
+
+    std::unique_ptr<::ctran::bootstrap::ISocket> socket =
+        std::move(maybeSocket.value());
+
+    uint64_t magic{0};
+    HANDLE_SOCKET_ERROR(socket->recv(&magic, sizeof(uint64_t)), self);
+    if (magic != kBootstrapMagic) {
+      CLOGF(
+          WARN,
+          "CTRAN-IB: Invalid magic - received {:x} but expected {:x} for commHash {:x} commDesc {}. "
+          "Likely unexpected connection attempt. Ignoring. Local Addr: {},  Peer Addr: {}",
+          magic,
+          kBootstrapMagic,
+          self->commHash_,
+          self->commDesc_,
+          socket->getLocalAddress().describe(),
+          socket->getPeerAddress().describe());
+      continue;
+    }
+
+    int peerRank;
+    HANDLE_SOCKET_ERROR(socket->recv(&peerRank, sizeof(int)), self);
+    const auto err = self->exchangeAndPublish(
+        std::move(socket), /*isServer=*/true, peerRank);
+    if (err != 0) { // TODO: We may want to handle certain errors differently?
+      CLOGF(
+          ERR,
+          "CTRAN-IB: Failed to establish connection with peer rank {} for commHash {:x} commDesc {}, err={}",
+          peerRank,
+          self->commHash_,
+          self->commDesc_,
+          err);
+      continue;
+    }
+  }
+
+  CLOGF(
+      INFO,
+      "CTRAN-IB: Listen thread terminating, rank {} commHash {:x} commDesc {}",
+      self->rank_,
+      self->commHash_,
+      self->commDesc_);
+  return;
+}
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/BootstrapInternal.h
+++ b/comms/ctran/backends/ib/BootstrapInternal.h
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef CTRAN_IB_BOOTSTRAP_INTERNAL_H_
+#define CTRAN_IB_BOOTSTRAP_INTERNAL_H_
+
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include <folly/Expected.h>
+#include <folly/SocketAddress.h>
+
+#include <sys/socket.h>
+
+#include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/bootstrap/ISocketFactory.h"
+#include "comms/ctran/utils/Abort.h"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/utils/commSpecs.h"
+
+class CtranComm;
+
+namespace ctran::ib {
+
+class VcState;
+
+// Bootstrap is the internal handshake driver for one CtranIb instance. It
+// owns the listen socket and accept thread, knows how to client-connect to
+// a peer, and publishes every freshly-handshaken VC into the supplied
+// VcState. CtranIb only ever calls start() / connect() / shutdown() /
+// getListenAddress() on this object; the rest of the bootstrap surface is
+// private to BootstrapInternal.cc.
+//
+// Lifetime: held by std::unique_ptr<Bootstrap> bootstrap_ on CtranIb.
+// Allocated only when bootstrapMode != kExternal. Must be destroyed before
+// VcState (its accept thread calls vcState_.setupAndPublishVc).
+class Bootstrap {
+ public:
+  Bootstrap(
+      VcState& vcState,
+      std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory,
+      std::shared_ptr<::ctran::utils::Abort> abortCtrl,
+      const CommLogData& logData,
+      CtranComm* comm,
+      std::vector<CtranIbDevice>& devices,
+      uint32_t trafficClass,
+      int cudaDev,
+      int rank,
+      uint64_t commHash,
+      const std::string& commDesc);
+  ~Bootstrap();
+
+  Bootstrap(const Bootstrap&) = delete;
+  Bootstrap& operator=(const Bootstrap&) = delete;
+  Bootstrap(Bootstrap&&) = delete;
+  Bootstrap& operator=(Bootstrap&&) = delete;
+
+  // Bind+listen on either the default interface (when qpServerAddr is
+  // absent — equivalent to BootstrapMode::kDefaultServer) or on the
+  // provided address (equivalent to BootstrapMode::kSpecifiedServer),
+  // optionally allGather listen addrs across the communicator, and spawn
+  // the accept thread.
+  void start(std::optional<const SocketServerAddr*> qpServerAddr);
+
+  // Slow path: open a client socket to the peer, exchange business cards,
+  // and publish the resulting VC via vcState_.setupAndPublishVc(...).
+  commResult_t connect(
+      int peerRank,
+      std::optional<const SocketServerAddr*> peerAddr);
+
+  // Shut down the listen socket and join the accept thread. Idempotent;
+  // safe to call from CtranIb's destructor or from ~Bootstrap.
+  void shutdown();
+
+  // Returns the bound listen address, or an error code if the socket has
+  // not been bound yet.
+  folly::Expected<folly::SocketAddress, int> getListenAddress() const;
+
+ private:
+  static void acceptLoop(Bootstrap* self);
+
+  // Shared post-handshake path used by both the server accept side and the
+  // client connect side.
+  commResult_t exchangeAndPublish(
+      std::unique_ptr<::ctran::bootstrap::ISocket> sock,
+      bool isServer,
+      int peerRank);
+
+  VcState& vcState_;
+  std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory_;
+  std::shared_ptr<::ctran::utils::Abort> abortCtrl_;
+  const CommLogData& logData_;
+  CtranComm* comm_{nullptr};
+  std::vector<CtranIbDevice>& devices_;
+  uint32_t trafficClass_{0};
+  int cudaDev_{-1};
+  int rank_{-1};
+  uint64_t commHash_{0};
+  std::string commDesc_;
+
+  std::unique_ptr<::ctran::bootstrap::IServerSocket> listenSocket_;
+  std::vector<sockaddr_storage> allListenSocketAddrs_;
+  std::thread listenThread_;
+  // Guards shutdown() so that listenSocket_->shutdown() and
+  // listenThread_.join() each happen at most once even though shutdown()
+  // is called both explicitly by CtranIb::~CtranIb() and again by
+  // ~Bootstrap() as a safety net.
+  bool shutdownCalled_{false};
+};
+
+} // namespace ctran::ib
+
+#endif // CTRAN_IB_BOOTSTRAP_INTERNAL_H_

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -1,8 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/ctran/backends/ib/CtranIb.h"
-
-#include <unistd.h>
+#include "comms/ctran/backends/ib/BootstrapExternal.h"
+#include "comms/ctran/backends/ib/BootstrapInternal.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
 
 #include <fmt/core.h>
 #include <folly/ScopeGuard.h>
@@ -39,12 +40,8 @@ using namespace ctran::ibvwrap;
 
 namespace {
 #define CTRAN_IB_ANY_PORT -1
-const std::string kCtranIbLogEventName{"CtranIb-QpExchange"};
-
 constexpr int kH100CudaArch = 900;
 constexpr int kGb300CudaArch = 1030;
-
-const uint64_t kBootstrapMagic = 0xfaceb00cdeadbeef;
 }; // namespace
 
 thread_local std::unordered_map<void*, std::atomic_bool> epochLockedFlags;
@@ -448,9 +445,6 @@ void CtranIb::init(
     socketFactory_ = std::make_shared<ctran::bootstrap::SocketFactory>();
   }
 
-  listenSocket = socketFactory_->createServerSocket(
-      static_cast<int>(NCCL_SOCKET_RETRY_CNT), abortCtrl_);
-
   const bool commAbortEnabled = comm && comm->abortEnabled();
   if (commAbortEnabled && abortCtrl->Enabled()) {
     throw ::ctran::utils::Exception(
@@ -620,21 +614,24 @@ void CtranIb::init(
       cudaDev,
       dmaBufSupported);
 
-  // assign the lock-free vcStateMaps ptr for fast path access when applicable
-  {
-    auto locked = vcStateMaps.wlock();
-    vcStateMapsPtr = &(*locked);
-  }
-
-  if (comm) {
-    // initialize connection map before preConnect() is called by any algorithm
-    connectedPeerMap.resize(comm->statex_->nRanks(), false);
-  }
+  // Initialize the per-peer VC state (rank/qp maps, connectedPeerMap, and
+  // lock-free fast-path pointer). Must run before any incoming connection is
+  // accepted (i.e., before bootstrap_->start() spawns the listen thread).
+  vcState_.init(this, this->ncclLogData, comm ? comm->statex_->nRanks() : 0);
 
   // Optionally start internal bootstrap service.
   // If kExternal, external callsite would explicitly manage it and thus we skip
   // the internal bootstrap.
   if (this->bootstrapMode == BootstrapMode::kExternal) {
+    externalBootstrap_ = std::make_unique<ctran::ib::BootstrapExternal>(
+        vcState_,
+        devices,
+        comm,
+        cudaDev,
+        commHash,
+        commDesc,
+        ncclLogData,
+        getPgToTrafficClassValue());
     CLOGF_SUBSYS(
         INFO,
         INIT,
@@ -643,7 +640,19 @@ void CtranIb::init(
         commHash,
         commDesc);
   } else {
-    bootstrapStart(qpServerAddr);
+    bootstrap_ = std::make_unique<Bootstrap>(
+        vcState_,
+        socketFactory_,
+        abortCtrl_,
+        ncclLogData,
+        comm,
+        devices,
+        getPgToTrafficClassValue(),
+        cudaDev,
+        rank,
+        commHash,
+        commDesc);
+    bootstrap_->start(qpServerAddr);
   }
 
   CLOGF_SUBSYS(
@@ -653,75 +662,6 @@ void CtranIb::init(
       (void*)this,
       commHash,
       commDesc);
-}
-
-void CtranIb::bootstrapStart(
-    std::optional<const SocketServerAddr*> qpServerAddr) {
-  // Setup the listen socket
-  std::string resolvedIfName;
-  folly::SocketAddress addrSockAddr;
-  if (this->bootstrapMode == BootstrapMode::kDefaultServer) {
-    // Use default NCCL socket ifname
-    auto maybeAddr = ctran::bootstrap::getInterfaceAddress(
-        NCCL_SOCKET_IFNAME, NCCL_SOCKET_IPADDR_PREFIX, true, &resolvedIfName);
-    if (maybeAddr.hasError()) {
-      CLOGF(WARN, "CTRAN-IB: No socket interfaces found");
-      throw ::ctran::utils::Exception(
-          "CTRAN-IB : No socket interfaces found",
-          commSystemError,
-          this->rank,
-          this->commHash,
-          this->commDesc);
-    }
-
-    addrSockAddr = folly::SocketAddress(maybeAddr.value(), 0 /* port */);
-  } else {
-    FB_CHECKABORT(
-        qpServerAddr.has_value(),
-        "CTRAN-IB: Expect bootstrap with specified server address, but is not provided. It indicates a COMM bug");
-
-    auto qpServerAddrPtr = qpServerAddr.value();
-    // use provided addr(i.e. ip, port, host) to initialize ctranIB
-    addrSockAddr = toSocketAddress(*qpServerAddrPtr);
-    resolvedIfName = qpServerAddrPtr->ifName;
-  }
-
-  FB_SYSCHECKTHROW_EX(
-      this->listenSocket->bindAndListen(addrSockAddr, resolvedIfName),
-      this->rank,
-      this->commHash,
-      this->commDesc);
-  CLOGF_SUBSYS(
-      INFO,
-      INIT,
-      "CTRAN-IB: Rank {} created listen socket with {} listenAddr {} ifname {}",
-      rank,
-      bootstrapMode == BootstrapMode::kSpecifiedServer ? "specified"
-                                                       : "self-finding",
-      this->listenSocket->getListenAddress()->describe().c_str(),
-      resolvedIfName);
-
-  // Exchange listen sock address among all ranks
-  if (comm) {
-    allListenSocketAddrs.resize(comm->statex_->nRanks());
-    auto maybeListenAddr = this->listenSocket->getListenAddress();
-    if (maybeListenAddr.hasError()) {
-      FB_SYSCHECKTHROW_EX(
-          maybeListenAddr.error(), this->rank, this->commHash, this->commDesc);
-    }
-    maybeListenAddr->getAddress(&allListenSocketAddrs[rank]);
-
-    auto resFuture = comm->bootstrap_->allGather(
-        allListenSocketAddrs.data(),
-        sizeof(allListenSocketAddrs.at(0)),
-        comm->statex_->rank(),
-        comm->statex_->nRanks());
-    FB_COMMCHECKTHROW_EX(
-        static_cast<commResult_t>(std::move(resFuture).get()),
-        this->ncclLogData);
-  }
-
-  this->listenThread = std::thread{bootstrapAccept, this};
 }
 
 std::string CtranIb::getIbDevName(int device) const {
@@ -736,9 +676,8 @@ CtranIb::~CtranIb(void) {
   auto s = CtranIbSingleton::getInstance();
   CHECK_VALID_IB_SINGLETON(s);
 
-  if (bootstrapMode != BootstrapMode::kExternal) {
-    listenSocket->shutdown();
-    listenThread.join();
+  if (bootstrap_) {
+    bootstrap_->shutdown();
   }
 
   FB_COMMCHECKIGNORE(releaseRemoteTransStates(true /* fromDestructor */));
@@ -947,7 +886,7 @@ commResult_t CtranIb::iflush(
 }
 
 commResult_t CtranIb::getVcConfig(int peerRank, CtranIbVcConfig_t& config) {
-  std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+  std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
   FB_COMMCHECK(checkValidVc(vc, peerRank));
 
   config = {
@@ -963,12 +902,9 @@ commResult_t CtranIb::releaseRemoteTransStates(bool fromDestructor) {
   // resource. Skip epochLock if called from destructor
   CtranIbEpochRAII epochRAII(fromDestructor ? nullptr : this);
 
-  { // Explicitly release all virtual connections before destroying cq.
-    auto lockedVcStateMaps = vcStateMaps.wlock();
-    lockedVcStateMaps->rankToVcMap.clear();
-    lockedVcStateMaps->qpToVcMap.clear();
-    vcStateMapsPtr = nullptr;
-  }
+  // Explicitly release all virtual connections (and clear connectedPeerMap)
+  // before destroying cq.
+  vcState_.releaseAll();
 
   // Epoch lock only ensures no external access to CtranIb while releasing
   // resources; We still need per-object lock here to ensure the internal
@@ -987,7 +923,6 @@ commResult_t CtranIb::releaseRemoteTransStates(bool fromDestructor) {
     rankToPendingOpsMap.clear();
   }
 
-  this->connectedPeerMap.clear();
   return commSuccess;
 }
 
@@ -1028,27 +963,26 @@ commResult_t CtranIb::initRemoteTransStates(void) {
 }
 
 commResult_t CtranIb::preConnect(const std::unordered_set<int>& peerRanks) {
-  std::shared_ptr<CtranIbVirtualConn> vc = nullptr;
   bool newConnection = false;
   // if map is empty, it means we don't know comm size and peerAddr
-  if (connectedPeerMap.empty()) {
+  if (!vcState_.hasConnectedPeerMap()) {
     return commSuccess;
   }
   // Actively connect to peers with larger rank number, if not already connected
   for (int peerRank : peerRanks) {
     FB_COMMCHECK(checkValidPeer(peerRank));
-    if (rank < peerRank && getVcImpl(peerRank) == nullptr) {
-      FB_COMMCHECK(bootstrapConnect(peerRank));
+    if (rank < peerRank && vcState_.getVc(peerRank) == nullptr) {
+      FB_COMMCHECK(bootstrap_->connect(peerRank, std::nullopt));
     }
   }
   // check if all requested peers are connected
   for (int peerRank : peerRanks) {
-    if (!connectedPeerMap.at(peerRank)) {
-      while (getVcImpl(peerRank) == nullptr) {
+    if (!vcState_.isPeerConnected(peerRank)) {
+      while (vcState_.getVc(peerRank) == nullptr) {
         // wait listening thread to establish connections with rest of peers
         // with smaller rank number
       }
-      connectedPeerMap.at(peerRank) = true;
+      vcState_.markPeerConnected(peerRank);
       newConnection = true;
     }
   }
@@ -1065,245 +999,9 @@ commResult_t CtranIb::preConnect(const std::unordered_set<int>& peerRanks) {
   return commSuccess;
 }
 
-commResult_t CtranIb::connectVc(
-    std::unique_ptr<ctran::bootstrap::ISocket> sock,
-    const bool isServer,
-    const int peerRank) {
-  // Create a new VC for the peer
-  FB_COMMCHECK(this->checkValidPeer(peerRank));
-  std::shared_ptr<CtranIbVirtualConn> vc = createVc(peerRank);
-
-  std::string localBusCard, remoteBusCard;
-  {
-    // No need to lock since VC is not yet exposed to local rank. Lock to
-    // simply follow VC thread-safety semantics.
-    const std::lock_guard<std::mutex> lock(vc->mutex);
-
-    /* exchange business cards */
-    std::size_t size = vc->getBusCardSize();
-    localBusCard.resize(size);
-    remoteBusCard.resize(size);
-    FB_COMMCHECK(vc->getLocalBusCard(localBusCard.data()));
-    if (isServer) {
-      FB_SYSCHECKRETURN(
-          sock->recv(remoteBusCard.data(), size), commRemoteError);
-      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
-    } else {
-      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
-      FB_SYSCHECKRETURN(
-          sock->recv(remoteBusCard.data(), size), commRemoteError);
-    }
-  }
-
-  connectVcDirect(remoteBusCard, peerRank);
-
-  // Ack that the connection is fully established.
-  // Ensure remote rank don't use the VC before local setupVc and
-  // vcStateMaps update.
-  int ack{0};
-  if (isServer) {
-    FB_SYSCHECKRETURN(sock->send(&ack, sizeof(int)), commRemoteError);
-    FB_SYSCHECKRETURN(sock->recv(&ack, sizeof(int)), commRemoteError);
-  } else {
-    FB_SYSCHECKRETURN(sock->recv(&ack, sizeof(int)), commRemoteError);
-    FB_SYSCHECKRETURN(sock->send(&ack, sizeof(int)), commRemoteError);
-  }
-  return commSuccess;
-}
-
-std::string CtranIb::getLocalVcIdentifier(const int peerRank) {
-  std::string localBusCard;
-  auto vc = createVc(peerRank);
-  {
-    const std::lock_guard<std::mutex> lock(vc->mutex);
-    localBusCard.resize(vc->getBusCardSize());
-    FB_COMMCHECKTHROW_EX(
-        vc->getLocalBusCard(localBusCard.data()), this->ncclLogData);
-  }
-  return localBusCard;
-}
-
-commResult_t CtranIb::connectVcDirect(
-    const std::string& remoteVcIdentifier,
-    const int peerRank) {
-  // Connect the VC
-  auto vc = createVc(peerRank);
-  {
-    const std::lock_guard<std::mutex> lock(vc->mutex);
-
-    // Verify that getLocalVcIdentifier() was called first to create QPs.
-    // This is a precondition for connectVcDirect().
-    if (!vc->areQpsInitialized()) {
-      CLOGF(
-          ERR,
-          "CTRAN-IB: connectVcDirect called for peerRank {} before getLocalVcIdentifier(). "
-          "QPs must be initialized first. commHash {:x}, commDesc {}",
-          peerRank,
-          commHash,
-          commDesc);
-      return commInternalError;
-    }
-
-    FB_COMMCHECKTHROW_EX(
-        vc->setupVc((void*)remoteVcIdentifier.data()), this->ncclLogData);
-  }
-
-  uint32_t controlQp = vc->getControlQpNum();
-  uint32_t notifyQp = vc->getNotifyQpNum();
-  uint32_t atomicQp = vc->getAtomicQpNum();
-  std::vector<uint32_t> dataQps = vc->getDataQpNums();
-
-  // Till now VC is not yet exposed to local rank. Local rank can use the VC
-  // once updated the vcStateMaps.
-  FB_COMMCHECKTHROW_EX(updateVcState(vc, peerRank), this->ncclLogData);
-
-  CLOGF_SUBSYS(
-      INFO,
-      INIT,
-      "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, "
-      "vc {}, rank {}, peer {}, control qpn {}, notify qpn {}, atomic qpn {}, data qpns {}",
-      commHash,
-      commDesc,
-      (void*)vc.get(),
-      rank,
-      peerRank,
-      controlQp,
-      notifyQp,
-      atomicQp,
-      vecToStr(dataQps));
-
-  return commSuccess;
-}
-
-// TODO: We may want to retry if err is ECONNRESET,
-// ETIMEDOUT, or ECONNRESET. For other errors, we
-// may still want to throw an ctran::utils::Exception,
-// like what would happen if FT is disabled (via
-// the FB_SYSCHECKTHROW_EX macro).
-#define HANDLE_SOCKET_ERROR(cmd, ib)                                  \
-  if (!ib->abortCtrl_->Enabled()) {                                   \
-    FB_SYSCHECKTHROW_EX(cmd, ib->rank, ib->commHash, ib->commDesc);   \
-  } else {                                                            \
-    int errCode = cmd;                                                \
-    if (errCode || ib->abortCtrl_->Test()) {                          \
-      CLOGF(ERR, "Socket error encountered: {}. Aborting.", errCode); \
-      ib->abortCtrl_->Set(); /* Ensure remote is notified */          \
-      break;                                                          \
-    }                                                                 \
-  }
-
-void CtranIb::bootstrapAccept(CtranIb* ib) {
-  // Set cudaDev for logging
-  FB_CUDACHECKTHROW_EX(
-      cudaSetDevice(ib->cudaDev), ib->rank, ib->commHash, ib->commDesc);
-  commNamedThreadStart(
-      "CTranIbListen", ib->rank, ib->commHash, ib->commDesc.c_str(), __func__);
-  while (1) {
-    // Accept a connection from a peer. Socket will automatically closed when
-    // it'll go out of scope (part of its destructor).
-    auto maybeSocket = ib->listenSocket->acceptSocket();
-    if (maybeSocket.hasError()) {
-      if (ib->listenSocket->hasShutDown()) {
-        break; // listen socket is closed or the CtranIb instance was aborted
-      }
-      HANDLE_SOCKET_ERROR(maybeSocket.error(), ib);
-    }
-
-    std::unique_ptr<ctran::bootstrap::ISocket> socket =
-        std::move(maybeSocket.value());
-
-    uint64_t magic{0};
-    HANDLE_SOCKET_ERROR(socket->recv(&magic, sizeof(uint64_t)), ib);
-    if (magic != kBootstrapMagic) {
-      CLOGF(
-          WARN,
-          "CTRAN-IB: Invalid magic - received {:x} but expected {:x} for commHash {:x} commDesc {}. "
-          "Likely unexpected connection attempt. Ignoring. Local Addr: {},  Peer Addr: {}",
-          magic,
-          kBootstrapMagic,
-          ib->commHash,
-          ib->commDesc,
-          socket->getLocalAddress().describe(),
-          socket->getPeerAddress().describe());
-      continue;
-    }
-
-    int peerRank;
-    HANDLE_SOCKET_ERROR(socket->recv(&peerRank, sizeof(int)), ib);
-    const auto err = ib->connectVc(std::move(socket), true, peerRank);
-    if (err != 0) { // TODO: We may want to handle certain errors differently?
-      CLOGF(
-          ERR,
-          "CTRAN-IB: Failed to establish connection with peer rank {} for commHash {:x} commDesc {}, err={}",
-          peerRank,
-          ib->commHash,
-          ib->commDesc,
-          err);
-      continue;
-    }
-  }
-
-  CLOGF(
-      INFO,
-      "CTRAN-IB: Listen thread terminating, rank {} commHash {:x} commDesc {}",
-      ib->rank,
-      ib->commHash,
-      ib->commDesc);
-  return;
-}
-
-commResult_t CtranIb::bootstrapConnect(
-    int peerRank,
-    std::optional<const SocketServerAddr*> peerAddr) {
-  folly::SocketAddress peerSockAddr;
-  const std::string* clientIfName;
-  // When peer server address is passed, connect to it directly.
-  // Otherwise, use the pre-exchanged listen socket address which requires an
-  // associated communicator.
-  if (peerAddr.has_value()) {
-    auto peerAddrPtr = peerAddr.value();
-    peerSockAddr = toSocketAddress(*peerAddrPtr);
-    // always use the same ifname as remote server
-    clientIfName = &peerAddrPtr->ifName;
-  } else {
-    FB_CHECKABORT(
-        allListenSocketAddrs.size() > 0,
-        "Peer address is not specified, but pre-exchanged listen sockets is empty. It indicates a COMM internal bug.");
-    peerSockAddr = toSocketAddress(allListenSocketAddrs[peerRank]);
-    clientIfName = &NCCL_CLIENT_SOCKET_IFNAME;
-  }
-
-  NcclScubaEvent scubaEvent(kCtranIbLogEventName, &ncclLogData);
-  scubaEvent.startAndRecord();
-  SCOPE_EXIT {
-    scubaEvent.stopAndRecord();
-  };
-
-  CLOGF_SUBSYS(
-      INFO,
-      INIT,
-      "CTRAN-IB: Establishing connection: commHash {:x}, commDesc {}, rank {}, peer {}, peer listenAddr {} clientIfName {}",
-      commHash,
-      commDesc,
-      rank,
-      peerRank,
-      peerSockAddr.describe(),
-      *clientIfName);
-
-  // Send SETUP command to remote listenThread
-  std::unique_ptr<ctran::bootstrap::ISocket> sock =
-      socketFactory_->createClientSocket(abortCtrl_);
-  FB_SYSCHECKRETURN(
-      sock->connect(
-          peerSockAddr,
-          *clientIfName,
-          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
-          NCCL_SOCKET_RETRY_CNT),
-      commRemoteError);
-  FB_SYSCHECKRETURN(
-      sock->send(&kBootstrapMagic, sizeof(uint64_t)), commRemoteError);
-  FB_SYSCHECKRETURN(sock->send(&rank, sizeof(int)), commRemoteError);
-  return connectVc(std::move(sock), false, peerRank);
+folly::Expected<folly::SocketAddress, int>
+CtranIb::getListenSocketListenAddr() {
+  return bootstrap_->getListenAddress();
 }
 
 const char* CtranIb::ibv_wc_status_str(enum ibverbx::ibv_wc_status status) {
@@ -1355,72 +1053,6 @@ const char* CtranIb::ibv_wc_status_str(enum ibverbx::ibv_wc_status status) {
     default:
       return "unrecognized error";
   }
-}
-
-commResult_t CtranIb::updateVcState(
-    std::shared_ptr<CtranIbVirtualConn> vc,
-    int peerRank) {
-  auto locked = vcStateMaps.wlock();
-  if (locked->rankToVcMap.find(peerRank) != locked->rankToVcMap.end()) {
-    CLOGF(
-        ERR,
-        "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
-        peerRank,
-        (void*)this,
-        commHash,
-        commDesc);
-    return commInternalError;
-  }
-
-  locked->rankToVcMap[peerRank] = vc;
-  QpUniqueId controlQpId = std::make_pair(vc->getControlQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, controlQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
-  }
-  QpUniqueId notifyQpId = std::make_pair(vc->getNotifyQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, notifyQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
-  }
-  QpUniqueId atomicQpId = std::make_pair(vc->getAtomicQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, atomicQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
-  }
-
-  std::vector<uint32_t> dataQps = vc->getDataQpNums();
-  for (int qpIdx = 0; qpIdx < dataQps.size(); qpIdx++) {
-    int device = vc->getIbDevFromQpIdx(qpIdx);
-    QpUniqueId qpId = std::make_pair(dataQps[qpIdx], device);
-    if (checkAndInsertQpToVcMap(locked->qpToVcMap, qpId, vc) != commSuccess) {
-      return commInternalError;
-    }
-  }
-
-  {
-    // Remove from pendingVcs_ since the VC is now established and ownership
-    // transferred to vcStateMaps
-    // TODO: for now we apply a hot fix to address segfault caused by race from
-    // concurrent threads updating pendingVcs_. We need to revisit why we
-    // need pendingVcs_? To add explanation to it or remove
-    std::lock_guard<std::mutex> lock(cqMutex);
-    pendingVcs_.erase(peerRank);
-  }
-
-  return commSuccess;
-}
-
-std::shared_ptr<CtranIbVirtualConn> CtranIb::createVc(int peerRank) {
-  std::lock_guard<std::mutex> lock(cqMutex);
-  auto it = pendingVcs_.emplace(peerRank, nullptr);
-  if (!it.second) {
-    return it.first->second;
-  }
-  // Create a new VC and assign
-  it.first->second = std::make_shared<CtranIbVirtualConn>(
-      devices, peerRank, comm, getPgToTrafficClassValue(), cudaDev);
-  return it.first->second;
 }
 
 commResult_t CtranIb::setPgToTrafficClassMap() {

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -9,10 +9,12 @@
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/backends/CtranCtrl.h"
+#include "comms/ctran/backends/ib/BootstrapInternal.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/backends/ib/CtranIbImpl.h"
 #include "comms/ctran/backends/ib/CtranIbLocalVc.h"
 #include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/backends/ib/VcState.h"
 #include "comms/ctran/bootstrap/AbortableSocket.h"
 #include "comms/ctran/bootstrap/ISocketFactory.h"
 #include "comms/ctran/ibverbx/Ibverbx.h"
@@ -26,6 +28,9 @@
 
 class CtranIb;
 class CtranIbVirtualConn;
+namespace ctran::ib {
+class BootstrapExternal;
+} // namespace ctran::ib
 commResult_t checkEpochLock(CtranIb* ctranIb);
 
 /**
@@ -434,26 +439,17 @@ class CtranIb {
 
   CtranComm* comm{nullptr};
 
-  // Setup virtual connection with a connected peer.
-  // If serverRank is given, it indicates the calling rank behaves as client and
-  // the other side behaves as server, so that we can switch the socket
-  // send/recv to match.
-  // Input arguments:
-  // - sock: socket connection established by callsite. Used for internal
-  //         business card exchange
-  // - isServer: whether the local rank is isServer
-  // - peerRank: the peer rank of remote client or server
-  commResult_t connectVc(
-      std::unique_ptr<ctran::bootstrap::ISocket> sock,
-      const bool isServer,
-      const int peerRank);
-
-  // APIs to get the connection identifier for a given rank, and establish
-  // the connection to remote VC.
-  std::string getLocalVcIdentifier(const int peerRank);
-  commResult_t connectVcDirect(
-      const std::string& remoteVcIdentifier,
-      const int peerRank);
+  // Accessor for the external bootstrap helper.
+  //
+  // Returns a non-owning pointer to the BootstrapExternal owned by this
+  // CtranIb when constructed with BootstrapMode::kExternal; nullptr
+  // otherwise. The caller (today only RdmaTransport) drives the
+  // two-step handshake by calling getLocalVcId() / connectVc() on the
+  // returned object directly. The returned pointer is valid for the
+  // lifetime of the owning CtranIb.
+  ::ctran::ib::BootstrapExternal* externalBootstrap() {
+    return externalBootstrap_.get();
+  }
 
   // Get the virtual connection for a given peer.
   // If the peer is not yet connected, return nullptr.
@@ -466,13 +462,11 @@ class CtranIb {
   // - peerRank: the peer rank
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline std::shared_ptr<CtranIbVirtualConn> getVc(int peerRank) {
-    return getVcImpl<PerfConfig>(peerRank);
+    return vcState_.getVc<PerfConfig>(peerRank);
   }
 
   // Return the listen address of the listen socket.
-  folly::Expected<folly::SocketAddress, int> getListenSocketListenAddr() {
-    return listenSocket->getListenAddress();
-  }
+  folly::Expected<folly::SocketAddress, int> getListenSocketListenAddr();
 
   int getRank() const {
     return rank;
@@ -506,33 +500,11 @@ class CtranIb {
       std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
       std::optional<int> maxNumCqe = std::nullopt);
 
-  void bootstrapStart(std::optional<const SocketServerAddr*> qpServerAddr);
-  static void bootstrapAccept(CtranIb* ib);
-  commResult_t bootstrapConnect(
-      int peerRank,
-      std::optional<const SocketServerAddr*> peerAddr = std::nullopt);
-
-  // Create a virtual connection for a given peer.
-  // Expect used only in bootstrapAccept() and bootstrapConnect().
-  std::shared_ptr<CtranIbVirtualConn> createVc(int peerRank);
-
-  // Update and query vcStateMaps.
-  // It is thread-safe to be called by server and client threads concurrently.
-  // NOTE: vc lock doesn't protect qpToRankMap, since it is for all peers.
-  commResult_t updateVcState(std::shared_ptr<CtranIbVirtualConn> vc, int rank);
-  commResult_t queryQpToRank(uint32_t qpn, int& rank);
-
   commResult_t setPgToTrafficClassMap();
 
   uint32_t getPgToTrafficClassValue() const;
 
   const char* ibv_wc_status_str(enum ibverbx::ibv_wc_status status);
-
-  // check where the peer is connected
-  inline bool isPeerConnected(int peerRank) const {
-    return (
-        connectedPeerMap.size() > peerRank && connectedPeerMap.at(peerRank));
-  }
 
   inline bool canTransfer(CtranIbVirtualConn* vc) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, { return vc->canTransferData(); });
@@ -561,74 +533,6 @@ class CtranIb {
       return commInternalError;
     }
     return commSuccess;
-  }
-
-  inline commResult_t checkAndInsertQpToVcMap(
-      folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>>& map,
-      QpUniqueId& qpId,
-      std::shared_ptr<CtranIbVirtualConn>& vc) {
-    if (map.find(qpId) != map.end()) {
-      CLOGF(
-          ERR,
-          "CTRAN-IB: QP {} on device {} already exists in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
-          qpId.first,
-          qpId.second,
-          (void*)this,
-          commHash,
-          commDesc);
-      return commInternalError;
-    }
-    map.emplace(qpId, vc);
-    return commSuccess;
-  }
-
-  // Get a virtual connection for a given peer or QP.
-  // If the peer is not yet connected, return nullptr.
-  // For a returned VC, it is guaranteed to be ready to use.
-  template <typename PerfConfig = DefaultPerfCollConfig>
-  inline std::shared_ptr<CtranIbVirtualConn> getVcImpl(int peerRank) {
-    if (PerfConfig::skipVcConnectionCheck ||
-        (vcStateMapsPtr && isPeerConnected(peerRank))) {
-      return vcStateMapsPtr->rankToVcMap.at(peerRank);
-    } else {
-      auto locked = vcStateMaps.rlock();
-
-      auto it = locked->rankToVcMap.find(peerRank);
-      if (it == locked->rankToVcMap.end()) {
-        return nullptr;
-      }
-
-      return it->second;
-    }
-  }
-
-  template <typename PerfConfig = DefaultPerfCollConfig>
-  inline std::shared_ptr<CtranIbVirtualConn> getVcByQp(QpUniqueId qpUniqueId) {
-    // lambda function to get VC from a given pointer
-    auto getVcFrom = [&](const VcStateMaps* maybeLockedVcStateMapsPtr)
-        -> std::shared_ptr<CtranIbVirtualConn> {
-      auto it = maybeLockedVcStateMapsPtr->qpToVcMap.find(qpUniqueId);
-      // VC should be already created and added to vcStateMaps. If not found, it
-      // likely indicates a NCCL bug, e.g., not using CtranIb epoch lock
-      if (it == maybeLockedVcStateMapsPtr->qpToVcMap.end()) {
-        CLOGF(
-            ERR,
-            "CTRAN-IB: Received unknown QP number {} on IB device {} in pimpl {} commHash {:x}, commDesc {}. Known QPs: {}. It likely indicates a COMM bug.",
-            qpUniqueId.first,
-            qpUniqueId.second,
-            (void*)this,
-            commHash,
-            commDesc,
-            f14FastMapToStr(maybeLockedVcStateMapsPtr->qpToVcMap));
-        return nullptr;
-      }
-      return it->second;
-    };
-
-    auto vcstatemaps = PerfConfig::skipVcConnectionCheck
-        ? vcStateMapsPtr
-        : &(*vcStateMaps.rlock());
-    return getVcFrom(vcstatemaps);
   }
 
   // Check whether vc is ready and no outstanding pending ops
@@ -685,7 +589,7 @@ class CtranIb {
       for (auto it = rankToPendingOpsMap.begin();
            it != rankToPendingOpsMap.end();) {
         int peerRank = it->first;
-        std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+        std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
         // If VC has established, move the pendingOps list to readyToIssueOps;
         // otherwise, skip and move to next peer.
         if (vc) {
@@ -705,7 +609,7 @@ class CtranIb {
 
     // Post ready-to-issue pending ops
     for (auto& [peerRank, pendingOps] : readyToIssueOps) {
-      std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+      std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
       CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
         for (auto& op : pendingOps) {
           if (op->opType == PendingOp::PendingOpType::ISEND_CTRL) {
@@ -757,7 +661,8 @@ class CtranIb {
     FB_COMMCHECK(checkEpochLock(this));
     FB_COMMCHECK(checkValidPeer(peerRank));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
 
     // nullptr VC indicates not yet established connection; try to connect.
     // For smaller peerRank, wait peerRank connects to local listenThread.
@@ -765,13 +670,14 @@ class CtranIb {
     // progress.
     if (!PerfConfig::skipVcConnectionCheck && rank < peerRank &&
         vc == nullptr) {
-      FB_COMMCHECK(bootstrapConnect(peerRank, peerServerAddr));
+      FB_COMMCHECK(bootstrap_->connect(peerRank, peerServerAddr));
       // Get VC again after connection is established
-      vc = getVcImpl<PerfConfig>(peerRank);
+      vc = vcState_.getVc<PerfConfig>(peerRank);
     }
 
     // Skip vc and pendingOps check if pre-connected
-    if (PerfConfig::skipVcConnectionCheck || isPeerConnected(peerRank) ||
+    if (PerfConfig::skipVcConnectionCheck ||
+        vcState_.isPeerConnected(peerRank) ||
         !addToPendingOpsIfRequired(
             type,
             // FIXME: need refactor to keep the constness if possible
@@ -798,7 +704,8 @@ class CtranIb {
     FB_COMMCHECK(checkEpochLock(this));
     FB_COMMCHECK(checkValidPeer(peerRank));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
 
     // nullptr VC indicates not yet established connection; try to connect.
     // For smaller peerRank, wait peerRank connects to local listenThread.
@@ -806,13 +713,14 @@ class CtranIb {
     // progress.
     if (!PerfConfig::skipVcConnectionCheck && rank < peerRank &&
         vc == nullptr) {
-      FB_COMMCHECK(bootstrapConnect(peerRank, peerServerAddr));
+      FB_COMMCHECK(bootstrap_->connect(peerRank, peerServerAddr));
       // Get VC again after connection is established
-      vc = getVcImpl<PerfConfig>(peerRank);
+      vc = vcState_.getVc<PerfConfig>(peerRank);
     }
 
     // Skip vc and pendingOps check if pre-connected
-    if (PerfConfig::skipVcConnectionCheck || isPeerConnected(peerRank) ||
+    if (PerfConfig::skipVcConnectionCheck ||
+        vcState_.isPeerConnected(peerRank) ||
         !addToPendingOpsIfRequired(
             std::nullopt,
             payload,
@@ -835,7 +743,8 @@ class CtranIb {
       int peerRank) {
     FB_COMMCHECK(checkEpochLock(this));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVc<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     CTRAN_IB_PER_OBJ_LOCK_GUARD(
@@ -858,7 +767,8 @@ class CtranIb {
       bool fast) {
     FB_COMMCHECK(checkEpochLock(this));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
@@ -890,7 +800,8 @@ class CtranIb {
       bool fast) {
     FB_COMMCHECK(checkEpochLock(this));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVc<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
@@ -909,7 +820,7 @@ class CtranIb {
       void* ibRegElem,
       struct CtranIbRemoteAccessKey remoteAccessKey,
       CtranIbRequest* req) {
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
       FB_COMMCHECK(vc->ifetchAndAdd(
@@ -924,7 +835,7 @@ class CtranIb {
       int peerRank,
       struct CtranIbRemoteAccessKey remoteAccessKey,
       CtranIbRequest* req) {
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
     CTRAN_IB_PER_OBJ_LOCK_GUARD(vc->mutex, {
       FB_COMMCHECK(vc->iatomicSet(dbuf, val, remoteAccessKey, req));
@@ -935,7 +846,7 @@ class CtranIb {
   inline commResult_t notifyImpl(int peerRank, CtranIbRequest* req) {
     FB_COMMCHECK(checkEpochLock(this));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc = vcState_.getVc(peerRank);
     FB_COMMCHECK(checkValidVc(vc, peerRank));
 
     // Waits till the VC can transfer data before posting a put
@@ -957,7 +868,8 @@ class CtranIb {
 
     FB_COMMCHECK(this->progressInternal<PerfConfig>());
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
 
     // VC may not be established yet, e.g., if the connection is established by
     // listenThread. Return and check again next time.
@@ -973,12 +885,13 @@ class CtranIb {
     FB_COMMCHECK(checkEpochLock(this));
     FB_COMMCHECK(checkValidPeer(peerRank));
 
-    std::shared_ptr<CtranIbVirtualConn> vc = getVcImpl<PerfConfig>(peerRank);
+    std::shared_ptr<CtranIbVirtualConn> vc =
+        vcState_.getVc<PerfConfig>(peerRank);
     // VC may not be established yet, e.g., if the connection is established
     // by listenThread. Continue check till it is established.
     if (!PerfConfig::skipVcConnectionCheck) {
       while (vc == nullptr && !abortCtrl_->Test()) {
-        vc = getVcImpl<PerfConfig>(peerRank);
+        vc = vcState_.getVc<PerfConfig>(peerRank);
       }
     }
 
@@ -1045,7 +958,7 @@ class CtranIb {
         // Expect received CQE should be with a registered rank and established
         // VC
         std::shared_ptr<CtranIbVirtualConn> vc =
-            getVcByQp<PerfConfig>(std::make_pair(wc.qp_num, device));
+            vcState_.getVcByQp<PerfConfig>(std::make_pair(wc.qp_num, device));
         if (vc == nullptr) {
           CLOGF(
               ERR,
@@ -1091,29 +1004,20 @@ class CtranIb {
 
   std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory_;
 
-  // bitmap to indicate whether a peer is connected.
-  // note that only one thread access it (e.g., GPE thread) or the epoch lock
-  // needs to be acquired.
-  std::vector<bool> connectedPeerMap;
+  // All per-peer virtual-connection state (rank/qp lookup maps and the
+  // connectedPeerMap bitmap). Late-initialized in init() once ncclLogData
+  // is populated.
+  ::ctran::ib::VcState vcState_;
 
-  std::unique_ptr<ctran::bootstrap::IServerSocket> listenSocket;
-  std::vector<sockaddr_storage> allListenSocketAddrs{};
-  std::thread listenThread;
+  // Internal-bootstrap service: owns listen socket + accept thread +
+  // client-connect path, and publishes every freshly-handshaken VC into
+  // vcState_. Null when bootstrapMode == kExternal.
+  std::unique_ptr<::ctran::ib::Bootstrap> bootstrap_;
 
-  // Virtual connection status for all peers.
-  // NOTE: when using a VC, additional per-VC lock is required.
-  struct VcStateMaps {
-    folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>>
-        qpToVcMap;
-    folly::F14FastMap<int, std::shared_ptr<CtranIbVirtualConn>> rankToVcMap;
-  };
-  // VCs that are created but not yet connected
-  std::unordered_map<int, std::shared_ptr<CtranIbVirtualConn>> pendingVcs_;
-
-  folly::Synchronized<VcStateMaps> vcStateMaps;
-  // Lock-free struct to be used in eager connect mode which gurantees
-  // single-threaded access
-  VcStateMaps* vcStateMapsPtr{nullptr};
+  // External-bootstrap helper: callsite-managed handshake driver. Owns
+  // its own pendingVcs_ map + mutex. Allocated only when bootstrapMode
+  // == BootstrapMode::kExternal; nullptr otherwise.
+  std::unique_ptr<::ctran::ib::BootstrapExternal> externalBootstrap_;
 
   // Local virtual connection for local flush.
   std::unique_ptr<::ctran::ib::LocalVirtualConn> localVc;

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -1,0 +1,139 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/backends/ib/VcState.h"
+
+#include <utility>
+#include <vector>
+
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/utils/StrUtils.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::ib {
+
+void VcState::init(void* owner, const CommLogData& logData, int nRanks) {
+  owner_ = owner;
+  logData_ = &logData;
+  // assign the lock-free vcStateMaps ptr for fast path access when applicable
+  {
+    auto locked = vcStateMaps_.wlock();
+    vcStateMapsPtr_ = &(*locked);
+  }
+  if (nRanks > 0) {
+    // initialize connection map before preConnect() is called by any algorithm
+    connectedPeerMap_.resize(nRanks, false);
+  }
+}
+
+void VcState::releaseAll() {
+  { // Explicitly release all virtual connections before destroying cq.
+    auto locked = vcStateMaps_.wlock();
+    locked->rankToVcMap.clear();
+    locked->qpToVcMap.clear();
+    vcStateMapsPtr_ = nullptr;
+  }
+  connectedPeerMap_.clear();
+}
+
+commResult_t VcState::setupAndPublishVc(
+    std::shared_ptr<CtranIbVirtualConn> vc,
+    const std::string& remoteVcIdentifier,
+    int peerRank) {
+  {
+    const std::lock_guard<std::mutex> lock(vc->mutex);
+    FB_COMMCHECKTHROW_EX(
+        vc->setupVc((void*)remoteVcIdentifier.data()), *logData_);
+  }
+
+  uint32_t controlQp = vc->getControlQpNum();
+  uint32_t notifyQp = vc->getNotifyQpNum();
+  uint32_t atomicQp = vc->getAtomicQpNum();
+  std::vector<uint32_t> dataQps = vc->getDataQpNums();
+
+  // Till now VC is not yet exposed to local rank. Local rank can use the VC
+  // once updated the vcStateMaps_.
+  FB_COMMCHECKTHROW_EX(updateVcState(vc, peerRank), *logData_);
+
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, "
+      "vc {}, rank {}, peer {}, control qpn {}, notify qpn {}, atomic qpn {}, data qpns {}",
+      logData_->commHash,
+      logData_->commDesc,
+      (void*)vc.get(),
+      logData_->rank,
+      peerRank,
+      controlQp,
+      notifyQp,
+      atomicQp,
+      vecToStr(dataQps));
+
+  return commSuccess;
+}
+
+commResult_t VcState::updateVcState(
+    std::shared_ptr<CtranIbVirtualConn> vc,
+    int peerRank) {
+  auto locked = vcStateMaps_.wlock();
+  if (locked->rankToVcMap.find(peerRank) != locked->rankToVcMap.end()) {
+    CLOGF(
+        ERR,
+        "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
+        peerRank,
+        owner_,
+        logData_->commHash,
+        logData_->commDesc);
+    return commInternalError;
+  }
+
+  locked->rankToVcMap[peerRank] = vc;
+  QpUniqueId controlQpId = std::make_pair(vc->getControlQpNum(), 0);
+  if (checkAndInsertQpToVcMap(locked->qpToVcMap, controlQpId, vc) !=
+      commSuccess) {
+    return commInternalError;
+  }
+  QpUniqueId notifyQpId = std::make_pair(vc->getNotifyQpNum(), 0);
+  if (checkAndInsertQpToVcMap(locked->qpToVcMap, notifyQpId, vc) !=
+      commSuccess) {
+    return commInternalError;
+  }
+  QpUniqueId atomicQpId = std::make_pair(vc->getAtomicQpNum(), 0);
+  if (checkAndInsertQpToVcMap(locked->qpToVcMap, atomicQpId, vc) !=
+      commSuccess) {
+    return commInternalError;
+  }
+
+  std::vector<uint32_t> dataQps = vc->getDataQpNums();
+  for (int qpIdx = 0; qpIdx < dataQps.size(); qpIdx++) {
+    int device = vc->getIbDevFromQpIdx(qpIdx);
+    QpUniqueId qpId = std::make_pair(dataQps[qpIdx], device);
+    if (checkAndInsertQpToVcMap(locked->qpToVcMap, qpId, vc) != commSuccess) {
+      return commInternalError;
+    }
+  }
+
+  return commSuccess;
+}
+
+commResult_t VcState::checkAndInsertQpToVcMap(
+    folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>>& map,
+    QpUniqueId& qpId,
+    std::shared_ptr<CtranIbVirtualConn>& vc) {
+  if (map.find(qpId) != map.end()) {
+    CLOGF(
+        ERR,
+        "CTRAN-IB: QP {} on device {} already exists in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
+        qpId.first,
+        qpId.second,
+        owner_,
+        logData_->commHash,
+        logData_->commDesc);
+    return commInternalError;
+  }
+  map.emplace(qpId, vc);
+  return commSuccess;
+}
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -1,0 +1,167 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef CTRAN_IB_VC_STATE_H_
+#define CTRAN_IB_VC_STATE_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/utils/CtranPerf.h"
+#include "comms/utils/StrUtils.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/logger/LogUtils.h"
+
+namespace ctran::ib {
+
+// Virtual connection status for all peers.
+// NOTE: when using a VC, additional per-VC lock is required.
+struct VcStateMaps {
+  folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>> qpToVcMap;
+  folly::F14FastMap<int, std::shared_ptr<CtranIbVirtualConn>> rankToVcMap;
+};
+
+// VcState owns all per-peer virtual-connection state for a single CtranIb
+// instance. Both the internal bootstrap path (ctran::ib::Bootstrap) and the
+// external bootstrap path (BootstrapExternal.cc) publish established VCs
+// through setupAndPublishVc(); critical-path callers look them up through
+// getVc/getVcByQp. The class is intentionally not thread-safe at the
+// construction / init / releaseAll boundary; all mutating operations after
+// init() are themselves thread-safe (vcStateMaps_ is folly::Synchronized).
+class VcState {
+ public:
+  VcState() = default;
+  ~VcState() = default;
+
+  VcState(const VcState&) = delete;
+  VcState& operator=(const VcState&) = delete;
+  VcState(VcState&&) = delete;
+  VcState& operator=(VcState&&) = delete;
+
+  // Late init. Called by CtranIb::init() after ncclLogData is populated.
+  //   - owner: opaque pointer used as "pimpl" in log messages.
+  //   - logData: reference to the owner's CommLogData; must outlive *this.
+  //   - nRanks: number of ranks. Pass 0 to skip connectedPeerMap setup
+  //             (used when there is no associated CtranComm).
+  void init(void* owner, const CommLogData& logData, int nRanks);
+
+  // Release every established VC, clear connectedPeerMap, and reset the
+  // lock-free fast-path pointer. Callers must invoke this before tearing
+  // down resources referenced by the VCs (e.g., the shared CQ).
+  void releaseAll();
+
+  // Setup a freshly-constructed VC with the remote bus card, publish it into
+  // vcStateMaps_, and log the established connection. Shared between the
+  // internal bootstrap path (ctran::ib::Bootstrap) and the external
+  // bootstrap path (BootstrapExternal.cc). The VC must not already be
+  // present.
+  commResult_t setupAndPublishVc(
+      std::shared_ptr<CtranIbVirtualConn> vc,
+      const std::string& remoteVcIdentifier,
+      int peerRank);
+
+  // Update vcStateMaps_ to include the established VC.
+  // Thread-safe; callable concurrently by server and client threads.
+  commResult_t updateVcState(
+      std::shared_ptr<CtranIbVirtualConn> vc,
+      int peerRank);
+
+  // Returns true if the peer has been pre-connected (preConnect path).
+  inline bool isPeerConnected(int peerRank) const {
+    return (
+        connectedPeerMap_.size() > peerRank && connectedPeerMap_.at(peerRank));
+  }
+
+  // Mark a peer as connected. Used by preConnect() once it observes that
+  // the connection has been established on the listen thread.
+  inline void markPeerConnected(int peerRank) {
+    connectedPeerMap_.at(peerRank) = true;
+  }
+
+  // Whether connectedPeerMap_ has been sized (non-empty means nRanks is
+  // known). Used by preConnect() to early-out when no comm is associated.
+  inline bool hasConnectedPeerMap() const {
+    return !connectedPeerMap_.empty();
+  }
+
+  // Get a virtual connection for a given peer.
+  // If the peer is not yet connected, return nullptr.
+  // For a returned VC, it is guaranteed to be ready to use.
+  template <typename PerfConfig = DefaultPerfCollConfig>
+  inline std::shared_ptr<CtranIbVirtualConn> getVc(int peerRank) {
+    if (PerfConfig::skipVcConnectionCheck ||
+        (vcStateMapsPtr_ && isPeerConnected(peerRank))) {
+      return vcStateMapsPtr_->rankToVcMap.at(peerRank);
+    } else {
+      auto locked = vcStateMaps_.rlock();
+
+      auto it = locked->rankToVcMap.find(peerRank);
+      if (it == locked->rankToVcMap.end()) {
+        return nullptr;
+      }
+
+      return it->second;
+    }
+  }
+
+  // Get the virtual connection associated with the given QP.
+  // Returns nullptr (and logs) when the QP is unknown.
+  template <typename PerfConfig = DefaultPerfCollConfig>
+  inline std::shared_ptr<CtranIbVirtualConn> getVcByQp(QpUniqueId qpUniqueId) {
+    auto getVcFrom = [&](const VcStateMaps* maybeLockedVcStateMapsPtr)
+        -> std::shared_ptr<CtranIbVirtualConn> {
+      auto it = maybeLockedVcStateMapsPtr->qpToVcMap.find(qpUniqueId);
+      // VC should be already created and added to vcStateMaps_. If not
+      // found, it likely indicates a COMM bug, e.g., not using CtranIb
+      // epoch lock.
+      if (it == maybeLockedVcStateMapsPtr->qpToVcMap.end()) {
+        CLOGF(
+            ERR,
+            "CTRAN-IB: Received unknown QP number {} on IB device {} in pimpl {} commHash {:x}, commDesc {}. Known QPs: {}. It likely indicates a COMM bug.",
+            qpUniqueId.first,
+            qpUniqueId.second,
+            owner_,
+            logData_ ? logData_->commHash : 0,
+            logData_ ? logData_->commDesc : std::string{},
+            f14FastMapToStr(maybeLockedVcStateMapsPtr->qpToVcMap));
+        return nullptr;
+      }
+      return it->second;
+    };
+
+    auto vcstatemaps = PerfConfig::skipVcConnectionCheck
+        ? vcStateMapsPtr_
+        : &(*vcStateMaps_.rlock());
+    return getVcFrom(vcstatemaps);
+  }
+
+ private:
+  commResult_t checkAndInsertQpToVcMap(
+      folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>>& map,
+      QpUniqueId& qpId,
+      std::shared_ptr<CtranIbVirtualConn>& vc);
+
+  // Opaque "pimpl" pointer (the owning CtranIb*), used only for log output
+  // so we can match the existing error messages.
+  void* owner_{nullptr};
+  // Non-owning pointer to the owner's CommLogData. Set in init().
+  const CommLogData* logData_{nullptr};
+
+  folly::Synchronized<VcStateMaps> vcStateMaps_;
+  // Lock-free struct to be used in eager connect mode which guarantees
+  // single-threaded access.
+  VcStateMaps* vcStateMapsPtr_{nullptr};
+
+  // bitmap to indicate whether a peer is connected.
+  // note that only one thread accesses it (e.g., GPE thread) or the epoch
+  // lock needs to be acquired.
+  std::vector<bool> connectedPeerMap_;
+};
+
+} // namespace ctran::ib
+
+#endif // CTRAN_IB_VC_STATE_H_

--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -8,6 +8,7 @@
 
 #include <folly/init/Init.h>
 
+#include "comms/ctran/backends/ib/BootstrapExternal.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/utils/Exception.h"
 
@@ -100,12 +101,18 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
       CtranIb::BootstrapMode::kExternal);
 
   // Connect senderIb and receiverIb
-  auto senderVcIdentifier = senderIb->getLocalVcIdentifier(kDummyRank);
-  auto receiverVcIdentifier = receiverIb->getLocalVcIdentifier(kDummyRank);
+  auto senderVcIdentifier =
+      senderIb->externalBootstrap()->getLocalVcId(kDummyRank);
+  auto receiverVcIdentifier =
+      receiverIb->externalBootstrap()->getLocalVcId(kDummyRank);
   CHECK_EQ(
-      senderIb->connectVcDirect(receiverVcIdentifier, kDummyRank), commSuccess);
+      senderIb->externalBootstrap()->connectVc(
+          receiverVcIdentifier, kDummyRank),
+      commSuccess);
   CHECK_EQ(
-      receiverIb->connectVcDirect(senderVcIdentifier, kDummyRank), commSuccess);
+      receiverIb->externalBootstrap()->connectVc(
+          senderVcIdentifier, kDummyRank),
+      commSuccess);
 
   // Allocate memory on the sender side
   CHECK_EQ(cudaSetDevice(cudaDev0), cudaSuccess);

--- a/comms/ctran/backends/ib/docs/structure.md
+++ b/comms/ctran/backends/ib/docs/structure.md
@@ -1,0 +1,160 @@
+# `CtranIb` structure
+
+This directory implements `CtranIb`, the InfiniBand backend used by ctran.
+The class is composed of a few small, single-purpose helpers that all
+plug into one main facade (`CtranIb`).
+
+## At a glance
+
+```
+        ┌────────────────────────────────────────────────────────┐
+        │                       CtranIb                          │
+        │  (public IB ops: iput / iget / iflush / progress /     │
+        │   isendCtrlMsg / irecvCtrlMsg / preConnect / regMem,   │
+        │   lifecycle, epoch lock, CtranIbSingleton glue)        │
+        │                                                        │
+        │  members:                                              │
+        │    ctran::ib::VcState                  vcState_        │
+        │    std::unique_ptr<Bootstrap>          bootstrap_      │
+        │    std::unique_ptr<BootstrapExternal>  externalBootstrap_ │
+        └─────────┬──────────────┬──────────────────┬────────────┘
+                  │              │                  │
+                  ▼              ▼                  ▼
+   ┌────────────────────┐  ┌─────────────────┐  ┌─────────────────────────┐
+   │   ctran::ib::      │  │ ctran::ib::     │  │ ctran::ib::             │
+   │      VcState       │  │   Bootstrap     │  │   BootstrapExternal     │
+   │                    │  │                 │  │                         │
+   │  - rank→VC map     │  │  - listen sock  │  │  - pendingVcs_ map      │
+   │  - QP→VC map       │  │  - accept thrd  │  │  - mutex_               │
+   │  - connectedPeer   │  │  - connect()    │  │  - getLocalVcId()       │
+   │  - getVc/getVcByQp │  │  - shutdown()   │  │  - connectVc()          │
+   │  - setupAndPublish │  │                 │  │  (allocated only in     │
+   │                    │  │                 │  │   kExternal mode)       │
+   └────────────────────┘  └────────┬────────┘  └─────────────┬───────────┘
+            ▲                       │                         │
+            │                       │ setupAndPublishVc       │ setupAndPublishVc
+            └───────────────────────┴─────────────────────────┘
+                              one-way arrow:
+                       Bootstrap / BootstrapExternal
+                              publish into VcState
+```
+
+## File map
+
+| File | Purpose |
+|---|---|
+| `CtranIb.h` / `CtranIb.cc` | Facade. Owns `VcState`, `Bootstrap`, `BootstrapExternal`. Implements all public IB operations + lifecycle + epoch lock. Includes the `CtranIbSingleton` (per-process IBV resources). |
+| `VcState.h` / `VcState.cc` | Per-peer VC registry. `rankToVcMap` / `qpToVcMap` (`folly::Synchronized<VcStateMaps>`), `connectedPeerMap` bitmap, `getVc`/`getVcByQp` templates, `setupAndPublishVc`. Pure data + lookup; no I/O. |
+| `BootstrapInternal.h` / `BootstrapInternal.cc` | `ctran::ib::Bootstrap`. Owns the listen socket, accept thread, business-card exchange, and slow-path `connect()`. Publishes finished VCs into `VcState` via `setupAndPublishVc`. |
+| `BootstrapExternal.h` / `BootstrapExternal.cc` | `ctran::ib::BootstrapExternal`. Owns the `pendingVcs_` map and the `getLocalVcId()` / `connectVc()` methods used by callsite-managed handshakes. Used only when `bootstrapMode == kExternal`; callers reach it via `CtranIb::externalBootstrap()`. |
+| `CtranIbVc.{h,cc}` | `CtranIbVirtualConn` — one QP-group per peer. Owns the IB QPs (control / notify / atomic / data). Used by VC state map. |
+| `CtranIbLocalVc.{h,cc}` | `LocalVirtualConn` — self-loop VC used by `iflush()` to force PCIe ordering. |
+| `CtranIbBase.h` | Tiny POD types shared by everyone (`CtranIbDevice`, `CtranIbRequest`, `PendingOp`). |
+| `CtranIbImpl.h` | Internal macros (`CTRAN_IB_PER_OBJ_LOCK_GUARD`, `CQE_ERROR_CHECK`) + `getRemoteKeysImpl`. |
+| `CtranIbSingleton.h` | Process-global IBV PD/CQ context + async-event thread + memory-registration accounting. |
+| `IbvWrap.{h,cc}` / `ibutils.{h,cc}` | Thin wrappers around libibverbs. |
+
+## Namespace conventions
+
+- `CtranIb`, `CtranIbVirtualConn`, `CtranIbBase`, `CtranIbRequest`,
+  `QpUniqueId`, `CtranIbEpochRAII`, `CtranIbSingleton` — global namespace
+  (legacy; the `CtranIb*` prefix is the namespace scope).
+- `ctran::ib::VcState`, `ctran::ib::VcStateMaps`, `ctran::ib::Bootstrap`,
+  `ctran::ib::BootstrapExternal`, `ctran::ib::LocalVirtualConn`,
+  `ctran::ib::getRemoteKeysImpl` — new generic helpers live in
+  `ctran::ib`.
+
+## Lifecycle
+
+```
+CtranIb(...)                         ──►   init(...)
+                                            │
+                                            ▼
+                              vcState_.init(owner, logData, nRanks)
+                                            │
+                              ┌─────────────┴──────────────┐
+                              ▼                            ▼
+              bootstrapMode == kExternal           bootstrapMode != kExternal
+              externalBootstrap_ =                 bootstrap_ = make_unique<Bootstrap>(
+                  make_unique<BootstrapExternal>(    vcState_, socketFactory_,
+                      vcState_, devices, comm,       abortCtrl_, ncclLogData,
+                      cudaDev, commHash, commDesc,   comm, devices,
+                      ncclLogData,                   trafficClass, cudaDev,
+                      trafficClass);                 rank, commHash, commDesc);
+                                                   bootstrap_->start(qpServerAddr);
+                                                     ↓
+                                                   spawns accept thread
+                                                     ↓
+                                                   listenThread_ runs acceptLoop,
+                                                   which calls
+                                                   vcState_.setupAndPublishVc(...)
+                                                   for each accepted peer
+
+~CtranIb()                           ──►   if (bootstrap_) bootstrap_->shutdown();
+                                            └─► closes listenSocket_, joins thread
+                                          releaseRemoteTransStates(true)
+                                            └─► vcState_.releaseAll(), free CQ, free localVc
+                                          members destruct (in reverse declaration order):
+                                            externalBootstrap_ → bootstrap_ → vcState_
+```
+
+The "slow path" for an outbound message (template in `CtranIb.h`):
+
+```
+isendCtrlMsgImpl / irecvCtrlMsgImpl
+   │
+   │  vc = vcState_.getVc(peerRank)
+   │
+   │  if (vc == nullptr  &&  rank < peerRank):
+   │      bootstrap_->connect(peerRank, peerAddr)
+   │                                                  │
+   │                                                  │  open client socket,
+   │                                                  │  exchange business cards,
+   │                                                  │  vcState_.setupAndPublishVc(...)
+   │
+   │  vc = vcState_.getVc(peerRank)
+   │  vc->isendCtrlMsg(...) / vc->irecvCtrlMsg(...)
+```
+
+The external-bootstrap path (driven by `RdmaTransport`):
+
+```
+RdmaTransport::bind()
+   │
+   │  return ib_->externalBootstrap()->getLocalVcId(peerRank)
+   │      └─► constructs CtranIbVirtualConn, stashes it in pendingVcs_,
+   │          returns the serialized local bus card
+   │
+RdmaTransport::connect(remoteBusCard)
+   │
+   │  ib_->externalBootstrap()->connectVc(remoteBusCard, peerRank)
+   │      └─► pops pending VC, runs vc->setupVc(remoteBusCard),
+   │          vcState_.setupAndPublishVc(...)
+```
+
+## Coupling rules
+
+1. `VcState` depends on nothing in this directory except `CtranIbVirtualConn`
+   (and `CommLogData` for logging). It does **not** include or
+   forward-declare `Bootstrap` or `BootstrapExternal`.
+2. `Bootstrap` depends on `VcState` (one method: `setupAndPublishVc`) and
+   on the bootstrap I/O primitives in `comms/ctran/bootstrap/`. It does
+   **not** depend on `CtranIb`.
+3. `BootstrapExternal` depends on `VcState` (one method:
+   `setupAndPublishVc`) and on `CtranIbVirtualConn`. It does **not**
+   depend on `CtranIb`.
+4. `CtranIb.h` includes `VcState.h` fully (`vcState_` is a value member)
+   and `BootstrapInternal.h` so templates in the header can call
+   `bootstrap_->connect(...)` directly. It forward-declares
+   `BootstrapExternal` only (the external path is reached only via the
+   `externalBootstrap()` accessor, which returns a forward-declared
+   pointer).
+5. `CtranIb.cc` includes `BootstrapInternal.h` and `BootstrapExternal.h`
+   (so `~CtranIb()` and the `make_unique<BootstrapExternal>(...)` call
+   in `init()` see complete types).
+
+This means the entire external-bootstrap path — `BootstrapExternal`,
+`CtranIb::externalBootstrap()`, and the `kExternal` enum value — lives
+in three places (CtranIb.h field + accessor + `BootstrapExternal.{h,cc}`)
+and can be removed in one shot once its only caller (`RdmaTransport`)
+moves to Uniflow.

--- a/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbConnectionTest.cc
@@ -8,6 +8,7 @@
 
 #include <folly/futures/Future.h>
 
+#include "comms/ctran/backends/ib/BootstrapExternal.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 
@@ -74,14 +75,15 @@ class CtranIbConnectionTest : public ::testing::Test {
         /*abortCtrl=*/abortCtrl);
 
     // Get and provide VC identifier
-    std::string myVcId = ctranIb->getLocalVcIdentifier(peerRank);
+    std::string myVcId = ctranIb->externalBootstrap()->getLocalVcId(peerRank);
     syncObjects.myVcIdPromise.setValue(myVcId);
 
     // Wait for peer's VC identifier
     std::string peerVcId = std::move(syncObjects.peerVcIdFuture).get();
 
     // Connect to peer
-    commResult_t connectResult = ctranIb->connectVcDirect(peerVcId, peerRank);
+    commResult_t connectResult =
+        ctranIb->externalBootstrap()->connectVc(peerVcId, peerRank);
     EXPECT_EQ(connectResult, commSuccess);
 
     // Allow time for connection establishment
@@ -265,9 +267,10 @@ TEST_F(CtranIbConnectionTest, TestAbortCtrl) {
   this->runTest(/*testAbort=*/true);
 }
 
-// Test that calling connectVcDirect before getLocalVcIdentifier returns an
-// error instead of segfaulting. This validates the fix for the segfault caused
-// by uninitialized QPs when setupVc is called before getLocalBusCard.
+// Test that calling BootstrapExternal::connectVc before
+// BootstrapExternal::getLocalVcId returns an error instead of segfaulting. This
+// validates the fix for the segfault caused by uninitialized QPs when setupVc
+// is called before getLocalBusCard.
 TEST_F(CtranIbConnectionTest, ConnectVcDirectWithoutLocalVcIdentifierFails) {
   const uint64_t commHash = 0x12345678;
   const std::string commDesc = "test_uninitialized_qp";
@@ -292,10 +295,45 @@ TEST_F(CtranIbConnectionTest, ConnectVcDirectWithoutLocalVcIdentifierFails) {
   // doesn't matter for this test since we expect early failure)
   std::string fakeRemoteVcId(256, '\0');
 
-  // Calling connectVcDirect without first calling getLocalVcIdentifier should
-  // fail gracefully with commInternalError, not segfault.
-  // This tests the fix for the segfault in CtranIbVirtualConn::setupVc when
-  // QPs are not initialized.
+  // Calling BootstrapExternal::connectVc without first calling getLocalVcId
+  // should fail gracefully with commInternalError, not segfault. This tests
+  // the fix for the segfault in CtranIbVirtualConn::setupVc when QPs are not
+  // initialized.
   EXPECT_EQ(
-      ctranIb->connectVcDirect(fakeRemoteVcId, peerRank), commInternalError);
+      ctranIb->externalBootstrap()->connectVc(fakeRemoteVcId, peerRank),
+      commInternalError);
+}
+
+// Verify that the externalBootstrap() accessor returns nullptr when CtranIb is
+// constructed in an internal bootstrap mode (kSpecifiedServer here). This
+// replaces the previous death-test-based guard against misuse: in the new
+// design BootstrapExternal is only allocated in kExternal mode, so the only
+// way to reach its methods is through the accessor which returns nullptr
+// otherwise.
+TEST_F(CtranIbConnectionTest, ExternalBootstrapAccessorNullInInternalMode) {
+  const uint64_t commHash = 0x12345678;
+  const std::string commDesc = "test_external_in_internal_mode";
+  const int rank = 0;
+
+  // Use localhost with OS-assigned port so the listen thread starts cleanly
+  // without requiring a real cluster network configuration.
+  SocketServerAddr serverAddr;
+  serverAddr.port = 0;
+  serverAddr.ipv4 = "127.0.0.1";
+  serverAddr.ifName = "lo";
+
+  EXPECT_EQ(cudaSetDevice(rank), cudaSuccess);
+
+  auto abortCtrl = ctran::utils::createAbort(/*enabled=*/false);
+  auto ctranIb = std::make_unique<CtranIb>(
+      rank,
+      rank, // cudaDev
+      commHash,
+      commDesc,
+      false, // enableLocalFlush
+      CtranIb::BootstrapMode::kSpecifiedServer,
+      /*qpServerAddr=*/&serverAddr,
+      /*abortCtrl=*/abortCtrl);
+
+  EXPECT_EQ(ctranIb->externalBootstrap(), nullptr);
 }

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -33,6 +33,8 @@ inline void algoStrToVal(
     val = NCCL_ALLGATHER_ALGO::ctring;
   } else if (str == "ctrd") {
     val = NCCL_ALLGATHER_ALGO::ctrd;
+  } else if (str == "ctsrd") {
+    val = NCCL_ALLGATHER_ALGO::ctsrd;
   } else if (str == "ctbrucks") {
     val = NCCL_ALLGATHER_ALGO::ctbrucks;
   } else if (str == "ctgraph") {
@@ -114,6 +116,8 @@ inline std::string algoValToStr(enum NCCL_ALLGATHER_ALGO val) {
       return "ctring";
     case NCCL_ALLGATHER_ALGO::ctrd:
       return "ctrd";
+    case NCCL_ALLGATHER_ALGO::ctsrd:
+      return "ctsrd";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "ctbrucks";
     case NCCL_ALLGATHER_ALGO::ctgraph:

--- a/comms/ncclx/meta/commstate/FactoryCommStateX.cc
+++ b/comms/ncclx/meta/commstate/FactoryCommStateX.cc
@@ -90,8 +90,7 @@ ncclResult_t initCommStateXFromNcclComm(void* _comm, CtranComm* ctranComm) {
 
   auto* bootstrap = ctranComm->bootstrap_.get();
 
-  const int vCliqueSize =
-      commVCliqueSize(NCCLX_CONFIG_FIELD(comm->config, vCliqueSize));
+  const int vCliqueSize = NCCLX_CONFIG_FIELD(comm->config, vCliqueSize);
 
   ctranComm->statex_ = std::make_unique<CommStateX>(
       comm->rank,

--- a/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
+++ b/comms/ncclx/meta/commstate/tests/CommStateXTest.cc
@@ -10,7 +10,6 @@
 #include "comms/ctran/tests/VerifyCommStateXUtil.h"
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 using ctran::testing::VerifyCommStateXHelper;
@@ -22,14 +21,9 @@ class CommStateXDistTest : public NcclxBaseTestFixture {
 
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-        ncclSuccess);
   }
 
   void TearDown() override {
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -41,8 +35,11 @@ class CommStateXDistTest : public NcclxBaseTestFixture {
 };
 
 TEST_F(CommStateXDistTest, CreateFromNcclComm) {
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
 
@@ -61,14 +58,11 @@ TEST_F(CommStateXDistTest, CreateFromNcclComm) {
 }
 
 TEST_F(CommStateXDistTest, CreateNoLocalFromNcclComm) {
-  // FIXME: replace with per-comm ncclx::Hints config once noLocal is
-  // supported as a per-comm hint field (global hints will be deprecated)
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}, {"noLocal", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   ASSERT_TRUE(ctranInitialized(comm->ctranComm_.get()));
 
@@ -88,7 +82,7 @@ TEST_F(CommStateXDistTest, CreateNoLocalFromNcclComm) {
 
 TEST_F(CommStateXDistTest, CreateVCliqueSizeFromNcclComm) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
-  ncclx::Hints hints({{"vCliqueSize", "2"}});
+  ncclx::Hints hints({{"vCliqueSize", "2"}, {"useCtran", "1"}});
   config.hints = &hints;
 
   ncclx::test::NcclCommRAII comm{

--- a/comms/ncclx/meta/tests/AllGatherTest.cc
+++ b/comms/ncclx/meta/tests/AllGatherTest.cc
@@ -15,9 +15,6 @@
 #include "comms/testinfra/TestUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-#include "meta/hints/GlobalHints.h"
-#endif
 
 using testinfra::AlgoRAII;
 
@@ -33,20 +30,19 @@ class AllGatherTest : public NcclxBaseTestFixture {
     envs.push_back({"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"});
 #endif
     NcclxBaseTestFixture::SetUp(envs);
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
 #ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+    ncclx::Hints hints{{"noLocal", "1"}};
+    config.hints = &hints;
 #endif
     this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
     CUDACHECK_TEST(cudaSetDevice(localRank));
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-#endif
     NCCLCHECK_TEST(ncclCommDestroy(comm));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NcclxBaseTestFixture::TearDown();

--- a/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSplitPerCommConfigTest.cc
@@ -7,7 +7,6 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "meta/transport/NcclxIbNetCommConfig.h" // @manual
 #include "nccl.h" // @manual
 
@@ -15,11 +14,11 @@ class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
  public:
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    ncclConfig_t initConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints initHints{{"noLocal", "1"}};
+    initConfig.hints = &initHints;
     comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &initConfig);
     CUDACHECK_TEST(cudaStreamCreate(&stream));
     CUDACHECK_TEST(cudaMalloc(&dataBuf, sizeof(int) * dataCount));
   }
@@ -28,7 +27,6 @@ class CommSplitPerCommConfigTest : public NcclxBaseTestFixture {
     CUDACHECK_TEST(cudaFree(dataBuf));
     CUDACHECK_TEST(cudaStreamDestroy(stream));
     NCCLCHECK_TEST(ncclCommDestroy(comm));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 

--- a/comms/ncclx/meta/tests/CommWithCtranTest.cc
+++ b/comms/ncclx/meta/tests/CommWithCtranTest.cc
@@ -18,7 +18,6 @@
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
 #include "meta/NcclxConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 #define dceil(x, y) ((x / y) + !!(x % y))
@@ -439,13 +438,9 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
 
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
-  ncclx::Hints ctranHints;
+  ncclx::Hints ctranHints{{"useCtran", "1"}};
   config.hints = &ctranHints;
 
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-      ncclSuccess);
   ncclComm_t comm2;
   if (createMode == TestCommCreateMode::kDefault) {
     comm2 = ncclx::test::createNcclComm(
@@ -469,10 +464,8 @@ TEST_P(CommWithCtranTestParam, CtranEnableByHint) {
   }
 
   ASSERT_TRUE(ctranInitialized(comm2->ctranComm_.get()));
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran)));
 
-  // Now it should be disabled again after hint reset
+  // Now it should be disabled again after no hint
   ncclComm_t comm3 = ncclx::test::createNcclComm(
       globalRank, numRanks, localRank, bootstrap_.get());
   ASSERT_NE(comm3, nullptr);

--- a/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
+++ b/comms/ncclx/meta/tests/CommWithNoLocalTest.cc
@@ -10,8 +10,6 @@
 #include "comm.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
 #include "comms/testinfra/TestUtils.h"
-#include "meta/hints/CommHintConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 #include "transport.h"
 
@@ -35,7 +33,6 @@ class CommWithNoLocalTest : public NcclxBaseTestFixture {
   }
 
   void TearDown() override {
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
     NcclxBaseTestFixture::TearDown();
   }
 };
@@ -68,13 +65,8 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "noLocal");
-  ncclx::Hints noLocalHints({{"commDesc", commDescStr}});
+  ncclx::Hints noLocalHints({{"commDesc", commDescStr}, {"noLocal", "1"}});
   config.hints = &noLocalHints;
-
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
   std::optional<ncclx::test::NcclCommRAII> comm2Default;
@@ -102,9 +94,6 @@ TEST_P(CommWithNoLocalTestParam, NoLocalEnableByHint) {
   }
 
   EXPECT_TRUE(comm2->noLocal_);
-
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal)));
 
   // Now disabled again
   {
@@ -142,16 +131,11 @@ class CommWithNoLocalCollTest
   void SetUp() override {
     NcclxBaseTestFixture::SetUp();
     algoStats_.enable();
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran), "1"),
-        ncclSuccess);
     CUDACHECK_TEST(cudaStreamCreate(&stream));
   }
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommUseCtran));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -333,14 +317,14 @@ class CommWithNoLocalCollTest
 TEST_P(CommWithNoLocalCollTest, BaselineRun) {
   const auto [noLocal, collectiveOp] = GetParam();
 
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}};
   if (noLocal) {
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    hints.set("noLocal", "1");
   }
-
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_EQ(comm->noLocal_, noLocal);
 
@@ -359,12 +343,11 @@ TEST_P(CommWithNoLocalCollTest, CtranRun) {
     GTEST_SKIP() << "CtranRun only tests noLocal mode";
   }
 
-  ASSERT_EQ(
-      ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"useCtran", "1"}, {"noLocal", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_TRUE(comm->noLocal_);
 

--- a/comms/ncclx/meta/tests/CommWithPatAvgTest.cc
+++ b/comms/ncclx/meta/tests/CommWithPatAvgTest.cc
@@ -9,8 +9,6 @@
 
 #include "comm.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
-#include "meta/hints/CommHintConfig.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h"
 
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
@@ -24,9 +22,6 @@ class CommWithPatAvgTest : public NcclxBaseTestFixture {
   }
 
   void TearDown() override {
-    // Only reset our hint value, don't unregister all keys
-    ncclx::resetGlobalHint(
-        std::string(ncclx::HintKeys::kCommAlgoReduceScatter));
     NcclxBaseTestFixture::TearDown();
   }
 };
@@ -47,17 +42,24 @@ TEST_F(CommWithPatAvgTest, PatAvgEnableByCvar) {
   EXPECT_TRUE(comm->usePatAvg_);
 }
 
-TEST_F(CommWithPatAvgTest, PatAvgNotEnabledForOtherValues) {
+TEST_F(CommWithPatAvgTest, PatAvgNotEnabledByExplicitDisable) {
   EnvRAII cvarEnv(NCCL_REDUCESCATTER_PAT_AVG_ENABLE, false);
-
-  // Set hint to a different value
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "sum:ring"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "0"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII comm{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
+  ASSERT_NE(comm.get(), nullptr);
+  EXPECT_FALSE(comm->usePatAvg_);
+}
+
+TEST_F(CommWithPatAvgTest, PatAvgNotEnabledByUnrelatedHint) {
+  EnvRAII cvarEnv(NCCL_REDUCESCATTER_PAT_AVG_ENABLE, false);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"commDesc", "unrelated_hint"}};
+  config.hints = &hints;
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ASSERT_NE(comm.get(), nullptr);
   EXPECT_FALSE(comm->usePatAvg_);
 }
@@ -84,14 +86,8 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   config.blocking = blockingInit ? 1 : 0;
   const auto commDescStr = fmt::format("{}-{}", kNcclUtCommDesc, "usePatAvg");
-  ncclx::Hints patAvgHints({{"commDesc", commDescStr}});
+  ncclx::Hints patAvgHints({{"commDesc", commDescStr}, {"usePatAvg", "1"}});
   config.hints = &patAvgHints;
-
-  // Enable by hint
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
 
   // Use appropriate RAII wrapper based on creation mode
   std::optional<ncclx::test::NcclCommRAII> comm2Default;
@@ -119,10 +115,6 @@ TEST_P(CommWithPatAvgTestParam, PatAvgEnableByHintWithModes) {
   }
 
   EXPECT_TRUE(comm2->usePatAvg_);
-
-  ASSERT_TRUE(
-      ncclx::resetGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter)));
 
   // Now disabled again
   {

--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -14,7 +14,6 @@
 #include "nccl.h"
 
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "meta/hints/GlobalHints.h"
 
 class NcclxLazyConnectTestFixture
     : public NcclxBaseTestFixture,
@@ -37,8 +36,11 @@ class NcclxLazyConnectTestFixture
 
   ncclComm_t createRootComm() {
     if (isNoLocal()) {
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommNoLocal).c_str(), "1");
+      ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+      ncclx::Hints hints{{"noLocal", "1"}};
+      config.hints = &hints;
+      return ncclx::test::createNcclComm(
+          globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
     }
     return ncclx::test::createNcclComm(
         globalRank, numRanks, localRank, bootstrap_.get());
@@ -51,9 +53,6 @@ class NcclxLazyConnectTestFixture
   }
 
   void TearDown() override {
-    if (isNoLocal()) {
-      ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-    }
     if (sendBuf) {
       CUDACHECK_TEST(cudaFree(sendBuf));
       sendBuf = nullptr;

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -25,7 +25,6 @@
 #include "comm.h" // @manual
 #include "comms/ncclx/meta/logger/tests/LoggerUtil.h"
 #include "debug.h" // @manual
-#include "meta/hints/GlobalHints.h" // @manual
 #include "nccl.h" // @manual
 
 class MemoryTraceTestFixture : public NcclxBaseTestFixture,
@@ -221,18 +220,14 @@ class MemoryTraceTestFixture : public NcclxBaseTestFixture,
   void* sendBuf{nullptr};
   void* recvBuf{nullptr};
   bool mockPassthru{true};
+  bool noLocal_{false};
 };
 
 class MemoryTraceNolocalTestFixture : public MemoryTraceTestFixture {
  public:
   void SetUp() override {
-    ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1");
+    noLocal_ = true;
     MemoryTraceTestFixture::SetUp();
-  }
-
-  void TearDown() override {
-    MemoryTraceTestFixture::TearDown();
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
   }
 };
 
@@ -263,8 +258,14 @@ void MemoryTraceTestFixture::runNcclInternalBufferLogTest() {
   // First comm creation as well as first kernel launch has some extra memory
   // usage (https://fburl.com/code/rxjvjads), use second comm
   // creation/collective for testing
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  if (noLocal_) {
+    hints.set("noLocal", "1");
+  }
+  config.hints = &hints;
   comm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
   std::cout << "Rank " << this->globalRank << " finished init, run AR"
             << std::endl;
   size_t count = 1 << 10; // 1K elements
@@ -365,8 +366,14 @@ void MemoryTraceTestFixture::runUserBufferLoggingTest() {
 
   auto logFileName = initLogger();
   EXPECT_EQ(NCCL_COMM_WORLD, nullptr);
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints;
+  if (noLocal_) {
+    hints.set("noLocal", "1");
+  }
+  config.hints = &hints;
   comm = ncclx::test::createNcclComm(
-      globalRank, numRanks, localRank, bootstrap_.get());
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
   /* mapper registration logic */
   void *buf = nullptr, *segHdl = nullptr;

--- a/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterPatSelectTest.cc
@@ -21,7 +21,6 @@
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "meta/collectives/PatAvgHelper.h"
-#include "meta/hints/GlobalHints.h" // @manual
 #include "meta/wrapper/DataTypeStrUtils.h"
 
 /**
@@ -46,9 +45,6 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
 
   void TearDown() override {
     CUDACHECK_TEST(cudaStreamDestroy(stream));
-    // Reset global hint to avoid affecting subsequent tests
-    ncclx::resetGlobalHint(
-        std::string(ncclx::HintKeys::kCommAlgoReduceScatter));
     NcclxBaseTestFixture::TearDown();
   }
 
@@ -76,10 +72,12 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
       std::optional<std::string> expectedAlgo = std::nullopt,
       std::optional<std::string> unexpectedAlgo = std::nullopt,
       std::optional<double> tolerance = std::nullopt) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints{{"usePatAvg", usePatAvg ? "1" : "0"}};
+    config.hints = &hints;
     ncclx::test::NcclCommRAII commGuard{
-        globalRank, numRanks, localRank, bootstrap_.get()};
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
     ncclComm_t comm = commGuard.get();
-    comm->usePatAvg_ = usePatAvg;
 
     const size_t count = 8000;
     const size_t allocSize = count * numRanks * sizeof(T);
@@ -132,14 +130,11 @@ class ReduceScatterPatSelectTest : public NcclxBaseTestFixture {
  * so user ops continue through normal algorithm selection.
  */
 TEST_F(ReduceScatterPatSelectTest, UserPreMulSumNotConvertedToPatAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -193,14 +188,11 @@ TEST_F(ReduceScatterPatSelectTest, UserPreMulSumNotConvertedToPatAvg) {
  * and produces correct results (sum / nRanks).
  */
 TEST_F(ReduceScatterPatSelectTest, BuiltInAvgWithPatAvgWorks) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -360,14 +352,11 @@ INSTANTIATE_TEST_SUITE_P(
  * This is a negative test - it validates that the proper error is returned.
  */
 TEST_F(ReduceScatterPatSelectTest, GroupedReduceScatterPatAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 
@@ -477,14 +466,11 @@ TEST_F(ReduceScatterPatSelectTest, UsePatAvgCvarControl) {
  * 2. Other collectives (AllReduce with ncclAvg) - not affected
  */
 TEST_F(ReduceScatterPatSelectTest, UsePatAvgOnlyAffectsReduceScatterAvg) {
-  // Enable PAT AVG via global hint before comm creation
-  ASSERT_EQ(
-      ncclx::setGlobalHint(
-          std::string(ncclx::HintKeys::kCommAlgoReduceScatter), "avg:patavg"),
-      ncclSuccess);
-
+  ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints{{"usePatAvg", "1"}};
+  config.hints = &hints;
   ncclx::test::NcclCommRAII commGuard{
-      globalRank, numRanks, localRank, bootstrap_.get()};
+      globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
   ncclComm_t comm = commGuard.get();
   ASSERT_TRUE(comm->usePatAvg_);
 

--- a/comms/ncclx/meta/tests/SendRecvTest.cc
+++ b/comms/ncclx/meta/tests/SendRecvTest.cc
@@ -27,13 +27,14 @@ class SendRecvTest : public NcclxBaseTestFixture {
     setenv("NCCL_CTRAN_ENABLE", "1", 1);
     NcclxBaseTestFixture::SetUp();
     ctranAlgoStats_.enable();
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints;
 #ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ASSERT_EQ(
-        ncclx::setGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal), "1"),
-        ncclSuccess);
+    hints.set("noLocal", "1");
 #endif
+    config.hints = &hints;
     this->comm = ncclx::test::createNcclComm(
-        globalRank, numRanks, localRank, bootstrap_.get());
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config);
 
     CUDACHECK_TEST(cudaSetDevice(this->localRank));
     CUDACHECK_TEST(cudaStreamCreate(&this->stream));
@@ -42,9 +43,6 @@ class SendRecvTest : public NcclxBaseTestFixture {
   void TearDown() override {
     NCCLCHECK_TEST(ncclCommDestroy(this->comm));
     CUDACHECK_TEST(cudaStreamDestroy(this->stream));
-#ifdef NCCL_COMM_STATE_DEBUG_TOPO_NOLOCAL
-    ncclx::resetGlobalHint(std::string(ncclx::HintKeys::kCommNoLocal));
-#endif
     NcclxBaseTestFixture::TearDown();
   }
 

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -2425,10 +2425,10 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
-  // Ctran can be enabled either globally via CVAR or per-communicator using hint
-  comm->useCtran_ = ncclx::commUseCtran();
-  comm->usePatAvg_ = ncclx::commUsePatAvg();
-  comm->noLocal_ = ncclx::commNoLocal();
+  // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
+  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
@@ -3148,10 +3148,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
-    // Ctran can be enabled either globally via CVAR or per-communicator using hint
-    childComm->useCtran_ = ncclx::commUseCtran();
-    childComm->usePatAvg_ = ncclx::commUsePatAvg();
-    childComm->noLocal_ = ncclx::commNoLocal();
+    // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
+    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2585,10 +2585,10 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
   NCCLCHECKGOTO(ncclCudaHostCalloc(&comm->abortFlagDev, 1), res, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->abortFlagRefCount, 1), res, fail);
   comm->startMagic = comm->endMagic = NCCL_MAGIC; // Used to detect comm corruption.
-  // Ctran can be enabled either globally via CVAR or per-communicator using hint
-  comm->useCtran_ = ncclx::commUseCtran();
-  comm->usePatAvg_ = ncclx::commUsePatAvg();
-  comm->noLocal_ = ncclx::commNoLocal();
+  // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+  comm->useCtran_ = NCCLX_CONFIG_FIELD(*config, useCtran);
+  comm->usePatAvg_ = NCCLX_CONFIG_FIELD(*config, usePatAvg);
+  comm->noLocal_ = NCCLX_CONFIG_FIELD(*config, noLocal);
   INFO(NCCL_INIT, "CommInit comm %p commHash 0x%lx commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
        comm, getHash(commId->internal, NCCL_UNIQUE_ID_BYTES),
        NCCLX_CONFIG_FIELD(*config, commDesc).c_str(),
@@ -3309,10 +3309,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     /* start with ncclInternalError and will be changed to ncclSuccess if init succeeds. */
     childComm->initState = ncclInternalError;
-    // Ctran can be enabled either globally via CVAR or per-communicator using hint
-    childComm->useCtran_ = ncclx::commUseCtran();
-    childComm->usePatAvg_ = ncclx::commUsePatAvg();
-    childComm->noLocal_ = ncclx::commNoLocal();
+    // [META:PER_COMM_CONFIG] Read per-comm config from parsed ncclx::Config
+    childComm->useCtran_ = NCCLX_CONFIG_FIELD(childComm->config, useCtran);
+    childComm->usePatAvg_ = NCCLX_CONFIG_FIELD(childComm->config, usePatAvg);
+    childComm->noLocal_ = NCCLX_CONFIG_FIELD(childComm->config, noLocal);
     INFO(NCCL_INIT, "CommSplit comm %p commDesc %s useCtran %d usePatAvg %d noLocal %d: %s %s %s",
         childComm, NCCLX_CONFIG_FIELD(childComm->config, commDesc).c_str(),
         childComm->useCtran_, childComm->usePatAvg_, childComm->noLocal_, ncclx::getCommUseCtranConfig().c_str(),

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -5,6 +5,7 @@
 #include <folly/synchronization/CallOnce.h>
 
 #include <fmt/core.h>
+#include "comms/ctran/backends/ib/BootstrapExternal.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/utils/Checks.h"
@@ -200,11 +201,11 @@ bool RdmaTransport::supported() {
 }
 
 std::string RdmaTransport::bind() {
-  return ib_->getLocalVcIdentifier(kDummyRank);
+  return ib_->externalBootstrap()->getLocalVcId(kDummyRank);
 }
 
 commResult_t RdmaTransport::connect(const std::string& peerId) {
-  FB_COMMCHECK(ib_->connectVcDirect(peerId, kDummyRank));
+  FB_COMMCHECK(ib_->externalBootstrap()->connectVc(peerId, kDummyRank));
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary:
`CtranIb.cc` mixed four unrelated concerns into ~1500 lines:
- per-peer VC registry (rank/qp maps, connectedPeerMap)
- internal-bootstrap listen+accept+connect path
- external-bootstrap path (callsite-managed, used only by RdmaTransport
  while it migrates to Uniflow)
- core IB ops (iput/iget/iflush/progress/ctrlMsg)

This diff splits along those seams behavior-neutrally.

**New `ctran::ib::VcState`** (`VcState.{h,cpp}`) — pure registry. Owns
`vcStateMaps_`, `connectedPeerMap_`, `getVc`/`getVcByQp` templates,
`setupAndPublishVc`, `updateVcState`,
`isPeerConnected`/`markPeerConnected`. No I/O. Knows nothing about
bootstrap.

**New `ctran::ib::Bootstrap`** (`BootstrapInternal.{h,cpp}`) — internal
bootstrap service. Owns the listen socket, accept thread, and
client-connect path. Holds a `VcState&` and calls
`vcState_.setupAndPublishVc(...)` to publish each handshake. Public
surface: `start(qpServerAddr)`, `connect(peerRank, peerAddr)`,
`shutdown()` (idempotent via `shutdownCalled_` guard), `getListenAddress()`.

**`ctran::ib::ExternalBootstrapState` + `initExternalBootstrap`**
(`BootstrapExternal.{h,cpp}`) — the external path is isolated and
namespaced. Allocated only when `bootstrapMode == kExternal`. One-shot
deletable once RdmaTransport finishes moving to Uniflow. The CtranIb
member is named `externalBootstrapState_` to match its type.

**`CtranIb`** keeps its public API identical, and now holds three sibling
members:
- `ctran::ib::VcState vcState_`
- `std::unique_ptr<ctran::ib::Bootstrap> bootstrap_`
- `std::unique_ptr<ctran::ib::ExternalBootstrapState> externalBootstrapState_`

The listen-socket / listen-thread members and the
`bootstrapStart/Accept/Connect`/`connectVc` declarations are removed
from `CtranIb.h`. Templates that previously inlined
`bootstrapConnect(...)` now go through a private `ensureConnected(...)`
thunk defined in `CtranIb.cc`, so `CtranIb.h` never sees `Bootstrap`'s
definition. `getListenSocketListenAddr()` becomes non-inline (forwards
to `bootstrap_->getListenAddress()`).

**Coupling**: a single one-way arrow `Bootstrap → VcState`, single
method (`setupAndPublishVc`). `VcState` does not reference `Bootstrap`.
The external path is independent of both.

**Result**: `CtranIb.cc` shrinks from ~1500 to ~1080 lines; new
`docs/structure.md` documents the file map, namespacing, lifecycle, and
coupling rules.

Reviewed By: minsii

Differential Revision: D105665435
