### PR TITLE
Consolidate ctgraph AllGather lifecycle into single switch

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -118,89 +118,69 @@ commResult_t ctranAllGatherCudagraphAware(
       statex->nLocalRanks(),
       statex->nNodes());
 
-  // Buffer registration + cleanup guard
-  ctran::CtranWin* win = nullptr;
-  CtranPersistentRequest* request = nullptr;
-
+  // Each branch handles registration, cleanup guard, execute, and deferred
+  // cleanup transfer in one block so the full lifecycle is visible together.
   switch (algo) {
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
-    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
+      ctran::CtranWin* win = nullptr;
+      CtranPersistentRequest* request = nullptr;
       FB_COMMCHECK(
           winPersistBuffReg(recvbuff, recvBytes, comm, stream, &win, &request));
+      FB_CHECKABORT(
+          win != nullptr, "winPersistBuffReg succeeded but win is null");
+      FB_CHECKABORT(
+          request != nullptr,
+          "winPersistBuffReg succeeded but request is null");
+
+      auto cleanup = [request, win]() {
+        ctran::allGatherWinDestroy(request);
+        delete request;
+        win->free(true /* skipBarrier */);
+        delete win;
+      };
+      auto cleanupGuard = folly::makeGuard(cleanup);
+
+      auto* pAlgo =
+          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
+      if (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline) {
+        FB_COMMCHECK(pAlgo->execStreamedRecursiveDoubling(
+            sendbuff, sendcount, datatype));
+      } else {
+        FB_COMMCHECK(pAlgo->execPipeline(sendbuff, sendcount, datatype));
+      }
+
+      cleanupGuard.dismiss();
+      comm->cudagraphDeferredCleanup.add(std::move(cleanup));
       break;
+    }
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:
-    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
+    case NCCL_ALLGATHER_ALGO::ctgraph_rd: {
       FB_COMMCHECK(localPersistBuffReg(recvbuff, recvBytes));
+
+      auto cleanup = [recvbuff, recvBytes]() {
+        ctran::globalDeregisterWithPtr(recvbuff, recvBytes);
+      };
+      auto cleanupGuard = folly::makeGuard(cleanup);
+
+      if (algo == NCCL_ALLGATHER_ALGO::ctgraph_ring) {
+        FB_COMMCHECK(ctranAllGatherRing(
+            sendbuff, recvbuff, sendcount, datatype, comm, stream));
+      } else {
+        FB_COMMCHECK(ctranAllGatherStreamedRd(
+            sendbuff, recvbuff, sendcount, datatype, comm, stream));
+      }
+
+      cleanupGuard.dismiss();
+      comm->cudagraphDeferredCleanup.add(std::move(cleanup));
       break;
+    }
     default:
       FB_ERRORRETURN(
           commInvalidArgument,
           "Unexpected algo {} in ctranAllGatherCudagraphAware",
           allGatherAlgoName(algo));
   }
-
-  // Cleanup lambda: shared between error guard and deferred cleanup.
-  std::function<void()> cleanup;
-  switch (algo) {
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
-    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline:
-      cleanup = [request, win]() {
-        if (request) {
-          ctran::allGatherWinDestroy(request);
-          delete request;
-        }
-        if (win) {
-          win->free(true /* skipBarrier */);
-          delete win;
-        }
-      };
-      break;
-    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
-    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
-      cleanup = [recvbuff, recvBytes]() {
-        ctran::globalDeregisterWithPtr(recvbuff, recvBytes);
-      };
-      break;
-    default:
-      break;
-  }
-
-  auto cleanupGuard = folly::makeGuard([&cleanup]() {
-    if (cleanup) {
-      cleanup();
-    }
-  });
-
-  // Execute (captured into graph)
-  switch (algo) {
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline: {
-      auto* pAlgo =
-          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
-      FB_COMMCHECK(pAlgo->execPipeline(sendbuff, sendcount, datatype));
-      break;
-    }
-    case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
-      auto* pAlgo =
-          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
-      FB_COMMCHECK(
-          pAlgo->execStreamedRecursiveDoubling(sendbuff, sendcount, datatype));
-      break;
-    }
-    case NCCL_ALLGATHER_ALGO::ctgraph_ring:
-      FB_COMMCHECK(ctranAllGatherRing(
-          sendbuff, recvbuff, sendcount, datatype, comm, stream));
-      break;
-    case NCCL_ALLGATHER_ALGO::ctgraph_rd:
-      FB_COMMCHECK(ctranAllGatherStreamedRd(
-          sendbuff, recvbuff, sendcount, datatype, comm, stream));
-      break;
-    default:
-      break;
-  }
-
-  // Success — transfer ownership to deferred cleanup
-  cleanupGuard.dismiss();
-  comm->cudagraphDeferredCleanup.add(std::move(cleanup));
 
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -10,7 +10,7 @@
 //
 //   winPersistBuffReg (ctgraph_pipeline/rdpipeline, nLocalRanks > 1):
 //     Both local and remote addresses must be stable across replays.
