### PR TITLE
BackendWrapper: route through TorchComm so hooks fire

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -142,7 +142,6 @@ c10::intrusive_ptr<c10::ivalue::Future> WorkWrapper::getFuture() {
 BackendWrapper::BackendWrapper(std::shared_ptr<TorchComm> comm)
     : Backend(comm->getRank(), comm->getSize()),
       comm_(comm),
-      backend_(comm->getBackendImpl()),
       options_(c10::make_intrusive<Options>()) {}
 
 c10::intrusive_ptr<c10d::Work> BackendWrapper::broadcast(
@@ -160,7 +159,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::broadcast(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->broadcast(
+      comm_->broadcast(
           tensors.at(0), static_cast<int>(opts.rootRank), opts.asyncOp, bopts),
       tensors);
 }
@@ -180,7 +179,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allreduce(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_reduce(
+      comm_->all_reduce(
           tensors.at(0), toReduceOp(opts.reduceOp), opts.asyncOp, bopts),
       tensors);
 }
@@ -200,7 +199,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allreduce_coalesced(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_reduce(
+      comm_->all_reduce(
           tensors.at(0), toReduceOp(opts.reduceOp), opts.asyncOp, bopts),
       tensors);
 }
@@ -220,7 +219,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->reduce(
+      comm_->reduce(
           tensors.at(0),
           static_cast<int>(opts.rootRank),
           toReduceOp(opts.reduceOp),
@@ -248,7 +247,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_gather(
+      comm_->all_gather(
           outputTensors.at(0), inputTensors.at(0), opts.asyncOp, bopts),
       outputTensors.at(0));
 }
@@ -272,7 +271,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather_coalesced(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_gather(
+      comm_->all_gather(
           outputTensorLists.at(0), inputTensors.at(0), opts.asyncOp, bopts),
       outputTensorLists.at(0));
 }
@@ -299,7 +298,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::allgather_into_tensor_coalesced(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_gather_single(
+      comm_->all_gather_single(
           output_tensors.at(0), inputTensors.at(0), opts.asyncOp, bopts),
       output_tensors);
 }
@@ -315,8 +314,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::_allgather_base(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_gather_single(
-          outputTensor, inputTensor, opts.asyncOp, bopts),
+      comm_->all_gather_single(outputTensor, inputTensor, opts.asyncOp, bopts),
       std::vector<at::Tensor>{outputTensor});
 }
 
@@ -339,7 +337,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::gather(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->gather(
+      comm_->gather(
           outputTensors.at(0),
           inputTensors.at(0),
           static_cast<int>(opts.rootRank),
@@ -374,7 +372,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::scatter(
     inputTensors.emplace_back();
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->scatter(
+      comm_->scatter(
           outputTensors.at(0),
           inputTensors.at(0),
           static_cast<int>(opts.rootRank),
@@ -402,7 +400,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce_scatter(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->reduce_scatter(
+      comm_->reduce_scatter(
           outputTensors.at(0),
           inputTensors.at(0),
           toReduceOp(opts.reduceOp),
@@ -433,7 +431,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::reduce_scatter_tensor_coalesced(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->reduce_scatter_single(
+      comm_->reduce_scatter_single(
           outputTensors.at(0),
           inputTensors.at(0),
           toReduceOp(opts.reduceOp),
@@ -453,7 +451,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::_reduce_scatter_base(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->reduce_scatter_single(
+      comm_->reduce_scatter_single(
           outputTensor,
           inputTensor,
           toReduceOp(opts.reduceOp),
@@ -476,7 +474,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall_base(
       bopts.timeout = options_->timeout;
     }
     return c10::make_intrusive<WorkWrapper>(
-        backend_->all_to_all_single(
+        comm_->all_to_all_single(
             outputTensor, inputTensor, opts.asyncOp, bopts),
         std::vector<at::Tensor>{outputTensor});
   } else {
@@ -487,7 +485,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall_base(
       bopts.timeout = options_->timeout;
     }
     return c10::make_intrusive<WorkWrapper>(
-        backend_->all_to_all_v_single(
+        comm_->all_to_all_v_single(
             outputTensor,
             inputTensor,
             toVecUint64(outputSplitSizes),
@@ -509,7 +507,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::alltoall(
     bopts.timeout = options_->timeout;
   }
   return c10::make_intrusive<WorkWrapper>(
-      backend_->all_to_all(outputTensors, inputTensors, opts.asyncOp, bopts),
+      comm_->all_to_all(outputTensors, inputTensors, opts.asyncOp, bopts),
       outputTensors);
 }
 
@@ -521,8 +519,7 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   } else {
     bopts.timeout = options_->timeout;
   }
-  return c10::make_intrusive<WorkWrapper>(
-      backend_->barrier(opts.asyncOp, bopts));
+  return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
 }
 
 c10::intrusive_ptr<c10d::Work>
@@ -533,7 +530,7 @@ BackendWrapper::send(std::vector<at::Tensor>& tensors, int dstRank, int tag) {
       tensors.size(),
       " tensors");
   return c10::make_intrusive<WorkWrapper>(
-      backend_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
+      comm_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
 }
 
 c10::intrusive_ptr<c10d::Work>
@@ -544,7 +541,7 @@ BackendWrapper::recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) {
       tensors.size(),
       " tensors");
   return c10::make_intrusive<WorkWrapper>(
-      backend_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
+      comm_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
 }
 
 std::shared_ptr<TorchComm> BackendWrapper::getComm() const {

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -148,7 +148,6 @@ class BackendWrapper : public c10d::Backend {
 
  private:
   std::shared_ptr<TorchComm> comm_;
-  std::shared_ptr<TorchCommBackend> backend_;
   c10::intrusive_ptr<Options> options_;
 };
 

--- a/comms/torchcomms/tests/unit/py/test_backend_wrapper.py
+++ b/comms/torchcomms/tests/unit/py/test_backend_wrapper.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Tests that BackendWrapper (the c10d::Backend shim around TorchComm) routes
+collectives through TorchComm so that pre/post hooks registered on the
+underlying TorchComm fire.
+"""
+
+import unittest
+
+import torch
+import torch.distributed as dist
+import torchcomms
+from torchcomms._comms import _BackendWrapper, OpName
+
+
+def _make_wrapped_pg(name: str) -> tuple[torchcomms.TorchComm, dist.ProcessGroup]:
+    """Create a fake-backend TorchComm wrapped in a ProcessGroup."""
+    comm = torchcomms.new_comm("fake", torch.device("cpu"), name=name)
+    wrapper = _BackendWrapper(comm)
+
+    dummy_store = dist.HashStore()
+    pg = dist.ProcessGroup(dummy_store, comm.get_rank(), comm.get_size())
+    pg._register_backend(
+        comm.get_device(),
+        dist.ProcessGroup.BackendType.CUSTOM,
+        # pyre-fixme[6]: _BackendWrapper implements dist.Backend but stubs aren't aware
+        wrapper,
+    )
+    # pyre-fixme[6]: _set_group_name expects GroupName, which is an alias for str
+    pg._set_group_name(name)
+    return comm, pg
+
+
+class TestBackendWrapperHooks(unittest.TestCase):
+    def test_hooks_fire_when_invoked_through_backend_wrapper(self) -> None:
+        """Pre/post hooks on TorchComm fire when collectives go through the wrapper."""
+        comm, pg = _make_wrapped_pg("test_hooks_fire")
+
+        pre_ops: list[OpName] = []
+        post_count = 0
+
+        def pre_hook(name: OpName, op_id: int, args) -> None:
+            pre_ops.append(name)
+
+        def post_hook(op_id: int, args) -> None:
+            nonlocal post_count
+            post_count += 1
+
+        comm.register_pre_hook(pre_hook)
+        comm.register_post_hook(post_hook)
+
+        tensor = torch.ones(10)
+
+        pg.allreduce([tensor]).wait()
+        pg.broadcast(tensor, root=0).wait()
+        pg.barrier().wait()
+
+        self.assertEqual(pre_ops, [OpName.all_reduce, OpName.broadcast, OpName.barrier])
+        self.assertEqual(post_count, 3)
+
+        comm.finalize()
+
+    def test_hook_op_ids_correlate_and_increase(self) -> None:
+        """Pre/post op_ids match per call and increase across calls."""
+        comm, pg = _make_wrapped_pg("test_op_ids")
+
+        pre_ids: list[int] = []
+        post_ids: list[int] = []
+
+        def pre_hook(name: OpName, op_id: int, args) -> None:
+            pre_ids.append(op_id)
+
+        def post_hook(op_id: int, args) -> None:
+            post_ids.append(op_id)
+
+        comm.register_pre_hook(pre_hook)
+        comm.register_post_hook(post_hook)
+
+        tensor = torch.ones(10)
+        pg.allreduce([tensor]).wait()
+        pg.barrier().wait()
+
+        self.assertEqual(len(pre_ids), 2)
+        self.assertEqual(len(post_ids), 2)
+        self.assertEqual(pre_ids[0], post_ids[0])
+        self.assertEqual(pre_ids[1], post_ids[1])
+        self.assertLess(pre_ids[0], pre_ids[1])
+
+        comm.finalize()
+
+    def test_removed_hooks_do_not_fire(self) -> None:
+        """After remove(), hooks no longer fire for wrapper-invoked collectives."""
+        comm, pg = _make_wrapped_pg("test_removed")
+
+        pre_count = 0
+        post_count = 0
+
+        def pre_hook(name: OpName, op_id: int, args) -> None:
+            nonlocal pre_count
+            pre_count += 1
+
+        def post_hook(op_id: int, args) -> None:
+            nonlocal post_count
+            post_count += 1
+
+        pre_handle = comm.register_pre_hook(pre_hook)
+        post_handle = comm.register_post_hook(post_hook)
+
+        tensor = torch.ones(10)
+        pg.allreduce([tensor]).wait()
+        self.assertEqual(pre_count, 1)
+        self.assertEqual(post_count, 1)
+
+        pre_handle.remove()
+        post_handle.remove()
+
+        pg.allreduce([tensor]).wait()
+        self.assertEqual(pre_count, 1)
+        self.assertEqual(post_count, 1)
+
+        comm.finalize()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Calls to BackendWrapper (the c10d::Backend shim) previously dispatched straight to the backend impl, bypassing the pre/post hooks registered on the owning TorchComm. Route every collective/p2p call through comm_ instead so distwrap users observe the same hook lifecycle as direct TorchComm users.

Adds a gtest that registers hooks on the TorchComm, invokes ops through the wrapper, and verifies the hooks fire with correlated op_ids and respect remove().