### PR TITLE
Add CtranAllReduceTest correctness matrix (#2649)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -29,6 +29,18 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
     case NCCL_ALLREDUCE_ALGO::ctree:
+      if (!NCCL_CTRAN_USE_PIPES) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+        return false;
+      }
+      if (comm->statex_->nNodes() > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+        return false;
+      }
       return true;
     default: // invalid query
       return false;

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,13 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+/**
+ * Run the Pipes-backed tree AllReduce implementation.
+ *
+ * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
+ * It relies on Pipes NVL and IBGDA transport staging for transient receives and
+ * does not allocate message-size-dependent AllReduce staging.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -2,12 +2,22 @@
 
 #include <algorithm>
 #include <climits>
+#include <memory>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PIPES)
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#include "comms/pipes/MultiPeerTransport.h"
+#endif
 
 namespace {
 
@@ -25,8 +35,111 @@ void populateTreeTopology(
   }
 }
 
+/** Return whether the ctree device kernel supports `datatype`. */
+bool isSupportedTreeType(commDataType_t datatype) {
+  return datatype == commFloat32 || datatype == commFloat16;
+}
+
+/** Return the tree fanout for this run; default to NCCL-like binary trees. */
+int getAllReduceTreeFanOut() {
+  constexpr int kDefaultFanOut = 2;
+  const int fanOut = NCCL_CTRAN_TREE_FANOUT;
+  if (fanOut >= 1 && fanOut <= ctran::algos::topo::kMaxTreeChildren) {
+    return fanOut;
+  }
+
+  CLOGF(
+      WARN,
+      "Ignoring invalid NCCL_CTRAN_TREE_FANOUT={} for ctree fanout; using {}",
+      fanOut,
+      kDefaultFanOut);
+  return kDefaultFanOut;
+}
+
+#if defined(ENABLE_PIPES)
+/** Return the topology-wide cap for CTREE logical CUDA blocks. */
+int getAllReduceTreeNumBlockCap() {
+  return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
+}
+
+/**
+ * Select the number of independent data tiles for this launch.
+ *
+ * The algorithm is correct with one tile block. Larger values only expose more
+ * tile parallelism. `NCCL_CTRAN_MAX_NBLOCKS` caps the default policy. The
+ * automatic policy starts at the cap, then reduces the number of blocks while
+ * the message has less than one block-threshold of work per block.
+ */
+int getAllReduceTreeNumBlocks(size_t totalBytes) {
+  const int cap = getAllReduceTreeNumBlockCap();
+  const size_t perBlockThresholdBytes =
+      static_cast<size_t>(ctran::allreduce::tree::kBlockSize) * 64;
+
+  int numBlocks = cap;
+  while (numBlocks > 1 &&
+         totalBytes < static_cast<size_t>(numBlocks) * perBlockThresholdBytes) {
+    numBlocks--;
+  }
+  return numBlocks;
+}
+
+commResult_t validateAllReduceTreeIbPeer(
+    const comms::pipes::MultiPeerTransport& transport,
+    int rank,
+    int peerRank,
+    const char* treeName,
+    const char* edgeName) {
+  const auto type = transport.get_transport_type(peerRank);
+  if (type == comms::pipes::TransportType::P2P_IBGDA) {
+    return commSuccess;
+  }
+
+  CLOGF(
+      ERR,
+      "AllReduce ctree requires P2P_IBGDA transport for {} {} edge "
+      "rank {} -> peer {}; got {}",
+      treeName,
+      edgeName,
+      rank,
+      peerRank,
+      comms::pipes::transport_type_name(type));
+  return commInvalidArgument;
+}
+
+commResult_t validateAllReduceTreeIbTopology(
+    const comms::pipes::MultiPeerTransport& transport,
+    int rank,
+    const ctran::allreduce::TreeTopology& tree,
+    const char* treeName) {
+  if (tree.parentRank >= 0) {
+    commResult_t result = validateAllReduceTreeIbPeer(
+        transport, rank, tree.parentRank, treeName, "parent");
+    if (result != commSuccess) {
+      return result;
+    }
+  }
+  for (int c = 0; c < tree.numChildren; c++) {
+    commResult_t result = validateAllReduceTreeIbPeer(
+        transport, rank, tree.childRanks[c], treeName, "child");
+    if (result != commSuccess) {
+      return result;
+    }
+  }
+  return commSuccess;
+}
+#endif
+
 } // namespace
 
