### PR TITLE
Add hierarchical reduce-scatter for Pipes

### DIFF
--- a/comms/pipes/collectives/DirectCollectiveUtils.cuh
+++ b/comms/pipes/collectives/DirectCollectiveUtils.cuh
@@ -104,4 +104,89 @@ hierarchical_allgather_nvl_broadcast_from_recvbuf(
 #endif
 }
 
+template <typename T, typename ReduceOp, typename Group>
+__device__ __forceinline__ void
+hierarchical_reduce_scatter_nvl_reduce_to_workspace(
+    Group& group,
+    int ib_size,
+    int nvl_rank,
+    int nvl_size,
+    std::size_t chunk_elements,
+    std::size_t max_sig,
+    const P2pNvlTransportDevice* peers,
+    const T* input,
+    T* workspace,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  const std::size_t chunk_bytes = chunk_elements * sizeof(T);
+  const char* input_base = reinterpret_cast<const char*>(input);
+  char* workspace_base = reinterpret_cast<char*>(workspace);
+
+  TiledBuffer<char> tile(nullptr, chunk_bytes, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  for (int ib_dst = 0; ib_dst < ib_size; ++ib_dst) {
+    const std::size_t workspace_chunk =
+        static_cast<std::size_t>(ib_dst) * chunk_bytes;
+    const std::size_t input_chunk =
+        (static_cast<std::size_t>(ib_dst) * nvl_size + nvl_rank) * chunk_bytes;
+    char* dst = workspace_base + workspace_chunk + tile_offset;
+
+    memcpy_vectorized(
+        dst, input_base + input_chunk + tile_offset, tile_bytes, group);
+    group.sync();
+
+    if (nvl_size <= 1 || tile_bytes == 0) {
+      continue;
+    }
+
+    const std::size_t pipeline_window =
+        direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups);
+    PIPES_DEVICE_CHECK_MSG(
+        pipeline_window != 0,
+        "hierarchical reduce-scatter NVLink reduce pipeline window is zero");
+
+    for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = tile_bytes - off;
+      const std::size_t window =
+          remaining < pipeline_window ? remaining : pipeline_window;
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        const std::size_t peer_input_chunk =
+            (static_cast<std::size_t>(ib_dst) * nvl_size + peer_rank) *
+            chunk_bytes;
+        auto peer = peers[peer_rank];
+        peer.send(
+            group,
+            input_base + peer_input_chunk + tile_offset + off,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        char* window_dst = dst + off;
+        auto peer = peers[peer_rank];
+        peer.template recv<ReduceOp>(
+            group,
+            window_dst,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            window_dst);
+      }
+    }
+  }
+#endif
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirect.cu
+++ b/comms/pipes/collectives/ReduceScatterDirect.cu
@@ -5,6 +5,7 @@
 #include "comms/pipes/CopyOp.cuh"
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
@@ -82,5 +83,126 @@ template __global__ void
 direct_reduce_scatter_nvl_kernel<float, SumOp, 16384, 512>(
     const __grid_constant__ DirectReduceScatterNvlArgs<float>,
     Timeout);
+
+template <typename T, typename ReduceOp, typename Group>
+__device__ __forceinline__ void hierarchical_reduce_scatter_ib_ring(
+    Group& group,
+    int ib_rank,
+    int ib_size,
+    std::size_t chunk_elements,
+    std::size_t max_sig,
+    const HierarchicalReduceScatterIbgdaRing& topo,
+    const T* workspace,
+    T* output,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  const std::size_t chunk_bytes = chunk_elements * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, chunk_bytes, group);
+  const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const char* input_base = reinterpret_cast<const char*>(workspace);
+  char* output_base = reinterpret_cast<char*>(output);
+
+  if (ib_size <= 1) {
+    memcpy_vectorized(
+        output_base + io_tile_offset,
+        input_base + io_tile_offset,
+        io_tile_bytes,
+        group);
+    return;
+  }
+
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical reduce-scatter IB pipeline window is zero");
+
+  const int stride = (ib_rank - topo.prev_rank + ib_size) % ib_size;
+  PIPES_DEVICE_CHECK_MSG(
+      stride != 0 && (ib_rank + stride) % ib_size == topo.next_rank,
+      "hierarchical reduce-scatter IB ring topology is inconsistent");
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    int current_rank = (ib_rank + ib_size - stride) % ib_size;
+    const char* send_src = input_base +
+        static_cast<std::size_t>(current_rank) * chunk_bytes + io_tile_offset +
+        off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    for (int step = 0; step < ib_size - 1; step++) {
+      current_rank = (current_rank + ib_size - stride) % ib_size;
+      const char* local_input = input_base +
+          static_cast<std::size_t>(current_rank) * chunk_bytes +
+          io_tile_offset + off;
+
+      if (step < ib_size - 2) {
+        prev.template forward<ReduceOp>(
+            group,
+            nullptr,
+            next,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      } else {
+        char* dst = output_base + io_tile_offset + off;
+        prev.template recv<ReduceOp>(
+            group,
+            dst,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      }
+    }
+  }
+#endif
+}
+
+__global__
+__launch_bounds__(512, 1) void hierarchical_reduce_scatter_fused_float_sum_kernel(
+    const __grid_constant__ HierarchicalReduceScatterFusedArgs<float> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  using ReduceOp = TileReduceStaged<float, SumOp, 16384, 512>;
+
+  hierarchical_reduce_scatter_nvl_reduce_to_workspace<float, ReduceOp>(
+      group,
+      args.ib_size,
+      args.nvl_rank,
+      args.nvl_size,
+      args.chunk_elements,
+      args.nvl_signaling_data_size,
+      args.nvl_peers,
+      args.input,
+      args.workspace,
+      timeout);
+  group.sync();
+
+  hierarchical_reduce_scatter_ib_ring<float, ReduceOp>(
+      group,
+      args.ib_rank,
+      args.ib_size,
+      args.chunk_elements,
+      args.ib_signaling_data_size,
+      args.ib_ring,
+      args.workspace,
+      args.output,
+      timeout);
+#endif
+}
 
 } // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirect.cuh
