### PR TITLE
S651852 [ctran][bugfix] ctaPartition unifies per-CTA byte ownership (#2661)

### DIFF
--- a/comms/ctran/algos/DevCommon.cuh
+++ b/comms/ctran/algos/DevCommon.cuh
@@ -384,6 +384,41 @@ copy(uint4* dst, const volatile uint4* src, size_t count) {
   }
 }
 
+// Per-CTA byte-ownership partition shared by every writer/reader family
+// that touches a buffer paired with `copyUnroll<Unroll16, T>`.
+//
+// The invariant any two such functions must satisfy: every byte of any
+// shared buffer must map to the same CTA in both. When that fails, a
+// later round's CTA can read or overwrite bytes a different CTA in the
+// earlier round hasn't yet committed — under per-CTA-only sync this is
+// undefined behavior (D69774173, S651852).
+//
+// Computing the partition in exactly one place makes the invariant
+// hold by construction. Inner-loop details (unroll factor, vectorized
+// vs scalar loads) remain free per writer; only the outer
+// per-CTA chunk size is fixed here.
+struct CtaPartition {
+  size_t numPerBlock; // per-CTA chunk size in T elements
+  size_t limitUnroll; // = roundDown(count, numPerBlock); identical across CTAs
+  bool ownsTail; // exactly one CTA per launch returns true
+};
+
+template <typename T, int Unroll16>
+__device__ __forceinline__ CtaPartition
+ctaPartition(size_t count, int groupIdx, int nGroups) {
+  // numPerBlock = blockDim * (16/sizeof(T)) * Unroll16. Keeping the
+  // sizeof(T) factor here is what guarantees that two writers
+  // instantiated with the same Unroll16 but different T's still agree
+  // on per-byte ownership (each block owns the same 16-byte region
+  // regardless of T).
+  constexpr int kTPer16Bytes = sizeof(uint4) / sizeof(T);
+  const size_t numPerBlock = blockDim.x * kTPer16Bytes * Unroll16;
+  const size_t limitUnroll = ctran::utils::roundDown(count, numPerBlock);
+  const bool ownsTail = (count != limitUnroll) &&
+      (groupIdx == ((limitUnroll / numPerBlock) % nGroups));
+  return {numPerBlock, limitUnroll, ownsTail};
+}
+
 // Thread blocks with the same groupIdx must own the same area of shared memory
 // in order to avoid race conditions. When a send and receive have mismatching
 // data types (one will have uint4 and the other will have T), each thread
