### PR TITLE
Reland: [ctran] Register cthierarchical_ring AllGather with topology/transport validation, overlap/fused dispatch, and build system Pipes dependency refactor (#2655)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -36,7 +36,9 @@ bool ctranAllGatherSupport(
     CtranComm* comm,
     enum NCCL_ALLGATHER_ALGO algo,
     cudaStream_t stream) {
-  if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
+  const bool pipesAlgo = algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  if (!ctranInitialized(comm) ||
+      (!pipesAlgo && !comm->ctran_->mapper->hasBackend())) {
     return false;
   }
 
@@ -56,12 +58,58 @@ bool ctranAllGatherSupport(
             allGatherAlgoName(algo));
       }
       break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+#if defined(ENABLE_PIPES)
+      if (statex->nRanks() <= 1 || statex->nNodes() <= 1) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires multiple nodes, got nRanks={} nNodes={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes());
+        supported = false;
+        break;
+      }
+      if (statex->nLocalRanks() < 1 ||
+          statex->nRanks() != statex->nNodes() * statex->nLocalRanks()) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes(),
+            statex->nLocalRanks());
+        supported = false;
+        break;
+      }
+      if (!comm->multiPeerTransport_) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      supported = true;
+#else
+      supported = false;
+#endif
+      break;
     case NCCL_ALLGATHER_ALGO::ctdirect:
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
-      break;
-    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      supported = false;
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -178,10 +226,8 @@ commResult_t ctranAllGather(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      FB_ERRORRETURN(
-          commInvalidUsage,
-          "AllGather {} not registered in this build layer",
-          allGatherAlgoName(algo));
+      return ctranAllGatherHierarchicalRing(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -1,0 +1,408 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/colltrace/CollTraceWrapper.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/AllGatherLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+static const auto myAlgo = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+using ::meta::comms::colltrace::CollTraceHandleTriggerState;
+
+namespace {
+
+commResult_t validateHierarchicalRingParams(CtranComm* comm, int numBlocks) {
+  if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  const auto dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+  if (dataBufferSize == 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires a positive IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or per-communicator pipesIbgdaDataBufferSize",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+  if (numBlocks <= 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires positive NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS; got {}",
+        allGatherAlgoName(myAlgo),
+        numBlocks);
+    return commInvalidArgument;
+  }
+  if (numBlocks > NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} numBlocks={} exceeds NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+        allGatherAlgoName(myAlgo),
+        numBlocks,
+        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+    return commInvalidArgument;
+  }
+  if (dataBufferSize / static_cast<uint64_t>(numBlocks) < 16) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} dataBufferSize={} is too small for numBlocks={}",
+        allGatherAlgoName(myAlgo),
+        dataBufferSize,
+        numBlocks);
+    return commInvalidArgument;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  if (nRanks <= 1 || nNodes <= 1) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires multiple nodes, got nRanks={} nNodes={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks < 1 || nRanks != static_cast<int64_t>(nNodes) * nLocalRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes,
+        nLocalRanks);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks > comms::pipes::kDirectNvlMaxRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} nLocalRanks={} exceeds direct NVLink peer capacity {}",
+        allGatherAlgoName(myAlgo),
+        nLocalRanks,
+        comms::pipes::kDirectNvlMaxRanks);
+    return commInvalidArgument;
+  }
+
+  for (int node = 0; node < nNodes; ++node) {
+    for (int localRank = 0; localRank < nLocalRanks; ++localRank) {
+      const int expectedRank = node * nLocalRanks + localRank;
+      const int rank = statex->localRankToRank(localRank, node);
+      if (rank != expectedRank) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires contiguous node-major rank layout; localRankToRank({}, {})={} expected {}",
+            allGatherAlgoName(myAlgo),
+            localRank,
+            node,
+            rank,
+            expectedRank);
+        return commInvalidArgument;
+      }
+    }
+  }
+
+  if (!comm->multiPeerTransport_) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  const int myNode = statex->node();
+  const int localRank = statex->localRank();
+  auto rings = comms::pipes::make_standard_rings(nNodes, myNode, 1);
+  if (!rings.has_value()) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} cannot construct IB ring for {} nodes",
+        allGatherAlgoName(myAlgo),
+        nNodes);
+    return commInvalidArgument;
+  }
+  const auto& ibRing = (*rings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  if (!mpt->has_ibgda(prevGlobal) || !mpt->has_ibgda(nextGlobal)) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires IBGDA prev/next transports; prev {} has_ibgda={} next {} has_ibgda={}",
+        allGatherAlgoName(myAlgo),
+        prevGlobal,
+        mpt->has_ibgda(prevGlobal),
+        nextGlobal,
+        mpt->has_ibgda(nextGlobal));
+    return commInvalidArgument;
+  }
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    if (!mpt->is_nvl_peer(peerGlobal)) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires NVLink transport to local peer globalRank={} localRank={}",
+          allGatherAlgoName(myAlgo),
+          peerGlobal,
+          peerLocal);
+      return commInvalidArgument;
+    }
+  }
+
+  return commSuccess;
+}
+
+commResult_t ensureReadyCounterCapacity(
+    CtranComm* comm,
+    size_t counterCount,
+    cudaStream_t stream) {
+  if (counterCount == 0) {
+    return commSuccess;
+  }
+  if (comm->hierarchicalAgReadyCounterCount_ >= counterCount &&
+      comm->hierarchicalAgReadyCounters_ != nullptr) {
+    return commSuccess;
+  }
+
+  if (comm->hierarchicalAgReadyCounters_ != nullptr) {
+    FB_CUDACHECK(cudaFree(comm->hierarchicalAgReadyCounters_));
+    comm->hierarchicalAgReadyCounters_ = nullptr;
+    comm->hierarchicalAgReadyCounterCount_ = 0;
+  }
+
+  void* ptr = nullptr;
+  FB_CUDACHECK(cudaMalloc(&ptr, counterCount * sizeof(uint64_t)));
+  comm->hierarchicalAgReadyCounters_ = static_cast<uint64_t*>(ptr);
+  comm->hierarchicalAgReadyCounterCount_ = counterCount;
+  FB_CUDACHECK(cudaMemsetAsync(
+      comm->hierarchicalAgReadyCounters_,
+      0,
+      counterCount * sizeof(uint64_t),
+      stream));
+  return commSuccess;
+}
+
+} // namespace
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  CTRAN_COLL_INFO(
+      allGatherAlgoName(myAlgo).c_str(),
+      sendbuff,
+      recvbuff,
+      sendcount,
+      datatype,
+      -1,
+      comm,
+      stream);
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  const int localRank = statex->localRank();
+  const int node = statex->node();
+  const size_t sendBytes = sendcount * commTypeSize(datatype);
+
+  if (nRanks == 1) {
+    if (sendBytes > 0 && sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff, sendbuff, sendBytes, cudaMemcpyDefault, stream));
+    }
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+  if (sendBytes == 0) {
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+
+  const bool useOverlap = NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1;
+  const int numBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS);
+  const int nvlNumBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS);
+  FB_COMMCHECK(validateHierarchicalRingParams(comm, numBlocks));
+  if (useOverlap) {
+    if (nvlNumBlocks <= 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS; got {}",
+          allGatherAlgoName(myAlgo),
+          nvlNumBlocks);
+      return commInvalidArgument;
+    }
+    if (static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES) == 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES",
+          allGatherAlgoName(myAlgo));
+      return commInvalidArgument;
+    }
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  auto ibRings = comms::pipes::make_standard_rings(nNodes, node, 1);
+  if (!ibRings.has_value()) {
+    return commInvalidArgument;
+  }
+
+  comms::pipes::HierarchicalAllgatherLaunchParams params{};
+  params.num_ranks = nRanks;
+  params.ib_rank = node;
+  params.ib_size = nNodes;
+  params.nvl_rank = localRank;
+  params.nvl_size = nLocalRanks;
+  // Pipes allgather kernels operate on byte-addressed char buffers.
+  params.sendcount = sendBytes;
+  params.ib_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES);
+  params.nvl_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES);
+  params.sendbuf = static_cast<const char*>(sendbuff);
+  params.recvbuf = static_cast<char*>(recvbuff);
+  params.ib_num_blocks = numBlocks;
+  params.timeout_ms = NCCL_CTRAN_HIER_AG_TIMEOUT_MS;
+  params.stream = stream;
+
+  const auto& ibRing = (*ibRings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  params.ib_ring.prev_rank = ibRing.prev_rank;
+  params.ib_ring.next_rank = ibRing.next_rank;
+  params.ib_ring.prev = mpt->get_p2p_ibgda_transport_device(prevGlobal);
+  params.ib_ring.next = mpt->get_p2p_ibgda_transport_device(nextGlobal);
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    new (&params.nvl_peers[peerLocal]) comms::pipes::P2pNvlTransportDevice(
+        mpt->get_p2p_nvl_transport_device(peerGlobal));
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLGATHER,
+      stream,
+      allGatherAlgoName(myAlgo),
+      comm->ctran_->getOpCount());
+  ctranKernelSetAllGatherArgs(
+      sendbuff,
+      recvbuff,
+      datatype,
+      sendcount,
+      comm->ctran_->algo->getDevState(),
+      &config.args);
+
+  std::vector<std::unique_ptr<struct OpElem>> emptyOpGroup;
+  auto colltraceHandle =
+      meta::comms::colltrace::getCollTraceHandle(comm, emptyOpGroup, config);
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  }
+  comm->recordAlgoStats("AllGather", allGatherAlgoName(myAlgo));
+
+  if (useOverlap) {
+    comms::pipes::HierarchicalAllgatherOverlapLaunchParams overlapParams{};
+    overlapParams.num_ranks = params.num_ranks;
+    overlapParams.ib_rank = params.ib_rank;
+    overlapParams.ib_size = params.ib_size;
+    overlapParams.nvl_rank = params.nvl_rank;
+    overlapParams.nvl_size = params.nvl_size;
+    overlapParams.sendcount = params.sendcount;
+    overlapParams.ib_signaling_data_size = params.ib_signaling_data_size;
+    overlapParams.nvl_signaling_data_size = params.nvl_signaling_data_size;
+    overlapParams.chunk_bytes =
+        static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES);
+    overlapParams.ready_sequence = comm->ctran_->getOpCount() + 1;
+    overlapParams.sendbuf = params.sendbuf;
+    overlapParams.recvbuf = params.recvbuf;
+    overlapParams.ib_num_blocks = params.ib_num_blocks;
+    overlapParams.nvl_num_blocks = nvlNumBlocks;
+    overlapParams.timeout_ms = params.timeout_ms;
+    overlapParams.stream = params.stream;
+    overlapParams.ib_ring = params.ib_ring;
+    for (int peer = 0; peer < nLocalRanks; ++peer) {
+      if (peer == localRank) {
+        continue;
+      }
+      new (&overlapParams.nvl_peers[peer])
+          comms::pipes::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    const size_t totalChunks =
+        (sendBytes + overlapParams.chunk_bytes - 1) / overlapParams.chunk_bytes;
+    const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
+    FB_COMMCHECK(
+        ensureReadyCounterCapacity(comm, readyCounters, overlapParams.stream));
+    overlapParams.ready_counters = comm->hierarchicalAgReadyCounters_;
+    comms::pipes::launch_hierarchical_allgather_overlap(overlapParams);
+  } else {
+    comms::pipes::launch_hierarchical_allgather_fused(params);
+  }
+  FB_CUDACHECK(cudaGetLastError());
+
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  }
+  comm->ctran_->updateOpCount();
+
+  return commSuccess;
+}
+
+#else // !ENABLE_PIPES
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* /*sendbuff*/,
+    void* /*recvbuff*/,
+    size_t /*sendcount*/,
+    commDataType_t /*datatype*/,
+    CtranComm* /*comm*/,
+    cudaStream_t /*stream*/) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -48,6 +48,14 @@ commResult_t ctranAllGatherBrucksFF(
     CtranComm* comm,
     cudaStream_t stream);
 
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 static inline const std::string allGatherAlgoName(
     enum NCCL_ALLGATHER_ALGO algo) {
   switch (algo) {
@@ -61,6 +69,8 @@ static inline const std::string allGatherAlgoName(
       return "CtranAllGatherRing";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "CtranBrucksFF";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "CtranAllGatherHierarchicalRing";
     case NCCL_ALLGATHER_ALGO::ctran:
       return "CtranAuto";
     case NCCL_ALLGATHER_ALGO::ctgraph:

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -156,6 +156,17 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   std::unique_ptr<CtranComm> ctranComm{nullptr};
 };
 
+namespace {
+
+const ctran::CtranEnvs kHierarchicalRingEnvs = {
+    {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+    {"NCCL_CTRAN_USE_PIPES", "1"},
+    {"NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1"},
+    {"NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432"},
+};
+
+} // namespace
+
 // Param: (CtranEnvs, (algo, offset, count, inplace, memType, iter, pairColl))
 using CtranAllgatherParams = std::tuple<
     enum NCCL_ALLGATHER_ALGO,
@@ -250,12 +261,15 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
         << " on rank " << globalRank << " received from peer " << i;
   }
 
+  std::vector<CtranMapperBackend> excludedBackends{CtranMapperBackend::NVL};
+  if (algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring) {
+    excludedBackends.push_back(CtranMapperBackend::IB);
+  }
   verifyBackendsUsed(
       ctranComm->ctran_.get(),
       ctranComm->statex_.get(),
       memType,
-      // AllGatherDirect uses kernel bcast not NVL iput
-      {CtranMapperBackend::NVL});
+      excludedBackends);
   verifyGpeLeak(ctranComm->ctran_.get());
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -439,6 +453,21 @@ INSTANTIATE_TEST_SUITE_P(
             testing::Values(kTestInPlace, kTestOutOfPlace),
             testing::Values(kCuMemAllocDisjoint),
             testing::Values(5),
+            testing::Values(kTestPairNone))),
+    getTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTestHierarchicalRing,
+    CtranAllgatherTestParam,
+    ::testing::Combine(
+        ::testing::Values(kHierarchicalRingEnvs),
+        ::testing::Combine(
+            testing::Values(NCCL_ALLGATHER_ALGO::cthierarchical_ring),
+            testing::Values(0),
+            testing::Values(8192, 1),
+            testing::Values(kTestInPlace, kTestOutOfPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(1),
             testing::Values(kTestPairNone))),
     getTestName);
 

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -12,6 +12,11 @@
 #include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/collectives/AllGatherDirect.cuh"
 
