### PR TITLE
Raise RDMA queue depth and READ credits (#2637)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -779,7 +779,10 @@ Result<uint32_t> RdmaTransport::spray(
 // ---------------------------------------------------------------------------
 
 void RdmaTransport::ioLooper() noexcept {
-  // Phase 1 — Post: walk pendingTransfers_ front-to-back.
+  // Phase 1 — Poll: drain all CQs (round-robin).
+  pollCompletions();
+
+  // Phase 2 — Post: walk pendingTransfers_ front-to-back.
   while (!pendingTransfers_.empty()) {
     auto& entry = pendingTransfers_.front();
 
@@ -819,9 +822,6 @@ void RdmaTransport::ioLooper() noexcept {
       break;
     }
   }
-
-  // Phase 2 — Poll: drain all CQs.
-  pollCompletions();
 
   // Phase 3 — Fulfill: walk pendingCompletions_ front-to-back for in-order
   // promise delivery.
@@ -914,10 +914,21 @@ std::future<Status> RdmaTransport::rdmaTransfer(
 void RdmaTransport::pollCompletions() {
   constexpr int kNumBatch = 16;
 
-  for (size_t i = 0; i < cqs_.size(); ++i) {
-    int expected = numPendingCqe_[i];
-    ibv_wc wcs[kNumBatch];
-    while (expected > 0) {
+  // Cap total CQEs per call to ensure fairness with other transports
+  // sharing the same EventBase.
+  const uint64_t maxCqes = config_.maxWr * qps_.size();
+  uint64_t totalDrained = 0;
+
+  // Round-robin: poll one batch from each CQ per round, repeat until
+  // CQs are empty or the cap is reached.
+  while (totalDrained < maxCqes) {
+    uint64_t before = totalDrained;
+    for (size_t i = 0; i < cqs_.size() && totalDrained < maxCqes; ++i) {
+      if (numPendingCqe_[i] <= 0) {
+        continue;
+      }
+
+      ibv_wc wcs[kNumBatch];
       auto pollResult = ibvApi_->pollCq(cqs_[i], kNumBatch, wcs);
       if (pollResult.hasError()) {
         UNIFLOW_LOG_ERROR(
@@ -933,6 +944,7 @@ void RdmaTransport::pollCompletions() {
       }
 
       int n = pollResult.value();
+      totalDrained += static_cast<uint64_t>(n);
       for (const auto& wc : std::span(wcs).subspan(0, n)) {
         uint32_t taskId = static_cast<uint32_t>(wc.wr_id >> 32);
         uint32_t numWrs = static_cast<uint32_t>(wc.wr_id & 0xffffffff);
@@ -967,12 +979,9 @@ void RdmaTransport::pollCompletions() {
           it->second->recordCompletion(numWrs);
         }
       }
-
-      if (n < kNumBatch) {
-        break;
-      }
-
-      expected -= kNumBatch;
+    }
+    if (totalDrained == before) {
+      break;
     }
   }
 }

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -421,7 +421,7 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     rtrAttr.path_mtu = negotiatedMtu;
     rtrAttr.dest_qp_num = remote.qpInfos[i].qpNum;
     rtrAttr.rq_psn = remote.qpInfos[i].psn;
-    rtrAttr.max_dest_rd_atomic = 1;
+    rtrAttr.max_dest_rd_atomic = config_.maxRdAtomic;
     rtrAttr.min_rnr_timer = 12;
 
     if (remoteNic.linkLayer == IBV_LINK_LAYER_ETHERNET) {
@@ -455,7 +455,7 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     rtsAttr.timeout = config_.timeout;
     rtsAttr.retry_cnt = config_.retryCnt;
     rtsAttr.rnr_retry = 7;
-    rtsAttr.max_rd_atomic = 1;
+    rtsAttr.max_rd_atomic = config_.maxRdAtomic;
 
     int rtsMask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT |
         IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_MAX_QP_RD_ATOMIC;

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -42,7 +42,14 @@ struct RdmaTransportConfig {
   uint8_t retryCnt{7}; /* Number of retries before reporting an error. */
   uint8_t trafficClass{0}; /* Traffic class for GRH (QoS / DSCP). */
   uint16_t pkeyIndex{0}; /* Partition key index for QP INIT. */
-  uint32_t maxWr{128}; /* Max outstanding send WRs per QP. */
+  /* Max outstanding send WRs per QP. The default leaves enough SQ depth for
+   * high-throughput multi-NIC CPU RDMA without requiring a benchmark override.
+   */
+  uint32_t maxWr{2048};
+  /* Max outstanding RDMA READ/atomic operations per QP. This directly controls
+   * requester-side READ pipelining and responder-side inbound READ capacity.
+   */
+  uint32_t maxRdAtomic{8};
   uint32_t maxSge{1}; /* Max scatter/gather entries per WR. */
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -17,12 +17,10 @@ using namespace uniflow;
 using ::testing::_;
 using ::testing::Return;
 
-// Use default config values for test constants.
 static const RdmaTransportConfig kDefaultConfig{};
-// must match RdmaTransportConfig default
 constexpr size_t kChunkSize = 512 * 1024;
-// must match RdmaTransportConfig default
-constexpr size_t kDefaultMaxWr = 128;
+// Keep data-path queue-capacity tests small and deterministic.
+constexpr size_t kTestMaxWr = 128;
 
 namespace uniflow {
 
@@ -838,12 +836,15 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     nics->push_back(
         makeNic(&fakeDev_, &fakeCtx_, &fakePd_, mockApi_, 0x1234, gid));
 
+    RdmaTransportConfig config{};
+    config.maxWr = kTestMaxWr;
     transport_ = std::make_unique<RdmaTransport>(
         mockApi_,
         mockCudaApi_,
         evbThread_->getEventBase(),
         nics,
-        kLocalDomainId);
+        kLocalDomainId,
+        config);
     transport_->bind();
 
     RdmaTransportInfo remoteInfo;
@@ -1064,8 +1065,7 @@ TEST_P(RdmaTransportOpcodeTest, WcErrorFailsTask) {
 }
 
 TEST_P(RdmaTransportOpcodeTest, RetriesWhenQpIsFull) {
-  constexpr size_t kMaxWr = 128; // must match RdmaTransportConfig default
-  constexpr size_t kNumWr = kMaxWr + 1; // 129 WRs
+  constexpr size_t kNumWr = kTestMaxWr + 1; // 129 WRs
   constexpr size_t kBufSize = kNumWr * kChunkSize; // 129 chunks
 
   auto ts = makeTestSegments(kBufSize);
@@ -1123,9 +1123,9 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   // regressions that poison per-QP queue-depth accounting.
   constexpr uint64_t kLocalDomainId = 42;
   constexpr uint64_t kRemoteDomainId = 99;
-  constexpr size_t kNumWr = 2 * kDefaultMaxWr + 1;
+  constexpr size_t kNumWr = 2 * kTestMaxWr + 1;
   constexpr size_t kBufSize = kNumWr * kChunkSize;
-  constexpr size_t kLookupRegressionBufSize = (kDefaultMaxWr + 1) * kChunkSize;
+  constexpr size_t kLookupRegressionBufSize = (kTestMaxWr + 1) * kChunkSize;
 
   fakeQp0_.qp_num = 100;
   fakeQp1_.qp_num = 100;
@@ -1150,6 +1150,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   nics->push_back(
       makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 2};
+  config.maxWr = kTestMaxWr;
   RdmaTransport transport(
       mockApi_,
       mockCudaApi_,
@@ -1217,7 +1218,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
             const uint32_t numWrs = static_cast<uint32_t>(wrId & 0xffffffff);
             // Phase 2 expects a lookup regression to make QP0 look more
             // available than it is, causing an over-capacity post to QP0.
-            if (numWrs > kDefaultMaxWr) {
+            if (numWrs > kTestMaxWr) {
               *badWr = wr;
               return Err(ErrCode::DriverError, "posted over QP capacity");
             }
@@ -1390,7 +1391,7 @@ TEST_P(RdmaTransportOpcodeTest, ShutdownDrainsInflightTransfer) {
 TEST_P(RdmaTransportOpcodeTest, SubsequentTransferAfterWcError) {
   // Verify that a WC error on one transfer does not prevent subsequent
   // transfers from succeeding — the error is per-task, not transport-wide.
-  auto ts = makeTestSegments(kChunkSize * kDefaultMaxWr);
+  auto ts = makeTestSegments(kChunkSize * kTestMaxWr);
 
   std::vector<uint64_t> capturedWrIds;
   EXPECT_CALL(*mockApi_, postSend(&fakeQp_, _, _))


### PR DESCRIPTION
Summary:

Raise the default per-QP send queue depth from 128 to 2048 and make RDMA READ/atomic credit depth configurable with `maxRdAtomic` defaulting to 8 instead of hardcoding 1.

| Area | Change | Why |
|---|---|---|
| Send queue depth | Default `RdmaTransportConfig::maxWr` raised from 128 to 2048 | Large messages expand into many 512KB WRs; 128 WRs per QP was too shallow for stable multi-NIC CPU RDMA throughput. |
| READ credits | Add `RdmaTransportConfig::maxRdAtomic`, default 8, and program `max_rd_atomic` / `max_dest_rd_atomic` during QP transition | The old hardcoded value 1 limited GET/READ to about 21 GB/s per NIC. |

## Before maxRdAtomic Fix

| Topology | GET Throughput Before Fix |
|---|---|
| 1 NIC | ~20.88-21.33 GB/s |
| 2 NIC | ~41.81-42.91 GB/s |
| 4 NIC | ~83.45-85.46 GB/s from 2MB-1GB |

Reviewed By: saifhhasan

Differential Revision: D105785775
