### PR TITLE
Fix conda build: remove stale AllGatherRecDbl.cu from device Makefiles (#2676)

### DIFF
--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -123,7 +123,6 @@ SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
-SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu


### PR DESCRIPTION
Summary:

- Remove non-existent `AllGatherRecDbl.cu` from v2_29 and v2_30 device Makefiles
- D105641025 deleted `AllGatherRecDbl.cu` (consolidated into `StreamedRd/`) but missed removing the Makefile entry
- `StreamedRd/Impl.cu` is already correctly listed on the next line in both Makefiles
- This fixes conda nccl feedstock builds which use Make (buck builds are unaffected as they use BUCK files)

Reviewed By: elvinlife

Differential Revision: D106238938


