### PR TITLE
Add Python bindings for `HRDWRingBuffer` (#2688)

### DIFF
--- a/comms/utils/hrdw_ring_buffer/CMakeLists.txt
+++ b/comms/utils/hrdw_ring_buffer/CMakeLists.txt
@@ -1,0 +1,85 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# CMake build for the HRDWRingBuffer Python bindings (`_native`)
+# and the host-side kernel launcher TU (`_native_kernels.cu`).
+#
+# Uses the standard CMake CUDA language so nvcc handles the device→host
+# fatbinary flow natively, and pybind11's add_module helper handles the
+# Python extension linking.
+#
+# Mirrors the buck target `fbcode//comms/utils/hrdw_ring_buffer:_native`
+# (`gpu_cpp_python_extension` with `cuda_srcs`) at the conda-env level.
+#
+# Install destination is configurable via `HRDW_INSTALL_DEST` (default
+# `hrdw_ring_buffer`) so downstream feedstocks can drop the artifacts
+# under a different package namespace.
+
+cmake_minimum_required(VERSION 3.18)
+
+# Target SM. Accept either:
+#   -DCMAKE_CUDA_ARCHITECTURES=100        (native CMake)
+#   -DGPU_ARCH=sm_100                     (matches the bitcode CMake's flag,
+#                                          and feedstock build.sh's value)
+# Must run BEFORE `project(... LANGUAGES CUDA)` — otherwise CMake's CUDA
+# initialization picks a default (often sm_75) and our late override is
+# ignored, producing a .so that won't load on GB200/Blackwell.
+#
+# When GPU_ARCH is passed, write CMAKE_CUDA_ARCHITECTURES into the cache
+# with FORCE so we override any stale value from a prior configure (e.g.
+# the build dir was first created on an sm_75 host and reused on a
+# GB200). Without FORCE, the cached arch wins and we silently build for
+# the wrong device.
+if(DEFINED GPU_ARCH)
+    # Strip `sm_` prefix and any `a`/`f` suffix; e.g. sm_100a -> 100.
+    string(REGEX REPLACE "^sm_" "" _cuda_arch "${GPU_ARCH}")
+    string(REGEX REPLACE "[af]$" "" _cuda_arch "${_cuda_arch}")
+    set(CMAKE_CUDA_ARCHITECTURES "${_cuda_arch}" CACHE STRING
+        "CUDA architectures to build (derived from -DGPU_ARCH=)" FORCE)
+elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES 100)  # GB200 default
+endif()
+
+project(hrdw_ring_buffer_pyext LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+find_package(CUDAToolkit REQUIRED)
+
+set(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+
+# Build the extension. The .cpp holds the pybind11 module definition;
+# the .cu holds the explicit template instantiation of
+# launchRingBufferWrite that the bindings call into. Merging both into
+# the same module makes the .so self-contained at runtime.
+pybind11_add_module(_native
+    _native.cpp
+    _native_kernels.cu
+)
+
+target_include_directories(_native PRIVATE "${ROOT}")
+# `atomic` resolves `__atomic_load_16` / `__atomic_compare_exchange_16`
+# libcalls that the System-scope reader's 16B atomic load lowers to on
+# platforms without an inline LDP/cmpxchg16b instruction (aarch64
+# without -march=...+lse2, x86_64 without -mcx16). Device-scope poll
+# uses cudaMemcpy so doesn't strictly need libatomic, but the System
+# scope does and both compile into the same .so.
+target_link_libraries(_native PRIVATE CUDA::cudart atomic)
+
+# nvcc needs to know to forward C++20 to the host compiler.
+target_compile_options(_native PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
+)
+
+if(NOT DEFINED HRDW_INSTALL_DEST)
+    set(HRDW_INSTALL_DEST "hrdw_ring_buffer")
+endif()
+
+install(TARGETS _native LIBRARY DESTINATION "${HRDW_INSTALL_DEST}")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_native.pyi"
+    DESTINATION "${HRDW_INSTALL_DEST}")

--- a/comms/utils/hrdw_ring_buffer/__init__.py
+++ b/comms/utils/hrdw_ring_buffer/__init__.py
@@ -1,0 +1,142 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, cast, Generic, NamedTuple, TypeVar
+
+from hrdw_ring_buffer._native import (
+    DevicePollResult,
+    Reader as _Reader,
+    RingBuffer as _RingBuffer,
+    SystemPollResult,
+)
+
+T = TypeVar("T")
+
+
+class RingHandle(NamedTuple):
+    """Device handle for kernel launches: (ring_ptr, write_index_ptr, mask, shift).
+
+    Unpacks via ``*handle`` for direct kernel-arg injection, or use named
+    fields when you need to pass them individually.
+    """
+
+    ring_ptr: int
+    write_index_ptr: int
+    mask: int
+    shift: int
+
+
+@dataclass
+class Entry(Generic[T]):
+    """A ring buffer entry with decoded data."""
+
+    timestamp: int
+    epoch: int
+    data: T
+
+
+class RingBuffer(Generic[T]):
+    """Device-scope GPU ring buffer with user-defined event types.
+
+    The underlying ring stores (uint32 timestamp, uint32 epoch, uint64 data)
+    16-byte entries. An optional ``unpack`` function decodes the raw uint64
+    data field into a user-defined type on poll.
+
+    A consumer Reader is auto-constructed and bound to this buffer; call
+    ``poll(stream)`` to drain entries since the previous poll. The read
+    cursor auto-advances per poll and the device writeIndex grows
+    monotonically (slots wrap into the ring via ``& mask``), so no reset
+    is needed between polls.
+
+    Examples::
+
+        # Raw uint64 tags (no unpack)
+        ring: RingBuffer[int] = RingBuffer(8192)
+        entries, result = ring.poll(stream)
+        for e in entries:
+            print(e.timestamp, e.data)  # data is int
+
+        # Custom event type
+        @dataclass
+        class KernelEvent:
+            kernel_id: int  # upper 32 bits
+            op_type: int    # lower 32 bits
+
+        ring: RingBuffer[KernelEvent] = RingBuffer(
+            8192,
+            unpack=lambda d: KernelEvent(d >> 32, d & 0xFFFFFFFF),
+        )
+        entries, result = ring.poll(stream)
+        for e in entries:
+            print(e.data.kernel_id, e.data.op_type)
+    """
+
+    def __init__(
+        self,
+        size: int,
+        unpack: Callable[[int], T] | None = None,
+    ) -> None:
+        self._ring = _RingBuffer(size)
+        self._reader = _Reader(self._ring)
+        self._unpack = unpack
+
+    @property
+    def valid(self) -> bool:
+        return self._ring.valid()
+
+    @property
+    def size(self) -> int:
+        return self._ring.size
+
+    def device_handle(self) -> RingHandle:
+        """Returns the device handle for kernel launches. Unpack with ``*handle``."""
+        return RingHandle(*self._ring.device_handle())
+
+    def poll(self, stream: int) -> tuple[list[Entry[T]], DevicePollResult]:
+        """Poll newly-written entries from the ring buffer.
+
+        Auto-advances the internal read cursor on every call — successive
+        polls only return entries written since the previous poll. The
+        device writeIndex grows monotonically and slots wrap into the
+        ring via `& mask`, so there's no need to reset between polls.
+
+        Args:
+            stream: raw cudaStream_t as int64.
+
+        Returns:
+            (entries, result) where each entry has .timestamp, .epoch, and
+            .data (decoded via unpack if provided), and result is a
+            DevicePollResult with entries_read / entries_lost / error.
+        """
+        raw_entries, result = self._reader.poll(stream)
+        unpack = self._unpack
+        # When unpack is None, T is bound to int by the caller; cast lets
+        # pyre see both branches yielding T.
+        decode: Callable[[int], T] = (
+            unpack if unpack is not None else cast(Callable[[int], T], lambda d: d)
+        )
+        entries: list[Entry[T]] = [
+            Entry(timestamp=e.timestamp, epoch=e.epoch, data=decode(e.data))
+            for e in raw_entries
+        ]
+        # This wrapper is device-scope only, so the variant is always
+        # DevicePollResult — assert + cast for type narrowing.
+        assert isinstance(result, DevicePollResult)
+        return entries, result
+
+    def write(self, stream: int, data: int) -> None:
+        """Write one entry from the host (launches a single-thread kernel)."""
+        self._ring.write(stream, data)
+
+
+__all__ = [
+    "DevicePollResult",
+    "Entry",
+    "RingBuffer",
+    "RingHandle",
+    "SystemPollResult",
+]

--- a/comms/utils/hrdw_ring_buffer/_native.cpp
+++ b/comms/utils/hrdw_ring_buffer/_native.cpp
@@ -1,0 +1,450 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Python bindings for HRDWRingBuffer.
+//
+// One `RingBuffer` / `Reader` pair handles both `MemoryCoherenceScope`
+// variants by holding a `std::variant<Device..., System...>` under the
+// hood and dispatching via `std::visit`. Callers pick the scope at
+// construction time with the `Scope` enum:
+//
+//     ring = RingBuffer(8192, Scope.DEVICE)
+//     reader = Reader(ring)
+//     entries, result = reader.poll(stream=my_stream)
+//
+//     ring = RingBuffer(8192, Scope.SYSTEM)
+//     reader = Reader(ring)
+//     entries, result =
+//     reader.poll(timeout=datetime.timedelta(milliseconds=10))
+//
+// DataT is fixed to uint64_t — sufficient for tag-style telemetry events.
+
+#include <chrono>
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <pybind11/chrono.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+namespace py = pybind11;
+
+using namespace hrdw_ring_buffer;
+
+using DataT = uint64_t;
+
+using DeviceRing = HRDWRingBuffer<DataT, MemoryCoherenceScope::Device>;
+using SystemRing = HRDWRingBuffer<DataT, MemoryCoherenceScope::System>;
+using DeviceReader = HRDWRingBufferReader<DataT, MemoryCoherenceScope::Device>;
+using SystemReader = HRDWRingBufferReader<DataT, MemoryCoherenceScope::System>;
+
+namespace {
+
+// Python-facing scope enum. The integer values are kept stable so
+// callers can serialize.
+enum class PyScope : int { Device = 0, System = 1 };
+
+// Single Python Entry struct shared across scopes. Both
+// HRDWEntry<u64, Device> and HRDWEntry<u64, System> have identical
+// {timestamp, epoch, data} layouts, so the poll lambda copies fields
+// into this scope-agnostic representation. The raw on-device timestamp
+// is a uint32 tick (=globaltimer ns >> US_TICK_TIMESTAMP_SHIFT, 10 →
+// ~1024 ns per tick) that fits the 16-byte slot; the poll lambda runs
+// it through GlobaltimerCalibration::toWallClock(uint32_t) before
+// handing to Python so the timestamp is reconstructed against the
+// process-wide host↔GPU calibration anchor and arrives as wall-clock
+// nanoseconds since the system_clock epoch — directly comparable with
+// `time.time_ns()` on the host. The 32-bit tick reconstruction is
+// accurate as long as the event is within ~73 minutes of "now"; for
+// long-running processes call `refresh_clock()` periodically (~1 Hz is
+// what colltrace does) to bound oscillator drift between anchors.
+struct PyEntry {
+  uint64_t timestamp;
+  uint32_t epoch;
+  uint64_t data;
+};
+
+// Per-scope Python PollResult variants. Each carries the shared
+// entries_read / entries_lost counters plus the scope-specific field its
+// poll() implementation can populate. `Reader.poll()` returns one or the
+// other depending on the ring's scope (bound to a Python typed union).
+struct PyDevicePollResult {
+  uint64_t entries_read{0};
+  uint64_t entries_lost{0};
+  // Error from cudaStreamSynchronize / cudaMemcpy during the drain.
+  cudaError_t error{cudaSuccess};
+};
+
+struct PySystemPollResult {
+  uint64_t entries_read{0};
+  uint64_t entries_lost{0};
+  // True if poll() exited because the timeout elapsed before any new
+  // entries arrived.
+  bool timed_out{false};
+};
+
+// PIMPL wrapper for the ring buffer. The variant carries the actual
+// HRDWRingBuffer<...> instance; the scope tag is cached separately so
+// `scope()` and dispatch checks don't need to std::visit.
+class PyRingBuffer {
+ public:
+  PyRingBuffer(uint32_t size, PyScope scope)
+      : scope_(scope), ring_(make_(size, scope)) {}
+
+  bool valid() const {
+    return std::visit([](const auto& r) { return r.valid(); }, ring_);
+  }
+
+  uint32_t size() const {
+    return std::visit([](const auto& r) { return r.size(); }, ring_);
+  }
+
+  PyScope scope() const {
+    return scope_;
+  }
+
+  // (ring_ptr, write_index_ptr, mask, shift) as int64s, for passing to
+  // device kernels.
+  std::tuple<int64_t, int64_t, uint32_t, uint32_t> device_handle() const {
+    return std::visit(
+        [](const auto& r) -> std::tuple<int64_t, int64_t, uint32_t, uint32_t> {
+          auto h = r.deviceHandle();
+          return {
+              reinterpret_cast<int64_t>(h.ring),
+              reinterpret_cast<int64_t>(h.writeIndex),
+              h.mask,
+              h.shift};
+        },
+        ring_);
+  }
+
+  // Host-side single-thread kernel write — only intended for tests
+  // that don't want to launch a real device-side writer.
+  void write(int64_t stream, uint64_t data) {
+    auto err = std::visit(
+        [stream, data](auto& r) {
+          // Python boundary: torch passes cudaStream_t as int64
+          // (torch.cuda.current_stream().cuda_stream).
+          // NOLINTNEXTLINE(performance-no-int-to-ptr)
+          return r.write(reinterpret_cast<cudaStream_t>(stream), DataT{data});
+        },
+        ring_);
+    if (err != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("write failed: ") + cudaGetErrorString(err));
+    }
+  }
+
+ private:
+  friend class PyReader;
+
+  PyScope scope_;
+  std::variant<DeviceRing, SystemRing> ring_;
+
+  static std::variant<DeviceRing, SystemRing> make_(
+      uint32_t size,
+      PyScope scope) {
+    if (scope == PyScope::Device) {
+      return DeviceRing(size);
+    }
+    return SystemRing(size);
+  }
+};
+
+// PIMPL wrapper for the reader. Variant alternative is chosen from the
+// ring's scope at construction.
+class PyReader {
+ public:
+  explicit PyReader(const PyRingBuffer& ring)
+      : scope_(ring.scope_), reader_(make_(ring)) {}
+
+  // Device scope: stream is required; returns PyDevicePollResult.
+  // System scope: timeout is honored, stream is ignored; returns
+  // PySystemPollResult.
+  //
+  // pybind11 maps `std::variant<A, B>` to a Python typed union — the
+  // returned object is the concrete variant for the active scope, so
+  // callers can use `.error` (device) or `.timed_out` (system) without
+  // isinstance branching when the scope is statically known.
+  std::pair<
+      std::vector<PyEntry>,
+      std::variant<PyDevicePollResult, PySystemPollResult>>
+  poll(int64_t stream, std::chrono::milliseconds timeout) {
+    std::vector<PyEntry> out;
+    // Hoist the calibration singleton fetch out of the per-entry lambda
+    // (same pattern as comms/utils/colltrace/CollTrace.cc) — get() is
+    // function-local-static so the per-call check is cheap but pointless.
+    // Used by both scope branches below so `Entry.timestamp` is wall-clock
+    // ns since the system_clock epoch regardless of ring scope.
+    const auto& cal = GlobaltimerCalibration::get();
+    auto toWallNs = [&cal](uint32_t tick) -> uint64_t {
+      return static_cast<uint64_t>(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(
+              cal.toWallClock(tick).time_since_epoch())
+              .count());
+    };
+    if (scope_ == PyScope::Device) {
+      auto& r = std::get<DeviceReader>(reader_);
+      // Python boundary: torch passes cudaStream_t as int64
+      // (torch.cuda.current_stream().cuda_stream).
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      auto raw = r.poll(
+          reinterpret_cast<cudaStream_t>(stream), [&](const auto& e, uint64_t) {
+            out.push_back({toWallNs(e.timestamp), e.epoch, e.data});
+          });
+      if (raw.error != cudaSuccess) {
+        throw std::runtime_error(
+            std::string("poll failed: ") + cudaGetErrorString(raw.error));
+      }
+      PyDevicePollResult result;
+      result.entries_read = raw.entriesRead;
+      result.entries_lost = raw.entriesLost;
+      result.error = raw.error;
+      return {std::move(out), result};
+    }
+    auto& r = std::get<SystemReader>(reader_);
+    auto raw = r.poll(
+        [&](const auto& e, uint64_t) {
+          out.push_back({toWallNs(e.timestamp), e.epoch, e.data});
+        },
+        timeout);
+    PySystemPollResult result;
+    result.entries_read = raw.entriesRead;
+    result.entries_lost = raw.entriesLost;
+    result.timed_out = raw.timedOut;
+    return {std::move(out), result};
+  }
+
+ private:
+  PyScope scope_;
+  std::variant<DeviceReader, SystemReader> reader_;
+
+  static std::variant<DeviceReader, SystemReader> make_(
+      const PyRingBuffer& ring) {
+    if (ring.scope_ == PyScope::Device) {
+      return DeviceReader(std::get<DeviceRing>(ring.ring_));
+    }
+    return SystemReader(std::get<SystemRing>(ring.ring_));
+  }
+};
+
+} // namespace
+
+PYBIND11_MODULE(_native, m) {
+  m.doc() = R"(
+Low-latency GPU ring buffer for device-side telemetry.
+
+Two coherence scopes are supported via the `Scope` enum:
+
+  - `Scope.DEVICE`: cudaMalloc'd device memory, device-scope 128b
+    atomic writes, host drains via cudaMemcpy after
+    cudaStreamSynchronize. Use this for graph-captured kernel telemetry
+    where the host reads between training steps.
+
+  - `Scope.SYSTEM`: pinned mapped host memory, system-scope 128b
+    atomic writes, host polls concurrently via mapped pointers
+    (lock-free, optional timeout). Use this when the host needs to
+    observe events as they happen.
+
+Both scopes require sm_90+ for atom.exch.b128 and use the same
+per-slot epoch validation to discard torn / stale-generation entries.
+
+    from hrdw_ring_buffer._native import RingBuffer, Reader, Scope
+
+    ring = RingBuffer(8192, Scope.DEVICE)
+    reader = Reader(ring)
+    handle = ring.device_handle()  # (ring_ptr, write_idx_ptr, mask, shift)
+
+    # ... launch kernel that writes via the handle ...
+
+    entries, result = reader.poll(stream=torch.cuda.current_stream().cuda_stream)
+    for e in entries:
+        print(f"timestamp={e.timestamp} tag={e.data}")
+)";
+
+  py::enum_<PyScope>(m, "Scope")
+      .value(
+          "DEVICE",
+          PyScope::Device,
+          "Device-scope ring: cudaMalloc memory, host drain via cudaMemcpy.")
+      .value(
+          "SYSTEM",
+          PyScope::System,
+          "System-scope ring: pinned mapped memory, lock-free host polling.");
+
+  py::class_<PyEntry>(
+      m, "Entry", "A single ring buffer entry (timestamp, epoch, data).")
+      .def_readonly(
+          "timestamp",
+          &PyEntry::timestamp,
+          "Wall-clock nanoseconds since the system_clock epoch — directly "
+          "comparable with `time.time_ns()` on the host. The on-device "
+          "tick (uint32 globaltimer_ns >> 10) is run through "
+          "GlobaltimerCalibration::toWallClock(uint32_t) inside the poll "
+          "lambda; the same conversion is applied to both Device and "
+          "System scope rings so Entry.timestamp has the same reference "
+          "frame regardless of scope. Reconstruction is accurate as long "
+          "as the event is within ~73 minutes of \"now\"; call "
+          "`refresh_clock()` periodically (~1 Hz, what colltrace does) to "
+          "bound oscillator drift between anchors for long-running "
+          "processes.")
+      .def_readonly(
+          "epoch",
+          &PyEntry::epoch,
+          "Slot generation, used by the reader for torn-write detection.")
+      .def_readonly("data", &PyEntry::data, "User-supplied uint64 tag.")
+      .def("__repr__", [](const PyEntry& e) {
+        return "Entry(timestamp=" + std::to_string(e.timestamp) +
+            ", epoch=" + std::to_string(e.epoch) +
+            ", data=" + std::to_string(e.data) + ")";
+      });
+
+  py::class_<PyDevicePollResult>(
+      m,
+      "DevicePollResult",
+      "Result metadata from a device-scope Reader.poll() call.")
+      .def_readonly("entries_read", &PyDevicePollResult::entries_read)
+      .def_readonly("entries_lost", &PyDevicePollResult::entries_lost)
+      .def_readonly(
+          "error",
+          &PyDevicePollResult::error,
+          "cudaError_t from the stream sync / memcpy drain (always "
+          "cudaSuccess on a successful poll — non-success is also raised "
+          "as RuntimeError).")
+      .def("__repr__", [](const PyDevicePollResult& r) {
+        return "DevicePollResult(entries_read=" +
+            std::to_string(r.entries_read) +
+            ", entries_lost=" + std::to_string(r.entries_lost) +
+            ", error=" + std::to_string(static_cast<int>(r.error)) + ")";
+      });
+
+  py::class_<PySystemPollResult>(
+      m,
+      "SystemPollResult",
+      "Result metadata from a system-scope Reader.poll() call.")
+      .def_readonly("entries_read", &PySystemPollResult::entries_read)
+      .def_readonly("entries_lost", &PySystemPollResult::entries_lost)
+      .def_readonly(
+          "timed_out",
+          &PySystemPollResult::timed_out,
+          "True if poll returned because the timeout elapsed without any "
+          "new entries arriving.")
+      .def("__repr__", [](const PySystemPollResult& r) {
+        return "SystemPollResult(entries_read=" +
+            std::to_string(r.entries_read) +
+            ", entries_lost=" + std::to_string(r.entries_lost) +
+            ", timed_out=" + (r.timed_out ? "True" : "False") + ")";
+      });
+
+  py::class_<PyRingBuffer>(m, "RingBuffer", R"(
+GPU ring buffer with uint64 data entries.
+
+Args:
+    size: Number of slots (rounded up to next power of 2).
+    scope: `Scope.DEVICE` (default) or `Scope.SYSTEM`. See module docs
+        for the trade-offs.
+)")
+      .def(
+          py::init<uint32_t, PyScope>(),
+          py::arg("size"),
+          py::arg("scope") = PyScope::Device)
+      .def(
+          "valid",
+          &PyRingBuffer::valid,
+          "True if the ring buffer was allocated successfully.")
+      .def_property_readonly(
+          "size", &PyRingBuffer::size, "Number of slots (power of 2).")
+      .def_property_readonly(
+          "scope",
+          &PyRingBuffer::scope,
+          "The MemoryCoherenceScope of this ring.")
+      .def(
+          "device_handle",
+          &PyRingBuffer::device_handle,
+          R"(
+Returns (ring_ptr, write_index_ptr, mask, shift) for passing to
+device kernels. Pointers are raw device pointers as int64.
+)")
+      .def(
+          "write",
+          &PyRingBuffer::write,
+          py::arg("stream"),
+          py::arg("data"),
+          // Releases the GIL while the host launch + cudaGetLastError run
+          // so concurrent Python threads aren't blocked on the kernel
+          // launch's host overhead.
+          py::call_guard<py::gil_scoped_release>(),
+          "Enqueue a single-thread kernel that writes one entry (for testing).");
+
+  py::class_<PyReader>(m, "Reader", R"(
+Host-side consumer for a RingBuffer. The reader binds to the ring's
+scope at construction; `poll()` takes the args appropriate for that
+scope (and ignores the others).
+
+Args:
+    ring: The RingBuffer to consume from. Must outlive the reader.
+)")
+      .def(
+          py::init<const PyRingBuffer&>(),
+          py::arg("ring"),
+          // The underlying HRDWRingBufferReader stores non-owning
+          // pointers into the ring; pin the ring (arg 2) to the reader
+          // (arg 1) so a Python caller can't drop the RingBuffer while
+          // still holding the Reader.
+          py::keep_alive<1, 2>())
+      .def(
+          "poll",
+          &PyReader::poll,
+          py::arg("stream") = 0,
+          py::arg("timeout") = std::chrono::milliseconds{0},
+          // Release the GIL for the duration of the poll: Device-scope
+          // calls cudaStreamSynchronize + cudaMemcpy; System-scope can
+          // wait up to `timeout` for the first entry. Both block the
+          // calling thread and would otherwise starve other Python
+          // threads.
+          py::call_guard<py::gil_scoped_release>(),
+          R"(
+Drain newly-written entries from the ring buffer.
+
+Device scope: requires `stream` (raw cudaStream_t as int64). The reader
+synchronizes the stream, cudaMemcpys the ring window to host, and
+returns the valid entries.
+
+System scope: optional `timeout` (a datetime.timedelta). The reader
+polls the pinned mapped memory directly; if no entries are available
+yet, it waits up to `timeout` for the first one before returning.
+
+The internal read cursor auto-advances on every call, so successive
+polls only return entries written since the previous one. No reset
+is required between polls.
+
+Returns:
+    (entries, result) — `entries` is a list of `Entry`, and `result`
+    is a `DevicePollResult` (device scope) or `SystemPollResult`
+    (system scope) carrying `entries_read`, `entries_lost`, and the
+    scope-specific `error` / `timed_out` field.
+)");
+
+  m.def(
+      "refresh_clock",
+      []() { return GlobaltimerCalibration::get().refresh(); },
+      py::call_guard<py::gil_scoped_release>(),
+      R"(
+Re-anchor the process-wide GPU-globaltimer ↔ wall-clock calibration that
+`Entry.timestamp` uses. Cheap (one single-thread kernel + one stream sync
+on a dedicated side stream); colltrace invokes it at ~1 Hz to keep
+residual oscillator drift under ~100 ns at 100 ppm. Call periodically
+from the polling thread for long-running processes. Idempotent and
+thread-safe — concurrent callers race on an internal flag and the loser
+short-circuits without touching the CUDA stream.
+
+Returns True when the anchor was successfully replaced, False when a
+concurrent caller already had a refresh in flight or the refresh failed
+(the prior anchor is kept; failure is logged).
+)");
+}

