### PR TITLE
Add pipesflatring AllReduce CVAR and dispatch wiring (#2700)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -21,6 +21,9 @@
 
 namespace {
 
+/** Default per-peer IBGDA send/recv data buffer for ctree AllReduce. */
+constexpr uint64_t kCtreeAllReduceIbgdaDataBufferSize = 32ULL * 1024 * 1024;
+
 bool ctranPipesTraceEnabled() {
   return NCCL_CTRAN_PIPES_TRACE_ENABLE;
 }
@@ -142,6 +145,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     uint64_t ibgdaDataBufferSize = (pc.ibgdaDataBufferSize > 0)
         ? static_cast<size_t>(pc.ibgdaDataBufferSize)
         : static_cast<size_t>(NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE);
+    if (NCCL_ALLREDUCE_ALGO == NCCL_ALLREDUCE_ALGO::ctree &&
+        ibgdaDataBufferSize == 0) {
+      ibgdaDataBufferSize = kCtreeAllReduceIbgdaDataBufferSize;
+    }
     if (hierAgOverlapEnabled && NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE > 0) {
       ibgdaDataBufferSize = std::max(
           ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -42,6 +42,18 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
         return false;
       }
       return true;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+#if defined(ENABLE_PIPES)
+      if (comm->multiPeerTransport_ && NCCL_CTRAN_PIPES_SENDRECV_ENABLE &&
+          comm->statex_->nLocalRanks() == 1) {
+        return true;
+      }
+      CLOGF(
+          WARN,
+          "pipesflatring requires ENABLE_PIPES, NCCL_CTRAN_USE_PIPES=1, "
+          "NCCL_CTRAN_PIPES_SENDRECV_ENABLE=1, and nLocalRanks=1");
+#endif
+      return false;
     default: // invalid query
       return false;
   }
@@ -81,6 +93,13 @@ commResult_t ctranAllReduce(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctree:
       return ctranAllReduceTree(
+          sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      if (comm->statex_->nRanks() == 1) {
+        return ctranAllReduceDirect(
+            sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+      }
+      return ctranAllReducePipesFlatRing(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -28,6 +28,8 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctran:
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return true;
     default: // invalid query
       return false;
   }
@@ -64,6 +66,9 @@ commResult_t ctranAllReduce(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       return ctranAllReduceRing(
+          sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return ctranAllReduceTree(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -29,6 +29,18 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
     case NCCL_ALLREDUCE_ALGO::ctree:
+      if (!NCCL_CTRAN_USE_PIPES) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+        return false;
+      }
+      if (comm->statex_->nNodes() > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+        return false;
+      }
       return true;
     default: // invalid query
       return false;

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,15 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+commResult_t ctranAllReduceTree(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 static inline const std::string allReduceAlgoName(
     enum NCCL_ALLREDUCE_ALGO algo) {
@@ -38,6 +47,8 @@ static inline const std::string allReduceAlgoName(
       return "Baseline";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "CtranAllReduceRing";
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return "CtranAllReduceTree";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -27,6 +27,18 @@ commResult_t ctranAllReduceRing(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 /**
+ * Run the Pipes-backed ring AllReduce implementation.
+ */
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+/**
  * Run the Pipes-backed tree AllReduce implementation.
  *
  * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
@@ -56,6 +68,8 @@ static inline const std::string allReduceAlgoName(
       return "CtranAllReduceRing";
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "CtranAllReduceTree";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "PipesFlatRingAllReduce";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,13 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+/**
+ * Run the Pipes-backed tree AllReduce implementation.
+ *
+ * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
+ * It relies on Pipes NVL and IBGDA transport staging for transient receives and
+ * does not allocate message-size-dependent AllReduce staging.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <chrono>
+#include <optional>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  return commInternalError;
+}
+
+#else
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void*,
+    void*,
+    size_t,
+    commDataType_t,
+    commRedOp_t,
+    CtranComm*,
+    cudaStream_t,
+    std::optional<std::chrono::milliseconds>) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/logger/LogUtils.h"
+
+commResult_t ctranAllReduceTree(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  CLOGF(ERR, "AllReduce ctree algorithm is not yet implemented");
+  return commResult_t::commInternalError;
+}

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -1,8 +1,31 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <algorithm>
+#include <climits>
+
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/topo/CtranTreeBuilder.h"
 #include "comms/utils/logger/LogUtils.h"
+
+namespace {
+
+template <typename NodeToRank>
+void populateTreeTopology(
+    ctran::allreduce::TreeTopology& dst,
+    const ctran::algos::topo::TreeNeighbors& src,
+    const NodeToRank& nodeToRank) {
+  dst.parentRank = nodeToRank(src.parent);
+  dst.numChildren = src.numChildren;
+  dst.isRoot = src.isRoot;
+  dst.isLeaf = src.isLeaf;
+  for (int c = 0; c < src.numChildren; c++) {
+    dst.childRanks[c] = nodeToRank(src.children[c]);
+  }
+}
+
+} // namespace
 
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
@@ -13,6 +36,100 @@ commResult_t ctranAllReduceTree(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout) {
-  CLOGF(ERR, "AllReduce ctree algorithm is not yet implemented");
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int localRank = statex->localRank();
+  const int nodeId = statex->node();
+
+  // Single rank: just copy
+  if (nRanks == 1) {
+    if (sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * commTypeSize(datatype),
+          cudaMemcpyDeviceToDevice,
+          stream));
+    }
+    return commSuccess;
+  }
+
+  // Compute P_min: minimum nLocalRanks across all nodes
+  int pMin = INT_MAX;
+  for (int n = 0; n < nNodes; n++) {
+    int someRankOnNode = statex->localRankToRank(0, n);
+    pMin = std::min(pMin, statex->nLocalRanks(someRankOnNode));
+  }
+
+  const size_t segmentElems = (count + pMin - 1) / pMin;
+  const bool participatesInIB = (localRank < pMin);
+  const int fanOut = 2; // binary trees for V1
+
+  // Build dual trees (in node-space: 0..nNodes-1)
+  ctran::allreduce::TreeTopology tree0{};
+  ctran::allreduce::TreeTopology tree1{};
+
+  if (participatesInIB && nNodes > 1) {
+    int nodeRank = nodeId;
+    auto [t0, t1] =
+        ctran::algos::topo::buildDualKaryTree(nNodes, nodeRank, fanOut);
+
+    // Map node-space neighbors to communicator ranks
+    auto nodeToRank = [&](int node) -> int {
+      if (node < 0) {
+        return -1;
+      }
+      return statex->localRankToRank(localRank, node);
+    };
+
+    populateTreeTopology(tree0, t0, nodeToRank);
+    populateTreeTopology(tree1, t1, nodeToRank);
+  } else if (participatesInIB && nNodes == 1) {
+    // Single node: no IB tree needed, Phase 2 is a no-op
+    tree0.isRoot = true;
+    tree0.isLeaf = true;
+    tree1.isRoot = true;
+    tree1.isLeaf = true;
+  }
+
+  int treeDepth = 0;
+  {
+    int n = nNodes;
+    while (n > 1) {
+      n = (n + fanOut - 1) / fanOut;
+      treeDepth++;
+    }
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce ctree: rank {} localRank {} nNodes {} pMin {} "
+      "segmentElems {} treeDepth {} participatesInIB {} "
+      "tree0[parent={} children={} root={} leaf={}] "
+      "tree1[parent={} children={} root={} leaf={}]",
+      rank,
+      localRank,
+      nNodes,
+      pMin,
+      segmentElems,
+      treeDepth,
+      participatesInIB,
+      tree0.parentRank,
+      tree0.numChildren,
+      tree0.isRoot,
+      tree0.isLeaf,
+      tree1.parentRank,
+      tree1.numChildren,
+      tree1.isRoot,
+      tree1.isLeaf);
+
+  // TODO: Populate kernel args and launch kernel (Diffs 4+5)
+  CLOGF(ERR, "AllReduce ctree kernel not yet implemented");
   return commResult_t::commInternalError;
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -2,14 +2,29 @@
 
 #include <algorithm>
 #include <climits>
+#include <memory>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/ctran/utils/CudaUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
+#if defined(ENABLE_PIPES)
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#endif
+
 namespace {
+
+enum class TreeGpuArch {
+  Hopper,
+  Blackwell,
+};
 
 template <typename NodeToRank>
 void populateTreeTopology(
@@ -25,8 +40,92 @@ void populateTreeTopology(
   }
 }
 
+/** Return whether the ctree device kernel supports `datatype`. */
+bool isSupportedTreeType(commDataType_t datatype) {
+  return datatype == commFloat32 || datatype == commFloat16;
+}
+
+/** Return whether this is an nccl-tests control communicator. */
+bool isNcclTestsSyncComm(CtranComm* comm) {
+  const auto& commDesc = comm->statex_->commDesc();
+  return commDesc == "nccl-tests-suite-global-sync-comm" ||
+      commDesc == "nccl-tests-suite-sync-comm";
+}
+
+/** Return the tree fanout for this run; default to NCCL-like binary trees. */
+int getAllReduceTreeFanOut() {
+  constexpr int kDefaultFanOut = 2;
+  const int fanOut = NCCL_CTRAN_TREE_FANOUT;
+  if (fanOut >= 1 && fanOut <= ctran::algos::topo::kMaxTreeChildren) {
+    return fanOut;
+  }
+
+  CLOGF(
+      WARN,
+      "Ignoring invalid NCCL_CTRAN_TREE_FANOUT={} for ctree fanout; using {}",
+      fanOut,
+      kDefaultFanOut);
+  return kDefaultFanOut;
+}
+
+#if defined(ENABLE_PIPES)
+/** Resolve the local GPU architecture bucket used by ctree tuning. */
+commResult_t getTreeGpuArch(TreeGpuArch* arch) {
+  *arch = TreeGpuArch::Blackwell;
+  int cudaDev = 0;
+  FB_CUDACHECK(cudaGetDevice(&cudaDev));
+  auto cudaArch = ctran::utils::getCudaArch(cudaDev);
+  if (!cudaArch.hasValue()) {
+    CLOGF(ERR, "{}", cudaArch.error());
+    return commUnhandledCudaError;
+  }
+  if (cudaArch.value() < 1000) {
+    *arch = TreeGpuArch::Hopper;
+  }
+  return commSuccess;
+}
+
+/** Return the topology-wide cap for CTREE logical CUDA blocks. */
+int getAllReduceTreeNumBlockCap(TreeGpuArch /* arch */, bool /* hasIbPhase */) {
+  return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
+}
+
+/**
+ * Select the number of independent data tiles for this launch.
+ *
+ * The algorithm is correct with one tile block. Larger values only expose more
+ * tile parallelism. `NCCL_CTRAN_MAX_NBLOCKS` caps the default policy. The
+ * automatic policy starts at the cap, then reduces the number of blocks while
+ * the message has less than one block-threshold of work per block.
+ */
+int getAllReduceTreeNumBlocks(
+    size_t totalBytes,
+    TreeGpuArch arch,
+    bool hasIbPhase) {
+  const int cap = getAllReduceTreeNumBlockCap(arch, hasIbPhase);
+  const size_t perBlockThresholdBytes =
+      static_cast<size_t>(ctran::allreduce::tree::kBlockSize) * 64;
+
+  int numBlocks = cap;
+  while (numBlocks > 1 &&
+         totalBytes < static_cast<size_t>(numBlocks) * perBlockThresholdBytes) {
+    numBlocks--;
+  }
+  return numBlocks;
+}
+#endif
+
 } // namespace
 
+/**
+ * Run CTRAN tree AllReduce using NVL reduce-scatter, dual IB trees, and NVL
+ * all-gather.
+ *
+ * The tensor is split across `pMin` owner ranks per node. Each owner segment is
+ * further partitioned into logical CUDA blocks so multiple blocks can process a
+ * segment concurrently while the two tree lanes operate on disjoint halves of
+ * each block-owned tile.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,
@@ -47,7 +146,7 @@ commResult_t ctranAllReduceTree(
   const int localRank = statex->localRank();
   const int nodeId = statex->node();
 
-  // Single rank: just copy
+  // Single rank AllReduce is the identity for every datatype and reduction op.
   if (nRanks == 1) {
     if (sendbuff != recvbuff) {
       FB_CUDACHECK(cudaMemcpyAsync(
@@ -60,6 +159,41 @@ commResult_t ctranAllReduceTree(
     return commSuccess;
   }
 
+  if (isNcclTestsSyncComm(comm)) {
+    CLOGF(
+        DBG,
+        "AllReduce ctree delegates nccl-tests sync comm {} to ctdirect",
+        statex->commDesc());
+    return ctranAllReduceDirect(
+        sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+  }
+
+  if (redOp != commSum) {
+    CLOGF(ERR, "AllReduce ctree currently supports commSum only");
+    return commInvalidArgument;
+  }
+
+  if (!isSupportedTreeType(datatype)) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree unsupported datatype {}",
+        commDataTypeToString(datatype));
+    return commInvalidArgument;
+  }
+
+  if (nNodes > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+    return commInvalidArgument;
+  }
+  if (!NCCL_CTRAN_USE_PIPES) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+    return commInvalidArgument;
+  }
+
   // Compute P_min: minimum nLocalRanks across all nodes
   int pMin = INT_MAX;
   for (int n = 0; n < nNodes; n++) {
@@ -69,7 +203,7 @@ commResult_t ctranAllReduceTree(
 
   const size_t segmentElems = (count + pMin - 1) / pMin;
   const bool participatesInIB = (localRank < pMin);
-  const int fanOut = 2; // binary trees for V1
+  const int fanOut = getAllReduceTreeFanOut();
 
   // Build dual trees (in node-space: 0..nNodes-1)
   ctran::allreduce::TreeTopology tree0{};
@@ -110,7 +244,7 @@ commResult_t ctranAllReduceTree(
   CLOGF(
       DBG,
       "AllReduce ctree: rank {} localRank {} nNodes {} pMin {} "
-      "segmentElems {} treeDepth {} participatesInIB {} "
+      "segmentElems {} fanOut {} treeDepth {} participatesInIB {} "
       "tree0[parent={} children={} root={} leaf={}] "
       "tree1[parent={} children={} root={} leaf={}]",
       rank,
@@ -118,6 +252,7 @@ commResult_t ctranAllReduceTree(
       nNodes,
       pMin,
       segmentElems,
+      fanOut,
       treeDepth,
       participatesInIB,
       tree0.parentRank,
@@ -129,7 +264,96 @@ commResult_t ctranAllReduceTree(
       tree1.isRoot,
       tree1.isLeaf);
 
-  // TODO: Populate kernel args and launch kernel (Diffs 4+5)
-  CLOGF(ERR, "AllReduce ctree kernel not yet implemented");
-  return commResult_t::commInternalError;
+#if defined(ENABLE_PIPES)
+  TreeGpuArch gpuArch = TreeGpuArch::Blackwell;
+  FB_COMMCHECK(getTreeGpuArch(&gpuArch));
+  const int nLocalRanks = statex->nLocalRanks();
+  const size_t elementSize = commTypeSize(datatype);
+  const size_t totalBytes = count * elementSize;
+  const size_t segmentBytes = segmentElems * elementSize;
+  const bool hasIbPhase = participatesInIB && nNodes > 1;
+  const int numBlocks =
+      getAllReduceTreeNumBlocks(totalBytes, gpuArch, hasIbPhase);
+
+  // phase2Buf holds the locally-reduced segment from Phase 1 and serves as
+  // the working buffer for Phase 2's reduce-up + broadcast-down. Use
+  // recvbuff at this GPU's segment offset — after Phase 2 completes, the
+  // result is copied to the same location so Phase 3 can read it.
+  void* phase2Buf = static_cast<char*>(recvbuff) +
+      static_cast<size_t>(localRank) * segmentBytes;
+
+  CLOGF(
+      DBG,
+      "AllReduce ctree launch: totalBytes {} segmentBytes {} numBlocks {} "
+      "threadsPerBlock {} hasIbPhase {}",
+      totalBytes,
+      segmentBytes,
+      numBlocks,
+      ctran::allreduce::tree::kBlockSize,
+      hasIbPhase);
+
+  auto opCount = comm->ctran_->getOpCount();
+
+  // Populate kernel args
+  ctran::allreduce::tree::KernArgs kernArgs{};
+  kernArgs.sendbuff = sendbuff;
+  kernArgs.recvbuff = recvbuff;
+  kernArgs.phase2Buf = phase2Buf;
+  kernArgs.count = count;
+  kernArgs.segmentElems = segmentElems;
+  kernArgs.nNodes = nNodes;
+  kernArgs.pMin = pMin;
+  kernArgs.nLocalRanks = nLocalRanks;
+  kernArgs.localRank = localRank;
+  kernArgs.numBlocks = numBlocks;
+  kernArgs.datatype = datatype;
+  kernArgs.redOp = redOp;
+  kernArgs.transports = comm->getMultiPeerTransportsPtr();
+  if (kernArgs.transports == nullptr) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: getMultiPeerTransportsPtr() returned null — "
+        "Pipes transport not initialized. Ensure ENABLE_PIPES is defined "
+        "and multiPeerTransport is set up.");
+    return commInternalError;
+  }
+  kernArgs.tree0 = tree0;
+  kernArgs.tree1 = tree1;
+
+  // Build local rank -> global rank mapping
+  if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: nLocalRanks {} exceeds CTRAN_MAX_NVL_PEERS {}",
+        nLocalRanks,
+        CTRAN_MAX_NVL_PEERS);
+    return commInternalError;
+  }
+  for (int lr = 0; lr < nLocalRanks; lr++) {
+    kernArgs.localRankToGlobalRank[lr] = statex->localRankToRank(lr);
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLREDUCE, stream, "AllReduceTree", opCount);
+
+  config.numBlocks = static_cast<unsigned int>(numBlocks);
+  config.numThreads = ctran::allreduce::tree::kBlockSize;
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  // Device kernel drives all NVL and IB transport progress; no host-side GPE
+  // opGroup is needed.
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ctranKernelAllReduceTree)));
+
+  return commSuccess;
+#else
+  CLOGF(ERR, "AllReduce ctree requires ENABLE_PIPES");
+  return commInternalError;
+#endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cu
@@ -1,0 +1,860 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstdint>
+
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Tile.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/Transport.cuh"
+
+/** Elements processed by one NVL tile operation in the reduction helpers. */
+static constexpr int kNvlTileElems = 15360;
+/** Elements processed by one IB tile operation in the reduction helpers. */
+static constexpr int kIbTileElems = 5120;
+
+/** Return true when a pointer satisfies the tile API's 16-byte alignment. */
+__device__ __forceinline__ bool isAligned16(const void* ptr) {
+  return (reinterpret_cast<uintptr_t>(ptr) & 15) == 0;
+}
+
+/**
+ * Accumulate `staging` into `accum` without assuming tile alignment.
+ *
+ * This path covers small buffers and tails where using the Pipes tile API is
+ * not profitable or not legal.
+ */
+template <typename T>
+__device__ __forceinline__ void scalarReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  for (size_t i = group.thread_id_in_group; i < nelems; i += group.group_size) {
+    accum[i] += staging[i];
+  }
+}
+
+/**
+ * Accumulate `staging` into `accum` using Pipes tiles when alignment allows.
+ */
+template <typename T, int kTileElems, int kGroupSize>
+__device__ __forceinline__ void tileReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  if (!isAligned16(accum) || !isAligned16(staging) || nelems < kTileElems) {
+    scalarReduce(accum, staging, nelems, group);
+    return;
+  }
+
+  const size_t nFullTiles = nelems / kTileElems;
+  const size_t rem = nelems % kTileElems;
+
+  for (size_t t = 0; t < nFullTiles; t++) {
+    auto acc =
+        comms::pipes::tile_load<T, kTileElems, kGroupSize>(accum, t, group);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, t, group);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(accum, t, acc, group);
+  }
+  if (rem > 0) {
+    auto acc = comms::pipes::tile_load<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, group, rem);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, nFullTiles, group, rem);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, acc, group, rem);
+  }
+}
+
+/**
+ * Copy operation used by cooperative NVL receives in Phase 1.
+ *
+ * The transport writes the remote payload into staging first; this functor
+ * then combines that staged payload with the current local input for the same
+ * segment and writes the result into `dst`. Aligned slices use the tile
+ * reduction path; unaligned tail segments fall back to scalar reduction
+ * because the Pipes tile API requires 16-byte-aligned pointers.
+ */
+template <typename T>
+struct TreeNvlReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t byteOffset,
+      const char* localInput,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* out = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const T* local = reinterpret_cast<const T*>(localInput + byteOffset);
+    const size_t nelems = nbytes / sizeof(T);
+
+    if (out != local) {
+      for (size_t i = group.thread_id_in_group; i < nelems;
+           i += group.group_size) {
+        out[i] = local[i];
+      }
+      group.sync();
+    }
+    tileReduce<T, kNvlTileElems, ctran::allreduce::tree::kBlockSize>(
+        out, staged, nelems, group);
+#endif
+  }
+};
+
+/**
+ * Copy operation used by IBGDA child receives in Phase 2.
+ *
+ * IBGDA owns the transient recv staging ring. CTREE must consume that staging
+ * inside this callback before the transport acknowledges and reuses the slot.
+ */
+template <typename T>
+struct TreeIbReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t /* byteOffset */,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* accum = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const size_t nelems = nbytes / sizeof(T);
+
+    tileReduce<T, kIbTileElems, ctran::allreduce::tree::kBlockSize>(
+        accum, staged, nelems, group);
+#endif
+  }
+};
+
+// ============================================================================
+// Phase 1: NVL ReduceScatter (AllToFewer pattern)
+//
+// Each GPU's input tensor M is partitioned into pMin segments of size
+// segmentElems. All nLocalRanks GPUs participate. The first pMin GPUs
+// (segment owners) each hold one locally-reduced segment after this phase.
+//
+// Communication: for each peer, the paired send/recv operations happen
+// simultaneously. We iterate peers in a rotating order so that at each step,
+// sends and recvs are correctly paired across GPUs.
+//
+// Owners: self-copy own segment to phase2Buf, then recv-reduce from each peer.
+// Non-owners: send segment data for each owner to that owner.
+// ============================================================================
+/**
+ * Compute the actual number of elements in a segment, including tail handling.
+ */
+__device__ __forceinline__ size_t
+actualSegElems(size_t count, size_t segmentElems, int rank) {
+  const size_t start = static_cast<size_t>(rank) * segmentElems;
+  if (start >= count) {
+    return 0;
+  }
+  return (start + segmentElems <= count) ? segmentElems : (count - start);
+}
+
+/**
+ * Convert the physical block group into the logical num-block group used by
+ * cooperative Pipes operations.
+ */
+__device__ __forceinline__ comms::pipes::ThreadGroup
+logicalDataGroup(comms::pipes::ThreadGroup group, int blockId, int numBlocks) {
+  group.group_id = static_cast<uint32_t>(blockId);
+  group.total_groups = static_cast<uint32_t>(numBlocks);
+  return group;
+}
+
+/**
+ * Tile view for one logical segment owned by the current num-block group.
+ */
+struct SegmentTile {
+  size_t offsetBytes;
+  size_t bytes;
+};
+
+/**
+ * Element tile assigned to an IB subgroup inside one tree lane.
+ */
+struct ElementTile {
+  size_t offsetElems;
+  size_t elems;
+};
+
+__device__ __forceinline__ SegmentTile
+segmentTileForBlock(size_t totalBytes, int numBlocks, int blockId) {
+  comms::pipes::TiledBuffer<char> tile(nullptr, totalBytes, numBlocks);
+  return SegmentTile{
+      .offsetBytes = static_cast<size_t>(blockId) * tile.tile_elements,
+      .bytes = tile.tile_bytes(blockId),
+  };
+}
+
+__device__ __forceinline__ SegmentTile
+segmentTile(size_t totalBytes, const comms::pipes::ThreadGroup& group) {
+  return segmentTileForBlock(totalBytes, group.total_groups, group.group_id);
+}
+
+template <typename T>
+__device__ __forceinline__ ElementTile
+elementTileForGroup(size_t totalElems, int groups, int groupId) {
+  comms::pipes::TiledBuffer<T> tile(nullptr, totalElems, groups);
+  return ElementTile{
+      .offsetElems = static_cast<size_t>(groupId) * tile.tile_elements,
+      .elems = tile.tile_size(groupId),
+  };
+}
+
+/**
+ * Return the largest owner tile participating in local NVL exchange.
+ */
+template <typename T>
+__device__ __forceinline__ size_t maxOwnerTileBytes(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t maxBytes = 0;
+  for (int owner = 0; owner < args.pMin; owner++) {
+    const size_t ownerElems =
+        actualSegElems(args.count, args.segmentElems, owner);
+    const auto ownerTile = segmentTile(ownerElems * sizeof(T), group);
+    maxBytes = ownerTile.bytes > maxBytes ? ownerTile.bytes : maxBytes;
+  }
+  return maxBytes;
+}
+
+/**
+ * Return a pipeline window that is valid for all local NVL peers.
+ */
+__device__ __forceinline__ size_t nvlPipelineWindow(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t window = 0;
+  for (int peer = 0; peer < args.nLocalRanks; peer++) {
+    if (peer == args.localRank) {
+      continue;
+    }
+    const int peerGlobalRank = args.localRankToGlobalRank[peer];
+    const size_t peerWindow =
+        args.transports[peerGlobalRank].p2p_nvl.pipeline_window(
+            group.total_groups);
+    window = window == 0 || peerWindow < window ? peerWindow : window;
+  }
+  return window;
+}
+
+/**
+ * Return the byte count for the current pipeline step.
+ */
+__device__ __forceinline__ size_t
+pipelineStepBytes(size_t totalBytes, size_t offset, size_t pipelineWindow) {
+  const size_t remaining = totalBytes - offset;
+  return remaining < pipelineWindow ? remaining : pipelineWindow;
+}
+
+template <typename T>
+__device__ __noinline__ void phase1ReduceScatter(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  const char* sendbuff = static_cast<const char*>(args.sendbuff);
+  char* phase2Buf = static_cast<char*>(args.phase2Buf);
+
+  comms::pipes::Timeout timeout{};
+
+  // Every owner initializes its tile before receiving peer contributions. The
+  // tile view is derived from the group identity, so numBlocks=1 is just the
+  // degenerate full-segment tile.
+  SegmentTile myTile{};
+  bool copiedLocalTile = false;
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+    const size_t mySegmentOffset =
+        static_cast<size_t>(localRank) * segmentBytes;
+    const char* src = sendbuff + mySegmentOffset + myTile.offsetBytes;
+    char* dst = phase2Buf + myTile.offsetBytes;
+    if (myTile.bytes > 0 && dst != src) {
+      comms::pipes::memcpy_vectorized(dst, src, myTile.bytes, group);
+      copiedLocalTile = true;
+    }
+  }
+
+  if (nLocalRanks <= 1) {
+    // Local-only topology has no NVL traffic. Synchronize only when this block
+    // copied out-of-place data that Phase 2 may read immediately.
+    if (copiedLocalTile) {
+      group.sync();
+    }
+    return;
+  }
+
+  group.sync();
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 1 NVL reduce-scatter pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  char* myDst = phase2Buf + myTile.offsetBytes;
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.send(
+          group,
+          sendbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.recv<TreeNvlReduceCopy<T>>(
+            group,
+            myDst + off,
+            window,
+            group.total_groups,
+            0,
+            timeout,
+            myDst + off);
+      }
+    }
+  }
+}
+
+enum class TreeLanePhase : uint8_t {
+  ReduceLeafSend,
+  ReduceRecvChild,
+  ReduceInternalSend,
+  BcastRootSendChild,
+  BcastInternalRecv,
+  BcastInternalSendChild,
+  BcastLeafRecv,
+  Done,
+};
+
+__device__ __forceinline__ TreeLanePhase
+firstReducePhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  return tree.isLeaf ? TreeLanePhase::ReduceLeafSend
+                     : TreeLanePhase::ReduceRecvChild;
+}
+
+__device__ __forceinline__ TreeLanePhase
+firstBcastPhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  if (tree.isRoot) {
+    return TreeLanePhase::BcastRootSendChild;
+  }
+  return tree.isLeaf ? TreeLanePhase::BcastLeafRecv
+                     : TreeLanePhase::BcastInternalRecv;
+}
+
+/**
+ * Persistent state for one half of the dual IB tree.
+ *
+ * A full CUDA block repeatedly calls `progressTreeLane()` for both lane states.
+ * Each call performs at most one bounded transport step or one local reduction
+ * step, and returns immediately if the current transport dependency is not
+ * ready.
+ */
+template <typename T>
+struct TreeLaneProgressState {
+  ctran::allreduce::TreeTopology tree;
+  T* dataBuf{nullptr};
+  size_t dataBytes{0};
+  size_t pipelineWindow{0};
+  size_t offsetBytes{0};
+  int activeBlocks{0};
+  int childIdx{0};
+  bool ibOpActive{false};
+  TreeLanePhase phase{TreeLanePhase::Done};
+  comms::pipes::IbgdaSendRecvProgressState ibOp{};
+};
+
+template <typename T>
+__device__ __forceinline__ size_t
+currentLaneWindowBytes(const TreeLaneProgressState<T>& state) {
+  return pipelineStepBytes(
+      state.dataBytes, state.offsetBytes, state.pipelineWindow);
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceReduceWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.offsetBytes = 0;
+    state.phase = firstBcastPhase(state.tree);
+  } else {
+    state.phase = firstReducePhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceBcastWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.phase = TreeLanePhase::Done;
+  } else {
+    state.phase = firstBcastPhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ TreeLaneProgressState<T> makeTreeLaneState(
+    const ctran::allreduce::tree::KernArgs& args,
+    const ctran::allreduce::TreeTopology& tree,
+    T* dataBuf,
+    size_t dataElems,
+    int activeBlocks) {
+  TreeLaneProgressState<T> state{};
+  state.tree = tree;
+  state.dataBuf = dataBuf;
+  state.dataBytes = dataElems * sizeof(T);
+  state.activeBlocks = activeBlocks;
+
+  if (state.dataBytes == 0) {
+    state.phase = TreeLanePhase::Done;
+    return state;
+  }
+
+  state.pipelineWindow = state.dataBytes;
+  if (!tree.isLeaf && tree.numChildren > 0) {
+    auto* t = args.transports[tree.childRanks[0]].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  } else if (!tree.isRoot && tree.parentRank >= 0) {
+    auto* t = args.transports[tree.parentRank].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  }
+  PIPES_DEVICE_CHECK_MSG(
+      state.pipelineWindow != 0, "ctree Phase 2 IB pipeline window is zero");
+  state.phase = firstReducePhase(tree);
+  return state;
+}
+
+template <typename T>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneSend(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    const char* src,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    state.ibOp = transport->init_send_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_send_once(group, state.ibOp, src, timeout);
+}
+
+template <typename T, typename CopyOp = comms::pipes::Memcpy>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneRecv(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    char* dst,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    state.ibOp = transport->init_recv_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_recv_once<CopyOp>(group, state.ibOp, dst, timeout);
+}
+
+template <typename T, int kGroupSize>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressTreeLane(
+    const ctran::allreduce::tree::KernArgs& args,
+    TreeLaneProgressState<T>& state,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  using comms::pipes::IbgdaSendRecvProgressStatus;
+
+  if (state.phase == TreeLanePhase::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  const size_t window = currentLaneWindowBytes(state);
+  char* const data = reinterpret_cast<char*>(state.dataBuf) + state.offsetBytes;
+
+  switch (state.phase) {
+    case TreeLanePhase::ReduceLeafSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceRecvChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        if (state.tree.isRoot) {
+          advanceReduceWindow(state);
+        } else {
+          state.phase = TreeLanePhase::ReduceInternalSend;
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status = progressLaneRecv<T, TreeIbReduceCopy<T>>(
+          state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          if (state.tree.isRoot) {
+            advanceReduceWindow(state);
+          } else {
+            state.phase = TreeLanePhase::ReduceInternalSend;
+          }
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceInternalSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastRootSendChild:
+    case TreeLanePhase::BcastInternalSendChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status =
+          progressLaneSend(state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          advanceBcastWindow(state);
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastInternalRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx = 0;
+        state.phase = TreeLanePhase::BcastInternalSendChild;
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastLeafRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::Done:
+      return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  return IbgdaSendRecvProgressStatus::Waiting;
+}
+
+// ============================================================================
+// Phase 2: Inter-Node IB Dual Tree AllReduce
+//
+// Tree-0 operates on the first half of each block-owned tile and Tree-1 on the
+// second half. One 640-thread block cooperatively drives both tree lanes from
+// a progress loop. Each lane uses a disjoint transport group id; if one lane
+// is waiting on a remote signal or free transport staging slot, its progress
+// call returns immediately and the same block tries the other lane.
+//
+// Only GPUs with localRank < pMin participate. Non-owners skip this phase.
+// Single-node case (nNodes == 1) is a no-op (root-and-leaf in both trees).
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase2IbDualTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& blockGroup) {
+  if (args.localRank >= args.pMin) {
+    return;
+  }
+
+  // Single-node: both trees have isRoot && isLeaf — nothing to do. Phase 1
+  // already wrote the segment slice into recvbuff.
+  if (args.nNodes <= 1) {
+    return;
+  }
+
+  const size_t actualElems =
+      actualSegElems(args.count, args.segmentElems, args.localRank);
+  const auto tile = segmentTile(actualElems * sizeof(T), blockGroup);
+  const size_t tileOffsetElems = tile.offsetBytes / sizeof(T);
+  const size_t tileElems = tile.bytes / sizeof(T);
+
+  // If the whole segment has at most one element per block, lane 1 would be
+  // empty for every block. Compress transport group ids to a single lane for
+  // that tiny-message shape; otherwise keep the stable two-lane mapping.
+  const bool useSingleLane = actualElems <= static_cast<size_t>(args.numBlocks);
+  const int activeIbLanesPerBlock =
+      useSingleLane ? 1 : ctran::allreduce::tree::kTreeLanes;
+
+  const size_t halfElems0 = useSingleLane ? tileElems : (tileElems + 1) / 2;
+  const size_t halfElems1 = useSingleLane ? 0 : tileElems - halfElems0;
+  T* phase2Buf = static_cast<T*>(args.phase2Buf);
+  const int activeIbGroups = args.numBlocks * activeIbLanesPerBlock;
+
+  auto lane0Group = blockGroup;
+  lane0Group.group_id = blockGroup.group_id * activeIbLanesPerBlock;
+  lane0Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+  auto lane1Group = blockGroup;
+  lane1Group.group_id = blockGroup.group_id * activeIbLanesPerBlock + 1;
+  lane1Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+
+  auto lane0 = makeTreeLaneState<T>(
+      args,
+      args.tree0,
+      phase2Buf + tileOffsetElems,
+      halfElems0,
+      activeIbGroups);
+  auto lane1 = makeTreeLaneState<T>(
+      args,
+      args.tree1,
+      phase2Buf + tileOffsetElems + halfElems0,
+      halfElems1,
+      activeIbGroups);
+
+  comms::pipes::Timeout timeout{};
+  bool lane0Active = lane0.phase != TreeLanePhase::Done;
+  bool lane1Active = lane1.phase != TreeLanePhase::Done;
+  while (lane0Active || lane1Active) {
+    if (lane0Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane0, lane0Group, timeout);
+      lane0Active = lane0.phase != TreeLanePhase::Done;
+    }
+    if (lane1Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane1, lane1Group, timeout);
+      lane1Active = lane1.phase != TreeLanePhase::Done;
+    }
+  }
+}
+
+// ============================================================================
+// Phase 3: NVL AllGather
+//
+// Segment owners broadcast their globally-reduced segment to all local peers.
+// After Phase 2, each owner's recvbuff contains its globally-reduced segment
+// at offset [localRank * segmentBytes].
+//
+// Communication: uses rotating-peer order for globally consistent pairing.
+// Owners send their segment; all GPUs receive from owners.
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase3AllGather(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  char* recvbuff = static_cast<char*>(args.recvbuff);
+
+  comms::pipes::Timeout timeout{};
+
+  if (nLocalRanks <= 1) {
+    return;
+  }
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 3 NVL all-gather pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  SegmentTile myTile{};
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+  }
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t mySegmentOffset =
+          static_cast<size_t>(localRank) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.send(
+            group,
+            recvbuff + mySegmentOffset + myTile.offsetBytes + off,
+            window,
+            group.total_groups,
+            0,
+            timeout);
+      }
+    }
+
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.recv(
+          group,
+          recvbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+  }
+}
+
+/**
+ * Run the three ctree phases for one logical data tile.
+ *
+ * A tile is fully owned by one CUDA block. Multi-block launches only add more
+ * independent tiles; the algorithm does not require inter-block coordination.
+ */
+template <typename T>
+__device__ __forceinline__ void runAllReduceTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  phase1ReduceScatter<T>(args, group);
+  if (args.nLocalRanks > 1) {
+    group.sync();
+  }
+  if (args.nNodes > 1) {
+    phase2IbDualTree<T>(args, group);
+    if (args.nLocalRanks > 1) {
+      group.sync();
+    }
+  }
+  if (args.nLocalRanks > 1) {
+    phase3AllGather<T>(args, group);
+  }
+}
+
+// ============================================================================
+// Main kernel: dispatches datatype then runs Phase 1, both Phase 2 tree lanes,
+// and Phase 3 for the block-owned tile.
+// ============================================================================
+__global__
+__launch_bounds__(ctran::allreduce::tree::kBlockSize, 1) void ctranKernelAllReduceTree(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::tree::KernArgs args) {
+  auto blockGroup = comms::pipes::make_block_group();
+  const int blockId = static_cast<int>(blockIdx.x);
+  if (blockId >= args.numBlocks) {
+    return;
+  }
+  auto group = logicalDataGroup(blockGroup, blockId, args.numBlocks);
+
+  if (args.datatype == commFloat32) {
+    runAllReduceTree<float>(args, group);
+  } else if (args.datatype == commFloat16) {
+    runAllReduceTree<__half>(args, group);
+  }
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cuh
@@ -1,0 +1,93 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/topo/TreeConstants.h"
+#include "comms/utils/commSpecs.h"
+
+namespace comms::pipes {
+struct Transport;
+}
+
+namespace ctran::allreduce::tree {
+
+/** Number of independent inter-node tree lanes in the dual-tree phase. */
+static constexpr int kTreeLanes = 2;
+
+/** CUDA threads per block used by the ctree kernel. */
+static constexpr int kBlockSize = 640;
+
+/**
+ * Device kernel arguments for the Pipes-backed CTRAN tree AllReduce.
+ *
+ * User buffers are owned by the caller. NVL and IB receive staging are owned by
+ * the Pipes transports and are consumed only inside transport copy callbacks.
+ */
+struct KernArgs {
+  /** User input buffer; may alias `recvbuff` for in-place AllReduce. */
+  const void* sendbuff;
+  /** User output buffer that receives the final reduced tensor. */
+  void* recvbuff;
+  /**
+   * Phase 2 working buffer.
+   *
+   * Segment owners write locally reduced segments here in Phase 1, the IB tree
+   * reads and writes the same buffer in Phase 2, and Phase 3 reads from it.
+   */
+  void* phase2Buf;
+
+  /** Total number of elements in the user tensor. */
+  size_t count;
+  /** Elements per owner segment, equal to `ceil(count / pMin)`. */
+  size_t segmentElems;
+
+  /** Number of nodes in the communicator. */
+  int nNodes;
+  /** Minimum number of local ranks across all nodes. */
+  int pMin;
+  /** Number of local ranks on this node. */
+  int nLocalRanks;
+  /** This GPU's local rank on its node. */
+  int localRank;
+  /** Number of logical data partitions processed by CUDA blocks per GPU. */
+  int numBlocks;
+
+  /** Collective datatype implemented by the kernel dispatch. */
+  commDataType_t datatype;
+  /** Reduction operation implemented by the kernel dispatch. */
+  commRedOp_t redOp;
+
+  /** Unified transport array containing NVL and IB transports by global rank.
+   */
+  comms::pipes::Transport* transports;
+
+  /** Inter-node tree used for the first half of each data partition. */
+  ctran::allreduce::TreeTopology tree0;
+  /** Inter-node tree used for the second half of each data partition. */
+  ctran::allreduce::TreeTopology tree1;
+
+  /** Maps local rank index `[0, nLocalRanks)` to global communicator rank. */
+  int localRankToGlobalRank[CTRAN_MAX_NVL_PEERS];
+};
+
+} // namespace ctran::allreduce::tree
+
+/**
+ * CUDA kernel entry point for CTRAN tree AllReduce.
+ *
+ * Each block owns one tile partition and runs Phase 1, both Phase 2 tree
+ * lanes, and Phase 3 for that tile. Phase 2 uses one full-block work group to
+ * poll and progress the two disjoint IB tree lanes cooperatively.
+ * Multi-block launches are independent tiling for performance; correctness
+ * does not require inter-block sync.
+ */
+__global__ void ctranKernelAllReduceTree(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::tree::KernArgs args);
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/topo/TreeConstants.h"
 #include "comms/utils/commSpecs.h"
 
 // Forward declaration
@@ -36,6 +37,17 @@ struct KernelArgs {
   // IPC imported ptr to each of the local peers' RecvBuff
   void* intraNodeRemoteRecvBuffs[CTRAN_MAX_NVL_PEERS];
   KernelElem* kernelElems[ALLREDUCE_MAX_KERNEL_ELEMS];
+};
+
+// Tree topology for one half of the dual tree pair.
+// Holds communicator ranks — transport dispatch uses the shared Transport
+// array.
+struct TreeTopology {
+  int parentRank{-1};
+  int childRanks[ctran::algos::topo::kMaxTreeChildren]{-1, -1, -1};
+  int numChildren{0};
+  bool isRoot{false};
+  bool isLeaf{false};
 };
 
 } // namespace ctran::allreduce

