### PR TITLE
Reland: [ctran] Add AllGather NCCL-vs-ctran comparison benchmark with dual-communicator isolation, configurable algorithm/sizes, and per-rank max-latency timing (#2656)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -36,7 +36,9 @@ bool ctranAllGatherSupport(
     CtranComm* comm,
     enum NCCL_ALLGATHER_ALGO algo,
     cudaStream_t stream) {
-  if (!ctranInitialized(comm) || !comm->ctran_->mapper->hasBackend()) {
+  const bool pipesAlgo = algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  if (!ctranInitialized(comm) ||
+      (!pipesAlgo && !comm->ctran_->mapper->hasBackend())) {
     return false;
   }
 
@@ -56,12 +58,58 @@ bool ctranAllGatherSupport(
             allGatherAlgoName(algo));
       }
       break;
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+#if defined(ENABLE_PIPES)
+      if (statex->nRanks() <= 1 || statex->nNodes() <= 1) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires multiple nodes, got nRanks={} nNodes={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes());
+        supported = false;
+        break;
+      }
+      if (statex->nLocalRanks() < 1 ||
+          statex->nRanks() != statex->nNodes() * statex->nLocalRanks()) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}. Falling back to baseline",
+            allGatherAlgoName(algo),
+            statex->nRanks(),
+            statex->nNodes(),
+            statex->nLocalRanks());
+        supported = false;
+        break;
+      }
+      if (!comm->multiPeerTransport_) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+            allGatherAlgoName(algo));
+        supported = false;
+        break;
+      }
+      supported = true;
+#else
+      supported = false;
+#endif
+      break;
     case NCCL_ALLGATHER_ALGO::ctdirect:
     case NCCL_ALLGATHER_ALGO::ctran:
       supported = true;
