### PR TITLE
Move HRDWRingBuffer + GpuClockCalibration to comms/utils/hrdw_ring_buffer/ + hrdw_ring_buffer namespace (#2685)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -86,8 +86,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## HRDWRingBuffer + GpuClockCalibration host sources
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -94,8 +94,10 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/*.cc)
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/memtrace/*.cc)
 ## CollTrace source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/*.cc)
+## HRDWRingBuffer + GpuClockCalibration host sources
+LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
-LIBSRCFILES += ${BASE_DIR}/comms/utils/GpuClockCalibration.cu
+LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ## CollTrace plugin source files
 LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/colltrace/plugins/*.cc)

--- a/comms/pipes/PipesTrace.cc
+++ b/comms/pipes/PipesTrace.cc
@@ -8,7 +8,7 @@
 #include <mutex>
 #include <utility>
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 #include "comms/utils/logger/LogUtils.h"
 
 namespace comms::pipes {
@@ -103,7 +103,7 @@ void PipesTrace::ensure(uint32_t ringSize) {
   }
 
   reader_ = std::make_unique<Reader>(*buffer_);
-  ::meta::comms::colltrace::GlobaltimerCalibration::get();
+  ::hrdw_ring_buffer::GlobaltimerCalibration::get();
   startLogThread();
   CLOGF(INFO, "Pipes trace buffer ready ring_size={}", buffer_->size());
 }
@@ -148,7 +148,7 @@ void PipesTrace::enqueueLogBatch(PendingLogBatch batch) {
 }
 
 void PipesTrace::logBatch(const PendingLogBatch& batch) const {
-  auto& calibration = ::meta::comms::colltrace::GlobaltimerCalibration::get();
+  auto& calibration = ::hrdw_ring_buffer::GlobaltimerCalibration::get();
   for (const auto& pendingEntry : batch.entries) {
     const auto& entry = pendingEntry.entry;
     const auto wallTime = calibration.toWallClock(entry.timestamp);

--- a/comms/pipes/PipesTrace.h
+++ b/comms/pipes/PipesTrace.h
@@ -14,18 +14,18 @@
 #include <vector>
 
 #include "comms/pipes/PipesTraceTypes.h"
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 
 namespace comms::pipes {
 
 class PipesTrace {
  public:
   using Buffer =
-      ::meta::comms::colltrace::HRDWRingBuffer<comms::pipes::PipesTraceEvent>;
+      ::hrdw_ring_buffer::HRDWRingBuffer<comms::pipes::PipesTraceEvent>;
   using Entry = typename Buffer::Entry;
-  using Reader = ::meta::comms::colltrace::HRDWRingBufferReader<
-      comms::pipes::PipesTraceEvent>;
+  using Reader =
+      ::hrdw_ring_buffer::HRDWRingBufferReader<comms::pipes::PipesTraceEvent>;
 
   PipesTrace() = default;
   ~PipesTrace();

--- a/comms/pipes/PipesTraceTypes.h
+++ b/comms/pipes/PipesTraceTypes.h
@@ -4,7 +4,7 @@
 
 #include <cstdint>
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace comms::pipes {
 
@@ -27,7 +27,7 @@ struct PipesTraceEvent {
 static_assert(sizeof(PipesTraceEvent) == 8);
 
 using PipesTraceHandle =
-    ::meta::comms::colltrace::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
+    ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 __device__ __forceinline__ void write_pipes_trace(

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1013,9 +1013,9 @@ set(COMMON_FILES
   comms/utils/commSpecs.h
   comms/utils/Conversion.cc
   comms/utils/Conversion.h
-  comms/utils/GpuClockCalibration.cc
-  comms/utils/GpuClockCalibration.cu
-  comms/utils/GpuClockCalibration.h
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
+  comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
   comms/utils/CudaChecks.h
   comms/utils/CudaRAII.cc
   comms/utils/CudaRAII.h

--- a/comms/utils/colltrace/CollTrace.cc
+++ b/comms/utils/colltrace/CollTrace.cc
@@ -12,7 +12,6 @@
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
 #include "comms/utils/CommsMaybeChecks.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceHandle.h"
@@ -20,6 +19,7 @@
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 namespace meta::comms::colltrace {
 
@@ -78,7 +78,7 @@ CollTrace::CollTrace(
     // Eagerly initialize the globaltimer calibration singleton now (outside
     // graph capture) so it is ready when GraphCudaWaitEvent is constructed
     // during capture.
-    GlobaltimerCalibration::get();
+    ::hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // 2x the max plugin retention ensures the ring holds at least the last
     // max_retention collective entries (each collective has 1x start + 1x end
@@ -472,7 +472,7 @@ void CollTrace::pollGraphEvents(
     return;
   }
 
-  const auto& cal = GlobaltimerCalibration::get();
+  const auto& cal = ::hrdw_ring_buffer::GlobaltimerCalibration::get();
 
   auto pollResult = ringReader_->poll(
       [&](const auto& entry, uint64_t /*slot*/) {
@@ -727,7 +727,7 @@ void CollTrace::collTraceThread(
       auto now = std::chrono::steady_clock::now();
       if (now - lastReanchor >= kReanchorInterval) {
         if (ringBuffer_.has_value()) {
-          GlobaltimerCalibration::get().refresh();
+          ::hrdw_ring_buffer::GlobaltimerCalibration::get().refresh();
         }
         if (auto* refpt = CudaReferencePoint::tryGet()) {
           refpt->refresh();

--- a/comms/utils/colltrace/CollTrace.h
+++ b/comms/utils/colltrace/CollTrace.h
@@ -14,14 +14,14 @@
 #include <folly/MPMCQueue.h>
 #include <folly/concurrency/ConcurrentHashMap.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
 #include "comms/utils/colltrace/CollTraceEvent.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CollTraceInterface.h"
 #include "comms/utils/colltrace/CollTracePlugin.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/commSpecs.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 
 struct CUstream_st;
 
@@ -192,9 +192,11 @@ class CollTrace : public ICollTrace {
 
   // Single shared ring buffer for ALL cuda graphs. RAII-managed via
   // HRDWRingBuffer (mapped pinned memory, GPU-writable, CPU-readable).
-  std::optional<HRDWRingBuffer<GraphCollTraceEvent>> ringBuffer_;
+  std::optional<::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>>
+      ringBuffer_;
   // CPU-side reader for the shared ring buffer (poll thread only).
-  std::optional<HRDWRingBufferReader<GraphCollTraceEvent>> ringReader_;
+  std::optional<::hrdw_ring_buffer::HRDWRingBufferReader<GraphCollTraceEvent>>
+      ringReader_;
   // Map from collId to GraphCollectiveEntry* for fast lookup during polling.
   // Only accessed from the colltrace thread (no mutex needed). Entries are
   // added under graphStatesMutex_ and then inserted here on first poll.

--- a/comms/utils/colltrace/GraphCudaWaitEvent.cc
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.cc
@@ -10,9 +10,9 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/utils/CudaRAII.h"
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/checks.h"
 #include "comms/utils/colltrace/PrecisionClock.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
@@ -41,7 +41,8 @@ GraphCudaWaitEvent::~GraphCudaWaitEvent() {
 }
 
 void GraphCudaWaitEvent::attachRingBuffer(
-    HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept {
+    ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
+        ringBuffer) noexcept {
   ringBuffer_ = ringBuffer;
 }
 

--- a/comms/utils/colltrace/GraphCudaWaitEvent.h
+++ b/comms/utils/colltrace/GraphCudaWaitEvent.h
@@ -4,10 +4,10 @@
 
 #include <cuda_runtime.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/colltrace/CollWaitEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
 #include "comms/utils/colltrace/GraphCollTraceState.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
 namespace meta::comms::colltrace {
 
@@ -54,7 +54,8 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   CommsMaybe<system_clock_time_point> getCollEndTime() noexcept override;
 
   void attachRingBuffer(
-      HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer) noexcept;
+      ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>*
+          ringBuffer) noexcept;
 
   cudaStream_t getStream() const noexcept {
     return stream_;
@@ -81,7 +82,7 @@ class GraphCudaWaitEvent : public ICollWaitEvent {
   cudaEvent_t depEvent_{nullptr};
 
   // owned by CollTrace, shared across ALL graphs. set via attachRingBuffer().
-  HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
+  ::hrdw_ring_buffer::HRDWRingBuffer<GraphCollTraceEvent>* ringBuffer_{nullptr};
 };
 
 } // namespace meta::comms::colltrace

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
@@ -6,7 +6,7 @@
 
 #include "comms/utils/colltrace/HRDWRingBufferInstantiations.cuh"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     cudaStream_t,
@@ -16,4 +16,4 @@ template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     uint32_t,
     GraphCollTraceEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
+++ b/comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
@@ -7,12 +7,14 @@
 // NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
 #pragma once
 
-#include "comms/utils/HRDWRingBuffer.h"
 #include "comms/utils/colltrace/GraphCollTraceEvent.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // --- GraphCollTraceEvent (graph-initiated colltrace) ---
+using ::meta::comms::colltrace::GraphCollTraceEvent;
+
 extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     cudaStream_t,
     HRDWEntry<GraphCollTraceEvent>*,
@@ -21,4 +23,4 @@ extern template cudaError_t launchRingBufferWrite<GraphCollTraceEvent>(
     uint32_t,
     GraphCollTraceEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/colltrace/tests/GraphCollTraceUT.cc
+++ b/comms/utils/colltrace/tests/GraphCollTraceUT.cc
@@ -20,12 +20,12 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/CudaWaitEvent.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 using meta::comms::colltrace::CollTrace;
 using meta::comms::colltrace::CollTraceConfig;
@@ -159,7 +159,7 @@ class GraphColltraceProgressingTest : public ::testing::Test {
     // Enable cudagraph tracing for these tests.
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
 
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     auto progressPlugin = std::make_unique<ProgressTrackingPlugin>();
     progressPlugin_ = progressPlugin.get();

--- a/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
+++ b/comms/utils/colltrace/tests/GraphColltraceTopologyTest.cc
@@ -11,12 +11,12 @@
 #include <gtest/gtest.h>
 
 #include "comms/testinfra/TestXPlatUtils.h"
-#include "comms/utils/GpuClockCalibration.h"
 #include "comms/utils/colltrace/CollTrace.h"
 #include "comms/utils/colltrace/CollTraceHandle.h"
 #include "comms/utils/colltrace/GraphCudaWaitEvent.h"
 #include "comms/utils/colltrace/plugins/CommDumpPlugin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 #include "comms/utils/test_utils/CudaGraphTestUtils.h"
 
 using meta::comms::colltrace::CollTrace;
@@ -64,7 +64,7 @@ class GraphColltraceTopologyTest : public ::testing::Test {
     // Enable cudagraph tracing for these tests.
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
 
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaMalloc(&buf1_, kWorkBytes);
@@ -641,7 +641,7 @@ TEST(GraphColltraceTopologyDisabledTest, NoTelemetryNodesWhenDisabled) {
 
   // Eagerly initialize globaltimer calibration before capture starts —
   // it does cudaHostAlloc which is illegal during stream capture.
-  meta::comms::colltrace::GlobaltimerCalibration::get();
+  hrdw_ring_buffer::GlobaltimerCalibration::get();
 
   // Capture a graph — recordCollective should fail for graph-captured
   // collectives when the ring buffer is not allocated.
@@ -705,7 +705,7 @@ class GraphColltraceFlushTest : public ::testing::Test {
     cudaStreamCreate(&stream_);
 
     cvarGuard_.emplace(NCCL_COLLTRACE_TRACE_CUDA_GRAPH, true);
-    meta::comms::colltrace::GlobaltimerCalibration::get();
+    hrdw_ring_buffer::GlobaltimerCalibration::get();
 
     // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
     cudaMalloc(&buf1_, kWorkBytes);

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 
@@ -32,7 +32,7 @@
     }                                  \
   } while (0)
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 std::chrono::system_clock::time_point GlobaltimerCalibration::toWallClock(
     uint64_t gpu_ns) const {
@@ -129,7 +129,7 @@ bool GlobaltimerCalibration::refresh() {
   // so the host timestamp is no earlier than the device reading.
   *anchor_.wlock() = Anchor{
       .device_ns = *mapped_ptr_,
-      .host_time = colltrace::precisionNow(),
+      .host_time = ::meta::comms::colltrace::precisionNow(),
   };
   return true;
 }
@@ -201,4 +201,4 @@ GlobaltimerCalibration::createForTest(
 
 #undef CUDA_CHECK_CC
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
@@ -4,9 +4,9 @@
 
 #include <cstdint>
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 namespace {
 
@@ -21,4 +21,4 @@ cudaError_t launchReadGlobaltimer(cudaStream_t stream, uint64_t* out) {
   return cudaGetLastError();
 }
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
+++ b/comms/utils/hrdw_ring_buffer/GpuClockCalibration.h
@@ -26,7 +26,7 @@
 // GlobaltimerCalibration::toWallClock(uint32_t).
 #define US_TICK_TIMESTAMP_SHIFT 10
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // Calibration anchor mapping GPU %globaltimer nanoseconds to wall-clock time.
 // The first anchor is taken lazily on first use of get(); subsequent anchors
@@ -140,4 +140,4 @@ __device__ __forceinline__ uint64_t readGlobaltimer() {
 }
 #endif
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h
@@ -9,7 +9,7 @@
 #endif
 
 // needed for US_TICK_TIMESTAMP_SHIFT
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <algorithm>
 #if __cplusplus >= 202002L
@@ -26,7 +26,7 @@
 // writes encode epoch = uint32_t(slot >> shift) + 1, so 0 is unused.
 #define HRDW_RINGBUFFER_SLOT_EMPTY 0u
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // ==========================================================================
 // HRDWRingBuffer — Host-Read Device-Write ring buffer for GPU-to-CPU
@@ -480,4 +480,4 @@ class HRDWRingBuffer {
   uint32_t shift_{0};
 };
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh
@@ -25,4 +25,4 @@
 
 #pragma once // NOLINT(clang-diagnostic-pragma-once-outside-header)
 
-#include "comms/utils/HRDWRingBuffer.h" // IWYU pragma: export
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h" // IWYU pragma: export

--- a/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
+++ b/comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h
@@ -9,9 +9,9 @@
 #include <utility>
 #include <vector>
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 // Relaxed atomic load from GPU-mapped pinned memory. The reader doesn't
 // need acquire ordering: the writer publishes writeIndex and ring[idx]
@@ -193,4 +193,4 @@ class HRDWRingBufferReader {
   std::vector<std::pair<Entry, uint64_t>> validEntries_;
 };
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/tests/GpuClockCalibrationTest.cc
+++ b/comms/utils/tests/GpuClockCalibrationTest.cc
@@ -1,13 +1,13 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/utils/GpuClockCalibration.h"
+#include "comms/utils/hrdw_ring_buffer/GpuClockCalibration.h"
 
 #include <chrono>
 #include <cstdint>
 
 #include <gtest/gtest.h>
 
-using meta::comms::colltrace::GlobaltimerCalibration;
+using hrdw_ring_buffer::GlobaltimerCalibration;
 using namespace std::chrono_literals;
 
 namespace {

--- a/comms/utils/tests/HRDWRingBufferDeviceHandleTest.cu
+++ b/comms/utils/tests/HRDWRingBufferDeviceHandleTest.cu
@@ -7,14 +7,14 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferDeviceHandle.cuh"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferDeviceHandle;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferDeviceHandle;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 // kernel to write count entries to the buffer (one per thread)
 __global__ void inlineWriteKernel(

--- a/comms/utils/tests/HRDWRingBufferStressTest.cc
+++ b/comms/utils/tests/HRDWRingBufferStressTest.cc
@@ -13,12 +13,12 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 class HRDWRingBufferStressTest : public ::testing::Test {
  protected:

--- a/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
+++ b/comms/utils/tests/HRDWRingBufferTestInstantiations.cu
@@ -3,10 +3,10 @@
 // Explicit instantiations for test event types.
 // The template definition lives in HRDWRingBuffer.h.
 
-#include "comms/utils/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 template cudaError_t launchRingBufferWrite<TestEvent>(
     cudaStream_t,
@@ -16,4 +16,4 @@ template cudaError_t launchRingBufferWrite<TestEvent>(
     uint32_t,
     TestEvent);
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer

--- a/comms/utils/tests/HRDWRingBufferUT.cu
+++ b/comms/utils/tests/HRDWRingBufferUT.cu
@@ -5,12 +5,12 @@
 
 #include <gtest/gtest.h>
 
-#include "comms/utils/HRDWRingBuffer.h"
-#include "comms/utils/HRDWRingBufferReader.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #include "comms/utils/tests/HRDWRingBufferTestTypes.h"
 
-using meta::comms::colltrace::HRDWRingBuffer;
-using meta::comms::colltrace::HRDWRingBufferReader;
+using hrdw_ring_buffer::HRDWRingBuffer;
+using hrdw_ring_buffer::HRDWRingBufferReader;
 
 using TestBuffer = HRDWRingBuffer<TestEvent>;
 using TestReader = HRDWRingBufferReader<TestEvent>;
@@ -18,7 +18,7 @@ using TestEntry = TestBuffer::Entry;
 
 // Test accessor — friend of HRDWRingBuffer, provides access to internals
 // for CPU-side simulation of GPU writes.
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 template <typename DataT>
 class HRDWRingBufferTestAccessor {
  public:
@@ -35,9 +35,8 @@ class HRDWRingBufferTestAccessor {
     return buf.writeIndex_;
   }
 };
-} // namespace meta::comms::colltrace
-using TestAccess =
-    meta::comms::colltrace::HRDWRingBufferTestAccessor<TestEvent>;
+} // namespace hrdw_ring_buffer
+using TestAccess = hrdw_ring_buffer::HRDWRingBufferTestAccessor<TestEvent>;
 
 class HRDWRingBufferTest : public ::testing::Test {};
 
@@ -603,7 +602,7 @@ TEST(HRDWRingBufferDestructionTest, PartialFillOnlyDestructsWritten) {
 // Explicit instantiation for CountedEvent so buf.write() works.
 // ---------------------------------------------------------------------------
 
-namespace meta::comms::colltrace {
+namespace hrdw_ring_buffer {
 
 namespace {
 template <typename DataT>
@@ -631,4 +630,4 @@ cudaError_t launchRingBufferWrite<CountedEvent>(
   return cudaGetLastError();
 }
 
-} // namespace meta::comms::colltrace
+} // namespace hrdw_ring_buffer


### PR DESCRIPTION
Summary:

Pure refactor: relocate the HRDWRingBuffer + GpuClockCalibration code into a self-contained `comms/utils/hrdw_ring_buffer/` subdirectory and move it out of `meta::comms::colltrace` into a top-level `hrdw_ring_buffer` namespace.

Motivation: the ring buffer + GPU clock calibration are conceptually independent of colltrace — they're general-purpose GPU telemetry primitives used by colltrace, pipes, and the upcoming standalone `hrdw_ring_buffer` conda feedstock + Python bindings. Putting them in their own dir + namespace makes that boundary explicit, lets the conda package install as a clean top-level `hrdw_ring_buffer` Python package, and removes the awkward "import meta.comms.colltrace.* to get a ring buffer" coupling.

Files moved (via `hg mv` — preserved as renames):
- `comms/utils/HRDWRingBuffer.h` → `comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h`
- `comms/utils/HRDWRingBufferReader.h` → `comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h`
- `comms/utils/HRDWRingBufferDeviceHandle.cuh` → `comms/utils/hrdw_ring_buffer/HRDWRingBufferDeviceHandle.cuh`
- `comms/utils/GpuClockCalibration.h` → `comms/utils/hrdw_ring_buffer/GpuClockCalibration.h`
- `comms/utils/GpuClockCalibration.cc` → `comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc`
- `comms/utils/GpuClockCalibration.cu` → `comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu`

Namespace change: `meta::comms::colltrace` → `hrdw_ring_buffer` for `HRDWRingBuffer`, `HRDWRingBufferReader`, `HRDWRingBufferDeviceHandle`, `HRDWEntry`, `HrdwRingBufferWriter`, `HrdwRingBufferStorage`, `MemoryCoherenceScope`, `PollResult`, `GlobaltimerCalibration`, `readGlobaltimer`, `launchReadGlobaltimer`. Callers updated to either qualify (`::hrdw_ring_buffer::HRDWRingBuffer<T>`) or pull the type in with a `using` declaration in test files.

`comms/utils:hrdw_ring_buffer` and `comms/utils:gpu_clock_calibration` BUCK targets updated to point at the new `hrdw_ring_buffer/` subdirectory. Target names and dep references are unchanged so downstream targets keep building without modification.

No semantic changes — pure rename + relocate.

Reviewed By: ngimel

Differential Revision: D106397604
