### PR TITLE
Gate ctgraph AG RD variants on power-of-two topology (#2653)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -6,6 +6,7 @@
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
+#include "comms/ctran/utils/MathUtils.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 static bool isGraphAwareAlgo(enum NCCL_ALLGATHER_ALGO algo) {
@@ -151,6 +152,30 @@ bool ctranAllGatherSupport(
             "Falling back to baseline",
             allGatherAlgoName(algo),
             statex->nLocalRanks());
+        supported = false;
+        break;
+      }
+      if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline &&
+          !ctran::utils::isPowerOfTwo(statex->nNodes())) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires power-of-2 nNodes, got {}. "
+            "Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nNodes());
+        supported = false;
+        break;
+      }
+      if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rd &&
+          !ctran::utils::isPowerOfTwo(statex->nRanks())) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires power-of-2 nRanks, got {}. "
+            "Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks());
         supported = false;
         break;
       }

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -3,12 +3,12 @@
 // Cudagraph-aware AllGather: when ctranAllGather() is called during CUDA graph
 // capture with a ctgraph* algorithm, this module handles buffer registration
 // and algorithm dispatch. The algo is either explicitly specified
-// (ctgraph_pipeline, ctgraph_ring, ctgraph_rd) or auto-selected by
-// selectCtgraphAlgo() based on topology and message size.
+// (ctgraph_pipeline, ctgraph_rdpipeline, ctgraph_ring, ctgraph_rd) or
+// auto-selected by selectCtgraphAlgo() based on topology and message size.
 //
 // Two registration strategies:
 //
-//   winPersistBuffReg (ctgraph_pipeline, nLocalRanks > 1):
+//   winPersistBuffReg (ctgraph_pipeline/rdpipeline, nLocalRanks > 1):
 //     Both local and remote addresses must be stable across replays.
 //     Uses window: ctranWinRegister → allGatherWinInit → allGatherWinExec.
 //
@@ -29,6 +29,7 @@
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
+#include "comms/ctran/utils/MathUtils.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -72,12 +73,15 @@ commResult_t localPersistBuffReg(void* recvbuff, size_t recvBytes) {
 enum NCCL_ALLGATHER_ALGO selectCtgraphAlgo(
     size_t sendBytes,
     const ncclx::CommStateX* statex) {
+  const bool largeMessage = sendBytes >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
   if (statex->nLocalRanks() > 1) {
-    return NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
+    return (!largeMessage && ctran::utils::isPowerOfTwo(statex->nNodes()))
+        ? NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline
+        : NCCL_ALLGATHER_ALGO::ctgraph_pipeline;
   }
-  return (sendBytes >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD)
-      ? NCCL_ALLGATHER_ALGO::ctgraph_ring
-      : NCCL_ALLGATHER_ALGO::ctgraph_rd;
+  return (!largeMessage && ctran::utils::isPowerOfTwo(statex->nRanks()))
+      ? NCCL_ALLGATHER_ALGO::ctgraph_rd
+      : NCCL_ALLGATHER_ALGO::ctgraph_ring;
 }
 
 } // namespace

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -13,6 +13,7 @@
 #include "comms/ctran/tests/VerifyAlgoStatsUtil.h"
 #include "comms/ctran/tests/cudagraph/CtranCudaGraphParamTest.h"
 #include "comms/ctran/utils/Alloc.h"
+#include "comms/ctran/utils/MathUtils.h"
 
 #define NCCLCHECK_TEST_BENCH(cmd)                                         \
   do {                                                                    \
@@ -54,11 +55,13 @@ static AlgoDescriptor makeAllGatherCtgraph(
         statex->nLocalRanks() > 1) {
       return false;
     }
-    if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline) {
-      const auto nNodes = statex->nNodes();
-      if (nNodes > 1 && (nNodes & (nNodes - 1)) != 0) {
-        return false;
-      }
+    if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline &&
+        !ctran::utils::isPowerOfTwo(statex->nNodes())) {
+      return false;
+    }
+    if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rd &&
+        !ctran::utils::isPowerOfTwo(statex->nRanks())) {
+      return false;
     }
     return true;
   };
@@ -131,12 +134,15 @@ TEST_P(CudaGraphAllGatherCtgraphExpandable, CaptureReplayVerify) {
       statex->nLocalRanks() > 1) {
     GTEST_SKIP() << allGatherAlgoName(algo) << " requires nLocalRanks == 1";
   }
