### PR TITLE
disable `GraphEventTracker` monitoring when colltrace graph tracing is enabled and enable colltrace-based watchdog

### DIFF
--- a/.github/scripts/setup_env.sh
+++ b/.github/scripts/setup_env.sh
@@ -42,7 +42,7 @@ fi
 
 # Install system packages
 dnf config-manager --set-enabled powertools
-dnf install -y almalinux-release-devel
+dnf install -y almalinux-release-devel gcc-toolset-13-libatomic-devel
 
 if [ "$INSTALL_CMAKE" = true ]; then
   dnf install -y ninja-build cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,13 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.31)
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 endif()
 
-# colltrace's HRDWRingBufferReader uses __atomic_load_n on a 128-bit value,
-# which the compiler lowers to __atomic_load_16 (libatomic). On x86_64 we
-# sidestep this in source via an SSE2 MOVDQA specialization (see
-# HRDWRingBufferReader.h), so no libatomic dep is needed there. On other
-# archs (aarch64, etc.) we fall back to linking libatomic.
-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
-    add_link_options("LINKER:--push-state,--no-as-needed" "-latomic" "LINKER:--pop-state")
-endif()
+# colltrace's HRDWRingBufferReader and TrainerContext use 128-bit atomic
+# loads/stores. The compiler may lower these to __atomic_load_16 /
+# __atomic_store_16 (libatomic) depending on the target and flags. Link
+# libatomic unconditionally so the libcall always resolves; on x86_64 with
+# -mcx16 (or aarch64 with LSE2) most ops inline and the dep is effectively
+# free.
+add_link_options("LINKER:--push-state,--no-as-needed" "-latomic" "LINKER:--pop-state")
 
 # Options
 option(USE_NCCL "Whether to build NCCL or not" ON)

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -326,18 +326,11 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
   auto plugins =
       std::vector<std::unique_ptr<meta::comms::colltrace::ICollTracePlugin>>{};
 
-  auto evictionMode = NCCL_COLLTRACE_ITERATION_MODE
-      ? meta::comms::colltrace::EvictionMode::Iteration
-      : meta::comms::colltrace::EvictionMode::FixedCount;
-
   auto commDumpPlugin =
       std::make_unique<meta::comms::colltrace::CommDumpPlugin>(
           meta::comms::colltrace::CommDumpConfig{
               .pastCollSize = NCCL_COLLTRACE_RECORD_MAX,
               .pendingCollSize = NCCL_COLLTRACE_PENDING_QUEUE_SIZE,
-              .evictionMode = evictionMode,
-              .maxIterations = NCCL_COLLTRACE_RECORD_MAX_ITERATIONS,
-              .iterationUpperBound = NCCL_COLLTRACE_ITERATION_UPPER_BOUND,
           });
   plugins.push_back(std::move(commDumpPlugin));
 

--- a/comms/ncclx/v2_29/makefiles/common.mk
+++ b/comms/ncclx/v2_29/makefiles/common.mk
@@ -83,15 +83,13 @@ NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --expt-extended-lambda -Xp
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt -lstdc++fs
 
-# colltrace's HRDWRingBufferReader uses __atomic_load_n on a 128-bit value,
-# which the compiler lowers to __atomic_load_16 (libatomic). On x86_64 we
-# sidestep this in source via an SSE2 MOVDQA specialization (see
-# HRDWRingBufferReader.h), so no libatomic dep is needed there. On other
-# archs (e.g. aarch64) we fall back to linking libatomic.
-HOST_ARCH := $(shell uname -m)
-ifneq ($(HOST_ARCH),x86_64)
+# colltrace's HRDWRingBufferReader and TrainerContext use 128-bit atomic
+# loads/stores. The compiler may lower these to __atomic_load_16 /
+# __atomic_store_16 (libatomic) depending on the target and flags. Link
+# libatomic unconditionally so the libcall always resolves; on x86_64 with
+# -mcx16 (or aarch64 with LSE2) most ops inline and the dep is effectively
+# free.
 LDFLAGS   += -latomic
-endif
 
 NVCUFLAGS_SYM :=
 

--- a/comms/ncclx/v2_30/makefiles/common.mk
+++ b/comms/ncclx/v2_30/makefiles/common.mk
@@ -106,15 +106,13 @@ endif
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt
 
-# colltrace's HRDWRingBufferReader uses __atomic_load_n on a 128-bit value,
-# which the compiler lowers to __atomic_load_16 (libatomic). On x86_64 we
-# sidestep this in source via an SSE2 MOVDQA specialization (see
-# HRDWRingBufferReader.h), so no libatomic dep is needed there. On other
-# archs (e.g. aarch64) we fall back to linking libatomic.
-HOST_ARCH := $(shell uname -m)
-ifneq ($(HOST_ARCH),x86_64)
+# colltrace's HRDWRingBufferReader and TrainerContext use 128-bit atomic
+# loads/stores. The compiler may lower these to __atomic_load_16 /
+# __atomic_store_16 (libatomic) depending on the target and flags. Link
+# libatomic unconditionally so the libcall always resolves; on x86_64 with
+# -mcx16 (or aarch64 with LSE2) most ops inline and the dep is effectively
+# free.
 LDFLAGS   += -latomic
-endif
 
 NVCUFLAGS_SYM :=
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -52,6 +52,15 @@ void validateIntDtype(const at::Tensor& tensor, std::string_view name) {
 
 std::atomic<int> g_graphTimeoutMonitoringState{-1};
 
+bool isColltraceGraphTracingEnabled() {
+  const char* env = std::getenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  if (env == nullptr) {
+    return false;
+  }
+  std::string val(env);
+  return val == "1" || val == "true";
+}
+
 } // namespace
 
 bool isGraphTimeoutMonitoringEnabled() {
@@ -63,6 +72,13 @@ bool isGraphTimeoutMonitoringEnabled() {
       std::string val(env);
       enabled = (val != "0" && val != "false");
     }
+    if (enabled && isColltraceGraphTracingEnabled()) {
+      LOG(WARNING)
+          << "[TC] NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled — "
+          << "disabling GraphEventTracker timeout monitoring in favor of "
+          << "colltrace watchdog plugin";
+      enabled = false;
+    }
     state = enabled ? 1 : 0;
     g_graphTimeoutMonitoringState.store(state, std::memory_order_relaxed);
   }