--- a/comms/utils/hrdw_ring_buffer/_native.pyi
+++ b/comms/utils/hrdw_ring_buffer/_native.pyi
@@ -1,0 +1,45 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import datetime
+import enum
+
+class Scope(enum.IntEnum):
+    DEVICE = 0
+    SYSTEM = 1
+
+class Entry:
+    timestamp: int
+    epoch: int
+    data: int
+
+class DevicePollResult:
+    entries_read: int
+    entries_lost: int
+    error: int
+
+class SystemPollResult:
+    entries_read: int
+    entries_lost: int
+    timed_out: bool
+
+class RingBuffer:
+    def __init__(self, size: int, scope: Scope = Scope.DEVICE) -> None: ...
+    def valid(self) -> bool: ...
+    @property
+    def size(self) -> int: ...
+    @property
+    def scope(self) -> Scope: ...
+    def device_handle(self) -> tuple[int, int, int, int]: ...
+    def write(self, stream: int, data: int) -> None: ...
+
+class Reader:
+    def __init__(self, ring: RingBuffer) -> None: ...
+    def poll(
+        self,
+        stream: int = 0,
+        timeout: datetime.timedelta = ...,
+    ) -> tuple[list[Entry], DevicePollResult | SystemPollResult]: ...
+
+def refresh_clock() -> bool: ...

