### PR TITLE
Add k-ary tree topology builder for Tree AllReduce (#2645)

### DIFF
--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -1,0 +1,136 @@
+# CTRAN AllReduce Algorithm Design
+
+This document describes the CTRAN AllReduce algorithm shape used by the current stack and records the details of the implemented tree-based path. The implementation is selected with `NCCL_ALLREDUCE_ALGO=ctree` and uses Pipes `MultiPeerTransport` for `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies.
+
+## Goals
+
+The CTRAN AllReduce path is structured as local reduction, cross-node reduction, and local publication phases. This keeps topology-specific pieces isolated enough that the cross-node phase can use a tree today and later grow ring or other implementations without changing the local phase contract.
+
+The current `ctree` implementation targets lower latency than ring-style inter-node traversal by reducing the IB phase to tree depth. It keeps correctness independent of CUDA inter-block synchronization: a single-block launch is valid for every supported topology, and additional blocks only add independent tile parallelism.
+
+The implementation currently supports `commSum` for `commFloat32` and `commFloat16`. Unsupported reduction ops and datatypes are rejected on the host.
+
+## Algorithm Overview
+
+1. **NVL ReduceScatter**: local GPUs reduce each owner segment into a per-owner Phase 2 buffer.
+2. **IB AllReduce**: active segment owners run the cross-node implementation for their segment. The current implementation is dual-tree.
+3. **NVL AllGather**: segment owners publish the globally reduced segments to local peers.
+
+Degenerate topology paths are skipped:
+
+- `nRanks == 1`: identity copy for out-of-place, no kernel launch for in-place.
+- `nLocalRanks <= 1`: NVL phases and NVL phase-transition sync are no-ops.
+- `nNodes == 1`: IB Phase 2 is a no-op.
+
+## Partitioning and Topology
+
+Let `pMin = min(nLocalRanks(node))` across nodes. The algorithm partitions the tensor into `pMin` owner segments. Local ranks `< pMin` own one segment and participate in the IB phase; extra local ranks on larger nodes contribute during NVL ReduceScatter and receive the final tensor during NVL AllGather, but do not join IB.
+
+Each owner segment is split across `numBlocks` logical CUDA blocks. Each block owns a disjoint segment tile. Inside the block tile, the IB phase splits data into two lane halves:
+
+- Lane 0: Tree-0 over the first half.
+- Lane 1: Tree-1 over the second half.
+
+No block owns data or staging used by another block.
+
+### Binary Dual Trees
+
+The implementation uses binary dual trees. Tree-0 is a BFS binary tree rooted at rank `0`. For even node counts, Tree-1 is the mirror of Tree-0 over rank space. For odd node counts, Tree-1 uses the shift-by-1 construction implemented by the topology builder.
+
+For the 8-rank `IB_ONLY` case, the exact topology is:
+
+```text
+Tree-0, rooted at rank 0:
+  0 -> {1, 2}
+  1 -> {3, 4}
+  2 -> {5, 6}
+  3 -> {7}
+
+Tree-1, mirrored and rooted at rank 7:
+  7 -> {6, 5}
+  6 -> {4, 3}
+  5 -> {2, 1}
+  4 -> {0}
+```
+
+The two trees process disjoint data halves and use disjoint staging slices and transport group IDs. They are intended to make concurrent progress, not to run Tree-0 to completion before Tree-1.
+
+## Phase Behavior
+
+### Phase 1: NVL ReduceScatter
+
+When `nLocalRanks > 1`, each local GPU contributes the segment data needed by each owner. Segment owners reduce local contributions into `phase2Buf`. The current implementation uses Pipes NVL transport staging because user buffers are not assumed to be directly usable as NVL transport buffers.
+
+When `nLocalRanks <= 1`, Phase 1 is a no-op and the IB tree reads directly from the local owner segment.
+
+### Phase 2: IB AllReduce
+
+The cross-node phase is the replaceable part of the design. Its contract is to reduce each owner segment across nodes and leave the globally reduced segment in the owner's Phase 2 buffer. The current implementation uses a dual-tree IB phase.
+
+#### Current Tree Implementation
+
+When `nNodes > 1`, each active owner rank runs the dual-tree phase. One full CUDA block services both tree lanes cooperatively. The block creates two virtual IB transport groups:
+
+```text
+groupId(lane) = blockIdx.x * 2 + lane
+```
+
+Each lane has its own data half, staging slice, and transport group ID. The scheduler calls bounded progress functions for lane 0 and lane 1 in a uniform loop. If a lane is waiting on `NIC_DONE`, `SLOT_FREE`, or `DATA_READY`, that progress attempt returns immediately and the block tries the other lane. This avoids serial tree-lane scheduling while keeping all threads in the block on a uniform control path.
+
+Internal tree nodes receive from all children through transport-owned staging, reduce local and child inputs, and then forward the reduced data upward. Broadcast then flows from root to leaves.
+
+### Phase 3: NVL AllGather
+
+When `nLocalRanks > 1`, segment owners publish globally reduced segments to all local peers using Pipes NVL transport. Each block waits for both IB lanes for its tile before publishing that tile locally. When `nLocalRanks <= 1`, Phase 3 is skipped.
+
+## Launch and Tiling Policy
+
+The kernel uses `640` CUDA threads per block. `numBlocks` is capped at `16` for H100 and current GB200/GB300 use. The default policy starts at the cap and reduces blocks for small messages while:
+
+```text
+totalBytes < numBlocks * 640 * 64
+```
+
+`NCCL_CTRAN_MAX_NBLOCKS` controls the cap and defaults to `16`, which keeps the tree implementation below the NCCL Tree CTA count used on the current H100 and GB200/GB300 validation setups.
+
+The implementation uses phase-specific tile widths:
+
+- `kNvlTileElems = 15360`
+- `kIbTileElems = 5120`
+
+Both are selected to satisfy Pipes tile divisibility constraints with `640`-thread blocks and the vector widths used by supported datatypes.
+
+## Staging and Memory Lifetime
+
+The tree implementation does not allocate message-size-dependent AllReduce staging. NVL and IB receives use Pipes transport-owned staging buffers, and the tree path consumes those transient staging slices inside transport copy callbacks before the transport acknowledges and reuses the slots.
+
+The IBGDA send/recv transport data buffer is configured by per-communicator hint or `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` when provided. The current validation and tuning use the Pipes default `32MiB` per-peer IBGDA data buffer.
+
+## Correctness Invariants
+
+- No inter-block synchronization is required or assumed.
+- Each block owns disjoint data and transport group IDs.
+- `group.sync()` is used only for block-local phase transitions.
+- In-place and out-of-place reductions use the same block ownership model; a block finishes the reads needed for its tile before that tile can be overwritten by later local publication.
+- Tail elements are handled by tile bounds and byte-count checks; only valid user elements are read or written.
+- All remote lane progress uses device-visible signaling and memory ordering from Pipes transport primitives.
+
+## Validation
+
+The integration test is algorithm-agnostic and validates numerical correctness plus bitwise deterministic output across repeated runs, not trace shape. It covers `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies; world sizes `1`, `2`, `3`, `4`, `7`, and `8` for local single-host topologies; and zero, small, medium, large, and tail message sizes in both in-place and out-of-place modes.
+
+Latest local and RE validation, benchmark commands, and 8-rank performance tables are recorded in:
+
+- https://www.internalfb.com/intern/paste/P2354738362/
+- https://pxl.cl/9ZhCc
+
+The primary benchmark comparison is forced NCCL Tree against CTREE using the third-party `nccl_allreduce_perf` target. The latest H100 8-rank `IB_ONLY` sweep covers `4B` through `1G` with `#wrong = 0` for CTREE.
+
+## Further Work
+
+- **Performance tuning**: continue tuning launch shape, tile sizing, transport progress, and tiny-message overhead.
+- **LL protocol for IB**: add a lower-latency IB protocol for small payloads.
+- **NVLS-based ReduceScatter**: replace the current Phase 1 implementation with an NVLS-based local ReduceScatter path.
+- **Ring-based IB implementation**: add a ring implementation for the IB phase so the cross-node phase can choose between Ring and Tree implementations.
+- **Wider reduction ops and datatypes**: add support beyond the current `commSum` scope, with correctness tests and benchmark coverage across all topologies.
+- **Uneven `pMin` topology coverage**: add targeted validation for mixed local-rank-count topologies where extra local ranks contribute to NVL phases but do not participate in IB.

--- a/comms/ctran/algos/topo/CtranTreeBuilder.h
+++ b/comms/ctran/algos/topo/CtranTreeBuilder.h
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+#include <glog/logging.h>
+
+#include "comms/ctran/algos/topo/TreeConstants.h"
+
+namespace ctran::algos::topo {
+
+struct TreeNeighbors {
+  int parent{-1};
+  std::array<int, kMaxTreeChildren> children;
+  int numChildren{0};
+
+  TreeNeighbors() {
+    children.fill(-1);
+  }
+
+  bool isRoot() const {
+    return parent == -1;
+  }
+
+  bool isLeaf() const {
+    return numChildren == 0;
+  }
+};
+
+// Build a single k-ary tree over numNodes using BFS level-order assignment.
+// fanOut must be in [1, kMaxTreeChildren], which keeps parent and child
+// relationships representable by TreeNeighbors.
+static inline TreeNeighbors
+buildKaryTree(int numNodes, int nodeRank, int fanOut) {
+  CHECK_GE(fanOut, 1);
+  CHECK_LE(fanOut, kMaxTreeChildren);
+
+  if (numNodes <= 1) {
+    return TreeNeighbors{};
+  }
+
+  TreeNeighbors result;
+
+  // BFS-order k-ary tree: node i has parent (i-1)/k, children k*i+1 .. k*i+k
+  // This gives a complete k-ary tree with level-order node assignment.
+  if (nodeRank == 0) {
+    result.parent = -1;
+  } else {
+    result.parent = (nodeRank - 1) / fanOut;
+  }
+
+  for (int c = 0; c < fanOut && c < kMaxTreeChildren; c++) {
+    int child = fanOut * nodeRank + 1 + c;
+    if (child < numNodes) {
+      result.children[result.numChildren++] = child;
+    }
+  }
+
+  return result;
+}
+
+// Build dual complementary k-ary trees.
+//
+// For k=2 (binary):
+//   Tree-0: standard binary tree in BFS order.
+//   Tree-1 (even N): mirror — build tree over mapping r' = N-1-r, remap back.
+//   Tree-1 (odd N): shift-by-1 — build tree over mapping r' = (r-1+N)%N, remap
+//   back. Property: leaves in Tree-0 are internal nodes in Tree-1
+//   (phase-complementary).
+//
+// For k>2:
+//   Tree-0: standard k-ary tree.
+//   Tree-1: k-ary tree with shifted root (root at node N/2).
+//   Phase-complementary property is NOT guaranteed for k>2.
+static inline std::pair<TreeNeighbors, TreeNeighbors>
+buildDualKaryTree(int numNodes, int nodeRank, int fanOut = 2) {
+  if (numNodes <= 1) {
+    TreeNeighbors single;
+    return {single, single};
+  }
+
+  // Tree-0: standard k-ary tree
+  TreeNeighbors tree0 = buildKaryTree(numNodes, nodeRank, fanOut);
+
+  // Tree-1: complementary tree
+  TreeNeighbors tree1;
+
+  if (fanOut == 2) {
+    // Binary dual tree: mirror/shift construction
+    int mappedRank;
+    if (numNodes % 2 == 0) {
+      // Even N: mirror r' = N-1-r
+      mappedRank = numNodes - 1 - nodeRank;
+    } else {
+      // Odd N: shift r' = (r-1+N) % N
+      mappedRank = (nodeRank - 1 + numNodes) % numNodes;
+    }
+
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    // Remap results back
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      if (numNodes % 2 == 0) {
+        return numNodes - 1 - r;
+      } else {
+        return (r + 1) % numNodes;
+      }
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  } else {
+    // k>2: shifted root construction
+    int shift = numNodes / 2;
+    int mappedRank = (nodeRank - shift + numNodes) % numNodes;
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      return (r + shift) % numNodes;
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  }
+
+  return {tree0, tree1};
+}
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/TreeConstants.h
+++ b/comms/ctran/algos/topo/TreeConstants.h
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace ctran::algos::topo {
+
+inline constexpr int kMaxTreeChildren = 3;
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
+++ b/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
@@ -1,0 +1,394 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <queue>
+#include <set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+
+namespace ctran::algos::topo {
+
+class CtranTreeBuilderTest : public ::testing::Test {};
+
+// Verify that BFS from the unique root reaches all nodes exactly once.
+static void verifyConnectivity(
+    const std::vector<TreeNeighbors>& nodes,
+    int expectedRoot = -1) {
+  const int numNodes = static_cast<int>(nodes.size());
+  int rootCount = 0;
+  int rootIdx = -1;
+  for (int i = 0; i < numNodes; i++) {
+    if (nodes[i].isRoot()) {
+      rootCount++;
+      rootIdx = i;
+    }
+  }
+  ASSERT_EQ(rootCount, 1) << "Exactly one root expected";
+  if (expectedRoot >= 0) {
+    ASSERT_EQ(rootIdx, expectedRoot);
+  }
+
+  std::set<int> visited;
+  std::queue<int> bfs;
+  bfs.push(rootIdx);
+  visited.insert(rootIdx);
+
+  while (!bfs.empty()) {
+    int cur = bfs.front();
+    bfs.pop();
+    for (int c = 0; c < nodes[cur].numChildren; c++) {
+      int child = nodes[cur].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      ASSERT_EQ(visited.count(child), 0)
+          << "Node " << child << " visited twice (cycle or shared child)";
+      visited.insert(child);
+      bfs.push(child);
+    }
+  }
+
+  ASSERT_EQ(static_cast<int>(visited.size()), numNodes)
+      << "BFS did not reach all nodes. Reached " << visited.size() << " out of "
+      << numNodes;
+}
+
+// Verify that BFS from root reaches all N nodes exactly once.
+static void verifyConnectivity(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  verifyConnectivity(nodes, 0);
+}
+
+// Verify parent-child consistency: if A lists B as child, B must list A as
+// parent.
+static void verifyParentChildConsistency(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < nodes[i].numChildren; c++) {
+      int child = nodes[i].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      EXPECT_EQ(nodes[child].parent, i)
+          << "Node " << i << " lists " << child
+          << " as child, but child's parent is " << nodes[child].parent;
+    }
+    if (nodes[i].parent >= 0) {
+      int par = nodes[i].parent;
+      bool found = false;
+      for (int c = 0; c < nodes[par].numChildren; c++) {
+        if (nodes[par].children[c] == i) {
+          found = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(found) << "Node " << i << " has parent " << par
+                         << " but parent does not list it as a child";
+    }
+  }
+}
+
+// Verify leaf/root roles are derived from parent and child count.
+static void verifyDerivedRoles(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    EXPECT_EQ(nodes[i].isLeaf(), nodes[i].numChildren == 0)
+        << "Node " << i << ": isLeaf inconsistent with numChildren";
+    EXPECT_EQ(nodes[i].isRoot(), nodes[i].parent == -1)
+        << "Node " << i << ": isRoot inconsistent with parent";
+  }
+}
+
+static void verifyUnusedChildSlotsAreSentinels(
+    const TreeNeighbors& node,
+    int nodeRank) {
+  for (int c = node.numChildren; c < kMaxTreeChildren; c++) {
+    EXPECT_EQ(node.children[c], -1) << "Node " << nodeRank << " child slot "
+                                    << c << " should keep the sentinel value";
+  }
+}
+
+static int expectedTree1Root(int numNodes, int fanOut) {
+  if (numNodes <= 1) {
+    return 0;
+  }
+  if (fanOut == 2) {
+    return numNodes % 2 == 0 ? numNodes - 1 : 1;
+  }
+  return numNodes / 2;
+}
+
+// --- Single K-ary Tree Tests ---
+
+class KaryTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(KaryTreeTest, Connectivity) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyConnectivity(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, ParentChildConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyParentChildConsistency(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, FlagConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyDerivedRoles(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, MaxChildrenRespected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    auto node = buildKaryTree(numNodes, i, fanOut);
+    EXPECT_LE(node.numChildren, fanOut);
+    EXPECT_LE(node.numChildren, kMaxTreeChildren);
+  }
+}
+
+TEST_P(KaryTreeTest, UnusedChildSlotsAreSentinels) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    verifyUnusedChildSlotsAreSentinels(buildKaryTree(numNodes, i, fanOut), i);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BinaryAndTernary,
+    KaryTreeTest,
+    ::testing::Values(
+        // (numNodes, fanOut)
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(1, 3),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(7, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(15, 3),
+        std::make_pair(16, 3),
+        std::make_pair(27, 3),
+        std::make_pair(32, 3),
+        std::make_pair(64, 3)));
+
+// --- Dual Tree Tests ---
+
+class DualTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(DualTreeTest, BothTreesConnected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int r = 0; r < numNodes; r++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, r, fanOut);
+    // Both trees should produce valid nodes
+    EXPECT_GE(t0.parent, -1);
+    EXPECT_GE(t1.parent, -1);
+    EXPECT_LE(t0.numChildren, fanOut);
+    EXPECT_LE(t1.numChildren, fanOut);
+  }
+
+  // Verify full connectivity for both trees independently
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+  verifyConnectivity(t0Nodes, 0);
+  verifyConnectivity(t1Nodes);
+}
+
+TEST_P(DualTreeTest, Tree1Connectivity) {
+  auto [numNodes, fanOut] = GetParam();
+  std::vector<TreeNeighbors> t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t1Nodes[i] = t1;
+  }
+
+  verifyConnectivity(t1Nodes, expectedTree1Root(numNodes, fanOut));
+}
+
+TEST_P(DualTreeTest, UnusedChildSlotsAreSentinels) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    verifyUnusedChildSlotsAreSentinels(t0, i);
+    verifyUnusedChildSlotsAreSentinels(t1, i);
+  }
+}
+
+TEST_P(DualTreeTest, ParentChildConsistencyBothTrees) {
+  auto [numNodes, fanOut] = GetParam();
+
+  // Verify Tree-0 consistency
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < t0Nodes[i].numChildren; c++) {
+      int child = t0Nodes[i].children[c];
+      EXPECT_EQ(t0Nodes[child].parent, i)
+          << "Tree-0 inconsistency at node " << i;
+    }
+    for (int c = 0; c < t1Nodes[i].numChildren; c++) {
+      int child = t1Nodes[i].children[c];
+      EXPECT_EQ(t1Nodes[child].parent, i)
+          << "Tree-1 inconsistency at node " << i;
+    }
+  }
+}
+
+TEST_P(DualTreeTest, DifferentRoots) {
+  auto [numNodes, fanOut] = GetParam();
+  if (numNodes <= 1) {
+    return; // Single node — both trees are trivially the same
+  }
+
+  int root0 = -1, root1 = -1;
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    if (t0.isRoot())
+      root0 = i;
+    if (t1.isRoot())
+      root1 = i;
+  }
+  EXPECT_NE(root0, root1) << "Dual trees should have different roots";
+}
+
+// Phase-complementary property: leaves in tree-0 are internal in tree-1.
+// This is only guaranteed for binary (k=2) dual trees.
+class BinaryDualTreeComplementaryTest
+    : public CtranTreeBuilderTest,
+      public ::testing::WithParamInterface<int> {};
+
+TEST_P(BinaryDualTreeComplementaryTest, LeavesSwapWithInternal) {
+  int numNodes = GetParam();
+  if (numNodes <= 2) {
+    return; // Too small to have meaningful leaf/internal distinction
+  }
+
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, 2);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    bool isLeaf0 = t0Nodes[i].isLeaf();
+    bool isLeaf1 = t1Nodes[i].isLeaf();
+    bool isRoot0 = t0Nodes[i].isRoot();
+    bool isRoot1 = t1Nodes[i].isRoot();
+
+    // Skip roots — root in one tree can be anything in the other
+    if (isRoot0 || isRoot1) {
+      continue;
+    }
+
+    EXPECT_NE(isLeaf0, isLeaf1)
+        << "Node " << i
+        << ": leaf in tree-0 should be internal in tree-1 (or vice versa). "
+        << "tree-0 isLeaf=" << isLeaf0 << " tree-1 isLeaf=" << isLeaf1;
+  }
+}
+
+// Phase-complementary property is only guaranteed for even N.
+// For odd N, one node must be leaf in both trees (unequal leaf/internal
+// counts).
+INSTANTIATE_TEST_SUITE_P(
+    BinaryComplementary,
+    BinaryDualTreeComplementaryTest,
+    ::testing::Values(4, 8, 16, 32, 64));
+
+INSTANTIATE_TEST_SUITE_P(
+    AllFanOuts,
+    DualTreeTest,
+    ::testing::Values(
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(27, 3),
+        std::make_pair(64, 3)));
+
+// --- Edge Case Tests ---
+
+TEST_F(CtranTreeBuilderTest, SingleNode) {
+  auto node = buildKaryTree(1, 0, 2);
+  EXPECT_TRUE(node.isRoot());
+  EXPECT_TRUE(node.isLeaf());
+  EXPECT_EQ(node.numChildren, 0);
+  EXPECT_EQ(node.parent, -1);
+}
+
+TEST_F(CtranTreeBuilderTest, TwoNodesBinary) {
+  auto n0 = buildKaryTree(2, 0, 2);
+  auto n1 = buildKaryTree(2, 1, 2);
+
+  EXPECT_TRUE(n0.isRoot());
+  EXPECT_FALSE(n0.isLeaf());
+  EXPECT_EQ(n0.numChildren, 1);
+  EXPECT_EQ(n0.children[0], 1);
+
+  EXPECT_FALSE(n1.isRoot());
+  EXPECT_TRUE(n1.isLeaf());
+  EXPECT_EQ(n1.parent, 0);
+}
+
+TEST_F(CtranTreeBuilderTest, DualSingleNode) {
+  auto [t0, t1] = buildDualKaryTree(1, 0, 2);
+  EXPECT_TRUE(t0.isRoot());
+  EXPECT_TRUE(t0.isLeaf());
+  EXPECT_TRUE(t1.isRoot());
+  EXPECT_TRUE(t1.isLeaf());
+}
+
+TEST_F(CtranTreeBuilderTest, InvalidFanOutRejected) {
+  EXPECT_DEATH(buildKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+}
+
+} // namespace ctran::algos::topo


### PR DESCRIPTION
Summary:

Adds `CtranTreeBuilder.h` with reusable tree topology construction utilities for the Tree AllReduce algorithm (ctree):

- `buildKaryTree(numNodes, nodeRank, fanOut)`: builds a single k-ary tree using BFS-order level assignment. Supports binary (k=2) and ternary (k=3) fan-out.
- `buildDualKaryTree(numNodes, nodeRank, fanOut)`: builds complementary dual trees. For k=2, uses mirror (even N) or shift-by-1 (odd N) construction to produce phase-complementary trees where leaves in tree-0 are internal nodes in tree-1. For k>2, uses shifted-root construction.

Includes 147 unit tests covering connectivity (BFS reachability), parent-child consistency, flag correctness, max children bounds, dual tree connectivity, different roots, and the phase-complementary invariant for even N.

Also removes external implementation references from `TreeAllReduce.md` design spec.

Reviewed By: Scusemua, arttianezhu

Differential Revision: D105366055