@@ -71,6 +87,37 @@ bool isGraphTimeoutMonitoringEnabled() {
 
 void resetGraphTimeoutMonitoringCacheForTest() {
   g_graphTimeoutMonitoringState.store(-1, std::memory_order_relaxed);
+}
+
+bool tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds timeout) {
+  const char* monitoringEnv =
+      std::getenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
+  if (monitoringEnv != nullptr) {
+    std::string val(monitoringEnv);
+    if (val == "0" || val == "false") {
+      return false;
+    }
+  }
+  if (!isColltraceGraphTracingEnabled()) {
+    return false;
+  }
+  if (ncclx::setGlobalHint("ncclx.colltrace.crashOnAsyncError", "1") !=
+      ncclSuccess) {
+    LOG(WARNING) << "[TC] Failed to enable colltrace async error checking";
+    return false;
+  }
+  if (ncclx::setGlobalHint("ncclx.colltrace.crashOnTimeout", "1") !=
+      ncclSuccess) {
+    LOG(WARNING) << "[TC] Failed to enable colltrace timeout checking";
+    return false;
+  }
+  if (ncclx::setGlobalHint(
+          "ncclx.colltrace.timeoutMs", std::to_string(timeout.count())) !=
+      ncclSuccess) {
+    LOG(WARNING) << "[TC] Failed to set colltrace watchdog timeout";
+    return false;
+  }
+  return true;
 }
 
 TorchCommNCCLX::TorchCommNCCLX()
