### PR TITLE
Dispatch ctgraph_rdpipeline to StreamedRecursiveDoubling

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -10,7 +10,7 @@
 //
 //   winPersistBuffReg (ctgraph_pipeline/rdpipeline, nLocalRanks > 1):
 //     Both local and remote addresses must be stable across replays.
-//     Uses window: ctranWinRegister → allGatherWinInit → allGatherWinExec.
+//     Uses window: ctranWinRegister → allGatherWinInit → AlgoImpl dispatch.
 //
 //   localPersistBuffReg (ctgraph_ring/rd, nLocalRanks == 1):
 //     Only local registration persists; remote exchange happens at each replay
@@ -27,6 +27,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/MathUtils.h"
@@ -172,16 +173,17 @@ commResult_t ctranAllGatherCudagraphAware(
 
   // Execute (captured into graph)
   switch (algo) {
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline: {
+      auto* pAlgo =
+          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
+      FB_COMMCHECK(pAlgo->execPipeline(sendbuff, sendcount, datatype));
+      break;
+    }
     case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
-      auto savedPAlgo = NCCL_ALLGATHER_P_ALGO;
-      NCCL_ALLGATHER_P_ALGO = (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline)
-          ? NCCL_ALLGATHER_P_ALGO::ctrdpipeline
-          : NCCL_ALLGATHER_P_ALGO::ctpipeline;
-      auto pAlgoGuard = folly::makeGuard(
-          [savedPAlgo]() { NCCL_ALLGATHER_P_ALGO = savedPAlgo; });
+      auto* pAlgo =
+          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
       FB_COMMCHECK(
-          ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+          pAlgo->execStreamedRecursiveDoubling(sendbuff, sendcount, datatype));
       break;
     }
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:

--- a/comms/ctran/algos/AllGather/StreamedRd/Common.h
+++ b/comms/ctran/algos/AllGather/StreamedRd/Common.h
@@ -1,0 +1,267 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::allgather::ctsrd::common {
+
+// Resolve the NCCL_CTRAN_ALLGATHER_CTSRD_FWD_PEERS cvar to a concrete forward
+// depth for the given nSteps. -1 (default) and any value >= nSteps are clamped
+// to nSteps, which is the maximally-streamed configuration (every received
+// chunk is forwarded immediately to all future-step peers).
+inline int resolveFwdPeers(int nSteps) {
+  const int fwdPeers = NCCL_CTRAN_ALLGATHER_CTSRD_FWD_PEERS;
+  if (fwdPeers < 0 || fwdPeers >= nSteps) {
+    return nSteps;
+  }
+  return fwdPeers;
+}
+
+struct PutQElem {
+  int step;
+  int chunk;
+};
+
+} // namespace ctran::allgather::ctsrd::common
+
+namespace ctran::allgather::ctsrd {
+
+struct AlgoContext {
+  CtranMapper* mapper;
+  void* recvbuff;
+  void* memHdl;
+  const size_t sendSize;
+  const Plan& recvPlan;
+  const Plan& sendPlan;
+
+  // Per-step ctrl exchange state.
+  std::vector<void*> remoteRecvBuffs;
+  std::vector<CtranMapperRemoteAccessKey> remoteAccessKeys;
+  std::vector<CtranMapperRequest> irecvReqs;
+  std::vector<CtranMapperRequest> isendReqs;
+  // Per-chunk notification, indexed by chunk offset in recvbuff.
+  std::vector<CtranMapperNotify> notifyVec;
+
+  std::deque<common::PutQElem> putQ;
+  // One tracked request per peer (= per step), indexed by step.
+  // Only the last iput to each peer uses a tracked request; earlier iputs
+  // pass nullptr (fire-and-forget, safe due to in-order completion guarantee).
+  std::vector<CtranMapperRequest> iputReqs;
+
+  // Per-step deferred puts flushed at step start.
+  std::vector<std::vector<common::PutQElem>> deferredPuts;
+  // Per-step count of received notifications.
+  std::vector<int> numReceived;
+
+  // Per-step count of enqueued puts, for plan order verification.
+  std::vector<int> putCount;
+
+  AlgoContext(
+      CtranMapper* mapper,
+      void* recvbuff,
+      void* memHdl,
+      size_t sendSize,
+      size_t notifyVecSize,
+      const Plan& recvPlan,
+      const Plan& sendPlan)
+      : mapper(mapper),
+        recvbuff(recvbuff),
+        memHdl(memHdl),
+        sendSize(sendSize),
+        recvPlan(recvPlan),
+        sendPlan(sendPlan),
+        remoteRecvBuffs(recvPlan.nSteps()),
+        remoteAccessKeys(recvPlan.nSteps()),
+        irecvReqs(recvPlan.nSteps()),
+        isendReqs(recvPlan.nSteps()),
+        notifyVec(notifyVecSize),
+        iputReqs(recvPlan.nSteps()),
+        deferredPuts(recvPlan.nSteps()),
+        numReceived(recvPlan.nSteps(), 0),
+        putCount(recvPlan.nSteps(), 0) {}
+
+  AlgoContext(
+      CtranMapper* mapper,
+      void* recvbuff,
+      size_t sendSize,
+      size_t notifyVecSize,
+      const Plan& recvPlan,
+      const Plan& sendPlan)
+      : AlgoContext(
+            mapper,
+            recvbuff,
+            nullptr,
+            sendSize,
+            notifyVecSize,
+            recvPlan,
+            sendPlan) {}
+};
+
+} // namespace ctran::allgather::ctsrd
+
+namespace ctran::allgather::ctsrd::common {
+
+// Exchange ctrl messages and initialize per-chunk notifications for all steps.
+template <typename AlgoContext>
+inline commResult_t exchangeCtrl(AlgoContext& ctx) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  for (int step = 0; step < nSteps; step++) {
+    const auto peer = ctx.peer(step);
+    FB_COMMCHECK(ctx.mapper->irecvCtrl(
+        &ctx.remoteRecvBuffs.at(step),
+        &ctx.remoteAccessKeys.at(step),
+        peer,
+        &ctx.irecvReqs.at(step)));
+    FB_COMMCHECK(ctx.mapper->isendCtrl(
+        ctx.recvbuff, ctx.memHdl, peer, &ctx.isendReqs.at(step)));
+    for (const auto chunkOffset : ctx.recvPlan.chunks(step)) {
+      FB_COMMCHECK(ctx.mapper->initNotify(
+          peer, ctx.memHdl, &ctx.notifyVec.at(chunkOffset)));
+    }
+  }
+  for (int step = 0; step < nSteps; step++) {
+    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.irecvReqs.at(step)));
+  }
+  return commSuccess;
+}
+
+template <typename AlgoContext>
+inline commResult_t waitCtrl(AlgoContext& ctx) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  for (int step = 0; step < nSteps; step++) {
+    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.isendReqs.at(step)));
+  }
+  return commSuccess;
+}
+
+// Receive chunks for the current step and post forward puts for future steps.
+template <typename AlgoContext>
+inline commResult_t progressRecvFwd(AlgoContext& ctx, int step) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  const auto expNumRecv = static_cast<int>(ctx.recvPlan.chunks(step).size());
+  while (ctx.numReceived.at(step) < expNumRecv) {
+    const auto recvIdx = ctx.numReceived.at(step);
+    const auto chunk = ctx.recvPlan.chunk(step, recvIdx);
+    auto received = false;
+    FB_COMMCHECK(ctx.mapper->checkNotify(&ctx.notifyVec.at(chunk), &received));
+    if (!received) {
+      break;
+    }
+    ctx.numReceived.at(step)++;
+
+    const int immEnd = std::min(step + 1 + ctx.recvPlan.fwdPeers(), nSteps);
+    for (int fwd = step + 1; fwd < immEnd; fwd++) {
+      ctx.enqueuePut(fwd, chunk);
+    }
+    for (int fwd = immEnd; fwd < nSteps; fwd++) {
+      ctx.deferredPuts.at(fwd).push_back({fwd, chunk});
+    }
+  }
+  return commSuccess;
+}
+
+template <typename AlgoContext>
+inline commResult_t
+issuePut(AlgoContext& ctx, const PutQElem& elem, CtranMapperRequest* req) {
+  const auto peer = ctx.peer(elem.step);
+  const auto offset = ctx.chunkByteOffset(elem.chunk);
+  FB_COMMCHECK(ctx.mapper->iput(
+      reinterpret_cast<char*>(ctx.recvbuff) + offset,
+      reinterpret_cast<char*>(ctx.remoteRecvBuffs.at(elem.step)) + offset,
+      ctx.sendSize,
+      peer,
+      CtranMapperConfig{
+          .memHdl_ = ctx.memHdl,
+          .remoteAccessKey_ = ctx.remoteAccessKeys.at(elem.step),
+          .notify_ = true},
+      req));
+  return commSuccess;
+}
+
+// Issue ready puts from the queue. Only the last iput per peer is tracked.
+template <typename AlgoContext>
+inline commResult_t progressPuts(AlgoContext& ctx) {
+  while (!ctx.putQ.empty()) {
+    const auto elem = ctx.putQ.front();
+    CtranMapperRequest* req = nullptr;
+    if (ctx.sendPlan.isLastChunk(elem.step, elem.chunk)) {
+      req = &ctx.iputReqs.at(elem.step);
+    }
+    FB_COMMCHECK(issuePut(ctx, elem, req));
+    ctx.putQ.pop_front();
+  }
+  return commSuccess;
+}
+
+// Flush pending fwds deferred from earlier steps into putQ.
+template <typename AlgoContext>
+inline void postDeferredPuts(AlgoContext& ctx, int step) {
+  for (const auto& fwd : ctx.deferredPuts.at(step)) {
+    ctx.enqueuePut(fwd.step, fwd.chunk);
+  }
+}
+
+// Wait for all tracked iput requests (one per peer/step).
+template <typename AlgoContext>
+inline commResult_t waitAllPuts(AlgoContext& ctx) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  for (int step = 0; step < nSteps; step++) {
+    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.iputReqs.at(step)));
+  }
+  return commSuccess;
+}
+
+template <typename AlgoContext>
+inline commResult_t progressSteps(AlgoContext& ctx, int localChunk) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  for (int step = 0; step < nSteps; step++) {
+    ctx.enqueuePut(step, localChunk);
+  }
+
+  for (int step = 0; step < nSteps; step++) {
+    postDeferredPuts(ctx, step);
+    const auto expNumRecv = static_cast<int>(ctx.recvPlan.chunks(step).size());
+    while (ctx.numReceived.at(step) < expNumRecv) {
+      FB_COMMCHECK(progressRecvFwd(ctx, step));
+      FB_COMMCHECK(progressPuts(ctx));
+    }
+    FB_COMMCHECK(ctx.onStepComplete(step));
+  }
+
+  FB_COMMCHECK(waitAllPuts(ctx));
+  return commSuccess;
+}
+
+template <typename AlgoContext>
+inline commResult_t runExchangeAndProgress(
+    AlgoContext& ctx,
+    int localChunk,
+    ctran::Profiler* profiler) {
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
+  FB_COMMCHECK(exchangeCtrl(ctx));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
+
+  // Data transfer: step-ordered event loop.
+  CTRAN_PROFILER_IF(
+      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
+  FB_COMMCHECK(progressSteps(ctx, localChunk));
+  CTRAN_PROFILER_IF(
+      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
+
+  FB_COMMCHECK(waitCtrl(ctx));
+  return commSuccess;
+}
+
+} // namespace ctran::allgather::ctsrd::common

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -1,77 +1,43 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include <algorithm>
-#include <deque>
-
 #include <folly/ScopeGuard.h>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllGather/StreamedRd/Common.h"
 #include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
-#include "comms/utils/cvars/nccl_cvars.h"
 
 namespace {
 
-using ctran::algos::IPersistPlan;
 using ctran::algos::PersistPlanKey;
 using ctran::allgather::ctsrd::createPersistPlan;
 using ctran::allgather::ctsrd::PersistPlan;
-using ctran::allgather::ctsrd::Plan;
+using ctran::allgather::ctsrd::common::resolveFwdPeers;
+using ctran::allgather::ctsrd::common::runExchangeAndProgress;
 
 const auto myAlgo = NCCL_ALLGATHER_ALGO::ctsrd;
+using CtsrdAlgoContext = ctran::allgather::ctsrd::AlgoContext;
 
-// Resolve the NCCL_CTRAN_ALLGATHER_CTSRD_FWD_PEERS cvar to a concrete forward
-// depth for the given nSteps. -1 (default) and any value >= nSteps are clamped
-// to nSteps, which is the maximally-streamed configuration (every received
-// chunk is forwarded immediately to all future-step peers).
-int resolveFwdPeers(int nSteps) {
-  const int v = NCCL_CTRAN_ALLGATHER_CTSRD_FWD_PEERS;
-  if (v < 0 || v >= nSteps) {
-    return nSteps;
+struct AlgoContext : CtsrdAlgoContext {
+  using Base = CtsrdAlgoContext;
+  using Base::Base;
+
+  inline int peer(int step) const {
+    return recvPlan.peer(step);
   }
-  return v;
-}
 
-struct PutQElem {
-  int step;
-  int chunkOffset;
-};
+  inline commResult_t onStepComplete(int /* step */) {
+    return commSuccess;
+  }
 
-struct AlgoContext {
-  CtranMapper* mapper;
-  void* recvbuff;
-  void* memHdl;
-  const size_t sendSize;
-  const Plan& recvPlan;
-  const Plan& sendPlan;
+  inline size_t chunkByteOffset(int chunk) const {
+    return static_cast<size_t>(chunk) * sendSize;
+  }
 
-  // Per-step ctrl exchange state
-  std::vector<void*> remoteRecvBuffs;
-  std::vector<CtranMapperRemoteAccessKey> remoteAccessKeys;
-  std::vector<CtranMapperRequest> irecvReqs;
-  std::vector<CtranMapperRequest> isendReqs;
-  // Per-chunk notification, indexed by chunk offset in recvbuff
-  std::vector<CtranMapperNotify> notifyVec;
-
-  std::deque<PutQElem> putQ;
-  // One tracked request per peer (= per step), indexed by step.
-  // Only the last iput to each peer uses a tracked request; earlier iputs
-  // pass nullptr (fire-and-forget, safe due to in-order completion guarantee).
-  std::vector<CtranMapperRequest> iputReqs;
-
-  // Per-step deferred puts flushed at step start. Always sized to nSteps.
-  // For fwdPeers >= nSteps this stays empty and postDeferredPuts is a no-op.
-  std::vector<std::vector<PutQElem>> deferredPuts;
-  // Per-step count of received notifications
-  std::vector<int> numReceived;
-
-  // Per-step count of enqueued puts, for plan order verification.
-  std::vector<int> putCount;
-
-  void enqueuePut(int step, int chunkOffset) {
+  inline void enqueuePut(int step, int chunkOffset) {
     const auto nth = putCount.at(step)++;
     const auto expChunkOffset = sendPlan.chunk(step, nth);
     FB_CHECKABORT(
@@ -83,135 +49,7 @@ struct AlgoContext {
         chunkOffset);
     putQ.push_back({step, chunkOffset});
   }
-
-  AlgoContext(
-      CtranMapper* mapper,
-      void* recvbuff,
-      size_t sendSize,
-      size_t nRanks,
-      const Plan& recvPlan,
-      const Plan& sendPlan)
-      : mapper(mapper),
-        recvbuff(recvbuff),
-        memHdl(nullptr),
-        sendSize(sendSize),
-        recvPlan(recvPlan),
-        sendPlan(sendPlan),
-        remoteRecvBuffs(recvPlan.nSteps()),
-        remoteAccessKeys(recvPlan.nSteps()),
-        irecvReqs(recvPlan.nSteps()),
-        isendReqs(recvPlan.nSteps()),
-        notifyVec(nRanks),
-        iputReqs(recvPlan.nSteps()),
-        deferredPuts(recvPlan.nSteps()),
-        numReceived(recvPlan.nSteps(), 0),
-        putCount(recvPlan.nSteps(), 0) {}
 };
-
-// Enqueue or defer a chunk received at step `recvStep` based on fwdPeers.
-// Chunks with target step in [recvStep+1, recvStep+fwdPeers] are enqueued
-// immediately; chunks with target step in [recvStep+fwdPeers+1, nSteps-1]
-// are pushed onto deferredPuts and flushed at the start of the target step.
-inline void
-fwdChunk(AlgoContext& ctx, int recvStep, int chunkOffset, int fwdPeers) {
-  const auto nSteps = ctx.recvPlan.nSteps();
-  const int immEnd = std::min(recvStep + 1 + fwdPeers, nSteps);
-  for (int fwd = recvStep + 1; fwd < immEnd; fwd++) {
-    ctx.enqueuePut(fwd, chunkOffset);
-  }
-  for (int fwd = immEnd; fwd < nSteps; fwd++) {
-    ctx.deferredPuts.at(fwd).push_back({fwd, chunkOffset});
-  }
-}
-
-// Receive chunks for the current step and post forward puts for future steps.
-inline commResult_t
-progressRecvFwd(AlgoContext& ctx, int step, int expNumRecv, int fwdPeers) {
-  while (ctx.numReceived.at(step) < expNumRecv) {
-    const auto cid = ctx.numReceived.at(step);
-    const auto chunkOffset = ctx.recvPlan.chunk(step, cid);
-    auto rcvd = false;
-    FB_COMMCHECK(
-        ctx.mapper->checkNotify(&ctx.notifyVec.at(chunkOffset), &rcvd));
-    if (!rcvd) {
-      break;
-    }
-    ctx.numReceived.at(step)++;
-    fwdChunk(ctx, step, chunkOffset, fwdPeers);
-  }
-  return commSuccess;
-}
-
-// Wait for all tracked iput requests (one per peer/step).
-inline commResult_t waitAllPuts(AlgoContext& ctx) {
-  const auto nSteps = ctx.recvPlan.nSteps();
-  for (int step = 0; step < nSteps; step++) {
-    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.iputReqs.at(step)));
-  }
-  return commSuccess;
-}
-
-// Issue ready puts from the queue. Only the last iput per peer is tracked.
-inline commResult_t progressPuts(AlgoContext& ctx) {
-  while (!ctx.putQ.empty()) {
-    const auto& elem = ctx.putQ.front();
-    CtranMapperRequest* req = nullptr;
-    if (ctx.sendPlan.isLastChunk(elem.step, elem.chunkOffset)) {
-      req = &ctx.iputReqs.at(elem.step);
-    }
-    FB_COMMCHECK(ctx.mapper->iput(
-        reinterpret_cast<char*>(ctx.recvbuff) + elem.chunkOffset * ctx.sendSize,
-        reinterpret_cast<char*>(ctx.remoteRecvBuffs.at(elem.step)) +
-            elem.chunkOffset * ctx.sendSize,
-        ctx.sendSize,
-        ctx.recvPlan.peer(elem.step),
-        CtranMapperConfig{
-            .memHdl_ = ctx.memHdl,
-            .remoteAccessKey_ = ctx.remoteAccessKeys.at(elem.step),
-            .notify_ = true},
-        req));
-    ctx.putQ.pop_front();
-  }
-  return commSuccess;
-}
-
-// Exchange ctrl messages and initialize per-chunk notifications for all steps.
-inline commResult_t exchangeCtrl(AlgoContext& ctx) {
-  const auto nSteps = ctx.recvPlan.nSteps();
-  for (int step = 0; step < nSteps; step++) {
-    const auto peer = ctx.recvPlan.peer(step);
-    FB_COMMCHECK(ctx.mapper->irecvCtrl(
-        &ctx.remoteRecvBuffs.at(step),
-        &ctx.remoteAccessKeys.at(step),
-        peer,
-        &ctx.irecvReqs.at(step)));
-    FB_COMMCHECK(ctx.mapper->isendCtrl(
-        ctx.recvbuff, ctx.memHdl, peer, &ctx.isendReqs.at(step)));
-    for (const auto chunkOffset : ctx.recvPlan.chunks(step)) {
-      FB_COMMCHECK(ctx.mapper->initNotify(
-          peer, ctx.memHdl, &ctx.notifyVec.at(chunkOffset)));
-    }
-  }
-  for (int step = 0; step < nSteps; step++) {
-    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.irecvReqs.at(step)));
-  }
-  return commSuccess;
-}
-
-// Flush pending fwds deferred from earlier steps into putQ.
-inline void postDeferredPuts(AlgoContext& ctx, int step) {
-  for (auto& fwd : ctx.deferredPuts.at(step)) {
-    ctx.enqueuePut(fwd.step, fwd.chunkOffset);
-  }
-}
-
-inline commResult_t waitCtrl(AlgoContext& ctx) {
-  const auto nSteps = ctx.recvPlan.nSteps();
-  for (int step = 0; step < nSteps; step++) {
-    FB_COMMCHECK(ctx.mapper->waitRequest(&ctx.isendReqs.at(step)));
-  }
-  return commSuccess;
-}
 
 commResult_t impl(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   auto* op = opGroup.front().get();
@@ -260,8 +98,6 @@ commResult_t impl(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   if (recvPlan.nSteps() == 0) {
     return commSuccess;
   }
-  const auto nSteps = recvPlan.nSteps();
-  const auto fwdPeers = recvPlan.fwdPeers();
   AlgoContext ctx(
       mapper,
       reinterpret_cast<void*>(op->allgather.recvbuff),
@@ -284,38 +120,7 @@ commResult_t impl(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   CTRAN_PROFILER_IF(
       profiler, profiler->endEvent(ctran::ProfilerEvent::BUF_REG));
 
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_CTRL));
-  FB_COMMCHECK(exchangeCtrl(ctx));
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_CTRL));
-
-  // Data transfer: step-ordered event loop
-  CTRAN_PROFILER_IF(
-      profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
-
-  // Pre-enqueue own chunk for EVERY step at startup, regardless of fwdPeers.
-  // Own has no network dependency — we want it on the wire as early as
-  // possible so the receiver gets our data immediately.
-  for (int step = 0; step < nSteps; step++) {
-    ctx.enqueuePut(step, rank);
-  }
-
-  for (int step = 0; step < nSteps; step++) {
-    postDeferredPuts(ctx, step);
-    const int expNumRecv = static_cast<int>(ctx.recvPlan.chunks(step).size());
-    while (ctx.numReceived.at(step) < expNumRecv) {
-      FB_COMMCHECK(progressRecvFwd(ctx, step, expNumRecv, fwdPeers));
-      FB_COMMCHECK(progressPuts(ctx));
-    }
-  }
-
-  FB_COMMCHECK(waitAllPuts(ctx));
-
-  CTRAN_PROFILER_IF(
-      profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
-
-  FB_COMMCHECK(waitCtrl(ctx));
+  FB_COMMCHECK(runExchangeAndProgress(ctx, rank, profiler));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -58,6 +58,19 @@ class AlgoImpl {
       const size_t count,
       const commDataType_t datatype);
 
+  // Execute the streamed recursive-doubling algorithm of allgatherP.
+  // - Uses the ctsrd plan on logical node IDs. Each local rank owns one rail
+  //   column, so a logical node chunk maps to recvbuff[node * nLocalRanks +
+  //   localRank].
+  // - Inter-node forwarding streams per chunk on the GPE thread.
+  // - Intra-node NVL broadcast remains step-based: once all chunks for a step
+  //   arrive, every local rank crosses one local barrier and broadcasts that
+  //   step's received column chunks via CopyEngine.
+  commResult_t execStreamedRecursiveDoubling(
+      const void* sendbuff,
+      const size_t count,
+      const commDataType_t datatype);
+
   static inline const std::string algoName(enum NCCL_ALLGATHER_P_ALGO algo) {
     switch (algo) {
       case NCCL_ALLGATHER_P_ALGO::ctdirect:
@@ -66,6 +79,8 @@ class AlgoImpl {
         return "CtranAllGatherPPipeline";
       case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
         return "CtranAllGatherPRecDbl";
+      case NCCL_ALLGATHER_P_ALGO::ctsrdpipeline:
+        return "CtranAllGatherPStreamedRd";
       default:
         return "Unknown";
     }

--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -238,6 +238,8 @@ commResult_t allGatherPExec(
       return algo->execPipeline(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctsrdpipeline:
+      return algo->execStreamedRecursiveDoubling(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -1,0 +1,319 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <memory>
+#include <vector>
+
+#include <folly/ScopeGuard.h>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllGather/StreamedRd/Common.h"
+#include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
+#include "comms/ctran/algos/AllGatherP/CommUtils.h"
+#include "comms/ctran/algos/AllGatherP/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/algos/IPersistPlan.h"
+#include "comms/ctran/mapper/CtranMapper.h"
+#include "comms/ctran/profiler/Profiler.h"
+#include "comms/ctran/utils/DevUtils.cuh"
+#include "comms/ctran/utils/ExtUtils.h"
+#include "comms/ctran/utils/MathUtils.h"
+
+using ctran::algos::PersistPlanKey;
+using ctran::allgather::ctsrd::createPersistPlan;
+using ctran::allgather::ctsrd::PersistPlan;
+using ctran::allgather::ctsrd::Plan;
+using ctran::allgather::ctsrd::common::resolveFwdPeers;
+using ctran::allgather::ctsrd::common::runExchangeAndProgress;
+using ctran::allgatherp::AlgoImpl;
+using ctran::allgatherp::PersistArgs;
+using ctran::allgatherp::Resource;
+
+namespace {
+const auto myAlgo = NCCL_ALLGATHER_P_ALGO::ctsrdpipeline;
+using CtsrdAlgoContext = ctran::allgather::ctsrd::AlgoContext;
+
+struct AlgoContext : CtsrdAlgoContext {
+  using Base = CtsrdAlgoContext;
+
+  Resource* resource;
+  const int localRank;
+  const int nLocalRanks;
+
+  inline AlgoContext(
+      CtranMapper* mapper,
+      Resource* resource,
+      PersistArgs* pArgs,
+      size_t sendSize,
+      int localRank,
+      int nLocalRanks,
+      int nNodes,
+      const Plan& recvPlan,
+      const Plan& sendPlan)
+      : Base(
+            mapper,
+            pArgs->recvbuff,
+            pArgs->recvHdl,
+            sendSize,
+            nNodes,
+            recvPlan,
+            sendPlan),
+        resource(resource),
+        localRank(localRank),
+        nLocalRanks(nLocalRanks) {}
+
+  inline int peer(int step) const {
+    return recvPlan.peer(step) * nLocalRanks + localRank;
+  }
+
+  inline commResult_t onStepComplete(int step) {
+    if (nLocalRanks > 1) {
+      resource->pipeSync->post(step);
+    }
+    return commSuccess;
+  }
+
+  inline size_t chunkByteOffset(int node) const {
+    return (static_cast<size_t>(node) * nLocalRanks + localRank) * sendSize;
+  }
+
+  inline void enqueuePut(int step, int node) {
+    const auto nth = putCount.at(step)++;
+    const auto expectedNode = sendPlan.chunk(step, nth);
+    FB_CHECKABORT(
+        expectedNode == node,
+        "ctsrdpipeline enqueuePut: step {} put #{} expected node {} got {}",
+        step,
+        nth,
+        expectedNode,
+        node);
+    putQ.push_back({step, node});
+  }
+};
+
+commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  struct OpElem* op = opGroup.front().get();
+  auto* resource = reinterpret_cast<Resource*>(op->allgatherP.algoResource);
+  auto* pArgs = reinterpret_cast<PersistArgs*>(op->allgatherP.pArgs);
+  const auto sendSize =
+      op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
+  CtranComm* comm = opGroup.front()->comm_;
+
+  const auto statex = comm->statex_.get();
+  const auto rank = statex->rank();
+  const auto nRanks = statex->nRanks();
+  const auto localRank = statex->localRank();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto nNodes = statex->nNodes();
+  const auto nodeId = rank / nLocalRanks;
+  auto mapper = comm->ctran_->mapper.get();
+
+  CtranAlgoLogger logger(AlgoImpl::algoName(myAlgo), op->opCount, comm);
+
+  ctran::Profiler* profiler = comm->ctran_->profiler.get();
+  if (profiler) {
+    profiler->initForEachColl(
+        op->opCount, NCCL_CTRAN_ALGO_PROFILING_SAMPLING_WEIGHT);
+  }
+  auto profileGuard = folly::makeGuard([&]() {
+    CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
+    mapper->reportProfiling();
+  });
+
+  CTRAN_PROFILER_IF(profiler, {
+    auto& algoContext = profiler->algoContext;
+    algoContext.algorithmName = AlgoImpl::algoName(myAlgo);
+    algoContext.sendContext.messageSizes = std::to_string(sendSize);
+    algoContext.recvContext.messageSizes = std::to_string(sendSize * nRanks);
+  });
+
+  CtranMapperContext mapperContext(
+      AlgoImpl::algoName(myAlgo), sendSize, sendSize * nRanks);
+  mapper->setContext(std::move(mapperContext));
+
+  auto* persistPlan = static_cast<const PersistPlan*>(
+      comm->ctran_->algo->getOrCreatePersistPlan(
+          PersistPlanKey::kAllgatherPCtsrd, [&]() {
+            return std::make_unique<PersistPlan>(createPersistPlan(
+                nodeId, nNodes, resolveFwdPeers(ctran::utils::log2i(nNodes))));
+          }));
+  const auto& recvPlan = persistPlan->recvPlan();
+  const auto& sendPlan = persistPlan->sendPlan();
+  if (recvPlan.nSteps() == 0) {
+    return commSuccess;
+  }
+
+  AlgoContext ctx(
+      mapper,
+      resource,
+      pArgs,
+      sendSize,
+      localRank,
+      nLocalRanks,
+      nNodes,
+      recvPlan,
+      sendPlan);
+
+  FB_COMMCHECK(runExchangeAndProgress(ctx, nodeId, profiler));
+
+  return commSuccess;
+}
+} // namespace
+
+namespace ctran::allgatherp {
+extern __global__ void ncclKernelAllGatherPPipeStart(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+extern __global__ void ncclKernelAllGatherPPipeSync(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeSyncKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipeEnd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    PipeEndKernArgs args);
+extern __global__ void ncclKernelAllGatherPPipe(
+    int* flag,
+    CtranAlgoDeviceState* devState);
+
+commResult_t AlgoImpl::execStreamedRecursiveDoubling(
+    const void* sendbuff,
+    const size_t count,
+    const commDataType_t datatype) {
+  auto recvbuff = pArgs.recvbuff;
+  auto ctran = comm_->ctran_.get();
+  const auto statex = comm_->statex_.get();
+  const auto opCount = ctran->getOpCount();
+  const auto sendSize = count * commTypeSize(datatype);
+
+  const auto nRanks = statex->nRanks();
+  const auto nLocalRanks = statex->nLocalRanks();
+  const auto myRank = statex->rank();
+  const auto localRank = statex->localRank();
+  const auto nNodes = statex->nNodes();
+  const auto myNode = myRank / nLocalRanks;
+
+  if (nLocalRanks > 1 && nRanks % nLocalRanks != 0) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctsrdpipeline requires nRanks ({}) to be evenly divisible by "
+        "nLocalRanks ({}), nNodes={}",
+        nRanks,
+        nLocalRanks,
+        nNodes);
+  }
+  if (nNodes > 1 && !ctran::utils::isPowerOfTwo(nNodes)) {
+    FB_ERRORRETURN(
+        commInvalidUsage,
+        "AllGatherP ctsrdpipeline requires nNodes ({}) to be a power of 2",
+        nNodes);
+  }
+
+  CTRAN_COLL_INFO(
+      AlgoImpl::algoName(myAlgo),
+      sendbuff,
+      recvbuff,
+      count,
+      datatype,
+      -1,
+      comm_,
+      stream_);
+
+  if (nLocalRanks > 1) {
+    FB_COMMCHECK(waitInit());
+  }
+
+  auto* persistPlan =
+      static_cast<const PersistPlan*>(ctran->algo->getOrCreatePersistPlan(
+          PersistPlanKey::kAllgatherPCtsrd, [&]() {
+            return std::make_unique<PersistPlan>(createPersistPlan(
+                myNode, nNodes, resolveFwdPeers(ctran::utils::log2i(nNodes))));
+          }));
+  const auto& recvPlan = persistPlan->recvPlan();
+
+  auto config = KernelConfig(
+      KernelConfig::KernelType::ALLGATHERP,
+      stream_,
+      AlgoImpl::algoName(myAlgo),
+      opCount);
+  config.numBlocks = 1;
+  config.numThreads = 1;
+  config.args.devState_d = ctran->algo->getDevState();
+
+  // The streamed GPE path sources every outgoing chunk from recvbuff, including
+  // the local rank's own chunk. Keep the copy stream-ordered before PipeStart.
+  FB_COMMCHECK(copyToSelf(comm_, sendbuff, sendSize, pArgs, stream_));
+
+  if (nNodes > 1) {
+    auto op = std::make_unique<OpElem>(
+        OpElem::opType::ALLGATHERP, stream_, comm_, opCount);
+    op->allgatherP.pArgs = &pArgs;
+    op->allgatherP.algoResource = &resource_;
+    op->allgatherP.sendbuff = sendbuff;
+    op->allgatherP.count = count;
+    op->allgatherP.datatype = datatype;
+
+    std::vector<std::unique_ptr<struct OpElem>> opGroup;
+    opGroup.push_back(std::move(op));
+
+    if (nLocalRanks > 1) {
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeStart)));
+    } else {
+      FB_COMMCHECK(ctran->gpe->submit(
+          std::move(opGroup),
+          gpeFn,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipe)));
+    }
+  }
+
+  if (nLocalRanks > 1) {
+    FB_COMMCHECK(nvlCeBcast(
+        comm_, sendbuff, sendSize, myRank * sendSize, pArgs, stream_));
+
+    for (int step = 0; step < recvPlan.nSteps(); step++) {
+      PipeSyncKernArgs syncArgs = {
+          .stepId = step,
+          .pipeSync = resource_.pipeSync,
+      };
+      config.algoArgs = reinterpret_cast<void*>(&syncArgs);
+      FB_COMMCHECK(ctran->gpe->submit(
+          {},
+          nullptr,
+          config,
+          reinterpret_cast<void*>(ncclKernelAllGatherPPipeSync)));
+
+      int chunkIndex = 0;
+      for (const auto node : recvPlan.chunks(step)) {
+        const auto offset =
+            (static_cast<size_t>(node) * nLocalRanks + localRank) * sendSize;
+        auto srcPtr = ctran::allgatherp::getPtr(pArgs.recvbuff, offset);
+        FB_COMMCHECK(nvlCeBcast(
+            comm_,
+            srcPtr,
+            sendSize,
+            offset,
+            pArgs,
+            stream_,
+            chunkIndex++ == 0));
+      }
+    }
+
+    PipeEndKernArgs endArgs = {
+        .pipeSync = resource_.pipeSync,
+    };
+    config.algoArgs = reinterpret_cast<void*>(&endArgs);
+    FB_COMMCHECK(ctran->gpe->submit(
+        {},
+        nullptr,
+        config,
+        reinterpret_cast<void*>(ncclKernelAllGatherPPipeEnd)));
+  }
+
+  return commSuccess;
+}
+} // namespace ctran::allgatherp

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -130,6 +130,8 @@ commResult_t allGatherWinExec(
       return algo->execPipeline(sendbuff, count, datatype);
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return algo->execRecursiveDoubling(sendbuff, count, datatype);
+    case NCCL_ALLGATHER_P_ALGO::ctsrdpipeline:
+      return algo->execStreamedRecursiveDoubling(sendbuff, count, datatype);
     default:
       return ErrorStackTraceUtil::log(commInternalError);
   }

--- a/comms/ctran/algos/IPersistPlan.h
+++ b/comms/ctran/algos/IPersistPlan.h
@@ -10,6 +10,7 @@ namespace ctran::algos {
 // Add new entries here when registering plans for additional algorithms.
 enum class PersistPlanKey {
   kAllgatherCtsrd,
+  kAllgatherPCtsrd,
 };
 
 struct PersistPlanKeyHash {

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -18,6 +18,7 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
 #include "comms/ctran/tests/CtranTestUtils.h"
+#include "comms/ctran/utils/MathUtils.h"
 #include "comms/testinfra/TestXPlatUtils.h"
 #include "comms/testinfra/TestsCuUtils.h"
 // Test sources uses ncclMemAlloc API from nccl.h/rccl.h, so adding this check
@@ -287,27 +288,32 @@ static std::string algoToStr(enum NCCL_ALLGATHER_P_ALGO algo) {
       return "ctpipeline";
     case NCCL_ALLGATHER_P_ALGO::ctrdpipeline:
       return "ctrdpipeline";
+    case NCCL_ALLGATHER_P_ALGO::ctsrdpipeline:
+      return "ctsrdpipeline";
     default:
       return "unknown";
   }
+}
+
+static bool requiresPowerOfTwoNodes(enum NCCL_ALLGATHER_P_ALGO algo) {
+  return algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline ||
+      algo == NCCL_ALLGATHER_P_ALGO::ctsrdpipeline;
 }
 
 TEST_P(CtranAllgatherPTestParam, Basic) {
   const auto& [maxSendCount, count, inplace, memType, algo] = GetParam();
   const std::string algoStr = algoToStr(algo);
   SysEnvRAII algoEnv("NCCL_ALLGATHER_P_ALGO", algoStr);
+  const auto nNodes = ctranComm->statex_->nNodes();
 
   if (memType == kMemNcclMemAlloc && ncclIsCuMemSupported() == false) {
     GTEST_SKIP() << "CuMem not supported, skipping this test";
   } else if (ctranComm->ctran_->mapper->ctranIbPtr() == nullptr) {
     GTEST_SKIP() << "No IB Backend found, skip test";
   } else if (
-      algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline &&
-      ctranComm->statex_->nNodes() > 1 &&
-      (ctranComm->statex_->nNodes() & (ctranComm->statex_->nNodes() - 1)) !=
-          0) {
-    GTEST_SKIP()
-        << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+      requiresPowerOfTwoNodes(algo) && nNodes > 1 &&
+      !ctran::utils::isPowerOfTwo(nNodes)) {
+    GTEST_SKIP() << algoStr << " requires nNodes to be a power of 2, skip test";
   } else {
     run(maxSendCount, count, inplace, memType, ctranComm.get());
   }
@@ -335,10 +341,10 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasic) {
     ASSERT_EQ(testComm->statex_->nLocalRanks(), 4);
     const auto vnodeNNodes = numRanks / 4;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
-        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
-      GTEST_SKIP()
-          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    if (requiresPowerOfTwoNodes(algo) && vnodeNNodes > 1 &&
+        !ctran::utils::isPowerOfTwo(vnodeNNodes)) {
+      GTEST_SKIP() << algoStr
+                   << " requires nNodes to be a power of 2, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -370,10 +376,10 @@ TEST_P(CtranAllgatherPTestParam, VnodeBasicMultiStep) {
     ASSERT_EQ(testComm->statex_->nLocalRanks(), 2);
     const auto vnodeNNodes = numRanks / 2;
     ASSERT_EQ(testComm->statex_->nNodes(), vnodeNNodes);
-    if (algo == NCCL_ALLGATHER_P_ALGO::ctrdpipeline && vnodeNNodes > 1 &&
-        (vnodeNNodes & (vnodeNNodes - 1)) != 0) {
-      GTEST_SKIP()
-          << "ctrdpipeline requires nNodes to be a power of 2, skip test";
+    if (requiresPowerOfTwoNodes(algo) && vnodeNNodes > 1 &&
+        !ctran::utils::isPowerOfTwo(vnodeNNodes)) {
+      GTEST_SKIP() << algoStr
+                   << " requires nNodes to be a power of 2, skip test";
     }
     run(maxSendCount, count, inplace, memType, testComm.get());
   }
@@ -706,7 +712,8 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(
             NCCL_ALLGATHER_P_ALGO::ctdirect,
             NCCL_ALLGATHER_P_ALGO::ctpipeline,
-            NCCL_ALLGATHER_P_ALGO::ctrdpipeline)),
+            NCCL_ALLGATHER_P_ALGO::ctrdpipeline,
+            NCCL_ALLGATHER_P_ALGO::ctsrdpipeline)),
     getTestName);
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/tests/CtranWinAllGatherTest.cc
+++ b/comms/ctran/tests/CtranWinAllGatherTest.cc
@@ -7,6 +7,7 @@
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/MathUtils.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -70,9 +71,9 @@ class CtranWinAllGatherTest : public ctran::CtranDistTestFixture {
       GTEST_SKIP() << "allGatherP not supported on this topology";
     }
     const auto nNodes = statex->nNodes();
-    if (algoStr == "ctrdpipeline" && nNodes > 1 &&
-        (nNodes & (nNodes - 1)) != 0) {
-      GTEST_SKIP() << "ctrd requires nNodes to be a power of 2";
+    if ((algoStr == "ctrdpipeline" || algoStr == "ctsrdpipeline") &&
+        nNodes > 1 && !ctran::utils::isPowerOfTwo(nNodes)) {
+      GTEST_SKIP() << algoStr << " requires nNodes to be a power of 2";
     }
 
     cudaStream_t stream;
@@ -145,7 +146,11 @@ INSTANTIATE_TEST_SUITE_P(
     CtranWinAllGatherTestParam,
     ::testing::Combine(
         ::testing::Values(1024, 8192, 65536),
-        ::testing::Values("ctdirect", "ctpipeline", "ctrdpipeline")),
+        ::testing::Values(
+            "ctdirect",
+            "ctpipeline",
+            "ctrdpipeline",
+            "ctsrdpipeline")),
     [](const ::testing::TestParamInfo<CtranWinAllGatherTestParam::ParamType>&
            info) {
       return "count_" + std::to_string(std::get<0>(info.param)) + "_" +

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -282,7 +282,7 @@ TEST_P(CudaGraphAllGatherCtgraphAutoSelect, CaptureReplayVerify) {
       count * sizeof(int32_t) >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
   const std::string expectedAlgo = (statex->nLocalRanks() > 1)
       ? ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nNodes()))
-             ? "RecDbl"
+             ? "StreamedRd"
              : "Pipeline")
       : ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nRanks()))
              ? "StreamedRd"

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -957,24 +957,6 @@ class Hints {
         kvType kv;
 };
 