+/**
+ * Run CTRAN tree AllReduce using NVL reduce-scatter, dual IB trees, and NVL
+ * all-gather.
+ *
+ * The tensor is split across `pMin` owner ranks per node. Each owner segment is
+ * further partitioned into logical CUDA blocks so multiple blocks can process a
+ * segment concurrently while the two tree lanes operate on disjoint halves of
+ * each block-owned tile.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,
@@ -46,8 +159,9 @@ commResult_t ctranAllReduceTree(
   const int nNodes = statex->nNodes();
   const int localRank = statex->localRank();
   const int nodeId = statex->node();
+  (void)timeout;
 
-  // Single rank: just copy
+  // Single rank AllReduce is the identity for every datatype and reduction op.
   if (nRanks == 1) {
     if (sendbuff != recvbuff) {
       FB_CUDACHECK(cudaMemcpyAsync(
@@ -60,6 +174,32 @@ commResult_t ctranAllReduceTree(
     return commSuccess;
   }
 
+  if (redOp != commSum) {
+    CLOGF(ERR, "AllReduce ctree currently supports commSum only");
+    return commInvalidArgument;
+  }
+
+  if (!isSupportedTreeType(datatype)) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree unsupported datatype {}",
+        commDataTypeToString(datatype));
+    return commInvalidArgument;
+  }
+
+  if (nNodes > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+    return commInvalidArgument;
+  }
+  if (!NCCL_CTRAN_USE_PIPES) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+    return commInvalidArgument;
+  }
+
   // Compute P_min: minimum nLocalRanks across all nodes
   int pMin = INT_MAX;
   for (int n = 0; n < nNodes; n++) {
@@ -69,7 +209,7 @@ commResult_t ctranAllReduceTree(
 
   const size_t segmentElems = (count + pMin - 1) / pMin;
   const bool participatesInIB = (localRank < pMin);
-  const int fanOut = 2; // binary trees for V1
+  const int fanOut = getAllReduceTreeFanOut();
 
   // Build dual trees (in node-space: 0..nNodes-1)
   ctran::allreduce::TreeTopology tree0{};
@@ -101,7 +241,7 @@ commResult_t ctranAllReduceTree(
   CLOGF(
       DBG,
       "AllReduce ctree: rank {} localRank {} nNodes {} pMin {} "
-      "segmentElems {} participatesInIB {} "
+      "segmentElems {} fanOut {} participatesInIB {} "
       "tree0[parent={} children={} root={} leaf={}] "
       "tree1[parent={} children={} root={} leaf={}]",
       rank,
@@ -109,6 +249,7 @@ commResult_t ctranAllReduceTree(
       nNodes,
       pMin,
       segmentElems,
+      fanOut,
       participatesInIB,
       tree0.parentRank,
       tree0.numChildren,
@@ -119,7 +260,127 @@ commResult_t ctranAllReduceTree(
       tree1.isRoot,
       tree1.isLeaf);
 
-  // TODO: Populate kernel args and launch kernel (Diffs 4+5)
-  CLOGF(ERR, "AllReduce ctree kernel not yet implemented");
-  return commResult_t::commInternalError;
+#if defined(ENABLE_PIPES)
+  const int nLocalRanks = statex->nLocalRanks();
+  const size_t elementSize = commTypeSize(datatype);
+  const size_t totalBytes = count * elementSize;
+  const size_t segmentBytes = segmentElems * elementSize;
+  const bool hasIbPhase = participatesInIB && nNodes > 1;
+  const int numBlocks = getAllReduceTreeNumBlocks(totalBytes);
+  if (hasIbPhase) {
+    if (!comm->multiPeerTransport_) {
+      CLOGF(
+          ERR,
+          "AllReduce ctree requires MultiPeerTransport for inter-node IB transfers");
+      return commInvalidArgument;
+    }
+    commResult_t result = validateAllReduceTreeIbTopology(
+        *comm->multiPeerTransport_, rank, tree0, "tree0");
+    if (result != commSuccess) {
+      return result;
+    }
+    result = validateAllReduceTreeIbTopology(
+        *comm->multiPeerTransport_, rank, tree1, "tree1");
+    if (result != commSuccess) {
+      return result;
+    }
+
+    const int maxIbGroups = NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS;
+    const int requiredIbGroups = numBlocks * ctran::allreduce::tree::kTreeLanes;
+    if (requiredIbGroups > maxIbGroups) {
+      CLOGF(
+          ERR,
+          "AllReduce ctree requires {} IBGDA send/recv groups, exceeding "
+          "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+          requiredIbGroups,
+          maxIbGroups);
+      return commInvalidArgument;
+    }
+  }
+
+  // phase2Buf holds the locally-reduced segment from Phase 1 and serves as
+  // the working buffer for Phase 2's reduce-up + broadcast-down. Non-owner
+  // local ranks do not dereference phase2Buf, but keep it inside the user
+  // buffer so the kernel never receives an out-of-range pointer in
+  // heterogeneous topologies.
+  void* phase2Buf = recvbuff;
+  if (participatesInIB) {
+    phase2Buf = static_cast<char*>(recvbuff) +
+        static_cast<size_t>(localRank) * segmentBytes;
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce ctree launch: totalBytes {} segmentBytes {} numBlocks {} "
+      "threadsPerBlock {} hasIbPhase {}",
+      totalBytes,
+      segmentBytes,
+      numBlocks,
+      ctran::allreduce::tree::kBlockSize,
+      hasIbPhase);
+
+  auto opCount = comm->ctran_->getOpCount();
+
+  // Populate kernel args
+  ctran::allreduce::tree::KernArgs kernArgs{};
+  kernArgs.sendbuff = sendbuff;
+  kernArgs.recvbuff = recvbuff;
+  kernArgs.phase2Buf = phase2Buf;
+  kernArgs.count = count;
+  kernArgs.segmentElems = segmentElems;
+  kernArgs.nNodes = nNodes;
+  kernArgs.pMin = pMin;
+  kernArgs.nLocalRanks = nLocalRanks;
+  kernArgs.localRank = localRank;
+  kernArgs.numBlocks = numBlocks;
+  kernArgs.datatype = datatype;
+  kernArgs.redOp = redOp;
+  kernArgs.transports = comm->getMultiPeerTransportsPtr();
+  if (kernArgs.transports == nullptr) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: getMultiPeerTransportsPtr() returned null - "
+        "Pipes transport not initialized. Ensure ENABLE_PIPES is defined "
+        "and multiPeerTransport is set up.");
+    return commInternalError;
+  }
+  kernArgs.tree0 = tree0;
+  kernArgs.tree1 = tree1;
+
+  // Build local rank -> global rank mapping
+  if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: nLocalRanks {} exceeds CTRAN_MAX_NVL_PEERS {}",
+        nLocalRanks,
+        CTRAN_MAX_NVL_PEERS);
+    return commInternalError;
+  }
+  for (int lr = 0; lr < nLocalRanks; lr++) {
+    kernArgs.localRankToGlobalRank[lr] = statex->localRankToRank(lr);
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLREDUCE, stream, "AllReduceTree", opCount);
+
+  config.numBlocks = static_cast<unsigned int>(numBlocks);
+  config.numThreads = ctran::allreduce::tree::kBlockSize;
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  // Device kernel drives all NVL and IB transport progress; no host-side GPE
+  // opGroup is needed.
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ctranKernelAllReduceTree)));
+
+  return commSuccess;
+#else
+  CLOGF(ERR, "AllReduce ctree requires ENABLE_PIPES");
+  return commInternalError;
+#endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cu
@@ -1,0 +1,842 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_fp16.h>
+
+#include <cstdint>
+
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Tile.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/Transport.cuh"
+
+/** Elements processed by one NVL tile operation in the reduction helpers. */
+static constexpr int kNvlTileElems = 15360;
+/** Elements processed by one IB tile operation in the reduction helpers. */
+static constexpr int kIbTileElems = 5120;
+
+/** Return true when a pointer satisfies the tile API's 16-byte alignment. */
+__device__ __forceinline__ bool isAligned16(const void* ptr) {
+  return (reinterpret_cast<uintptr_t>(ptr) & 15) == 0;
+}
+
+/**
+ * Accumulate `staging` into `accum` without assuming tile alignment.
+ *
+ * This path covers small buffers and tails where using the Pipes tile API is
+ * not profitable or not legal.
+ */
+template <typename T>
+__device__ __forceinline__ void scalarReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  for (size_t i = group.thread_id_in_group; i < nelems; i += group.group_size) {
+    accum[i] += staging[i];
+  }
+}
+
+/**
+ * Accumulate `staging` into `accum` using Pipes tiles when alignment allows.
+ */
+template <typename T, int kTileElems, int kGroupSize>
+__device__ __forceinline__ void tileReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  if (!isAligned16(accum) || !isAligned16(staging) || nelems < kTileElems) {
+    scalarReduce(accum, staging, nelems, group);
+    return;
+  }
+
+  const size_t nFullTiles = nelems / kTileElems;
+  const size_t rem = nelems % kTileElems;
+
+  for (size_t t = 0; t < nFullTiles; t++) {
+    auto acc =
+        comms::pipes::tile_load<T, kTileElems, kGroupSize>(accum, t, group);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, t, group);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(accum, t, acc, group);
+  }
+  if (rem > 0) {
+    auto acc = comms::pipes::tile_load<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, group, rem);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, nFullTiles, group, rem);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, acc, group, rem);
+  }
+}
+
+/**
+ * Copy operation used by cooperative NVL receives in Phase 1.
+ *
+ * The transport writes the remote payload into staging first; this functor
+ * then combines that staged payload with the current local input for the same
+ * segment and writes the result into `dst`. Aligned slices use the tile
+ * reduction path; unaligned tail segments fall back to scalar reduction
+ * because the Pipes tile API requires 16-byte-aligned pointers.
+ */
+template <typename T>
+struct TreeNvlReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t byteOffset,
+      const char* localInput,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* out = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const T* local = reinterpret_cast<const T*>(localInput + byteOffset);
+    const size_t nelems = nbytes / sizeof(T);
+
+    if (out != local) {
+      for (size_t i = group.thread_id_in_group; i < nelems;
+           i += group.group_size) {
+        out[i] = local[i];
+      }
+      group.sync();
+    }
+    tileReduce<T, kNvlTileElems, ctran::allreduce::tree::kBlockSize>(
+        out, staged, nelems, group);
+#endif
+  }
+};
+
+/**
+ * Copy operation used by IBGDA child receives in Phase 2.
+ *
+ * IBGDA owns the transient recv staging ring. CTREE must consume that staging
+ * inside this callback before the transport acknowledges and reuses the slot.
+ */
+template <typename T>
+struct TreeIbReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t /* byteOffset */,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* accum = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const size_t nelems = nbytes / sizeof(T);
+
+    tileReduce<T, kIbTileElems, ctran::allreduce::tree::kBlockSize>(
+        accum, staged, nelems, group);
+#endif
+  }
+};
+
+// ============================================================================
+// Phase 1: NVL ReduceScatter (AllToFewer pattern)
+//
+// Each GPU's input tensor M is partitioned into pMin segments of size
+// segmentElems. All nLocalRanks GPUs participate. The first pMin GPUs
+// (segment owners) each hold one locally-reduced segment after this phase.
+//
+// Communication: for each peer, the paired send/recv operations happen
+// simultaneously. We iterate peers in a rotating order so that at each step,
+// sends and recvs are correctly paired across GPUs.
+//
+// Owners: self-copy own segment to phase2Buf, then recv-reduce from each peer.
+// Non-owners: send segment data for each owner to that owner.
+// ============================================================================
+/**
+ * Compute the actual number of elements in a segment, including tail handling.
+ */
+__device__ __forceinline__ size_t
+actualSegElems(size_t count, size_t segmentElems, int rank) {
+  const size_t start = static_cast<size_t>(rank) * segmentElems;
+  if (start >= count) {
+    return 0;
+  }
+  return (start + segmentElems <= count) ? segmentElems : (count - start);
+}
+
+/**
+ * Convert the physical block group into the logical num-block group used by
+ * cooperative Pipes operations.
+ */
+__device__ __forceinline__ comms::pipes::ThreadGroup
+logicalDataGroup(comms::pipes::ThreadGroup group, int blockId, int numBlocks) {
+  group.group_id = static_cast<uint32_t>(blockId);
+  group.total_groups = static_cast<uint32_t>(numBlocks);
+  return group;
+}
+
+/**
+ * Tile view for one logical segment owned by the current num-block group.
+ */
+struct SegmentTile {
+  size_t offsetBytes;
+  size_t bytes;
+};
+
+__device__ __forceinline__ SegmentTile
+segmentTileForBlock(size_t totalBytes, int numBlocks, int blockId) {
+  comms::pipes::TiledBuffer<char> tile(nullptr, totalBytes, numBlocks);
+  return SegmentTile{
+      .offsetBytes = static_cast<size_t>(blockId) * tile.tile_elements,
+      .bytes = tile.tile_bytes(blockId),
+  };
+}
+
+__device__ __forceinline__ SegmentTile
+segmentTile(size_t totalBytes, const comms::pipes::ThreadGroup& group) {
+  return segmentTileForBlock(totalBytes, group.total_groups, group.group_id);
+}
+
+/**
+ * Return the largest owner tile participating in local NVL exchange.
+ */
+template <typename T>
+__device__ __forceinline__ size_t maxOwnerTileBytes(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t maxBytes = 0;
+  for (int owner = 0; owner < args.pMin; owner++) {
+    const size_t ownerElems =
+        actualSegElems(args.count, args.segmentElems, owner);
+    const auto ownerTile = segmentTile(ownerElems * sizeof(T), group);
+    maxBytes = ownerTile.bytes > maxBytes ? ownerTile.bytes : maxBytes;
+  }
+  return maxBytes;
+}
+
+/**
+ * Return a pipeline window that is valid for all local NVL peers.
+ */
+__device__ __forceinline__ size_t nvlPipelineWindow(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t window = 0;
+  for (int peer = 0; peer < args.nLocalRanks; peer++) {
+    if (peer == args.localRank) {
+      continue;
+    }
+    const int peerGlobalRank = args.localRankToGlobalRank[peer];
+    const size_t peerWindow =
+        args.transports[peerGlobalRank].p2p_nvl.pipeline_window(
+            group.total_groups);
+    window = window == 0 || peerWindow < window ? peerWindow : window;
+  }
+  return window;
+}
+
+/**
+ * Return the byte count for the current pipeline step.
+ */
+__device__ __forceinline__ size_t
+pipelineStepBytes(size_t totalBytes, size_t offset, size_t pipelineWindow) {
+  const size_t remaining = totalBytes - offset;
+  return remaining < pipelineWindow ? remaining : pipelineWindow;
+}
+
+template <typename T>
+__device__ __noinline__ void phase1ReduceScatter(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  const char* sendbuff = static_cast<const char*>(args.sendbuff);
+  char* phase2Buf = static_cast<char*>(args.phase2Buf);
+
+  comms::pipes::Timeout timeout{};
+
+  // Every owner initializes its tile before receiving peer contributions. The
+  // tile view is derived from the group identity, so numBlocks=1 is just the
+  // degenerate full-segment tile.
+  SegmentTile myTile{};
+  bool copiedLocalTile = false;
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+    const size_t mySegmentOffset =
+        static_cast<size_t>(localRank) * segmentBytes;
+    const char* src = sendbuff + mySegmentOffset + myTile.offsetBytes;
+    char* dst = phase2Buf + myTile.offsetBytes;
+    if (myTile.bytes > 0 && dst != src) {
+      comms::pipes::memcpy_vectorized(dst, src, myTile.bytes, group);
+      copiedLocalTile = true;
+    }
+  }
+
+  if (nLocalRanks <= 1) {
+    // Local-only topology has no NVL traffic. Synchronize only when this block
+    // copied out-of-place data that Phase 2 may read immediately.
+    if (copiedLocalTile) {
+      group.sync();
+    }
+    return;
+  }
+
+  group.sync();
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 1 NVL reduce-scatter pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  char* myDst = phase2Buf + myTile.offsetBytes;
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.send(
+          group,
+          sendbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.recv<TreeNvlReduceCopy<T>>(
+            group,
+            myDst + off,
+            window,
+            group.total_groups,
+            0,
+            timeout,
+            myDst + off);
+      }
+    }
+  }
+}
+
+enum class TreeLanePhase : uint8_t {
+  ReduceLeafSend,
+  ReduceRecvChild,
+  ReduceInternalSend,
+  BcastRootSendChild,
+  BcastInternalRecv,
+  BcastInternalSendChild,
+  BcastLeafRecv,
+  Done,
+};
+
+__device__ __forceinline__ TreeLanePhase
+firstReducePhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  return tree.isLeaf ? TreeLanePhase::ReduceLeafSend
+                     : TreeLanePhase::ReduceRecvChild;
+}
+
+__device__ __forceinline__ TreeLanePhase
+firstBcastPhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  if (tree.isRoot) {
+    return TreeLanePhase::BcastRootSendChild;
+  }
+  return tree.isLeaf ? TreeLanePhase::BcastLeafRecv
+                     : TreeLanePhase::BcastInternalRecv;
+}
+
+/**
+ * Persistent state for one half of the dual IB tree.
+ *
+ * A full CUDA block repeatedly calls `progressTreeLane()` for both lane states.
+ * Each call performs at most one bounded transport step or one local reduction
+ * step, and returns immediately if the current transport dependency is not
+ * ready.
+ */
+template <typename T>
+struct TreeLaneProgressState {
+  ctran::allreduce::TreeTopology tree;
+  T* dataBuf{nullptr};
+  size_t dataBytes{0};
+  size_t pipelineWindow{0};
+  size_t offsetBytes{0};
+  int activeBlocks{0};
+  int childIdx{0};
+  bool ibOpActive{false};
+  TreeLanePhase phase{TreeLanePhase::Done};
+};
+
+template <typename T>
+__device__ __forceinline__ size_t
+currentLaneWindowBytes(const TreeLaneProgressState<T>& state) {
+  return pipelineStepBytes(
+      state.dataBytes, state.offsetBytes, state.pipelineWindow);
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceReduceWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.offsetBytes = 0;
+    state.phase = firstBcastPhase(state.tree);
+  } else {
+    state.phase = firstReducePhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceBcastWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.phase = TreeLanePhase::Done;
+  } else {
+    state.phase = firstBcastPhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ TreeLaneProgressState<T> makeTreeLaneState(
+    const ctran::allreduce::tree::KernArgs& args,
+    const ctran::allreduce::TreeTopology& tree,
+    T* dataBuf,
+    size_t dataElems,
+    int activeBlocks) {
+  TreeLaneProgressState<T> state{};
+  state.tree = tree;
+  state.dataBuf = dataBuf;
+  state.dataBytes = dataElems * sizeof(T);
+  state.activeBlocks = activeBlocks;
+
+  if (state.dataBytes == 0) {
+    state.phase = TreeLanePhase::Done;
+    return state;
+  }
+
+  // Safe to query a single tree edge: pipeline_window() is comm-uniform, not
+  // per-peer. If per-peer buffer sizes diverge, active edges must agree.
+  state.pipelineWindow = state.dataBytes;
+  if (!tree.isLeaf && tree.numChildren > 0) {
+    auto* t = args.transports[tree.childRanks[0]].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  } else if (!tree.isRoot && tree.parentRank >= 0) {
+    auto* t = args.transports[tree.parentRank].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  }
+  PIPES_DEVICE_CHECK_MSG(
+      state.pipelineWindow != 0, "ctree Phase 2 IB pipeline window is zero");
+  state.phase = firstReducePhase(tree);
+  return state;
+}
+
+template <typename T>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneSend(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    const char* src,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    transport->init_send_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_send_once(group, src, timeout);
+}
+
+template <typename T, typename CopyOp = comms::pipes::Memcpy>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneRecv(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    char* dst,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    transport->init_recv_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_recv_once<CopyOp>(group, dst, timeout);
+}
+
+template <typename T, int kGroupSize>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressTreeLane(
+    const ctran::allreduce::tree::KernArgs& args,
+    TreeLaneProgressState<T>& state,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  using comms::pipes::IbgdaSendRecvProgressStatus;
+
+  if (state.phase == TreeLanePhase::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  const size_t window = currentLaneWindowBytes(state);
+  char* const data = reinterpret_cast<char*>(state.dataBuf) + state.offsetBytes;
+
+  switch (state.phase) {
+    case TreeLanePhase::ReduceLeafSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceRecvChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        if (state.tree.isRoot) {
+          advanceReduceWindow(state);
+        } else {
+          state.phase = TreeLanePhase::ReduceInternalSend;
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status = progressLaneRecv<T, TreeIbReduceCopy<T>>(
+          state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          if (state.tree.isRoot) {
+            advanceReduceWindow(state);
+          } else {
+            state.phase = TreeLanePhase::ReduceInternalSend;
+          }
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceInternalSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastRootSendChild:
+    case TreeLanePhase::BcastInternalSendChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status =
+          progressLaneSend(state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          advanceBcastWindow(state);
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastInternalRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx = 0;
+        state.phase = TreeLanePhase::BcastInternalSendChild;
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastLeafRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::Done:
+      return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  return IbgdaSendRecvProgressStatus::Waiting;
+}
+
+// ============================================================================
+// Phase 2: Inter-Node IB Dual Tree AllReduce
+//
+// Tree-0 operates on the first half of each block-owned tile and Tree-1 on the
+// second half. One 640-thread block cooperatively drives both tree lanes from
+// a progress loop. Each lane uses a disjoint transport group id; if one lane
+// is waiting on a remote signal or free transport staging slot, its progress
+// call returns immediately and the same block tries the other lane.
+//
+// Only GPUs with localRank < pMin participate. Non-owners skip this phase.
+// Single-node case (nNodes == 1) is a no-op (root-and-leaf in both trees).
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase2IbDualTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& blockGroup) {
+  if (args.localRank >= args.pMin) {
+    return;
+  }
+
+  // Single-node: both trees have isRoot && isLeaf — nothing to do. Phase 1
+  // already wrote the segment slice into recvbuff.
+  if (args.nNodes <= 1) {
+    return;
+  }
+
+  const size_t actualElems =
+      actualSegElems(args.count, args.segmentElems, args.localRank);
+  const auto tile = segmentTile(actualElems * sizeof(T), blockGroup);
+  const size_t tileOffsetElems = tile.offsetBytes / sizeof(T);
+  const size_t tileElems = tile.bytes / sizeof(T);
+
+  // If the whole segment has at most one element per block, lane 1 would be
+  // empty for every block. Compress transport group ids to a single lane for
+  // that tiny-message shape; otherwise keep the stable two-lane mapping.
+  const bool useSingleLane = actualElems <= static_cast<size_t>(args.numBlocks);
+  const int activeIbLanesPerBlock =
+      useSingleLane ? 1 : ctran::allreduce::tree::kTreeLanes;
+
+  const size_t halfElems0 = useSingleLane ? tileElems : (tileElems + 1) / 2;
+  const size_t halfElems1 = useSingleLane ? 0 : tileElems - halfElems0;
+  T* phase2Buf = static_cast<T*>(args.phase2Buf);
+  const int activeIbGroups = args.numBlocks * activeIbLanesPerBlock;
+
+  auto lane0Group = blockGroup;
+  lane0Group.group_id = blockGroup.group_id * activeIbLanesPerBlock;
+  lane0Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+  auto lane1Group = blockGroup;
+  lane1Group.group_id = blockGroup.group_id * activeIbLanesPerBlock + 1;
+  lane1Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+
+  auto lane0 = makeTreeLaneState<T>(
+      args,
+      args.tree0,
+      phase2Buf + tileOffsetElems,
+      halfElems0,
+      activeIbGroups);
+  auto lane1 = makeTreeLaneState<T>(
+      args,
+      args.tree1,
+      phase2Buf + tileOffsetElems + halfElems0,
+      halfElems1,
+      activeIbGroups);
+
+  comms::pipes::Timeout timeout{};
+  bool lane0Active = lane0.phase != TreeLanePhase::Done;
+  bool lane1Active = lane1.phase != TreeLanePhase::Done;
+  while (lane0Active || lane1Active) {
+    if (lane0Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane0, lane0Group, timeout);
+      lane0Active = lane0.phase != TreeLanePhase::Done;
+    }
+    if (lane1Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane1, lane1Group, timeout);
+      lane1Active = lane1.phase != TreeLanePhase::Done;
+    }
+  }
+}
+
+// ============================================================================
+// Phase 3: NVL AllGather
+//
+// Segment owners broadcast their globally-reduced segment to all local peers.
+// After Phase 2, each owner's recvbuff contains its globally-reduced segment
+// at offset [localRank * segmentBytes].
+//
+// Communication: uses rotating-peer order for globally consistent pairing.
+// Owners send their segment; all GPUs receive from owners.
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase3AllGather(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  char* recvbuff = static_cast<char*>(args.recvbuff);
+
+  comms::pipes::Timeout timeout{};
+
+  if (nLocalRanks <= 1) {
+    return;
+  }
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 3 NVL all-gather pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  SegmentTile myTile{};
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+  }
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t mySegmentOffset =
+          static_cast<size_t>(localRank) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.send(
+            group,
+            recvbuff + mySegmentOffset + myTile.offsetBytes + off,
+            window,
+            group.total_groups,
+            0,
+            timeout);
+      }
+    }
+
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.recv(
+          group,
+          recvbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+  }
+}
+
+/**
+ * Run the three ctree phases for one logical data tile.
+ *
+ * A tile is fully owned by one CUDA block. Multi-block launches only add more
+ * independent tiles; the algorithm does not require inter-block coordination.
+ */
+template <typename T>
+__device__ __forceinline__ void runAllReduceTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  phase1ReduceScatter<T>(args, group);
+  if (args.nLocalRanks > 1) {
+    group.sync();
+  }
+  if (args.nNodes > 1) {
+    phase2IbDualTree<T>(args, group);
+    if (args.nLocalRanks > 1) {
+      group.sync();
+    }
+  }
+  if (args.nLocalRanks > 1) {
+    phase3AllGather<T>(args, group);
+  }
+}
+
+// ============================================================================
+// Main kernel: dispatches datatype then runs Phase 1, both Phase 2 tree lanes,
+// and Phase 3 for the block-owned tile.
+// ============================================================================
+__global__
+__launch_bounds__(ctran::allreduce::tree::kBlockSize, 1) void ctranKernelAllReduceTree(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::tree::KernArgs args) {
+  auto blockGroup = comms::pipes::make_block_group();
+  const int blockId = static_cast<int>(blockIdx.x);
+  if (blockId >= args.numBlocks) {
+    return;
+  }
+  auto group = logicalDataGroup(blockGroup, blockId, args.numBlocks);
+
+  if (args.datatype == commFloat32) {
+    runAllReduceTree<float>(args, group);
+  } else if (args.datatype == commFloat16) {
+    runAllReduceTree<__half>(args, group);
+  }
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cuh
@@ -1,0 +1,93 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/topo/TreeConstants.h"
+#include "comms/utils/commSpecs.h"
+
+namespace comms::pipes {
+struct Transport;
+}
+
+namespace ctran::allreduce::tree {
+
+/** Number of independent inter-node tree lanes in the dual-tree phase. */
+static constexpr int kTreeLanes = 2;
+
+/** CUDA threads per block used by the ctree kernel. */
+static constexpr int kBlockSize = 640;
+
+/**
+ * Device kernel arguments for the Pipes-backed CTRAN tree AllReduce.
+ *
+ * User buffers are owned by the caller. NVL and IB receive staging are owned by
+ * the Pipes transports and are consumed only inside transport copy callbacks.
+ */
+struct KernArgs {
+  /** User input buffer; may alias `recvbuff` for in-place AllReduce. */
+  const void* sendbuff;
+  /** User output buffer that receives the final reduced tensor. */
+  void* recvbuff;
+  /**
+   * Phase 2 working buffer.
+   *
+   * Segment owners write locally reduced segments here in Phase 1, the IB tree
+   * reads and writes the same buffer in Phase 2, and Phase 3 reads from it.
+   */
+  void* phase2Buf;
+
+  /** Total number of elements in the user tensor. */
+  size_t count;
+  /** Elements per owner segment, equal to `ceil(count / pMin)`. */
+  size_t segmentElems;
+
+  /** Number of nodes in the communicator. */
+  int nNodes;
+  /** Minimum number of local ranks across all nodes. */
+  int pMin;
+  /** Number of local ranks on this node. */
+  int nLocalRanks;
+  /** This GPU's local rank on its node. */
+  int localRank;
+  /** Number of logical data partitions processed by CUDA blocks per GPU. */
+  int numBlocks;
+
+  /** Collective datatype implemented by the kernel dispatch. */
+  commDataType_t datatype;
+  /** Reduction operation implemented by the kernel dispatch. */
+  commRedOp_t redOp;
+
+  /** Unified transport array containing NVL and IB transports by global rank.
+   */
+  comms::pipes::Transport* transports;
+
+  /** Inter-node tree used for the first half of each data partition. */
+  ctran::allreduce::TreeTopology tree0;
+  /** Inter-node tree used for the second half of each data partition. */
+  ctran::allreduce::TreeTopology tree1;
+
+  /** Maps local rank index `[0, nLocalRanks)` to global communicator rank. */
+  int localRankToGlobalRank[CTRAN_MAX_NVL_PEERS];
+};
+
+} // namespace ctran::allreduce::tree
+
+/**
+ * CUDA kernel entry point for CTRAN tree AllReduce.
+ *
+ * Each block owns one tile partition and runs Phase 1, both Phase 2 tree
+ * lanes, and Phase 3 for that tile. Phase 2 uses one full-block work group to
+ * poll and progress the two disjoint IB tree lanes cooperatively.
+ * Multi-block launches are independent tiling for performance; correctness
+ * does not require inter-block sync.
+ */
+__global__ void ctranKernelAllReduceTree(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::tree::KernArgs args);
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cu
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cu
@@ -1,0 +1,328 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+namespace {
+
+void checkCuda(
+    cudaError_t result,
+    const char* expr,
+    const char* file,
+    int line) {
+  if (result != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "Failed: Cuda error %s:%d '%s' while running %s\n",
+        file,
+        line,
+        cudaGetErrorString(result),
+        expr);
+    std::abort();
+  }
+}
+
+#define CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cmd) \
+  checkCuda((cmd), #cmd, __FILE__, __LINE__)
+
+struct CudaFreeDeleter {
+  void operator()(void* ptr) const {
+    if (ptr != nullptr) {
+      CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaFree(ptr));
+    }
+  }
+};
+
+template <typename T>
+std::unique_ptr<T, CudaFreeDeleter> makeDeviceScratch(size_t count) {
+  T* ptr = nullptr;
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaMalloc(&ptr, count * sizeof(T)));
+  return std::unique_ptr<T, CudaFreeDeleter>(ptr);
+}
+
+} // namespace
+
+template <typename T>
+struct TestValueOps;
+
+template <>
+struct TestValueOps<float> {
+  using Word = uint32_t;
+
+  __device__ __forceinline__ static float fromFloat(float value) {
+    return value;
+  }
+
+  __device__ __forceinline__ static double toDouble(float value) {
+    return static_cast<double>(value);
+  }
+};
+
+template <>
+struct TestValueOps<__half> {
+  using Word = uint16_t;
+
+  __device__ __forceinline__ static __half fromFloat(float value) {
+    return __float2half(value);
+  }
+
+  __device__ __forceinline__ static double toDouble(__half value) {
+    return static_cast<double>(__half2float(value));
+  }
+};
+
+// Per-element value: 1.0f / (1.0f + (rep + rank + i) % 256)
+// This produces different values per element and per rank.
+__device__ static float elementValue(int rank, int rep, size_t i) {
+  return 1.0f / (1.0f + static_cast<float>((rep + rank + i) % 256));
+}
+
+template <typename T>
+__global__ void initDataKernel(T* buf, size_t count, int rank, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    buf[idx] = TestValueOps<T>::fromFloat(elementValue(rank, rep, idx));
+  }
+}
+
+template <typename T>
+__global__ void initExpectedKernel(T* buf, size_t count, int nranks, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    float sum = 0.0f;
+    for (int r = 0; r < nranks; r++) {
+      sum += elementValue(r, rep, idx);
+    }
+    buf[idx] = TestValueOps<T>::fromFloat(sum);
+  }
+}
+
+// Each block computes the max abs delta over its assigned elements, then
+// writes the per-block maximum into blockMaxes[blockIdx.x].
+template <typename T>
+__global__ void deltaKernel(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    double* blockMaxes) {
+  extern __shared__ double sdata[];
+
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  double localMax = 0.0;
+  if (idx < count) {
+    localMax = fabs(
+        TestValueOps<T>::toDouble(actual[idx]) -
+        TestValueOps<T>::toDouble(expected[idx]));
+  }
+
+  sdata[threadIdx.x] = localMax;
+  __syncthreads();
+
+  // Tree reduction within the block
+  for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (threadIdx.x < s) {
+      sdata[threadIdx.x] = fmax(sdata[threadIdx.x], sdata[threadIdx.x + s]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    blockMaxes[blockIdx.x] = sdata[0];
+  }
+}
+
+__device__ __forceinline__ uint64_t mixChecksum(uint64_t acc, uint64_t value) {
+  acc ^= value + 0x9e3779b97f4a7c15ULL + (acc << 6) + (acc >> 2);
+  return acc * 0x100000001b3ULL;
+}
+
+template <typename T>
+__global__ void
+rawBitsChecksumKernel(const T* data, size_t count, uint64_t* result) {
+  constexpr int kBlockSize = 256;
+  __shared__ uint64_t partials[kBlockSize];
+
+  using Word = typename TestValueOps<T>::Word;
+  const Word* words = reinterpret_cast<const Word*>(data);
+  uint64_t local = 0xcbf29ce484222325ULL ^
+      (static_cast<uint64_t>(threadIdx.x) << 32) ^ count ^
+      (static_cast<uint64_t>(sizeof(T)) << 56);
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    const uint64_t taggedValue =
+        (static_cast<uint64_t>(words[i]) << 32) ^ static_cast<uint64_t>(i);
+    local = mixChecksum(local, taggedValue);
+  }
+
+  partials[threadIdx.x] = local;
+  __syncthreads();
+
+  for (int stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      partials[threadIdx.x] =
+          mixChecksum(partials[threadIdx.x], partials[threadIdx.x + stride]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *result = partials[0];
+  }
+}
+
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+template <typename T>
+double computeMaxDeltaTyped(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return 0.0;
+  }
+
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+
+  auto dBlockMaxes = makeDeviceScratch<double>(numBlocks);
+
+  size_t sharedBytes = kBlockSize * sizeof(double);
+  deltaKernel<<<numBlocks, kBlockSize, sharedBytes, stream>>>(
+      actual, expected, count, dBlockMaxes.get());
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+
+  std::vector<double> hBlockMaxes(numBlocks);
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaMemcpyAsync(
+      hBlockMaxes.data(),
+      dBlockMaxes.get(),
+      numBlocks * sizeof(double),
+      cudaMemcpyDeviceToHost,
+      stream));
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  double maxDelta = 0.0;
+  for (int i = 0; i < numBlocks; i++) {
+    maxDelta = std::fmax(maxDelta, hBlockMaxes[i]);
+  }
+
+  return maxDelta;
+}
+
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+template <typename T>
+uint64_t
+computeRawBitsChecksumTyped(const T* data, size_t count, cudaStream_t stream) {
+  if (count == 0) {
+    return 0;
+  }
+
+  auto dChecksum = makeDeviceScratch<uint64_t>(1);
+
+  constexpr int kBlockSize = 256;
+  rawBitsChecksumKernel<<<1, kBlockSize, 0, stream>>>(
+      data, count, dChecksum.get());
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaPeekAtLastError());
+
+  uint64_t hChecksum = 0;
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaMemcpyAsync(
+      &hChecksum,
+      dChecksum.get(),
+      sizeof(uint64_t),
+      cudaMemcpyDeviceToHost,
+      stream));
+  CTRAN_ALLREDUCE_TREE_TEST_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  return hChecksum;
+}
+
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}
+
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cuh
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cuh
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+// Initialize data buffer: each element = 1.0f / (1.0f + (rep + rank + i) % 256)
+// Produces different values per element AND per rank, avoiding uniform fill.
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+// Initialize expected buffer: expected[i] = sum over all ranks of
+// initData(rank, i) This is exactly what AllReduce(sum) should produce.
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+// Compute max |actual[i] - expected[i]| across all elements.
+// Returns the result synchronously (blocks on stream).
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream);
+
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream);
+
+// Compute a deterministic checksum of the raw output bits using a single CUDA
+// block. Returns synchronously after copying one uint64_t to host.
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream);
+
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream);

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -1,0 +1,496 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "CtranUtUtils.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+/**
+ * Distributed CTRAN AllReduce correctness fixture.
+ *
+ * The fixture is algorithm-parameterized and validates execution status plus
+ * the numerical reduction result. It intentionally avoids colltrace assertions
+ * so the same test can cover CTREE and future AllReduce algorithm variants.
+ */
+class CtranAllReduceTest : public ctran::CtranDistTestFixture,
+                           public CtranBaseTest {
+ public:
+  CtranAllReduceTest() = default;
+
+  /** Identical-input repeats used to check bitwise deterministic output. */
+  static constexpr int kDeterminismRepeats = 4;
+
+  static void* allocateDeviceBuffer(size_t bytes) {
+    void* ptr = nullptr;
+    COMMCHECK_TEST(
+        ctran::utils::commCuMemAlloc(
+            &ptr,
+            nullptr,
+            ctran::utils::getCuMemAllocHandleType(),
+            bytes,
+            nullptr,
+            "CtranAllReduceTest"));
+    return ptr;
+  }
+
+  struct DeviceBufferDeleter {
+    void operator()(void* ptr) const {
+      if (ptr != nullptr) {
+        releaseDeviceBuffer(ptr);
+      }
+    }
+  };
+
+  using DeviceBuffer = std::unique_ptr<void, DeviceBufferDeleter>;
+
+  static DeviceBuffer makeDeviceBuffer(size_t bytes) {
+    return DeviceBuffer(allocateDeviceBuffer(bytes));
+  }
+
+  static void releaseDeviceBuffer(void* ptr) {
+    COMMCHECK_TEST(ctran::utils::commCuMemFree(ptr));
+  }
+
+  static void launchInitData(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int rank,
+      int rep,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitDataKernel(
+            static_cast<float*>(buf), count, rank, rep, stream);
+        return;
+      case commFloat16:
+        launchInitDataKernel(
+            static_cast<__half*>(buf), count, rank, rep, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static void launchInitExpected(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int nranks,
+      int rep,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitExpectedKernel(
+            static_cast<float*>(buf), count, nranks, rep, stream);
+        return;
+      case commFloat16:
+        launchInitExpectedKernel(
+            static_cast<__half*>(buf), count, nranks, rep, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static double computeMaxDeltaForType(
+      const void* actual,
+      const void* expected,
+      commDataType_t datatype,
+      size_t count,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        return computeMaxDelta(
+            static_cast<const float*>(actual),
+            static_cast<const float*>(expected),
+            count,
+            stream);
+      case commFloat16:
+        return computeMaxDelta(
+            static_cast<const __half*>(actual),
+            static_cast<const __half*>(expected),
+            count,
+            stream);
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return DBL_MAX;
+    }
+  }
+
+  static uint64_t computeRawBitsChecksumForType(
+      const void* data,
+      commDataType_t datatype,
+      size_t count,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        return computeRawBitsChecksum(
+            static_cast<const float*>(data), count, stream);
+      case commFloat16:
+        return computeRawBitsChecksum(
+            static_cast<const __half*>(data), count, stream);
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return 0;
+    }
+  }
+
+  static double thresholdForDatatype(commDataType_t datatype, int nranks) {
+    const int rankScale = std::max(1, nranks - 1);
+    switch (datatype) {
+      case commFloat32:
+        return 1e-5 * rankScale;
+      case commFloat16:
+        // FP16 accumulation error grows with rank count, but keep the bound
+        // tight enough to catch small bit-corruption regressions.
+        return 1e-3 * rankScale;
+      default:
+        return 0.0;
+    }
+  }
+
+  /**
+   * Configure CTRAN AllReduce and Pipes before constructing the communicator.
+   */
+  void SetUp() override {
+    ctran::CtranDistTestFixture::SetUp(envOverrides());
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    ctran::CtranDistTestFixture::TearDown();
+    ncclCvarInit();
+  }
+
+  /**
+   * Run one `commSum` AllReduce case and validate max absolute error.
+   */
+  void runCorrectnessTest(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      commDataType_t datatype,
+      size_t count,
+      bool inPlace) {
+    // Check support before the zero-count no-op so disabled algorithms skip
+    // consistently with non-empty cases.
+    if (!ctranAllReduceSupport(ctranComm.get(), algo)) {
+      GTEST_SKIP() << "ctranAllReduceSupport returns false for algo "
+                   << allReduceAlgoName(algo) << ", skip test";
+    }
+
+    // Zero-element case: no-op path
+    if (count == 0) {
+      auto res = runAllReduce(
+          algo,
+          nullptr,
+          nullptr,
+          0,
+          datatype,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+      return;
+    }
+
+    const size_t bytes = count * commTypeSize(datatype);
+    DeviceBuffer sendbuf = makeDeviceBuffer(bytes);
+    DeviceBuffer recvbuf = inPlace ? nullptr : makeDeviceBuffer(bytes);
+    DeviceBuffer expectedBuf = makeDeviceBuffer(bytes);
+    void* const sendPtr = sendbuf.get();
+    void* const recvPtr = inPlace ? sendPtr : recvbuf.get();
+
+    // Initialize expected: sum of initData across all ranks
+    launchInitExpected(
+        expectedBuf.get(),
+        datatype,
+        count,
+        numRanks,
+        /*rep=*/0,
+        testStream);
+
+    std::array<uint64_t, kDeterminismRepeats> checksums{};
+    for (int repeat = 0; repeat < kDeterminismRepeats; ++repeat) {
+      // Reinitialize identical inputs for each repeat. This keeps in-place
+      // cases from feeding the previous reduction result into the next run.
+      launchInitData(
+          sendPtr,
+          datatype,
+          count,
+          globalRank,
+          /*rep=*/0,
+          testStream);
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      commResult_t res = runAllReduce(
+          algo,
+          sendPtr,
+          recvPtr,
+          count,
+          datatype,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      // Validate: max absolute error across all elements
+      const void* resultBuf = inPlace ? sendPtr : recvPtr;
+      double maxDelta = computeMaxDeltaForType(
+          resultBuf, expectedBuf.get(), datatype, count, testStream);
+
+      double threshold = thresholdForDatatype(datatype, numRanks);
+      ASSERT_LT(maxDelta, threshold)
+          << "maxDelta=" << maxDelta << " threshold=" << threshold
+          << " count=" << count << " rank=" << globalRank
+          << " datatype=" << commDataTypeToString(datatype)
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+
+      checksums[repeat] =
+          computeRawBitsChecksumForType(resultBuf, datatype, count, testStream);
+    }
+
+    for (int repeat = 1; repeat < kDeterminismRepeats; ++repeat) {
+      ASSERT_EQ(checksums[0], checksums[repeat])
+          << "non-deterministic AllReduce output checksum for count=" << count
+          << " rank=" << globalRank
+          << " datatype=" << commDataTypeToString(datatype)
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+    }
+
+    verifyGpeLeak(ctranComm->ctran_.get());
+  }
+
+ protected:
+  /** Dispatch one AllReduce call for the algorithm under test. */
+  commResult_t runAllReduce(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      const void* sendbuf,
+      void* recvbuf,
+      size_t count,
+      commDataType_t datatype,
+      commRedOp_t redOp,
+      CtranComm* comm,
+      cudaStream_t stream,
+      std::optional<std::chrono::milliseconds> timeout) {
+    switch (algo) {
+      case NCCL_ALLREDUCE_ALGO::ctree:
+        return ctranAllReduceTree(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      default:
+        return commInvalidArgument;
+    }
+  }
+
+  /** CUDA stream used by buffer initialization, AllReduce, and validation. */
+  cudaStream_t testStream{0};
+  /** Communicator under test for this distributed rank. */
+  std::unique_ptr<CtranComm> ctranComm{nullptr};
+
+  /**
+   * Return per-test environment overrides that must be visible before
+   * communicator construction and restored after fixture teardown.
+   */
+  virtual ctran::CtranEnvs envOverrides() const {
+    ctran::CtranEnvs envs{
+        {"NCCL_ALLREDUCE_ALGO", "ctree"},
+        {"NCCL_CTRAN_USE_PIPES", "1"},
+        {"NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1"},
+        {"NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432"},
+    };
+#ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
+    envs.emplace_back("NCCL_CTRAN_BACKENDS", "socket, nvl");
+#endif
+    return envs;
+  }
+};
+
+using AllReduceParam =
+    std::tuple<enum NCCL_ALLREDUCE_ALGO, commDataType_t, size_t, bool>;
+
+const std::vector<size_t>& allReduceElementCounts() {
+  static const std::vector<size_t> counts{
+      // Zero
+      0,
+      // Tiny
+      1,
+      7,
+      16,
+      // Small
+      64,
+      256,
+      1024,
+      // Medium
+      4096,
+      16384,
+      65536,
+      // Large
+      262144,
+      1048576,
+      4194304,
+      // Large + tail
+      1048576 - 7,
+      1048576 + 7,
+      4194304 - 13,
+      4194304 + 13,
+  };
+  return counts;
+}
+
+const std::vector<commDataType_t>& allReduceDataTypes() {
+  static const std::vector<commDataType_t> datatypes{
+      commFloat32,
+      commFloat16,
+  };
+  return datatypes;
+}
+
+std::string dataTypeTestName(commDataType_t datatype) {
+  switch (datatype) {
+    case commFloat32:
+      return "FP32";
+    case commFloat16:
+      return "FP16";
+    default:
+      return "UnsupportedType";
+  }
+}
+
+std::string allReduceTestName(
+    enum NCCL_ALLREDUCE_ALGO algo,
+    commDataType_t datatype,
+    size_t count,
+    bool inPlace) {
+  return allReduceAlgoName(algo) + "_" + dataTypeTestName(datatype) + "_" +
+      std::to_string(count) + "elements_" +
+      (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+#if defined(CTRAN_ALLREDUCE_TEST_NVL_ONLY)
+/**
+ * NVL-only topology test using the default local topology.
+ */
+class NVL_ONLY : public CtranAllReduceTest,
+                 public ::testing::WithParamInterface<AllReduceParam> {};
+
+TEST_P(NVL_ONLY, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string nvlTestName(
+    const testing::TestParamInfo<NVL_ONLY::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    NVL_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    nvlTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY)
+/**
+ * IB-only topology test that disables local P2P and forces a no-local topology.
+ */
+class IB_ONLY : public CtranAllReduceTest,
+                public ::testing::WithParamInterface<AllReduceParam> {
+ public:
+  /**
+   * Extend the base CTREE overrides to force the inter-node path without
+   * leaking topology overrides into later tests.
+   */
+  ctran::CtranEnvs envOverrides() const override {
+    auto envs = CtranAllReduceTest::envOverrides();
+    envs.emplace_back("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal");
+    envs.emplace_back("NCCL_IGNORE_TOPO_LOAD_FAILURE", "1");
+    envs.emplace_back("NCCL_P2P_DISABLE", "1");
+    return envs;
+  }
+};
+
+TEST_P(IB_ONLY, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string ibTestName(
+    const testing::TestParamInfo<IB_ONLY::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    IB_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    ibTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_HYBRID)
+/**
+ * Hybrid topology test that exercises NVL and IB paths together.
+ */
+class HYBRID : public CtranAllReduceTest,
+               public ::testing::WithParamInterface<AllReduceParam> {};
+
+TEST_P(HYBRID, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string hybridTestName(
+    const testing::TestParamInfo<HYBRID::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    HYBRID,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    hybridTestName);
+#endif
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -13,6 +13,9 @@ SRCDIR = $(abspath ./)
 NCCLDIR = $(abspath ../)
 SHAREDDIR = $(abspath ${NCCLDIR}/..)
 
+# fbcode/Pipes CUDA sources include Folly headers that require C++20.
+CXXSTD ?= -std=c++20
+
 include ../makefiles/common.mk
 include ../makefiles/version.mk
 
@@ -27,6 +30,7 @@ endif
 
 ifeq ($(ENABLE_PIPES),1)
 CXXFLAGS += -DENABLE_PIPES
+NVCUFLAGS += -DENABLE_PIPES
 endif
 
 ##### src files
@@ -92,6 +96,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
 LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+ifeq ($(ENABLE_PIPES),1)
+## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceTree.cu
+endif
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
 ## Include ibverbx files
@@ -441,7 +449,7 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
 $(OBJDIR)/%.cu.o : %.cu $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
-	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
+	$(NVCC) $(NVCUFLAGS) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
 
 $(OBJDIR)/misc/git_version.o: $(GIT_VERSION_FILE)
 

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -13,6 +13,9 @@ SRCDIR = $(abspath ./)
 NCCLDIR = $(abspath ../)
 SHAREDDIR = $(abspath ${NCCLDIR}/..)
 
+# fbcode/Pipes CUDA sources include Folly headers that require C++20.
+CXXSTD ?= -std=c++20
+
 include ../makefiles/common.mk
 include ../makefiles/version.mk
 
@@ -27,6 +30,7 @@ endif
 
 ifeq ($(ENABLE_PIPES),1)
 CXXFLAGS += -DENABLE_PIPES
+NVCUFLAGS += -DENABLE_PIPES
 endif
 
 ##### src files
@@ -100,6 +104,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
 LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+ifeq ($(ENABLE_PIPES),1)
+## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceTree.cu
+endif
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)
 ## Include ibverbx files
@@ -469,7 +477,7 @@ $(OBJDIR)/%.o : %.c $(INCTARGETS)
 $(OBJDIR)/%.cu.o : %.cu $(INCTARGETS)
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
-	$(NVCC) $(NVCC_GENCODE) $(CXXSTD) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
+	$(NVCC) $(NVCUFLAGS) -Xcompiler -fPIC -Xcompiler -fvisibility=hidden -I. -I$(INCDIR) -I$(OBJDIR)/include $(INCLUDES) -I$(INCPLUGIN) -I$(DOCA_HOME)/include -c $< -o $@
 
 $(OBJDIR)/misc/git_version.o: $(GIT_VERSION_FILE)
 

--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -414,6 +414,43 @@ struct IbgdaBufferExchInfo {
   }
 };
 
+namespace detail {
+
+/**
+ * Internal stage for one transport-owned resumable send/recv operation.
+ *
+ * `Done` is intentionally zero so freshly zeroed transport memory starts idle.
+ * Send operations use `WaitNicDone` and `WaitSlotFree`; recv operations use
+ * `WaitDataReady`.
+ */
+enum class IbSendRecvProgressStage : uint8_t {
+  Done,
+  WaitNicDone,
+  WaitSlotFree,
+  WaitDataReady,
+};
+
+/**
+ * Internal resumable state for one transport-owned send/recv operation.
+ *
+ * The state is indexed by direction and transport group. It tracks the
+ * reserved protocol byte range and the current staging-ring cursor for the
+ * progress APIs in `P2pIbgdaTransportDevice`.
+ */
+struct IbSendRecvProgressState {
+  int groupId{0};
+  int activeBlocks{0};
+  std::size_t nbytes{0};
+  std::size_t maxSignalBytes{0};
+  std::size_t perBlockSlot{0};
+  std::size_t chunkSize{0};
+  std::size_t nextByte{0};
+  int64_t baseStep{0};
+  IbSendRecvProgressStage stage{IbSendRecvProgressStage::Done};
+};
+
+} // namespace detail
+
 /**
  * IbSendRecvState — device-side state for pipelined RDMA send/recv.
  *
@@ -444,6 +481,10 @@ struct IbgdaBufferExchInfo {
  *   stepState: 2 * maxGroups * sizeof(int64_t).
  *     [0, maxGroups)             — sender byte cursors
  *     [maxGroups, 2*maxGroups)   — receiver byte cursors
+ *
+ *   progressState: 2 * maxGroups internal progress states.
+ *     [0, maxGroups)             — sender progress slots
+ *     [maxGroups, 2*maxGroups)   — receiver progress slots
  */
 struct IbSendRecvState {
   IbgdaLocalBuffer
@@ -457,6 +498,8 @@ struct IbSendRecvState {
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
   int64_t* stepState{nullptr}; ///< Per-group byte cursors
+  detail::IbSendRecvProgressState* progressState{
+      nullptr}; ///< Per-group progress slots
   int maxGroups{0}; ///< Layout size for signals/step arrays
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring
   std::size_t dataBufferSize{0}; ///< Size of one pipeline slot in bytes

--- a/comms/pipes/MultipeerIbgdaTransport.cc
+++ b/comms/pipes/MultipeerIbgdaTransport.cc
@@ -84,6 +84,7 @@ struct PeerBufferSizes {
   std::size_t srSignal{0};
   std::size_t srCounter{0};
   std::size_t srStepState{0};
+  std::size_t srProgressState{0};
   std::size_t slotSignal{0};
   std::size_t slotCounter{0};
   std::size_t slotDiscard{0};
@@ -94,13 +95,14 @@ struct PeerBufferSizes {
   void* srSignalPtr{nullptr};
   void* srCounterPtr{nullptr};
   void* srStepStatePtr{nullptr};
+  void* srProgressStatePtr{nullptr};
   void* slotSignalPtr{nullptr};
   void* slotCounterPtr{nullptr};
   void* slotDiscardPtr{nullptr};
 
   std::size_t total() const {
-    return staging * 2 + srSignal + srCounter + srStepState + slotSignal +
-        slotCounter + slotDiscard;
+    return staging * 2 + srSignal + srCounter + srStepState + srProgressState +
+        slotSignal + slotCounter + slotDiscard;
   }
 
   void layout(void* base) {
@@ -115,6 +117,8 @@ struct PeerBufferSizes {
     p += srCounter;
     srStepStatePtr = p;
     p += srStepState;
+    srProgressStatePtr = p;
+    p += srProgressState;
     slotSignalPtr = p;
     p += slotSignal;
     slotCounterPtr = p;
@@ -801,6 +805,8 @@ PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
     sizes.srSignal = 2 * sr.maxGroups * sizeof(uint64_t);
     sizes.srCounter = sr.maxGroups * sizeof(uint64_t);
     sizes.srStepState = 2 * sr.maxGroups * sizeof(int64_t);
+    sizes.srProgressState =
+        2 * sr.maxGroups * sizeof(detail::IbSendRecvProgressState);
   }
   sizes.slotSignal =
       static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
@@ -859,6 +865,7 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
         .remoteSignalBuf = pb.remoteSignal,
         .localCounterBuf = pb.counter,
         .stepState = pb.stepState,
+        .progressState = pb.progressState,
         .maxGroups = config_.sendRecv->maxGroups,
         .pipelineDepth = config_.sendRecv->pipelineDepth,
         .dataBufferSize = config_.dataBufferSize,
@@ -1807,6 +1814,7 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
   const auto signalPerPeer = sizes.srSignal;
   const auto counterPerPeer = sizes.srCounter;
   const auto stepStatePerPeer = sizes.srStepState;
+  const auto progressStatePerPeer = sizes.srProgressState;
 
   auto allocateBulk = [&](std::size_t perPeer) {
     auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
@@ -1827,6 +1835,7 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
     signalBulk_ = allocateBulk(signalPerPeer);
     counterBulk_ = allocateBulk(counterPerPeer);
     stepStateBulk_ = allocateBulk(stepStatePerPeer);
+    progressStateBulk_ = allocateBulk(progressStatePerPeer);
 
     auto sendStagingBulkReg =
         registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
@@ -1845,11 +1854,14 @@ void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
       pb.counter = counterBulkReg_.subBuffer(i * counterPerPeer);
       pb.stepState = reinterpret_cast<int64_t*>(
           static_cast<char*>(stepStateBulk_->get()) + i * stepStatePerPeer);
+      pb.progressState = reinterpret_cast<detail::IbSendRecvProgressState*>(
+          static_cast<char*>(progressStateBulk_->get()) +
+          i * progressStatePerPeer);
     }
 
     VLOG(1) << "MultipeerIbgdaTransport: eager mode — allocated tile buffers "
             << "for " << numPeers << " peers (staging=" << stagingPerPeer
-            << "B per peer, 5 bulks)";
+            << "B per peer, 6 bulks)";
   } else {
     VLOG(1) << "MultipeerIbgdaTransport: lazy mode — per-peer allocation "
             << "deferred to materializePeer";
@@ -1912,6 +1924,7 @@ void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
   signalBulk_.reset();
   counterBulk_.reset();
   stepStateBulk_.reset();
+  progressStateBulk_.reset();
 }
 
 bool MultipeerIbgdaTransport::isPeerMaterialized(int peerRank) const {
@@ -1997,6 +2010,8 @@ void MultipeerIbgdaTransport::allocatePeerBuffers(
     pb.signal = IbgdaLocalBuffer(sizes.srSignalPtr, reg.lkey_per_device);
     pb.counter = IbgdaLocalBuffer(sizes.srCounterPtr, reg.lkey_per_device);
     pb.stepState = reinterpret_cast<int64_t*>(sizes.srStepStatePtr);
+    pb.progressState = reinterpret_cast<detail::IbSendRecvProgressState*>(
+        sizes.srProgressStatePtr);
 
     payload.recvStaging.addr = reinterpret_cast<uint64_t>(sizes.recvStagingPtr);
     payload.recvStaging.numNics = numNics_;

--- a/comms/pipes/MultipeerIbgdaTransport.h
+++ b/comms/pipes/MultipeerIbgdaTransport.h
@@ -648,6 +648,7 @@ class MultipeerIbgdaTransport {
     IbgdaLocalBuffer signal;
     IbgdaLocalBuffer counter;
     int64_t* stepState{nullptr};
+    detail::IbSendRecvProgressState* progressState{nullptr};
     IbgdaRemoteBuffer remoteRecvStaging;
     IbgdaRemoteBuffer remoteSignal;
   };
@@ -659,13 +660,14 @@ class MultipeerIbgdaTransport {
   std::unique_ptr<meta::comms::DeviceBuffer> signalBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> counterBulk_;
   std::unique_ptr<meta::comms::DeviceBuffer> stepStateBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> progressStateBulk_;
   IbgdaLocalBuffer recvStagingBulkReg_;
   IbgdaLocalBuffer signalBulkReg_;
   IbgdaLocalBuffer counterBulkReg_;
 
   // Lazy mode: per-peer contiguous allocation (staging + signal + counter +
-  // stepState + slot-index). Null for unmaterialized peers. Empty in eager
-  // mode.
+  // stepState + progressState + slot-index). Null for unmaterialized peers.
+  // Empty in eager mode.
   std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
 
   // Lazy mode: set to true after writeDeviceTransportSlot completes.

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -41,6 +41,26 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 // `PIPES_DEVICE_TRAP()` is defined in `comms/pipes/DeviceMacros.cuh` and
 // is intentionally available across all `comms/pipes` device headers.
 
+/**
+ * Result of one bounded send/recv progress attempt.
+ *
+ * `progress_send_once()` and `progress_recv_once()` are intended for callers
+ * that multiplex several independent transfers from one kernel. A single call
+ * may complete immediately, advance one protocol step, or find that the next
+ * signal/counter dependency is not ready yet.
+ *
+ * `Waiting` means no user-visible data movement or protocol signal was
+ * issued. The caller may retry the same transport operation later after
+ * making progress on another lane. `Progressed` means the call advanced the
+ * operation but more calls are required. `Done` means the transfer has
+ * completed the byte range reserved by the corresponding init call.
+ */
+enum class IbgdaSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+};
+
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
 // constructed with no owned signal/counter buffer (numSlots == 0).
@@ -1181,6 +1201,462 @@ class P2pIbgdaTransportDevice {
   //   }
 
   /**
+   * Resumable send/recv compatibility with blocking send()/recv().
+   *
+   * The progress API deliberately uses the same wire protocol as blocking
+   * send()/recv(). For a chunk with logical byte range [streamStart,
+   * streamEnd), both APIs derive the same ring slot and staging offset from:
+   *
+   *   pipelineBytes = perBlockSlot * pipelineDepth
+   *   pipelineOff   = streamStart % pipelineBytes
+   *   slot          = pipelineOff / perBlockSlot
+   *   stagingOff    = slot * dataBufferSize + groupId * perBlockSlot +
+   *                   (pipelineOff - slot * perBlockSlot)
+   *
+   * Sender chunk state machine:
+   *
+   *   WaitNicDone
+   *        |
+   *        | local sendStaging is reusable; copy user src -> sendStaging
+   *        v
+   *   WaitSlotFree
+   *        |
+   *        | remote recvStaging is reusable; RDMA put + DATA_READY + NIC_DONE
+   *        v
+   *   Done for this chunk, then either WaitNicDone for next chunk or Done
+   *
+   * Receiver chunk state machine:
+   *
+   *   WaitDataReady
+   *        |
+   *        | DATA_READY reached streamEnd; copy recvStaging -> user dst
+   *        v
+   *   Signal SLOT_FREE, then either WaitDataReady for next chunk or Done
+   *
+   * Compatibility follows from using the same cumulative byte counters:
+   * DATA_READY advances by bytesThis/chunk.bytes on each put, SLOT_FREE
+   * advances by the same amount after recv copies out of staging, and NIC_DONE
+   * advances by the same amount after the NIC completes the sender's WQE.
+   * Blocking send()/recv() advance the transport cursor when the call
+   * completes; progress init reserves that cursor range before returning so
+   * multiple resumable states and later blocking calls cannot reuse the same
+   * protocol bytes.
+   *
+   * Usage starts by initializing the transport-owned state for one logical
+   * transfer, then calling the matching progress method until it returns
+   * `Done`:
+   *
+   *   transport->init_send_progress(
+   *       group, nbytes, active_blocks, max_signal_bytes);
+   *   while (transport->progress_send_once(group, src, timeout) !=
+   *          IbgdaSendRecvProgressStatus::Done) {
+   *     // Try another independent lane or return to the scheduler.
+   *   }
+   *
+   * Receivers use the symmetric `init_recv_progress()` and
+   * `progress_recv_once()` pair with the same `active_blocks` and compatible
+   * `max_signal_bytes`. Zero-byte operations initialize directly to `Done`, so
+   * callers can use the same loop shape for empty and non-empty transfers.
+   *
+   * The progress state is a property of this transport, indexed by
+   * `group.group_id` and direction. A caller may have one send and one recv in
+   * flight for the same group, but a second send or second recv init for the
+   * same group before the previous operation reaches `Done` traps on device.
+   */
+
+  /**
+   * Initialize transport-owned state for one pipelined send operation.
+   *
+   * The transport reserves the sender-side byte stream for `group.group_id`
+   * and starts the internal state in the sender state machine unless
+   * `nbytes == 0`. It does not capture the source pointer; callers pass the
+   * pointer to each `progress_send_once()` call.
+   *
+   * The send progress slot for this group must be idle. Re-initializing a
+   * group while a previous send is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * `active_blocks == 0` means all configured groups participate. Non-zero
+   * values must match the peer's recv-side initialization for the same logical
+   * transfer. `max_signal_bytes == 0` sends one signal per per-block staging
+   * partition; smaller non-zero values split that partition into multiple
+   * signaled sub-chunks for finer overlap with the receiver.
+   *
+   * Zero-byte sends mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `send()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to send for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_send_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "send");
+    detail::IbSendRecvProgressState state{
+        .groupId = static_cast<int>(group.group_id),
+        .activeBlocks =
+            active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups,
+        .nbytes = nbytes,
+        .maxSignalBytes = max_signal_bytes,
+        .stage = nbytes == 0 ? detail::IbSendRecvProgressStage::Done
+                             : detail::IbSendRecvProgressStage::WaitNicDone,
+    };
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    init_progress_geometry(group, state);
+    state.baseStep = reserve_progress_step(group, state.groupId, nbytes);
+    store_progress_state(group, progressIndex, state);
+#endif
+  }
+
+  /**
+   * Initialize transport-owned state for one pipelined recv operation.
+   *
+   * The transport reserves the receiver-side byte stream for `group.group_id`
+   * and starts the internal state in the receiver state machine unless
+   * `nbytes == 0`. It does not capture the destination pointer; callers pass
+   * the pointer to each `progress_recv_once()` call.
+   *
+   * The recv progress slot for this group must be idle. Re-initializing a
+   * group while a previous recv is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * The sender and receiver must use the same `active_blocks` and compatible
+   * `max_signal_bytes` for a logical transfer. The staging offset and protocol
+   * signal values are derived from those values, so a mismatch can make one
+   * side wait on a different byte range than the other side produced.
+   *
+   * Zero-byte receives mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `recv()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to receive for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_recv_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "recv");
+    detail::IbSendRecvProgressState state{
+        .groupId = static_cast<int>(group.group_id),
+        .activeBlocks =
+            active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups,
+        .nbytes = nbytes,
+        .maxSignalBytes = max_signal_bytes,
+        .stage = nbytes == 0 ? detail::IbSendRecvProgressStage::Done
+                             : detail::IbSendRecvProgressStage::WaitDataReady,
+    };
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    init_progress_geometry(group, state);
+    state.baseStep = reserve_progress_step(
+        group, sendRecvState_.maxGroups + state.groupId, nbytes);
+    store_progress_state(group, progressIndex, state);
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized send.
+   *
+   * This method advances at most one staged copy plus one RDMA put for the
+   * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
+   * dependency is not ready, it returns immediately so a higher-level scheduler
+   * can try another independent lane. If a `Timeout` is enabled, it is checked
+   * only at those readiness points and should already have been started by the
+   * caller.
+   *
+   * The send path first waits for NIC_DONE before reusing the local
+   * send-staging range, then copies user data into send-staging through
+   * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
+   * range, and finally issues an RDMA put that piggybacks DATA_READY and
+   * records NIC_DONE in the local counter. Returning `Done` means the reserved
+   * byte range has completed.
+   *
+   * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param group Thread group matching the one used during initialization.
+   * @param src Source user buffer. The range `[src, src + nbytes)` must remain
+   *            valid until `Done`.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::send`.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "P2pIbgdaTransportDevice::progress_send_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_send_index(group);
+    detail::IbSendRecvProgressState state =
+        progress_state_slot(group, progressIndex);
+    if (state.stage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    if (state.nextByte >= state.nbytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once nextByte=%llu >= nbytes=%llu "
+            "without Done stage\n",
+            static_cast<unsigned long long>(state.nextByte),
+            static_cast<unsigned long long>(state.nbytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_send_progress_stage(group, state);
+
+    const detail::IbSendRecvProgressStage initialStage = state.stage;
+    const std::size_t initialNextByte = state.nextByte;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+
+    if (state.stage == detail::IbSendRecvProgressStage::WaitNicDone) {
+      const ProgressChunk chunk = next_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_counter(sendRecvState_.localCounterBuf.subBuffer(
+                  state.groupId * sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      CopyOp::send(
+          sendRecvState_.sendStagingPtr + chunk.stagingOff,
+          static_cast<const char*>(src) + chunk.dataOff,
+          chunk.bytes,
+          group,
+          chunk.dataOff,
+          args...);
+      group.sync();
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+    }
+
+    if (state.stage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+      const ProgressChunk chunk = next_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                  (sendRecvState_.maxGroups + state.groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          if (state.stage != initialStage ||
+              state.nextByte != initialNextByte) {
+            store_progress_state(group, progressIndex, state);
+            return IbgdaSendRecvProgressStatus::Progressed;
+          }
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        put(solo,
+            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            chunk.bytes,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes,
+            sendRecvState_.localCounterBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes);
+      }
+      group.sync();
+
+      state.nextByte += chunk.bytes;
+      if (state.nextByte >= state.nbytes) {
+        transition_progress_stage(
+            group, state, detail::IbSendRecvProgressStage::Done);
+        store_progress_state(group, progressIndex, state);
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
+    }
+
+    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
+    // WaitNicDone in one call, leaving the stage unchanged while nextByte
+    // advances. Check both fields so that case reports Progressed.
+    if (state.stage != initialStage || state.nextByte != initialNextByte) {
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Progressed;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized recv.
+   *
+   * This method advances at most one recv-staging copy for the current chunk.
+   * It never spins on DATA_READY: if the sender has not signaled the next
+   * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
+   * checked only while the DATA_READY dependency is not ready and should
+   * already have been started by the caller.
+   *
+   * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
+   * transport-owned recv-staging into the caller's destination through
+   * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
+   * means the reserved byte range has completed.
+   *
+   * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param group Thread group matching the one used during initialization.
+   * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
+   *            remain valid until `Done`.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::recv`.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "P2pIbgdaTransportDevice::progress_recv_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_recv_index(group);
+    detail::IbSendRecvProgressState state =
+        progress_state_slot(group, progressIndex);
+    if (state.stage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    if (state.nextByte >= state.nbytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= nbytes=%llu "
+            "without Done stage\n",
+            static_cast<unsigned long long>(state.nextByte),
+            static_cast<unsigned long long>(state.nbytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_recv_progress_stage(group, state);
+
+    const ProgressChunk chunk = next_chunk(state);
+    const uint64_t expected = chunk.streamEnd;
+    uint32_t ready = 1;
+    unsigned long long current = 0;
+    if (group.is_leader()) {
+      current = static_cast<unsigned long long>(
+          read_signal(sendRecvState_.localSignalBuf.subBuffer(
+              state.groupId * sizeof(uint64_t))));
+      ready = current >= expected ? 1U : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_recv_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            static_cast<unsigned long long>(expected),
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    CopyOp::recv(
+        static_cast<char*>(dst) + chunk.dataOff,
+        sendRecvState_.recvStagingPtr + chunk.stagingOff,
+        chunk.bytes,
+        group,
+        chunk.dataOff,
+        args...);
+    group.sync();
+
+    signal(
+        group,
+        sendRecvState_.remoteSignalBuf.subBuffer(
+            (sendRecvState_.maxGroups + state.groupId) * sizeof(uint64_t)),
+        chunk.bytes);
+
+    state.nextByte += chunk.bytes;
+    if (state.nextByte >= state.nbytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    store_progress_state(group, progressIndex, state);
+    return IbgdaSendRecvProgressStatus::Progressed;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
    * send — send one block's tile via pipelined RDMA.
    *
    * Copies src → sendStaging, then RDMA puts sendStaging → peer's recvStaging.
@@ -1819,6 +2295,373 @@ class P2pIbgdaTransportDevice {
   }
 
  private:
+  /**
+   * Physical staging range for the next resumable progress step.
+   *
+   * `stagingOff` is an offset into the transport-owned send/recv staging
+   * buffers. `dataOff` is the matching offset into the caller's user buffer.
+   * `bytes` never crosses a per-block staging partition or the requested byte
+   * count. `streamEnd` is the absolute protocol byte value after this chunk and
+   * is used as the DATA_READY, SLOT_FREE, and NIC_DONE readiness threshold.
+   */
+  struct ProgressChunk {
+    std::size_t stagingOff;
+    std::size_t dataOff;
+    std::size_t bytes;
+    uint64_t streamEnd;
+  };
+
+  /**
+   * Return the internal send progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, 0);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return the internal recv progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, sendRecvState_.maxGroups);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Validate a progress group and map it into the transport-owned slot array.
+   */
+  __device__ __forceinline__ int progress_index_for_group(
+      ThreadGroup& group,
+      int baseIndex) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (sendRecvState_.progressState == nullptr) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: progressState is null\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (sendRecvState_.maxGroups <= 0 ||
+        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%u out of range [0, %d)\n",
+            group.group_id,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    return baseIndex + static_cast<int>(group.group_id);
+#else
+    (void)group;
+    (void)baseIndex;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return a reference to a transport-owned progress state slot.
+   */
+  __device__ __forceinline__ detail::IbSendRecvProgressState&
+  progress_state_slot(ThreadGroup& group, int progressIndex) const {
+    (void)group;
+    return sendRecvState_.progressState[progressIndex];
+  }
+
+  /**
+   * Trap if a caller tries to start a second send/recv before the first ends.
+   */
+  __device__ __forceinline__ void assert_progress_slot_idle(
+      ThreadGroup& group,
+      const detail::IbSendRecvProgressState& state,
+      const char* direction) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.stage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: init_%s_progress called with outstanding %s "
+            "for group_id=%u stage=%d nextByte=%llu nbytes=%llu\n",
+            direction,
+            direction,
+            group.group_id,
+            static_cast<int>(state.stage),
+            static_cast<unsigned long long>(state.nextByte),
+            static_cast<unsigned long long>(state.nbytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#else
+    (void)group;
+    (void)state;
+    (void)direction;
+#endif
+  }
+
+  /**
+   * Commit an updated local progress state back to its transport-owned slot.
+   */
+  __device__ __forceinline__ void store_progress_state(
+      ThreadGroup& group,
+      int progressIndex,
+      const detail::IbSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (group.is_leader()) {
+      sendRecvState_.progressState[progressIndex] = state;
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)progressIndex;
+    (void)state;
+#endif
+  }
+
+  /**
+   * Validate and finalize the staging geometry stored in a progress state.
+   *
+   * This helper is called by the public init APIs before the internal state is
+   * committed to the transport. It verifies that the state belongs to the
+   * current `ThreadGroup`, that the group participates in this transfer, and
+   * that the requested active block count can fit at least one 16-byte-aligned
+   * region in each staging slot.
+   *
+   * On success, `perBlockSlot` is the caller's partition within each logical
+   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A
+   * zero `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the
+   * value is rounded down to the same 16-byte alignment used by the blocking
+   * send/recv path. Invalid geometry traps on device because continuing would
+   * corrupt another block group's staging partition.
+   *
+   * The public init methods handle zero-byte operations before calling this
+   * helper. This helper is therefore only responsible for valid, non-empty
+   * transfer geometry.
+   */
+  __device__ __forceinline__ void init_progress_geometry(
+      ThreadGroup& group,
+      detail::IbSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.groupId != static_cast<int>(group.group_id)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress state group_id=%d but group.group_id=%u\n",
+            state.groupId,
+            group.group_id);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (state.activeBlocks > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress active_blocks=%d > maxGroups=%d\n",
+            state.activeBlocks,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (state.groupId < 0 || state.groupId >= state.activeBlocks) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%d >= active_blocks=%d\n",
+            state.groupId,
+            state.activeBlocks);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    state.perBlockSlot =
+        (sendRecvState_.dataBufferSize / state.activeBlocks) & ~15ULL;
+    if (state.perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            state.activeBlocks);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    state.chunkSize =
+        (state.maxSignalBytes > 0 && state.maxSignalBytes < state.perBlockSlot)
+        ? (state.maxSignalBytes & ~15ULL)
+        : state.perBlockSlot;
+    if (state.chunkSize == 0) {
+      state.chunkSize = state.perBlockSlot;
+    }
+#endif
+  }
+
+  /**
+   * Reserve a non-overlapping protocol byte range for one progress state.
+   *
+   * Blocking send()/recv() read `stepState` at call entry and commit it at
+   * completion. Progress init cannot wait until completion because progress
+   * operations may complete across many bounded calls. Reserving at init gives
+   * the transport-owned state a stable byte-stream base and makes later
+   * blocking calls start after all in-flight progress ranges.
+   */
+  __device__ __forceinline__ int64_t reserve_progress_step(
+      ThreadGroup& group,
+      int stepIndex,
+      std::size_t nbytes) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    uint64_t baseStep = 0;
+    if (group.is_leader()) {
+      baseStep = static_cast<uint64_t>(sendRecvState_.stepState[stepIndex]);
+      sendRecvState_.stepState[stepIndex] =
+          static_cast<int64_t>(baseStep + nbytes);
+    }
+    baseStep = group.broadcast<uint64_t>(baseStep);
+    return static_cast<int64_t>(baseStep);
+#else
+    (void)group;
+    (void)stepIndex;
+    (void)nbytes;
+    return 0;
+#endif
+  }
+
+  /**
+   * Trap if a send progress state is not in a sender-owned stage.
+   *
+   * Without this check, corrupted or mismatched transport-owned state could
+   * return `Waiting` forever because no send-side transition would match.
+   * Trapping turns that misuse into an immediate device failure with a clear
+   * diagnostic.
+   */
+  __device__ __forceinline__ void validate_send_progress_stage(
+      ThreadGroup& group,
+      const detail::IbSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.stage != detail::IbSendRecvProgressStage::WaitNicDone &&
+        state.stage != detail::IbSendRecvProgressStage::WaitSlotFree &&
+        state.stage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
+            static_cast<int>(state.stage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Trap if a recv progress state is not in a receiver-owned stage.
+   *
+   * Receiver progress is only valid while waiting for DATA_READY. Sender
+   * stages are protocol misuse and cannot make progress on the recv path.
+   */
+  __device__ __forceinline__ void validate_recv_progress_stage(
+      ThreadGroup& group,
+      const detail::IbSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.stage != detail::IbSendRecvProgressStage::WaitDataReady &&
+        state.stage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
+            static_cast<int>(state.stage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Return whether `current -> next` is a valid progress-state transition.
+   */
+  __device__ __forceinline__ bool is_valid_progress_transition(
+      detail::IbSendRecvProgressStage current,
+      detail::IbSendRecvProgressStage next) const {
+    switch (current) {
+      case detail::IbSendRecvProgressStage::WaitNicDone:
+        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
+      case detail::IbSendRecvProgressStage::WaitSlotFree:
+        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
+            next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::WaitDataReady:
+        return next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::Done:
+        return false;
+    }
+    return false;
+  }
+
+  /**
+   * Apply one legal progress-state transition.
+   *
+   * The explicit transition table keeps the send/recv state machine local and
+   * auditable. If future progress states are added, this switch must opt into
+   * each new legal edge instead of allowing silent fallthrough.
+   */
+  __device__ __forceinline__ void transition_progress_stage(
+      ThreadGroup& group,
+      detail::IbSendRecvProgressState& state,
+      detail::IbSendRecvProgressStage next) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const detail::IbSendRecvProgressStage current = state.stage;
+    if (!is_valid_progress_transition(current, next)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
+            static_cast<int>(current),
+            static_cast<int>(next));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    state.stage = next;
+#endif
+  }
+
+  /**
+   * Map the state's logical byte cursor to the next staging-ring chunk.
+   *
+   * The transport stores each logical slot as `dataBufferSize` bytes, split
+   * into `activeBlocks` per-group partitions. The protocol cursor advances in
+   * bytes, not slots, so `baseStep + nextByte` is reduced modulo
+   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
+   *
+   * The returned chunk is clipped by three boundaries: the configured
+   * sub-chunk size, remaining user bytes, and remaining bytes in the current
+   * per-block staging partition. This keeps every progress call bounded and
+   * prevents a single RDMA put or recv copy from spanning two staging slots.
+   */
+  __device__ __forceinline__ ProgressChunk
+  next_chunk(const detail::IbSendRecvProgressState& state) const {
+    const uint64_t streamStart =
+        static_cast<uint64_t>(state.baseStep) + state.nextByte;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / state.perBlockSlot);
+    const std::size_t slotOff =
+        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+    const std::size_t chunkOff =
+        pipelineOff - static_cast<std::size_t>(slot) * state.perBlockSlot;
+    const std::size_t slotRemaining = state.perBlockSlot - chunkOff;
+    const std::size_t dataRemaining = state.nbytes - state.nextByte;
+    std::size_t bytes =
+        state.chunkSize < dataRemaining ? state.chunkSize : dataRemaining;
+    bytes = bytes < slotRemaining ? bytes : slotRemaining;
+    return ProgressChunk{
+        .stagingOff = slotOff +
+            static_cast<std::size_t>(state.groupId) * state.perBlockSlot +
+            chunkOff,
+        .dataOff = state.nextByte,
+        .bytes = bytes,
+        .streamEnd = streamStart + bytes,
+    };
+  }
+
   struct NicQpIndex {
     int nic_id;
     int qp_id;

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cc
@@ -1002,6 +1002,221 @@ TEST_F(MultipeerIbgdaTransportTestFixture, PutSignalCounter) {
   }
 }
 
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    ProgressInitReservesTransportStepRanges) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "progress send/recv is not supported for this build";
+  }
+
+  const std::size_t sendBytes = 4 * 1024;
+  const std::size_t recvBytes = 12 * 1024;
+  const std::size_t dataBufferSize = 64 * 1024;
+  const int pipelineDepth = 2;
+  const int numBlocks = 1;
+  const int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .dataBufferSize = dataBufferSize,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = numBlocks,
+                .pipelineDepth = pipelineDepth,
+            },
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer outputBuffer(2 * sizeof(int64_t));
+    auto* d_output = static_cast<int64_t*>(outputBuffer.get());
+    CUDACHECK_TEST(cudaMemset(d_output, 0, 2 * sizeof(int64_t)));
+
+    test::testProgressReservations(
+        peerTransportPtr,
+        d_output,
+        sendBytes,
+        recvBytes,
+        numBlocks,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::array<int64_t, 2> output{};
+    CUDACHECK_TEST(cudaMemcpy(
+        output.data(),
+        d_output,
+        output.size() * sizeof(int64_t),
+        cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(output[0], static_cast<int64_t>(sendBytes));
+    EXPECT_EQ(output[1], static_cast<int64_t>(recvBytes));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_F(
+    MultipeerIbgdaTransportTestFixture,
+    ProgressSendRecvCompatibleWithBlockingSendRecv) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "progress send/recv is not supported for this build";
+  }
+
+  const std::size_t nbytes = 192 * 1024;
+  const std::size_t dataBufferSize = 64 * 1024;
+  const std::size_t maxSignalBytes = 4 * 1024;
+  const int pipelineDepth = 2;
+  const int numBlocks = 1;
+  const int blockSize = 128;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const uint8_t rank0Pattern = 0x34;
+  const uint8_t rank1Pattern = 0x89;
+
+  try {
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .dataBufferSize = dataBufferSize,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = numBlocks,
+                .pipelineDepth = pipelineDepth,
+            },
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer sendBuffer(nbytes);
+    DeviceBuffer recvBuffer(nbytes);
+    DeviceBuffer errorCountBuf(sizeof(int));
+    auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+
+    if (globalRank == 0) {
+      test::fillBufferWithPattern(
+          sendBuffer.get(), nbytes, rank0Pattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      test::testProgressSendRecv(
+          peerTransportPtr,
+          sendBuffer.get(),
+          nbytes,
+          numBlocks,
+          maxSignalBytes,
+          true,
+          numBlocks,
+          blockSize);
+    } else {
+      test::testSendRecv(
+          peerTransportPtr,
+          recvBuffer.get(),
+          nbytes,
+          numBlocks,
+          maxSignalBytes,
+          false,
+          numBlocks,
+          blockSize);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          recvBuffer.get(),
+          nbytes,
+          rank0Pattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0) << "progress send to blocking recv corrupted "
+                                 << h_errorCount << " bytes";
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      test::fillBufferWithPattern(
+          sendBuffer.get(), nbytes, rank1Pattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(recvBuffer.get(), 0, nbytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 1) {
+      test::testSendRecv(
+          peerTransportPtr,
+          sendBuffer.get(),
+          nbytes,
+          numBlocks,
+          maxSignalBytes,
+          true,
+          numBlocks,
+          blockSize);
+    } else {
+      test::testProgressSendRecv(
+          peerTransportPtr,
+          recvBuffer.get(),
+          nbytes,
+          numBlocks,
+          maxSignalBytes,
+          false,
+          numBlocks,
+          blockSize);
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    if (globalRank == 0) {
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          recvBuffer.get(),
+          nbytes,
+          rank1Pattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0) << "blocking send to progress recv corrupted "
+                                 << h_errorCount << " bytes";
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
 // =============================================================================
 // Reset Signal Test - Tests resetting signals for reuse
 // =============================================================================

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cu
@@ -311,6 +311,156 @@ void testPutOnly(
 }
 
 // =============================================================================
+// Kernel: Blocking send/recv and resumable progress send/recv
+// =============================================================================
+
+bool supportsProgressSendRecv() {
+#ifdef __HIP_PLATFORM_AMD__
+  return false;
+#else
+  return true;
+#endif
+}
+
+__global__ void sendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    transport->send(
+        group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout);
+  } else {
+    transport->recv(
+        group, buffer, nbytes, activeBlocks, maxSignalBytes, timeout);
+  }
+}
+
+void testSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+  sendRecvKernel<<<numBlocks, blockSize>>>(
+      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void progressSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+  if (send) {
+    transport->init_send_progress(group, nbytes, activeBlocks, maxSignalBytes);
+    while (transport->progress_send_once(group, buffer, timeout) !=
+           IbgdaSendRecvProgressStatus::Done) {
+    }
+  } else {
+    transport->init_recv_progress(group, nbytes, activeBlocks, maxSignalBytes);
+    while (transport->progress_recv_once(group, buffer, timeout) !=
+           IbgdaSendRecvProgressStatus::Done) {
+    }
+  }
+}
+
+__global__ void progressReservationKernel(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* output,
+    std::size_t sendBytes,
+    std::size_t recvBytes,
+    int activeBlocks) {
+  auto group = make_block_group();
+  transport->init_send_progress(group, sendBytes, activeBlocks);
+  transport->init_recv_progress(group, recvBytes, activeBlocks);
+
+  if (group.is_leader()) {
+    const auto& sendRecvState = transport->send_recv_state();
+    output[0] = sendRecvState.stepState[group.group_id];
+    output[1] =
+        sendRecvState.stepState[sendRecvState.maxGroups + group.group_id];
+  }
+}
+#endif
+
+void testProgressSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)buffer;
+  (void)nbytes;
+  (void)activeBlocks;
+  (void)maxSignalBytes;
+  (void)send;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("progress send/recv is NVIDIA-only");
+#else
+  progressSendRecvKernel<<<numBlocks, blockSize>>>(
+      transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+void testProgressReservations(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* output,
+    std::size_t sendBytes,
+    std::size_t recvBytes,
+    int activeBlocks,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)output;
+  (void)sendBytes;
+  (void)recvBytes;
+  (void)activeBlocks;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("progress send/recv is NVIDIA-only");
+#else
+  progressReservationKernel<<<numBlocks, blockSize>>>(
+      transport, output, sendBytes, recvBytes, activeBlocks);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+#endif
+}
+
+// =============================================================================
 // Kernel: Fill buffer with pattern
 // =============================================================================
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.cuh
@@ -71,6 +71,31 @@ __global__ void putOnlyKernel(
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes);
 
+__global__ void sendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send);
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void progressSendRecvKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send);
+
+__global__ void progressReservationKernel(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* output,
+    std::size_t sendBytes,
+    std::size_t recvBytes,
+    int activeBlocks);
+#endif
+
 __global__ void
 fillPatternKernel(uint8_t* buffer, std::size_t nbytes, uint8_t baseValue);
 

--- a/comms/pipes/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/pipes/tests/MultipeerIbgdaTransportTest.h
@@ -116,6 +116,50 @@ void testPutOnly(
     int blockSize);
 
 /**
+ * Return whether resumable send/recv progress kernels are available.
+ */
+bool supportsProgressSendRecv();
+
+/**
+ * Test kernel: Blocking pipelined send or recv.
+ */
+void testSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: Resumable pipelined send or recv progress loop.
+ */
+void testProgressSendRecv(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    std::size_t maxSignalBytes,
+    bool send,
+    int numBlocks,
+    int blockSize);
+
+/**
+ * Test kernel: initialize transport-owned send/recv progress state and report
+ * the reserved byte cursors.
+ */
+void testProgressReservations(
+    P2pIbgdaTransportDevice* transport,
+    int64_t* output,
+    std::size_t sendBytes,
+    std::size_t recvBytes,
+    int activeBlocks,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Fill a device buffer with a pattern based on index
  */
 void fillBufferWithPattern(

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1806,6 +1806,19 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
+ - name        : NCCL_CTRAN_MAX_NBLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Maximum number of logical CUDA blocks used by CTRAN collectives that support message-size-based block tuning.
+
+ - name        : NCCL_CTRAN_TREE_FANOUT
+   type        : int
+   default     : 2
+   description : |-
+     Fanout used when building CTREE tree topologies for experimental benchmarking.
+     Valid values are 1 through the compile-time maximum tree children.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false


### PR DESCRIPTION
Summary:

Add `CtranAllReduceTest`, an algorithm-agnostic distributed AllReduce correctness matrix for CTREE-style implementations. The test parameterizes algorithm, topology, datatype, and message size, validates FP32/FP16 reduction results with explicit error margins, and checks deterministic output by hashing repeated identical runs.

The matrix covers `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies. Local `IB_ONLY` uses the no-local debug topology to force the IB path on a single H100 host; `HYBRID_2x8` is intended for RE multi-node placement.

Differential Revision: D105589768