@@ -391,26 +426,15 @@ copy(uint4* dst, const volatile uint4* src, size_t count) {
 template <int Unroll16, typename T>
 __device__ __forceinline__ void
 copyUnroll(T* dst, const T* src, size_t count, int groupIdx, int nGroups) {
-  // How many Ts are in a uint4-equivalent
+  // How many Ts are in a uint4-equivalent.
   constexpr int kTPer16Bytes = sizeof(uint4) / sizeof(T);
-
-  // Unroll16 is how many uint4-equivalents we load/store each iteration
+  // Unroll16 is how many uint4-equivalents we load/store each iteration.
   constexpr int kUnroll = kTPer16Bytes * Unroll16;
 
-  auto numPerBlock = blockDim.x * kUnroll;
-  auto limitUnroll = ctran::utils::roundDown(count, numPerBlock);
+  const auto p = ctaPartition<T, Unroll16>(count, groupIdx, nGroups);
 
-  // Some number of CTAs (groupIdx) will fit into this loop, and we may have
-  // some remainder which is guaranteed to lie in a single CTA (groupIdx), as
-  // limitUnroll is a multiple of the number of T elements handled per groupIdx
-  //
-  // As per the comment at the top of the function, we guarantee that each
-  // groupIdx handles a contiguous block of blockDim.x * Unroll16 * 16 bytes of
-  // data regardless of data type T passed, thus guaranteeing the same
-  // writer groupIdx would always touch the same region of memory.
-
-  for (size_t i = groupIdx * numPerBlock + threadIdx.x; i < limitUnroll;
-       i += nGroups * numPerBlock) {
+  for (size_t i = groupIdx * p.numPerBlock + threadIdx.x; i < p.limitUnroll;
+       i += nGroups * p.numPerBlock) {
     T v[kUnroll];
 
 #pragma unroll
@@ -424,18 +448,11 @@ copyUnroll(T* dst, const T* src, size_t count, int groupIdx, int nGroups) {
     }
   }
 
-  // remainder epilogue
-
-  // To avoid issues of trying to slice up the remaining data among CTAs and
-  // having different CTAs access different regions of memory, just give it to
-  // the group that is responsible for that part of the temporary
-  // buffer.
-  // The maximum number of bytes remaining to copy is
-  // less than blockDim.x * kUnroll * sizeof(T)
-  // e.g., 640 x 4 x 16 = less than 40 kiB, so not huge
-  if (count != limitUnroll &&
-      groupIdx == ((limitUnroll / numPerBlock) % nGroups)) {
-    for (size_t i = limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
+  // Single-CTA tail: the owner under ctaPartition handles all remaining bytes.
+  // Tail size < numPerBlock < blockDim * kUnroll * sizeof(T) (~40 kiB
+  // worst case), so this is cheap.
+  if (p.ownsTail) {
+    for (size_t i = p.limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
       dst[i] = src[i];
     }
   }
@@ -468,14 +485,15 @@ __device__ __forceinline__ void copyUnroll(
     return;
   }
 
+  // How many Ts are in a uint4-equivalent.
   constexpr int kTPer16Bytes = sizeof(uint4) / sizeof(T);
+  // Unroll16 is how many uint4-equivalents we load/store each iteration.
   constexpr int kUnroll = kTPer16Bytes * Unroll16;
 
-  auto numPerBlock = blockDim.x * kUnroll;
-  auto limitUnroll = ctran::utils::roundDown(count, numPerBlock);
+  const auto p = ctaPartition<T, Unroll16>(count, groupIdx, nGroups);
 
-  for (size_t i = groupIdx * numPerBlock + threadIdx.x; i < limitUnroll;
-       i += nGroups * numPerBlock) {
+  for (size_t i = groupIdx * p.numPerBlock + threadIdx.x; i < p.limitUnroll;
+       i += nGroups * p.numPerBlock) {
     T v[kUnroll];
 
 #pragma unroll
@@ -490,9 +508,9 @@ __device__ __forceinline__ void copyUnroll(
     }
   }
 
-  if (count != limitUnroll &&
-      groupIdx == ((limitUnroll / numPerBlock) % nGroups)) {
-    for (size_t i = limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
+  // Single-CTA tail; ownership computed once in `ctaPartition` above.
+  if (p.ownsTail) {
+    for (size_t i = p.limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
       T val = src[i];
       dst1[i] = val;
       dst2[i] = val;

--- a/comms/ctran/algos/localReduce.cuh
+++ b/comms/ctran/algos/localReduce.cuh
@@ -20,6 +20,7 @@
 #endif
 
 #include "comms/common/DeviceConstants.cuh"
+#include "comms/ctran/algos/DevCommon.cuh"
 #include "comms/ctran/utils/DevUtils.cuh"
 
 /* FIXME: We are not currently using vectorized arithmetic.  We only
@@ -188,24 +189,17 @@ __device__ __forceinline__ void localReduceVectorized(
   constexpr uint32_t kWordsPerWarp =
       comms::device::kWarpSize * kWordsPerVectorLoad * kUnroll;
 
-  // Per-block granularity matches `copyUnroll<4, T>`'s numPerBlock
-  // (`fbcode/comms/ctran/algos/DevCommon.cuh:391-442`):
-  // blockDim.x * (16/sizeof(T)) * 4 = warpsPerBlock * kWordsPerWarp.
-  // Rounding `limitCount` down to this granularity (instead of
-  // `kWordsPerWarp`) makes the per-CTA byte ownership of this main loop
-  // identical to copyUnroll's, so a single-designated-CTA tail (matching
-  // the fix Pavan applied in D69774173) is well-defined and avoids the
-  // cross-CTA read race when the same buffer is written by both writers
-  // in adjacent rounds with only per-CTA sync between them.
-  const uint32_t numPerBlock = blockDim.x * kWordsPerVectorLoad * kUnroll;
+  // Per-CTA byte ownership comes from the shared `ctaPartition<T, 4>`
+  // helper — same source of truth as `copyUnroll<4, T>` (and the
+  // fallback path below). Inner-loop unroll/vectorization stays
+  // specialized here.
+  const auto p = ctaPartition<T, /*Unroll16=*/4>(count, workerId, numWorkers);
+  const uint32_t limitCount = static_cast<uint32_t>(p.limitUnroll);
 
   const uint32_t linearThreadId = blockDim.x * workerId + threadIdx.x;
   const uint32_t warpId = linearThreadId / comms::device::kWarpSize;
   const uint32_t laneId = threadIdx.x % comms::device::kWarpSize;
   const uint32_t numWarps = numWorkers * blockDim.x / comms::device::kWarpSize;
-
-  const uint32_t u32Count = uint32_t(count);
-  const uint32_t limitCount = ctran::utils::roundDown(u32Count, numPerBlock);
 
   TVec s[kUnroll][NSrcs];
 
@@ -257,14 +251,8 @@ __device__ __forceinline__ void localReduceVectorized(
     }
   }
 
-  // Loop epilogue to handle remainder. Single designated CTA mirrors
-  // `copyUnroll`'s tail (DevCommon.cuh:436-441): the worker whose main-loop
-  // stride covers this part of the buffer handles the entire tail. Required
-  // for per-CTA byte-ownership equality with the copyUnroll-family writers
-  // (`ctranKernCopyRaw`, `ctranKernCopyMultiDestRaw`) when both are invoked
-  // on the same buffer in adjacent rounds with per-CTA sync only.
-  if (count != limitCount &&
-      workerId == ((limitCount / numPerBlock) % numWorkers)) {
+  // Single-CTA tail; ownership computed once in `ctaPartition` above.
+  if (p.ownsTail) {
     for (uint32_t i = limitCount + threadIdx.x; i < count; i += blockDim.x) {
       T s = srcs[0][i];
 #pragma unroll
@@ -310,73 +298,79 @@ __device__ __forceinline__ void localReduceFallback(
   constexpr int kVectors = CTRAN_MAX_NVL_PEERS;
   assert(nsrcs <= kVectors);
 
+  // Inner per-thread unroll — controls register pressure of the
+  // `T s[kUnroll][kVectors]` array. Independent from the outer
+  // byte-ownership unroll (see Unroll16 below); see static_assert for
+  // the divisibility invariant the two must satisfy.
   // FIXME: adjust unroll factor for this un-vectorized version
   constexpr uint32_t kUnroll = 8;
 
-  // Each warp will handle kUnroll values (warp contiguous and sequential)
-  // at a time
+  // Each warp handles kUnroll values per inner iteration (warp-contiguous,
+  // lane-stride 1, k-stride kWarpSize).
   constexpr uint32_t kWordsPerWarp = comms::device::kWarpSize * kUnroll;
 
-  // Per-block granularity = warpsPerBlock * kWordsPerWarp = blockDim.x *
-  // kUnroll. Rounding `limitCount` down to this (instead of
-  // `kWordsPerWarp`) makes the per-CTA byte ownership self-consistent
-  // for the fallback's own internal loop, so the single-designated-CTA
-  // tail below is well-defined.
-  //
-  // NOTE: this `numPerBlock` does NOT match `copyUnroll<4, T>`'s
-  // `blockDim.x * (16/sizeof(T)) * 4` for `sizeof(T) < 8`. Fallback is
-  // intentionally left on its own partition because (a) the ring AR
-  // path never hits this fallback (its inputs are 16-byte aligned, so
-  // the dispatcher in `localReduce` always picks `localReduceVectorized`),
-  // and (b) fully aligning fallback with copyUnroll requires
-  // re-architecting the per-warp unroll. If a future algorithm pairs
-  // `localReduceFallback` with a copyUnroll-family writer on the same
-  // buffer for `sizeof(T) < 8`, the partitions still disagree and a
-  // separate fix is needed there.
-  const uint32_t numPerBlock = blockDim.x * kUnroll;
+  // Outer per-CTA chunk size comes from the shared `ctaPartition<T, Unroll16>`
+  // helper — same source of truth as `copyUnroll<Unroll16, T>` and
+  // `localReduceVectorized`. The inner warp-strided loop below covers
+  // one chunk per outer iteration with the existing kUnroll=8 unroll;
+  // for `sizeof(T) < 8` this means multiple inner iterations per chunk
+  // (e.g. 2 for fp32, 4 for fp16). For `sizeof(T) == 8` chunk size
+  // matches the inner stride exactly and behavior is unchanged.
+  constexpr int kOuterUnroll16 = 4;
+  // Inner kUnroll must divide the per-thread T-element count of the
+  // outer per-CTA chunk; otherwise the inner warp-strided loop
+  // overshoots / misaligns the chunk owned by this CTA.
+  static_assert(
+      ((sizeof(uint4) / sizeof(T)) * kOuterUnroll16) % kUnroll == 0,
+      "kUnroll must divide (16/sizeof(T)) * kOuterUnroll16");
+  const auto p = ctaPartition<T, kOuterUnroll16>(count, workerId, numWorkers);
 
-  const uint32_t linearThreadId = blockDim.x * workerId + threadIdx.x;
-  const uint32_t globalWarpId = linearThreadId / comms::device::kWarpSize;
   const uint32_t laneId = threadIdx.x % comms::device::kWarpSize;
-  const uint32_t numGlobalWarps =
-      numWorkers * blockDim.x / comms::device::kWarpSize;
-
-  const size_t limitCount = ctran::utils::roundDown(count, size_t(numPerBlock));
+  const uint32_t blockWarpId = threadIdx.x / comms::device::kWarpSize;
+  const uint32_t warpsPerBlock = blockDim.x / comms::device::kWarpSize;
+  const size_t inBlockStride =
+      size_t(warpsPerBlock) * kWordsPerWarp; // = blockDim * kUnroll
 
   T s[kUnroll][kVectors];
 
-  for (size_t i = globalWarpId * kWordsPerWarp + laneId; i < limitCount;
-       i += numGlobalWarps * kWordsPerWarp) {
-    for (uint32_t j = 0; j < nsrcs; ++j) {
+  // Outer loop: per-CTA chunks, striped across CTAs.
+  for (size_t blockBase = size_t(workerId) * p.numPerBlock;
+       blockBase < p.limitUnroll;
+       blockBase += size_t(numWorkers) * p.numPerBlock) {
+    // Inner loop: this CTA covers [blockBase, blockBase + numPerBlock)
+    // using the warp-strided pattern.
+    for (size_t warpBase = blockBase + size_t(blockWarpId) * kWordsPerWarp;
+         warpBase < blockBase + p.numPerBlock;
+         warpBase += inBlockStride) {
+      const size_t i = warpBase + laneId;
+      for (uint32_t j = 0; j < nsrcs; ++j) {
 #pragma unroll
-      for (int k = 0; k < kUnroll; ++k) {
-        s[k][j] = *(&srcs[j][i + k * comms::device::kWarpSize]);
+        for (int k = 0; k < kUnroll; ++k) {
+          s[k][j] = *(&srcs[j][i + k * comms::device::kWarpSize]);
+        }
       }
-    }
 
-    // reduce vertically along the vectors
+      // reduce vertically along the vectors
 #pragma unroll
-    for (int j = 0; j < kUnroll; ++j) {
-      for (uint32_t k = 1; k < nsrcs; ++k) {
-        s[j][0] = reduceNcclOp1<T, RedOp>(s[j][0], s[j][k]);
-      }
+      for (int j = 0; j < kUnroll; ++j) {
+        for (uint32_t k = 1; k < nsrcs; ++k) {
+          s[j][0] = reduceNcclOp1<T, RedOp>(s[j][0], s[j][k]);
+        }
 
-      if constexpr (RedOp == commAvg) {
-        s[j][0] = s[j][0] / int(nRanks);
-      }
+        if constexpr (RedOp == commAvg) {
+          s[j][0] = s[j][0] / int(nRanks);
+        }
 
-      for (int d = 0; d < ndsts; ++d) {
-        dsts[d][i + j * comms::device::kWarpSize] = s[j][0];
+        for (int d = 0; d < ndsts; ++d) {
+          dsts[d][i + j * comms::device::kWarpSize] = s[j][0];
+        }
       }
     }
   }
 
-  // Loop epilogue to handle remainder. Single designated CTA mirrors
-  // `copyUnroll`'s tail (DevCommon.cuh:436-441); see the matching comment
-  // in localReduceVectorized for the per-CTA byte-ownership rationale.
-  if (count != limitCount &&
-      workerId == ((limitCount / numPerBlock) % numWorkers)) {
-    for (size_t i = limitCount + threadIdx.x; i < count; i += blockDim.x) {
+  // Single-CTA tail; ownership computed once in `ctaPartition` above.
+  if (p.ownsTail) {
+    for (size_t i = p.limitUnroll + threadIdx.x; i < count; i += blockDim.x) {
       T s = srcs[0][i];
 #pragma unroll
       for (int j = 1; j < nsrcs; ++j) {

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUT.cc
@@ -2,25 +2,40 @@
 
 // GPU reproducer for the per-CTA byte-ownership invariant violation
 // between `copyUnroll<4, T>` (`fbcode/comms/ctran/algos/DevCommon.cuh`)
-// and `localReduceVectorized` (`fbcode/comms/ctran/algos/localReduce.cuh`).
+// and `localReduce*` (`fbcode/comms/ctran/algos/localReduce.cuh`).
 //
-// D69774173 gave `copyUnroll`'s tail a single
-// designated CTA so per-byte ownership is stable across calls on the
-// same buffer. The same fix was never applied to `localReduce.cuh`.
+// Invariant: every byte of a shared buffer must map to the same CTA in
+// both the writer and the next reader on that buffer. When that holds,
+// each CTA's phase-2 read sees only its own phase-1 write — no
+// cross-CTA dependency for memory visibility, so a per-CTA self-fence
+// (release-store + acquire-load on the same CTA's own flag) is
+// sufficient. D69774173 gave `copyUnroll`'s tail a single designated
+// CTA so this invariant holds across calls on the same buffer. The
+// matching fix was never applied to `localReduce.cuh`.
 //
-// In ring AllReduce the bug surfaces at the RS→AG transition: RS-last-step
-// writes `recvbuff` (and `tmpSendBuf`) via `localReduce` (line 121); AG
-// steps touch the same buffers via `copyUnroll`-via-`ctranKernCopy*`
-// (lines 127, 137, 268, 278). Inter-round sync is per-CTA only via
-// `GpeKernelSync.completeFlag[blockIdx]`. When per-CTA ownership of two
-// writers disagrees, a CTA in the next round can read or overwrite bytes
-// a different CTA in the prior round hasn't yet committed.
+// In ring AllReduce the bug surfaces at the RS->AG transition: RS-last
+// writes `recvbuff` (and `tmpSendBuf`) via `localReduce`; AG steps
+// touch the same buffers via `copyUnroll`-via-`ctranKernCopy*`. Cross-
+// round visibility is mediated by the GPE host thread via separate
+// sync structs (`recvRedCopySync`, `revSendCopySync`, ...), not by per-
+// CTA flags; but the host gate at `AllReduceRing.cc:689`
+// (`progressRevSendCheckSendBuf`) only checks `revSendTrans.done`, not
+// `recvRedCopy.isComplete`, so the host relay does not fully serialize
+// writer and reader CTAs across this edge. When per-CTA byte ownership
+// of the two ops disagrees, a CTA in the next round can read bytes a
+// different CTA in the prior round hasn't yet committed.
+//
+// The test isolates the invariant: it uses no host relay at all and
+// only intra-CTA fences (see `LocalReduceTailRaceUTKernels.cu`), so
+// the byte-ownership invariant is the only thing standing between the
+// two ops. Pre-fix the invariant fails; post-fix it holds.
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <cstdint>
 #include <new>
+#include <string>
 #include <vector>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 #include "comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh"
@@ -33,19 +48,22 @@ class LocalReduceTailRaceTest : public ::testing::Test {
   }
 };
 
-TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
-  // count=2200, blockDim=128, gridDim=8, fp32:
-  // - copyUnroll-tail designated CTA = (2048/2048) % 8 = 1, so block 1
-  //   reads ALL of [2048, 2200) in phase 2.
-  // - Pre-fix localReduceVectorized-tail: block 0 writes [2048, 2176),
-  //   block 1 writes [2176, 2200) (grid-strided over linearThreadId).
-  // - Post-fix: block 1 writes [2048, 2200) (single-CTA tail mirrors
-  //   copyUnroll's predicate).
-  constexpr size_t count = 2200;
+namespace {
+
+// Launches `multiWriterTailRaceKernel<int32_t, UseFallback>` with the
+// production `GpeKernelSync` host-pinned allocation and pre-post, then
+// asserts that every `out[i] == src[i]` (i.e. no stale 0xCD-init read
+// reached phase 2).
+template <bool UseFallback>
+void runMultiWriterTailRaceTest(
+    size_t count,
+    int delayedBlock,
+    const std::string& failureContext) {
   constexpr int gridDim = 8;
   constexpr int blockDim = 128;
-  // 50 ms is well above any plausible time block 1 needs to reach phase 2.
-  constexpr unsigned long long block0DelayNs = 50ULL * 1000ULL * 1000ULL;
+  // 50 ms is well above any plausible time the other blocks need to
+  // reach phase 2.
+  constexpr unsigned long long delayNs = 50ULL * 1000ULL * 1000ULL;
   using T = int32_t;
   const size_t bytes = count * sizeof(T);
 
@@ -86,10 +104,18 @@ TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
   dim3 grid{gridDim, 1, 1};
   dim3 block{blockDim, 1, 1};
   size_t countLocal = count;
-  unsigned long long delayLocal = block0DelayNs;
-  void* args[] = {&bufDev, &outDev, &srcDev, &countLocal, &sync, &delayLocal};
+  int delayedLocal = delayedBlock;
+  unsigned long long delayLocal = delayNs;
+  void* args[] = {
+      &bufDev,
+      &outDev,
+      &srcDev,
+      &countLocal,
+      &sync,
+      &delayedLocal,
+      &delayLocal};
   CUDACHECK_TEST(cudaLaunchKernel(
-      reinterpret_cast<void*>(multiWriterTailRaceKernel<T>),
+      reinterpret_cast<void*>(multiWriterTailRaceKernel<T, UseFallback>),
       grid,
       block,
       args));
@@ -110,12 +136,47 @@ TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
   EXPECT_EQ(firstStale, count)
       << "stale read at out[" << firstStale
       << "] = " << static_cast<uint32_t>(outHost[firstStale]) << " (expected "
-      << static_cast<uint32_t>(srcHost[firstStale]) << ")"
-      << " — block 1 read a slot block 0 had not yet written in phase 1";
+      << static_cast<uint32_t>(srcHost[firstStale]) << ") — " << failureContext;
 
   CUDACHECK_TEST(cudaFree(srcDev));
   CUDACHECK_TEST(cudaFree(bufDev));
   CUDACHECK_TEST(cudaFree(outDev));
   sync->~GpeKernelSync();
   CUDACHECK_TEST(cudaFreeHost(syncPtr));
+}
+
+} // namespace
+
+TEST_F(LocalReduceTailRaceTest, DelayedBlockZeroExposesBlockOneStaleRead) {
+  // count=2200, blockDim=128, gridDim=8, fp32 (vectorized path):
+  // - copyUnroll-tail designated CTA = (2048/2048) % 8 = 1, so block 1
+  //   reads ALL of [2048, 2200) in phase 2.
+  // - Pre-fix localReduceVectorized-tail: block 0 writes [2048, 2176),
+  //   block 1 writes [2176, 2200) (grid-strided over linearThreadId).
+  //   Delaying block 0 makes block 1 read 0xCD in [2048, 2176).
+  // - Post-fix: block 1 writes [2048, 2200) (single-CTA tail mirrors
+  //   copyUnroll's predicate); delay has no effect.
+  runMultiWriterTailRaceTest</*UseFallback=*/false>(
+      /*count=*/2200,
+      /*delayedBlock=*/0,
+      "block 1 read a slot block 0 had not yet written in phase 1");
+}
+
+TEST_F(LocalReduceTailRaceTest, FallbackPathPartitionMismatchExposesStaleRead) {
+  // count=2048, blockDim=128, gridDim=8, fp32 (fallback path, aligned on
+  // numPerBlock so this isolates the MAIN-loop partition disagreement;
+  // tail coverage is already exercised by the vectorized test above):
+  // - copyUnroll<4, fp32> per-CTA chunk = 128 * 4 * 4 = 2048. With
+  //   count=2048, block 0's main loop covers [0, 2048).
+  // - Pre-fix localReduceFallback per-CTA chunk = 128 * 8 = 1024.
+  //   Block 0 writes [0, 1024); block 1 writes [1024, 2048).
+  //   Delaying block 1 makes block 0's phase-2 read of [1024, 2048) hit
+  //   0xCD.
+  // - Post-fix (ctaPartition<T, 4>): fallback's per-CTA chunk also = 2048.
+  //   Block 0 writes [0, 2048) entirely; delaying block 1 has no effect.
+  runMultiWriterTailRaceTest</*UseFallback=*/true>(
+      /*count=*/2048,
+      /*delayedBlock=*/1,
+      "block 0 read a slot fallback assigned to block 1 under its "
+      "(pre-fix) numPerBlock; block 1 was sleeping in phase 1");
 }

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cu
@@ -7,12 +7,15 @@
 
 namespace {
 
-// Spin-sleep on block 0 only via a clock-cycle busy wait. Cross-platform
-// (NVIDIA + AMD/HIP); `__nanosleep` is NVIDIA-only. Cycle-to-ns
-// conversion is approximate (~2 GHz upper bound) which is fine since
-// the goal is just "delay enough that block 1 reaches phase 2 first".
-__device__ __forceinline__ void block0Delay(unsigned long long totalNs) {
-  if (blockIdx.x != 0 || threadIdx.x != 0) {
+// Spin-sleep on a single designated block via a clock-cycle busy wait.
+// Cross-platform (NVIDIA + AMD/HIP); `__nanosleep` is NVIDIA-only.
+// Cycle-to-ns conversion is approximate (~2 GHz upper bound) which is
+// fine since the goal is just "delay enough that other blocks reach
+// phase 2 first".
+__device__ __forceinline__ void blockNDelay(
+    int targetBlock,
+    unsigned long long totalNs) {
+  if (blockIdx.x != targetBlock || threadIdx.x != 0) {
     return;
   }
   constexpr unsigned long long kCyclesPerNs = 2;
@@ -25,59 +28,84 @@ __device__ __forceinline__ void block0Delay(unsigned long long totalNs) {
 
 } // namespace
 
-template <typename T>
+template <typename T, bool UseFallback>
 __global__ void multiWriterTailRaceKernel(
     T* buf,
     T* out,
     const T* src,
     size_t count,
     ctran::algos::GpeKernelSync* sync,
-    unsigned long long block0DelayNs) {
-  // Delay block 0 so other blocks reach phase 2 before block 0 finishes
-  // phase 1. The delay runs only on block 0's thread 0; the rest of
-  // block 0 waits at the barrier below. Other blocks pass through
+    int delayedBlockIdx,
+    unsigned long long delayNs) {
+  // Delay one block so other blocks reach phase 2 before it finishes
+  // phase 1. The delay runs only on the target block's thread 0; the rest
+  // of that block waits at the barrier below. Other blocks pass through
   // immediately and proceed to phase 1.
-  block0Delay(block0DelayNs);
+  blockNDelay(delayedBlockIdx, delayNs);
   __syncthreads();
 
-  // Phase 1: real `localReduceVectorized` writes `buf` from `src`. With
-  // NSrcs=1 + commSum the reduction is identity, so `buf` should equal
-  // `src` for every byte once all CTAs' writes have committed.
+  // Phase 1: real `localReduce*` writes `buf` from `src`. With NSrcs=1 +
+  // commSum the reduction is identity, so `buf` should equal `src` for
+  // every byte once all CTAs' writes have committed.
   {
     const T* srcs[1] = {src};
     T* dsts[1] = {buf};
-    localReduceVectorized<T, commSum, 1, 1>(
-        srcs, dsts, count, blockIdx.x, gridDim.x);
+    if constexpr (UseFallback) {
+      localReduceFallback<T, commSum>(
+          /*nsrcs=*/1, srcs, /*ndsts=*/1, dsts, count, blockIdx.x, gridDim.x);
+    } else {
+      localReduceVectorized<T, commSum, 1, 1>(
+          srcs, dsts, count, blockIdx.x, gridDim.x);
+    }
   }
 
-  // Per-CTA release + per-CTA acquire-on-own-flag, using the REAL
-  // production sync API. `complete` does `__syncthreads()` +
-  // `st.release.sys.global` on `sync->completeFlag[blockIdx.x]`.
-  // `waitPost` polls `sync->postFlag[blockIdx.x]` with `ld.acquire.sys.global`
-  // until it observes a value >= step. The host pre-posted step=1 for
-  // every worker before kernel launch, so `waitPost` returns immediately
-  // — but the acquire fence still fires. There is intentionally NO
-  // cross-CTA acquire here (no host `isComplete` between phases),
-  // matching the per-CTA-only sync pattern that opens the bug window.
+  // Intra-CTA release-then-acquire on this CTA's own flag pair. Purpose
+  // is purely a per-CTA fence between phase-1 writes and phase-2 reads
+  // on `buf` (without it, compiler/GPU may reorder across the phases).
+  // Each call only touches `sync->completeFlag[blockIdx.x]` /
+  // `sync->postFlag[blockIdx.x]`; no CTA reads another CTA's slot, so
+  // these calls provide NO cross-CTA visibility. Host pre-posted step=1
+  // for every worker before launch, so `waitPost` returns past the
+  // acquire fence immediately.
+  //
+  // GpeKernelSync is a GPE-thread<->kernel primitive
+  // (`comms/ctran/algos/common/GpeKernelSync.h`), not a CTA<->CTA
+  // primitive — we reuse its device-side primitives here only because
+  // they give us the release/acquire fence shape we want for the
+  // intra-CTA phase boundary. The test deliberately omits any cross-CTA
+  // barrier so that the byte-ownership invariant between phase-1 writer
+  // and phase-2 reader is the only thing standing between the two
+  // ops — pre-fix that invariant fails for some byte ranges, and the
+  // delayed-block setup turns the resulting stale read into a
+  // deterministic failure.
   ctran::algos::GpeKernelSyncDev::complete(sync, blockIdx.x, /*step=*/1);
   ctran::algos::GpeKernelSyncDev::waitPost(sync, blockIdx.x, /*step=*/1);
 
   // Phase 2: real `copyUnroll<4, T>` reads `buf` and writes `out`. Each
   // CTA reads only the bytes it owns under copyUnroll's per-CTA
-  // partition. If localReduceVectorized's per-CTA partition assigned
-  // some of those bytes to a different CTA in phase 1 (the bug), this
-  // CTA's read may hit init sentinel because the writer CTA was still
-  // sleeping in `block0Delay` and hadn't issued its phase-1 writes yet.
+  // partition. If the phase-1 writer's per-CTA partition assigned some
+  // of those bytes to a different CTA, this CTA's read may hit init
+  // sentinel because the writer CTA was still sleeping in `blockNDelay`
+  // and hadn't issued its phase-1 writes yet.
   copyUnroll<4, T>(out, buf, count, blockIdx.x, gridDim.x);
 }
 
-#define DECL_MULTI_WRITER_KERN(T)                        \
-  template __global__ void multiWriterTailRaceKernel<T>( \
-      T * buf,                                           \
-      T * out,                                           \
-      const T* src,                                      \
-      size_t count,                                      \
-      ctran::algos::GpeKernelSync* sync,                 \
-      unsigned long long block0DelayNs)
+#define DECL_MULTI_WRITER_KERN(T)                               \
+  template __global__ void multiWriterTailRaceKernel<T, false>( \
+      T * buf,                                                  \
+      T * out,                                                  \
+      const T* src,                                             \
+      size_t count,                                             \
+      ctran::algos::GpeKernelSync* sync,                        \
+      int delayedBlockIdx,                                      \
+      unsigned long long delayNs);                              \
+  template __global__ void multiWriterTailRaceKernel<T, true>(  \
+      T * buf,                                                  \
+      T * out,                                                  \
+      const T* src,                                             \
+      size_t count,                                             \
+      ctran::algos::GpeKernelSync* sync,                        \
+      int delayedBlockIdx,                                      \
+      unsigned long long delayNs)
 
 DECL_MULTI_WRITER_KERN(int32_t);

--- a/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
+++ b/comms/ctran/algos/tests/LocalReduceTailRaceUTKernels.cuh
@@ -6,33 +6,47 @@
 #include <cstdint>
 #include "comms/ctran/algos/common/GpeKernelSync.h"
 
-// Single-kernel multi-writer test that DELIBERATELY delays block 0 so
-// block 1 reaches phase 2 before block 0 finishes phase 1. With the
-// pre-fix tail in `localReduceVectorized`, block 0 is the writer for
-// part of the byte range that block 1 reads in `copyUnroll`'s tail.
-// Because block 0 hasn't issued its writes yet (it's sleeping), block 1
-// reads the pre-init sentinel from L2 — `out` then carries that
-// sentinel instead of `src`, and the test fails.
+// Single-kernel multi-writer test that DELIBERATELY delays one block
+// (`delayedBlockIdx`) so other blocks reach phase 2 before that block
+// finishes phase 1. `UseFallback` picks between
+// `localReduceVectorized` (false) and `localReduceFallback` (true) as
+// the phase-1 writer; `copyUnroll<4, T>` is always the phase-2 reader.
 //
-// With the fix (single-designated-CTA tail in localReduce matching
-// copyUnroll's), block 1 owns its entire copyUnroll-tail range in BOTH
-// writers, so block 1's phase 2 read returns block 1's own phase 1
-// write — no dependency on block 0 — and the test passes.
+// Pre-fix, each writer family used its own per-CTA byte ownership that
+// disagreed with `copyUnroll`'s in different ways:
+//   - vectorized: tail partition disagreed (`UseFallback=false`,
+//     count not on numPerBlock boundary).
+//   - fallback: main-loop chunk = blockDim * 8 instead of
+//     blockDim * (16/sizeof(T)) * 4 (`UseFallback=true`,
+//     `sizeof(T) < 8`).
+// In either case, the delayed block is the writer for some bytes the
+// reader block then reads in phase 2 — and because the writer hasn't
+// issued its writes yet, the reader hits the pre-init sentinel.
+//
+// Post-fix (single shared `ctaPartition<T, 4>` between all three), each
+// CTA owns the same byte ranges in writer and reader — no cross-CTA
+// dependency — so the test passes regardless of `UseFallback`.
 //
 // `sync` is the REAL `ctran::algos::GpeKernelSync` allocated via
 // `cudaHostAlloc` and pre-posted by the host (post(1) for all workers
-// before launch). The kernel uses `GpeKernelSyncDev::complete` for the
-// release on `completeFlag` and `GpeKernelSyncDev::waitPost` for the
-// acquire on `postFlag` — exactly the production sync code path
-// (`comms/ctran/algos/common/GpeKernelSyncDev.cuh`). This means the
-// test exercises the SAME visibility chain that ring AllReduce uses
-// between rounds; if `GpeKernelSync`'s sync semantics ever change, the
-// test moves with it.
-template <typename T>
+// before launch). The kernel uses `GpeKernelSyncDev::complete` /
+// `GpeKernelSyncDev::waitPost` only as an intra-CTA release/acquire
+// fence between the two phases — each CTA touches only its own slot
+// (`completeFlag[blockIdx]`, `postFlag[blockIdx]`), so these calls do
+// NOT provide cross-CTA visibility.
+//
+// Production cross-round visibility in ring AllReduce is mediated by
+// the GPE host thread (host's `post`/`isComplete` aggregating across
+// all workers on different sync structs across different ops), not by
+// per-CTA flags. The test deliberately omits that host relay so the
+// byte-ownership invariant between writer and reader is the only
+// safety net — which is what we want to assert in isolation.
+template <typename T, bool UseFallback>
 __global__ void multiWriterTailRaceKernel(
     T* buf,
     T* out,
     const T* src,
     size_t count,
     ctran::algos::GpeKernelSync* sync,
-    unsigned long long block0DelayNs);
+    int delayedBlockIdx,
+    unsigned long long delayNs);


### PR DESCRIPTION
Summary:

PAFT replica consistency checks on S651852 still reproduce on TOT despite D103324874's fix to `localReduceVectorized`'s tail. That fix only covered the vectorized path; the `localReduceFallback` path was left with its own per-CTA partition (`numPerBlock = blockDim * kUnroll = blockDim * 8`), which disagrees with `copyUnroll<4, T>`'s `numPerBlock = blockDim * (16/sizeof(T)) * 4` for any `sizeof(T) < 8` (factor of 2x for fp32). The disagreement was documented in code comments as a latent footgun.

The fallback path is hit whenever any source/destination pointer fails the 16B alignment check in the `localReduce` dispatcher (`fbcode/comms/ctran/algos/localReduce.cuh:421`). For a 5-replica AllReduce of 16777728 fp32 elements -- the failing case in `S651852_latest_v13e_tpp_600_TIER1_54M_PAFT-f9n152r5` -- `shardNumel = floor(16777728 / 5) = 3355545` makes 3 of 5 shard offsets non-16B-aligned (byte offsets `13422180`, `26844360`, `40266540` are all `4`/`8`/`12 mod 16`). The dispatcher falls back, so per-CTA byte ownership of the producer (`localReduceFallback`) disagrees with the consumer (`copyUnroll<4, fp32>` via `ctranKernCopyRaw`) at the RS-last -> BIDIR-AG transition where `_progressRevSend` reads reduced shards out of `recvbuff` (`AllReduceRing.cuh:244-250`).

Cross-round visibility between these two ops would in principle serialize all writer CTAs before any reader CTA via the GPE host thread -- host's `post`/`isComplete` aggregate across all workers when applied to the same sync struct. In ring AR the host gate for revSend at `progressRevSendCheckSendBuf` (`AllReduceRing.cc:689`) only checks `revSendTrans.done` for buffer-slot recycling, not `recvRedCopy.isComplete`, so the host relay does NOT fully fence writer and reader CTAs across this edge. With per-CTA byte ownership in agreement (the invariant `copyUnroll` already satisfied via D69774173), each reader CTA reads only bytes its own self wrote and a per-CTA acquire fence is sufficient. With the invariant violated -- as `localReduceFallback` violates it for `sizeof(T) < 8` -- a reader CTA reads bytes a different writer CTA was supposed to commit, and nothing in the system orders the two. (`GpeKernelSync` is a GPE-thread<->kernel primitive, not a CTA<->CTA primitive; the test reproducer in this diff strips the host relay entirely and uses `complete`/`waitPost` only as intra-CTA fences to isolate the invariant.)

**Why only misaligned shards race -- aligned vs misaligned, side-by-side.** Toy dims: `blockDim=1`, `gridDim=2`, fp32, 24-element shard. Two phases run back-to-back on the same shard; per-CTA byte ownership is the only safety net between them at this edge. Consumer (`copyUnroll<4, fp32>`) always uses `numPerBlock = 1 * (16/4) * 4 = 16`; the producer's `numPerBlock` depends on which dispatch path runs.

**Aligned shard** -> producer is `localReduceVectorized` (`numPerBlock = 16`, matches consumer):

```
index:   0       8       16      24
         |-------|-------|-------|

PHASE 1 (localReduceVectorized writes):
  block 0: WWWWWWWWWWWWWWWW           <- writes [0, 16)
  block 1:                 WWWWWWWW   <- writes tail [16, 24)

PHASE 2 (copyUnroll<4, fp32> reads):
  block 0: RRRRRRRRRRRRRRRR           <- reads [0, 16)
  block 1:                 RRRRRRRR   <- reads tail [16, 24)
```

Same block writes and reads each byte; each CTA's phase-2 read sees only its own phase-1 writes. No cross-CTA dependency. Safe.

**Misaligned shard (pre-fix)** -> producer is `localReduceFallback` (`numPerBlock = 1 * 8 = 8`, half the consumer's):

```
index:   0       8       16      24
         |-------|-------|-------|

PHASE 1 (localReduceFallback writes, chunk=8, stride=16):
  block 0: WWWWWWWW        WWWWWWWW  <- writes [0, 8) AND [16, 24)
  block 1:         WWWWWWWW          <- writes [8, 16)

PHASE 2 (copyUnroll<4, fp32> reads, chunk=16):
  block 0: RRRRRRRRRRRRRRRR          <- reads [0, 16)
  block 1:                 RRRRRRRR  <- reads tail [16, 24)
```

Per-byte producer/consumer mismatch creates cross-CTA dependencies that no per-CTA fence covers and the host relay at this edge does not enforce:

| byte range | producer | consumer | what would need to order them |
|---|---|---|---|
| `[0, 8)`   | block 0 | block 0 | own writes -- safe |
| `[8, 16)`  | block 1 | block 0 | block 1's writes -- no acquire by block 0 |
| `[16, 24)` | block 0 | block 1 (tail) | block 0's writes -- no acquire by block 1 |

Two cross-CTA edges in every shard the dispatcher routes to fallback. The SEV's 5-rank/fp32 case puts 4 of 5 shards on this path (only shard 0's pointer is `0 mod 16`); change either factor so `shardNumel * sizeof(T)` is a multiple of 16 and every shard takes the vectorized path -- no cross-CTA edge.

Root-cause fix: extract per-CTA byte ownership into a single shared helper `ctaPartition<T, Unroll16>` in `DevCommon.cuh`. Make `copyUnroll`, `localReduceVectorized`, and `localReduceFallback` all compute their per-CTA chunk from this one helper, so the invariant holds by construction for every `T` and `Unroll16`.

Reviewed By: arttianezhu

Differential Revision: D105625831