-//     Uses window: ctranWinRegister → allGatherWinInit → allGatherWinExec.
+//     Uses window: ctranWinRegister → allGatherWinInit → AlgoImpl dispatch.
 //
 //   localPersistBuffReg (ctgraph_ring/rd, nLocalRanks == 1):
 //     Only local registration persists; remote exchange happens at each replay
@@ -27,6 +27,7 @@
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/utils/CudaGraphUtils.h"
 #include "comms/ctran/utils/MathUtils.h"
@@ -172,16 +173,17 @@ commResult_t ctranAllGatherCudagraphAware(
 
   // Execute (captured into graph)
   switch (algo) {
-    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
+    case NCCL_ALLGATHER_ALGO::ctgraph_pipeline: {
+      auto* pAlgo =
+          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
+      FB_COMMCHECK(pAlgo->execPipeline(sendbuff, sendcount, datatype));
+      break;
+    }
     case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
-      auto savedPAlgo = NCCL_ALLGATHER_P_ALGO;
-      NCCL_ALLGATHER_P_ALGO = (algo == NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline)
-          ? NCCL_ALLGATHER_P_ALGO::ctrdpipeline
-          : NCCL_ALLGATHER_P_ALGO::ctpipeline;
-      auto pAlgoGuard = folly::makeGuard(
-          [savedPAlgo]() { NCCL_ALLGATHER_P_ALGO = savedPAlgo; });
+      auto* pAlgo =
+          reinterpret_cast<ctran::allgatherp::AlgoImpl*>(request->algo);
       FB_COMMCHECK(
-          ctran::allGatherWinExec(sendbuff, sendcount, datatype, request));
+          pAlgo->execStreamedRecursiveDoubling(sendbuff, sendcount, datatype));
       break;
     }
     case NCCL_ALLGATHER_ALGO::ctgraph_ring:

--- a/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
+++ b/comms/ctran/tests/cudagraph/CtranCudaGraphAllGatherCtgraphTest.cc
@@ -282,7 +282,7 @@ TEST_P(CudaGraphAllGatherCtgraphAutoSelect, CaptureReplayVerify) {
       count * sizeof(int32_t) >= NCCL_CTGRAPH_ALLGATHER_RING_THRESHOLD;
   const std::string expectedAlgo = (statex->nLocalRanks() > 1)
       ? ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nNodes()))
-             ? "RecDbl"
+             ? "StreamedRd"
              : "Pipeline")
       : ((!largeMessage && ctran::utils::isPowerOfTwo(statex->nRanks()))
              ? "StreamedRd"


### PR DESCRIPTION
Summary:
- Merge the three separate switch sections (registration, cleanup, execute) into one switch where each branch handles its full lifecycle: registration → cleanup guard → execute → deferred cleanup transfer
- Add `FB_CHECKABORT` after `winPersistBuffReg` to assert `request != nullptr`
- No behavioral change, purely structural refactoring for readability

Reviewed By: dsjohns2

Differential Revision: D106441436


