### PR TITLE
Fix IBGDA tile byte cursor flow control (#2673)

### DIFF
--- a/comms/pipes/IbgdaBuffer.h
+++ b/comms/pipes/IbgdaBuffer.h
@@ -431,8 +431,8 @@ struct IbgdaBufferExchInfo {
  *     If max_signal_bytes is smaller than perBlockSlot, each per-block region
  *     is further subdivided into signaled sub-chunks:
  *       chunkSize = floor16(min(perBlockSlot, max_signal_bytes))
- *       chunksPerSlot = perBlockSlot / chunkSize
- *     stepState counts these sub-chunks, not whole slots.
+ *     stepState counts bytes, not sub-chunks, so max_signal_bytes may change
+ *     between calls as long as active_blocks is unchanged.
  *
  *   signalBuf: 2 * maxGroups * sizeof(uint64_t).
  *     [0, maxGroups)             — DATA_READY (sender -> receiver)
@@ -442,8 +442,8 @@ struct IbgdaBufferExchInfo {
  *     [0, maxGroups)             — NIC_DONE counters (loopback atomic)
  *
  *   stepState: 2 * maxGroups * sizeof(int64_t).
- *     [0, maxGroups)             — sender step counters
- *     [maxGroups, 2*maxGroups)   — receiver step counters
+ *     [0, maxGroups)             — sender byte cursors
+ *     [maxGroups, 2*maxGroups)   — receiver byte cursors
  */
 struct IbSendRecvState {
   IbgdaLocalBuffer
@@ -456,7 +456,7 @@ struct IbSendRecvState {
   IbgdaLocalBuffer localSignalBuf; ///< Signal inbox (DATA_READY + SLOT_FREE)
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
-  int64_t* stepState{nullptr}; ///< Per-group step counters
+  int64_t* stepState{nullptr}; ///< Per-group byte cursors
   int maxGroups{0}; ///< Layout size for signals/step arrays
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring
   std::size_t dataBufferSize{0}; ///< Size of one pipeline slot in bytes

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -1140,15 +1140,14 @@ class P2pIbgdaTransportDevice {
   //                      send()/recv() call. Must be <= maxGroups.
   //   perBlockSlot     = one block-group's partition within a slot:
   //                      (dataBufferSize / active_blocks) & ~15ULL
-  //   sub-chunk        = one signaled piece within a perBlockSlot. When
+  //   sub-chunk        = one signaled byte range within a perBlockSlot. When
   //                      max_signal_bytes == 0, a sub-chunk is the whole
   //                      perBlockSlot. Otherwise:
   //                        chunkSize = floor16(min(perBlockSlot,
   //                                             max_signal_bytes))
-  //                        chunksPerSlot = perBlockSlot / chunkSize
-  //   stepState        = persistent sub-chunk cursor. It advances by one per
-  //                      DATA_READY / SLOT_FREE / NIC_DONE event, not one per
-  //                      whole slot.
+  //   stepState        = persistent byte cursor. DATA_READY, SLOT_FREE, and
+  //                      NIC_DONE counters also advance by bytes, which keeps
+  //                      cursor state independent of max_signal_bytes.
   //
   // Typical usage:
   //   auto [role, sub] = group.partition(2);
@@ -1174,9 +1173,9 @@ class P2pIbgdaTransportDevice {
    * Signaling protocol (per group):
    *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
    *                send waits on this before overwriting local sendStaging.
-   *   SLOT_FREE  — receiver increments per sub-chunk (symmetric with
-   *                DATA_READY). send waits before overwriting recvStaging.
-   *   DATA_READY — sender increments per sub-chunk, piggybacked on put.
+   *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
+   *                range. send waits before overwriting recvStaging.
+   *   DATA_READY — sender increments by bytesThis, piggybacked on put.
    *                recv waits on this before reading recvStaging.
    *
    * stepState persists across calls, so send() resumes the staging-ring cursor
@@ -1184,9 +1183,9 @@ class P2pIbgdaTransportDevice {
    * pipeline across repeated send() calls without a separate drain.
    *
    * The caller must keep the staging layout stable while a sequence is in
-   * flight. If active_blocks, max_signal_bytes, or any other parameter that
-   * changes the slot/sub-chunk mapping is modified, both sides must perform a
-   * higher-level barrier/quiescence step before issuing the next send()/recv().
+   * flight. Changing active_blocks changes the per-block staging partition, so
+   * both sides must perform a higher-level barrier/quiescence step first.
+   * max_signal_bytes may vary across calls with the same active_blocks.
    *
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
@@ -1262,38 +1261,37 @@ class P2pIbgdaTransportDevice {
     if (chunkSize == 0) {
       chunkSize = perBlockSlot;
     }
-    const std::size_t chunksPerSlot = perBlockSlot / chunkSize;
-    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
 
-    const int64_t baseStep = sendRecvState_.stepState[groupId];
     const int pipelineDepth = sendRecvState_.pipelineDepth;
     const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
     const int maxGroups = sendRecvState_.maxGroups;
-    const int64_t chunksPerSlot64 = static_cast<int64_t>(chunksPerSlot);
-    const int64_t pipelineChunks =
-        static_cast<int64_t>(pipelineDepth) * chunksPerSlot64;
+    const uint64_t baseByte =
+        static_cast<uint64_t>(sendRecvState_.stepState[groupId]);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
 
-    for (std::size_t s = 0; s < totalChunks; ++s) {
-      const int64_t chunkStep = baseStep + static_cast<int64_t>(s);
-      const int64_t slotStep = chunkStep / chunksPerSlot64;
-      const int64_t subStep = chunkStep % chunksPerSlot64;
-      const int slot = static_cast<int>(slotStep % pipelineDepth);
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
       const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff =
-          static_cast<std::size_t>(subStep) * chunkSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
       const std::size_t stagingOff =
           slotOff + groupId * perBlockSlot + chunkOff;
-      const std::size_t dataOff = s * chunkSize;
-      const std::size_t bytesThis =
-          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
+      const uint64_t streamEnd = streamStart + bytesThis;
 
       // (1) Wait for NIC to finish with this slot's local sendStaging.
-      if (chunkStep >= pipelineChunks) {
+      if (streamEnd > pipelineBytes) {
         wait_counter(
             group,
             sendRecvState_.localCounterBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            static_cast<uint64_t>(chunkStep - pipelineChunks + 1),
+            streamEnd - pipelineBytes,
             timeout);
       }
 
@@ -1307,14 +1305,14 @@ class P2pIbgdaTransportDevice {
           args...);
       group.sync();
 
-      // (3) Backpressure: wait for receiver to free this sub-chunk's
-      //     recvStaging offset. Symmetric with DATA_READY (per sub-chunk).
-      if (chunkStep >= pipelineChunks) {
+      // (3) Backpressure: wait for receiver to free this byte range's
+      //     recvStaging offset. Symmetric with DATA_READY.
+      if (streamEnd > pipelineBytes) {
         wait_signal(
             group,
             sendRecvState_.localSignalBuf.subBuffer(
                 (maxGroups + groupId) * sizeof(uint64_t)),
-            static_cast<uint64_t>(chunkStep - pipelineChunks + 1),
+            streamEnd - pipelineBytes,
             timeout);
       }
 
@@ -1331,17 +1329,18 @@ class P2pIbgdaTransportDevice {
             bytesThis,
             sendRecvState_.remoteSignalBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            1ULL,
+            bytesThis,
             sendRecvState_.localCounterBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            1ULL);
+            bytesThis);
       }
       group.sync();
+      dataOff += bytesThis;
     }
 
     if (group.is_leader()) {
       sendRecvState_.stepState[groupId] =
-          baseStep + static_cast<int64_t>(totalChunks);
+          static_cast<int64_t>(baseByte + nbytes);
     }
     group.sync();
 #endif
@@ -1357,9 +1356,9 @@ class P2pIbgdaTransportDevice {
    * match the sender.
    *
    * Signaling protocol (per group, symmetric with send):
-   *   DATA_READY — sender increments per sub-chunk after RDMA put completes.
+   *   DATA_READY — sender increments by bytesThis after RDMA put completes.
    *                recv waits on this before copying from recvStaging.
-   *   SLOT_FREE  — recv increments per sub-chunk (symmetric with DATA_READY)
+   *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
    *                to release backpressure on sender.
    *
    * @param group           ThreadGroup (all threads participate in memcpy,
@@ -1437,35 +1436,35 @@ class P2pIbgdaTransportDevice {
     if (chunkSize == 0) {
       chunkSize = perBlockSlot;
     }
-    const std::size_t chunksPerSlot = perBlockSlot / chunkSize;
-    const std::size_t totalChunks = (nbytes + chunkSize - 1) / chunkSize;
 
-    const int64_t baseStep =
-        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId];
     const int pipelineDepth = sendRecvState_.pipelineDepth;
     const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
     const int maxGroups = sendRecvState_.maxGroups;
-    const int64_t chunksPerSlot64 = static_cast<int64_t>(chunksPerSlot);
+    const uint64_t baseByte = static_cast<uint64_t>(
+        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId]);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
 
-    for (std::size_t s = 0; s < totalChunks; ++s) {
-      const int64_t chunkStep = baseStep + static_cast<int64_t>(s);
-      const int64_t slotStep = chunkStep / chunksPerSlot64;
-      const int64_t subStep = chunkStep % chunksPerSlot64;
-      const int slot = static_cast<int>(slotStep % pipelineDepth);
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
       const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff =
-          static_cast<std::size_t>(subStep) * chunkSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
       const std::size_t stagingOff =
           slotOff + groupId * perBlockSlot + chunkOff;
-      const std::size_t dataOff = s * chunkSize;
-      const std::size_t bytesThis =
-          (dataOff + chunkSize <= nbytes) ? chunkSize : (nbytes - dataOff);
+      const uint64_t streamEnd = streamStart + bytesThis;
 
       // (1) Wait for sender's DATA_READY signal.
       wait_signal(
           group,
           sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          static_cast<uint64_t>(chunkStep + 1),
+          streamEnd,
           timeout);
 
       // (2) Cooperative copy: local recvStaging → dst via CopyOp.
@@ -1478,19 +1477,19 @@ class P2pIbgdaTransportDevice {
           args...);
       group.sync();
 
-      // (3) Signal SLOT_FREE to sender — per sub-chunk (symmetric with
-      //     DATA_READY). Sender waits per sub-chunk before reusing remote
-      //     recvStaging at the same offset.
+      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
+      //     threshold before reusing remote recvStaging at the same offset.
       signal(
           group,
           sendRecvState_.remoteSignalBuf.subBuffer(
               (maxGroups + groupId) * sizeof(uint64_t)),
-          1ULL);
+          bytesThis);
+      dataOff += bytesThis;
     }
 
     if (group.is_leader()) {
       sendRecvState_.stepState[sendRecvState_.maxGroups + groupId] =
-          baseStep + static_cast<int64_t>(totalChunks);
+          static_cast<int64_t>(baseByte + nbytes);
     }
     group.sync();
 #endif
@@ -1641,83 +1640,67 @@ class P2pIbgdaTransportDevice {
       fwdChunkSize = fwdPerBlockSlot;
     }
 
-    const std::size_t recvChunksPerSlot = recvPerBlockSlot / recvChunkSize;
-    const std::size_t fwdChunksPerSlot = fwdPerBlockSlot / fwdChunkSize;
-    const std::size_t totalRecvChunks =
-        (nbytes + recvChunkSize - 1) / recvChunkSize;
-    const std::size_t totalFwdChunks =
-        (nbytes + fwdChunkSize - 1) / fwdChunkSize;
-
-    // Step state
-    const int64_t recvBaseStep =
-        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId];
     const int recvPipelineDepth = sendRecvState_.pipelineDepth;
     const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
     const int recvMaxGroups = sendRecvState_.maxGroups;
-    const int64_t recvChunksPerSlot64 = static_cast<int64_t>(recvChunksPerSlot);
+    const uint64_t recvBaseByte = static_cast<uint64_t>(
+        sendRecvState_.stepState[sendRecvState_.maxGroups + groupId]);
+    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
 
-    const int64_t fwdBaseStep = fwd.sendRecvState_.stepState[groupId];
     const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
     const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
     const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
-    const int64_t fwdChunksPerSlot64 = static_cast<int64_t>(fwdChunksPerSlot);
-    const int64_t fwdPipelineChunks =
-        static_cast<int64_t>(fwdPipelineDepth) * fwdChunksPerSlot64;
+    const uint64_t fwdBaseByte =
+        static_cast<uint64_t>(fwd.sendRecvState_.stepState[groupId]);
+    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
 
-    // Both sides process the same nbytes; chunk sizes must match so that
-    // the loop counter advances recv and fwd step states in lockstep.
-    if (totalRecvChunks != totalFwdChunks) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward chunk count mismatch: "
-            "recv=%llu fwd=%llu\n",
-            (unsigned long long)totalRecvChunks,
-            (unsigned long long)totalFwdChunks);
-      }
-      __trap();
-    }
-
-    for (std::size_t s = 0; s < totalRecvChunks; ++s) {
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
       // --- Recv side offsets ---
-      const int64_t recvChunkStep = recvBaseStep + static_cast<int64_t>(s);
-      const int64_t recvSlotStep = recvChunkStep / recvChunksPerSlot64;
-      const int64_t recvSubStep = recvChunkStep % recvChunksPerSlot64;
-      const int recvSlot = static_cast<int>(recvSlotStep % recvPipelineDepth);
+      const uint64_t recvStreamStart = recvBaseByte + dataOff;
+      const std::size_t recvPipelineOff =
+          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
       const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
       const std::size_t recvChunkOff =
-          static_cast<std::size_t>(recvSubStep) * recvChunkSize;
+          recvPipelineOff - recvSlot * recvPerBlockSlot;
       const std::size_t recvStagingOff =
           recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
-      const std::size_t dataOff = s * recvChunkSize;
-      const std::size_t bytesThis = (dataOff + recvChunkSize <= nbytes)
-          ? recvChunkSize
-          : (nbytes - dataOff);
 
       // --- Fwd side offsets ---
-      const int64_t fwdChunkStep = fwdBaseStep + static_cast<int64_t>(s);
-      const int64_t fwdSlotStep = fwdChunkStep / fwdChunksPerSlot64;
-      const int64_t fwdSubStep = fwdChunkStep % fwdChunksPerSlot64;
-      const int fwdSlot = static_cast<int>(fwdSlotStep % fwdPipelineDepth);
+      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
+      const std::size_t fwdPipelineOff =
+          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
       const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
       const std::size_t fwdChunkOff =
-          static_cast<std::size_t>(fwdSubStep) * fwdChunkSize;
+          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
       const std::size_t fwdStagingOff =
           fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
+      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t bytesThis =
+          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
+      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
+      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
 
       // (1) Wait for sender's DATA_READY.
       wait_signal(
           group,
           sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          static_cast<uint64_t>(recvChunkStep + 1),
+          recvStreamEnd,
           timeout);
 
       // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-      if (fwdChunkStep >= fwdPipelineChunks) {
+      if (fwdStreamEnd > fwdPipelineBytes) {
         fwd.wait_counter(
             group,
             fwd.sendRecvState_.localCounterBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            fwdStreamEnd - fwdPipelineBytes,
             timeout);
       }
 
@@ -1739,16 +1722,16 @@ class P2pIbgdaTransportDevice {
           group,
           sendRecvState_.remoteSignalBuf.subBuffer(
               (recvMaxGroups + groupId) * sizeof(uint64_t)),
-          1ULL);
+          bytesThis);
 
       // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
       //     recvStaging).
-      if (fwdChunkStep >= fwdPipelineChunks) {
+      if (fwdStreamEnd > fwdPipelineBytes) {
         fwd.wait_signal(
             group,
             fwd.sendRecvState_.localSignalBuf.subBuffer(
                 (fwdMaxGroups + groupId) * sizeof(uint64_t)),
-            static_cast<uint64_t>(fwdChunkStep - fwdPipelineChunks + 1),
+            fwdStreamEnd - fwdPipelineBytes,
             timeout);
       }
 
@@ -1764,20 +1747,21 @@ class P2pIbgdaTransportDevice {
             bytesThis,
             fwd.sendRecvState_.remoteSignalBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            1ULL,
+            bytesThis,
             fwd.sendRecvState_.localCounterBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
-            1ULL);
+            bytesThis);
       }
       group.sync();
+      dataOff += bytesThis;
     }
 
     // Update step state for both recv and fwd sides.
     if (group.is_leader()) {
       sendRecvState_.stepState[sendRecvState_.maxGroups + groupId] =
-          recvBaseStep + static_cast<int64_t>(totalRecvChunks);
+          static_cast<int64_t>(recvBaseByte + nbytes);
       fwd.sendRecvState_.stepState[groupId] =
-          fwdBaseStep + static_cast<int64_t>(totalRecvChunks);
+          static_cast<int64_t>(fwdBaseByte + nbytes);
     }
     group.sync();
 #endif

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -97,6 +97,11 @@ struct RemoteState {
  * P2pNvlTransportDevice via set_tile_state(). Invisible to users.
  */
 struct NvlinkTransportTileState {
+  // Persistent byte cursors:
+  //   [0, tile_max_groups) tracks send progress per tile group.
+  //   [tile_max_groups, 2 * tile_max_groups) tracks recv progress.
+  // The byte cursor is independent of max_signal_bytes, so callers may change
+  // signal granularity between calls as long as active_blocks is unchanged.
   DeviceSpan<int64_t> step_state;
   int tile_max_groups{0};
   DeviceSpan<SignalState> local_signals;
@@ -1480,36 +1485,30 @@ class P2pNvlTransportDevice {
     const std::size_t effectiveChunk =
         chunkSize > 0 ? chunkSize : perBlockSlotSize;
 
-    const std::size_t totalSteps =
-        (nbytes + effectiveChunk - 1) / effectiveChunk;
-    const std::size_t stepsPerSlot =
-        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
-    const std::size_t pipelineSteps = stepsPerSlot * options_.pipelineDepth;
+    const std::size_t pipelineBytes = perBlockSlotSize * options_.pipelineDepth;
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
-    const int64_t baseStep = tile_state_.step_state[groupId];
+    const uint64_t baseByte =
+        static_cast<uint64_t>(tile_state_.step_state[groupId]);
 
-    for (std::size_t s = 0; s < totalSteps; ++s) {
-      const int64_t step = baseStep + static_cast<int64_t>(s);
-      const std::size_t stepIndex = static_cast<std::size_t>(step);
-      const std::size_t slotStep = stepIndex / stepsPerSlot;
-      const std::size_t subStep = stepIndex % stepsPerSlot;
-      const std::size_t slot = slotStep % options_.pipelineDepth;
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const std::size_t slot = pipelineOff / perBlockSlotSize;
       const std::size_t slotOff = slot * slotSize;
-      const std::size_t chunkOff = subStep * effectiveChunk;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
+      const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t copyBytes =
+          effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+      copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      const uint64_t streamEnd = streamStart + copyBytes;
 
-      const std::size_t dataOff = s * effectiveChunk;
-      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
-          ? effectiveChunk
-          : (dataOff < nbytes ? nbytes - dataOff : 0);
-
-      if (subStep == 0 && stepIndex >= pipelineSteps) {
+      if (streamEnd > pipelineBytes) {
         tile_state_.local_signals[headSignalId].wait_until(
-            group,
-            CmpOp::CMP_GE,
-            static_cast<uint64_t>(stepIndex - pipelineSteps + 1),
-            timeout);
+            group, CmpOp::CMP_GE, streamEnd - pipelineBytes, timeout);
       }
 
       if (copyBytes > 0) {
@@ -1523,13 +1522,13 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         tile_state_.remote_signals[tailSignalId].signal(
-            SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
+            SignalOp::SIGNAL_SET, streamEnd);
       }
+      dataOff += copyBytes;
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[groupId] =
-          baseStep + static_cast<int64_t>(totalSteps);
+      tile_state_.step_state[groupId] = static_cast<int64_t>(baseByte + nbytes);
     }
     group.sync();
 #endif
@@ -1594,32 +1593,30 @@ class P2pNvlTransportDevice {
     const std::size_t effectiveChunk =
         chunkSize > 0 ? chunkSize : perBlockSlotSize;
 
-    const std::size_t totalSteps =
-        (nbytes + effectiveChunk - 1) / effectiveChunk;
-    const std::size_t stepsPerSlot =
-        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+    const std::size_t pipelineBytes = perBlockSlotSize * options_.pipelineDepth;
 
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
-    const int64_t baseStep = tile_state_.step_state[max_groups + groupId];
+    const uint64_t baseByte =
+        static_cast<uint64_t>(tile_state_.step_state[max_groups + groupId]);
 
-    for (std::size_t s = 0; s < totalSteps; ++s) {
-      const int64_t step = baseStep + static_cast<int64_t>(s);
-      const std::size_t stepIndex = static_cast<std::size_t>(step);
-      const std::size_t slotStep = stepIndex / stepsPerSlot;
-      const std::size_t subStep = stepIndex % stepsPerSlot;
-      const std::size_t slot = slotStep % options_.pipelineDepth;
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const std::size_t slot = pipelineOff / perBlockSlotSize;
       const std::size_t slotOff = slot * slotSize;
-      const std::size_t chunkOff = subStep * effectiveChunk;
-
-      const std::size_t dataOff = s * effectiveChunk;
-      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
-          ? effectiveChunk
-          : (dataOff < nbytes ? nbytes - dataOff : 0);
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
+      const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t copyBytes =
+          effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+      copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      const uint64_t streamEnd = streamStart + copyBytes;
 
       tile_state_.local_signals[tailSignalId].wait_until(
-          group, CmpOp::CMP_GE, static_cast<uint64_t>(step + 1), timeout);
+          group, CmpOp::CMP_GE, streamEnd, timeout);
 
       if (copyBytes > 0) {
         CopyOp::recv(
@@ -1633,16 +1630,18 @@ class P2pNvlTransportDevice {
 
       group.sync();
       if (group.is_leader()) {
-        if (subStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+        if (chunkOff + copyBytes == perBlockSlotSize ||
+            dataOff + copyBytes == nbytes) {
           tile_state_.remote_signals[headSignalId].signal(
-              SignalOp::SIGNAL_SET, static_cast<uint64_t>(step + 1));
+              SignalOp::SIGNAL_SET, streamEnd);
         }
       }
+      dataOff += copyBytes;
     }
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          baseStep + static_cast<int64_t>(totalSteps);
+          static_cast<int64_t>(baseByte + nbytes);
     }
     group.sync();
 #endif
@@ -1667,7 +1666,9 @@ class P2pNvlTransportDevice {
    *   to successor.remoteState_.dataBuffer)
    * - Both transports must have matching options (dataBufferSize,
    *   tile_max_groups, pipelineDepth) and consistent active_blocks /
-   *   max_signal_bytes choices across calls
+   *   active_blocks choices across calls unless callers use a barrier before
+   *   changing active_blocks. max_signal_bytes may vary across calls with the
+   *   same active_blocks.
    *
    * @param group ThreadGroup for cooperative processing (group-local)
    * @param dst Local user buffer to copy data into
@@ -1741,54 +1742,53 @@ class P2pNvlTransportDevice {
     const std::size_t effectiveChunk =
         chunkSize > 0 ? chunkSize : perBlockSlotSize;
 
-    const std::size_t totalSteps =
-        (nbytes + effectiveChunk - 1) / effectiveChunk;
-    const std::size_t stepsPerSlot =
-        (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
-    const std::size_t pipelineSteps = stepsPerSlot * options_.pipelineDepth;
+    const std::size_t pipelineBytes = perBlockSlotSize * options_.pipelineDepth;
     const uint64_t tailSignalId = groupId;
     const uint64_t headSignalId = max_groups + groupId;
 
-    // Recv side step counter (this transport: predecessor → me).
+    // Recv side byte cursor (this transport: predecessor → me).
     // Stored in step_state[max_groups + groupId], matching recv().
-    const int64_t recvBaseStep = tile_state_.step_state[max_groups + groupId];
-    // Send side step counter (successor transport: me → successor).
+    const uint64_t recvBaseByte =
+        static_cast<uint64_t>(tile_state_.step_state[max_groups + groupId]);
+    // Send side byte cursor (successor transport: me → successor).
     // Stored in step_state[groupId], matching send().
-    const int64_t sendBaseStep = successor.tile_state_.step_state[groupId];
+    const uint64_t sendBaseByte =
+        static_cast<uint64_t>(successor.tile_state_.step_state[groupId]);
 
-    for (std::size_t s = 0; s < totalSteps; ++s) {
-      const int64_t recvStep = recvBaseStep + static_cast<int64_t>(s);
-      const int64_t sendStep = sendBaseStep + static_cast<int64_t>(s);
-      const std::size_t recvStepIndex = static_cast<std::size_t>(recvStep);
-      const std::size_t recvSlotStep = recvStepIndex / stepsPerSlot;
-      const std::size_t recvSubStep = recvStepIndex % stepsPerSlot;
-      const std::size_t recvSlot = recvSlotStep % options_.pipelineDepth;
+    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+      const uint64_t recvStreamStart = recvBaseByte + dataOff;
+      const std::size_t recvPipelineOff =
+          static_cast<std::size_t>(recvStreamStart % pipelineBytes);
+      const std::size_t recvSlot = recvPipelineOff / perBlockSlotSize;
       const std::size_t recvSlotOff = recvSlot * slotSize;
-      const std::size_t recvChunkOff = recvSubStep * effectiveChunk;
-      const std::size_t sendStepIndex = static_cast<std::size_t>(sendStep);
-      const std::size_t sendSlotStep = sendStepIndex / stepsPerSlot;
-      const std::size_t sendSubStep = sendStepIndex % stepsPerSlot;
-      const std::size_t sendSlot = sendSlotStep % options_.pipelineDepth;
+      const std::size_t recvChunkOff =
+          recvPipelineOff - recvSlot * perBlockSlotSize;
+      const uint64_t sendStreamStart = sendBaseByte + dataOff;
+      const std::size_t sendPipelineOff =
+          static_cast<std::size_t>(sendStreamStart % pipelineBytes);
+      const std::size_t sendSlot = sendPipelineOff / perBlockSlotSize;
       const std::size_t sendSlotOff = sendSlot * slotSize;
-      const std::size_t sendChunkOff = sendSubStep * effectiveChunk;
-
-      const std::size_t dataOff = s * effectiveChunk;
-      const std::size_t copyBytes = (dataOff + effectiveChunk <= nbytes)
-          ? effectiveChunk
-          : (dataOff < nbytes ? nbytes - dataOff : 0);
+      const std::size_t sendChunkOff =
+          sendPipelineOff - sendSlot * perBlockSlotSize;
+      const std::size_t recvSlotRemaining = perBlockSlotSize - recvChunkOff;
+      const std::size_t sendSlotRemaining = perBlockSlotSize - sendChunkOff;
+      const std::size_t dataRemaining = nbytes - dataOff;
+      std::size_t copyBytes =
+          effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+      copyBytes = copyBytes < recvSlotRemaining ? copyBytes : recvSlotRemaining;
+      copyBytes = copyBytes < sendSlotRemaining ? copyBytes : sendSlotRemaining;
+      const uint64_t recvStreamEnd = recvStreamStart + copyBytes;
+      const uint64_t sendStreamEnd = sendStreamStart + copyBytes;
 
       // 1. Wait for predecessor data to be ready (recv side, every step).
       tile_state_.local_signals[tailSignalId].wait_until(
-          group, CmpOp::CMP_GE, static_cast<uint64_t>(recvStep + 1), timeout);
+          group, CmpOp::CMP_GE, recvStreamEnd, timeout);
 
-      // 2. Wait for successor's staging slot to be free (send side, only at
-      //    slot boundaries once we have wrapped around the pipeline).
-      if (sendSubStep == 0 && sendStepIndex >= pipelineSteps) {
+      // 2. Wait for successor's staging step to be free once we have wrapped
+      //    around the pipeline.
+      if (sendStreamEnd > pipelineBytes) {
         successor.tile_state_.local_signals[headSignalId].wait_until(
-            group,
-            CmpOp::CMP_GE,
-            static_cast<uint64_t>(sendStepIndex - pipelineSteps + 1),
-            timeout);
+            group, CmpOp::CMP_GE, sendStreamEnd - pipelineBytes, timeout);
       }
 
       // 3. Dual-dst copy: predecessor staging → local user buf +
@@ -1808,22 +1808,24 @@ class P2pNvlTransportDevice {
       if (group.is_leader()) {
         // 4. Signal successor that data is ready (send semantic: every step).
         successor.tile_state_.remote_signals[tailSignalId].signal(
-            SignalOp::SIGNAL_SET, static_cast<uint64_t>(sendStep + 1));
+            SignalOp::SIGNAL_SET, sendStreamEnd);
 
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
-        if (recvSubStep == stepsPerSlot - 1 || s == totalSteps - 1) {
+        if (recvChunkOff + copyBytes == perBlockSlotSize ||
+            dataOff + copyBytes == nbytes) {
           tile_state_.remote_signals[headSignalId].signal(
-              SignalOp::SIGNAL_SET, static_cast<uint64_t>(recvStep + 1));
+              SignalOp::SIGNAL_SET, recvStreamEnd);
         }
       }
+      dataOff += copyBytes;
     }
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          recvBaseStep + static_cast<int64_t>(totalSteps);
+          static_cast<int64_t>(recvBaseByte + nbytes);
       successor.tile_state_.step_state[groupId] =
-          sendBaseStep + static_cast<int64_t>(totalSteps);
+          static_cast<int64_t>(sendBaseByte + nbytes);
     }
     group.sync();
 #endif

--- a/comms/pipes/benchmarks/IbgdaSendRecv.cu
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.cu
@@ -17,6 +17,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   auto group = make_block_group();
 
@@ -35,10 +36,12 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
 
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
-      transport->send(sub, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      transport->send(
+          sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
-      transport->recv(sub, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+      transport->recv(
+          sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
     }
   }
 }
@@ -50,12 +53,93 @@ void launch_ibgda_send_recv(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   ibgda_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
-      transport, src, dst, nbytes, numBlocks, timeout);
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf("[PIPES] Kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    int numBlocks,
+    std::size_t firstMaxSignalBytes,
+    std::size_t secondMaxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  if (isSender) {
+    TiledBuffer<char> first(src, firstBytes, sub);
+    transport->send(
+        sub,
+        first.data(),
+        first.bytes(),
+        numBlocks,
+        firstMaxSignalBytes,
+        timeout);
+    TiledBuffer<char> second(src + firstBytes, secondBytes, sub);
+    transport->send(
+        sub,
+        second.data(),
+        second.bytes(),
+        numBlocks,
+        secondMaxSignalBytes,
+        timeout);
+  } else {
+    TiledBuffer<char> first(dst, firstBytes, sub);
+    transport->recv(
+        sub,
+        first.data(),
+        first.bytes(),
+        numBlocks,
+        firstMaxSignalBytes,
+        timeout);
+    TiledBuffer<char> second(dst + firstBytes, secondBytes, sub);
+    transport->recv(
+        sub,
+        second.data(),
+        second.bytes(),
+        numBlocks,
+        secondMaxSignalBytes,
+        timeout);
+  }
+}
+
+void launch_ibgda_send_recv_two_call(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    int numBlocks,
+    std::size_t firstMaxSignalBytes,
+    std::size_t secondMaxSignalBytes,
+    cudaStream_t stream,
+    Timeout timeout) {
+  ibgda_send_recv_two_call_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport,
+      src,
+      dst,
+      firstBytes,
+      secondBytes,
+      numBlocks,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
+      timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] two-call kernel launch failed: %s\n", cudaGetErrorString(err));
   }
 }
 
@@ -64,6 +148,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
     char* src,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   auto group = make_block_group();
 
@@ -73,7 +158,8 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
-    transport->send(group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    transport->send(
+        group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
   }
 }
 
@@ -82,6 +168,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   auto group = make_block_group();
 
@@ -91,7 +178,8 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
-    transport->recv(group, tiles.data(), tiles.bytes(), numBlocks, 0, timeout);
+    transport->recv(
+        group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
   }
 }
 
@@ -101,9 +189,10 @@ void launch_ibgda_send(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   ibgda_send_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, src, nbytes, numBlocks, timeout);
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
 }
 
 void launch_ibgda_recv(
@@ -112,9 +201,10 @@ void launch_ibgda_recv(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
+    std::size_t maxSignalBytes,
     Timeout timeout) {
   ibgda_recv_kernel<<<numBlocks, 512, 0, stream>>>(
-      transport, dst, nbytes, numBlocks, timeout);
+      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
 }
 
 __global__ void ibgda_snapshot_step_state_kernel(

--- a/comms/pipes/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.cuh
@@ -26,6 +26,18 @@ __global__ void ibgda_send_recv_kernel(
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+
+__global__ void ibgda_send_recv_two_call_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    int numBlocks,
+    std::size_t firstMaxSignalBytes,
+    std::size_t secondMaxSignalBytes,
     Timeout timeout);
 
 /**
@@ -37,6 +49,7 @@ __global__ void ibgda_send_kernel(
     char* src,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout);
 
 /**
@@ -48,6 +61,7 @@ __global__ void ibgda_recv_kernel(
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
+    std::size_t maxSignalBytes,
     Timeout timeout);
 
 } // namespace comms::pipes::benchmark

--- a/comms/pipes/benchmarks/IbgdaSendRecv.h
+++ b/comms/pipes/benchmarks/IbgdaSendRecv.h
@@ -26,6 +26,7 @@ namespace comms::pipes::benchmark {
  * @param nbytes     Total bytes to transfer
  * @param numBlocks  Number of send blocks (= number of recv blocks)
  * @param stream     CUDA stream
+ * @param maxSignalBytes Max bytes per signaled sub-chunk
  * @param timeout    Optional timeout for wait operations
  */
 void launch_ibgda_send_recv(
@@ -34,6 +35,23 @@ void launch_ibgda_send_recv(
     char* dst,
     std::size_t nbytes,
     int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch bidirectional tile sendrecv kernel that performs two back-to-back
+ * send()/recv() calls with independent maxSignalBytes values.
+ */
+void launch_ibgda_send_recv_two_call(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t firstBytes,
+    std::size_t secondBytes,
+    int numBlocks,
+    std::size_t firstMaxSignalBytes,
+    std::size_t secondMaxSignalBytes,
     cudaStream_t stream,
     Timeout timeout = Timeout());
 
@@ -46,6 +64,7 @@ void launch_ibgda_send(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
     Timeout timeout = Timeout());
 
 /**
@@ -57,6 +76,7 @@ void launch_ibgda_recv(
     std::size_t nbytes,
     int numBlocks,
     cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
     Timeout timeout = Timeout());
 
 /**

--- a/comms/pipes/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/pipes/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -68,6 +68,30 @@ void expectUniformBuffer(
   }
 }
 
+void expectUniformBufferRange(
+    const DeviceBuffer& buf,
+    std::size_t offset,
+    std::size_t nbytes,
+    uint8_t expected,
+    int rank,
+    const char* label) {
+  std::vector<uint8_t> hostBuf(nbytes);
+  cudaError_t err = cudaMemcpy(
+      hostBuf.data(),
+      static_cast<const char*>(buf.get()) + offset,
+      nbytes,
+      cudaMemcpyDeviceToHost);
+  ASSERT_EQ(err, cudaSuccess)
+      << "cudaMemcpy failed: " << cudaGetErrorString(err);
+
+  for (std::size_t i = 0; i < nbytes; ++i) {
+    ASSERT_EQ(hostBuf[i], expected)
+        << "Rank " << rank << ": " << label << " data mismatch at byte " << i
+        << ", expected " << static_cast<int>(expected) << ", got "
+        << static_cast<int>(hostBuf[i]);
+  }
+}
+
 void expectStepState(
     const std::vector<int64_t>& steps,
     int maxGroups,
@@ -193,6 +217,7 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
   constexpr std::size_t kSectionsSecond = 2;
   constexpr std::size_t kBytesFirst = kSectionsFirst * kSlotSize;
   constexpr std::size_t kBytesSecond = kSectionsSecond * kSlotSize;
+  constexpr std::size_t kBytesPerGroupPerSection = kSlotSize / kNumBlocks;
   constexpr std::size_t kMaxBytes = kBytesFirst;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -236,7 +261,7 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
   expectStepState(
       snapshotStepState(deviceTransport, kNumBlocks, stream_),
       kNumBlocks,
-      static_cast<int64_t>(kSectionsFirst));
+      static_cast<int64_t>(kSectionsFirst * kBytesPerGroupPerSection));
 
   const uint8_t secondPattern = static_cast<uint8_t>(0x50 + globalRank);
   ASSERT_EQ(
@@ -258,7 +283,91 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
   expectStepState(
       snapshotStepState(deviceTransport, kNumBlocks, stream_),
       kNumBlocks,
-      static_cast<int64_t>(kSectionsFirst + kSectionsSecond));
+      static_cast<int64_t>(
+          (kSectionsFirst + kSectionsSecond) * kBytesPerGroupPerSection));
+}
+
+TEST_F(IbgdaSendRecvTest, ChangingMaxSignalBytesWithinKernelUsesByteCursor) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr int kNumBlocks = 4;
+  constexpr int kPipelineDepth = 2;
+  constexpr std::size_t kPerBlockSlot = 64 * 1024;
+  constexpr std::size_t kSlotSize = kPerBlockSlot * kNumBlocks;
+  constexpr std::size_t kFirstBytes = kSlotSize;
+  constexpr std::size_t kSecondBytes = (kPerBlockSlot / 2) * kNumBlocks;
+  constexpr std::size_t kTotalBytes = kFirstBytes + kSecondBytes;
+  constexpr std::size_t kFirstMaxSignalBytes = kPerBlockSlot;
+  constexpr std::size_t kSecondMaxSignalBytes = 16 * 1024;
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kNumBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kTotalBytes);
+  DeviceBuffer recvBuf(kTotalBytes);
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+  const uint8_t firstPattern = static_cast<uint8_t>(0x60 + globalRank);
+  const uint8_t secondPattern = static_cast<uint8_t>(0x70 + globalRank);
+  ASSERT_EQ(cudaMemset(sendBuf.get(), firstPattern, kFirstBytes), cudaSuccess);
+  ASSERT_EQ(
+      cudaMemset(
+          static_cast<char*>(sendBuf.get()) + kFirstBytes,
+          secondPattern,
+          kSecondBytes),
+      cudaSuccess);
+  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kTotalBytes), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  bootstrap->barrierAll();
+
+  launch_ibgda_send_recv_two_call(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kFirstBytes,
+      kSecondBytes,
+      kNumBlocks,
+      kFirstMaxSignalBytes,
+      kSecondMaxSignalBytes,
+      stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  bootstrap->barrierAll();
+
+  expectUniformBufferRange(
+      recvBuf,
+      0,
+      kFirstBytes,
+      static_cast<uint8_t>(0x60 + peerRank),
+      globalRank,
+      "first");
+  expectUniformBufferRange(
+      recvBuf,
+      kFirstBytes,
+      kSecondBytes,
+      static_cast<uint8_t>(0x70 + peerRank),
+      globalRank,
+      "second");
+  expectStepState(
+      snapshotStepState(deviceTransport, kNumBlocks, stream_),
+      kNumBlocks,
+      static_cast<int64_t>(kPerBlockSlot + kPerBlockSlot / 2));
 }
 
 TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
@@ -272,6 +381,7 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
   constexpr std::size_t kSlotSize = 1 * 1024 * 1024;
   constexpr std::size_t kSectionsPerReplay = 2;
   constexpr std::size_t kBytesPerReplay = kSectionsPerReplay * kSlotSize;
+  constexpr std::size_t kBytesPerGroupPerSection = kSlotSize / kNumBlocks;
   constexpr int kReplays = 3;
 
   int peerRank = (globalRank == 0) ? 1 : 0;
@@ -340,7 +450,8 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
     expectStepState(
         snapshotStepState(deviceTransport, kNumBlocks, stream_),
         kNumBlocks,
-        static_cast<int64_t>((replay + 1) * kSectionsPerReplay));
+        static_cast<int64_t>(
+            (replay + 1) * kSectionsPerReplay * kBytesPerGroupPerSection));
   }
 
   ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);

--- a/comms/pipes/benchmarks/TileSendRecv.cuh
+++ b/comms/pipes/benchmarks/TileSendRecv.cuh
@@ -34,19 +34,23 @@
 // PIPELINING (inside send / recv)
 // =========================================
 // Each block's tile may be larger than the per-block staging area. The tile
-// is therefore pipelined through the staging buffer in multiple steps:
+// is therefore pipelined through the staging buffer as a byte stream:
 //
 //   perBlockSlotSize = floor(dataBufferSize / numBlocks) & ~15
-//   totalSlotSteps   = ceil(tileBytes / perBlockSlotSize)
+//   pipelineBytes    = perBlockSlotSize * pipelineDepth
 //
-// Each step uses one of `pipelineDepth` slots (step % pipelineDepth) to
-// allow sender and receiver to overlap:
+// Each copy chunk maps its absolute byte cursor into the pipeline ring:
 //
-//   Step 0: sender writes to slot 0, signals tail=1
-//   Step 1: sender writes to slot 1, signals tail=2
-//           receiver reads slot 0, signals head=1
-//   Step 2: sender waits for head >= 1 (slot 0 freed), writes slot 0
-//           receiver reads slot 1, signals head=2
+//   pipelineOff = cursor % pipelineBytes
+//   slot        = pipelineOff / perBlockSlotSize
+//   chunkOff    = pipelineOff % perBlockSlotSize
+//
+// max_signal_bytes controls the largest copy/signaling chunk, but each chunk is
+// also capped at the end of the current per-block staging row. This keeps the
+// staging layout independent of max_signal_bytes across calls.
+//
+// The sender waits for head >= streamEnd - pipelineBytes before overwriting a
+// wrapped byte range. The receiver waits for tail >= streamEnd before reading.
 //   ...
 //
 // SIGNAL PROTOCOL
@@ -58,11 +62,11 @@
 //   signal[numBlocks + i]   = head counter for block pair i
 //                              (receiver → sender: "slot is freed")
 //
-// Both counters are monotonically increasing. The sender waits for
-//   head >= step - pipelineDepth + 1
-// before reusing a slot (backpressure). The receiver waits for
-//   tail >= step + 1
-// before reading (data availability).
+// Both counters are monotonically increasing byte cursors. The sender waits for
+//   head >= streamEnd - pipelineBytes
+// before reusing a byte range. The receiver waits for
+//   tail >= streamEnd
+// before reading.
 //
 // Memory ordering:
 //   - signal() uses st.release.sys.global → all prior writes (memcpy data)
@@ -72,14 +76,17 @@
 //
 // MULTI-CALL CORRECTNESS
 // ======================
-// The step counters are persisted in device memory (`stepState`):
-//   stepState[0..numBlocks-1]           = sender step per block
-//   stepState[numBlocks..2*numBlocks-1] = receiver step per block
+// The byte cursors are persisted in device memory (`stepState`):
+//   stepState[0..numBlocks-1]           = sender byte cursor per block
+//   stepState[numBlocks..2*numBlocks-1] = receiver byte cursor per block
 //
-// On first call (stepState zeroed), sender starts at step=0, receiver at
-// step=0. On subsequent calls, they resume from where they left off.
+// On first call (stepState zeroed), sender and receiver start at byte 0. On
+// subsequent calls, they resume from where they left off.
 // Because signals are monotonically increasing, old signal values from
 // previous calls are always < current expected values, so no ABA issue.
+// Since the cursor is in bytes, changing max_signal_bytes between calls with
+// the same active_blocks is safe. Changing active_blocks changes the staging
+// layout and requires a barrier first.
 //
 // PRECONDITION: stepState must be zeroed before the first kernel launch.
 // The transport's exchange() zeroes the signal buffers. For repeated

--- a/comms/pipes/tests/P2pNvlTransportTest.cc
+++ b/comms/pipes/tests/P2pNvlTransportTest.cc
@@ -460,6 +460,94 @@ TEST_F(P2pNvlTransportTestFixture, TileSendRecvMultiCall) {
   }
 }
 
+TEST_F(P2pNvlTransportTestFixture, TileSendRecvCudaGraphReplay) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const size_t nBytes = 2 * 1024 * 1024;
+  const int numSendBlocks = 4;
+  const size_t maxSignalBytes = 16 * 1024;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 512 * 1024,
+      .chunkSize = 512 * 1024,
+      .pipelineDepth = 2,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(nBytes);
+  DeviceBuffer recvBuf(nBytes);
+  comms::pipes::TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), nBytes, numSendBlocks);
+  comms::pipes::TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
+
+  int numBlocksArg = numSendBlocks;
+  std::size_t maxSignalBytesArg = maxSignalBytes;
+  Timeout timeout;
+  void* args[] = {
+      &p2pHost,
+      &sendTiles,
+      &recvTiles,
+      &numBlocksArg,
+      &maxSignalBytesArg,
+      &timeout};
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+  cudaGraph_t graph;
+  cudaGraphExec_t graphExec;
+
+  CUDACHECK_TEST(cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
+  CUDACHECK_TEST(cudaLaunchKernel(
+      (void*)comms::pipes::benchmark::p2pTileSendRecv,
+      dim3(numSendBlocks * 2),
+      dim3(256),
+      args,
+      0,
+      stream));
+  CUDACHECK_TEST(cudaStreamEndCapture(stream, &graph));
+  CUDACHECK_TEST(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  for (int iter = 0; iter < 3; ++iter) {
+    const int pattern = 0x40 + globalRank + iter * 0x20;
+    const int peerPattern = 0x40 + peerRank + iter * 0x20;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaGraphLaunch(graphExec, stream));
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    std::vector<char> hostBuf(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostBuf.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nBytes; ++i) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostBuf[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "CudaGraph iter " << iter << ": mismatch at byte " << i;
+      if (static_cast<unsigned char>(hostBuf[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        break;
+      }
+    }
+  }
+
+  CUDACHECK_TEST(cudaGraphExecDestroy(graphExec));
+  CUDACHECK_TEST(cudaGraphDestroy(graph));
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+}
+
 // =============================================================================
 // send / recv (per-group) Tests
 // =============================================================================
@@ -614,37 +702,42 @@ static void expectPersistentTwoCallStagingPattern(
     const std::string& label) {
   const size_t callBytes[] = {firstCallBytes, secondCallBytes};
   const size_t perBlockSlotSize = (slotSize / numBlocks) & ~15ULL;
-  const size_t stepsPerSlot =
-      (perBlockSlotSize + maxSignalBytes - 1) / maxSignalBytes;
+  const size_t chunkSize =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
+      ? (maxSignalBytes & ~15ULL)
+      : perBlockSlotSize;
+  const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
+  const size_t pipelineBytes = perBlockSlotSize * pipelineDepth;
 
   for (int block = 0; block < numBlocks; ++block) {
-    size_t baseStep = 0;
+    uint64_t baseByte = 0;
     for (int call = 0; call < 2; ++call) {
       const unsigned char expected = multiCallPattern(sourceRank, call);
-      const size_t chunks =
-          (callBytes[call] + maxSignalBytes - 1) / maxSignalBytes;
-      for (size_t chunk = 0; chunk < chunks; ++chunk) {
-        const size_t step = baseStep + chunk;
-        const size_t slotStep = step / stepsPerSlot;
-        const size_t subStep = step % stepsPerSlot;
-        const size_t slot = slotStep % pipelineDepth;
-        const size_t chunkBytes =
-            ((chunk + 1) * maxSignalBytes <= callBytes[call])
-            ? maxSignalBytes
-            : callBytes[call] - chunk * maxSignalBytes;
-        const size_t offset = slot * slotSize + block * perBlockSlotSize +
-            subStep * maxSignalBytes;
+      for (size_t dataOff = 0; dataOff < callBytes[call];) {
+        const uint64_t streamStart = baseByte + dataOff;
+        const size_t pipelineOff =
+            static_cast<size_t>(streamStart % pipelineBytes);
+        const size_t slot = pipelineOff / perBlockSlotSize;
+        const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
+        const size_t slotRemaining = perBlockSlotSize - chunkOff;
+        const size_t dataRemaining = callBytes[call] - dataOff;
+        size_t chunkBytes =
+            effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+        chunkBytes = chunkBytes < slotRemaining ? chunkBytes : slotRemaining;
+        const size_t offset =
+            slot * slotSize + block * perBlockSlotSize + chunkOff;
 
         for (size_t i = 0; i < chunkBytes; ++i) {
           EXPECT_EQ(static_cast<unsigned char>(data[offset + i]), expected)
               << label << ": block=" << block << " call=" << call
-              << " chunk=" << chunk << " byte=" << i;
+              << " dataOff=" << dataOff << " byte=" << i;
           if (static_cast<unsigned char>(data[offset + i]) != expected) {
             return;
           }
         }
+        dataOff += chunkBytes;
       }
-      baseStep += chunks;
+      baseByte += callBytes[call];
     }
   }
 }
@@ -678,6 +771,97 @@ static P2pNvlTransportDevice makeLocalTileDevice(
   return P2pNvlTransportDevice(
       0, 1, options, localState, remoteState, tileState);
 }
+
+class LocalTileHarness {
+ public:
+  LocalTileHarness(const P2pNvlTransportOptions& options, int numBlocks)
+      : options_(options),
+        numBlocks_(numBlocks),
+        stagingBytes_(options.dataBufferSize * options.pipelineDepth),
+        stateSlots_(numBlocks * 2),
+        stepStateBytes_(sizeof(int64_t) * stateSlots_),
+        signalBytes_(sizeof(SignalState) * stateSlots_),
+        stagingBuf_(stagingBytes_),
+        stepStateBuf_(stepStateBytes_),
+        localSignalsBuf_(signalBytes_),
+        remoteSignalsBuf_(signalBytes_) {
+    zero();
+  }
+
+  void zero() {
+    CUDACHECK_TEST(cudaMemset(stagingBuf_.get(), 0, stagingBytes_));
+    CUDACHECK_TEST(cudaMemset(stepStateBuf_.get(), 0, stepStateBytes_));
+    CUDACHECK_TEST(cudaMemset(localSignalsBuf_.get(), 0, signalBytes_));
+    CUDACHECK_TEST(cudaMemset(remoteSignalsBuf_.get(), 0, signalBytes_));
+  }
+
+  P2pNvlTransportDevice device(
+      char* localData = nullptr,
+      char* remoteData = nullptr) {
+    return makeLocalTileDevice(
+        options_,
+        numBlocks_,
+        localData,
+        remoteData,
+        stepState(),
+        localSignals(),
+        remoteSignals());
+  }
+
+  P2pNvlTransportDevice stagingDevice() {
+    return device(staging(), staging());
+  }
+
+  P2pNvlTransportDevice loopbackDevice() {
+    return makeLocalTileDevice(
+        options_,
+        numBlocks_,
+        staging(),
+        staging(),
+        stepState(),
+        localSignals(),
+        localSignals());
+  }
+
+  DeviceSpan<int64_t> stepState() {
+    return DeviceSpan<int64_t>(
+        static_cast<int64_t*>(stepStateBuf_.get()), stateSlots_);
+  }
+
+  DeviceSpan<SignalState> localSignals() {
+    return DeviceSpan<SignalState>(
+        static_cast<SignalState*>(localSignalsBuf_.get()), stateSlots_);
+  }
+
+  DeviceSpan<SignalState> remoteSignals() {
+    return DeviceSpan<SignalState>(
+        static_cast<SignalState*>(remoteSignalsBuf_.get()), stateSlots_);
+  }
+
+  char* staging() {
+    return static_cast<char*>(stagingBuf_.get());
+  }
+
+  DeviceBuffer& stagingBuffer() {
+    return stagingBuf_;
+  }
+
+  size_t stagingBytes() const {
+    return stagingBytes_;
+  }
+
+ private:
+  const P2pNvlTransportOptions options_;
+  const int numBlocks_;
+  const size_t stagingBytes_;
+  const int stateSlots_;
+  const size_t stepStateBytes_;
+  const size_t signalBytes_;
+  DeviceBuffer stagingBuf_;
+  DeviceBuffer stepStateBuf_;
+  DeviceBuffer localSignalsBuf_;
+  DeviceBuffer remoteSignalsBuf_;
+};
 
 // Test various message sizes with default config
 TEST_F(P2pNvlTransportTestFixture, TileSendRecvMessageSizes) {
@@ -928,37 +1112,17 @@ TEST_F(
       .chunkSize = maxSignalBytes,
       .pipelineDepth = 2,
   };
-  const size_t stagingBytes = options.dataBufferSize * options.pipelineDepth;
+  LocalTileHarness p2pHarness(options, numBlocks);
 
   const std::vector<char> hostSend =
       makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
   DeviceBuffer sendBuf(totalBytes);
   DeviceBuffer recvBuf(totalBytes);
-  DeviceBuffer stagingBuf(stagingBytes);
-  const size_t stepStateBytes = sizeof(int64_t) * numBlocks * 2;
-  const size_t signalBytes = sizeof(SignalState) * numBlocks * 2;
-  DeviceBuffer stepStateBuf(stepStateBytes);
-  DeviceBuffer localSignalsBuf(signalBytes);
-  DeviceBuffer remoteSignalsBuf(signalBytes);
   CUDACHECK_TEST(cudaMemcpy(
       sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
   CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
-  CUDACHECK_TEST(cudaMemset(stagingBuf.get(), 0, stagingBytes));
-  CUDACHECK_TEST(cudaMemset(stepStateBuf.get(), 0, stepStateBytes));
-  CUDACHECK_TEST(cudaMemset(localSignalsBuf.get(), 0, signalBytes));
-  CUDACHECK_TEST(cudaMemset(remoteSignalsBuf.get(), 0, signalBytes));
 
-  auto p2pHost = makeLocalTileDevice(
-      options,
-      numBlocks,
-      static_cast<char*>(stagingBuf.get()),
-      static_cast<char*>(stagingBuf.get()),
-      DeviceSpan<int64_t>(
-          static_cast<int64_t*>(stepStateBuf.get()), numBlocks * 2),
-      DeviceSpan<SignalState>(
-          static_cast<SignalState*>(localSignalsBuf.get()), numBlocks * 2),
-      DeviceSpan<SignalState>(
-          static_cast<SignalState*>(remoteSignalsBuf.get()), numBlocks * 2));
+  auto p2pHost = p2pHarness.stagingDevice();
 
   TiledBuffer<char> sendTiles(
       static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
@@ -984,11 +1148,11 @@ TEST_F(
       threadCount);
   CUDACHECK_TEST(cudaDeviceSynchronize());
 
-  std::vector<char> hostStaging(stagingBytes);
+  std::vector<char> hostStaging(p2pHarness.stagingBytes());
   CUDACHECK_TEST(cudaMemcpy(
       hostStaging.data(),
-      stagingBuf.get(),
-      stagingBytes,
+      p2pHarness.stagingBuffer().get(),
+      p2pHarness.stagingBytes(),
       cudaMemcpyDeviceToHost));
   expectPersistentTwoCallStagingPattern(
       hostStaging,
@@ -1031,6 +1195,494 @@ TEST_F(
       numBlocks,
       0,
       "tile recv persistent cursor");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileSendRecvChangingMaxSignalBytesWithoutBarrier) {
+  const int numBlocks = 4;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 64 * 1024;
+  const size_t firstMaxSignalBytes = perBlockSlotSize;
+  const size_t secondMaxSignalBytes = 16 * 1024;
+  const size_t firstCallBytes = perBlockSlotSize;
+  const size_t secondCallBytes = perBlockSlotSize / 2;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = perBlockSlotSize,
+      .pipelineDepth = 2,
+  };
+  LocalTileHarness p2pHarness(options, numBlocks);
+
+  const std::vector<char> hostSend =
+      makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
+  DeviceBuffer sendBuf(totalBytes);
+  DeviceBuffer recvBuf(totalBytes);
+
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+
+  auto p2pHost = p2pHarness.loopbackDevice();
+
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  int device = 0;
+  CUDACHECK_TEST(cudaGetDevice(&device));
+  Timeout timeout = makeTimeout(5000, device);
+
+  test::testTileTwoCallVariableSignalSendRecv(
+      p2pHost,
+      sendTiles,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
+      true,
+      threadCount,
+      timeout);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile sendrecv changing max_signal_bytes");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileForwardChangingMaxSignalBytesWithoutBarrier) {
+  const int numBlocks = 4;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 64 * 1024;
+  const size_t firstMaxSignalBytes = perBlockSlotSize;
+  const size_t secondMaxSignalBytes = 16 * 1024;
+  const size_t firstCallBytes = perBlockSlotSize;
+  const size_t secondCallBytes = perBlockSlotSize / 2;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = perBlockSlotSize,
+      .pipelineDepth = 2,
+  };
+  LocalTileHarness predHarness(options, numBlocks);
+  LocalTileHarness succHarness(options, numBlocks);
+
+  auto pred = predHarness.device(predHarness.staging(), nullptr);
+  auto succ = succHarness.device(nullptr, succHarness.staging());
+
+  test::testPrepareTileTwoCallStaging(
+      pred,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      secondMaxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceBuffer dstBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, totalBytes));
+  TiledBuffer<char> dstTiles(
+      static_cast<char*>(dstBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallVariableSignalForward(
+      pred,
+      succ,
+      dstTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostDst(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(), dstBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostDst,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile forward changing max_signal_bytes dst");
+
+  std::vector<char> hostSuccStaging(succHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostSuccStaging.data(),
+      succHarness.stagingBuffer().get(),
+      succHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostSuccStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      secondMaxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile forward changing max_signal_bytes successor staging");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileSendRecvChangingLaunchedBlocksWithSameActiveBlocks) {
+  if (numRanks != 2) {
+    XLOGF(WARNING, "Skipping: requires 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+  const int activeBlocks = 4;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 64 * 1024;
+  const size_t maxSignalBytes = 16 * 1024;
+  const size_t nBytes = 512 * 1024;
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = perBlockSlotSize * activeBlocks,
+      .chunkSize = perBlockSlotSize,
+      .pipelineDepth = 2,
+      .tile_max_groups = activeBlocks,
+  };
+
+  auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  transport.exchange();
+  auto p2pHost = transport.buildP2pTransportDevice(peerRank);
+
+  DeviceBuffer sendBuf(nBytes);
+  DeviceBuffer recvBuf(nBytes);
+  Timeout timeout;
+
+  const std::vector<int> launchedBlocks = {2, 4, 1, 4};
+  for (size_t round = 0; round < launchedBlocks.size(); ++round) {
+    const int numSendBlocks = launchedBlocks[round];
+    const int pattern = 0x50 + globalRank + static_cast<int>(round) * 0x20;
+    const int peerPattern = 0x50 + peerRank + static_cast<int>(round) * 0x20;
+
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), pattern, nBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, nBytes));
+
+    comms::pipes::TiledBuffer<char> sendTiles(
+        static_cast<char*>(sendBuf.get()), nBytes, numSendBlocks);
+    comms::pipes::TiledBuffer<char> recvTiles(
+        static_cast<char*>(recvBuf.get()), nBytes, numSendBlocks);
+    int activeBlocksArg = activeBlocks;
+    std::size_t maxSignalBytesArg = maxSignalBytes;
+    void* args[] = {
+        &p2pHost,
+        &sendTiles,
+        &recvTiles,
+        &activeBlocksArg,
+        &maxSignalBytesArg,
+        &timeout};
+
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    CUDACHECK_TEST(cudaLaunchKernel(
+        (void*)comms::pipes::benchmark::p2pTileSendRecv,
+        dim3(numSendBlocks * 2),
+        dim3(threadCount),
+        args,
+        0,
+        nullptr));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    std::vector<char> hostRecv(nBytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        hostRecv.data(), recvBuf.get(), nBytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < nBytes; ++i) {
+      EXPECT_EQ(
+          static_cast<unsigned char>(hostRecv[i]),
+          static_cast<unsigned char>(peerPattern))
+          << "round=" << round << " launchedBlocks=" << numSendBlocks
+          << " byte=" << i;
+      if (static_cast<unsigned char>(hostRecv[i]) !=
+          static_cast<unsigned char>(peerPattern)) {
+        break;
+      }
+    }
+  }
+}
+
+TEST_F(P2pNvlTransportTestFixture, TileSendAndForwardWaitForWrappedSubstepAck) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t maxSignalBytes = 16 * 1024;
+  const size_t perBlockSlotSize = 4 * maxSignalBytes;
+  const size_t nbytes = 2 * maxSignalBytes;
+  const size_t pipelineDepth = 1;
+  const size_t pipelineSteps = 4;
+  const size_t wrappedStep = pipelineSteps;
+  const size_t wrappedByte = wrappedStep * maxSignalBytes;
+  const size_t wrappedSubstepOffset = maxSignalBytes;
+  const uint64_t initialAckValue = 0;
+  const unsigned char sentinel = 0x7e;
+  const unsigned char sendPattern = 0x42;
+  const unsigned char forwardPattern = 0x55;
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = pipelineDepth,
+  };
+  const int numSignalSlots = numBlocks * 2;
+  const size_t signalBytes = sizeof(SignalState) * numSignalSlots;
+  const size_t stepStateBytes = sizeof(int64_t) * numBlocks * 2;
+
+  auto makeSignals = [&](uint64_t headValue) {
+    std::vector<SignalState> signals(numSignalSlots);
+    signals[numBlocks].signal_ = headValue;
+    return signals;
+  };
+
+  {
+    std::vector<char> hostSend(nbytes, static_cast<char>(sendPattern));
+    std::vector<char> hostStaging(options.dataBufferSize, sentinel);
+    std::vector<int64_t> hostStepState(numBlocks * 2);
+    hostStepState[0] = static_cast<int64_t>(wrappedByte);
+    auto hostLocalSignals = makeSignals(initialAckValue);
+    std::vector<SignalState> hostRemoteSignals(numSignalSlots);
+
+    DeviceBuffer sendBuf(nbytes);
+    DeviceBuffer stagingBuf(options.dataBufferSize);
+    DeviceBuffer stepStateBuf(stepStateBytes);
+    DeviceBuffer localSignalsBuf(signalBytes);
+    DeviceBuffer remoteSignalsBuf(signalBytes);
+    DeviceBuffer observedBuf(sizeof(int));
+    const int initialObserved = -1;
+
+    CUDACHECK_TEST(cudaMemcpy(
+        sendBuf.get(), hostSend.data(), nbytes, cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        stagingBuf.get(),
+        hostStaging.data(),
+        hostStaging.size(),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        stepStateBuf.get(),
+        hostStepState.data(),
+        stepStateBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        localSignalsBuf.get(),
+        hostLocalSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        remoteSignalsBuf.get(),
+        hostRemoteSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        observedBuf.get(),
+        &initialObserved,
+        sizeof(initialObserved),
+        cudaMemcpyHostToDevice));
+
+    auto p2pHost = makeLocalTileDevice(
+        options,
+        numBlocks,
+        static_cast<char*>(stagingBuf.get()),
+        static_cast<char*>(stagingBuf.get()),
+        DeviceSpan<int64_t>(
+            static_cast<int64_t*>(stepStateBuf.get()), numBlocks * 2),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(localSignalsBuf.get()), numSignalSlots),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(remoteSignalsBuf.get()), numSignalSlots));
+
+    test::testTileSendWaitsForWrappedSubstepAck(
+        p2pHost,
+        static_cast<const char*>(sendBuf.get()),
+        numBlocks,
+        nbytes,
+        maxSignalBytes,
+        sentinel,
+        static_cast<int*>(observedBuf.get()),
+        threadCount);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    int observed = -1;
+    CUDACHECK_TEST(cudaMemcpy(
+        &observed,
+        observedBuf.get(),
+        sizeof(observed),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(observed, 0)
+        << "tile send reused a wrapped nonzero substep before the receiver ACK";
+
+    std::vector<char> finalStaging(options.dataBufferSize);
+    CUDACHECK_TEST(cudaMemcpy(
+        finalStaging.data(),
+        stagingBuf.get(),
+        finalStaging.size(),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(
+        static_cast<unsigned char>(finalStaging[wrappedSubstepOffset]),
+        sendPattern);
+  }
+
+  {
+    std::vector<char> hostPredStaging(options.dataBufferSize, 0);
+    std::fill(
+        hostPredStaging.begin(),
+        hostPredStaging.begin() + nbytes,
+        static_cast<char>(forwardPattern));
+    std::vector<char> hostSuccStaging(options.dataBufferSize, sentinel);
+    std::vector<int64_t> predStepState(numBlocks * 2);
+    std::vector<int64_t> succStepState(numBlocks * 2);
+    succStepState[0] = static_cast<int64_t>(wrappedByte);
+    std::vector<SignalState> predLocalSignals(numSignalSlots);
+    predLocalSignals[0].signal_ = nbytes;
+    std::vector<SignalState> predRemoteSignals(numSignalSlots);
+    auto succLocalSignals = makeSignals(initialAckValue);
+    std::vector<SignalState> succRemoteSignals(numSignalSlots);
+
+    DeviceBuffer predStagingBuf(options.dataBufferSize);
+    DeviceBuffer succStagingBuf(options.dataBufferSize);
+    DeviceBuffer dstBuf(nbytes);
+    DeviceBuffer predStepStateBuf(stepStateBytes);
+    DeviceBuffer succStepStateBuf(stepStateBytes);
+    DeviceBuffer predLocalSignalsBuf(signalBytes);
+    DeviceBuffer predRemoteSignalsBuf(signalBytes);
+    DeviceBuffer succLocalSignalsBuf(signalBytes);
+    DeviceBuffer succRemoteSignalsBuf(signalBytes);
+    DeviceBuffer observedBuf(sizeof(int));
+    const int initialObserved = -1;
+
+    CUDACHECK_TEST(cudaMemcpy(
+        predStagingBuf.get(),
+        hostPredStaging.data(),
+        hostPredStaging.size(),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        succStagingBuf.get(),
+        hostSuccStaging.data(),
+        hostSuccStaging.size(),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, nbytes));
+    CUDACHECK_TEST(cudaMemcpy(
+        predStepStateBuf.get(),
+        predStepState.data(),
+        stepStateBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        succStepStateBuf.get(),
+        succStepState.data(),
+        stepStateBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        predLocalSignalsBuf.get(),
+        predLocalSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        predRemoteSignalsBuf.get(),
+        predRemoteSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        succLocalSignalsBuf.get(),
+        succLocalSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        succRemoteSignalsBuf.get(),
+        succRemoteSignals.data(),
+        signalBytes,
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        observedBuf.get(),
+        &initialObserved,
+        sizeof(initialObserved),
+        cudaMemcpyHostToDevice));
+
+    auto pred = makeLocalTileDevice(
+        options,
+        numBlocks,
+        static_cast<char*>(predStagingBuf.get()),
+        nullptr,
+        DeviceSpan<int64_t>(
+            static_cast<int64_t*>(predStepStateBuf.get()), numBlocks * 2),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(predLocalSignalsBuf.get()),
+            numSignalSlots),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(predRemoteSignalsBuf.get()),
+            numSignalSlots));
+    auto succ = makeLocalTileDevice(
+        options,
+        numBlocks,
+        nullptr,
+        static_cast<char*>(succStagingBuf.get()),
+        DeviceSpan<int64_t>(
+            static_cast<int64_t*>(succStepStateBuf.get()), numBlocks * 2),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(succLocalSignalsBuf.get()),
+            numSignalSlots),
+        DeviceSpan<SignalState>(
+            static_cast<SignalState*>(succRemoteSignalsBuf.get()),
+            numSignalSlots));
+
+    test::testTileForwardWaitsForWrappedSubstepAck(
+        pred,
+        succ,
+        static_cast<char*>(dstBuf.get()),
+        numBlocks,
+        nbytes,
+        maxSignalBytes,
+        sentinel,
+        static_cast<int*>(observedBuf.get()),
+        threadCount);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    int observed = -1;
+    CUDACHECK_TEST(cudaMemcpy(
+        &observed,
+        observedBuf.get(),
+        sizeof(observed),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(observed, 0)
+        << "tile forward reused a wrapped nonzero substep before successor ACK";
+
+    std::vector<char> finalSuccStaging(options.dataBufferSize);
+    std::vector<char> finalDst(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        finalSuccStaging.data(),
+        succStagingBuf.get(),
+        finalSuccStaging.size(),
+        cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaMemcpy(
+        finalDst.data(),
+        dstBuf.get(),
+        finalDst.size(),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(
+        static_cast<unsigned char>(finalSuccStaging[wrappedSubstepOffset]),
+        forwardPattern);
+    EXPECT_EQ(static_cast<unsigned char>(finalDst[0]), forwardPattern);
+  }
 }
 
 // Test multi-call with different message sizes per call

--- a/comms/pipes/tests/P2pNvlTransportTest.cu
+++ b/comms/pipes/tests/P2pNvlTransportTest.cu
@@ -175,6 +175,7 @@ __device__ void wait_for_second_call_signal(
     P2pNvlTransportDevice& p2p,
     ThreadGroup& group,
     int blockId,
+    int activeBlocks,
     size_t bytesPerCall,
     size_t maxSignalBytes,
     bool enabled,
@@ -182,10 +183,17 @@ __device__ void wait_for_second_call_signal(
   if (!enabled) {
     return;
   }
-  const uint64_t chunksPerCall =
-      (bytesPerCall + maxSignalBytes - 1) / maxSignalBytes;
+  const size_t perBlockSlotSize =
+      (p2p.options().dataBufferSize / activeBlocks) & ~15ULL;
+  const size_t chunkSize =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
+      ? (maxSignalBytes & ~15ULL)
+      : perBlockSlotSize;
+  const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
+  const uint64_t secondCallStarted = bytesPerCall +
+      (bytesPerCall < effectiveChunk ? bytesPerCall : effectiveChunk);
   p2p.tile_state().local_signals[blockId].wait_until(
-      group, CmpOp::CMP_GE, chunksPerCall + 1, timeout);
+      group, CmpOp::CMP_GE, secondCallStarted, timeout);
 }
 
 __global__ void testTileMultiCallSendRecvKernel(
@@ -220,6 +228,7 @@ __global__ void testTileMultiCallSendRecvKernel(
         p2p,
         sub,
         blockId,
+        activeBlocks,
         bytesPerCall,
         maxSignalBytes,
         waitForSecondCallSignal,
@@ -234,6 +243,67 @@ __global__ void testTileMultiCallSendRecvKernel(
           maxSignalBytes,
           timeout);
     }
+  }
+}
+
+__global__ void testTileTwoCallVariableSignalSendRecvKernel(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    bool waitForSecondCallSignal,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const int blockId = sub.group_id;
+
+  if (role == 0) {
+    char* sendTile = sendTiles.tile_data(blockId);
+    p2p.send(
+        sub,
+        sendTile,
+        firstCallBytes,
+        activeBlocks,
+        firstMaxSignalBytes,
+        timeout);
+    p2p.send(
+        sub,
+        sendTile + firstCallBytes,
+        secondCallBytes,
+        activeBlocks,
+        secondMaxSignalBytes,
+        timeout);
+  } else {
+    wait_for_second_call_signal(
+        p2p,
+        sub,
+        blockId,
+        activeBlocks,
+        firstCallBytes,
+        secondMaxSignalBytes,
+        waitForSecondCallSignal,
+        timeout);
+    char* recvTile = recvTiles.tile_data(blockId);
+    p2p.recv(
+        sub,
+        recvTile,
+        firstCallBytes,
+        activeBlocks,
+        firstMaxSignalBytes,
+        timeout);
+    p2p.recv(
+        sub,
+        recvTile + firstCallBytes,
+        secondCallBytes,
+        activeBlocks,
+        secondMaxSignalBytes,
+        timeout);
   }
 }
 
@@ -285,6 +355,109 @@ __global__ void testTileTwoCallSendOnlyKernel(
       timeout);
 }
 
+__device__ void check_wrapped_substep_with_existing_signals(
+    P2pNvlTransportDevice& p2p,
+    ThreadGroup& group,
+    int activeBlocks,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    const Timeout& timeout) {
+  const size_t slotSize = p2p.options().dataBufferSize;
+  const size_t perBlockSlotSize = (slotSize / activeBlocks) & ~15ULL;
+  const size_t effectiveChunk =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
+      ? (maxSignalBytes & ~15ULL)
+      : perBlockSlotSize;
+  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
+  const uint64_t streamStart =
+      static_cast<uint64_t>(p2p.tile_state().step_state[0]);
+  const uint64_t firstStreamEnd = streamStart + effectiveChunk;
+  const uint64_t firstAckValue = firstStreamEnd - pipelineBytes;
+  const uint64_t targetStreamStart = firstStreamEnd;
+  const size_t targetPipelineOff =
+      static_cast<size_t>(targetStreamStart % pipelineBytes);
+  const size_t targetSlot = targetPipelineOff / perBlockSlotSize;
+  const size_t targetChunkOff =
+      targetPipelineOff - targetSlot * perBlockSlotSize;
+  const size_t targetOffset = targetSlot * slotSize + targetChunkOff;
+  const uint64_t targetStreamEnd = targetStreamStart + effectiveChunk;
+  const uint64_t targetAckValue = targetStreamEnd - pipelineBytes;
+  const int tailSignalId = 0;
+  const int headSignalId = p2p.tile_state().tile_max_groups;
+
+  // Drive the existing head signal to the minimum threshold that releases only
+  // the first wrapped chunk. Real recv() may coalesce head updates at slot
+  // boundaries; this test is intentionally isolating the sender/forwarder wait
+  // predicate for the following nonzero wrapped substep.
+  p2p.tile_state().local_signals[headSignalId].signal(
+      group, SignalOp::SIGNAL_SET, firstAckValue);
+  p2p.tile_state().remote_signals[tailSignalId].wait_until(
+      group, CmpOp::CMP_GE, firstStreamEnd, timeout);
+
+  if (group.is_leader()) {
+    const auto observed =
+        static_cast<unsigned char>(p2p.remote_state().dataBuffer[targetOffset]);
+    *observedEarlyOverwrite = observed == sentinel ? 0 : 1;
+    p2p.tile_state().local_signals[headSignalId].signal(
+        SignalOp::SIGNAL_SET, targetAckValue);
+  }
+}
+
+__global__ void testTileSendWaitsForWrappedSubstepAckKernel(
+    P2pNvlTransportDevice p2p,
+    const char* sendData,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  if (blockIdx.x == 0) {
+    p2p.send(group, sendData, nbytes, activeBlocks, maxSignalBytes, timeout);
+  } else {
+    check_wrapped_substep_with_existing_signals(
+        p2p,
+        group,
+        activeBlocks,
+        maxSignalBytes,
+        sentinel,
+        observedEarlyOverwrite,
+        timeout);
+  }
+}
+
+__global__ void testTileForwardWaitsForWrappedSubstepAckKernel(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    char* dst,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  if (blockIdx.x == 0) {
+    pred.forward(
+        group, dst, nbytes, succ, activeBlocks, maxSignalBytes, timeout);
+  } else {
+    check_wrapped_substep_with_existing_signals(
+        succ,
+        group,
+        activeBlocks,
+        maxSignalBytes,
+        sentinel,
+        observedEarlyOverwrite,
+        timeout);
+  }
+}
+
 __global__ void testPrepareTileStagingKernel(
     P2pNvlTransportDevice p2p,
     int activeBlocks,
@@ -301,37 +474,42 @@ __global__ void testPrepareTileStagingKernel(
 
   const size_t slotSize = p2p.options().dataBufferSize;
   const size_t perBlockSlotSize = (slotSize / activeBlocks) & ~15ULL;
-  const size_t effectiveChunk = maxSignalBytes;
-  const size_t chunksPerCall =
-      (bytesPerCall + effectiveChunk - 1) / effectiveChunk;
-  const size_t stepsPerSlot =
-      (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+  const size_t chunkSize =
+      maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
+      ? (maxSignalBytes & ~15ULL)
+      : perBlockSlotSize;
+  const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
+  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
   const size_t stagingOff = blockId * perBlockSlotSize;
 
+  uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t s = 0; s < chunksPerCall; ++s) {
-      const size_t step = call * chunksPerCall + s;
-      const size_t slotStep = step / stepsPerSlot;
-      const size_t subStep = step % stepsPerSlot;
-      const size_t slot = slotStep % p2p.options().pipelineDepth;
-      const size_t dataOff = s * effectiveChunk;
-      const size_t copyBytes = (dataOff + effectiveChunk <= bytesPerCall)
-          ? effectiveChunk
-          : bytesPerCall - dataOff;
-      const size_t bufferOff =
-          slot * slotSize + stagingOff + subStep * effectiveChunk;
+    for (size_t dataOff = 0; dataOff < bytesPerCall;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const size_t pipelineOff =
+          static_cast<size_t>(streamStart % pipelineBytes);
+      const size_t slot = pipelineOff / perBlockSlotSize;
+      const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
+      const size_t slotRemaining = perBlockSlotSize - chunkOff;
+      const size_t dataRemaining = bytesPerCall - dataOff;
+      size_t copyBytes =
+          effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+      copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
       for (size_t idx = group.thread_id_in_group; idx < copyBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
+      dataOff += copyBytes;
     }
+    baseByte += bytesPerCall;
   }
 
   group.sync();
   if (group.is_leader()) {
     p2p.tile_state().local_signals[blockId].signal(
-        SignalOp::SIGNAL_SET, static_cast<uint64_t>(numCalls) * chunksPerCall);
+        SignalOp::SIGNAL_SET, baseByte);
   }
 }
 
@@ -355,38 +533,38 @@ __global__ void testPrepareTileTwoCallStagingKernel(
       maxSignalBytes > 0 && maxSignalBytes < perBlockSlotSize
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
-  const size_t stepsPerSlot =
-      (perBlockSlotSize + effectiveChunk - 1) / effectiveChunk;
+  const size_t pipelineBytes = perBlockSlotSize * p2p.options().pipelineDepth;
   const size_t stagingOff = blockId * perBlockSlotSize;
 
-  size_t baseStep = 0;
+  uint64_t baseByte = 0;
   for (int call = 0; call < 2; ++call) {
     const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
-    const size_t chunks = (callBytes + effectiveChunk - 1) / effectiveChunk;
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t s = 0; s < chunks; ++s) {
-      const size_t step = baseStep + s;
-      const size_t slotStep = step / stepsPerSlot;
-      const size_t subStep = step % stepsPerSlot;
-      const size_t slot = slotStep % p2p.options().pipelineDepth;
-      const size_t dataOff = s * effectiveChunk;
-      const size_t copyBytes = (dataOff + effectiveChunk <= callBytes)
-          ? effectiveChunk
-          : callBytes - dataOff;
-      const size_t bufferOff =
-          slot * slotSize + stagingOff + subStep * effectiveChunk;
+    for (size_t dataOff = 0; dataOff < callBytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const size_t pipelineOff =
+          static_cast<size_t>(streamStart % pipelineBytes);
+      const size_t slot = pipelineOff / perBlockSlotSize;
+      const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
+      const size_t slotRemaining = perBlockSlotSize - chunkOff;
+      const size_t dataRemaining = callBytes - dataOff;
+      size_t copyBytes =
+          effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
+      copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
       for (size_t idx = group.thread_id_in_group; idx < copyBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
+      dataOff += copyBytes;
     }
-    baseStep += chunks;
+    baseByte += callBytes;
   }
 
   group.sync();
   if (group.is_leader()) {
     p2p.tile_state().local_signals[blockId].signal(
-        SignalOp::SIGNAL_SET, static_cast<uint64_t>(baseStep));
+        SignalOp::SIGNAL_SET, baseByte);
   }
 }
 
@@ -456,6 +634,7 @@ __global__ void testTileMultiCallForwardKernel(
       pred,
       group,
       blockId,
+      activeBlocks,
       bytesPerCall,
       maxSignalBytes,
       waitForSecondCallSignal,
@@ -503,6 +682,39 @@ __global__ void testTileTwoCallForwardKernel(
       succ,
       activeBlocks,
       maxSignalBytes,
+      timeout);
+}
+
+__global__ void testTileTwoCallVariableSignalForwardKernel(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    Timeout timeout) {
+  timeout.start();
+
+  auto group = make_block_group();
+  const int blockId = group.group_id;
+  char* dstTile = dstTiles.tile_data(blockId);
+  pred.forward(
+      group,
+      dstTile,
+      firstCallBytes,
+      succ,
+      activeBlocks,
+      firstMaxSignalBytes,
+      timeout);
+  pred.forward(
+      group,
+      dstTile + firstCallBytes,
+      secondCallBytes,
+      succ,
+      activeBlocks,
+      secondMaxSignalBytes,
       timeout);
 }
 
@@ -625,6 +837,37 @@ void testTileMultiCallSendRecv(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+void testTileTwoCallVariableSignalSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    Timeout timeout,
+    cudaStream_t stream) {
+  testTileTwoCallVariableSignalSendRecvKernel<<<
+      activeBlocks * 2,
+      blockSize,
+      0,
+      stream>>>(
+      p2p,
+      sendTiles,
+      recvTiles,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
+      waitForSecondCallSignal,
+      timeout);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 void testTileMultiCallSendOnly(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
@@ -661,6 +904,52 @@ void testTileTwoCallSendOnly(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileSendWaitsForWrappedSubstepAck(
+    P2pNvlTransportDevice p2p,
+    const char* sendData,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileSendWaitsForWrappedSubstepAckKernel<<<2, blockSize, 0, stream>>>(
+      p2p,
+      sendData,
+      activeBlocks,
+      nbytes,
+      maxSignalBytes,
+      sentinel,
+      observedEarlyOverwrite,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileForwardWaitsForWrappedSubstepAck(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    char* dst,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileForwardWaitsForWrappedSubstepAckKernel<<<2, blockSize, 0, stream>>>(
+      pred,
+      succ,
+      dst,
+      activeBlocks,
+      nbytes,
+      maxSignalBytes,
+      sentinel,
+      observedEarlyOverwrite,
       Timeout());
   PIPES_KERNEL_LAUNCH_CHECK();
 }
@@ -787,6 +1076,34 @@ void testTileTwoCallForward(
       firstCallBytes,
       secondCallBytes,
       maxSignalBytes,
+      Timeout());
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void testTileTwoCallVariableSignalForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    int blockSize,
+    cudaStream_t stream) {
+  testTileTwoCallVariableSignalForwardKernel<<<
+      activeBlocks,
+      blockSize,
+      0,
+      stream>>>(
+      pred,
+      succ,
+      dstTiles,
+      activeBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      firstMaxSignalBytes,
+      secondMaxSignalBytes,
       Timeout());
   PIPES_KERNEL_LAUNCH_CHECK();
 }

--- a/comms/pipes/tests/P2pNvlTransportTest.cuh
+++ b/comms/pipes/tests/P2pNvlTransportTest.cuh
@@ -143,6 +143,20 @@ void testTileMultiCallSendRecv(
     int blockSize,
     cudaStream_t stream = nullptr);
 
+void testTileTwoCallVariableSignalSendRecv(
+    P2pNvlTransportDevice p2p,
+    TiledBuffer<char> sendTiles,
+    TiledBuffer<char> recvTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
+    bool waitForSecondCallSignal,
+    int blockSize,
+    Timeout timeout = Timeout(),
+    cudaStream_t stream = nullptr);
+
 void testTileMultiCallSendOnly(
     P2pNvlTransportDevice p2p,
     TiledBuffer<char> sendTiles,
@@ -160,6 +174,29 @@ void testTileTwoCallSendOnly(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileSendWaitsForWrappedSubstepAck(
+    P2pNvlTransportDevice p2p,
+    const char* sendData,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileForwardWaitsForWrappedSubstepAck(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    char* dst,
+    int activeBlocks,
+    size_t nbytes,
+    size_t maxSignalBytes,
+    unsigned char sentinel,
+    int* observedEarlyOverwrite,
     int blockSize,
     cudaStream_t stream = nullptr);
 
@@ -223,6 +260,18 @@ void testTileTwoCallForward(
     size_t firstCallBytes,
     size_t secondCallBytes,
     size_t maxSignalBytes,
+    int blockSize,
+    cudaStream_t stream = nullptr);
+
+void testTileTwoCallVariableSignalForward(
+    P2pNvlTransportDevice pred,
+    P2pNvlTransportDevice succ,
+    TiledBuffer<char> dstTiles,
+    int activeBlocks,
+    size_t firstCallBytes,
+    size_t secondCallBytes,
+    size_t firstMaxSignalBytes,
+    size_t secondMaxSignalBytes,
     int blockSize,
     cudaStream_t stream = nullptr);
 


### PR DESCRIPTION
Summary:

Mirror the NVLink tile cursor fix in P2pIbgdaTransportDevice by storing persistent send/recv/forward cursors in bytes instead of max_signal_bytes-dependent sub-chunk counts. IBGDA DATA_READY, SLOT_FREE, and NIC_DONE are atomic-add counters, so each posted copy now increments by bytesThis and waits on cumulative byte thresholds; changing max_signal_bytes remains safe when active_blocks is unchanged, while active block layout changes still require quiescence.

Reviewed By: goelayu

Differential Revision: D106141647