--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -86,10 +86,10 @@ When `nLocalRanks > 1`, segment owners publish globally reduced segments to all 
 The kernel uses `640` CUDA threads per block. `numBlocks` is capped at `16` for H100 and current GB200/GB300 use. The default policy starts at the cap and reduces blocks for small messages while:
 
 ```text
-totalBytes < numBlocks * 512 * 64
+totalBytes < numBlocks * 640 * 64
 ```
 
-This mirrors NCCL Tree Simple's channel-reduction shape while preserving CTREE's own cap. `NCCL_CTRAN_ALLREDUCE_TREE_NUM_BLOCKS` can override the selected block count for testing; the old `NCCL_CTRAN_ALLREDUCE_TREE_DATA_BLOCKS` spelling is retained as a compatibility alias.
+`NCCL_CTRAN_MAX_NBLOCKS` controls the cap and defaults to `16`, which keeps CTREE below the NCCL Tree CTA count used on the current H100 and GB200/GB300 validation setups.
 
 The implementation uses phase-specific tile widths:
 
@@ -100,16 +100,14 @@ Both are selected to satisfy Pipes tile divisibility constraints with `640`-thre
 
 ## Staging and Memory Lifetime
 
-CTREE uses communicator-lifetime staging for explicit tree receives. Staging is allocated with `ctran::utils::commCuMemAlloc` on the first CTREE collective call for the communicator and freed during communicator teardown with `commCuMemFree`.
-
-Later CTREE calls reuse the allocation when it is large enough. If a later call needs more staging than the first call reserved, the collective fails clearly and asks the caller to recreate the communicator with a first call that covers the maximum required message size. The implementation does not reallocate staging while a communicator may have in-flight transport users.
+CTREE does not allocate message-size-dependent AllReduce staging. NVL and IB receives use Pipes transport-owned staging buffers, and CTREE consumes those transient staging slices inside transport copy callbacks before the transport acknowledges and reuses the slots.
 
 The IBGDA send/recv transport data buffer is configured by per-communicator hint or `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` when provided. If neither is set and `NCCL_ALLREDUCE_ALGO=ctree`, CTREE defaults the per-peer IBGDA data buffer to `32MiB`.
 
 ## Correctness Invariants
 
 - No inter-block synchronization is required or assumed.
