### PR TITLE
Add commSetConfig API (#2658)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -2,7 +2,9 @@
 
 #include "meta/NcclxConfig.h"
 
+#include "comm.h" // NOLINT
 #include "debug.h"
+#include "group.h" // NOLINT
 #include "nccl.h" // @manual
 #include "param.h"
 
@@ -288,6 +290,42 @@ Config::Config(const ncclConfig_t* config) {
   parseAlgoHint("rmaAlgo", rmaAlgo);
 }
 
+ncclResult_t Config::update(const ncclx::Hints* hints) {
+  if (hints == nullptr) {
+    return ncclSuccess;
+  }
+
+  const auto& mutableKeys = ncclx::mutableHintKeys();
+
+  for (const auto& key : ncclx::knownHintKeys()) {
+    if (std::find(mutableKeys.begin(), mutableKeys.end(), key) !=
+        mutableKeys.end()) {
+      continue;
+    }
+    std::string val;
+    if (hints->get(key, val) == ncclSuccess) {
+      WARN(
+          "ncclx::commSetConfig: hint key '%s' is not mutable post-init",
+          key.c_str());
+      return ncclInvalidUsage;
+    }
+  }
+
+  auto parseAlgoHint = [&](const char* key, auto& field) {
+    std::string val;
+    if (hints->get(key, val) == ncclSuccess) {
+      algoStrToVal(val, field);
+    }
+  };
+  parseAlgoHint("sendrecvAlgo", sendrecvAlgo);
+  parseAlgoHint("allgatherAlgo", allgatherAlgo);
+  parseAlgoHint("allreduceAlgo", allreduceAlgo);
+  parseAlgoHint("alltoallvAlgo", alltoallvAlgo);
+  parseAlgoHint("rmaAlgo", rmaAlgo);
+
+  return ncclSuccess;
+}
+
 } // namespace ncclx
 
 // C-style wrapper around the ncclx::Config parsing constructor.
@@ -300,4 +338,72 @@ ncclResult_t ncclxParseCommConfig(ncclConfig_t* config) {
   } catch (const std::exception&) {
     return ncclInvalidArgument;
   }
+}
+
+__attribute__((visibility("default"))) ncclResult_t
+ncclx::commSetConfig(ncclComm_t comm, const ncclConfig_t* config) {
+  if (comm == nullptr) {
+    WARN("ncclx::commSetConfig: comm is null");
+    return ncclInvalidArgument;
+  }
+
+  NCCLCHECK(ncclCommEnsureReady(comm));
+
+  if (ncclGroupDepth > 0) {
+    WARN("ncclx::commSetConfig: cannot update config inside a group call");
+    return ncclInvalidUsage;
+  }
+
+  if (config == nullptr) {
+    WARN("ncclx::commSetConfig: config is null");
+    return ncclInvalidArgument;
+  }
+
+  if (config->magic != NCCL_API_MAGIC) {
+    WARN(
+        "ncclx::commSetConfig: ncclConfig_t not initialized with "
+        "NCCL_CONFIG_INITIALIZER");
+    return ncclInvalidArgument;
+  }
+
+  if (config->blocking != NCCL_CONFIG_UNDEF_INT ||
+      config->cgaClusterSize != NCCL_CONFIG_UNDEF_INT ||
+      config->minCTAs != NCCL_CONFIG_UNDEF_INT ||
+      config->maxCTAs != NCCL_CONFIG_UNDEF_INT ||
+      config->splitShare != NCCL_CONFIG_UNDEF_INT ||
+      config->trafficClass != NCCL_CONFIG_UNDEF_INT ||
+      config->collnetEnable != NCCL_CONFIG_UNDEF_INT ||
+      config->CTAPolicy != NCCL_CONFIG_UNDEF_INT ||
+      config->shrinkShare != NCCL_CONFIG_UNDEF_INT ||
+      config->nvlsCTAs != NCCL_CONFIG_UNDEF_INT ||
+      config->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT ||
+      config->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT ||
+      config->graphUsageMode != NCCL_CONFIG_UNDEF_INT ||
+      config->numRmaCtx != NCCL_CONFIG_UNDEF_INT ||
+      config->netName != NCCL_CONFIG_UNDEF_PTR ||
+      config->commName != NCCL_CONFIG_UNDEF_PTR ||
+      config->commDesc != nullptr ||
+      config->splitGroupRanks != NCCL_CONFIG_UNDEF_PTR ||
+      config->splitGroupSize != NCCL_CONFIG_UNDEF_INT ||
+      config->fastInitMode != NCCL_CONFIG_UNDEF_INT ||
+      config->ncclxConfig != NCCL_CONFIG_UNDEF_PTR) {
+    WARN(
+        "ncclx::commSetConfig: ncclConfig_t fields are not mutable; "
+        "only algo hints are allowed");
+    return ncclInvalidUsage;
+  }
+
+  if (config->hints == NCCL_CONFIG_UNDEF_PTR || config->hints == nullptr) {
+    return ncclSuccess;
+  }
+
+  if (comm->config.ncclxConfig == NCCL_CONFIG_UNDEF_PTR ||
+      comm->config.ncclxConfig == nullptr) {
+    WARN("ncclx::commSetConfig: comm has no parsed ncclx::Config");
+    return ncclInvalidArgument;
+  }
+
+  auto* cfg = static_cast<ncclx::Config*>(comm->config.ncclxConfig);
+  const auto* hints = static_cast<const ncclx::Hints*>(config->hints);
+  return cfg->update(hints);
 }

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -57,6 +57,8 @@ class Config {
 
   // Defer per-peer IBGDA state to first use (hint > CVAR).
   bool ibLazyConnect = false;
+  // Update mutable hint fields (algo config only).  Rejects immutable keys.
+  ncclResult_t update(const ncclx::Hints* hints);
 };
 
 // Hint keys corresponding to Config fields above.  Used by