@@ -160,6 +207,14 @@ void TorchCommNCCLX::init(
     TC_LOG(INFO, this)
         << "TorchCommNCCLX dynamic regime enabled, deferring initialization";
     return;
+  }
+
+  // When TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is enabled (default) and
+  // NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, set colltrace watchdog hints before
+  // creating the NCCL communicator — the colltrace plugin is configured
+  // during ncclCommInitRank and must see the hints at that point.
+  if (!isGraphTimeoutMonitoringEnabled()) {
+    tryEnableColltraceTimeoutWatchdog(options_.timeout);
   }
 
   if (device_.index() == -1 || nccl_comm_ == nullptr) {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -64,10 +64,19 @@ constexpr size_t kDefaultGraphTimeoutCheckIntervalMs = 1000;
 // Global call-once check for graph timeout monitoring (env var gated).
 // Reads TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING on first call; caches result.
 // Default: enabled. Set to "0" or "false" to disable (for benchmarking).
+// Also returns false when NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled, since
+// the colltrace watchdog plugin handles graph timeout detection instead.
 bool isGraphTimeoutMonitoringEnabled();
 
 // Test-only: reset the cached state so next call re-reads the env var.
 void resetGraphTimeoutMonitoringCacheForTest();
+
+// When NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled, configures the colltrace
+// watchdog plugin to handle async error checking and timeout detection for
+// graph-captured collectives via ncclx global hints.
+// No-op when TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is explicitly disabled.
+// Returns true if colltrace graph tracing is active and all hints succeeded.
+bool tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds timeout);
 
 class TorchCommNCCLX : public TorchCommBackend,
                        public std::enable_shared_from_this<TorchCommNCCLX> {

--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -1,0 +1,348 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Integration tests for TorchComms colltrace-based timeout watchdog.
+// Validates that when NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, TorchCommNCCLX::init()
+// automatically enables the colltrace watchdog plugin via
+// tryEnableColltraceTimeoutWatchdog(), and that it correctly detects timeouts.
+
+#include <folly/Conv.h>
+#include <folly/FileUtil.h>
+#include <folly/Random.h>
+#include <folly/stop_watch.h>
+#include <folly/testing/TestUtil.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/csrc/distributed/c10d/PrefixStore.hpp> // @manual
+#include <torch/csrc/distributed/c10d/TCPStore.hpp> // @manual
+
+#include "nccl.h" // @manual
+
+#include "comms/mccl/integration_tests/CollectiveIntegrationTestMixin.h"
+#include "comms/mccl/integration_tests/McclIntegrationTestUtil.h"
+#include "comms/mccl/tests/CudaTestUtil.h"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommOptions.hpp"
+#include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
+
+class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
+                                   public ::testing::Test {
+ public:
+  void SetUp() override {
+    int numRanks = 4;
+
+    mccl::CollectiveIntegrationTestMixin::SetUp(
+        mccl::CollectiveIntegrationTestMixin::Config{
+            .numRanks = numRanks,
+            .shouldExitOnFailure = false,
+            .env =
+                {
+                    "NCCL_HPC_JOB_IDS=",
+                    "NCCL_SOCKET_IFNAME=eth0",
+                    "NCCL_CLIENT_SOCKET_IFNAME=eth0",
+                    "NCCL_FASTINIT_MODE=none",
+                    "NCCL_SOCKET_IPADDR_PREFIX=",
+                    "NCCL_COMMSMONITOR_ENABLE=1",
+                    "NCCL_COLLTRACE=trace",
+                    "NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1",
+                    "TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=1",
+                    "NCCL_CTRAN_ENABLE=1",
+                    "NCCL_CTRAN_REGISTRATION_SIZE_CHECK=1",
+                    "NCCL_CTRAN_BACKENDS=ib,socket,nvl",
+                    "NCCL_DEBUG=INFO",
+                    fmt::format(
+                        "NCCL_DEBUG_FILE={}",
+                        (tmpDir_.path() / "logfile%p").string()),
+                },
+        });
+  }
+
+  folly::test::TemporaryDirectory tmpDir_{
+      fmt::format("ColltraceGraphWatchdog{}", folly::Random::rand64())};
+
+  std::shared_ptr<torch::comms::TorchComm>
+  createTorchComm(int rank, int worldSize, std::chrono::milliseconds timeout) {
+    auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+
+    // Connect a new TCPStore client to the mixin's existing server.
+    auto mixinStore = getTCPStore();
+    auto storeOpts = c10d::TCPStoreOptions{};
+    storeOpts.port = mixinStore->getPort();
+    storeOpts.isServer = false;
+    auto store = c10::make_intrusive<c10d::TCPStore>("127.0.0.1", storeOpts);
+
+    // Wrap in PrefixStore to avoid key collisions with the mixin
+    auto prefixStore =
+        c10::make_intrusive<c10d::PrefixStore>("torchcomm_test", store);
+
+    torch::comms::CommOptions options;
+    options.store = prefixStore;
+    options.timeout = timeout;
+
+    return torch::comms::new_comm(
+        "ncclx",
+        c10::Device(c10::DeviceType::CUDA, deviceId),
+        "test_colltrace_watchdog",
+        options);
+  }
+
+  void testDriverCheckSucceed() {
+    ASSERT_TRUE(
+        std::holds_alternative<
+            mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+            this->state_));
+    auto& testDriverState =
+        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+            this->state_);
+    EXPECT_THAT(
+        testDriverState.workerExitCodes, ::testing::Each(::testing::Eq(0)));
+  }
+
+  void testDriverCheckCrashedWithWatchdog() {
+    ASSERT_TRUE(
+        std::holds_alternative<
+            mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+            this->state_));
+    auto& testDriverState =
+        std::get<mccl::CollectiveIntegrationTestMixin::TestDriverState>(
+            this->state_);
+    EXPECT_THAT(
+        testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
+
+    // Verify at least one NCCL debug log contains the colltrace watchdog
+    // timeout. Ranks 1-3 crash via XLOG(FATAL) in the test body (goes to
+    // stderr), so only rank 0's NCCL log will have the watchdog message.
+    bool foundWatchdogTimeout = false;
+    for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
+      std::string fileContents;
+      if (folly::readFile(entry.path().c_str(), fileContents) &&
+          fileContents.find("watchdog timeout") != std::string::npos) {
+        foundWatchdogTimeout = true;
+      }
+    }
+    EXPECT_TRUE(foundWatchdogTimeout)
+        << "Expected at least one NCCL log to contain 'watchdog timeout'";
+  }
+};
+
+// Creates a TorchComm via new_comm("ncclx", ...) with
+// NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1, verifying that init() automatically
+// enables the colltrace watchdog and it detects a timeout when a collective
+// hangs.
+TEST_F(ColltraceGraphWatchdogTest, TestTimeoutViaTorchCommsInit) {
+  if (isTestDriverProcess()) {
+    testDriverCheckCrashedWithWatchdog();
+    return;
+  }
+
+  constexpr auto timeout{std::chrono::seconds{5}};
+  int rank = getRank();
+  int worldSize = getWorldSize();
+
+  // Create TorchComm via the full init path.
+  // NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1 is set in the env, so
+  // initNcclxResources() will call tryEnableColltraceTimeoutWatchdog(timeout)
+  // which sets crashOnAsyncError, crashOnTimeout, and timeoutMs hints.
+  auto torchcomm = createTorchComm(
+      rank,
+      worldSize,
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
+
+  ASSERT_NE(torchcomm, nullptr);
+  ASSERT_EQ(torchcomm->getRank(), rank);
+  ASSERT_EQ(torchcomm->getSize(), worldSize);
+
+  // Warmup AllReduce via TorchComms API
+  auto tensor =
+      at::ones({32}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  torchcomm->all_reduce(
+      tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+
+  // Trigger timeout: ranks 1-3 sleep while rank 0 issues AllReduce
+  if (rank != 0) {
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+    XLOG(FATAL, "COMM FATAL");
+  } else {
+    torchcomm->all_reduce(
+        tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+  }
+
+  FAIL() << "Watchdog did not trigger after timeout is reached";
+}
+
+// Captures an AllReduce into a CUDA graph via TorchComms, replays it, and
+// verifies the colltrace watchdog detects a timeout during graph replay.
+TEST_F(ColltraceGraphWatchdogTest, TestGraphReplayTimeout) {
+  if (isTestDriverProcess()) {
+    testDriverCheckCrashedWithWatchdog();
+    return;
+  }
+
+  constexpr auto timeout{std::chrono::seconds{5}};
+  int rank = getRank();
+  int worldSize = getWorldSize();
+
+  auto torchcomm = createTorchComm(
+      rank,
+      worldSize,
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
+
+  ASSERT_NE(torchcomm, nullptr);
+
+  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto tensor = at::ones(
+      {32}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, deviceId));
+
+  // Warmup AllReduce (eager) to trigger pre-connect
+  torchcomm->all_reduce(
+      tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+
+  // Use a non-default stream for graph capture (default stream doesn't
+  // support capture). Set it as the current PyTorch stream so TorchComms
+  // dispatches work onto it.
+  auto captureStream = at::cuda::getStreamFromPool(false, deviceId);
+  at::cuda::setCurrentCUDAStream(captureStream);
+
+  // Capture AllReduce into a CUDA graph via TorchComms
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(
+          captureStream.stream(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+
+  torchcomm->all_reduce(tensor, torch::comms::ReduceOp::SUM, /*async_op=*/true);
+
+  ASSERT_EQ(cudaStreamEndCapture(captureStream.stream(), &graph), cudaSuccess);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  // Successful warmup replay — all ranks participate
+  ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(captureStream.stream()), cudaSuccess);
+
+  // Timeout replay — ranks 1-3 sleep while rank 0 replays
+  if (rank != 0) {
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+    XLOG(FATAL, "COMM FATAL");
+  } else {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+  }
+
+  cudaGraphExecDestroy(graphExec);
+  cudaGraphDestroy(graph);
+
+  FAIL() << "Watchdog did not trigger after timeout is reached";
+}
+
+// Replays a graph N times successfully, then hangs on the N+1th replay.
+// Verifies the colltrace watchdog correctly resets timers between replays
+// and still detects timeouts on later replays.
+TEST_F(
+    ColltraceGraphWatchdogTest,
+    TestGraphReplayTimeoutAfterSuccessfulReplays) {
+  if (isTestDriverProcess()) {
+    testDriverCheckCrashedWithWatchdog();
+    return;
+  }
+
+  constexpr auto timeout{std::chrono::seconds{5}};
+  constexpr int kSuccessfulReplays = 3;
+  int rank = getRank();
+  int worldSize = getWorldSize();
+
+  auto torchcomm = createTorchComm(
+      rank,
+      worldSize,
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
+
+  ASSERT_NE(torchcomm, nullptr);
+
+  auto deviceId = mccl::CudaTestUtil::getCudaDeviceId(rank);
+  auto tensor = at::ones(
+      {32}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, deviceId));
+
+  // Warmup AllReduce (eager)
+  torchcomm->all_reduce(
+      tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+
+  // Use a non-default stream for graph capture
+  auto captureStream = at::cuda::getStreamFromPool(false, deviceId);
+  at::cuda::setCurrentCUDAStream(captureStream);
+
+  // Capture AllReduce into a CUDA graph
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(
+          captureStream.stream(), cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  torchcomm->all_reduce(tensor, torch::comms::ReduceOp::SUM, /*async_op=*/true);
+  ASSERT_EQ(cudaStreamEndCapture(captureStream.stream(), &graph), cudaSuccess);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
+      cudaSuccess);
+
+  // N successful replays — all ranks participate
+  for (int i = 0; i < kSuccessfulReplays; ++i) {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(captureStream.stream()), cudaSuccess);
+  }
+
+  // N+1th replay: ranks 1-3 sleep, rank 0 replays → timeout
+  if (rank != 0) {
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+    XLOG(FATAL, "COMM FATAL");
+  } else {
+    ASSERT_EQ(cudaGraphLaunch(graphExec, captureStream.stream()), cudaSuccess);
+    std::this_thread::sleep_for(timeout + std::chrono::seconds{3});
+  }
+
+  cudaGraphExecDestroy(graphExec);
+  cudaGraphDestroy(graph);
+
+  FAIL() << "Watchdog did not trigger after timeout is reached";
+}
+
+// Same init path, but all ranks complete within the timeout — verifies no
+// false positive.
+TEST_F(ColltraceGraphWatchdogTest, TestBelowTimeoutSucceeds) {
+  if (isTestDriverProcess()) {
+    testDriverCheckSucceed();
+    return;
+  }
+
+  constexpr auto timeout{std::chrono::seconds{60}};
+  int rank = getRank();
+  int worldSize = getWorldSize();
+
+  auto torchcomm = createTorchComm(
+      rank,
+      worldSize,
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout));
+
+  ASSERT_NE(torchcomm, nullptr);
+
+  auto tensor =
+      at::ones({32}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+
+  // Warmup
+  torchcomm->all_reduce(
+      tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+
+  // Short delay, well within the 60s timeout
+  if (rank != 0) {
+    std::this_thread::sleep_for(std::chrono::seconds{5});
+  }
+
+  torchcomm->all_reduce(
+      tensor, torch::comms::ReduceOp::SUM, /*async_op=*/false);
+
+  torchcomm->finalize();
+}

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -1228,4 +1228,156 @@ TEST_F(
   resetGraphTimeoutMonitoringCacheForTest();
   setupFinalizeExpectations(*comm);
 }
+// --- Colltrace graph tracing disables GraphEventTracker monitoring ---
+
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_DisablesGraphTimeoutMonitoring) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_MonitoringEnabledWhenNotSet) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_ExplicitDisableOverridesColltrace) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::setenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING", "0", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_NoStartEndEventsOrReplayCounter) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  comm->init(*device_, "test_colltrace_graph_no_events", options);
+
+  setupGraphCaptureMocks();
+
+  // Only sync_event_ created — no start_event_ or end_event_
+  cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
+  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+      .WillOnce(DoAll(SetArgPointee<0>(sync), Return(cudaSuccess)));
+
+  // No replay counter kernel
+  EXPECT_CALL(*cuda_mock_, launchHostFunc(_, _, _)).Times(0);
+
+  // Cleanup callback still installed
+  EXPECT_CALL(*cuda_mock_, userObjectCreate(_, _, _, _, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          Return(cudaSuccess)));
+  EXPECT_CALL(*cuda_mock_, graphRetainUserObject(_, _, _, _))
+      .WillOnce(Return(cudaSuccess));
+
+  setupEventRecordMocks();
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+  setupFinalizeExpectations(*comm);
+}
+
+TEST_F(GraphEventTrackerTest, ColltraceGraphTracing_CheckGraphEventsReturnsOK) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  auto comm = createMockedTorchComm();
+  cuda_mock_->setupDefaultBehaviors();
+  nccl_mock_->setupDefaultBehaviors();
+
+  auto options = createAbortModeOptions();
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  comm->init(*device_, "test_colltrace_graph_check_ok", options);
+
+  setupGraphCaptureMocks();
+
+  cudaEvent_t sync = reinterpret_cast<cudaEvent_t>(0xA003);
+  EXPECT_CALL(*cuda_mock_, eventCreateWithFlags(_, _))
+      .WillOnce(DoAll(SetArgPointee<0>(sync), Return(cudaSuccess)))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0xA100)),
+          Return(cudaSuccess)));
+
+  setupEventRecordMocks();
+
+  auto tensor = createTestTensor({10, 10});
+
+  {
+    auto work = comm->send(tensor, 1, true);
+  }
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  switchToReplayMode();
+
+  // No event queries — checkAll() returns OK immediately
+  EXPECT_CALL(*cuda_mock_, eventQuery(_)).Times(0);
+
+  comm->checkGraphEvents();
+
+  ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+  setupFinalizeExpectations(*comm);
+}
+
+// --- tryEnableColltraceTimeoutWatchdog env var gating ---
+
+TEST_F(
+    GraphEventTrackerTest,
+    TryEnableColltraceWatchdog_ReturnsFalseWhenGraphTracingDisabled) {
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  EXPECT_FALSE(
+      tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    TryEnableColltraceWatchdog_ReturnsFalseWhenMonitoringExplicitlyDisabled) {
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  ::setenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING", "0", 1);
+  EXPECT_FALSE(
+      tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
+}
+
 } // namespace torch::comms::test

--- a/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(TorchCommOptionsTest PRIVATE
     torchcomms
     GTest::gtest_main
     GTest::gmock
+    atomic
 )
 target_link_options(TorchCommOptionsTest PRIVATE
     "LINKER:--allow-shlib-undefined"

--- a/comms/utils/HRDWRingBufferReader.h
+++ b/comms/utils/HRDWRingBufferReader.h
@@ -2,15 +2,12 @@
 
 #pragma once
 
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <utility>
 #include <vector>
-
-#if defined(__x86_64__)
-#include <emmintrin.h>
-#endif
 
 #include "comms/utils/HRDWRingBuffer.h"
 
@@ -21,27 +18,20 @@ namespace meta::comms::colltrace {
 // independently (each as its own atomic), and the per-slot epoch check
 // in tryRead classifies any stale state as kNotReady / kOverwritten if
 // the writeIndex bump becomes visible before the slot publication.
+//
+// For the 16-byte ring entry, both paths lower to lock cmpxchg16b
+// (x86_64 with -mcx16) or to a libcall to __atomic_load_16 otherwise.
+// The v2_29/v2_30 makefiles and the github CMakeLists link -latomic
+// unconditionally so the libcall always resolves at link time.
 template <typename T>
 __attribute__((always_inline)) inline T relaxedLoad(const T* ptr) {
+#if defined(__cpp_lib_atomic_ref)
+  return std::atomic_ref<T>(*const_cast<T*>(ptr))
+      .load(std::memory_order_relaxed);
+#else
   return __atomic_load_n(ptr, __ATOMIC_RELAXED);
-}
-
-// 16-byte specialization. __atomic_load_n on __int128 emits a libcall to
-// __atomic_load_16 (libatomic) — even with -mcx16, GCC doesn't reliably
-// inline cmpxchg16b for it. Some build images don't ship libatomic, so on
-// x86_64 we sidestep the libcall via SSE2 MOVDQA, which is single-copy
-// atomic for naturally-aligned 16-byte addresses on every production
-// x86_64 CPU. The slot is alignas(16), so this is always safe.
-#if defined(__x86_64__)
-template <>
-__attribute__((always_inline)) inline unsigned __int128 relaxedLoad(
-    const unsigned __int128* ptr) {
-  __m128i v = _mm_load_si128(reinterpret_cast<const __m128i*>(ptr));
-  unsigned __int128 result;
-  __builtin_memcpy(&result, &v, sizeof(result));
-  return result;
-}
 #endif
+}
 
 // Result of a single poll() call.
 struct PollResult {

--- a/comms/utils/colltrace/CollRecord.cc
+++ b/comms/utils/colltrace/CollRecord.cc
@@ -110,18 +110,11 @@ bool CollTimingRecord::operator==(const CollTimingRecord& other) const {
 // CollRecord implementation
 CollRecord::CollRecord(
     uint64_t collId,
-    std::shared_ptr<ICollMetadata> ICollMetadata,
-    int64_t iteration)
-    : collId_(collId),
-      iteration_(iteration),
-      collMetadata_(std::move(ICollMetadata)) {}
+    std::shared_ptr<ICollMetadata> ICollMetadata)
+    : collId_(collId), collMetadata_(std::move(ICollMetadata)) {}
 
 uint64_t CollRecord::getCollId() const noexcept {
   return collId_;
-}
-
-int64_t CollRecord::getIteration() const noexcept {
-  return iteration_;
 }
 
 const std::shared_ptr<ICollMetadata>& CollRecord::getCollMetadata() const {
@@ -134,8 +127,7 @@ CollTimingRecord& CollRecord::getTimingInfo() {
 
 std::size_t CollRecord::hash() const {
   // Hash the collId and timingInfo
-  std::size_t seed =
-      folly::hash::hash_combine(collId_, iteration_, timingInfo_.hash());
+  std::size_t seed = folly::hash::hash_combine(collId_, timingInfo_.hash());
 
   // Add the hash of collMetadata if it exists
   if (collMetadata_) {
@@ -147,8 +139,7 @@ std::size_t CollRecord::hash() const {
 
 bool CollRecord::equals(const CollRecord& other) const noexcept {
   // Compare collId and timingInfo
-  if (collId_ != other.collId_ || iteration_ != other.iteration_ ||
-      !(timingInfo_ == other.timingInfo_)) {
+  if (collId_ != other.collId_ || !(timingInfo_ == other.timingInfo_)) {
     return false;
   }
 
@@ -181,7 +172,6 @@ folly::dynamic CollRecord::toDynamic() const noexcept {
   // and call it "opCount". We should switch to use collId in the future.
   result["collId"] = collId_;
   result["opCount"] = collId_;
-  result["iteration"] = iteration_;
 
   return result;
 }

--- a/comms/utils/colltrace/CollRecord.h
+++ b/comms/utils/colltrace/CollRecord.h
@@ -55,13 +55,9 @@ class ICollRecord {
 
 class CollRecord : public ICollRecord {
  public:
-  CollRecord(
-      uint64_t collId,
-      std::shared_ptr<ICollMetadata> ICollMetadata,
-      int64_t iteration = -1);
+  CollRecord(uint64_t collId, std::shared_ptr<ICollMetadata> ICollMetadata);
 
   uint64_t getCollId() const noexcept override;
-  int64_t getIteration() const noexcept;
   const std::shared_ptr<ICollMetadata>& getCollMetadata() const;
 
   // Timing info is the only field that we could modify after init
@@ -75,7 +71,6 @@ class CollRecord : public ICollRecord {
 
  private:
   uint64_t collId_;
-  int64_t iteration_;
   std::shared_ptr<ICollMetadata> collMetadata_;
   CollTimingRecord timingInfo_;
 };

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -20,7 +20,6 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h"
-#include "comms/utils/trainer/TrainerContext.h"
 
 namespace meta::comms::colltrace {
 
@@ -261,8 +260,7 @@ CommsMaybe<std::shared_ptr<ICollTraceHandle>> CollTrace::recordCollective(
   }
 
   pendingEnqueueColl_ = std::make_unique<CollTraceEvent>(
-      std::make_shared<CollRecord>(
-          collId_.fetch_add(1), std::move(metadata), ncclxGetIteration()),
+      std::make_shared<CollRecord>(collId_.fetch_add(1), std::move(metadata)),
       std::move(waitEvent));
   auto handle =
       std::make_shared<CollTraceHandle>(this, pendingEnqueueColl_.get());
@@ -369,8 +367,8 @@ CollTrace::recordGraphCollectiveImpl(
 
   rawWaitEvent->attachRingBuffer(&*ringBuffer_);
 
-  auto collRecord = std::make_shared<CollRecord>(
-      collIdVal, std::move(metadata), ncclxGetIteration());
+  auto collRecord =
+      std::make_shared<CollRecord>(collIdVal, std::move(metadata));
   auto recordPtr = std::static_pointer_cast<ICollRecord>(collRecord);
 
   auto collEvent = std::make_unique<CollTraceEvent>(CollTraceEvent{
@@ -511,9 +509,7 @@ void CollTrace::pollGraphEvents(
           auto& prev = collEntry.event->collRecord;
 
           auto frozenRecord = std::make_shared<CollRecord>(
-              collId_.fetch_add(1),
-              prev->getCollMetadata(),
-              prev->getIteration());
+              collId_.fetch_add(1), prev->getCollMetadata());
           frozenRecord->getTimingInfo().setCollEnqueueTs(timestamp);
           frozenRecord->getTimingInfo().setCollStartTs(timestamp);
 

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.cc
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -157,7 +157,7 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
   }
 
   lockedCollTraceDump->pastCollsHeap.push(std::move(*it));
-  evictPastColls(*lockedCollTraceDump, curEvent.collRecord->getIteration());
+  evictPastColls(*lockedCollTraceDump);
   lockedCollTraceDump->currentColls.erase(it);
 
   auto iterSnap = ncclxGetIterationSnapshot();
@@ -184,36 +184,11 @@ CommsMaybeVoid CommDumpPlugin::afterCollKernelEnd(
   return folly::unit;
 }
 
-void CommDumpPlugin::evictPastColls(
-    CollTraceDump& dump,
-    int64_t completedIteration) {
-  switch (config_.evictionMode) {
-    case EvictionMode::FixedCount: {
-      while (config_.pastCollSize >= 0 &&
-             static_cast<int64_t>(dump.pastCollsHeap.size()) >
-                 config_.pastCollSize) {
-        dump.pastCollsHeap.pop();
-      }
-      break;
-    }
-    case EvictionMode::Iteration: {
-      if (completedIteration > maxIterationSeen_) {
-        maxIterationSeen_ = completedIteration;
-      }
-      int64_t evictionThreshold = maxIterationSeen_ - config_.maxIterations + 1;
-      while (!dump.pastCollsHeap.empty()) {
-        const auto& oldest = dump.pastCollsHeap.top();
-        bool overHardLimit = static_cast<int64_t>(dump.pastCollsHeap.size()) >
-            config_.iterationUpperBound;
-        bool oldIteration = oldest->getIteration() < evictionThreshold;
-        if (overHardLimit || oldIteration) {
-          dump.pastCollsHeap.pop();
-        } else {
-          break;
-        }
-      }
-      break;
-    }
+void CommDumpPlugin::evictPastColls(CollTraceDump& dump) {
+  while (config_.pastCollSize >= 0 &&
+         static_cast<int64_t>(dump.pastCollsHeap.size()) >
+             config_.pastCollSize) {
+    dump.pastCollsHeap.pop();
   }
 }
 
@@ -334,9 +309,6 @@ std::unordered_map<std::string, std::string> commDumpToMap(
 }
 
 int64_t CommDumpPlugin::maxEventRetention() const noexcept {
-  if (config_.evictionMode == EvictionMode::Iteration) {
-    return config_.iterationUpperBound;
-  }
   return config_.pastCollSize;
 }
 
@@ -344,7 +316,6 @@ CommsMaybeVoid CommDumpPlugin::testOnlyClearColls() noexcept {
   collTraceDump_.exchange(CollTraceDump{});
   newPendingColls_ =
       folly::MPMCQueue<std::shared_ptr<CollRecord>>(config_.pendingCollSize);
-  maxIterationSeen_ = -1;
   return folly::unit;
 }
 

--- a/comms/utils/colltrace/plugins/CommDumpPlugin.h
+++ b/comms/utils/colltrace/plugins/CommDumpPlugin.h
@@ -15,11 +15,6 @@
 
 namespace meta::comms::colltrace {
 
-enum class EvictionMode {
-  FixedCount, // Keep last N records (current behavior)
-  Iteration, // Keep records from current iteration, with hard upper bound
-};
-
 struct CommDumpConfig {
   // Default size of queue storing past collective communication operations.
   // The default value should be enough for debugging past collective. For slow
@@ -28,7 +23,6 @@ struct CommDumpConfig {
   // 1024 elements should be sufficiently large to handle the number of
   // collective calls that is hanging when we dump the trace.
   static constexpr int kCommDumpQueueSize = 1024;
-
   // Default timeout for waiting for the lock to be acquired for dump. We don't
   // want to block the dump thread if there is any issue with the lock.
   static constexpr auto kDumpLockAcquireTimeout = std::chrono::seconds(1);
@@ -42,15 +36,6 @@ struct CommDumpConfig {
   // dropped if the queue is full.
   int64_t pendingCollSize{kCommDumpQueueSize};
   std::chrono::milliseconds dumpLockAcquireTimeout{kDumpLockAcquireTimeout};
-
-  EvictionMode evictionMode{EvictionMode::FixedCount};
-  // Number of recent iterations to retain when using Iteration mode.
-  // 1 = current iteration only, 2 = current + previous, etc.
-  int64_t maxIterations{1};
-  // Hard upper bound on retained past records when using Iteration mode.
-  // Prevents unbounded growth if ncclxSetIteration is never called.
-  static constexpr int64_t kDefaultIterationUpperBound{3000};
-  int64_t iterationUpperBound{kDefaultIterationUpperBound};
 };
 
 struct CollRecordGreaterCollId {
@@ -117,10 +102,9 @@ class CommDumpPlugin : public ICollTracePlugin {
   static constexpr std::string_view kCommDumpPluginName = "CommDumpPlugin";
 
  private:
-  void evictPastColls(CollTraceDump& dump, int64_t completedIteration);
+  void evictPastColls(CollTraceDump& dump);
 
   CommDumpConfig config_;
-  int64_t maxIterationSeen_{-1};
 
   folly::Synchronized<CollTraceDump> collTraceDump_;
 

--- a/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
+++ b/comms/utils/colltrace/plugins/tests/CommDumpPluginUT.cc
@@ -45,17 +45,9 @@ class CommDumpPluginTest : public ::testing::Test {
     plugin.reset();
   }
 
-  // Helper method to create a CollTraceEvent with a CollRecord
   CollTraceEvent createCollTraceEvent(uint64_t collId) {
-    return createCollTraceEventWithIteration(collId, -1);
-  }
-
-  CollTraceEvent createCollTraceEventWithIteration(
-      uint64_t collId,
-      int64_t iteration) {
     auto metadata = std::make_unique<MockCollMetadata>();
-    auto collRecord =
-        std::make_shared<CollRecord>(collId, std::move(metadata), iteration);
+    auto collRecord = std::make_shared<CollRecord>(collId, std::move(metadata));
 
     CollTraceEvent event;
     event.collRecord = collRecord;
@@ -404,99 +396,6 @@ TEST_F(CommDumpPluginTest, ConcurrentActiveCollectives) {
   EXPECT_VALUE(dump3);
   EXPECT_TRUE(dump3.value().currentColls.empty());
   EXPECT_EQ(dump3.value().pastColls.size(), 2);
-}
-
-// ---- Iteration-based eviction tests ----
-
-class CommDumpPluginIterationTest : public CommDumpPluginTest {
- protected:
-  void SetUp() override {
-    plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
-        .evictionMode = EvictionMode::Iteration,
-        .maxIterations = 1,
-        .iterationUpperBound = 3000,
-    });
-  }
-};
-
-TEST_F(CommDumpPluginIterationTest, EvictsOlderIterations) {
-  // Process events from iteration 1
-  auto event1 = createCollTraceEventWithIteration(1, 1);
-  auto event2 = createCollTraceEventWithIteration(2, 1);
-  processFullLifecycle(event1);
-  processFullLifecycle(event2);
-
-  auto dump1 = plugin->dump();
-  EXPECT_VALUE(dump1);
-  EXPECT_EQ(dump1.value().pastColls.size(), 2);
-
-  // Process event from iteration 2 — iteration 1 records should be evicted
-  auto event3 = createCollTraceEventWithIteration(3, 2);
-  processFullLifecycle(event3);
-
-  auto dump2 = plugin->dump();
-  EXPECT_VALUE(dump2);
-  EXPECT_EQ(dump2.value().pastColls.size(), 1);
-  EXPECT_EQ(dump2.value().pastColls.front()->getCollId(), 3);
-  EXPECT_EQ(dump2.value().pastColls.front()->getIteration(), 2);
-}
-
-TEST_F(CommDumpPluginIterationTest, RetainsCurrentIteration) {
-  auto event1 = createCollTraceEventWithIteration(1, 5);
-  auto event2 = createCollTraceEventWithIteration(2, 5);
-  auto event3 = createCollTraceEventWithIteration(3, 5);
-  processFullLifecycle(event1);
-  processFullLifecycle(event2);
-  processFullLifecycle(event3);
-
-  auto dump = plugin->dump();
-  EXPECT_VALUE(dump);
-  EXPECT_EQ(dump.value().pastColls.size(), 3);
-}
-
-TEST_F(CommDumpPluginIterationTest, HardUpperBoundEnforced) {
-  plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
-      .evictionMode = EvictionMode::Iteration,
-      .maxIterations = 1,
-      .iterationUpperBound = 5,
-  });
-
-  // All events have iteration -1 (simulating broken iteration tracking)
-  for (uint64_t i = 0; i < 10; ++i) {
-    auto event = createCollTraceEventWithIteration(i, -1);
-    processFullLifecycle(event);
-  }
-
-  auto dump = plugin->dump();
-  EXPECT_VALUE(dump);
-  EXPECT_LE(static_cast<int64_t>(dump.value().pastColls.size()), 5);
-}
-
-TEST_F(CommDumpPluginIterationTest, MaxIterationsRetention) {
-  // Configure to retain last 2 iterations
-  plugin = std::make_unique<CommDumpPlugin>(CommDumpConfig{
-      .evictionMode = EvictionMode::Iteration,
-      .maxIterations = 2,
-      .iterationUpperBound = 3000,
-  });
-
-  auto event1 = createCollTraceEventWithIteration(1, 1);
-  auto event2 = createCollTraceEventWithIteration(2, 2);
-  auto event3 = createCollTraceEventWithIteration(3, 3);
-  processFullLifecycle(event1);
-  processFullLifecycle(event2);
-  processFullLifecycle(event3);
-
-  auto dump = plugin->dump();
-  EXPECT_VALUE(dump);
-  // Should retain iterations 2 and 3, evict iteration 1
-  EXPECT_EQ(dump.value().pastColls.size(), 2);
-  EXPECT_EQ(dump.value().pastColls[0]->getIteration(), 2);
-  EXPECT_EQ(dump.value().pastColls[1]->getIteration(), 3);
-}
-
-TEST_F(CommDumpPluginIterationTest, MaxEventRetentionReturnsUpperBound) {
-  EXPECT_EQ(plugin->maxEventRetention(), 3000);
 }
 
 // ---- Iteration comm time tracking tests ----

--- a/comms/utils/colltrace/tests/CollRecordUT.cc
+++ b/comms/utils/colltrace/tests/CollRecordUT.cc
@@ -281,46 +281,4 @@ TEST_F(CollRecordTest, NullMetadata) {
   EXPECT_FALSE(collRecord_->equals(*recordWithNullMetadata));
 }
 
-TEST_F(CollRecordTest, IterationDefaultValue) {
-  EXPECT_EQ(collRecord_->getIteration(), -1);
-}
-
-TEST_F(CollRecordTest, IterationExplicitValue) {
-  auto metadata = std::make_unique<NiceMock<MockCollMetadata>>();
-  auto record = std::make_unique<CollRecord>(1, std::move(metadata), 42);
-  EXPECT_EQ(record->getIteration(), 42);
-}
-
-TEST_F(CollRecordTest, IterationInToDynamic) {
-  auto metadata = std::make_unique<NiceMock<MockCollMetadata>>();
-  folly::dynamic emptyObj = folly::dynamic::object;
-  ON_CALL(*metadata, toDynamic()).WillByDefault(Return(emptyObj));
-  auto record = std::make_unique<CollRecord>(1, std::move(metadata), 7);
-  auto result = record->toDynamic();
-  ASSERT_TRUE(result.count("iteration"));
-  EXPECT_EQ(result["iteration"].asInt(), 7);
-}
-
-TEST_F(CollRecordTest, IterationAffectsHash) {
-  auto meta1 = std::make_unique<NiceMock<MockCollMetadata>>();
-  ON_CALL(*meta1, hash()).WillByDefault(Return(0));
-  auto meta2 = std::make_unique<NiceMock<MockCollMetadata>>();
-  ON_CALL(*meta2, hash()).WillByDefault(Return(0));
-
-  auto record1 = std::make_unique<CollRecord>(1, std::move(meta1), 10);
-  auto record2 = std::make_unique<CollRecord>(1, std::move(meta2), 20);
-  EXPECT_NE(record1->hash(), record2->hash());
-}
-
-TEST_F(CollRecordTest, IterationAffectsEquals) {
-  auto meta1 = std::make_unique<NiceMock<MockCollMetadata>>();
-  ON_CALL(*meta1, equals(_)).WillByDefault(Return(true));
-  auto meta2 = std::make_unique<NiceMock<MockCollMetadata>>();
-  ON_CALL(*meta2, equals(_)).WillByDefault(Return(true));
-
-  auto record1 = std::make_unique<CollRecord>(1, std::move(meta1), 10);
-  auto record2 = std::make_unique<CollRecord>(1, std::move(meta2), 20);
-  EXPECT_FALSE(record1->equals(*record2));
-}
-
 } // namespace

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -18,7 +18,6 @@
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
-#include "comms/utils/trainer/TrainerContext.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
@@ -902,7 +901,6 @@ TEST_F(GraphColltraceTopologyTest, ReplayTimingConsistency) {
   constexpr uint32_t kNumColls = 5;
   constexpr int kNumReplays = 10;
 
-  ncclxSetIteration(0);
   auto graph = captureSerial(kNumColls);
   ASSERT_NE(graph, nullptr);
 
@@ -938,13 +936,12 @@ TEST_F(GraphColltraceTopologyTest, ReplayTimingConsistency) {
     auto dur =
         std::chrono::duration_cast<std::chrono::microseconds>(endTs - startTs)
             .count();
-    auto iter = coll->getIteration();
-
-    EXPECT_GT(dur, 0) << "iter=" << iter << " collId=" << coll->getCollId()
+    EXPECT_GT(dur, 0) << "collId=" << coll->getCollId()
                       << " has non-positive duration " << dur << "us";
-    EXPECT_GE(endTs, startTs) << "iter=" << iter << ": endTs < startTs";
+    EXPECT_GE(endTs, startTs)
+        << "collId=" << coll->getCollId() << ": endTs < startTs";
     EXPECT_EQ(enqueueTs, startTs)
-        << "iter=" << iter << " collId=" << coll->getCollId()
+        << "collId=" << coll->getCollId()
         << ": enqueueTs != startTs — pastColls entry was mutated"
            " by a subsequent replay's start event";
 
@@ -958,6 +955,4 @@ TEST_F(GraphColltraceTopologyTest, ReplayTimingConsistency) {
   cudaGraphExecDestroy(instance);
   // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
   cudaGraphDestroy(graph);
-
-  ncclxSetIteration(-1);
 }

--- a/comms/utils/trainer/TrainerContext.cc
+++ b/comms/utils/trainer/TrainerContext.cc
@@ -4,69 +4,31 @@
 
 #include <atomic>
 #include <chrono>
-#include <cstring>
-
-#if defined(__x86_64__)
-#include <emmintrin.h>
-#endif
+#include <cstdint>
 
 namespace {
 
 // Pack iteration (high 64 bits) and timestampUs (low 64 bits) into a single
-// 128-bit atomic so readers always see a consistent pair.
-__int128 packIteration(int64_t iteration, int64_t timestampUs) {
-  __int128 v = 0;
-  std::memcpy(&v, &timestampUs, 8);
-  std::memcpy(reinterpret_cast<char*>(&v) + 8, &iteration, 8);
-  return v;
+// 128-bit value so readers always observe a consistent pair. constexpr so
+// gIterationPacked below is constant-initialized (no SIOF window).
+constexpr __int128 packIteration(int64_t iteration, int64_t timestampUs) {
+  return (static_cast<__int128>(static_cast<uint64_t>(iteration)) << 64) |
+      static_cast<__int128>(static_cast<uint64_t>(timestampUs));
 }
 
 IterationSnapshot unpackIteration(__int128 v) {
   IterationSnapshot snap;
-  std::memcpy(&snap.timestampUs, &v, 8);
-  std::memcpy(&snap.iteration, reinterpret_cast<const char*>(&v) + 8, 8);
+  snap.iteration = static_cast<int64_t>(static_cast<uint64_t>(v >> 64));
+  snap.timestampUs = static_cast<int64_t>(static_cast<uint64_t>(v));
   return snap;
 }
 
-// SSE2 MOVDQA is single-copy atomic for naturally-aligned 16-byte addresses
-// on every production x86_64 CPU, avoiding the __atomic_{store,load}_16
-// libatomic libcalls that GCC emits for std::atomic<__int128>.
-#if defined(__x86_64__)
-
+// std::atomic<__int128> is lock-free on x86_64 (cmpxchg16b, with -mcx16) and
+// on aarch64 with LSE2; elsewhere it falls back to libatomic's lock table.
+// We link -latomic unconditionally in the v2_29/v2_30 makefiles and the
+// github CMakeLists so the fallback always resolves at link time.
 // NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
-alignas(16) __int128 gIterationPacked = packIteration(/*iteration=*/-1,
-                                                      /*timestampUs=*/0);
-
-void releaseStore128(__int128* dst, __int128 val) {
-  __m128i v;
-  __builtin_memcpy(&v, &val, sizeof(v));
-  std::atomic_thread_fence(std::memory_order_release);
-  _mm_store_si128(reinterpret_cast<__m128i*>(dst), v);
-}
-
-__int128 acquireLoad128(const __int128* src) {
-  __m128i v = _mm_load_si128(reinterpret_cast<const __m128i*>(src));
-  std::atomic_thread_fence(std::memory_order_acquire);
-  __int128 result;
-  __builtin_memcpy(&result, &v, sizeof(result));
-  return result;
-}
-
-#else
-
-// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
-std::atomic<__int128> gIterationPacked{
-    packIteration(/*iteration=*/-1, /*timestampUs=*/0)};
-
-void releaseStore128(std::atomic<__int128>* dst, __int128 val) {
-  dst->store(val, std::memory_order_release);
-}
-
-__int128 acquireLoad128(const std::atomic<__int128>* src) {
-  return src->load(std::memory_order_acquire);
-}
-
-#endif
+std::atomic<__int128> gIterationPacked{packIteration(-1, 0)};
 
 } // namespace
 
@@ -74,7 +36,8 @@ void ncclxSetIteration(int64_t iteration) {
   auto timestampUs = std::chrono::duration_cast<std::chrono::microseconds>(
                          std::chrono::system_clock::now().time_since_epoch())
                          .count();
-  releaseStore128(&gIterationPacked, packIteration(iteration, timestampUs));
+  gIterationPacked.store(
+      packIteration(iteration, timestampUs), std::memory_order_release);
 }
 
 int64_t ncclxGetIteration() {
@@ -86,5 +49,5 @@ int64_t ncclxGetIterationTimestampUs() {
 }
 
 IterationSnapshot ncclxGetIterationSnapshot() {
-  return unpackIteration(acquireLoad128(&gIterationPacked));
+  return unpackIteration(gIterationPacked.load(std::memory_order_acquire));
 }


### PR DESCRIPTION
Summary:
When `NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1`, the colltrace watchdog plugin already handles timeout detection for graph-captured collectives via its ring buffer entries. In that case, the TorchComms-level `GraphEventTracker` monitoring (replay counters, start/end events, event queries) is redundant.

This commit makes `isGraphTimeoutMonitoringEnabled()` return `false` when colltrace graph tracing is active, so that when `TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING=1` (the default) and `NCCL_COLLTRACE_TRACE_CUDA_GRAPH=1`, we rely on the colltrace-based watchdog (`tryEnableCollTraceAsWatchdog`, already enabled by default in ProcessGroupNCCLX) instead of creating the extra external events.

This is a stepping stone toward the singleton colltrace refactor (D105355416), allowing us to maintain timeout support without the overhead of `GraphEventTracker`'s external events when colltrace is already processing ring entries for per-iteration-time-spent aggregation.

Reviewed By: YulunW

Differential Revision: D105755295


