### PR TITLE
Remove `NCCL_ENABLE_P2C_RDMA_FLUSH` cvar and P2C flush META patch (#2662)

### DIFF
--- a/comms/ctran/profiler/GpeProfilerReport.h
+++ b/comms/ctran/profiler/GpeProfilerReport.h
@@ -65,6 +65,8 @@ constexpr std::string_view tracePointName(GpeTracePoint p) {
 // "abnormal_exit") and lands in the Scuba "message" column.
 struct GpeProfilerReport {
   const CommLogData* logMetaData{nullptr};
+  uint64_t commHash{0};
+  int rank{-1};
   uint64_t opCount{0};
   int opType{-1};
   GpeTracePoint tracePoint{GpeTracePoint::ITER_START};

--- a/comms/ncclx/v2_29/src/graph/paths.cc
+++ b/comms/ncclx/v2_29/src/graph/paths.cc
@@ -584,14 +584,6 @@ ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev,
   if (gpu->paths[NET][n].type <= PATH_PXB && gpu->paths[CPU][c].type == PATH_C2C) {
     *flush = 1;
   }
-  // [META] PATH_P2C (C2C to CPU + PCIe to NIC) also requires flush: RDMA data
-  // arrives via PCIe while the proxy tail update reaches GPU via a different path,
-  // with no cross-path ordering guarantee.
-  int netPathType = gpu->paths[NET][n].type;
-  int cpuPathType = gpu->paths[CPU][c].type;
-  if (NCCL_ENABLE_P2C_RDMA_FLUSH && netPathType == PATH_P2C && cpuPathType == PATH_C2C) {
-    *flush = 1;
-  }
   return ncclSuccess;
 }
 

--- a/comms/ncclx/v2_30/src/graph/paths.cc
+++ b/comms/ncclx/v2_30/src/graph/paths.cc
@@ -611,12 +611,6 @@ ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev,
     if (gpu->paths[NET][n].type <= PATH_PXB && gpu->paths[CPU][c].type == PATH_C2C) {
       *flush = ncclTopoFlushC2c;
     }
-    // [META] PATH_P2C (C2C to CPU + PCIe to NIC) also requires flush: RDMA data
-    // arrives via PCIe while the proxy tail update reaches GPU via a different path,
-    // with no cross-path ordering guarantee.
-    if (NCCL_ENABLE_P2C_RDMA_FLUSH && gpu->paths[NET][n].type == PATH_P2C && gpu->paths[CPU][c].type == PATH_C2C) {
-      *flush = ncclTopoFlushC2c;
-    }
   }
   return ncclSuccess;
 }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -569,16 +569,6 @@ cvars:
    default     : 0
    description : https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-net-force-flush
 
- - name        : NCCL_ENABLE_P2C_RDMA_FLUSH
-   type        : bool
-   default     : true
-   description : |-
-     Enable RDMA READ flush for PATH_P2C topology (C2C to CPU + PCIe to NIC)
-     on GB200. When RDMA data arrives via PCIe and the proxy tail update reaches
-     GPU via a different path (C2C), there is no cross-path ordering guarantee.
-     The flush drains pending PCIe writes before signaling the GPU kernel.
-     Set to false to disable for performance comparison.
-
  - name        : NCCL_NET_DISABLE_INTRA
    type        : int64_t
    default     : 0


### PR DESCRIPTION
Summary:

Upstream NCCL topo detection now correctly handles flush on GB200 PATH_P2C topology, so the META-side cvar and flush patch are no longer needed:
- Remove the `NCCL_ENABLE_P2C_RDMA_FLUSH` cvar definition from `nccl_cvars.yaml`
- Remove the P2C flush block from `ncclTopoNeedFlush()` in v2_29 and v2_30 `paths.cc`, making the function identical to upstream
- Remove the flush ordering investigation doc (`ncclx-gb200-flush-ordering-investigation.md`)

Differential Revision: D106023448