@@ -73,6 +75,18 @@ inline const std::vector<std::string>& knownHintKeys() {
       "vCliqueSize",       "ncclBuffSize",
       "ibSplitDataOnQps",  "ibQpsPerConnection",
       "ibLazyConnect",
+  };
+  return keys;
+}
+
+// Algo hint keys that are safe to update on a live communicator.
+inline const std::vector<std::string>& mutableHintKeys() {
+  static const std::vector<std::string> keys = {
+      "sendrecvAlgo",
+      "allgatherAlgo",
+      "allreduceAlgo",
+      "alltoallvAlgo",
+      "rmaAlgo",
   };
   return keys;
 }

--- a/comms/ncclx/meta/tests/CommSetConfigTest.cc
+++ b/comms/ncclx/meta/tests/CommSetConfigTest.cc
@@ -1,0 +1,271 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "meta/NcclxConfig.h"
+#include "nccl.h"
+
+class CommSetConfigTest : public NcclxBaseTestFixture {};
+
+TEST_F(CommSetConfigTest, SetSingleAlgoHint) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+  EXPECT_EQ(
+      NCCL_ALLGATHER_ALGO::ctdirect,
+      NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+}
+
+TEST_F(CommSetConfigTest, SetAllAlgoHints) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({
+      {"allgatherAlgo", "ctring"},
+      {"allreduceAlgo", "ctdirect"},
+      {"sendrecvAlgo", "ctran"},
+      {"alltoallvAlgo", "ctran"},
+      {"rmaAlgo", "ctran"},
+  });
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+  EXPECT_EQ(
+      NCCL_ALLGATHER_ALGO::ctring,
+      NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+  EXPECT_EQ(
+      NCCL_ALLREDUCE_ALGO::ctdirect,
+      NCCLX_CONFIG_FIELD(comm->config, allreduceAlgo));
+  EXPECT_EQ(
+      NCCL_SENDRECV_ALGO::ctran,
+      NCCLX_CONFIG_FIELD(comm->config, sendrecvAlgo));
+  EXPECT_EQ(
+      NCCL_ALLTOALLV_ALGO::ctran,
+      NCCLX_CONFIG_FIELD(comm->config, alltoallvAlgo));
+  EXPECT_EQ(NCCL_RMA_ALGO::ctran, NCCLX_CONFIG_FIELD(comm->config, rmaAlgo));
+}
+
+TEST_F(CommSetConfigTest, RejectImmutableHintKey) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"useCtran", "1"}});
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectImmutableHintKeyNcclBuffSize) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"ncclBuffSize", "1048576"}});
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectFlatFieldBlocking) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  newConfig.blocking = 1;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectFlatFieldMinCTAs) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  newConfig.minCTAs = 4;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectNcclxFlatFieldCommDesc) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  newConfig.commDesc = "test";
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectUninitializedConfig) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclConfig_t newConfig{};
+
+  EXPECT_EQ(ncclInvalidArgument, ncclx::commSetConfig(comm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, RejectNullConfig) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  EXPECT_EQ(ncclInvalidArgument, ncclx::commSetConfig(comm, nullptr));
+}
+
+TEST_F(CommSetConfigTest, NoOpWithNoHints) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  const auto origAlgo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+  EXPECT_EQ(origAlgo, NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+}
+
+TEST_F(CommSetConfigTest, MultipleSequentialUpdates) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_EQ(
+        NCCL_ALLGATHER_ALGO::ctdirect,
+        NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+  }
+
+  {
+    ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allgatherAlgo", "ctring"}});
+    newConfig.hints = &hints;
+    EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+    EXPECT_EQ(
+        NCCL_ALLGATHER_ALGO::ctring,
+        NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+  }
+}
+
+TEST_F(CommSetConfigTest, RejectMixedMutableAndImmutableHints) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  const auto origAlgo = NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo);
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({
+      {"allgatherAlgo", "ctdirect"},
+      {"useCtran", "1"},
+  });
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+  EXPECT_EQ(origAlgo, NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+}
+
+TEST_F(CommSetConfigTest, RejectInsideGroupCall) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ncclGroupStart();
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclInvalidUsage, ncclx::commSetConfig(comm, &newConfig));
+
+  ncclGroupEnd();
+}
+
+TEST_F(CommSetConfigTest, RejectWhenAsyncOpInProgress) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  ASSERT_EQ(ncclSuccess, ncclCommSetAsyncError(comm, ncclInProgress));
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+  newConfig.hints = &hints;
+
+  EXPECT_NE(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+
+  ASSERT_EQ(ncclSuccess, ncclCommSetAsyncError(comm, ncclSuccess));
+}
+
+TEST_F(CommSetConfigTest, RejectAfterCommAbort) {
+  ncclComm_t rawComm = ncclx::test::createNcclComm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, rawComm);
+
+  ASSERT_EQ(ncclSuccess, ncclCommAbort(rawComm));
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+  newConfig.hints = &hints;
+
+  EXPECT_NE(ncclSuccess, ncclx::commSetConfig(rawComm, &newConfig));
+}
+
+TEST_F(CommSetConfigTest, SetConfigAfterCollective) {
+  ncclx::test::NcclCommRAII comm(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ASSERT_NE(nullptr, comm.get());
+
+  const size_t count = 1024;
+  void* buf = nullptr;
+  ASSERT_EQ(cudaSuccess, cudaMalloc(&buf, count * sizeof(float)));
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaSuccess, cudaStreamCreate(&stream));
+
+  ASSERT_EQ(
+      ncclSuccess,
+      ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
+  ASSERT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
+
+  ncclConfig_t newConfig = NCCL_CONFIG_INITIALIZER;
+  ncclx::Hints hints({{"allgatherAlgo", "ctdirect"}});
+  newConfig.hints = &hints;
+
+  EXPECT_EQ(ncclSuccess, ncclx::commSetConfig(comm, &newConfig));
+  EXPECT_EQ(
+      NCCL_ALLGATHER_ALGO::ctdirect,
+      NCCLX_CONFIG_FIELD(comm->config, allgatherAlgo));
+
+  cudaStreamDestroy(stream);
+  cudaFree(buf);
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -956,6 +956,25 @@ class Hints {
     private:
         kvType kv;
 };
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -964,6 +964,25 @@ class Hints {
     private:
         kvType kv;
 };
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif


### PR DESCRIPTION
Summary:

..., `allgatherAlgo`, `allreduceAlgo`, `alltoallvAlgo`, `rmaAlgo`) are mutable post-init; all other `ncclConfig_t` flat fields and non-algo hint keys are rejected with `ncclInvalidUsage`.

- Add `Config::update(const Hints*)` method that validates hint keys against a mutable whitelist and applies algo changes via `algoStrToVal`
- Add `mutableHintKeys()` returning the 5 algo key names
- Add `ncclx::commSetConfig` in `meta/NcclxConfig.cc` with validation: `ncclCommEnsureReady` (rejects aborted/async-in-progress comms), `ncclGroupDepth > 0` (rejects calls inside group regions), magic check, flat field UNDEF check, immutable hint key rejection
- Declare `ncclx::commSetConfig` in `nccl.h.in` for both v2_29 and v2_30 with `[META:COMM_SET_CONFIG]` labels
- Add 16 distributed tests covering: algo hint setting (single + all 5), immutable hint rejection, flat field rejection, uninitialized/null config rejection, no-op, sequential updates, mixed mutable+immutable rejection, group-call rejection, aborted-comm rejection, async-in-progress rejection, post-collective update

Differential Revision: D105741192


