### PR TITLE
Fix NVLink tile persistent step cursor

### DIFF
--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -1484,16 +1484,17 @@ class P2pNvlTransportDevice {
         (nbytes + effectiveChunk - 1) / effectiveChunk;
     const std::size_t stepsPerSlot =
         (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
-
+    const std::size_t pipelineSteps = stepsPerSlot * options_.pipelineDepth;
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
-    int64_t step = tile_state_.step_state[groupId];
+    const int64_t baseStep = tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t absStep = static_cast<std::size_t>(step);
-      const std::size_t slotStep = absStep / stepsPerSlot;
-      const std::size_t subStep = absStep % stepsPerSlot;
+      const int64_t step = baseStep + static_cast<int64_t>(s);
+      const std::size_t stepIndex = static_cast<std::size_t>(step);
+      const std::size_t slotStep = stepIndex / stepsPerSlot;
+      const std::size_t subStep = stepIndex % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1503,13 +1504,11 @@ class P2pNvlTransportDevice {
           ? effectiveChunk
           : (dataOff < nbytes ? nbytes - dataOff : 0);
 
-      if (subStep == 0 &&
-          step >= static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
+      if (subStep == 0 && stepIndex >= pipelineSteps) {
         tile_state_.local_signals[headSignalId].wait_until(
             group,
             CmpOp::CMP_GE,
-            static_cast<uint64_t>(
-                step - stepsPerSlot * options_.pipelineDepth + 1),
+            static_cast<uint64_t>(stepIndex - pipelineSteps + 1),
             timeout);
       }
 
@@ -1526,12 +1525,11 @@ class P2pNvlTransportDevice {
         tile_state_.remote_signals[tailSignalId].signal(
             SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
       }
-
-      step++;
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[groupId] = step;
+      tile_state_.step_state[groupId] =
+          baseStep + static_cast<int64_t>(totalSteps);
     }
     group.sync();
 #endif
@@ -1604,12 +1602,13 @@ class P2pNvlTransportDevice {
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
-    int64_t step = tile_state_.step_state[max_groups + groupId];
+    const int64_t baseStep = tile_state_.step_state[max_groups + groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t absStep = static_cast<std::size_t>(step);
-      const std::size_t slotStep = absStep / stepsPerSlot;
-      const std::size_t subStep = absStep % stepsPerSlot;
+      const int64_t step = baseStep + static_cast<int64_t>(s);
+      const std::size_t stepIndex = static_cast<std::size_t>(step);
+      const std::size_t slotStep = stepIndex / stepsPerSlot;
+      const std::size_t subStep = stepIndex % stepsPerSlot;
       const std::size_t slot = slotStep % options_.pipelineDepth;
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = subStep * effectiveChunk;
@@ -1639,12 +1638,11 @@ class P2pNvlTransportDevice {
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
         }
       }
-
-      step++;
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[max_groups + groupId] = step;
+      tile_state_.step_state[max_groups + groupId] =
+          baseStep + static_cast<int64_t>(totalSteps);
     }
     group.sync();
 #endif
@@ -1747,28 +1745,29 @@ class P2pNvlTransportDevice {
         (nbytes + effectiveChunk - 1) / effectiveChunk;
     const std::size_t stepsPerSlot =
         (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
-
+    const std::size_t pipelineSteps = stepsPerSlot * options_.pipelineDepth;
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
     // Recv side step counter (this transport: predecessor → me).
     // Stored in step_state[max_groups + groupId], matching recv().
-    int64_t recvStep = tile_state_.step_state[max_groups + groupId];
+    const int64_t recvBaseStep = tile_state_.step_state[max_groups + groupId];
     // Send side step counter (successor transport: me → successor).
     // Stored in step_state[groupId], matching send().
-    int64_t sendStep = successor.tile_state_.step_state[groupId];
+    const int64_t sendBaseStep = successor.tile_state_.step_state[groupId];
 
     for (std::size_t s = 0; s < totalSteps; ++s) {
-      const std::size_t absRecvStep = static_cast<std::size_t>(recvStep);
-      const std::size_t recvSlotStep = absRecvStep / stepsPerSlot;
-      const std::size_t recvSubStep = absRecvStep % stepsPerSlot;
+      const int64_t recvStep = recvBaseStep + static_cast<int64_t>(s);
+      const int64_t sendStep = sendBaseStep + static_cast<int64_t>(s);
+      const std::size_t recvStepIndex = static_cast<std::size_t>(recvStep);
+      const std::size_t recvSlotStep = recvStepIndex / stepsPerSlot;
+      const std::size_t recvSubStep = recvStepIndex % stepsPerSlot;
       const std::size_t recvSlot = recvSlotStep % options_.pipelineDepth;
       const std::size_t recvSlotOff = recvSlot * slotSize;
       const std::size_t recvChunkOff = recvSubStep * effectiveChunk;
-
-      const std::size_t absSendStep = static_cast<std::size_t>(sendStep);
-      const std::size_t sendSlotStep = absSendStep / stepsPerSlot;
-      const std::size_t sendSubStep = absSendStep % stepsPerSlot;
+      const std::size_t sendStepIndex = static_cast<std::size_t>(sendStep);
+      const std::size_t sendSlotStep = sendStepIndex / stepsPerSlot;
+      const std::size_t sendSubStep = sendStepIndex % stepsPerSlot;
       const std::size_t sendSlot = sendSlotStep % options_.pipelineDepth;
       const std::size_t sendSlotOff = sendSlot * slotSize;
       const std::size_t sendChunkOff = sendSubStep * effectiveChunk;
@@ -1784,14 +1783,11 @@ class P2pNvlTransportDevice {
 
       // 2. Wait for successor's staging slot to be free (send side, only at
       //    slot boundaries once we have wrapped around the pipeline).
-      if (sendSubStep == 0 &&
-          sendStep >=
-              static_cast<int64_t>(stepsPerSlot * options_.pipelineDepth)) {
+      if (sendSubStep == 0 && sendStepIndex >= pipelineSteps) {
         successor.tile_state_.local_signals[headSignalId].wait_until(
             group,
             CmpOp::CMP_GE,
-            static_cast<uint64_t>(
-                sendStep - stepsPerSlot * options_.pipelineDepth + 1),
+            static_cast<uint64_t>(sendStepIndex - pipelineSteps + 1),
             timeout);
       }
 
@@ -1821,14 +1817,13 @@ class P2pNvlTransportDevice {
               SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
         }
       }
-
-      recvStep++;
-      sendStep++;
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[max_groups + groupId] = recvStep;
-      successor.tile_state_.step_state[groupId] = sendStep;
+      tile_state_.step_state[max_groups + groupId] =
+          recvBaseStep + static_cast<int64_t>(totalSteps);
+      successor.tile_state_.step_state[groupId] =
+          sendBaseStep + static_cast<int64_t>(totalSteps);
     }
     group.sync();
 #endif

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -548,6 +548,137 @@ static void runTileTest(
   }
 }
 
+static unsigned char multiCallPattern(int rank, int call) {
+  return static_cast<unsigned char>(0x30 + rank * 0x20 + call);
+}
+
+static std::vector<char> makeTwoCallPatternBuffer(
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    int numBlocks,
+    int rank) {
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  std::vector<char> data(tileBytes * numBlocks);
+
+  for (int block = 0; block < numBlocks; ++block) {
+    const size_t offset = block * tileBytes;
+    std::fill(
+        data.begin() + offset,
+        data.begin() + offset + firstCallBytes,
+        static_cast<char>(multiCallPattern(rank, 0)));
+    std::fill(
+        data.begin() + offset + firstCallBytes,
+        data.begin() + offset + tileBytes,
+        static_cast<char>(multiCallPattern(rank, 1)));
+  }
+
+  return data;
+}
+
+static void expectTwoCallPattern(
+    const std::vector<char>& data,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    int numBlocks,
+    int sourceRank,
+    const std::string& label) {
+  const size_t callBytes[] = {firstCallBytes, secondCallBytes};
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+
+  for (int block = 0; block < numBlocks; ++block) {
+    size_t callOffset = block * tileBytes;
+    for (int call = 0; call < 2; ++call) {
+      const unsigned char expected = multiCallPattern(sourceRank, call);
+      for (size_t i = 0; i < callBytes[call]; ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(data[callOffset + i]), expected)
+            << label << ": block=" << block << " call=" << call
+            << " byte=" << i;
+        if (static_cast<unsigned char>(data[callOffset + i]) != expected) {
+          return;
+        }
+      }
+      callOffset += callBytes[call];
+    }
+  }
+}
+
+static void expectPersistentTwoCallStagingPattern(
+    const std::vector<char>& data,
+    size_t slotSize,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    size_t pipelineDepth,
+    int numBlocks,
+    int sourceRank,
+    const std::string& label) {
+  const size_t callBytes[] = {firstCallBytes, secondCallBytes};
+  const size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
+  const size_t stepsPerSlot =
+      (perBlockSlotSize + maxSignalBytes - 1) / maxSignalBytes;
+
+  for (int block = 0; block < numBlocks; ++block) {
+    size_t baseStep = 0;
+    for (int call = 0; call < 2; ++call) {
+      const unsigned char expected = multiCallPattern(sourceRank, call);
+      const size_t chunks =
+          (callBytes[call] + maxSignalBytes - 1) / maxSignalBytes;
+      for (size_t chunk = 0; chunk < chunks; ++chunk) {
+        const size_t step = baseStep + chunk;
+        const size_t slotStep = step / stepsPerSlot;
+        const size_t subStep = step % stepsPerSlot;
+        const size_t slot = slotStep % pipelineDepth;
+        const size_t chunkBytes =
+            ((chunk + 1) * maxSignalBytes <= callBytes[call])
+            ? maxSignalBytes
+            : callBytes[call] - chunk * maxSignalBytes;
+        const size_t offset = slot * slotSize + block * perBlockSlotSize +
+            subStep * maxSignalBytes;
+
+        for (size_t i = 0; i < chunkBytes; ++i) {
+          EXPECT_EQ(static_cast<unsigned char>(data[offset + i]), expected)
+              << label << ": block=" << block << " call=" << call
+              << " chunk=" << chunk << " byte=" << i;
+          if (static_cast<unsigned char>(data[offset + i]) != expected) {
+            return;
+          }
+        }
+      }
+      baseStep += chunks;
+    }
+  }
+}
+
+static P2pNvlTransportDevice makeLocalTileDevice(
+    const P2pNvlTransportOptions& options,
+    int numBlocks,
+    char* localData,
+    char* remoteData,
+    DeviceSpan<int64_t> stepState,
+    DeviceSpan<SignalState> localSignals,
+    DeviceSpan<SignalState> remoteSignals) {
+  LocalState localState{
+      localData,
+      DeviceSpan<ChunkState>(),
+      DeviceSpan<ChunkState>(),
+      localSignals,
+      DeviceSpan<BarrierState>(),
+      nullptr};
+
+  RemoteState remoteState{
+      remoteData,
+      DeviceSpan<ChunkState>(),
+      DeviceSpan<ChunkState>(),
+      remoteSignals,
+      DeviceSpan<BarrierState>(),
+      nullptr};
+
+  NvlinkTransportTileState tileState{
+      stepState, numBlocks, localSignals, remoteSignals};
+  return P2pNvlTransportDevice(
+      0, 1, options, localState, remoteState, tileState);
+}
+
 // Test various message sizes with default config
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMessageSizes) {
   if (numRanks != 2) {
@@ -779,6 +910,127 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCallPersistentStep) {
       2,
       4,
       5);
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileSendRecvMultiCallWithoutDrainUsesPersistentCursor) {
+  const int numBlocks = 4;
+  const int threadCount = 256;
+  const size_t maxSignalBytes = 16 * 1024;
+  const size_t firstCallBytes = maxSignalBytes;
+  const size_t secondCallBytes = maxSignalBytes * 3;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = tileBytes * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+  const size_t stagingBytes = options.dataBufferSize * options.pipelineDepth;
+
+  const std::vector<char> hostSend =
+      makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
+  DeviceBuffer sendBuf(totalBytes);
+  DeviceBuffer recvBuf(totalBytes);
+  DeviceBuffer stagingBuf(stagingBytes);
+  const size_t stepStateBytes = sizeof(int64_t) * numBlocks * 2;
+  const size_t signalBytes = sizeof(SignalState) * numBlocks * 2;
+  DeviceBuffer stepStateBuf(stepStateBytes);
+  DeviceBuffer localSignalsBuf(signalBytes);
+  DeviceBuffer remoteSignalsBuf(signalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+  CUDACHECK_TEST(cudaMemset(stagingBuf.get(), 0, stagingBytes));
+  CUDACHECK_TEST(cudaMemset(stepStateBuf.get(), 0, stepStateBytes));
+  CUDACHECK_TEST(cudaMemset(localSignalsBuf.get(), 0, signalBytes));
+  CUDACHECK_TEST(cudaMemset(remoteSignalsBuf.get(), 0, signalBytes));
+
+  auto p2pHost = makeLocalTileDevice(
+      options,
+      numBlocks,
+      static_cast<char*>(stagingBuf.get()),
+      static_cast<char*>(stagingBuf.get()),
+      DeviceSpan<int64_t>(
+          static_cast<int64_t*>(stepStateBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(localSignalsBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(remoteSignalsBuf.get()), numBlocks * 2));
+
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  test::testPrepareTileTwoCallStaging(
+      p2pHost,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      2,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  test::testTileTwoCallSendOnly(
+      p2pHost,
+      sendTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostStaging(stagingBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostStaging.data(),
+      stagingBuf.get(),
+      stagingBytes,
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile send persistent cursor staging");
+
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+  test::testPrepareTileTwoCallStaging(
+      p2pHost,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  test::testTileTwoCallRecvOnly(
+      p2pHost,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile recv persistent cursor");
 }
 
 // Test multi-call with different message sizes per call
@@ -4424,6 +4676,123 @@ TEST_F(P2pNvlTransportTestFixture, TileForwardDesynchronizedStepState) {
       }
     }
   }
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileForwardMultiCallWithoutDrainUsesPersistentCursor) {
+  const int numBlocks = 4;
+  const int threadCount = 256;
+  const size_t maxSignalBytes = 16 * 1024;
+  const size_t firstCallBytes = maxSignalBytes;
+  const size_t secondCallBytes = maxSignalBytes * 3;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = tileBytes * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+  const size_t stagingBytes = options.dataBufferSize * options.pipelineDepth;
+
+  DeviceBuffer sourceStagingBuf(stagingBytes);
+  DeviceBuffer forwardedStagingBuf(stagingBytes);
+  DeviceBuffer dstBuf(totalBytes);
+  const size_t stepStateBytes = sizeof(int64_t) * numBlocks * 2;
+  const size_t signalBytes = sizeof(SignalState) * numBlocks * 2;
+  DeviceBuffer predStepStateBuf(stepStateBytes);
+  DeviceBuffer predLocalSignalsBuf(signalBytes);
+  DeviceBuffer predRemoteSignalsBuf(signalBytes);
+  DeviceBuffer succStepStateBuf(stepStateBytes);
+  DeviceBuffer succLocalSignalsBuf(signalBytes);
+  DeviceBuffer succRemoteSignalsBuf(signalBytes);
+
+  CUDACHECK_TEST(cudaMemset(sourceStagingBuf.get(), 0, stagingBytes));
+  CUDACHECK_TEST(cudaMemset(forwardedStagingBuf.get(), 0, stagingBytes));
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, totalBytes));
+  CUDACHECK_TEST(cudaMemset(predStepStateBuf.get(), 0, stepStateBytes));
+  CUDACHECK_TEST(cudaMemset(predLocalSignalsBuf.get(), 0, signalBytes));
+  CUDACHECK_TEST(cudaMemset(predRemoteSignalsBuf.get(), 0, signalBytes));
+  CUDACHECK_TEST(cudaMemset(succStepStateBuf.get(), 0, stepStateBytes));
+  CUDACHECK_TEST(cudaMemset(succLocalSignalsBuf.get(), 0, signalBytes));
+  CUDACHECK_TEST(cudaMemset(succRemoteSignalsBuf.get(), 0, signalBytes));
+
+  auto pred = makeLocalTileDevice(
+      options,
+      numBlocks,
+      static_cast<char*>(sourceStagingBuf.get()),
+      nullptr,
+      DeviceSpan<int64_t>(
+          static_cast<int64_t*>(predStepStateBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(predLocalSignalsBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(predRemoteSignalsBuf.get()),
+          numBlocks * 2));
+  auto succ = makeLocalTileDevice(
+      options,
+      numBlocks,
+      nullptr,
+      static_cast<char*>(forwardedStagingBuf.get()),
+      DeviceSpan<int64_t>(
+          static_cast<int64_t*>(succStepStateBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(succLocalSignalsBuf.get()), numBlocks * 2),
+      DeviceSpan<SignalState>(
+          static_cast<SignalState*>(succRemoteSignalsBuf.get()),
+          numBlocks * 2));
+
+  test::testPrepareTileTwoCallStaging(
+      pred,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  TiledBuffer<char> dstTiles(
+      static_cast<char*>(dstBuf.get()), totalBytes, numBlocks);
+  test::testTileTwoCallForward(
+      pred,
+      succ,
+      dstTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostStaging(stagingBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostStaging.data(),
+      forwardedStagingBuf.get(),
+      stagingBytes,
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile forward persistent cursor staging");
+
+  std::vector<char> hostDst(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(), dstBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostDst,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile forward persistent cursor dst");
 }
 
 // Partial tiles (nbytes not evenly divisible by numBlocks)

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -171,6 +171,350 @@ __global__ void testWeightedRecvSendKernel(
   }
 }
 
+__device__ void wait_for_second_call_signal(
+    P2pNvlTransportDevice& p2p,
+    ThreadGroup& group,
+    int blockId,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool enabled,
+    const Timeout& timeout) {
+  if (!enabled) {
+    return;
+  }
+  const uint64_t chunksPerCall =
+      (bytesPerCall + maxSignalBytes - 1) / maxSignalBytes;
+  p2p.tile_state().local_signals[blockId].wait_until(
+      group, CmpOp::CMP_GE, chunksPerCall + 1, timeout);
+}
+
+__global__ void testTileMultiCallSendRecvKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const int blockId = sub.group_id;
+
+  if (role == 0) {
+    char* sendTile = sendTiles.tile_data(blockId);
+    for (int i = 0; i < numCalls; ++i) {
+      p2p.send(
+          sub,
+          sendTile + i * bytesPerCall,
+          bytesPerCall,
+          activeBlocks,
+          maxSignalBytes,
+          timeout);
+    }
+  } else {
+    wait_for_second_call_signal(
+        p2p,
+        sub,
+        blockId,
+        bytesPerCall,
+        maxSignalBytes,
+        waitForSecondCallSignal,
+        timeout);
+    char* recvTile = recvTiles.tile_data(blockId);
+    for (int i = 0; i < numCalls; ++i) {
+      p2p.recv(
+          sub,
+          recvTile + i * bytesPerCall,
+          bytesPerCall,
+          activeBlocks,
+          maxSignalBytes,
+          timeout);
+    }
+  }
+}
+
+__global__ void testTileMultiCallSendOnlyKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* sendTile = sendTiles.tile_data(blockId);
+  for (int i = 0; i < numCalls; ++i) {
+    p2p.send(
+        group,
+        sendTile + i * bytesPerCall,
+        bytesPerCall,
+        activeBlocks,
+        maxSignalBytes,
+        timeout);
+  }
+}
+
+__global__ void testTileTwoCallSendOnlyKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* sendTile = sendTiles.tile_data(blockId);
+  p2p.send(
+      group, sendTile, firstCallBytes, activeBlocks, maxSignalBytes, timeout);
+  p2p.send(
+      group,
+      sendTile + firstCallBytes,
+      secondCallBytes,
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+}
+
+__global__ void testPrepareTileStagingKernel(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int sourceRank,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* staging = p2p.local_state().dataBuffer;
+
+  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perBlockSlotSize = (slotSize / activeBlocks) & ~15ULL;
+  const size_t effectiveChunk = maxSignalBytes;
+  const size_t chunksPerCall =
+      (bytesPerCall + effectiveChunk - 1) / effectiveChunk;
+  const size_t stepsPerSlot =
+      (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+  const size_t stagingOff = blockId * perBlockSlotSize;
+
+  for (int call = 0; call < numCalls; ++call) {
+    const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
+    for (size_t s = 0; s < chunksPerCall; ++s) {
+      const size_t step = call * chunksPerCall + s;
+      const size_t slotStep = step / stepsPerSlot;
+      const size_t subStep = step % stepsPerSlot;
+      const size_t slot = slotStep % p2p.options().pipelineDepth;
+      const size_t dataOff = s * effectiveChunk;
+      const size_t copyBytes = (dataOff + effectiveChunk <= bytesPerCall)
+          ? effectiveChunk
+          : bytesPerCall - dataOff;
+      const size_t bufferOff =
+          slot * slotSize + stagingOff + subStep * effectiveChunk;
+      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+           idx += group.group_size) {
+        staging[bufferOff + idx] = pattern;
+      }
+    }
+  }
+
+  group.sync();
+  if (group.is_leader()) {
+    p2p.tile_state().local_signals[blockId].signal(
+        SignalOp::SIGNAL_SET, static_cast<uint64_t>(numCalls) * chunksPerCall);
+  }
+}
+
+__global__ void testPrepareTileTwoCallStagingKernel(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int sourceRank,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* staging = p2p.local_state().dataBuffer;
+
+  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perBlockSlotSize = (slotSize / activeBlocks) & ~15ULL;
+  const size_t effectiveChunk =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
+      ? (maxSignalBytes & ~15ULL)
+      : perBlockSlotSize;
+  const size_t stepsPerSlot =
+      (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+  const size_t stagingOff = blockId * perBlockSlotSize;
+
+  size_t baseStep = 0;
+  for (int call = 0; call < 2; ++call) {
+    const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
+    const size_t chunks = (callBytes + effectiveChunk - 1) / effectiveChunk;
+    const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
+    for (size_t s = 0; s < chunks; ++s) {
+      const size_t step = baseStep + s;
+      const size_t slotStep = step / stepsPerSlot;
+      const size_t subStep = step % stepsPerSlot;
+      const size_t slot = slotStep % p2p.options().pipelineDepth;
+      const size_t dataOff = s * effectiveChunk;
+      const size_t copyBytes = (dataOff + effectiveChunk <= callBytes)
+          ? effectiveChunk
+          : callBytes - dataOff;
+      const size_t bufferOff =
+          slot * slotSize + stagingOff + subStep * effectiveChunk;
+      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+           idx += group.group_size) {
+        staging[bufferOff + idx] = pattern;
+      }
+    }
+    baseStep += chunks;
+  }
+
+  group.sync();
+  if (group.is_leader()) {
+    p2p.tile_state().local_signals[blockId].signal(
+        SignalOp::SIGNAL_SET, static_cast<uint64_t>(baseStep));
+  }
+}
+
+__global__ void testTileMultiCallRecvOnlyKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* recvTile = recvTiles.tile_data(blockId);
+  for (int i = 0; i < numCalls; ++i) {
+    p2p.recv(
+        group,
+        recvTile + i * bytesPerCall,
+        bytesPerCall,
+        activeBlocks,
+        maxSignalBytes,
+        timeout);
+  }
+}
+
+__global__ void testTileTwoCallRecvOnlyKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* recvTile = recvTiles.tile_data(blockId);
+  p2p.recv(
+      group, recvTile, firstCallBytes, activeBlocks, maxSignalBytes, timeout);
+  p2p.recv(
+      group,
+      recvTile + firstCallBytes,
+      secondCallBytes,
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+}
+
+__global__ void testTileMultiCallForwardKernel(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  wait_for_second_call_signal(
+      pred,
+      group,
+      blockId,
+      bytesPerCall,
+      maxSignalBytes,
+      waitForSecondCallSignal,
+      timeout);
+
+  char* dstTile = dstTiles.tile_data(blockId);
+  for (int i = 0; i < numCalls; ++i) {
+    pred.forward(
+        group,
+        dstTile + i * bytesPerCall,
+        bytesPerCall,
+        succ,
+        activeBlocks,
+        maxSignalBytes,
+        timeout);
+  }
+}
+
+__global__ void testTileTwoCallForwardKernel(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* dstTile = dstTiles.tile_data(blockId);
+  pred.forward(
+      group,
+      dstTile,
+      firstCallBytes,
+      succ,
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+  pred.forward(
+      group,
+      dstTile + firstCallBytes,
+      secondCallBytes,
+      succ,
+      activeBlocks,
+      maxSignalBytes,
+      timeout);
+}
+
+__global__ void testCopyLocalStagingKernel(
+    P2pNvlTransportDevice p2p,
+    void* dst,
+    size_t nbytes) {
+  auto group = make_block_group();
+  memcpy_vectorized(
+      static_cast<char*>(dst), p2p.local_state().dataBuffer, nbytes, group);
+}
+
 void testSend(
     P2pNvlTransportDevice* p2p,
     void* src_d,
@@ -254,6 +598,206 @@ void testMultiRecv(
     int /*blocksPerGroup*/) {
   testMultiRecvKernel<<<numBlocks, blockSize>>>(
       p2p, dst_d, nbytes, numRecvs, groupType);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileMultiCallSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileMultiCallSendRecvKernel<<<activeBlocks * 2, blockSize, 0, stream>>>(
+      p2p,
+      sendTiles,
+      recvTiles,
+      activeBlocks,
+      numCalls,
+      bytesPerCall,
+      maxSignalBytes,
+      waitForSecondCallSignal,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileMultiCallSendOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileMultiCallSendOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      sendTiles,
+      activeBlocks,
+      numCalls,
+      bytesPerCall,
+      maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileTwoCallSendOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileTwoCallSendOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      sendTiles,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testPrepareTileStaging(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int sourceRank,
+    int blockSize,
+    cudaStream_t stream) {
+  testPrepareTileStagingKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      activeBlocks,
+      numCalls,
+      bytesPerCall,
+      maxSignalBytes,
+      sourceRank,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testPrepareTileTwoCallStaging(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int sourceRank,
+    int blockSize,
+    cudaStream_t stream) {
+  testPrepareTileTwoCallStagingKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      sourceRank,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileMultiCallRecvOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileMultiCallRecvOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      recvTiles,
+      activeBlocks,
+      numCalls,
+      bytesPerCall,
+      maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileTwoCallRecvOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileTwoCallRecvOnlyKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      p2p,
+      recvTiles,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileMultiCallForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileMultiCallForwardKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      pred,
+      succ,
+      dstTiles,
+      activeBlocks,
+      numCalls,
+      bytesPerCall,
+      maxSignalBytes,
+      waitForSecondCallSignal,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileTwoCallForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileTwoCallForwardKernel<<<activeBlocks, blockSize, 0, stream>>>(
+      pred,
+      succ,
+      dstTiles,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testCopyLocalStaging(
+    P2pNvlTransportDevice p2p,
+    void* dst,
+    size_t nbytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testCopyLocalStagingKernel<<<1, blockSize, 0, stream>>>(p2p, dst, nbytes);
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
 
 namespace comms::pipes::test {
 
@@ -129,6 +130,108 @@ void testWeightedRecvSend(
     uint32_t recvWeight,
     uint32_t sendWeight,
     GroupType groupType = GroupType::WARP);
+
+void testTileMultiCallSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileMultiCallSendOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileTwoCallSendOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testPrepareTileStaging(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int sourceRank,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testPrepareTileTwoCallStaging(
+    P2pNvlTransportDevice p2p,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int sourceRank,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileMultiCallRecvOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileTwoCallRecvOnly(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileMultiCallForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    int numCalls,
+    size_t bytesPerCall,
+    size_t maxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileTwoCallForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testCopyLocalStaging(
+    P2pNvlTransportDevice p2p,
+    void* dst,
+    size_t nbytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
 
 // Test put() - one-sided direct memory write to peer GPU and signal peer
 // Unlike send()/recv(), put() writes directly to dst_d without staging buffers


### PR DESCRIPTION
Summary: Make P2pNvlTransportDevice tile send/recv/forward derive staging slots and substeps from persistent step state, matching the IBGDA transport behavior across repeated calls. Add multi-call no-drain tests for send/recv and forward that would overwrite slot 0 with the old per-call cursor math.

Reviewed By: snarayankh

Differential Revision: D106038317