-      break;
-    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      supported = false;
       break;
     case NCCL_ALLGATHER_ALGO::ctgraph:
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
@@ -178,10 +226,8 @@ commResult_t ctranAllGather(
           sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-      FB_ERRORRETURN(
-          commInvalidUsage,
-          "AllGather {} not registered in this build layer",
-          allGatherAlgoName(algo));
+      return ctranAllGatherHierarchicalRing(
+          sendbuff, recvbuff, sendcount, datatype, comm, stream);
 
     case NCCL_ALLGATHER_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -1,0 +1,408 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <vector>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/colltrace/CollTraceWrapper.h"
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/AllGatherLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+static const auto myAlgo = NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+using ::meta::comms::colltrace::CollTraceHandleTriggerState;
+
+namespace {
+
+commResult_t validateHierarchicalRingParams(CtranComm* comm, int numBlocks) {
+  if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  const auto dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+  if (dataBufferSize == 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires a positive IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or per-communicator pipesIbgdaDataBufferSize",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+  if (numBlocks <= 0) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires positive NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS; got {}",
+        allGatherAlgoName(myAlgo),
+        numBlocks);
+    return commInvalidArgument;
+  }
+  if (numBlocks > NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} numBlocks={} exceeds NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+        allGatherAlgoName(myAlgo),
+        numBlocks,
+        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+    return commInvalidArgument;
+  }
+  if (dataBufferSize / static_cast<uint64_t>(numBlocks) < 16) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} dataBufferSize={} is too small for numBlocks={}",
+        allGatherAlgoName(myAlgo),
+        dataBufferSize,
+        numBlocks);
+    return commInvalidArgument;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  if (nRanks <= 1 || nNodes <= 1) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires multiple nodes, got nRanks={} nNodes={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks < 1 || nRanks != static_cast<int64_t>(nNodes) * nLocalRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires rectangular rank geometry, got nRanks={} nNodes={} nLocalRanks={}",
+        allGatherAlgoName(myAlgo),
+        nRanks,
+        nNodes,
+        nLocalRanks);
+    return commInvalidArgument;
+  }
+  if (nLocalRanks > comms::pipes::kDirectNvlMaxRanks) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} nLocalRanks={} exceeds direct NVLink peer capacity {}",
+        allGatherAlgoName(myAlgo),
+        nLocalRanks,
+        comms::pipes::kDirectNvlMaxRanks);
+    return commInvalidArgument;
+  }
+
+  for (int node = 0; node < nNodes; ++node) {
+    for (int localRank = 0; localRank < nLocalRanks; ++localRank) {
+      const int expectedRank = node * nLocalRanks + localRank;
+      const int rank = statex->localRankToRank(localRank, node);
+      if (rank != expectedRank) {
+        CLOGF_SUBSYS(
+            WARN,
+            COLL,
+            "AllGather {} requires contiguous node-major rank layout; localRankToRank({}, {})={} expected {}",
+            allGatherAlgoName(myAlgo),
+            localRank,
+            node,
+            rank,
+            expectedRank);
+        return commInvalidArgument;
+      }
+    }
+  }
+
+  if (!comm->multiPeerTransport_) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires MultiPeerTransport (NCCL_CTRAN_USE_PIPES=1)",
+        allGatherAlgoName(myAlgo));
+    return commInvalidArgument;
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  const int myNode = statex->node();
+  const int localRank = statex->localRank();
+  auto rings = comms::pipes::make_standard_rings(nNodes, myNode, 1);
+  if (!rings.has_value()) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} cannot construct IB ring for {} nodes",
+        allGatherAlgoName(myAlgo),
+        nNodes);
+    return commInvalidArgument;
+  }
+  const auto& ibRing = (*rings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  if (!mpt->has_ibgda(prevGlobal) || !mpt->has_ibgda(nextGlobal)) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} requires IBGDA prev/next transports; prev {} has_ibgda={} next {} has_ibgda={}",
+        allGatherAlgoName(myAlgo),
+        prevGlobal,
+        mpt->has_ibgda(prevGlobal),
+        nextGlobal,
+        mpt->has_ibgda(nextGlobal));
+    return commInvalidArgument;
+  }
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    if (!mpt->is_nvl_peer(peerGlobal)) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires NVLink transport to local peer globalRank={} localRank={}",
+          allGatherAlgoName(myAlgo),
+          peerGlobal,
+          peerLocal);
+      return commInvalidArgument;
+    }
+  }
+
+  return commSuccess;
+}
+
+commResult_t ensureReadyCounterCapacity(
+    CtranComm* comm,
+    size_t counterCount,
+    cudaStream_t stream) {
+  if (counterCount == 0) {
+    return commSuccess;
+  }
+  if (comm->hierarchicalAgReadyCounterCount_ >= counterCount &&
+      comm->hierarchicalAgReadyCounters_ != nullptr) {
+    return commSuccess;
+  }
+
+  if (comm->hierarchicalAgReadyCounters_ != nullptr) {
+    FB_CUDACHECK(cudaFree(comm->hierarchicalAgReadyCounters_));
+    comm->hierarchicalAgReadyCounters_ = nullptr;
+    comm->hierarchicalAgReadyCounterCount_ = 0;
+  }
+
+  void* ptr = nullptr;
+  FB_CUDACHECK(cudaMalloc(&ptr, counterCount * sizeof(uint64_t)));
+  comm->hierarchicalAgReadyCounters_ = static_cast<uint64_t*>(ptr);
+  comm->hierarchicalAgReadyCounterCount_ = counterCount;
+  FB_CUDACHECK(cudaMemsetAsync(
+      comm->hierarchicalAgReadyCounters_,
+      0,
+      counterCount * sizeof(uint64_t),
+      stream));
+  return commSuccess;
+}
+
+} // namespace
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream) {
+  CTRAN_COLL_INFO(
+      allGatherAlgoName(myAlgo).c_str(),
+      sendbuff,
+      recvbuff,
+      sendcount,
+      datatype,
+      -1,
+      comm,
+      stream);
+
+  const auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int nLocalRanks = statex->nLocalRanks();
+  const int localRank = statex->localRank();
+  const int node = statex->node();
+  const size_t sendBytes = sendcount * commTypeSize(datatype);
+
+  if (nRanks == 1) {
+    if (sendBytes > 0 && sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff, sendbuff, sendBytes, cudaMemcpyDefault, stream));
+    }
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+  if (sendBytes == 0) {
+    comm->ctran_->updateOpCount();
+    return commSuccess;
+  }
+
+  const bool useOverlap = NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1;
+  const int numBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS);
+  const int nvlNumBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS);
+  FB_COMMCHECK(validateHierarchicalRingParams(comm, numBlocks));
+  if (useOverlap) {
+    if (nvlNumBlocks <= 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_NVL_NUM_BLOCKS; got {}",
+          allGatherAlgoName(myAlgo),
+          nvlNumBlocks);
+      return commInvalidArgument;
+    }
+    if (static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES) == 0) {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "AllGather {} requires positive NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES",
+          allGatherAlgoName(myAlgo));
+      return commInvalidArgument;
+    }
+  }
+
+  auto* mpt = comm->multiPeerTransport_.get();
+  auto ibRings = comms::pipes::make_standard_rings(nNodes, node, 1);
+  if (!ibRings.has_value()) {
+    return commInvalidArgument;
+  }
+
+  comms::pipes::HierarchicalAllgatherLaunchParams params{};
+  params.num_ranks = nRanks;
+  params.ib_rank = node;
+  params.ib_size = nNodes;
+  params.nvl_rank = localRank;
+  params.nvl_size = nLocalRanks;
+  // Pipes allgather kernels operate on byte-addressed char buffers.
+  params.sendcount = sendBytes;
+  params.ib_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_IB_SIGNAL_BYTES);
+  params.nvl_signaling_data_size =
+      static_cast<size_t>(NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES);
+  params.sendbuf = static_cast<const char*>(sendbuff);
+  params.recvbuf = static_cast<char*>(recvbuff);
+  params.ib_num_blocks = numBlocks;
+  params.timeout_ms = NCCL_CTRAN_HIER_AG_TIMEOUT_MS;
+  params.stream = stream;
+
+  const auto& ibRing = (*ibRings)[0];
+  const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
+  const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
+  params.ib_ring.prev_rank = ibRing.prev_rank;
+  params.ib_ring.next_rank = ibRing.next_rank;
+  params.ib_ring.prev = mpt->get_p2p_ibgda_transport_device(prevGlobal);
+  params.ib_ring.next = mpt->get_p2p_ibgda_transport_device(nextGlobal);
+
+  for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
+    if (peerLocal == localRank) {
+      continue;
+    }
+    const int peerGlobal = statex->localRankToRank(peerLocal);
+    new (&params.nvl_peers[peerLocal]) comms::pipes::P2pNvlTransportDevice(
+        mpt->get_p2p_nvl_transport_device(peerGlobal));
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLGATHER,
+      stream,
+      allGatherAlgoName(myAlgo),
+      comm->ctran_->getOpCount());
+  ctranKernelSetAllGatherArgs(
+      sendbuff,
+      recvbuff,
+      datatype,
+      sendcount,
+      comm->ctran_->algo->getDevState(),
+      &config.args);
+
+  std::vector<std::unique_ptr<struct OpElem>> emptyOpGroup;
+  auto colltraceHandle =
+      meta::comms::colltrace::getCollTraceHandle(comm, emptyOpGroup, config);
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
+  }
+  comm->recordAlgoStats("AllGather", allGatherAlgoName(myAlgo));
+
+  if (useOverlap) {
+    comms::pipes::HierarchicalAllgatherOverlapLaunchParams overlapParams{};
+    overlapParams.num_ranks = params.num_ranks;
+    overlapParams.ib_rank = params.ib_rank;
+    overlapParams.ib_size = params.ib_size;
+    overlapParams.nvl_rank = params.nvl_rank;
+    overlapParams.nvl_size = params.nvl_size;
+    overlapParams.sendcount = params.sendcount;
+    overlapParams.ib_signaling_data_size = params.ib_signaling_data_size;
+    overlapParams.nvl_signaling_data_size = params.nvl_signaling_data_size;
+    overlapParams.chunk_bytes =
+        static_cast<size_t>(NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES);
+    overlapParams.ready_sequence = comm->ctran_->getOpCount() + 1;
+    overlapParams.sendbuf = params.sendbuf;
+    overlapParams.recvbuf = params.recvbuf;
+    overlapParams.ib_num_blocks = params.ib_num_blocks;
+    overlapParams.nvl_num_blocks = nvlNumBlocks;
+    overlapParams.timeout_ms = params.timeout_ms;
+    overlapParams.stream = params.stream;
+    overlapParams.ib_ring = params.ib_ring;
+    for (int peer = 0; peer < nLocalRanks; ++peer) {
+      if (peer == localRank) {
+        continue;
+      }
+      new (&overlapParams.nvl_peers[peer])
+          comms::pipes::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    const size_t totalChunks =
+        (sendBytes + overlapParams.chunk_bytes - 1) / overlapParams.chunk_bytes;
+    const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
+    FB_COMMCHECK(
+        ensureReadyCounterCapacity(comm, readyCounters, overlapParams.stream));
+    overlapParams.ready_counters = comm->hierarchicalAgReadyCounters_;
+    comms::pipes::launch_hierarchical_allgather_overlap(overlapParams);
+  } else {
+    comms::pipes::launch_hierarchical_allgather_fused(params);
+  }
+  FB_CUDACHECK(cudaGetLastError());
+
+  if (colltraceHandle != nullptr) {
+    colltraceHandle->trigger(CollTraceHandleTriggerState::AfterEnqueueKernel);
+  }
+  comm->ctran_->updateOpCount();
+
+  return commSuccess;
+}
+
+#else // !ENABLE_PIPES
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* /*sendbuff*/,
+    void* /*recvbuff*/,
+    size_t /*sendcount*/,
+    commDataType_t /*datatype*/,
+    CtranComm* /*comm*/,
+    cudaStream_t /*stream*/) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllGather/AllGatherImpl.h
+++ b/comms/ctran/algos/AllGather/AllGatherImpl.h
@@ -48,6 +48,14 @@ commResult_t ctranAllGatherBrucksFF(
     CtranComm* comm,
     cudaStream_t stream);
 
