### PR TITLE
Add hierarchical reduce-scatter unit tests (#2698)

### DIFF
--- a/comms/pipes/collectives/HierarchicalReduceScatterDirect.cu
+++ b/comms/pipes/collectives/HierarchicalReduceScatterDirect.cu
@@ -1,0 +1,236 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/HierarchicalReduceScatterDirect.cuh"
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
+
+namespace comms::pipes {
+
+// Runs the NVLink reduction phase of hierarchical reduce-scatter. For each
+// `ib_dst` slot the local rank's slice is reduced with all other NVL peers'
+// slices. The reduction destination is `workspace[ib_dst]` for every slot
+// EXCEPT `ib_dst == ib_rank`, which is written directly into `output`. The IB
+// ring's final reduce-into-output step consumes that slot as `local_input`, so
+// diverting it here removes one full workspace round-trip (one write here +
+// one read in the IB ring) for the `ib_rank` slot.
+template <typename T, typename ReduceOp, typename Group>
+__device__ __forceinline__ void hierarchical_reduce_scatter_nvl_reduce_phase(
+    Group& group,
+    int ib_size,
+    int ib_rank,
+    int nvl_rank,
+    int nvl_size,
+    std::size_t chunk_elements,
+    std::size_t max_sig,
+    const P2pNvlTransportDevice* peers,
+    const T* input,
+    T* workspace,
+    T* output,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  const std::size_t chunk_bytes = chunk_elements * sizeof(T);
+  const char* input_base = reinterpret_cast<const char*>(input);
+  char* workspace_base = reinterpret_cast<char*>(workspace);
+  char* output_base = reinterpret_cast<char*>(output);
+
+  TiledBuffer<char> tile(nullptr, chunk_bytes, group);
+  const std::size_t tile_offset = group.group_id * tile.tile_elements;
+  const std::size_t tile_bytes = tile.bytes();
+
+  // Peer set and group are loop-invariant, so compute pipeline_window once.
+  const std::size_t pipeline_window = (nvl_size > 1)
+      ? direct_pipeline_window(peers, nvl_rank, nvl_size, group.total_groups)
+      : 0;
+  if (nvl_size > 1) {
+    PIPES_DEVICE_CHECK_MSG(
+        pipeline_window != 0,
+        "hierarchical reduce-scatter NVLink reduce pipeline window is zero");
+  }
+
+  for (int ib_dst = 0; ib_dst < ib_size; ++ib_dst) {
+    const std::size_t input_chunk =
+        (static_cast<std::size_t>(ib_dst) * nvl_size + nvl_rank) * chunk_bytes;
+    // Divert the `ib_rank` slot directly into output; everything else lands in
+    // workspace as before.
+    char* dst = (ib_dst == ib_rank)
+        ? (output_base + tile_offset)
+        : (workspace_base + static_cast<std::size_t>(ib_dst) * chunk_bytes +
+           tile_offset);
+
+    memcpy_vectorized(
+        dst, input_base + input_chunk + tile_offset, tile_bytes, group);
+    group.sync();
+
+    if (nvl_size <= 1 || tile_bytes == 0) {
+      continue;
+    }
+
+    for (std::size_t off = 0; off < tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = tile_bytes - off;
+      const std::size_t window =
+          remaining < pipeline_window ? remaining : pipeline_window;
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        const std::size_t peer_input_chunk =
+            (static_cast<std::size_t>(ib_dst) * nvl_size + peer_rank) *
+            chunk_bytes;
+        auto peer = peers[peer_rank];
+        peer.send(
+            group,
+            input_base + peer_input_chunk + tile_offset + off,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout);
+      }
+
+      for (int peer_rank = 0; peer_rank < nvl_size; ++peer_rank) {
+        if (peer_rank == nvl_rank) {
+          continue;
+        }
+        char* window_dst = dst + off;
+        auto peer = peers[peer_rank];
+        peer.template recv<ReduceOp>(
+            group,
+            window_dst,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            window_dst);
+      }
+    }
+  }
+#endif
+}
+
+template <typename T, typename ReduceOp, typename Group>
+__device__ __forceinline__ void hierarchical_reduce_scatter_ib_ring(
+    Group& group,
+    int ib_rank,
+    int ib_size,
+    std::size_t chunk_elements,
+    std::size_t max_sig,
+    const HierarchicalReduceScatterIbgdaRing& topo,
+    const T* workspace,
+    T* output,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  // For ib_size <= 1 the NVL reduction phase has already written the final
+  // result for `ib_dst == ib_rank` directly into `output`, so the IB ring has
+  // nothing to do.
+  if (ib_size <= 1) {
+    return;
+  }
+
+  const std::size_t chunk_bytes = chunk_elements * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, chunk_bytes, group);
+  const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const char* input_base = reinterpret_cast<const char*>(workspace);
+  char* output_base = reinterpret_cast<char*>(output);
+
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipeline_window != 0,
+      "hierarchical reduce-scatter IB pipeline window is zero");
+
+  const int stride = (ib_rank - topo.prev_rank + ib_size) % ib_size;
+  PIPES_DEVICE_CHECK_MSG(
+      stride != 0 && (ib_rank + stride) % ib_size == topo.next_rank,
+      "hierarchical reduce-scatter IB ring topology is inconsistent");
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    int current_rank = (ib_rank + ib_size - stride) % ib_size;
+    const char* send_src = input_base +
+        static_cast<std::size_t>(current_rank) * chunk_bytes + io_tile_offset +
+        off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    for (int step = 0; step < ib_size - 1; step++) {
+      current_rank = (current_rank + ib_size - stride) % ib_size;
+
+      if (step < ib_size - 2) {
+        const char* local_input = input_base +
+            static_cast<std::size_t>(current_rank) * chunk_bytes +
+            io_tile_offset + off;
+        prev.template forward<ReduceOp>(
+            group,
+            nullptr,
+            next,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      } else {
+        // Final step: current_rank == ib_rank by construction. The NVL phase
+        // has already written this rank's NVL-reduced slice into `output`, so
+        // we use `output` itself as local_input for the reduce instead of
+        // reading workspace[ib_rank]. This eliminates the workspace round-trip
+        // for the `ib_rank` slot.
+        char* dst = output_base + io_tile_offset + off;
+        prev.template recv<ReduceOp>(
+            group, dst, window, group.total_groups, max_sig, timeout, dst);
+      }
+    }
+  }
+#endif
+}
+
+__global__
+__launch_bounds__(512, 1) void hierarchical_reduce_scatter_fused_float_sum_kernel(
+    const __grid_constant__ HierarchicalReduceScatterFusedArgs<float> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  using ReduceOp = TileReduceStaged<float, SumOp, 16384, 512>;
+
+  hierarchical_reduce_scatter_nvl_reduce_phase<float, ReduceOp>(
+      group,
+      args.ib_size,
+      args.ib_rank,
+      args.nvl_rank,
+      args.nvl_size,
+      args.chunk_elements,
+      args.nvl_signaling_data_size,
+      args.nvl_peers,
+      args.input,
+      args.workspace,
+      args.output,
+      timeout);
+  group.sync();
+
+  hierarchical_reduce_scatter_ib_ring<float, ReduceOp>(
+      group,
+      args.ib_rank,
+      args.ib_size,
+      args.chunk_elements,
+      args.ib_signaling_data_size,
+      args.ib_ring,
+      args.workspace,
+      args.output,
+      timeout);
+#endif
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/HierarchicalReduceScatterDirect.cuh
+++ b/comms/pipes/collectives/HierarchicalReduceScatterDirect.cuh
@@ -1,0 +1,15 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/HierarchicalReduceScatterTypes.h"
+
+namespace comms::pipes {
+
+__global__
+    __launch_bounds__(512, 1) void hierarchical_reduce_scatter_fused_float_sum_kernel(
+        const __grid_constant__ HierarchicalReduceScatterFusedArgs<float> args,
+        Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/HierarchicalReduceScatterLauncher.cu
+++ b/comms/pipes/collectives/HierarchicalReduceScatterLauncher.cu
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/HierarchicalReduceScatterLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/Checks.h"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/HierarchicalReduceScatterDirect.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+void validate_direct_nvl(int num_ranks) {
+  if (num_ranks < 1 || num_ranks > kDirectNvlMaxRanks) {
+    throw std::runtime_error(
+        "Unsupported direct NVLink num_ranks=" + std::to_string(num_ranks) +
+        " (supported: 1.." + std::to_string(kDirectNvlMaxRanks) + ")");
+  }
+}
+
+Timeout make_launch_timeout(float timeout_ms) {
+  Timeout timeout;
+  if (timeout_ms > 0) {
+    int device = 0;
+    PIPES_CUDA_CHECK(cudaGetDevice(&device));
+    timeout = makeTimeout(timeout_ms, device);
+  }
+  return timeout;
+}
+
+} // namespace
+
+void launch_hierarchical_reduce_scatter_fused(
+    const HierarchicalReduceScatterLaunchParams& params) {
+  validate_direct_nvl(params.nvl_size);
+  if (params.ib_size < 1 ||
+      params.ib_size * params.nvl_size != params.num_ranks) {
+    throw std::runtime_error(
+        "Invalid hierarchical reduce-scatter rank geometry");
+  }
+
+  HierarchicalReduceScatterFusedArgs<float> args{};
+  args.ib_rank = params.ib_rank;
+  args.ib_size = params.ib_size;
+  args.nvl_rank = params.nvl_rank;
+  args.nvl_size = params.nvl_size;
+  args.chunk_elements = params.chunk_elements;
+  args.ib_signaling_data_size = params.ib_signaling_data_size;
+  args.nvl_signaling_data_size = params.nvl_signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
+  args.workspace = params.workspace;
+  args.ib_ring = params.ib_ring;
+
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == params.nvl_rank) {
+      continue;
+    }
+    new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
+  }
+
+  hierarchical_reduce_scatter_fused_float_sum_kernel<<<
+      params.num_blocks,
+      512,
+      0,
+      params.stream>>>(args, make_launch_timeout(params.timeout_ms));
+  PIPES_CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/HierarchicalReduceScatterLauncher.h
+++ b/comms/pipes/collectives/HierarchicalReduceScatterLauncher.h
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/HierarchicalReduceScatterTypes.h"
+
+namespace comms::pipes {
+
+struct HierarchicalReduceScatterLaunchParams {
+  int num_ranks{0};
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t chunk_elements{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  float* workspace{nullptr};
+  int num_blocks{16};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+  HierarchicalReduceScatterIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+void launch_hierarchical_reduce_scatter_fused(
+    const HierarchicalReduceScatterLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/HierarchicalReduceScatterTypes.h
+++ b/comms/pipes/collectives/HierarchicalReduceScatterTypes.h
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+#include "comms/pipes/P2pNvlTransportDevice.cuh"
+#include "comms/pipes/collectives/DirectCollectiveTypes.h"
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct HierarchicalReduceScatterIbgdaRing {
+  int prev_rank{0};
+  int next_rank{0};
+  P2pIbgdaTransportDevice* prev{nullptr};
+  P2pIbgdaTransportDevice* next{nullptr};
+};
+
+template <typename T>
+struct HierarchicalReduceScatterFusedArgs {
+  int ib_rank{0};
+  int ib_size{0};
+  int nvl_rank{0};
+  int nvl_size{0};
+  std::size_t chunk_elements{0};
+  std::size_t ib_signaling_data_size{0};
+  std::size_t nvl_signaling_data_size{0};
+  const T* input{nullptr};
+  T* output{nullptr};
+  T* workspace{nullptr};
+  HierarchicalReduceScatterIbgdaRing ib_ring{};
+  P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+};
+
+static_assert(
+    sizeof(HierarchicalReduceScatterFusedArgs<float>) <= 32764,
+    "Hierarchical reduce-scatter launch args exceed CUDA kernel parameter limit");
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/tests/HierarchicalReduceScatterTest.cc
+++ b/comms/pipes/collectives/tests/HierarchicalReduceScatterTest.cc
@@ -1,0 +1,209 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+#include "comms/pipes/MultiPeerNvlTransport.h"
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/pipes/collectives/HierarchicalReduceScatterLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/ReduceScatterTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct HierarchicalReduceScatterTestParams {
+  ReduceScatterTestConfig config;
+  int ib_size;
+  int nvl_size;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<HierarchicalReduceScatterTestParams>& info) {
+  return info.param.config.name;
+}
+
+class HierarchicalReduceScatterTest : public ReduceScatterTestBase,
+                                      public ::testing::WithParamInterface<
+                                          HierarchicalReduceScatterTestParams> {
+};
+
+TEST_P(HierarchicalReduceScatterTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize != params.ib_size * params.nvl_size) {
+    GTEST_SKIP() << "Hierarchical reduce-scatter test expects "
+                 << params.ib_size * params.nvl_size << " ranks";
+  }
+  if (localSize < params.nvl_size) {
+    GTEST_SKIP() << "Hierarchical reduce-scatter test needs " << params.nvl_size
+                 << " local ranks per NVLink group";
+  }
+
+  const int ibRank = globalRank / params.nvl_size;
+  const int nvlRank = globalRank % params.nvl_size;
+
+  std::unique_ptr<MultipeerIbgdaTransport> ibTransport;
+  if (params.ib_size > 1) {
+    try {
+      MultipeerIbgdaTransportConfig ibConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = 1024 * 1024,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks,
+                  .pipelineDepth = 2,
+              },
+      };
+      ibTransport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, ibConfig);
+      ibTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    }
+  }
+
+  std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
+  if (params.nvl_size > 1) {
+    try {
+      MultiPeerNvlTransportConfig nvlConfig{
+          .dataBufferSize = 1024 * 1024,
+          .chunkSize = 1024 * 1024,
+          .pipelineDepth = 2,
+          .p2pSignalCount = static_cast<std::size_t>(config.num_blocks),
+          .tile_max_groups = config.num_blocks,
+          .memSharingMode = MemSharingMode::kCudaIpc,
+      };
+      std::vector<int> nvlRankToGlobal(params.nvl_size);
+      for (int peer = 0; peer < params.nvl_size; ++peer) {
+        nvlRankToGlobal[peer] = ibRank * params.nvl_size + peer;
+      }
+      auto nvlBootstrap = std::make_shared<NvlBootstrapAdapter>(
+          bootstrap, std::move(nvlRankToGlobal));
+      nvlTransport = std::make_unique<MultiPeerNvlTransport>(
+          nvlRank, params.nvl_size, nvlBootstrap, nvlConfig);
+      nvlTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "NVLink transport not available: " << e.what();
+    }
+  }
+
+  const std::size_t totalElements = config.chunk_elements * worldSize;
+  const std::size_t chunkBytes = config.chunk_elements * sizeof(float);
+  const std::size_t workspaceBytes =
+      static_cast<std::size_t>(params.ib_size) * chunkBytes;
+  DeviceBuffer inputBuf(totalElements * sizeof(float));
+  DeviceBuffer outputBuf(chunkBytes);
+  DeviceBuffer workspaceBuf(workspaceBytes);
+  CUDACHECK_TEST(cudaMemset(outputBuf.get(), 0, chunkBytes));
+  CUDACHECK_TEST(cudaMemset(workspaceBuf.get(), 0, workspaceBytes));
+
+  fill_input(static_cast<float*>(inputBuf.get()), totalElements);
+
+  HierarchicalReduceScatterLaunchParams launchParams{};
+  launchParams.num_ranks = worldSize;
+  launchParams.ib_rank = ibRank;
+  launchParams.ib_size = params.ib_size;
+  launchParams.nvl_rank = nvlRank;
+  launchParams.nvl_size = params.nvl_size;
+  launchParams.chunk_elements = config.chunk_elements;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.workspace = static_cast<float*>(workspaceBuf.get());
+  launchParams.num_blocks = config.num_blocks;
+  launchParams.timeout_ms = 30000.0f;
+
+  if (params.ib_size > 1) {
+    auto ibRingsOpt = make_standard_rings(params.ib_size, ibRank, 1);
+    ASSERT_TRUE(ibRingsOpt.has_value());
+    const auto& ibRing = (*ibRingsOpt)[0];
+    const int prevGlobal = ibRing.prev_rank * params.nvl_size + nvlRank;
+    const int nextGlobal = ibRing.next_rank * params.nvl_size + nvlRank;
+    launchParams.ib_ring.prev_rank = ibRing.prev_rank;
+    launchParams.ib_ring.next_rank = ibRing.next_rank;
+    launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
+    launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
+  }
+
+  for (int peer = 0; peer < params.nvl_size; ++peer) {
+    if (peer == nvlRank) {
+      continue;
+    }
+    new (&launchParams.nvl_peers[peer])
+        P2pNvlTransportDevice(nvlTransport->getP2pTransportDevice(peer));
+  }
+
+  bootstrap->barrierAll();
+  launch_hierarchical_reduce_scatter_fused(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_reduce_scatter(
+      static_cast<const float*>(outputBuf.get()), config.chunk_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Hierarchical,
+    HierarchicalReduceScatterTest,
+    ::testing::Values(
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib2Nvl2_64KB_4B",
+                },
+            .ib_size = 2,
+            .nvl_size = 2,
+        },
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib1Nvl4_64KB_4B",
+                },
+            .ib_size = 1,
+            .nvl_size = 4,
+        },
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 16 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib4Nvl1_64KB_4B",
+                },
+            .ib_size = 4,
+            .nvl_size = 1,
+        },
+        HierarchicalReduceScatterTestParams{
+            .config =
+                {
+                    .chunk_elements = 1024 * 1024,
+                    .num_blocks = 4,
+                    .name = "Ib4Nvl2_4MB_4B",
+                },
+            .ib_size = 4,
+            .nvl_size = 2,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:

Add distributed unit tests for hierarchical reduce-scatter. Defines two test targets:
  - hierarchical_reduce_scatter_test (single-node, 4 ranks)
  - hierarchical_reduce_scatter_multinode_test (2 nodes, 2 ppn)

The test matrix includes Ib4Nvl1_64KB_4B so prev.forward<ReduceOp> is exercised instead of only the ib_size <= 2 paths. Depends on the algorithm/launcher diff below in the stack.

Differential Revision: D106421078