+++ b/comms/pipes/collectives/ReduceScatterDirect.cuh
@@ -13,4 +13,9 @@ __global__
         const __grid_constant__ DirectReduceScatterNvlArgs<T> args,
         Timeout timeout);
 
+__global__
+    __launch_bounds__(512, 1) void hierarchical_reduce_scatter_fused_float_sum_kernel(
+        const __grid_constant__ HierarchicalReduceScatterFusedArgs<float> args,
+        Timeout timeout);
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterDirectTypes.h
+++ b/comms/pipes/collectives/ReduceScatterDirectTypes.h
@@ -9,6 +9,8 @@
 
 namespace comms::pipes {
 
+class P2pIbgdaTransportDevice;
+
 template <typename T>
 struct DirectReduceScatterNvlArgs {
   int my_rank{0};
@@ -19,5 +21,32 @@ struct DirectReduceScatterNvlArgs {
   const T* input{nullptr};
   T* output{nullptr};
 };
+
+struct HierarchicalReduceScatterIbgdaRing {
+  int prev_rank{0};
+  int next_rank{0};
+  P2pIbgdaTransportDevice* prev{nullptr};
+  P2pIbgdaTransportDevice* next{nullptr};
+};
+
+template <typename T>
+struct HierarchicalReduceScatterFusedArgs {
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t chunk_elements{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const T* input{nullptr};
+  T* output{nullptr};
+  T* workspace{nullptr};
+  HierarchicalReduceScatterIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+static_assert(
+    sizeof(HierarchicalReduceScatterFusedArgs<float>) <= 32764,
+    "Hierarchical reduce-scatter launch args exceed CUDA kernel parameter limit");
 
 } // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterLauncher.cu
+++ b/comms/pipes/collectives/ReduceScatterLauncher.cu
@@ -62,4 +62,41 @@ void launch_direct_reduce_scatter_nvl(
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
+void launch_hierarchical_reduce_scatter_fused(
+    const HierarchicalReduceScatterLaunchParams& params) {
+  validate_direct_nvl(params.nvl_size);
+  if (params.ib_size < 1 ||
+      params.ib_size * params.nvl_size != params.num_ranks) {
+    throw std::runtime_error(
+        "Invalid hierarchical reduce-scatter rank geometry");
+  }
+
+  HierarchicalReduceScatterFusedArgs<float> args{};
+  args.ib_rank = params.ib_rank;
+  args.ib_size = params.ib_size;
+  args.nvl_rank = params.nvl_rank;
+  args.nvl_size = params.nvl_size;
+  args.chunk_elements = params.chunk_elements;
+  args.ib_signaling_data_size = params.ib_signaling_data_size;
+  args.nvl_signaling_data_size = params.nvl_signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+  args.workspace = params.workspace;
+  args.ib_ring = params.ib_ring;
+
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == params.nvl_rank) {
+      continue;
+    }
+    new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
+  }
+
+  hierarchical_reduce_scatter_fused_float_sum_kernel<<<
+      params.num_blocks,
+      512,
+      0,
+      params.stream>>>(args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/ReduceScatterLauncher.h
+++ b/comms/pipes/collectives/ReduceScatterLauncher.h
@@ -27,4 +27,26 @@ struct DirectReduceScatterNvlLaunchParams {
 void launch_direct_reduce_scatter_nvl(
     const DirectReduceScatterNvlLaunchParams& params);
 
+struct HierarchicalReduceScatterLaunchParams {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t chunk_elements{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  float* workspace{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  HierarchicalReduceScatterIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_hierarchical_reduce_scatter_fused(
+    const HierarchicalReduceScatterLaunchParams& params);
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/HierarchicalReduceScatterBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/HierarchicalReduceScatterBenchmark.cc
@@ -1,0 +1,631 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <memory>
+#include <new>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/pipes/collectives/ReduceScatterLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+constexpr int kBenchmarkNumBlocks = 8;
+constexpr int kBenchmarkIbLinks = 4;
+constexpr std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+constexpr int kPipelineDepth = 2;
+constexpr std::size_t kDefaultIbSignalBytes = 1024 * 1024;
+
+std::string format_size(std::size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+  }
+  if (bytes >= 1024 * 1024) {
+    return std::to_string(bytes / (1024 * 1024)) + "MB";
+  }
+  if (bytes >= 1024) {
+    return std::to_string(bytes / 1024) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+std::vector<std::size_t> benchmark_sizes() {
+  return {
+      8 * 1024,
+      16 * 1024,
+      32 * 1024,
+      64 * 1024,
+      128 * 1024,
+      256 * 1024,
+      512 * 1024,
+      1024 * 1024,
+      2 * 1024 * 1024,
+      4 * 1024 * 1024,
+      8 * 1024 * 1024,
+      16 * 1024 * 1024,
+      32 * 1024 * 1024,
+      64 * 1024 * 1024,
+      128 * 1024 * 1024,
+      256 * 1024 * 1024,
+      512UL * 1024 * 1024,
+      1024UL * 1024 * 1024,
+  };
+}
+
+std::vector<std::size_t> configured_benchmark_sizes() {
+  const char* only_bytes = std::getenv("HIER_RS_BENCH_ONLY_BYTES");
+  if (only_bytes != nullptr) {
+    return {std::strtoull(only_bytes, nullptr, 10)};
+  }
+  return benchmark_sizes();
+}
+
+int read_int_env(const char* name, int default_value) {
+  const char* value = std::getenv(name);
+  if (value == nullptr) {
+    return default_value;
+  }
+  return static_cast<int>(std::strtol(value, nullptr, 10));
+}
+
+std::size_t read_size_env(const char* name, std::size_t default_value) {
+  const char* value = std::getenv(name);
+  if (value == nullptr) {
+    return default_value;
+  }
+  return std::strtoull(value, nullptr, 10);
+}
+
+bool env_flag_enabled(const char* name, bool default_value) {
+  const char* value = std::getenv(name);
+  if (value == nullptr) {
+    return default_value;
+  }
+  return std::strtol(value, nullptr, 10) != 0;
+}
+
+int benchmark_num_blocks() {
+  return read_int_env("HIER_RS_BENCH_NUM_BLOCKS", kBenchmarkNumBlocks);
+}
+
+int benchmark_nvl_size(int world_size) {
+  const char* nvl_size = std::getenv("HIER_RS_BENCH_NVL_SIZE");
+  if (nvl_size != nullptr) {
+    return static_cast<int>(std::strtol(nvl_size, nullptr, 10));
+  }
+  const int local_size = read_int_env("LOCAL_SIZE", 0);
+  if (local_size > 0 && local_size <= kDirectNvlMaxRanks &&
+      world_size % local_size == 0) {
+    return local_size;
+  }
+  return world_size % 4 == 0 ? 4 : world_size;
+}
+
+std::size_t benchmark_ib_signal_bytes(
+    std::size_t data_buffer_size,
+    int num_blocks) {
+  const char* signal_bytes = std::getenv("HIER_RS_BENCH_IB_SIGNAL_BYTES");
+  if (signal_bytes != nullptr) {
+    return std::strtoull(signal_bytes, nullptr, 10);
+  }
+  const std::size_t per_block_slot =
+      (data_buffer_size / static_cast<std::size_t>(num_blocks)) & ~15ULL;
+  return std::min(per_block_slot, kDefaultIbSignalBytes);
+}
+
+struct HierarchicalReduceScatterBenchmarkConfig {
+  std::size_t chunk_elements;
+  std::size_t total_bytes;
+  std::size_t ib_signaling_data_size;
+  std::size_t nvl_signaling_data_size;
+  int num_blocks;
+  int ib_links;
+  int ib_size;
+  int nvl_size;
+  std::string ib_hca;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct HierarchicalReduceScatterBenchmarkResult {
+  std::string test_name;
+  std::size_t chunk_elements{};
+  std::size_t total_bytes{};
+  int num_blocks{};
+  int ib_links{};
+  int ib_nics{};
+  std::size_t ib_signaling_data_size{};
+  std::size_t data_buffer_size{};
+  int pipeline_depth{};
+  int ib_size{};
+  int nvl_size{};
+  float nccl_bandwidth{};
+  float hierarchical_bandwidth{};
+  float nccl_latency{};
+  float hierarchical_latency{};
+  float speedup{};
+};
+
+class HierarchicalReduceScatterBenchmarkFixture
+    : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_ALGO", "Ring", 1);
+    setenv("NCCL_PROTO", "Simple", 1);
+    setenv("NCCL_NVLS_ENABLE", "0", 1);
+    setenv(
+        "NCCL_P2P_DISABLE",
+        env_flag_enabled("HIER_RS_BENCH_NCCL_P2P_DISABLE", true) ? "1" : "0",
+        1);
+    setenv(
+        "NCCL_SHM_DISABLE",
+        env_flag_enabled("HIER_RS_BENCH_NCCL_SHM_DISABLE", true) ? "1" : "0",
+        1);
+    const std::string ib_hca = benchmark_ib_hca();
+    if (!ib_hca.empty()) {
+      setenv("NCCL_IB_HCA", ib_hca.c_str(), 1);
+    }
+    const std::string num_blocks = std::to_string(benchmark_num_blocks());
+    setenv("NCCL_MIN_NCHANNELS", num_blocks.c_str(), 1);
+    setenv("NCCL_MAX_NCHANNELS", num_blocks.c_str(), 1);
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+    if (!benchmark_skip_nccl()) {
+      NCCL_CHECK_VOID(
+          ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    }
+  }
+
+  void TearDown() override {
+    if (nccl_comm_ != nullptr) {
+      NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    }
+    if (stream_ != nullptr) {
+      CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    }
+    BenchmarkTestFixture::TearDown();
+  }
+
+  std::string benchmark_ib_hca() {
+    const char* ib_hca = std::getenv("HIER_RS_BENCH_IB_HCA");
+    if (ib_hca != nullptr) {
+      return ib_hca;
+    }
+    return "";
+  }
+
+  bool benchmark_skip_nccl() {
+    return env_flag_enabled("HIER_RS_BENCH_SKIP_NCCL", false);
+  }
+
+  float benchmark_timeout_ms() {
+    const char* timeout_ms = std::getenv("HIER_RS_BENCH_TIMEOUT_MS");
+    if (timeout_ms != nullptr) {
+      return std::strtof(timeout_ms, nullptr);
+    }
+    return 30000.0f;
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id;
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const HierarchicalReduceScatterBenchmarkConfig& config,
+      float& latency_us) {
+    DeviceBuffer send_buf(config.total_bytes);
+    DeviceBuffer recv_buf(config.chunk_elements * sizeof(float));
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, config.total_bytes));
+    CUDA_CHECK(
+        cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
+
+    CudaEvent start, stop;
+    const bool full_bench = std::getenv("HIER_RS_BENCH_FULL") != nullptr;
+    const int n_warmup = full_bench ? 5 : 2;
+    const int n_iter = full_bench ? 100 : 10;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclReduceScatter(
+          send_buf.get(),
+          recv_buf.get(),
+          config.chunk_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclReduceScatter(
+          send_buf.get(),
+          recv_buf.get(),
+          config.chunk_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    const float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    const float bw = (config.total_bytes / 1e9f) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_hierarchical_benchmark(
+      const HierarchicalReduceScatterBenchmarkConfig& config,
+      int& ib_nics,
+      float& latency_us) {
+    const int nvl_rank = globalRank % config.nvl_size;
+    const int ib_rank = globalRank / config.nvl_size;
+    const std::size_t chunk_bytes = config.chunk_elements * sizeof(float);
+    const std::size_t workspace_bytes =
+        static_cast<std::size_t>(config.ib_size) * chunk_bytes;
+
+    DeviceBuffer send_buf(config.total_bytes);
+    DeviceBuffer recv_buf(chunk_bytes);
+    DeviceBuffer workspace_buf(workspace_bytes);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, config.total_bytes));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, chunk_bytes));
+    CUDA_CHECK(cudaMemset(workspace_buf.get(), 0, workspace_bytes));
+
+    std::unique_ptr<MultipeerIbgdaTransport> ib_transport;
+    if (config.ib_size > 1) {
+      try {
+        MultipeerIbgdaTransportConfig transport_config{
+            .cudaDevice = localRank,
+            .dataBufferSize = config.data_buffer_size,
+            .sendRecv =
+                MultipeerIbgdaTransportConfig::SendRecvConfig{
+                    .maxGroups = config.num_blocks,
+                    .pipelineDepth = config.pipeline_depth,
+                },
+            .numQpsPerPeerPerNic = config.num_qps,
+        };
+        transport_config.ibHca = config.ib_hca;
+        ib_transport = std::make_unique<MultipeerIbgdaTransport>(
+            globalRank, worldSize, bootstrap, transport_config);
+        ib_transport->exchange();
+        ib_nics = ib_transport->numNics();
+      } catch (const std::exception& e) {
+        XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+        latency_us = 0.0f;
+        return 0.0f;
+      }
+    }
+
+    std::unique_ptr<MultiPeerNvlTransport> nvl_transport;
+    if (config.nvl_size > 1) {
+      try {
+        std::vector<int> nvl_rank_to_global(config.nvl_size);
+        for (int peer = 0; peer < config.nvl_size; ++peer) {
+          nvl_rank_to_global[peer] = ib_rank * config.nvl_size + peer;
+        }
+        auto nvl_bootstrap = std::make_shared<NvlBootstrapAdapter>(
+            bootstrap, std::move(nvl_rank_to_global));
+        MultiPeerNvlTransportConfig transport_config{
+            .dataBufferSize = config.data_buffer_size,
+            .chunkSize = config.data_buffer_size,
+            .pipelineDepth = static_cast<std::size_t>(config.pipeline_depth),
+            .p2pSignalCount = static_cast<std::size_t>(config.num_blocks),
+            .tile_max_groups = config.num_blocks,
+            .memSharingMode = MemSharingMode::kCudaIpc,
+        };
+        nvl_transport = std::make_unique<MultiPeerNvlTransport>(
+            nvl_rank, config.nvl_size, nvl_bootstrap, transport_config);
+        nvl_transport->exchange();
+      } catch (const std::exception& e) {
+        XLOGF(ERR, "NVLink transport not available: {}", e.what());
+        latency_us = 0.0f;
+        return 0.0f;
+      }
+    }
+
+    HierarchicalReduceScatterLaunchParams launch_params{};
+    launch_params.num_ranks = worldSize;
+    launch_params.ib_rank = ib_rank;
+    launch_params.ib_size = config.ib_size;
+    launch_params.nvl_rank = nvl_rank;
+    launch_params.nvl_size = config.nvl_size;
+    launch_params.chunk_elements = config.chunk_elements;
+    launch_params.ib_signaling_data_size = config.ib_signaling_data_size;
+    launch_params.nvl_signaling_data_size = config.nvl_signaling_data_size;
+    launch_params.input = static_cast<const float*>(send_buf.get());
+    launch_params.output = static_cast<float*>(recv_buf.get());
+    launch_params.workspace = static_cast<float*>(workspace_buf.get());
+    launch_params.num_blocks = config.num_blocks;
+    launch_params.timeout_ms = benchmark_timeout_ms();
+    launch_params.stream = stream_;
+
+    if (config.ib_size > 1) {
+      auto ib_rings_opt = make_standard_rings(config.ib_size, ib_rank, 1);
+      if (!ib_rings_opt) {
+        XLOGF(ERR, "Cannot construct IB ring for {} IB ranks", config.ib_size);
+        latency_us = 0.0f;
+        return 0.0f;
+      }
+      const auto& ib_ring = (*ib_rings_opt)[0];
+      const int prev_global = ib_ring.prev_rank * config.nvl_size + nvl_rank;
+      const int next_global = ib_ring.next_rank * config.nvl_size + nvl_rank;
+      launch_params.ib_ring.prev_rank = ib_ring.prev_rank;
+      launch_params.ib_ring.next_rank = ib_ring.next_rank;
+      launch_params.ib_ring.prev =
+          ib_transport->getP2pTransportDevice(prev_global);
+      launch_params.ib_ring.next =
+          ib_transport->getP2pTransportDevice(next_global);
+    }
+
+    for (int peer = 0; peer < config.nvl_size; ++peer) {
+      if (peer == nvl_rank) {
+        continue;
+      }
+      new (&launch_params.nvl_peers[peer])
+          P2pNvlTransportDevice(nvl_transport->getP2pTransportDevice(peer));
+    }
+
+    CudaEvent start, stop;
+    const bool full_bench = std::getenv("HIER_RS_BENCH_FULL") != nullptr;
+    const int n_warmup = full_bench ? 5 : 2;
+    const int n_iter = full_bench ? 100 : 10;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_hierarchical_reduce_scatter_fused(launch_params);
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      launch_hierarchical_reduce_scatter_fused(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    const float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    const float bw = (config.total_bytes / 1e9f) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(
+      const std::vector<HierarchicalReduceScatterBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "  NCCL ReduceScatter vs Hierarchical ReduceScatter (NVLink RS + IB Ring RS)\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(10) << "Chunk" << std::right
+       << std::setw(8) << "Blocks" << std::right << std::setw(6) << "IB"
+       << std::right << std::setw(6) << "NVL" << std::right << std::setw(8)
+       << "IBNics" << std::right << std::setw(9) << "IBLinks" << std::right
+       << std::setw(10) << "IBSig" << std::right << std::setw(10) << "DBuf"
+       << std::right << std::setw(7) << "Pipe" << std::right << std::setw(12)
+       << "NCCL Alg" << std::right << std::setw(12) << "Hier Alg" << std::right
+       << std::setw(10) << "Speedup" << std::right << std::setw(12)
+       << "NCCL Lat" << std::right << std::setw(12) << "Hier Lat\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << format_size(r.total_bytes) << std::right
+         << std::setw(10) << format_size(r.chunk_elements * sizeof(float))
+         << std::right << std::setw(8) << r.num_blocks << std::right
+         << std::setw(6) << r.ib_size << std::right << std::setw(6)
+         << r.nvl_size << std::right << std::setw(8) << r.ib_nics << std::right
+         << std::setw(9) << r.ib_links << std::right << std::setw(10)
+         << (r.ib_signaling_data_size == 0
+                 ? "auto"
+                 : format_size(r.ib_signaling_data_size))
+         << std::right << std::setw(10) << format_size(r.data_buffer_size)
+         << std::right << std::setw(7) << r.pipeline_depth << std::right
+         << std::setw(12) << std::fixed << std::setprecision(2)
+         << r.nccl_bandwidth << std::right << std::setw(12) << std::fixed
+         << std::setprecision(2) << r.hierarchical_bandwidth << std::right
+         << std::setw(9) << std::fixed << std::setprecision(2) << r.speedup
+         << "x" << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.nccl_latency << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.hierarchical_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize
+       << " ranks, size = total input bytes, chunk = per-rank output bytes\n";
+    ss << "Algorithmic bandwidth = total input bytes / latency, not NIC wire bandwidth\n";
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(HierarchicalReduceScatterBenchmarkFixture, VsNccl) {
+  const int nvl_size = benchmark_nvl_size(worldSize);
+  if (nvl_size <= 0 || nvl_size > kDirectNvlMaxRanks ||
+      worldSize % nvl_size != 0) {
+    XLOGF(
+        ERR,
+        "Invalid HIER_RS_BENCH_NVL_SIZE={} for worldSize={}",
+        nvl_size,
+        worldSize);
+    std::abort();
+  }
+
+  const int num_blocks = benchmark_num_blocks();
+  const int ib_links =
+      read_int_env("HIER_RS_BENCH_IB_LINKS", kBenchmarkIbLinks);
+  const std::size_t data_buffer_size =
+      read_size_env("HIER_RS_BENCH_DATA_BUFFER_SIZE", kDataBufferSize);
+  const int pipeline_depth =
+      read_int_env("HIER_RS_BENCH_PIPELINE_DEPTH", kPipelineDepth);
+  if (num_blocks <= 0 || ib_links <= 0 || data_buffer_size == 0 ||
+      pipeline_depth <= 0) {
+    XLOG(ERR, "Invalid hierarchical reduce-scatter benchmark configuration");
+    std::abort();
+  }
+
+  if (globalRank == 0) {
+    XLOGF(
+        INFO,
+        "\n=== Hierarchical ReduceScatter vs NCCL Comparison (IB groups={}, NVL groups={}) ===\n",
+        worldSize / nvl_size,
+        nvl_size);
+  }
+
+  const bool skip_nccl = benchmark_skip_nccl();
+  const std::size_t ib_signal_bytes =
+      benchmark_ib_signal_bytes(data_buffer_size, num_blocks);
+  const std::size_t nvl_signal_bytes =
+      read_size_env("HIER_RS_BENCH_NVL_SIGNAL_BYTES", 0);
+  const std::string ib_hca = benchmark_ib_hca();
+
+  std::vector<HierarchicalReduceScatterBenchmarkConfig> configs;
+  for (std::size_t total_bytes : configured_benchmark_sizes()) {
+    const std::size_t total_elements = total_bytes / sizeof(float);
+    if (total_bytes % sizeof(float) != 0 ||
+        total_elements % static_cast<std::size_t>(worldSize) != 0) {
+      XLOGF(
+          ERR,
+          "ReduceScatter size {} is not divisible by {} float ranks",
+          total_bytes,
+          worldSize);
+      std::abort();
+    }
+    configs.push_back({
+        .chunk_elements = total_elements / static_cast<std::size_t>(worldSize),
+        .total_bytes = total_bytes,
+        .ib_signaling_data_size = ib_signal_bytes,
+        .nvl_signaling_data_size = nvl_signal_bytes,
+        .num_blocks = num_blocks,
+        .ib_links = ib_links,
+        .ib_size = worldSize / nvl_size,
+        .nvl_size = nvl_size,
+        .ib_hca = ib_hca,
+        .data_buffer_size = data_buffer_size,
+        .pipeline_depth = pipeline_depth,
+        .num_qps = ib_links,
+        .name =
+            format_size(total_bytes) + "_" + std::to_string(num_blocks) + "B",
+    });
+  }
+
+  std::vector<HierarchicalReduceScatterBenchmarkResult> results;
+  for (const auto& config : configs) {
+    float nccl_lat = 0.0f;
+    float nccl_bw = 0.0f;
+    if (!skip_nccl) {
+      nccl_bw = run_nccl_benchmark(config, nccl_lat);
+    }
+
+    float hierarchical_lat = 0.0f;
+    int ib_nics = 0;
+    float hierarchical_bw =
+        run_hierarchical_benchmark(config, ib_nics, hierarchical_lat);
+
+    if (globalRank == 0) {
+      XLOGF(
+          INFO,
+          "ReduceScatter {} result: NCCL={:.2f} GB/s ({:.1f} us), Hier={:.2f} GB/s ({:.1f} us), Hier/NCCL={:.2f}x",
+          config.name,
+          nccl_bw,
+          nccl_lat,
+          hierarchical_bw,
+          hierarchical_lat,
+          (nccl_bw > 0) ? hierarchical_bw / nccl_bw : 0.0f);
+      results.push_back({
+          .test_name = config.name,
+          .chunk_elements = config.chunk_elements,
+          .total_bytes = config.total_bytes,
+          .num_blocks = config.num_blocks,
+          .ib_links = config.ib_links,
+          .ib_nics = ib_nics,
+          .ib_signaling_data_size = config.ib_signaling_data_size,
+          .data_buffer_size = config.data_buffer_size,
+          .pipeline_depth = config.pipeline_depth,
+          .ib_size = config.ib_size,
+          .nvl_size = config.nvl_size,
+          .nccl_bandwidth = nccl_bw,
+          .hierarchical_bandwidth = hierarchical_bw,
+          .nccl_latency = nccl_lat,
+          .hierarchical_latency = hierarchical_lat,
+          .speedup = (nccl_bw > 0) ? hierarchical_bw / nccl_bw : 0.0f,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/HierarchicalReduceScatterTest.cc
+++ b/comms/pipes/collectives/tests/HierarchicalReduceScatterTest.cc
@@ -1,0 +1,199 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/pipes/collectives/ReduceScatterLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/ReduceScatterTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct HierarchicalReduceScatterTestParams {
+  ReduceScatterTestConfig config;
+  int ib_size;
+  int nvl_size;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<HierarchicalReduceScatterTestParams>& info) {
+  return info.param.config.name;
+}
+
+class HierarchicalReduceScatterTest : public ReduceScatterTestBase,
+                                      public ::testing::WithParamInterface<
+                                          HierarchicalReduceScatterTestParams> {
+};
+
+TEST_P(HierarchicalReduceScatterTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize != params.ib_size * params.nvl_size) {
+    GTEST_SKIP() << "Hierarchical reduce-scatter test expects "
+                 << params.ib_size * params.nvl_size << " ranks";
+  }
+  if (localSize < params.nvl_size) {
+    GTEST_SKIP() << "Hierarchical reduce-scatter test needs " << params.nvl_size
+                 << " local ranks per NVLink group";
+  }
+
+  const int ibRank = globalRank / params.nvl_size;
+  const int nvlRank = globalRank % params.nvl_size;
+
+  std::unique_ptr<MultipeerIbgdaTransport> ibTransport;
+  if (params.ib_size > 1) {
+    try {
+      MultipeerIbgdaTransportConfig ibConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = 1024 * 1024,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks,
+                  .pipelineDepth = 2,
+              },
+      };
+      ibTransport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, ibConfig);
+      ibTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    }
+  }
+
+  std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
+  if (params.nvl_size > 1) {
+    try {
+      MultiPeerNvlTransportConfig nvlConfig{
+          .dataBufferSize = 1024 * 1024,
+          .chunkSize = 1024 * 1024,
+          .pipelineDepth = 2,
+          .p2pSignalCount = static_cast<std::size_t>(config.num_blocks),
+          .tile_max_groups = config.num_blocks,
+          .memSharingMode = MemSharingMode::kCudaIpc,
+      };
+      std::vector<int> nvlRankToGlobal(params.nvl_size);
+      for (int peer = 0; peer < params.nvl_size; ++peer) {
+        nvlRankToGlobal[peer] = ibRank * params.nvl_size + peer;
+      }
+      auto nvlBootstrap = std::make_shared<NvlBootstrapAdapter>(
+          bootstrap, std::move(nvlRankToGlobal));
+      nvlTransport = std::make_unique<MultiPeerNvlTransport>(
+          nvlRank, params.nvl_size, nvlBootstrap, nvlConfig);
+      nvlTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "NVLink transport not available: " << e.what();
+    }
+  }
+
+  const std::size_t totalElements = config.chunk_elements * worldSize;
+  const std::size_t chunkBytes = config.chunk_elements * sizeof(float);
+  const std::size_t workspaceBytes =
+      static_cast<std::size_t>(params.ib_size) * chunkBytes;
+  DeviceBuffer inputBuf(totalElements * sizeof(float));
+  DeviceBuffer outputBuf(chunkBytes);
+  DeviceBuffer workspaceBuf(workspaceBytes);
+  CUDACHECK_TEST(cudaMemset(outputBuf.get(), 0, chunkBytes));
+  CUDACHECK_TEST(cudaMemset(workspaceBuf.get(), 0, workspaceBytes));
+
+  fill_input(static_cast<float*>(inputBuf.get()), totalElements);
+
+  HierarchicalReduceScatterLaunchParams launchParams{};
+  launchParams.num_ranks = worldSize;
+  launchParams.ib_rank = ibRank;
+  launchParams.ib_size = params.ib_size;
+  launchParams.nvl_rank = nvlRank;
+  launchParams.nvl_size = params.nvl_size;
+  launchParams.chunk_elements = config.chunk_elements;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.workspace = static_cast<float*>(workspaceBuf.get());
+  launchParams.num_blocks = config.num_blocks;
+  launchParams.timeout_ms = 30000.0f;
+
+  if (params.ib_size > 1) {
+    auto ibRingsOpt = make_standard_rings(params.ib_size, ibRank, 1);
+    ASSERT_TRUE(ibRingsOpt.has_value());
+    const auto& ibRing = (*ibRingsOpt)[0];
+    const int prevGlobal = ibRing.prev_rank * params.nvl_size + nvlRank;
+    const int nextGlobal = ibRing.next_rank * params.nvl_size + nvlRank;
+    launchParams.ib_ring.prev_rank = ibRing.prev_rank;
+    launchParams.ib_ring.next_rank = ibRing.next_rank;
+    launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
+    launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
+  }
+
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == nvlRank) {
+      continue;
+    }
+    new (&launchParams.nvl_peers[peer])
+        P2pNvlTransportDevice(nvlTransport->getP2pTransportDevice(peer));
+  }
+
+  bootstrap->barrierAll();
+  launch_hierarchical_reduce_scatter_fused(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_reduce_scatter(
+      static_cast<const float*>(outputBuf.get()), config.chunk_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Hierarchical,
+    HierarchicalReduceScatterTest,
+    ::testing::Values(
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib2Nvl2_64KB_4B",
+                },
+            .ib_size = 2,
+            .nvl_size = 2,
+        },
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib1Nvl4_64KB_4B",
+                },
+            .ib_size = 1,
+            .nvl_size = 4,
+        },
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib4Nvl1_64KB_4B",
+                },
+            .ib_size = 4,
+            .nvl_size = 1,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Add hierarchical reduce-scatter for Pipes following the same organization as hierarchical all-gather: the NVLink phase reduces local ranks into workspace, the IBGDA phase runs a ring reduce-scatter across IB ranks, and the host launcher wires the transport/device arguments through the existing direct collectives API.

This update also adds review-readiness coverage: the IB ring now validates that the supplied `prev_rank`/`next_rank` topology is internally consistent, `HierarchicalReduceScatterFusedArgs<float>` has a compile-time CUDA kernel-parameter size guard, and the distributed test matrix includes `Ib4Nvl1_64KB_4B` so `prev.forward<ReduceOp>` is exercised instead of only the `ib_size <= 2` paths.

Performance analysis: measured on GB300 MAST with ACL-free image `pipes_benchmark_launcher_gb300:4848692fa6c5250edbbb251b5556a4a8`, region `lco`, `HIER_RS_BENCH_NVL_SIZE=1`, and NCCL baseline flags disabling NVLS, MNNVL, P2P, and SHM. The completed `2x1` and `4x1` full-size sweeps exercise the cross-node IB path with one rank per node. Hierarchical RS is competitive only in a narrow mid-size band (`1MB` at `2x1`, `256KB`-`2MB` at `4x1`) and trails NCCL at large sizes; at `1GB`, `2x1` is `85.81 GB/s` vs NCCL `153.26 GB/s` (`0.56x`), and `4x1` is `62.78 GB/s` vs NCCL `114.33 GB/s` (`0.55x`). The large-message plateau indicates the current Pipes RS path is not saturating the available GB300 transport and needs follow-up tuning of launch/transport parallelism (`HIER_RS_BENCH_NUM_BLOCKS`, `HIER_RS_BENCH_IB_LINKS`, pipeline depth, and buffer sizing).

Differential Revision: D105388827


