### PR TITLE
Fix cudaFreeHost crash during Transport singleton destruction

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -11,6 +11,8 @@
 
 namespace ctran {
 
+std::atomic<int> CtranTcpDm::activeInstances_{0};
+
 #define COMMCHECK_TCP(cmd)                                            \
   do {                                                                \
     ::comms::tcp_devmem::Status RES = cmd;                            \
@@ -184,6 +186,7 @@ commResult_t CtranTcpDm::bootstrapConnect(
 
 CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
   transport_ = CtranTcpDmSingleton::getTransport();
+  activeInstances_.fetch_add(1, std::memory_order_acq_rel);
 
   cudaDev_ = comm->statex_->cudaDev();
   rank_ = comm->statex_->rank();
@@ -214,6 +217,13 @@ CtranTcpDm::~CtranTcpDm() {
   }
   for (auto comm : recvComms_) {
     transport_->closeRecv(comm.second);
+  }
+
+  // Shut down the transport when the last CtranTcpDm instance is destroyed,
+  // while the CUDA context is still alive. Deferring to the folly::Singleton
+  // destructor at process exit causes cudaFreeHost() to fail.
+  if (activeInstances_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    transport_->shutdown(false);
   }
 }
 

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <unordered_map>
 
 #include "comms/ctran/CtranComm.h"
@@ -90,6 +91,11 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool);
 
  private:
+  // Tracks the number of live CtranTcpDm instances so the last one to be
+  // destroyed can shut down the Transport while CUDA is still alive,
+  // rather than leaving it to the folly::Singleton destructor at process exit.
+  static std::atomic<int> activeInstances_;
+
   std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;
   ctran::bootstrap::ServerSocket listenSocket_{
       static_cast<int>(NCCL_SOCKET_RETRY_CNT)};


### PR DESCRIPTION
Summary:
## Problem

After D104762243 switched CtranTcpDmSingleton from LeakySingleton to
folly::Singleton, `cudaFreeHost` crashes with `cudaErrorInvalidValue` (rc=1)
at process exit when using nccl-test (MPI mode) with unpack enabled.

## Root Cause

The CUDA primary context is invalidated by MPI/NCCL teardown before the
folly::Singleton Transport destructor runs.

The singleton always holds one internal reference, so the Transport outlives
all `CtranTcpDm` instances and is only destroyed at process exit.

## Fix

1. Call `transport_->shutdown(false)` from `CtranTcpDm::~CtranTcpDm()` to trigger Transport cleanup while CUDA context is still alive.

2. Move `devices_.clear()` and `availableDevices_.clear()` from `stopWorkers()`
   to the end of `shutdown()`. since they are needed in `shutdownUnpack()`.

Reviewed By: erfan111

Differential Revision: D105644598