-/*
- * Comm Set Config
- *
- * Update mutable configuration fields on a live communicator. Only
- * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
- * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
- *
- * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
- * flat ncclConfig_t fields must remain at their undefined defaults; only the
- * hints pointer is read. Setting any flat field or any non-algo hint key
- * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
- * returns ncclInvalidArgument.
- *
- * The caller must ensure no concurrent collective or config update is in
- * progress on the same communicator.
- */
-// [META:COMM_SET_CONFIG]
-ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif
@@ -1413,6 +1395,25 @@ std::shared_ptr<const std::unordered_map<std::string, std::string>> getNcclxInfo
 // exactly the hints are used and what will happen if the hints are set after
 // initialization depends on the receiver of the hints.
 ncclResult_t setGlobalHint(std::string key, std::string val);
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 
 } // namespace ncclx
 

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -965,24 +965,6 @@ class Hints {
         kvType kv;
 };
 
-/*
- * Comm Set Config
- *
- * Update mutable configuration fields on a live communicator. Only
- * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
- * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
- *
- * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
- * flat ncclConfig_t fields must remain at their undefined defaults; only the
- * hints pointer is read. Setting any flat field or any non-algo hint key
- * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
- * returns ncclInvalidArgument.
- *
- * The caller must ensure no concurrent collective or config update is in
- * progress on the same communicator.
- */
-// [META:COMM_SET_CONFIG]
-ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 } // namespace ncclx
 
 #endif
