### PR TITLE
Add missing `commHash` and `rank` fields to `GpeProfilerReport`

### DIFF
--- a/comms/ctran/profiler/GpeProfilerReport.h
+++ b/comms/ctran/profiler/GpeProfilerReport.h
@@ -65,6 +65,8 @@ constexpr std::string_view tracePointName(GpeTracePoint p) {
 // "abnormal_exit") and lands in the Scuba "message" column.
 struct GpeProfilerReport {
   const CommLogData* logMetaData{nullptr};
+  uint64_t commHash{0};
+  int rank{-1};
   uint64_t opCount{0};
   int opType{-1};
   GpeTracePoint tracePoint{GpeTracePoint::ITER_START};


### PR DESCRIPTION
Summary:
- `GpeProfiler::reportRaw()` uses designated initializers with `.commHash` and `.rank`, but `GpeProfilerReport` struct was missing these fields
- This causes a compile error in OSS CI (GCC with stricter designated-initializer checking): `'const ctran::GpeProfilerReport' has no non-static data member named 'commHash'`
- Add both fields between `logMetaData` and `opCount` to match the initialization order in `GpeProfiler.cc`

Differential Revision: D106043727


