### PR TITLE
Refactor collective perf benchmarks for multi-adapter comparison

### DIFF
--- a/comms/torchcomms/tests/perf/py/README.md
+++ b/comms/torchcomms/tests/perf/py/README.md
@@ -1,0 +1,213 @@
+# Collective Performance Benchmarks
+
+A unified benchmarking suite for PyTorch distributed collectives. It runs
+the same collective across three comm adapters, producing CSV results
+alongside side-by-side comparison reports and plots.
+
+Comm adapters:
+
+- `torchcomms`
+- `c10d`
+- `c10d_torchcomms` (c10d routed through torchcomms)
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Supported Collectives](#supported-collectives)
+- [Running a Benchmark](#running-a-benchmark)
+- [Command-Line Options](#command-line-options)
+- [CSV Output](#csv-output)
+- [Comparing Comm Adapters](#comparing-comm-adapters)
+- [Analyzing Results](#analyzing-results)
+- [Adding a New Collective](#adding-a-new-collective)
+
+## Prerequisites
+
+- A working torchcomms install (see the repo root README / CLAUDE.md for build instructions).
+- PyTorch build with the desired backend (NCCL, RCCL, XCCL, Gloo, …).
+- For analysis: `pip install -r requirements.txt` (matplotlib, pandas).
+
+## Supported Collectives
+
+### Reduction collectives
+
+Accept `--reduce-op`: `all_reduce`, `reduce`, `reduce_scatter`,
+`reduce_scatter_single`.
+
+### Data-movement collectives
+
+`all_gather`, `all_gather_single`, `all_to_all`, `all_to_all_single`,
+`broadcast`, `scatter`, `gather`.
+
+### Point-to-point
+
+`send_recv` (paired ping-pong).
+
+### Synchronization
+
+`barrier`.
+
+To add a new collective see [Adding a New Collective](#adding-a-new-collective).
+
+## Running a Benchmark
+
+Set `TEST_BACKEND` to the backend name passed to `new_comm` /
+`init_process_group` (e.g. `nccl`, `xccl`, `gloo`). Optionally set
+`TEST_DEVICE` to a torch device string (`cuda`, `xpu`, `cpu`; defaults to
+`cuda`).
+
+Optional: `TEST_FAST_INIT_MODE` — forwarded to torchcomms as the `fastInitMode` hint.
+
+Launch with `torchrun`:
+
+```bash
+TEST_BACKEND=nccl torchrun --nproc_per_node=8 \
+collective_perf_test.py all_reduce --csv
+```
+
+## Command-Line Options
+
+```bash
+python collective_perf_test.py <collective> [options]
+```
+
+`<collective>` is the name of the collective to benchmark (e.g. `all_reduce`,
+`all_to_all`, `barrier`). Pass `all` to sweep every supported collective; reduction collectives are
+additionally swept across all supported reduction ops (see `--reduce-op`). See
+[Supported Collectives](#supported-collectives) for the full list.
+
+### Comm adapter selection
+
+By default the `torchcomms` adapter is used. Pass one of the flags below to
+switch adapters or run all three.
+
+| Option | Default | Description |
+|---|---|---|
+| `--c10d` | off | Use `torch.distributed` instead of `torchcomms` |
+| `--c10d-torchcomms` | off | Use `torch.distributed` with `use_torchcomms=True` |
+| `--all-comm-adapters` | off | Run sequentially against all three adapters in a single invocation; overrides `--c10d` / `--c10d-torchcomms` |
+
+### Sweep config
+
+| Option | Default | Description |
+|---|---|---|
+| `--min-size <n>` | 4 | Minimum message size in bytes |
+| `--max-size <n>` | 67108864 | Maximum message size in bytes (64 MB); must equal `min_size * size_scaling_factor^n` and divide evenly by the dtype element size |
+| `--size-scaling-factor <n>` | 2 | Multiplier between sizes (must be ≥ 2) |
+| `--dtype <type>` | float32 | `float32`, `float16`, `bfloat16`, `float64`, `int32`, `int64` |
+| `--reduce-op <op>` | sum | Reduction collectives only: `sum`, `min`, `max`, `avg`, `product`, or `all` to sweep every supported op |
+
+### Timing
+
+| Option | Default | Description |
+|---|---|---|
+| `--warmup <n>` | 5 | Warmup iterations (not timed) |
+| `--iters <n>` | 1000 | Measurement iterations |
+| `--sync-interval <n>` | 0 | `0` = bulk timing, `1` = per-iteration (min/max), `N>1` = sync every N iters |
+| `--async` | off | Run collectives async (`async_op=True` + `wait()`); default is sync |
+
+`--sync-interval` modes:
+
+- `0` — single start/stop around the whole loop. Lowest overhead; min/max latency equal the average.
+- `1` — per-iteration sync. Accurate min/max at the cost of per-call overhead.
+- `N > 1` — windowed sync every N iterations. Trade-off between the two.
+
+### Output
+
+| Option | Default | Description |
+|---|---|---|
+| `--csv` | off | Write per-collective CSVs (one file per collective) |
+| `--output-dir <path>` | `./<adapter>/` | Directory for CSV output. With `--all-comm-adapters`, a per-adapter subdir is created underneath the given path |
+| `--quiet`, `-q` | off | Suppress terminal output |
+| `--help`, `-h` | — | Print usage |
+
+## CSV Output
+
+With `--csv`, each collective writes to `<adapter>/<collective>[_<op>].csv`
+by default (e.g. `torchcomms/all_reduce_sum.csv`), so separate runs of
+different adapters don't collide. Pass `--output-dir <path>` to redirect
+the output (the per-adapter subdir is then only used under
+`--all-comm-adapters`, where collision avoidance is needed).
+
+The schema covers test identity, benchmark config, results, and environment
+metadata. See `_CSV_COLUMNS` in [perf_test_helpers.py](perf_test_helpers.py)
+for the full list.
+
+## Comparing Comm Adapters
+
+The simplest way is `--all-comm-adapters`, which runs the full benchmark against
+`torchcomms`, `c10d`, and `c10d_torchcomms` in a single invocation and writes
+one CSV directory per adapter:
+
+```bash
+# 1. Run against all three comm adapters in one go
+TEST_BACKEND=nccl torchrun --nproc_per_node=8 \
+    collective_perf_test.py all --all-comm-adapters --csv
+
+# 2. Analyze — baseline is c10d, others compared against it
+python analyze_perf.py \
+    --dir c10d:./c10d \
+    --dir c10d_torchcomms:./c10d_torchcomms \
+    --dir torchcomms:./torchcomms \
+    --baseline c10d
+```
+
+The same workflow can also be split into three separate runs. Each run
+writes to its own `./<adapter>/` directory by default, so they don't
+collide:
+
+```bash
+# torchcomms (default)
+TEST_BACKEND=nccl torchrun --nproc_per_node=8 \
+    collective_perf_test.py all --csv
+
+# c10d
+TEST_BACKEND=nccl torchrun --nproc_per_node=8 \
+    collective_perf_test.py all --c10d --csv
+
+# c10d_torchcomms
+TEST_BACKEND=nccl torchrun --nproc_per_node=8 \
+    collective_perf_test.py all --c10d-torchcomms --csv
+```
+
+Then analyze the same way as above.
+
+## Analyzing Results
+
+`analyze_perf.py` consumes the CSVs produced above and writes reports under
+`./perf_results/` (or `--outdir`):
+
+```
+perf_results/
+├── perf_summary_<adapter>.{txt,csv}     # per-adapter; latency + bus BW per (collective, message size)
+├── perf_comparison.{txt,csv}            # absolute values + LatChange(%) / BwChange(%) vs baseline
+├── plots/<collective>/                  # one PNG per collective per metric (latency, bus BW);
+│   └── ...                              #   relative (% change) plots also here when --baseline is set
+└── <adapter>_vs_<baseline>/             # one subdir per pairwise comparison
+    ├── perf_regress.{txt,csv}           # rows whose latency regressed beyond --regression-threshold
+    ├── perf_improve.{txt,csv}           # rows whose latency improved beyond --improvement-threshold
+    └── perf_highlights.{txt,csv}        # counts and averages of improved / regressed / neutral points
+```
+
+### Key options
+
+| Option | Default | Description |
+|---|---|---|
+| `--dir LABEL:PATH` | `torchcomms:./torchcomms` | Result directory; repeat for multiple adapters |
+| `--baseline LABEL` | none | Enables relative plots and comparison reports |
+| `--outdir PATH` | `./perf_results/` | Where to write figures and reports |
+| `--regression-threshold PCT` | 5.0 | Latency increase to count as a regression |
+| `--improvement-threshold PCT` | 5.0 | Latency decrease to count as an improvement |
+| `--summary-only` | off | Skip figures, write only summary reports |
+
+## Adding a New Collective
+
+1. Create `<collective>_perf.py` with a `run_<collective>_perf(comm, record, device)` function.
+2. Inside, define two callbacks and delegate to `run_bench_sweep`:
+   - `setup_fn(num_elements, rank, num_ranks, device, dtype) -> (args, kwargs)`
+   - `bus_bw_fn(num_elements, element_size, num_ranks, avg_time_us) -> gbps`
+3. Register it in `COLLECTIVE_RUNNERS` in [collective_perf_test.py](collective_perf_test.py).
+4. If it accepts a reduction operator, add it to `REDUCE_COLLECTIVES` in the
+   same file and to `_REDUCE_COLLECTIVES` in [perf_test_helpers.py](perf_test_helpers.py).
+
+See [all_reduce_perf.py](all_reduce_perf.py) for a minimal example.

--- a/comms/torchcomms/tests/perf/py/all_gather_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_gather_perf.py
@@ -2,91 +2,29 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_gather_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllGather Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor list
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
         output_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_list, input_tensor), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_gather(output_list, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllGather: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_gather(output_list, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllGather bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_gather", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_gather_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_gather_perf.py
@@ -2,91 +2,29 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_gather_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllGather Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor list
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
         output_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_list, input_tensor), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_gather(output_list, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllGather: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_gather(output_list, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllGather bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_gather", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_gather_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_gather_single_perf.py
@@ -2,90 +2,27 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_gather_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
+        output_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllGatherSingle Performance ===")
-    print_perf_header(rank)
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllGatherSingle: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor (single tensor for all ranks)
-        output_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_gather_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_gather_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllGatherSingle bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_gather_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_gather_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_gather_single_perf.py
@@ -2,90 +2,27 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_gather_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
+        output_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllGatherSingle Performance ===")
-    print_perf_header(rank)
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllGatherSingle: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor (single tensor for all ranks)
-        output_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_gather_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_gather_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllGatherSingle bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_gather_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_reduce_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_reduce_perf.py
@@ -2,85 +2,28 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_reduce_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllReduce Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllReduce: 2 * (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * 2.0 * (num_ranks - 1) / num_ranks / 1000.0
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllReduce bus bandwidth: 2 * (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = 2.0 * (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_reduce", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_reduce_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_reduce_perf.py
@@ -2,85 +2,28 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_reduce_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllReduce Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllReduce: 2 * (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * 2.0 * (num_ranks - 1) / num_ranks / 1000.0
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllReduce bus bandwidth: 2 * (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = 2.0 * (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_reduce", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_to_all_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_to_all_perf.py
@@ -2,95 +2,32 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_to_all_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllToAll Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-
-        # Create input and output tensor lists
+    def setup(num_elements, rank, num_ranks, device, dtype):
         input_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
         output_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_list, input_list), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_to_all(output_list, input_list, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_to_all(output_list, input_list, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllToAll bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllToAll: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_to_all", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_to_all_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_to_all_perf.py
@@ -2,95 +2,32 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_to_all_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllToAll Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-
-        # Create input and output tensor lists
+    def setup(num_elements, rank, num_ranks, device, dtype):
         input_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
         output_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_list, input_list), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_to_all(output_list, input_list, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_to_all(output_list, input_list, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllToAll bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllToAll: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_to_all", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_to_all_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_to_all_single_perf.py
@@ -2,93 +2,28 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_to_all_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        output_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllToAllSingle Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-
-        # Create input and output tensors (single tensors for all ranks)
-        input_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-        output_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_to_all_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_to_all_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllToAllSingle bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllToAllSingle: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_to_all_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/all_to_all_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/all_to_all_single_perf.py
@@ -2,93 +2,28 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_all_to_all_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        output_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} AllToAllSingle Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-
-        # Create input and output tensors (single tensors for all ranks)
-        input_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-        output_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.all_to_all_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.all_to_all_single(output_tensor, input_tensor, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # AllToAllSingle bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # AllToAllSingle: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "all_to_all_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/analyze_perf.py
+++ b/comms/torchcomms/tests/perf/py/analyze_perf.py
@@ -1,0 +1,1373 @@
+#!/usr/bin/env python3
+"""
+Analyze collective performance results.
+
+For every CSV found across the provided result directories a figure is produced
+with two separate figures: Latency (us) and Bus Bandwidth (GB/s) vs message
+size.  When --baseline is provided, relative plots and comparison reports are
+also generated.
+
+Usage:
+    # Single adapter results (saves PNGs into ./perf_results/plots/)
+    python analyze_perf.py  --dir torchcomms:./torchcomms
+
+    # Compare multiple adapters
+    python analyze_perf.py  --dir torchcomms:./torchcomms --dir c10d:./c10d
+
+    # Three-way comparison with baseline for relative plots
+    python analyze_perf.py  --dir torchcomms:./torchcomms --dir c10d:./c10d \
+                             --dir c10d_torchcomms:./c10d_torchcomms --baseline c10d
+
+    # Save all figures into a custom directory
+    python analyze_perf.py  --dir torchcomms:./torchcomms --outdir my_plots
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REQUIRED_COLS = {
+    "Collective",
+    "SendMsgSize(B)",
+    "LatAvg(us)",
+    "LatMin(us)",
+    "LatMax(us)",
+    "BusBw(GB/s)",
+}
+
+
+def human_bytes(n):
+    """Human-readable byte count using powers of 1024."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:g} {unit}"
+        n /= 1024
+    return f"{n:g} TB"
+
+
+def fmt_xaxis(ax, sizes):
+    """Log-2 x-axis with human-readable tick labels."""
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(sizes)
+    ax.set_xticklabels(
+        [human_bytes(s) for s in sizes], rotation=45, ha="right", fontsize=8
+    )
+    ax.xaxis.set_minor_locator(ticker.NullLocator())
+
+
+def load_csv(path: Path) -> pd.DataFrame | None:
+    """Load and validate a CSV file. Returns None on failure."""
+    try:
+        df = pd.read_csv(path)
+    except Exception as e:
+        print(f"Warning: could not read {path}: {e}", file=sys.stderr)
+        return None
+    if not REQUIRED_COLS.issubset(df.columns):
+        missing = REQUIRED_COLS - set(df.columns)
+        print(f"Warning: {path} missing columns {missing}, skipping.", file=sys.stderr)
+        return None
+    if df.empty:
+        print(f"Warning: {path} has no data rows, skipping.", file=sys.stderr)
+        return None
+    return df.sort_values("SendMsgSize(B)").reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def add_latency_series(ax, df: pd.DataFrame, label: str, color: str, marker: str):
+    """Draw one latency curve (+ optional min/max band) onto ax."""
+    sizes = df["SendMsgSize(B)"].values
+    avg = df["LatAvg(us)"].values
+    mn = df["LatMin(us)"].values
+    mx = df["LatMax(us)"].values
+
+    ax.plot(
+        sizes, avg, marker=marker, ms=4, linewidth=1.5, color=color, label=f"{label}"
+    )
+    if not ((mn == avg).all() and (mx == avg).all()):
+        ax.fill_between(
+            sizes, mn, mx, alpha=0.18, color=color, label=f"{label} Min-Max"
+        )
+
+
+def add_bw_series(ax, df: pd.DataFrame, label: str, color: str, marker: str):
+    """Draw one bus-bandwidth curve onto ax."""
+    sizes = df["SendMsgSize(B)"].values
+    bw = df["BusBw(GB/s)"].values
+    ax.plot(sizes, bw, marker=marker, ms=4, linewidth=1.5, color=color, label=label)
+
+
+def build_latency_figure(
+    collective: str, series: list[tuple[str, pd.DataFrame]]
+) -> plt.Figure:
+    """Return a standalone Latency figure for *collective*."""
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    all_sizes = sorted({s for _, df in series for s in df["SendMsgSize(B)"].values})
+
+    for idx, (label, df) in enumerate(series):
+        add_latency_series(
+            ax,
+            df,
+            label,
+            color=colors[idx % len(colors)],
+            marker=markers[idx % len(markers)],
+        )
+
+    ax.set_title(collective)
+    ax.set_xlabel("Message Size")
+    ax.set_ylabel("Latency (µs)")
+    ax.set_yscale("log")
+    fmt_xaxis(ax, all_sizes)
+    ax.grid(True, which="major", linestyle="--", linewidth=0.5)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    return fig
+
+
+def build_bw_figure(
+    collective: str, series: list[tuple[str, pd.DataFrame]]
+) -> plt.Figure:
+    """Return a standalone Bus Bandwidth figure for *collective*."""
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    all_sizes = sorted({s for _, df in series for s in df["SendMsgSize(B)"].values})
+
+    for idx, (label, df) in enumerate(series):
+        add_bw_series(
+            ax,
+            df,
+            label,
+            color=colors[idx % len(colors)],
+            marker=markers[idx % len(markers)],
+        )
+
+    ax.set_title(collective)
+    ax.set_xlabel("Message Size")
+    ax.set_ylabel("Bus Bandwidth (GB/s)")
+    fmt_xaxis(ax, all_sizes)
+    ax.grid(True, which="major", linestyle="--", linewidth=0.5)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    return fig
+
+
+def _get_relative_data(
+    series: list[tuple[str, pd.DataFrame]],
+    baseline_label: str = "c10d",
+) -> tuple[pd.DataFrame | None, list[tuple[str, pd.DataFrame]]]:
+    """Find the baseline and the non-baseline series. Returns (baseline_df, others)."""
+    baseline_df = None
+    for label, df in series:
+        if label == baseline_label:
+            baseline_df = df
+            break
+    others = [(label, df) for label, df in series if label != baseline_label]
+    return baseline_df, others
+
+
+def build_relative_latency_figure(
+    collective: str,
+    series: list[tuple[str, pd.DataFrame]],
+    baseline_label: str = "c10d",
+) -> plt.Figure | None:
+    """Return a figure showing % latency change relative to *baseline_label*.
+
+    Latency change = (baseline - other) / baseline * 100
+    (positive ⟹ lower latency ⟹ better)
+
+    Returns None when the baseline is not present in *series*.
+    """
+    baseline_df, others = _get_relative_data(series, baseline_label)
+    if baseline_df is None or not others:
+        return None
+
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    for idx, (label, other_df) in enumerate(others):
+        merged = pd.merge(
+            baseline_df[["SendMsgSize(B)", "LatAvg(us)"]],
+            other_df[["SendMsgSize(B)", "LatAvg(us)"]],
+            on="SendMsgSize(B)",
+            suffixes=("_base", "_other"),
+        )
+        if merged.empty:
+            continue
+
+        sizes = merged["SendMsgSize(B)"].values
+        lat_pct = (
+            (merged["LatAvg(us)_base"] - merged["LatAvg(us)_other"])
+            / merged["LatAvg(us)_base"]
+            * 100
+        ).values
+
+        ax.plot(
+            sizes,
+            lat_pct,
+            marker=markers[idx % len(markers)],
+            ms=4,
+            linewidth=1.5,
+            color=colors[idx % len(colors)],
+            label=label,
+        )
+
+    all_sizes = sorted({s for _, df in series for s in df["SendMsgSize(B)"].values})
+    ax.set_title(f"{collective} — Latency Change vs {baseline_label}")
+    ax.set_xlabel("Message Size")
+    ax.set_ylabel("Latency Change (%)")
+    ax.axhline(0, color="grey", linewidth=0.8, linestyle="--")
+    fmt_xaxis(ax, all_sizes)
+    ax.grid(True, which="major", linestyle="--", linewidth=0.5)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    return fig
+
+
+def build_relative_bw_figure(
+    collective: str,
+    series: list[tuple[str, pd.DataFrame]],
+    baseline_label: str = "c10d",
+) -> plt.Figure | None:
+    """Return a figure showing % bandwidth change relative to *baseline_label*.
+
+    Bandwidth change = (other - baseline) / baseline * 100
+    (positive ⟹ higher bandwidth ⟹ better)
+
+    Returns None when the baseline is not present in *series*.
+    """
+    baseline_df, others = _get_relative_data(series, baseline_label)
+    if baseline_df is None or not others:
+        return None
+
+    colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    markers = ["o", "s", "^", "D", "v", "P", "X", "*"]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+
+    for idx, (label, other_df) in enumerate(others):
+        merged = pd.merge(
+            baseline_df[["SendMsgSize(B)", "BusBw(GB/s)"]],
+            other_df[["SendMsgSize(B)", "BusBw(GB/s)"]],
+            on="SendMsgSize(B)",
+            suffixes=("_base", "_other"),
+        )
+        if merged.empty:
+            continue
+
+        sizes = merged["SendMsgSize(B)"].values
+        bw_pct = (
+            (merged["BusBw(GB/s)_other"] - merged["BusBw(GB/s)_base"])
+            / merged["BusBw(GB/s)_base"]
+            * 100
+        ).values
+
+        ax.plot(
+            sizes,
+            bw_pct,
+            marker=markers[idx % len(markers)],
+            ms=4,
+            linewidth=1.5,
+            color=colors[idx % len(colors)],
+            label=label,
+        )
+
+    all_sizes = sorted({s for _, df in series for s in df["SendMsgSize(B)"].values})
+    ax.set_title(f"{collective} — Bandwidth Change vs {baseline_label}")
+    ax.set_xlabel("Message Size")
+    ax.set_ylabel("Bus Bandwidth Change (%)")
+    ax.axhline(0, color="grey", linewidth=0.8, linestyle="--")
+    fmt_xaxis(ax, all_sizes)
+    ax.grid(True, which="major", linestyle="--", linewidth=0.5)
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Summary report
+# ---------------------------------------------------------------------------
+
+
+def build_adapter_summary_df(
+    all_series: dict[str, list[tuple[str, pd.DataFrame]]],
+    adapter_label: str,
+) -> pd.DataFrame:
+    """Build a summary DataFrame for a single adapter (no baseline comparison).
+
+    Returns an empty DataFrame when there is nothing to summarise.
+    """
+    rows: list[dict] = []
+
+    for file_base, series in sorted(all_series.items()):
+        for label, df in series:
+            if label != adapter_label:
+                continue
+            for _, r in df.iterrows():
+                msg_size = int(r["SendMsgSize(B)"])
+                rows.append(
+                    {
+                        "Collective": file_base,
+                        "NumRanks": int(r["Ranks"]) if "Ranks" in r.index else None,
+                        "DeviceName": (
+                            r["DeviceName"] if "DeviceName" in r.index else None
+                        ),
+                        "MsgSize": human_bytes(msg_size),
+                        "SendMsgSize(B)": msg_size,
+                        "LatAvg(us)": round(r["LatAvg(us)"], 2),
+                        "LatMin(us)": round(r["LatMin(us)"], 2),
+                        "LatMax(us)": round(r["LatMax(us)"], 2),
+                        "BusBw(GB/s)": round(r["BusBw(GB/s)"], 2),
+                    }
+                )
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    df.sort_values(["Collective", "SendMsgSize(B)"], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def build_comparison_summary_df(
+    all_series: dict[str, list[tuple[str, pd.DataFrame]]],
+    baseline_label: str,
+) -> pd.DataFrame:
+    """Build a summary DataFrame with per-collective, per-message-size stats.
+
+    *all_series* maps ``file_base`` (e.g. ``"all_reduce_sum"``) to the list of
+    ``(adapter_label, df)`` pairs collected during the per-CSV loop.
+
+    For every adapter and message size the report contains:
+      - ``LatAvg(us)``, ``LatMin(us)``, ``LatMax(us)``
+      - ``BusBw(GB/s)``
+      - ``LatChange(%)``  = (baseline - adapter) / baseline * 100
+      - ``BwChange(%)``   = (adapter  - baseline) / baseline * 100
+    (positive values = improvement over baseline)
+
+    Returns an empty DataFrame when there is nothing to summarise.
+    """
+    rows: list[dict] = []
+
+    for file_base, series in sorted(all_series.items()):
+        # Pre-compute baseline keyed by message size
+        baseline_by_size: dict[int, pd.Series] = {}
+        for label, df in series:
+            if label == baseline_label:
+                for _, r in df.iterrows():
+                    baseline_by_size[int(r["SendMsgSize(B)"])] = r
+                break
+
+        for label, df in series:
+            for _, r in df.iterrows():
+                msg_size = int(r["SendMsgSize(B)"])
+                lat_avg = r["LatAvg(us)"]
+                lat_min = r["LatMin(us)"]
+                lat_max = r["LatMax(us)"]
+                bw = r["BusBw(GB/s)"]
+
+                ranks = int(r["Ranks"]) if "Ranks" in r.index else None
+                device = r["DeviceName"] if "DeviceName" in r.index else None
+
+                row = {
+                    "Collective": file_base,
+                    "Adapter": label,
+                    "NumRanks": ranks,
+                    "DeviceName": device,
+                    "MsgSize": human_bytes(msg_size),
+                    "SendMsgSize(B)": msg_size,
+                    "LatAvg(us)": round(lat_avg, 2),
+                    "LatMin(us)": round(lat_min, 2),
+                    "LatMax(us)": round(lat_max, 2),
+                    "BusBw(GB/s)": round(bw, 2),
+                    "LatChange(%)": None,
+                    "BwChange(%)": None,
+                }
+
+                if msg_size in baseline_by_size and label != baseline_label:
+                    base = baseline_by_size[msg_size]
+                    base_lat = base["LatAvg(us)"]
+                    base_bw = base["BusBw(GB/s)"]
+                    if base_lat > 0:
+                        row["LatChange(%)"] = round(
+                            (base_lat - lat_avg) / base_lat * 100, 1
+                        )
+                    if base_bw > 0:
+                        row["BwChange(%)"] = round((bw - base_bw) / base_bw * 100, 1)
+
+                rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows)
+    df.sort_values(["Collective", "SendMsgSize(B)", "Adapter"], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def _format_table(df: pd.DataFrame) -> str:
+    """Format a DataFrame as a table string with separators between collectives."""
+    table = df.to_string(index=False)
+    table_lines = table.splitlines()
+    header = table_lines[0]
+    separator = "-" * len(header)
+
+    lines: list[str] = [header, separator]
+    prev_collective = None
+    for line in table_lines[1:]:
+        collective = line.split()[0]
+        if prev_collective is not None and collective != prev_collective:
+            lines.append(separator)
+        lines.append(line)
+        prev_collective = collective
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _filter_regressions(
+    summary_df: pd.DataFrame,
+    baseline_label: str,
+    threshold: float,
+) -> pd.DataFrame:
+    """Return non-baseline rows where latency regressed beyond *threshold*.
+
+    A regression is a row where ``LatChange(%) < -threshold`` (higher latency)
+    compared to the baseline.
+    """
+    non_baseline = summary_df[summary_df["Adapter"] != baseline_label]
+    return non_baseline[
+        non_baseline["LatChange(%)"].notna()
+        & (non_baseline["LatChange(%)"] < -threshold)
+    ]
+
+
+def _filter_improvements(
+    summary_df: pd.DataFrame,
+    baseline_label: str,
+    threshold: float,
+) -> pd.DataFrame:
+    """Return non-baseline rows where latency improved beyond *threshold*.
+
+    An improvement is a row where ``LatChange(%) > threshold`` (lower latency)
+    compared to the baseline.
+    """
+    non_baseline = summary_df[summary_df["Adapter"] != baseline_label]
+    return non_baseline[
+        non_baseline["LatChange(%)"].notna()
+        & (non_baseline["LatChange(%)"] > threshold)
+    ]
+
+
+def save_adapter_summary_txt(
+    summary_df: pd.DataFrame, adapter_label: str, path: Path
+) -> None:
+    """Save a per-adapter summary report as a formatted text file."""
+    if summary_df.empty:
+        return
+
+    display_cols = [
+        "Collective",
+        "NumRanks",
+        "MsgSize",
+        "LatAvg(us)",
+        "LatMin(us)",
+        "LatMax(us)",
+        "BusBw(GB/s)",
+        "DeviceName",
+    ]
+    df = summary_df[display_cols].copy()
+
+    lines = [
+        "=" * 80,
+        f"PERFORMANCE SUMMARY — {adapter_label}",
+        "=" * 80,
+        _format_table(df),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def save_adapter_summary_csv(summary_df: pd.DataFrame, path: Path) -> None:
+    """Save a per-adapter summary DataFrame to a CSV file."""
+    if summary_df.empty:
+        return
+    csv_cols = [
+        "Collective",
+        "NumRanks",
+        "MsgSize",
+        "SendMsgSize(B)",
+        "LatAvg(us)",
+        "LatMin(us)",
+        "LatMax(us)",
+        "BusBw(GB/s)",
+        "DeviceName",
+    ]
+    summary_df[csv_cols].to_csv(path, index=False)
+
+
+def save_comparison_summary_txt(
+    summary_df: pd.DataFrame, baseline_label: str, path: Path
+) -> None:
+    """Save the comparison summary report as a formatted text file."""
+    if summary_df.empty:
+        return
+
+    display_cols = [
+        "Collective",
+        "Adapter",
+        "NumRanks",
+        "MsgSize",
+        "LatAvg(us)",
+        "LatMin(us)",
+        "LatMax(us)",
+        "BusBw(GB/s)",
+        "LatChange(%)",
+        "BwChange(%)",
+        "DeviceName",
+    ]
+    df = summary_df[display_cols].copy()
+    is_baseline = df["Adapter"] == baseline_label
+    df["LatChange(%)"] = df["LatChange(%)"].apply(
+        lambda v: f"{v:+.1f}" if pd.notna(v) else "n/a"
+    )
+    df["BwChange(%)"] = df["BwChange(%)"].apply(
+        lambda v: f"{v:+.1f}" if pd.notna(v) else "n/a"
+    )
+    df.loc[is_baseline, "LatChange(%)"] = "baseline"
+    df.loc[is_baseline, "BwChange(%)"] = "baseline"
+
+    lines = ["=" * 80, "COMPARISON SUMMARY", "=" * 80, _format_table(df)]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def save_comparison_summary_csv(summary_df: pd.DataFrame, path: Path) -> None:
+    """Save the comparison summary DataFrame to a CSV file."""
+    if summary_df.empty:
+        return
+    csv_cols = [
+        "Collective",
+        "Adapter",
+        "NumRanks",
+        "MsgSize",
+        "SendMsgSize(B)",
+        "LatAvg(us)",
+        "LatMin(us)",
+        "LatMax(us)",
+        "BusBw(GB/s)",
+        "LatChange(%)",
+        "BwChange(%)",
+        "DeviceName",
+    ]
+    summary_df[csv_cols].to_csv(path, index=False)
+
+
+_REPORT_DISPLAY_COLS = [
+    "Collective",
+    "Adapter",
+    "NumRanks",
+    "MsgSize",
+    "LatAvg(us)",
+    "LatMin(us)",
+    "LatMax(us)",
+    "BusBw(GB/s)",
+    "LatChange(%)",
+    "BwChange(%)",
+    "DeviceName",
+]
+
+_REPORT_CSV_COLS = [
+    "Collective",
+    "Adapter",
+    "NumRanks",
+    "MsgSize",
+    "SendMsgSize(B)",
+    "LatAvg(us)",
+    "LatMin(us)",
+    "LatMax(us)",
+    "BusBw(GB/s)",
+    "LatChange(%)",
+    "BwChange(%)",
+    "DeviceName",
+]
+
+
+def _write_filtered_report(
+    filtered_df: pd.DataFrame,
+    title: str,
+    threshold: float,
+    empty_msg: str,
+    txt_path: Path,
+    csv_path: Path,
+) -> None:
+    """Write txt + csv for an already-filtered DataFrame."""
+    if filtered_df.empty:
+        txt_path.write_text(f"{empty_msg} {threshold:.1f}% detected.\n")
+        pd.DataFrame(columns=_REPORT_CSV_COLS).to_csv(csv_path, index=False)
+        return
+
+    df = filtered_df[_REPORT_DISPLAY_COLS].copy()
+    df["LatChange(%)"] = df["LatChange(%)"].apply(
+        lambda v: f"{v:+.1f}" if pd.notna(v) else "n/a"
+    )
+    df["BwChange(%)"] = df["BwChange(%)"].apply(
+        lambda v: f"{v:+.1f}" if pd.notna(v) else "n/a"
+    )
+
+    lines = ["=" * 80, title, "=" * 80, _format_table(df)]
+    txt_path.write_text("\n".join(lines) + "\n")
+
+    filtered_df[_REPORT_CSV_COLS].to_csv(csv_path, index=False)
+
+
+def save_regression_reports(
+    summary_df: pd.DataFrame,
+    baseline_label: str,
+    threshold: float,
+    outdir: Path,
+) -> list[Path]:
+    """Save per-adapter regression reports (txt + csv).
+
+    Files are written to ``{adapter}_vs_{baseline}/perf_regress.{ext}``.
+    Returns the list of saved paths.
+    """
+    if summary_df.empty:
+        return []
+
+    saved: list[Path] = []
+    adapters = [a for a in summary_df["Adapter"].unique() if a != baseline_label]
+
+    for adapter in adapters:
+        adapter_df = summary_df[summary_df["Adapter"] == adapter]
+        regressed = _filter_regressions(adapter_df, baseline_label, threshold)
+        tag = f"{adapter}_vs_{baseline_label}"
+        pair_dir = outdir / tag
+        pair_dir.mkdir(parents=True, exist_ok=True)
+
+        txt_path = pair_dir / "perf_regress.txt"
+        csv_path = pair_dir / "perf_regress.csv"
+        _write_filtered_report(
+            regressed,
+            title=f"PERFORMANCE REGRESSIONS — {adapter} vs {baseline_label} (threshold: {threshold:.1f}%)",
+            threshold=threshold,
+            empty_msg=f"No performance regressions for {adapter} vs {baseline_label} exceeding",
+            txt_path=txt_path,
+            csv_path=csv_path,
+        )
+        saved.extend([txt_path, csv_path])
+
+    return saved
+
+
+def save_improvement_reports(
+    summary_df: pd.DataFrame,
+    baseline_label: str,
+    threshold: float,
+    outdir: Path,
+) -> list[Path]:
+    """Save per-adapter improvement reports (txt + csv).
+
+    Files are written to ``{adapter}_vs_{baseline}/perf_improve.{ext}``.
+    Returns the list of saved paths.
+    """
+    if summary_df.empty:
+        return []
+
+    saved: list[Path] = []
+    adapters = [a for a in summary_df["Adapter"].unique() if a != baseline_label]
+
+    for adapter in adapters:
+        adapter_df = summary_df[summary_df["Adapter"] == adapter]
+        improved = _filter_improvements(adapter_df, baseline_label, threshold)
+        tag = f"{adapter}_vs_{baseline_label}"
+        pair_dir = outdir / tag
+        pair_dir.mkdir(parents=True, exist_ok=True)
+
+        txt_path = pair_dir / "perf_improve.txt"
+        csv_path = pair_dir / "perf_improve.csv"
+        _write_filtered_report(
+            improved,
+            title=f"PERFORMANCE IMPROVEMENTS — {adapter} vs {baseline_label} (threshold: {threshold:.1f}%)",
+            threshold=threshold,
+            empty_msg=f"No performance improvements for {adapter} vs {baseline_label} exceeding",
+            txt_path=txt_path,
+            csv_path=csv_path,
+        )
+        saved.extend([txt_path, csv_path])
+
+    return saved
+
+
+def _extract_bench_info(
+    all_series: dict[str, list[tuple[str, pd.DataFrame]]],
+    adapter_label: str | None = None,
+) -> dict[str, str]:
+    """Extract high-level benchmark metadata from the raw CSV DataFrames.
+
+    Scans DataFrames for common metadata columns and returns a dict of
+    field-name to display-value (using the first non-empty value found, or
+    aggregating where appropriate like message-size range).
+
+    When *adapter_label* is given, only DataFrames whose label matches are
+    considered — this prevents mixing metadata from different adapters
+    (e.g. baseline backend version leaking into an adapter-specific report).
+    """
+    info: dict[str, str] = {}
+    all_dfs: list[pd.DataFrame] = []
+    for series in all_series.values():
+        for label, df in series:
+            if adapter_label is None or label == adapter_label:
+                all_dfs.append(df)
+
+    if not all_dfs:
+        return info
+
+    sample = all_dfs[0]
+
+    # DeviceName
+    if "DeviceName" in sample.columns:
+        info["Device"] = str(sample["DeviceName"].iloc[0])
+
+    # DeviceType
+    if "DeviceType" in sample.columns:
+        info["Device type"] = str(sample["DeviceType"].iloc[0])
+
+    # Ranks
+    if "Ranks" in sample.columns:
+        all_ranks = sorted(
+            {
+                int(r)
+                for df in all_dfs
+                if "Ranks" in df.columns
+                for r in df["Ranks"].unique()
+            }
+        )
+        info["Number of ranks"] = ", ".join(str(r) for r in all_ranks)
+
+    # Message size range
+    all_sizes = sorted(
+        {int(s) for df in all_dfs for s in df["SendMsgSize(B)"].unique()}
+    )
+    if all_sizes:
+        info["Message size range"] = (
+            f"{human_bytes(all_sizes[0])} – {human_bytes(all_sizes[-1])}"
+        )
+        info["Message sizes"] = str(len(all_sizes))
+
+    # DispatchMode
+    if "DispatchMode" in sample.columns:
+        modes = sorted(
+            {
+                str(m)
+                for df in all_dfs
+                if "DispatchMode" in df.columns
+                for m in df["DispatchMode"].unique()
+            }
+        )
+        info["Dispatch mode"] = ", ".join(modes)
+
+    # DType
+    if "DType" in sample.columns:
+        dtypes = sorted(
+            {
+                str(d)
+                for df in all_dfs
+                if "DType" in df.columns
+                for d in df["DType"].unique()
+            }
+        )
+        info["DType"] = ", ".join(dtypes)
+
+    # WarmupIters / MeasureIters / SyncInterval
+    for col, label in [
+        ("WarmupIters", "Warmup iterations"),
+        ("MeasureIters", "Measure iterations"),
+        ("SyncInterval", "Sync interval"),
+    ]:
+        if col in sample.columns:
+            vals = sorted(
+                {
+                    int(v)
+                    for df in all_dfs
+                    if col in df.columns
+                    for v in df[col].unique()
+                }
+            )
+            info[label] = ", ".join(str(v) for v in vals)
+
+    # CommBackend
+    if "CommBackend" in sample.columns:
+        backends = sorted(
+            {
+                str(b)
+                for df in all_dfs
+                if "CommBackend" in df.columns
+                for b in df["CommBackend"].unique()
+            }
+        )
+        info["Backend"] = ", ".join(backends)
+
+    # CommBackendVersion
+    if "CommBackendVersion" in sample.columns:
+        bversions = sorted(
+            {
+                str(v)
+                for df in all_dfs
+                if "CommBackendVersion" in df.columns
+                for v in df["CommBackendVersion"].dropna().unique()
+                if str(v) not in ("n/a", "nan", "")
+            }
+        )
+        if bversions:
+            info["Backend version"] = ", ".join(bversions)
+
+    # TorchVersion
+    if "TorchVersion" in sample.columns:
+        versions = sorted(
+            {
+                str(v)
+                for df in all_dfs
+                if "TorchVersion" in df.columns
+                for v in df["TorchVersion"].unique()
+            }
+        )
+        info["Torch version"] = ", ".join(versions)
+
+    return info
+
+
+def save_highlights_report(
+    summary_df: pd.DataFrame,
+    baseline_label: str,
+    regression_threshold: float,
+    improvement_threshold: float,
+    outdir: Path,
+    all_series: dict[str, list[tuple[str, pd.DataFrame]]] | None = None,
+) -> list[Path]:
+    """Save per-adapter highlights reports (txt + csv).
+
+    Each report contains:
+      - High-level benchmark information (device, ranks, message sizes, etc.).
+      - Total collectives and data points examined.
+      - Number of collectives and data points classified as improvements,
+        regressions, or neutral (within both thresholds).
+
+    Files are written to ``{adapter}_vs_{baseline}/perf_highlights.{ext}``.
+    Returns the list of saved paths.
+    """
+    if summary_df.empty:
+        return []
+
+    saved: list[Path] = []
+    adapters = [a for a in summary_df["Adapter"].unique() if a != baseline_label]
+
+    for adapter in adapters:
+        bench_info = (
+            _extract_bench_info(all_series, adapter_label=adapter) if all_series else {}
+        )
+        adapter_df = summary_df[summary_df["Adapter"] == adapter]
+        # Only rows with a valid LatChange comparison
+        compared = adapter_df[adapter_df["LatChange(%)"].notna()]
+
+        total_collectives = compared["Collective"].nunique()
+        total_points = len(compared)
+
+        improved = _filter_improvements(
+            adapter_df, baseline_label, improvement_threshold
+        )
+        regressed = _filter_regressions(
+            adapter_df, baseline_label, regression_threshold
+        )
+
+        improve_collectives = (
+            improved["Collective"].nunique() if not improved.empty else 0
+        )
+        improve_points = len(improved)
+        regress_collectives = (
+            regressed["Collective"].nunique() if not regressed.empty else 0
+        )
+        regress_points = len(regressed)
+
+        # Neutral: compared points that are neither improved nor regressed
+        neutral_points = total_points - improve_points - regress_points
+        # Collectives that appear only in neutral (not in either filtered set)
+        all_colls = set(compared["Collective"].unique())
+        improve_colls = (
+            set(improved["Collective"].unique()) if not improved.empty else set()
+        )
+        regress_colls = (
+            set(regressed["Collective"].unique()) if not regressed.empty else set()
+        )
+        neutral_only_colls = all_colls - improve_colls - regress_colls
+        neutral_collectives = len(neutral_only_colls)
+
+        # Build neutral DataFrame for stats
+        imp_idx = improved.index if not improved.empty else pd.Index([])
+        reg_idx = regressed.index if not regressed.empty else pd.Index([])
+        neutral_df = compared.loc[~compared.index.isin(imp_idx.union(reg_idx))]
+
+        def _avg(df: pd.DataFrame, col: str = "LatChange(%)") -> float | None:
+            vals = df[col].dropna()
+            return round(vals.mean(), 1) if len(vals) > 0 else None
+
+        def _med(df: pd.DataFrame, col: str = "LatChange(%)") -> float | None:
+            vals = df[col].dropna()
+            return round(vals.median(), 1) if len(vals) > 0 else None
+
+        # Global stats
+        imp_avg = _avg(improved)
+        imp_med = _med(improved)
+        reg_avg = _avg(regressed)
+        reg_med = _med(regressed)
+        neu_avg = _avg(neutral_df)
+        neu_med = _med(neutral_df)
+        total_avg = _avg(compared)
+        total_med = _med(compared)
+
+        tag = f"{adapter}_vs_{baseline_label}"
+        pair_dir = outdir / tag
+        pair_dir.mkdir(parents=True, exist_ok=True)
+        txt_path = pair_dir / "perf_highlights.txt"
+        csv_path = pair_dir / "perf_highlights.csv"
+
+        # --- Build text report ---
+        w = 89
+
+        def _pct(n: int, total: int) -> str:
+            return f"{n / total * 100:.1f}%" if total > 0 else "n/a"
+
+        def _fmt(v: float | None) -> str:
+            return f"{v:+.1f}%" if v is not None else "n/a"
+
+        lines = [
+            "=" * w,
+            f"PERFORMANCE HIGHLIGHTS — {adapter} vs {baseline_label}",
+            "=" * w,
+        ]
+
+        # Benchmark info section
+        if bench_info:
+            lines.append("")
+            lines.append("Benchmark Info:")
+            label_w = max(len(k) for k in bench_info) + 2
+            for key, val in bench_info.items():
+                lines.append(f"  {key:<{label_w}}: {val}")
+
+        lines += [
+            "",
+            f"  Regression threshold : {regression_threshold:.1f}%",
+            f"  Improvement threshold: {improvement_threshold:.1f}%",
+            "",
+            "-" * w,
+            f"  {'Category':<20} {'Collectives':>12} {'Points':>10} {'%':>8} {'AvgLatChange(%)':>16} {'MedLatChange(%)':>16}",
+            "-" * w,
+            f"  {'Improved':<20} {improve_collectives:>12} {improve_points:>10} {_pct(improve_points, total_points):>8} {_fmt(imp_avg):>16} {_fmt(imp_med):>16}",
+            f"  {'Regressions':<20} {regress_collectives:>12} {regress_points:>10} {_pct(regress_points, total_points):>8} {_fmt(reg_avg):>16} {_fmt(reg_med):>16}",
+            f"  {'Neutral':<20} {neutral_collectives:>12} {neutral_points:>10} {_pct(neutral_points, total_points):>8} {_fmt(neu_avg):>16} {_fmt(neu_med):>16}",
+            "-" * w,
+            f"  {'Total examined':<20} {total_collectives:>12} {total_points:>10} {'100.0%':>8}",
+            "",
+        ]
+
+        # Per-collective breakdown
+        lines.append("Per-collective breakdown:")
+        lines.append("")
+        lines.append(
+            f"  {'Collective':<30} {'Imp':>6} {'Reg':>6} {'Neu':>6} {'Tot':>6}"
+            f" {'Imp(%)':>7} {'Reg(%)':>7} {'Neu(%)':>7}"
+            f" {'AvgLatImp(%)':>13} {'AvgLatReg(%)':>13} {'AvgLatNeu(%)':>13}"
+            f" {'MedLatImp(%)':>13} {'MedLatReg(%)':>13} {'MedLatNeu(%)':>13}"
+        )
+        lines.append("  " + "-" * 166)
+
+        for coll in sorted(all_colls):
+            coll_compared = compared[compared["Collective"] == coll]
+            coll_total = len(coll_compared)
+            coll_imp_df = (
+                improved[improved["Collective"] == coll]
+                if not improved.empty
+                else improved
+            )
+            coll_reg_df = (
+                regressed[regressed["Collective"] == coll]
+                if not regressed.empty
+                else regressed
+            )
+            coll_imp = len(coll_imp_df)
+            coll_reg = len(coll_reg_df)
+            coll_neu = coll_total - coll_imp - coll_reg
+            coll_neu_df = coll_compared.loc[
+                ~coll_compared.index.isin(coll_imp_df.index.union(coll_reg_df.index))
+            ]
+            lines.append(
+                f"  {coll:<30} {coll_imp:>6} {coll_reg:>6} {coll_neu:>6} {coll_total:>6}"
+                f" {_pct(coll_imp, coll_total):>7} {_pct(coll_reg, coll_total):>7} {_pct(coll_neu, coll_total):>7}"
+                f" {_fmt(_avg(coll_imp_df)):>13} {_fmt(_avg(coll_reg_df)):>13} {_fmt(_avg(coll_neu_df)):>13}"
+                f" {_fmt(_med(coll_imp_df)):>13} {_fmt(_med(coll_reg_df)):>13} {_fmt(_med(coll_neu_df)):>13}"
+            )
+
+        lines.append("  " + "-" * 166)
+        lines.append(
+            f"  {'Total':<30} {improve_points:>6} {regress_points:>6} {neutral_points:>6} {total_points:>6}"
+        )
+
+        lines.append("")
+        txt_path.write_text("\n".join(lines) + "\n")
+
+        # --- Build CSV report ---
+        def _pct_val(n: int, total: int) -> float | None:
+            return round(n / total * 100, 1) if total > 0 else None
+
+        csv_rows = []
+        for coll in sorted(all_colls):
+            coll_compared = compared[compared["Collective"] == coll]
+            coll_total = len(coll_compared)
+            coll_imp_df = (
+                improved[improved["Collective"] == coll]
+                if not improved.empty
+                else improved
+            )
+            coll_reg_df = (
+                regressed[regressed["Collective"] == coll]
+                if not regressed.empty
+                else regressed
+            )
+            coll_imp = len(coll_imp_df)
+            coll_reg = len(coll_reg_df)
+            coll_neu = coll_total - coll_imp - coll_reg
+            coll_neu_df = coll_compared.loc[
+                ~coll_compared.index.isin(coll_imp_df.index.union(coll_reg_df.index))
+            ]
+            csv_rows.append(
+                {
+                    "Collective": coll,
+                    "Adapter": adapter,
+                    "Baseline": baseline_label,
+                    "ImprovedPoints": coll_imp,
+                    "RegressedPoints": coll_reg,
+                    "NeutralPoints": coll_neu,
+                    "TotalPoints": coll_total,
+                    "Improved(%)": _pct_val(coll_imp, coll_total),
+                    "Regressed(%)": _pct_val(coll_reg, coll_total),
+                    "Neutral(%)": _pct_val(coll_neu, coll_total),
+                    "AvgLatImp(%)": _avg(coll_imp_df),
+                    "AvgLatReg(%)": _avg(coll_reg_df),
+                    "AvgLatNeu(%)": _avg(coll_neu_df),
+                    "MedLatImp(%)": _med(coll_imp_df),
+                    "MedLatReg(%)": _med(coll_reg_df),
+                    "MedLatNeu(%)": _med(coll_neu_df),
+                }
+            )
+        # Summary row
+        csv_rows.append(
+            {
+                "Collective": "ALL",
+                "Adapter": adapter,
+                "Baseline": baseline_label,
+                "ImprovedPoints": improve_points,
+                "RegressedPoints": regress_points,
+                "NeutralPoints": neutral_points,
+                "TotalPoints": total_points,
+                "Improved(%)": _pct_val(improve_points, total_points),
+                "Regressed(%)": _pct_val(regress_points, total_points),
+                "Neutral(%)": _pct_val(neutral_points, total_points),
+                "AvgLatImp(%)": imp_avg,
+                "AvgLatReg(%)": reg_avg,
+                "AvgLatNeu(%)": neu_avg,
+                "MedLatImp(%)": imp_med,
+                "MedLatReg(%)": reg_med,
+                "MedLatNeu(%)": neu_med,
+            }
+        )
+        pd.DataFrame(csv_rows).to_csv(csv_path, index=False)
+        saved.extend([txt_path, csv_path])
+
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_dir_arg(value: str) -> tuple[str, Path]:
+    """Parse a 'label:path' string into (label, Path)."""
+    if ":" in value:
+        label, path_str = value.split(":", 1)
+        return label.strip(), Path(path_str.strip())
+    # No label provided — derive from directory name
+    p = Path(value)
+    return p.name, p
+
+
+def parse_args():
+    script_dir = Path(__file__).parent
+
+    parser = argparse.ArgumentParser(
+        description="Analyze collective performance results.",
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s --dir torchcomms:./torchcomms\n"
+            "  %(prog)s --dir torchcomms:./torchcomms --dir c10d:./c10d\n"
+            "  %(prog)s --dir c10d:./c10d --dir c10d_torchcomms:./c10d_torchcomms --baseline c10d\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dir",
+        dest="dirs",
+        action="append",
+        metavar="LABEL:PATH",
+        help=(
+            "Result directory in 'label:path' format. May be repeated. "
+            "CSVs are discovered across all directories. "
+            "If omitted, defaults to ./torchcomms/."
+        ),
+    )
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default=None,
+        help=(
+            "Adapter label to use as the baseline for relative plots "
+            "and comparison reports. Must match a --dir label. "
+            "When omitted, only absolute plots are generated."
+        ),
+    )
+    parser.add_argument(
+        "--outdir",
+        type=Path,
+        default=script_dir / "perf_results",
+        help="Directory to write performance analysis results (default: ./perf_results/).",
+    )
+    parser.add_argument(
+        "--regression-threshold",
+        type=float,
+        default=5.0,
+        metavar="PCT",
+        help=(
+            "Minimum percentage regression in latency to include in the performance "
+            "regression report (default: 5.0)."
+        ),
+    )
+    parser.add_argument(
+        "--improvement-threshold",
+        type=float,
+        default=5.0,
+        metavar="PCT",
+        help=(
+            "Minimum percentage improvement in latency to include in the performance "
+            "improvement report (default: 5.0)."
+        ),
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        default=False,
+        help="Generate only the summary reports (CSV + terminal), skip generating figures.",
+    )
+
+    args = parser.parse_args()
+
+    # Default: single torchcomms directory
+    if not args.dirs:
+        args.dirs = [f"torchcomms:{script_dir / 'torchcomms'}"]
+
+    # Parse label:path pairs
+    args.parsed_dirs = [_parse_dir_arg(d) for d in args.dirs]
+
+    return args
+
+
+def main():
+    args = parse_args()
+
+    # Validate directories — warn and skip any that don't exist.
+    validated_dirs: list[tuple[str, Path]] = []
+    for label, dir_path in args.parsed_dirs:
+        if not dir_path.is_dir():
+            print(
+                f"Warning: directory not found for '{label}' ({dir_path}), skipping.",
+                file=sys.stderr,
+            )
+            continue
+        validated_dirs.append((label, dir_path))
+
+    if not validated_dirs:
+        print("Error: no valid result directories found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate --baseline label matches a directory if provided
+    dir_labels = {label for label, _ in validated_dirs}
+    if args.baseline is not None and args.baseline not in dir_labels:
+        print(
+            f"Error: --baseline '{args.baseline}' does not match any --dir label "
+            f"({', '.join(sorted(dir_labels))})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Discover CSV filenames across all directories (union)
+    csv_names: dict[str, None] = {}
+    for _, dir_path in validated_dirs:
+        for csv_path in sorted(dir_path.glob("*.csv")):
+            csv_names[csv_path.name] = None
+
+    if not csv_names:
+        print(
+            f"No CSV files found in any result directory.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    plt.rcParams.update({"figure.dpi": 120})
+
+    # Collect all series for the summary report (keyed by file_base)
+    all_series: dict[str, list[tuple[str, pd.DataFrame]]] = {}
+
+    for csv_name in csv_names:
+        # Load from each directory that has this CSV
+        series: list[tuple[str, pd.DataFrame]] = []
+        for label, dir_path in validated_dirs:
+            csv_path = dir_path / csv_name
+            if csv_path.exists():
+                df = load_csv(csv_path)
+                if df is not None:
+                    series.append((label, df))
+
+        if not series:
+            continue
+
+        collective = series[0][1]["Collective"].iloc[0]
+
+        # Detect reduce op from the CSV (non-"n/a" ReduceOp column)
+        reduce_op = None
+        first_df = series[0][1]
+        if "ReduceOp" in first_df.columns:
+            op_val = first_df["ReduceOp"].iloc[0]
+            if isinstance(op_val, str) and op_val != "n/a":
+                reduce_op = op_val
+
+        # Use "collective (op)" for titles when a reduce op is present
+        title = f"{collective} ({reduce_op})" if reduce_op else collective
+        # Append op to filenames for reduce collectives
+        file_base = f"{collective}_{reduce_op}" if reduce_op else collective
+
+        all_series[file_base] = series
+
+        if not args.summary_only:
+            fig_lat = build_latency_figure(title, series)
+            fig_bw = build_bw_figure(title, series)
+
+            collective_dir = args.outdir / "plots" / collective
+            collective_dir.mkdir(parents=True, exist_ok=True)
+
+            adapters = "_vs_".join(label for label, _ in series)
+            suffix = f"_{adapters}" if len(series) > 1 else f"_{series[0][0]}"
+            lat_path = collective_dir / f"{file_base}{suffix}_latency.png"
+            bw_path = collective_dir / f"{file_base}{suffix}_busbw.png"
+            fig_lat.savefig(lat_path, bbox_inches="tight")
+            fig_bw.savefig(bw_path, bbox_inches="tight")
+            print(f"Saved: {lat_path}")
+            print(f"Saved: {bw_path}")
+            plt.close(fig_lat)
+            plt.close(fig_bw)
+
+            if args.baseline is not None:
+                fig_rel_lat = build_relative_latency_figure(
+                    title, series, baseline_label=args.baseline
+                )
+                fig_rel_bw = build_relative_bw_figure(
+                    title, series, baseline_label=args.baseline
+                )
+                if fig_rel_lat is not None:
+                    rel_lat_path = (
+                        collective_dir / f"{file_base}{suffix}_relative_latency.png"
+                    )
+                    fig_rel_lat.savefig(rel_lat_path, bbox_inches="tight")
+                    print(f"Saved: {rel_lat_path}")
+                    plt.close(fig_rel_lat)
+                if fig_rel_bw is not None:
+                    rel_bw_path = (
+                        collective_dir / f"{file_base}{suffix}_relative_busbw.png"
+                    )
+                    fig_rel_bw.savefig(rel_bw_path, bbox_inches="tight")
+                    print(f"Saved: {rel_bw_path}")
+                    plt.close(fig_rel_bw)
+
+    # --- Per-adapter summary reports ---
+    for label, _ in validated_dirs:
+        adapter_df = build_adapter_summary_df(all_series, label)
+        if adapter_df.empty:
+            continue
+
+        csv_path = args.outdir / f"perf_summary_{label}.csv"
+        save_adapter_summary_csv(adapter_df, csv_path)
+        print(f"Saved: {csv_path}")
+
+        txt_path = args.outdir / f"perf_summary_{label}.txt"
+        save_adapter_summary_txt(adapter_df, label, txt_path)
+        print(f"Saved: {txt_path}")
+
+    # --- Baseline comparison reports ---
+    if args.baseline is not None:
+        summary_df = build_comparison_summary_df(all_series, args.baseline)
+        if not summary_df.empty:
+            summary_csv_path = args.outdir / "perf_comparison.csv"
+            save_comparison_summary_csv(summary_df, summary_csv_path)
+            print(f"Saved: {summary_csv_path}")
+
+            summary_txt_path = args.outdir / "perf_comparison.txt"
+            save_comparison_summary_txt(summary_df, args.baseline, summary_txt_path)
+            print(f"Saved: {summary_txt_path}")
+
+            for p in save_regression_reports(
+                summary_df,
+                args.baseline,
+                args.regression_threshold,
+                args.outdir,
+            ):
+                print(f"Saved: {p}")
+
+            for p in save_improvement_reports(
+                summary_df,
+                args.baseline,
+                args.improvement_threshold,
+                args.outdir,
+            ):
+                print(f"Saved: {p}")
+
+            for p in save_highlights_report(
+                summary_df,
+                args.baseline,
+                args.regression_threshold,
+                args.improvement_threshold,
+                args.outdir,
+                all_series=all_series,
+            ):
+                print(f"Saved: {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/torchcomms/tests/perf/py/barrier_perf.py
+++ b/comms/torchcomms/tests/perf/py/barrier_perf.py
@@ -2,54 +2,46 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
-    PerfParams,
-    PerfResult,
+    BenchRecord,
+    CommAdapter,
+    log_perf_header,
+    log_perf_result,
     PerfTimer,
-    print_perf_header,
-    print_perf_result,
     sync_device,
 )
 
 
 def run_barrier_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
     rank = comm.get_rank()
     num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Barrier Performance ===")
-    print_perf_header(rank)
+    params = record.params
+    config = record.config
 
     # Barrier has no message size, run once
     # Warmup
     for _ in range(params.warmup_iterations):
-        work = comm.barrier(params.async_op)
-        if params.async_op:
-            work.wait()
+        comm.run_collective("barrier", async_op=params.async_op)
 
     # Synchronize all ranks before measurement
-    comm.barrier(False)
+    comm.run_collective("barrier", async_op=False)
 
     # Measure
     timer = PerfTimer()
-    sync_device(device)
+    sync_device()
     timer.start()
 
     for i in range(params.measure_iterations):
-        work = comm.barrier(params.async_op)
-        if params.async_op:
-            work.wait()
+        comm.run_collective("barrier", async_op=params.async_op)
 
-        if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-            sync_device(device)
+        if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
+            sync_device()
 
-    sync_device(device)
+    sync_device()
     timer.stop()
 
     # Calculate statistics
@@ -57,15 +49,10 @@ def run_barrier_perf(
     avg_time = total / params.measure_iterations
 
     # Barrier has no data transfer, so bus bandwidth is 0
-    result = PerfResult(
-        message_size_bytes=0,
-        num_ranks=num_ranks,
-        iterations=params.measure_iterations,
-        total_time_us=total,
-        avg_time_us=avg_time,
-        min_time_us=avg_time,
-        max_time_us=avg_time,
-        bus_bw_gbps=0.0,
-    )
+    record.metrics.total_time_us = total
+    record.metrics.avg_time_us = avg_time
+    record.metrics.min_time_us = avg_time
+    record.metrics.max_time_us = avg_time
+    record.metrics.bus_bw_gbps = 0.0
 
-    print_perf_result(result, rank)
+    log_perf_result(record, rank)

--- a/comms/torchcomms/tests/perf/py/barrier_perf.py
+++ b/comms/torchcomms/tests/perf/py/barrier_perf.py
@@ -2,39 +2,33 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
-    PerfParams,
-    PerfResult,
+    BenchRecord,
+    CommAdapter,
+    log_perf_header,
+    log_perf_result,
     PerfTimer,
-    print_perf_header,
-    print_perf_result,
     sync_device,
 )
 
 
 def run_barrier_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
     rank = comm.get_rank()
     num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Barrier Performance ===")
-    print_perf_header(rank)
+    params = record.params
+    config = record.config
 
     # Barrier has no message size, run once
     # Warmup
     for _ in range(params.warmup_iterations):
-        work = comm.barrier(params.async_op)
-        if params.async_op:
-            work.wait()
+        comm.run_collective("barrier", async_op=params.async_op)
 
     # Synchronize all ranks before measurement
-    comm.barrier(False)
+    comm.run_collective("barrier", async_op=False)
 
     # Measure
     timer = PerfTimer()
@@ -42,11 +36,9 @@ def run_barrier_perf(
     timer.start()
 
     for i in range(params.measure_iterations):
-        work = comm.barrier(params.async_op)
-        if params.async_op:
-            work.wait()
+        comm.run_collective("barrier", async_op=params.async_op)
 
-        if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
+        if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
             sync_device()
 
     sync_device()
@@ -57,15 +49,10 @@ def run_barrier_perf(
     avg_time = total / params.measure_iterations
 
     # Barrier has no data transfer, so bus bandwidth is 0
-    result = PerfResult(
-        message_size_bytes=0,
-        num_ranks=num_ranks,
-        iterations=params.measure_iterations,
-        total_time_us=total,
-        avg_time_us=avg_time,
-        min_time_us=avg_time,
-        max_time_us=avg_time,
-        bus_bw_gbps=0.0,
-    )
+    record.metrics.total_time_us = total
+    record.metrics.avg_time_us = avg_time
+    record.metrics.min_time_us = avg_time
+    record.metrics.max_time_us = avg_time
+    record.metrics.bus_bw_gbps = 0.0
 
-    print_perf_result(result, rank)
+    log_perf_result(record, rank)

--- a/comms/torchcomms/tests/perf/py/broadcast_perf.py
+++ b/comms/torchcomms/tests/perf/py/broadcast_perf.py
@@ -2,86 +2,27 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_broadcast_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, root), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Broadcast Performance ===")
-    print_perf_header(rank)
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Broadcast: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.broadcast(tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.broadcast(tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Broadcast bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "broadcast", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/broadcast_perf.py
+++ b/comms/torchcomms/tests/perf/py/broadcast_perf.py
@@ -2,86 +2,27 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_broadcast_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, root), {}
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Broadcast Performance ===")
-    print_perf_header(rank)
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Broadcast: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.broadcast(tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.broadcast(tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Broadcast bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "broadcast", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/collective_perf_test.py
+++ b/comms/torchcomms/tests/perf/py/collective_perf_test.py
@@ -16,11 +16,14 @@ from torchcomms.tests.perf.py.barrier_perf import run_barrier_perf
 from torchcomms.tests.perf.py.broadcast_perf import run_broadcast_perf
 from torchcomms.tests.perf.py.gather_perf import run_gather_perf
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     dtype_to_string,
+    init_csv_file,
+    log_perf_header,
     parse_dtype,
-    PerfParams,
     print_usage,
-    validate_params,
+    validate_bench_params,
 )
 from torchcomms.tests.perf.py.reduce_perf import run_reduce_perf
 from torchcomms.tests.perf.py.reduce_scatter_perf import run_reduce_scatter_perf
@@ -48,85 +51,181 @@ COLLECTIVE_RUNNERS = {
     "barrier": run_barrier_perf,
 }
 
+# Collectives that accept a reduce op
+REDUCE_COLLECTIVES = {"all_reduce", "reduce_scatter", "reduce_scatter_single", "reduce"}
 
-def _default_perf_params() -> PerfParams:
-    params = PerfParams()
-    if os.environ.get("TEST_FULL_SWEEP") == "0":
-        # Keep Buck/TestX runs as smoke coverage. Manual benchmark runs can use
-        # `-c comms.full_sweep=1` or pass explicit command-line values.
-        params.warmup_iterations = 1
-        params.measure_iterations = 3
-        params.max_size = 1024
-    return params
+# All supported reduce ops
+REDUCE_OPS = ["sum", "min", "max", "avg", "product"]
 
 
-def parse_args(args: list) -> Tuple[str, PerfParams, Optional[str]]:
-    """Parse command-line arguments and return (collective, params, error)."""
-    collective = "all"
-    params = _default_perf_params()
+VALUE_FLAGS = {
+    "--warmup",
+    "--iters",
+    "--sync-interval",
+    "--min-size",
+    "--max-size",
+    "--size-scaling-factor",
+    "--dtype",
+    "--reduce-op",
+    "--output-dir",
+}
+
+
+def parse_args(args: list) -> Tuple[BenchRecord, Optional[str]]:
+    """Parse command-line arguments and return (record, error)."""
+    record = BenchRecord()
 
     i = 0
     while i < len(args):
         arg = args[i]
 
-        if arg in ("--help", "-h"):
-            return collective, params, "help"
+        if arg in VALUE_FLAGS:
+            if i + 1 >= len(args):
+                return record, f"Missing value for {arg}"
+            value = args[i + 1]
+            i += 1
+            if arg == "--warmup":
+                record.params.warmup_iterations = int(value)
+            elif arg == "--iters":
+                record.params.measure_iterations = int(value)
+            elif arg == "--sync-interval":
+                record.params.sync_interval = int(value)
+            elif arg == "--min-size":
+                record.config.min_size = int(value)
+            elif arg == "--max-size":
+                record.config.max_size = int(value)
+            elif arg == "--size-scaling-factor":
+                record.config.size_scaling_factor = int(value)
+            elif arg == "--dtype":
+                record.params.dtype = parse_dtype(value)
+            elif arg == "--reduce-op":
+                value = value.lower()
+                record.config.reduce_op_explicit = True
+                if value == "all":
+                    record.config.run_all_reduce_ops = True
+                else:
+                    record.params.reduce_op = value
+            elif arg == "--output-dir":
+                record.config.output_dir = value
+        elif arg in ("--help", "-h"):
+            return record, "help"
         elif arg == "--async":
-            params.async_op = True
-        elif arg == "--warmup" and i + 1 < len(args):
-            i += 1
-            params.warmup_iterations = int(args[i])
-        elif arg == "--iters" and i + 1 < len(args):
-            i += 1
-            params.measure_iterations = int(args[i])
-        elif arg == "--window" and i + 1 < len(args):
-            i += 1
-            params.iteration_window = int(args[i])
-        elif arg == "--min-size" and i + 1 < len(args):
-            i += 1
-            params.min_size = int(args[i])
-        elif arg == "--max-size" and i + 1 < len(args):
-            i += 1
-            params.max_size = int(args[i])
-        elif arg == "--size-scaling-factor" and i + 1 < len(args):
-            i += 1
-            params.size_scaling_factor = int(args[i])
-        elif arg == "--dtype" and i + 1 < len(args):
-            i += 1
-            params.dtype = parse_dtype(args[i])
+            record.params.async_op = True
+        elif arg == "--csv":
+            record.config.csv_enabled = True
+        elif arg in ("--quiet", "-q"):
+            record.config.quiet = True
+        elif arg == "--c10d":
+            record.params.comm_adapter = "c10d"
+        elif arg == "--c10d-torchcomms":
+            record.params.comm_adapter = "c10d_torchcomms"
+        elif arg == "--all-comm-adapters":
+            record.config.run_all_comm_adapters = True
         elif not arg.startswith("-"):
-            collective = arg
+            if arg == "all":
+                record.config.run_all_collectives = True
+            elif arg in COLLECTIVE_RUNNERS:
+                record.params.collective_name = arg
+            else:
+                return record, f"Unknown collective '{arg}'"
+        else:
+            return record, f"Unknown argument '{arg}'"
 
         i += 1
 
-    return collective, params, None
+    return record, None
 
 
 def run_collectives(
-    collective: str,
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
     """Run the specified collective performance test(s)."""
-    if collective == "all":
-        for runner in COLLECTIVE_RUNNERS.values():
-            runner(comm, params, device)
-    elif collective in COLLECTIVE_RUNNERS:
-        COLLECTIVE_RUNNERS[collective](comm, params, device)
+    config = record.config
+    rank = comm.get_rank()
+    csv_dir = None
+
+    if config.csv_enabled and rank == 0:
+        if config.output_dir:
+            csv_dir = (
+                os.path.join(config.output_dir, record.info.comm_adapter_name)
+                if config.run_all_comm_adapters
+                else config.output_dir
+            )
+        else:
+            csv_dir = record.info.comm_adapter_name
+        os.makedirs(csv_dir, exist_ok=True)
+
+    if config.run_all_collectives:
+        for collective_name, collective_runner in COLLECTIVE_RUNNERS.items():
+            record.params.collective_name = collective_name
+            if collective_name in REDUCE_COLLECTIVES:
+                ops = REDUCE_OPS
+            else:
+                ops = [None]
+            for op in ops:
+                if op is not None:
+                    record.params.reduce_op = op
+                if csv_dir:
+                    filename = collective_name
+                    if op is not None:
+                        filename = f"{collective_name}_{op}"
+                    config.csv_file = os.path.join(csv_dir, f"{filename}.csv")
+                    init_csv_file(config.csv_file)
+                log_perf_header(record, rank)
+                try:
+                    collective_runner(comm, record, device)
+                except Exception as e:
+                    print(
+                        f"Error running {collective_name}"
+                        f"{f' ({op})' if op else ''}: {e}",
+                        file=sys.stderr,
+                    )
+    elif record.params.collective_name in COLLECTIVE_RUNNERS:
+        collective_name = record.params.collective_name
+        if config.run_all_reduce_ops and collective_name in REDUCE_COLLECTIVES:
+            ops = REDUCE_OPS
+        else:
+            ops = [None]
+        for op in ops:
+            if op is not None:
+                record.params.reduce_op = op
+            if csv_dir:
+                filename = collective_name
+                if op is not None:
+                    filename = f"{collective_name}_{op}"
+                config.csv_file = os.path.join(csv_dir, f"{filename}.csv")
+                init_csv_file(config.csv_file)
+            log_perf_header(record, rank)
+            if len(ops) > 1:
+                try:
+                    COLLECTIVE_RUNNERS[collective_name](comm, record, device)
+                except Exception as e:
+                    print(
+                        f"Error running {collective_name} ({op}): {e}",
+                        file=sys.stderr,
+                    )
+            else:
+                COLLECTIVE_RUNNERS[collective_name](comm, record, device)
 
 
 def main() -> int:
-    collective, params, parse_error = parse_args(sys.argv[1:])
+    record, parse_output = parse_args(sys.argv[1:])
 
-    if parse_error == "help":
+    if parse_output == "help":
         print_usage(sys.argv[0])
         return 0
 
-    error = validate_params(collective, params)
+    if parse_output is not None:
+        print(f"Error: {parse_output}", file=sys.stderr)
+        print(f"Run '{sys.argv[0]} --help' for usage.", file=sys.stderr)
+        return 1
+
+    error = validate_bench_params(record)
     if error:
-        print(f"Error: {error}\n", file=sys.stderr)
-        print_usage(sys.argv[0])
+        print(f"Error: {error}", file=sys.stderr)
+        print(f"Run '{sys.argv[0]} --help' for usage.", file=sys.stderr)
         return 1
 
     device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
@@ -141,38 +240,73 @@ def main() -> int:
     if fast_init_mode:
         hints["fastInitMode"] = fast_init_mode
 
-    comm = torchcomms.new_comm(
-        test_backend,
-        device,
-        name="collective_perf_test",
-        hints=hints if hints else None,
-    )
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    info = record.info
+    params = record.params
+    config = record.config
 
-    if rank == 0:
-        print("TorchComms Collective Performance Test")
-        print("======================================")
-        print(f"Backend: {comm.get_backend()}")
-        print(f"Ranks: {num_ranks}")
-        print(f"Collective: {collective}")
-        print(f"Mode: {'async' if params.async_op else 'sync'}")
-        print(f"Dtype: {dtype_to_string(params.dtype)}")
-        print(f"Warmup: {params.warmup_iterations}")
-        print(f"Iterations: {params.measure_iterations}")
-        print(f"Window: {params.iteration_window}")
-        print(
-            f"Size range: {params.min_size} - {params.max_size} "
-            f"bytes (x{params.size_scaling_factor})"
-        )
-        print()
+    info.device_type = device.type
+    if info.device_type == "xpu":
+        info.device_name = torch.xpu.get_device_name()
+    elif info.device_type == "cuda":
+        info.device_name = torch.cuda.get_device_name()
+    else:
+        info.device_name = "n/a"
 
-    run_collectives(collective, comm, params, device)
+    try:
+        torchcomms_version = torchcomms.__version__
+    except AttributeError:
+        torchcomms_version = "unknown"
+
+    if config.run_all_comm_adapters:
+        adapters = ["torchcomms", "c10d", "c10d_torchcomms"]
+    else:
+        adapters = [params.comm_adapter]
+
+    rank = 0
+    for adapter_name in adapters:
+        params.comm_adapter = adapter_name
+        info.comm_adapter_name = adapter_name
+
+        comm = CommAdapter(info.comm_adapter_name)
+        comm.init(test_backend, device, hints)
+
+        rank = comm.get_rank()
+        num_ranks = comm.get_size()
+
+        params.num_ranks = num_ranks
+        params.dispatch_mode = "async" if params.async_op else "sync"
+
+        info.comm_backend_name = comm.get_backend()
+        info.comm_backend_version = comm.get_backend_version()
+
+        if torch.accelerator.is_available():
+            device_count = torch.accelerator.device_count()
+            if device_count > 0:
+                torch.accelerator.set_device_index(rank % device_count)
+
+        if rank == 0 and not record.config.quiet:
+            print("Collective Performance Test")
+            print("======================================")
+            print(f"Comm adapter: {adapter_name}")
+            if record.config.csv_enabled:
+                if record.config.output_dir:
+                    csv_path = (
+                        os.path.join(
+                            record.config.output_dir, record.info.comm_adapter_name
+                        )
+                        if record.config.run_all_comm_adapters
+                        else record.config.output_dir
+                    )
+                else:
+                    csv_path = record.info.comm_adapter_name
+                print(f"CSV output: {csv_path}/")
+
+        run_collectives(comm, record, device)
+
+        comm.finalize()
 
     if rank == 0:
         print("\nPerformance test completed.")
-
-    comm.finalize()
 
     return 0
 

--- a/comms/torchcomms/tests/perf/py/gather_perf.py
+++ b/comms/torchcomms/tests/perf/py/gather_perf.py
@@ -2,94 +2,33 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_gather_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Gather Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor list (only used at root)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
         output_list = []
         if rank == root:
             output_list = [
-                create_tensor(num_elements, rank, device, params.dtype)
+                create_tensor(num_elements, rank, device, dtype)
                 for _ in range(num_ranks)
             ]
+        return (output_list, input_tensor, root), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.gather(output_list, input_tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Gather: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.gather(output_list, input_tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Gather bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "gather", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/gather_perf.py
+++ b/comms/torchcomms/tests/perf/py/gather_perf.py
@@ -2,94 +2,33 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_gather_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Gather Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        input_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create output tensor list (only used at root)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        input_tensor = create_tensor(num_elements, rank, device, dtype)
         output_list = []
         if rank == root:
             output_list = [
-                create_tensor(num_elements, rank, device, params.dtype)
+                create_tensor(num_elements, rank, device, dtype)
                 for _ in range(num_ranks)
             ]
+        return (output_list, input_tensor, root), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.gather(output_list, input_tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Gather: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.gather(output_list, input_tensor, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Gather bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "gather", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/perf_test_helpers.py
+++ b/comms/torchcomms/tests/perf/py/perf_test_helpers.py
@@ -1,17 +1,252 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # pyre-unsafe
 
+import collections.abc
+import csv
+import os
 import time
 from dataclasses import dataclass, field
+from typing import Callable, Literal, Optional, Tuple
 
 import torch
+import torch.distributed.config as dist_config
+import torchcomms
+from torch import distributed as dist
+
+
+class CommAdapter:
+    def __init__(
+        self,
+        name: Literal["torchcomms", "c10d", "c10d_torchcomms"],
+        comm_name: Optional[str] = "collective_perf_test",
+    ):
+        self.name = name
+        self.comm_name = comm_name
+        self.initialized = False
+        self.dist_comm = None
+
+    def init(
+        self,
+        backend: str,
+        device: torch.device,
+        hints: Optional[collections.abc.Mapping] = None,
+    ) -> None:
+        if self.name == "torchcomms":
+            self.dist_comm = torchcomms.new_comm(
+                backend,
+                device,
+                name=self.comm_name,
+                hints=hints,
+            )
+        elif self.name.startswith("c10d"):
+            if self.name == "c10d_torchcomms":
+                dist_config.use_torchcomms = True
+            dist.init_process_group(backend=backend, init_method="env://")
+            self.dist_comm = dist
+        self.initialized = True
+
+    def _require_initialized(self) -> None:
+        if not self.initialized:
+            raise RuntimeError("Comm adapter not initialized. Call init() first.")
+
+    # c10d uses different names for some collectives
+    _C10D_NAME_MAP = {
+        "all_gather_single": "all_gather_into_tensor",
+        "reduce_scatter_single": "reduce_scatter_tensor",
+    }
+
+    def run_collective(self, collective_fn, *args, **kwargs) -> None:
+        """Dispatch a collective on the underlying adapter.
+
+        ``async_op`` is consumed here (not forwarded to torchcomms / c10d
+        verbatim): when True, the adapter awaits the returned handle before
+        returning. For c10d send/recv this also rewrites the call to
+        ``isend`` / ``irecv``. Callers must pass ``async_op`` as a keyword.
+
+        For hot loops, prefer :meth:`resolve_collective` to lift the dispatch
+        and lookup overhead out of the timing loop.
+        """
+        async_op = kwargs.pop("async_op", False)
+        bound, args, kwargs = self._resolve(collective_fn, args, kwargs, async_op)
+        handle = bound(*args, **kwargs)
+        if async_op and handle is not None:
+            handle.wait()
+
+    def resolve_collective(self, collective_fn, *args, **kwargs):
+        """Pre-resolve a collective into a zero-overhead callable for hot loops.
+
+        Returns ``(call, args, kwargs)`` where ``call(*args, **kwargs)`` runs
+        the collective and waits on the handle (matching :meth:`run_collective`
+        semantics). All adapter-specific name mapping, arg reshaping, and
+        ``async_op`` handling is performed once here, so the returned callable
+        can be invoked tightly in a measurement loop without per-iteration
+        Python overhead.
+
+        ``async_op`` must be passed as a keyword.
+        """
+        self._require_initialized()
+        async_op = kwargs.pop("async_op", False)
+        bound, args, kwargs = self._resolve(collective_fn, args, kwargs, async_op)
+        if async_op:
+
+            def call(*a, **kw):
+                handle = bound(*a, **kw)
+                if handle is not None:
+                    handle.wait()
+        else:
+            call = bound
+        return call, args, kwargs
+
+    def _resolve(self, collective_fn, args, kwargs, async_op):
+        """Compute the bound callable plus adjusted args/kwargs for one call."""
+        self._require_initialized()
+        fn_name = collective_fn
+        if self.name.startswith("c10d"):
+            fn_name = self._C10D_NAME_MAP.get(collective_fn, collective_fn)
+            # gather: torchcomms takes (output_list, input_tensor, root, ...)
+            #         c10d takes (tensor, gather_list, dst, ...)
+            if collective_fn == "gather" and len(args) >= 2:
+                args = (args[1], args[0]) + args[2:]
+            # c10d send/recv have no async_op; use isend/irecv for async
+            if collective_fn in ("send", "recv"):
+                if async_op:
+                    fn_name = "i" + collective_fn
+            else:
+                kwargs["async_op"] = async_op
+        else:
+            # torchcomms: pass async_op positionally to match the pre-refactor
+            # call shape exactly. The pybind11 binding has fewer overheads on
+            # the positional path than on the kwargs path.
+            args = args + (async_op,)
+
+        try:
+            bound = getattr(self.dist_comm, fn_name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Collective operation '{fn_name}' not found on "
+                f"comm adapter '{self.name}'."
+            ) from exc
+        return bound, args, kwargs
+
+    def get_rank(self) -> int:
+        self._require_initialized()
+        return self.dist_comm.get_rank()
+
+    def get_size(self) -> int:
+        self._require_initialized()
+        if self.name == "torchcomms":
+            return self.dist_comm.get_size()
+        elif self.name.startswith("c10d"):
+            return self.dist_comm.get_world_size()
+        raise NotImplementedError(f"get_size not implemented for adapter '{self.name}'")
+
+    def get_backend(self) -> str:
+        self._require_initialized()
+        return self.dist_comm.get_backend()
+
+    def get_backend_version(self) -> str:
+        self._require_initialized()
+        if self.name in ["torchcomms", "c10d_torchcomms"]:
+            try:
+                return self.dist_comm.get_backend_version()
+            except (AttributeError, NotImplementedError, RuntimeError):
+                return "n/a"
+        elif self.name.startswith("c10d"):
+            backend = self.get_backend()
+            if backend == "nccl" and torch.cuda.is_available():
+                return ".".join(str(v) for v in torch.cuda.nccl.version())
+            return "n/a"
+        return "n/a"
+
+    _REDUCE_OP_MAP_TORCHCOMMS = {
+        "sum": torchcomms.ReduceOp.SUM,
+        "min": torchcomms.ReduceOp.MIN,
+        "max": torchcomms.ReduceOp.MAX,
+        "avg": torchcomms.ReduceOp.AVG,
+        "product": torchcomms.ReduceOp.PRODUCT,
+    }
+    _REDUCE_OP_MAP_C10D = {
+        "sum": dist.ReduceOp.SUM,
+        "min": dist.ReduceOp.MIN,
+        "max": dist.ReduceOp.MAX,
+        "avg": dist.ReduceOp.AVG,
+        "product": dist.ReduceOp.PRODUCT,
+    }
+
+    def get_reduce_op(self, op_name: str):
+        """Map a reduce op name to the appropriate ReduceOp type."""
+        self._require_initialized()
+        op_map = (
+            self._REDUCE_OP_MAP_TORCHCOMMS
+            if self.name == "torchcomms"
+            else self._REDUCE_OP_MAP_C10D
+        )
+        if op_name not in op_map:
+            raise ValueError(
+                f"Unknown reduce op '{op_name}'. Supported: {', '.join(op_map.keys())}"
+            )
+        return op_map[op_name]
+
+    def finalize(self) -> None:
+        if self.initialized:
+            if self.name == "torchcomms":
+                self.dist_comm.finalize()
+            elif self.name.startswith("c10d"):
+                self.dist_comm.destroy_process_group()
+            self.initialized = False
 
 
 @dataclass
-class PerfResult:
-    message_size_bytes: int = 0
+class EnvInfo:
+    device_type: str = None
+    device_name: str = None
+    torch_version: str = torch.__version__
+    torchcomms_version: str = "n/a"
+    comm_adapter_name: Literal["torchcomms", "c10d", "c10d_torchcomms"] = None
+    comm_backend_name: str = None
+    comm_backend_version: str = None
+
+
+@dataclass
+class BenchConfig:
+    run_all_collectives: bool = False
+    run_all_comm_adapters: bool = False
+    run_all_reduce_ops: bool = False
+    reduce_op_explicit: bool = False
+    # Message size range in bytes (powers of 2)
+    min_size: int = 4  # 4 bytes
+    max_size: int = 67108864 if os.environ.get("TEST_FULL_SWEEP") != "0" else 1024  # 64 MiB or 1 KiB
+    # Scaling factor for message sizes (default 2 = powers of 2)
+    size_scaling_factor: int = 2
+    # Whether to save results to CSV files
+    csv_enabled: bool = False
+    # Whether to suppress terminal output
+    quiet: bool = False
+    # CSV output file path (set dynamically per collective)
+    csv_file: Optional[str] = None
+    # Base directory for CSV output (per-adapter subdir created underneath)
+    output_dir: Optional[str] = None
+
+@dataclass
+class BenchParams:
+    comm_adapter: Literal["torchcomms", "c10d", "c10d_torchcomms"] = "torchcomms"
+    collective_name: str = None
     num_ranks: int = 0
-    iterations: int = 0
+    async_op: bool = False
+    dispatch_mode: str = "sync"
+    reduce_op: str = "sum"    
+    warmup_iterations: int = 5 if os.environ.get("TEST_FULL_SWEEP") != "0" else 1
+    measure_iterations: int = 1000 if os.environ.get("TEST_FULL_SWEEP") != "0" else 3
+    # Number of iterations between stream synchronizations during measurement.
+    # If 0, only synchronize after all iterations complete.
+    sync_interval: int = 0
+    # Data type
+    dtype: torch.dtype = field(default_factory=lambda: torch.float32)
+
+
+@dataclass
+class BenchMetrics:
+    message_size_bytes: int = 0
     total_time_us: float = 0.0
     avg_time_us: float = 0.0
     min_time_us: float = 0.0
@@ -20,20 +255,11 @@ class PerfResult:
 
 
 @dataclass
-class PerfParams:
-    async_op: bool = False
-    warmup_iterations: int = 5
-    measure_iterations: int = 1000
-    # Number of iterations between stream synchronizations during measurement.
-    # If 0, only synchronize after all iterations complete.
-    iteration_window: int = 0
-    # Message size range in bytes (powers of 2)
-    min_size: int = 4  # 4 bytes
-    max_size: int = 67108864  # 64 MB
-    # Scaling factor for message sizes (default 2 = powers of 2)
-    size_scaling_factor: int = 2
-    # Data type
-    dtype: torch.dtype = field(default_factory=lambda: torch.float32)
+class BenchRecord:
+    info: EnvInfo = field(default_factory=EnvInfo)
+    config: BenchConfig = field(default_factory=BenchConfig)
+    params: BenchParams = field(default_factory=BenchParams)
+    metrics: BenchMetrics = field(default_factory=BenchMetrics)
 
 
 class PerfTimer:
@@ -60,24 +286,114 @@ class PerfTimer:
         return self.elapsed_us() / 1000.0
 
 
-def print_perf_header(rank: int) -> None:
-    if rank != 0:
-        return
-    print(
-        f"{'SendMsgSize(B)':<15}{'Ranks':<10}{'Iters':<10}"
-        f"{'Avg(us)':<15}{'Min(us)':<15}{'Max(us)':<15}{'BusBw(GB/s)':<15}"
-    )
-    print("-" * 95)
+# Column definitions for terminal output and CSV files.
+# Each entry is (header_name, column_width). The width is used only for
+# terminal alignment; CSV output ignores it.
+# Ordered as: test identity → benchmark config → results → environment,
+# so the most frequently compared fields appear first when scrolling right.
+_CSV_COLUMNS = [
+    # Test identity
+    ("Collective", 25),
+    ("DType", 10),
+    ("ReduceOp", 12),
+    ("SendMsgSize(B)", 15),
+    ("Ranks", 10),
+    # Benchmark config
+    ("DispatchMode", 14),
+    ("WarmupIters", 12),
+    ("MeasureIters", 14),
+    ("SyncInterval", 14),
+    # Results
+    ("LatAvg(us)", 15),
+    ("LatMin(us)", 15),
+    ("LatMax(us)", 15),
+    ("BusBw(GB/s)", 15),
+    # Environment
+    ("DeviceType", 12),
+    ("DeviceName", 40),
+    ("CommAdapter", 20),
+    ("CommBackend", 13),
+    ("CommBackendVersion", 20),
+    ("TorchVersion", 30),
+    ("TorchCommsVersion", 20),
+]
 
 
-def print_perf_result(result: PerfResult, rank: int) -> None:
-    if rank != 0:
+# Collectives that accept a reduction operator (e.g. sum, min, max).
+# Used in log_perf_result to decide whether to display the ReduceOp column
+# value or substitute "n/a" for collectives that do not perform a reduction.
+_REDUCE_COLLECTIVES = {
+    "all_reduce",
+    "reduce",
+    "reduce_scatter",
+    "reduce_scatter_single",
+}
+
+
+def collective_to_camel_case(s: str) -> str:
+    return "".join(word.capitalize() for word in s.split("_"))
+
+
+def init_csv_file(csv_file: str) -> None:
+    """Create the CSV file and write the header row."""
+    with open(csv_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([name for name, _ in _CSV_COLUMNS])
+
+
+def log_perf_header(record: BenchRecord, rank: int) -> None:
+    if rank != 0 or record.config.quiet:
         return
     print(
-        f"{result.message_size_bytes:<15}{result.num_ranks:<10}{result.iterations:<10}"
-        f"{result.avg_time_us:<15.2f}{result.min_time_us:<15.2f}{result.max_time_us:<15.2f}"
-        f"{result.bus_bw_gbps:<15.2f}"
+        f"\n=== {collective_to_camel_case(record.params.collective_name)} Performance ===\n"
     )
+    header = "".join(f"{name:<{width}}" for name, width in _CSV_COLUMNS)
+    print(header)
+    print("-" * len(header))
+
+
+def log_perf_result(record: BenchRecord, rank: int) -> None:
+    if rank != 0:
+        return
+    reduce_op_display = (
+        record.params.reduce_op
+        if record.params.collective_name in _REDUCE_COLLECTIVES
+        else "n/a"
+    )
+    values = [
+        # Test identity
+        record.params.collective_name,
+        dtype_to_string(record.params.dtype),
+        reduce_op_display,
+        record.metrics.message_size_bytes,
+        record.params.num_ranks,
+        # Benchmark config
+        record.params.dispatch_mode,
+        record.params.warmup_iterations,
+        record.params.measure_iterations,
+        record.params.sync_interval,
+        # Results
+        f"{record.metrics.avg_time_us:.2f}",
+        f"{record.metrics.min_time_us:.2f}",
+        f"{record.metrics.max_time_us:.2f}",
+        f"{record.metrics.bus_bw_gbps:.2f}",
+        # Environment
+        record.info.device_type,
+        record.info.device_name,
+        record.info.comm_adapter_name,
+        record.info.comm_backend_name,
+        record.info.comm_backend_version,
+        record.info.torch_version,
+        record.info.torchcomms_version,
+    ]
+    if not record.config.quiet:
+        print("".join(f"{v:<{w}}" for v, (_, w) in zip(values, _CSV_COLUMNS)))
+
+    csv_file = record.config.csv_file
+    if csv_file:
+        with open(csv_file, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(values)
 
 
 def create_tensor(
@@ -89,10 +405,112 @@ def create_tensor(
     return torch.ones(num_elements, dtype=dtype, device=device) * float(rank + 1)
 
 
-def sync_device(device: torch.device) -> None:
-    """Synchronize the device stream if it's a CUDA device."""
-    if device.type == "cuda":
-        torch.cuda.synchronize()
+def sync_device() -> None:
+    """Synchronize the device stream if it's an accelerator."""
+    if torch.accelerator.is_available():
+        torch.accelerator.synchronize()
+
+
+def run_bench_sweep(
+    comm: CommAdapter,
+    record: BenchRecord,
+    device: torch.device,
+    collective_name: str,
+    setup_fn: Callable[
+        [int, int, int, torch.device, torch.dtype],
+        Tuple[tuple, dict],
+    ],
+    bus_bw_fn: Callable[[int, int, int, float], float],
+) -> None:
+    """Generic message-size sweep with warmup, measurement, and logging.
+
+    Args:
+        comm: The communication adapter.
+        record: Benchmark record (config + params + metrics).
+        device: Torch device.
+        collective_name: Name passed to ``comm.run_collective``.
+        setup_fn: ``(num_elements, rank, num_ranks, device, dtype) -> (args, kwargs)``
+            returning positional args and keyword args for the collective call.
+            ``async_op`` is appended automatically and must not be included.
+        bus_bw_fn: ``(num_elements, element_size, num_ranks, avg_time_us) -> bus_bw_gbps``
+            computing the bus bandwidth in GB/s.
+    """
+    rank = comm.get_rank()
+    num_ranks = comm.get_size()
+    params = record.params
+    config = record.config
+
+    element_size = torch.tensor([], dtype=params.dtype).element_size()
+
+    msg_size = config.min_size
+    while msg_size <= config.max_size:
+        num_elements = msg_size // element_size
+        if num_elements == 0:
+            num_elements = 1
+
+        raw_args, raw_kwargs = setup_fn(
+            num_elements, rank, num_ranks, device, params.dtype
+        )
+
+        # Pre-resolve once so the timing loop calls a bound method directly.
+        call, call_args, call_kwargs = comm.resolve_collective(
+            collective_name, *raw_args, **raw_kwargs, async_op=params.async_op
+        )
+
+        # Warmup
+        for _ in range(params.warmup_iterations):
+            call(*call_args, **call_kwargs)
+
+        comm.run_collective("barrier", async_op=False)
+
+        # Measure
+        timer = PerfTimer()
+
+        if params.sync_interval == 1:
+            # Per-iteration timing: sync after every iteration to get min/max.
+            iter_times: list[float] = []
+            sync_device()
+            for _ in range(params.measure_iterations):
+                timer.start()
+                call(*call_args, **call_kwargs)
+                sync_device()
+                timer.stop()
+                iter_times.append(timer.elapsed_us())
+
+            total = sum(iter_times)
+            avg_time = total / params.measure_iterations
+            min_time = min(iter_times)
+            max_time = max(iter_times)
+        else:
+            # Bulk timing: single start/stop around all iterations.
+            sync_device()
+            timer.start()
+
+            for i in range(params.measure_iterations):
+                call(*call_args, **call_kwargs)
+                if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
+                    sync_device()
+
+            sync_device()
+            timer.stop()
+
+            total = timer.elapsed_us()
+            avg_time = total / params.measure_iterations
+            min_time = avg_time
+            max_time = avg_time
+
+        bus_bw_gbps = bus_bw_fn(num_elements, element_size, num_ranks, avg_time)
+
+        record.metrics.message_size_bytes = num_elements * element_size
+        record.metrics.total_time_us = total
+        record.metrics.avg_time_us = avg_time
+        record.metrics.min_time_us = min_time
+        record.metrics.max_time_us = max_time
+        record.metrics.bus_bw_gbps = bus_bw_gbps
+
+        log_perf_result(record, rank)
+
+        msg_size *= config.size_scaling_factor
 
 
 def print_usage(program_name: str) -> None:
@@ -118,12 +536,23 @@ Options:
   --async                - Run async mode (default: sync)
   --warmup <n>           - Number of warmup iterations (default: 5)
   --iters <n>            - Number of measurement iterations (default: 1000)
-  --window <n>           - Iterations between stream syncs (default: 0)
+  --sync-interval <n>    - Iterations between stream syncs (default: 0)
   --min-size <n>         - Min message size in bytes (default: 4)
   --max-size <n>         - Max message size in bytes (default: 67108864)
   --size-scaling-factor <n> - Size multiplier between tests (default: 2)
   --dtype <type>         - Data type: float32, float16, bfloat16, float64,
                            int32, int64 (default: float32)
+  --reduce-op <op>       - Reduction operation: sum, min, max, avg, product,
+                           or 'all' to sweep every supported op (reduction
+                           collectives only) (default: sum)
+  --c10d                 - Use c10d instead of torchcomms
+  --c10d-torchcomms      - Use c10d with torchcomms backend
+  --all-comm-adapters    - Run against all comm adapters (torchcomms, c10d,
+                           c10d_torchcomms)
+  --csv                  - Save results to CSV files (one per collective)
+  --output-dir <path>    - Base dir for CSV output (default: cwd); a
+                           per-adapter subdirectory is created underneath
+  --quiet, -q            - Suppress terminal output
   --help, -h             - Show this help message
 """)
 
@@ -165,67 +594,79 @@ def dtype_to_string(dtype: torch.dtype) -> str:
     return dtype_map[dtype]
 
 
-def validate_params(collective: str, params: PerfParams) -> str:
-    valid_collectives = [
-        "all_reduce",
-        "allreduce",
-        "all_gather",
-        "allgather",
-        "all_gather_single",
-        "allgathersingle",
-        "reduce_scatter",
-        "reducescatter",
-        "reduce_scatter_single",
-        "reducescattersingle",
-        "all_to_all",
-        "alltoall",
-        "all_to_all_single",
-        "alltoallsingle",
-        "broadcast",
-        "reduce",
-        "scatter",
-        "gather",
-        "send_recv",
-        "sendrecv",
-        "barrier",
-        "all",
-    ]
+def validate_bench_params(record: BenchRecord) -> Optional[str]:
+    config = record.config
+    params = record.params
 
-    if collective not in valid_collectives:
-        return f"Unknown collective '{collective}'"
+    if not config.run_all_collectives and params.collective_name is None:
+        return "No collective specified"
 
-    if params.size_scaling_factor < 2:
+    if config.quiet and not config.csv_enabled:
+        return "--quiet/-q requires --csv; otherwise results would be discarded"
+
+    if config.reduce_op_explicit and config.run_all_collectives:
+        return (
+            "--reduce-op is implicit when running 'all'; reduction collectives "
+            "are always swept across every supported op"
+        )
+
+    if config.size_scaling_factor < 2:
         return "size_scaling_factor must be at least 2"
 
-    if params.min_size <= 0:
+    if config.min_size <= 0:
         return "min_size must be positive"
 
-    if params.max_size < params.min_size:
+    if config.max_size < config.min_size:
         return "max_size must be >= min_size"
 
     # Validate that max_size is reachable from min_size via scaling factor
-    size = params.min_size
-    while size < params.max_size:
-        size *= params.size_scaling_factor
-    if size != params.max_size and params.min_size != params.max_size:
+    size = config.min_size
+    while size < config.max_size:
+        size *= config.size_scaling_factor
+    if size != config.max_size and config.min_size != config.max_size:
         return "max_size must be min_size * size_scaling_factor^n for some integer n"
 
     # Validate dtype divides sizes evenly
     element_size = torch.tensor([], dtype=params.dtype).element_size()
-    if params.min_size % element_size != 0:
+    if config.min_size % element_size != 0:
         return (
             f"min_size must be divisible by dtype element size ({element_size} bytes)"
         )
-    if params.max_size % element_size != 0:
+    if config.max_size % element_size != 0:
         return (
             f"max_size must be divisible by dtype element size ({element_size} bytes)"
+        )
+
+    if (
+        config.reduce_op_explicit
+        and not config.run_all_collectives
+        and params.collective_name not in _REDUCE_COLLECTIVES
+    ):
+        return (
+            f"--reduce-op is only valid for reduction collectives "
+            f"({', '.join(sorted(_REDUCE_COLLECTIVES))}); "
+            f"got '{params.collective_name}'"
+        )
+
+    valid_reduce_ops = {"sum", "min", "max", "avg", "product"}
+    if (
+        not config.run_all_reduce_ops
+        and params.reduce_op not in valid_reduce_ops
+        and (
+            config.run_all_collectives or params.collective_name in _REDUCE_COLLECTIVES
+        )
+    ):
+        return (
+            f"Unknown reduce op '{params.reduce_op}' for collective "
+            f"'{params.collective_name}'. Supported: "
+            f"{', '.join(sorted(valid_reduce_ops))}"
         )
 
     if params.warmup_iterations < 0:
         return "warmup_iterations must be non-negative"
     if params.measure_iterations <= 0:
         return "measure_iterations must be positive"
-    if params.iteration_window < 0:
-        return "iteration_window must be non-negative"
+    if params.sync_interval < 0:
+        return "sync_interval must be non-negative"
 
-    return ""  # Valid
+    return None  # Valid

--- a/comms/torchcomms/tests/perf/py/perf_test_helpers.py
+++ b/comms/torchcomms/tests/perf/py/perf_test_helpers.py
@@ -1,17 +1,255 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # pyre-unsafe
 
+import collections.abc
+import csv
+import os
 import time
 from dataclasses import dataclass, field
+from typing import Callable, Literal, Optional, Tuple
 
 import torch
+import torch.distributed.config as dist_config
+import torchcomms
+from torch import distributed as dist
+
+
+class CommAdapter:
+    def __init__(
+        self,
+        name: Literal["torchcomms", "c10d", "c10d_torchcomms"],
+        comm_name: Optional[str] = "collective_perf_test",
+    ):
+        self.name = name
+        self.comm_name = comm_name
+        self.initialized = False
+        self.dist_comm = None
+
+    def init(
+        self,
+        backend: str,
+        device: torch.device,
+        hints: Optional[collections.abc.Mapping] = None,
+    ) -> None:
+        if self.name == "torchcomms":
+            self.dist_comm = torchcomms.new_comm(
+                backend,
+                device,
+                name=self.comm_name,
+                hints=hints,
+            )
+        elif self.name.startswith("c10d"):
+            if self.name == "c10d_torchcomms":
+                dist_config.use_torchcomms = True
+            dist.init_process_group(backend=backend, init_method="env://")
+            self.dist_comm = dist
+        self.initialized = True
+
+    def _require_initialized(self) -> None:
+        if not self.initialized:
+            raise RuntimeError("Comm adapter not initialized. Call init() first.")
+
+    # c10d uses different names for some collectives
+    _C10D_NAME_MAP = {
+        "all_gather_single": "all_gather_into_tensor",
+        "reduce_scatter_single": "reduce_scatter_tensor",
+    }
+
+    def run_collective(self, collective_fn, *args, **kwargs) -> None:
+        """Dispatch a collective on the underlying adapter.
+
+        ``async_op`` is consumed here (not forwarded to torchcomms / c10d
+        verbatim): when True, the adapter awaits the returned handle before
+        returning. For c10d send/recv this also rewrites the call to
+        ``isend`` / ``irecv``. Callers must pass ``async_op`` as a keyword.
+
+        For hot loops, prefer :meth:`resolve_collective` to lift the dispatch
+        and lookup overhead out of the timing loop.
+        """
+        async_op = kwargs.pop("async_op", False)
+        bound, args, kwargs = self._resolve(collective_fn, args, kwargs, async_op)
+        handle = bound(*args, **kwargs)
+        if async_op and handle is not None:
+            handle.wait()
+
+    def resolve_collective(self, collective_fn, *args, **kwargs):
+        """Pre-resolve a collective into a zero-overhead callable for hot loops.
+
+        Returns ``(call, args, kwargs)`` where ``call(*args, **kwargs)`` runs
+        the collective and waits on the handle (matching :meth:`run_collective`
+        semantics). All adapter-specific name mapping, arg reshaping, and
+        ``async_op`` handling is performed once here, so the returned callable
+        can be invoked tightly in a measurement loop without per-iteration
+        Python overhead.
+
+        ``async_op`` must be passed as a keyword.
+        """
+        self._require_initialized()
+        async_op = kwargs.pop("async_op", False)
+        bound, args, kwargs = self._resolve(collective_fn, args, kwargs, async_op)
+        if async_op:
+
+            def call(*a, **kw):
+                handle = bound(*a, **kw)
+                if handle is not None:
+                    handle.wait()
+        else:
+            call = bound
+        return call, args, kwargs
+
+    def _resolve(self, collective_fn, args, kwargs, async_op):
+        """Compute the bound callable plus adjusted args/kwargs for one call."""
+        self._require_initialized()
+        fn_name = collective_fn
+        if self.name.startswith("c10d"):
+            fn_name = self._C10D_NAME_MAP.get(collective_fn, collective_fn)
+            # gather: torchcomms takes (output_list, input_tensor, root, ...)
+            #         c10d takes (tensor, gather_list, dst, ...)
+            if collective_fn == "gather" and len(args) >= 2:
+                args = (args[1], args[0]) + args[2:]
+            # c10d send/recv have no async_op; use isend/irecv for async
+            if collective_fn in ("send", "recv"):
+                if async_op:
+                    fn_name = "i" + collective_fn
+            else:
+                kwargs["async_op"] = async_op
+        else:
+            # torchcomms: pass async_op positionally to match the pre-refactor
+            # call shape exactly. The pybind11 binding has fewer overheads on
+            # the positional path than on the kwargs path.
+            args = args + (async_op,)
+
+        try:
+            bound = getattr(self.dist_comm, fn_name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Collective operation '{fn_name}' not found on "
+                f"comm adapter '{self.name}'."
+            ) from exc
+        return bound, args, kwargs
+
+    def get_rank(self) -> int:
+        self._require_initialized()
+        return self.dist_comm.get_rank()
+
+    def get_size(self) -> int:
+        self._require_initialized()
+        if self.name == "torchcomms":
+            return self.dist_comm.get_size()
+        elif self.name.startswith("c10d"):
+            return self.dist_comm.get_world_size()
+        raise NotImplementedError(f"get_size not implemented for adapter '{self.name}'")
+
+    def get_backend(self) -> str:
+        self._require_initialized()
+        return self.dist_comm.get_backend()
+
+    def get_backend_version(self) -> str:
+        self._require_initialized()
+        if self.name in ["torchcomms", "c10d_torchcomms"]:
+            try:
+                return self.dist_comm.get_backend_version()
+            except (AttributeError, NotImplementedError, RuntimeError):
+                return "n/a"
+        elif self.name.startswith("c10d"):
+            backend = self.get_backend()
+            if backend == "nccl" and torch.cuda.is_available():
+                return ".".join(str(v) for v in torch.cuda.nccl.version())
+            return "n/a"
+        return "n/a"
+
+    _REDUCE_OP_MAP_TORCHCOMMS = {
+        "sum": torchcomms.ReduceOp.SUM,
+        "min": torchcomms.ReduceOp.MIN,
+        "max": torchcomms.ReduceOp.MAX,
+        "avg": torchcomms.ReduceOp.AVG,
+        "product": torchcomms.ReduceOp.PRODUCT,
+    }
+    _REDUCE_OP_MAP_C10D = {
+        "sum": dist.ReduceOp.SUM,
+        "min": dist.ReduceOp.MIN,
+        "max": dist.ReduceOp.MAX,
+        "avg": dist.ReduceOp.AVG,
+        "product": dist.ReduceOp.PRODUCT,
+    }
+
+    def get_reduce_op(self, op_name: str):
+        """Map a reduce op name to the appropriate ReduceOp type."""
+        self._require_initialized()
+        op_map = (
+            self._REDUCE_OP_MAP_TORCHCOMMS
+            if self.name == "torchcomms"
+            else self._REDUCE_OP_MAP_C10D
+        )
+        if op_name not in op_map:
+            raise ValueError(
+                f"Unknown reduce op '{op_name}'. Supported: {', '.join(op_map.keys())}"
+            )
+        return op_map[op_name]
+
+    def finalize(self) -> None:
+        if self.initialized:
+            if self.name == "torchcomms":
+                self.dist_comm.finalize()
+            elif self.name.startswith("c10d"):
+                self.dist_comm.destroy_process_group()
+            self.initialized = False
 
 
 @dataclass
-class PerfResult:
-    message_size_bytes: int = 0
+class EnvInfo:
+    device_type: str = None
+    device_name: str = None
+    torch_version: str = torch.__version__
+    torchcomms_version: str = "n/a"
+    comm_adapter_name: Literal["torchcomms", "c10d", "c10d_torchcomms"] = None
+    comm_backend_name: str = None
+    comm_backend_version: str = None
+
+
+@dataclass
+class BenchConfig:
+    run_all_collectives: bool = False
+    run_all_comm_adapters: bool = False
+    run_all_reduce_ops: bool = False
+    reduce_op_explicit: bool = False
+    # Message size range in bytes (powers of 2)
+    min_size: int = 4  # 4 bytes
+    max_size: int = (
+        67108864 if os.environ.get("TEST_FULL_SWEEP") != "0" else 1024
+    )  # 64 MiB or 1 KiB
+    # Scaling factor for message sizes (default 2 = powers of 2)
+    size_scaling_factor: int = 2
+    # Whether to save results to CSV files
+    csv_enabled: bool = False
+    # Whether to suppress terminal output
+    quiet: bool = False
+    # CSV output file path (set dynamically per collective)
+    csv_file: Optional[str] = None
+    # Base directory for CSV output (per-adapter subdir created underneath)
+    output_dir: Optional[str] = None
+
+
+@dataclass
+class BenchParams:
+    comm_adapter: Literal["torchcomms", "c10d", "c10d_torchcomms"] = "torchcomms"
+    collective_name: str = None
     num_ranks: int = 0
-    iterations: int = 0
+    async_op: bool = False
+    dispatch_mode: str = "sync"
+    reduce_op: str = "sum"
+    warmup_iterations: int = 5 if os.environ.get("TEST_FULL_SWEEP") != "0" else 1
+    measure_iterations: int = 1000 if os.environ.get("TEST_FULL_SWEEP") != "0" else 3
+    # Number of iterations between stream synchronizations during measurement.
+    # If 0, only synchronize after all iterations complete.
+    sync_interval: int = 0
+    # Data type
+    dtype: torch.dtype = field(default_factory=lambda: torch.float32)
+
+
+@dataclass
+class BenchMetrics:
+    message_size_bytes: int = 0
     total_time_us: float = 0.0
     avg_time_us: float = 0.0
     min_time_us: float = 0.0
@@ -20,20 +258,11 @@ class PerfResult:
 
 
 @dataclass
-class PerfParams:
-    async_op: bool = False
-    warmup_iterations: int = 5
-    measure_iterations: int = 1000
-    # Number of iterations between stream synchronizations during measurement.
-    # If 0, only synchronize after all iterations complete.
-    iteration_window: int = 0
-    # Message size range in bytes (powers of 2)
-    min_size: int = 4  # 4 bytes
-    max_size: int = 67108864  # 64 MB
-    # Scaling factor for message sizes (default 2 = powers of 2)
-    size_scaling_factor: int = 2
-    # Data type
-    dtype: torch.dtype = field(default_factory=lambda: torch.float32)
+class BenchRecord:
+    info: EnvInfo = field(default_factory=EnvInfo)
+    config: BenchConfig = field(default_factory=BenchConfig)
+    params: BenchParams = field(default_factory=BenchParams)
+    metrics: BenchMetrics = field(default_factory=BenchMetrics)
 
 
 class PerfTimer:
@@ -60,24 +289,114 @@ class PerfTimer:
         return self.elapsed_us() / 1000.0
 
 
-def print_perf_header(rank: int) -> None:
-    if rank != 0:
-        return
-    print(
-        f"{'SendMsgSize(B)':<15}{'Ranks':<10}{'Iters':<10}"
-        f"{'Avg(us)':<15}{'Min(us)':<15}{'Max(us)':<15}{'BusBw(GB/s)':<15}"
-    )
-    print("-" * 95)
+# Column definitions for terminal output and CSV files.
+# Each entry is (header_name, column_width). The width is used only for
+# terminal alignment; CSV output ignores it.
+# Ordered as: test identity → benchmark config → results → environment,
+# so the most frequently compared fields appear first when scrolling right.
+_CSV_COLUMNS = [
+    # Test identity
+    ("Collective", 25),
+    ("DType", 10),
+    ("ReduceOp", 12),
+    ("SendMsgSize(B)", 15),
+    ("Ranks", 10),
+    # Benchmark config
+    ("DispatchMode", 14),
+    ("WarmupIters", 12),
+    ("MeasureIters", 14),
+    ("SyncInterval", 14),
+    # Results
+    ("LatAvg(us)", 15),
+    ("LatMin(us)", 15),
+    ("LatMax(us)", 15),
+    ("BusBw(GB/s)", 15),
+    # Environment
+    ("DeviceType", 12),
+    ("DeviceName", 40),
+    ("CommAdapter", 20),
+    ("CommBackend", 13),
+    ("CommBackendVersion", 20),
+    ("TorchVersion", 30),
+    ("TorchCommsVersion", 20),
+]
 
 
-def print_perf_result(result: PerfResult, rank: int) -> None:
-    if rank != 0:
+# Collectives that accept a reduction operator (e.g. sum, min, max).
+# Used in log_perf_result to decide whether to display the ReduceOp column
+# value or substitute "n/a" for collectives that do not perform a reduction.
+_REDUCE_COLLECTIVES = {
+    "all_reduce",
+    "reduce",
+    "reduce_scatter",
+    "reduce_scatter_single",
+}
+
+
+def collective_to_camel_case(s: str) -> str:
+    return "".join(word.capitalize() for word in s.split("_"))
+
+
+def init_csv_file(csv_file: str) -> None:
+    """Create the CSV file and write the header row."""
+    with open(csv_file, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([name for name, _ in _CSV_COLUMNS])
+
+
+def log_perf_header(record: BenchRecord, rank: int) -> None:
+    if rank != 0 or record.config.quiet:
         return
     print(
-        f"{result.message_size_bytes:<15}{result.num_ranks:<10}{result.iterations:<10}"
-        f"{result.avg_time_us:<15.2f}{result.min_time_us:<15.2f}{result.max_time_us:<15.2f}"
-        f"{result.bus_bw_gbps:<15.2f}"
+        f"\n=== {collective_to_camel_case(record.params.collective_name)} Performance ===\n"
     )
+    header = "".join(f"{name:<{width}}" for name, width in _CSV_COLUMNS)
+    print(header)
+    print("-" * len(header))
+
+
+def log_perf_result(record: BenchRecord, rank: int) -> None:
+    if rank != 0:
+        return
+    reduce_op_display = (
+        record.params.reduce_op
+        if record.params.collective_name in _REDUCE_COLLECTIVES
+        else "n/a"
+    )
+    values = [
+        # Test identity
+        record.params.collective_name,
+        dtype_to_string(record.params.dtype),
+        reduce_op_display,
+        record.metrics.message_size_bytes,
+        record.params.num_ranks,
+        # Benchmark config
+        record.params.dispatch_mode,
+        record.params.warmup_iterations,
+        record.params.measure_iterations,
+        record.params.sync_interval,
+        # Results
+        f"{record.metrics.avg_time_us:.2f}",
+        f"{record.metrics.min_time_us:.2f}",
+        f"{record.metrics.max_time_us:.2f}",
+        f"{record.metrics.bus_bw_gbps:.2f}",
+        # Environment
+        record.info.device_type,
+        record.info.device_name,
+        record.info.comm_adapter_name,
+        record.info.comm_backend_name,
+        record.info.comm_backend_version,
+        record.info.torch_version,
+        record.info.torchcomms_version,
+    ]
+    if not record.config.quiet:
+        print("".join(f"{v:<{w}}" for v, (_, w) in zip(values, _CSV_COLUMNS)))
+
+    csv_file = record.config.csv_file
+    if csv_file:
+        with open(csv_file, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(values)
 
 
 def create_tensor(
@@ -93,6 +412,108 @@ def sync_device() -> None:
     """Synchronize the current accelerator's stream if an accelerator is present."""
     if torch.accelerator.is_available():
         torch.accelerator.synchronize()
+
+
+def run_bench_sweep(
+    comm: CommAdapter,
+    record: BenchRecord,
+    device: torch.device,
+    collective_name: str,
+    setup_fn: Callable[
+        [int, int, int, torch.device, torch.dtype],
+        Tuple[tuple, dict],
+    ],
+    bus_bw_fn: Callable[[int, int, int, float], float],
+) -> None:
+    """Generic message-size sweep with warmup, measurement, and logging.
+
+    Args:
+        comm: The communication adapter.
+        record: Benchmark record (config + params + metrics).
+        device: Torch device.
+        collective_name: Name passed to ``comm.run_collective``.
+        setup_fn: ``(num_elements, rank, num_ranks, device, dtype) -> (args, kwargs)``
+            returning positional args and keyword args for the collective call.
+            ``async_op`` is appended automatically and must not be included.
+        bus_bw_fn: ``(num_elements, element_size, num_ranks, avg_time_us) -> bus_bw_gbps``
+            computing the bus bandwidth in GB/s.
+    """
+    rank = comm.get_rank()
+    num_ranks = comm.get_size()
+    params = record.params
+    config = record.config
+
+    element_size = torch.tensor([], dtype=params.dtype).element_size()
+
+    msg_size = config.min_size
+    while msg_size <= config.max_size:
+        num_elements = msg_size // element_size
+        if num_elements == 0:
+            num_elements = 1
+
+        raw_args, raw_kwargs = setup_fn(
+            num_elements, rank, num_ranks, device, params.dtype
+        )
+
+        # Pre-resolve once so the timing loop calls a bound method directly.
+        call, call_args, call_kwargs = comm.resolve_collective(
+            collective_name, *raw_args, **raw_kwargs, async_op=params.async_op
+        )
+
+        # Warmup
+        for _ in range(params.warmup_iterations):
+            call(*call_args, **call_kwargs)
+
+        comm.run_collective("barrier", async_op=False)
+
+        # Measure
+        timer = PerfTimer()
+
+        if params.sync_interval == 1:
+            # Per-iteration timing: sync after every iteration to get min/max.
+            iter_times: list[float] = []
+            sync_device()
+            for _ in range(params.measure_iterations):
+                timer.start()
+                call(*call_args, **call_kwargs)
+                sync_device()
+                timer.stop()
+                iter_times.append(timer.elapsed_us())
+
+            total = sum(iter_times)
+            avg_time = total / params.measure_iterations
+            min_time = min(iter_times)
+            max_time = max(iter_times)
+        else:
+            # Bulk timing: single start/stop around all iterations.
+            sync_device()
+            timer.start()
+
+            for i in range(params.measure_iterations):
+                call(*call_args, **call_kwargs)
+                if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
+                    sync_device()
+
+            sync_device()
+            timer.stop()
+
+            total = timer.elapsed_us()
+            avg_time = total / params.measure_iterations
+            min_time = avg_time
+            max_time = avg_time
+
+        bus_bw_gbps = bus_bw_fn(num_elements, element_size, num_ranks, avg_time)
+
+        record.metrics.message_size_bytes = num_elements * element_size
+        record.metrics.total_time_us = total
+        record.metrics.avg_time_us = avg_time
+        record.metrics.min_time_us = min_time
+        record.metrics.max_time_us = max_time
+        record.metrics.bus_bw_gbps = bus_bw_gbps
+
+        log_perf_result(record, rank)
+
+        msg_size *= config.size_scaling_factor
 
 
 def print_usage(program_name: str) -> None:
@@ -118,12 +539,23 @@ Options:
   --async                - Run async mode (default: sync)
   --warmup <n>           - Number of warmup iterations (default: 5)
   --iters <n>            - Number of measurement iterations (default: 1000)
-  --window <n>           - Iterations between stream syncs (default: 0)
+  --sync-interval <n>    - Iterations between stream syncs (default: 0)
   --min-size <n>         - Min message size in bytes (default: 4)
   --max-size <n>         - Max message size in bytes (default: 67108864)
   --size-scaling-factor <n> - Size multiplier between tests (default: 2)
   --dtype <type>         - Data type: float32, float16, bfloat16, float64,
                            int32, int64 (default: float32)
+  --reduce-op <op>       - Reduction operation: sum, min, max, avg, product,
+                           or 'all' to sweep every supported op (reduction
+                           collectives only) (default: sum)
+  --c10d                 - Use c10d instead of torchcomms
+  --c10d-torchcomms      - Use c10d with torchcomms backend
+  --all-comm-adapters    - Run against all comm adapters (torchcomms, c10d,
+                           c10d_torchcomms)
+  --csv                  - Save results to CSV files (one per collective)
+  --output-dir <path>    - Base dir for CSV output (default: cwd); a
+                           per-adapter subdirectory is created underneath
+  --quiet, -q            - Suppress terminal output
   --help, -h             - Show this help message
 """)
 
@@ -165,67 +597,79 @@ def dtype_to_string(dtype: torch.dtype) -> str:
     return dtype_map[dtype]
 
 
-def validate_params(collective: str, params: PerfParams) -> str:
-    valid_collectives = [
-        "all_reduce",
-        "allreduce",
-        "all_gather",
-        "allgather",
-        "all_gather_single",
-        "allgathersingle",
-        "reduce_scatter",
-        "reducescatter",
-        "reduce_scatter_single",
-        "reducescattersingle",
-        "all_to_all",
-        "alltoall",
-        "all_to_all_single",
-        "alltoallsingle",
-        "broadcast",
-        "reduce",
-        "scatter",
-        "gather",
-        "send_recv",
-        "sendrecv",
-        "barrier",
-        "all",
-    ]
+def validate_bench_params(record: BenchRecord) -> Optional[str]:
+    config = record.config
+    params = record.params
 
-    if collective not in valid_collectives:
-        return f"Unknown collective '{collective}'"
+    if not config.run_all_collectives and params.collective_name is None:
+        return "No collective specified"
 
-    if params.size_scaling_factor < 2:
+    if config.quiet and not config.csv_enabled:
+        return "--quiet/-q requires --csv; otherwise results would be discarded"
+
+    if config.reduce_op_explicit and config.run_all_collectives:
+        return (
+            "--reduce-op is implicit when running 'all'; reduction collectives "
+            "are always swept across every supported op"
+        )
+
+    if config.size_scaling_factor < 2:
         return "size_scaling_factor must be at least 2"
 
-    if params.min_size <= 0:
+    if config.min_size <= 0:
         return "min_size must be positive"
 
-    if params.max_size < params.min_size:
+    if config.max_size < config.min_size:
         return "max_size must be >= min_size"
 
     # Validate that max_size is reachable from min_size via scaling factor
-    size = params.min_size
-    while size < params.max_size:
-        size *= params.size_scaling_factor
-    if size != params.max_size and params.min_size != params.max_size:
+    size = config.min_size
+    while size < config.max_size:
+        size *= config.size_scaling_factor
+    if size != config.max_size and config.min_size != config.max_size:
         return "max_size must be min_size * size_scaling_factor^n for some integer n"
 
     # Validate dtype divides sizes evenly
     element_size = torch.tensor([], dtype=params.dtype).element_size()
-    if params.min_size % element_size != 0:
+    if config.min_size % element_size != 0:
         return (
             f"min_size must be divisible by dtype element size ({element_size} bytes)"
         )
-    if params.max_size % element_size != 0:
+    if config.max_size % element_size != 0:
         return (
             f"max_size must be divisible by dtype element size ({element_size} bytes)"
+        )
+
+    if (
+        config.reduce_op_explicit
+        and not config.run_all_collectives
+        and params.collective_name not in _REDUCE_COLLECTIVES
+    ):
+        return (
+            f"--reduce-op is only valid for reduction collectives "
+            f"({', '.join(sorted(_REDUCE_COLLECTIVES))}); "
+            f"got '{params.collective_name}'"
+        )
+
+    valid_reduce_ops = {"sum", "min", "max", "avg", "product"}
+    if (
+        not config.run_all_reduce_ops
+        and params.reduce_op not in valid_reduce_ops
+        and (
+            config.run_all_collectives or params.collective_name in _REDUCE_COLLECTIVES
+        )
+    ):
+        return (
+            f"Unknown reduce op '{params.reduce_op}' for collective "
+            f"'{params.collective_name}'. Supported: "
+            f"{', '.join(sorted(valid_reduce_ops))}"
         )
 
     if params.warmup_iterations < 0:
         return "warmup_iterations must be non-negative"
     if params.measure_iterations <= 0:
         return "measure_iterations must be positive"
-    if params.iteration_window < 0:
-        return "iteration_window must be non-negative"
+    if params.sync_interval < 0:
+        return "sync_interval must be non-negative"
 
-    return ""  # Valid
+    return None  # Valid

--- a/comms/torchcomms/tests/perf/py/reduce_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_perf.py
@@ -2,86 +2,29 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Reduce Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, root, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Reduce: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce(tensor, root, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce(tensor, root, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Reduce bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/reduce_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_perf.py
@@ -2,86 +2,29 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Reduce Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        tensor = create_tensor(num_elements, rank, device, dtype)
+        return (tensor, root, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Reduce: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce(tensor, root, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce(tensor, root, torchcomms.ReduceOp.SUM, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Reduce bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/reduce_scatter_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_scatter_perf.py
@@ -2,96 +2,32 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_scatter_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} ReduceScatter Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor list
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
         input_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_tensor, input_list, op), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce_scatter(
-                output_tensor, input_list, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce_scatter(
-                output_tensor, input_list, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # ReduceScatter bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # ReduceScatter: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce_scatter", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/reduce_scatter_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_scatter_perf.py
@@ -2,96 +2,32 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_scatter_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} ReduceScatter Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor list
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
         input_list = [
-            create_tensor(num_elements, rank, device, params.dtype)
-            for _ in range(num_ranks)
+            create_tensor(num_elements, rank, device, dtype) for _ in range(num_ranks)
         ]
+        return (output_tensor, input_list, op), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce_scatter(
-                output_tensor, input_list, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce_scatter(
-                output_tensor, input_list, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # ReduceScatter bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # ReduceScatter: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce_scatter", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/reduce_scatter_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_scatter_single_perf.py
@@ -2,95 +2,30 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_scatter_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} ReduceScatterSingle Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
+        input_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor (single tensor for all ranks)
-        input_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce_scatter_single(
-                output_tensor, input_tensor, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce_scatter_single(
-                output_tensor, input_tensor, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # ReduceScatterSingle bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # ReduceScatterSingle: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce_scatter_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/reduce_scatter_single_perf.py
+++ b/comms/torchcomms/tests/perf/py/reduce_scatter_single_perf.py
@@ -2,95 +2,30 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_reduce_scatter_single_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
+    op = comm.get_reduce_op(record.params.reduce_op)
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} ReduceScatterSingle Performance ===")
-    print_perf_header(rank)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
+        input_tensor = create_tensor(num_elements * num_ranks, rank, device, dtype)
+        return (output_tensor, input_tensor, op), {}
 
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor (single tensor for all ranks)
-        input_tensor = create_tensor(
-            num_elements * num_ranks, rank, device, params.dtype
-        )
-
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.reduce_scatter_single(
-                output_tensor, input_tensor, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.reduce_scatter_single(
-                output_tensor, input_tensor, torchcomms.ReduceOp.SUM, params.async_op
-            )
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # ReduceScatterSingle bus bandwidth: (n-1) / n * total_size / time
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # ReduceScatterSingle: (n-1) / n * total_size / time
         total_size = num_elements * num_ranks * element_size
-        algo_bw = total_size / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
+        algo_bw = total_size / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        result = PerfResult(
-            message_size_bytes=num_elements * num_ranks * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "reduce_scatter_single", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/requirements.txt
+++ b/comms/torchcomms/tests/perf/py/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+pandas

--- a/comms/torchcomms/tests/perf/py/scatter_perf.py
+++ b/comms/torchcomms/tests/perf/py/scatter_perf.py
@@ -2,94 +2,33 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_scatter_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Scatter Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor list (only used at root)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
         input_list = []
         if rank == root:
             input_list = [
-                create_tensor(num_elements, rank, device, params.dtype)
+                create_tensor(num_elements, rank, device, dtype)
                 for _ in range(num_ranks)
             ]
+        return (output_tensor, input_list, root), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.scatter(output_tensor, input_list, root, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Scatter: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device(device)
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.scatter(output_tensor, input_list, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
-
-        sync_device(device)
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Scatter bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "scatter", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/scatter_perf.py
+++ b/comms/torchcomms/tests/perf/py/scatter_perf.py
@@ -2,94 +2,33 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
-    PerfTimer,
-    print_perf_header,
-    print_perf_result,
-    sync_device,
+    run_bench_sweep,
 )
 
 
 def run_scatter_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
     root: int = 0,
 ) -> None:
-    rank = comm.get_rank()
-    num_ranks = comm.get_size()
-
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} Scatter Performance ===")
-    print_perf_header(rank)
-
-    element_size = torch.tensor([], dtype=params.dtype).element_size()
-
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
-        num_elements = msg_size // element_size
-        if num_elements == 0:
-            num_elements = 1
-        output_tensor = create_tensor(num_elements, rank, device, params.dtype)
-
-        # Create input tensor list (only used at root)
+    def setup(num_elements, rank, num_ranks, device, dtype):
+        output_tensor = create_tensor(num_elements, rank, device, dtype)
         input_list = []
         if rank == root:
             input_list = [
-                create_tensor(num_elements, rank, device, params.dtype)
+                create_tensor(num_elements, rank, device, dtype)
                 for _ in range(num_ranks)
             ]
+        return (output_tensor, input_list, root), {}
 
-        # Warmup
-        for _ in range(params.warmup_iterations):
-            work = comm.scatter(output_tensor, input_list, root, params.async_op)
-            if params.async_op:
-                work.wait()
+    def bus_bw(num_elements, element_size, num_ranks, avg_time_us):
+        # Scatter: (n-1) / n * size / time
+        algo_bw = (num_elements * element_size) / avg_time_us
+        return algo_bw * (num_ranks - 1) / num_ranks / 1000.0
 
-        # Synchronize all ranks before measurement
-        comm.barrier(False)
-
-        # Measure
-        timer = PerfTimer()
-        sync_device()
-        timer.start()
-
-        for i in range(params.measure_iterations):
-            work = comm.scatter(output_tensor, input_list, root, params.async_op)
-            if params.async_op:
-                work.wait()
-
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device()
-
-        sync_device()
-        timer.stop()
-
-        # Calculate statistics
-        total = timer.elapsed_us()
-        avg_time = total / params.measure_iterations
-
-        # Scatter bus bandwidth: (n-1) / n * size / time
-        algo_bw = (num_elements * element_size) / avg_time  # bytes/us = MB/s
-        bus_bw_factor = (num_ranks - 1) / num_ranks
-        bus_bw_gbps = algo_bw * bus_bw_factor / 1000.0  # Convert to GB/s
-
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=num_ranks,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time,
-            min_time_us=avg_time,
-            max_time_us=avg_time,
-            bus_bw_gbps=bus_bw_gbps,
-        )
-
-        print_perf_result(result, rank)
-
-        msg_size *= params.size_scaling_factor
+    run_bench_sweep(comm, record, device, "scatter", setup, bus_bw)

--- a/comms/torchcomms/tests/perf/py/send_recv_perf.py
+++ b/comms/torchcomms/tests/perf/py/send_recv_perf.py
@@ -2,49 +2,45 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
+    log_perf_header,
+    log_perf_result,
     PerfTimer,
-    print_perf_header,
-    print_perf_result,
     sync_device,
 )
 
 
 def _do_ping_pong(
-    comm: torchcomms.TorchComm,
-    tensor: torch.Tensor,
+    send_call,
+    send_args,
+    send_kwargs,
+    recv_call,
+    recv_args,
+    recv_kwargs,
     rank: int,
     peer: int,
-    async_op: bool,
 ) -> None:
-    """Execute one ping-pong iteration between paired ranks."""
-    if rank % 2 == 0:
-        work = comm.send(tensor, peer, async_op)
-        if async_op:
-            work.wait()
-        work2 = comm.recv(tensor, peer, async_op)
-        if async_op:
-            work2.wait()
+    """Execute one ping-pong iteration between rank and peer."""
+    if rank < peer:
+        send_call(*send_args, **send_kwargs)
+        recv_call(*recv_args, **recv_kwargs)
     else:
-        work = comm.recv(tensor, peer, async_op)
-        if async_op:
-            work.wait()
-        work2 = comm.send(tensor, peer, async_op)
-        if async_op:
-            work2.wait()
+        recv_call(*recv_args, **recv_kwargs)
+        send_call(*send_args, **send_kwargs)
 
 
 def run_send_recv_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
     rank = comm.get_rank()
     num_ranks = comm.get_size()
+    params = record.params
+    config = record.config
 
     if num_ranks < 2:
         if rank == 0:
@@ -55,39 +51,66 @@ def run_send_recv_perf(
             print("SendRecv test requires an even number of ranks, skipping")
         return
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} SendRecv Performance ===")
-    print_perf_header(rank)
-
-    peer = rank + 1 if rank % 2 == 0 else rank - 1
+    # Pair adjacent ranks (0<->1, 2<->3, …) so all pairs run concurrently, matching
+    # the nccl-tests / OSU send-recv benchmark patterns:
+    #   XOR with 1 flips the least significant bit, giving each rank its peer.
+    #   With an odd rank count the last rank computes a peer >= num_ranks so we skip it.
+    peer = rank ^ 1
+    if peer >= num_ranks:
+        return
     element_size = torch.tensor([], dtype=params.dtype).element_size()
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
+    msg_size = config.min_size
+    while msg_size <= config.max_size:
         num_elements = msg_size // element_size
         if num_elements == 0:
             num_elements = 1
         tensor = create_tensor(num_elements, rank, device, params.dtype)
 
+        # Pre-resolve send/recv once so the timing loop avoids per-call dispatch.
+        send_call, send_args, send_kwargs = comm.resolve_collective(
+            "send", tensor, peer, async_op=params.async_op
+        )
+        recv_call, recv_args, recv_kwargs = comm.resolve_collective(
+            "recv", tensor, peer, async_op=params.async_op
+        )
+
         # Warmup
         for _ in range(params.warmup_iterations):
-            _do_ping_pong(comm, tensor, rank, peer, params.async_op)
+            _do_ping_pong(
+                send_call,
+                send_args,
+                send_kwargs,
+                recv_call,
+                recv_args,
+                recv_kwargs,
+                rank,
+                peer,
+            )
 
-        comm.barrier(False)
+        comm.run_collective("barrier", async_op=False)
 
         # Measure ping-pong latency
         timer = PerfTimer()
-        sync_device(device)
+        sync_device()
         timer.start()
 
         for i in range(params.measure_iterations):
-            _do_ping_pong(comm, tensor, rank, peer, params.async_op)
+            _do_ping_pong(
+                send_call,
+                send_args,
+                send_kwargs,
+                recv_call,
+                recv_args,
+                recv_kwargs,
+                rank,
+                peer,
+            )
 
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
-                sync_device(device)
+            if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
+                sync_device()
 
-        sync_device(device)
+        sync_device()
         timer.stop()
 
         total = timer.elapsed_us()
@@ -98,17 +121,13 @@ def run_send_recv_perf(
         algo_bw = (num_elements * element_size) / one_way_time  # bytes/us = MB/s
         bus_bw_gbps = algo_bw / 1000.0  # Convert to GB/s
 
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=2,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time / 2,
-            min_time_us=avg_time / 2,
-            max_time_us=avg_time / 2,
-            bus_bw_gbps=bus_bw_gbps,
-        )
+        record.metrics.message_size_bytes = num_elements * element_size
+        record.metrics.total_time_us = total
+        record.metrics.avg_time_us = avg_time / 2
+        record.metrics.min_time_us = avg_time / 2
+        record.metrics.max_time_us = avg_time / 2
+        record.metrics.bus_bw_gbps = bus_bw_gbps
 
-        print_perf_result(result, rank)
+        log_perf_result(record, rank)
 
-        msg_size *= params.size_scaling_factor
+        msg_size *= config.size_scaling_factor

--- a/comms/torchcomms/tests/perf/py/send_recv_perf.py
+++ b/comms/torchcomms/tests/perf/py/send_recv_perf.py
@@ -2,49 +2,45 @@
 # pyre-unsafe
 
 import torch
-import torchcomms
 from torchcomms.tests.perf.py.perf_test_helpers import (
+    BenchRecord,
+    CommAdapter,
     create_tensor,
-    PerfParams,
-    PerfResult,
+    log_perf_header,
+    log_perf_result,
     PerfTimer,
-    print_perf_header,
-    print_perf_result,
     sync_device,
 )
 
 
 def _do_ping_pong(
-    comm: torchcomms.TorchComm,
-    tensor: torch.Tensor,
+    send_call,
+    send_args,
+    send_kwargs,
+    recv_call,
+    recv_args,
+    recv_kwargs,
     rank: int,
     peer: int,
-    async_op: bool,
 ) -> None:
-    """Execute one ping-pong iteration between paired ranks."""
-    if rank % 2 == 0:
-        work = comm.send(tensor, peer, async_op)
-        if async_op:
-            work.wait()
-        work2 = comm.recv(tensor, peer, async_op)
-        if async_op:
-            work2.wait()
+    """Execute one ping-pong iteration between rank and peer."""
+    if rank < peer:
+        send_call(*send_args, **send_kwargs)
+        recv_call(*recv_args, **recv_kwargs)
     else:
-        work = comm.recv(tensor, peer, async_op)
-        if async_op:
-            work.wait()
-        work2 = comm.send(tensor, peer, async_op)
-        if async_op:
-            work2.wait()
+        recv_call(*recv_args, **recv_kwargs)
+        send_call(*send_args, **send_kwargs)
 
 
 def run_send_recv_perf(
-    comm: torchcomms.TorchComm,
-    params: PerfParams,
+    comm: CommAdapter,
+    record: BenchRecord,
     device: torch.device,
 ) -> None:
     rank = comm.get_rank()
     num_ranks = comm.get_size()
+    params = record.params
+    config = record.config
 
     if num_ranks < 2:
         if rank == 0:
@@ -55,26 +51,44 @@ def run_send_recv_perf(
             print("SendRecv test requires an even number of ranks, skipping")
         return
 
-    if rank == 0:
-        mode = "Asynchronous" if params.async_op else "Synchronous"
-        print(f"\n=== {mode} SendRecv Performance ===")
-    print_perf_header(rank)
-
-    peer = rank + 1 if rank % 2 == 0 else rank - 1
+    # Pair adjacent ranks (0<->1, 2<->3, …) so all pairs run concurrently, matching
+    # the nccl-tests / OSU send-recv benchmark patterns:
+    #   XOR with 1 flips the least significant bit, giving each rank its peer.
+    #   With an odd rank count the last rank computes a peer >= num_ranks so we skip it.
+    peer = rank ^ 1
+    if peer >= num_ranks:
+        return
     element_size = torch.tensor([], dtype=params.dtype).element_size()
 
-    msg_size = params.min_size
-    while msg_size <= params.max_size:
+    msg_size = config.min_size
+    while msg_size <= config.max_size:
         num_elements = msg_size // element_size
         if num_elements == 0:
             num_elements = 1
         tensor = create_tensor(num_elements, rank, device, params.dtype)
 
+        # Pre-resolve send/recv once so the timing loop avoids per-call dispatch.
+        send_call, send_args, send_kwargs = comm.resolve_collective(
+            "send", tensor, peer, async_op=params.async_op
+        )
+        recv_call, recv_args, recv_kwargs = comm.resolve_collective(
+            "recv", tensor, peer, async_op=params.async_op
+        )
+
         # Warmup
         for _ in range(params.warmup_iterations):
-            _do_ping_pong(comm, tensor, rank, peer, params.async_op)
+            _do_ping_pong(
+                send_call,
+                send_args,
+                send_kwargs,
+                recv_call,
+                recv_args,
+                recv_kwargs,
+                rank,
+                peer,
+            )
 
-        comm.barrier(False)
+        comm.run_collective("barrier", async_op=False)
 
         # Measure ping-pong latency
         timer = PerfTimer()
@@ -82,9 +96,18 @@ def run_send_recv_perf(
         timer.start()
 
         for i in range(params.measure_iterations):
-            _do_ping_pong(comm, tensor, rank, peer, params.async_op)
+            _do_ping_pong(
+                send_call,
+                send_args,
+                send_kwargs,
+                recv_call,
+                recv_args,
+                recv_kwargs,
+                rank,
+                peer,
+            )
 
-            if params.iteration_window > 0 and (i + 1) % params.iteration_window == 0:
+            if params.sync_interval > 0 and (i + 1) % params.sync_interval == 0:
                 sync_device()
 
         sync_device()
@@ -98,17 +121,13 @@ def run_send_recv_perf(
         algo_bw = (num_elements * element_size) / one_way_time  # bytes/us = MB/s
         bus_bw_gbps = algo_bw / 1000.0  # Convert to GB/s
 
-        result = PerfResult(
-            message_size_bytes=num_elements * element_size,
-            num_ranks=2,
-            iterations=params.measure_iterations,
-            total_time_us=total,
-            avg_time_us=avg_time / 2,
-            min_time_us=avg_time / 2,
-            max_time_us=avg_time / 2,
-            bus_bw_gbps=bus_bw_gbps,
-        )
+        record.metrics.message_size_bytes = num_elements * element_size
+        record.metrics.total_time_us = total
+        record.metrics.avg_time_us = avg_time / 2
+        record.metrics.min_time_us = avg_time / 2
+        record.metrics.max_time_us = avg_time / 2
+        record.metrics.bus_bw_gbps = bus_bw_gbps
 
-        print_perf_result(result, rank)
+        log_perf_result(record, rank)
 
-        msg_size *= params.size_scaling_factor
+        msg_size *= config.size_scaling_factor


### PR DESCRIPTION
Reengineers the per-collective benchmark suite under `comms/torchcomms/tests/perf/py/` to enable side-by-side benchmarking of `torchcomms`, `c10d`, and `c10d_torchcomms` (`c10d` routed through `torchcomms`), and to lay the groundwork for longitudinal performance monitoring after `c10d` retirement.

Key changes:

- Add `CommAdapter` that normalizes the API differences between `torchcomms` and `c10d` (init/finalize, naming, gather arg order, async send/recv) so every collective runs through one/same code path with no per-iteration dispatch overhead as resolution happens once per message size via `resolve_collective()`, and the timing loop calls a bound method directly.
- Replace per-file timing loops with a shared `run_bench_sweep()` driver; each collective now provides only a `setup_fn` and a `bus_bw_fn`.
- Replace flat `PerfParams`/`PerfResult` with `BenchRecord` (`EnvInfo` + `BenchConfig` + `BenchParams` + `BenchMetrics`), passed through the call stack as a single argument.
- Add structured CSV output with environment metadata per row; schema centralized in `_CSV_COLUMNS`. Default output is `./<adapter>/<collective>[_<op>].csv`, overridable via `--output-dir`. Under `--all-comm-adapters`, a per-adapter subdir is created under the given base path to avoid collisions.
- Add `analyze_perf.py` for per-adapter summaries, side-by-side and relative plots, and regression/improvement detection. Output is organized under `perf_results/`: plots under `plots/<collective>/`, and pairwise comparison reports (regress/improve/highlights) under `<adapter>_vs_<baseline>/`.
- Add `--all-comm-adapters` to sweep all three adapters in one run; add `--reduce-op` all to sweep every reduction op on a single collective.
- Rename `--window` to `--sync-interval`; add modes `0/1/N>1` to trade off measurement overhead vs `min`/`max` accuracy.
- Add `--quiet` / `-q` to suppress terminal output independently of CSV.
- Reshape `send`/`recv` into a paired ping-pong: ranks pair via `XOR` (0<->1, 2<->3, ...) so all pairs run concurrently and the test scales beyond two ranks; matches nccl-tests / OSU patterns.
- Reject unknown flags and positionals at parse time; validate that `--reduce-op` only applies to reduction collectives, that `--reduce-op` is not redundantly set with the 'all' collective, and that `--quiet` requires `--csv` (otherwise results would be discarded).
- Switch `sync_device()` to use `torch.accelerator` (no device argument).
- Rename `validate_params`/`print_perf_header`/`print_perf_result` to `validate_bench_params`/`log_perf_header`/`log_perf_result`.
- Add README.md documenting CLI, sweep workflow, analysis pipeline.

Out-of-tree callers of `run_<collective>_perf` must update to the new `CommAdapter` + `BenchRecord` signature.