### PR TITLE
Move `commSetConfig` declaration outside `extern "C"` for proper symbol export (#2684)

### DIFF
--- a/comms/ncclx/meta/NcclxConfig.cc
+++ b/comms/ncclx/meta/NcclxConfig.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 using ncclx::algoconf::algoStrToVal;
+using ncclx::algoconf::algoValToStr;
 
 namespace ncclx {
 
@@ -328,6 +329,93 @@ ncclResult_t Config::update(const ncclx::Hints* hints) {
 
 } // namespace ncclx
 
+void ncclxLogCommConfig(ncclComm_t comm) {
+  if (comm == nullptr) {
+    return;
+  }
+
+  const auto& cfg = comm->config;
+
+  // Log non-UNDEF ncclConfig_t and ncclx::Config fields
+  std::string fields;
+  auto append = [&](const std::string& kv) {
+    if (!fields.empty()) {
+      fields += ' ';
+    }
+    fields += kv;
+  };
+  auto appendInt = [&](const char* name, int val) {
+    if (val != NCCL_CONFIG_UNDEF_INT) {
+      append(fmt::format("{}={}", name, val));
+    }
+  };
+  auto appendStr = [&](const char* name, const char* val) {
+    if (val != nullptr && val != NCCL_CONFIG_UNDEF_PTR) {
+      append(fmt::format("{}={}", name, val));
+    }
+  };
+
+  // ncclConfig_t fields
+  appendInt("blocking", cfg.blocking);
+  appendInt("cgaClusterSize", cfg.cgaClusterSize);
+  appendInt("minCTAs", cfg.minCTAs);
+  appendInt("maxCTAs", cfg.maxCTAs);
+  appendStr("netName", cfg.netName);
+  appendInt("splitShare", cfg.splitShare);
+  appendInt("trafficClass", cfg.trafficClass);
+  appendStr("commName", cfg.commName);
+  appendInt("collnetEnable", cfg.collnetEnable);
+  appendInt("CTAPolicy", cfg.CTAPolicy);
+  appendInt("shrinkShare", cfg.shrinkShare);
+  appendInt("nvlsCTAs", cfg.nvlsCTAs);
+  appendInt("nChannelsPerNetPeer", cfg.nChannelsPerNetPeer);
+  appendInt("nvlinkCentricSched", cfg.nvlinkCentricSched);
+  appendInt("graphUsageMode", cfg.graphUsageMode);
+  appendInt("numRmaCtx", cfg.numRmaCtx);
+  appendStr("commDesc", cfg.commDesc);
+  appendInt("fastInitMode", cfg.fastInitMode);
+
+  // ncclx::Config fields
+  if (cfg.ncclxConfig != NCCL_CONFIG_UNDEF_PTR && cfg.ncclxConfig != nullptr) {
+    const auto* xCfg = static_cast<const ncclx::Config*>(cfg.ncclxConfig);
+    auto appendAlgo = [&](const char* name, const auto& field) {
+      append(fmt::format("{}={}", name, algoValToStr(field)));
+    };
+    append(fmt::format("useCtran={}", xCfg->useCtran));
+    append(fmt::format("usePatAvg={}", xCfg->usePatAvg));
+    append(fmt::format("noLocal={}", xCfg->noLocal));
+    append(fmt::format("ibLazyConnect={}", xCfg->ibLazyConnect));
+    appendAlgo("sendrecvAlgo", xCfg->sendrecvAlgo);
+    appendAlgo("allgatherAlgo", xCfg->allgatherAlgo);
+    appendAlgo("allreduceAlgo", xCfg->allreduceAlgo);
+    appendAlgo("alltoallvAlgo", xCfg->alltoallvAlgo);
+    appendAlgo("rmaAlgo", xCfg->rmaAlgo);
+    auto appendIfSet = [&](const char* name, const auto& opt) {
+      if (opt.has_value()) {
+        append(fmt::format("{}={}", name, *opt));
+      }
+    };
+    if (xCfg->vCliqueSize != 0) {
+      append(fmt::format("vCliqueSize={}", xCfg->vCliqueSize));
+    }
+    appendIfSet("pipesNvlChunkSize", xCfg->pipesNvlChunkSize);
+    appendIfSet("pipesUseDualStateBuffer", xCfg->pipesUseDualStateBuffer);
+    appendIfSet("pipesIbgdaDataBufferSize", xCfg->pipesIbgdaDataBufferSize);
+    appendIfSet("ncclBuffSize", xCfg->ncclBuffSize);
+    appendIfSet("ibSplitDataOnQps", xCfg->ibSplitDataOnQps);
+    appendIfSet("ibQpsPerConnection", xCfg->ibQpsPerConnection);
+  }
+
+  INFO(
+      NCCL_INIT,
+      "NCCLX CONFIG: [commHash=%lx commDesc=%s rank=%d nRanks=%d] init %s",
+      comm->commHash,
+      NCCLX_CONFIG_FIELD(comm->config, commDesc).c_str(),
+      comm->rank,
+      comm->nRanks,
+      fields.empty() ? "(defaults)" : fields.c_str());
+}
+
 // C-style wrapper around the ncclx::Config parsing constructor.
 // Most NCCL code is C-based, so this function translates C++
 // exceptions into ncclResult_t error codes for the C callers.
@@ -405,5 +493,33 @@ ncclx::commSetConfig(ncclComm_t comm, const ncclConfig_t* config) {
 
   auto* cfg = static_cast<ncclx::Config*>(comm->config.ncclxConfig);
   const auto* hints = static_cast<const ncclx::Hints*>(config->hints);
-  return cfg->update(hints);
+  NCCLCHECK(cfg->update(hints));
+
+  std::string updated;
+  auto appendIfSet = [&](const char* key, const auto& field) {
+    std::string val;
+    if (hints->get(key, val) == ncclSuccess) {
+      if (!updated.empty()) {
+        updated += ' ';
+      }
+      updated += fmt::format("{}={}", key, algoValToStr(field));
+    }
+  };
+  appendIfSet("sendrecvAlgo", cfg->sendrecvAlgo);
+  appendIfSet("allgatherAlgo", cfg->allgatherAlgo);
+  appendIfSet("allreduceAlgo", cfg->allreduceAlgo);
+  appendIfSet("alltoallvAlgo", cfg->alltoallvAlgo);
+  appendIfSet("rmaAlgo", cfg->rmaAlgo);
+
+  if (!updated.empty()) {
+    INFO(
+        NCCL_INIT,
+        "NCCLX CONFIG: [commHash=%lx commDesc=%s rank=%d nRanks=%d] update %s",
+        comm->commHash,
+        cfg->commDesc.c_str(),
+        comm->rank,
+        comm->nRanks,
+        updated.c_str());
+  }
+  return ncclSuccess;
 }

--- a/comms/ncclx/meta/NcclxConfig.h
+++ b/comms/ncclx/meta/NcclxConfig.h
@@ -106,3 +106,7 @@ inline const std::vector<std::string>& mutableHintKeys() {
 // exactly once per config.
 // TODO: Move into ncclx namespace as ncclx::parseCommConfig and update callers.
 ncclResult_t ncclxParseCommConfig(ncclConfig_t* config);
+
+// Log all specified ncclConfig_t and resolved ncclx::Config fields for a
+// communicator.  Call after comm creation when commHash is available.
+void ncclxLogCommConfig(ncclComm_t comm);

--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1913,6 +1913,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", job->funcName,
          comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
   }
+  // [META:PER_COMM_CONFIG] Log ncclConfig_t and ncclx::Config after init
+  ncclxLogCommConfig(comm);
   sum_timers = 0.0;
   for (int it = 1; it < TIMERS_INIT_COUNT; ++it)
     sum_timers += (timers[it] / 1e9);

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -957,24 +957,6 @@ class Hints {
         kvType kv;
 };
 
-/*
- * Comm Set Config
- *
- * Update mutable configuration fields on a live communicator. Only
- * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
- * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
- *
- * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
- * flat ncclConfig_t fields must remain at their undefined defaults; only the
- * hints pointer is read. Setting any flat field or any non-algo hint key
- * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
- * returns ncclInvalidArgument.
- *
- * The caller must ensure no concurrent collective or config update is in
- * progress on the same communicator.
- */
-// [META:COMM_SET_CONFIG]
-ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif
@@ -1413,6 +1395,25 @@ std::shared_ptr<const std::unordered_map<std::string, std::string>> getNcclxInfo
 // exactly the hints are used and what will happen if the hints are set after
 // initialization depends on the receiver of the hints.
 ncclResult_t setGlobalHint(std::string key, std::string val);
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 
 } // namespace ncclx
 

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -123,7 +123,6 @@ SRCS = common.cu onerank.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
-SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRecDbl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu

--- a/comms/ncclx/v2_30/src/init.cc
+++ b/comms/ncclx/v2_30/src/init.cc
@@ -2051,6 +2051,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", job->funcName,
          comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
   }
