### PR TITLE
Add Pipes IBRC mode selection (#2691)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -211,6 +211,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           config.ibgdaConfig.dataBufferSize);
     }
 
+    if (NCCL_CTRAN_PIPES_IB_MODE == NCCL_CTRAN_PIPES_IB_MODE::ibrc) {
+      config.ibMode = comms::prims::IbBackendMode::kIbrc;
+    }
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||
         NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal;

--- a/comms/prims/transport/IbTransportConfig.h
+++ b/comms/prims/transport/IbTransportConfig.h
@@ -1,0 +1,12 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::prims {
+
+enum class IbBackendMode {
+  kIbgda,
+  kIbrc,
+};
+
+} // namespace comms::prims

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -109,6 +109,12 @@ void MultiPeerTransport::initFromTopology(
     }
     // ibgdaPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
   } else {
+    if (config.ibMode == IbBackendMode::kIbrc) {
+      throw std::runtime_error(
+          "MultiPeerTransport: IBRC mode selected, but the IBRC "
+          "backend is not implemented yet.");
+    }
+
     for (int r = 0; r < nRanks_; ++r) {
       if (r == myRank_) {
         typePerRank_.at(r) = TransportType::SELF;

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -22,6 +22,7 @@
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
+#include "comms/prims/transport/IbTransportConfig.h"
 #include "comms/prims/transport/Transport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
@@ -36,6 +37,9 @@ struct MultiPeerDeviceHandle;
 struct MultiPeerTransportConfig {
   MultiPeerNvlTransportConfig nvlConfig;
   MultipeerIbgdaTransportConfig ibgdaConfig;
+
+  // Selects the IB backend for non-NVL peers. Default remains IBGDA.
+  IbBackendMode ibMode{IbBackendMode::kIbgda};
 
   // MNNVL topology overrides for UUID and clique ID.
   // See TopologyConfig for field-level documentation.

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1888,6 +1888,15 @@ cvars:
      to be NVL-connected. All data movement and sync operations go over
      NVLink. Requires that all ranks are in the same NVL domain.
 
+ - name        : NCCL_CTRAN_PIPES_IB_MODE
+   type        : enum
+   default     : ibgda
+   choices     : ibgda, ibrc
+   description : |-
+     Select the IB backend used by Pipes MultiPeerTransport for non-NVL peers.
+     ibgda - use GPU-posted IBGDA.
+     ibrc - use CPU-posted IBRC.
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024


### PR DESCRIPTION
Summary:

Introduce the process-wide `NCCL_CTRAN_PIPES_IB_MODE` enum cvar with `ibgda` as the default and `ibrc_proxy` as the explicit opt-in. Wire the resolved mode through `MultiPeerTransportConfig` and fail clearly if `IBRC_PROXY` is selected before the backend is implemented.

Reviewed By: snarayankh

Differential Revision: D106133118


