### PR TITLE
Add `MemoryCoherenceScope::Device` to `HRDWRingBuffer` (#2667)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -86,8 +86,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## HRDWRingBuffer + GpuClockCalibration host sources
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -94,8 +94,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## HRDWRingBuffer + GpuClockCalibration host sources
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)

--- a/comms/pipes/PipesTrace.cc
+++ b/comms/pipes/PipesTrace.cc
@@ -8,7 +8,7 @@
 #include <mutex>
 #include <utility>
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 #include "comms/utils/logger/LogUtils.h"
 
 namespace comms::pipes {
@@ -103,7 +103,7 @@ void PipesTrace::ensure(uint32_t ringSize) {
   }
 
   reader_ = std::make_unique<Reader>(*buffer_);
-  ::meta::comms::colltrace::GlobaltimerCalibration::get();
+  ::hrdw_ring_buffer::GlobaltimerCalibration::get();
   startLogThread();
   CLOGF(INFO, "Pipes trace buffer ready ring_size={}", buffer_->size());
 }
@@ -148,7 +148,7 @@ void PipesTrace::enqueueLogBatch(PendingLogBatch batch) {
 }
 
 void PipesTrace::logBatch(const PendingLogBatch& batch) const {
-  auto& calibration = ::meta::comms::colltrace::GlobaltimerCalibration::get();
+  auto& calibration = ::hrdw_ring_buffer::GlobaltimerCalibration::get();
   for (const auto& pendingEntry : batch.entries) {
     const auto& entry = pendingEntry.entry;
     const auto wallTime = calibration.toWallClock(entry.timestamp);

--- a/comms/pipes/PipesTrace.h
+++ b/comms/pipes/PipesTrace.h
@@ -14,18 +14,18 @@
 #include <vector>
 
 #include "comms/pipes/PipesTraceTypes.h"
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 
 namespace comms::pipes {
 
 class PipesTrace {
  public:
   using Buffer =
-      ::meta::comms::colltrace::HRDWRingBuffer<comms::pipes::PipesTraceEvent>;
+      ::hrdw_ring_buffer::HRDWRingBuffer<comms::pipes::PipesTraceEvent>;
   using Entry = typename Buffer::Entry;
-  using Reader = ::meta::comms::colltrace::HRDWRingBufferReader<
-      comms::pipes::PipesTraceEvent>;
+  using Reader =
+      ::hrdw_ring_buffer::HRDWRingBufferReader<comms::pipes::PipesTraceEvent>;
 
   PipesTrace() = default;
   ~PipesTrace();

--- a/comms/pipes/PipesTraceTypes.h
+++ b/comms/pipes/PipesTraceTypes.h
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace comms::pipes {
 
@@ -27,7 +27,7 @@ struct PipesTraceEvent {
 static_assert(sizeof(PipesTraceEvent) == 8);
 
 using PipesTraceHandle =
-    ::meta::comms::colltrace::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
+    ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 __device__ __forceinline__ void write_pipes_trace(

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1013,9 +1013,9 @@ set(COMMON_FILES
   comms/utils/commSpecs.h
   comms/utils/Conversion.cc
   comms/utils/Conversion.h
-  comms/utils/GpuClockCalibration.cc
-  comms/utils/GpuClockCalibration.cu
-  comms/utils/GpuClockCalibration.h
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
   comms/utils/CudaChecks.h
   comms/utils/CudaRAII.cc
   comms/utils/CudaRAII.h

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -12,7 +12,6 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include "comms/utils/CommsMaybeChecks.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
@@ -20,6 +19,7 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 namespace meta::comms::colltrace {
 
@@ -78,7 +78,7 @@ CollTrace::CollTrace(
     // Eagerly initialize the globaltimer calibration singleton now (outside
     // graph capture) so it is ready when GraphCudaWaitEvent is constructed
     // during capture.
-    GlobaltimerCalibration::get();
+    ::hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // 2x the max plugin retention ensures the ring holds at least the last
     // max_retention collective entries (each collective has 1x start + 1x end
@@ -472,7 +472,7 @@ void CollTrace::pollGraphEvents(
     return;
   }
 
-  const auto& cal = GlobaltimerCalibration::get();
+  const auto& cal = ::hrdw_ring_buffer::GlobaltimerCalibration::get();
 
   auto pollResult = ringReader_->poll(
       [&](const auto& entry, uint64_t /*slot*/) {
@@ -727,7 +727,7 @@ void CollTrace::collTraceThread(
       auto now = std::chrono::steady_clock::now();
       if (now - lastReanchor >= kReanchorInterval) {
         if (ringBuffer_.has_value()) {
-          GlobaltimerCalibration::get().refresh();
+          ::hrdw_ring_buffer::GlobaltimerCalibration::get().refresh();
         }
         if (auto* refpt = CudaReferencePoint::tryGet()) {
           refpt->refresh();

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -14,14 +14,14 @@
 #include <folly/MPMCQueue.h>
 #include <folly/concurrency/ConcurrentHashMap.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
 #include "comms/utils/colltrace/CollTraceEvent.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/colltrace/CollTracePlugin.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 
 struct CUstream_st;
 
@@ -192,9 +192,11 @@ class CollTrace : public ICollTrace {
 
   // Single shared ring buffer for ALL cuda graphs. RAII-managed via
   // HRDWRingBuffer (mapped pinned memory, GPU-writable, CPU-readable).
-  std::optional<HRDWRingBuffer<GraphCollTraceEvent>> ringBuffer_;
+  std::optional<::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>>
+      ringBuffer_;
   // CPU-side reader for the shared ring buffer (poll thread only).
-  std::optional<HRDWRingBufferReader<GraphCollTraceEvent>> ringReader_;
+  std::optional<::hrdw_ring_buffer::HRDWRingBufferReader<GraphCollTraceEvent>>
+      ringReader_;
   // Map from collId to GraphCollectiveEntry* for fast lookup during polling.
   // Only accessed from the colltrace thread (no mutex needed). Entries are
   // added under graphStatesMutex_ and then inserted here on first poll.

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -10,9 +10,9 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/CudaRAII.h"
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
@@ -41,7 +41,8 @@ GraphCudaWaitEvent::~GraphCudaWaitEvent() {
 }
 
 void GraphCudaWaitEvent::attachRingBuffer(
-    HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept {
+    ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
+        ringBuffer) noexcept {
   ringBuffer_ = ringBuffer;
 }
 

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -4,10 +4,10 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
@@ -54,7 +54,8 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   CommsMaybe<system_clock_time_point> getCollEndTime() noexcept override;
 
   void attachRingBuffer(
-      HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept;
+      ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
+          ringBuffer) noexcept;
 
   cudaStream_t getStream() const noexcept {
     return stream_;
@@ -81,7 +82,7 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   cudaEvent_t depEvent_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
-  HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
+  ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
@@ -6,7 +6,7 @@
 
 #include "comms/utils/colltrace/HRDWRingBufferInstantiations.cuh"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     cudaStream_t,
@@ -16,4 +16,4 @@ template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     uint32_t,
     GraphCollTraceEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
@@ -7,12 +7,14 @@
 // NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
 #pragma once
 
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // --- GraphCollTraceEvent (graph-initiated colltrace) ---
+using ::meta::comms::colltrace::GraphCollTraceEvent;
+
 extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     cudaStream_t,
     HRDWEntry<GraphCollTraceEvent>*,
@@ -21,4 +23,4 @@ extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     uint32_t,
     GraphCollTraceEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -20,12 +20,12 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
@@ -159,7 +159,7 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     // Enable cudagraph tracing for these tests.
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
 
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     auto progressPlugin = std::make_unique<ProgressTrackingPlugin>();
     progressPlugin_ = progressPlugin.get();

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -11,12 +11,12 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
 
 using meta::comms::colltrace::CollTrace;
@@ -64,7 +64,7 @@ class GraphColltraceTopologyTest : public ::testing::Test {
     // Enable cudagraph tracing for these tests.
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
 
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaMalloc(&buf1_, kWorkBytes);
@@ -641,7 +641,7 @@ TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
 
   // Eagerly initialize globaltimer calibration before capture starts —
   // it does cudaHostAlloc which is illegal during stream capture.
-  meta::comms::colltrace::GlobaltimerCalibration::get();
+  hrdw_ring_buffer::GlobaltimerCalibration::get();
 
   // Capture a graph — recordCollective should fail for graph-captured
   // collectives when the ring buffer is not allocated.
@@ -705,7 +705,7 @@ class GraphColltraceFlushTest : public ::testing::Test {
     cudaStreamCreate(&stream_);
 
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaMalloc(&buf1_, kWorkBytes);

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
@@ -32,7 +32,7 @@
     }                                  \
   } while (0)
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     uint64_t gpu_ns) const {
@@ -129,7 +129,7 @@ bool GlobaltimerCalibration::refresh() {
   // so the host timestamp is no earlier than the device reading.
   *anchor_.wlock() = Anchor{
       .device_ns = *mapped_ptr_,
-      .host_time = colltrace::precisionNow(),
+      .host_time = ::meta::comms::colltrace::precisionNow(),
   };
   return true;
 }
@@ -201,4 +201,4 @@ GlobaltimerCalibration::createForTest(
 
 #undef CUDA_CHECK_CC
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
@@ -4,9 +4,9 @@
 
 #include <cstdint>
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 namespace {
 
@@ -21,4 +21,4 @@ cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out) {
   return cudaGetLastError();
 }
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
@@ -26,7 +26,7 @@
 // GlobaltimerCalibration::toWallClock(uint32_t).
 #define US_TICK_TIMESTAMP_SHIFT 10
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // Calibration anchor mapping GPU %globaltimer nanoseconds to wall-clock time.
 // The first anchor is taken lazily on first use of get(); subsequent anchors
@@ -140,4 +140,4 @@ __device__ __forceinline__ uint64_t readGlobaltimer() {
 }
 #endif
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -28,6 +28,19 @@
 
 namespace hrdw_ring_buffer {
 
+// Memory coherence scope controls the allocation strategy, atomic
+// operations, and read/write paths of the ring buffer.
+//
+//   System — pinned mapped memory, system-scope atomics, 128-bit atomic
+//            slot exchanges. Host can poll concurrently via mapped
+//            pointers. Requires sm_90+ for atom.exch.b128.
+//
+//   Device — device-global memory, device-scope atomics, 128-bit atomic
+//            slot exchanges. Host reads via cudaMemcpy after
+//            cudaStreamSynchronize (no concurrent reader). Requires
+//            sm_90+ for atom.exch.b128.
+enum class MemoryCoherenceScope { System, Device };
+
 // ==========================================================================
 // HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
 // event transfer with lock-free, torn-read-safe polling.
@@ -39,7 +52,7 @@ namespace hrdw_ring_buffer {
 //   which the writer's slot-atomic publication guarantees observes either
 //   the fully-old or fully-new state — no torn reads, no retries.
 //
-// USAGE
+// USAGE (MemoryCoherenceScope::System — default)
 //   1. Create a ring buffer. DataT must fit in 8 bytes (the entry packs
 //      into exactly 16 bytes for atomic 128b stores). For non-trivially-
 //      destructible DataT, the destructor IS invoked on the displaced
@@ -63,6 +76,32 @@ namespace hrdw_ring_buffer {
 //          auto wall = cal.toWallClock(entry.timestamp);
 //        });
 //
+// USAGE (MemoryCoherenceScope::Device)
+//   1. Create a ring buffer. DataT must be ≤ 8 bytes so the entry
+//      packs into 16 bytes for atomic 128b stores. Non-trivially-
+//      destructible DataT will silently leak per-occupant resources
+//      on ring teardown — the host can't reach into device memory to
+//      run ~DataT(). Drain + destruct host-side if cleanup matters.
+//
+//        HRDWRingBuffer<MyEvent, MemoryCoherenceScope::Device> buf(4096);
+//
+//   2. Write events from GPU kernels via the device handle:
+//
+//        auto handle = buf.deviceHandle();
+//        myKernel<<<...>>>(handle, ...);
+//        // inside kernel: handle.write(myEvent);
+//
+//   3. Create a reader and poll from the host between steps:
+//
+//        HRDWRingBufferReader<MyEvent, MemoryCoherenceScope::Device>
+//            reader(buf);
+//        reader.poll(stream, [&](const auto& entry, uint64_t slot) {
+//          const MyEvent& evt = entry.data;
+//        });
+//        // Poll again whenever you want fresh entries — poll() auto-
+//        // advances its internal read cursor, so successive calls only
+//        // return entries written since the previous one.
+//
 // LAYOUT (16 bytes, 16-byte aligned)
 //   - timestamp: uint32_t — globaltimer_ns >> 10 (~1024ns ticks). Wraps
 //                every 2^42 ns ≈ 73 min; the reader reconstructs full
@@ -78,6 +117,7 @@ namespace hrdw_ring_buffer {
 //   - data:      DataT, ≤ 8 bytes (padded to 16 if smaller).
 //
 // MEMORY ORDERING
+//   System scope:
 //   - The writer issues a single 128b atomic exchange at system scope via
 //     cuda::atomic_ref<unsigned __int128, thread_scope_system>::exchange
 //     (libcu++). Lowers to atom.exch.b128 / atom.cas.b128 on sm_90+,
@@ -85,9 +125,9 @@ namespace hrdw_ring_buffer {
 //     atomicAdd already serialized us against other writers. The
 //     exchange is slot-atomic in hardware — the reader never sees a torn
 //     entry from a concurrent writer.
-//   - On unsupported architectures (HIP, pre-Hopper CUDA),
-//     hrdwRingBufferWrite compiles to a no-op so fat binaries link
-//     cleanly; only sm_90+ cubins carry the real trace path.
+//   - On unsupported architectures (HIP, pre-Hopper CUDA), the System
+//     writer compiles to a trap so fat binaries link cleanly; only
+//     sm_90+ cubins carry the real trace path.
 //   - The displaced bytes are reinterpreted as HRDWEntry<DataT> and
 //     ~DataT() is invoked on the previous occupant when the slot was
 //     non-empty, so refcounted DataT types stay balanced across slot
@@ -102,6 +142,16 @@ namespace hrdw_ring_buffer {
 //     host load sees either the fully-old or fully-new state. The reader
 //     then compares the loaded epoch against `(slot >> log2(size_)) + 1`
 //     to classify the entry as kSuccess / kOverwritten / kNotReady.
+//   Device scope:
+//   - Same writer pattern as System but uses atom.exch.relaxed.gpu.b128
+//     (device scope rather than system scope). The b128 atomic store
+//     prevents torn writes when two writers' slot claims collide on a
+//     lapping ring; the reader uses the per-slot epoch to discard
+//     stale-generation slots whose atomic stores happened to complete
+//     out of claim order.
+//   - Host reader uses cudaMemcpy after cudaStreamSynchronize rather
+//     than concurrent mapped-memory polling, so there is no host-vs-
+//     device race to worry about.
 //
 // RING SIZING
 //   The size is rounded up to a power of 2. Larger rings reduce loss
@@ -109,129 +159,151 @@ namespace hrdw_ring_buffer {
 // ==========================================================================
 
 // 16-byte ring buffer entry. Layout is fixed for atomic 128b stores.
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 struct alignas(16) HRDWEntry {
   uint32_t timestamp;
   uint32_t epoch;
   DataT data;
 };
 
-// Device-side inline write into a ring buffer. Performs a single 128b
-// atomic exchange of {timestamp, epoch, data} after claiming a slot via
-// atomicAdd. Compiled to a no-op on unsupported architectures (HIP, and
-// pre-Hopper CUDA) so fat binaries build cleanly — only sm_90+ cubins
-// carry the real trace path.
-#if defined(__CUDACC__) || defined(__HIPCC__)
-template <typename DataT>
-__device__ __forceinline__ void hrdwRingBufferWrite(
-    HRDWEntry<DataT>* ring,
-    uint64_t* writeIndex,
-    uint32_t mask,
-    uint32_t shift,
-    DataT data) {
+// Device-side inline write into a ring buffer. Claims a slot via a
+// scope-appropriate atomicAdd, then publishes {timestamp, epoch, data}
+// as a single 128b atomic exchange (`.sys` for System, `.gpu` for
+// Device). The b128 atomic publication is what prevents torn writes
+// when two writers' slot claims collide on a lapping ring.
+//
+// Compiled to a trap on unsupported architectures (HIP, pre-Hopper
+// CUDA) so fat binaries build cleanly — only sm_90+ cubins carry the
+// real trace path.
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
+struct HrdwRingBufferWriter {
+  using EntryT = HRDWEntry<DataT, C>;
   static_assert(
-      sizeof(HRDWEntry<DataT>) == 16,
+      sizeof(EntryT) == 16,
       "HRDWEntry must be exactly 16 bytes (DataT must be <= 8 bytes)");
-  static_assert(
-      alignof(HRDWEntry<DataT>) == 16, "HRDWEntry must be 16-byte aligned");
+  static_assert(alignof(EntryT) == 16, "HRDWEntry must be 16-byte aligned");
 
+#if defined(__CUDACC__) || defined(__HIPCC__)
+  __device__ __forceinline__ static void write(
+      EntryT* ring,
+      uint64_t* writeIndex,
+      uint32_t mask,
+      [[maybe_unused]] uint32_t shift,
+      DataT data) {
 #if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 900)
-  // Unsupported arch — atom.exch.b128 / atom.cas.b128 require sm_90+,
-  // and HIP doesn't yet have a wired-up 128b atomic system-scope store.
-  // Log and trap so the kernel fails loudly — the CUDA runtime surfaces
-  // this as an error on the next API call, rather than silently dropping
-  // events.
-  (void)ring;
-  (void)writeIndex;
-  (void)mask;
-  (void)shift;
-  (void)data;
-  printf(
-      "[HRDWRingBuffer] hrdwRingBufferWrite unsupported on this GPU "
-      "(requires sm_90+)\n");
+    (void)ring;
+    (void)writeIndex;
+    (void)mask;
+    (void)data;
+    printf(
+        "[HRDWRingBuffer] write unsupported on this GPU (requires sm_90+)\n");
 #if defined(__HIPCC__)
-  abort();
+    abort();
 #else
-  __trap();
+    __trap();
 #endif
 #else
-  // Relaxed system-scope fetch-add: the only invariant we need from this
-  // is "every writer gets a unique slot number"; ordering with the
-  // subsequent slot publication is unnecessary (the reader's epoch check
-  // is self-correcting if the writeIndex bump and the slot bytes become
-  // host-visible in either order).
-  uint64_t slot =
-      cuda::atomic_ref<uint64_t, cuda::thread_scope_system>(*writeIndex)
-          .fetch_add(1ULL, cuda::memory_order_relaxed);
-  uint64_t idx = slot & mask;
+    // Relaxed fetch-add: the only invariant we need from this is "every
+    // writer gets a unique slot number"; ordering with the subsequent
+    // slot publication is unnecessary (the reader's epoch check is
+    // self-correcting if the writeIndex bump and the slot bytes become
+    // host-visible in either order).
+    constexpr auto kScope = (C == MemoryCoherenceScope::System)
+        ? cuda::thread_scope_system
+        : cuda::thread_scope_device;
+    uint64_t slot = cuda::atomic_ref<uint64_t, kScope>(*writeIndex)
+                        .fetch_add(1ULL, cuda::memory_order_relaxed);
+    uint64_t idx = slot & mask;
 
-  HRDWEntry<DataT> packed{};
-  packed.timestamp =
-      static_cast<uint32_t>(readGlobaltimer() >> US_TICK_TIMESTAMP_SHIFT);
-  packed.epoch = static_cast<uint32_t>(slot >> shift) + 1u;
-  packed.data = data;
+    EntryT packed{};
+    packed.timestamp =
+        static_cast<uint32_t>(readGlobaltimer() >> US_TICK_TIMESTAMP_SHIFT);
+    packed.epoch = static_cast<uint32_t>(slot >> shift) + 1u;
+    packed.data = data;
 
-  // Single 128b atomic exchange at system scope via raw PTX. We use
-  // atom.exch.relaxed.sys.b128 for ALL DataT (not st.relaxed.sys.b128
-  // even for trivially-destructible types), because the RMW form is the
-  // only one hardware guarantees as atomic across the GPU↔host boundary
-  // on systems without negotiated PCIe AtomicOp support — st.b128 can
-  // decompose into two 64b transactions, and the host's 16B atomic load
-  // would observe a torn write whose halves landed in a stale order.
-  // (Going through libcu++'s cuda::atomic_ref<T> for 16B T also
-  // miscompiled on sm_100a in practice, so we emit the instruction
-  // directly.)
-  //
-  // For non-trivially-destructible DataT we run ~DataT() on the
-  // displaced occupant; for trivially-destructible DataT the compiler
-  // DCEs the prev_lo/prev_hi outputs.
-  uint64_t packed_lo, packed_hi;
-  __builtin_memcpy(&packed_lo, &packed, sizeof(packed_lo));
-  __builtin_memcpy(
-      &packed_hi,
-      reinterpret_cast<const char*>(&packed) + sizeof(packed_lo),
-      sizeof(packed_hi));
+    // Single 128b atomic exchange via raw PTX. We use atom.exch.relaxed
+    // (not st.relaxed) for ALL DataT — even trivially-destructible types
+    // — because the RMW form is the only one hardware guarantees as
+    // atomic across the GPU↔host boundary on systems without negotiated
+    // PCIe AtomicOp support: st.b128 can decompose into two 64b
+    // transactions, and the host's 16B atomic load would observe a torn
+    // write whose halves landed in a stale order. (Going through
+    // libcu++'s cuda::atomic_ref<T> for 16B T also miscompiled on
+    // sm_100a in practice, so we emit the instruction directly.)
+    //
+    // For non-trivially-destructible DataT we run ~DataT() on the
+    // displaced occupant; for trivially-destructible DataT the compiler
+    // DCEs the prev_lo/prev_hi outputs.
+    uint64_t packed_lo, packed_hi;
+    __builtin_memcpy(&packed_lo, &packed, sizeof(packed_lo));
+    __builtin_memcpy(
+        &packed_hi,
+        reinterpret_cast<const char*>(&packed) + sizeof(packed_lo),
+        sizeof(packed_hi));
 
-  [[maybe_unused]] uint64_t prev_lo, prev_hi;
-  asm volatile(
-      "{ .reg .b128 _src, _dst;\n\t"
-      "  mov.b128 _src, {%2, %3};\n\t"
-      "  atom.exch.relaxed.sys.b128 _dst, [%4], _src;\n\t"
-      "  mov.b128 {%0, %1}, _dst; }"
-      : "=l"(prev_lo), "=l"(prev_hi)
-      : "l"(packed_lo), "l"(packed_hi), "l"(&ring[idx])
-      : "memory");
-
-  if constexpr (!std::is_trivially_destructible_v<DataT>) {
-    // Hold the displaced bytes in a raw char buffer (not a
-    // HRDWEntry<DataT>) so the compiler never auto-destructs them at
-    // scope exit — that would double-call ~DataT() after our explicit
-    // destruction below.
-    alignas(HRDWEntry<DataT>) char prev_buf[sizeof(HRDWEntry<DataT>)];
-    __builtin_memcpy(prev_buf, &prev_lo, sizeof(prev_lo));
-    __builtin_memcpy(prev_buf + sizeof(prev_lo), &prev_hi, sizeof(prev_hi));
-    auto* prev = reinterpret_cast<HRDWEntry<DataT>*>(prev_buf);
-    if (prev->epoch != HRDW_RINGBUFFER_SLOT_EMPTY) {
-      prev->data.~DataT();
+    // The two asm blocks are identical except for the PTX scope qualifier
+    // on the atom.exch:
+    //   .sys — coherent with all observers, including the host CPU and
+    //          peer GPUs. Required for System scope because the host
+    //          polls the pinned mapped ring concurrently with the GPU
+    //          writer; the store must be flushed past L2 with a
+    //          system-level fence so the host sees it.
+    //   .gpu — coherent only within this GPU's L2 domain. Sufficient
+    //          for Device scope because the only host read happens after
+    //          cudaStreamSynchronize, which inserts its own full barrier.
+    //          Cheaper per write (no cross-device fence). Would be a
+    //          correctness bug for System.
+    [[maybe_unused]] uint64_t prev_lo, prev_hi;
+    if constexpr (C == MemoryCoherenceScope::System) {
+      asm volatile(
+          "{ .reg .b128 _src, _dst;\n\t"
+          "  mov.b128 _src, {%2, %3};\n\t"
+          "  atom.exch.relaxed.sys.b128 _dst, [%4], _src;\n\t"
+          "  mov.b128 {%0, %1}, _dst; }"
+          : "=l"(prev_lo), "=l"(prev_hi)
+          : "l"(packed_lo), "l"(packed_hi), "l"(&ring[idx])
+          : "memory");
+    } else {
+      asm volatile(
+          "{ .reg .b128 _src, _dst;\n\t"
+          "  mov.b128 _src, {%2, %3};\n\t"
+          "  atom.exch.relaxed.gpu.b128 _dst, [%4], _src;\n\t"
+          "  mov.b128 {%0, %1}, _dst; }"
+          : "=l"(prev_lo), "=l"(prev_hi)
+          : "l"(packed_lo), "l"(packed_hi), "l"(&ring[idx])
+          : "memory");
     }
+
+    if constexpr (!std::is_trivially_destructible_v<DataT>) {
+      // Hold the displaced bytes in a raw char buffer (not an EntryT) so
+      // the compiler never auto-destructs them at scope exit — that would
+      // double-call ~DataT() after our explicit destruction below.
+      alignas(EntryT) char prev_buf[sizeof(EntryT)];
+      __builtin_memcpy(prev_buf, &prev_lo, sizeof(prev_lo));
+      __builtin_memcpy(prev_buf + sizeof(prev_lo), &prev_hi, sizeof(prev_hi));
+      auto* prev = reinterpret_cast<EntryT*>(prev_buf);
+      if (prev->epoch != HRDW_RINGBUFFER_SLOT_EMPTY) {
+        prev->data.~DataT();
+      }
+    }
+#endif
   }
 #endif
-}
-#endif
+};
 
 // Lightweight, trivially-copyable handle for writing into an HRDWRingBuffer
 // from device code. Pass by value to GPU kernels. See
 // HRDWRingBufferDeviceHandle.cuh for full documentation and usage examples.
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 struct HRDWRingBufferDeviceHandle {
-  HRDWEntry<DataT>* ring;
+  HRDWEntry<DataT, C>* ring;
   uint64_t* writeIndex;
   uint32_t mask;
   uint32_t shift;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
   __device__ __forceinline__ void write(DataT data) {
-    hrdwRingBufferWrite(ring, writeIndex, mask, shift, data);
+    HrdwRingBufferWriter<DataT, C>::write(ring, writeIndex, mask, shift, data);
   }
 #endif
 };
@@ -242,66 +314,232 @@ struct HRDWRingBufferDeviceHandle {
 // comms/utils/colltrace/HRDWRingBufferInstantiations.cu for examples).
 #if defined(__CUDACC__) || defined(__HIPCC__)
 namespace detail {
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 __global__ void ringBufferWriteKernel(
-    HRDWEntry<DataT>* ring,
+    HRDWEntry<DataT, C>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
     uint32_t shift,
     DataT data) {
-  hrdwRingBufferWrite(ring, writeIdx, mask, shift, data);
+  HrdwRingBufferWriter<DataT, C>::write(ring, writeIdx, mask, shift, data);
 }
 } // namespace detail
 
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 cudaError_t launchRingBufferWrite(
     cudaStream_t stream,
-    HRDWEntry<DataT>* ring,
+    HRDWEntry<DataT, C>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
     uint32_t shift,
     DataT data) {
   // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
-  detail::ringBufferWriteKernel<<<1, 1, 0, stream>>>(
-      ring, writeIdx, mask, shift, data);
+  detail::ringBufferWriteKernel<DataT, C>
+      <<<1, 1, 0, stream>>>(ring, writeIdx, mask, shift, data);
   return cudaGetLastError();
 }
 #else
 // Declaration only — .cc files link against explicit instantiations.
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 cudaError_t launchRingBufferWrite(
     cudaStream_t stream,
-    HRDWEntry<DataT>* ring,
+    HRDWEntry<DataT, C>* ring,
     uint64_t* writeIdx,
     uint32_t mask,
     uint32_t shift,
     DataT data);
 #endif
 
-// Host-Read Device-Write (HRDW) ring buffer. Device kernels atomically claim
-// slots via writeIndex, then emit a single 128b atomic exchange of
-// {timestamp, epoch, data}. The host reader uses writeIndex to bound scans
-// and validates each entry via the per-entry epoch field.
+namespace detail {
+
+// Per-scope storage policy. Encapsulates allocation, deallocation, and
+// teardown so HRDWRingBuffer's lifecycle helpers stay scope-agnostic.
 //
-// DataT must fit in 8 bytes so the entry packs into exactly 16 bytes for
-// atomic 128b writes. For non-trivially-destructible DataT, the writer
-// runs ~DataT() on the displaced occupant when a slot is overwritten, so
-// refcounted DataT types stay balanced across overwrites.
+//   System: pinned mapped host memory (cudaHostAlloc). Slots are
+//           initialized to HRDW_RINGBUFFER_SLOT_EMPTY so the reader's
+//           epoch check classifies them as kNotReady until the writer
+//           publishes. ~DataT() is invoked on live entries at teardown
+//           because the System writer reclaims displaced bytes on
+//           overwrite — only the first `min(written, size)` slots are
+//           still live.
 //
-// Owns the ring buffer (mapped pinned) and write index (mapped pinned).
-// Move-only — CUDA resources are not copyable.
+//   Device: device-global memory (cudaMalloc). Slots are zeroed at
+//           allocation so every slot's epoch starts at
+//           HRDW_RINGBUFFER_SLOT_EMPTY, mirroring the System path —
+//           drain bounds reads to `head - tail` so unwritten slots
+//           are normally never observed, but the per-slot epoch check
+//           still validates against stale-generation slots from
+//           lapping writers. destructLiveEntries is a no-op because
+//           the host can't dereference device pointers to run ~DataT()
+//           on occupants — non-trivial DataT will silently leak its
+//           occupant-held resources on teardown; callers needing
+//           per-occupant cleanup must drain and destruct on the host
+//           themselves.
+template <typename DataT, MemoryCoherenceScope C>
+struct HrdwRingBufferStorage;
+
 template <typename DataT>
+struct HrdwRingBufferStorage<DataT, MemoryCoherenceScope::System> {
+  using EntryT = HRDWEntry<DataT, MemoryCoherenceScope::System>;
+
+  static EntryT* allocateRing(uint32_t size) {
+    void* p = nullptr;
+    auto err = cudaHostAlloc(&p, sizeof(EntryT) * size, cudaHostAllocDefault);
+    if (err != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate ring buffer: %s\n",
+          cudaGetErrorString(err));
+      return nullptr;
+    }
+    auto* ring = static_cast<EntryT*>(p);
+    for (uint32_t i = 0; i < size; ++i) {
+      ring[i].epoch = HRDW_RINGBUFFER_SLOT_EMPTY;
+    }
+    return ring;
+  }
+
+  static uint64_t* allocateWriteIndex() {
+    void* p = nullptr;
+    auto err = cudaHostAlloc(&p, sizeof(uint64_t), cudaHostAllocDefault);
+    if (err != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate write index: %s\n",
+          cudaGetErrorString(err));
+      return nullptr;
+    }
+    auto* idx = static_cast<uint64_t*>(p);
+    *idx = 0;
+    return idx;
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  static void freeRing(EntryT* ring) {
+    (void)cudaFreeHost(ring);
+  }
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  static void freeWriteIndex(uint64_t* idx) {
+    (void)cudaFreeHost(idx);
+  }
+
+  static void
+  destructLiveEntries(EntryT* ring, const uint64_t* writeIndex, uint32_t size) {
+    if constexpr (!std::is_trivially_destructible_v<DataT>) {
+      if (ring && writeIndex) {
+        uint64_t written = *writeIndex;
+        uint64_t count = std::min(written, static_cast<uint64_t>(size));
+        for (uint64_t i = 0; i < count; ++i) {
+          ring[i].data.~DataT();
+        }
+      }
+    }
+  }
+};
+
+template <typename DataT>
+struct HrdwRingBufferStorage<DataT, MemoryCoherenceScope::Device> {
+  using EntryT = HRDWEntry<DataT, MemoryCoherenceScope::Device>;
+
+  static EntryT* allocateRing(uint32_t size) {
+    void* p = nullptr;
+    auto err = cudaMalloc(&p, sizeof(EntryT) * size);
+    if (err != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate ring buffer: %s\n",
+          cudaGetErrorString(err));
+      return nullptr;
+    }
+    auto* ring = static_cast<EntryT*>(p);
+    // Zero the ring so every slot's epoch starts at HRDW_RINGBUFFER_SLOT_EMPTY.
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    auto memsetErr = cudaMemset(ring, 0, sizeof(EntryT) * size);
+    if (memsetErr != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to zero ring buffer: %s\n",
+          cudaGetErrorString(memsetErr));
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      (void)cudaFree(ring);
+      return nullptr;
+    }
+    return ring;
+  }
+
+  static uint64_t* allocateWriteIndex() {
+    void* p = nullptr;
+    auto err = cudaMalloc(&p, sizeof(uint64_t));
+    if (err != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to allocate write index: %s\n",
+          cudaGetErrorString(err));
+      return nullptr;
+    }
+    auto* idx = static_cast<uint64_t*>(p);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    auto memsetErr = cudaMemset(idx, 0, sizeof(uint64_t));
+    if (memsetErr != cudaSuccess) {
+      fprintf(
+          stderr,
+          "HRDWRingBuffer: Failed to zero write index: %s\n",
+          cudaGetErrorString(memsetErr));
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      (void)cudaFree(idx);
+      return nullptr;
+    }
+    return idx;
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  static void freeRing(EntryT* ring) {
+    (void)cudaFree(ring);
+  }
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  static void freeWriteIndex(uint64_t* idx) {
+    (void)cudaFree(idx);
+  }
+
+  // Teardown is a no-op: the ring lives in cudaMalloc'd device memory,
+  // and the host can't dereference device pointers to invoke ~DataT()
+  // on individual occupants. Callers passing a non-trivially-destructible
+  // DataT are on the hook for their own cleanup — whatever resources
+  // those occupants hold will not be released by ring destruction.
+  static void destructLiveEntries(EntryT*, const uint64_t*, uint32_t) {}
+};
+
+} // namespace detail
+
+// Host-Read Device-Write (HRDW) ring buffer. Device kernels atomically claim
+// slots via writeIndex, then write entries whose format and atomicity depend
+// on the MemoryCoherenceScope:
+//
+//   System: 128b atomic exchange on pinned mapped memory. The host reader
+//           polls concurrently via mapped pointers and validates each entry
+//           via a per-entry epoch field. DataT must be ≤ 8 bytes. For
+//           non-trivially-destructible DataT, the writer runs ~DataT() on
+//           the displaced occupant when a slot is overwritten.
+//
+//   Device: 128b atomic exchange (atom.exch.relaxed.gpu.b128, device
+//           scope) on cudaMalloc'd device memory. The host reads via
+//           cudaMemcpy after cudaStreamSynchronize (drain). DataT must
+//           be ≤ 8 bytes (entry packs into 16 bytes for atomic 128b
+//           stores) and is best kept trivially destructible — the host
+//           can't run ~DataT() on device-resident occupants, so
+//           non-trivial DataT will leak its per-occupant resources on
+//           ring destruction. Per-slot epoch lets the reader discard
+//           stale-generation slots whose atomic stores completed out
+//           of claim order. Requires sm_90+ for atom.exch.b128.
+//
+// Move-only — CUDA resources are not copyable.
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 class HRDWRingBuffer {
-  static_assert(
-      sizeof(HRDWEntry<DataT>) == 16,
-      "HRDWEntry must be exactly 16 bytes (DataT must be <= 8 bytes)");
-  static_assert(
-      alignof(HRDWEntry<DataT>) == 16,
-      "HRDWEntry must be 16-byte aligned");
+  using Storage = detail::HrdwRingBufferStorage<DataT, C>;
+  static constexpr bool isSystem = (C == MemoryCoherenceScope::System);
 
  public:
-  using Entry = HRDWEntry<DataT>;
-
+  using Entry = HRDWEntry<DataT, C>;
   explicit HRDWRingBuffer(uint32_t size) {
     // Round up to next power of 2 if needed.
     if (size == 0) {
@@ -345,18 +583,20 @@ class HRDWRingBuffer {
     }
 #endif
 
-    allocatePinnedMapped();
+    ring_ = Storage::allocateRing(size_);
+    if (!ring_) {
+      return;
+    }
+    writeIndex_ = Storage::allocateWriteIndex();
   }
 
   ~HRDWRingBuffer() {
-    destructLiveEntries();
+    Storage::destructLiveEntries(ring_, writeIndex_, size_);
     if (ring_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      (void)cudaFreeHost(ring_);
+      Storage::freeRing(ring_);
     }
     if (writeIndex_) {
-      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-      (void)cudaFreeHost(writeIndex_);
+      Storage::freeWriteIndex(writeIndex_);
     }
   }
 
@@ -373,14 +613,12 @@ class HRDWRingBuffer {
 
   HRDWRingBuffer& operator=(HRDWRingBuffer&& other) noexcept {
     if (this != &other) {
-      destructLiveEntries();
+      Storage::destructLiveEntries(ring_, writeIndex_, size_);
       if (ring_) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        (void)cudaFreeHost(ring_);
+        Storage::freeRing(ring_);
       }
       if (writeIndex_) {
-        // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
-        (void)cudaFreeHost(writeIndex_);
+        Storage::freeWriteIndex(writeIndex_);
       }
       ring_ = std::exchange(other.ring_, nullptr);
       writeIndex_ = std::exchange(other.writeIndex_, nullptr);
@@ -400,74 +638,29 @@ class HRDWRingBuffer {
     return ring_ != nullptr && writeIndex_ != nullptr;
   }
 
-  // Launch a single-thread kernel that atomically claims a slot, packs
-  // timestamp + epoch + data, and emits a single 128b store.
+  // Launch a single-thread kernel that atomically claims a slot and
+  // writes an entry.
   cudaError_t write(cudaStream_t stream, DataT data) {
     assert(valid());
-    return launchRingBufferWrite<DataT>(
+    return launchRingBufferWrite<DataT, C>(
         stream, ring_, writeIndex_, mask_, shift_, data);
   }
 
   // Return a lightweight, trivially-copyable handle that can be passed by
   // value to GPU kernels for inline device-side writes. See
   // HRDWRingBufferDeviceHandle.cuh for usage.
-  HRDWRingBufferDeviceHandle<DataT> deviceHandle() const {
+  HRDWRingBufferDeviceHandle<DataT, C> deviceHandle() const {
     assert(valid());
     return {ring_, writeIndex_, mask_, shift_};
   }
 
  private:
-  template <typename>
+  template <typename, MemoryCoherenceScope>
   friend class HRDWRingBufferReader;
-  template <typename>
+  template <typename, MemoryCoherenceScope>
+  friend class HRDWRingBufferReaderBase;
+  template <typename, MemoryCoherenceScope>
   friend class HRDWRingBufferTestAccessor;
-
-  void destructLiveEntries() {
-    if constexpr (!std::is_trivially_destructible_v<DataT>) {
-      if (ring_ && writeIndex_) {
-        uint64_t written = *writeIndex_;
-        uint64_t count = std::min(written, static_cast<uint64_t>(size_));
-        for (uint64_t i = 0; i < count; ++i) {
-          ring_[i].data.~DataT();
-        }
-      }
-    }
-  }
-
-  void allocatePinnedMapped() {
-    void* ringPtr = nullptr;
-    auto ringErr =
-        cudaHostAlloc(&ringPtr, sizeof(Entry) * size_, cudaHostAllocDefault);
-    if (ringErr == cudaSuccess) {
-      ring_ = static_cast<Entry*>(ringPtr);
-      // Stamp HRDW_RINGBUFFER_SLOT_EMPTY (0) into every slot's epoch.
-      // The other bytes are raw storage from cudaHostAlloc; the first
-      // writer overwrites the full 16B slot via atom.exch.b128, and
-      // skips ~DataT() on the displaced bytes because epoch==0 means
-      // the slot had no prior occupant.
-      for (uint32_t i = 0; i < size_; ++i) {
-        ring_[i].epoch = HRDW_RINGBUFFER_SLOT_EMPTY;
-      }
-    } else {
-      fprintf(
-          stderr,
-          "HRDWRingBuffer: Failed to allocate ring buffer: %s\n",
-          cudaGetErrorString(ringErr));
-      return;
-    }
-    void* writeIdxPtr = nullptr;
-    auto idxErr =
-        cudaHostAlloc(&writeIdxPtr, sizeof(uint64_t), cudaHostAllocDefault);
-    if (idxErr == cudaSuccess) {
-      writeIndex_ = static_cast<uint64_t*>(writeIdxPtr);
-      *writeIndex_ = 0;
-    } else {
-      fprintf(
-          stderr,
-          "HRDWRingBuffer: Failed to allocate write index: %s\n",
-          cudaGetErrorString(idxErr));
-    }
-  }
 
   Entry* ring_{nullptr};
   uint64_t* writeIndex_{nullptr};

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -9,7 +9,7 @@
 #endif
 
 // needed for US_TICK_TIMESTAMP_SHIFT
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <algorithm>
 #if __cplusplus >= 202002L
@@ -26,7 +26,7 @@
 // writes encode epoch = uint32_t(slot >> shift) + 1, so 0 is unused.
 #define HRDW_RINGBUFFER_SLOT_EMPTY 0u
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // ==========================================================================
 // HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
@@ -480,4 +480,4 @@ class HRDWRingBuffer {
   uint32_t shift_{0};
 };
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh
@@ -25,4 +25,4 @@
 
 #pragma once // NOLINT(clang-diagnostic-pragma-once-outside-header)
 
-#include "comms/utils/HRDWRingBuffer.h" // IWYU pragma: export
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h" // IWYU pragma: export

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
@@ -9,9 +9,9 @@
 #include <utility>
 #include <vector>
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // Relaxed atomic load from GPU-mapped pinned memory. The reader doesn't
 // need acquire ordering: the writer publishes writeIndex and ring[idx]
@@ -193,4 +193,4 @@ class HRDWRingBufferReader {
   std::vector<std::pair<Entry, uint64_t>> validEntries_;
 };
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
@@ -33,26 +33,63 @@ __attribute__((always_inline)) inline T relaxedLoad(const T* ptr) {
 #endif
 }
 
-// Result of a single poll() call.
-struct PollResult {
+// Result of a single poll() call, specialized per MemoryCoherenceScope.
+// Both specializations carry entriesRead and entriesLost; each adds the
+// scope-specific fields its poll() implementation can populate.
+template <MemoryCoherenceScope C>
+struct PollResult;
+
+template <>
+struct PollResult<MemoryCoherenceScope::System> {
   uint64_t entriesRead{0};
   uint64_t entriesLost{0};
+  // True if poll() exited because the timeout elapsed before any new
+  // entries arrived.
   bool timedOut{false};
 };
 
-// CPU-side consumer for a HRDWRingBuffer. Uses the mapped writeIndex to
-// know how far ahead writers have gone, then validates each entry via
-// the per-entry epoch field. If the reader falls behind by more than
-// ringSize, it jumps to the tail and counts skipped entries as lost.
-//
-// Non-owning — the HRDWRingBuffer must outlive this reader. Single-threaded
-// (only the poll thread should call poll()).
-template <typename DataT>
-class HRDWRingBufferReader {
-  using Entry = typename HRDWRingBuffer<DataT>::Entry;
+template <>
+struct PollResult<MemoryCoherenceScope::Device> {
+  uint64_t entriesRead{0};
+  uint64_t entriesLost{0};
+  // Error from cudaStreamSynchronize / cudaMemcpy during the drain.
+  cudaError_t error{cudaSuccess};
+};
 
+// CPU-side consumer for an HRDWRingBuffer. Both scopes expose the same
+// public method — poll(...) — but the implementation differs per
+// MemoryCoherenceScope:
+//
+//   System: poll() reads pinned mapped memory directly and validates
+//           each entry via the per-slot epoch field. Lock-free and
+//           concurrent with the writer. Takes a callback and an
+//           optional timeout.
+//
+//   Device: poll() synchronizes the stream, cudaMemcpys the ring + write
+//           index to host, then iterates the host-side copy. Takes a
+//           stream and a callback. The internal read cursor advances
+//           on every poll, so successive calls only return entries
+//           written since the previous one.
+//
+// Non-owning — the HRDWRingBuffer must outlive this reader. Single-
+// threaded (only one thread should call into the reader).
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
+class HRDWRingBufferReader;
+
+// State + ctor shared by the System and Device readers. The handle
+// fields (ring_, writeIndex_, size_, mask_, shift_) and the read
+// cursor are identical across scopes; only poll() differs.
+template <typename DataT, MemoryCoherenceScope C>
+class HRDWRingBufferReaderBase {
  public:
-  explicit HRDWRingBufferReader(const HRDWRingBuffer<DataT>& buffer)
+  uint64_t lastReadIndex() const {
+    return lastReadIndex_;
+  }
+
+ protected:
+  using EntryT = HRDWEntry<DataT, C>;
+
+  explicit HRDWRingBufferReaderBase(const HRDWRingBuffer<DataT, C>& buffer)
       : ring_(buffer.ring_),
         writeIndex_(buffer.writeIndex_),
         size_(buffer.size_),
@@ -60,6 +97,37 @@ class HRDWRingBufferReader {
         shift_(buffer.shift_) {
     assert(buffer.valid());
   }
+
+  EntryT* ring_;
+  uint64_t* writeIndex_;
+  uint32_t size_;
+  // size_ - 1. Cached so `slot & mask_` is one bitwise op per read
+  // instead of `slot % size_`.
+  uint32_t mask_;
+  // log2(size_). Cached so the per-slot expected epoch is computed as
+  // `(slot >> shift_) + 1` — a shift instead of a divide.
+  uint32_t shift_;
+  uint64_t lastReadIndex_{0};
+};
+
+template <typename DataT>
+class HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>
+    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System> {
+  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::System>;
+  using Base::lastReadIndex_;
+  using Base::mask_;
+  using Base::ring_;
+  using Base::shift_;
+  using Base::size_;
+  using Base::writeIndex_;
+  using typename Base::EntryT;
+
+ public:
+  using Result = PollResult<MemoryCoherenceScope::System>;
+
+  explicit HRDWRingBufferReader(
+      const HRDWRingBuffer<DataT, MemoryCoherenceScope::System>& buffer)
+      : Base(buffer) {}
 
   enum class ReadResult { kSuccess, kOverwritten, kNotReady };
 
@@ -74,12 +142,12 @@ class HRDWRingBufferReader {
   // Relaxed (rather than acquire) is sufficient because we don't rely on
   // ring[idx] writes being ordered with the writeIndex bump: the epoch
   // check below classifies any stale state as kNotReady / kOverwritten.
-  ReadResult tryRead(uint64_t slot, Entry& dest) const {
+  ReadResult tryRead(uint64_t slot, EntryT& dest) const {
     uint64_t idx = slot & mask_;
     uint32_t expected = static_cast<uint32_t>(slot >> shift_) + 1u;
 
     static_assert(
-        sizeof(Entry) == sizeof(unsigned __int128),
+        sizeof(EntryT) == sizeof(unsigned __int128),
         "Entry must be exactly 16 bytes for the atomic load");
     unsigned __int128 raw =
         relaxedLoad(reinterpret_cast<const unsigned __int128*>(&ring_[idx]));
@@ -105,12 +173,12 @@ class HRDWRingBufferReader {
   // If timeout is non-zero, waits up to that duration for the first entry
   // before returning empty.
   //
-  // Returns a PollResult with counts of entries read and lost.
+  // Returns a Result with counts of entries read and lost.
   template <typename Callback>
-  PollResult poll(
+  Result poll(
       Callback&& callback,
       std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) {
-    PollResult result;
+    Result result;
 
     auto deadline = std::chrono::steady_clock::now() + timeout;
 
@@ -137,7 +205,7 @@ class HRDWRingBufferReader {
     validEntries_.clear();
 
     while (lastReadIndex_ < head) {
-      Entry entry;
+      EntryT entry;
       auto readResult = tryRead(lastReadIndex_, entry);
 
       switch (readResult) {
@@ -173,24 +241,115 @@ class HRDWRingBufferReader {
     return result;
   }
 
-  uint64_t lastReadIndex() const {
-    return lastReadIndex_;
+ private:
+  // Reusable buffer for accumulated entries — avoids allocation per poll().
+  std::vector<std::pair<EntryT, uint64_t>> validEntries_;
+};
+
+// Device-scope reader. Single-consumer, synchronous: poll() pulls a
+// cudaMemcpy snapshot of the ring after a stream sync, then invokes the
+// callback for each fresh entry. The internal read cursor advances on
+// every poll, so successive calls only return entries written since
+// the previous one.
+template <typename DataT>
+class HRDWRingBufferReader<DataT, MemoryCoherenceScope::Device>
+    : public HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device> {
+  using Base = HRDWRingBufferReaderBase<DataT, MemoryCoherenceScope::Device>;
+  using Base::lastReadIndex_;
+  using Base::mask_;
+  using Base::ring_;
+  using Base::shift_;
+  using Base::size_;
+  using Base::writeIndex_;
+  using typename Base::EntryT;
+
+ public:
+  using Result = PollResult<MemoryCoherenceScope::Device>;
+
+  explicit HRDWRingBufferReader(
+      const HRDWRingBuffer<DataT, MemoryCoherenceScope::Device>& buffer)
+      : Base(buffer) {}
+
+  // Poll for new entries since the last poll(). Synchronizes the stream,
+  // copies the ring and writeIndex from device to host, then invokes
+  // callback(entry, slot) for each valid entry. Entries that were lapped
+  // before this poll are counted in entriesLost.
+  template <typename Callback>
+  Result poll(cudaStream_t stream, Callback&& callback) {
+    Result result;
+
+    result.error = cudaStreamSynchronize(stream);
+    if (result.error != cudaSuccess) {
+      return result;
+    }
+
+    uint64_t head = 0;
+    result.error =
+        cudaMemcpy(&head, writeIndex_, sizeof(head), cudaMemcpyDeviceToHost);
+    if (result.error != cudaSuccess) {
+      return result;
+    }
+
+    if (head <= lastReadIndex_) {
+      return result;
+    }
+
+    uint64_t tail = lastReadIndex_;
+    if (head - tail > size_) {
+      result.entriesLost = head - tail - size_;
+      tail = head - size_;
+    }
+
+    uint64_t count = head - tail;
+    drainBuf_.resize(count);
+
+    // The entries may wrap around the ring. Copy in up to two segments.
+    uint64_t startIdx = tail & mask_;
+    uint64_t firstChunk =
+        std::min(count, static_cast<uint64_t>(size_) - startIdx);
+    result.error = cudaMemcpy(
+        drainBuf_.data(),
+        ring_ + startIdx,
+        firstChunk * sizeof(EntryT),
+        cudaMemcpyDeviceToHost);
+    if (result.error != cudaSuccess) {
+      return result;
+    }
+    if (firstChunk < count) {
+      result.error = cudaMemcpy(
+          drainBuf_.data() + firstChunk,
+          ring_,
+          (count - firstChunk) * sizeof(EntryT),
+          cudaMemcpyDeviceToHost);
+      if (result.error != cudaSuccess) {
+        return result;
+      }
+    }
+
+    // Validate epoch per slot. Two writers can claim slots that map to
+    // the same idx (slot and slot + size_); their atom.exch.b128 stores
+    // are non-torn but order isn't determined by claim order, so an
+    // older-generation entry can be observed at an idx whose current-
+    // generation entry was claimed first. The epoch check classifies
+    // such stale slots as lost rather than delivering wrong-generation
+    // data to the callback.
+    for (uint64_t i = 0; i < count; ++i) {
+      uint64_t slot = tail + i;
+      uint32_t expected = static_cast<uint32_t>(slot >> shift_) + 1u;
+      if (drainBuf_[i].epoch == expected) {
+        callback(drainBuf_[i], slot);
+        ++result.entriesRead;
+      } else {
+        ++result.entriesLost;
+      }
+    }
+    lastReadIndex_ = head;
+
+    return result;
   }
 
  private:
-  Entry* ring_;
-  uint64_t* writeIndex_;
-  uint32_t size_;
-  // size_ - 1. Cached so `slot & mask_` is one bitwise op per read
-  // instead of `slot % size_`.
-  uint32_t mask_;
-  // log2(size_). Cached so the per-slot expected epoch is computed as
-  // `(slot >> shift_) + 1` — a shift instead of a divide.
-  uint32_t shift_;
-  uint64_t lastReadIndex_{0};
-
-  // Reusable buffer for accumulated entries — avoids allocation per poll().
-  std::vector<std::pair<Entry, uint64_t>> validEntries_;
+  std::vector<EntryT> drainBuf_;
 };
 
 } // namespace hrdw_ring_buffer

--- a/comms/utils/tests/GpuClockCalibrationTest.cc
+++ b/comms/utils/tests/GpuClockCalibrationTest.cc
@@ -1,13 +1,13 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <chrono>
 #include <cstdint>
 
 #include <gtest/gtest.h>
 
-using meta::comms::colltrace::GlobaltimerCalibration;
+using hrdw_ring_buffer::GlobaltimerCalibration;
 using namespace std::chrono_literals;
 
 namespace {

--- a/comms/utils/tests/HRDWRingBufferDeviceHandleTest.cu
+++ b/comms/utils/tests/HRDWRingBufferDeviceHandleTest.cu
@@ -7,14 +7,14 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferDeviceHandle.cuh"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferDeviceHandle;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferDeviceHandle;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 // kernel to write count entries to the buffer (one per thread)
 __global__ void inlineWriteKernel(

--- a/comms/utils/tests/HRDWRingBufferDeviceScopeStressTest.cu
+++ b/comms/utils/tests/HRDWRingBufferDeviceScopeStressTest.cu
@@ -1,0 +1,293 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// GPU stress tests for HRDWRingBuffer with MemoryCoherenceScope::Device.
+// Exercises multi-stream and multi-block concurrent writes, timestamp
+// ordering, wrap-around under lapping pressure, and drain correctness.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferDeviceHandle;
+using hrdw_ring_buffer::HRDWRingBufferReader;
+using hrdw_ring_buffer::MemoryCoherenceScope;
+
+struct StressEvent {
+  uint32_t tag;
+};
+
+using DeviceBuffer = HRDWRingBuffer<StressEvent, MemoryCoherenceScope::Device>;
+using DeviceReader =
+    HRDWRingBufferReader<StressEvent, MemoryCoherenceScope::Device>;
+using DeviceHandle =
+    HRDWRingBufferDeviceHandle<StressEvent, MemoryCoherenceScope::Device>;
+
+__global__ void
+stressWriteKernel(DeviceHandle handle, int writesPerThread, uint32_t tagBase) {
+  uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  for (int i = 0; i < writesPerThread; ++i) {
+    handle.write(StressEvent{tagBase + tid});
+  }
+}
+
+struct StressConfig {
+  uint32_t ringSize;
+  int numStreams;
+  int numWrites;
+
+  int totalWrites() const {
+    return numStreams * numWrites;
+  }
+};
+
+static const StressConfig kStressConfigs[] = {
+    {64, 4, 500},
+    {256, 8, 200},
+    {4096, 1, 2000},
+    {4096, 10, 200},
+    {16, 1, 1000},
+};
+
+class DeviceScopeStressTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+  }
+};
+
+TEST_F(DeviceScopeStressTest, MultiStreamWriteAndDrain) {
+  for (const auto& cfg : kStressConfigs) {
+    SCOPED_TRACE(
+        "ring=" + std::to_string(cfg.ringSize) +
+        " streams=" + std::to_string(cfg.numStreams) +
+        " writes=" + std::to_string(cfg.numWrites));
+
+    DeviceBuffer buf(cfg.ringSize);
+    ASSERT_TRUE(buf.valid());
+    DeviceReader reader(buf);
+
+    std::vector<cudaStream_t> streams(cfg.numStreams);
+    for (auto& s : streams) {
+      ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    }
+
+    for (int i = 0; i < cfg.numWrites; ++i) {
+      auto& s = streams[i % cfg.numStreams];
+      ASSERT_EQ(buf.write(s, StressEvent{0}), cudaSuccess);
+    }
+
+    for (auto& s : streams) {
+      ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    }
+
+    uint64_t badEntries = 0;
+    auto result = reader.poll(streams[0], [&](const auto& e, uint64_t) {
+      if (e.timestamp == 0) {
+        ++badEntries;
+      }
+    });
+    ASSERT_EQ(result.error, cudaSuccess);
+    EXPECT_EQ(badEntries, 0u);
+    EXPECT_EQ(
+        result.entriesRead + result.entriesLost,
+        static_cast<uint64_t>(cfg.numWrites));
+
+    for (auto& s : streams) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(s);
+    }
+  }
+}
+
+TEST_F(DeviceScopeStressTest, SingleStreamMonotonicTimestamps) {
+  for (const auto& cfg : kStressConfigs) {
+    if (cfg.numStreams != 1) {
+      continue;
+    }
+    SCOPED_TRACE(
+        "ring=" + std::to_string(cfg.ringSize) +
+        " writes=" + std::to_string(cfg.numWrites));
+
+    DeviceBuffer buf(cfg.ringSize);
+    ASSERT_TRUE(buf.valid());
+    DeviceReader reader(buf);
+
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    for (int i = 0; i < cfg.numWrites; ++i) {
+      ASSERT_EQ(buf.write(stream, StressEvent{0}), cudaSuccess);
+    }
+
+    uint64_t badEntries = 0;
+    uint64_t prevTimestamp = 0;
+    auto result = reader.poll(stream, [&](const auto& e, uint64_t) {
+      if (e.timestamp == 0) {
+        ++badEntries;
+      }
+      if (prevTimestamp > 0 && e.timestamp < prevTimestamp) {
+        ++badEntries;
+      }
+      prevTimestamp = e.timestamp;
+    });
+    ASSERT_EQ(result.error, cudaSuccess);
+    EXPECT_EQ(badEntries, 0u);
+    EXPECT_EQ(
+        result.entriesRead + result.entriesLost,
+        static_cast<uint64_t>(cfg.numWrites));
+
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamDestroy(stream);
+  }
+}
+
+TEST_F(DeviceScopeStressTest, MultiBlockConcurrentInlineWrites) {
+  constexpr int kNumBlocks = 32;
+  constexpr int kThreadsPerBlock = 128;
+  constexpr int kWritesPerThread = 10;
+  constexpr int kTotal = kNumBlocks * kThreadsPerBlock * kWritesPerThread;
+
+  DeviceBuffer buf(65536);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  auto handle = buf.deviceHandle();
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  stressWriteKernel<<<kNumBlocks, kThreadsPerBlock, 0, stream>>>(
+      handle, kWritesPerThread, 0);
+
+  uint64_t badTimestamps = 0;
+  auto result = reader.poll(stream, [&](const auto& e, uint64_t) {
+    if (e.timestamp == 0) {
+      ++badTimestamps;
+    }
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+  EXPECT_EQ(badTimestamps, 0u);
+  EXPECT_EQ(result.entriesRead, kTotal);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamDestroy(stream);
+}
+
+TEST_F(DeviceScopeStressTest, LappingPressureDrainAccounting) {
+  constexpr uint32_t kRingSize = 16;
+  constexpr int kTotalWrites = 1000;
+
+  DeviceBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  for (int i = 0; i < kTotalWrites; ++i) {
+    ASSERT_EQ(
+        buf.write(stream, StressEvent{static_cast<uint32_t>(i)}), cudaSuccess);
+  }
+
+  auto result = reader.poll(stream, [](const auto&, uint64_t) {});
+  ASSERT_EQ(result.error, cudaSuccess);
+  EXPECT_EQ(result.entriesRead + result.entriesLost, kTotalWrites);
+  EXPECT_EQ(result.entriesRead, kRingSize);
+  EXPECT_EQ(
+      result.entriesLost, static_cast<uint64_t>(kTotalWrites - kRingSize));
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamDestroy(stream);
+}
+
+TEST_F(DeviceScopeStressTest, RepeatedDrainResetCycles) {
+  constexpr int kCycles = 20;
+  constexpr int kWritesPerCycle = 100;
+
+  DeviceBuffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  cudaStream_t stream;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+  auto handle = buf.deviceHandle();
+
+  for (int cycle = 0; cycle < kCycles; ++cycle) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+    stressWriteKernel<<<1, kWritesPerCycle, 0, stream>>>(
+        handle, 1, static_cast<uint32_t>(cycle * 1000));
+
+    uint64_t readCount = 0;
+    auto result =
+        reader.poll(stream, [&](const auto&, uint64_t) { ++readCount; });
+    ASSERT_EQ(result.error, cudaSuccess);
+    EXPECT_EQ(readCount, kWritesPerCycle);
+    EXPECT_EQ(result.entriesLost, 0u);
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaStreamDestroy(stream);
+}
+
+TEST_F(DeviceScopeStressTest, MultiStreamInlineWriteNeverBlocks) {
+  constexpr int kNumStreams = 4;
+  constexpr int kWritesPerStream = 500;
+  constexpr uint32_t kRingSize = 32;
+
+  DeviceBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  auto handle = buf.deviceHandle();
+
+  cudaStream_t streams[kNumStreams];
+  for (auto& s : streams) {
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+  }
+
+  for (int w = 0; w < kWritesPerStream; ++w) {
+    for (int si = 0; si < kNumStreams; ++si) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+      stressWriteKernel<<<1, 1, 0, streams[si]>>>(
+          handle, 1, static_cast<uint32_t>(si * 10000 + w));
+    }
+  }
+
+  for (auto& s : streams) {
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+  }
+
+  uint64_t badTimestamps = 0;
+  auto result = reader.poll(streams[0], [&](const auto& e, uint64_t) {
+    if (e.timestamp == 0) {
+      ++badTimestamps;
+    }
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+  EXPECT_EQ(badTimestamps, 0u);
+
+  uint64_t totalSlots = static_cast<uint64_t>(kNumStreams) * kWritesPerStream;
+  EXPECT_EQ(result.entriesRead + result.entriesLost, totalSlots);
+
+  for (auto& s : streams) {
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamDestroy(s);
+  }
+}

--- a/comms/utils/tests/HRDWRingBufferDeviceScopeTest.cu
+++ b/comms/utils/tests/HRDWRingBufferDeviceScopeTest.cu
@@ -1,0 +1,309 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferDeviceHandle;
+using hrdw_ring_buffer::HRDWRingBufferReader;
+using hrdw_ring_buffer::MemoryCoherenceScope;
+
+struct DeviceTestEvent {
+  uint32_t tag;
+};
+
+using DeviceBuffer =
+    HRDWRingBuffer<DeviceTestEvent, MemoryCoherenceScope::Device>;
+using DeviceReader =
+    HRDWRingBufferReader<DeviceTestEvent, MemoryCoherenceScope::Device>;
+using DeviceHandle =
+    HRDWRingBufferDeviceHandle<DeviceTestEvent, MemoryCoherenceScope::Device>;
+
+__global__ void deviceScopeWriteKernel(DeviceHandle rb, int count) {
+  unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  if (tid < count) {
+    rb.write(DeviceTestEvent{static_cast<uint32_t>(tid)});
+  }
+}
+
+class HRDWRingBufferDeviceScopeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaSetDevice(0);
+    ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+  }
+
+  void TearDown() override {
+    if (stream_) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  cudaStream_t stream_{nullptr};
+};
+
+TEST_F(HRDWRingBufferDeviceScopeTest, ConstructionAndValid) {
+  DeviceBuffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), 64u);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, MoveConstruction) {
+  DeviceBuffer buf(32);
+  ASSERT_TRUE(buf.valid());
+
+  DeviceBuffer moved(std::move(buf));
+  EXPECT_TRUE(moved.valid());
+  EXPECT_EQ(moved.size(), 32u);
+  EXPECT_FALSE(buf.valid()); // NOLINT(bugprone-use-after-move)
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, MoveAssignment) {
+  DeviceBuffer buf1(32);
+  DeviceBuffer buf2(64);
+  ASSERT_TRUE(buf1.valid());
+  ASSERT_TRUE(buf2.valid());
+
+  buf1 = std::move(buf2);
+  EXPECT_TRUE(buf1.valid());
+  EXPECT_EQ(buf1.size(), 64u);
+  EXPECT_FALSE(buf2.valid()); // NOLINT(bugprone-use-after-move)
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, SingleWriteAndDrain) {
+  DeviceBuffer buf(16);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{42}), cudaSuccess);
+
+  std::vector<uint32_t> seen;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    seen.push_back(entry.data.tag);
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+
+  EXPECT_EQ(result.entriesRead, 1u);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  const std::vector<uint32_t> expected{42};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, MultipleWritesAndDrain) {
+  DeviceBuffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  for (uint32_t i = 0; i < 10; ++i) {
+    ASSERT_EQ(buf.write(stream_, DeviceTestEvent{i}), cudaSuccess);
+  }
+
+  std::vector<uint32_t> seen;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    seen.push_back(entry.data.tag);
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+
+  EXPECT_EQ(result.entriesRead, 10u);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  const std::vector<uint32_t> expected{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, InlineDeviceWriteAndDrain) {
+  constexpr int kCount = 128;
+  DeviceBuffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  auto handle = buf.deviceHandle();
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  deviceScopeWriteKernel<<<1, kCount, 0, stream_>>>(handle, kCount);
+
+  std::vector<uint32_t> tags;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    tags.push_back(entry.data.tag);
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+
+  EXPECT_EQ(result.entriesRead, kCount);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  std::sort(tags.begin(), tags.end());
+  std::vector<uint32_t> expected(kCount);
+  std::iota(expected.begin(), expected.end(), 0u);
+  EXPECT_EQ(tags, expected);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, MultiBlockConcurrentWriteAndDrain) {
+  constexpr int kThreadsPerBlock = 64;
+  constexpr int kNumBlocks = 8;
+  constexpr int kTotal = kThreadsPerBlock * kNumBlocks;
+
+  DeviceBuffer buf(1024);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  auto handle = buf.deviceHandle();
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  deviceScopeWriteKernel<<<kNumBlocks, kThreadsPerBlock, 0, stream_>>>(
+      handle, kTotal);
+
+  std::vector<uint32_t> tags;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    tags.push_back(entry.data.tag);
+  });
+
+  EXPECT_EQ(result.entriesRead, kTotal);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  std::sort(tags.begin(), tags.end());
+  std::vector<uint32_t> expected(kTotal);
+  std::iota(expected.begin(), expected.end(), 0u);
+  EXPECT_EQ(tags, expected);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, DrainWithLapping) {
+  constexpr uint32_t kRingSize = 16;
+  DeviceBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  // Write more than the ring can hold.
+  for (uint32_t i = 0; i < kRingSize + 5; ++i) {
+    ASSERT_EQ(buf.write(stream_, DeviceTestEvent{i}), cudaSuccess);
+  }
+
+  std::vector<uint32_t> seen;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    seen.push_back(entry.data.tag);
+  });
+  ASSERT_EQ(result.error, cudaSuccess);
+
+  EXPECT_EQ(result.entriesRead, kRingSize);
+  EXPECT_EQ(result.entriesLost, 5u);
+  EXPECT_EQ(result.entriesRead + result.entriesLost, kRingSize + 5u);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, PollAutoAdvancesReadCursor) {
+  DeviceBuffer buf(16);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{1}), cudaSuccess);
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{2}), cudaSuccess);
+
+  // First poll reads both initial entries.
+  uint64_t firstCount = 0;
+  reader.poll(stream_, [&](const auto&, uint64_t) { ++firstCount; });
+  EXPECT_EQ(firstCount, 2u);
+
+  // Write more entries — poll() must auto-advance its read cursor so the
+  // second poll only sees the newly-written entries, not the original two.
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{10}), cudaSuccess);
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{20}), cudaSuccess);
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{30}), cudaSuccess);
+
+  std::vector<uint32_t> seen;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    seen.push_back(entry.data.tag);
+  });
+
+  EXPECT_EQ(result.entriesRead, 3u);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  const std::vector<uint32_t> expected{10, 20, 30};
+  EXPECT_EQ(seen, expected);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, EmptyDrainReturnsNothing) {
+  DeviceBuffer buf(16);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  uint64_t callbackCount = 0;
+  auto result =
+      reader.poll(stream_, [&](const auto&, uint64_t) { ++callbackCount; });
+  ASSERT_EQ(result.error, cudaSuccess);
+
+  EXPECT_EQ(result.entriesRead, 0u);
+  EXPECT_EQ(result.entriesLost, 0u);
+  EXPECT_EQ(callbackCount, 0u);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, MultipleDrainCycles) {
+  DeviceBuffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  uint64_t totalRead = 0;
+
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    ASSERT_EQ(
+        buf.write(stream_, DeviceTestEvent{static_cast<uint32_t>(cycle)}),
+        cudaSuccess);
+    auto result = reader.poll(stream_, [](const auto&, uint64_t) {});
+    totalRead += result.entriesRead;
+  }
+
+  EXPECT_EQ(totalRead, 5u);
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, TimestampsAreNonZero) {
+  DeviceBuffer buf(16);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{1}), cudaSuccess);
+
+  reader.poll(stream_, [](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u) << "GPU timestamp should be non-zero";
+  });
+}
+
+TEST_F(HRDWRingBufferDeviceScopeTest, WrapAroundDrainReadsCorrectly) {
+  constexpr uint32_t kRingSize = 8;
+  DeviceBuffer buf(kRingSize);
+  ASSERT_TRUE(buf.valid());
+  DeviceReader reader(buf);
+
+  // Fill ring exactly, drain, then write a few more that wrap.
+  for (uint32_t i = 0; i < kRingSize; ++i) {
+    ASSERT_EQ(buf.write(stream_, DeviceTestEvent{i}), cudaSuccess);
+  }
+  reader.poll(stream_, [](const auto&, uint64_t) {});
+
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{100}), cudaSuccess);
+  ASSERT_EQ(buf.write(stream_, DeviceTestEvent{101}), cudaSuccess);
+
+  std::vector<uint32_t> seen;
+  auto result = reader.poll(stream_, [&](const auto& entry, uint64_t) {
+    seen.push_back(entry.data.tag);
+  });
+
+  EXPECT_EQ(result.entriesRead, 2u);
+  EXPECT_EQ(result.entriesLost, 0u);
+
+  const std::vector<uint32_t> expected{100, 101};
+  EXPECT_EQ(seen, expected);
+}

--- a/comms/utils/tests/HRDWRingBufferStressTest.cc
+++ b/comms/utils/tests/HRDWRingBufferStressTest.cc
@@ -13,12 +13,12 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 class HRDWRingBufferStressTest : public ::testing::Test {
  protected:

--- a/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
+++ b/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
@@ -3,10 +3,10 @@
 // Explicit instantiations for test event types.
 // The template definition lives in HRDWRingBuffer.h.
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 template cudaError_t launchRingBufferWrite<TestEvent>(
     cudaStream_t,
@@ -16,4 +16,4 @@ template cudaError_t launchRingBufferWrite<TestEvent>(
     uint32_t,
     TestEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/tests/HRDWRingBufferUT.cu
+++ b/comms/utils/tests/HRDWRingBufferUT.cu
@@ -5,12 +5,12 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 using TestBuffer = HRDWRingBuffer<TestEvent>;
 using TestReader = HRDWRingBufferReader<TestEvent>;
@@ -18,7 +18,7 @@ using TestEntry = TestBuffer::Entry;
 
 // Test accessor — friend of HRDWRingBuffer, provides access to internals
 // for CPU-side simulation of GPU writes.
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 template <typename DataT>
 class HRDWRingBufferTestAccessor {
  public:
@@ -35,9 +35,8 @@ class HRDWRingBufferTestAccessor {
     return buf.writeIndex_;
   }
 };
-} // namespace meta::comms::colltrace
-using TestAccess =
-    meta::comms::colltrace::HRDWRingBufferTestAccessor<TestEvent>;
+} // namespace hrdw_ring_buffer
+using TestAccess = hrdw_ring_buffer::HRDWRingBufferTestAccessor<TestEvent>;
 
 class HRDWRingBufferTest : public ::testing::Test {};
 
@@ -603,7 +602,7 @@ TEST(HRDWRingBufferDestructionTest, PartialFillOnlyDestructsWritten) {
 // Explicit instantiation for CountedEvent so buf.write() works.
 // ---------------------------------------------------------------------------
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 namespace {
 template <typename DataT>
@@ -631,4 +630,4 @@ cudaError_t launchRingBufferWrite<CountedEvent>(
   return cudaGetLastError();
 }
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/tests/HRDWRingBufferUT.cu
+++ b/comms/utils/tests/HRDWRingBufferUT.cu
@@ -19,19 +19,19 @@ using TestEntry = TestBuffer::Entry;
 // Test accessor — friend of HRDWRingBuffer, provides access to internals
 // for CPU-side simulation of GPU writes.
 namespace hrdw_ring_buffer {
-template <typename DataT>
+template <typename DataT, MemoryCoherenceScope C = MemoryCoherenceScope::System>
 class HRDWRingBufferTestAccessor {
  public:
-  static HRDWEntry<DataT>* ring(const HRDWRingBuffer<DataT>& buf) {
+  static HRDWEntry<DataT, C>* ring(const HRDWRingBuffer<DataT, C>& buf) {
     return buf.ring_;
   }
-  static uint32_t mask(const HRDWRingBuffer<DataT>& buf) {
+  static uint32_t mask(const HRDWRingBuffer<DataT, C>& buf) {
     return buf.mask_;
   }
-  static uint32_t shift(const HRDWRingBuffer<DataT>& buf) {
+  static uint32_t shift(const HRDWRingBuffer<DataT, C>& buf) {
     return buf.shift_;
   }
-  static uint64_t* writeIndex(const HRDWRingBuffer<DataT>& buf) {
+  static uint64_t* writeIndex(const HRDWRingBuffer<DataT, C>& buf) {
     return buf.writeIndex_;
   }
 };
@@ -612,7 +612,7 @@ __global__ void countedEventRingBufferWriteKernel(
     uint32_t mask,
     uint32_t shift,
     DataT data) {
-  hrdwRingBufferWrite(ring, writeIdx, mask, shift, data);
+  HrdwRingBufferWriter<DataT>::write(ring, writeIdx, mask, shift, data);
 }
 } // namespace
 


### PR DESCRIPTION
Summary:

Add a `MemoryCoherenceScope` enum template parameter to `HRDWRingBuffer` with two values:

- `System` (default, unchanged): pinned mapped memory via `cudaHostAlloc`, system-scope 128b atomic exchange (`atom.exch.b128`, system scope), concurrent host polling via mapped pointers, optional timeout on `poll()`.

- `Device` (new): device-global memory via `cudaMalloc`, device-scope 128b atomic exchange (`atom.exch.relaxed.gpu.b128`), host reads via `cudaStreamSynchronize` + `cudaMemcpy` snapshot of the `[lastReadIndex_, head)` window. Same per-slot epoch validation as System — the b128 atomic store still prevents torn writes when two writers' slot claims collide on a lapping ring, and the reader discards stale-generation slots whose stores landed out of claim order.

The host-vs-device read pattern is the only meaningful behavioral difference. Both scopes share: 128b atomic writer, sm_90+ requirement for `atom.exch.b128`, ≤ 8 byte DataT, per-slot epoch + writeIndex bound for stale-detection, and `validIndex < lastReadIndex + size` lapping semantics.

### Storage policy

A new `detail::HrdwRingBufferStorage<DataT, C>` template encapsulates allocation/deallocation/teardown per scope:

- `System`: `cudaHostAlloc` for the ring + writeIndex; `destructLiveEntries` walks the first `min(written, size)` slots and runs `~DataT()` so non-trivially-destructible occupants stay balanced.
- `Device`: `cudaMalloc` for the ring + writeIndex (zeroed at allocation so every slot's epoch starts at `HRDW_RINGBUFFER_SLOT_EMPTY`); `destructLiveEntries` is a no-op because the host can't dereference device memory to run `~DataT()`. Non-trivially-destructible DataT will silently leak occupant-held resources on teardown — callers needing per-occupant cleanup must drain + destruct host-side.

### Reader

A new `HRDWRingBufferReader<DataT, Device>` specialization drains via `cudaStreamSynchronize` + `cudaMemcpy` of the live window, then per-slot epoch validation on the host-side copy. Both reader specializations now share state and ctor via a common `HRDWRingBufferReaderBase<DataT, C>`:

- 5 handle fields (`ring_`, `writeIndex_`, `size_`, `mask_`, `shift_`)
- the monotonic read cursor (`lastReadIndex_`)
- ctor that initializes from a `HRDWRingBuffer<DataT, C>&` and asserts `valid()`
- public `lastReadIndex()` accessor

Only the `poll()` body differs — System keeps its mapped-memory lock-free polling with optional timeout; Device adds its stream-based cudaMemcpy snapshot.

A `PollResult<C>` template adds per-scope fields: `timedOut` for System, `error` (the `cudaError_t` from sync/memcpy) for Device.

### Compatibility

All existing callers are unaffected — `HRDWRingBuffer<DataT>` defaults to `MemoryCoherenceScope::System`.

Reviewed By: ngimel

Differential Revision: D105895072