-- Each block owns disjoint data, staging, and transport group IDs.
+- Each block owns disjoint data and transport group IDs.
 - `group.sync()` is used only for block-local phase transitions.
 - In-place and out-of-place reductions use the same block ownership model; a block finishes the reads needed for its tile before that tile can be overwritten by later local publication.
 - Tail elements are handled by tile bounds and byte-count checks; only valid user elements are read or written.

--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -1,0 +1,127 @@
+# CTREE AllReduce Design Specification
+
+This document describes the implemented CTREE AllReduce algorithm in CTRAN. The implementation uses Pipes `MultiPeerTransport` for `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies.
+
+## Goals
+
+CTREE targets lower latency than ring-style AllReduce by reducing the inter-node phase from linear rank traversal to tree depth. The implemented algorithm keeps correctness independent of CUDA inter-block synchronization: a single-block launch is valid for every supported topology, and additional blocks only add independent tile parallelism.
+
+The implementation currently supports `commSum` for `commFloat32` and `commFloat16`. Unsupported reduction ops and datatypes are rejected on the host.
+
+## Algorithm Overview
+
+For a tensor of `count` elements:
+
+1. **NVL ReduceScatter**: local GPUs reduce each owner segment into a per-owner Phase 2 buffer.
+2. **IB dual-tree AllReduce**: active segment owners run two complementary inter-node tree lanes over disjoint halves of each block partition.
+3. **NVL AllGather**: segment owners publish the globally reduced segments to local peers.
+
+Degenerate topology paths are skipped:
+
+- `nRanks == 1`: identity copy for out-of-place, no kernel launch for in-place.
+- `nLocalRanks <= 1`: NVL phases and NVL phase-transition sync are no-ops.
+- `nNodes == 1`: IB Phase 2 is a no-op.
+
+The algorithm delegates nccl-tests sync communicators to `ctdirect` so benchmark control reductions do not exercise the narrow CTREE payload surface.
+
+## Partitioning and Topology
+
+Let `pMin = min(nLocalRanks(node))` across nodes. CTREE partitions the tensor into `pMin` owner segments. Local ranks `< pMin` own one segment and participate in the IB tree phase; extra local ranks on larger nodes contribute during NVL ReduceScatter and receive the final tensor during NVL AllGather, but do not join IB.
+
+Each owner segment is split across `numBlocks` logical CUDA blocks. Each block owns a disjoint segment tile. Inside the block tile, the IB phase splits data into two lane halves:
+
+- Lane 0: Tree-0 over the first half.
+- Lane 1: Tree-1 over the second half.
+
+No block owns data or staging used by another block.
+
+### Binary Dual Trees
+
+The implementation uses binary dual trees. Tree-0 is a BFS binary tree rooted at rank `0`. For even node counts, Tree-1 is the mirror of Tree-0 over rank space. For odd node counts, Tree-1 uses the shift-by-1 construction implemented by the topology builder.
+
+For the 8-rank `IB_ONLY` case, the exact topology is:
+
+```text
+Tree-0, rooted at rank 0:
+  0 -> {1, 2}
+  1 -> {3, 4}
+  2 -> {5, 6}
+  3 -> {7}
+
+Tree-1, mirrored and rooted at rank 7:
+  7 -> {6, 5}
+  6 -> {4, 3}
+  5 -> {2, 1}
+  4 -> {0}
+```
+
+The two trees process disjoint data halves and use disjoint staging slices and transport group IDs. They are intended to make concurrent progress, not to run Tree-0 to completion before Tree-1.
+
+## Phase Behavior
+
+### Phase 1: NVL ReduceScatter
+
+When `nLocalRanks > 1`, each local GPU contributes the segment data needed by each owner. Segment owners reduce local contributions into `phase2Buf`. This phase uses Pipes NVL transport staging because user buffers are not assumed to be directly usable as NVL transport buffers.
+
+When `nLocalRanks <= 1`, Phase 1 is a no-op and the IB tree reads directly from the local owner segment.
+
+### Phase 2: IB Dual Tree
+
+When `nNodes > 1`, each active owner rank runs the dual-tree phase. One full CUDA block services both tree lanes cooperatively. The block creates two virtual IB transport groups:
+
+```text
+groupId(lane) = blockIdx.x * 2 + lane
+```
+
+Each lane has its own data half, staging slice, and transport group ID. The scheduler calls bounded progress functions for lane 0 and lane 1 in a uniform loop. If a lane is waiting on `NIC_DONE`, `SLOT_FREE`, or `DATA_READY`, that progress attempt returns immediately and the block tries the other lane. This avoids serial tree-lane scheduling while keeping all threads in the block on a uniform control path.
+
+Internal tree nodes receive from all children into per-child staging, reduce local and child inputs, and then forward the reduced data upward. Broadcast then flows from root to leaves.
+
+### Phase 3: NVL AllGather
+
+When `nLocalRanks > 1`, segment owners publish globally reduced segments to all local peers using Pipes NVL transport. Each block waits for both IB lanes for its tile before publishing that tile locally. When `nLocalRanks <= 1`, Phase 3 is skipped.
+
+## Launch and Tiling Policy
+
+The kernel uses `640` CUDA threads per block. `numBlocks` is capped at `16` for H100 and current GB200/GB300 use. The default policy starts at the cap and reduces blocks for small messages while:
+
+```text
+totalBytes < numBlocks * 512 * 64
+```
+
+This mirrors NCCL Tree Simple's channel-reduction shape while preserving CTREE's own cap. `NCCL_CTRAN_ALLREDUCE_TREE_NUM_BLOCKS` can override the selected block count for testing; the old `NCCL_CTRAN_ALLREDUCE_TREE_DATA_BLOCKS` spelling is retained as a compatibility alias.
+
+The implementation uses phase-specific tile widths:
+
+- `kNvlTileElems = 15360`
+- `kIbTileElems = 5120`
+
+Both are selected to satisfy Pipes tile divisibility constraints with `640`-thread blocks and the vector widths used by supported datatypes.
+
+## Staging and Memory Lifetime
+
+CTREE uses communicator-lifetime staging for explicit tree receives. Staging is allocated with `ctran::utils::commCuMemAlloc` on the first CTREE collective call for the communicator and freed during communicator teardown with `commCuMemFree`.
+
+Later CTREE calls reuse the allocation when it is large enough. If a later call needs more staging than the first call reserved, the collective fails clearly and asks the caller to recreate the communicator with a first call that covers the maximum required message size. The implementation does not reallocate staging while a communicator may have in-flight transport users.
+
+The IBGDA send/recv transport data buffer is configured by per-communicator hint or `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` when provided. If neither is set and `NCCL_ALLREDUCE_ALGO=ctree`, CTREE defaults the per-peer IBGDA data buffer to `32MiB`.
+
+## Correctness Invariants
+
+- No inter-block synchronization is required or assumed.
+- Each block owns disjoint data, staging, and transport group IDs.
+- `group.sync()` is used only for block-local phase transitions.
+- In-place and out-of-place reductions use the same block ownership model; a block finishes the reads needed for its tile before that tile can be overwritten by later local publication.
+- Tail elements are handled by tile bounds and byte-count checks; only valid user elements are read or written.
+- All remote lane progress uses device-visible signaling and memory ordering from Pipes transport primitives.
+
+## Validation
+
+The integration test is algorithm-agnostic and validates numerical correctness, not trace shape. It covers `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies; world sizes `1`, `2`, `3`, `4`, `7`, and `8` for local single-host topologies; and zero, small, medium, large, and tail message sizes in both in-place and out-of-place modes.
+
+Latest local and RE validation, benchmark commands, and 8-rank performance tables are recorded in:
+
+- https://www.internalfb.com/intern/paste/P2354738362/
+- https://pxl.cl/9ZhCc
+
+The primary benchmark comparison is forced NCCL Tree against CTREE using the third-party `nccl_allreduce_perf` target. The latest H100 8-rank `IB_ONLY` sweep covers `4B` through `1G` with `#wrong = 0` for CTREE.

