### PR TITLE
Add WR admission control and spray capacity fill

### DIFF
--- a/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
+++ b/comms/uniflow/benchmarks/scripts/compare_rdma_bandwidth.py
@@ -375,7 +375,7 @@ class UniflowBenchmark:
             f"--benchmark rdma_bandwidth --transport rdma"
             f" --iterations {a.iterations} --warmup {a.warmup}"
             f" --min-size {a.min_size} --max-size {a.max_size}"
-            f" --direction put --batch-size {a.batch_size}"
+            f" --direction {a.direction} --batch-size {a.batch_size}"
             f" --tx-depth {a.tx_depth}"
             f" --chunk-size {a.chunk_size}"
             f" --format csv --output {REMOTE_DIR}/results.csv"
@@ -387,13 +387,21 @@ class UniflowBenchmark:
         if a.nics:
             bench_flags += f" --rdma-devices {a.nics}"
 
-        env = f"MASTER_ADDR={a.master_ip} MASTER_PORT=29500 WORLD_SIZE=2"
+        env = f"MASTER_ADDR={a.master_ip} MASTER_PORT={a.master_port} WORLD_SIZE=2"
         if _verbose:
             env = f'SPDLOG_LEVEL="uniflow=info" {env}'
-        r0_cmd = f"{env} RANK=0 LOCAL_RANK=0 {self.binary_path} {bench_flags}"
+        command_prefix = ""
+        if a.numa_node >= 0:
+            command_prefix = (
+                f"numactl --cpunodebind={a.numa_node} --membind={a.numa_node} "
+            )
+        r0_cmd = (
+            f"{env} RANK=0 LOCAL_RANK=0 "
+            f"{command_prefix}{self.binary_path} {bench_flags}"
+        )
         r1_cmd = (
             f"{env} RANK=1 LOCAL_RANK={a.rank1_local_rank}"
-            f" {self.binary_path} {bench_flags}"
+            f" {command_prefix}{self.binary_path} {bench_flags}"
         )
 
         if dry_run:
@@ -842,6 +850,24 @@ def _parse_args():
         help="RDMA transfer chunk size in bytes (default: 524288)",
     )
     parser.add_argument(
+        "--master-port",
+        type=int,
+        default=29500,
+        help="Control-plane port for uniflow benchmark rendezvous (default: 29500)",
+    )
+    parser.add_argument(
+        "--numa-node",
+        type=int,
+        default=-1,
+        help="Run uniflow_bench under numactl for the given NUMA node (default: disabled)",
+    )
+    parser.add_argument(
+        "--direction",
+        default="put",
+        choices=["put", "get", "both"],
+        help="RDMA transfer direction for uniflow: put | get | both (default: put)",
+    )
+    parser.add_argument(
         "--no-cuda",
         action="store_true",
         help="Use CPU memory instead of GPU Direct RDMA (default: GPU Direct)",
@@ -983,8 +1009,12 @@ def _print_config(args, sizes):
         f" ({len(sizes)} steps)"
     )
     print(f"  Iterations: {args.iterations}")
+    print(f"  Direction:  {args.direction}")
     print(f"  Batch size: {args.batch_size}")
     print(f"  TX depth:   {args.tx_depth}")
+    print(f"  Port:       {args.master_port}")
+    if args.numa_node >= 0:
+        print(f"  NUMA node:  {args.numa_node}")
     if args.num_nics > 0:
         print(f"  Num NICs:   {args.num_nics}")
     if args.use_cuda:

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -730,6 +730,23 @@ Result<uint32_t> RdmaTransport::spray(
     totalAssigned += share;
   }
 