-  if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline) {
-    const auto nNodes = statex->nNodes();
-    if (nNodes > 1 && (nNodes & (nNodes - 1)) != 0) {
-      GTEST_SKIP() << allGatherAlgoName(algo)
-                   << " requires nNodes to be a power of 2";
-    }
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline &&
+      !ctran::utils::isPowerOfTwo(statex->nNodes())) {
+    GTEST_SKIP() << allGatherAlgoName(algo)
+                 << " requires nNodes to be a power of 2";
+  }
+  if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rd &&
+      !ctran::utils::isPowerOfTwo(statex->nRanks())) {
+    GTEST_SKIP() << allGatherAlgoName(algo)
+                 << " requires nRanks to be a power of 2";
   }
 
   const int nRanks = numRanks;
@@ -209,13 +215,13 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Verifies ctgraph auto-select picks the correct algorithm based on topology
 // and message size. Parameterized by sendcount (element count).
-// nLocalRanks > 1 → pipeline; nLocalRanks == 1 + small msg → rd;
-// nLocalRanks == 1 + large msg (>= threshold) → ring.
+// nLocalRanks > 1 + small msg + power-of-2 nNodes → rdpipeline;
+// nLocalRanks > 1 + large msg or non-power-of-2 nNodes → pipeline;
+// nLocalRanks == 1 + small msg + power-of-2 nRanks → rd/ctsrd;
+// nLocalRanks == 1 + large msg or non-power-of-2 nRanks → ring.
 struct AutoSelectParam {
   std::string name;
   size_t count;
-  std::string expectedAlgoWhenLocal;
-  std::string expectedAlgoWhenNolocal;
 };
 
 class CudaGraphAllGatherCtgraphAutoSelect
@@ -242,12 +248,6 @@ TEST_P(CudaGraphAllGatherCtgraphAutoSelect, CaptureReplayVerify) {
   const size_t count = param.count;
   const int nRanks = numRanks;
   const auto statex = comm->statex_.get();
-
-  // Large msg test only meaningful with nLocalRanks == 1
-  if (count * sizeof(int32_t) >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD &&
-      statex->nLocalRanks() > 1) {
-    GTEST_SKIP() << "Large message ring test requires nLocalRanks == 1";
-  }
 
   ctran::TestDeviceBuffer send(count * sizeof(int32_t));
   ctran::TestDeviceBuffer recv(count * nRanks * sizeof(int32_t));
@@ -278,9 +278,15 @@ TEST_P(CudaGraphAllGatherCtgraphAutoSelect, CaptureReplayVerify) {
 
   verifyAllGather(recv.get(), count, nRanks);
 
-  const auto& expectedAlgo = (statex->nLocalRanks() > 1)
-      ? param.expectedAlgoWhenLocal
-      : param.expectedAlgoWhenNolocal;
+  const bool largeMessage =
+      count * sizeof(int32_t) >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
+  const std::string expectedAlgo = (statex->nLocalRanks() > 1)
+      ? ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nNodes()))
+             ? "RecDbl"
+             : "Pipeline")
+      : ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nRanks()))
+             ? "StreamedRd"
+             : "Ring");
   algoStats_.verify(comm.get(), "AllGather", expectedAlgo);
 
   ASSERT_EQ(cudaGraphExecDestroy(exec), cudaSuccess);
@@ -296,8 +302,8 @@ INSTANTIATE_TEST_SUITE_P(
     CudaGraphAllGatherCtgraphAutoSelectTests,
     CudaGraphAllGatherCtgraphAutoSelect,
     ::testing::Values(
-        AutoSelectParam{"SmallMsg", 1024, "Pipeline", "Rd"},
-        AutoSelectParam{"LargeMsg", kRingThresholdCount, "Pipeline", "Ring"}),
+        AutoSelectParam{"SmallMsg", 1024},
+        AutoSelectParam{"LargeMsg", kRingThresholdCount}),
     [](const ::testing::TestParamInfo<AutoSelectParam>& info) {
       return info.param.name;
     });

--- a/comms/ctran/utils/MathUtils.h
+++ b/comms/ctran/utils/MathUtils.h
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <type_traits>
+
+namespace ctran::utils {
+
+template <typename T>
+constexpr bool isPowerOfTwo(T value) {
+  static_assert(std::is_integral_v<T>);
+  return value > T{0} && (value & (value - T{1})) == T{0};
+}
+
+} // namespace ctran::utils


### PR DESCRIPTION
Summary:

Update `ctgraph` AllGather auto-selection so local multi-rank captures use `ctgraph_rdpipeline` only for small messages with power-of-two `nNodes`, otherwise `ctgraph_pipeline`, and no-local captures use `ctgraph_rd` only for small messages with power-of-two `nRanks`, otherwise `ctgraph_ring`. Add matching explicit support checks and update the cudagraph ctgraph test expectations.

Reviewed By: minsii

Differential Revision: D105740855


