### PR TITLE
Remove dangling AllGatherRecDbl.cu from device Makefile SRCS

### DIFF
--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -123,7 +123,6 @@ SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
-SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu


### PR DESCRIPTION
Summary:
**Context:**
The conda feedstock build for `xlformers_gbunified_conda` (workflow 1008806316548264410) has been failing on the `nccl` recipe since 2026-05-22 with:

  make[2]: *** No rule to make target '.../comms/ctran/algos/AllGather/AllGatherRecDbl.cu.o', needed by '.../build/obj/device/manifest'. Stop.

**Motivation:**
D105641025 ("Consolidate ctrd and ctsrd AllGather into unified streamed RD") deleted `comms/ctran/algos/AllGather/AllGatherRecDbl.{cc,cu}` but missed the corresponding entry in `comms/ncclx/v2_30/src/device/Makefile`. The Buck-based test plan in that diff did not catch this because Buck does not consume this Makefile; the conda feedstock build (`build_ncclx.sh` → `make src.install`) does. v2_29's analogous Makefile has no such entry.

**This diff:**
- Remove the dangling `SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu` line from `comms/ncclx/v2_30/src/device/Makefile`.

Differential Revision: D106390039


