### PR TITLE
add C10dBatchIsendIrecvTest covering PP-style batch_isend_irecv via BackendWrapper (#2622)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/torchcomms/BackendWrapper.hpp"
 #include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/utils/Logging.hpp"
 
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
 
@@ -587,6 +588,36 @@ bool BackendWrapper::verifyWorkTimeoutForTest(
 void BackendWrapper::setTimeout(std::chrono::milliseconds timeout) {
   options_->timeout = timeout;
 }
+void BackendWrapper::shutdown() {
+  // Idempotent: destroy_process_group iterates all backends and calls
+  // shutdown() on each, but multiple BackendWrappers can share the same
+  // underlying TorchComm (mixed cpu:gloo,cuda:nccl PGs registered through
+  // the backendType-to-wrapper dedup path). Finalize-on-already-finalized
+  // throws "TorchCommNCCL already finalized" — log and continue so destroy
+  // is always safe to call.
+  if (comm_) {
+    try {
+      comm_->finalize();
+    } catch (const std::exception& e) {
+      TC_LOG(WARNING)
+          << "BackendWrapper::shutdown: TorchComm::finalize() raised, "
+          << "treating as no-op (likely already finalized): " << e.what();
+    }
+  }
+}
+
+void BackendWrapper::abort() {
+  if (comm_) {
+    try {
+      comm_->abort();
+    } catch (const std::exception& e) {
+      TC_LOG(WARNING) << "BackendWrapper::abort: TorchComm::abort() raised, "
+                      << "treating as no-op (likely already aborted): "
+                      << e.what();
+    }
+  }
+}
+
 c10::intrusive_ptr<c10d::Backend> BackendWrapper::split(
     const c10::intrusive_ptr<c10d::Store>& /* store */,
     const std::vector<int>& ranks,

--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -534,26 +534,69 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
 }
 
-c10::intrusive_ptr<c10d::Work>
-BackendWrapper::send(std::vector<at::Tensor>& tensors, int dstRank, int tag) {
+c10::intrusive_ptr<c10d::Work> BackendWrapper::send(
+    std::vector<at::Tensor>& tensors,
+    int dstRank,
+    int /*tag*/) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
+  if (coalescing_batch_.has_value()) {
+    coalescing_batch_->send(tensors.at(0), dstRank);
+    // Per-op Work returned during coalescing is a no-op sentinel; the real
+    // Work covering the whole batch is returned by endCoalescing(). c10d's
+    // batch_isend_irecv discards these per-op returns.
+    return c10::make_intrusive<WorkWrapper>(
+        c10::make_intrusive<TorchWorkCompleted>(), tensors);
+  }
   return c10::make_intrusive<WorkWrapper>(
       comm_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
 }
 
-c10::intrusive_ptr<c10d::Work>
-BackendWrapper::recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) {
+c10::intrusive_ptr<c10d::Work> BackendWrapper::recv(
+    std::vector<at::Tensor>& tensors,
+    int srcRank,
+    int /*tag*/) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
+  if (coalescing_batch_.has_value()) {
+    coalescing_batch_->recv(tensors.at(0), srcRank);
+    return c10::make_intrusive<WorkWrapper>(
+        c10::make_intrusive<TorchWorkCompleted>(), tensors);
+  }
   return c10::make_intrusive<WorkWrapper>(
       comm_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
+}
+
+void BackendWrapper::startCoalescing() {
+  TORCH_CHECK(
+      !coalescing_batch_.has_value(),
+      "BackendWrapper::startCoalescing called while a batch is already active");
+  coalescing_batch_.emplace(comm_->batch_op_create());
+}
+
+c10::intrusive_ptr<c10d::Work> BackendWrapper::endCoalescing() {
+  TORCH_CHECK(
+      coalescing_batch_.has_value(),
+      "BackendWrapper::endCoalescing called without a matching startCoalescing");
+  // Move the batch out so we always reset state, even if issue() throws.
+  auto batch = std::move(*coalescing_batch_);
+  coalescing_batch_.reset();
+  if (batch.ops.empty()) {
+    // Empty coalescing window — return a completed sentinel so callers can
+    // .wait() without blocking.
+    return c10::make_intrusive<WorkWrapper>(
+        c10::make_intrusive<TorchWorkCompleted>());
+  }
+  BatchP2POptions bopts;
+  bopts.timeout = options_->timeout;
+  return c10::make_intrusive<WorkWrapper>(
+      batch.issue(/*async_op=*/true, bopts));
 }
 
 std::shared_ptr<TorchComm> BackendWrapper::getComm() const {

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -7,8 +7,11 @@
 #include <torch/csrc/distributed/c10d/Work.hpp> // @manual=//caffe2:torch-cpp-cpu
 
 #include "comms/torchcomms/TorchCommBackend.hpp"
+#include "comms/torchcomms/TorchCommBatch.hpp"
 #include "comms/torchcomms/TorchCommTypes.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
+
+#include <optional>
 
 namespace torch::comms {
 
@@ -117,6 +120,17 @@ class BackendWrapper : public c10d::Backend {
   c10::intrusive_ptr<c10d::Work>
   recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) override;
 
+  // Coalescing hooks: c10d's _coalescing_manager (used by
+  // dist.batch_isend_irecv) calls these around a sequence of send/recv ops so
+  // the backend can issue them as one ncclGroupStart/End. Without them, mixed
+  // P2P batches on a single PG (e.g. PP 1F1B middle stage) deadlock because
+  // each tc.send/tc.recv is enqueued ungrouped on the same NCCL stream.
+  bool supportsCoalescing() const override {
+    return true;
+  }
+  void startCoalescing() override;
+  c10::intrusive_ptr<c10d::Work> endCoalescing() override;
+
   // Get the underlying backend comm for backend-specific operations
   std::shared_ptr<TorchComm> getComm() const;
 
@@ -161,6 +175,12 @@ class BackendWrapper : public c10d::Backend {
  private:
   std::shared_ptr<TorchComm> comm_;
   c10::intrusive_ptr<Options> options_;
+
+  // Active coalescing batch. Engaged between startCoalescing() and
+  // endCoalescing(); send()/recv() append into it instead of issuing
+  // immediately. c10d's coalescing manager serializes per-PG, so a single
+  // slot suffices.
+  std::optional<BatchSendRecv> coalescing_batch_;
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -146,6 +146,18 @@ class BackendWrapper : public c10d::Backend {
       const std::vector<int>& ranks,
       const c10::intrusive_ptr<c10d::Backend::Options>& opts) override;
 
+  // Called by torch.distributed.destroy_process_group(). Calls
+  // TorchComm::finalize() to drain in-flight work and close the comm
+  // gracefully — without this override the inherited base no-op leaves the
+  // communicator alive and the destructor's synchronous ncclCommDestroy
+  // can deadlock against the NCCL GC thread holding Work refs.
+  void shutdown() override;
+
+  // Called by destroy_process_group when the user wants forceful teardown.
+  // Delegates to TorchComm::abort() which uses graceful revoke in
+  // reconfigurable mode and destructive abort otherwise.
+  void abort() override;
+
  private:
   std::shared_ptr<TorchComm> comm_;
   c10::intrusive_ptr<Options> options_;

--- a/comms/torchcomms/TorchComm.cpp
+++ b/comms/torchcomms/TorchComm.cpp
@@ -4,6 +4,7 @@
 #include "comms/torchcomms/TorchCommFactory.hpp"
 
 #include <atomic>
+#include <limits>
 
 namespace torch::comms {
 
@@ -88,10 +89,17 @@ std::shared_ptr<TorchComm> new_comm(
 }
 
 void TorchComm::finalize() {
-  auto op_id = GlobalOpIdGenerator::instance().nextOpId();
-  preHook(op_id, FinalizePreHookArgs{});
+  // finalize is a lifecycle event, not a collective — don't consume a
+  // global op_id slot. Built-in hooks (FlightRecorder, Clog) all
+  // short-circuit on finalize, and FlightRecorder keys its ring-buffer
+  // slot off op_id. Bumping the global counter here would leave a hole
+  // in the FR's index space. Use a sentinel op_id instead so
+  // pre/post hooks still pair on the same value for finalize-aware
+  // Python custom hooks.
+  constexpr size_t kFinalizeOpId = std::numeric_limits<size_t>::max();
+  preHook(kFinalizeOpId, FinalizePreHookArgs{});
   impl_->finalize();
-  postHook(op_id, FinalizePostHookArgs{});
+  postHook(kFinalizeOpId, FinalizePostHookArgs{});
 }
 
 int TorchComm::getRank() const {

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderFinalizeOpIdTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderFinalizeOpIdTest.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Regression test for the FlightRecorder gap-on-finalize bug.
+
+``TorchComm::finalize()`` previously consumed a slot from the global
+``op_id`` counter via ``GlobalOpIdGenerator::nextOpId()``, but the
+``FlightRecorderHook`` short-circuits before recording finalize. That
+left a hole in the recorder's index space and, because ``record()``
+keys its ring-buffer slot off ``op_id % max_entries_``, the next real
+collective tripped the growth-phase assertion
+``entries_.size() == idx + 1``.
+
+This test exercises the exact sequence: create comm, record a
+collective, finalize, then create a *new* comm and record another
+collective sharing the same recorder. Pre-fix, the second collective
+trips the assertion. Post-fix, both collectives are recorded with
+sequential ``op_id`` values and no gap.
+"""
+
+import json
+import os
+import unittest
+from datetime import timedelta
+
+import torch
+import torchcomms
+from torchcomms.hooks import FlightRecorderHook
+
+
+class TestFlightRecorderFinalizeOpId(unittest.TestCase):
+    backend = os.environ["TEST_BACKEND"]
+    device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+
+    def test_finalize_does_not_consume_op_id(self) -> None:
+        # ``isolated=True`` resets the global op_id generator so the
+        # comm's first op starts at 0, making the post-fix expectation
+        # below deterministic.
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+
+        # --- First comm life cycle: one collective, then finalize. ---
+        comm1 = torchcomms.new_comm(
+            backend=self.backend,
+            device=self.device,
+            name="fr_finalize_op_id_1",
+            timeout=timedelta(seconds=300),
+        )
+        recorder.register_with_comm(comm1)
+        t = torch.rand(4, device=self.device)
+        comm1.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+        comm1.finalize()
+
+        # --- Second comm life cycle: one more collective on a fresh
+        # comm sharing the same recorder. Pre-fix this is where the FR
+        # growth-phase assertion fires because finalize on comm1 bumped
+        # the global op_id counter without producing a recorder entry. ---
+        comm2 = torchcomms.new_comm(
+            backend=self.backend,
+            device=self.device,
+            name="fr_finalize_op_id_2",
+            timeout=timedelta(seconds=300),
+        )
+        recorder.register_with_comm(comm2)
+        comm2.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Two collectives recorded; finalize must not have caused a gap.
+        self.assertEqual(recorder.size(), 2)
+        dump = json.loads(recorder.dump_json())
+        op_ids = [entry["op_id"] for entry in dump["entries"]]
+        self.assertEqual(
+            len(op_ids), 2, f"expected 2 recorded ops, got entries={dump['entries']}"
+        )
+        op_ids.sort()
+        # Sequential, no gap from finalize between them.
+        self.assertEqual(
+            op_ids[1] - op_ids[0],
+            1,
+            f"finalize on comm1 must not consume an op_id slot, but got "
+            f"non-sequential op_ids={op_ids}",
+        )
+
+        comm2.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/tests/integration/py/BackendWrapperCoalescingTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperCoalescingTest.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Verify ``BackendWrapper`` implements c10d's coalescing hooks so
+``dist.batch_isend_irecv`` issues each batch as one ``ncclGroupStart``/
+``ncclGroupEnd`` pair via the underlying ``TorchCommBatch`` instead of
+running each P2POp ungrouped (which can deadlock for mixed send/recv
+batches like the PP 1F1B middle stage).
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torchcomms.tests.helpers.py.test_helpers import skip_if_ncclx
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+
+@skip_if_ncclx
+class TestBackendWrapperCoalescing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dist.config.use_torchcomms = True
+        rank, world_size = get_rank_and_size()
+        dist.init_process_group(
+            backend=os.environ["TEST_BACKEND"], rank=rank, world_size=world_size
+        )
+        device = get_device(os.environ["TEST_BACKEND"], dist.get_rank())
+        torch.set_default_device(device)
+        cls.device = device
+
+    @classmethod
+    def tearDownClass(cls):
+        dist.destroy_process_group()
+
+    def test_supports_coalescing_is_true(self):
+        """``supportsCoalescing`` is overridden to ``True`` so c10d's
+        ``_coalescing_manager`` (used by ``batch_isend_irecv``) calls
+        ``startCoalescing`` / ``endCoalescing`` instead of issuing each
+        P2POp individually."""
+        pg = dist.distributed_c10d._get_default_group()
+        backend = pg._get_backend(self.device)
+        self.assertTrue(
+            backend.supports_coalescing,
+            "BackendWrapper.supports_coalescing must be True so "
+            "batch_isend_irecv takes the coalescing path",
+        )
+
+    def test_batch_isend_irecv_mixed_send_recv(self):
+        """A mixed isend+irecv batch in a single ``batch_isend_irecv``
+        call delivers correctly. Without coalescing this pattern (mirrors
+        PP 1F1B middle stage) deadlocks because each tc.send / tc.recv is
+        enqueued ungrouped on the same NCCL stream."""
+        world_size = dist.get_world_size()
+        if world_size < 2:
+            self.skipTest("need at least 2 ranks for batch_isend_irecv")
+
+        rank = dist.get_rank()
+        peer = (rank + 1) % world_size
+        recv_peer = (rank - 1) % world_size
+        send_tensor = torch.full((4,), float(rank), dtype=torch.float32)
+        recv_tensor = torch.empty(4, dtype=torch.float32)
+
+        ops = [
+            dist.P2POp(dist.isend, send_tensor, peer),
+            dist.P2POp(dist.irecv, recv_tensor, recv_peer),
+        ]
+        for req in dist.batch_isend_irecv(ops):
+            req.wait()
+        if self.device.type == "cuda":
+            torch.cuda.synchronize()
+
+        expected = torch.full((4,), float(recv_peer), dtype=torch.float32)
+        self.assertTrue(
+            torch.equal(recv_tensor, expected),
+            f"recv mismatch: got {recv_tensor.tolist()}, expected {expected.tolist()}",
+        )
+
+    def test_batch_isend_irecv_multiple_peers(self):
+        """A batch of N sends + N recvs across multiple peers in a single
+        coalesced batch — exercises the ncclGroupStart/End grouping over
+        more than one P2P pair."""
+        world_size = dist.get_world_size()
+        if world_size < 3:
+            self.skipTest("need at least 3 ranks for multi-peer batch")
+
+        rank = dist.get_rank()
+        # Send to (rank+1) and (rank+2), receive from (rank-1) and (rank-2).
+        send_tensors = [
+            torch.full((4,), float(rank * 10 + i), dtype=torch.float32)
+            for i in range(2)
+        ]
+        recv_tensors = [torch.empty(4, dtype=torch.float32) for _ in range(2)]
+        send_peers = [(rank + 1) % world_size, (rank + 2) % world_size]
+        recv_peers = [(rank - 1) % world_size, (rank - 2) % world_size]
+
+        ops = []
+        for i in range(2):
+            ops.append(dist.P2POp(dist.isend, send_tensors[i], send_peers[i]))
+            ops.append(dist.P2POp(dist.irecv, recv_tensors[i], recv_peers[i]))
+
+        for req in dist.batch_isend_irecv(ops):
+            req.wait()
+        if self.device.type == "cuda":
+            torch.cuda.synchronize()
+
+        for i in range(2):
+            expected_value = float(recv_peers[i] * 10 + i)
+            expected = torch.full((4,), expected_value, dtype=torch.float32)
+            self.assertTrue(
+                torch.equal(recv_tensors[i], expected),
+                f"slot {i} (from rank {recv_peers[i]}): got "
+                f"{recv_tensors[i].tolist()}, expected {expected.tolist()}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+"""Verify ``BackendWrapper::shutdown`` and ``::abort`` close the underlying
+``TorchComm`` cleanly when ``torch.distributed.destroy_process_group()``
+is called.
+
+Two regressions guarded against:
+
+1. **Deadlock on destroy**: without a ``shutdown`` override the wrapper's
+   destructor would invoke ``ncclCommDestroy`` synchronously and could
+   deadlock against the NCCL GC thread.
+
+2. **Double-finalize raise**: a mixed ``cpu:gloo,cuda:nccl`` PG ends up
+   with two BackendWrappers sharing one underlying ``TorchComm`` (via the
+   BackendType-to-wrapper dedup). ``destroy_process_group`` calls
+   ``shutdown`` on each backend; ``TorchComm::finalize`` is not idempotent
+   and would raise ``RuntimeError: TorchCommNCCL already finalized`` on
+   the second call. The wrapper swallows the exception so destroy is safe
+   to call any number of times.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from packaging.version import InvalidVersion, Version
+from torchcomms.tests.helpers.py.test_helpers import skip_if_ncclx
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+_TORCHCOMMS_CONFIG_AVAILABLE = hasattr(dist, "config") and hasattr(
+    dist.config, "use_torchcomms"
+)
+
+_PR_182057_TORCH_VERSION = Version("2.13.0.dev20260502")
+
+
+def _torch_predates_pr_182057() -> bool:
+    try:
+        return Version(torch.__version__) < _PR_182057_TORCH_VERSION
+    except InvalidVersion:
+        # Unparsable version string — assume newer to avoid silently
+        # skipping on something we can't classify.
+        return False
+
+
+def _local_rank() -> int:
+    return int(os.environ.get("LOCAL_RANK", get_rank_and_size()[0]))
+
+
+@unittest.skipUnless(
+    _TORCHCOMMS_CONFIG_AVAILABLE,
+    "dist.config.use_torchcomms not available in this PyTorch version",
+)
+@skip_if_ncclx
+class TestBackendWrapperShutdown(unittest.TestCase):
+    """Each test creates its own PG, runs a small collective, then tears
+    it down — no shared setUpClass, since the goal is to exercise the
+    init+destroy cycle itself."""
+
+    def _init_pg(self, backend: str) -> None:
+        rank, world_size = get_rank_and_size()
+        # NCCL requires a CUDA device to be bound to this rank before
+        # ``init_process_group`` so that the per-rank communicator gets
+        # the right device. Without this, all ranks default to cuda:0
+        # and NCCL bootstrap fails. ``get_device`` can return
+        # ``torch.device("cuda")`` with no index when ``TEST_DEVICE=cuda``
+        # is set, so resolve the index explicitly from LOCAL_RANK / rank.
+        device = get_device(os.environ["TEST_BACKEND"], rank)
+        if device.type == "cuda":
+            if device.index is None:
+                device = torch.device(f"cuda:{_local_rank()}")
+            torch.cuda.set_device(device)
+        dist.config.use_torchcomms = True
+        dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+        torch.set_default_device(device)
+
+    def test_destroy_after_collective_no_hang(self):
+        """A simple init → all_reduce → destroy cycle finishes without
+        hanging. Catches the original ``ncclCommDestroy`` deadlock."""
+        self._init_pg(os.environ["TEST_BACKEND"])
+        try:
+            tensor = torch.ones(8, dtype=torch.float32)
+            dist.all_reduce(tensor)
+            self.assertEqual(tensor[0].item(), float(dist.get_world_size()))
+        finally:
+            dist.destroy_process_group()
+
+    def test_mixed_backend_destroy_idempotent(self):
+        """Mixed ``cpu:gloo,cuda:nccl`` PG: ``destroy_process_group``
+        shuts down both sub-backends, which share one ``TorchComm``.
+        Without idempotent ``shutdown``, the second call raises
+        ``TorchCommNCCL already finalized``."""
+        if os.environ["TEST_BACKEND"] != "nccl":
+            self.skipTest("mixed backend test is nccl-specific")
+        if _torch_predates_pr_182057():
+            self.skipTest(
+                f"torch {torch.__version__} predates pytorch/pytorch#182057 "
+                f"({_PR_182057_TORCH_VERSION}); mixed cpu:gloo,cuda:nccl + "
+                "device_id= trips the ProcessGroup::setBackend "
+                "bound_device_id check on init"
+            )
+
+        rank, world_size = get_rank_and_size()
+        local_rank = _local_rank()
+        torch.cuda.set_device(local_rank)
+        dist.config.use_torchcomms = True
+        dist.init_process_group(
+            backend="cpu:gloo,cuda:nccl",
+            rank=rank,
+            world_size=world_size,
+            device_id=torch.device(f"cuda:{local_rank}"),
+        )
+        try:
+            torch.set_default_device(f"cuda:{local_rank}")
+            cpu_tensor = torch.ones(4, dtype=torch.float32, device="cpu")
+            cuda_tensor = torch.ones(
+                4, dtype=torch.float32, device=f"cuda:{local_rank}"
+            )
+            dist.all_reduce(cpu_tensor)
+            dist.all_reduce(cuda_tensor)
+            self.assertEqual(cpu_tensor[0].item(), float(world_size))
+            self.assertEqual(cuda_tensor[0].item(), float(world_size))
+        finally:
+            # Must not raise even though both sub-backends share the comm.
+            dist.destroy_process_group()

--- a/comms/torchcomms/tests/integration/py/C10dBatchIsendIrecvTest.py
+++ b/comms/torchcomms/tests/integration/py/C10dBatchIsendIrecvTest.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# pyre-unsafe
+
+"""Integration tests for dist.batch_isend_irecv routed through BackendWrapper.
+
+Pipeline parallel uses dist.batch_isend_irecv to issue mixed (send + recv)
+batches on a single PG. Without coalescing support in BackendWrapper, each
+ungrouped tc.send/tc.recv is enqueued back-to-back on the same NCCL stream
+and bidirectional patterns deadlock. The tests below exercise exactly that
+pattern to guard the BackendWrapper coalescing path.
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+from torchcomms.tests.helpers.py.test_helpers import skip_if_ncclx
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_device,
+    get_rank_and_size,
+)
+
+
+@skip_if_ncclx
+class TestC10dBackendWrapperBatchIsendIrecv(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        dist.config.use_torchcomms = True
+        rank, world_size = get_rank_and_size()
+        dist.init_process_group(
+            backend=os.environ["TEST_BACKEND"], rank=rank, world_size=world_size
+        )
+        device = get_device(os.environ["TEST_BACKEND"], dist.get_rank())
+        torch.set_default_device(device)
+
+    @classmethod
+    def tearDownClass(cls):
+        dist.destroy_process_group()
+
+    def setUp(self):
+        if dist.get_world_size() < 2:
+            self.skipTest("batch_isend_irecv tests require world_size >= 2")
+        self.rank = dist.get_rank()
+        self.world = dist.get_world_size()
+        self.next = (self.rank + 1) % self.world
+        self.prev = (self.rank - 1 + self.world) % self.world
+
+    def test_supports_coalescing(self):
+        """BackendWrapper must advertise coalescing for batch_isend_irecv to
+        use the grouped fast path instead of the per-op fallback."""
+        device = get_device(os.environ["TEST_BACKEND"], self.rank)
+        backend = dist.group.WORLD._get_backend(device)
+        self.assertTrue(backend.supports_coalescing)
+
+    def test_batch_isend_irecv_mixed_ring(self):
+        """Each rank concurrently sends to next and receives from prev — the
+        canonical PP 1F1B middle-stage pattern. Without ncclGroupStart/End
+        coalescing this deadlocks; with it, every rank gets the prev rank's
+        value back."""
+        send_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+
+        ops = [
+            dist.P2POp(dist.isend, send_tensor, self.next),
+            dist.P2POp(dist.irecv, recv_tensor, self.prev),
+        ]
+        works = dist.batch_isend_irecv(ops)
+        for w in works:
+            w.wait()
+
+        self.assertEqual(recv_tensor.item(), float(self.prev))
+
+    def test_batch_isend_irecv_recv_first(self):
+        """Same as above but with the recv listed before the send. Order
+        within a batch shouldn't matter once the ops are coalesced into a
+        single ncclGroup."""
+        send_tensor = torch.tensor([self.rank * 10 + 1], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+
+        ops = [
+            dist.P2POp(dist.irecv, recv_tensor, self.prev),
+            dist.P2POp(dist.isend, send_tensor, self.next),
+        ]
+        works = dist.batch_isend_irecv(ops)
+        for w in works:
+            w.wait()
+
+        self.assertEqual(recv_tensor.item(), float(self.prev * 10 + 1))
+
+    def test_batch_isend_irecv_multiple_ops_per_peer(self):
+        """Multiple sends and recvs to/from the same peers in one batch —
+        exercises the batch with >2 ops, the realistic PP middle-stage shape
+        when activations and gradients overlap on the same neighbor."""
+        send1 = torch.tensor([self.rank], dtype=torch.float32)
+        send2 = torch.tensor([self.rank + 100], dtype=torch.float32)
+        recv1 = torch.empty(1, dtype=torch.float32)
+        recv2 = torch.empty(1, dtype=torch.float32)
+
+        ops = [
+            dist.P2POp(dist.isend, send1, self.next),
+            dist.P2POp(dist.irecv, recv1, self.prev),
+            dist.P2POp(dist.isend, send2, self.next),
+            dist.P2POp(dist.irecv, recv2, self.prev),
+        ]
+        works = dist.batch_isend_irecv(ops)
+        for w in works:
+            w.wait()
+
+        self.assertEqual(recv1.item(), float(self.prev))
+        self.assertEqual(recv2.item(), float(self.prev + 100))
+
+    def test_individual_isend_irecv_outside_coalescing(self):
+        """Verify the non-coalesced path still works after coalescing was
+        used — coalescing_batch_ must be cleared on endCoalescing."""
+        # First do a coalesced batch.
+        send_tensor = torch.tensor([self.rank], dtype=torch.float32)
+        recv_tensor = torch.empty(1, dtype=torch.float32)
+        ops = [
+            dist.P2POp(dist.isend, send_tensor, self.next),
+            dist.P2POp(dist.irecv, recv_tensor, self.prev),
+        ]
+        for w in dist.batch_isend_irecv(ops):
+            w.wait()
+
+        # Then a separate ordinary send/recv ring — must not see leftover
+        # coalescing state.
+        send2 = torch.tensor([self.rank + 1000], dtype=torch.float32)
+        recv2 = torch.empty(1, dtype=torch.float32)
+        if self.rank % 2 == 0:
+            dist.send(send2, dst=self.next)
+            dist.recv(recv2, src=self.prev)
+        else:
+            dist.recv(recv2, src=self.prev)
+            dist.send(send2, dst=self.next)
+        self.assertEqual(recv2.item(), float(self.prev + 1000))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:

Adds `comms/torchcomms/tests/integration/py/C10dBatchIsendIrecvTest.py`, a c10d-level integration test that exercises `dist.batch_isend_irecv` routed through `BackendWrapper` to guard the PP coalescing path.

Reviewed By: kapilsh, d4l3k

Differential Revision: D105355057


