### PR TITLE
Enable pipes by default for NCCLX builds (#2672)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -6,7 +6,7 @@
 #
 
 ENABLE_TCPDM ?= 0
-ENABLE_PIPES ?= 0
+ENABLE_PIPES ?= 1
 
 # Assuming calling from src directory
 SRCDIR = $(abspath ./)

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -6,7 +6,7 @@
 #
 
 ENABLE_TCPDM ?= 0
-ENABLE_PIPES ?= 0
+ENABLE_PIPES ?= 1
 
 # Assuming calling from src directory
 SRCDIR = $(abspath ./)


### PR DESCRIPTION
Summary:

Enable `ENABLE_PIPES` by default for the NCCLX 2.29 and 2.30 source Makefiles, and force pipes on for the `nccl` and `torchcomms` conda feedstocks. The `nccl` recipe now always includes the `pipes` dependency so flagship TOML `ENABLE_PIPES = "0"` entries do not disable the conda build path.

Reviewed By: siyengar

Differential Revision: D106141756


