### PR TITLE
Add device adapter abstraction (#2666)

### DIFF
--- a/comms/uniflow/drivers/DeviceAdapter.h
+++ b/comms/uniflow/drivers/DeviceAdapter.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "comms/uniflow/Result.h"
+
+namespace uniflow {
+
+class CudaApi;
+
+/// DeviceAdapter abstracts device-specific host pinned memory allocation
+/// for use with DMA from a NIC or accelerator.
+class DeviceAdapter {
+ public:
+  virtual ~DeviceAdapter() = default;
+
+  /// Allocate page-aligned, host-pinned memory suitable for DMA from a NIC
+  /// or accelerator.
+  virtual Result<void*> pinnedHostAlloc(size_t size) = 0;
+
+  /// Release memory previously returned by pinnedHostAlloc().
+  virtual Status pinnedHostFree(void* ptr) = 0;
+
+  /// Return a device-accessible pointer for `hostPtr` (which must have been
+  /// obtained from pinnedHostAlloc()).
+  virtual Result<void*> hostGetDevicePointer(void* hostPtr) = 0;
+};
+
+/// Returns a DeviceAdapter for the current build configuration.
+///
+/// The CUDA implementation accepts an optional CudaApi for dependency
+/// injection in tests; if null, a default CudaApi is constructed. The
+/// parameter is ignored by non-CUDA implementations.
+std::shared_ptr<DeviceAdapter> createDeviceAdapter(
+    std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+} // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CMakeLists.txt
+++ b/comms/uniflow/drivers/cuda/CMakeLists.txt
@@ -3,11 +3,13 @@
 set(UNIFLOW_CUDA_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaApi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDriverApi.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/CudaDeviceAdapter.cpp
 )
 
 set(UNIFLOW_CUDA_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaApi.h
     ${CMAKE_CURRENT_SOURCE_DIR}/CudaDriverApi.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/CudaDeviceAdapter.h
 )
 
 add_library(uniflow_cuda OBJECT

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/drivers/cuda/CudaDeviceAdapter.h"
+
+namespace uniflow {
+
+Result<void*> CudaDeviceAdapter::pinnedHostAlloc(size_t size) {
+  return cudaApi_->hostAlloc(size, cudaHostAllocMapped | cudaHostAllocPortable);
+}
+
+Status CudaDeviceAdapter::pinnedHostFree(void* ptr) {
+  return cudaApi_->hostFree(ptr);
+}
+
+Result<void*> CudaDeviceAdapter::hostGetDevicePointer(void* hostPtr) {
+  return cudaApi_->hostGetDevicePointer(hostPtr);
+}
+
+std::shared_ptr<DeviceAdapter> createDeviceAdapter(
+    std::shared_ptr<CudaApi> cudaApi) {
+  if (!cudaApi) {
+    cudaApi = std::make_shared<CudaApi>();
+  }
+  return std::make_shared<CudaDeviceAdapter>(std::move(cudaApi));
+}
+
+} // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+
+#include "comms/uniflow/drivers/DeviceAdapter.h"
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+
+namespace uniflow {
+
+class CudaDeviceAdapter : public DeviceAdapter {
+ public:
+  explicit CudaDeviceAdapter(std::shared_ptr<CudaApi> cudaApi)
+      : cudaApi_(std::move(cudaApi)) {}
+
+  Result<void*> pinnedHostAlloc(size_t size) override;
+  Status pinnedHostFree(void* ptr) override;
+  Result<void*> hostGetDevicePointer(void* hostPtr) override;
+
+ private:
+  std::shared_ptr<CudaApi> cudaApi_;
+};
+
+} // namespace uniflow

--- a/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/drivers/cuda/CudaDeviceAdapter.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+
+namespace uniflow {
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace {
+
+constexpr size_t kSize = 4096;
+
+} // namespace
+
+TEST(CudaDeviceAdapterTest, PinnedHostAllocPassesMappedPortableFlags) {
+  // pinnedHostAlloc must request mapped + portable so the returned host
+  // pointer is usable for both DMA from a NIC and host-mapped device
+  // access from any CUDA context. Verifying the flag argument is the
+  // observable contract that callers (RdmaSlabPool, RdmaTransport) rely
+  // on -- a bare delegation/round-trip check would not catch a regression
+  // in those flags.
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int sentinel = 0;
+  EXPECT_CALL(
+      *mock, hostAlloc(kSize, cudaHostAllocMapped | cudaHostAllocPortable))
+      .WillOnce(Return(Result<void*>(&sentinel)));
+
+  CudaDeviceAdapter adapter(mock);
+
+  auto res = adapter.pinnedHostAlloc(kSize);
+  ASSERT_FALSE(res.hasError());
+}
+
+TEST(CudaDeviceAdapterTest, PinnedHostAllocPropagatesError) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  EXPECT_CALL(*mock, hostAlloc(kSize, _))
+      .WillOnce(Return(Err(ErrCode::DriverError, "oom")));
+
+  CudaDeviceAdapter adapter(mock);
+
+  auto res = adapter.pinnedHostAlloc(kSize);
+  ASSERT_TRUE(res.hasError());
+  EXPECT_EQ(res.error().code(), ErrCode::DriverError);
+}
+
+TEST(CudaDeviceAdapterTest, PinnedHostFreeDelegatesToCudaApi) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int sentinel = 0;
+  void* fakePtr = &sentinel;
+  EXPECT_CALL(*mock, hostFree(fakePtr)).WillOnce(Return(Ok()));
+
+  CudaDeviceAdapter adapter(mock);
+
+  EXPECT_FALSE(adapter.pinnedHostFree(fakePtr).hasError());
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaSlabPool.cpp
+++ b/comms/uniflow/transport/rdma/RdmaSlabPool.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <span>
 
+#include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaResources.h"
 
@@ -17,21 +18,20 @@ namespace uniflow {
 
 class PinnedBuffer {
  public:
-  PinnedBuffer(size_t size, std::shared_ptr<CudaApi> cudaApi)
-      : cudaApi_(std::move(cudaApi)) {
-    auto result =
-        cudaApi_->hostAlloc(size, cudaHostAllocMapped | cudaHostAllocPortable);
+  PinnedBuffer(size_t size, std::shared_ptr<DeviceAdapter> deviceAdapter)
+      : deviceAdapter_(std::move(deviceAdapter)) {
+    auto result = deviceAdapter_->pinnedHostAlloc(size);
     if (!result) {
       throw std::runtime_error(
-          "PinnedBuffer: cudaHostAlloc failed: " + result.error().toString());
+          "PinnedBuffer: pinnedHostAlloc failed: " + result.error().toString());
     }
     hostPtr_ = result.value();
 
-    auto devResult = cudaApi_->hostGetDevicePointer(hostPtr_);
+    auto devResult = deviceAdapter_->hostGetDevicePointer(hostPtr_);
     if (!devResult) {
-      cudaApi_->hostFree(hostPtr_);
+      deviceAdapter_->pinnedHostFree(hostPtr_);
       throw std::runtime_error(
-          "PinnedBuffer: cudaHostGetDevicePointer failed: " +
+          "PinnedBuffer: hostGetDevicePointer failed: " +
           devResult.error().toString());
     }
     devicePtr_ = reinterpret_cast<uintptr_t>(devResult.value());
@@ -39,32 +39,14 @@ class PinnedBuffer {
 
   ~PinnedBuffer() {
     if (hostPtr_) {
-      cudaApi_->hostFree(hostPtr_);
+      deviceAdapter_->pinnedHostFree(hostPtr_);
     }
   }
 
   PinnedBuffer(const PinnedBuffer&) = delete;
   PinnedBuffer& operator=(const PinnedBuffer&) = delete;
-  PinnedBuffer(PinnedBuffer&& other) noexcept
-      : cudaApi_(std::move(other.cudaApi_)),
-        hostPtr_(other.hostPtr_),
-        devicePtr_(other.devicePtr_) {
-    other.hostPtr_ = nullptr;
-    other.devicePtr_ = 0;
-  }
-  PinnedBuffer& operator=(PinnedBuffer&& other) noexcept {
-    if (this != &other) {
-      if (hostPtr_) {
-        cudaApi_->hostFree(hostPtr_);
-      }
-      cudaApi_ = std::move(other.cudaApi_);
-      hostPtr_ = other.hostPtr_;
-      devicePtr_ = other.devicePtr_;
-      other.hostPtr_ = nullptr;
-      other.devicePtr_ = 0;
-    }
-    return *this;
-  }
+  PinnedBuffer(PinnedBuffer&&) = delete;
+  PinnedBuffer& operator=(PinnedBuffer&&) = delete;
 
   void* hostPtr() const {
     return hostPtr_;
@@ -74,7 +56,7 @@ class PinnedBuffer {
   }
 
  private:
-  std::shared_ptr<CudaApi> cudaApi_;
+  std::shared_ptr<DeviceAdapter> deviceAdapter_;
   void* hostPtr_{nullptr};
   uintptr_t devicePtr_{0};
 };
@@ -295,11 +277,13 @@ RdmaSlabPool::RdmaSlabPool(
         "RdmaSlabPool: slabSize must be > 0 and slabNum must be > 0");
   }
 
+  auto deviceAdapter = createDeviceAdapter(cudaApi);
+
   const size_t bufferSize = config_.slabNum * config_.slabSize;
   const size_t stateSize = config_.slabNum * sizeof(uint64_t);
   const size_t totalSize = bufferSize + stateSize;
 
-  buffer_ = std::make_unique<PinnedBuffer>(totalSize, cudaApi);
+  buffer_ = std::make_unique<PinnedBuffer>(totalSize, std::move(deviceAdapter));
   std::memset(static_cast<char*>(buffer_->hostPtr()), 0, totalSize);
 
   mrSet_ = std::make_unique<MrSet>(

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
+#include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
@@ -221,6 +222,8 @@ RdmaTransport::RdmaTransport(
   CHECK_THROW_EXCEPTION(
       config_.numQps > 0 && config_.numQps <= 255, std::invalid_argument);
 
+  deviceAdapter_ = createDeviceAdapter(cudaApi_);
+
   const uint32_t numNics =
       std::min(config_.numQps, static_cast<uint32_t>(nicsHandle_->size()));
   nics_ = std::span<NicResources>(nicsHandle_->data(), numNics);
@@ -252,8 +255,7 @@ TransportInfo RdmaTransport::bind() {
   // CTS and Notify are separate regions so bidirectional send/recv is safe.
   const size_t ctrlSize = ctrlBufferSize();
   info_.ctrl.length = static_cast<uint32_t>(ctrlSize);
-  auto ctrlAllocResult = cudaApi_->hostAlloc(
-      ctrlSize, cudaHostAllocMapped | cudaHostAllocPortable);
+  auto ctrlAllocResult = deviceAdapter_->pinnedHostAlloc(ctrlSize);
   if (!ctrlAllocResult) {
     UNIFLOW_LOG_ERROR("bind: failed to allocate ctrl buffer");
     state_ = TransportState::Error;
@@ -1729,7 +1731,7 @@ void RdmaTransport::shutdown() {
   ctrlMrs_.clear();
 
   if (ctrlBuffer_) {
-    cudaApi_->hostFree(ctrlBuffer_);
+    deviceAdapter_->pinnedHostFree(ctrlBuffer_);
     ctrlBuffer_ = nullptr;
   }
 
@@ -1883,7 +1885,7 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
     }
   } fdGuard;
 
-  // For cuMemGetHandleForAddressRange, the address must be page-aligned.
+  // dma buffers must be page aligned, the address must be page-aligned.
   // Align down to page boundary and track the offset for regDmabufMr.
   uint64_t dmaBufOffset = 0;
   uintptr_t addr = reinterpret_cast<uintptr_t>(segment.mutable_data());

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -11,6 +11,7 @@
 
 #include "comms/uniflow/transport/rdma/CopyEngine.h"
 
+#include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
@@ -522,6 +523,7 @@ class RdmaTransport : public Transport {
   const std::shared_ptr<IbvApi> ibvApi_;
   const std::shared_ptr<CudaApi> cudaApi_;
   std::shared_ptr<CudaDriverApi> cudaDriverApi_;
+  std::shared_ptr<DeviceAdapter> deviceAdapter_;
   EventBase* evb_{nullptr};
 
   std::string name_;
@@ -678,6 +680,7 @@ class RdmaTransportFactory : public TransportFactory {
   std::shared_ptr<IbvApi> ibvApi_;
   std::shared_ptr<CudaDriverApi> cudaDriverApi_;
   std::shared_ptr<CudaApi> cudaApi_;
+
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
   size_t pageSize_{0};


### PR DESCRIPTION
Summary:

Introduce a DeviceAdapter abstractiont that allows shared user code to use both cuda and mtia APIs.

Reviewed By: tanquer

Differential Revision: D106037276