--- a/comms/ctran/algos/topo/CtranTreeBuilder.h
+++ b/comms/ctran/algos/topo/CtranTreeBuilder.h
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <algorithm>
+#include <utility>
+
+#include <glog/logging.h>
+
+#include "comms/ctran/algos/topo/TreeConstants.h"
+
+namespace ctran::algos::topo {
+
+struct TreeNeighbors {
+  int parent{-1};
+  int children[kMaxTreeChildren]{-1, -1, -1};
+  int numChildren{0};
+  bool isRoot{false};
+  bool isLeaf{false};
+};
+
+// Build a single k-ary tree over numNodes using BFS level-order assignment.
+// fanOut must be in [1, kMaxTreeChildren], which keeps parent and child
+// relationships representable by TreeNeighbors.
+static inline TreeNeighbors
+buildKaryTree(int numNodes, int nodeRank, int fanOut) {
+  CHECK_GE(fanOut, 1);
+  CHECK_LE(fanOut, kMaxTreeChildren);
+
+  if (numNodes <= 1) {
+    TreeNeighbors result;
+    result.isRoot = true;
+    result.isLeaf = true;
+    return result;
+  }
+
+  TreeNeighbors result;
+
+  // BFS-order k-ary tree: node i has parent (i-1)/k, children k*i+1 .. k*i+k
+  // This gives a complete k-ary tree with level-order node assignment.
+  if (nodeRank == 0) {
+    result.isRoot = true;
+    result.parent = -1;
+  } else {
+    result.parent = (nodeRank - 1) / fanOut;
+  }
+
+  for (int c = 0; c < fanOut && c < kMaxTreeChildren; c++) {
+    int child = fanOut * nodeRank + 1 + c;
+    if (child < numNodes) {
+      result.children[result.numChildren++] = child;
+    }
+  }
+
+  result.isLeaf = (result.numChildren == 0);
+  return result;
+}
+
+// Build dual complementary k-ary trees.
+//
+// For k=2 (binary):
+//   Tree-0: standard binary tree in BFS order.
+//   Tree-1 (even N): mirror — build tree over mapping r' = N-1-r, remap back.
+//   Tree-1 (odd N): shift-by-1 — build tree over mapping r' = (r-1+N)%N, remap
+//   back. Property: leaves in Tree-0 are internal nodes in Tree-1
+//   (phase-complementary).
+//
+// For k>2:
+//   Tree-0: standard k-ary tree.
+//   Tree-1: k-ary tree with shifted root (root at node N/2).
+//   Phase-complementary property is NOT guaranteed for k>2.
+static inline std::pair<TreeNeighbors, TreeNeighbors>
+buildDualKaryTree(int numNodes, int nodeRank, int fanOut = 2) {
+  if (numNodes <= 1) {
+    TreeNeighbors single;
+    single.isRoot = true;
+    single.isLeaf = true;
+    return {single, single};
+  }
+
+  // Tree-0: standard k-ary tree
+  TreeNeighbors tree0 = buildKaryTree(numNodes, nodeRank, fanOut);
+
+  // Tree-1: complementary tree
+  TreeNeighbors tree1;
+
+  if (fanOut == 2) {
+    // Binary dual tree: mirror/shift construction
+    int mappedRank;
+    if (numNodes % 2 == 0) {
+      // Even N: mirror r' = N-1-r
+      mappedRank = numNodes - 1 - nodeRank;
+    } else {
+      // Odd N: shift r' = (r-1+N) % N
+      mappedRank = (nodeRank - 1 + numNodes) % numNodes;
+    }
+
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    // Remap results back
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      if (numNodes % 2 == 0) {
+        return numNodes - 1 - r;
+      } else {
+        return (r + 1) % numNodes;
+      }
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.isRoot = mapped.isRoot;
+    tree1.isLeaf = mapped.isLeaf;
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  } else {
+    // k>2: shifted root construction
+    int shift = numNodes / 2;
+    int mappedRank = (nodeRank - shift + numNodes) % numNodes;
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      return (r + shift) % numNodes;
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.isRoot = mapped.isRoot;
+    tree1.isLeaf = mapped.isLeaf;
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  }
+
+  return {tree0, tree1};
+}
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/TreeConstants.h
+++ b/comms/ctran/algos/topo/TreeConstants.h
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace ctran::algos::topo {
+
+inline constexpr int kMaxTreeChildren = 3;
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
+++ b/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
@@ -1,0 +1,348 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <queue>
+#include <set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+
+namespace ctran::algos::topo {
+
+class CtranTreeBuilderTest : public ::testing::Test {};
+
+// Verify that BFS from the unique root reaches all nodes exactly once.
+static void verifyConnectivity(
+    const std::vector<TreeNeighbors>& nodes,
+    int expectedRoot = -1) {
+  const int numNodes = static_cast<int>(nodes.size());
+  int rootCount = 0;
+  int rootIdx = -1;
+  for (int i = 0; i < numNodes; i++) {
+    if (nodes[i].isRoot) {
+      rootCount++;
+      rootIdx = i;
+    }
+  }
+  ASSERT_EQ(rootCount, 1) << "Exactly one root expected";
+  if (expectedRoot >= 0) {
+    ASSERT_EQ(rootIdx, expectedRoot);
+  }
+
+  std::set<int> visited;
+  std::queue<int> bfs;
+  bfs.push(rootIdx);
+  visited.insert(rootIdx);
+
+  while (!bfs.empty()) {
+    int cur = bfs.front();
+    bfs.pop();
+    for (int c = 0; c < nodes[cur].numChildren; c++) {
+      int child = nodes[cur].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      ASSERT_EQ(visited.count(child), 0)
+          << "Node " << child << " visited twice (cycle or shared child)";
+      visited.insert(child);
+      bfs.push(child);
+    }
+  }
+
+  ASSERT_EQ(static_cast<int>(visited.size()), numNodes)
+      << "BFS did not reach all nodes. Reached " << visited.size() << " out of "
+      << numNodes;
+}
+
+// Verify that BFS from root reaches all N nodes exactly once.
+static void verifyConnectivity(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  verifyConnectivity(nodes, 0);
+}
+
+// Verify parent-child consistency: if A lists B as child, B must list A as
+// parent.
+static void verifyParentChildConsistency(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < nodes[i].numChildren; c++) {
+      int child = nodes[i].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      EXPECT_EQ(nodes[child].parent, i)
+          << "Node " << i << " lists " << child
+          << " as child, but child's parent is " << nodes[child].parent;
+    }
+    if (nodes[i].parent >= 0) {
+      int par = nodes[i].parent;
+      bool found = false;
+      for (int c = 0; c < nodes[par].numChildren; c++) {
+        if (nodes[par].children[c] == i) {
+          found = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(found) << "Node " << i << " has parent " << par
+                         << " but parent does not list it as a child";
+    }
+  }
+}
+
+// Verify leaf/root flags are consistent.
+static void verifyFlags(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    EXPECT_EQ(nodes[i].isLeaf, nodes[i].numChildren == 0)
+        << "Node " << i << ": isLeaf flag inconsistent with numChildren";
+    EXPECT_EQ(nodes[i].isRoot, nodes[i].parent == -1)
+        << "Node " << i << ": isRoot flag inconsistent with parent";
+  }
+}
+
+// --- Single K-ary Tree Tests ---
+
+class KaryTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(KaryTreeTest, Connectivity) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyConnectivity(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, ParentChildConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyParentChildConsistency(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, FlagConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyFlags(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, MaxChildrenRespected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    auto node = buildKaryTree(numNodes, i, fanOut);
+    EXPECT_LE(node.numChildren, fanOut);
+    EXPECT_LE(node.numChildren, kMaxTreeChildren);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BinaryAndTernary,
+    KaryTreeTest,
+    ::testing::Values(
+        // (numNodes, fanOut)
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(1, 3),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(7, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(15, 3),
+        std::make_pair(16, 3),
+        std::make_pair(27, 3),
+        std::make_pair(32, 3),
+        std::make_pair(64, 3)));
+
+// --- Dual Tree Tests ---
+
+class DualTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(DualTreeTest, BothTreesConnected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int r = 0; r < numNodes; r++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, r, fanOut);
+    // Both trees should produce valid nodes
+    EXPECT_GE(t0.parent, -1);
+    EXPECT_GE(t1.parent, -1);
+    EXPECT_LE(t0.numChildren, fanOut);
+    EXPECT_LE(t1.numChildren, fanOut);
+  }
+
+  // Verify full connectivity for both trees independently
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+  verifyConnectivity(t0Nodes, 0);
+  verifyConnectivity(t1Nodes);
+}
+
+TEST_P(DualTreeTest, ParentChildConsistencyBothTrees) {
+  auto [numNodes, fanOut] = GetParam();
+
+  // Verify Tree-0 consistency
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < t0Nodes[i].numChildren; c++) {
+      int child = t0Nodes[i].children[c];
+      EXPECT_EQ(t0Nodes[child].parent, i)
+          << "Tree-0 inconsistency at node " << i;
+    }
+    for (int c = 0; c < t1Nodes[i].numChildren; c++) {
+      int child = t1Nodes[i].children[c];
+      EXPECT_EQ(t1Nodes[child].parent, i)
+          << "Tree-1 inconsistency at node " << i;
+    }
+  }
+}
+
+TEST_P(DualTreeTest, DifferentRoots) {
+  auto [numNodes, fanOut] = GetParam();
+  if (numNodes <= 1) {
+    return; // Single node — both trees are trivially the same
+  }
+
+  int root0 = -1, root1 = -1;
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    if (t0.isRoot)
+      root0 = i;
+    if (t1.isRoot)
+      root1 = i;
+  }
+  EXPECT_NE(root0, root1) << "Dual trees should have different roots";
+}
+
+// Phase-complementary property: leaves in tree-0 are internal in tree-1.
+// This is only guaranteed for binary (k=2) dual trees.
+class BinaryDualTreeComplementaryTest
+    : public CtranTreeBuilderTest,
+      public ::testing::WithParamInterface<int> {};
+
+TEST_P(BinaryDualTreeComplementaryTest, LeavesSwapWithInternal) {
+  int numNodes = GetParam();
+  if (numNodes <= 2) {
+    return; // Too small to have meaningful leaf/internal distinction
+  }
+
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, 2);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    bool isLeaf0 = t0Nodes[i].isLeaf;
+    bool isLeaf1 = t1Nodes[i].isLeaf;
+    bool isRoot0 = t0Nodes[i].isRoot;
+    bool isRoot1 = t1Nodes[i].isRoot;
+
+    // Skip roots — root in one tree can be anything in the other
+    if (isRoot0 || isRoot1) {
+      continue;
+    }
+
+    EXPECT_NE(isLeaf0, isLeaf1)
+        << "Node " << i
+        << ": leaf in tree-0 should be internal in tree-1 (or vice versa). "
+        << "tree-0 isLeaf=" << isLeaf0 << " tree-1 isLeaf=" << isLeaf1;
+  }
+}
+
+// Phase-complementary property is only guaranteed for even N.
+// For odd N, one node must be leaf in both trees (unequal leaf/internal
+// counts).
+INSTANTIATE_TEST_SUITE_P(
+    BinaryComplementary,
+    BinaryDualTreeComplementaryTest,
+    ::testing::Values(4, 8, 16, 32, 64));
+
+INSTANTIATE_TEST_SUITE_P(
+    AllFanOuts,
+    DualTreeTest,
+    ::testing::Values(
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(27, 3),
+        std::make_pair(64, 3)));
+
+// --- Edge Case Tests ---
+
+TEST_F(CtranTreeBuilderTest, SingleNode) {
+  auto node = buildKaryTree(1, 0, 2);
+  EXPECT_TRUE(node.isRoot);
+  EXPECT_TRUE(node.isLeaf);
+  EXPECT_EQ(node.numChildren, 0);
+  EXPECT_EQ(node.parent, -1);
+}
+
+TEST_F(CtranTreeBuilderTest, TwoNodesBinary) {
+  auto n0 = buildKaryTree(2, 0, 2);
+  auto n1 = buildKaryTree(2, 1, 2);
+
+  EXPECT_TRUE(n0.isRoot);
+  EXPECT_FALSE(n0.isLeaf);
+  EXPECT_EQ(n0.numChildren, 1);
+  EXPECT_EQ(n0.children[0], 1);
+
+  EXPECT_FALSE(n1.isRoot);
+  EXPECT_TRUE(n1.isLeaf);
+  EXPECT_EQ(n1.parent, 0);
+}
+
+TEST_F(CtranTreeBuilderTest, DualSingleNode) {
+  auto [t0, t1] = buildDualKaryTree(1, 0, 2);
+  EXPECT_TRUE(t0.isRoot);
+  EXPECT_TRUE(t0.isLeaf);
+  EXPECT_TRUE(t1.isRoot);
+  EXPECT_TRUE(t1.isLeaf);
+}
+
+TEST_F(CtranTreeBuilderTest, InvalidFanOutRejected) {
+  EXPECT_DEATH(buildKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+}
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cu
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cu
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+// Per-element value: 1.0f / (1.0f + (rep + rank + i) % 256)
+// This produces different values per element and per rank.
+__device__ static float elementValue(int rank, int rep, size_t i) {
+  return 1.0f / (1.0f + static_cast<float>((rep + rank + i) % 256));
+}
+
+__global__ void initDataKernel(float* buf, size_t count, int rank, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    buf[idx] = elementValue(rank, rep, idx);
+  }
+}
+
+__global__ void
+initExpectedKernel(float* buf, size_t count, int nranks, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    float sum = 0.0f;
+    for (int r = 0; r < nranks; r++) {
+      sum += elementValue(r, rep, idx);
+    }
+    buf[idx] = sum;
+  }
+}
+
+// Each block computes the max abs delta over its assigned elements, then
+// writes the per-block maximum into blockMaxes[blockIdx.x].
+__global__ void deltaKernel(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    double* blockMaxes) {
+  extern __shared__ double sdata[];
+
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  double localMax = 0.0;
+  if (idx < count) {
+    localMax = fabs(
+        static_cast<double>(actual[idx]) - static_cast<double>(expected[idx]));
+  }
+
+  sdata[threadIdx.x] = localMax;
+  __syncthreads();
+
+  // Tree reduction within the block
+  for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (threadIdx.x < s) {
+      sdata[threadIdx.x] = fmax(sdata[threadIdx.x], sdata[threadIdx.x + s]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    blockMaxes[blockIdx.x] = sdata[0];
+  }
+}
+
+__device__ __forceinline__ uint64_t mixChecksum(uint64_t acc, uint64_t value) {
+  acc ^= value + 0x9e3779b97f4a7c15ULL + (acc << 6) + (acc >> 2);
+  return acc * 0x100000001b3ULL;
+}
+
+__global__ void
+rawBitsChecksumKernel(const float* data, size_t count, uint64_t* result) {
+  constexpr int kBlockSize = 256;
+  __shared__ uint64_t partials[kBlockSize];
+
+  const uint32_t* words = reinterpret_cast<const uint32_t*>(data);
+  uint64_t local = 0xcbf29ce484222325ULL ^
+      (static_cast<uint64_t>(threadIdx.x) << 32) ^ count;
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    const uint64_t taggedValue =
+        (static_cast<uint64_t>(words[i]) << 32) ^ static_cast<uint64_t>(i);
+    local = mixChecksum(local, taggedValue);
+  }
+
+  partials[threadIdx.x] = local;
+  __syncthreads();
+
+  for (int stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      partials[threadIdx.x] =
+          mixChecksum(partials[threadIdx.x], partials[threadIdx.x + stride]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *result = partials[0];
+  }
+}
+
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+}
+
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+}
+
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return 0.0;
+  }
+
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+
+  double* dBlockMaxes = nullptr;
+  cudaMalloc(&dBlockMaxes, numBlocks * sizeof(double));
+
+  size_t sharedBytes = kBlockSize * sizeof(double);
+  deltaKernel<<<numBlocks, kBlockSize, sharedBytes, stream>>>(
+      actual, expected, count, dBlockMaxes);
+
+  std::vector<double> hBlockMaxes(numBlocks);
+  cudaMemcpyAsync(
+      hBlockMaxes.data(),
+      dBlockMaxes,
+      numBlocks * sizeof(double),
+      cudaMemcpyDeviceToHost,
+      stream);
+  cudaStreamSynchronize(stream);
+
+  double maxDelta = 0.0;
+  for (int i = 0; i < numBlocks; i++) {
+    maxDelta = std::fmax(maxDelta, hBlockMaxes[i]);
+  }
+
+  cudaFree(dBlockMaxes);
+  return maxDelta;
+}
+
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream) {
+  if (count == 0) {
+    return 0;
+  }
+
+  uint64_t* dChecksum = nullptr;
+  cudaMalloc(&dChecksum, sizeof(uint64_t));
+
+  constexpr int kBlockSize = 256;
+  rawBitsChecksumKernel<<<1, kBlockSize, 0, stream>>>(data, count, dChecksum);
+
+  uint64_t hChecksum = 0;
+  cudaMemcpyAsync(
+      &hChecksum, dChecksum, sizeof(uint64_t), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+
+  cudaFree(dChecksum);
+  return hChecksum;
+}

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cuh
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cuh
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+// Initialize data buffer: each element = 1.0f / (1.0f + (rep + rank + i) % 256)
+// Produces different values per element AND per rank, avoiding uniform fill.
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+// Initialize expected buffer: expected[i] = sum over all ranks of
+// initData(rank, i) This is exactly what AllReduce(sum) should produce.
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+// Compute max |actual[i] - expected[i]| across all elements.
+// Returns the result synchronously (blocks on stream).
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream);
+
+// Compute a deterministic checksum of the raw FP32 output bits using a single
+// CUDA block. Returns synchronously after copying one uint64_t to host.
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream);

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -1,0 +1,417 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "CtranUtUtils.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+/**
+ * Distributed CTRAN AllReduce correctness fixture.
+ *
+ * The fixture is algorithm-parameterized and validates execution status plus
+ * the numerical reduction result. It intentionally avoids colltrace assertions
+ * so the same test can cover multiple algorithm implementations.
+ */
+class CtranAllReduceTest : public ctran::CtranDistTestFixture,
+                           public CtranBaseTest {
+ public:
+  CtranAllReduceTest() = default;
+
+  /** Identical-input repeats used to check bitwise deterministic output. */
+  static constexpr int kDeterminismRepeats = 4;
+
+  /**
+   * Configure CTRAN AllReduce and Pipes before constructing the communicator.
+   */
+  void SetUp() override {
+#ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
+    setenv("NCCL_CTRAN_BACKENDS", "socket, nvl", 1);
+#endif
+    setenv("NCCL_ALLREDUCE_ALGO", "ctree", 1);
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 1);
+    setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 1);
+    setenv("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432", 1);
+    // Re-read CVAR-backed environment overrides before fixture setup.
+    ncclCvarInit();
+    ctran::CtranDistTestFixture::SetUp();
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  /**
+   * Temporarily override the ctree block count for one collective call.
+   */
+  class ScopedTreeNumBlocksOverride {
+   public:
+    explicit ScopedTreeNumBlocksOverride(std::optional<int> numBlocks) {
+      const char* current = getenv(kEnvName);
+      if (current != nullptr) {
+        previousValue_ = current;
+      }
+      if (numBlocks.has_value()) {
+        const std::string value = std::to_string(*numBlocks);
+        setenv(kEnvName, value.c_str(), 1);
+      }
+    }
+
+    ~ScopedTreeNumBlocksOverride() {
+      if (previousValue_.has_value()) {
+        setenv(kEnvName, previousValue_->c_str(), 1);
+      } else {
+        unsetenv(kEnvName);
+      }
+    }
+
+   private:
+    static constexpr const char* kEnvName =
+        "NCCL_CTRAN_ALLREDUCE_TREE_NUM_BLOCKS";
+    std::optional<std::string> previousValue_;
+  };
+
+  /**
+   * Return whether this message size should also exercise numBlocks=1.
+   */
+  static bool shouldRunSingleBlockCoverage(size_t count) {
+    return count == 1 || count == 4096 || count == (1048576 + 7);
+  }
+
+  /**
+   * Run one FP32 `commSum` AllReduce case and validate max absolute error.
+   */
+  void runCorrectnessTest(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      size_t count,
+      bool inPlace,
+      std::optional<int> numBlocksOverride = std::nullopt) {
+    ScopedTreeNumBlocksOverride scopedOverride(numBlocksOverride);
+
+    // Check support before the zero-count no-op so disabled algorithms skip
+    // consistently with non-empty cases.
+    if (!ctranAllReduceSupport(ctranComm.get(), algo)) {
+      GTEST_SKIP() << "ctranAllReduceSupport returns false for algo "
+                   << allReduceAlgoName(algo) << ", skip test";
+    }
+
+    // Zero-element case: no-op path
+    if (count == 0) {
+      auto res = runAllReduce(
+          algo,
+          nullptr,
+          nullptr,
+          0,
+          commFloat,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+      return;
+    }
+
+    const size_t bytes = count * sizeof(float);
+    const size_t allocBytes = bytes < CTRAN_MIN_REGISTRATION_SIZE
+        ? CTRAN_MIN_REGISTRATION_SIZE
+        : bytes;
+
+    std::vector<TestMemSegment> segments;
+    void* sendbuf = prepareBuf(allocBytes, kMemNcclMemAlloc, segments);
+    void* recvbuf =
+        inPlace ? sendbuf : prepareBuf(allocBytes, kMemNcclMemAlloc, segments);
+    void* expectedBuf = prepareBuf(allocBytes, kMemNcclMemAlloc, segments);
+
+    for (auto& segment : segments) {
+      COMMCHECK_TEST(ctran::globalRegisterWithPtr(segment.ptr, segment.size));
+    }
+
+    // Initialize expected: sum of initData across all ranks
+    launchInitExpectedKernel(
+        static_cast<float*>(expectedBuf),
+        count,
+        numRanks,
+        /*rep=*/0,
+        testStream);
+
+    std::array<uint64_t, kDeterminismRepeats> checksums{};
+    for (int repeat = 0; repeat < kDeterminismRepeats; ++repeat) {
+      // Reinitialize identical inputs for each repeat. This keeps in-place
+      // cases from feeding the previous reduction result into the next run.
+      launchInitDataKernel(
+          static_cast<float*>(sendbuf),
+          count,
+          globalRank,
+          /*rep=*/0,
+          testStream);
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      commResult_t res = runAllReduce(
+          algo,
+          sendbuf,
+          recvbuf,
+          count,
+          commFloat,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      // Validate: max absolute error across all elements
+      const float* resultBuf =
+          inPlace ? static_cast<float*>(sendbuf) : static_cast<float*>(recvbuf);
+      double maxDelta = computeMaxDelta(
+          resultBuf, static_cast<float*>(expectedBuf), count, testStream);
+
+      // Threshold: 1e-5 * max(1, numRanks - 1) accounts for FP32 accumulation
+      // error. For single-rank (numRanks=1), use 1e-5 as minimum threshold.
+      double threshold = 1e-5 * std::max(1, numRanks - 1);
+      ASSERT_LT(maxDelta, threshold)
+          << "maxDelta=" << maxDelta << " threshold=" << threshold
+          << " count=" << count << " rank=" << globalRank
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+
+      checksums[repeat] = computeRawBitsChecksum(resultBuf, count, testStream);
+    }
+
+    for (int repeat = 1; repeat < kDeterminismRepeats; ++repeat) {
+      ASSERT_EQ(checksums[0], checksums[repeat])
+          << "non-deterministic AllReduce output checksum for count=" << count
+          << " rank=" << globalRank << " inPlace=" << inPlace
+          << " repeat=" << repeat;
+    }
+
+    verifyGpeLeak(ctranComm->ctran_.get());
+
+    for (auto& segment : segments) {
+      COMMCHECK_TEST(ctran::globalDeregisterWithPtr(segment.ptr, segment.size));
+    }
+
+    if (!inPlace) {
+      releaseBuf(recvbuf, allocBytes, kMemNcclMemAlloc);
+    }
+    releaseBuf(expectedBuf, allocBytes, kMemNcclMemAlloc);
+    releaseBuf(sendbuf, allocBytes, kMemNcclMemAlloc);
+  }
+
+ protected:
+  /** Dispatch one AllReduce call for the algorithm under test. */
+  commResult_t runAllReduce(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      const void* sendbuf,
+      void* recvbuf,
+      size_t count,
+      commDataType_t datatype,
+      commRedOp_t redOp,
+      CtranComm* comm,
+      cudaStream_t stream,
+      std::optional<std::chrono::milliseconds> timeout) {
+    switch (algo) {
+      case NCCL_ALLREDUCE_ALGO::ctree:
+        return ctranAllReduceTree(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::ctring:
+        return ctranAllReduceRing(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::ctdirect:
+        return ctranAllReduceDirect(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      default:
+        return commInvalidArgument;
+    }
+  }
+
+  /** CUDA stream used by buffer initialization, AllReduce, and validation. */
+  cudaStream_t testStream{0};
+  /** Communicator under test for this distributed rank. */
+  std::unique_ptr<CtranComm> ctranComm{nullptr};
+};
+
+#if defined(CTRAN_ALLREDUCE_TEST_NVL_ONLY)
+/**
+ * NVL-only topology test using the default local topology.
+ */
+class NVL_ONLY : public CtranAllReduceTest,
+                 public ::testing::WithParamInterface<
+                     std::tuple<enum NCCL_ALLREDUCE_ALGO, size_t, bool>> {};
+
+TEST_P(NVL_ONLY, Correctness) {
+  auto [algo, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, count, inPlace);
+  if (CtranAllReduceTest::shouldRunSingleBlockCoverage(count)) {
+    runCorrectnessTest(algo, count, inPlace, /*numBlocksOverride=*/1);
+  }
+}
+
+inline std::string nvlTestName(
+    const testing::TestParamInfo<NVL_ONLY::ParamType>& info) {
+  auto [algo, count, inPlace] = info.param;
+  return allReduceAlgoName(algo) + "_" + std::to_string(count) + "elements_" +
+      (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    NVL_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::Values(
+            // Zero
+            (size_t)0,
+            // Tiny
+            (size_t)1,
+            (size_t)7,
+            (size_t)16,
+            // Small
+            (size_t)64,
+            (size_t)256,
+            (size_t)1024,
+            // Medium
+            (size_t)4096,
+            (size_t)16384,
+            (size_t)65536,
+            // Large
+            (size_t)262144,
+            (size_t)1048576,
+            (size_t)4194304,
+            // Large + tail
+            (size_t)(1048576 - 7),
+            (size_t)(1048576 + 7),
+            (size_t)(4194304 - 13),
+            (size_t)(4194304 + 13)),
+        ::testing::Bool()),
+    nvlTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY)
+/**
+ * IB-only topology test that disables local P2P and forces a no-local topology.
+ */
+class IB_ONLY : public CtranAllReduceTest,
+                public ::testing::WithParamInterface<
+                    std::tuple<enum NCCL_ALLREDUCE_ALGO, size_t, bool>> {
+ public:
+  /**
+   * Force traffic through the inter-node path before communicator creation.
+   */
+  void SetUp() override {
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    setenv("NCCL_IGNORE_TOPO_LOAD_FAILURE", "1", 1);
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    CtranAllReduceTest::SetUp();
+  }
+
+  void TearDown() override {
+    unsetenv("NCCL_COMM_STATE_DEBUG_TOPO");
+    unsetenv("NCCL_IGNORE_TOPO_LOAD_FAILURE");
+    unsetenv("NCCL_P2P_DISABLE");
+    CtranAllReduceTest::TearDown();
+  }
+};
+
+TEST_P(IB_ONLY, Correctness) {
+  auto [algo, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, count, inPlace);
+  if (CtranAllReduceTest::shouldRunSingleBlockCoverage(count)) {
+    runCorrectnessTest(algo, count, inPlace, /*numBlocksOverride=*/1);
+  }
+}
+
+inline std::string ibTestName(
+    const testing::TestParamInfo<IB_ONLY::ParamType>& info) {
+  auto [algo, count, inPlace] = info.param;
+  return allReduceAlgoName(algo) + "_" + std::to_string(count) + "elements_" +
+      (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    IB_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::Values(
+            // Zero
+            (size_t)0,
+            // Tiny
+            (size_t)1,
+            (size_t)7,
+            (size_t)16,
+            // Small
+            (size_t)64,
+            (size_t)256,
+            (size_t)1024,
+            // Medium
+            (size_t)4096,
+            (size_t)16384,
+            (size_t)65536,
+            // Large
+            (size_t)262144,
+            (size_t)1048576,
+            (size_t)4194304,
+            // Large + tail
+            (size_t)(1048576 - 7),
+            (size_t)(1048576 + 7),
+            (size_t)(4194304 - 13),
+            (size_t)(4194304 + 13)),
+        ::testing::Bool()),
+    ibTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_HYBRID)
+/**
+ * Hybrid topology test that exercises NVL and IB paths together.
+ */
+class HYBRID : public CtranAllReduceTest,
+               public ::testing::WithParamInterface<
+                   std::tuple<enum NCCL_ALLREDUCE_ALGO, size_t, bool>> {};
+
+TEST_P(HYBRID, Correctness) {
+  auto [algo, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, count, inPlace);
+  if (CtranAllReduceTest::shouldRunSingleBlockCoverage(count)) {
+    runCorrectnessTest(algo, count, inPlace, /*numBlocksOverride=*/1);
+  }
+}
+
+inline std::string hybridTestName(
+    const testing::TestParamInfo<HYBRID::ParamType>& info) {
+  auto [algo, count, inPlace] = info.param;
+  return allReduceAlgoName(algo) + "_" + std::to_string(count) + "elements_" +
+      (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    HYBRID,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::Values(
+            (size_t)1,
+            (size_t)4096,
+            (size_t)1048576,
+            (size_t)(1048576 - 7),
+            (size_t)(1048576 + 7)),
+        ::testing::Bool()),
+    hybridTestName);
+#endif
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -61,6 +61,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctdirect;
   } else if (str == "ctring") {
     val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else if (str == "ctree") {
+    val = NCCL_ALLREDUCE_ALGO::ctree;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -144,6 +146,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctdirect";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "ctring";
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return "ctree";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -63,6 +63,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctring;
   } else if (str == "ctree") {
     val = NCCL_ALLREDUCE_ALGO::ctree;
+  } else if (str == "pipesflatring") {
+    val = NCCL_ALLREDUCE_ALGO::pipesflatring;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -148,6 +150,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctring";
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "ctree";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "pipesflatring";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -98,6 +98,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctree:
       str = "ctree";
       break;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      str = "pipesflatring";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -175,6 +178,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::pipesflatring);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -95,6 +95,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctring:
       str = "ctring";
       break;
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      str = "ctree";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -171,6 +174,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctran);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -41,6 +41,40 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 // `PIPES_DEVICE_TRAP()` is defined in `comms/pipes/DeviceMacros.cuh` and
 // is intentionally available across all `comms/pipes` device headers.
 
+/** Result of one bounded send/recv progress attempt. */
+enum class IbgdaSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+};
+
+/** Internal stage for a resumable pipelined send or recv operation. */
+enum class IbgdaSendRecvProgressStage : uint8_t {
+  WaitNicDone,
+  WaitSlotFree,
+  WaitDataReady,
+  Done,
+};
+
+/**
+ * Resumable state for one transport-managed pipelined send or recv.
+ *
+ * The caller owns this state and repeatedly passes it to `progress*Once()`.
+ * Each progress call performs bounded work and returns immediately if the next
+ * signal/counter dependency is not ready.
+ */
+struct IbgdaSendRecvProgressState {
+  int groupId{0};
+  int activeBlocks{0};
+  std::size_t nbytes{0};
+  std::size_t maxSignalBytes{0};
+  std::size_t perBlockSlot{0};
+  std::size_t chunkSize{0};
+  std::size_t nextByte{0};
+  int64_t baseStep{0};
+  IbgdaSendRecvProgressStage stage{IbgdaSendRecvProgressStage::Done};
+};
+
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
 // constructed with no owned signal/counter buffer (numSlots == 0).
@@ -1179,6 +1213,378 @@ class P2pIbgdaTransportDevice {
   //     else
   //       transport->recv(sub, tiles.data(), tiles.bytes(), active_blocks);
   //   }
+
+ private:
+  struct ProgressChunk {
+    std::size_t stagingOff;
+    std::size_t dataOff;
+    std::size_t bytes;
+    uint64_t streamEnd;
+  };
+
+  __device__ __forceinline__ void init_progress_geometry(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.nbytes == 0) {
+      return;
+    }
+    if (state.groupId != static_cast<int>(group.group_id)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress state group_id=%d but group.group_id=%u\n",
+            state.groupId,
+            group.group_id);
+      }
+      __trap();
+    }
+    if (state.activeBlocks > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress active_blocks=%d > maxGroups=%d\n",
+            state.activeBlocks,
+            sendRecvState_.maxGroups);
+      }
+      __trap();
+    }
+    if (state.groupId < 0 || state.groupId >= state.activeBlocks) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%d >= active_blocks=%d\n",
+            state.groupId,
+            state.activeBlocks);
+      }
+      __trap();
+    }
+
+    state.perBlockSlot =
+        (sendRecvState_.dataBufferSize / state.activeBlocks) & ~15ULL;
+    if (state.perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            state.activeBlocks);
+      }
+      __trap();
+    }
+
+    state.chunkSize =
+        (state.maxSignalBytes > 0 && state.maxSignalBytes < state.perBlockSlot)
+        ? (state.maxSignalBytes & ~15ULL)
+        : state.perBlockSlot;
+    if (state.chunkSize == 0) {
+      state.chunkSize = state.perBlockSlot;
+    }
+#endif
+  }
+
+  __device__ __forceinline__ ProgressChunk
+  progress_chunk(const IbgdaSendRecvProgressState& state) const {
+    const uint64_t streamStart =
+        static_cast<uint64_t>(state.baseStep) + state.nextByte;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / state.perBlockSlot);
+    const std::size_t slotOff =
+        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+    const std::size_t chunkOff =
+        pipelineOff - static_cast<std::size_t>(slot) * state.perBlockSlot;
+    const std::size_t slotRemaining = state.perBlockSlot - chunkOff;
+    const std::size_t dataRemaining = state.nbytes - state.nextByte;
+    std::size_t bytes =
+        state.chunkSize < dataRemaining ? state.chunkSize : dataRemaining;
+    bytes = bytes < slotRemaining ? bytes : slotRemaining;
+    return ProgressChunk{
+        .stagingOff = slotOff +
+            static_cast<std::size_t>(state.groupId) * state.perBlockSlot +
+            chunkOff,
+        .dataOff = state.nextByte,
+        .bytes = bytes,
+        .streamEnd = streamStart + bytes,
+    };
+  }
+
+ public:
+  /**
+   * Initialize resumable state for one pipelined send operation.
+   *
+   * The returned state is independent of the source pointer. A caller may keep
+   * the state in its own scheduler and call `progress_send_once()` until it
+   * returns `Done`.
+   */
+  __device__ __forceinline__ IbgdaSendRecvProgressState init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    IbgdaSendRecvProgressState state{};
+    state.groupId = static_cast<int>(group.group_id);
+    state.activeBlocks =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    state.nbytes = nbytes;
+    state.maxSignalBytes = max_signal_bytes;
+    state.stage = nbytes == 0 ? IbgdaSendRecvProgressStage::Done
+                              : IbgdaSendRecvProgressStage::WaitNicDone;
+    init_progress_geometry(group, state);
+    if (nbytes != 0) {
+      state.baseStep = sendRecvState_.stepState[state.groupId];
+    }
+    return state;
+#else
+    return {};
+#endif
+  }
+
+  /**
+   * Initialize resumable state for one pipelined recv operation.
+   *
+   * The returned state is independent of the destination pointer. A caller may
+   * keep the state in its own scheduler and call `progress_recv_once()` until
+   * it returns `Done`.
+   */
+  __device__ __forceinline__ IbgdaSendRecvProgressState init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    IbgdaSendRecvProgressState state{};
+    state.groupId = static_cast<int>(group.group_id);
+    state.activeBlocks =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    state.nbytes = nbytes;
+    state.maxSignalBytes = max_signal_bytes;
+    state.stage = nbytes == 0 ? IbgdaSendRecvProgressStage::Done
+                              : IbgdaSendRecvProgressStage::WaitDataReady;
+    init_progress_geometry(group, state);
+    if (nbytes != 0) {
+      state.baseStep =
+          sendRecvState_.stepState[sendRecvState_.maxGroups + state.groupId];
+    }
+    return state;
+#else
+    return {};
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized send.
+   *
+   * This method never spins on NIC_DONE or SLOT_FREE. If either dependency is
+   * not ready, it returns `Waiting` immediately so a higher-level scheduler can
+   * try another independent lane.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state,
+      const void* __restrict__ src,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::progress_send_once() requires NVIDIA GPU");
+#endif
+    if (state.stage == IbgdaSendRecvProgressStage::Done ||
+        state.nextByte >= state.nbytes) {
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    bool progressed = false;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+
+    if (state.stage == IbgdaSendRecvProgressStage::WaitNicDone) {
+      const ProgressChunk chunk = progress_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_counter(sendRecvState_.localCounterBuf.subBuffer(
+                  state.groupId * sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      CopyOp::send(
+          sendRecvState_.sendStagingPtr + chunk.stagingOff,
+          static_cast<const char*>(src) + chunk.dataOff,
+          chunk.bytes,
+          group,
+          chunk.dataOff,
+          args...);
+      group.sync();
+      state.stage = IbgdaSendRecvProgressStage::WaitSlotFree;
+      progressed = true;
+    }
+
+    if (state.stage == IbgdaSendRecvProgressStage::WaitSlotFree) {
+      const ProgressChunk chunk = progress_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                  (sendRecvState_.maxGroups + state.groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return progressed ? IbgdaSendRecvProgressStatus::Progressed
+                            : IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        put(solo,
+            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            chunk.bytes,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes,
+            sendRecvState_.localCounterBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes);
+      }
+      group.sync();
+
+      state.nextByte += chunk.bytes;
+      progressed = true;
+      if (state.nextByte >= state.nbytes) {
+        if (group.is_leader()) {
+          sendRecvState_.stepState[state.groupId] =
+              state.baseStep + static_cast<int64_t>(state.nbytes);
+        }
+        group.sync();
+        state.stage = IbgdaSendRecvProgressStage::Done;
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      state.stage = IbgdaSendRecvProgressStage::WaitNicDone;
+    }
+
+    return progressed ? IbgdaSendRecvProgressStatus::Progressed
+                      : IbgdaSendRecvProgressStatus::Waiting;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized recv.
+   *
+   * This method never spins on DATA_READY. If the sender has not signaled the
+   * next chunk yet, it returns `Waiting` immediately.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state,
+      void* __restrict__ dst,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::progress_recv_once() requires NVIDIA GPU");
+#endif
+    if (state.stage == IbgdaSendRecvProgressStage::Done ||
+        state.nextByte >= state.nbytes) {
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    const ProgressChunk chunk = progress_chunk(state);
+    const uint64_t expected = chunk.streamEnd;
+    uint32_t ready = 1;
+    unsigned long long current = 0;
+    if (group.is_leader()) {
+      current = static_cast<unsigned long long>(
+          read_signal(sendRecvState_.localSignalBuf.subBuffer(
+              state.groupId * sizeof(uint64_t))));
+      ready = current >= expected ? 1U : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_recv_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            static_cast<unsigned long long>(expected),
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    CopyOp::recv(
+        static_cast<char*>(dst) + chunk.dataOff,
+        sendRecvState_.recvStagingPtr + chunk.stagingOff,
+        chunk.bytes,
+        group,
+        chunk.dataOff,
+        args...);
+    group.sync();
+
+    signal(
+        group,
+        sendRecvState_.remoteSignalBuf.subBuffer(
+            (sendRecvState_.maxGroups + state.groupId) * sizeof(uint64_t)),
+        chunk.bytes);
+
+    state.nextByte += chunk.bytes;
+    if (state.nextByte >= state.nbytes) {
+      if (group.is_leader()) {
+        sendRecvState_.stepState[sendRecvState_.maxGroups + state.groupId] =
+            state.baseStep + static_cast<int64_t>(state.nbytes);
+      }
+      group.sync();
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    return IbgdaSendRecvProgressStatus::Progressed;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
 
   /**
    * send — send one block's tile via pipelined RDMA.

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -1,0 +1,130 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+RingTopology to_ring_topology(
+    const RingAllReduceLaunchParams::RingParams& src) {
+  return RingTopology{
+      .prev_rank = src.prev_rank,
+      .next_rank = src.next_rank,
+      .prev = src.prev,
+      .next = src.next,
+  };
+}
+
+void check_kernel_launch(const char* kernel_name) {
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(kernel_name) +
+        " kernel launch failed: " + cudaGetErrorString(err));
+  }
+}
+
+template <int NumRings>
+void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
+  const int my_rank = params.my_rank;
+  const int num_ranks = params.num_ranks;
+  const std::size_t chunk_elements = params.count / num_ranks;
+  const std::size_t chunk_bytes = chunk_elements * sizeof(float);
+
+  // Phase 1: ReduceScatter
+  // Writes reduced shard to output[my_rank * chunk_elements]
+  {
+    RingReduceScatterArgs<NumRings, float> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.chunk_elements = chunk_elements;
+    args.signaling_data_size = params.signaling_data_size;
+    args.input = params.input;
+    args.output = params.output + my_rank * chunk_elements;
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("ReduceScatter");
+  }
+
+  // Phase 2: AllGather
+  // Reads reduced shard from output[my_rank * chunk_bytes], gathers into output
+  {
+    RingAllgatherArgs<NumRings> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.sendcount = chunk_bytes;
+    args.signaling_data_size = params.signaling_data_size;
+    args.sendbuf =
+        reinterpret_cast<const char*>(params.output) + my_rank * chunk_bytes;
+    args.recvbuf = reinterpret_cast<char*>(params.output);
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_allgather_kernel<NumRings, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("AllGather");
+  }
+}
+
+} // namespace
+
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params) {
+  if (params.num_ranks == 0) {
+    throw std::runtime_error("num_ranks must be > 0");
+  }
+  if (params.count % params.num_ranks != 0) {
+    throw std::runtime_error(
+        "count (" + std::to_string(params.count) +
+        ") must be divisible by num_ranks (" +
+        std::to_string(params.num_ranks) + ")");
+  }
+
+  Timeout timeout;
+  if (params.timeout_ms > 0) {
+    int device = 0;
+    cudaError_t cudaErr = cudaGetDevice(&device);
+    if (cudaErr != cudaSuccess) {
+      throw std::runtime_error(
+          "Failed to get CUDA device: " +
+          std::string(cudaGetErrorString(cudaErr)));
+    }
+
+    timeout = makeTimeout(params.timeout_ms, device);
+  }
+
+  switch (params.num_rings) {
+    case 1:
+      launch_impl<1>(params, timeout);
+      break;
+    case 2:
+      launch_impl<2>(params, timeout);
+      break;
+    case 4:
+      launch_impl<4>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error(
+          "Unsupported num_rings=" + std::to_string(params.num_rings) +
+          " (supported: 1, 2, 4)");
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduceLauncher.h
+++ b/comms/pipes/collectives/RingAllReduceLauncher.h
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct RingAllReduceLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t count{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  int num_rings{1};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+
+  struct RingParams {
+    int prev_rank{0};
+    int next_rank{0};
+    P2pIbgdaTransportDevice* prev{nullptr};
+    P2pIbgdaTransportDevice* next{nullptr};
+  };
+  static constexpr int kMaxRings = 4;
+  RingParams rings[kMaxRings]{};
+};
+
+// Launches a ring allreduce on the specified stream.
+//
+// Preconditions:
+// - count must be divisible by num_ranks
+// - transport devices must be bound and connected
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2649,13 +2649,14 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring
+   choices     : orig, ctran, ctdirect, ctring, ctree
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
      ctran - Picks the best ctran-based algorithm
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - ctran-based ring algorithm
+     ctree - Ctran-based tree algorithm (Pipes-native)
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1806,6 +1806,19 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
+ - name        : NCCL_CTRAN_MAX_NBLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Maximum number of logical CUDA blocks used by CTRAN collectives that support message-size-based block tuning.
+
+ - name        : NCCL_CTRAN_TREE_FANOUT
+   type        : int
+   default     : 2
+   description : |-
+     Fanout used when building CTREE tree topologies for experimental benchmarking.
+     Valid values are 1 through the compile-time maximum tree children.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2662,7 +2662,7 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctree
+   choices     : orig, ctran, ctdirect, ctring, ctree, pipesflatring
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
@@ -2670,6 +2670,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - ctran-based ring algorithm
      ctree - Ctran-based tree algorithm (Pipes-native)
+     pipesflatring - Pipes-based device-native ring algorithm (IBGDA)
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum


### PR DESCRIPTION
Summary:

Wire Pipes-based Ring AllReduce into the Ctran dispatch as a new `pipesring` algorithm.

Add three new CVARs (`NCCL_CTRAN_PIPES_SENDRECV_ENABLE`, `_MAX_GROUPS`, `_PIPELINE_DEPTH`) to enable pipelined send/recv staging buffers on the IBGDA transport, as required by ring collectives' `send()`/`recv()`/`forward()` protocol.

Add `AllReducePipesRing.cc` implementing the Ctran-side dispatch that builds ring topology, gets per-peer IBGDA transport handles, and launches the Pipes AllReduce. Uses the scratch-free "Option B" buffer layout. Currently supports float32 + Sum only, `nLocalRanks=1` (IB-only, matching PAFT inter-replica topology).

Differential Revision: D104701020
