### PR TITLE
PrecisionClock: use fbclock UTC variant, not TAI

### DIFF
--- a/comms/utils/colltrace/PrecisionClock.cc
+++ b/comms/utils/colltrace/PrecisionClock.cc
@@ -75,15 +75,20 @@ class PrecisionClockImpl {
   }
 
 #if COMMS_HAS_FBCLOCK
-  // Reads fbclock without holding a mutex. fbclock_gettime mutates
+  // Reads fbclock without holding a mutex. fbclock_gettime_utc mutates
   // lib_.min_phc_delay (a monotonically-decreasing int64) on every call;
   // this is a benign race accepted by common/time/PTP.cpp as well.
   // The shared-memory read uses fbclock's own seqlock/CRC protocol.
+  //
+  // Uses the UTC variant (not fbclock_gettime, which returns TAI) so the
+  // returned ns count is on the same epoch as std::chrono::system_clock —
+  // otherwise callers wrapping the result in a system_clock::time_point
+  // would land ~37s in the future (current TAI-UTC leap-second offset).
   bool getTruetime(fbclock_truetime* out) noexcept {
     if (!usingPtp_) {
       return false;
     }
-    return fbclock_gettime(&lib_, out) == FBCLOCK_E_NO_ERROR;
+    return fbclock_gettime_utc(&lib_, out) == FBCLOCK_E_NO_ERROR;
   }
 #endif
 


### PR DESCRIPTION
Summary:
`PrecisionClockImpl::getTruetime` was calling `fbclock_gettime`, which returns nanoseconds on the TAI epoch. The result was then wrapped in a `std::chrono::system_clock::time_point` by `precisionNow()` and `precisionNowNs()`, both of which the header documents as Unix-epoch UTC. On a host with PTP enabled (the default via `NCCL_USE_PTP_DEFAULT_LITERAL = true`) this put every returned time_point ~37s in the future of real wall-clock time — the current TAI-UTC leap-second offset.

Switch to `fbclock_gettime_utc`, the documented UTC entry point in `time/fbclock/fbclock.h` (line 184). This is the canonical pattern used elsewhere in fbcode when fbclock readings are compared against `system_clock` or fed into Unix-epoch timestamps (e.g. `longbow/logging/Utils.cpp`, `unicorn/utils/NtpOffset.cpp`, `time/fbclock/fbclock.go`'s `GetTimeUTC`).

User-visible effect: `CudaWaitEvent::getCollStartTime()` / `getCollEndTime()` / `getCollEnqueueTime()` and any caller of `precisionNow()` (`CollTrace.cc`, `CPUWaitEvent.cc`, `GpuClockCalibration.cc`, `GraphCudaWaitEvent.cc`) now return times on the same epoch as `std::chrono::system_clock::now()`, eliminating a 37-second skew in colltrace timestamps and in any external comparison against wall-clock time. The previously-failing `CudaWaitEventTest.GetCollStartTimeInMargin` (which compared a system_clock sample against `getCollStartTime()`) now passes.

Reviewed By: YulunW

Differential Revision: D106011306


