### PR TITLE
Remove deleted AllGatherRecDbl from device Makefile

### DIFF
--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -118,7 +118,6 @@ SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
-SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu


### PR DESCRIPTION
Summary:
Remove the stale AllGatherRecDbl.cu source entry from the NCCLX device
Makefile. The source was deleted when AllGather recursive doubling was
consolidated into StreamedRd, but the standalone conda/NCCLX Makefile
still referenced it.

Differential Revision: D106260866