--- a/comms/utils/hrdw_ring_buffer/_native_kernels.cu
+++ b/comms/utils/hrdw_ring_buffer/_native_kernels.cu
@@ -1,0 +1,35 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Explicit template instantiations for launchRingBufferWrite<uint64_t, *>.
+// Linked by the pybinding .cpp so both Device and System scope rings can
+// expose a host-side write() helper for testing. Compiled for both CUDA
+// and HIP via the BUCK target's `cuda_srcs` + `hip_srcs` listing — the
+// device-side `HrdwRingBufferWriter<DataT, C>::write` in HRDWRingBuffer.h
+// has an explicit `#if defined(__HIPCC__)` branch that prints + aborts
+// instead of executing the `atom.exch.b128` PTX (no HIP equivalent), so
+// the HIP-side instantiations link cleanly even though the host helper
+// is functionally unsupported under AMD.
+
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+
+namespace hrdw_ring_buffer {
+
+template cudaError_t
+launchRingBufferWrite<uint64_t, MemoryCoherenceScope::Device>(
+    cudaStream_t,
+    HRDWEntry<uint64_t, MemoryCoherenceScope::Device>*,
+    uint64_t*,
+    uint32_t,
+    uint32_t,
+    uint64_t);
+
+template cudaError_t
+launchRingBufferWrite<uint64_t, MemoryCoherenceScope::System>(
+    cudaStream_t,
+    HRDWEntry<uint64_t, MemoryCoherenceScope::System>*,
+    uint64_t*,
+    uint32_t,
+    uint32_t,
+    uint64_t);
+
+} // namespace hrdw_ring_buffer