+// Keep the kernel definitions in this translation unit. Package builds link
+// this launcher as a standalone shared object, and CUDA kernel symbols are
+// hidden across that boundary.
+#include "AllGatherDirect.cu"
+
 namespace comms::pipes {
 
 namespace {


### PR DESCRIPTION
Summary:


Adds the ctran AllGather entry point for `NCCL_ALLGATHER_ALGO=cthierarchical_ring`. This diff connects the ctran dispatch layer to the Pipes hierarchical kernel added in D105521698, performing comprehensive topology and transport validation before launch, managing device-side ready counter resources, and dispatching to either the overlapped kernel (IB+NVLink concurrent) or the fused kernel (sequential phases) based on configuration.

## Dispatch Flow

```
ctranAllGather(algo=cthierarchical_ring)
|
+---> ctranAllGatherSupport()  [AllGather.cc]
|     |-- ctranInitialized?
|     |-- (skip mapper backend check for Pipes algorithms)
|     |-- nRanks > 1 && nNodes > 1?
|     |-- Rectangular geometry? (nRanks == nNodes * nLocalRanks)
|     |-- MultiPeerTransport initialized? (NCCL_CTRAN_USE_PIPES=1)
|     '-- IBGDA sendrecv enabled? (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1)
|
+---> ctranAllGatherHierarchicalRing()  [AllGatherHierarchicalRing.cc]
      |
      +-- CTRAN_COLL_INFO (logging)
      |
      +-- Degenerate cases:
      |   |-- nRanks == 1: cudaMemcpyAsync sendbuf->recvbuf, return
      |   '-- sendBytes == 0: no-op, return
      |
      +-- validateHierarchicalRingParams()
      |   |-- IBGDA sendrecv enabled?
      |   |-- Effective IBGDA data buffer size > 0?
      |   |   (per-communicator override takes precedence over CVAR)
      |   |-- numBlocks > 0 and <= SENDRECV_MAX_GROUPS?
      |   |-- dataBufferSize/numBlocks >= 16 bytes? (minimum staging)
      |   |-- Multi-node topology? (nRanks > 1, nNodes > 1)
      |   |-- Rectangular rank geometry? (nRanks == nNodes * nLocalRanks)
      |   |-- nLocalRanks <= kDirectNvlMaxRanks?
      |   |-- Contiguous node-major rank layout?
      |   |   (localRankToRank(lr, node) == node*nLocalRanks+lr for all)
      |   |-- MultiPeerTransport present?
      |   |-- IB ring constructible? (make_standard_rings succeeds)
      |   |-- IBGDA prev/next transports available for same-localRank ring?
      |   '-- NVLink transport to all local peers?
      |
      +-- Build launch params
      |   |-- IB ring: prev/next via make_standard_rings(nNodes, node, 1)
      |   |-- NVLink peers: localRankToRank(peerLocal) -> get_p2p_nvl_transport_device()
      |   |-- sendcount, signal bytes, timeout from CVARs
      |   '-- stream from caller
      |
      +-- KernelConfig + colltrace (BeforeEnqueueKernel / AfterEnqueueKernel)
      +-- recordAlgoStats("AllGather", "CtranAllGatherHierarchicalRing")
      |
      +-- Dispatch:
      |   |
      |   +-- OVERLAP_ENABLE && nLocalRanks > 1?
      |   |   |
      |   |   YES: Build HierarchicalAllgatherOverlapLaunchParams
      |   |        |-- ready_sequence = opCount + 1 (monotonic)
      |   |        |-- chunk_bytes from NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES
      |   |        |-- ensureReadyCounterCapacity(nNodes * totalChunks)
      |   |        '-- launch_hierarchical_allgather_overlap()
      |   |
      |   |   NO:  launch_hierarchical_allgather_fused()
      |   |        (sequential IB ring then NVLink fanout)
      |
      +-- cudaGetLastError() (synchronous launch error check)
      +-- colltrace AfterEnqueueKernel
      '-- updateOpCount()
```

## Detailed Changes

### 1. Entry Point (`AllGatherHierarchicalRing.cc`, ~416 lines)

New file guarded by `#if defined(ENABLE_PIPES)`:
- **`effectiveIbgdaDataBufferSize()`**: Returns the per-communicator override if positive, otherwise falls back to `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` CVAR
- **`validateHierarchicalRingParams()`**: Comprehensive pre-launch validation covering IBGDA configuration, topology geometry, rank layout, and transport availability (13 individual checks with descriptive WARN logs on failure)
- **`ensureReadyCounterCapacity()`**: Lazily allocates or grows the `hierarchicalAgReadyCounters_` device buffer via `cudaMalloc`/`cudaMemsetAsync`, with proper cleanup of previous allocations
- **`ctranAllGatherHierarchicalRing()`**: Main entry point that orchestrates validation, launch param construction, colltrace integration, and dispatch

### 2. Support Checking (`AllGather.cc`)

- Adds `cthierarchical_ring` case to `ctranAllGatherSupport()` with topology and transport gate checks
- Bypasses `comm->ctran_->mapper->hasBackend()` check for Pipes-based algorithms (these don't use `CtranMapper`)
- Adds dispatch case in `ctranAllGather()` routing to `ctranAllGatherHierarchicalRing()`

### 3. Algorithm Name (`AllGatherImpl.h`)

- Adds `allGatherAlgoName(cthierarchical_ring)` returning `"CtranAllGatherHierarchicalRing"`
- Adds `ctranAllGatherHierarchicalRing()` function declaration

### 4. Ready Counter Management

- **Capacity tracking**: `hierarchicalAgReadyCounterCount_` tracks the allocated counter array size; counter count = `nNodes * ceil(sendBytes / chunk_bytes)`
- **Lazy growth**: `ensureReadyCounterCapacity()` only reallocates when the current capacity is insufficient
- **Initialization**: Counters zeroed via `cudaMemsetAsync` on the collective stream for proper stream ordering
- **Monotonic sequencing**: `ready_sequence = opCount + 1` ensures each collective uses a unique sequence value that is never zero

### 5. Build System Refactor (`def_build.bzl`)

Significant cleanup of the dependency and compiler flag organization:
- Extracts Pipes-specific deps into `CTRAN_PIPES_DEPS` -- gated by `CTRAN_ENABLE_PIPES` and `select(DEFAULT/ovr_config//gpu:amd)` -- adding `allgather_launcher` and `ring_utils`
- Extracts optional deps (compression, scuba) into `CTRAN_OPTIONAL_DEPS`
- Extracts Pipes compiler flags into `CTRAN_PIPES_INTERNAL_COMPILER_FLAGS` and `CTRAN_PIPES_EXPORTED_PREPROCESSOR_FLAGS`
- Combines all into clean `CTRAN_DEPS` and `CTRAN_COMMON_INTERNAL_COMPILER_FLAGS` lists using list concatenation
- Removes mutable `list.append()` / `list + select()` pattern in favor of immutable `(base + optional + pipes)` construction

Differential Revision: D106000685