@@ -1421,6 +1403,25 @@ std::shared_ptr<const std::unordered_map<std::string, std::string>> getNcclxInfo
 // exactly the hints are used and what will happen if the hints are set after
 // initialization depends on the receiver of the hints.
 ncclResult_t setGlobalHint(std::string key, std::string val);
+
+/*
+ * Comm Set Config
+ *
+ * Update mutable configuration fields on a live communicator. Only
+ * algorithm-selection hint keys (sendrecvAlgo, allgatherAlgo, allreduceAlgo,
+ * alltoallvAlgo, rmaAlgo) may be changed after communicator creation.
+ *
+ * The config parameter must be initialized with NCCL_CONFIG_INITIALIZER. All
+ * flat ncclConfig_t fields must remain at their undefined defaults; only the
+ * hints pointer is read. Setting any flat field or any non-algo hint key
+ * returns ncclInvalidUsage. Passing an uninitialized config (missing magic)
+ * returns ncclInvalidArgument.
+ *
+ * The caller must ensure no concurrent collective or config update is in
+ * progress on the same communicator.
+ */
+// [META:COMM_SET_CONFIG]
+ncclResult_t commSetConfig(ncclComm_t comm, const ncclConfig_t* config);
 
 } // namespace ncclx
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2087,7 +2087,7 @@ cvars:
  - name        : NCCL_ALLGATHER_P_ALGO
    type        : enum
    default     : ctpipeline