+commResult_t ctranAllGatherHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t sendcount,
+    commDataType_t datatype,
+    CtranComm* comm,
+    cudaStream_t stream);
+
 static inline const std::string allGatherAlgoName(
     enum NCCL_ALLGATHER_ALGO algo) {
   switch (algo) {
@@ -61,6 +69,8 @@ static inline const std::string allGatherAlgoName(
       return "CtranAllGatherRing";
     case NCCL_ALLGATHER_ALGO::ctbrucks:
       return "CtranBrucksFF";
+    case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
+      return "CtranAllGatherHierarchicalRing";
     case NCCL_ALLGATHER_ALGO::ctran:
       return "CtranAuto";
     case NCCL_ALLGATHER_ALGO::ctgraph:

--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -1,0 +1,441 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <fmt/core.h>
+#include <folly/init/Init.h>
+#include <nccl.h>
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/testinfra/TestsCuUtils.h"
+
+int gWarmupIters = 5;
+int gBenchIters = 50;
+std::string gCtranAlgo = "cthierarchical_ring";
+std::optional<size_t> gSizeBytes;
+bool gTotalSizeBytes = false;
+
+#define NCCLCHECK_TEST(cmd)                  \
+  do {                                       \
+    ncclResult_t r = cmd;                    \
+    if (r != ncclSuccess) {                  \
+      printf(                                \
+          "Failed, NCCL error %s:%d '%s'\n", \
+          __FILE__,                          \
+          __LINE__,                          \
+          ncclGetErrorString(r));            \
+      exit(EXIT_FAILURE);                    \
+    }                                        \
+  } while (0)
+
+namespace {
+
+struct Result {
+  size_t sizeBytes{};
+  double ncclGbps{};
+  double ctranGbps{};
+  double ncclLatencyUs{};
+  double ctranLatencyUs{};
+};
+
+std::string formatSize(size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return fmt::format("{} GB", bytes / (1024UL * 1024 * 1024));
+  }
+  if (bytes >= 1024UL * 1024) {
+    return fmt::format("{} MB", bytes / (1024UL * 1024));
+  }
+  return fmt::format("{} KB", bytes / 1024UL);
+}
+
+std::vector<size_t> benchmarkSizes() {
+  if (gSizeBytes.has_value()) {
+    return {*gSizeBytes};
+  }
+  std::vector<size_t> sizes;
+  for (size_t size = 8 * 1024; size <= 1024UL * 1024 * 1024; size *= 2) {
+    sizes.push_back(size);
+  }
+  return sizes;
+}
+
+std::optional<std::string> parseFlagValue(
+    const std::string& arg,
+    const std::string& name) {
+  const std::string prefix = "--" + name + "=";
+  if (arg.rfind(prefix, 0) == 0) {
+    return arg.substr(prefix.size());
+  }
+  return std::nullopt;
+}
+
+bool parseBoolValue(const std::string& value) {
+  return value == "1" || value == "true" || value == "TRUE" || value == "yes" ||
+      value == "YES" || value == "on" || value == "ON";
+}
+
+class ScopedEnvVar {
+ public:
+  ScopedEnvVar(std::string name, std::optional<std::string> value)
+      : name_(std::move(name)) {
+    const char* oldValue = std::getenv(name_.c_str());
+    oldValue_ = oldValue ? std::optional<std::string>(oldValue) : std::nullopt;
+    if (value.has_value()) {
+      setenv(name_.c_str(), value->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+  ~ScopedEnvVar() {
+    if (oldValue_.has_value()) {
+      setenv(name_.c_str(), oldValue_->c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+ private:
+  std::string name_;
+  std::optional<std::string> oldValue_;
+};
+
+void parseBenchmarkFlags(int* argc, char** argv) {
+  int write = 1;
+  for (int read = 1; read < *argc; ++read) {
+    const std::string arg = argv[read];
+    if (auto value = parseFlagValue(arg, "warmup_iters")) {
+      gWarmupIters = std::stoi(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "bench_iters")) {
+      gBenchIters = std::stoi(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "ctran_algo")) {
+      gCtranAlgo = *value;
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "size_bytes")) {
+      gSizeBytes = std::stoull(*value);
+      continue;
+    }
+    if (auto value = parseFlagValue(arg, "total_size_bytes")) {
+      gTotalSizeBytes = parseBoolValue(*value);
+      continue;
+    }
+    argv[write++] = argv[read];
+  }
+  *argc = write;
+}
+
+void parseBenchmarkEnv() {
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_WARMUP_ITERS")) {
+    gWarmupIters = std::stoi(value);
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_ITERS")) {
+    gBenchIters = std::stoi(value);
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_ALGO")) {
+    gCtranAlgo = value;
+  }
+  if (const char* value = std::getenv("CTRAN_ALLGATHER_BENCH_SIZE_BYTES")) {
+    gSizeBytes = std::stoull(value);
+  }
+  if (const char* value =
+          std::getenv("CTRAN_ALLGATHER_BENCH_TOTAL_SIZE_BYTES")) {
+    gTotalSizeBytes = parseBoolValue(value);
+  }
+}
+
+bool validateBenchmarkConfig() {
+  if (gWarmupIters < 0) {
+    std::cerr
+        << "--warmup_iters / CTRAN_ALLGATHER_BENCH_WARMUP_ITERS must be >= 0"
+        << std::endl;
+    return false;
+  }
+  if (gBenchIters <= 0) {
+    std::cerr << "--bench_iters / CTRAN_ALLGATHER_BENCH_ITERS must be > 0"
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+enum NCCL_ALLGATHER_ALGO parseCtranAlgo(const std::string& algo) {
+  if (algo == "cthierarchical_ring") {
+    return NCCL_ALLGATHER_ALGO::cthierarchical_ring;
+  }
+  if (algo == "ctring") {
+    return NCCL_ALLGATHER_ALGO::ctring;
+  }
+  if (algo == "ctdirect") {
+    return NCCL_ALLGATHER_ALGO::ctdirect;
+  }
+  if (algo == "ctrd") {
+    return NCCL_ALLGATHER_ALGO::ctrd;
+  }
+  if (algo == "ctbrucks") {
+    return NCCL_ALLGATHER_ALGO::ctbrucks;
+  }
+  std::cerr << "Unsupported --ctran_algo=" << algo << std::endl;
+  std::abort();
+}
+
+} // namespace
+
+class CtranAllGatherBenchmark : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 0);
+    setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 0);
+    setenv("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "8388608", 0);
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 0);
+    setenv("NCCL_DEBUG", "WARN", 0);
+
+    ctran::CtranDistTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    ctranComm_ = makeCtranComm();
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+
+    ctranAlgo_ = parseCtranAlgo(gCtranAlgo);
+    if (!ctranAllGatherSupport(ctranComm_.get(), ctranAlgo_, stream_)) {
+      GTEST_SKIP() << allGatherAlgoName(ctranAlgo_)
+                   << " is not supported on this topology";
+    }
+
+    ncclUniqueId ncclId;
+    if (globalRank == 0) {
+      NCCLCHECK_TEST(ncclGetUniqueId(&ncclId));
+    }
+    std::vector<char> idBuf(numRanks * sizeof(ncclId));
+    memcpy(idBuf.data() + globalRank * sizeof(ncclId), &ncclId, sizeof(ncclId));
+    auto rc =
+        ctranComm_->bootstrap_
+            ->allGather(idBuf.data(), sizeof(ncclId), globalRank, numRanks)
+            .get();
+    EXPECT_EQ(rc, 0) << "Bootstrap allGather for ncclUniqueId failed";
+    memcpy(&ncclId, idBuf.data(), sizeof(ncclId));
+
+    {
+      ScopedEnvVar disableCtran(
+          "NCCL_CTRAN_ENABLE", std::optional<std::string>{"0"});
+      ScopedEnvVar disablePipes(
+          "NCCL_CTRAN_USE_PIPES", std::optional<std::string>{"0"});
+      ScopedEnvVar unsetAllGatherAlgo("NCCL_ALLGATHER_ALGO", std::nullopt);
+      ncclCvarInit();
+      NCCLCHECK_TEST(
+          ncclCommInitRank(&ncclComm_, numRanks, ncclId, globalRank));
+    }
+    ncclCvarInit();
+  }
+
+  void TearDown() override {
+    if (ncclComm_ != nullptr) {
+      ncclCommDestroy(ncclComm_);
+    }
+    if (stream_ != nullptr) {
+      CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    }
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  double maxAcrossRanks(double value) {
+    std::vector<char> buf(numRanks * sizeof(double));
+    memcpy(buf.data() + globalRank * sizeof(double), &value, sizeof(double));
+    auto rc = ctranComm_->bootstrap_
+                  ->allGather(buf.data(), sizeof(double), globalRank, numRanks)
+                  .get();
+    EXPECT_EQ(rc, 0) << "Bootstrap allGather for timing failed";
+
+    double maxValue = 0.0;
+    for (int rank = 0; rank < numRanks; ++rank) {
+      double rankValue;
+      memcpy(&rankValue, buf.data() + rank * sizeof(double), sizeof(double));
+      maxValue = std::max(maxValue, rankValue);
+    }
+    return maxValue;
+  }
+
+  void barrier() {
+    auto rc = ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+    EXPECT_EQ(rc, 0) << "Bootstrap barrier failed";
+  }
+
+  double runNccl(size_t sizeBytes, void* sendbuf, void* recvbuf) {
+    CUDACHECK_TEST(cudaMemset(sendbuf, globalRank, sizeBytes));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, sizeBytes * numRanks));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    barrier();
+    for (int i = 0; i < gWarmupIters; ++i) {
+      NCCLCHECK_TEST(ncclAllGather(
+          sendbuf, recvbuf, sizeBytes, ncclChar, ncclComm_, stream_));
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    barrier();
+
+    cudaEvent_t start, stop;
+    CUDACHECK_TEST(cudaEventCreate(&start));
+    CUDACHECK_TEST(cudaEventCreate(&stop));
+    CUDACHECK_TEST(cudaEventRecord(start, stream_));
+    for (int i = 0; i < gBenchIters; ++i) {
+      NCCLCHECK_TEST(ncclAllGather(
+          sendbuf, recvbuf, sizeBytes, ncclChar, ncclComm_, stream_));
+    }
+    CUDACHECK_TEST(cudaEventRecord(stop, stream_));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    float totalMs = 0.0f;
+    CUDACHECK_TEST(cudaEventElapsedTime(&totalMs, start, stop));
+    CUDACHECK_TEST(cudaEventDestroy(start));
+    CUDACHECK_TEST(cudaEventDestroy(stop));
+    return maxAcrossRanks(totalMs / gBenchIters);
+  }
+
+  double runCtran(size_t sizeBytes, void* sendbuf, void* recvbuf) {
+    CUDACHECK_TEST(cudaMemset(sendbuf, globalRank, sizeBytes));
+    CUDACHECK_TEST(cudaMemset(recvbuf, 0, sizeBytes * numRanks));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    barrier();
+    for (int i = 0; i < gWarmupIters; ++i) {
+      COMMCHECK_TEST(ctranAllGather(
+          sendbuf,
+          recvbuf,
+          sizeBytes,
+          commChar,
+          ctranComm_.get(),
+          stream_,
+          ctranAlgo_));
+    }
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    barrier();
+
+    cudaEvent_t start, stop;
+    CUDACHECK_TEST(cudaEventCreate(&start));
+    CUDACHECK_TEST(cudaEventCreate(&stop));
+    CUDACHECK_TEST(cudaEventRecord(start, stream_));
+    for (int i = 0; i < gBenchIters; ++i) {
+      COMMCHECK_TEST(ctranAllGather(
+          sendbuf,
+          recvbuf,
+          sizeBytes,
+          commChar,
+          ctranComm_.get(),
+          stream_,
+          ctranAlgo_));
+    }
+    CUDACHECK_TEST(cudaEventRecord(stop, stream_));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    float totalMs = 0.0f;
+    CUDACHECK_TEST(cudaEventElapsedTime(&totalMs, start, stop));
+    CUDACHECK_TEST(cudaEventDestroy(start));
+    CUDACHECK_TEST(cudaEventDestroy(stop));
+    return maxAcrossRanks(totalMs / gBenchIters);
+  }
+
+  void printResults(const std::vector<Result>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::cout << "\nNCCL vs ctran AllGather " << allGatherAlgoName(ctranAlgo_)
+              << "\n";
+    std::cout << std::left << std::setw(10) << "Size" << std::right
+              << std::setw(12) << "NCCL GB/s" << std::setw(13) << "Ctran GB/s"
+              << std::setw(9) << "Ratio" << std::setw(14) << "NCCL us"
+              << std::setw(14) << "Ctran us" << "\n";
+    for (const auto& result : results) {
+      const double ratio = result.ctranGbps / result.ncclGbps;
+      std::cout << std::left << std::setw(10) << formatSize(result.sizeBytes)
+                << std::right << std::fixed << std::setprecision(2)
+                << std::setw(12) << result.ncclGbps << std::setw(13)
+                << result.ctranGbps << std::setw(8) << ratio << "x"
+                << std::setprecision(1) << std::setw(14) << result.ncclLatencyUs
+                << std::setw(14) << result.ctranLatencyUs << "\n";
+    }
+    std::cout << std::flush;
+  }
+
+  void runBenchmark() {
+    const auto sizes = benchmarkSizes();
+    const auto sendSizeBytes = [&](size_t sizeBytes) {
+      if (!gTotalSizeBytes) {
+        return sizeBytes;
+      }
+      EXPECT_EQ(sizeBytes % numRanks, 0)
+          << "Total size must be divisible by numRanks";
+      return sizeBytes / numRanks;
+    };
+
+    const size_t maxSizeBytes = sendSizeBytes(sizes.back());
+    void* sendbuf = nullptr;
+    void* recvbuf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&sendbuf, maxSizeBytes));
+    CUDACHECK_TEST(cudaMalloc(&recvbuf, maxSizeBytes * numRanks));
+
+    std::vector<Result> results;
+    for (const size_t resultSizeBytes : sizes) {
+      const size_t sizeBytes = sendSizeBytes(resultSizeBytes);
+      const double ncclMs = runNccl(sizeBytes, sendbuf, recvbuf);
+      const double ctranMs = runCtran(sizeBytes, sendbuf, recvbuf);
+      const double totalBytes = gTotalSizeBytes
+          ? static_cast<double>(resultSizeBytes)
+          : static_cast<double>(sizeBytes) * numRanks;
+      results.push_back(
+          Result{
+              .sizeBytes = resultSizeBytes,
+              .ncclGbps = totalBytes / (ncclMs / 1000.0) / 1e9,
+              .ctranGbps = totalBytes / (ctranMs / 1000.0) / 1e9,
+              .ncclLatencyUs = ncclMs * 1000.0,
+              .ctranLatencyUs = ctranMs * 1000.0,
+          });
+      if (globalRank == 0) {
+        const auto& result = results.back();
+        std::cout << "Finished " << formatSize(resultSizeBytes)
+                  << ": NCCL=" << result.ncclGbps
+                  << " GB/s ctran=" << result.ctranGbps << " GB/s\n";
+      }
+    }
+
+    printResults(results);
+    CUDACHECK_TEST(cudaFree(sendbuf));
+    CUDACHECK_TEST(cudaFree(recvbuf));
+  }
+
+ private:
+  std::unique_ptr<CtranComm> ctranComm_;
+  ncclComm_t ncclComm_{nullptr};
+  cudaStream_t stream_{nullptr};
+  enum NCCL_ALLGATHER_ALGO ctranAlgo_ {
+    NCCL_ALLGATHER_ALGO::cthierarchical_ring
+  };
+};
+
+TEST_F(CtranAllGatherBenchmark, VsNccl) {
+  runBenchmark();
+}
+
+int main(int argc, char* argv[]) {
+  parseBenchmarkEnv();
+  parseBenchmarkFlags(&argc, argv);
+  if (!validateBenchmarkConfig()) {
+    return EXIT_FAILURE;
+  }
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranDistAllgatherTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherTests.cc
@@ -156,6 +156,17 @@ class CtranAllgatherTest : public ctran::CtranDistTestFixture,
   std::unique_ptr<CtranComm> ctranComm{nullptr};
 };
 
+namespace {
+
+const ctran::CtranEnvs kHierarchicalRingEnvs = {
+    {"NCCL_COMM_STATE_DEBUG_TOPO", "nolocal"},
+    {"NCCL_CTRAN_USE_PIPES", "1"},
+    {"NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1"},
+    {"NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432"},
+};
+
+} // namespace
+
 // Param: (CtranEnvs, (algo, offset, count, inplace, memType, iter, pairColl))
 using CtranAllgatherParams = std::tuple<
     enum NCCL_ALLGATHER_ALGO,
@@ -250,12 +261,15 @@ TEST_P(CtranAllgatherTestParam, AllgatherAlgo) {
         << " on rank " << globalRank << " received from peer " << i;
   }
 
+  std::vector<CtranMapperBackend> excludedBackends{CtranMapperBackend::NVL};
+  if (algo == NCCL_ALLGATHER_ALGO::cthierarchical_ring) {
+    excludedBackends.push_back(CtranMapperBackend::IB);
+  }
   verifyBackendsUsed(
       ctranComm->ctran_.get(),
       ctranComm->statex_.get(),
       memType,
-      // AllGatherDirect uses kernel bcast not NVL iput
-      {CtranMapperBackend::NVL});
+      excludedBackends);
   verifyGpeLeak(ctranComm->ctran_.get());
 
   CUDACHECK_TEST(cudaDeviceSynchronize());
@@ -439,6 +453,21 @@ INSTANTIATE_TEST_SUITE_P(
             testing::Values(kTestInPlace, kTestOutOfPlace),
             testing::Values(kCuMemAllocDisjoint),
             testing::Values(5),
+            testing::Values(kTestPairNone))),
+    getTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranTestHierarchicalRing,
+    CtranAllgatherTestParam,
+    ::testing::Combine(
+        ::testing::Values(kHierarchicalRingEnvs),
+        ::testing::Combine(
+            testing::Values(NCCL_ALLGATHER_ALGO::cthierarchical_ring),
+            testing::Values(0),
+            testing::Values(8192, 1),
+            testing::Values(kTestInPlace, kTestOutOfPlace),
+            testing::Values(kMemNcclMemAlloc),
+            testing::Values(1),
             testing::Values(kTestPairNone))),
     getTestName);
 

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -12,6 +12,11 @@
 #include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/collectives/AllGatherDirect.cuh"
 
