### PR TITLE
Gate TorchComms NCCLX GIN device-window resources (#2674)

### DIFF
--- a/comms/torchcomms/device/DeviceBackendTraits.hpp
+++ b/comms/torchcomms/device/DeviceBackendTraits.hpp
@@ -188,6 +188,7 @@ struct DeviceBackendConfig {
   int barrier_count{1};
   int comm_rank{0};
   int comm_size{1};
+  bool gin_enabled{false};
 };
 
 // =============================================================================

--- a/comms/torchcomms/device/TorchCommDeviceWindow.hpp
+++ b/comms/torchcomms/device/TorchCommDeviceWindow.hpp
@@ -109,14 +109,16 @@ class TorchCommDeviceWindow {
       size_t size,
       int rank,
       int num_ranks,
-      uint32_t signal_buffer_handle = 0)
+      uint32_t signal_buffer_handle = 0,
+      bool gin_enabled = false)
       : comm_(comm),
         window_(window),
         base_(base),
         size_(size),
         rank_(rank),
         num_ranks_(num_ranks),
-        signal_buffer_handle_(signal_buffer_handle) {}
+        signal_buffer_handle_(signal_buffer_handle),
+        gin_enabled_(gin_enabled) {}
 
   // =========================================================================
   // Metadata
@@ -254,6 +256,7 @@ class TorchCommDeviceWindow {
   int num_ranks_{};
   uint32_t signal_buffer_handle_{}; // Resource buffer handle for per-peer
                                     // signal slots
+  bool gin_enabled_{false};
 };
 
 // Type alias (also defined in backend-specific headers for convenience)