+  // [META:PER_COMM_CONFIG] Log ncclConfig_t and ncclx::Config after init
+  ncclxLogCommConfig(comm);
   sum_timers = 0.0;
   for (int it = 1; it < TIMERS_INIT_COUNT; ++it)
     sum_timers += (timers[it] / 1e9);

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -965,24 +965,6 @@ class Hints {
         kvType kv;
 };
 
-/*
- * Comm Set Config
- *
- * Update mutable configuration fields on a live communicator. Only
- * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
- * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
- *
- * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
- * flat ncclConfig_t fields must remain at their undefined defaults; only the
- * hints pointer is read. Setting any flat field or any non-algo hint key
- * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
- * returns ncclInvalidArgument.
- *
- * The caller must ensure no concurrent collective or config update is in
- * progress on the same communicator.
- */
-// [META:COMM_SET_CONFIG]
-ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif
@@ -1421,6 +1403,25 @@ std::shared_ptr<const std::unordered_map<std::string, std::string>> getNcclxInfo
 // exactly the hints are used and what will happen if the hints are set after
 // initialization depends on the receiver of the hints.
 ncclResult_t setGlobalHint(std::string key, std::string val);
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 
 } // namespace ncclx
 


### PR DESCRIPTION
Summary:

Move `ncclx::commSetConfig` declaration from the inner `namespace ncclx` block (inside `extern "C"`) to the outer `namespace ncclx` block (outside `extern "C"`) in both v2_29 and v2_30 `nccl.h.in`. The `extern "C"` linkage suppresses C++ name mangling, causing the symbol to be emitted as plain `commSetConfig` instead of the mangled `_ZN5ncclx13commSetConfig...`. The linker version script (`version.script`) only exports symbols matching `*nccl*`, so the unmangled name is hidden as a local symbol despite `__attribute__((visibility("default")))` on the definition. Moving the declaration outside `extern "C"` restores proper C++ mangling, making the symbol match `*nccl*` and get exported from `libnccl.so`.

Reviewed By: elvinlife

Differential Revision: D106244845


