### PR TITLE
Add GpeProfiler class + sampling cvar + unit tests (#2681)

### DIFF
--- a/comms/ctran/profiler/GpeProfiler.cc
+++ b/comms/ctran/profiler/GpeProfiler.cc
@@ -1,0 +1,164 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/GpeProfiler.h"
+
+#include <utility>
+
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/ctran/utils/Abort.h"
+
+namespace ctran {
+
+GpeProfiler::GpeProfiler(
+    const CommLogData* logMetaData,
+    int rank,
+    uint64_t commHash,
+    int samplingWeight,
+    std::unique_ptr<IGpeProfilerReporter> reporter,
+    std::shared_ptr<::ctran::utils::Abort> abort)
+    : logMetaData_(logMetaData),
+      rank_(rank),
+      commHash_(commHash),
+      samplingWeight_(samplingWeight),
+      reporter_(std::move(reporter)),
+      abort_(std::move(abort)) {}
+
+void GpeProfiler::mark(GpeTracePoint p, std::string_view message) {
+  if (p == GpeTracePoint::ITER_START) {
+    // Iter anchor: reset Watch + per-iter timeline. Stamp ITER_START
+    // at iterUs=0 but DEFER its Scuba emit — the first sampled or
+    // aborted emit later in this iter will backfill it via the
+    // universal in-order backfill rule below.
+    watch_.reset();
+    lastStampUs_ = 0;
+    iterAnchored_ = true;
+    shouldTrace_ = false;
+    for (auto& s : stamped_) {
+      s.reset();
+    }
+    for (auto& r : reported_) {
+      r = false;
+    }
+    stamped_[static_cast<size_t>(p)] = 0;
+    return;
+  }
+  if (!iterAnchored_) {
+    // Marks before ITER_START are silently dropped.
+    return;
+  }
+
+  const uint64_t iterUs = static_cast<uint64_t>(watch_.elapsed().count());
+
+  // Always stamp the timeline so debugString() and the backfill walk
+  // reflect every mark regardless of sampling.
+  stamped_[static_cast<size_t>(p)] = iterUs;
+
+  // Single gate decision: do we emit anything for this mark?
+  //   - isAlwaysOn: tracepoint bypasses sampling unconditionally
+  //     (ALGO_ABORTED carries an abort reason; TERMINATE_CMD signals
+  //     GPE-thread exit and emits at most once per comm lifetime)
+  //   - liveAborted: comm is in abort state at this mark — bypass
+  //     sampling so post-abort tracepoints always reach Scuba
+  //   - shouldTrace_: per-iter sampling verdict from injectMetadata
+  const bool isAlwaysOn =
+      (p == GpeTracePoint::ALGO_ABORTED) || (p == GpeTracePoint::TERMINATE_CMD);
+  const bool liveAborted = (abort_ != nullptr) && abort_->Test();
+  const bool shouldEmit = isAlwaysOn || liveAborted || shouldTrace_;
+  if (!shouldEmit) {
+    return;
+  }
+
+  // Universal in-order backfill: emit any stamped-but-not-reported
+  // predecessor rows in this iter so the Scuba waterfall lands in
+  // chronological order. stamped_[] values are monotonically
+  // increasing (assigned from a monotonic Watch), so the loop walks
+  // them in true chronological order.
+  for (size_t i = 0; i < static_cast<size_t>(p); ++i) {
+    if (stamped_[i].has_value() && !reported_[i]) {
+      const uint64_t backfillUs = stamped_[i].value();
+      DCHECK_GE(backfillUs, lastStampUs_)
+          << "GpeTracePoint enum order must match chronological mark() "
+          << "order in gpeThreadFn; out-of-order stamp at "
+          << tracePointName(static_cast<GpeTracePoint>(i));
+      const uint64_t backfillDur = backfillUs - lastStampUs_;
+      // Backfilled rows carry empty message (they're not the marker).
+      if (reportRaw(
+              static_cast<GpeTracePoint>(i),
+              backfillUs,
+              backfillDur,
+              std::string_view{})) {
+        reported_[i] = true;
+        lastStampUs_ = backfillUs;
+      }
+    }
+  }
+
+  // Emit current row with durationUs recomputed against the new
+  // lastStampUs_ (which the backfill may have advanced).
+  DCHECK_GE(iterUs, lastStampUs_)
+      << "GpeTracePoint enum order must match chronological mark() "
+      << "order in gpeThreadFn; out-of-order stamp at " << tracePointName(p);
+  const uint64_t durationUs = iterUs - lastStampUs_;
+  if (reportRaw(p, iterUs, durationUs, message)) {
+    reported_[static_cast<size_t>(p)] = true;
+    lastStampUs_ = iterUs;
+  }
+}
+
+void GpeProfiler::injectMetadata(const GpeIterMetadata& md) {
+  opCount_ = md.opCount;
+  opType_ = md.opType;
+  shouldTrace_ = (samplingWeight_ > 0) && (md.opCount % samplingWeight_ == 0);
+}
+
+bool GpeProfiler::reportRaw(
+    GpeTracePoint p,
+    uint64_t iterUs,
+    uint64_t durationUs,
+    std::string_view message) {
+  if (!reporter_) {
+    return false;
+  }
+  const bool isAbortMarker = (p == GpeTracePoint::ALGO_ABORTED);
+  const GpeProfilerReport r{
+      .logMetaData = logMetaData_,
+      .commHash = commHash_,
+      .rank = rank_,
+      .opCount = opCount_,
+      .opType = opType_,
+      .tracePoint = p,
+      .iterUs = iterUs,
+      .durationUs = durationUs,
+      .aborted = isAbortMarker,
+      .message = message,
+  };
+  reporter_->report(r);
+  return true;
+}
+
+std::string GpeProfiler::debugString() const {
+  // For each tracepoint i in [1, NUM_TRACE_POINTS), emit
+  // "<name(i)>Us=<v>" where v = stamped_[i] - stamped_[i-1]. A
+  // duration is omitted if either endpoint wasn't stamped this iter.
+  std::string out;
+  for (size_t i = 1; i < kNumPoints; ++i) {
+    const auto& curr = stamped_[i];
+    const auto& prev = stamped_[i - 1];
+    if (curr.has_value() && prev.has_value()) {
+      fmt::format_to(
+          std::back_inserter(out),
+          "{}Us={} ",
+          tracePointName(static_cast<GpeTracePoint>(i)),
+          *curr - *prev);
+    }
+  }
+  if (!out.empty() && out.back() == ' ') {
+    out.pop_back();
+  }
+  return out;
+}
+
+} // namespace ctran

--- a/comms/ctran/profiler/GpeProfiler.h
+++ b/comms/ctran/profiler/GpeProfiler.h
@@ -1,0 +1,179 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/ctran/profiler/IGpeProfilerReporter.h"
+#include "comms/ctran/utils/StopWatch.h"
+
+struct CommLogData;
+namespace ctran::utils {
+class Abort;
+} // namespace ctran::utils
+
+namespace ctran {
+
+// Per-iteration metadata supplied by the caller after cmdDequeue
+// returns and before mark(CMD_DEQUEUE). Drives the per-iter sampling
+// decision (opCount % samplingWeight).
+struct GpeIterMetadata {
+  uint64_t opCount{0};
+  int opType{-1};
+};
+
+// Single-threaded per-CtranGpe::Impl tracepoint stamper for the
+// gpeThreadFn loop. Writes one Scuba row per mark() call eagerly —
+// no buffering — so a crash mid-iter leaves all completed marks
+// visible in Scuba.
+//
+// Lifecycle: constructed in CtranGpe ctor once per GPE thread.
+// Used by gpeThreadFn directly — no locking required because only the
+// single GPE thread ever touches it.
+//
+// CONTRACT for callers (gpeThreadFn):
+//   1. mark(GpeTracePoint::ITER_START) is the iteration anchor.
+//      Resets the internal Watch and per-iter timeline. Stamps
+//      ITER_START at iterUs=0 but DEFERS the Scuba emit; the row
+//      will be backfilled by the first sampled / aborted emit
+//      later in this iter (see "Universal in-order backfill"
+//      below). If the iter never reaches a sampled / aborted
+//      emit, no Scuba rows are written for it.
+//   2. injectMetadata(GpeIterMetadata{...}) MUST be called after
+//      cmdDequeue returns and before mark(CMD_DEQUEUE). Sets opCount
+//      / opType for downstream rows AND decides this iter's sampling
+//      verdict.
+//   3. mark(WAIT_KERNEL / HOST_ALGO / TERMINATE_KERNEL / CMD_DEQUEUE):
+//      emits iff (a) the iter was sampled by injectMetadata, OR
+//      (b) `abort->Test()` is true at mark time (live-abort bypass),
+//      OR (c) this is the ALGO_ABORTED marker. The per-iter timeline
+//      is stamped on every mark regardless of sampling so
+//      debugString() and the backfill walk see the full waterfall.
+//   4. To record an abort, call mark(ALGO_ABORTED, reason) from the
+//      per-iteration SCOPE_EXIT when comm->testAbort() is true. The
+//      ALGO_ABORTED tracepoint always forces an emit regardless of
+//      sampling. `message` (if non-empty) lands on the row for
+//      downstream consumers (e.g., the McclScubaSink writes it to
+//      the `message` column); empty `message` is allowed and just
+//      means no reason annotation. Reason string_view lifetime
+//      must outlast the call.
+//
+// Universal in-order backfill: whenever a mark decides to emit
+// (sampled, live-aborted, or marker), it first emits any earlier
+// stamped-but-not-reported tracepoints from the same iter. This
+// guarantees the Scuba waterfall lands in chronological order:
+//   - Sampled iter: CMD_DEQUEUE backfills ITER_START.
+//   - Live-aborted iter (abort flips mid-iter): the post-abort mark
+//     backfills all skipped predecessors.
+//   - SCOPE_EXIT-only abort: the ALGO_ABORTED marker backfills all
+//     5 stamped predecessors.
+//
+// Sampling: 1-in-N (based on opCount). Set samplingWeight=0 to
+// disable happy-path Scuba rows entirely (only abort-marker rows
+// + their backfill reach the reporter). debugString() always
+// reflects every stamped tracepoint regardless of sampling.
+class GpeProfiler {
+ public:
+  using Watch =
+      utils::StopWatch<std::chrono::steady_clock, std::chrono::microseconds>;
+
+  // reporter may be nullptr — mark() then no-ops the report() calls.
+  // abort may be nullptr — disables the live-abort sampling bypass; the
+  // gate then only fires for sampled iters and the ALGO_ABORTED marker.
+  // Production callers obtain abort via `comm->getAbort()`.
+  GpeProfiler(
+      const CommLogData* logMetaData,
+      int rank,
+      uint64_t commHash,
+      int samplingWeight,
+      std::unique_ptr<IGpeProfilerReporter> reporter = nullptr,
+      std::shared_ptr<::ctran::utils::Abort> abort = nullptr);
+
+  ~GpeProfiler() = default;
+
+  GpeProfiler(const GpeProfiler&) = delete;
+  GpeProfiler& operator=(const GpeProfiler&) = delete;
+  GpeProfiler(GpeProfiler&&) = delete;
+  GpeProfiler& operator=(GpeProfiler&&) = delete;
+
+  // Stamp a tracepoint and (if sampled / always-on / aborted) emit
+  // one Scuba row immediately. mark(ITER_START) resets per-iter
+  // state. Pass a non-empty `message` on mark(ALGO_ABORTED, ...) to
+  // force-emit an abort row. Empty `message` means "no message"
+  // (default).
+  void mark(GpeTracePoint p, std::string_view message = {});
+
+  // Set per-iteration metadata + decide sampling. Call once per
+  // iter, after cmdDequeue and before mark(CMD_DEQUEUE).
+  void injectMetadata(const GpeIterMetadata& md);
+
+  // Format the current iter's per-phase latencies as
+  // "<name1>Us=<v1> <name2>Us=<v2> ..." for inclusion in the
+  // SCOPE_EXIT abort log line. Reflects every stamped tracepoint,
+  // independent of sampling. Only adjacent-pair durations whose
+  // BOTH endpoints were stamped this iter are emitted; missing
+  // endpoints (e.g., abort-early before kernel start) are skipped.
+  // Returns "" when no adjacent pair is available.
+  std::string debugString() const;
+
+ private:
+  // Build the GpeProfilerReport and dispatch it to reporter_.
+  // No gate — the caller (mark()) decides whether to emit. Used
+  // both for the current row and for backfilled predecessors.
+  // Returns true iff dispatched (false only when reporter_ is null).
+  bool reportRaw(
+      GpeTracePoint p,
+      uint64_t iterUs,
+      uint64_t durationUs,
+      std::string_view message);
+
+  static constexpr size_t kNumPoints =
+      static_cast<size_t>(GpeTracePoint::NUM_TRACE_POINTS);
+
+  const CommLogData* const logMetaData_;
+  const int rank_;
+  const uint64_t commHash_;
+  const int samplingWeight_;
+  const std::unique_ptr<IGpeProfilerReporter> reporter_;
+  // Source of the live abort flag for the per-mark "is the comm
+  // aborted right now?" check that bypasses the sampling gate.
+  // nullptr disables the bypass (only sampled / marker rows emit).
+  const std::shared_ptr<::ctran::utils::Abort> abort_;
+
+  Watch watch_; // Reset on mark(ITER_START) to set iter t0.
+
+  // True between mark(ITER_START) and the next mark(ITER_START).
+  // Non-anchor marks before ITER_START are silently dropped.
+  bool iterAnchored_{false};
+  // Sampling verdict for the current iter, set by injectMetadata.
+  bool shouldTrace_{false};
+  // Iter-relative µs of the last *reported* mark. durationUs of the
+  // next reported mark = currentIterUs - lastStampUs_. Not updated
+  // for marks that bypass the reporter (sampling-gated tracepoints).
+  uint64_t lastStampUs_{0};
+
+  // Per-iter timeline, indexed by GpeTracePoint. Populated in
+  // mark() unconditionally (regardless of sampling or reporter
+  // state); consumed by debugString() for the SCOPE_EXIT abort log
+  // line. Reset on mark(ITER_START).
+  std::array<std::optional<uint64_t>, kNumPoints> stamped_{};
+
+  // Per-iter "did we already emit this tracepoint to Scuba?" flag.
+  // Used by the universal in-order backfill in mark() to avoid
+  // double-emitting any tracepoint. Reset on mark(ITER_START).
+  std::array<bool, kNumPoints> reported_{};
+
+  // Iter metadata captured at injectMetadata time, stamped on every
+  // emitted row of the current iter.
+  uint64_t opCount_{0};
+  int opType_{-1};
+};
+
+} // namespace ctran

--- a/comms/ctran/profiler/GpeProfilerReport.h
+++ b/comms/ctran/profiler/GpeProfilerReport.h
@@ -11,6 +11,10 @@ namespace ctran {
 
 // One of the GPE thread's instrumented tracepoints. Stamped by
 // gpeThreadFn at the corresponding boundary.
+//
+// INVARIANT: enum declaration order must match the chronological
+// order of mark() calls in CtranGpe::Impl::gpeThreadFn — enforced
+// by DCHECK_GE in GpeProfiler::mark().
 enum class GpeTracePoint : int {
   ITER_START, // Top of the GPE main loop iter (anchor; always emits).
   CMD_DEQUEUE, // cmdDequeue returned + injectMetadata ran (always emits).
@@ -58,7 +62,7 @@ constexpr std::string_view tracePointName(GpeTracePoint p) {
 // previous stamped tracepoint in the same iter (0 for ITER_START).
 // `aborted` and `message` are populated only on the ALGO_ABORTED row;
 // `message` carries the abort reason ("timeout" / "explicit" /
-// "abnormal_exit") and lands in the Scuba "Message" column.
+// "abnormal_exit") and lands in the Scuba "message" column.
 struct GpeProfilerReport {
   const CommLogData* logMetaData{nullptr};
   uint64_t commHash{0};

--- a/comms/ctran/profiler/tests/GpeProfilerTest.cc
+++ b/comms/ctran/profiler/tests/GpeProfilerTest.cc
@@ -1,0 +1,399 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/ctran/profiler/GpeProfiler.h"
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "comms/ctran/profiler/GpeProfilerReport.h"
+#include "comms/ctran/profiler/tests/MockGpeProfilerReporter.h"
+#include "comms/ctran/utils/Abort.h"
+
+using namespace ::testing;
+
+namespace ctran {
+
+namespace {
+
+// Wires the profiler to a captured-row vector via MockGpeProfilerReporter.
+// Returned mock pointer remains valid until the profiler is destroyed.
+struct ProfilerHarness {
+  std::unique_ptr<GpeProfiler> profiler;
+  MockGpeProfilerReporter* mockPtr{nullptr};
+  std::vector<GpeProfilerReport>* rowsPtr{nullptr};
+  std::shared_ptr<::ctran::utils::Abort> abort;
+};
+
+ProfilerHarness makeHarness(
+    std::vector<GpeProfilerReport>& rows,
+    int samplingWeight,
+    std::shared_ptr<::ctran::utils::Abort> abort = nullptr) {
+  auto mock = std::make_unique<MockGpeProfilerReporter>();
+  auto* mockPtr = mock.get();
+  EXPECT_CALL(*mockPtr, report(_))
+      .WillRepeatedly([&](const GpeProfilerReport& r) { rows.push_back(r); });
+  auto profiler = std::make_unique<GpeProfiler>(
+      /*logMetaData=*/nullptr,
+      /*rank=*/0,
+      /*commHash=*/0xabc,
+      samplingWeight,
+      std::move(mock),
+      abort);
+  return {std::move(profiler), mockPtr, &rows, std::move(abort)};
+}
+
+} // namespace
+
+class GpeProfilerTest : public ::testing::Test {};
+
+// mark(ITER_START) DEFERS its Scuba emit. The row is only written
+// when a later sampled / aborted emit triggers the backfill.
+TEST_F(GpeProfilerTest, IterStartDefersEmitUntilBackfill) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  EXPECT_TRUE(rows.empty()); // deferred — no row yet
+
+  // First sampled emit triggers backfill of ITER_START + then CMD_DEQUEUE.
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+
+  ASSERT_EQ(rows.size(), 2u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[0].iterUs, 0u);
+  EXPECT_EQ(rows[0].durationUs, 0u);
+  EXPECT_FALSE(rows[0].aborted);
+}
+
+// Sampled iter (samplingWeight=1, opCount=1): all 5 happy-path tracepoints
+// land in chronological order. ITER_START gets backfilled by CMD_DEQUEUE.
+TEST_F(GpeProfilerTest, SampledIterEmitsAllFiveRowsInOrder) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 7});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::TERMINATE_KERNEL);
+
+  ASSERT_EQ(rows.size(), 5u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::WAIT_KERNEL);
+  EXPECT_EQ(rows[3].tracePoint, GpeTracePoint::HOST_ALGO);
+  EXPECT_EQ(rows[4].tracePoint, GpeTracePoint::TERMINATE_KERNEL);
+
+  EXPECT_EQ(rows[0].iterUs, 0u);
+  EXPECT_EQ(rows[0].durationUs, 0u);
+  // Identity fields pass through from makeHarness ctor args
+  // (commHash=0xabc, rank=0, logMetaData=nullptr) to every row.
+  EXPECT_EQ(rows[0].commHash, 0xabcULL);
+  EXPECT_EQ(rows[0].rank, 0);
+  EXPECT_EQ(rows[0].logMetaData, nullptr);
+  for (size_t i = 1; i < rows.size(); ++i) {
+    EXPECT_EQ(rows[i].durationUs, rows[i].iterUs - rows[i - 1].iterUs);
+    EXPECT_GT(rows[i].iterUs, rows[i - 1].iterUs);
+    EXPECT_EQ(rows[i].opCount, 1u);
+    EXPECT_EQ(rows[i].opType, 7);
+    EXPECT_FALSE(rows[i].aborted);
+  }
+}
+
+// Unsampled, non-aborted iter (weight=1000, opCount=1): the gate rejects
+// every emit, so the reporter sees zero rows. (Replaces the old
+// "anchor pair always emits" semantic.)
+TEST_F(GpeProfilerTest, UnsampledNonAbortedIterEmitsZeroRows) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 1}); // 1 % 1000 != 0
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+  h.profiler->mark(GpeTracePoint::TERMINATE_KERNEL);
+
+  EXPECT_TRUE(rows.empty());
+}
+
+// samplingWeight=0 disables happy-path tracing entirely. Without an abort
+// marker or live abort, no rows are emitted.
+TEST_F(GpeProfilerTest, SamplingWeightZeroEmitsZeroRowsWithoutAbort) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/0);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+
+  EXPECT_TRUE(rows.empty());
+}
+
+// ALGO_ABORTED marker on an unsampled iter triggers backfill of all
+// stamped predecessors, then the marker itself. Marker carries the
+// reason in `message` and `aborted=true`; backfilled predecessors
+// have `aborted=false` and empty message.
+TEST_F(GpeProfilerTest, AbortMarkerBackfillsAllStampedPredecessors) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000); // unsampled
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 1});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::TERMINATE_KERNEL);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::ALGO_ABORTED, "timeout");
+
+  // 5 backfilled predecessors + ALGO_ABORTED marker = 6 rows.
+  ASSERT_EQ(rows.size(), 6u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::WAIT_KERNEL);
+  EXPECT_EQ(rows[3].tracePoint, GpeTracePoint::HOST_ALGO);
+  EXPECT_EQ(rows[4].tracePoint, GpeTracePoint::TERMINATE_KERNEL);
+  EXPECT_EQ(rows[5].tracePoint, GpeTracePoint::ALGO_ABORTED);
+
+  // Marker carries reason + aborted=true.
+  EXPECT_TRUE(rows[5].aborted);
+  EXPECT_EQ(rows[5].message, std::string_view{"timeout"});
+  // Backfilled predecessors carry empty message + aborted=false.
+  for (size_t i = 0; i < 5; ++i) {
+    EXPECT_FALSE(rows[i].aborted);
+    EXPECT_EQ(rows[i].message, std::string_view{});
+  }
+  // iterUs strictly monotonic.
+  EXPECT_EQ(rows[0].iterUs, 0u);
+  for (size_t i = 1; i < rows.size(); ++i) {
+    EXPECT_GT(rows[i].iterUs, rows[i - 1].iterUs);
+    EXPECT_EQ(rows[i].durationUs, rows[i].iterUs - rows[i - 1].iterUs);
+  }
+}
+
+// Backfill skips slots that were never stamped (e.g., abort fires before
+// some kernel-side phases were marked). The resulting waterfall is
+// "every tracepoint that did get stamped, in enum order".
+TEST_F(GpeProfilerTest, BackfillSkipsUnstampedSlots) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000); // unsampled
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  // Skip WAIT_KERNEL entirely — stamped_[WAIT_KERNEL] stays unset.
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::ALGO_ABORTED, "external");
+
+  // ITER_START + CMD_DEQUEUE + HOST_ALGO + ALGO_ABORTED = 4 rows.
+  ASSERT_EQ(rows.size(), 4u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::HOST_ALGO);
+  EXPECT_EQ(rows[3].tracePoint, GpeTracePoint::ALGO_ABORTED);
+  // No WAIT_KERNEL row — its slot was never stamped.
+}
+
+// Live abort: when the comm's Abort handle is set mid-iter, the next
+// mark() bypasses the sampling gate AND backfills any stamped predecessors.
+TEST_F(GpeProfilerTest, LiveAbortBypassesSamplingMidIter) {
+  std::vector<GpeProfilerReport> rows;
+  auto abort = ::ctran::utils::createAbort(/*enabled=*/true);
+  auto h = makeHarness(rows, /*samplingWeight=*/1000, abort);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0}); // unsampled
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+
+  EXPECT_TRUE(rows.empty()); // pre-abort + unsampled — nothing emitted
+
+  // Abort flips. Next mark must emit + backfill all 3 predecessors.
+  abort->Set();
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+
+  ASSERT_EQ(rows.size(), 4u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::WAIT_KERNEL);
+  EXPECT_EQ(rows[3].tracePoint, GpeTracePoint::HOST_ALGO);
+
+  // Subsequent marks emit normally (live abort still set), no backfill
+  // (already caught up).
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::TERMINATE_KERNEL);
+  ASSERT_EQ(rows.size(), 5u);
+  EXPECT_EQ(rows[4].tracePoint, GpeTracePoint::TERMINATE_KERNEL);
+}
+
+// markAborted before any mark(ITER_START) is silently dropped (very early
+// shutdown / pre-iter state).
+TEST_F(GpeProfilerTest, MarkAbortedBeforeIterStartIsDropped) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  h.profiler->mark(GpeTracePoint::ALGO_ABORTED, "too_early");
+  EXPECT_TRUE(rows.empty());
+}
+
+// mark(ALGO_ABORTED) with an empty message is still the abort marker —
+// it always emits (and triggers backfill) regardless of sampling. The
+// `message` field on the resulting row is just empty.
+TEST_F(GpeProfilerTest, AlgoAbortedWithEmptyMessageStillTriggersEmit) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000); // unsampled
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  // No message — still treated as marker, still triggers backfill.
+  h.profiler->mark(GpeTracePoint::ALGO_ABORTED);
+
+  // ITER_START + CMD_DEQUEUE (both backfilled) + ALGO_ABORTED = 3 rows.
+  ASSERT_EQ(rows.size(), 3u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::ALGO_ABORTED);
+  EXPECT_TRUE(rows[2].aborted);
+  EXPECT_EQ(rows[2].message, std::string_view{}); // empty
+}
+
+// TERMINATE_CMD is the GPE-exit signal: always emits regardless of
+// sampling, backfills ITER_START + CMD_DEQUEUE so the final iter
+// timeline lands in Scuba even when the comm was never sampled.
+// aborted=false on the row (TERMINATE is a normal exit, not an abort).
+TEST_F(GpeProfilerTest, TerminateCmdAlwaysEmitsAndBackfills) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000); // unsampled
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  // No injectMetadata — TERMINATE cmd has no opCount/opType.
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::TERMINATE_CMD);
+
+  // ITER_START + CMD_DEQUEUE (both backfilled) + TERMINATE_CMD = 3 rows.
+  ASSERT_EQ(rows.size(), 3u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::TERMINATE_CMD);
+  EXPECT_FALSE(rows[2].aborted);
+}
+
+// Marks before mark(ITER_START) are silently dropped.
+TEST_F(GpeProfilerTest, NonAnchorMarksBeforeIterStartAreDropped) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE); // dropped
+  h.profiler->mark(GpeTracePoint::HOST_ALGO); // dropped
+  EXPECT_TRUE(rows.empty());
+}
+
+// debugString walks the per-iter stamped_ timeline regardless of sampling
+// or backfill. Reset by mark(ITER_START).
+TEST_F(GpeProfilerTest, DebugStringWalksStampedTimeline) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  EXPECT_EQ(h.profiler->debugString(), "");
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  EXPECT_EQ(h.profiler->debugString(), "");
+
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  const auto s1 = h.profiler->debugString();
+  EXPECT_NE(s1.find("cmd_dequeueUs="), std::string::npos);
+  EXPECT_EQ(s1.find("wait_kernelUs="), std::string::npos);
+
+  // Next iter resets the timeline.
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  EXPECT_EQ(h.profiler->debugString(), "");
+}
+
+// debugString lifecycle: full waterfall is preserved on aborted iters
+// (regardless of sampling), since stamped_[] is updated on every mark.
+TEST_F(GpeProfilerTest, DebugString_Lifecycle_UnsampledAbortLate) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1000);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::WAIT_KERNEL);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::HOST_ALGO);
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::TERMINATE_KERNEL);
+  h.profiler->mark(GpeTracePoint::ALGO_ABORTED, "timeout");
+
+  // debugString MUST contain every enum-adjacent delta.
+  const auto s = h.profiler->debugString();
+  EXPECT_NE(s.find("cmd_dequeueUs="), std::string::npos);
+  EXPECT_NE(s.find("wait_kernelUs="), std::string::npos);
+  EXPECT_NE(s.find("host_algoUs="), std::string::npos);
+  EXPECT_NE(s.find("terminate_kernelUs="), std::string::npos);
+  EXPECT_NE(s.find("algo_abortedUs="), std::string::npos);
+}
+
+// Two iters in sequence: each ITER_START resets the Watch + reported state.
+// In sampled iters, the second ITER_START is backfilled from the second
+// CMD_DEQUEUE just like the first.
+TEST_F(GpeProfilerTest, SecondIterResetsState) {
+  std::vector<GpeProfilerReport> rows;
+  auto h = makeHarness(rows, /*samplingWeight=*/1);
+
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 1, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+
+  // Second iter.
+  h.profiler->mark(GpeTracePoint::ITER_START);
+  h.profiler->injectMetadata({.opCount = 2, .opType = 0});
+  std::this_thread::sleep_for(std::chrono::microseconds(50));
+  h.profiler->mark(GpeTracePoint::CMD_DEQUEUE);
+
+  ASSERT_EQ(rows.size(), 4u);
+  EXPECT_EQ(rows[0].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[0].iterUs, 0u);
+  EXPECT_EQ(rows[1].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[2].tracePoint, GpeTracePoint::ITER_START);
+  EXPECT_EQ(rows[2].iterUs, 0u);
+  EXPECT_EQ(rows[3].tracePoint, GpeTracePoint::CMD_DEQUEUE);
+  EXPECT_EQ(rows[1].durationUs, rows[1].iterUs);
+  EXPECT_EQ(rows[3].durationUs, rows[3].iterUs);
+}
+
+} // namespace ctran

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -86,6 +86,14 @@ cvars:
       to e.g. "scuba:nccl_profiler_gpe".
       (the same format with NCCL_COMM_EVENT_LOGGING)
 