-   choices     : ctdirect, ctpipeline, ctrdpipeline
+   choices     : ctdirect, ctpipeline, ctrdpipeline, ctsrdpipeline
    description : |-
      The algorithm to use for AllgatherP communication
      ctdirect - Ctran-based direct point-to-point algorithm
@@ -2096,6 +2096,9 @@ cvars:
      ctrdpipeline - Ctran-based hybrid algorithm that does recursive doubling across
                     rails for inter-node exchange and CopyEngine based broadcast
                     within the NVLink domain. Requires nNodes to be a power of 2.
+     ctsrdpipeline - Ctran-based hybrid algorithm that streams recursive-doubling
+                     forwards across rails while keeping NVLink-domain CopyEngine
+                     broadcast step-based. Requires nNodes to be a power of 2.
 
  - name        : NCCL_ALLGATHER_ALGO
    type        : enum


### PR DESCRIPTION
Summary:
- In `ctranAllGatherCudagraphAware`, replace the pattern of saving/overriding `NCCL_ALLGATHER_P_ALGO` cvar + calling `allGatherWinExec` with direct `AlgoImpl` method calls
- `ctgraph_pipeline` now directly calls `execPipeline`
- `ctgraph_rdpipeline` now directly calls `execStreamedRecursiveDoubling` (ctsrdpipeline)
- Each ctgraph variant has its own switch case, consistent with `ctgraph_ring` and `ctgraph_rd`

Reviewed By: dsjohns2

Differential Revision: D106419561