+  // Fill any capacity left by integer truncation in the weighted pass.
+  const uint32_t targetAssigned = std::min(remaining, totalAvail);
+  while (totalAssigned < targetAssigned) {
+    bool progressed = false;
+    for (uint32_t q = 0; q < numQps && totalAssigned < targetAssigned; ++q) {
+      if (qpAssigned[q] >= qpAvail[q]) {
+        continue;
+      }
+      ++qpAssigned[q];
+      ++totalAssigned;
+      progressed = true;
+    }
+    if (!progressed) {
+      break;
+    }
+  }
+
   // Post assigned chunks to each QP.
   uint32_t totalPosted = 0;
   for (uint32_t q = 0; q < numQps && idx < wrs.size(); ++q) {
@@ -774,6 +791,38 @@ Result<uint32_t> RdmaTransport::spray(
   return Result<uint32_t>(totalPosted);
 }
 
+size_t RdmaTransport::outstandingWrs() const {
+  size_t total = 0;
+  for (uint32_t count : numWrsPerQp_) {
+    total += count;
+  }
+  return total;
+}
+
+size_t RdmaTransport::admissionBudgetWrs() const {
+  const size_t totalCapacity = static_cast<size_t>(config_.maxWr) * qps_.size();
+  return std::max<size_t>(1, totalCapacity / 2);
+}
+
+bool RdmaTransport::canStartTransfer(const PendingTransfer& transfer) const {
+  if (transfer.idx != 0) {
+    return true;
+  }
+
+  const size_t outstanding = outstandingWrs();
+  if (outstanding == 0) {
+    return true;
+  }
+
+  const size_t transferWrs = transfer.sendWrs->size();
+  const size_t budget = admissionBudgetWrs();
+  if (transferWrs > budget) {
+    return false;
+  }
+
+  return outstanding + transferWrs <= budget;
+}
+
 // ---------------------------------------------------------------------------
 // Unified IO processing loop (EventBase thread)
 // ---------------------------------------------------------------------------
@@ -799,6 +848,10 @@ void RdmaTransport::ioLooper() noexcept {
       pendingCompletions_.push_back({entry.taskId, std::move(entry.task)});
       pendingTransfers_.pop_front();
       continue;
+    }
+
+    if (!canStartTransfer(entry)) {
+      break;
     }
 
     auto postResult =

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -779,7 +779,10 @@ Result<uint32_t> RdmaTransport::spray(
 // ---------------------------------------------------------------------------
 
 void RdmaTransport::ioLooper() noexcept {
-  // Phase 1 — Post: walk pendingTransfers_ front-to-back.
+  // Phase 1 — Poll: drain all CQs (round-robin).
+  pollCompletions();
+
+  // Phase 2 — Post: walk pendingTransfers_ front-to-back.
   while (!pendingTransfers_.empty()) {
     auto& entry = pendingTransfers_.front();
 
@@ -819,9 +822,6 @@ void RdmaTransport::ioLooper() noexcept {
       break;
     }
   }
-
-  // Phase 2 — Poll: drain all CQs.
-  pollCompletions();
 
   // Phase 3 — Fulfill: walk pendingCompletions_ front-to-back for in-order
   // promise delivery.
@@ -914,10 +914,21 @@ std::future<Status> RdmaTransport::rdmaTransfer(
 void RdmaTransport::pollCompletions() {
   constexpr int kNumBatch = 16;
 
-  for (size_t i = 0; i < cqs_.size(); ++i) {
-    int expected = numPendingCqe_[i];
-    ibv_wc wcs[kNumBatch];
-    while (expected > 0) {
+  // Cap total CQEs per call to ensure fairness with other transports
+  // sharing the same EventBase.
+  const uint64_t maxCqes = config_.maxWr * qps_.size();
+  uint64_t totalDrained = 0;
+
+  // Round-robin: poll one batch from each CQ per round, repeat until
+  // CQs are empty or the cap is reached.
+  while (totalDrained < maxCqes) {
+    uint64_t before = totalDrained;
+    for (size_t i = 0; i < cqs_.size() && totalDrained < maxCqes; ++i) {
+      if (numPendingCqe_[i] <= 0) {
+        continue;
+      }
+
+      ibv_wc wcs[kNumBatch];
       auto pollResult = ibvApi_->pollCq(cqs_[i], kNumBatch, wcs);
       if (pollResult.hasError()) {
         UNIFLOW_LOG_ERROR(
@@ -933,6 +944,7 @@ void RdmaTransport::pollCompletions() {
       }
 
       int n = pollResult.value();
+      totalDrained += static_cast<uint64_t>(n);
       for (const auto& wc : std::span(wcs).subspan(0, n)) {
         uint32_t taskId = static_cast<uint32_t>(wc.wr_id >> 32);
         uint32_t numWrs = static_cast<uint32_t>(wc.wr_id & 0xffffffff);
@@ -967,12 +979,9 @@ void RdmaTransport::pollCompletions() {
           it->second->recordCompletion(numWrs);
         }
       }
-
-      if (n < kNumBatch) {
-        break;
-      }
-
-      expected -= kNumBatch;
+    }
+    if (totalDrained == before) {
+      break;
     }
   }
 }

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -421,7 +421,7 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     rtrAttr.path_mtu = negotiatedMtu;
     rtrAttr.dest_qp_num = remote.qpInfos[i].qpNum;
     rtrAttr.rq_psn = remote.qpInfos[i].psn;
-    rtrAttr.max_dest_rd_atomic = 1;
+    rtrAttr.max_dest_rd_atomic = config_.maxRdAtomic;
     rtrAttr.min_rnr_timer = 12;
 
     if (remoteNic.linkLayer == IBV_LINK_LAYER_ETHERNET) {
@@ -455,7 +455,7 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     rtsAttr.timeout = config_.timeout;
     rtsAttr.retry_cnt = config_.retryCnt;
     rtsAttr.rnr_retry = 7;
-    rtsAttr.max_rd_atomic = 1;
+    rtsAttr.max_rd_atomic = config_.maxRdAtomic;
 
     int rtsMask = IBV_QP_STATE | IBV_QP_SQ_PSN | IBV_QP_TIMEOUT |
         IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_MAX_QP_RD_ATOMIC;

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -382,6 +382,18 @@ class RdmaTransport : public Transport {
       uint32_t taskId,
       std::shared_ptr<Task>& task);
 
+  /// Returns whether a pending transfer may begin posting without exceeding
+  /// the transport's conservative SQ admission budget.
+  bool canStartTransfer(const PendingTransfer& transfer) const;
+
+  /// Conservative global WR budget used to admit complete transfers. A single
+  /// transfer larger than this budget may still start when no other WRs are
+  /// outstanding, so very large messages continue to make progress.
+  size_t admissionBudgetWrs() const;
+
+  /// Total WRs currently outstanding across all QPs.
+  size_t outstandingWrs() const;
+
   /// Posts a chain of WRs to a single QP. On partial failure, posts a
   /// flush WR so the HCA generates a CQE for the consumed unsignaled WRs.
   ///

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -42,7 +42,14 @@ struct RdmaTransportConfig {
   uint8_t retryCnt{7}; /* Number of retries before reporting an error. */
   uint8_t trafficClass{0}; /* Traffic class for GRH (QoS / DSCP). */
   uint16_t pkeyIndex{0}; /* Partition key index for QP INIT. */
-  uint32_t maxWr{128}; /* Max outstanding send WRs per QP. */
+  /* Max outstanding send WRs per QP. The default leaves enough SQ depth for
+   * high-throughput multi-NIC CPU RDMA without requiring a benchmark override.
+   */
+  uint32_t maxWr{2048};
+  /* Max outstanding RDMA READ/atomic operations per QP. This directly controls
+   * requester-side READ pipelining and responder-side inbound READ capacity.
+   */
+  uint32_t maxRdAtomic{8};
   uint32_t maxSge{1}; /* Max scatter/gather entries per WR. */
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -17,12 +17,10 @@ using namespace uniflow;
 using ::testing::_;
 using ::testing::Return;
 
-// Use default config values for test constants.
 static const RdmaTransportConfig kDefaultConfig{};
-// must match RdmaTransportConfig default
 constexpr size_t kChunkSize = 512 * 1024;
-// must match RdmaTransportConfig default
-constexpr size_t kDefaultMaxWr = 128;
+// Keep data-path queue-capacity tests small and deterministic.
+constexpr size_t kTestMaxWr = 128;
 
 namespace uniflow {
 
@@ -838,12 +836,15 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     nics->push_back(
         makeNic(&fakeDev_, &fakeCtx_, &fakePd_, mockApi_, 0x1234, gid));
 
+    RdmaTransportConfig config{};
+    config.maxWr = kTestMaxWr;
     transport_ = std::make_unique<RdmaTransport>(
         mockApi_,
         mockCudaApi_,
         evbThread_->getEventBase(),
         nics,
-        kLocalDomainId);
+        kLocalDomainId,
+        config);
     transport_->bind();
 
     RdmaTransportInfo remoteInfo;
@@ -1064,8 +1065,7 @@ TEST_P(RdmaTransportOpcodeTest, WcErrorFailsTask) {
 }
 
 TEST_P(RdmaTransportOpcodeTest, RetriesWhenQpIsFull) {
-  constexpr size_t kMaxWr = 128; // must match RdmaTransportConfig default
-  constexpr size_t kNumWr = kMaxWr + 1; // 129 WRs
+  constexpr size_t kNumWr = kTestMaxWr + 1; // 129 WRs
   constexpr size_t kBufSize = kNumWr * kChunkSize; // 129 chunks
 
   auto ts = makeTestSegments(kBufSize);
@@ -1123,9 +1123,9 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   // regressions that poison per-QP queue-depth accounting.
   constexpr uint64_t kLocalDomainId = 42;
   constexpr uint64_t kRemoteDomainId = 99;
-  constexpr size_t kNumWr = 2 * kDefaultMaxWr + 1;
+  constexpr size_t kNumWr = 2 * kTestMaxWr + 1;
   constexpr size_t kBufSize = kNumWr * kChunkSize;
-  constexpr size_t kLookupRegressionBufSize = (kDefaultMaxWr + 1) * kChunkSize;
+  constexpr size_t kLookupRegressionBufSize = (kTestMaxWr + 1) * kChunkSize;
 
   fakeQp0_.qp_num = 100;
   fakeQp1_.qp_num = 100;
@@ -1150,6 +1150,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   nics->push_back(
       makeNic(&fakeDev1_, &fakeCtx1_, &fakePd1_, mockApi_, 0x2222, gid1));
   RdmaTransportConfig config{.numQps = 2};
+  config.maxWr = kTestMaxWr;
   RdmaTransport transport(
       mockApi_,
       mockCudaApi_,
@@ -1217,7 +1218,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
             const uint32_t numWrs = static_cast<uint32_t>(wrId & 0xffffffff);
             // Phase 2 expects a lookup regression to make QP0 look more
             // available than it is, causing an over-capacity post to QP0.
-            if (numWrs > kDefaultMaxWr) {
+            if (numWrs > kTestMaxWr) {
               *badWr = wr;
               return Err(ErrCode::DriverError, "posted over QP capacity");
             }
@@ -1390,7 +1391,7 @@ TEST_P(RdmaTransportOpcodeTest, ShutdownDrainsInflightTransfer) {
 TEST_P(RdmaTransportOpcodeTest, SubsequentTransferAfterWcError) {
   // Verify that a WC error on one transfer does not prevent subsequent
   // transfers from succeeding — the error is per-task, not transport-wide.
-  auto ts = makeTestSegments(kChunkSize * kDefaultMaxWr);
+  auto ts = makeTestSegments(kChunkSize * kTestMaxWr);
 
   std::vector<uint64_t> capturedWrIds;
   EXPECT_CALL(*mockApi_, postSend(&fakeQp_, _, _))


### PR DESCRIPTION
Summary:
Add whole-transfer WR-budget admission before starting a new pending transfer to prevent QP overfilling while preserving send-side FIFO message posting. Add a capacity-fill pass after the existing weighted spray assignment to avoid leaving usable QP WR slots idle due to integer truncation. Add benchmark runner controls for `--direction`, `--numa-node`, and `--master-port`.

| Area | Change | Why |
|---|---|---|
| Admission | Add whole-transfer WR-budget admission before starting a new pending transfer | Prevents overfilling QPs while preserving send-side FIFO message posting. |
| Spray | Add a capacity-fill pass after the existing weighted assignment | Avoids leaving usable QP WR slots idle due to integer truncation in weighted assignment. |
| Benchmark runner | Add `--direction`, `--numa-node`, and `--master-port` | Runner-only controls used to reproduce PUT vs GET and NUMA-pinned experiments. No C++ benchmark measurement logic changed. |

## Correctness and Ordering

| Property | Behavior |
|---|---|
| Send-side message posting order | Preserved. The transport always continues the front pending transfer before admitting the next transfer. |
| Partial posting | A partially posted front transfer is allowed to keep making progress; a later transfer is not started before the front transfer has been fully posted. |
| Concurrent completion | Later transfers may be posted while earlier transfers are still completing. This is intentional to keep NICs busy. |
| Future completion order | Completion futures are fulfilled in FIFO order. |

Reviewed By: saifhhasan

Differential Revision: D105785776
