### PR TITLE
Optimize NVLink sendrecv: pass staging pointers as direct tensor args for vectorized stores (#2670)

### DIFF
--- a/comms/pipes/triton/collectives/nvl/__init__.py
+++ b/comms/pipes/triton/collectives/nvl/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -94,10 +94,12 @@ _MODE_RECV_ONLY = 2
 def triton_nvl_sendrecv_kernel(  # noqa: C901
     send_ptr,
     recv_ptr,
-    buffer_ptrs,  # int64 device tensor, shape (world_size,)
-    signal_pad_ptrs,  # int64 device tensor, shape (world_size,)
-    sender_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
-    recver_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    remote_buf,  # direct tensor: peer's staging buffer
+    local_buf,  # direct tensor: own staging buffer
+    remote_sig,  # direct tensor: peer's signal pad (int64)
+    local_sig,  # direct tensor: own signal pad (int64)
+    sender_step_ptr,
+    recver_step_ptr,
     local_rank,
     peer_rank,
     send_numel,
@@ -118,6 +120,16 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
     path ``pid // 2`` and odd programs run receiver path ``pid // 2``.
     Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
     exactly one path.
+
+    Staging buffer and signal pad pointers are passed as direct typed
+    tensor arguments (via ``handle.get_buffer`` / ``handle.get_signal_pad``
+    on the host side) rather than loaded at runtime from a pointer-of-pointer
+    tensor. This is critical for Triton codegen: runtime-loaded store
+    destination pointers (``tl.load(...).to(pointer_type(...))``) trigger
+    the compiler's layout optimizer to emit scalar 16-bit stores
+    (``STG.E.U16``) instead of 128-bit vectorized stores (``STG.E.128``).
+    Direct tensor arguments avoid this, producing the same ``LDG.E.128 +
+    STG.E.128`` pattern that NCCL uses with ``uint4``.
     """
     TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
 
@@ -132,21 +144,8 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         is_sender = (pid % 2) == 0
         block_id = pid // 2
 
-    # ---- Buffer pointers ----
-    # Sender writes to peer rank's staging buffer; receiver reads its own.
-    buffer_ptrs_u64 = buffer_ptrs.to(tl.pointer_type(tl.uint64))
-    remote_buf = tl.load(buffer_ptrs_u64 + peer_rank).to(
-        tl.pointer_type(send_ptr.dtype.element_ty)
-    )
-    local_buf = tl.load(buffer_ptrs_u64 + local_rank).to(
-        tl.pointer_type(recv_ptr.dtype.element_ty)
-    )
-
-    # ---- Signal pad pointers ----
-    signal_pad_ptrs_u64 = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
-    remote_sig = tl.load(signal_pad_ptrs_u64 + peer_rank).to(tl.pointer_type(tl.int64))
-    local_sig = tl.load(signal_pad_ptrs_u64 + local_rank).to(tl.pointer_type(tl.int64))
-
+    # Buffer and signal pointers are already typed kernel arguments —
+    # no pointer-of-pointer load needed.
     HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
 
     flat_tid = get_flat_tid()

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -1,0 +1,289 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton NVLink-only copy-based send/recv kernel.
+
+Single peer-pair copy-based send, receive, or bidirectional sendrecv,
+double-buffered staging, monotonic int64 head/tail signaling. CUDA-graph
+replayable via persistent step-state counters that advance across replays.
+
+Scope: 2-rank groups only. ``send_peer`` and ``recv_peer`` are the same
+rank (single ``peer_rank`` arg). This kernel is **not** directly usable
+for Ring AllGather on world_size > 2 — ring needs ``(send_peer,
+recv_peer) = ((rank+1)%N, (rank-1)%N)`` plus per-sender staging slots.
+See ``sendrecv_op.py`` module docstring for the planned API/protocol
+extension.
+
+Architecture
+------------
+
+::
+
+    Rank A (sender)                        Rank B (receiver)
+    ┌─────────────┐                        ┌─────────────┐
+    │ src tensor  │──(1) read──→           │             │
+    │ (local HBM) │            │           │             │
+    └─────────────┘            │           │             │
+                               ▼           │             │
+                   ┌─────────────────────┐ │             │
+                   │ staging buffer      │ │             │
+                   │ (Rank B symm mem)   │─(2) read───→  │
+                   │ [slot 0 | slot 1]   │ │       ▼     │
+                   └─────────────────────┘ │  ┌─────────────┐
+                                           │  │ dst tensor  │
+                                           │  │ (local HBM) │
+                                           │  └─────────────┘
+                                           └────────────────┘
+
+    (1) Sender reads local src, REMOTE-writes to peer's staging buffer
+    (2) Receiver LOCAL-reads its staging buffer, writes to local dst
+
+All remote operations are NVLink fire-and-forget writes (zero NVLink reads).
+
+Block / signal / buffer mapping
+-------------------------------
+
+Each block ``k`` owns a fixed staging-buffer region
+``[k * BLOCK_STRIDE * PIPELINE_DEPTH, (k+1) * BLOCK_STRIDE * PIPELINE_DEPTH)``
+and a fixed ``(head[k], tail[k])`` signal pair. Sender block ``k`` and
+receiver block ``k`` use the SAME signal slot ``k`` and the SAME buffer
+region. The block→region mapping is determined by ``MAX_BLOCKS_PER_DIR``
+(constant) and is independent of the runtime ``NUM_SEND_BLOCKS``, so
+back-to-back kernel launches with different block counts cannot race.
+
+Signal-pad layout per rank (int64 entries; ``MBPD = MAX_BLOCKS_PER_DIR``)::
+
+    [0 .. MBPD):       TAIL — written by remote sender, polled by local receiver
+    [MBPD .. 2*MBPD):  HEAD — written by remote receiver, polled by local sender
+
+Memory ordering:
+
+  * **TAIL** (sender→receiver, publishes payload data): producer uses
+    :func:`fence_and_remote_store_i64` (release fence + relaxed store);
+    consumer uses :func:`wait_ge` (acquire poll). The fence guarantees the
+    receiver sees the staging-buffer data once it sees the new TAIL.
+
+  * **HEAD** (receiver→sender, only transfers slot ownership): producer
+    uses :func:`remote_store_i64_relaxed` (no fence) preceded by a local
+    ``sync_threads()`` execution barrier. Consumer uses
+    :func:`wait_ge_volatile` (no acquire). The sender does not read any
+    payload written by the receiver, so the fence is unnecessary.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from .utils import (
+    fence_and_remote_store_i64,
+    get_flat_tid,
+    remote_store_i64_relaxed,
+    sync_threads,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+_MODE_BIDIRECTIONAL = 0
+_MODE_SEND_ONLY = 1
+_MODE_RECV_ONLY = 2
+
+
+@triton.jit(do_not_specialize=["local_rank", "peer_rank"])
+def triton_nvl_sendrecv_kernel(  # noqa: C901
+    send_ptr,
+    recv_ptr,
+    buffer_ptrs,  # int64 device tensor, shape (world_size,)
+    signal_pad_ptrs,  # int64 device tensor, shape (world_size,)
+    sender_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    recver_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    local_rank,
+    peer_rank,
+    send_numel,
+    recv_numel,
+    TILE_ROWS: tl.constexpr,
+    TILE_COLS: tl.constexpr,
+    BLOCK_STRIDE_ELEMS: tl.constexpr,
+    PIPELINE_DEPTH: tl.constexpr,
+    MAX_BLOCKS_PER_DIR: tl.constexpr,
+    NUM_SEND_BLOCKS: tl.constexpr,
+    MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
+    MODE: tl.constexpr,
+):
+    """NVLink copy-based send/recv kernel.
+
+    Bidirectional mode launches grid ``(2 * NUM_SEND_BLOCKS,)`` and
+    interleaves paired sender/receiver programs: even programs run sender
+    path ``pid // 2`` and odd programs run receiver path ``pid // 2``.
+    Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
+    exactly one path.
+    """
+    TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
+
+    pid = tl.program_id(0)
+    if MODE == _MODE_SEND_ONLY:
+        is_sender = True
+        block_id = pid
+    elif MODE == _MODE_RECV_ONLY:
+        is_sender = False
+        block_id = pid
+    else:
+        is_sender = (pid % 2) == 0
+        block_id = pid // 2
+
+    # ---- Buffer pointers ----
+    # Sender writes to peer rank's staging buffer; receiver reads its own.
+    buffer_ptrs_u64 = buffer_ptrs.to(tl.pointer_type(tl.uint64))
+    remote_buf = tl.load(buffer_ptrs_u64 + peer_rank).to(
+        tl.pointer_type(send_ptr.dtype.element_ty)
+    )
+    local_buf = tl.load(buffer_ptrs_u64 + local_rank).to(
+        tl.pointer_type(recv_ptr.dtype.element_ty)
+    )
+
+    # ---- Signal pad pointers ----
+    signal_pad_ptrs_u64 = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
+    remote_sig = tl.load(signal_pad_ptrs_u64 + peer_rank).to(tl.pointer_type(tl.int64))
+    local_sig = tl.load(signal_pad_ptrs_u64 + local_rank).to(tl.pointer_type(tl.int64))
+
+    HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
+
+    flat_tid = get_flat_tid()
+
+    if is_sender:
+        # ===== SENDER =====
+        sender_id = block_id
+
+        # tail: REMOTE — written here, polled by remote receiver
+        # head: LOCAL — polled here, written by remote receiver
+        tail_remote_ptr = remote_sig + sender_id
+        head_local_ptr = local_sig + HEAD_OFFSET + sender_id
+
+        start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
+
+        local_rows = tl.arange(0, TILE_ROWS)
+        local_cols = tl.arange(0, TILE_COLS)
+        num_send_tiles = tl.cdiv(send_numel, TILE_NUMEL)
+
+        # int64 tile index so `send_tile_idx * TILE_NUMEL` cannot overflow
+        # int32 for multi-GiB tensors.
+        send_tile_idx = sender_id.to(tl.int64)
+        send_step = start_step
+
+        while send_tile_idx < num_send_tiles:
+            slot = (send_step - start_step) % PIPELINE_DEPTH
+            slot_base = (
+                sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                + slot * BLOCK_STRIDE_ELEMS
+            )
+
+            # Wait for slot to be free. For the first PIPELINE_DEPTH steps
+            # of a non-first call, the slot may still hold data the remote
+            # receiver has not yet consumed — gate on start_step.
+            if send_step < start_step + PIPELINE_DEPTH:
+                wait_target = start_step
+            else:
+                wait_target = send_step - PIPELINE_DEPTH + 1
+            if flat_tid == 0:
+                wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+            sync_threads()
+
+            buf_tile_idx = 0
+            tiles_to_send_this_step = min(
+                MAX_TILES_PER_BLOCK_PER_SLOT,
+                tl.cdiv(num_send_tiles - send_tile_idx, NUM_SEND_BLOCKS),
+            )
+            for _i in range(tiles_to_send_this_step):
+                flat_idx = (
+                    send_tile_idx * TILE_NUMEL
+                    + local_rows[:, None] * TILE_COLS
+                    + local_cols[None, :]
+                )
+                mask = flat_idx < send_numel
+                data = tl.load(send_ptr + flat_idx.to(tl.int64), mask=mask)
+
+                buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                    tl.int64
+                )
+                tl.store(remote_buf + slot_base + buf_off, data, mask=mask)
+
+                send_tile_idx += NUM_SEND_BLOCKS
+                buf_tile_idx += 1
+
+            sync_threads()
+            # ``bar.sync 0`` ensures all sender threads have finished issuing
+            # their staging stores before thread 0 issues the system fence.
+            # Without this barrier, thread 0's fence would only drain its own
+            # in-flight stores, leaving other threads' stores unsynchronized
+            # with the TAIL publish.
+            if flat_tid == 0:
+                fence_and_remote_store_i64(
+                    tail_remote_ptr, (send_step + 1).to(tl.int64)
+                )
+            send_step += 1
+
+        # Persist for next launch's start_step.
+        tl.store(sender_step_ptr + sender_id, send_step.to(tl.int64))
+
+    else:
+        # ===== RECEIVER =====
+        receiver_id = block_id
+
+        # tail: LOCAL — polled here, written by remote sender
+        # head: REMOTE — written here, polled by remote sender
+        tail_local_ptr = local_sig + receiver_id
+        head_remote_ptr = remote_sig + HEAD_OFFSET + receiver_id
+
+        start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
+
+        local_rows = tl.arange(0, TILE_ROWS)
+        local_cols = tl.arange(0, TILE_COLS)
+        num_recv_tiles = tl.cdiv(recv_numel, TILE_NUMEL)
+
+        # int64 tile index so `recv_tile_idx * TILE_NUMEL` cannot overflow
+        # int32 for multi-GiB tensors.
+        recv_tile_idx = receiver_id.to(tl.int64)
+        recv_step = start_step
+
+        while recv_tile_idx < num_recv_tiles:
+            slot = (recv_step - start_step) % PIPELINE_DEPTH
+            slot_base = (
+                receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                + slot * BLOCK_STRIDE_ELEMS
+            )
+
+            if flat_tid == 0:
+                wait_ge(tail_local_ptr, (recv_step + 1).to(tl.int64))
+            sync_threads()
+
+            buf_tile_idx = 0
+            tiles_to_recv_this_step = min(
+                MAX_TILES_PER_BLOCK_PER_SLOT,
+                tl.cdiv(num_recv_tiles - recv_tile_idx, NUM_SEND_BLOCKS),
+            )
+            for _i in range(tiles_to_recv_this_step):
+                flat_idx = (
+                    recv_tile_idx * TILE_NUMEL
+                    + local_rows[:, None] * TILE_COLS
+                    + local_cols[None, :]
+                )
+                mask = flat_idx < recv_numel
+
+                buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                    tl.int64
+                )
+                data = tl.load(local_buf + slot_base + buf_off, mask=mask)
+                tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
+
+                recv_tile_idx += NUM_SEND_BLOCKS
+                buf_tile_idx += 1
+
+            sync_threads()
+            if flat_tid == 0:
+                remote_store_i64_relaxed(head_remote_ptr, (recv_step + 1).to(tl.int64))
+            recv_step += 1
+
+        tl.store(recver_step_ptr + receiver_id, recv_step.to(tl.int64))

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -33,6 +33,7 @@ from typing import NamedTuple
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
 
 from .sendrecv import triton_nvl_sendrecv_kernel
 
@@ -83,10 +84,7 @@ def _per_pair_bytes() -> int:
 # caller multiplexes threads onto a single PG, wrap these in a lock.
 # ---------------------------------------------------------------------------
 
-_BUFFER_CACHE: dict[
-    dist.ProcessGroup,
-    tuple[object, torch.Tensor, torch.Tensor],  # (handle, buf_ptrs, sig_ptrs)
-] = {}
+_HANDLE_CACHE: dict[dist.ProcessGroup, _SymmetricMemory] = {}
 
 _STEP_STATE_CACHE: dict[
     dist.ProcessGroup,
@@ -97,8 +95,8 @@ _STEP_STATE_CACHE: dict[
 def _get_staging_buffer(
     group: dist.ProcessGroup,
     device: torch.device,
-) -> tuple[object, torch.Tensor, torch.Tensor]:
-    """Get or create the symmetric memory staging buffer for ``group``.
+) -> _SymmetricMemory:
+    """Get or create the symmetric memory handle for ``group``.
 
     The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
     on each block. ``symm_mem.empty`` zeroes the entire allocation including
@@ -107,7 +105,7 @@ def _get_staging_buffer(
     signal pad explicitly + barrier so the invariant holds even if the
     underlying allocator behaviour changes in a future torch release.
     """
-    cached = _BUFFER_CACHE.get(group)
+    cached = _HANDLE_CACHE.get(group)
     if cached is not None:
         return cached
 
@@ -124,10 +122,8 @@ def _get_staging_buffer(
     # rendezvous-then-barrier sequence below guarantees that.
     handle.get_signal_pad(handle.rank).zero_()
     dist.barrier(group)
-    buf_ptrs = torch.tensor(handle.buffer_ptrs, device=device, dtype=torch.int64)
-    sig_ptrs = torch.tensor(handle.signal_pad_ptrs, device=device, dtype=torch.int64)
-    _BUFFER_CACHE[group] = (handle, buf_ptrs, sig_ptrs)
-    return _BUFFER_CACHE[group]
+    _HANDLE_CACHE[group] = handle
+    return handle
 
 
 def _get_step_state(
@@ -289,7 +285,11 @@ def _launch(
     assert peer_rank != local_rank
     assert 0 <= peer_rank < world_size
 
-    _, buf_ptrs, sig_ptrs = _get_staging_buffer(group, send_buf.device)
+    # Buffer and signal pad pointers are passed as direct typed tensors
+    # (not pointer-of-pointer int64 tensors) so Triton emits 128-bit
+    # vectorized stores instead of 16-bit scalar stores. See the kernel
+    # docstring in sendrecv.py for the codegen rationale.
+    handle = _get_staging_buffer(group, send_buf.device)
     sender_step, recver_step = _get_step_state(group, send_buf.device)
 
     config = _compute_config(send_buf.element_size())
@@ -297,6 +297,16 @@ def _launch(
     tile_numel = config.tile_rows * config.tile_cols
     tile_bytes = tile_numel * send_buf.element_size()
     max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_DIR * _PIPELINE_DEPTH
+    remote_buf = handle.get_buffer(
+        peer_rank, sizes=[staging_elems], dtype=send_buf.dtype
+    )
+    local_buf = handle.get_buffer(
+        local_rank, sizes=[staging_elems], dtype=recv_buf.dtype
+    )
+    remote_sig = handle.get_signal_pad(peer_rank).view(torch.int64)
+    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
@@ -306,8 +316,10 @@ def _launch(
     triton_nvl_sendrecv_kernel[grid](
         send_ptr=send_buf,
         recv_ptr=recv_buf,
-        buffer_ptrs=buf_ptrs,
-        signal_pad_ptrs=sig_ptrs,
+        remote_buf=remote_buf,
+        local_buf=local_buf,
+        remote_sig=remote_sig,
+        local_sig=local_sig,
         sender_step_ptr=sender_step,
         recver_step_ptr=recver_step,
         local_rank=local_rank,

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -1,0 +1,327 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side wrapper for the NVLink copy-based Triton send/recv kernel.
+
+Allocates (and caches) the symmetric memory staging buffer plus the
+persistent step-state tensors, computes a kernel config, and launches.
+
+v1 scope (intentionally narrow):
+
+  * **2-rank groups only**. The staging buffer holds a single peer pair's
+    slot and the API takes a single ``peer_rank`` used for both directions
+    (sender → ``peer_rank``, receiver ← ``peer_rank``).
+  * Copy-based send-only, recv-only, and bidirectional sendrecv between
+    this rank and ``peer_rank``. Peer ranks must launch matching operations
+    simultaneously.
+
+The bidirectional single-peer API is **not** directly composable into Ring AllGather on N>2 ranks —
+ring needs ``send_peer = (rank+1)%N`` paired with ``recv_peer =
+(rank-1)%N`` (different peers per direction), and the staging buffer
+needs per-sender slots like the MSL ``all_to_all_single_non_contig``
+kernel uses. The follow-up to add ring AllGather will introduce a
+``triton_nvl_sendrecv(send, recv, send_peer, recv_peer, ...)`` variant
+plus per-peer staging slots indexed by sender rank.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import NamedTuple
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from .sendrecv import triton_nvl_sendrecv_kernel
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables (powers of 2). These match the analogous constants in
+# all_to_all_single_non_contig.py and are deliberately shape-independent
+# so back-to-back launches with different block counts cannot race.
+# ---------------------------------------------------------------------------
+
+_BLOCK_STRIDE_BYTES: int = 256 * 1024
+_PIPELINE_DEPTH: int = 2
+_MAX_BLOCKS_PER_DIR: int = 32
+_DEFAULT_NUM_SEND_BLOCKS: int = 16
+_DEFAULT_NUM_WARPS: int = 8
+_MODE_BIDIRECTIONAL: int = 0
+_MODE_SEND_ONLY: int = 1
+_MODE_RECV_ONLY: int = 2
+
+
+class _Config(NamedTuple):
+    tile_rows: int
+    tile_cols: int
+    num_stages: int
+
+
+def _compute_config(element_size: int) -> _Config:
+    return _Config(
+        tile_rows=32,
+        tile_cols=2048 // element_size,
+        num_stages=2,
+    )
+
+
+def _per_pair_bytes() -> int:
+    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_DIR
+
+
+# ---------------------------------------------------------------------------
+# Per-group caches
+#
+# These dicts are not thread-safe: a multi-threaded caller racing on the
+# first use of a given ``group`` could double-allocate the staging buffer
+# or step state. PyTorch's torch.distributed call sites are single-threaded
+# per rank in practice, so we accept the simpler dict here. If a future
+# caller multiplexes threads onto a single PG, wrap these in a lock.
+# ---------------------------------------------------------------------------
+
+_BUFFER_CACHE: dict[
+    dist.ProcessGroup,
+    tuple[object, torch.Tensor, torch.Tensor],  # (handle, buf_ptrs, sig_ptrs)
+] = {}
+
+_STEP_STATE_CACHE: dict[
+    dist.ProcessGroup,
+    tuple[torch.Tensor, torch.Tensor],
+] = {}
+
+
+def _get_staging_buffer(
+    group: dist.ProcessGroup,
+    device: torch.device,
+) -> tuple[object, torch.Tensor, torch.Tensor]:
+    """Get or create the symmetric memory staging buffer for ``group``.
+
+    The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
+    on each block. ``symm_mem.empty`` zeroes the entire allocation including
+    the signal pad (via ``cudaMemset`` in CUDASymmetricMemory.cu's
+    ``allocate``), so the first launch is safe. We additionally zero the
+    signal pad explicitly + barrier so the invariant holds even if the
+    underlying allocator behaviour changes in a future torch release.
+    """
+    cached = _BUFFER_CACHE.get(group)
+    if cached is not None:
+        return cached
+
+    num_bytes = _per_pair_bytes()
+    logger.info(
+        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes",
+        group.group_desc,
+        num_bytes,
+    )
+    raw = symm_mem.empty(num_bytes, dtype=torch.uint8, device=device)
+    handle = symm_mem.rendezvous(raw, group=group)
+    # Defensive: explicitly zero the signal pad before any block can poll it.
+    # Both ranks must complete the zero before either issues a wait_ge — the
+    # rendezvous-then-barrier sequence below guarantees that.
+    handle.get_signal_pad(handle.rank).zero_()
+    dist.barrier(group)
+    buf_ptrs = torch.tensor(handle.buffer_ptrs, device=device, dtype=torch.int64)
+    sig_ptrs = torch.tensor(handle.signal_pad_ptrs, device=device, dtype=torch.int64)
+    _BUFFER_CACHE[group] = (handle, buf_ptrs, sig_ptrs)
+    return _BUFFER_CACHE[group]
+
+
+def _get_step_state(
+    group: dist.ProcessGroup,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Get or create persistent monotonic step counters for ``group``."""
+    cached = _STEP_STATE_CACHE.get(group)
+    if cached is not None:
+        return cached
+
+    sender_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
+    recver_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
+    _STEP_STATE_CACHE[group] = (sender_step, recver_step)
+    return _STEP_STATE_CACHE[group]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def triton_nvl_sendrecv(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Bidirectional NVLink copy-based send/recv between this rank and ``peer_rank``.
+
+    Both ranks in the (sender, receiver) pair must call this function
+    simultaneously. ``send_buf`` and ``recv_buf`` must have the same shape
+    and dtype on both ranks.
+
+    .. warning::
+        ``dtype`` and ``numel`` of ``send_buf`` / ``recv_buf`` MUST match
+        between the two ranks. There is no cross-rank validation; a
+        mismatch silently produces wrong staging slot offsets and
+        corrupts data.
+
+    Args:
+        send_buf: Source tensor to send to ``peer_rank``. Contiguous, CUDA.
+        recv_buf: Destination tensor to receive from ``peer_rank``. Contiguous, CUDA.
+        peer_rank: Rank in ``group`` to exchange with. ``send_peer`` and
+            ``recv_peer`` are the same rank in v1; see the module docstring
+            for why this is **not** directly extensible to Ring AllGather.
+        group: Process group used for symm-mem rendezvous. **v1 requires
+            size 2** — the assertion below is the enforcement point.
+        num_blocks: Thread blocks per direction. Defaults to 16. The actual
+            grid is ``2 * num_blocks`` for bidirectional mode (so default
+            gives a 32-block grid, apple-to-apple with NCCL's 32 channels)
+            and ``num_blocks`` for send-only / recv-only.
+        num_warps: Triton warps per block. Defaults to 8.
+    """
+    assert send_buf.is_cuda and recv_buf.is_cuda
+    assert send_buf.is_contiguous() and recv_buf.is_contiguous()
+    assert send_buf.dtype == recv_buf.dtype
+    assert send_buf.numel() == recv_buf.numel()
+    _launch(
+        send_buf,
+        recv_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_BIDIRECTIONAL,
+    )
+
+
+def triton_nvl_send(
+    send_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Send ``send_buf`` to ``peer_rank`` over NVLink using copy-based staging.
+
+    Caller is responsible for ensuring the peer rank issues a matching
+    ``triton_nvl_recv`` with the same ``dtype`` and ``numel`` — there is
+    no cross-rank validation.
+    """
+    assert send_buf.is_cuda and send_buf.is_contiguous()
+    _launch(
+        send_buf,
+        send_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_SEND_ONLY,
+    )
+
+
+def triton_nvl_recv(
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Receive into ``recv_buf`` from ``peer_rank`` over NVLink.
+
+    Caller is responsible for ensuring the peer rank issues a matching
+    ``triton_nvl_send`` with the same ``dtype`` and ``numel`` — there is
+    no cross-rank validation.
+    """
+    assert recv_buf.is_cuda and recv_buf.is_contiguous()
+    _launch(
+        recv_buf,
+        recv_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_RECV_ONLY,
+    )
+
+
+def _launch(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int,
+    num_warps: int,
+    mode: int,
+) -> None:
+    assert send_buf.dtype == recv_buf.dtype, (
+        f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
+    )
+    assert 0 < num_blocks <= _MAX_BLOCKS_PER_DIR, (
+        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_DIR}], got {num_blocks}"
+    )
+    assert num_warps in (4, 8), (
+        f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
+    )
+
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        recv_buf.copy_(send_buf)
+        return
+
+    # v1 limit: single peer-pair staging buffer means we cannot service more
+    # than one (sender, receiver) pair per group. Lift this restriction in
+    # the follow-up that adds per-peer staging slots for Ring AllGather.
+    assert world_size == 2, (
+        f"triton_nvl_sendrecv v1 supports only 2-rank groups, got world_size={world_size}. "
+        "See module docstring for the planned per-peer slot API."
+    )
+
+    local_rank = dist.get_rank(group)
+    assert peer_rank != local_rank
+    assert 0 <= peer_rank < world_size
+
+    _, buf_ptrs, sig_ptrs = _get_staging_buffer(group, send_buf.device)
+    sender_step, recver_step = _get_step_state(group, send_buf.device)
+
+    config = _compute_config(send_buf.element_size())
+    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    tile_numel = config.tile_rows * config.tile_cols
+    tile_bytes = tile_numel * send_buf.element_size()
+    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
+
+    # pyre-ignore[28]: triton's `kernel[grid](...)` launcher accepts JIT-special
+    # kwargs (`num_warps`, `num_stages`) that pyre can't see in the kernel
+    # function's own signature. Not a real type error.
+    triton_nvl_sendrecv_kernel[grid](
+        send_ptr=send_buf,
+        recv_ptr=recv_buf,
+        buffer_ptrs=buf_ptrs,
+        signal_pad_ptrs=sig_ptrs,
+        sender_step_ptr=sender_step,
+        recver_step_ptr=recver_step,
+        local_rank=local_rank,
+        peer_rank=peer_rank,
+        send_numel=send_buf.numel(),
+        recv_numel=recv_buf.numel(),
+        TILE_ROWS=config.tile_rows,
+        TILE_COLS=config.tile_cols,
+        BLOCK_STRIDE_ELEMS=block_stride_elems,
+        PIPELINE_DEPTH=_PIPELINE_DEPTH,
+        MAX_BLOCKS_PER_DIR=_MAX_BLOCKS_PER_DIR,
+        NUM_SEND_BLOCKS=num_blocks,
+        MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
+        MODE=mode,
+        num_warps=num_warps,
+        num_stages=config.num_stages,
+    )

--- a/comms/pipes/triton/collectives/nvl/tests/__init__.py
+++ b/comms/pipes/triton/collectives/nvl/tests/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -280,12 +280,26 @@ def _bench_triton(
     def fn() -> None:
         if bidirectional:
             triton_nvl_sendrecv(
-                send, recv, peer_rank, group=group, num_blocks=num_blocks
+                send,
+                recv,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
             )
         elif local_rank == 0:
-            triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+            triton_nvl_send(
+                send,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
+            )
         else:
-            triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+            triton_nvl_recv(
+                recv,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
+            )
 
     fn()
     dist.barrier(group)

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -1,0 +1,512 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Benchmark for the NVLink copy-based Triton send/recv vs NCCL baseline.
+
+**Runtime-SM-matched** apples-to-apples unidirectional and bidirectional
+sendrecv between rank 0 and rank 1 on a single node, NVLink-only.
+
+Key point: ``NCCL_{MIN,MAX}_NCHANNELS`` only controls *allocation*. NCCL's
+in-kernel adaptive policy decides how many of those allocated channels
+(= CTAs = SMs) to actually launch per call. Therefore we **first measure
+NCCL's runtime grid for every (msg_size, allocation_cap)** via nsys (see
+``_nccl_grid_probe.py`` companion target) and then pin Triton's
+``num_blocks`` to that runtime grid — guaranteeing that the per-cell
+comparison reflects identical SM usage on both kernels.
+
+Measured NCCL P2P kernel grid (= active SM count) on H100, NCCLX 2.29::
+
+      size   cap=4  cap=8  cap=16  cap=32
+       32 B    1      1      1       1
+       64 B    1      1      1       1
+       1 KB    1      1      1       1
+       8 KB    1      1      1       1
+      64 KB    1      1      1       1
+       1 MB    2      4      8      16
+       8 MB    2      4      8      16
+      64 MB    4      4      8      16
+     256 MB    4      8     16      16
+       1 GB    4      8     16      32
+
+Both unidirectional and bidirectional ``batch_isend_irecv`` produce the
+same NCCL grid (channels shared across the op set). Triton bidirectional
+uses a 2*num_blocks grid by construction, so for bidirectional we set
+``num_blocks = max(nccl_grid // 2, 1)`` (resulting Triton grid =
+``max(nccl_grid, 2)``); the only mismatch is at small-msg bi where
+NCCL=1 but Triton=2 — disclosed in commit summary.
+
+Both calls are captured into CUDA graphs and timed via ``graph.replay()``
+to remove the per-iteration Python and host launcher overhead.
+
+Fairness caveats:
+  * **Dtype**: bf16 only (representative ML-training payload dtype).
+  * **NCCL P2P + CUDA graph**: requires PyTorch + a NCCL build with
+    graph-aware P2P (NCCL 2.18+ or fbsource ``hpc_comms.use_ncclx=stable``).
+  * **NCCL P2P uses Simple protocol only.** ``NCCL_PROTO=LL`` only
+    affects collectives (verified via ``NCCL_DEBUG=INFO`` — AllReduce
+    shows ``proto LL``, but ``batch_isend_irecv`` allocates Simple-style
+    10 MB proxy buffers). NCCL has no LL/LL128 P2P path, so the small-
+    msg comparison is Triton-Simple-vs-NCCL-Simple.
+  * **Bidirectional minimum grid asymmetry**: Triton bidirectional grid
+    is always ``2 * num_blocks >= 2``; NCCL bidirectional grid drops to
+    1 at small msg. At cells where the table prescribes Triton
+    num_blocks=1 (=>grid=2) vs NCCL grid=1, Triton uses 2× SMs, which
+    we explicitly disclose.
+
+Run::
+
+    buck2 run @mode/opt -c hpc_comms.use_ncclx=stable \\
+        //comms/pipes/triton/collectives/nvl/tests:benchmark_sendrecv
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.pipes.triton.collectives.nvl.sendrecv_op import (
+    triton_nvl_recv,
+    triton_nvl_send,
+    triton_nvl_sendrecv,
+)
+
+
+# Message sizes to sweep (in bytes). 8 B and 16 B are excluded:
+# they are not target cases, and the current Triton codegen hits a
+# tiny-message divisibility cliff there that is not representative of
+# the copy-based path.
+_MSG_SIZES_BYTES: list[int] = [
+    32,
+    64,
+    1024,
+    8 * 1024,
+    64 * 1024,
+    1 * 1024 * 1024,
+    8 * 1024 * 1024,
+    64 * 1024 * 1024,
+    256 * 1024 * 1024,
+    1024 * 1024 * 1024,
+]
+
+
+# NCCL ``NCCL_{MIN,MAX}_NCHANNELS`` allocation values to sweep.
+# At each cap we compare against NCCL with that allocation, and Triton
+# with ``num_blocks`` matched to NCCL's actual runtime grid (see table
+# in module docstring).
+_CAPS: list[int] = [4, 8, 16, 32]
+
+
+# Hardcoded NCCL P2P kernel runtime grid table, keyed by
+# (msg_bytes, cap) -> grid count. Generated via nsys profiling of
+# ``ncclDevKernel_SendRecv`` on H100, NCCLX 2.29 (see
+# ``_nccl_grid_probe.py``). ``ncclDevKernelArgs`` is the same for uni
+# and bi; both directions share the channel pool, so the runtime grid
+# is identical regardless of P2POp count.
+_NCCL_GRID_TABLE: dict[tuple[int, int], int] = {
+    (32, 4): 1,
+    (32, 8): 1,
+    (32, 16): 1,
+    (32, 32): 1,
+    (64, 4): 1,
+    (64, 8): 1,
+    (64, 16): 1,
+    (64, 32): 1,
+    (1024, 4): 1,
+    (1024, 8): 1,
+    (1024, 16): 1,
+    (1024, 32): 1,
+    (8 * 1024, 4): 1,
+    (8 * 1024, 8): 1,
+    (8 * 1024, 16): 1,
+    (8 * 1024, 32): 1,
+    (64 * 1024, 4): 1,
+    (64 * 1024, 8): 1,
+    (64 * 1024, 16): 1,
+    (64 * 1024, 32): 1,
+    (1 * 1024 * 1024, 4): 2,
+    (1 * 1024 * 1024, 8): 4,
+    (1 * 1024 * 1024, 16): 8,
+    (1 * 1024 * 1024, 32): 16,
+    (8 * 1024 * 1024, 4): 2,
+    (8 * 1024 * 1024, 8): 4,
+    (8 * 1024 * 1024, 16): 8,
+    (8 * 1024 * 1024, 32): 16,
+    (64 * 1024 * 1024, 4): 4,
+    (64 * 1024 * 1024, 8): 4,
+    (64 * 1024 * 1024, 16): 8,
+    (64 * 1024 * 1024, 32): 16,
+    (256 * 1024 * 1024, 4): 4,
+    (256 * 1024 * 1024, 8): 8,
+    (256 * 1024 * 1024, 16): 16,
+    (256 * 1024 * 1024, 32): 16,
+    (1024 * 1024 * 1024, 4): 4,
+    (1024 * 1024 * 1024, 8): 8,
+    (1024 * 1024 * 1024, 16): 16,
+    (1024 * 1024 * 1024, 32): 32,
+}
+
+
+def _triton_num_blocks_uni(msg_bytes: int, cap: int) -> int:
+    """Triton uni grid = num_blocks. Match NCCL runtime grid exactly."""
+    return _NCCL_GRID_TABLE[(msg_bytes, cap)]
+
+
+def _triton_num_blocks_bi(msg_bytes: int, cap: int) -> int:
+    """Triton bi grid = 2 * num_blocks. Half the NCCL grid; minimum 1.
+
+    At cells where NCCL bi grid = 1, Triton bi grid = 2 (slight
+    Triton-side over-provision; disclosed in module docstring).
+    """
+    return max(_NCCL_GRID_TABLE[(msg_bytes, cap)] // 2, 1)
+
+
+# Per-message iteration counts. The 64 KB / 64 MiB thresholds split the
+# sweep into three latency regimes:
+#   * <= 64 KB: copy time is microseconds; per-replay timing variance is
+#     a meaningful fraction of the signal, so 500 replays drives stderr
+#     down without inflating wall clock.
+#   * 64 KB – 64 MiB: bandwidth-bound regime; 200 replays is enough for
+#     stable means.
+#   * > 64 MiB: each replay is milliseconds, 50 replays keeps the full
+#     sweep under a couple of minutes per cap.
+def _iters_for_size(msg_bytes: int) -> int:
+    if msg_bytes <= 64 * 1024:
+        return 500
+    if msg_bytes <= 64 * 1024 * 1024:
+        return 200
+    return 50
+
+
+# Empirically chosen on H100: 20 replays is enough for steady-state SM
+# clock / cache state on the timed graph, and 3 capture-warmup replays
+# is enough to populate any first-call lazy state inside ``fn`` (e.g.,
+# Triton autotune cache, NCCL communicator hot path) before capture.
+_WARMUP_ITERS: int = 20
+_CAPTURE_WARMUP_ITERS: int = 3
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _capture_one_call(fn: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    """Warm up ``fn`` on a side stream, then capture a single call into a graph.
+
+    Standard PyTorch CUDA-graph capture pattern (see
+    https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs):
+
+      1. Warm up on a non-default stream so the kernel's JIT compile,
+         allocator, and any communicator setup happens before capture.
+      2. Make the current stream wait for the warmup to finish.
+      3. Capture a single ``fn`` call into the graph using the same
+         non-default stream.
+
+    The caller is responsible for ensuring ``fn`` does no Python-level
+    allocation that hasn't already happened by the time this helper
+    returns — graph replay only re-runs the recorded GPU ops.
+    """
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(_CAPTURE_WARMUP_ITERS):
+            fn()
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=side_stream):
+        fn()
+    return g
+
+
+def _time_replays(
+    g: torch.cuda.CUDAGraph,
+    iters: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+) -> float:
+    """Time ``iters`` replays of ``g`` using CUDA events. Returns μs/iter."""
+    for _ in range(_WARMUP_ITERS):
+        g.replay()
+    torch.cuda.synchronize(device)
+    # Align ranks at the start of the timed window so warmup skew on either
+    # side does not inflate the first few timed replays.
+    dist.barrier(group)
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        g.replay()
+    end.record()
+    torch.cuda.synchronize(device)
+    elapsed_ms = start.elapsed_time(end)
+    return (elapsed_ms * 1000.0) / iters
+
+
+def _max_rank_latency(
+    lat_us: float,
+    device: torch.device,
+    group: dist.ProcessGroup,
+) -> float:
+    latency = torch.tensor([lat_us], dtype=torch.float64, device=device)
+    dist.all_reduce(latency, op=dist.ReduceOp.MAX, group=group)
+    return float(latency.item())
+
+
+def _bench_triton(
+    msg_bytes: int,
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    num_blocks: int,
+) -> tuple[float, float]:
+    """Bench Triton send/recv via CUDA-graph replay. Returns (μs, GB/s)."""
+    device = torch.device(f"cuda:{local_rank}")
+    numel = max(msg_bytes // torch.bfloat16.itemsize, 1)
+    send: torch.Tensor = torch.ones(numel, dtype=torch.bfloat16, device=device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=torch.bfloat16, device=device)
+
+    def fn() -> None:
+        if bidirectional:
+            triton_nvl_sendrecv(
+                send, recv, peer_rank, group=group, num_blocks=num_blocks
+            )
+        elif local_rank == 0:
+            triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+        else:
+            triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+
+    fn()
+    dist.barrier(group)
+
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat_us = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    bw_gbps = (msg_bytes / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+    if bidirectional or local_rank == 1:
+        torch.cuda.synchronize(device)
+        expected = torch.ones(numel, dtype=torch.bfloat16, device=device)
+        assert torch.equal(recv, expected), (
+            f"Triton bench correctness check failed at msg_bytes={msg_bytes}, "
+            f"bidirectional={bidirectional}, num_blocks={num_blocks}"
+        )
+    return lat_us, bw_gbps
+
+
+def _bench_nccl(
+    msg_bytes: int,
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+) -> tuple[float, float]:
+    """Bench NCCL ``batch_isend_irecv`` via CUDA-graph replay. Returns (μs, GB/s).
+
+    NCCL channel allocation is set by ``NCCL_{MIN,MAX}_NCHANNELS`` in
+    the parent ``main()`` before ``mp.spawn``; per-call runtime grid is
+    NCCL's adaptive choice (captured in ``_NCCL_GRID_TABLE``).
+    """
+    device = torch.device(f"cuda:{local_rank}")
+    numel = max(msg_bytes // torch.bfloat16.itemsize, 1)
+    send: torch.Tensor = torch.ones(numel, dtype=torch.bfloat16, device=device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=torch.bfloat16, device=device)
+
+    def fn() -> None:
+        if bidirectional:
+            ops = [
+                dist.P2POp(dist.isend, send, peer_rank, group=group),
+                dist.P2POp(dist.irecv, recv, peer_rank, group=group),
+            ]
+        elif local_rank == 0:
+            ops = [dist.P2POp(dist.isend, send, peer_rank, group=group)]
+        else:
+            ops = [dist.P2POp(dist.irecv, recv, peer_rank, group=group)]
+        reqs = dist.batch_isend_irecv(ops)
+        for r in reqs:
+            r.wait()
+
+    fn()
+    dist.barrier(group)
+
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat_us = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    bw_gbps = (msg_bytes / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+    if bidirectional or local_rank == 1:
+        torch.cuda.synchronize(device)
+        expected = torch.ones(numel, dtype=torch.bfloat16, device=device)
+        assert torch.equal(recv, expected), (
+            f"NCCL bench correctness check failed at msg_bytes={msg_bytes}, "
+            f"bidirectional={bidirectional}"
+        )
+    return lat_us, bw_gbps
+
+
+def _fmt_size(b: int) -> str:
+    units = [("B", 1), ("KB", 1024), ("MB", 1024**2), ("GB", 1024**3)]
+    for name, scale in reversed(units):
+        if b >= scale:
+            return f"{b // scale}{name}" if b % scale == 0 else f"{b / scale:.1f}{name}"
+    return f"{b}B"
+
+
+def _print_header(rank: int, title: str) -> None:
+    if rank != 0:
+        return
+    print()
+    print("=" * 100)
+    print(title)
+    print(
+        f"{'msg_size':>10} | {'iters':>6} | {'tri_nb':>6} {'nccl_grid':>9} | "
+        f"{'triton_us':>10} {'triton_GB/s':>12} | "
+        f"{'nccl_us':>10} {'nccl_GB/s':>12} | {'speedup':>8}"
+    )
+    print("-" * 100)
+
+
+def _print_row(
+    rank: int,
+    msg_bytes: int,
+    iters: int,
+    triton_num_blocks: int,
+    nccl_grid: int,
+    triton_us: float,
+    triton_bw: float,
+    nccl_us: float,
+    nccl_bw: float,
+) -> None:
+    if rank != 0:
+        return
+    speedup = nccl_us / triton_us if triton_us > 0 else 0.0
+    print(
+        f"{_fmt_size(msg_bytes):>10} | {iters:>6} | {triton_num_blocks:>6} {nccl_grid:>9} | "
+        f"{triton_us:>10.2f} {triton_bw:>12.3f} | "
+        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x"
+    )
+
+
+def _run_table(
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    cap: int,
+) -> None:
+    direction = (
+        "Bidirectional sendrecv"
+        if bidirectional
+        else "Unidirectional rank0->rank1 send/recv"
+    )
+    title = f"{direction} | NCCL_NCHANNELS=cap={cap} (Triton num_blocks tracks NCCL runtime grid)"
+    _print_header(local_rank, title)
+    for msg_bytes in _MSG_SIZES_BYTES:
+        nccl_grid = _NCCL_GRID_TABLE[(msg_bytes, cap)]
+        if bidirectional:
+            triton_nb = _triton_num_blocks_bi(msg_bytes, cap)
+        else:
+            triton_nb = _triton_num_blocks_uni(msg_bytes, cap)
+
+        triton_us, triton_bw = _bench_triton(
+            msg_bytes,
+            local_rank,
+            peer_rank,
+            group,
+            bidirectional=bidirectional,
+            num_blocks=triton_nb,
+        )
+        dist.barrier(group)
+        nccl_us, nccl_bw = _bench_nccl(
+            msg_bytes, local_rank, peer_rank, group, bidirectional=bidirectional
+        )
+        dist.barrier(group)
+        _print_row(
+            local_rank,
+            msg_bytes,
+            _iters_for_size(msg_bytes),
+            triton_nb,
+            nccl_grid,
+            triton_us,
+            triton_bw,
+            nccl_us,
+            nccl_bw,
+        )
+
+
+def _worker(local_rank: int, master_port: int, cap: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+    # Pin NCCL channel allocation to ``cap`` for the lifetime of this
+    # process. Note: this only sets the allocation cap; NCCL's adaptive
+    # in-kernel grid policy decides how many of those channels to
+    # actually use per call (captured in ``_NCCL_GRID_TABLE``).
+    os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
+    os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+    peer_rank = 1 - local_rank
+
+    if local_rank == 0:
+        print()
+        print("#" * 100)
+        print(f"# NCCL_{{MIN,MAX}}_NCHANNELS = {cap}")
+        print(
+            "# Triton uni: num_blocks = NCCL runtime grid; "
+            "Triton bi: num_blocks = max(NCCL runtime grid // 2, 1)."
+        )
+        print("# BW = unidirectional payload bytes / latency.")
+        print("#" * 100)
+
+    _run_table(local_rank, peer_rank, group, bidirectional=False, cap=cap)
+    dist.barrier(group)
+    _run_table(local_rank, peer_rank, group, bidirectional=True, cap=cap)
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+
+
+def main() -> None:
+    print("Triton NVLink Copy-Based SendRecv vs NCCL batch_isend_irecv")
+    print("Runtime-SM-matched 2-rank sweep via CUDA-graph replay.")
+    print(
+        "Triton num_blocks set per-cell to match NCCL adaptive runtime grid "
+        f"(see _NCCL_GRID_TABLE); cap sweep: {_CAPS}"
+    )
+
+    for cap in _CAPS:
+        os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
+        os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
+        port = _find_free_port()
+        try:
+            mp.spawn(_worker, args=(port, cap), nprocs=2, join=True)
+        except Exception as e:
+            print(f"benchmark failed at cap={cap}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -1,0 +1,358 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Correctness tests for NVLink copy-based Triton send/recv."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.pipes.triton.collectives.nvl.sendrecv_op import (
+    triton_nvl_recv,
+    triton_nvl_send,
+    triton_nvl_sendrecv,
+)
+
+
+_BASE_CASES: list[tuple[str, int]] = [
+    ("small_64KB", 64 * 1024),
+    ("medium_1MB", 1024 * 1024),
+    ("large_16MB", 16 * 1024 * 1024),
+]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _numel(msg_bytes: int, dtype: torch.dtype) -> int:
+    return max(msg_bytes // dtype.itemsize, 1)
+
+
+def _make_pattern(
+    rank: int, numel: int, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    if dtype == torch.int32:
+        idx = torch.arange(numel, dtype=torch.int32, device=device)
+        return (idx & 0x00FFFFFF) | (int(rank) << 24)
+    return torch.full((numel,), float(rank + 1), dtype=dtype, device=device)
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _check_equal(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    label: str,
+    local_rank: int,
+) -> bool:
+    ok = torch.equal(actual, expected)
+    if not ok:
+        n_wrong = (actual != expected).sum().item()
+        print(
+            f"  FAIL(rank {local_rank}): {label} — {n_wrong}/{actual.numel()} mismatched, "
+            f"first-10 expected={expected[:10].tolist()} got={actual[:10].tolist()}"
+        )
+    return ok
+
+
+def _run_unidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    src_rank: int,
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+    num_warps: int = 8,
+) -> bool:
+    peer_rank = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    if local_rank == src_rank:
+        send = _make_pattern(local_rank, numel, dtype, device)
+        triton_nvl_send(
+            send, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+        )
+        local_ok = True
+    else:
+        recv = torch.zeros(numel, dtype=dtype, device=device)
+        expected = _make_pattern(peer_rank, numel, dtype, device)
+        triton_nvl_recv(
+            recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+        )
+        torch.cuda.synchronize(device)
+        local_ok = _check_equal(recv, expected, name, local_rank)
+
+    torch.cuda.synchronize(device)
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_bidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+    num_warps: int = 8,
+) -> bool:
+    peer_rank = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+    send = _make_pattern(local_rank, numel, dtype, device)
+    recv = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(peer_rank, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send, recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+    )
+    torch.cuda.synchronize(device)
+
+    ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_back_to_back(
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    graph: bool,
+) -> bool:
+    peer_rank: int = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    configs: list[tuple[int, int]] = [
+        (64 * 1024, 2),
+        (16 * 1024 * 1024, 32),
+        (256 * 1024, 16),
+    ]
+    dtype = torch.int32
+    sends: list[torch.Tensor] = []
+    recvs: list[torch.Tensor] = []
+    expected: list[torch.Tensor] = []
+    for msg_bytes, _ in configs:
+        numel = _numel(msg_bytes, dtype)
+        sends.append(_make_pattern(local_rank, numel, dtype, device))
+        recvs.append(torch.zeros(numel, dtype=dtype, device=device))
+        expected.append(_make_pattern(peer_rank, numel, dtype, device))
+
+    def sequence() -> None:
+        for i, (_, num_blocks) in enumerate(configs):
+            send = sends[i]
+            recv = recvs[i]
+            if bidirectional:
+                triton_nvl_sendrecv(
+                    send, recv, peer_rank, group=group, num_blocks=num_blocks
+                )
+            elif local_rank == 0:
+                triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+            else:
+                triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+
+    if graph:
+        sequence()
+        torch.cuda.synchronize(device)
+        graph_obj = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph_obj):
+            sequence()
+        for _ in range(5):
+            graph_obj.replay()
+    else:
+        sequence()
+    torch.cuda.synchronize(device)
+
+    if bidirectional or local_rank == 1:
+        local_ok = all(
+            _check_equal(actual, exp, "back_to_back", local_rank)
+            for actual, exp in zip(recvs, expected)
+        )
+    else:
+        local_ok = True
+
+    label = (
+        f"{'bidirectional' if bidirectional else 'unidirectional'}_"
+        f"back_to_back_{'graph' if graph else 'eager'}"
+    )
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {label}")
+    return ok
+
+
+def _run_graph_case(
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+) -> bool:
+    peer_rank: int = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+    numel = _numel(256 * 1024, dtype)
+    send: torch.Tensor = _make_pattern(local_rank, numel, dtype, device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(peer_rank, numel, dtype, device)
+
+    def fn() -> None:
+        if bidirectional:
+            triton_nvl_sendrecv(send, recv, peer_rank, group=group)
+        elif local_rank == 0:
+            triton_nvl_send(send, peer_rank, group=group)
+        else:
+            triton_nvl_recv(recv, peer_rank, group=group)
+
+    fn()
+    torch.cuda.synchronize(device)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+
+    local_ok = True
+    for _ in range(5):
+        recv.zero_()
+        g.replay()
+        torch.cuda.synchronize(device)
+        if bidirectional or local_rank == 1:
+            local_ok = local_ok and _check_equal(
+                recv, expected, "cuda_graph", local_rank
+            )
+
+    label = f"{'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {label}")
+    return ok
+
+
+def _record(
+    results: list[bool], fn: Callable[[], bool], group: dist.ProcessGroup
+) -> None:
+    results.append(fn())
+    dist.barrier(group)
+
+
+def _worker(local_rank: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+    for name, msg_bytes in _BASE_CASES:
+        _record(
+            results,
+            lambda name=name, msg_bytes=msg_bytes: _run_bidirectional(
+                f"bidirectional_{name}_int32", msg_bytes, torch.int32, local_rank, group
+            ),
+            group,
+        )
+
+    for dtype in (torch.bfloat16, torch.float32):
+        _record(
+            results,
+            lambda dtype=dtype: _run_bidirectional(
+                f"bidirectional_64KB_{dtype}_smoke",
+                64 * 1024,
+                dtype,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    for src_rank in (0, 1):
+        _record(
+            results,
+            lambda src_rank=src_rank: _run_unidirectional(
+                f"unidirectional_{src_rank}_to_{1 - src_rank}_1MB",
+                1024 * 1024,
+                torch.int32,
+                src_rank,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    for num_blocks in (2, 16, 32):
+        for num_warps in (4, 8):
+            _record(
+                results,
+                lambda num_blocks=num_blocks, num_warps=num_warps: _run_bidirectional(
+                    f"config_blocks_{num_blocks}_warps_{num_warps}",
+                    256 * 1024,
+                    torch.int32,
+                    local_rank,
+                    group,
+                    num_blocks=num_blocks,
+                    num_warps=num_warps,
+                ),
+                group,
+            )
+
+    for bidirectional in (False, True):
+        for graph in (False, True):
+            _record(
+                results,
+                lambda bidirectional=bidirectional, graph=graph: _run_back_to_back(
+                    local_rank, group, bidirectional=bidirectional, graph=graph
+                ),
+                group,
+            )
+
+    for bidirectional in (False, True):
+        _record(
+            results,
+            lambda bidirectional=bidirectional: _run_graph_case(
+                local_rank, group, bidirectional=bidirectional
+            ),
+            group,
+        )
+
+    if local_rank == 0:
+        n_pass = sum(1 for ok in results if ok)
+        print(f"\nResults: {n_pass}/{len(results)} passed")
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+    if local_rank == 0 and not all(results):
+        sys.exit(1)
+
+
+def main() -> None:
+    port = _find_free_port()
+    print("Running Triton NVLink SendRecv Correctness Tests")
+    print("=" * 52)
+    mp.spawn(_worker, args=(port,), nprocs=2, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/pipes/triton/collectives/nvl/utils.py
+++ b/comms/pipes/triton/collectives/nvl/utils.py
@@ -1,0 +1,174 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton device-side helpers for NVLink copy-based collectives."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def get_tid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %tid.x;
+        mov.u32 $1, %tid.y;
+        mov.u32 $2, %tid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_ntid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %ntid.x;
+        mov.u32 $1, %ntid.y;
+        mov.u32 $2, %ntid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_flat_tid():
+    tid_x, tid_y, tid_z = get_tid()
+    ntid_x, ntid_y, _ = get_ntid()
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def sync_threads():
+    """Block-scope barrier (``bar.sync 0``).
+
+    Triton's implicit ``__syncthreads`` is not always emitted around inline
+    asm sections, so we emit one explicitly when the protocol requires
+    cross-warp ordering inside a block.
+    """
+    tl.inline_asm_elementwise(
+        "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+    )
+
+
+@triton.jit
+def wait_ge(addr, target):
+    """Acquire-poll int64 until ``*addr >= target``.
+
+    All reads are LOCAL (no NVLink load). Used by the **receiver** to poll the
+    local TAIL counter — the acquire memory order pairs with the sender's
+    ``fence_and_remote_store_i64`` (release) so the receiver's subsequent
+    staging-buffer reads observe the sender's writes.
+
+    The sender's HEAD poll uses the volatile-only :func:`wait_ge_volatile`
+    instead, because the receiver's HEAD update does not publish payload data
+    (see :func:`remote_store_i64_relaxed`).
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u64   %tmp64_<1>;
+            .reg .pred  %p<1>;
+
+            wait_ge:
+                ld.global.acquire.sys.b64 %tmp64_0, [$1];
+                setp.lt.u64 %p0, %tmp64_0, $2;
+                @%p0 bra wait_ge;
+        }
+        """,
+        "=r, l, l",
+        [addr, target],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def wait_ge_volatile(addr, target):
+    """Volatile-poll int64 until ``*addr >= target``.
+
+    Use for credit counters that only transfer staging-slot ownership. The
+    counter does not publish payload data, so the polling load does not need
+    acquire semantics.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u64   %tmp64_<1>;
+            .reg .pred  %p<1>;
+
+            wait_ge_volatile:
+                ld.volatile.global.u64 %tmp64_0, [$1];
+                setp.lt.u64 %p0, %tmp64_0, $2;
+                @%p0 bra wait_ge_volatile;
+        }
+        """,
+        "=r, l, l",
+        [addr, target],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def fence_and_remote_store_i64(addr, val):
+    """System fence + REMOTE int64 store for monotonic counter advancement.
+
+    Drains all prior writes (staging buffer data) so the remote rank's
+    acquire-load of the counter sees the data. The store itself is
+    relaxed because the fence has already provided release ordering.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            fence.acq_rel.sys;
+            st.global.relaxed.sys.b64 [$1], $2;
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r, l, l",
+        [addr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def remote_store_i64_relaxed(addr, val):
+    """REMOTE relaxed int64 store **without** a preceding system fence.
+
+    For credit signals that only transfer staging-slot ownership, where the
+    consumer side does not read any payload published by the producer of the
+    signal.
+
+    A local execution barrier (e.g. ``sync_threads``) before this store is
+    sufficient to ensure all prior reads inside the producer block have
+    completed before the credit is posted. Do **not** use this for signals
+    that publish payload data (e.g. sender→receiver TAIL); use
+    :func:`fence_and_remote_store_i64` for those.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            st.global.relaxed.sys.b64 [$1], $2;
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r, l, l",
+        [addr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )


### PR DESCRIPTION
Summary:

Closes the medium/large message performance gap between the Triton NVLink sendrecv kernel and NCCL P2P Simple.

**Root cause**: the Triton compiler inserts shared-memory swizzle (STSM/LDSM) when the store destination is a pointer loaded at runtime via `tl.load(ptr_tensor).to(pointer_type(...))`. This forces 16-bit scalar stores (`STG.E.U16`) instead of 128-bit vectorized stores (`STG.E.128`), producing 8x instruction overhead on the store path.

**Fix**: pass the staging buffer and signal pad as direct typed tensor arguments obtained via `handle.get_buffer(rank, ...)` and `handle.get_signal_pad(rank).view(torch.int64)`. The compiler sees these as first-class typed pointers and emits `LDG.E.128 + STG.E.128` — the same pattern NCCL uses with `uint4`.

**Key insight**: a systematic ablation of 11 Triton kernel variants isolated the exact boundary. 2D tile indexing, while loops, staging offsets, inline ASM fences, `bar.sync` — all produce vectorized stores. The sole trigger for the swizzle is `tl.load(ptr_tensor).to(pointer_type(...))`.

Unidirectional results on H100, runtime-SM-matched (cap=4):

```
  msg_size |   before GB/s |    after GB/s |  nccl GB/s | after/nccl
       1MB |         28.5  |        44.2   |      41.5  |   1.06x
       8MB |         40.2  |        59.8   |      66.1  |   0.94x
      64MB |         78.2  |       120.9   |     131.5  |   0.92x
     256MB |         78.9  |       122.0   |     132.0  |   0.92x
       1GB |         79.1  |       122.3   |     132.6  |   0.92x
```

cap=16:
```
       1MB |         42.5  |        67.6   |      53.1  |   1.27x
       1GB |        157.9  |       241.8   |     263.7  |   0.92x
```

Closes the gap from ~0.60x to ~0.92x at large messages, with 1.5x throughput improvement over the previous kernel.

Reviewed By: cenzhaometa

Differential Revision: D105983710