+ - name        : NCCL_CTRAN_GPE_PROFILING_SAMPLING_WEIGHT
+   type        : int
+   default     : 1000
+   description : |-
+     1-in-N sampling weight for per-iteration GpeProfiler Scuba reports.
+     Set to 0 to disable happy-path tracing (abort-only). Aborted
+     iterations are always reported regardless of sampling.
+
  - name        : NCCL_MEMORY_EVENT_LOGGING
    type        : string
    default     : ""


### PR DESCRIPTION
Summary:

# Design
The class stamps named tracepoints inside a single iteration of
gpeThreadFn's while-loop. mark(ITER_START) is the implicit
iteration boundary that resets per-iter state; mark(p) defers
emit (or backfills predecessors) per the universal sampling rule.
injectMetadata sets the per-iter sampling decision (1-in-N happy
path; abort path always reports via the live-Abort or
ALGO_ABORTED-marker bypass). debugString() formats per-phase
latencies for the abort log.

# New files (under comms/ctran/profiler/)
- GpeProfiler.{h,cc}: the class.
- tests/GpeProfilerTest.cc: gtest fixture covering ITER_START
  defer, full-waterfall sampled iter, unsampled-no-emit,
  sampling-weight=0 -> abort-only, ALGO_ABORTED marker backfill,
  live-abort bypass, second-iter state reset, debugString
  formatting, TERMINATE_CMD always-on bypass.

# BUCK targets added
- gpe_profiler (ctran_cpp_library) — mirrors sibling profiler.
- gpe_profiler_test (cpp_unittest) — mirrors sibling profiler_test.

# Cvar added
- NCCL_CTRAN_GPE_PROFILING_SAMPLING_WEIGHT (int, default 1000).
  Mirrors NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT.

Depends on the reporter API landed in the prior diff.

Reviewed By: Scusemua

Differential Revision: D106110776