--- a/comms/utils/hrdw_ring_buffer/tests/test_hrdw_ring_buffer.py
+++ b/comms/utils/hrdw_ring_buffer/tests/test_hrdw_ring_buffer.py
@@ -1,0 +1,197 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import unittest
+from typing import TYPE_CHECKING
+
+import torch
+from hrdw_ring_buffer._native import (
+    DevicePollResult,
+    Entry,
+    Reader,
+    RingBuffer,
+    Scope,
+    SystemPollResult,
+)
+
+# Mixin pattern: at type-check time we inherit TestCase so pyre sees
+# `self.assert*` and `self.skipTest`; at runtime the mixin is a plain
+# object so unittest's auto-discovery doesn't instantiate it as a test
+# suite of its own.
+if TYPE_CHECKING:
+    _MixinBase = unittest.TestCase
+else:
+    _MixinBase = object
+
+
+class RingBufferBasicTest(unittest.TestCase):
+    """Tests for RingBuffer creation and properties."""
+
+    def test_creation(self) -> None:
+        ring = RingBuffer(1024)
+        self.assertTrue(ring.valid())
+        self.assertEqual(ring.size, 1024)
+        self.assertEqual(ring.scope, Scope.DEVICE)
+
+    def test_creation_system_scope(self) -> None:
+        ring = RingBuffer(1024, Scope.SYSTEM)
+        self.assertTrue(ring.valid())
+        self.assertEqual(ring.size, 1024)
+        self.assertEqual(ring.scope, Scope.SYSTEM)
+
+    def test_rounds_up_to_power_of_two(self) -> None:
+        ring = RingBuffer(1000)
+        self.assertTrue(ring.valid())
+        self.assertEqual(ring.size, 1024)
+
+    def test_device_handle_returns_four_ints(self) -> None:
+        ring = RingBuffer(512)
+        handle = ring.device_handle()
+        self.assertEqual(len(handle), 4)
+        ring_ptr, write_idx_ptr, mask, shift = handle
+        self.assertNotEqual(ring_ptr, 0)
+        self.assertNotEqual(write_idx_ptr, 0)
+        self.assertEqual(mask, 511)
+
+
+class _ReaderPollMixin(_MixinBase):
+    """Reader.poll tests parametrized by MemoryCoherenceScope.
+
+    Subclasses set ``SCOPE`` and inherit from this mixin + TestCase. The
+    helpers (`_make_ring`, `_poll`) abstract over the per-scope poll
+    signature (Device takes a stream; System takes a timeout), so the
+    test bodies stay scope-agnostic.
+    """
+
+    # Subclasses override.
+    SCOPE: Scope = Scope.DEVICE
+
+    def setUp(self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("No CUDA device available")
+        torch.cuda.set_device(0)
+
+    def _make_ring(self, size: int) -> RingBuffer:
+        return RingBuffer(size, self.SCOPE)
+
+    def _stream(self) -> int:
+        return torch.cuda.current_stream().cuda_stream
+
+    def _poll(
+        self, reader: Reader
+    ) -> tuple[list[Entry], DevicePollResult | SystemPollResult]:
+        # System reader doesn't need a stream — the writer's stream is
+        # synchronized separately (below) and the host reads pinned
+        # memory directly. Device reader requires the stream.
+        if self.SCOPE == Scope.DEVICE:
+            return reader.poll(stream=self._stream())
+        return reader.poll()
+
+    def _sync_writer(self) -> None:
+        # System-scope: host polls pinned memory without going through
+        # the CUDA stream, but the writes themselves are still issued on
+        # a stream; sync explicitly so the test observes them. For
+        # Device scope this is redundant with poll's internal sync.
+        if self.SCOPE == Scope.SYSTEM:
+            torch.cuda.synchronize()
+
+    def test_poll_empty_ring(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+        entries, result = self._poll(reader)
+        self.assertEqual(len(entries), 0)
+        self.assertEqual(result.entries_read, 0)
+        self.assertEqual(result.entries_lost, 0)
+
+    def test_poll_returns_entries(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+
+        ring.write(self._stream(), 42)
+        ring.write(self._stream(), 99)
+        self._sync_writer()
+
+        entries, result = self._poll(reader)
+        self.assertEqual(result.entries_read, 2)
+        self.assertEqual(result.entries_lost, 0)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0].data, 42)
+        self.assertEqual(entries[1].data, 99)
+        self.assertGreater(entries[0].timestamp, 0)
+        self.assertLessEqual(entries[0].timestamp, entries[1].timestamp)
+
+    def test_poll_incremental(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+
+        ring.write(self._stream(), 1)
+        self._sync_writer()
+        entries1, r1 = self._poll(reader)
+        self.assertEqual(r1.entries_read, 1)
+        self.assertEqual(entries1[0].data, 1)
+
+        ring.write(self._stream(), 2)
+        self._sync_writer()
+        entries2, r2 = self._poll(reader)
+        self.assertEqual(r2.entries_read, 1)
+        self.assertEqual(entries2[0].data, 2)
+
+    def test_entry_fields(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+
+        ring.write(self._stream(), 12345)
+        self._sync_writer()
+        entries, _ = self._poll(reader)
+        self.assertGreater(entries[0].timestamp, 0)
+        self.assertGreater(entries[0].epoch, 0)
+        self.assertEqual(entries[0].data, 12345)
+
+    def test_entry_repr(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+
+        ring.write(self._stream(), 42)
+        self._sync_writer()
+        entries, _ = self._poll(reader)
+        r = repr(entries[0])
+        self.assertIn("timestamp=", r)
+        self.assertIn("epoch=", r)
+        self.assertIn("data=42", r)
+
+    def test_poll_result_repr(self) -> None:
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+        _, result = self._poll(reader)
+        r = repr(result)
+        self.assertIn("entries_read=0", r)
+        self.assertIn("entries_lost=0", r)
+
+    def test_packed_uint64(self) -> None:
+        """Verify packing two uint32 fields into uint64 round-trips."""
+        ring = self._make_ring(256)
+        reader = Reader(ring)
+
+        kernel_id, phase = 42, 1
+        tag = (kernel_id << 32) | phase
+        ring.write(self._stream(), tag)
+        self._sync_writer()
+
+        entries, _ = self._poll(reader)
+        recovered_id = entries[0].data >> 32
+        recovered_phase = entries[0].data & 0xFFFFFFFF
+        self.assertEqual(recovered_id, 42)
+        self.assertEqual(recovered_phase, 1)
+
+
+class ReaderPollDeviceTest(_ReaderPollMixin, unittest.TestCase):
+    """Reader.poll tests against a Device-scope ring (cudaMalloc + cudaMemcpy drain)."""
+
+    SCOPE: Scope = Scope.DEVICE
+
+
+class ReaderPollSystemTest(_ReaderPollMixin, unittest.TestCase):
+    """Reader.poll tests against a System-scope ring (pinned mapped memory)."""
+
+    SCOPE: Scope = Scope.SYSTEM


### PR DESCRIPTION
Summary:

Exposes the HRDWRingBuffer as a standalone low-latency GPU telemetry primitive from Python, independent of colltrace. A single `RingBuffer` / `Reader` pair handles both `MemoryCoherenceScope` variants (Device + System) via a `std::variant<Device..., System...>` under the hood; callers pick the scope at construction time with a Python `Scope` enum.

DataT is fixed to `uint64_t` — sufficient for tag-style telemetry events; pack multi-field events into the 64 bits as needed.

API:

- `Scope.DEVICE` (default) / `Scope.SYSTEM` — coherence scope. Device: `cudaMalloc`'d device memory, device-scope 128b atomic writes, host drains via `cudaMemcpy` after `cudaStreamSynchronize`. System: pinned mapped host memory, system-scope 128b atomic writes, host polls concurrently via mapped pointers (lock-free, optional timeout). Both require sm_90+ and use per-slot epoch validation.
- `RingBuffer(size, scope=Scope.DEVICE)` — allocate a ring.
- `ring.scope` → `Scope` — read back the scope chosen at construction.
- `ring.device_handle()` → `RingHandle(ring_ptr, write_index_ptr, mask, shift)` — a `NamedTuple` for kernel launches. Destructure with `*handle` for direct kernel-arg injection, or access named fields when you need them individually.
- `ring.write(stream, data)` — host-side enqueue of a single-thread kernel that writes one entry (for tests). Releases the GIL while the launch runs.
- `Reader(ring)` — bind a consumer to the ring. Picks the matching scope automatically. The pybind binding declares `keep_alive<1, 2>` so the ring is pinned to the reader for its lifetime — a Python caller can't drop the `RingBuffer` ref while still holding the `Reader` and dangle the underlying non-owning pointers.
- `reader.poll(stream=..., timeout=...)` → `(entries, DevicePollResult | SystemPollResult)`. Device honors `stream` and ignores `timeout`; System honors `timeout` and ignores `stream`. The read cursor auto-advances across calls so successive polls only return entries written since the previous one. The binding releases the GIL for the duration of the call (Device: `cudaStreamSynchronize` + `cudaMemcpy`; System: blocking timeout wait) so other Python threads can make progress while the C++/CUDA call blocks.
- `Entry.timestamp` (uint32, globaltimer ns >> 10 — ~1024ns ticks; decode via `GlobaltimerCalibration::toWallClock`) / `Entry.epoch` (uint32, slot generation, used for torn-write detection) / `Entry.data` (uint64 user tag).
- `DevicePollResult.entries_read` / `entries_lost` / `error` — `error` is the `cudaError_t` from the stream-sync + memcpy drain. Always `cudaSuccess` on a successful poll; non-success is also raised as `RuntimeError`.
- `SystemPollResult.entries_read` / `entries_lost` / `timed_out` — `timed_out=True` if `poll` returned because the timeout elapsed before any new entries arrived.

The `hrdw_ring_buffer.__init__` Python wrapper additionally owns a `_Reader` internally and exposes `RingBuffer.poll(...)` as a single-call convenience that wraps the raw bindings, returning a `(list[Entry[T]], DevicePollResult)` with an optional `unpack` callable to decode the raw uint64 data field into a user-defined type.

The extension is gated out of the AMD / MTIA-SIMT builds — HRDWRingBuffer's `atom.exch.b128` inline PTX has no HIP equivalent, and the `_native_kernels.cu` template instantiations of `launchRingBufferWrite<DataT, C>` don't survive hipify (undefined symbols at link). CPU-only configs (pyre / type-check) stay compatible.

Reviewed By: ngimel

Differential Revision: D105895077