+// Keep the kernel definitions in this translation unit. Package builds link
+// this launcher as a standalone shared object, and CUDA kernel symbols are
+// hidden across that boundary.
+#include "AllGatherDirect.cu"
+
 namespace comms::pipes {
 
 namespace {


### PR DESCRIPTION
Summary:


Adds a non-persistent AllGather benchmark (`AllGatherBench.cc`) that provides head-to-head comparison of NCCL `ncclAllGather` against ctran `ctranAllGather` with `cthierarchical_ring` (or any ctran algorithm). The benchmark creates two separate communicators -- one pure NCCL baseline with ctran disabled, one ctran-enabled -- to ensure fair, isolated comparison without ctran overhead or memory allocation affecting the NCCL baseline measurements.

## Benchmark Architecture

```
SetUp:
+----------------------------------------------+
| 1. Set default env vars:                      |
|    NCCL_CTRAN_ENABLE=1                        |
|    NCCL_CTRAN_USE_PIPES=1                     |
|    NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1         |
|    NCCL_COMM_STATE_DEBUG_TOPO=nolocal         |
|                                               |
| 2. Create ctranComm (Pipes + IBGDA enabled)   |
|                                               |
| 3. Bootstrap allGather for ncclUniqueId       |
|                                               |
| 4. Create NCCL baseline comm with ctran OFF:  |
|    ScopedEnvVar("NCCL_CTRAN_ENABLE", "0")     |
|    ScopedEnvVar("NCCL_CTRAN_USE_PIPES", "0")  |
|    ncclCvarInit()  (re-read CVARs)            |
|    ncclCommInitRank()  (pure NCCL comm)       |
|                                               |
| 5. Restore ctran env vars + ncclCvarInit()    |
+----------------------------------------------+

Per-size Benchmark:
+----------------------------------------------+
| For each size in [8KB, 16KB, ..., 1GB]:       |
|                                               |
|   runNccl(size):                              |
|     memset sendbuf/recvbuf                    |
|     barrier()                                 |
|     warmup (gWarmupIters iterations)          |
|     cudaEventRecord(start)                    |
|     bench (gBenchIters iterations)            |
|     cudaEventRecord(stop)                     |
|     cudaStreamSynchronize()                   |
|     -> maxAcrossRanks(elapsed / iters)        |
|                                               |
|   runCtran(size):                             |
|     memset sendbuf/recvbuf                    |
|     barrier()                                 |
|     warmup (gWarmupIters iterations)          |
|     cudaEventRecord(start)                    |
|     bench (gBenchIters iterations)            |
|     cudaEventRecord(stop)                     |
|     cudaStreamSynchronize()                   |
|     -> maxAcrossRanks(elapsed / iters)        |
+----------------------------------------------+

Output:
+----------------------------------------------+
| Size    NCCL GB/s  Ctran GB/s  Ratio  Latency |
| 8 KB    X.XX       Y.YY        Z.ZZx  ...     |
| 16 KB   ...        ...         ...    ...     |
| ...                                           |
| 1 GB    ...        ...         ...    ...     |
+----------------------------------------------+
```

## Features

### Dual-Communicator Isolation
The NCCL baseline communicator is created while ctran is completely disabled via `ScopedEnvVar` RAII wrappers that temporarily set `NCCL_CTRAN_ENABLE=0` and `NCCL_CTRAN_USE_PIPES=0`. This prevents ctran initialization overhead, Pipes transport memory allocation, and IBGDA QP creation from affecting the NCCL baseline measurements.

### Timing Methodology
- **CUDA events**: Uses `cudaEventRecord`/`cudaEventElapsedTime` for GPU-accurate timing without host-side jitter
- **Max-latency aggregation**: Reports `max(elapsed)` across all ranks via bootstrap allGather, ensuring the slowest rank's time is reported (AllGather is complete only when the last rank finishes)
- **Warmup/measurement separation**: Configurable warmup iterations (default 5) run before timed iterations (default 50)

### Configuration Options

| Flag / Env Var | Default | Description |
|---|---|---|
| `--warmup_iters` / `CTRAN_ALLGATHER_BENCH_WARMUP_ITERS` | 5 | Warmup iterations before timing |
| `--bench_iters` / `CTRAN_ALLGATHER_BENCH_ITERS` | 50 | Timed iterations for measurement |
| `--ctran_algo` / `CTRAN_ALLGATHER_BENCH_ALGO` | `cthierarchical_ring` | ctran algorithm to benchmark (`cthierarchical_ring`, `ctring`, `ctdirect`, `ctrd`, `ctbrucks`) |
| `--size_bytes` / `CTRAN_ALLGATHER_BENCH_SIZE_BYTES` | (sweep) | Fixed per-rank send size; if unset, sweeps 8 KB through 1 GB |
| `--total_size_bytes` / `CTRAN_ALLGATHER_BENCH_TOTAL_SIZE_BYTES` | false | Treat `--size_bytes` as total AllGather output size (divided by numRanks for per-rank send) |

### Output Metrics
- **Per-rank send size** (formatted as KB/MB/GB)
- **NCCL algorithmic bandwidth** (GB/s)
- **Ctran algorithmic bandwidth** (GB/s)
- **Speedup ratio** (ctran/NCCL)
- **NCCL latency** (microseconds)
- **Ctran latency** (microseconds)

### BUCK Target
- `fbcode//comms/ctran/benchmarks:allgather_bench_4x1` -- 4 nodes x 1 GPU/node configuration with `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE=8MB`, `NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1`, `NCCL_CTRAN_USE_PIPES=1`, 1200s RE timeout

## Implementation Details

- Inherits from `ctran::CtranDistTestFixture` for MPI bootstrap, rank discovery, and `CtranComm` construction
- Uses `makeCtranComm()` for the ctran communicator (gets full Pipes + IBGDA transport setup)
- Uses `ncclCommInitRank()` for the NCCL baseline communicator (standard NCCL initialization)
- `ScopedEnvVar` RAII class saves/restores environment variables with automatic cleanup
- `parseBenchmarkFlags()` removes benchmark-specific flags before passing to GTest and folly
- `parseBenchmarkEnv()` reads environment variable overrides (lower priority than flags)
- Supports all ctran AllGather algorithms via `parseCtranAlgo()` dispatch

Differential Revision: D106000679


