### PR TITLE
Support IBGDA in TorchComms Triton transport send/recv

### DIFF
--- a/comms/torchcomms/triton/device_transport.cu
+++ b/comms/torchcomms/triton/device_transport.cu
@@ -1,15 +1,31 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // TorchComms Transport API - implementations for LLVM bitcode
 //
-// Extern C wrappers around comms::pipes P2pNvlTransportDevice methods.
+// Extern C wrappers around comms::pipes transport methods.
 // All operations construct a block-scope ThreadGroup internally.
 
 #include <cuda_runtime.h>
+
+#include <cstddef>
 
 #include "comms/pipes/MultiPeerDeviceHandle.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 
 using namespace comms::pipes;
+
+namespace {
+
+__device__ __noinline__ void
+unsupported_transport(const char* op, TransportType type, int peer) {
+  printf(
+      "torchcomms_transport_%s: unsupported transport type %d for peer %d\n",
+      op,
+      static_cast<int>(type),
+      peer);
+  __trap();
+}
+
+} // namespace
 
 extern "C" {
 
@@ -22,7 +38,19 @@ __device__ __noinline__ int torchcomms_transport_send_groups(
     unsigned long long nbytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).send_group(group, src_ptr, static_cast<size_t>(nbytes));
+  const TransportType type = handle->get_type(peer);
+  switch (type) {
+    case TransportType::P2P_NVL:
+      handle->get_nvl(peer).send_group(
+          group, src_ptr, static_cast<std::size_t>(nbytes));
+      break;
+    case TransportType::P2P_IBGDA:
+      unsupported_transport("send_groups", type, peer);
+      break;
+    default:
+      unsupported_transport("send_groups", type, peer);
+      break;
+  }
   return 0;
 }
 
@@ -33,7 +61,19 @@ __device__ __noinline__ int torchcomms_transport_recv_groups(
     unsigned long long nbytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).recv_group(group, dst_ptr, static_cast<size_t>(nbytes));
+  const TransportType type = handle->get_type(peer);
+  switch (type) {
+    case TransportType::P2P_NVL:
+      handle->get_nvl(peer).recv_group(
+          group, dst_ptr, static_cast<std::size_t>(nbytes));
+      break;
+    case TransportType::P2P_IBGDA:
+      unsupported_transport("recv_groups", type, peer);
+      break;
+    default:
+      unsupported_transport("recv_groups", type, peer);
+      break;
+  }
   return 0;
 }
 
@@ -82,12 +122,28 @@ __device__ __noinline__ int torchcomms_transport_send(
     unsigned long long max_signal_bytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).send(
-      group,
-      src_ptr,
-      static_cast<size_t>(nbytes),
-      active_blocks,
-      static_cast<size_t>(max_signal_bytes));
+  const TransportType type = handle->get_type(peer);
+  switch (type) {
+    case TransportType::P2P_NVL:
+      handle->get_nvl(peer).send(
+          group,
+          src_ptr,
+          static_cast<std::size_t>(nbytes),
+          active_blocks,
+          static_cast<std::size_t>(max_signal_bytes));
+      break;
+    case TransportType::P2P_IBGDA:
+      handle->get_ibgda(peer).send(
+          group,
+          src_ptr,
+          static_cast<std::size_t>(nbytes),
+          active_blocks,
+          static_cast<std::size_t>(max_signal_bytes));
+      break;
+    default:
+      unsupported_transport("send", type, peer);
+      break;
+  }
   return 0;
 }
 
@@ -100,12 +156,28 @@ __device__ __noinline__ int torchcomms_transport_recv(
     unsigned long long max_signal_bytes) {
   auto* handle = reinterpret_cast<MultiPeerDeviceHandle*>(handle_ptr);
   auto group = make_block_group();
-  handle->get_nvl(peer).recv(
-      group,
-      dst_ptr,
-      static_cast<size_t>(nbytes),
-      active_blocks,
-      static_cast<size_t>(max_signal_bytes));
+  const TransportType type = handle->get_type(peer);
+  switch (type) {
+    case TransportType::P2P_NVL:
+      handle->get_nvl(peer).recv(
+          group,
+          dst_ptr,
+          static_cast<std::size_t>(nbytes),
+          active_blocks,
+          static_cast<std::size_t>(max_signal_bytes));
+      break;
+    case TransportType::P2P_IBGDA:
+      handle->get_ibgda(peer).recv(
+          group,
+          dst_ptr,
+          static_cast<std::size_t>(nbytes),
+          active_blocks,
+          static_cast<std::size_t>(max_signal_bytes));
+      break;
+    default:
+      unsupported_transport("recv", type, peer);
+      break;
+  }
   return 0;
 }
 

--- a/comms/torchcomms/triton/device_transport.h
+++ b/comms/torchcomms/triton/device_transport.h
@@ -2,7 +2,7 @@
 // TorchComms Transport API - C-style declarations for LLVM bitcode
 //
 // Declares extern C wrappers for pipes transport operations
-// (P2pNvlTransportDevice send/recv/signal/barrier).
+// (P2pNvlTransportDevice or P2pIbgdaTransportDevice send/recv).
 // Compiled to LLVM bitcode with clang for linking with Triton kernels.
 //
 // Handle: void* device pointer to comms::pipes::MultiPeerDeviceHandle,
@@ -20,7 +20,7 @@ extern "C" {
 
 typedef void* TorchCommsTransportHandle;
 
-// --- Data Transfer (grid-collective, pipelined NVLink) ---
+// --- Data Transfer (grid-collective, NVLink only) ---
 
 __device__ int torchcomms_transport_send_groups(
     TorchCommsTransportHandle handle,
@@ -52,7 +52,7 @@ __device__ int torchcomms_transport_wait_signal(
     int op,
     unsigned long long value);
 
-// --- Send/Recv (block-cooperative, pipelined NVLink) ---
+// --- Send/Recv (block-cooperative, pipelined transport) ---
 // active_blocks: number of groups calling concurrently (0 = tile_max_groups)
 // max_signal_bytes: hint for signaling granularity (0 = one signal per slot)
 


### PR DESCRIPTION
Summary: Add transport-type dispatch to the Triton Pipes transport externs so block-cooperative send/recv calls use P2pIbgdaTransportDevice for P2P_IBGDA peers while preserving the existing P2pNvlTransportDevice path for NVLink peers. The grid-collective send_groups/recv_groups wrappers remain NVLink-only and explicitly trap on IBGDA; the Python docs and multinode test skips now reflect that narrower support.

Reviewed By: goelayu

Differential Revision: D105763788


