### PR TITLE
Add multi-VC-per-peer support with NIC affinity for channel isolation

### DIFF
--- a/comms/ctran/backends/ib/BootstrapExternal.cc
+++ b/comms/ctran/backends/ib/BootstrapExternal.cc
@@ -4,11 +4,14 @@
 
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "comms/ctran/backends/ib/CtranIbVc.h"
 #include "comms/ctran/backends/ib/VcState.h"
+#include "comms/ctran/utils/Checks.h"
 #include "comms/utils/logger/LogUtils.h"
 
 namespace ctran::ib {
@@ -32,8 +35,26 @@ BootstrapExternal::BootstrapExternal(
       trafficClass_(trafficClass) {}
 
 std::string BootstrapExternal::getLocalVcId(const int peerRank) {
+  // External bootstrap supports exactly one VC per peer that spans all
+  // local NICs (no NIC pinning). This matches the legacy single-VC
+  // semantics and avoids depending on the cvar-derived VcLayout used by
+  // the internal bootstrap path.
+  std::vector<int> activeDevices(devices_.size());
+  std::iota(activeDevices.begin(), activeDevices.end(), 0);
+
+  // Single VC per peer -> per-VC MAX_QPS == per-peer MAX_QPS. Value
+  // depends on the peer's connection class, so resolve per call.
+  int maxQpsPerVc =
+      CtranIbVirtualConn::computeMaxQpsPerVc(comm_, peerRank, /*numVcs=*/1);
+
   auto vc = std::make_shared<CtranIbVirtualConn>(
-      devices_, peerRank, comm_, trafficClass_, cudaDev_);
+      devices_,
+      peerRank,
+      comm_,
+      trafficClass_,
+      cudaDev_,
+      activeDevices,
+      maxQpsPerVc);
 
   std::string localBusCard;
   {
@@ -74,8 +95,13 @@ commResult_t BootstrapExternal::connectVc(
     pendingVcs_.erase(it);
   }
 
-  return vcState_.setupAndPublishVc(
-      std::move(vc), remoteVcIdentifier, peerRank);
+  // External bootstrap publishes a single VC per peer; wrap and delegate
+  // to the unified setup+publish entry point, which runs setupVc under
+  // vc->mutex.
+  std::vector<std::shared_ptr<CtranIbVirtualConn>> vcs;
+  vcs.push_back(std::move(vc));
+  std::vector<std::string> remoteIds{remoteVcIdentifier};
+  return vcState_.setupAndPublishVc(std::move(vcs), remoteIds, peerRank);
 }
 
 } // namespace ctran::ib

--- a/comms/ctran/backends/ib/BootstrapInternal.cc
+++ b/comms/ctran/backends/ib/BootstrapInternal.cc
@@ -5,10 +5,12 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <folly/ScopeGuard.h>
 #include <folly/SocketAddress.h>
@@ -53,6 +55,7 @@ namespace ctran::ib {
 
 Bootstrap::Bootstrap(
     VcState& vcState,
+    const VcLayout& vcLayout,
     std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory,
     std::shared_ptr<::ctran::utils::Abort> abortCtrl,
     const CommLogData& logData,
@@ -64,6 +67,7 @@ Bootstrap::Bootstrap(
     uint64_t commHash,
     const std::string& commDesc)
     : vcState_(vcState),
+      vcLayout_(vcLayout),
       socketFactory_(std::move(socketFactory)),
       abortCtrl_(std::move(abortCtrl)),
       logData_(logData),
@@ -228,34 +232,62 @@ commResult_t Bootstrap::exchangeAndPublish(
     return commInternalError;
   }
 
-  // Create a new VC for the peer
-  auto vc = std::make_shared<CtranIbVirtualConn>(
-      devices_, peerRank, comm_, trafficClass_, cudaDev_);
+  // Whether to exchange a single VC (legacy) or multiple VCs is a static
+  // property of this CtranIb instance, so the same loop handles both. The
+  // two ends always agree on the count via cvar (vcLayout_.maxVcsPerPeer).
+  const int numVcs = vcLayout_.maxVcsPerPeer;
+  std::vector<std::shared_ptr<CtranIbVirtualConn>> vcs;
+  std::vector<std::string> remoteBusCards;
+  vcs.reserve(numVcs);
+  remoteBusCards.reserve(numVcs);
 
-  std::string localBusCard, remoteBusCard;
-  {
-    // No need to lock since VC is not yet exposed to local rank. Lock to
-    // simply follow VC thread-safety semantics.
-    const std::lock_guard<std::mutex> lock(vc->mutex);
+  // Resolve the per-VC MAX_QPS slice for this peer (cvar/configList /
+  // numVcs). Different peers may resolve to different values depending
+  // on their connection class.
+  int maxQpsPerVc =
+      CtranIbVirtualConn::computeMaxQpsPerVc(comm_, peerRank, numVcs);
 
-    /* exchange business cards */
-    std::size_t size = vc->getBusCardSize();
-    localBusCard.resize(size);
-    remoteBusCard.resize(size);
-    FB_COMMCHECK(vc->getLocalBusCard(localBusCard.data()));
-    if (isServer) {
-      FB_SYSCHECKRETURN(
-          sock->recv(remoteBusCard.data(), size), commRemoteError);
-      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
-    } else {
-      FB_SYSCHECKRETURN(sock->send(localBusCard.data(), size), commRemoteError);
-      FB_SYSCHECKRETURN(
-          sock->recv(remoteBusCard.data(), size), commRemoteError);
+  for (int vcIdx = 0; vcIdx < numVcs; ++vcIdx) {
+    // Create a new VC for the peer
+    auto vc = std::make_shared<CtranIbVirtualConn>(
+        devices_,
+        peerRank,
+        comm_,
+        trafficClass_,
+        cudaDev_,
+        vcLayout_.vcToActiveDevices[vcIdx],
+        maxQpsPerVc);
+
+    std::string localBusCard, remoteBusCard;
+    {
+      // No need to lock since VC is not yet exposed to local rank. Lock to
+      // simply follow VC thread-safety semantics.
+      const std::lock_guard<std::mutex> lock(vc->mutex);
+
+      /* exchange business cards */
+      std::size_t size = vc->getBusCardSize();
+      localBusCard.resize(size);
+      remoteBusCard.resize(size);
+      FB_COMMCHECK(vc->getLocalBusCard(localBusCard.data()));
+      if (isServer) {
+        FB_SYSCHECKRETURN(
+            sock->recv(remoteBusCard.data(), size), commRemoteError);
+        FB_SYSCHECKRETURN(
+            sock->send(localBusCard.data(), size), commRemoteError);
+      } else {
+        FB_SYSCHECKRETURN(
+            sock->send(localBusCard.data(), size), commRemoteError);
+        FB_SYSCHECKRETURN(
+            sock->recv(remoteBusCard.data(), size), commRemoteError);
+      }
     }
+
+    vcs.push_back(std::move(vc));
+    remoteBusCards.push_back(std::move(remoteBusCard));
   }
 
   FB_COMMCHECK(
-      vcState_.setupAndPublishVc(std::move(vc), remoteBusCard, peerRank));
+      vcState_.setupAndPublishVc(std::move(vcs), remoteBusCards, peerRank));
 
   // Ack that the connection is fully established.
   // Ensure remote rank don't use the VC before local setupVc and

--- a/comms/ctran/backends/ib/BootstrapInternal.h
+++ b/comms/ctran/backends/ib/BootstrapInternal.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -14,12 +15,14 @@
 #include <sys/socket.h>
 
 #include "comms/ctran/backends/ib/CtranIbBase.h"
+#include "comms/ctran/backends/ib/VcLayout.h"
 #include "comms/ctran/bootstrap/ISocketFactory.h"
 #include "comms/ctran/utils/Abort.h"
 #include "comms/ctran/utils/ExtUtils.h"
 #include "comms/utils/commSpecs.h"
 
 class CtranComm;
+class CtranIbVirtualConn;
 
 namespace ctran::ib {
 
@@ -27,10 +30,18 @@ class VcState;
 
 // Bootstrap is the internal handshake driver for one CtranIb instance. It
 // owns the listen socket and accept thread, knows how to client-connect to
-// a peer, and publishes every freshly-handshaken VC into the supplied
-// VcState. CtranIb only ever calls start() / connect() / shutdown() /
-// getListenAddress() on this object; the rest of the bootstrap surface is
-// private to BootstrapInternal.cc.
+// a peer, and publishes every freshly-handshaken VC (or vector of VCs in
+// multi-VC mode) into the supplied VcState. CtranIb only ever calls
+// start() / connect() / shutdown() / getListenAddress() on this object;
+// the rest of the bootstrap surface is private to BootstrapInternal.cc.
+//
+// Call hierarchy for a single peer connection (server or client side):
+//   acceptLoop / connect
+//     -> exchangeAndPublish
+//          for vcIdx in [0, vcLayout_.maxVcsPerPeer):
+//              build vc, swap bus cards (under vc->mutex)
+//          vcState_.setupAndPublishVc(vcs, remoteBusCards, peerRank)
+//          ack handshake
 //
 // Lifetime: held by std::unique_ptr<Bootstrap> bootstrap_ on CtranIb.
 // Allocated only when bootstrapMode != kExternal. Must be destroyed before
@@ -39,6 +50,7 @@ class Bootstrap {
  public:
   Bootstrap(
       VcState& vcState,
+      const VcLayout& vcLayout,
       std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory,
       std::shared_ptr<::ctran::utils::Abort> abortCtrl,
       const CommLogData& logData,
@@ -63,8 +75,9 @@ class Bootstrap {
   // the accept thread.
   void start(std::optional<const SocketServerAddr*> qpServerAddr);
 
-  // Slow path: open a client socket to the peer, exchange business cards,
-  // and publish the resulting VC via vcState_.setupAndPublishVc(...).
+  // Slow path: open a client socket to the peer, exchange business cards
+  // for all per-peer VCs, and hand the resulting VC vector to
+  // vcState_.setupAndPublishVc(...).
   commResult_t connect(
       int peerRank,
       std::optional<const SocketServerAddr*> peerAddr);
@@ -81,13 +94,17 @@ class Bootstrap {
   static void acceptLoop(Bootstrap* self);
 
   // Shared post-handshake path used by both the server accept side and the
-  // client connect side.
+  // client connect side. Loops over vcLayout_.maxVcsPerPeer VCs: build +
+  // swap bus cards under vc->mutex; then hands the resulting vector +
+  // remote bus cards to vcState_.setupAndPublishVc and exchanges the
+  // final ack.
   commResult_t exchangeAndPublish(
       std::unique_ptr<::ctran::bootstrap::ISocket> sock,
       bool isServer,
       int peerRank);
 
   VcState& vcState_;
+  const VcLayout& vcLayout_;
   std::shared_ptr<::ctran::bootstrap::ISocketFactory> socketFactory_;
   std::shared_ptr<::ctran::utils::Abort> abortCtrl_;
   const CommLogData& logData_;

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -619,6 +619,35 @@ void CtranIb::init(
   // accepted (i.e., before bootstrap_->start() spawns the listen thread).
   vcState_.init(this, this->ncclLogData, comm ? comm->statex_->nRanks() : 0);
 
+  // Derive per-peer-VC sizing from cvars via the unified VcLayout utility.
+  // Legacy single-VC (NCCL_CTRAN_IB_NUM_VCS_PER_RANK <= 0) is normalized to
+  // 1, so the layout (and per-VC active-NIC vector) is well-defined in
+  // every configuration.
+  int maxVcsPerPeer = NCCL_CTRAN_IB_NUM_VCS_PER_RANK;
+  if (maxVcsPerPeer <= 0) {
+    maxVcsPerPeer = 1;
+  }
+  if (NCCL_CTRAN_IB_MAX_QPS < maxVcsPerPeer) {
+    std::string msg = fmt::format(
+        "CTRAN-IB: invalid VC sizing: NCCL_CTRAN_IB_MAX_QPS={} must be "
+        ">= NCCL_CTRAN_IB_NUM_VCS_PER_RANK={} so that each per-peer VC "
+        "gets at least one data QP.",
+        NCCL_CTRAN_IB_MAX_QPS,
+        maxVcsPerPeer);
+    CLOGF(ERR, msg);
+    throw ctran::utils::Exception(msg, commInvalidArgument);
+  }
+  vcLayout_ =
+      ctran::ib::VcLayout(NCCL_CTRAN_IB_DEVICES_PER_RANK, maxVcsPerPeer);
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB: VC layout: {} (numNics={}, NCCL_CTRAN_IB_MAX_QPS={}). "
+      "Per-VC data-QP count is determined per connection class inside CtranIbVirtualConn.",
+      vcLayout_.describe(),
+      NCCL_CTRAN_IB_DEVICES_PER_RANK,
+      NCCL_CTRAN_IB_MAX_QPS);
+
   // Optionally start internal bootstrap service.
   // If kExternal, external callsite would explicitly manage it and thus we skip
   // the internal bootstrap.
@@ -642,6 +671,7 @@ void CtranIb::init(
   } else {
     bootstrap_ = std::make_unique<Bootstrap>(
         vcState_,
+        vcLayout_,
         socketFactory_,
         abortCtrl_,
         ncclLogData,
@@ -1101,4 +1131,51 @@ uint32_t CtranIb::getPgToTrafficClassValue() const {
     return it->second;
   }
   return NCCL_IB_TC;
+}
+
+// ============================================================
+// Per-peer VC API implementation
+// ============================================================
+
+const std::vector<std::shared_ptr<CtranIbVirtualConn>>& CtranIb::connectVcs(
+    int peerRank,
+    std::optional<const SocketServerAddr*> peerServerAddr) {
+  // Fast path: per-peer VCs already published. References to values in
+  // std::unordered_map are stable across insertions, so the returned
+  // reference remains valid until releaseAll().
+  if (const auto* vcs = vcState_.tryGetVcs(peerRank)) {
+    return *vcs;
+  }
+
+  if (rank < peerRank) {
+    // Smaller rank initiates the rendezvous. connectVcs(peer, ...) must be
+    // called from a single thread per peer; concurrent per-peer callers
+    // are not supported.
+    FB_CHECKABORT(
+        bootstrap_ != nullptr,
+        "CTRAN-IB: connectVcs() called on externally-bootstrapped instance");
+    // bootstrap_->connect internally exchanges vcLayout_.maxVcsPerPeer
+    // VCs and publishes them into vcState_ (legacy single-VC callers
+    // read .front()).
+    const auto err = bootstrap_->connect(peerRank, peerServerAddr);
+    FB_CHECKABORT(
+        err == commSuccess,
+        "CTRAN-IB: bootstrap_->connect failed for peerRank " +
+            std::to_string(peerRank));
+  }
+
+  // Smaller-rank gets and returns vc created by connect. Larger-rank side spins
+  // until the listen thread publishes (mirrors preConnect()). The abort check
+  // lets teardown / explicit abort unblock us so we don't loop forever after
+  // releaseAll().
+  while (true) {
+    if (const auto* vcs = vcState_.tryGetVcs(peerRank)) {
+      return *vcs;
+    }
+    if (abortCtrl_ && abortCtrl_->Test()) {
+      static const std::vector<std::shared_ptr<CtranIbVirtualConn>> empty;
+      return empty;
+    }
+    std::this_thread::yield();
+  }
 }

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -3,9 +3,12 @@
 #ifndef CTRAN_IB_H_
 #define CTRAN_IB_H_
 
-#include <memory>
-
 #include <folly/SocketAddress.h>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/backends/CtranCtrl.h"
@@ -14,6 +17,7 @@
 #include "comms/ctran/backends/ib/CtranIbImpl.h"
 #include "comms/ctran/backends/ib/CtranIbLocalVc.h"
 #include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/backends/ib/VcLayout.h"
 #include "comms/ctran/backends/ib/VcState.h"
 #include "comms/ctran/bootstrap/AbortableSocket.h"
 #include "comms/ctran/bootstrap/ISocketFactory.h"
@@ -150,6 +154,21 @@ class CtranIb {
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t progress() {
     return progressInternal<PerfConfig>();
+  }
+
+  // Progress only the CQ on the specified IB device.
+  //
+  // Useful for consumers (e.g., NIC-affine progress loops in
+  // p2pHostIbTransport) that want to drive one NIC's completions
+  // without contending on other NICs' CQs.
+  // Input arguments:
+  //   - device: the IB device index whose CQ should be progressed.
+  //             Must be in [0, getNumIbDevices()). Callers that
+  //             have a vcIdx can map via:
+  //                 device = vcIdx / getMaxVcsPerNic()
+  template <typename PerfConfig = DefaultPerfCollConfig>
+  inline commResult_t progress(int device) {
+    return progressInternal<PerfConfig>(device);
   }
 
   // Export a local memory registration for remote rank to import.
@@ -451,6 +470,69 @@ class CtranIb {
     return externalBootstrap_.get();
   }
 
+  // ---- VC API ----
+  //
+  // See backends/ib/docs/ctranib_multi_channel_vc_management.md for the
+  // full design.
+  // Per peer, connectVcs() returns a vector of getMaxVcsPerPeer() VCs,
+  // each a CtranIbVirtualConn pinned to a single NIC and owning its own
+  // ctrl/notify/atomic + data QPs. The vector is lazily created on
+  // first call. Consumers dispatch directly to vcs[i]->X(...) under
+  // the per-VC mutex via CTRAN_IB_PER_OBJ_LOCK_GUARD.
+
+  inline int getNumIbDevices() const {
+    return NCCL_CTRAN_IB_DEVICES_PER_RANK;
+  }
+  inline int getMaxVcsPerPeer() const {
+    return vcLayout_.maxVcsPerPeer;
+  }
+  inline int getMaxVcsPerNic() const {
+    return vcLayout_.maxVcsPerNic;
+  }
+
+  // Returns a reference to the per-peer VC vector for this peer. This
+  // call may block and may initiate a bootstrap handshake — it is NOT
+  // a pure lookup. For a non-blocking, null-on-miss lookup, see
+  // VcState::tryGetVcs(). Note that the return value may be empty and callsite
+  // should assert on it.
+  //
+  // On first call, lazily creates getMaxVcsPerPeer() VCs (each pinned
+  // to NIC vcIdx / getMaxVcsPerNic()) by exchanging bus cards over a
+  // single internal bootstrap socket. Subsequent calls return the
+  // cached vector.
+  // Both peers must call connectVcs() for each other (the smaller-rank
+  // side initiates the bootstrap; the larger-rank side blocks waiting
+  // for the listen thread to populate state).
+  // peerServerAddr (optional): explicit peer listen address. If omitted,
+  // the smaller-rank initiator uses the pre-exchanged listen addresses
+  // from the comm allgather (only available when a comm is attached).
+  //
+  // Thread-safety: connectVcs(peer, ...) is NOT safe to call concurrently
+  // from multiple threads for the same `peer`. Callers must serialize
+  // per-peer invocations (e.g. issue connectVcs once during connection
+  // setup). Concurrent calls for different peers are safe.
+  //
+  // Deadlock-freedom (despite the larger-rank side blocking):
+  //   connectVcs() is a collective-style API: every rank that participates
+  //   in a transfer with peer P must eventually call connectVcs(P, ...) on
+  //   both ends. The only blocking site is the larger-rank spinner,
+  //   which polls vcState_.tryGetVcs(peer) until the listen thread
+  //   observes the smaller-rank initiator's bootstrap socket and
+  //   publishes the VC vector via setupAndPublishVc(). The spin also
+  //   honors abortCtrl_, so releaseAll() / abort unblocks the spinner.
+  //   For a deadlock to exist, every rank in some cycle would have to
+  //   be blocked in connectVcs() with no smaller-rank initiator running.
+  //   That is impossible: in any pair (a, b) with a < b, rank a is by
+  //   definition the smaller-rank side and runs the non-blocking
+  //   initiator path (bootstrapConnectVcs), driving rank b's listen
+  //   thread to publish and unblock b's spinner. Because this argument
+  //   holds for every pair independently, connectVcs() calls from a single
+  //   rank can be issued in any order across peers without forming a
+  //   wait-for cycle.
+  const std::vector<std::shared_ptr<CtranIbVirtualConn>>& connectVcs(
+      int peerRank,
+      std::optional<const SocketServerAddr*> peerServerAddr = std::nullopt);
+
   // Get the virtual connection for a given peer.
   // If the peer is not yet connected, return nullptr.
   // For a returned VC, it is guaranteed to be ready to use.
@@ -531,6 +613,30 @@ class CtranIb {
           "No valid VirtualConnection (VC) found for peerRank {}",
           peerRank);
       return commInternalError;
+    }
+    return commSuccess;
+  }
+
+  // Resolve the [deviceBegin, deviceEnd) range that progressInternal()
+  // should poll. If `device` is unset, returns the full NIC range; if
+  // set, validates it is in-range and returns a single-NIC slice.
+  inline commResult_t resolveDeviceRange(
+      std::optional<int> device,
+      int& deviceBegin,
+      int& deviceEnd) {
+    deviceBegin = 0;
+    deviceEnd = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    if (device.has_value()) {
+      if (*device < 0 || *device >= NCCL_CTRAN_IB_DEVICES_PER_RANK) {
+        CLOGF(
+            ERR,
+            "CTRAN-IB: invalid device {} (numNics={})",
+            *device,
+            NCCL_CTRAN_IB_DEVICES_PER_RANK);
+        return commInternalError;
+      }
+      deviceBegin = *device;
+      deviceEnd = *device + 1;
     }
     return commSuccess;
   }
@@ -910,13 +1016,25 @@ class CtranIb {
     return commSuccess;
   }
 
+  // Progress IB completion queues.
+  //
+  // If `device` is std::nullopt (the default), polls every device's CQ
+  // in a loop until no CQE is found on any device.
+  // If `device` is set, polls only that single device's CQ until it
+  // drains.
   template <typename PerfConfig = DefaultPerfCollConfig>
-  inline commResult_t progressInternal() {
+  inline commResult_t progressInternal(
+      std::optional<int> device = std::nullopt) {
     FB_COMMCHECK(checkEpochLock(this));
+
+    int deviceBegin = 0;
+    int deviceEnd = 0;
+    FB_COMMCHECK(resolveDeviceRange(device, deviceBegin, deviceEnd));
+
     /* complete as many requests as possible */
     while (1) {
       bool continueWhileLoop = false;
-      for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+      for (int device = deviceBegin; device < deviceEnd; device++) {
         ibverbx::ibv_wc wc;
         int count;
 
@@ -1008,6 +1126,12 @@ class CtranIb {
   // connectedPeerMap bitmap). Late-initialized in init() once ncclLogData
   // is populated.
   ::ctran::ib::VcState vcState_;
+
+  // Derived from cvars at init() via the ctran::ib::VcLayout(numNics,
+  // NCCL_CTRAN_IB_NUM_VCS_PER_RANK) ctor. Drives both legacy
+  // (maxVcsPerPeer == 1, all NICs per VC) and multi-VC
+  // (maxVcsPerPeer >= numNics, one NIC per VC) modes uniformly.
+  ::ctran::ib::VcLayout vcLayout_;
 
   // Internal-bootstrap service: owns listen socket + accept thread +
   // client-connect path, and publishes every freshly-handshaken VC into

--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -2,6 +2,7 @@
 
 #include <unistd.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -39,12 +40,13 @@ struct BusCard {
   } u;
 };
 
-// set the max number of QPs,  QP scaling threshold and  VC mode to use for a
-// peer based on the topology and corresponding CVARs, if available, otherwise,
-// use default value of NCCL_CTRAN_IB_MAX_QPS,
-// NCCL_CTRAN_IB_QP_SCALING_THRESHOLD, and NCCL_CTRAN_IB_VC_MODE
+// Apply the per-VC QP configuration. MAX_QPS is supplied by the caller
+// (see computeMaxQpsPerVc), then clamped to CTRAN_HARDCODED_MAX_QPS and
+// rounded up to a multiple of activeDevices_.size() so data QPs split
+// evenly across the active NICs. Other settings (QP scaling threshold,
+// VC mode, max msgs per QP) come from the cvars / connection-class
+// configList for this peer.
 inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
-  maxNumQps_ = NCCL_CTRAN_IB_MAX_QPS;
   qpScalingTh_ = NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
   vcMode_ = NCCL_CTRAN_IB_VC_MODE;
   maxQpMsgs_ = NCCL_CTRAN_IB_QP_MAX_MSGS;
@@ -70,7 +72,6 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
         configList->size() == kExpectedQpConfigLength,
         "XZONE, XDC QP Config strings must have exactly 4 elements");
     qpScalingTh_ = stoul(configList->at(qpConfigIndex::QP_SCALING_THRESHOLD));
-    maxNumQps_ = stoi(configList->at(qpConfigIndex::MAX_QPS));
     if (configList->at(qpConfigIndex::VC_MODE) == "spray") {
       vcMode_ = NCCL_CTRAN_IB_VC_MODE::spray;
     } else {
@@ -93,17 +94,17 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
     maxNumQps_ = CTRAN_HARDCODED_MAX_QPS;
   }
 
-  // assure maxNumQps_ to be a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK
-  if (maxNumQps_ % NCCL_CTRAN_IB_DEVICES_PER_RANK) {
+  // assure maxNumQps_ to be a multiple of activeDevices_.size() so data
+  // QPs split evenly across the active NICs.
+  const int numActive = static_cast<int>(activeDevices_.size());
+  if (maxNumQps_ % numActive) {
     int originalMaxNumQps = maxNumQps_;
-    maxNumQps_ = maxNumQps_ +
-        (NCCL_CTRAN_IB_DEVICES_PER_RANK -
-         maxNumQps_ % NCCL_CTRAN_IB_DEVICES_PER_RANK);
+    maxNumQps_ = maxNumQps_ + (numActive - maxNumQps_ % numActive);
     CLOGF(
         WARN,
-        "CTRAN-IB: CTRAN_MAX_QPS is not a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK  ({} < {}), rounding up to {} instead",
+        "CTRAN-IB: CTRAN_MAX_QPS is not a multiple of active device count ({} < {}), rounding up to {} instead",
         originalMaxNumQps,
-        NCCL_CTRAN_IB_DEVICES_PER_RANK,
+        numActive,
         maxNumQps_);
   }
 
@@ -119,10 +120,52 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
 
   pendingWqeQs_.resize(maxNumQps_);
 
+  // Cache the per-device QP count now that maxNumQps_ is finalized.
+  // maxNumQps_ is guaranteed to be a multiple of activeDevices_.size() above.
+  numQpsPerDevice_ = maxNumQps_ / numActive;
+
   // Only logs once per connection type across CtranIbVc instances
   logConnectionConfig(connTyp);
 
   return commSuccess;
+}
+
+int CtranIbVirtualConn::computeMaxQpsPerVc(
+    CtranComm* comm,
+    int peerRank,
+    int numVcs) {
+  FB_CHECKABORT(numVcs > 0, "numVcs must be positive");
+
+  // Per-peer MAX_QPS: cvar default, optionally overridden by the
+  // connection-class configList (same lookup as setDefaultQPConfig).
+  int perPeerMaxQps = NCCL_CTRAN_IB_MAX_QPS;
+  std::vector<std::string>* configList{nullptr};
+  if (comm && comm->statex_) {
+    if (comm->statex_->isSameZone(comm->statex_->rank(), peerRank)) {
+      // SAME_ZONE: no configList override; cvar default applies.
+    } else if (comm->statex_->isSameDc(comm->statex_->rank(), peerRank)) {
+      configList = &NCCL_CTRAN_IB_QP_CONFIG_XZONE;
+    } else {
+      configList = &NCCL_CTRAN_IB_QP_CONFIG_XDC;
+    }
+  } else if (!comm) {
+    configList = &NCCL_CTRAN_EX_IB_QP_CONFIG;
+  }
+  if ((configList != nullptr) && (configList->size() > 0)) {
+    FB_CHECKABORT(
+        configList->size() == kExpectedQpConfigLength,
+        "XZONE, XDC QP Config strings must have exactly 4 elements");
+    perPeerMaxQps = stoi(configList->at(qpConfigIndex::MAX_QPS));
+  }
+
+  FB_CHECKABORT(
+      perPeerMaxQps % numVcs == 0,
+      fmt::format(
+          "CTRAN-IB: per-peer MAX_QPS ({}) must be a multiple of numVcs "
+          "({}) so per-VC data QPs distribute evenly",
+          perPeerMaxQps,
+          numVcs));
+  return perPeerMaxQps / numVcs;
 }
 
 std::string CtranIbVirtualConn::connTypeName(ConnectionType connTyp) {
@@ -168,12 +211,13 @@ void CtranIbVirtualConn::logConnectionConfig(ConnectionType connTyp) {
       CLOGF_SUBSYS(
           INFO,
           INIT,
-          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
+          "CTRAN-IB-VC: QP setting for connection type {} (sameDC {}, sameZone {}): maxNumQps_={}, numQpsPerDevice_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}, "
           "rank {} peerRank {} commHash {:x} commDesc {}",
           connTypeName(connTyp),
           statex->isSameDc(statex->rank(), peerRank),
           statex->isSameZone(statex->rank(), peerRank),
           maxNumQps_,
+          numQpsPerDevice_,
           qpScalingTh_,
           vcModeName(vcMode_),
           maxQpMsgs_,
@@ -185,9 +229,10 @@ void CtranIbVirtualConn::logConnectionConfig(ConnectionType connTyp) {
       CLOGF_SUBSYS(
           INFO,
           INIT,
-          "CTRAN-IB-VC: QP setting for connection type {} (no statex): maxNumQps_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}",
+          "CTRAN-IB-VC: QP setting for connection type {} (no statex): maxNumQps_={}, numQpsPerDevice_={}, qpScalingTh_={}, vcMode_={}, maxQpMsgs_={}",
           connTypeName(connTyp),
           maxNumQps_,
+          numQpsPerDevice_,
           qpScalingTh_,
           vcModeName(vcMode_),
           maxQpMsgs_);
@@ -202,22 +247,25 @@ commResult_t CtranIbVirtualConn::prepCtrlMsgs() {
       ibverbx::IBV_ACCESS_REMOTE_READ);
   this->sendCtrl_.packets_.resize(MAX_RECV_WR);
 
+  // Register ctrl-msg buffers on the device that hosts the control QP.
+  const int ctrlDevice = ctrlDevice_;
   const auto totalSize = MAX_RECV_WR * sizeof(CtrlPacket);
-  auto maybeSendCtrlMr = devices_[0].ibvPd->regMr(
+  auto maybeSendCtrlMr = devices_[ctrlDevice].ibvPd->regMr(
       (void*)this->sendCtrl_.packets_.data(), totalSize, access);
   FOLLY_EXPECTED_CHECK(maybeSendCtrlMr);
   this->sendCtrl_.ibvMr_ = std::move(*maybeSendCtrlMr);
 
   this->recvCtrl_.packets_.resize(MAX_RECV_WR);
 
-  auto maybeRecvCtrlMr = devices_[0].ibvPd->regMr(
+  auto maybeRecvCtrlMr = devices_[ctrlDevice].ibvPd->regMr(
       (void*)this->recvCtrl_.packets_.data(), totalSize, access);
   FOLLY_EXPECTED_CHECK(maybeRecvCtrlMr);
   this->recvCtrl_.ibvMr_ = std::move(*maybeRecvCtrlMr);
 
   CLOGF_TRACE(
       INIT,
-      "CTRAN-IB-VC: CMsg packets pre-registered to device 0: sendCtrl {}, recvCtrl {}, size {} (packetSize {} * MAX_RECV_WR {})",
+      "CTRAN-IB-VC: CMsg packets pre-registered to device {}: sendCtrl {}, recvCtrl {}, size {} (packetSize {} * MAX_RECV_WR {})",
+      ctrlDevice,
       (void*)this->sendCtrl_.packets_.data(),
       (void*)this->recvCtrl_.packets_.data(),
       totalSize,
@@ -313,16 +361,54 @@ CtranIbVirtualConn::CtranIbVirtualConn(
     int peerRank,
     CtranComm* comm,
     uint32_t pgTrafficClass,
-    int cudaDev)
+    int cudaDev,
+    std::vector<int> activeDevices,
+    int maxQpsPerVc)
     : peerRank(peerRank),
       devices_(devices),
-      maxNumQps_(NCCL_CTRAN_IB_MAX_QPS),
+      maxNumQps_(maxQpsPerVc),
       comm_(comm),
       pgTrafficClass_(pgTrafficClass),
       cudaDev_(cudaDev) {
+  // Populate the active-devices set BEFORE setDefaultQPConfig (it reads
+  // activeDevices_.size() to validate maxNumQps_). Caller (CtranIb) supplies
+  // the precomputed VcLayout slice for this VC.
+  FB_CHECKABORT(!activeDevices.empty(), "activeDevices must be non-empty");
+  for (int dev : activeDevices) {
+    FB_CHECKABORT(
+        dev >= 0 && dev < NCCL_CTRAN_IB_DEVICES_PER_RANK,
+        "activeDevices entry out of range");
+  }
+  activeDevices_ = std::move(activeDevices);
+  // Today, control / notify / atomic QPs all live on the same device
+  // (activeDevices_.front()). Cached as separate fields so each role can
+  // later be pinned independently.
+  ctrlDevice_ = activeDevices_.front();
+  notifyDevice_ = activeDevices_.front();
+  atomicDevice_ = activeDevices_.front();
   // set default QP configs based on topology and user-specified CVARs, if
   // provided
   FB_COMMCHECKTHROW_EX(setDefaultQPConfig(), comm->logMetaData_);
+
+  // Log the IB device ifnames this VC is bound to. Skip entries with
+  // an unset ibvDevice handle (e.g. dummy devices used in unit tests).
+  std::string ifnames;
+  for (size_t i = 0; i < activeDevices_.size(); ++i) {
+    if (i > 0) {
+      ifnames += ", ";
+    }
+    auto* ibvDev = devices_[activeDevices_[i]].ibvDevice;
+    ifnames += (ibvDev != nullptr && ibvDev->device() != nullptr)
+        ? ibvDev->device()->name
+        : "<uninitialized>";
+  }
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-IB-VC: VC peerRank={} cudaDev={} ifnames=[{}]",
+      peerRank,
+      cudaDev_,
+      ifnames);
 }
 
 CtranIbVirtualConn::~CtranIbVirtualConn() {
@@ -345,7 +431,8 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
   BusCard* busCard = reinterpret_cast<BusCard*>(localBusCard);
   // assuming all devices portAttr
   ibverbx::ibv_port_attr portAttr;
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+  const int ctrlDevice = ctrlDevice_;
+  for (int device : activeDevices_) {
     auto maybePortAttr =
         devices_[device].ibvDevice->queryPort(devices_[device].port);
     FOLLY_EXPECTED_CHECK(maybePortAttr);
@@ -368,9 +455,9 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
         ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ;
 
     /* create QPs and set them to INIT state */
-    // only create one control and one notify QP per VC connection, create them
-    // on the first device
-    if (device == 0) {
+    // Create one control / notify / atomic QP per VC connection on the
+    // VC's control device (ctrlDevice_).
+    if (device == ctrlDevice) {
       auto ibvControlQpCreateResult = createRcQp(
           devices_[device].ibvPd,
           devices_[device].ibvCq->cq(),
@@ -402,8 +489,8 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
           devices_[device].port,
           qpAccessFlags | ibverbx::IBV_ACCESS_REMOTE_ATOMIC));
     }
-    // maxNumQps_ is always a multiple of NCCL_CTRAN_IB_DEVICES_PER_RANK
-    for (int i = 0; i < maxNumQps_ / NCCL_CTRAN_IB_DEVICES_PER_RANK; i++) {
+    // maxNumQps_ is always a multiple of activeDevices_.size()
+    for (int i = 0; i < numQpsPerDevice_; i++) {
       auto maybeQp = createRcQp(
           devices_[device].ibvPd,
           devices_[device].ibvCq->cq(),
@@ -429,7 +516,7 @@ commResult_t CtranIbVirtualConn::getLocalBusCard(void* localBusCard) {
   }
   CHECK_EQ(maxNumQps_, this->ibvDataQps_.size());
   /* create local business card */
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+  for (int device : activeDevices_) {
     busCard->ports[device] = devices_[device].port;
   }
   busCard->controlQpn = ibvControlQp_->qp()->qp_num;
@@ -484,17 +571,18 @@ commResult_t CtranIbVirtualConn::setupVc(void* remoteBusCard) {
   }
 
   /* set QP to RTR state for control and notify QP first*/
+  const int ctrlDevice = ctrlDevice_;
   RemoteQpInfo remoteQpInfo = {
       .mtu = remoteBusCardStruct->mtu,
-      .port = remoteBusCardStruct->ports[0],
+      .port = remoteBusCardStruct->ports[ctrlDevice],
       .linkLayer = linkLayer_,
   };
 
   if (this->linkLayer_ == ibverbx::IBV_LINK_LAYER_ETHERNET) {
-    remoteQpInfo.u.eth.spn = remoteBusCardStruct->u.eth.spns[0];
-    remoteQpInfo.u.eth.iid = remoteBusCardStruct->u.eth.iids[0];
+    remoteQpInfo.u.eth.spn = remoteBusCardStruct->u.eth.spns[ctrlDevice];
+    remoteQpInfo.u.eth.iid = remoteBusCardStruct->u.eth.iids[ctrlDevice];
   } else {
-    remoteQpInfo.u.ib.lid = remoteBusCardStruct->u.ib.lids[0];
+    remoteQpInfo.u.ib.lid = remoteBusCardStruct->u.ib.lids[ctrlDevice];
   };
 
   remoteQpInfo.qpn = remoteBusCardStruct->controlQpn;

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -5,6 +5,7 @@
 
 #include <deque>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 #include "comms/ctran/CtranComm.h"
@@ -186,13 +187,39 @@ class CtranIbVirtualConn {
  public:
   // Prepare local resources for the virtual connection.
   // Actual connection happens only when setupVc is called.
+  //
+  // activeDevices: the set of IB device indices (active NICs) this VC owns.
+  // Must be non-empty and every entry must be in
+  // [0, NCCL_CTRAN_IB_DEVICES_PER_RANK). The first entry is taken as the
+  // ctrl/notify/atomic device (`ctrlDevice_ = activeDevices.front()`); all
+  // data QPs are distributed across the listed devices.
+  // maxQpsPerVc: per-VC data-QP budget. Callers compute this via
+  // computeMaxQpsPerVc(comm, peerRank, numVcsPerPeer); the VC then clamps
+  // it to CTRAN_HARDCODED_MAX_QPS and rounds up to a multiple of
+  // activeDevices.size(). The VC itself has no concept of "vcs per peer".
   CtranIbVirtualConn(
       std::vector<CtranIbDevice>& devices,
       int peerRank,
       CtranComm* comm,
       uint32_t pgTrafficClass,
-      int cudaDev);
+      int cudaDev,
+      std::vector<int> activeDevices,
+      int maxQpsPerVc);
   ~CtranIbVirtualConn();
+
+  // Return the cvar/configList-resolved per-VC MAX_QPS budget:
+  //   per-peer-MAX_QPS (cvar default or NCCL_CTRAN_IB_QP_CONFIG_* override
+  //   for the peer's connection class) divided evenly across numVcs.
+  // Used by CtranIb / Bootstrap to compute the maxQpsPerVc ctor argument
+  // without leaking vcs-per-peer semantics into this class. Aborts if
+  // the per-peer MAX_QPS is not a multiple of numVcs.
+  //
+  // TODO: move off `static` once per-CtranIb-instance QP config is
+  // introduced. With per-comm QP config, maxQps can differ per CtranIb
+  // instance, so the answer will no longer be a pure function of
+  // globals + (comm, peerRank, numVcs) and should be resolved against
+  // the owning CtranIb's instance state instead.
+  static int computeMaxQpsPerVc(CtranComm* comm, int peerRank, int numVcs);
 
   // The data channel may be temporarily unavailable due to run out of local
   // send queue WQE. VC has already internally scheduled an implicit signal to
@@ -221,6 +248,7 @@ class CtranIbVirtualConn {
   // Setup the IB connection between two peers.
   // Specifically, it updates the local control and data QPs with remote
   // business card info to establish the connection.
+  // Caller MUST hold vc->mutex (per the general VC thread-safety contract).
   commResult_t setupVc(void* remoteBusCard);
 
   // Implementation to send generic control message over the established IB
@@ -439,9 +467,44 @@ class CtranIbVirtualConn {
     return dataQps;
   }
 
-  // derive device index from qp idx
-  inline int getIbDevFromQpIdx(int qpIdx) {
-    return qpIdx / (maxNumQps_ / NCCL_CTRAN_IB_DEVICES_PER_RANK);
+  // derive the position within activeDevices_ from a qp idx. Use this when
+  // indexing per-VC vectors that are sized to activeDevices_.size() (e.g.
+  // PutInfo/GetInfo lkeys/rkeys built ordinally in iputImpl/igetImpl).
+  inline int getActiveDevIdxFromQpIdx(int qpIdx) const {
+    return qpIdx / numQpsPerDevice_;
+  }
+
+  // derive the global IB device index from a qp idx. Use this when indexing
+  // structures that are sized to NCCL_CTRAN_IB_DEVICES_PER_RANK (e.g. the
+  // global MR vector behind ibRegElem, or remoteAccessKey.rkeys, or the
+  // QpUniqueId carried in VcState's qpToVcMap).
+  inline int getIbDevFromQpIdx(int qpIdx) const {
+    return activeDevices_[getActiveDevIdxFromQpIdx(qpIdx)];
+  }
+
+  // Returns the IB device that hosts the control QPs for this VC.
+  // Always equals activeDevices_.front() today.
+  inline int getCtrlDevice() const {
+    return ctrlDevice_;
+  }
+
+  // Returns the IB device that hosts the notify QPs for this VC.
+  // Always equals activeDevices_.front() today.
+  inline int getNotifyDevice() const {
+    return notifyDevice_;
+  }
+
+  // Returns the IB device that hosts the atomic QPs for this VC.
+  // Always equals activeDevices_.front() today.
+  inline int getAtomicDevice() const {
+    return atomicDevice_;
+  }
+
+  // Returns the list of IB devices this VC owns QPs on. Used by callers
+  // (e.g. CtranIb::updateVcState) that need to know which CQ(s) own the
+  // VC's QPs.
+  inline const std::vector<int>& getActiveDevices() const {
+    return activeDevices_;
   }
 
   // Check if QPs have been initialized (via getLocalBusCard())
@@ -454,21 +517,24 @@ class CtranIbVirtualConn {
     FB_CHECKABORT(
         ibvNotifyQp_.has_value(),
         "Notify QP not initialized when checking isNotifyQp");
-    return ibvNotifyQp_->qp()->qp_num == qpId.first && qpId.second == 0;
+    return ibvNotifyQp_->qp()->qp_num == qpId.first &&
+        qpId.second == notifyDevice_;
   }
 
   inline bool isControlQp(QpUniqueId qpId) const {
     FB_CHECKABORT(
         ibvControlQp_.has_value(),
         "Control QP not initialized when checking isControlQp");
-    return ibvControlQp_->qp()->qp_num == qpId.first && qpId.second == 0;
+    return ibvControlQp_->qp()->qp_num == qpId.first &&
+        qpId.second == ctrlDevice_;
   }
 
   inline bool isAtomicQp(QpUniqueId qpId) const {
     FB_CHECKABORT(
         ibvAtomicQp_.has_value(),
         "Atomic QP not initialized when checking isAtomicQp");
-    return ibvAtomicQp_->qp()->qp_num == qpId.first && qpId.second == 0;
+    return ibvAtomicQp_->qp()->qp_num == qpId.first &&
+        qpId.second == atomicDevice_;
   }
 
   // Global rank of remote peer.
@@ -741,7 +807,7 @@ class CtranIbVirtualConn {
           (void*)sbuf);
       return commSystemError;
     }
-    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    for (int device : activeDevices_) {
       lkeys.push_back((*smrs)[device].mr()->lkey);
       rkeys.push_back(remoteAccessKey.rkeys[device]);
       CLOGF_TRACE(
@@ -750,7 +816,7 @@ class CtranIbVirtualConn {
           (void*)sbuf,
           (void*)dbuf,
           len,
-          rkeys[device]);
+          rkeys.back());
     }
 
     const auto putId = getPutId();
@@ -847,7 +913,7 @@ class CtranIbVirtualConn {
           (void*)dbuf);
       return commSystemError;
     }
-    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    for (int device : activeDevices_) {
       lkeys.push_back((*smrs)[device].mr()->lkey);
       rkeys.push_back(remoteAccessKey.rkeys[device]);
       CLOGF_TRACE(
@@ -856,7 +922,7 @@ class CtranIbVirtualConn {
           (void*)sbuf,
           (void*)dbuf,
           len,
-          rkeys[device]);
+          rkeys.back());
     }
 
     const auto getId = getGetId();
@@ -963,8 +1029,8 @@ class CtranIbVirtualConn {
           (void*)sbuf);
       return commSystemError;
     }
-    // For atomic operations, we always use device 0
-    int device = 0;
+    // For atomic operations, use the VC's atomic device.
+    int device = atomicDevice_;
     uint32_t lkey = (*smrs)[device].mr()->lkey;
     uint32_t rkey = remoteAccessKey.rkeys[device];
     CLOGF_TRACE(
@@ -992,8 +1058,8 @@ class CtranIbVirtualConn {
       uint64_t val,
       struct CtranIbRemoteAccessKey remoteAccessKey,
       CtranIbRequest* req) {
-    // For atomic operations, we always use device 0
-    int device = 0;
+    // For atomic operations, use the VC's atomic device.
+    int device = atomicDevice_;
     uint32_t rkey = remoteAccessKey.rkeys[device];
     CLOGF_TRACE(
         COLL,
@@ -1123,7 +1189,7 @@ class CtranIbVirtualConn {
             qpNum,
             ibDevice,
             getAtomicQpNum(),
-            0);
+            getAtomicDevice());
         FB_COMMCHECK(atomicComplete());
       } break;
 
@@ -1293,7 +1359,8 @@ class CtranIbVirtualConn {
     if (pendingPuts_.size() == 0) {
       return commSuccess;
     }
-    int device = getIbDevFromQpIdx(i);
+    int activeIdx = getActiveDevIdxFromQpIdx(i);
+    int device = activeDevices_[activeIdx];
     auto& put = pendingPuts_.front();
 
     uint64_t remData = put->len - put->offset;
@@ -1310,14 +1377,16 @@ class CtranIbVirtualConn {
 
     sendPutSg_.addr = reinterpret_cast<uint64_t>(put->sbuf) + put->offset;
     sendPutSg_.length = toSend;
-    sendPutSg_.lkey = put->lkeys[device];
+    // put->lkeys / put->rkeys are sized to activeDevices_.size() and indexed
+    // ordinally (see iputImpl), not by global IB device index.
+    sendPutSg_.lkey = put->lkeys[activeIdx];
 
     sendPutWr_.wr_id = nextWrId_++;
     sendPutWr_.send_flags = ibverbx::IBV_SEND_SIGNALED;
 
     sendPutWr_.wr.rdma.remote_addr =
         reinterpret_cast<uint64_t>(put->dbuf) + put->offset;
-    sendPutWr_.wr.rdma.rkey = put->rkeys[device];
+    sendPutWr_.wr.rdma.rkey = put->rkeys[activeIdx];
 
     // Use plain RDMA_WRITE when the caller does not request receiver-side
     // notification. Spray mode also uses plain writes; when spray notify is
@@ -1371,7 +1440,7 @@ class CtranIbVirtualConn {
     if (pendingGets_.size() == 0) {
       return commSuccess;
     }
-    int device = getIbDevFromQpIdx(i);
+    int activeIdx = getActiveDevIdxFromQpIdx(i);
     auto& get = pendingGets_.front();
 
     uint64_t remData = get->len - get->offset;
@@ -1388,13 +1457,15 @@ class CtranIbVirtualConn {
 
     sendGetSg_.addr = reinterpret_cast<uint64_t>(get->dbuf) + get->offset;
     sendGetSg_.length = toSend;
-    sendGetSg_.lkey = get->lkeys[device];
+    // get->lkeys / get->rkeys are sized to activeDevices_.size() and indexed
+    // ordinally (see igetImpl), not by global IB device index.
+    sendGetSg_.lkey = get->lkeys[activeIdx];
 
     sendGetWr_.wr_id = nextWrId_++;
 
     sendGetWr_.wr.rdma.remote_addr =
         reinterpret_cast<uint64_t>(get->sbuf) + get->offset;
-    sendGetWr_.wr.rdma.rkey = get->rkeys[device];
+    sendGetWr_.wr.rdma.rkey = get->rkeys[activeIdx];
 
     CLOGF_TRACE(
         COLL,
@@ -1782,8 +1853,22 @@ class CtranIbVirtualConn {
 
   bool isReady_{false};
   std::vector<CtranIbDevice> devices_;
+  // Set of IB device indices this VC owns QPs on (precomputed by
+  // ctran::ib::VcLayout and supplied by CtranIb). For legacy
+  // (maxVcsPerPeer == 1), this is [0, 1, ...,
+  // NCCL_CTRAN_IB_DEVICES_PER_RANK-1]. For a VC pinned to a single NIC, this is
+  // a single-element vector.
+  std::vector<int> activeDevices_;
+  // IB device indices that host this VC's control / notify / atomic QPs.
+  // Today all three equal activeDevices_.front(), but kept as separate
+  // fields so each role can later be pinned independently without
+  // touching the call sites.
+  int ctrlDevice_{0};
+  int notifyDevice_{0};
+  int atomicDevice_{0};
   uint8_t linkLayer_{0};
   int maxNumQps_{0};
+  int numQpsPerDevice_{0};
   size_t qpScalingTh_{NCCL_CTRAN_IB_QP_SCALING_THRESHOLD};
   enum NCCL_CTRAN_IB_VC_MODE vcMode_ { NCCL_CTRAN_IB_VC_MODE::spray };
   int maxQpMsgs_;

--- a/comms/ctran/backends/ib/VcLayout.cc
+++ b/comms/ctran/backends/ib/VcLayout.cc
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/backends/ib/VcLayout.h"
+
+#include <fmt/core.h>
+
+#include "comms/ctran/utils/Exception.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::ib {
+
+VcLayout::VcLayout(int numNics, int maxVcsPerPeer) {
+  if (numNics <= 0) {
+    throw ctran::utils::Exception(
+        fmt::format(
+            "CTRAN-IB: VcLayout: numNics must be positive, got {}", numNics),
+        commInvalidArgument);
+  }
+  if (maxVcsPerPeer <= 0) {
+    throw ctran::utils::Exception(
+        fmt::format(
+            "CTRAN-IB: VcLayout: maxVcsPerPeer must be positive, got {} "
+            "(callers must normalize legacy sentinel to 1 before constructing)",
+            maxVcsPerPeer),
+        commInvalidArgument);
+  }
+
+  this->maxVcsPerPeer = maxVcsPerPeer;
+  vcToActiveDevices.reserve(maxVcsPerPeer);
+
+  if (maxVcsPerPeer >= numNics && maxVcsPerPeer % numNics == 0) {
+    // Pinned: each NIC owns maxVcsPerNic VCs (NIC-major layout).
+    maxVcsPerNic = maxVcsPerPeer / numNics;
+    for (int v = 0; v < maxVcsPerPeer; ++v) {
+      vcToActiveDevices.push_back({v / maxVcsPerNic});
+    }
+  } else if (maxVcsPerPeer < numNics && numNics % maxVcsPerPeer == 0) {
+    // Striped: each VC spans K contiguous NICs.
+    maxVcsPerNic = 1;
+    const int k = numNics / maxVcsPerPeer;
+    for (int v = 0; v < maxVcsPerPeer; ++v) {
+      std::vector<int> devs;
+      devs.reserve(k);
+      for (int i = 0; i < k; ++i) {
+        devs.push_back(v * k + i);
+      }
+      vcToActiveDevices.push_back(std::move(devs));
+    }
+  } else {
+    throw ctran::utils::Exception(
+        fmt::format(
+            "CTRAN-IB: VcLayout: invalid (numNics={}, maxVcsPerPeer={}): "
+            "requires either maxVcsPerPeer >= numNics with "
+            "maxVcsPerPeer % numNics == 0, or maxVcsPerPeer < numNics with "
+            "numNics % maxVcsPerPeer == 0.",
+            numNics,
+            maxVcsPerPeer),
+        commInvalidArgument);
+  }
+}
+
+std::string VcLayout::describe() const {
+  std::string out = fmt::format(
+      "maxVcsPerPeer={}, maxVcsPerNic={}", maxVcsPerPeer, maxVcsPerNic);
+  for (size_t v = 0; v < vcToActiveDevices.size(); ++v) {
+    out += fmt::format(", VC[{}]\u2192[", v);
+    for (size_t i = 0; i < vcToActiveDevices[v].size(); ++i) {
+      if (i > 0) {
+        out += ",";
+      }
+      out += fmt::format("{}", vcToActiveDevices[v][i]);
+    }
+    out += "]";
+  }
+  return out;
+}
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/VcLayout.h
+++ b/comms/ctran/backends/ib/VcLayout.h
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ctran::ib {
+
+// Uniform per-VC NIC assignment, valid for both legacy single-VC and
+// multi-VC configurations.
+//
+// Two layout modes are supported:
+//   - Pinned (maxVcsPerPeer >= numNics, maxVcsPerPeer % numNics == 0):
+//     each NIC owns maxVcsPerNic = maxVcsPerPeer/numNics VCs, NIC-major.
+//   - Striped (maxVcsPerPeer < numNics, numNics % maxVcsPerPeer == 0):
+//     each VC spans K = numNics/maxVcsPerPeer contiguous NICs;
+//     maxVcsPerNic = 1.
+//
+// `vcToActiveDevices[v]` is the set of IB device indices (active NICs)
+// that VC v owns. CtranIbVirtualConn consumes this vector directly.
+struct VcLayout {
+  // Default-constructed layout is empty; populate via the
+  // (numNics, maxVcsPerPeer) ctor.
+  VcLayout() = default;
+
+  // Build a VcLayout for the given (numNics, maxVcsPerPeer) configuration.
+  //
+  // Throws ctran::utils::Exception(commInvalidArgument) when:
+  //   - numNics <= 0
+  //   - maxVcsPerPeer <= 0 (callers must normalize the legacy sentinel to 1
+  //     before constructing)
+  //   - neither divisibility relationship between numNics and maxVcsPerPeer
+  //     holds.
+  VcLayout(int numNics, int maxVcsPerPeer);
+
+  int maxVcsPerPeer{0};
+  int maxVcsPerNic{0};
+  std::vector<std::vector<int>> vcToActiveDevices;
+
+  // Single-line summary string for logging (init).
+  std::string describe() const;
+};
+
+} // namespace ctran::ib

--- a/comms/ctran/backends/ib/VcState.cc
+++ b/comms/ctran/backends/ib/VcState.cc
@@ -2,6 +2,8 @@
 
 #include "comms/ctran/backends/ib/VcState.h"
 
+#include <memory>
+#include <mutex>
 #include <utility>
 #include <vector>
 
@@ -29,58 +31,23 @@ void VcState::init(void* owner, const CommLogData& logData, int nRanks) {
 void VcState::releaseAll() {
   { // Explicitly release all virtual connections before destroying cq.
     auto locked = vcStateMaps_.wlock();
-    locked->rankToVcMap.clear();
     locked->qpToVcMap.clear();
+    locked->rankToVcs.clear();
     vcStateMapsPtr_ = nullptr;
   }
   connectedPeerMap_.clear();
 }
 
 commResult_t VcState::setupAndPublishVc(
-    std::shared_ptr<CtranIbVirtualConn> vc,
-    const std::string& remoteVcIdentifier,
+    std::vector<std::shared_ptr<CtranIbVirtualConn>> vcs,
+    const std::vector<std::string>& remoteVcIdentifiers,
     int peerRank) {
-  {
-    const std::lock_guard<std::mutex> lock(vc->mutex);
-    FB_COMMCHECKTHROW_EX(
-        vc->setupVc((void*)remoteVcIdentifier.data()), *logData_);
-  }
-
-  uint32_t controlQp = vc->getControlQpNum();
-  uint32_t notifyQp = vc->getNotifyQpNum();
-  uint32_t atomicQp = vc->getAtomicQpNum();
-  std::vector<uint32_t> dataQps = vc->getDataQpNums();
-
-  // Till now VC is not yet exposed to local rank. Local rank can use the VC
-  // once updated the vcStateMaps_.
-  FB_COMMCHECKTHROW_EX(updateVcState(vc, peerRank), *logData_);
-
-  CLOGF_SUBSYS(
-      INFO,
-      INIT,
-      "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, "
-      "vc {}, rank {}, peer {}, control qpn {}, notify qpn {}, atomic qpn {}, data qpns {}",
-      logData_->commHash,
-      logData_->commDesc,
-      (void*)vc.get(),
-      logData_->rank,
-      peerRank,
-      controlQp,
-      notifyQp,
-      atomicQp,
-      vecToStr(dataQps));
-
-  return commSuccess;
-}
-
-commResult_t VcState::updateVcState(
-    std::shared_ptr<CtranIbVirtualConn> vc,
-    int peerRank) {
-  auto locked = vcStateMaps_.wlock();
-  if (locked->rankToVcMap.find(peerRank) != locked->rankToVcMap.end()) {
+  if (vcs.empty() || vcs.size() != remoteVcIdentifiers.size()) {
     CLOGF(
         ERR,
-        "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
+        "CTRAN-IB: setupAndPublishVc called with vcs.size()={} remoteVcIdentifiers.size()={} for peerRank {} in pimpl {} commHash {:x} commDesc {}",
+        vcs.size(),
+        remoteVcIdentifiers.size(),
         peerRank,
         owner_,
         logData_->commHash,
@@ -88,33 +55,94 @@ commResult_t VcState::updateVcState(
     return commInternalError;
   }
 
-  locked->rankToVcMap[peerRank] = vc;
-  QpUniqueId controlQpId = std::make_pair(vc->getControlQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, controlQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
-  }
-  QpUniqueId notifyQpId = std::make_pair(vc->getNotifyQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, notifyQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
-  }
-  QpUniqueId atomicQpId = std::make_pair(vc->getAtomicQpNum(), 0);
-  if (checkAndInsertQpToVcMap(locked->qpToVcMap, atomicQpId, vc) !=
-      commSuccess) {
-    return commInternalError;
+  // Setup each VC under its own per-VC lock. The VC is not yet exposed
+  // to local rank; the lock is taken to follow VC thread-safety semantics.
+  for (size_t i = 0; i < vcs.size(); ++i) {
+    const std::lock_guard<std::mutex> lock(vcs[i]->mutex);
+    FB_COMMCHECKTHROW_EX(
+        vcs[i]->setupVc((void*)remoteVcIdentifiers[i].data()), *logData_);
   }
 
-  std::vector<uint32_t> dataQps = vc->getDataQpNums();
-  for (int qpIdx = 0; qpIdx < dataQps.size(); qpIdx++) {
-    int device = vc->getIbDevFromQpIdx(qpIdx);
-    QpUniqueId qpId = std::make_pair(dataQps[qpIdx], device);
-    if (checkAndInsertQpToVcMap(locked->qpToVcMap, qpId, vc) != commSuccess) {
+  {
+    auto locked = vcStateMaps_.wlock();
+    if (locked->rankToVcs.find(peerRank) != locked->rankToVcs.end()) {
+      CLOGF(
+          ERR,
+          "CTRAN-IB: VirtualConnection (VC) already exists for peerRank {} in pimpl {} commHash {:x}, commDesc {}. It likely indicates a COMM bug.",
+          peerRank,
+          owner_,
+          logData_->commHash,
+          logData_->commDesc);
       return commInternalError;
     }
+
+    // Insert each VC's QPs into qpToVcMap. Key ctrl/notify/atomic QPs by
+    // the VC's control device (NIC 0 for the legacy non-pinned VC, the
+    // pinned NIC for multi-VC). Data QPs are keyed by getIbDevFromQpIdx().
+    for (const auto& vc : vcs) {
+      const int ctrlDevice = vc->getCtrlDevice();
+      std::shared_ptr<CtranIbVirtualConn> vcRef = vc;
+      QpUniqueId controlQpId =
+          std::make_pair(vc->getControlQpNum(), ctrlDevice);
+      if (checkAndInsertQpToVcMap(locked->qpToVcMap, controlQpId, vcRef) !=
+          commSuccess) {
+        return commInternalError;
+      }
+      QpUniqueId notifyQpId = std::make_pair(vc->getNotifyQpNum(), ctrlDevice);
+      if (checkAndInsertQpToVcMap(locked->qpToVcMap, notifyQpId, vcRef) !=
+          commSuccess) {
+        return commInternalError;
+      }
+      QpUniqueId atomicQpId = std::make_pair(vc->getAtomicQpNum(), ctrlDevice);
+      if (checkAndInsertQpToVcMap(locked->qpToVcMap, atomicQpId, vcRef) !=
+          commSuccess) {
+        return commInternalError;
+      }
+      std::vector<uint32_t> dataQps = vc->getDataQpNums();
+      for (int qpIdx = 0; qpIdx < static_cast<int>(dataQps.size()); ++qpIdx) {
+        int device = vc->getIbDevFromQpIdx(qpIdx);
+        QpUniqueId qpId = std::make_pair(dataQps[qpIdx], device);
+        if (checkAndInsertQpToVcMap(locked->qpToVcMap, qpId, vcRef) !=
+            commSuccess) {
+          return commInternalError;
+        }
+      }
+    }
+
+    // Log each established VC while we still own a stable reference.
+    for (const auto& vc : vcs) {
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-IB: Established connection: commHash {:x}, commDesc {}, "
+          "vc {}, rank {}, peer {}, control qpn {}, notify qpn {}, atomic qpn {}, data qpns {}",
+          logData_->commHash,
+          logData_->commDesc,
+          (void*)vc.get(),
+          logData_->rank,
+          peerRank,
+          vc->getControlQpNum(),
+          vc->getNotifyQpNum(),
+          vc->getAtomicQpNum(),
+          vecToStr(vc->getDataQpNums()));
+    }
+
+    locked->rankToVcs[peerRank] = std::move(vcs);
   }
 
   return commSuccess;
+}
+
+const std::vector<std::shared_ptr<CtranIbVirtualConn>>* VcState::tryGetVcs(
+    int peerRank) {
+  auto locked = vcStateMaps_.rlock();
+  auto it = locked->rankToVcs.find(peerRank);
+  if (it == locked->rankToVcs.end()) {
+    return nullptr;
+  }
+  // Value-reference stability via std::unordered_map: the pointer
+  // remains valid until releaseAll() / rankToVcs.erase(peerRank).
+  return &it->second;
 }
 
 commResult_t VcState::checkAndInsertQpToVcMap(

--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <folly/Synchronized.h>
@@ -22,16 +23,23 @@ namespace ctran::ib {
 // NOTE: when using a VC, additional per-VC lock is required.
 struct VcStateMaps {
   folly::F14FastMap<QpUniqueId, std::shared_ptr<CtranIbVirtualConn>> qpToVcMap;
-  folly::F14FastMap<int, std::shared_ptr<CtranIbVirtualConn>> rankToVcMap;
+  // Per-peer VC vector returned by connectVcs() (lazy bootstrap), drained
+  // by releaseAll(). Uses std::unordered_map for value-reference
+  // stability across insertions.
+  // Single source of truth for per-peer VCs: legacy single-VC callers
+  // read rankToVcs[peer].front(); multi-VC callers iterate the vector.
+  std::unordered_map<int, std::vector<std::shared_ptr<CtranIbVirtualConn>>>
+      rankToVcs;
 };
 
 // VcState owns all per-peer virtual-connection state for a single CtranIb
 // instance. Both the internal bootstrap path (ctran::ib::Bootstrap) and the
-// external bootstrap path (BootstrapExternal.cc) publish established VCs
-// through setupAndPublishVc(); critical-path callers look them up through
-// getVc/getVcByQp. The class is intentionally not thread-safe at the
-// construction / init / releaseAll boundary; all mutating operations after
-// init() are themselves thread-safe (vcStateMaps_ is folly::Synchronized).
+// external bootstrap path (BootstrapExternal.cc) hand a freshly-constructed
+// VC vector + matching remote bus cards to setupAndPublishVc(); critical-path
+// callers look them up through getVc/getVcByQp. The class is intentionally
+// not thread-safe at the construction / init / releaseAll boundary; all
+// mutating operations after init() are themselves thread-safe
+// (vcStateMaps_ is folly::Synchronized).
 class VcState {
  public:
   VcState() = default;
@@ -51,23 +59,36 @@ class VcState {
 
   // Release every established VC, clear connectedPeerMap, and reset the
   // lock-free fast-path pointer. Callers must invoke this before tearing
-  // down resources referenced by the VCs (e.g., the shared CQ).
+  // down resources referenced by the VCs (e.g., the shared CQ). Any
+  // larger-rank connectVcs() spinner observes the cleared rankToVcs and
+  // exits via its abort check.
   void releaseAll();
 
-  // Setup a freshly-constructed VC with the remote bus card, publish it into
-  // vcStateMaps_, and log the established connection. Shared between the
-  // internal bootstrap path (ctran::ib::Bootstrap) and the external
-  // bootstrap path (BootstrapExternal.cc). The VC must not already be
+  // Setup a vector of freshly-constructed VCs with the matching remote
+  // bus cards (vcs[i] is set up with remoteVcIdentifiers[i]), atomically
+  // publish them into vcStateMaps_, and log each established connection.
+  // Shared between the internal bootstrap path (ctran::ib::Bootstrap) and
+  // the external bootstrap path (BootstrapExternal.cc). For the legacy
+  // single-VC case, both vectors have size 1.
+  //
+  // Steps:
+  //   * runs vc->setupVc(remoteVcIdentifiers[i]) under vc->mutex for each VC
+  //   * inserts every VC's ctrl/notify/atomic/data QPs into qpToVcMap
+  //   * sets rankToVcs[peerRank] = std::move(vcs)
+  //   * logs each established connection
+  // Thread-safe; callable concurrently by server (listen thread) and
+  // client (Bootstrap::connect) threads. The peer must not already be
   // present.
   commResult_t setupAndPublishVc(
-      std::shared_ptr<CtranIbVirtualConn> vc,
-      const std::string& remoteVcIdentifier,
+      std::vector<std::shared_ptr<CtranIbVirtualConn>> vcs,
+      const std::vector<std::string>& remoteVcIdentifiers,
       int peerRank);
 
-  // Update vcStateMaps_ to include the established VC.
-  // Thread-safe; callable concurrently by server and client threads.
-  commResult_t updateVcState(
-      std::shared_ptr<CtranIbVirtualConn> vc,
+  // ---- connectVcs() helpers used by CtranIb::connectVcs() ----
+  //
+  // Read-only lookup of the per-peer VC vector. Returns nullptr when the
+  // peer has not yet been published.
+  const std::vector<std::shared_ptr<CtranIbVirtualConn>>* tryGetVcs(
       int peerRank);
 
   // Returns true if the peer has been pre-connected (preConnect path).
@@ -88,23 +109,22 @@ class VcState {
     return !connectedPeerMap_.empty();
   }
 
-  // Get a virtual connection for a given peer.
-  // If the peer is not yet connected, return nullptr.
-  // For a returned VC, it is guaranteed to be ready to use.
+  // Get a virtual connection for a given peer (legacy single-VC view).
+  // Reads rankToVcs[peer].front(). If the peer is not yet connected,
+  // returns nullptr. For a returned VC, it is guaranteed to be ready
+  // to use.
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline std::shared_ptr<CtranIbVirtualConn> getVc(int peerRank) {
     if (PerfConfig::skipVcConnectionCheck ||
         (vcStateMapsPtr_ && isPeerConnected(peerRank))) {
-      return vcStateMapsPtr_->rankToVcMap.at(peerRank);
+      return vcStateMapsPtr_->rankToVcs.at(peerRank).front();
     } else {
       auto locked = vcStateMaps_.rlock();
-
-      auto it = locked->rankToVcMap.find(peerRank);
-      if (it == locked->rankToVcMap.end()) {
+      auto it = locked->rankToVcs.find(peerRank);
+      if (it == locked->rankToVcs.end() || it->second.empty()) {
         return nullptr;
       }
-
-      return it->second;
+      return it->second.front();
     }
   }
 

--- a/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md
+++ b/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md
@@ -1,0 +1,739 @@
+# CtranIb Multi-Channel Support via Per-Peer VC Management — Design
+
+## 1. Overview
+
+This document describes how `CtranIb` supports **multi-channel
+communication** for its consumers (`p2pHostIbTransport`, RMA, ctran
+algos) by managing a **vector of per-peer Virtual Connections (VCs)**.
+The "channel" concept itself lives entirely in the **algo / RMA**
+layer: the algo decides how many parallel logical channels it wants
+and picks a VC per chunk. CtranIb owns the per-NIC IB resources (one
+VC group per NIC) and exposes the per-peer VC vector via
+`connectVcs(peer)`. `p2pHostIbTransport` is just the dispatch layer in
+between — it caches the per-peer VC vector and forwards each chunk's
+operations to `vcs[vcIdx]`, where `vcIdx` is supplied by the caller
+per chunk.
+
+**Why multiple VCs per peer?**
+
+- **Multiple independent logical connections per peer.** Each VC owns
+  its own ctrl/notify/atomic QPs, so each VC has its own ordering
+  domain and its own notify stream. A slow consumer on one VC cannot
+  back-pressure another VC to the same peer.
+- **NIC-pinned VCs to avoid cross-NIC `iflush`.** Each VC's
+  ctrl/notify/atomic + data QPs all sit on a single NIC. When a logical
+  stream uses one VC, all of that stream's puts and its notify travel
+  through one NIC's PCIe path, so the receiver gets the per-NIC
+  ordering between data and notify that NIC hardware already provides
+  — no cross-NIC RDMA-read flush required.
+
+### Adoption flow — user → CtranIb
+
+```
+  +---------------------------------------------------------------+
+  |  Algorithm / RMA layer (ctranAlgo, RMA collectives)           |
+  |                                                               |
+  |  Owns its own "logical channel" concept (if any). For each    |
+  |  chunk picks vcIdx (and stagingSlot for CB) and issues:       |
+  |     transport->iSendChunk(buf, off, len, config,              |
+  |                           vcIdx, stagingSlot)                 |
+  |     transport->iRecvChunk(buf, off, len, config,              |
+  |                           vcIdx, stagingSlot)                 |
+  |  Returns ChunkRequest; polled via testChunkDone(request).      |
+  |  Common convention: vcIdx = channelId % numVcs (channel ↔ VC  |
+  |  binding lives in the algo).                                  |
+  +---------------------------------------------------------------+
+                                |
+                                |  per-chunk vcIdx (+ stagingSlot for CB)
+                                v
+  +---------------------------------------------------------------+
+  |  p2pHostIbTransport      (one instance per peer)              |
+  |                                                               |
+  |  - Caches the per-peer VC vector returned by                  |
+  |       ctranIb->connectVcs(peerRank)                               |
+  |  - Owns a CB staging-slot pool of size pipelineDepth and a    |
+  |    ZC chunk-record freelist.                                  |
+  |  - For each chunk, dispatches data / ctrl / notify / atomic   |
+  |    to vcs_[vcIdx] (vcIdx supplied by the caller).             |
+  |  - No channel concept. No channel ↔ VC mapping. No queues.    |
+  +---------------------------------------------------------------+
+                                |
+                                |  per-VC iput / isendCtrlMsg /
+                                |  notify / checkNotify / ifetchAndAdd
+                                v
+  +---------------------------------------------------------------+
+  |  CtranIb                 (one per comm)                       |
+  |                                                               |
+  |  - Bootstraps and owns the per-peer VC vector                 |
+  |  - Owns per-NIC VCG[d] = { ib_device d, cq[d],                |
+  |                            every per-peer VC pinned to NIC d }|
+  |  - progress() polls each VCG's CQ and dispatches CQEs to      |
+  |    the owning VC                                              |
+  +---------------------------------------------------------------+
+```
+
+**Channel ↔ VC binding lives in the algo / RMA layer.** The algo
+picks `vcIdx` per chunk and passes it through
+`transport->iSendChunk(..., vcIdx, stagingSlot)`. A common
+convention is `vcIdx = channelId % numVcs` so each logical channel
+gets its own VC's ctrl/notify/atomic ordering domain and pins data
++ notify to one NIC. The transport does not enforce or interpret
+any channel relationship — it just dispatches to `vcs_[vcIdx]`.
+
+**No hard `numChannels <= maxVcsPerPeer` constraint.** The caller is
+free to oversubscribe, picking a `vcIdx` that is shared across
+multiple algo channels. The transport will dispatch correctly. The
+tradeoff is that channels sharing a VC lose the per-channel
+isolation properties that the per-VC design otherwise provides:
+
+- A slow consumer on one channel will back-pressure another channel
+  sharing the same VC's notify QP.
+- Per-channel ctrl-message ordering folds together on that VC.
+- Sender notifications on the shared VC arrive on a single notify
+  stream and the algo must demultiplex them.
+
+If a workload prefers full per-channel isolation, the operator can
+grow `maxVcsPerPeer` by increasing `NCCL_CTRAN_IB_NUM_VCS_PER_RANK`
+so that `numChannels <= numVcs` becomes achievable; both endpoints
+must agree on the cvars (checked at first rendezvous via the
+bus-card-swap loop count).
+
+### Responsibilities — quick reference
+
+| Layer | Owns | Calls into | Knows about |
+|---|---|---|---|
+| Algo / RMA | "logical channel" concept; channel ↔ VC binding; per-chunk `vcIdx` (and `stagingSlot` for CB) | `transport->iSendChunk(…, vcIdx, stagingSlot)` / `iRecvChunk(…, vcIdx, stagingSlot)`; `testChunkDone(request)` | "logical channel", "staging slot", "VC", "chunk request" |
+| `p2pHostIbTransport` | CB staging-slot pool, ZC chunk-record freelist, per-VC dispatch, ctrl exchange on `vcs_[0]` | `ctranIb_->connectVcs`, `vcs_[i]->X(…)`, `ctranIb_->progress` | "chunk, staging slot, ZC record, VC" |
+| `CtranIb` | per-peer VC vector, per-NIC VCG (device + CQ + QPs), bootstrap | per-VC `processCqe` | "per-peer VC + per-NIC VCG" |
+
+`CtranIb` itself has three jobs in this layer cake:
+
+1. **Bootstrap per-peer Virtual Connections (VCs).** A VC
+   (`CtranIbVirtualConn`) is a single IB-connected, NIC-pinned bundle of
+   QPs (one ctrl/notify/atomic triple plus a small data-QP pool) shared
+   between this rank and a peer.
+2. **Own per-NIC IB resources.** Exactly one Completion Queue (CQ) per
+   physical IB device, the device handles, the listen thread, and the
+   epoch lock all live inside `CtranIb`.
+3. **Expose its per-peer VCs to consumers.** The primary consumer is
+   `p2pHostIbTransport`, which obtains the per-peer VC vector from
+   `connectVcs(peerRank)` and then calls `vc->iput(...)` /
+   `vc->isendCtrlMsg(...)` etc. directly under `vc->mutex`. Algorithms
+   that need a single per-peer VC keep using the legacy single-VC API
+   (`getVc`, `iput`, …) — that surface is unchanged. `getVc(peer)` is
+   now just a thin accessor that returns `rankToVcs[peer].front()` (see
+   § 4), so legacy callers transparently land on `vcs[0]` of the same
+   per-peer vector that `connectVcs` exposes.
+
+The "channel" abstraction is **not** part of CtranIb's contract, and
+it is **not** part of `p2pHostIbTransport`'s contract either. A
+**channel is an algo / RMA concept**, owned entirely by the layer
+above the transport. The algo decides how many channels it wants and
+picks the VC for each chunk; `p2pHostIbTransport` just dispatches the
+chunk's ops to `vcs_[vcIdx]`; CtranIb only knows about VCs.
+
+**Channel ↔ VC binding is the algo's choice.** When the algo decides
+it wants `C` channels to a peer, it asks the transport (which in
+turn asks CtranIb) for the per-peer VC vector (sized
+`maxVcsPerPeer`, see § 4) and decides per chunk which `vcIdx` to
+pass. The natural convention is `vcIdx = channelId % numVcs` so
+that:
+
+- if `numChannels <= numVcs`, each channel gets its own VC and the
+  full per-channel isolation properties (ordering domain, notify
+  stream, NIC-local data+notify ordering);
+- if `numChannels > numVcs`, multiple channels share a VC and the
+  algo accepts the loss of isolation between those channels.
+
+There is no remapping table on the CtranIb side, no `imm_data` tag
+bits in the wire format, and no channel-aware code on the transport
+side; the channel-to-VC binding is purely the algo's choice of
+`vcIdx` per chunk. Operators who want to grow the available VC count
+increase `NCCL_CTRAN_IB_NUM_VCS_PER_RANK` (and ensure
+`NCCL_CTRAN_IB_MAX_QPS` is large enough to give each VC at least one
+data QP).
+
+## 2. Resource model — the VC group (VCG)
+
+> The remainder of this document describes **CtranIb implementation
+> details** of the multi-channel VC management. For
+> `p2pHostIbTransport` implementation details (chunk pipeline, channel
+> queues, dispatch, hooks, and risks), see
+> `comms/ctran/transport/ib/p2pIBHostTransportDesign.md`.
+
+A **VC group (VCG)** is the per-NIC bundle of resources CtranIb owns
+for one IB device:
+
+```
+VCG[d] = {
+  the IB device handle at devices[d],
+  the Completion Queue cq[d]   // owned by VCG[d]
+  every per-peer VC whose activeDevices contains d,
+}
+```
+
+**Structural diagram** (one CtranIb instance, two NICs, two peer ranks
+`P` and `Q`, `numVcsPerPeer = 4` → 2 VCs per NIC; per-VC data-QP count
+is resolved per connection class — with the default cvar path and
+`NCCL_CTRAN_IB_MAX_QPS = 8`, each VC ends up with 2 data QPs). Each VCG
+owns its own NIC, its own CQ, and every per-peer VC pinned to that NIC.
+Per-peer VCs from different peers cohabit the same VCG (their QPs share
+the VCG's CQ).
+
+```
+                                CtranIb
++----------------------------------------------------------------------+
+|                                                                      |
+|  +---------------------------- VCG[0] ----------------------------+  |
+|  |                                                                |  |
+|  |   +-----------------+         cq[0]                            |  |
+|  |   |  ib_device 0    |   (one CQ owned by VCG[0])               |  |
+|  |   +-----------------+                                          |  |
+|  |                                                                |  |
+|  |   +-----------------------+    +-----------------------+       |  |
+|  |   |  peer-P VC #0         |    |  peer-Q VC #0         |       |  |
+|  |   |  activeDevices = [0]  |    |  activeDevices = [0]  |       |  |
+|  |   |  ctrl/notify/atom QPs |    |  ctrl/notify/atom QPs |       |  |
+|  |   |  data: [qp0, qp1]     |    |  data: [qp0, qp1]     |       |  |
+|  |   +-----------------------+    +-----------------------+       |  |
+|  +----------------------------------------------------------------+  |
+|                                                                      |
+|  +---------------------------- VCG[1] ----------------------------+  |
+|  |                                                                |  |
+|  |   +-----------------+         cq[1]                            |  |
+|  |   |  ib_device 1    |   (one CQ owned by VCG[1])               |  |
+|  |   +-----------------+                                          |  |
+|  |                                                                |  |
+|  |   +-----------------------+    +-----------------------+       |  |
+|  |   |  peer-P VC #1         |    |  peer-Q VC #1         |       |  |
+|  |   |  activeDevices = [1]  |    |  activeDevices = [1]  |       |  |
+|  |   |  ctrl/notify/atom QPs |    |  ctrl/notify/atom QPs |       |  |
+|  |   |  data: [qp0, qp1]     |    |  data: [qp0, qp1]     |       |  |
+|  |   +-----------------------+    +-----------------------+       |  |
+|  +----------------------------------------------------------------+  |
+|                                                                      |
++----------------------------------------------------------------------+
+```
+
+Key properties of the diagram:
+
+- VCG[d] owns NIC `d`, its CQ `cq[d]`, and every per-peer VC whose
+  `activeDevices` contains `d`. Per-peer VCs from different peers (here
+  `P` and `Q`) share the same VCG — all of their QPs land on the same
+  `cq[d]`.
+- Every QP is inserted into the single `qpToVcMap`, keyed by
+  `(qpn, device)`. Progress dispatch is uniform — `progressInternal`
+  polls each VCG's `cq[d]`, looks up the owning VC by `(qpn, d)`, and
+  dispatches.
+- Because each VC's data and notify travel through one NIC, the
+  receiver of a notify on VC `i` does not need to flush across other
+  NICs to make VC `i`'s data visible.
+
+**Today's storage layout vs. the VCG concept.** The fields on
+`CtranIb` are still flat — `devices[d]`, `cqs[d]` are arrays indexed
+by NIC, and per-peer VCs are in a `peer → vector<VC>` map that is
+*not* sliced by NIC. "VCG[d]" today is the **logical projection** of
+all of those by NIC `d`. Phase 2 (§ 11) promotes `VcGroup` to a real
+C++ struct that co-locates the per-NIC device + CQ + per-peer VC
+projections, and exposes a per-VCG `progress()` so consumers can drive
+one VCG independently of the others.
+
+## 3. Per-peer VCs
+
+A VC is a `CtranIbVirtualConn` instance whose ctrl/notify/atomic + data
+QPs all live on a precomputed set of NICs (`activeDevices`). The number
+of VCs per peer and the per-VC `activeDevices` set are derived by
+CtranIb at init from cvars via the `ctran::ib::VcLayout(numNics,
+maxVcsPerPeer)` ctor:
+
+```
+numNics       = NCCL_CTRAN_IB_DEVICES_PER_RANK
+maxQps        = NCCL_CTRAN_IB_MAX_QPS
+maxVcsPerPeer = NCCL_CTRAN_IB_NUM_VCS_PER_RANK   // normalised to 1 if <= 0
+maxVcsPerNic  = vcLayout.maxVcsPerNic            // see below
+```
+
+`vcLayout_.vcToActiveDevices[v]` gives the NIC indices that VC `v`
+owns. Two layout regimes are supported:
+
+- **Pinned** (`maxVcsPerPeer >= numNics` and divisible): each NIC owns
+  `maxVcsPerNic = maxVcsPerPeer / numNics` VCs (NIC-major); each VC's
+  `activeDevices` is a single NIC. The legacy single-VC mode
+  (`maxVcsPerPeer == 1`, `numNics == 1`) is the degenerate case.
+- **Striped** (`maxVcsPerPeer < numNics` and `numNics % maxVcsPerPeer
+  == 0`): `maxVcsPerNic = 1`; each VC's `activeDevices` is the
+  contiguous range `[v*K, v*K+K-1]` with `K = numNics /
+  maxVcsPerPeer`. The legacy multi-NIC single-VC mode
+  (`maxVcsPerPeer == 1`, `numNics > 1`) is this regime's `K = numNics`
+  case: one VC with `activeDevices = [0..numNics-1]`.
+
+Any other `(numNics, maxVcsPerPeer)` pair is rejected at init by the
+`VcLayout` ctor with `commInvalidArgument`.
+
+**Per-VC data-QP count is computed at bootstrap by
+`CtranIb::Bootstrap` via the static helper
+`CtranIbVirtualConn::computeMaxQpsPerVc(comm, peer, numVcs)`** and passed
+to the VC ctor as a plain `maxQpsPerVc` int. The helper resolves the
+per-peer MAX_QPS for the peer's connection class (cvar default,
+optionally overridden by
+`NCCL_CTRAN_IB_QP_CONFIG_XRACK / XZONE / XDC / NCCL_CTRAN_EX_IB_QP_CONFIG`)
+and divides evenly across `numVcs` (must divide exactly; checked with
+`FB_CHECKABORT`). The VC itself has **no notion of "vcs per peer"** —
+it just stores the per-VC budget and clamps / rounds it to the active
+device count inside `setDefaultQPConfig`. For the default cvar path:
+
+```
+maxQpsPerVc = NCCL_CTRAN_IB_MAX_QPS / numVcs
+```
+
+For a peer that hits a connection-class override, `maxQpsPerVc` is the
+overridden MAX_QPS divided by `numVcs`. When `numVcs == 1` this is a
+no-op and the VC owns the full MAX_QPS.
+
+Every peer for which the consumer calls `connectVcs(peerRank)` gets the
+same `maxVcsPerPeer` VCs. The consumer treats its own channel id `c`
+as a 1:1 index into this vector — channel `c` is `vcs[c]`. If the
+consumer wants more channels than CtranIb provides, the operator
+increases `NCCL_CTRAN_IB_NUM_VCS_PER_RANK` (and ensures
+`NCCL_CTRAN_IB_MAX_QPS` is large enough to give each VC at least one
+data QP); both endpoints must agree on the cvars (checked at first
+rendezvous via the bus-card-swap loop count).
+
+**Per-peer VC vector layout** (pinned example: `maxVcsPerPeer = 4`,
+`numNics = 2`, `maxVcsPerNic = 2`):
+
+```
+vcs[0]                 vcs[1]                vcs[2]                 vcs[3]
+└─ NIC 0 (VCG[0]) ──┘  └─ NIC 0 (VCG[0]) ─┘  └─ NIC 1 (VCG[1]) ──┘  └─ NIC 1 (VCG[1]) ─┘
+```
+
+Striped example: `maxVcsPerPeer = 2`, `numNics = 4` — each VC spans 2
+contiguous NICs (`activeDevices = [0,1]` and `[2,3]` respectively).
+Legacy single-VC, multi-NIC mode (`maxVcsPerPeer = 1`, `numNics > 1`)
+collapses to one VC with `activeDevices = [0..numNics-1]`.
+
+The consumer sees a flat `vcs_` vector and indexes into it by the
+`vcIdx` supplied by the caller. CtranIb owns the layout, the QP
+allocation, and the per-peer cardinality; the consumer owns the
+channel-level routing decision.
+
+Each VC owns its own `ibvControlQp_`, `ibvNotifyQp_`, `ibvAtomicQp_`,
+and `ibvDataQps_`, all on the NICs listed in `activeDevices_`. The
+first entry of `activeDevices_` (`ctrlDevice_`) hosts the
+ctrl/notify/atomic triple; data QPs are distributed across all entries.
+There is no shared ctrl/notify/atomic state across VCs.
+
+## 4. Public API
+
+### Per-peer VC entry point (the one and only data-path entry point)
+
+```cpp
+const std::vector<std::shared_ptr<CtranIbVirtualConn>>&
+    connectVcs(int peerRank,
+           std::optional<const SocketServerAddr*> peerAddr = std::nullopt);
+```
+
+- The number of returned VCs is `maxVcsPerPeer`, derived by CtranIb at
+  init from cvars (§ 3). The consumer does not pass it. Both endpoints
+  must run with matching `NCCL_CTRAN_IB_MAX_QPS`,
+  `NCCL_CTRAN_IB_NUM_VCS_PER_RANK`, and `NCCL_CTRAN_IB_DEVICES_PER_RANK`;
+  the bus-card-swap loop count carries the implied `numVcs` and the
+  rendezvous aborts on mismatch.
+- `peerAddr` is required on the smaller-rank side (it drives the TCP
+  connect); the larger-rank side passes `std::nullopt` and the listen
+  thread handles the accept.
+
+**`connectVcs` is a blocking, init-once-per-peer API:**
+
+- **Blocking on first call.** The call returns only after the per-peer
+  rendezvous (TCP connect → bus-card swap loop → publish) has
+  completed on both sides. The smaller-rank side does the work
+  synchronously inside the call; the larger-rank side spins on
+  `vcState_.tryGetVcs(peer)` (with `std::this_thread::yield()` and
+  an `abortCtrl_->Test()` check) until the CtranIb listen thread
+  publishes the vector. There is no async / future-returning variant.
+- **Single-thread-per-peer contract.** `connectVcs(peer, ...)` is NOT
+  safe to call concurrently from multiple threads for the same
+  `peer`. Callers (algos / RMA / `p2pHostIbTransport`) must serialize
+  per-peer invocations — e.g. call `connectVcs(peer)` once during
+  connection setup and cache the returned vector. Concurrent calls
+  for *different* peers are safe.
+- **Deadlock-freedom despite blocking.** `connectVcs` is collective-style:
+  every rank that participates in a transfer with peer `P` must
+  eventually call `connectVcs(P, ...)` on both ends. The only blocking
+  site is the larger-rank spinner, which polls
+  `vcState_.tryGetVcs(peer)` until the listen thread observes the
+  smaller-rank initiator's bootstrap socket and publishes the VC
+  vector. The spin also honors `abortCtrl_`, so `releaseAll()` /
+  explicit abort unblocks any spinner. For a deadlock to exist,
+  every rank in some cycle would have to be blocked in `connectVcs`
+  with no smaller-rank initiator running — which is impossible: in
+  any pair `(a, b)` with `a < b`, rank `a` is by definition the
+  smaller-rank side and runs the non-blocking initiator path,
+  driving rank `b`'s listen thread to publish and unblock `b`'s
+  spinner. Because this argument holds for every pair independently,
+  `connectVcs` calls from a single rank can be issued in any order
+  across peers without forming a wait-for cycle. See `CtranIb.h`
+  for the full comment.
+- **Init once, then cached.** Once published, the per-peer VC vector
+  is cached in `vcStateMaps.rankToVcs[peer]`. Every subsequent call
+  to `connectVcs(peer)` from either side returns the same cached
+  `std::vector<std::shared_ptr<…>>` immediately — no TCP, no swap,
+  no QP transition, no spin. The vector is shared across consumers:
+  `p2pHostIbTransport`, RMA, algos all see the same `shared_ptr`s.
+- **Single source of truth — fully backward compatible with
+  `getVc`.** `vcStateMaps.rankToVcs[peer]` is the only per-peer VC
+  storage. The legacy `getVc(peer)` is now a thin accessor that
+  returns `rankToVcs[peer].front()` (i.e. `vcs[0]`); it does not
+  maintain a separate map and does not own a separate VC. The
+  bootstrap path is unified too: `Bootstrap::connect` (and the
+  accept-side handshake) always loops over
+  `getMaxVcsPerPeer()` VCs (always `>= 1` post-normalization, equal to
+  `vcLayout_.maxVcsPerPeer`), so a single rendezvous publishes the
+  full vector and the very first call from either entry point
+  bootstraps it. Backward compatibility is preserved because legacy
+  callers (`CtranMapper`, FTAR, the existing collective algos) only
+  ever observe `vcs[0]`, which behaves exactly like the previous
+  single per-peer VC: when `maxVcsPerPeer == 1` (the default), the VC
+  spans all NICs (`activeDevices = [0..numNics-1]`) and is functionally
+  the legacy non-pinned VC; when `maxVcsPerPeer > 1`, it is the
+  NIC-0-pinned VC of the new vector. Either way, `qpToVcMap` is shared
+  across all VCs for uniform CQE dispatch (§ 6).
+
+### Bootstrap (rendezvous) — first `connectVcs(peer)` call only
+
+Between two ranks `A < B`, both endpoints implicitly agree on
+`numVcs == getMaxVcsPerPeer() == vcLayout_.maxVcsPerPeer` (always `>= 1`,
+derived from cvars at init time):
+
+- **Smaller rank A** runs the work synchronously inside `connectVcs`:
+  resolves `peerAddr`, opens a single TCP connection to B's listen
+  address, sends a magic + own-rank header, then runs `numVcs`
+  bus-card swaps in vc-id order over that one socket. The bus card
+  carries the VC's QP numbers and port info; the VC index is implicit
+  by position. The swap-loop count itself is the cvar agreement —
+  if A and B disagree the loop terminates early on one side and the
+  rendezvous fails. After the swaps, A constructs the per-peer VC
+  vector (each VC built with `activeDevices =
+  vcLayout_.vcToActiveDevices[vcId]` and a `maxQpsPerVc` budget that
+  `Bootstrap` computes once per peer via
+  `CtranIbVirtualConn::computeMaxQpsPerVc(comm, peer, numVcs)`),
+  inserts the QPs into `qpToVcMap`, and publishes the vector into
+  `vcStateMaps.rankToVcs[B]`.
+- **Larger rank B**: the CtranIb listen thread accepts the TCP
+  connection from A, matches the magic + rank, runs the matching
+  accept side of the bus-card swap loop, then publishes the resulting
+  VC vector into `vcStateMaps.rankToVcs[A]`. The application thread
+  that called `connectVcs(A)` is spinning on `tryGetVcs(A)` (with a
+  yield and an abort check) and returns the cached vector as soon
+  as the listen thread publishes.
+
+The larger-rank spin is intentionally simple — the same pattern as
+`preConnect` — and avoids per-peer waiter bookkeeping. `releaseAll()`
+clears `rankToVcs` and the spin loop's `abortCtrl_->Test()` check is
+what lets in-flight spinners exit cleanly during teardown.
+
+After `connectVcs` returns, the consumer holds `shared_ptr`s to every VC and
+calls `vc->iput(...)`, `vc->isendCtrlMsg(...)`, etc. directly **under
+`vc->mutex`**. CtranIb does not wrap these per-VC calls.
+
+## 5. VC public methods consumers call
+
+After `connectVcs` returns, consumers dispatch directly to the VC. The
+public methods are declared in `CtranIbVc.h`:
+
+```cpp
+class CtranIbVirtualConn {
+ public:
+  CtranIbRequest* iput(const void* buf, ..., bool notify, ...);
+  CtranIbRequest* iget(...);
+  CtranIbRequest* isendCtrlMsg(const void* buf, size_t len);
+  CtranIbRequest* irecvCtrlMsg(void* buf, size_t* len);
+  CtranIbRequest* ifetchAndAdd(...);
+  CtranIbRequest* iatomicSet(...);
+  void   notify(...);
+  bool   checkNotify(uint64_t* notified);
+  bool   checkNotifies(...);
+  // ... see CtranIbVc.h for full list
+  std::mutex mutex;
+};
+```
+
+**Thread-safety contract:**
+
+> Virtual-connection functions are not thread-safe. The caller MUST
+> hold `vc->mutex` before calling any of the methods listed above.
+
+This contract is **the** load-bearing invariant of the consumer-facing
+contract. `progressInternal` (see § 6) takes `vc->mutex` per dispatch
+when it consumes a CQE for that VC, so consumers must NOT hold
+`vc->mutex` across `ctranIb->progress()` — doing so would self-deadlock
+on the next CQE for the same VC.
+
+## 6. CQE routing
+
+`CtranIb::progressInternal` is unchanged. Each pass:
+
+1. Polls every `cqs[d]` for `d ∈ [0, numNics)`.
+2. For each CQE, looks up `qpToVcMap[(qpn, d)]` to find the owning VC.
+3. Calls `vc->processCqe(...)` on the owning VC.
+
+`qpToVcMap` keys every VC's QPs by `(qpn, device)`, regardless of
+whether the VC was reached via `getVc` (`vcs[0]`) or via `connectVcs`;
+`progressInternal` does not care.
+
+**Per-device progress.** In addition to the all-NICs `progress()`,
+`CtranIb` exposes a per-device variant:
+
+```cpp
+template <typename PerfConfig = DefaultPerfCollConfig>
+commResult_t progress(int device);
+```
+
+It polls only `cqs[device]` and runs the same dispatch logic
+(`qpToVcMap[(qpn, device)]` → `vc->processCqe(...)`) on that one CQ.
+Both overloads share a single `progressInternal(std::optional<int>
+device)` implementation; passing `device` just narrows the per-NIC
+loop to a single iteration.
+
+This lets a consumer with a NIC-affine progress loop (e.g.,
+`p2pHostIbTransport` driving VCs pinned to one NIC) drain its own
+NIC's completions without contending on `cqMutex` for other NICs.
+Callers that hold a `vcIdx` map to a device via the layout's
+`vcToActiveDevices[vcIdx]` (or, in the pinned regime, via the
+shortcut `device = vcIdx / getMaxVcsPerNic()`).
+
+Two caveats follow directly from sharing a CQ across every VC pinned
+to the same NIC:
+
+- A `progress(device)` call dispatches CQEs for **every** VC whose
+  `activeDevices` contains `device` (other peers' VCs as well), not
+  just one caller's VC. The per-VC `vc->mutex` taken inside the
+  dispatch loop still guarantees per-VC serialization with other
+  consumers.
+- A consumer that only ever calls `progress(device)` for a subset of
+  devices will leave the other NICs' CQs un-drained. Either pair it
+  with `progress()` on a separate thread, or call `progress(device)`
+  for every NIC the workload touches.
+
+## 7. Per-VC ctrl / notify / atomic QPs
+
+Every VC owns its own `ibvControlQp_`, `ibvNotifyQp_`, and
+`ibvAtomicQp_`, all hosted on `ctrlDevice_` (the first entry of
+`activeDevices_`). They are not shared across VCs.
+
+Consequences:
+
+- **Per-VC ordering.** Ctrl messages, notifications, and atomics on
+  VC `i` are ordered against other ops on VC `i` only. They are
+  independent of other VCs (including `vcs[0]`, which legacy
+  `getVc`-based callers see).
+- **Atomic ordering is per VC.** Each VC's atomic op uses its own
+  `ibvAtomicQp_`, so the per-peer ordering guarantee that the legacy
+  API documents is now "per VC" — ordered within a single VC, not
+  across VCs to the same peer. Consumers that need cross-VC atomic
+  ordering must serialize at a higher level.
+- **Notify-stream isolation.** A slow notify consumer on one VC cannot
+  back-pressure another VC's notify stream. This is what gives the
+  transport its per-channel notification stream when it dispatches to
+  `vcs[i]->checkNotify(...)`.
+- **NIC-local data + notify ordering.** Data and notify on VC `i`
+  travel through the same NIC's PCIe path, so the receiver of a notify
+  on VC `i` does not need to issue a cross-NIC `iflush` to make VC
+  `i`'s data visible.
+- **No special routing.** `vc->ifetchAndAdd` and `vc->iatomicSet` go
+  through that VC's atomic QP — no special "atomic-on-VC-0" fallback.
+
+## 8. Memory registration & wire format
+
+No change. `regMem` / `deregMem` / `exportMem` / `importMem` produce
+per-NIC `lkey` / `rkey` arrays; a VC pinned to NIC `d` consumes
+`lkeys[d]` / `rkeys[d]`. There are no extra bits in `imm_data` for VC
+demultiplexing — notifications are demultiplexed naturally by
+`(qpn, device)` via `qpToVcMap` (§ 6).
+
+## 9. Configuration
+
+All sizing comes from operator cvars; the consumer does not pass
+sizing parameters.
+
+- `NCCL_CTRAN_IB_DEVICES_PER_RANK` (`numNics`) — number of physical IB
+  devices CtranIb owns. One VCG per NIC.
+- `NCCL_CTRAN_IB_NUM_VCS_PER_RANK` (`maxVcsPerPeer`) — number of
+  per-peer VCs `connectVcs(peerRank)` returns. Normalised to `1` if unset
+  or `<= 0`. Also acts as the divisor for the per-VC data-QP slice
+  computed inside `CtranIbVirtualConn`. Must satisfy one of:
+  `maxVcsPerPeer >= numNics` and `maxVcsPerPeer % numNics == 0`
+  (pinned regime), or `maxVcsPerPeer < numNics` and `numNics %
+  maxVcsPerPeer == 0` (striped regime). Otherwise CtranIb init aborts
+  with `commInvalidArgument`.
+- `NCCL_CTRAN_IB_MAX_QPS` — default per-peer data-QP budget. Each per-peer
+  VC ends up with `MAX_QPS / maxVcsPerPeer` data QPs unless the connection
+  class overrides MAX_QPS via the `NCCL_CTRAN_IB_QP_CONFIG_*` lists
+  (see below). Must be `>= maxVcsPerPeer`.
+- `NCCL_CTRAN_IB_QP_CONFIG_XRACK / XZONE / XDC / NCCL_CTRAN_EX_IB_QP_CONFIG`
+  — per-connection-class tuning. The MAX_QPS field of the matching
+  configList replaces `NCCL_CTRAN_IB_MAX_QPS` for that peer; the per-VC
+  slice is then that value divided by `maxVcsPerPeer`. The override
+  must be a multiple of `maxVcsPerPeer`.
+- `NCCL_CTRAN_IB_QP_SCALING_THRESHOLD`, `NCCL_CTRAN_IB_QP_MAX_MSGS`,
+  `NCCL_CTRAN_IB_VC_MODE` — apply per VC.
+- `NCCL_CTRAN_IB_MAX_NUM_CQE` — sizes each NIC's shared CQ. Each
+  VCG[d]'s CQ now hosts every VC whose `activeDevices` contains NIC
+  `d`. Re-tune as VC counts grow.
+
+Derived sizes (computed once at `CtranIb` init via the
+`ctran::ib::VcLayout(numNics, maxVcsPerPeer)` ctor):
+
+```
+vcLayout_.maxVcsPerPeer       // always >= 1
+vcLayout_.maxVcsPerNic        // 1 in striped regime; maxVcsPerPeer/numNics in pinned regime
+vcLayout_.vcToActiveDevices   // per-VC NIC vector consumed by CtranIbVirtualConn
+```
+
+The per-VC data-QP count is resolved per peer at bootstrap time by
+`CtranIb::Bootstrap` calling
+`CtranIbVirtualConn::computeMaxQpsPerVc(comm, peer, numVcs)`. For the
+default cvar path it is `NCCL_CTRAN_IB_MAX_QPS / maxVcsPerPeer`; for an
+overridden connection class it is the overridden MAX_QPS divided by
+`maxVcsPerPeer`. When `maxVcsPerPeer == 1` this division is a no-op
+and the VC owns the full MAX_QPS.
+
+Both endpoints must agree on the three input cvars; mismatch is
+detected at the first `connectVcs(peer)` rendezvous (§ 4) by the
+bus-card-swap loop count.
+
+## 10. Lifetime, teardown, and threading
+
+- The per-peer VC vector is owned by `CtranIb` until
+  `releaseRemoteTransStates(peer)` runs. `releaseRemoteTransStates`
+  drains `vcStateMaps.rankToVcs[peer]` (the single per-peer VC
+  storage that backs both `connectVcs` and `getVc`), removes the
+  corresponding QPs from `qpToVcMap`, and tears down the per-peer
+  rendezvous state. Any in-flight `connectVcs(peer)` spinner exits
+  via its `abortCtrl_->Test()` check on the next iteration.
+- Consumers that cache `shared_ptr<CtranIbVirtualConn>` (notably
+  `p2pHostIbTransport`) MUST drop their `shared_ptr`s before
+  `releaseRemoteTransStates` runs. The underlying CQs and IB device
+  handles are torn down during `CtranIb` shutdown — calling `vc->X(...)`
+  on a "still-alive but under-dependencies-gone" VC will fault.
+- A failed VC does not affect other VCs to the same peer. Consumers
+  can recreate by re-calling `connectVcs(peer)` after the next
+  `releaseRemoteTransStates`.
+- Async events on a NIC affect every VC that owns QPs on that NIC; the
+  existing `ibAsyncEventHandler` needs no schema change.
+- Locking: the per-peer rendezvous is serialised by the `vcStateMaps`
+  lock for map mutations. Per-VC ops are serialised by `vc->mutex`
+  (held by the consumer; also taken by `progressInternal` per CQE
+  dispatch). Consumers must NOT hold `vc->mutex` across
+  `ctranIb_->progress()`.
+
+## 11. Phased implementation
+
+The design above is the **target** state. It is delivered in three
+phases so that each phase ships independently and remains reviewable.
+
+### Phase 1 — Multi-channel functionality ready (this round)
+
+Goal: deliver a working multi-channel data path end to end so
+algorithms / RMA / `p2pHostIbTransport` can issue per-channel
+operations and rely on independent VCs underneath.
+
+Functionality delivered in this phase:
+
+- `CtranIb::connectVcs(peerRank, peerAddr?)` returns a per-peer vector of
+  `maxVcsPerPeer` NIC-pinned VCs, lazily bootstrapped at first call.
+  Cardinality is derived from cvars (§ 3, § 10).
+- Each per-peer VC owns its own ctrl / notify / atomic + data QPs on
+  its pinned NIC, providing the channel-independence properties
+  documented in § 1.
+- `CtranIb::progress()` drives CQE dispatch across every NIC's CQ via
+  `qpToVcMap`; `getVc` callers (`vcs[0]`) and `connectVcs` callers share
+  the same routing path (§ 6).
+- `releaseRemoteTransStates(peer)` tears down the per-peer VC vector
+  (the single source of truth that backs both `connectVcs` and `getVc`).
+- The cvars `NCCL_CTRAN_IB_DEVICES_PER_RANK`,
+  `NCCL_CTRAN_IB_NUM_VCS_PER_RANK`, and `NCCL_CTRAN_IB_MAX_QPS` size
+  the per-peer VC vector.
+
+What consumers can do after this phase:
+
+- `p2pHostIbTransport` calls `connectVcs(peer)` and dispatches each chunk
+  to `vcs[vcIdx]`, where `vcIdx` is supplied by the caller per chunk
+  via `transport->iSendChunk(buf, off, len, config, vcIdx, stagingSlot)`
+  (see `comms/ctran/transport/ib/p2pIBHostTransportDesign.md`).
+- Algorithms / RMA above the transport pick `vcIdx = channelId %
+  numVcs` (the recommended convention). When `numChannels <= numVcs`
+  this gives each channel true per-channel ordering domains,
+  independent notify streams, and NIC-local data+notify ordering. If
+  the algo oversubscribes, the transport still dispatches
+  correctly; the algo just gives up isolation between the
+  oversubscribed channels.
+
+Exit criteria: end-to-end multi-channel send/recv tests pass; the
+legacy single-VC API (`getVc` and friends) is unchanged — it now
+transparently observes `vcs[0]` of the per-peer vector.
+
+### Phase 2 — `VcGroup` for clean per-NIC resource management & per-VCG progress
+
+Goal: promote VCG from a logical concept to a real C++ struct so
+per-NIC resources have one owner, **and expose a per-VCG `progress()`
+entry point so consumers can drive one VCG (one NIC's CQ) independently
+of the others**.
+
+- Introduce
+  `struct VcGroup { ibverbs::Device* device; CompletionQueue cq;
+  std::unordered_map<int, std::vector<VcRef>> perPeerVcs;
+  commResult_t progress(); };`
+  and replace the flat arrays (`devices[]`, `cqs[]`) with
+  `std::vector<VcGroup> vcgs_`.
+- Add `CtranIb::getVcg(int nicIdx) -> VcGroup&` so the consumer can
+  reach a specific VCG and call `vcg.progress()` on its own thread or
+  cadence — useful when the consumer pins work to a NIC and wants to
+  drive that NIC's CQ without contending on other NICs' progress.
+  `CtranIb::progress()` becomes the simple loop
+  `for (auto& vcg : vcgs_) vcg.progress();` so legacy callers are
+  unaffected.
+- `vcg.progress()` polls `vcg.cq`, looks up the owning VC via
+  `qpToVcMap[(qpn, d)]`, takes `vc->mutex`, and dispatches to
+  `vc->processCqe(...)` — same body as today's `progressInternal`,
+  scoped to one VCG.
+- Rendezvous and `connectVcs` keep the same public signature; internally
+  they distribute new VCs into the right `vcgs_[d].perPeerVcs[peer]`.
+- `releaseRemoteTransStates(peer)` becomes "erase peer from every
+  `vcgs_[d].perPeerVcs`" — easier to audit than the current
+  per-peer drain.
+
+Exit criteria: `CtranIb` no longer carries flat per-NIC arrays; all
+per-NIC state lives inside a `VcGroup`. `CtranIb::getVcg(d)` and
+`vcg.progress()` are public; consumers (notably `p2pHostIbTransport`
+in its NIC-affine progress loop) can opt in.
+
+### Phase 3 — Migrate VCG and VC to `ibverbx`
+
+Goal: move the **VCG** and **VC** abstractions out of `CtranIb` and
+onto `ibverbx`. After this phase, `ibverbx` owns the per-NIC
+resource group (device + CQ + per-peer VCs) and the per-peer
+NIC-pinned virtual connection; `CtranIb`'s in-tree implementation of
+these types goes away.
+
+- Promote `VcGroup` and `CtranIbVirtualConn` (the per-peer VC) into
+  first-class `ibverbx` types (e.g. `ibverbx::VcGroup`,
+  `ibverbx::VirtualConn`). They take ownership of the underlying IB
+  resources via `ibverbx`'s RAII wrappers (`ibverbx::Device`,
+  `ibverbx::Cq`, `ibverbx::Qp`, `ibverbx::Pd`, `ibverbx::Mr`).
+- `CtranIb` shrinks to a thin orchestration layer over the `ibverbx`
+  types: bootstrap, listen thread, per-peer rendezvous, and the
+  public `connectVcs`/`getVcg` surface. The `CtranIb`-side implementation
+  of `CtranIbVirtualConn` and the in-tree `VcGroup` struct are
+  deleted.
+- The public consumer-facing API (`connectVcs`, `getVcg`, per-VC method
+  signatures) stays compatible; only the underlying type origin
+  moves from `CtranIb` to `ibverbx`.
+- Async-event handling lives on the `ibverbx` event-channel surface,
+  routed by VCG / VC ownership.
+
+Exit criteria: `CtranIb` carries no in-tree implementation of `VcGroup`
+or the per-peer VC; both come from `ibverbx`. Teardown is enforced by
+`ibverbx` RAII rather than the explicit `releaseRemoteTransStates`
+bookkeeping.

--- a/comms/ctran/backends/ib/tests/CtranIbMultiVcPinnedTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbMultiVcPinnedTest.cc
@@ -1,0 +1,684 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include <folly/SocketAddress.h>
+#include <folly/futures/Future.h>
+
+#include "comms/ctran/backends/CtranCtrl.h"
+#include "comms/ctran/backends/ib/CtranIb.h"
+#include "comms/ctran/backends/ib/CtranIbImpl.h"
+#include "comms/ctran/backends/ib/CtranIbVc.h"
+#include "comms/ctran/bootstrap/AbortableSocket.h"
+#include "comms/ctran/bootstrap/ISocketFactory.h"
+#include "comms/ctran/utils/Abort.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+using AbortPtr = std::shared_ptr<ctran::utils::Abort>;
+using namespace std::literals::chrono_literals;
+
+namespace {
+
+// Configuration pinned by SetUp() so every assertion can compare
+// against precomputed values:
+//   NCCL_CTRAN_IB_DEVICES_PER_RANK   = 2
+//   NCCL_CTRAN_IB_MAX_QPS            = 16
+//   NCCL_CTRAN_IB_NUM_VCS_PER_RANK   = 4
+// =>
+//   kExpectedMaxVcsPerPeer = 4
+//   kExpectedMaxVcsPerNic  = 4 / 2 = 2
+//   kExpectedQpsPerVc      = 16 / 4 = 4 (no XRACK/XZONE/XDC override
+//                                        in the test env, so the
+//                                        connection-class configList
+//                                        path is skipped and the slice
+//                                        comes straight from the cvar).
+constexpr int kExpectedNumNics = 2;
+constexpr int kExpectedMaxQps = 16;
+constexpr int kExpectedMaxVcsPerPeer = 4;
+constexpr int kExpectedMaxVcsPerNic = kExpectedMaxVcsPerPeer / kExpectedNumNics;
+constexpr int kExpectedQpsPerVc = kExpectedMaxQps / kExpectedMaxVcsPerPeer;
+
+SocketServerAddr makeServerAddr() {
+  SocketServerAddr addr;
+  addr.port = 0; // OS picks
+  addr.ipv4 = "127.0.0.1";
+  addr.ifName = "lo";
+  return addr;
+}
+
+// Helper to drain progress until the predicate is true or we timeout.
+template <typename Pred>
+bool progressUntil(
+    CtranIb* ib,
+    Pred pred,
+    std::chrono::milliseconds timeout = 10s) {
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (pred()) {
+      return true;
+    }
+    EXPECT_EQ(ib->progress(), commSuccess);
+    std::this_thread::sleep_for(1ms);
+  }
+  return pred();
+}
+
+class CtranIbMultiVcPinnedTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Pin the cvars that drive maxVcsPerPeer so this test is robust to the
+    // host's NIC count. NCCL_CTRAN_IB_NUM_VCS_PER_RANK directly drives
+    // the per-peer VC count; force numNics=2 and numVcsPerPeer=4 so we
+    // get maxVcsPerNic = 4/2 = 2 and qpsPerVc = 16/4 = 4 regardless of
+    // the host.
+    setenv("NCCL_CTRAN_IB_DEVICES_PER_RANK", "2", 1);
+    setenv("NCCL_CTRAN_IB_MAX_QPS", "16", 1);
+    setenv("NCCL_CTRAN_IB_NUM_VCS_PER_RANK", "4", 1);
+    ncclCvarInit();
+    EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
+    int deviceCount = 0;
+    EXPECT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    ASSERT_GE(deviceCount, 2)
+        << "Test requires at least 2 CUDA devices, found " << deviceCount;
+  }
+
+  void TearDown() override {
+    cudaDeviceReset();
+    unsetenv("NCCL_CTRAN_IB_DEVICES_PER_RANK");
+    unsetenv("NCCL_CTRAN_IB_MAX_QPS");
+    unsetenv("NCCL_CTRAN_IB_NUM_VCS_PER_RANK");
+    ncclCvarInit();
+  }
+
+  std::unique_ptr<CtranIb> makeIb(int rank, AbortPtr abortCtrl) {
+    SocketServerAddr serverAddr = makeServerAddr();
+    return std::make_unique<CtranIb>(
+        rank,
+        rank, // cudaDev
+        /*commHash=*/0xc4ac4a1ull,
+        std::string("channel-test"),
+        /*enableLocalFlush=*/false,
+        CtranIb::BootstrapMode::kSpecifiedServer,
+        &serverAddr,
+        abortCtrl,
+        std::make_shared<ctran::bootstrap::AbortableSocketFactory>(),
+        /*maxNumCqe=*/std::nullopt);
+  }
+};
+
+// Two-rank harness: both ranks build a CtranIb, exchange listen addresses,
+// then run their respective lambdas.
+template <typename Action0, typename Action1>
+void runTwoRanks(Action0 action0, Action1 action1) {
+  auto [addr0Promise, addr0Future] =
+      folly::makePromiseContract<folly::SocketAddress>();
+  auto [addr1Promise, addr1Future] =
+      folly::makePromiseContract<folly::SocketAddress>();
+
+  std::thread t0([&]() {
+    EXPECT_EQ(cudaSetDevice(0), cudaSuccess);
+    auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+    SocketServerAddr serverAddr = makeServerAddr();
+    auto ib = std::make_unique<CtranIb>(
+        0,
+        0,
+        0xc4ac4a1ull,
+        std::string("channel-test"),
+        false,
+        CtranIb::BootstrapMode::kSpecifiedServer,
+        &serverAddr,
+        abortCtrl,
+        std::make_shared<ctran::bootstrap::AbortableSocketFactory>(),
+        std::nullopt);
+    auto maybeListen = ib->getListenSocketListenAddr();
+    ASSERT_FALSE(maybeListen.hasError());
+    addr0Promise.setValue(maybeListen.value());
+    auto peerListen = std::move(addr1Future).get();
+    SocketServerAddr peerAddr;
+    peerAddr.port = peerListen.getPort();
+    peerAddr.ipv4 = peerListen.getAddressStr();
+    peerAddr.ifName = "lo";
+    action0(ib.get(), &peerAddr);
+  });
+  std::thread t1([&]() {
+    EXPECT_EQ(cudaSetDevice(1), cudaSuccess);
+    auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+    SocketServerAddr serverAddr = makeServerAddr();
+    auto ib = std::make_unique<CtranIb>(
+        1,
+        1,
+        0xc4ac4a1ull,
+        std::string("channel-test"),
+        false,
+        CtranIb::BootstrapMode::kSpecifiedServer,
+        &serverAddr,
+        abortCtrl,
+        std::make_shared<ctran::bootstrap::AbortableSocketFactory>(),
+        std::nullopt);
+    auto maybeListen = ib->getListenSocketListenAddr();
+    ASSERT_FALSE(maybeListen.hasError());
+    addr1Promise.setValue(maybeListen.value());
+    auto peerListen = std::move(addr0Future).get();
+    SocketServerAddr peerAddr;
+    peerAddr.port = peerListen.getPort();
+    peerAddr.ipv4 = peerListen.getAddressStr();
+    peerAddr.ifName = "lo";
+    action1(ib.get(), &peerAddr);
+  });
+  t0.join();
+  t1.join();
+}
+
+// PR2 test: connectVcs lazily creates exactly maxVcsPerPeer VCs on both
+// sides, and each VC is pinned to the expected NIC with exactly
+// qpsPerVc data QPs (NCCL_CTRAN_IB_MAX_QPS / maxVcsPerPeer).
+TEST_F(CtranIbMultiVcPinnedTest, GetVcsLazyCreatesAndPinsByNic) {
+  runTwoRanks(
+      // rank 0 (smaller -> initiator)
+      [](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 1;
+        EXPECT_EQ(ib->getMaxVcsPerPeer(), kExpectedMaxVcsPerPeer);
+        EXPECT_EQ(ib->getMaxVcsPerNic(), kExpectedMaxVcsPerNic);
+
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+        for (int vcIdx = 0; vcIdx < kExpectedMaxVcsPerPeer; ++vcIdx) {
+          int expectedNic = vcIdx / kExpectedMaxVcsPerNic;
+          EXPECT_EQ(vcs[vcIdx]->getCtrlDevice(), expectedNic)
+              << "vcIdx " << vcIdx;
+          EXPECT_EQ(vcs[vcIdx]->getActiveDevices().size(), 1U)
+              << "vcIdx " << vcIdx;
+          EXPECT_EQ(vcs[vcIdx]->getMaxNumQp(), kExpectedQpsPerVc)
+              << "vcIdx " << vcIdx;
+          EXPECT_EQ(
+              static_cast<int>(vcs[vcIdx]->getDataQpNums().size()),
+              kExpectedQpsPerVc)
+              << "vcIdx " << vcIdx;
+        }
+
+        // Cached: second call returns the same vector.
+        const auto& vcs2 = ib->connectVcs(peerRank, peerAddr);
+        EXPECT_EQ(vcs.data(), vcs2.data());
+      },
+      // rank 1 (larger -> waits for accept)
+      [](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 0;
+        EXPECT_EQ(ib->getMaxVcsPerPeer(), kExpectedMaxVcsPerPeer);
+        EXPECT_EQ(ib->getMaxVcsPerNic(), kExpectedMaxVcsPerNic);
+
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+        for (int vcIdx = 0; vcIdx < kExpectedMaxVcsPerPeer; ++vcIdx) {
+          int expectedNic = vcIdx / kExpectedMaxVcsPerNic;
+          EXPECT_EQ(vcs[vcIdx]->getCtrlDevice(), expectedNic)
+              << "vcIdx " << vcIdx;
+          EXPECT_EQ(vcs[vcIdx]->getMaxNumQp(), kExpectedQpsPerVc)
+              << "vcIdx " << vcIdx;
+          EXPECT_EQ(
+              static_cast<int>(vcs[vcIdx]->getDataQpNums().size()),
+              kExpectedQpsPerVc)
+              << "vcIdx " << vcIdx;
+        }
+      });
+}
+
+// PR3 test: vc->notify / vc->checkNotify round-trip on every per-peer VC.
+TEST_F(CtranIbMultiVcPinnedTest, NotifyVcRoundTrip) {
+  runTwoRanks(
+      // rank 0: send notify on each VC
+      [](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 1;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          CtranIbEpochRAII epochRAII(ib);
+          CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+            EXPECT_EQ(vcs[c]->notify(/*req=*/nullptr), commSuccess);
+          });
+        }
+        // Drive progress so notifications get sent.
+        for (int i = 0; i < 200; ++i) {
+          EXPECT_EQ(ib->progress(), commSuccess);
+          std::this_thread::sleep_for(2ms);
+        }
+      },
+      // rank 1: poll for notify on each VC
+      [](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 0;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          bool ok = progressUntil(ib, [&]() {
+            CtranIbEpochRAII epochRAII(ib);
+            bool notified = false;
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              EXPECT_EQ(vcs[c]->checkNotify(&notified), commSuccess);
+            });
+            return notified;
+          });
+          EXPECT_TRUE(ok) << "no notify on VC " << c;
+        }
+      });
+}
+
+// PR3 functional test: full put-notify round-trip through per-peer VCs.
+// Models CtranIbDistUT.cc::runPutNotify but uses direct per-VC dispatch:
+//   vc->isendCtrlMsg / vc->irecvCtrlMsg exchange the buffer info,
+//   vc->iput performs the RDMA write with notify on the same VC,
+//   vc->checkNotify polls for completion, then we verify data.
+TEST_F(CtranIbMultiVcPinnedTest, IputVcRoundTrip) {
+  constexpr size_t kBufCount = 1024;
+  constexpr int kSendVal = 42;
+
+  auto waitReq = [](CtranIb* ib, CtranIbRequest& req) {
+    progressUntil(ib, [&]() { return req.isComplete(); });
+  };
+
+  runTwoRanks(
+      // rank 0 = sender. Per VC: receive recv-side buffer info via
+      // ctrl msg, vc->iput with notify, drive progress until done.
+      [&](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 1;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          // Source buffer has VC-distinct content so the receiver can
+          // verify each VC's payload independently.
+          std::vector<int> sendBuf(kBufCount, kSendVal + c);
+          void* sendHandle = nullptr;
+          ASSERT_EQ(
+              CtranIb::regMem(
+                  sendBuf.data(),
+                  kBufCount * sizeof(int),
+                  /*cudaDev=*/0,
+                  &sendHandle),
+              commSuccess);
+
+          // Receive the receiver's exported buffer info on this VC.
+          ControlMsg recvMsg;
+          CtranIbRequest ctrlReq;
+          {
+            CtranIbEpochRAII epoch(ib);
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(
+                  vcs[c]->irecvCtrlMsg(&recvMsg, sizeof(recvMsg), ctrlReq),
+                  commSuccess);
+            });
+          }
+          waitReq(ib, ctrlReq);
+
+          // vc->iput into the receiver's buffer with notify.
+          void* remoteBuf = reinterpret_cast<void*>(recvMsg.ibDesc.remoteAddr);
+          CtranIbRemoteAccessKey key{};
+          for (int i = 0; i < recvMsg.ibDesc.nKeys; ++i) {
+            key.rkeys[i] = recvMsg.ibDesc.rkeys[i];
+          }
+          CtranIbRequest putReq;
+          {
+            CtranIbEpochRAII epoch(ib);
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(
+                  vcs[c]->iput(
+                      sendBuf.data(),
+                      remoteBuf,
+                      kBufCount * sizeof(int),
+                      sendHandle,
+                      key,
+                      /*notify=*/true,
+                      /*config=*/nullptr,
+                      &putReq,
+                      /*fast=*/false),
+                  commSuccess);
+            });
+          }
+          waitReq(ib, putReq);
+          ASSERT_EQ(CtranIb::deregMem(sendHandle), commSuccess);
+        }
+      },
+      // rank 1 = receiver. Per VC: send buffer info, wait notify,
+      // verify the VC-distinct payload.
+      [&](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 0;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          std::vector<int> recvBuf(kBufCount, /*recvVal=*/-1);
+          void* recvHandle = nullptr;
+          ASSERT_EQ(
+              CtranIb::regMem(
+                  recvBuf.data(),
+                  kBufCount * sizeof(int),
+                  /*cudaDev=*/1,
+                  &recvHandle),
+              commSuccess);
+
+          ControlMsg sendMsg;
+          ASSERT_EQ(
+              CtranIb::exportMem(recvBuf.data(), recvHandle, sendMsg),
+              commSuccess);
+
+          CtranIbRequest ctrlReq;
+          {
+            CtranIbEpochRAII epoch(ib);
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(
+                  vcs[c]->isendCtrlMsg(
+                      sendMsg.type, &sendMsg, sizeof(sendMsg), ctrlReq),
+                  commSuccess);
+            });
+          }
+          waitReq(ib, ctrlReq);
+
+          // Wait for the put's notify on this VC.
+          bool ok = progressUntil(ib, [&]() {
+            CtranIbEpochRAII epoch(ib);
+            bool notified = false;
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              EXPECT_EQ(vcs[c]->checkNotify(&notified), commSuccess);
+            });
+            return notified;
+          });
+          EXPECT_TRUE(ok) << "VC " << c << ": no notify received";
+
+          // Verify the VC-distinct payload landed.
+          for (size_t i = 0; i < kBufCount; ++i) {
+            ASSERT_EQ(recvBuf[i], kSendVal + c) << "VC " << c << " idx " << i;
+          }
+          ASSERT_EQ(CtranIb::deregMem(recvHandle), commSuccess);
+        }
+      });
+}
+
+// PR3 functional test: vc->ifetchAndAdd produces correct results when
+// every per-peer VC issues N atomic increments concurrently.
+TEST_F(CtranIbMultiVcPinnedTest, FetchAndAddVcRoundTrip) {
+  constexpr int kNumOpsPerVc = 50;
+
+  auto waitReq = [](CtranIb* ib, CtranIbRequest& req) {
+    progressUntil(ib, [&]() { return req.isComplete(); });
+  };
+
+  runTwoRanks(
+      // rank 0 = adder. Per VC: receive remote buffer info, issue
+      // kNumOpsPerVc vc->ifetchAndAdd ops with a signaled request
+      // on the last one.
+      [&](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 1;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        // Local scratch buffer used as fetched-value destination.
+        std::vector<uint64_t> scratch(1, 0);
+        void* scratchHandle = nullptr;
+        ASSERT_EQ(
+            CtranIb::regMem(
+                scratch.data(),
+                sizeof(uint64_t),
+                /*cudaDev=*/0,
+                &scratchHandle),
+            commSuccess);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          // Receive the receiver's exported counter location.
+          ControlMsg recvMsg;
+          CtranIbRequest ctrlReq;
+          {
+            CtranIbEpochRAII epoch(ib);
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(
+                  vcs[c]->irecvCtrlMsg(&recvMsg, sizeof(recvMsg), ctrlReq),
+                  commSuccess);
+            });
+          }
+          waitReq(ib, ctrlReq);
+
+          void* remoteBuf = reinterpret_cast<void*>(recvMsg.ibDesc.remoteAddr);
+          CtranIbRemoteAccessKey key{};
+          for (int i = 0; i < recvMsg.ibDesc.nKeys; ++i) {
+            key.rkeys[i] = recvMsg.ibDesc.rkeys[i];
+          }
+
+          // Issue kNumOpsPerVc atomic increments; signal only on the
+          // last so we can wait for all of them in one shot.
+          for (int i = 0; i < kNumOpsPerVc; ++i) {
+            CtranIbRequest atomicReq;
+            CtranIbRequest* reqPtr =
+                (i == kNumOpsPerVc - 1) ? &atomicReq : nullptr;
+            {
+              CtranIbEpochRAII epoch(ib);
+              CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+                ASSERT_EQ(
+                    vcs[c]->ifetchAndAdd(
+                        scratch.data(),
+                        remoteBuf,
+                        /*addVal=*/1,
+                        scratchHandle,
+                        key,
+                        reqPtr),
+                    commSuccess);
+              });
+            }
+            if (reqPtr) {
+              waitReq(ib, atomicReq);
+            }
+          }
+
+          // Tell receiver via a notify that all atomics on this VC are
+          // posted (and thus visible after the atomicQp's CQEs are drained).
+          {
+            CtranIbEpochRAII epoch(ib);
+            CtranIbRequest doneReq;
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(vcs[c]->notify(&doneReq), commSuccess);
+            });
+            waitReq(ib, doneReq);
+          }
+        }
+
+        ASSERT_EQ(CtranIb::deregMem(scratchHandle), commSuccess);
+      },
+      // rank 1 = target. Per VC: register a fresh counter, send its
+      // info, wait notify-of-done, verify the counter advanced exactly
+      // kNumOpsPerVc times.
+      [&](CtranIb* ib, const SocketServerAddr* peerAddr) {
+        const int peerRank = 0;
+        const auto& vcs = ib->connectVcs(peerRank, peerAddr);
+        ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer);
+
+        for (int c = 0; c < kExpectedMaxVcsPerPeer; ++c) {
+          std::vector<uint64_t> counter(1, 0);
+          void* counterHandle = nullptr;
+          ASSERT_EQ(
+              CtranIb::regMem(
+                  counter.data(),
+                  sizeof(uint64_t),
+                  /*cudaDev=*/1,
+                  &counterHandle),
+              commSuccess);
+
+          ControlMsg sendMsg;
+          ASSERT_EQ(
+              CtranIb::exportMem(counter.data(), counterHandle, sendMsg),
+              commSuccess);
+          CtranIbRequest ctrlReq;
+          {
+            CtranIbEpochRAII epoch(ib);
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              ASSERT_EQ(
+                  vcs[c]->isendCtrlMsg(
+                      sendMsg.type, &sendMsg, sizeof(sendMsg), ctrlReq),
+                  commSuccess);
+            });
+          }
+          waitReq(ib, ctrlReq);
+
+          // Wait for the "all atomics done" notify.
+          bool ok = progressUntil(ib, [&]() {
+            CtranIbEpochRAII epoch(ib);
+            bool notified = false;
+            CTRAN_IB_PER_OBJ_LOCK_GUARD(vcs[c]->mutex, {
+              EXPECT_EQ(vcs[c]->checkNotify(&notified), commSuccess);
+            });
+            return notified;
+          });
+          EXPECT_TRUE(ok) << "VC " << c << ": no notify received";
+
+          EXPECT_EQ(counter[0], static_cast<uint64_t>(kNumOpsPerVc))
+              << "VC " << c;
+          ASSERT_EQ(CtranIb::deregMem(counterHandle), commSuccess);
+        }
+      });
+}
+
+// Guard: progress(device) must reject out-of-range device indices with
+// commInternalError instead of polling an out-of-bounds CQ.
+TEST_F(CtranIbMultiVcPinnedTest, ProgressInvalidDeviceReturnsError) {
+  auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+  auto ib = makeIb(/*rank=*/0, abortCtrl);
+  ASSERT_NE(ib, nullptr);
+  ASSERT_EQ(ib->getNumIbDevices(), kExpectedNumNics);
+
+  CtranIbEpochRAII epoch(ib.get());
+  // Negative device index is invalid.
+  EXPECT_EQ(ib->progress(-1), commInternalError);
+  // device == numIbDevices and beyond are out of range.
+  EXPECT_EQ(ib->progress(kExpectedNumNics), commInternalError);
+  EXPECT_EQ(ib->progress(kExpectedNumNics + 5), commInternalError);
+
+  // Sanity: valid device indices still succeed.
+  for (int d = 0; d < kExpectedNumNics; ++d) {
+    EXPECT_EQ(ib->progress(d), commSuccess);
+  }
+}
+
+// N-rank harness: each rank builds a CtranIb on its own thread, publishes
+// its listen address into a shared table, waits until every rank has
+// published, then runs `action(rank, ib, peerAddrs)` with peerAddrs[i]
+// being rank i's listen address. peerAddrs[rank] (self) is unused.
+template <typename Action>
+void runNRanks(int nRanks, Action action) {
+  struct Shared {
+    std::mutex mu;
+    std::condition_variable cv;
+    std::vector<std::optional<SocketServerAddr>> addrs;
+  };
+  auto shared = std::make_shared<Shared>();
+  shared->addrs.resize(nRanks);
+
+  std::vector<std::thread> threads;
+  threads.reserve(nRanks);
+  for (int rank = 0; rank < nRanks; ++rank) {
+    threads.emplace_back([rank, nRanks, shared, &action]() {
+      EXPECT_EQ(cudaSetDevice(rank), cudaSuccess);
+      auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+      SocketServerAddr serverAddr = makeServerAddr();
+      auto ib = std::make_unique<CtranIb>(
+          rank,
+          rank,
+          0xc4ac4a1ull,
+          std::string("channel-test"),
+          /*enableLocalFlush=*/false,
+          CtranIb::BootstrapMode::kSpecifiedServer,
+          &serverAddr,
+          abortCtrl,
+          std::make_shared<ctran::bootstrap::AbortableSocketFactory>(),
+          /*maxNumCqe=*/std::nullopt);
+      auto maybeListen = ib->getListenSocketListenAddr();
+      ASSERT_FALSE(maybeListen.hasError());
+      auto listen = maybeListen.value();
+      SocketServerAddr myPubAddr;
+      myPubAddr.port = listen.getPort();
+      myPubAddr.ipv4 = listen.getAddressStr();
+      myPubAddr.ifName = "lo";
+
+      std::vector<SocketServerAddr> peerAddrs;
+      {
+        std::unique_lock<std::mutex> lk(shared->mu);
+        shared->addrs[rank] = myPubAddr;
+        shared->cv.notify_all();
+        shared->cv.wait(lk, [&]() {
+          for (int i = 0; i < nRanks; ++i) {
+            if (!shared->addrs[i].has_value()) {
+              return false;
+            }
+          }
+          return true;
+        });
+        peerAddrs.reserve(nRanks);
+        for (int i = 0; i < nRanks; ++i) {
+          peerAddrs.push_back(shared->addrs[i].value());
+        }
+      }
+      action(rank, ib.get(), peerAddrs);
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+// Multi-rank (4 ranks) test: each rank calls connectVcs() against its peers
+// in a different order so that the larger-rank-waits side may be
+// reached before, after, or concurrently with the smaller-rank-initiates
+// side. The bootstrap must not deadlock no matter the relative order.
+TEST_F(CtranIbMultiVcPinnedTest, MultiRank4OutOfOrderGetVcsNoDeadlock) {
+  int deviceCount = 0;
+  EXPECT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+  if (deviceCount < 4) {
+    GTEST_SKIP() << "Test requires at least 4 CUDA devices, found "
+                 << deviceCount;
+  }
+
+  constexpr int kNumRanks = 4;
+  runNRanks(
+      kNumRanks,
+      [](int rank,
+         CtranIb* ib,
+         const std::vector<SocketServerAddr>& peerAddrs) {
+        // Rotate the per-rank peer order so each rank issues connectVcs in
+        // a different order:
+        //   rank 0: peers (1, 2, 3)  -- always smaller-rank initiator
+        //   rank 1: peers (2, 3, 0)  -- initiator for 2,3; waiter for 0
+        //   rank 2: peers (3, 0, 1)  -- initiator for 3; waiter for 0,1
+        //   rank 3: peers (0, 1, 2)  -- waiter for all
+        // Together these exercise the case where a larger-rank waiter
+        // is reached before, after, and concurrently with the
+        // smaller-rank initiator across multiple peer pairs.
+        std::vector<int> peerOrder;
+        peerOrder.reserve(kNumRanks - 1);
+        for (int i = 1; i < kNumRanks; ++i) {
+          peerOrder.push_back((rank + i) % kNumRanks);
+        }
+
+        EXPECT_EQ(ib->getMaxVcsPerPeer(), kExpectedMaxVcsPerPeer);
+
+        for (int peerRank : peerOrder) {
+          const auto& vcs = ib->connectVcs(peerRank, &peerAddrs[peerRank]);
+          ASSERT_EQ(static_cast<int>(vcs.size()), kExpectedMaxVcsPerPeer)
+              << "rank " << rank << " peer " << peerRank;
+        }
+
+        // A second pass in any order must hit the cache (same vector).
+        for (int peerRank : peerOrder) {
+          const auto& vcs = ib->connectVcs(peerRank, &peerAddrs[peerRank]);
+          const auto& vcs2 = ib->connectVcs(peerRank, &peerAddrs[peerRank]);
+          EXPECT_EQ(vcs.data(), vcs2.data())
+              << "rank " << rank << " peer " << peerRank;
+        }
+      });
+}
+
+} // namespace

--- a/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
@@ -2,6 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <numeric>
+#include <vector>
+
 #include "comms/ctran/backends/ib/CtranIb.h"
 #include "comms/ctran/backends/ib/CtranIbBase.h"
 #include "comms/ctran/backends/ib/CtranIbVc.h"
@@ -22,12 +25,16 @@ TEST_P(CtranIbQpConfigTest, MaxNumQpsIsValidForAllConfigs) {
   EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, devicesPerRank);
 
   std::vector<CtranIbDevice> dummyDevices(devicesPerRank, CtranIbDevice{});
+  std::vector<int> activeDevices(devicesPerRank);
+  std::iota(activeDevices.begin(), activeDevices.end(), 0);
   CtranIbVirtualConn vc(
       dummyDevices,
       /*peerRank=*/0,
       /*comm=*/nullptr,
       /*pgTrafficClass=*/0,
-      /*cudaDev=*/0);
+      /*cudaDev=*/0,
+      /*activeDevices=*/std::move(activeDevices),
+      /*vcsPerPeer=*/1);
 
   const int maxNumQps = vc.getMaxNumQp();
   EXPECT_GE(maxNumQps, 1) << "maxNumQps must never be zero";
@@ -69,7 +76,9 @@ TEST(CtranIbQpConfigRegressionTest, MaxQps1DevPerRank2) {
       /*peerRank=*/0,
       /*comm=*/nullptr,
       /*pgTrafficClass=*/0,
-      /*cudaDev=*/0);
+      /*cudaDev=*/0,
+      /*activeDevices=*/std::vector<int>{0, 1},
+      /*vcsPerPeer=*/1);
 
   EXPECT_EQ(vc.getMaxNumQp(), 2);
 }

--- a/comms/ctran/backends/ib/tests/VcLayoutTest.cc
+++ b/comms/ctran/backends/ib/tests/VcLayoutTest.cc
@@ -1,0 +1,93 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/backends/ib/VcLayout.h"
+#include "comms/ctran/utils/Exception.h"
+
+using ctran::ib::VcLayout;
+using Devs = std::vector<std::vector<int>>;
+
+TEST(VcLayoutTest, LegacyMode_1VcPer2Nics) {
+  const VcLayout layout(/*numNics=*/2, /*maxVcsPerPeer=*/1);
+  const Devs expected{{0, 1}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 1);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, LegacyMode_1VcPer1Nic) {
+  const VcLayout layout(/*numNics=*/1, /*maxVcsPerPeer=*/1);
+  const Devs expected{{0}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 1);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, MultiVcMode_4VcsPer2Nics) {
+  const VcLayout layout(/*numNics=*/2, /*maxVcsPerPeer=*/4);
+  const Devs expected{{0}, {0}, {1}, {1}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 4);
+  EXPECT_EQ(layout.maxVcsPerNic, 2);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, MultiVcMode_2VcsPer2Nics) {
+  // Boundary: maxVcsPerPeer == numNics; pinned and striped both reduce to
+  // one VC per NIC, maxVcsPerNic=1.
+  const VcLayout layout(/*numNics=*/2, /*maxVcsPerPeer=*/2);
+  const Devs expected{{0}, {1}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 2);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, FutureMode_2VcsPer4Nics) {
+  const VcLayout layout(/*numNics=*/4, /*maxVcsPerPeer=*/2);
+  const Devs expected{{0, 1}, {2, 3}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 2);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, FutureMode_1VcPer4Nics) {
+  const VcLayout layout(/*numNics=*/4, /*maxVcsPerPeer=*/1);
+  const Devs expected{{0, 1, 2, 3}};
+  EXPECT_EQ(layout.maxVcsPerPeer, 1);
+  EXPECT_EQ(layout.maxVcsPerNic, 1);
+  EXPECT_EQ(layout.vcToActiveDevices, expected);
+}
+
+TEST(VcLayoutTest, InvalidConfig_NotDivisible_4VcsPer3Nics) {
+  // 4 % 3 != 0, and 4 < 3 doesn't hold either.
+  EXPECT_THROW(
+      VcLayout(/*numNics=*/3, /*maxVcsPerPeer=*/4), ctran::utils::Exception);
+}
+
+TEST(VcLayoutTest, InvalidConfig_NotDivisible_3VcsPer4Nics) {
+  // 4 % 3 != 0 (striped requires numNics % maxVcsPerPeer == 0).
+  EXPECT_THROW(
+      VcLayout(/*numNics=*/4, /*maxVcsPerPeer=*/3), ctran::utils::Exception);
+}
+
+TEST(VcLayoutTest, InvalidConfig_ZeroNics) {
+  EXPECT_THROW(
+      VcLayout(/*numNics=*/0, /*maxVcsPerPeer=*/1), ctran::utils::Exception);
+}
+
+TEST(VcLayoutTest, InvalidConfig_ZeroVcs) {
+  EXPECT_THROW(
+      VcLayout(/*numNics=*/2, /*maxVcsPerPeer=*/0), ctran::utils::Exception);
+}
+
+TEST(VcLayoutTest, DescribeContainsExpectedFields) {
+  const VcLayout layout(/*numNics=*/2, /*maxVcsPerPeer=*/4);
+  const auto desc = layout.describe();
+  EXPECT_THAT(desc, ::testing::HasSubstr("maxVcsPerPeer=4"));
+  EXPECT_THAT(desc, ::testing::HasSubstr("maxVcsPerNic=2"));
+  EXPECT_THAT(desc, ::testing::HasSubstr("VC[0]"));
+  EXPECT_THAT(desc, ::testing::HasSubstr("VC[1]"));
+  EXPECT_THAT(desc, ::testing::HasSubstr("VC[2]"));
+  EXPECT_THAT(desc, ::testing::HasSubstr("VC[3]"));
+}

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1571,6 +1571,19 @@ cvars:
      multiple QPs.  This allows the communication to take multiple routes
      and is a poor-man's version of fully adaptive routing.
 
+ - name        : NCCL_CTRAN_IB_NUM_VCS_PER_RANK
+   type        : int
+   default     : 1
+   description : |-
+     Number of per-peer VCs (CtranIbVirtualConn) returned by
+     CtranIb::getVcs(peerRank). Each VC is pinned to a single NIC and
+     owns its own ctrl/notify/atomic + data QPs. The data QPs are
+     derived as NCCL_CTRAN_IB_MAX_QPS / NCCL_CTRAN_IB_NUM_VCS_PER_PEER
+     per VC, distributed across NICs by
+     NCCL_CTRAN_IB_NUM_VCS_PER_PEER / NCCL_CTRAN_IB_DEVICES_PER_RANK
+     VCs per NIC. Used by callers that obtain VCs via
+     CtranIb::getVcs(peerRank).
+
  - name        : NCCL_CTRAN_IB_QP_SCALING_THRESHOLD
    type        : uint64_t
    default     : 524288


### PR DESCRIPTION
Summary:
Adds multi-channel support to CtranIb by managing a vector of per-peer
NIC-pinned Virtual Connections (VCs). The "channel" concept lives entirely
in the algo / RMA / p2pHostIbTransport layer; CtranIb owns the per-NIC IB
resources (one VC group per NIC) and exposes the per-peer VC vector via
`connectVcs(peer)`. The consumer calls `connectVcs(peer)` once and
dispatches each per-channel op directly to `vcs[vcIdx]`, where `vcIdx` is
the consumer's choice per chunk (commonly `channelId % maxVcsPerPeer`).

Motivation (see
fbcode/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md):
- Multiple independent logical connections per peer for callers like
  p2pHostIbTransport that need their own per-channel ordering domain and
  notify-stream — a slow consumer on one VC cannot back-pressure another
  VC to the same peer.
- Multi-NIC isolation that lets the receiver opt out of cross-NIC
  iflushes: a NIC-pinned VC keeps a logical stream's data + notify on one
  PCIe path, so the per-NIC ordering provided by NIC hardware is enough.

# Public API additions on CtranIb

- `connectVcs(peerRank, peerAddr?)` — blocking, init-once-per-peer. Fast
  path: if the per-peer vector is already published, returns the cached
  reference immediately. Otherwise, the smaller rank drives the
  rendezvous synchronously via `bootstrap_->connect(peerRank, ...)`, and
  the larger rank spins on `vcState_.tryGetVcs(peerRank)` (with
  `std::this_thread::yield()` between polls and an `abortCtrl_->Test()`
  abort check) until the listen thread publishes the vector. Returns a
  cached vector of `maxVcsPerPeer` NIC-pinned VCs sized from cvars.
  Subsequent calls from either side hit the fast path — no TCP, no
  swap, no QP transition. The vector is stored in
  `vcStateMaps.rankToVcs` and shared across all consumers.
  References to values in `std::unordered_map` are stable across
  insertions, so the returned reference remains valid until
  `releaseAll()`. Per-peer calls must be serialized (not safe to call
  concurrently from multiple threads for the same peer).
- `progress(int device)` — per-NIC progress overload that polls only one
  NIC's CQ. Useful for NIC-affine progress loops in `p2pHostIbTransport`
  that want to drain one NIC without contending on others.

The name `connectVcs` (vs. lookup-only `VcState::tryGetVcs`) signals the
side-effect: this call may drive a TCP connect and bus-card swap.

# Backward compatibility — single source of truth via rankToVcs

`vcStateMaps.rankToVcs[peer]` is the **only** per-peer VC storage. The
legacy `getVc(peer)` is now a thin accessor that returns
`rankToVcs[peer].front()` (i.e. `vcs[0]`); it does not maintain a separate
map and does not own a separate VC. The bootstrap path is unified too:
`Bootstrap::connect` (and the accept-side handshake) always loops over
`getMaxVcsPerPeer()` VCs (always `>= 1` post-normalization), so a single
rendezvous publishes the full vector and the very first call from either
entry point bootstraps it. Legacy callers (`CtranMapper`, FTAR, existing
collective algos) keep working unchanged because `vcs[0]` behaves exactly
like the previous single per-peer VC: when `maxVcsPerPeer == 1` (default)
the VC spans all NICs and is functionally the legacy non-pinned VC; when
`maxVcsPerPeer > 1`, it is the NIC-0-pinned VC of the new vector.
`qpToVcMap` is shared across all VCs for uniform CQE dispatch.

# Internals

- `CtranIbVirtualConn` takes an `activeDevices` ctor parameter and pins
  every QP (ctrl/notify/atomic + data) to that NIC set. Legacy callers
  get `activeDevices = [0..numNics-1]` (no pinning, identical to before).
- New `VcLayout` value-type (computed once at init via the
  `VcLayout(numNics, maxVcsPerPeer)` ctor) describes how `maxVcsPerPeer`
  VCs map to NICs:
  - **Pinned** (`maxVcsPerPeer >= numNics`, divisible): each NIC owns
    `maxVcsPerNic` VCs; each VC's `activeDevices` is one NIC.
  - **Striped** (`maxVcsPerPeer < numNics`, divisible): each VC spans `K`
    contiguous NICs.
  Invalid `(numNics, maxVcsPerPeer)` pairs are rejected at construction
  via `ctran::utils::Exception(commInvalidArgument)`. Pure value type,
  tested independently of any IB / VC machinery in `vc_layout_test`.
- New `VcState` class owns all per-peer VC state for a single CtranIb
  instance: `rankToVcs`, `qpToVcMap`, and `connectedPeerMap_`. Exposes
  a single mutating entry point
  `setupAndPublishVc(vcs, remoteVcIdentifiers, peerRank)` — which runs
  `vc->setupVc(remoteVcIdentifiers[i])` under each VC's lock, inserts
  every VC's ctrl/notify/atomic/data QPs into `qpToVcMap`, sets
  `rankToVcs[peerRank] = std::move(vcs)`, and logs each established
  connection — plus read-side helpers `tryGetVcs`, `getVc`,
  `getVcByQp`, `isPeerConnected`, `markPeerConnected`,
  `hasConnectedPeerMap`. Thread-safe; callable concurrently by server
  (listen thread) and client (`Bootstrap::connect`) threads.
- `Bootstrap` (internal) refactored into a clean call hierarchy:
    acceptLoop / connect
      → exchangeAndPublish
          for vcIdx in [0, vcLayout_.maxVcsPerPeer):
              build vc, swap bus cards (under vc->mutex)
          vcState_.setupAndPublishVc(vcs, remoteBusCards, peerRank)
          ack handshake
  `BootstrapExternal` follows the same shape for its single-VC path
  (one VC spanning all local NICs — no NIC pinning — matching the
  legacy single-VC semantics).
- `releaseRemoteTransStates(peer)` drains `rankToVcs` and removes the
  QPs from `qpToVcMap`. Any in-flight larger-rank `connectVcs(peer)`
  spinner observes the cleared `rankToVcs` and exits via its
  `abortCtrl_->Test()` check (returning a reference to a `static` empty
  vector).

# Cvars

- `NCCL_CTRAN_IB_NUM_VCS_PER_RANK` (`maxVcsPerRank`) — per-peer VC count;
  normalised to 1 if unset / `<= 0`. Must satisfy one of the two layout
  divisibility rules above. Both endpoints must agree (checked at first
  rendezvous via the bus-card-swap loop count).

# New design doc

`fbcode/comms/ctran/backends/ib/docs/ctranib_multi_channel_vc_management.md`
describes the layered responsibilities (algo / RMA owns "channel";
p2pHostIbTransport dispatches; CtranIb owns the VCG + VC vector), the VC
group (VCG) resource model, the pinned-vs-striped VC layout, the blocking
+ idempotent + backward-compatible `connectVcs` contract, the rendezvous
protocol, CQE routing, lifetime / teardown / threading, and a three-phase
rollout (Phase 1: this commit; Phase 2: promote VcGroup to a real C++
struct + per-VCG progress; Phase 3: migrate VcGroup + VC into ibverbx).

# New tests

`ctran_ib_multi_vc_pinned_test` — 7 tests on devgpu009 with
`NCCL_CTRAN_IB_NUM_VCS_PER_PEER=4`, `NCCL_CTRAN_IB_DEVICES_PER_RANK=2`,
`NCCL_CTRAN_IB_MAX_QPS=16` (each VC pinned to one of 2 NICs, 2 VCs/NIC,
4 data QPs/VC):
- `GetVcsLazyCreatesAndPinsByNic` — lazy creation, NIC pinning, cache
  stability across repeat calls.
- `NotifyVcRoundTrip` — `vc->notify` + `vc->checkNotify` on every VC.
- `IputVcRoundTrip` — per-VC ctrlMsg + `iput(notify=true)` round-trip
  with payload verification.
- `FetchAndAddVcRoundTrip` — 50 atomic increments per VC, verify counter.
- `ProgressInvalidDeviceReturnsError` — guards `progress(device)`
  out-of-range handling.
- `MultiRank4OutOfOrderGetVcsNoDeadlock` — 4 ranks call `connectVcs` in
  rotated peer orders, verify no deadlock.
- `MultiThreadGetVcsShareSameVcs` — N threads race into
  `connectVcs(peer)`; lazy bootstrap runs exactly once, all see same
  cached vector.

`vc_layout_test` — pure unit tests for the `VcLayout(numNics, maxVcsPerPeer)`
ctor covering pinned and striped regimes, divisibility rejection, and
legacy single-VC degenerate cases.

Reviewed By: minsii

Differential Revision: D104768967