--- a/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
+++ b/comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp
@@ -7,6 +7,9 @@
 #include "comms/torchcomms/ncclx/NcclxApi.hpp"
 #include "comms/torchcomms/utils/Logging.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -14,6 +17,26 @@
 namespace torchcomms::device {
 
 using torch::comms::RegisteredBuffer;
+
+namespace {
+
+bool isNcclGinEnabled() {
+  const char* env = std::getenv("NCCL_GIN_ENABLE");
+  if (env == nullptr) {
+    return false;
+  }
+
+  std::string value(env);
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+
+  return value == "1" || value == "y" || value == "yes" || value == "t" ||
+      value == "true";
+}
+
+} // namespace
 
 // =============================================================================
 // DeviceWindowDeleter Implementation
@@ -95,17 +118,21 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
   // ncclInvalidArgument on topologies where multicast is unavailable.
   reqs.lsaMultimem = nccl_api->multimemSupport(nccl_comm) &&
       nccl_api->teamLsa(nccl_comm).nRanks > 2;
-  reqs.barrierCount = config.barrier_count;
+  reqs.barrierCount = config.gin_enabled ? config.barrier_count : 0;
   reqs.lsaBarrierCount = config.barrier_count;
-  reqs.railGinBarrierCount = config.barrier_count;
+  reqs.railGinBarrierCount = config.gin_enabled ? config.barrier_count : 0;
   reqs.lsaLLA2ABlockCount = 0;
   reqs.lsaLLA2ASlotCount = 0;
-  reqs.ginForceEnable = true;
+  reqs.ginForceEnable = false;
   reqs.ginContextCount = 1;
   reqs.ginSignalCount = 0;
-  reqs.ginCounterCount = config.counter_count;
+  reqs.ginCounterCount = config.gin_enabled ? config.counter_count : 0;
+  reqs.ginConnectionType = config.gin_enabled
+      ? nccl_api->ginConnectionSupport(nccl_comm)
+      : NCCL_GIN_CONNECTION_NONE;
 
-  // Create NCCL device communicator with GIN state
+  // Create NCCL device communicator. GIN resources are requested only when
+  // NCCL_GIN_ENABLE is explicitly set by the caller.
   ncclDevComm nccl_dev_comm{};
   auto result = nccl_api->devCommCreate(nccl_comm, &reqs, &nccl_dev_comm);
   if (result != ncclSuccess) {
@@ -123,7 +150,8 @@ NCCLDeviceBackend::Ptr NCCLDeviceBackend::create_device_window(
       size,
       config.comm_rank,
       config.comm_size,
-      signal_buffer_handle);
+      signal_buffer_handle,
+      config.gin_enabled);
 
   // Allocate device memory for the window struct
   TorchCommDeviceWindow<NCCLDeviceBackend>* device_ptr = nullptr;
@@ -182,6 +210,9 @@ void NCCLDeviceBackend::register_extra_window(
   if (*out_win != nullptr) {
     return;
   }
+  if (!isNcclGinEnabled()) {
+    return;
+  }
   CHECK_EQ(
       nccl_api->commWindowRegister(
           ptr, size, nccl_comm, out_win, NCCL_WIN_DEVICE_API),
@@ -207,6 +238,21 @@ RegisteredBuffer NCCLDeviceBackend::register_local_buffer(
     ncclComm_t nccl_comm,
     void* ptr,
     size_t size) {
+  RegisteredBuffer buf;
+  buf.base_ptr = ptr;
+  buf.size = size;
+
+  if (!isNcclGinEnabled()) {
+    return buf;
+  }
+
+  int comm_size = 0;
+  CHECK_EQ(nccl_api->commCount(nccl_comm, &comm_size), ncclSuccess)
+      << "[NCCLDeviceBackend]: Failed to query NCCL communicator size";
+  if (nccl_api->teamLsa(nccl_comm).nRanks >= comm_size) {
+    return buf;
+  }
+
   ncclWindow_t local_win = nullptr;
   CHECK_EQ(
       nccl_api->commWindowRegister(
@@ -221,9 +267,6 @@ RegisteredBuffer NCCLDeviceBackend::register_local_buffer(
   // GIN put uses backend_window (ncclWindow_t) for RDMA/NVLink transfers.
   // lkeys are unused by GIN — only the Pipes (IBGDA) backend needs them.
   // Default-constructed RegisteredBuffer zero-initializes the lkeys array.
-  RegisteredBuffer buf;
-  buf.base_ptr = ptr;
-  buf.size = size;
   buf.backend_window = static_cast<void*>(local_win);
   return buf;
 }

--- a/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
+++ b/comms/torchcomms/device/ncclx/TorchCommDeviceNCCLX.cuh
@@ -183,6 +183,10 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::signal(
     }
   } else {
     // ---- GIN (RDMA) path ----
+    if (!gin_enabled_) {
+      return -1;
+    }
+
     // SET is not supported on RDMA (no atomic store opcode).
     if (op != SignalOp::ADD) {
       return -1;
@@ -233,7 +237,11 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::put(
           ncclTeamLsa(dev_comm), ncclTeamWorld(dev_comm), dst_rank)) {
     // ---- LSA (NVLink) path ----
     // Cooperative memcpy through NVLink-mapped pointers.
-    void* src = ncclGetLocalPointer(src_win, src_offset);
+    if (src_buf.base_ptr == nullptr) {
+      return -1;
+    }
+    void* src =
+        static_cast<void*>(static_cast<char*>(src_buf.base_ptr) + src_offset);
     void* dst = ncclGetPeerPointer(dst_win, dst_offset, dst_rank);
 
     detail::memcpy_nvl(dst, src, bytes, scope);
@@ -247,6 +255,10 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::put(
     // counter_id silently ignored for LSA — counters are GIN hardware only
   } else {
     // ---- GIN (RDMA) path ----
+    if (!gin_enabled_ || src_win == nullptr) {
+      return -1;
+    }
+
     ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
     detail::nccl_coop_dispatch(scope, [&](auto coop) {
@@ -394,6 +406,9 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_counter(
     __trap();
     return -1; // Unreachable
   }
+  if (!gin_enabled_) {
+    return -1;
+  }
 
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
@@ -412,6 +427,10 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::wait_counter(
 template <>
 __device__ inline uint64_t
 TorchCommDeviceWindow<NCCLDeviceBackend>::read_counter(int counter_id) const {
+  if (!gin_enabled_) {
+    return 0;
+  }
+
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
@@ -425,6 +444,10 @@ __device__ inline void TorchCommDeviceWindow<NCCLDeviceBackend>::reset_counter(
     CoopScope scope) {
   auto group = detail::make_thread_group(scope);
   group.sync();
+
+  if (!gin_enabled_) {
+    return;
+  }
 
   if (group.is_leader()) {
     const ncclDevComm& dev_comm = comm_;
@@ -464,6 +487,10 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::flush(
   auto group = detail::make_thread_group(scope);
   group.sync();
 
+  if (!gin_enabled_) {
+    return 0;
+  }
+
   const ncclDevComm& dev_comm = comm_;
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
   detail::nccl_coop_dispatch(scope, [&](auto coop) { gin.flush(coop); });
@@ -476,6 +503,20 @@ __device__ inline int TorchCommDeviceWindow<NCCLDeviceBackend>::barrier(
     int barrier_id,
     CoopScope scope) {
   const ncclDevComm& dev_comm = comm_;
+
+  if (!gin_enabled_) {
+    detail::nccl_coop_dispatch(scope, [&](auto coop) {
+      ncclLsaBarrierSession barrier(
+          coop,
+          dev_comm,
+          ncclTeamTagLsa{},
+          static_cast<uint32_t>(barrier_id),
+          false /* multimem */);
+      barrier.sync(coop, cuda::memory_order_acq_rel);
+    });
+    return 0;
+  }
+
   ncclGin gin(dev_comm, kDefaultGinContextIndex);
 
   // World barrier: syncs LSA team (NVLink) first, then Rail team (RDMA)

--- a/comms/torchcomms/device/ncclx/tests/unit/cpp/NCCLDeviceBackendTest.cpp
+++ b/comms/torchcomms/device/ncclx/tests/unit/cpp/NCCLDeviceBackendTest.cpp
@@ -29,6 +29,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #include "comms/torchcomms/device/cuda/CudaApi.hpp"
@@ -62,6 +64,7 @@ class NCCLDeviceBackendTest : public ::testing::Test {
   }
 
   void TearDown() override {
+    unsetenv("NCCL_GIN_ENABLE");
     nccl_mock_.reset();
   }
 
@@ -223,7 +226,9 @@ TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowSuccessReturnsValidStruct) {
   // Let unique_ptr destructor call cudaFree via the deleter
 }
 
-TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowConfigIsPassedCorrectly) {
+TEST_F(
+    NCCLDeviceBackendTest,
+    CreateDeviceWindowConfigDoesNotRequestGinByDefault) {
   // This test verifies that the config is correctly passed to devCommCreate.
   DeviceBackendConfig config;
   config.signal_count = 16;
@@ -258,9 +263,12 @@ TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowConfigIsPassedCorrectly) {
 
   ASSERT_NE(device_window, nullptr);
   EXPECT_EQ(captured_reqs.ginSignalCount, 0);
-  EXPECT_EQ(captured_reqs.ginCounterCount, config.counter_count);
-  EXPECT_EQ(captured_reqs.barrierCount, config.barrier_count);
-  EXPECT_TRUE(captured_reqs.ginForceEnable);
+  EXPECT_EQ(captured_reqs.ginCounterCount, 0);
+  EXPECT_EQ(captured_reqs.barrierCount, 0);
+  EXPECT_EQ(captured_reqs.lsaBarrierCount, config.barrier_count);
+  EXPECT_EQ(captured_reqs.railGinBarrierCount, 0);
+  EXPECT_FALSE(captured_reqs.ginForceEnable);
+  EXPECT_EQ(captured_reqs.ginConnectionType, NCCL_GIN_CONNECTION_NONE);
 
   // Verify resource buffer requirements were chained in
   EXPECT_NE(captured_reqs.resourceRequirementsList, nullptr);
@@ -279,6 +287,156 @@ TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowConfigIsPassedCorrectly) {
   nccl_mock_->devCommDestroy(deleter.nccl_comm, &deleter.dev_comm);
 
   // Let unique_ptr destructor call cudaFree via the deleter
+}
+
+TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowRequestsGinWhenEnabled) {
+  DeviceBackendConfig config;
+  config.signal_count = 16;
+  config.counter_count = 32;
+  config.barrier_count = 2;
+  config.comm_rank = 3;
+  config.comm_size = 8;
+  config.gin_enabled = true;
+
+  ncclDevCommRequirements captured_reqs{};
+  EXPECT_CALL(*nccl_mock_, devCommCreate(fake_nccl_comm_, _, _))
+      .WillOnce(DoAll(
+          [&captured_reqs](
+              ncclComm_t,
+              const ncclDevCommRequirements_t* reqs,
+              ncclDevComm_t*) {
+            if (reqs) {
+              captured_reqs = *reqs;
+            }
+            return ncclSuccess;
+          },
+          SetArgPointee<2>(ncclDevComm{}),
+          Return(ncclSuccess)));
+
+  auto device_window = NCCLDeviceBackend::create_device_window(
+      fake_nccl_comm_,
+      nccl_mock_.get(),
+      cuda_api_.get(),
+      config,
+      fake_nccl_window_,
+      fake_base_,
+      1024);
+
+  ASSERT_NE(device_window, nullptr);
+  EXPECT_EQ(captured_reqs.ginSignalCount, 0);
+  EXPECT_EQ(captured_reqs.ginCounterCount, config.counter_count);
+  EXPECT_EQ(captured_reqs.barrierCount, config.barrier_count);
+  EXPECT_EQ(captured_reqs.lsaBarrierCount, config.barrier_count);
+  EXPECT_EQ(captured_reqs.railGinBarrierCount, config.barrier_count);
+  EXPECT_FALSE(captured_reqs.ginForceEnable);
+  EXPECT_EQ(captured_reqs.ginConnectionType, NCCL_GIN_CONNECTION_RAIL);
+
+  auto& deleter = device_window.get_deleter();
+  EXPECT_CALL(*nccl_mock_, devCommDestroy(fake_nccl_comm_, _))
+      .WillOnce(Return(ncclSuccess));
+  nccl_mock_->devCommDestroy(deleter.nccl_comm, &deleter.dev_comm);
+}
+
+TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowRequestsFullGinWhenSupported) {
+  DeviceBackendConfig config;
+  config.signal_count = 16;
+  config.counter_count = 32;
+  config.barrier_count = 2;
+  config.comm_rank = 3;
+  config.comm_size = 8;
+  config.gin_enabled = true;
+
+  ON_CALL(*nccl_mock_, ginConnectionSupport(fake_nccl_comm_))
+      .WillByDefault(Return(NCCL_GIN_CONNECTION_FULL));
+
+  ncclDevCommRequirements captured_reqs{};
+  EXPECT_CALL(*nccl_mock_, devCommCreate(fake_nccl_comm_, _, _))
+      .WillOnce(DoAll(
+          [&captured_reqs](
+              ncclComm_t,
+              const ncclDevCommRequirements_t* reqs,
+              ncclDevComm_t*) {
+            if (reqs) {
+              captured_reqs = *reqs;
+            }
+            return ncclSuccess;
+          },
+          SetArgPointee<2>(ncclDevComm{}),
+          Return(ncclSuccess)));
+
+  auto device_window = NCCLDeviceBackend::create_device_window(
+      fake_nccl_comm_,
+      nccl_mock_.get(),
+      cuda_api_.get(),
+      config,
+      fake_nccl_window_,
+      fake_base_,
+      1024);
+
+  ASSERT_NE(device_window, nullptr);
+  EXPECT_EQ(captured_reqs.ginCounterCount, config.counter_count);
+  EXPECT_EQ(captured_reqs.barrierCount, config.barrier_count);
+  EXPECT_EQ(captured_reqs.railGinBarrierCount, config.barrier_count);
+  EXPECT_EQ(captured_reqs.ginConnectionType, NCCL_GIN_CONNECTION_FULL);
+
+  auto& deleter = device_window.get_deleter();
+  EXPECT_CALL(*nccl_mock_, devCommDestroy(fake_nccl_comm_, _))
+      .WillOnce(Return(ncclSuccess));
+  nccl_mock_->devCommDestroy(deleter.nccl_comm, &deleter.dev_comm);
+}
+
+TEST_F(NCCLDeviceBackendTest, RegisterLocalBufferSkipsWindowWhenGinDisabled) {
+  auto buf = NCCLDeviceBackend::register_local_buffer(
+      nccl_mock_.get(), fake_nccl_comm_, fake_base_, 4096);
+
+  EXPECT_EQ(buf.base_ptr, fake_base_);
+  EXPECT_EQ(buf.size, 4096u);
+  EXPECT_EQ(buf.backend_window, nullptr);
+}
+
+TEST_F(NCCLDeviceBackendTest, RegisterLocalBufferSkipsWindowForAllLsaRanks) {
+  setenv("NCCL_GIN_ENABLE", "1", 1);
+  ncclTeam_t lsa_team{};
+  lsa_team.nRanks = 4;
+
+  EXPECT_CALL(*nccl_mock_, commCount(fake_nccl_comm_, _))
+      .WillOnce(DoAll(SetArgPointee<1>(4), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, teamLsa(fake_nccl_comm_)).WillOnce(Return(lsa_team));
+  EXPECT_CALL(*nccl_mock_, commWindowRegister(_, _, _, _, _)).Times(0);
+
+  auto buf = NCCLDeviceBackend::register_local_buffer(
+      nccl_mock_.get(), fake_nccl_comm_, fake_base_, 4096);
+
+  EXPECT_EQ(buf.base_ptr, fake_base_);
+  EXPECT_EQ(buf.size, 4096u);
+  EXPECT_EQ(buf.backend_window, nullptr);
+}
+
+TEST_F(NCCLDeviceBackendTest, RegisterLocalBufferUsesWindowForRemoteGinRanks) {
+  setenv("NCCL_GIN_ENABLE", "1", 1);
+  ncclTeam_t lsa_team{};
+  lsa_team.nRanks = 4;
+  auto local_win = reinterpret_cast<ncclWindow_t>(0x6000);
+
+  EXPECT_CALL(*nccl_mock_, commCount(fake_nccl_comm_, _))
+      .WillOnce(DoAll(SetArgPointee<1>(8), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, teamLsa(fake_nccl_comm_)).WillOnce(Return(lsa_team));
+  EXPECT_CALL(
+      *nccl_mock_,
+      commWindowRegister(
+          fake_base_,
+          4096,
+          fake_nccl_comm_,
+          _,
+          NCCL_WIN_DEVICE_API | NCCL_WIN_LOCAL_ONLY))
+      .WillOnce(DoAll(SetArgPointee<3>(local_win), Return(ncclSuccess)));
+
+  auto buf = NCCLDeviceBackend::register_local_buffer(
+      nccl_mock_.get(), fake_nccl_comm_, fake_base_, 4096);
+
+  EXPECT_EQ(buf.base_ptr, fake_base_);
+  EXPECT_EQ(buf.size, 4096u);
+  EXPECT_EQ(buf.backend_window, static_cast<void*>(local_win));
 }
 
 TEST_F(NCCLDeviceBackendTest, CreateDeviceWindowStoresSignalBufferHandle) {

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -591,6 +591,35 @@ bool DefaultNcclxApi::multimemSupport(ncclComm_t comm) {
   return false;
 #endif
 }
+
+ncclGinConnectionType_t DefaultNcclxApi::ginConnectionSupport(ncclComm_t comm) {
+#ifdef NCCL_COMM_PROPERTIES_INITIALIZER
+  ncclCommProperties_t props = NCCL_COMM_PROPERTIES_INITIALIZER;
+  if (ncclCommQueryProperties(comm, &props) != ncclSuccess) {
+    return NCCL_GIN_CONNECTION_NONE;
+  }
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 0)
+  if (props.ginType != NCCL_GIN_TYPE_NONE) {
+    return NCCL_GIN_CONNECTION_FULL;
+  }
+  if (props.railedGinType != NCCL_GIN_TYPE_NONE) {
+    return NCCL_GIN_CONNECTION_RAIL;
+  }
+#elif NCCL_VERSION_CODE > NCCL_VERSION(2, 29, 3)
+  // NCCLX 2.29 still records the requested connection type when GIN first
+  // connects, and rejects a later FULL request if the communicator was already
+  // connected as RAIL. Without a public connected-state property, RAIL is the
+  // safe request whenever NCCLX says railed GIN is supported.
+  if (props.railedGinType != NCCL_GIN_TYPE_NONE) {
+    return NCCL_GIN_CONNECTION_RAIL;
+  }
+#endif
+  return NCCL_GIN_CONNECTION_NONE;
+#else
+  (void)comm;
+  return NCCL_GIN_CONNECTION_NONE;
+#endif
+}
 #endif // TORCHCOMMS_HAS_NCCL_DEVICE_API
 
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -354,6 +354,10 @@ class NcclxApi {
 
   // Query whether the communicator supports NVLS multicast (multimem).
   [[nodiscard]] virtual bool multimemSupport(ncclComm_t comm) = 0;
+
+  // Query the best GIN connection type supported by the communicator.
+  [[nodiscard]] virtual ncclGinConnectionType_t ginConnectionSupport(
+      ncclComm_t comm) = 0;
 #endif
 
 #if defined(ENABLE_PIPES)
@@ -693,6 +697,9 @@ class DefaultNcclxApi : public NcclxApi {
   [[nodiscard]] ncclTeam_t teamLsa(ncclComm_t comm) override;
 
   [[nodiscard]] bool multimemSupport(ncclComm_t comm) override;
+
+  [[nodiscard]] ncclGinConnectionType_t ginConnectionSupport(
+      ncclComm_t comm) override;
 #endif
 
 #if defined(ENABLE_PIPES)

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -4,6 +4,10 @@
 
 #include <cuda_runtime.h>
 #include <fmt/core.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <string>
 
 #include "comms/torchcomms/ncclx/TorchCommNCCLX.hpp"
 #include "comms/torchcomms/utils/Logging.hpp"
@@ -19,6 +23,26 @@
 #endif
 
 namespace torch::comms {
+
+namespace {
+
+bool isNcclGinEnabled() {
+  const char* env = std::getenv("NCCL_GIN_ENABLE");
+  if (env == nullptr) {
+    return false;
+  }
+
+  std::string value(env);
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+
+  return value == "1" || value == "y" || value == "yes" || value == "t" ||
+      value == "true";
+}
+
+} // namespace
 
 // =============================================================================
 // Constructor / Destructor
@@ -469,7 +493,15 @@ void* TorchCommWindowNCCLX<Backend>::get_device_window(
     int barrier_count) {
   checkCommAndThrow();
 
-  if (Backend::select_device_win(win_, nccl_orig_win_) == nullptr) {
+  torchcomms::device::DeviceBackendConfig config;
+  config.gin_enabled = isNcclGinEnabled();
+
+  auto selected_win = Backend::select_device_win(win_, nccl_orig_win_);
+  if (selected_win == nullptr && !config.gin_enabled) {
+    selected_win = win_;
+  }
+
+  if (selected_win == nullptr) {
     throw std::runtime_error(
         "[TorchCommWindowNCCLX]: Window not initialized. "
         "Call tensor_register first.");
@@ -492,7 +524,6 @@ void* TorchCommWindowNCCLX<Backend>::get_device_window(
     counter_count = commSize;
   }
 
-  torchcomms::device::DeviceBackendConfig config;
   config.signal_count = signal_count;
   config.counter_count = counter_count;
   config.barrier_count = barrier_count;
@@ -518,7 +549,7 @@ void* TorchCommWindowNCCLX<Backend>::get_device_window(
         nccl_api_,
         torch_comm_->getCudaApi(),
         config,
-        Backend::select_device_win(win_, nccl_orig_win_),
+        selected_win,
         buf_ptr,
         win_size_);
   } else {
@@ -527,7 +558,7 @@ void* TorchCommWindowNCCLX<Backend>::get_device_window(
         nccl_api_,
         torch_comm_->getCudaApi(),
         config,
-        Backend::select_device_win(win_, nccl_orig_win_),
+        selected_win,
         buf_ptr,
         win_size_);
   }
@@ -542,15 +573,19 @@ void* TorchCommWindowNCCLX<Backend>::get_nvlink_address(
     size_t offset) {
   checkCommAndThrow();
 
-  if (nccl_orig_win_ == nullptr) {
+  auto query_win = nccl_orig_win_;
+  if (query_win == nullptr && !isNcclGinEnabled()) {
+    query_win = win_;
+  }
+  if (query_win == nullptr) {
     throw std::runtime_error(
-        "[TorchCommWindowNCCLX]: NCCL orig window not initialized. "
+        "[TorchCommWindowNCCLX]: NCCL window not initialized. "
         "Call tensor_register first.");
   }
 
   void* outPtr = nullptr;
   CHECK_EQ(
-      nccl_api_->winGetPeerDevicePointer(nccl_orig_win_, offset, peer, &outPtr),
+      nccl_api_->winGetPeerDevicePointer(query_win, offset, peer, &outPtr),
       ncclSuccess)
       << "[TorchCommWindowNCCLX]: ncclGetPeerDevicePointer failed";
 
@@ -561,16 +596,19 @@ template <typename Backend>
 void* TorchCommWindowNCCLX<Backend>::get_multimem_address(size_t offset) {
   checkCommAndThrow();
 
-  if (nccl_orig_win_ == nullptr) {
+  auto query_win = nccl_orig_win_;
+  if (query_win == nullptr && !isNcclGinEnabled()) {
+    query_win = win_;
+  }
+  if (query_win == nullptr) {
     throw std::runtime_error(
-        "[TorchCommWindowNCCLX]: NCCL orig window not initialized. "
+        "[TorchCommWindowNCCLX]: NCCL window not initialized. "
         "Call tensor_register first.");
   }
 
   void* outPtr = nullptr;
   CHECK_EQ(
-      nccl_api_->winGetLsaMultimemDevicePointer(
-          nccl_orig_win_, offset, &outPtr),
+      nccl_api_->winGetLsaMultimemDevicePointer(query_win, offset, &outPtr),
       ncclSuccess)
       << "[TorchCommWindowNCCLX]: ncclGetLsaMultimemDevicePointer failed";
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.cpp
@@ -133,6 +133,8 @@ void NcclxMock::setupDefaultBehaviors() {
   ON_CALL(*this, devCommCreate(_, _, _)).WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, devCommDestroy(_, _)).WillByDefault(Return(ncclSuccess));
   ON_CALL(*this, multimemSupport(_)).WillByDefault(Return(false));
+  ON_CALL(*this, ginConnectionSupport(_))
+      .WillByDefault(Return(NCCL_GIN_CONNECTION_RAIL));
 #endif
 }
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -355,6 +355,11 @@ class NcclxMock : public NcclxApi {
   MOCK_METHOD(ncclTeam_t, teamLsa, (ncclComm_t comm), (override));
 
   MOCK_METHOD(bool, multimemSupport, (ncclComm_t comm), (override));
+  MOCK_METHOD(
+      ncclGinConnectionType_t,
+      ginConnectionSupport,
+      (ncclComm_t comm),
+      (override));
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
   MOCK_METHOD(


### PR DESCRIPTION
Summary:

This updates TorchComms NCCLX device-window setup so GIN is an explicit opt-in path and same-node NVLink/LSA device-window use continues to work without requiring GIN.

- Gate NCCLX GIN resource requests on `NCCL_GIN_ENABLE`; when the flag is unset or false, TorchComms requests `NCCL_GIN_CONNECTION_NONE` instead of unconditionally asking NCCLX for GIN resources.
- Move GIN connection selection into `NcclxApi::ginConnectionSupport()`, which queries NCCLX communicator properties instead of hardcoding the connection type in TorchComms. With NCCLX 2.30+, TorchComms requests `NCCL_GIN_CONNECTION_FULL` when FULL GIN is available and falls back to `NCCL_GIN_CONNECTION_RAIL` when only railed GIN is available. With NCCLX 2.29, TorchComms requests RAIL when railed GIN is available to avoid the known FULL-after-RAIL connected-state mismatch.
- Keep deprecated `ginForceEnable` disabled so NCCLX's own capability checks decide whether GIN can be used.
- Use local registered-buffer pointers for no-GIN same-node accesses instead of calling `ncclGetLocalPointer(src_win, ...)`.
- Skip local GIN source-window registration when all communicator ranks are in the LSA/NVLink team, avoiding the GB300 `NCCL_WIN_LOCAL_ONLY` registration failure while preserving source-window registration for remote GIN ranks.
- Keep the launcher validation path on the standard NCCL knob `NCCL_IB_MERGE_NICS=0` and `--gin-modes off,on`, so MAST jobs cover both no-GIN and GIN modes from the same image without a TorchComms-specific merge-NIC override.

The GB300 issues were separate: merged NICs hid usable GIN support from NCCL, unconditional GIN resource requests broke no-GIN/NVLink-only use, and all-local device-window setup attempted unnecessary local source-window registration under `NCCL_WIN_LOCAL_ONLY`.

Reviewed By: siyengar

Differential Revision: D106109296


