### PR TITLE
Use TileReduceStaged in fused Ring AllReduce kernel (#2703)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -25,6 +25,8 @@ bool ctranPipesTraceEnabled() {
   return NCCL_CTRAN_PIPES_TRACE_ENABLE;
 }
 
+constexpr uint64_t kDefaultIbgdaSendRecvDataBufferSize = 32ULL * 1024 * 1024;
+
 } // namespace
 
 commResult_t ctran::ctranPreparePipesTrace(
@@ -145,6 +147,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     if (hierAgOverlapEnabled && NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE > 0) {
       ibgdaDataBufferSize = std::max(
           ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);
+    }
+    if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE && ibgdaDataBufferSize == 0) {
+      ibgdaDataBufferSize = kDefaultIbgdaSendRecvDataBufferSize;
     }
     config.ibgdaConfig.dataBufferSize =
         static_cast<size_t>(ibgdaDataBufferSize);

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -44,13 +44,14 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
       return true;
     case NCCL_ALLREDUCE_ALGO::pipesflatring:
 #if defined(ENABLE_PIPES)
-      if (comm->multiPeerTransport_ && comm->statex_->nLocalRanks() == 1) {
+      if (comm->multiPeerTransport_ && NCCL_CTRAN_IBGDA_SENDRECV_ENABLE &&
+          comm->statex_->nLocalRanks() == 1) {
         return true;
       }
       CLOGF(
           WARN,
           "pipesflatring requires ENABLE_PIPES, NCCL_CTRAN_USE_PIPES=1, "
-          "NCCL_CTRAN_PIPES_SENDRECV_ENABLE=1, and nLocalRanks=1");
+          "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1, and nLocalRanks=1");
 #endif
       return false;
     default: // invalid query

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -28,6 +28,8 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctran:
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return true;
     default: // invalid query
       return false;
   }
@@ -64,6 +66,9 @@ commResult_t ctranAllReduce(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       return ctranAllReduceRing(
+          sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return ctranAllReduceTree(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -42,6 +42,17 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
         return false;
       }
       return true;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+#if defined(ENABLE_PIPES)
+      if (comm->multiPeerTransport_ && comm->statex_->nLocalRanks() == 1) {
+        return true;
+      }
+      CLOGF(
+          WARN,
+          "pipesflatring requires ENABLE_PIPES, NCCL_CTRAN_USE_PIPES=1, "
+          "NCCL_CTRAN_PIPES_SENDRECV_ENABLE=1, and nLocalRanks=1");
+#endif
+      return false;
     default: // invalid query
       return false;
   }
@@ -81,6 +92,13 @@ commResult_t ctranAllReduce(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctree:
       return ctranAllReduceTree(
+          sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      if (comm->statex_->nRanks() == 1) {
+        return ctranAllReduceDirect(
+            sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+      }
+      return ctranAllReducePipesFlatRing(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -29,6 +29,18 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
     case NCCL_ALLREDUCE_ALGO::ctree:
+      if (!NCCL_CTRAN_USE_PIPES) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+        return false;
+      }
+      if (comm->statex_->nNodes() > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF(
+            WARN,
+            "ctree algo requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+        return false;
+      }
       return true;
     default: // invalid query
       return false;

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,15 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+commResult_t ctranAllReduceTree(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 static inline const std::string allReduceAlgoName(
     enum NCCL_ALLREDUCE_ALGO algo) {
@@ -38,6 +47,8 @@ static inline const std::string allReduceAlgoName(
       return "Baseline";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "CtranAllReduceRing";
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return "CtranAllReduceTree";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -27,6 +27,18 @@ commResult_t ctranAllReduceRing(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 /**
+ * Run the Pipes-backed ring AllReduce implementation.
+ */
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+/**
  * Run the Pipes-backed tree AllReduce implementation.
  *
  * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
@@ -56,6 +68,8 @@ static inline const std::string allReduceAlgoName(
       return "CtranAllReduceRing";
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "CtranAllReduceTree";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "PipesFlatRingAllReduce";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,13 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+/**
+ * Run the Pipes-backed tree AllReduce implementation.
+ *
+ * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
+ * It relies on Pipes NVL and IBGDA transport staging for transient receives and
+ * does not allocate message-size-dependent AllReduce staging.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -1,17 +1,23 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include <chrono>
+#include <cstdint>
+#include <limits>
 #include <optional>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/gpe/CtranGpe.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
 #if defined(ENABLE_PIPES)
 
+#include "comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cuh"
 #include "comms/pipes/MultiPeerTransport.h"
-#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/TimeoutUtils.h"
 #include "comms/pipes/collectives/RingUtils.h"
 
 namespace {
@@ -34,6 +40,72 @@ int getPipesFlatRingNumBlocks() {
   return NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_BLOCKS;
 }
 
+commResult_t makePipesTimeout(
+    std::optional<std::chrono::milliseconds> timeout,
+    comms::pipes::Timeout& pipesTimeout) {
+  pipesTimeout = comms::pipes::Timeout();
+  if (!timeout.has_value() || timeout->count() <= 0) {
+    return commSuccess;
+  }
+
+  if (timeout->count() > std::numeric_limits<uint32_t>::max()) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce timeout {}ms exceeds supported maximum",
+        timeout->count());
+    return commInvalidArgument;
+  }
+
+  int device = 0;
+  const auto err = cudaGetDevice(&device);
+  if (err != cudaSuccess) {
+    CLOGF(
+        ERR,
+        "PipesFlatRingAllReduce cudaGetDevice failed while creating timeout: {}",
+        cudaGetErrorString(err));
+    return commInternalError;
+  }
+
+  try {
+    pipesTimeout = comms::pipes::makeTimeout(
+        static_cast<uint32_t>(timeout->count()), device);
+  } catch (const std::exception& ex) {
+    CLOGF(
+        ERR,
+        "PipesFlatRingAllReduce failed to create Pipes timeout: {}",
+        ex.what());
+    return commInternalError;
+  }
+  return commSuccess;
+}
+
+commResult_t submitPipesFlatRingPhase(
+    CtranComm* comm,
+    cudaStream_t stream,
+    const char* phaseName,
+    uint64_t opCount,
+    ctran::allreduce::pipesflatring::KernArgs& kernArgs,
+    const void* kernel,
+    std::optional<std::chrono::milliseconds> timeout) {
+  KernelConfig config(
+      KernelConfig::KernelType::ALLREDUCE, stream, phaseName, opCount);
+  config.numBlocks = static_cast<unsigned int>(kernArgs.numBlocks);
+  config.numThreads = ctran::allreduce::pipesflatring::kBlockSize;
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  config.args.collective.allreduce.sendbuff = kernArgs.sendbuff;
+  config.args.collective.allreduce.recvbuff = kernArgs.recvbuff;
+  config.args.collective.allreduce.redOp = commRedOp_t::commSum;
+  config.args.collective.allreduce.count = kernArgs.count;
+  config.args.collective.allreduce.datatype = commDataType_t::commFloat32;
+
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup), nullptr, config, kernel, timeout));
+  return commSuccess;
+}
+
 } // namespace
 
 commResult_t ctranAllReducePipesFlatRing(
@@ -45,6 +117,13 @@ commResult_t ctranAllReducePipesFlatRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout) {
+  if (comm == nullptr || comm->ctran_ == nullptr ||
+      comm->ctran_->gpe == nullptr || comm->ctran_->algo == nullptr ||
+      comm->statex_ == nullptr) {
+    CLOGF(ERR, "PipesFlatRingAllReduce requires initialized Ctran state");
+    return commInternalError;
+  }
+
   if (!comm->multiPeerTransport_) {
     CLOGF(
         ERR,
@@ -116,12 +195,12 @@ commResult_t ctranAllReducePipesFlatRing(
       return commInvalidArgument;
     }
 
-    if (numRings > comms::pipes::RingAllReduceLaunchParams::kMaxRings) {
+    if (numRings > ctran::allreduce::pipesflatring::kMaxRings) {
       CLOGF(
           WARN,
-          "PipesFlatRingAllReduce num_rings={} exceeds launcher max {}",
+          "PipesFlatRingAllReduce num_rings={} exceeds Ctran flat-ring max {}",
           numRings,
-          comms::pipes::RingAllReduceLaunchParams::kMaxRings);
+          ctran::allreduce::pipesflatring::kMaxRings);
       return commInvalidArgument;
     }
 
@@ -143,6 +222,23 @@ commResult_t ctranAllReducePipesFlatRing(
       return commInvalidArgument;
     }
 
+    const auto dataBufferSize = NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE;
+    if (dataBufferSize == 0) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce requires positive NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE");
+      return commInvalidArgument;
+    }
+
+    if (dataBufferSize / static_cast<uint64_t>(numBlocks) < 16) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce dataBufferSize={} is too small for num_blocks={}",
+          dataBufferSize,
+          numBlocks);
+      return commInvalidArgument;
+    }
+
     auto ringsOpt = comms::pipes::make_standard_rings(nRanks, rank, numRings);
     if (!ringsOpt.has_value()) {
       CLOGF(
@@ -156,31 +252,46 @@ commResult_t ctranAllReducePipesFlatRing(
 
     auto* mpt = comm->multiPeerTransport_.get();
 
-    comms::pipes::RingAllReduceLaunchParams params{};
-    params.my_rank = rank;
-    params.num_ranks = nRanks;
-    params.count = divisibleCount;
-    params.signaling_data_size = 0;
-    params.input = static_cast<const float*>(sendbuff);
-    params.output = static_cast<float*>(recvbuff);
-    params.num_blocks = numBlocks;
-    params.num_rings = numRings;
-    params.stream = stream;
+    comms::pipes::Timeout pipesTimeout;
+    FB_COMMCHECK(makePipesTimeout(timeout, pipesTimeout));
 
-    if (timeout.has_value()) {
-      params.timeout_ms = static_cast<float>(timeout->count());
-    }
-
+    ctran::allreduce::pipesflatring::KernArgs kernArgs{};
+    kernArgs.rank = rank;
+    kernArgs.nRanks = nRanks;
+    kernArgs.count = divisibleCount;
+    kernArgs.chunkElements = divisibleCount / nRanks;
+    kernArgs.sendbuff = static_cast<const float*>(sendbuff);
+    kernArgs.recvbuff = static_cast<float*>(recvbuff);
+    kernArgs.numBlocks = numBlocks;
+    kernArgs.numRings = numRings;
+    kernArgs.signalingDataSize = 0;
+    kernArgs.timeout = pipesTimeout;
     for (int r = 0; r < numRings; r++) {
-      params.rings[r].prev_rank = rings[r].prev_rank;
-      params.rings[r].next_rank = rings[r].next_rank;
-      params.rings[r].prev =
+      kernArgs.rings[r].prevRank = rings[r].prev_rank;
+      kernArgs.rings[r].nextRank = rings[r].next_rank;
+      kernArgs.rings[r].prev =
           mpt->get_p2p_ibgda_transport_device(rings[r].prev_rank);
-      params.rings[r].next =
+      kernArgs.rings[r].next =
           mpt->get_p2p_ibgda_transport_device(rings[r].next_rank);
     }
 
-    comms::pipes::launch_ring_allreduce(params);
+    const auto opCount = comm->ctran_->getOpCount();
+    FB_COMMCHECK(submitPipesFlatRingPhase(
+        comm,
+        stream,
+        "PipesFlatRingReduceScatter",
+        opCount,
+        kernArgs,
+        reinterpret_cast<void*>(ctranKernelAllReducePipesFlatRingReduceScatter),
+        timeout));
+    FB_COMMCHECK(submitPipesFlatRingPhase(
+        comm,
+        stream,
+        "PipesFlatRingAllGather",
+        opCount,
+        kernArgs,
+        reinterpret_cast<void*>(ctranKernelAllReducePipesFlatRingAllGather),
+        timeout));
   }
 
   if (remainder > 0) {

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <chrono>
+#include <optional>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  return commInternalError;
+}
+
+#else
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void*,
+    void*,
+    size_t,
+    commDataType_t,
+    commRedOp_t,
+    CtranComm*,
+    cudaStream_t,
+    std::optional<std::chrono::milliseconds>) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -14,6 +14,28 @@
 #include "comms/pipes/collectives/RingAllReduceLauncher.h"
 #include "comms/pipes/collectives/RingUtils.h"
 
+namespace {
+
+bool isSupportedRingCount(int numRings) {
+  return numRings == 1 || numRings == 2 || numRings == 4;
+}
+
+int getPipesFlatRingNumRings() {
+  if (NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_RINGS == -1) {
+    return 1;
+  }
+  return NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_RINGS;
+}
+
+int getPipesFlatRingNumBlocks() {
+  if (NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_BLOCKS == -1) {
+    return 16;
+  }
+  return NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_BLOCKS;
+}
+
+} // namespace
+
 commResult_t ctranAllReducePipesFlatRing(
     const void* sendbuff,
     void* recvbuff,
@@ -23,7 +45,162 @@ commResult_t ctranAllReducePipesFlatRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout) {
-  return commInternalError;
+  if (!comm->multiPeerTransport_) {
+    CLOGF(
+        ERR,
+        "PipesFlatRingAllReduce requires MultiPeerTransport "
+        "(NCCL_CTRAN_USE_PIPES=1)");
+    return commInternalError;
+  }
+
+  if (!NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1");
+    return commInvalidArgument;
+  }
+
+  if (datatype != commDataType_t::commFloat32) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce currently supports float32 only, got {}",
+        static_cast<int>(datatype));
+    return commInvalidArgument;
+  }
+
+  if (redOp != commRedOp_t::commSum) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce currently supports Sum only, got {}",
+        static_cast<int>(redOp));
+    return commInvalidArgument;
+  }
+
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int rank = statex->rank();
+
+  if (nRanks < 2) {
+    if (sendbuff != recvbuff) {
+      auto err = cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * sizeof(float),
+          cudaMemcpyDeviceToDevice,
+          stream);
+      if (err != cudaSuccess) {
+        CLOGF(
+            ERR,
+            "PipesFlatRingAllReduce cudaMemcpyAsync failed: {}",
+            cudaGetErrorString(err));
+        return commInternalError;
+      }
+    }
+    return commSuccess;
+  }
+
+  const size_t divisibleCount = (count / nRanks) * nRanks;
+  const size_t remainder = count - divisibleCount;
+
+  if (divisibleCount > 0) {
+    const int numRings = getPipesFlatRingNumRings();
+    if (!isSupportedRingCount(numRings)) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce unsupported num_rings={} (supported: 1, 2, 4)",
+          numRings);
+      return commInvalidArgument;
+    }
+
+    if (numRings > comms::pipes::RingAllReduceLaunchParams::kMaxRings) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce num_rings={} exceeds launcher max {}",
+          numRings,
+          comms::pipes::RingAllReduceLaunchParams::kMaxRings);
+      return commInvalidArgument;
+    }
+
+    const int numBlocks = getPipesFlatRingNumBlocks();
+    if (numBlocks <= 0) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce num_blocks must be positive, got {}",
+          numBlocks);
+      return commInvalidArgument;
+    }
+
+    if (NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS < numBlocks) {
+      CLOGF(
+          WARN,
+          "PipesFlatRingAllReduce num_blocks={} exceeds NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+          numBlocks,
+          NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+      return commInvalidArgument;
+    }
+
+    auto ringsOpt = comms::pipes::make_standard_rings(nRanks, rank, numRings);
+    if (!ringsOpt.has_value()) {
+      CLOGF(
+          ERR,
+          "PipesFlatRingAllReduce: failed to build {} rings for {} ranks",
+          numRings,
+          nRanks);
+      return commInvalidArgument;
+    }
+    const auto& rings = *ringsOpt;
+
+    auto* mpt = comm->multiPeerTransport_.get();
+
+    comms::pipes::RingAllReduceLaunchParams params{};
+    params.my_rank = rank;
+    params.num_ranks = nRanks;
+    params.count = divisibleCount;
+    params.signaling_data_size = 0;
+    params.input = static_cast<const float*>(sendbuff);
+    params.output = static_cast<float*>(recvbuff);
+    params.num_blocks = numBlocks;
+    params.num_rings = numRings;
+    params.stream = stream;
+
+    if (timeout.has_value()) {
+      params.timeout_ms = static_cast<float>(timeout->count());
+    }
+
+    for (int r = 0; r < numRings; r++) {
+      params.rings[r].prev_rank = rings[r].prev_rank;
+      params.rings[r].next_rank = rings[r].next_rank;
+      params.rings[r].prev =
+          mpt->get_p2p_ibgda_transport_device(rings[r].prev_rank);
+      params.rings[r].next =
+          mpt->get_p2p_ibgda_transport_device(rings[r].next_rank);
+    }
+
+    comms::pipes::launch_ring_allreduce(params);
+  }
+
+  if (remainder > 0) {
+    const size_t elemSize = sizeof(float);
+    const void* remainderSendbuff =
+        static_cast<const char*>(sendbuff) + divisibleCount * elemSize;
+    void* remainderRecvbuff =
+        static_cast<char*>(recvbuff) + divisibleCount * elemSize;
+    return ctranAllReduceDirect(
+        remainderSendbuff,
+        remainderRecvbuff,
+        remainder,
+        datatype,
+        redOp,
+        comm,
+        stream,
+        timeout);
+  }
+
+  return commSuccess;
 }
 
 #else

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cu
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cu
@@ -1,0 +1,129 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cuh"
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace {
+
+template <int NumRings>
+__device__ comms::pipes::RingReduceScatterArgs<NumRings, float>
+makeReduceScatterArgs(const ctran::allreduce::pipesflatring::KernArgs& args) {
+  comms::pipes::RingReduceScatterArgs<NumRings, float> phaseArgs{};
+  phaseArgs.my_rank = args.rank;
+  phaseArgs.num_ranks = args.nRanks;
+  phaseArgs.chunk_elements = args.chunkElements;
+  phaseArgs.signaling_data_size = args.signalingDataSize;
+  phaseArgs.input = args.sendbuff;
+  phaseArgs.output = args.recvbuff + args.rank * args.chunkElements;
+
+  for (int r = 0; r < NumRings; r++) {
+    phaseArgs.rings[r] = comms::pipes::RingTopology{
+        .prev_rank = args.rings[r].prevRank,
+        .next_rank = args.rings[r].nextRank,
+        .prev = args.rings[r].prev,
+        .next = args.rings[r].next,
+    };
+  }
+  return phaseArgs;
+}
+
+template <int NumRings>
+__device__ comms::pipes::RingAllgatherArgs<NumRings> makeAllGatherArgs(
+    const ctran::allreduce::pipesflatring::KernArgs& args) {
+  comms::pipes::RingAllgatherArgs<NumRings> phaseArgs{};
+  phaseArgs.my_rank = args.rank;
+  phaseArgs.num_ranks = args.nRanks;
+  phaseArgs.sendcount = args.chunkElements * sizeof(float);
+  phaseArgs.signaling_data_size = args.signalingDataSize;
+  phaseArgs.sendbuf = reinterpret_cast<const char*>(
+      args.recvbuff + args.rank * args.chunkElements);
+  phaseArgs.recvbuf = reinterpret_cast<char*>(args.recvbuff);
+
+  for (int r = 0; r < NumRings; r++) {
+    phaseArgs.rings[r] = comms::pipes::RingTopology{
+        .prev_rank = args.rings[r].prevRank,
+        .next_rank = args.rings[r].nextRank,
+        .prev = args.rings[r].prev,
+        .next = args.rings[r].next,
+    };
+  }
+  return phaseArgs;
+}
+
+template <int NumRings>
+__device__ void runReduceScatter(
+    const ctran::allreduce::pipesflatring::KernArgs& args) {
+  auto phaseArgs = makeReduceScatterArgs<NumRings>(args);
+  comms::pipes::ring_reduce_scatter_device<
+      NumRings,
+      float,
+      comms::pipes::SumOp,
+      ctran::allreduce::pipesflatring::kTileElems,
+      ctran::allreduce::pipesflatring::kBlockSize>(phaseArgs, args.timeout);
+}
+
+template <int NumRings>
+__device__ void runAllGather(
+    const ctran::allreduce::pipesflatring::KernArgs& args) {
+  auto phaseArgs = makeAllGatherArgs<NumRings>(args);
+  comms::pipes::ring_allgather_device<
+      NumRings,
+      ctran::allreduce::pipesflatring::kBlockSize>(phaseArgs, args.timeout);
+}
+
+} // namespace
+
+__global__
+__launch_bounds__(ctran::allreduce::pipesflatring::kBlockSize, 1) void ctranKernelAllReducePipesFlatRingReduceScatter(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::pipesflatring::KernArgs args) {
+  if (blockIdx.x >= args.numBlocks) {
+    return;
+  }
+
+  switch (args.numRings) {
+    case 1:
+      runReduceScatter<1>(args);
+      break;
+    case 2:
+      runReduceScatter<2>(args);
+      break;
+    case 4:
+      runReduceScatter<4>(args);
+      break;
+    default:
+      break;
+  }
+}
+
+__global__
+__launch_bounds__(ctran::allreduce::pipesflatring::kBlockSize, 1) void ctranKernelAllReducePipesFlatRingAllGather(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::pipesflatring::KernArgs args) {
+  if (blockIdx.x >= args.numBlocks) {
+    return;
+  }
+
+  switch (args.numRings) {
+    case 1:
+      runAllGather<1>(args);
+      break;
+    case 2:
+      runAllGather<2>(args);
+      break;
+    case 4:
+      runAllGather<4>(args);
+      break;
+    default:
+      break;
+  }
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cuh
@@ -1,0 +1,55 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include <cstddef>
+
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/pipes/Timeout.cuh"
+
+namespace comms::pipes {
+class P2pIbgdaTransportDevice;
+}
+
+namespace ctran::allreduce::pipesflatring {
+
+static constexpr int kBlockSize = 512;
+static constexpr int kTileElems = 16384;
+static constexpr int kMaxRings = 4;
+
+struct Ring {
+  int prevRank{0};
+  int nextRank{0};
+  comms::pipes::P2pIbgdaTransportDevice* prev{nullptr};
+  comms::pipes::P2pIbgdaTransportDevice* next{nullptr};
+};
+
+struct KernArgs {
+  const float* sendbuff{nullptr};
+  float* recvbuff{nullptr};
+  size_t count{0};
+  size_t chunkElements{0};
+  int rank{0};
+  int nRanks{0};
+  int numRings{0};
+  int numBlocks{0};
+  size_t signalingDataSize{0};
+  comms::pipes::Timeout timeout{};
+  Ring rings[kMaxRings]{};
+};
+
+} // namespace ctran::allreduce::pipesflatring
+
+__global__ void ctranKernelAllReducePipesFlatRingReduceScatter(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::pipesflatring::KernArgs args);
+
+__global__ void ctranKernelAllReducePipesFlatRingAllGather(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::pipesflatring::KernArgs args);
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/logger/LogUtils.h"
+
+commResult_t ctranAllReduceTree(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  CLOGF(ERR, "AllReduce ctree algorithm is not yet implemented");
+  return commResult_t::commInternalError;
+}

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -1,8 +1,31 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <algorithm>
+#include <climits>
+
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/topo/CtranTreeBuilder.h"
 #include "comms/utils/logger/LogUtils.h"
+
+namespace {
+
+template <typename NodeToRank>
+void populateTreeTopology(
+    ctran::allreduce::TreeTopology& dst,
+    const ctran::algos::topo::TreeNeighbors& src,
+    const NodeToRank& nodeToRank) {
+  dst.parentRank = nodeToRank(src.parent);
+  dst.numChildren = src.numChildren;
+  dst.isRoot = src.isRoot();
+  dst.isLeaf = src.isLeaf();
+  for (int c = 0; c < src.numChildren; c++) {
+    dst.childRanks[c] = nodeToRank(src.children[c]);
+  }
+}
+
+} // namespace
 
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
@@ -13,6 +36,90 @@ commResult_t ctranAllReduceTree(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout) {
-  CLOGF(ERR, "AllReduce ctree algorithm is not yet implemented");
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int localRank = statex->localRank();
+  const int nodeId = statex->node();
+
+  // Single rank: just copy
+  if (nRanks == 1) {
+    if (sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * commTypeSize(datatype),
+          cudaMemcpyDeviceToDevice,
+          stream));
+    }
+    return commSuccess;
+  }
+
+  // Compute P_min: minimum nLocalRanks across all nodes
+  int pMin = INT_MAX;
+  for (int n = 0; n < nNodes; n++) {
+    int someRankOnNode = statex->localRankToRank(0, n);
+    pMin = std::min(pMin, statex->nLocalRanks(someRankOnNode));
+  }
+
+  const size_t segmentElems = (count + pMin - 1) / pMin;
+  const bool participatesInIB = (localRank < pMin);
+  const int fanOut = 2; // binary trees for V1
+
+  // Build dual trees (in node-space: 0..nNodes-1)
+  ctran::allreduce::TreeTopology tree0{};
+  ctran::allreduce::TreeTopology tree1{};
+
+  if (participatesInIB && nNodes > 1) {
+    int nodeRank = nodeId;
+    auto [t0, t1] =
+        ctran::algos::topo::buildDualKaryTree(nNodes, nodeRank, fanOut);
+
+    // Map node-space neighbors to communicator ranks
+    auto nodeToRank = [&](int node) -> int {
+      if (node < 0) {
+        return -1;
+      }
+      return statex->localRankToRank(localRank, node);
+    };
+
+    populateTreeTopology(tree0, t0, nodeToRank);
+    populateTreeTopology(tree1, t1, nodeToRank);
+  } else if (participatesInIB && nNodes == 1) {
+    // Single node: no IB tree needed, Phase 2 is a no-op
+    tree0.isRoot = true;
+    tree0.isLeaf = true;
+    tree1.isRoot = true;
+    tree1.isLeaf = true;
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce ctree: rank {} localRank {} nNodes {} pMin {} "
+      "segmentElems {} participatesInIB {} "
+      "tree0[parent={} children={} root={} leaf={}] "
+      "tree1[parent={} children={} root={} leaf={}]",
+      rank,
+      localRank,
+      nNodes,
+      pMin,
+      segmentElems,
+      participatesInIB,
+      tree0.parentRank,
+      tree0.numChildren,
+      tree0.isRoot,
+      tree0.isLeaf,
+      tree1.parentRank,
+      tree1.numChildren,
+      tree1.isRoot,
+      tree1.isLeaf);
+
+  // TODO: Populate kernel args and launch kernel (Diffs 4+5)
+  CLOGF(ERR, "AllReduce ctree kernel not yet implemented");
   return commResult_t::commInternalError;
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -2,12 +2,21 @@
 
 #include <algorithm>
 #include <climits>
+#include <memory>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+#include "comms/ctran/gpe/CtranGpe.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PIPES)
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#endif
 
 namespace {
 
@@ -25,8 +34,73 @@ void populateTreeTopology(
   }
 }
 
+/** Return whether the ctree device kernel supports `datatype`. */
+bool isSupportedTreeType(commDataType_t datatype) {
+  return datatype == commFloat32 || datatype == commFloat16;
+}
+
+/** Return whether this is an nccl-tests control communicator. */
+bool isNcclTestsSyncComm(CtranComm* comm) {
+  const auto& commDesc = comm->statex_->commDesc();
+  return commDesc == "nccl-tests-suite-global-sync-comm" ||
+      commDesc == "nccl-tests-suite-sync-comm";
+}
+
+/** Return the tree fanout for this run; default to NCCL-like binary trees. */
+int getAllReduceTreeFanOut() {
+  constexpr int kDefaultFanOut = 2;
+  const int fanOut = NCCL_CTRAN_TREE_FANOUT;
+  if (fanOut >= 1 && fanOut <= ctran::algos::topo::kMaxTreeChildren) {
+    return fanOut;
+  }
+
+  CLOGF(
+      WARN,
+      "Ignoring invalid NCCL_CTRAN_TREE_FANOUT={} for ctree fanout; using {}",
+      fanOut,
+      kDefaultFanOut);
+  return kDefaultFanOut;
+}
+
+#if defined(ENABLE_PIPES)
+/** Return the topology-wide cap for CTREE logical CUDA blocks. */
+int getAllReduceTreeNumBlockCap() {
+  return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
+}
+
+/**
+ * Select the number of independent data tiles for this launch.
+ *
+ * The algorithm is correct with one tile block. Larger values only expose more
+ * tile parallelism. `NCCL_CTRAN_MAX_NBLOCKS` caps the default policy. The
+ * automatic policy starts at the cap, then reduces the number of blocks while
+ * the message has less than one block-threshold of work per block.
+ */
+int getAllReduceTreeNumBlocks(size_t totalBytes) {
+  const int cap = getAllReduceTreeNumBlockCap();
+  const size_t perBlockThresholdBytes =
+      static_cast<size_t>(ctran::allreduce::tree::kBlockSize) * 64;
+
+  int numBlocks = cap;
+  while (numBlocks > 1 &&
+         totalBytes < static_cast<size_t>(numBlocks) * perBlockThresholdBytes) {
+    numBlocks--;
+  }
+  return numBlocks;
+}
+#endif
+
 } // namespace
 
+/**
+ * Run CTRAN tree AllReduce using NVL reduce-scatter, dual IB trees, and NVL
+ * all-gather.
+ *
+ * The tensor is split across `pMin` owner ranks per node. Each owner segment is
+ * further partitioned into logical CUDA blocks so multiple blocks can process a
+ * segment concurrently while the two tree lanes operate on disjoint halves of
+ * each block-owned tile.
+ */
 commResult_t ctranAllReduceTree(
     const void* sendbuff,
     void* recvbuff,
@@ -47,7 +121,7 @@ commResult_t ctranAllReduceTree(
   const int localRank = statex->localRank();
   const int nodeId = statex->node();
 
-  // Single rank: just copy
+  // Single rank AllReduce is the identity for every datatype and reduction op.
   if (nRanks == 1) {
     if (sendbuff != recvbuff) {
       FB_CUDACHECK(cudaMemcpyAsync(
@@ -60,6 +134,41 @@ commResult_t ctranAllReduceTree(
     return commSuccess;
   }
 
+  if (isNcclTestsSyncComm(comm)) {
+    CLOGF(
+        DBG,
+        "AllReduce ctree delegates nccl-tests sync comm {} to ctdirect",
+        statex->commDesc());
+    return ctranAllReduceDirect(
+        sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+  }
+
+  if (redOp != commSum) {
+    CLOGF(ERR, "AllReduce ctree currently supports commSum only");
+    return commInvalidArgument;
+  }
+
+  if (!isSupportedTreeType(datatype)) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree unsupported datatype {}",
+        commDataTypeToString(datatype));
+    return commInvalidArgument;
+  }
+
+  if (nNodes > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+    return commInvalidArgument;
+  }
+  if (!NCCL_CTRAN_USE_PIPES) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+    return commInvalidArgument;
+  }
+
   // Compute P_min: minimum nLocalRanks across all nodes
   int pMin = INT_MAX;
   for (int n = 0; n < nNodes; n++) {
@@ -69,7 +178,7 @@ commResult_t ctranAllReduceTree(
 
   const size_t segmentElems = (count + pMin - 1) / pMin;
   const bool participatesInIB = (localRank < pMin);
-  const int fanOut = 2; // binary trees for V1
+  const int fanOut = getAllReduceTreeFanOut();
 
   // Build dual trees (in node-space: 0..nNodes-1)
   ctran::allreduce::TreeTopology tree0{};
@@ -101,7 +210,7 @@ commResult_t ctranAllReduceTree(
   CLOGF(
       DBG,
       "AllReduce ctree: rank {} localRank {} nNodes {} pMin {} "
-      "segmentElems {} participatesInIB {} "
+      "segmentElems {} fanOut {} participatesInIB {} "
       "tree0[parent={} children={} root={} leaf={}] "
       "tree1[parent={} children={} root={} leaf={}]",
       rank,
@@ -109,6 +218,7 @@ commResult_t ctranAllReduceTree(
       nNodes,
       pMin,
       segmentElems,
+      fanOut,
       participatesInIB,
       tree0.parentRank,
       tree0.numChildren,
@@ -119,7 +229,110 @@ commResult_t ctranAllReduceTree(
       tree1.isRoot,
       tree1.isLeaf);
 
-  // TODO: Populate kernel args and launch kernel (Diffs 4+5)
-  CLOGF(ERR, "AllReduce ctree kernel not yet implemented");
-  return commResult_t::commInternalError;
+#if defined(ENABLE_PIPES)
+  const int nLocalRanks = statex->nLocalRanks();
+  const size_t elementSize = commTypeSize(datatype);
+  const size_t totalBytes = count * elementSize;
+  const size_t segmentBytes = segmentElems * elementSize;
+  const bool hasIbPhase = participatesInIB && nNodes > 1;
+  const int numBlocks = getAllReduceTreeNumBlocks(totalBytes);
+  if (hasIbPhase) {
+    const int maxIbGroups = NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS;
+    const int requiredIbGroups = numBlocks * ctran::allreduce::tree::kTreeLanes;
+    if (requiredIbGroups > maxIbGroups) {
+      CLOGF(
+          ERR,
+          "AllReduce ctree requires {} IBGDA send/recv groups, exceeding "
+          "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+          requiredIbGroups,
+          maxIbGroups);
+      return commInvalidArgument;
+    }
+  }
+
+  // phase2Buf holds the locally-reduced segment from Phase 1 and serves as
+  // the working buffer for Phase 2's reduce-up + broadcast-down. Non-owner
+  // local ranks do not dereference phase2Buf, but keep it inside the user
+  // buffer so the kernel never receives an out-of-range pointer in
+  // heterogeneous topologies.
+  void* phase2Buf = recvbuff;
+  if (participatesInIB) {
+    phase2Buf = static_cast<char*>(recvbuff) +
+        static_cast<size_t>(localRank) * segmentBytes;
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce ctree launch: totalBytes {} segmentBytes {} numBlocks {} "
+      "threadsPerBlock {} hasIbPhase {}",
+      totalBytes,
+      segmentBytes,
+      numBlocks,
+      ctran::allreduce::tree::kBlockSize,
+      hasIbPhase);
+
+  auto opCount = comm->ctran_->getOpCount();
+
+  // Populate kernel args
+  ctran::allreduce::tree::KernArgs kernArgs{};
+  kernArgs.sendbuff = sendbuff;
+  kernArgs.recvbuff = recvbuff;
+  kernArgs.phase2Buf = phase2Buf;
+  kernArgs.count = count;
+  kernArgs.segmentElems = segmentElems;
+  kernArgs.nNodes = nNodes;
+  kernArgs.pMin = pMin;
+  kernArgs.nLocalRanks = nLocalRanks;
+  kernArgs.localRank = localRank;
+  kernArgs.numBlocks = numBlocks;
+  kernArgs.datatype = datatype;
+  kernArgs.redOp = redOp;
+  kernArgs.transports = comm->getMultiPeerTransportsPtr();
+  if (kernArgs.transports == nullptr) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: getMultiPeerTransportsPtr() returned null — "
+        "Pipes transport not initialized. Ensure ENABLE_PIPES is defined "
+        "and multiPeerTransport is set up.");
+    return commInternalError;
+  }
+  kernArgs.tree0 = tree0;
+  kernArgs.tree1 = tree1;
+
+  // Build local rank -> global rank mapping
+  if (nLocalRanks > CTRAN_MAX_NVL_PEERS) {
+    CLOGF(
+        ERR,
+        "AllReduce ctree: nLocalRanks {} exceeds CTRAN_MAX_NVL_PEERS {}",
+        nLocalRanks,
+        CTRAN_MAX_NVL_PEERS);
+    return commInternalError;
+  }
+  for (int lr = 0; lr < nLocalRanks; lr++) {
+    kernArgs.localRankToGlobalRank[lr] = statex->localRankToRank(lr);
+  }
+
+  KernelConfig config(
+      KernelConfig::KernelType::ALLREDUCE, stream, "AllReduceTree", opCount);
+
+  config.numBlocks = static_cast<unsigned int>(numBlocks);
+  config.numThreads = ctran::allreduce::tree::kBlockSize;
+  config.args.devState_d = comm->ctran_->algo->getDevState();
+  config.algoArgs = &kernArgs;
+
+  // Device kernel drives all NVL and IB transport progress; no host-side GPE
+  // opGroup is needed.
+  std::vector<std::unique_ptr<struct OpElem>> opGroup;
+
+  FB_COMMCHECK(comm->ctran_->gpe->submit(
+      std::move(opGroup),
+      nullptr,
+      config,
+      reinterpret_cast<void*>(ctranKernelAllReduceTree)));
+
+  return commSuccess;
+#else
+  CLOGF(ERR, "AllReduce ctree requires ENABLE_PIPES");
+  return commInternalError;
+#endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cu
@@ -1,0 +1,842 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PIPES)
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <cstdint>
+
+#include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/P2pIbgdaTransportDevice.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/Tile.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/Transport.cuh"
+
+/** Elements processed by one NVL tile operation in the reduction helpers. */
+static constexpr int kNvlTileElems = 15360;
+/** Elements processed by one IB tile operation in the reduction helpers. */
+static constexpr int kIbTileElems = 5120;
+
+/** Return true when a pointer satisfies the tile API's 16-byte alignment. */
+__device__ __forceinline__ bool isAligned16(const void* ptr) {
+  return (reinterpret_cast<uintptr_t>(ptr) & 15) == 0;
+}
+
+/**
+ * Accumulate `staging` into `accum` without assuming tile alignment.
+ *
+ * This path covers small buffers and tails where using the Pipes tile API is
+ * not profitable or not legal.
+ */
+template <typename T>
+__device__ __forceinline__ void scalarReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  for (size_t i = group.thread_id_in_group; i < nelems; i += group.group_size) {
+    accum[i] += staging[i];
+  }
+}
+
+/**
+ * Accumulate `staging` into `accum` using Pipes tiles when alignment allows.
+ */
+template <typename T, int kTileElems, int kGroupSize>
+__device__ __forceinline__ void tileReduce(
+    T* accum,
+    const T* staging,
+    size_t nelems,
+    comms::pipes::ThreadGroup& group) {
+  if (!isAligned16(accum) || !isAligned16(staging) || nelems < kTileElems) {
+    scalarReduce(accum, staging, nelems, group);
+    return;
+  }
+
+  const size_t nFullTiles = nelems / kTileElems;
+  const size_t rem = nelems % kTileElems;
+
+  for (size_t t = 0; t < nFullTiles; t++) {
+    auto acc =
+        comms::pipes::tile_load<T, kTileElems, kGroupSize>(accum, t, group);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, t, group);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(accum, t, acc, group);
+  }
+  if (rem > 0) {
+    auto acc = comms::pipes::tile_load<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, group, rem);
+    comms::pipes::
+        tile_load_accumulate<T, comms::pipes::SumOp, kTileElems, kGroupSize>(
+            acc, staging, nFullTiles, group, rem);
+    comms::pipes::tile_store<T, kTileElems, kGroupSize>(
+        accum, nFullTiles, acc, group, rem);
+  }
+}
+
+/**
+ * Copy operation used by cooperative NVL receives in Phase 1.
+ *
+ * The transport writes the remote payload into staging first; this functor
+ * then combines that staged payload with the current local input for the same
+ * segment and writes the result into `dst`. Aligned slices use the tile
+ * reduction path; unaligned tail segments fall back to scalar reduction
+ * because the Pipes tile API requires 16-byte-aligned pointers.
+ */
+template <typename T>
+struct TreeNvlReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t byteOffset,
+      const char* localInput,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* out = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const T* local = reinterpret_cast<const T*>(localInput + byteOffset);
+    const size_t nelems = nbytes / sizeof(T);
+
+    if (out != local) {
+      for (size_t i = group.thread_id_in_group; i < nelems;
+           i += group.group_size) {
+        out[i] = local[i];
+      }
+      group.sync();
+    }
+    tileReduce<T, kNvlTileElems, ctran::allreduce::tree::kBlockSize>(
+        out, staged, nelems, group);
+#endif
+  }
+};
+
+/**
+ * Copy operation used by IBGDA child receives in Phase 2.
+ *
+ * IBGDA owns the transient recv staging ring. CTREE must consume that staging
+ * inside this callback before the transport acknowledges and reuses the slot.
+ */
+template <typename T>
+struct TreeIbReduceCopy {
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::pipes::ThreadGroup& group,
+      size_t /* byteOffset */,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* accum = reinterpret_cast<T*>(dst);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const size_t nelems = nbytes / sizeof(T);
+
+    tileReduce<T, kIbTileElems, ctran::allreduce::tree::kBlockSize>(
+        accum, staged, nelems, group);
+#endif
+  }
+};
+
+// ============================================================================
+// Phase 1: NVL ReduceScatter (AllToFewer pattern)
+//
+// Each GPU's input tensor M is partitioned into pMin segments of size
+// segmentElems. All nLocalRanks GPUs participate. The first pMin GPUs
+// (segment owners) each hold one locally-reduced segment after this phase.
+//
+// Communication: for each peer, the paired send/recv operations happen
+// simultaneously. We iterate peers in a rotating order so that at each step,
+// sends and recvs are correctly paired across GPUs.
+//
+// Owners: self-copy own segment to phase2Buf, then recv-reduce from each peer.
+// Non-owners: send segment data for each owner to that owner.
+// ============================================================================
+/**
+ * Compute the actual number of elements in a segment, including tail handling.
+ */
+__device__ __forceinline__ size_t
+actualSegElems(size_t count, size_t segmentElems, int rank) {
+  const size_t start = static_cast<size_t>(rank) * segmentElems;
+  if (start >= count) {
+    return 0;
+  }
+  return (start + segmentElems <= count) ? segmentElems : (count - start);
+}
+
+/**
+ * Convert the physical block group into the logical num-block group used by
+ * cooperative Pipes operations.
+ */
+__device__ __forceinline__ comms::pipes::ThreadGroup
+logicalDataGroup(comms::pipes::ThreadGroup group, int blockId, int numBlocks) {
+  group.group_id = static_cast<uint32_t>(blockId);
+  group.total_groups = static_cast<uint32_t>(numBlocks);
+  return group;
+}
+
+/**
+ * Tile view for one logical segment owned by the current num-block group.
+ */
+struct SegmentTile {
+  size_t offsetBytes;
+  size_t bytes;
+};
+
+__device__ __forceinline__ SegmentTile
+segmentTileForBlock(size_t totalBytes, int numBlocks, int blockId) {
+  comms::pipes::TiledBuffer<char> tile(nullptr, totalBytes, numBlocks);
+  return SegmentTile{
+      .offsetBytes = static_cast<size_t>(blockId) * tile.tile_elements,
+      .bytes = tile.tile_bytes(blockId),
+  };
+}
+
+__device__ __forceinline__ SegmentTile
+segmentTile(size_t totalBytes, const comms::pipes::ThreadGroup& group) {
+  return segmentTileForBlock(totalBytes, group.total_groups, group.group_id);
+}
+
+/**
+ * Return the largest owner tile participating in local NVL exchange.
+ */
+template <typename T>
+__device__ __forceinline__ size_t maxOwnerTileBytes(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t maxBytes = 0;
+  for (int owner = 0; owner < args.pMin; owner++) {
+    const size_t ownerElems =
+        actualSegElems(args.count, args.segmentElems, owner);
+    const auto ownerTile = segmentTile(ownerElems * sizeof(T), group);
+    maxBytes = ownerTile.bytes > maxBytes ? ownerTile.bytes : maxBytes;
+  }
+  return maxBytes;
+}
+
+/**
+ * Return a pipeline window that is valid for all local NVL peers.
+ */
+__device__ __forceinline__ size_t nvlPipelineWindow(
+    const ctran::allreduce::tree::KernArgs& args,
+    const comms::pipes::ThreadGroup& group) {
+  size_t window = 0;
+  for (int peer = 0; peer < args.nLocalRanks; peer++) {
+    if (peer == args.localRank) {
+      continue;
+    }
+    const int peerGlobalRank = args.localRankToGlobalRank[peer];
+    const size_t peerWindow =
+        args.transports[peerGlobalRank].p2p_nvl.pipeline_window(
+            group.total_groups);
+    window = window == 0 || peerWindow < window ? peerWindow : window;
+  }
+  return window;
+}
+
+/**
+ * Return the byte count for the current pipeline step.
+ */
+__device__ __forceinline__ size_t
+pipelineStepBytes(size_t totalBytes, size_t offset, size_t pipelineWindow) {
+  const size_t remaining = totalBytes - offset;
+  return remaining < pipelineWindow ? remaining : pipelineWindow;
+}
+
+template <typename T>
+__device__ __noinline__ void phase1ReduceScatter(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  const char* sendbuff = static_cast<const char*>(args.sendbuff);
+  char* phase2Buf = static_cast<char*>(args.phase2Buf);
+
+  comms::pipes::Timeout timeout{};
+
+  // Every owner initializes its tile before receiving peer contributions. The
+  // tile view is derived from the group identity, so numBlocks=1 is just the
+  // degenerate full-segment tile.
+  SegmentTile myTile{};
+  bool copiedLocalTile = false;
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+    const size_t mySegmentOffset =
+        static_cast<size_t>(localRank) * segmentBytes;
+    const char* src = sendbuff + mySegmentOffset + myTile.offsetBytes;
+    char* dst = phase2Buf + myTile.offsetBytes;
+    if (myTile.bytes > 0 && dst != src) {
+      comms::pipes::memcpy_vectorized(dst, src, myTile.bytes, group);
+      copiedLocalTile = true;
+    }
+  }
+
+  if (nLocalRanks <= 1) {
+    // Local-only topology has no NVL traffic. Synchronize only when this block
+    // copied out-of-place data that Phase 2 may read immediately.
+    if (copiedLocalTile) {
+      group.sync();
+    }
+    return;
+  }
+
+  group.sync();
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 1 NVL reduce-scatter pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  char* myDst = phase2Buf + myTile.offsetBytes;
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.send(
+          group,
+          sendbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.recv<TreeNvlReduceCopy<T>>(
+            group,
+            myDst + off,
+            window,
+            group.total_groups,
+            0,
+            timeout,
+            myDst + off);
+      }
+    }
+  }
+}
+
+enum class TreeLanePhase : uint8_t {
+  ReduceLeafSend,
+  ReduceRecvChild,
+  ReduceInternalSend,
+  BcastRootSendChild,
+  BcastInternalRecv,
+  BcastInternalSendChild,
+  BcastLeafRecv,
+  Done,
+};
+
+__device__ __forceinline__ TreeLanePhase
+firstReducePhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  return tree.isLeaf ? TreeLanePhase::ReduceLeafSend
+                     : TreeLanePhase::ReduceRecvChild;
+}
+
+__device__ __forceinline__ TreeLanePhase
+firstBcastPhase(const ctran::allreduce::TreeTopology& tree) {
+  if (tree.isRoot && tree.isLeaf) {
+    return TreeLanePhase::Done;
+  }
+  if (tree.isRoot) {
+    return TreeLanePhase::BcastRootSendChild;
+  }
+  return tree.isLeaf ? TreeLanePhase::BcastLeafRecv
+                     : TreeLanePhase::BcastInternalRecv;
+}
+
+/**
+ * Persistent state for one half of the dual IB tree.
+ *
+ * A full CUDA block repeatedly calls `progressTreeLane()` for both lane states.
+ * Each call performs at most one bounded transport step or one local reduction
+ * step, and returns immediately if the current transport dependency is not
+ * ready.
+ */
+template <typename T>
+struct TreeLaneProgressState {
+  ctran::allreduce::TreeTopology tree;
+  T* dataBuf{nullptr};
+  size_t dataBytes{0};
+  size_t pipelineWindow{0};
+  size_t offsetBytes{0};
+  int activeBlocks{0};
+  int childIdx{0};
+  bool ibOpActive{false};
+  TreeLanePhase phase{TreeLanePhase::Done};
+  comms::pipes::IbgdaSendRecvProgressState ibOp{};
+};
+
+template <typename T>
+__device__ __forceinline__ size_t
+currentLaneWindowBytes(const TreeLaneProgressState<T>& state) {
+  return pipelineStepBytes(
+      state.dataBytes, state.offsetBytes, state.pipelineWindow);
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceReduceWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.offsetBytes = 0;
+    state.phase = firstBcastPhase(state.tree);
+  } else {
+    state.phase = firstReducePhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ void advanceBcastWindow(
+    TreeLaneProgressState<T>& state) {
+  state.offsetBytes += currentLaneWindowBytes(state);
+  state.childIdx = 0;
+  state.ibOpActive = false;
+  if (state.offsetBytes >= state.dataBytes) {
+    state.phase = TreeLanePhase::Done;
+  } else {
+    state.phase = firstBcastPhase(state.tree);
+  }
+}
+
+template <typename T>
+__device__ __forceinline__ TreeLaneProgressState<T> makeTreeLaneState(
+    const ctran::allreduce::tree::KernArgs& args,
+    const ctran::allreduce::TreeTopology& tree,
+    T* dataBuf,
+    size_t dataElems,
+    int activeBlocks) {
+  TreeLaneProgressState<T> state{};
+  state.tree = tree;
+  state.dataBuf = dataBuf;
+  state.dataBytes = dataElems * sizeof(T);
+  state.activeBlocks = activeBlocks;
+
+  if (state.dataBytes == 0) {
+    state.phase = TreeLanePhase::Done;
+    return state;
+  }
+
+  state.pipelineWindow = state.dataBytes;
+  if (!tree.isLeaf && tree.numChildren > 0) {
+    auto* t = args.transports[tree.childRanks[0]].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  } else if (!tree.isRoot && tree.parentRank >= 0) {
+    auto* t = args.transports[tree.parentRank].p2p_ibgda;
+    state.pipelineWindow = t->pipeline_window(activeBlocks);
+  }
+  PIPES_DEVICE_CHECK_MSG(
+      state.pipelineWindow != 0, "ctree Phase 2 IB pipeline window is zero");
+  state.phase = firstReducePhase(tree);
+  return state;
+}
+
+template <typename T>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneSend(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    const char* src,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    state.ibOp = transport->init_send_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_send_once(group, state.ibOp, src, timeout);
+}
+
+template <typename T, typename CopyOp = comms::pipes::Memcpy>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressLaneRecv(
+    TreeLaneProgressState<T>& state,
+    comms::pipes::P2pIbgdaTransportDevice* transport,
+    char* dst,
+    size_t bytes,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  if (!state.ibOpActive) {
+    state.ibOp = transport->init_recv_progress(
+        group, bytes, state.activeBlocks, 0 /* max_signal_bytes */);
+    state.ibOpActive = true;
+  }
+  return transport->progress_recv_once<CopyOp>(group, state.ibOp, dst, timeout);
+}
+
+template <typename T, int kGroupSize>
+__device__ __forceinline__ comms::pipes::IbgdaSendRecvProgressStatus
+progressTreeLane(
+    const ctran::allreduce::tree::KernArgs& args,
+    TreeLaneProgressState<T>& state,
+    comms::pipes::ThreadGroup& group,
+    const comms::pipes::Timeout& timeout) {
+  using comms::pipes::IbgdaSendRecvProgressStatus;
+
+  if (state.phase == TreeLanePhase::Done) {
+    return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  const size_t window = currentLaneWindowBytes(state);
+  char* const data = reinterpret_cast<char*>(state.dataBuf) + state.offsetBytes;
+
+  switch (state.phase) {
+    case TreeLanePhase::ReduceLeafSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceRecvChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        if (state.tree.isRoot) {
+          advanceReduceWindow(state);
+        } else {
+          state.phase = TreeLanePhase::ReduceInternalSend;
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status = progressLaneRecv<T, TreeIbReduceCopy<T>>(
+          state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          if (state.tree.isRoot) {
+            advanceReduceWindow(state);
+          } else {
+            state.phase = TreeLanePhase::ReduceInternalSend;
+          }
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::ReduceInternalSend: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneSend(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceReduceWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastRootSendChild:
+    case TreeLanePhase::BcastInternalSendChild: {
+      if (state.childIdx >= state.tree.numChildren) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      auto* childTransport =
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+      const auto status =
+          progressLaneSend(state, childTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx++;
+        if (state.childIdx >= state.tree.numChildren) {
+          advanceBcastWindow(state);
+        }
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastInternalRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        state.ibOpActive = false;
+        state.childIdx = 0;
+        state.phase = TreeLanePhase::BcastInternalSendChild;
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::BcastLeafRecv: {
+      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      const auto status = progressLaneRecv(
+          state, parentTransport, data, window, group, timeout);
+      if (status == IbgdaSendRecvProgressStatus::Done) {
+        advanceBcastWindow(state);
+        return IbgdaSendRecvProgressStatus::Progressed;
+      }
+      return status;
+    }
+    case TreeLanePhase::Done:
+      return IbgdaSendRecvProgressStatus::Done;
+  }
+
+  return IbgdaSendRecvProgressStatus::Waiting;
+}
+
+// ============================================================================
+// Phase 2: Inter-Node IB Dual Tree AllReduce
+//
+// Tree-0 operates on the first half of each block-owned tile and Tree-1 on the
+// second half. One 640-thread block cooperatively drives both tree lanes from
+// a progress loop. Each lane uses a disjoint transport group id; if one lane
+// is waiting on a remote signal or free transport staging slot, its progress
+// call returns immediately and the same block tries the other lane.
+//
+// Only GPUs with localRank < pMin participate. Non-owners skip this phase.
+// Single-node case (nNodes == 1) is a no-op (root-and-leaf in both trees).
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase2IbDualTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& blockGroup) {
+  if (args.localRank >= args.pMin) {
+    return;
+  }
+
+  // Single-node: both trees have isRoot && isLeaf — nothing to do. Phase 1
+  // already wrote the segment slice into recvbuff.
+  if (args.nNodes <= 1) {
+    return;
+  }
+
+  const size_t actualElems =
+      actualSegElems(args.count, args.segmentElems, args.localRank);
+  const auto tile = segmentTile(actualElems * sizeof(T), blockGroup);
+  const size_t tileOffsetElems = tile.offsetBytes / sizeof(T);
+  const size_t tileElems = tile.bytes / sizeof(T);
+
+  // If the whole segment has at most one element per block, lane 1 would be
+  // empty for every block. Compress transport group ids to a single lane for
+  // that tiny-message shape; otherwise keep the stable two-lane mapping.
+  const bool useSingleLane = actualElems <= static_cast<size_t>(args.numBlocks);
+  const int activeIbLanesPerBlock =
+      useSingleLane ? 1 : ctran::allreduce::tree::kTreeLanes;
+
+  const size_t halfElems0 = useSingleLane ? tileElems : (tileElems + 1) / 2;
+  const size_t halfElems1 = useSingleLane ? 0 : tileElems - halfElems0;
+  T* phase2Buf = static_cast<T*>(args.phase2Buf);
+  const int activeIbGroups = args.numBlocks * activeIbLanesPerBlock;
+
+  auto lane0Group = blockGroup;
+  lane0Group.group_id = blockGroup.group_id * activeIbLanesPerBlock;
+  lane0Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+  auto lane1Group = blockGroup;
+  lane1Group.group_id = blockGroup.group_id * activeIbLanesPerBlock + 1;
+  lane1Group.total_groups = static_cast<uint32_t>(activeIbGroups);
+
+  auto lane0 = makeTreeLaneState<T>(
+      args,
+      args.tree0,
+      phase2Buf + tileOffsetElems,
+      halfElems0,
+      activeIbGroups);
+  auto lane1 = makeTreeLaneState<T>(
+      args,
+      args.tree1,
+      phase2Buf + tileOffsetElems + halfElems0,
+      halfElems1,
+      activeIbGroups);
+
+  comms::pipes::Timeout timeout{};
+  bool lane0Active = lane0.phase != TreeLanePhase::Done;
+  bool lane1Active = lane1.phase != TreeLanePhase::Done;
+  while (lane0Active || lane1Active) {
+    if (lane0Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane0, lane0Group, timeout);
+      lane0Active = lane0.phase != TreeLanePhase::Done;
+    }
+    if (lane1Active) {
+      (void)progressTreeLane<T, ctran::allreduce::tree::kBlockSize>(
+          args, lane1, lane1Group, timeout);
+      lane1Active = lane1.phase != TreeLanePhase::Done;
+    }
+  }
+}
+
+// ============================================================================
+// Phase 3: NVL AllGather
+//
+// Segment owners broadcast their globally-reduced segment to all local peers.
+// After Phase 2, each owner's recvbuff contains its globally-reduced segment
+// at offset [localRank * segmentBytes].
+//
+// Communication: uses rotating-peer order for globally consistent pairing.
+// Owners send their segment; all GPUs receive from owners.
+// ============================================================================
+template <typename T>
+__device__ __noinline__ void phase3AllGather(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  const int localRank = args.localRank;
+  const int nLocalRanks = args.nLocalRanks;
+  const int pMin = args.pMin;
+  const size_t segmentElems = args.segmentElems;
+  const size_t segmentBytes = segmentElems * sizeof(T);
+
+  char* recvbuff = static_cast<char*>(args.recvbuff);
+
+  comms::pipes::Timeout timeout{};
+
+  if (nLocalRanks <= 1) {
+    return;
+  }
+
+  const size_t pipelineWindow = nvlPipelineWindow(args, group);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0,
+      "ctree Phase 3 NVL all-gather pipeline window is zero");
+
+  const size_t maxTileBytes = maxOwnerTileBytes<T>(args, group);
+  SegmentTile myTile{};
+  if (localRank < pMin) {
+    const size_t myActualElems =
+        actualSegElems(args.count, segmentElems, localRank);
+    myTile = segmentTile(myActualElems * sizeof(T), group);
+  }
+
+  for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
+    if (localRank < pMin && off < myTile.bytes) {
+      const size_t mySegmentOffset =
+          static_cast<size_t>(localRank) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+      for (int peer = 0; peer < nLocalRanks; peer++) {
+        if (peer == localRank) {
+          continue;
+        }
+        const int peerGlobalRank = args.localRankToGlobalRank[peer];
+        args.transports[peerGlobalRank].p2p_nvl.send(
+            group,
+            recvbuff + mySegmentOffset + myTile.offsetBytes + off,
+            window,
+            group.total_groups,
+            0,
+            timeout);
+      }
+    }
+
+    for (int owner = 0; owner < pMin; owner++) {
+      if (owner == localRank) {
+        continue;
+      }
+
+      const size_t ownerActualElems =
+          actualSegElems(args.count, segmentElems, owner);
+      const auto ownerTile = segmentTile(ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes) {
+        continue;
+      }
+
+      const int ownerGlobalRank = args.localRankToGlobalRank[owner];
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const size_t window =
+          pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+      args.transports[ownerGlobalRank].p2p_nvl.recv(
+          group,
+          recvbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          window,
+          group.total_groups,
+          0,
+          timeout);
+    }
+  }
+}
+
+/**
+ * Run the three ctree phases for one logical data tile.
+ *
+ * A tile is fully owned by one CUDA block. Multi-block launches only add more
+ * independent tiles; the algorithm does not require inter-block coordination.
+ */
+template <typename T>
+__device__ __forceinline__ void runAllReduceTree(
+    const ctran::allreduce::tree::KernArgs& args,
+    comms::pipes::ThreadGroup& group) {
+  phase1ReduceScatter<T>(args, group);
+  if (args.nLocalRanks > 1) {
+    group.sync();
+  }
+  if (args.nNodes > 1) {
+    phase2IbDualTree<T>(args, group);
+    if (args.nLocalRanks > 1) {
+      group.sync();
+    }
+  }
+  if (args.nLocalRanks > 1) {
+    phase3AllGather<T>(args, group);
+  }
+}
+
+// ============================================================================
+// Main kernel: dispatches datatype then runs Phase 1, both Phase 2 tree lanes,
+// and Phase 3 for the block-owned tile.
+// ============================================================================
+__global__
+__launch_bounds__(ctran::allreduce::tree::kBlockSize, 1) void ctranKernelAllReduceTree(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::tree::KernArgs args) {
+  auto blockGroup = comms::pipes::make_block_group();
+  const int blockId = static_cast<int>(blockIdx.x);
+  if (blockId >= args.numBlocks) {
+    return;
+  }
+  auto group = logicalDataGroup(blockGroup, blockId, args.numBlocks);
+
+  if (args.datatype == commFloat32) {
+    runAllReduceTree<float>(args, group);
+  } else if (args.datatype == commFloat16) {
+    runAllReduceTree<__half>(args, group);
+  }
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cuh
@@ -1,0 +1,93 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/ctran/algos/AllReduce/Types.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/topo/TreeConstants.h"
+#include "comms/utils/commSpecs.h"
+
+namespace comms::pipes {
+struct Transport;
+}
+
+namespace ctran::allreduce::tree {
+
+/** Number of independent inter-node tree lanes in the dual-tree phase. */
+static constexpr int kTreeLanes = 2;
+
+/** CUDA threads per block used by the ctree kernel. */
+static constexpr int kBlockSize = 640;
+
+/**
+ * Device kernel arguments for the Pipes-backed CTRAN tree AllReduce.
+ *
+ * User buffers are owned by the caller. NVL and IB receive staging are owned by
+ * the Pipes transports and are consumed only inside transport copy callbacks.
+ */
+struct KernArgs {
+  /** User input buffer; may alias `recvbuff` for in-place AllReduce. */
+  const void* sendbuff;
+  /** User output buffer that receives the final reduced tensor. */
+  void* recvbuff;
+  /**
+   * Phase 2 working buffer.
+   *
+   * Segment owners write locally reduced segments here in Phase 1, the IB tree
+   * reads and writes the same buffer in Phase 2, and Phase 3 reads from it.
+   */
+  void* phase2Buf;
+
+  /** Total number of elements in the user tensor. */
+  size_t count;
+  /** Elements per owner segment, equal to `ceil(count / pMin)`. */
+  size_t segmentElems;
+
+  /** Number of nodes in the communicator. */
+  int nNodes;
+  /** Minimum number of local ranks across all nodes. */
+  int pMin;
+  /** Number of local ranks on this node. */
+  int nLocalRanks;
+  /** This GPU's local rank on its node. */
+  int localRank;
+  /** Number of logical data partitions processed by CUDA blocks per GPU. */
+  int numBlocks;
+
+  /** Collective datatype implemented by the kernel dispatch. */
+  commDataType_t datatype;
+  /** Reduction operation implemented by the kernel dispatch. */
+  commRedOp_t redOp;
+
+  /** Unified transport array containing NVL and IB transports by global rank.
+   */
+  comms::pipes::Transport* transports;
+
+  /** Inter-node tree used for the first half of each data partition. */
+  ctran::allreduce::TreeTopology tree0;
+  /** Inter-node tree used for the second half of each data partition. */
+  ctran::allreduce::TreeTopology tree1;
+
+  /** Maps local rank index `[0, nLocalRanks)` to global communicator rank. */
+  int localRankToGlobalRank[CTRAN_MAX_NVL_PEERS];
+};
+
+} // namespace ctran::allreduce::tree
+
+/**
+ * CUDA kernel entry point for CTRAN tree AllReduce.
+ *
+ * Each block owns one tile partition and runs Phase 1, both Phase 2 tree
+ * lanes, and Phase 3 for that tile. Phase 2 uses one full-block work group to
+ * poll and progress the two disjoint IB tree lanes cooperatively.
+ * Multi-block launches are independent tiling for performance; correctness
+ * does not require inter-block sync.
+ */
+__global__ void ctranKernelAllReduceTree(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::tree::KernArgs args);
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/ctran/algos/topo/TreeConstants.h"
 #include "comms/utils/commSpecs.h"
 
 // Forward declaration
@@ -36,6 +37,17 @@ struct KernelArgs {
   // IPC imported ptr to each of the local peers' RecvBuff
   void* intraNodeRemoteRecvBuffs[CTRAN_MAX_NVL_PEERS];
   KernelElem* kernelElems[ALLREDUCE_MAX_KERNEL_ELEMS];
+};
+
+// Tree topology for one half of the dual tree pair.
+// Holds communicator ranks — transport dispatch uses the shared Transport
+// array.
+struct TreeTopology {
+  int parentRank{-1};
+  int childRanks[ctran::algos::topo::kMaxTreeChildren]{-1, -1, -1};
+  int numChildren{0};
+  bool isRoot{false};
+  bool isLeaf{false};
 };
 
 } // namespace ctran::allreduce

--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -1,0 +1,136 @@
+# CTRAN AllReduce Algorithm Design
+
+This document describes the CTRAN AllReduce algorithm shape used by the current stack and records the details of the implemented tree-based path. The implementation is selected with `NCCL_ALLREDUCE_ALGO=ctree` and uses Pipes `MultiPeerTransport` for `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies.
+
+## Goals
+
+The CTRAN AllReduce path is structured as local reduction, cross-node reduction, and local publication phases. This keeps topology-specific pieces isolated enough that the cross-node phase can use a tree today and later grow ring or other implementations without changing the local phase contract.
+
+The current `ctree` implementation targets lower latency than ring-style inter-node traversal by reducing the IB phase to tree depth. It keeps correctness independent of CUDA inter-block synchronization: a single-block launch is valid for every supported topology, and additional blocks only add independent tile parallelism.
+
+The implementation currently supports `commSum` for `commFloat32` and `commFloat16`. Unsupported reduction ops and datatypes are rejected on the host.
+
+## Algorithm Overview
+
+1. **NVL ReduceScatter**: local GPUs reduce each owner segment into a per-owner Phase 2 buffer.
+2. **IB AllReduce**: active segment owners run the cross-node implementation for their segment. The current implementation is dual-tree.
+3. **NVL AllGather**: segment owners publish the globally reduced segments to local peers.
+
+Degenerate topology paths are skipped:
+
+- `nRanks == 1`: identity copy for out-of-place, no kernel launch for in-place.
+- `nLocalRanks <= 1`: NVL phases and NVL phase-transition sync are no-ops.
+- `nNodes == 1`: IB Phase 2 is a no-op.
+
+## Partitioning and Topology
+
+Let `pMin = min(nLocalRanks(node))` across nodes. The algorithm partitions the tensor into `pMin` owner segments. Local ranks `< pMin` own one segment and participate in the IB phase; extra local ranks on larger nodes contribute during NVL ReduceScatter and receive the final tensor during NVL AllGather, but do not join IB.
+
+Each owner segment is split across `numBlocks` logical CUDA blocks. Each block owns a disjoint segment tile. Inside the block tile, the IB phase splits data into two lane halves:
+
+- Lane 0: Tree-0 over the first half.
+- Lane 1: Tree-1 over the second half.
+
+No block owns data or staging used by another block.
+
+### Binary Dual Trees
+
+The implementation uses binary dual trees. Tree-0 is a BFS binary tree rooted at rank `0`. For even node counts, Tree-1 is the mirror of Tree-0 over rank space. For odd node counts, Tree-1 uses the shift-by-1 construction implemented by the topology builder.
+
+For the 8-rank `IB_ONLY` case, the exact topology is:
+
+```text
+Tree-0, rooted at rank 0:
+  0 -> {1, 2}
+  1 -> {3, 4}
+  2 -> {5, 6}
+  3 -> {7}
+
+Tree-1, mirrored and rooted at rank 7:
+  7 -> {6, 5}
+  6 -> {4, 3}
+  5 -> {2, 1}
+  4 -> {0}
+```
+
+The two trees process disjoint data halves and use disjoint staging slices and transport group IDs. They are intended to make concurrent progress, not to run Tree-0 to completion before Tree-1.
+
+## Phase Behavior
+
+### Phase 1: NVL ReduceScatter
+
+When `nLocalRanks > 1`, each local GPU contributes the segment data needed by each owner. Segment owners reduce local contributions into `phase2Buf`. The current implementation uses Pipes NVL transport staging because user buffers are not assumed to be directly usable as NVL transport buffers.
+
+When `nLocalRanks <= 1`, Phase 1 is a no-op and the IB tree reads directly from the local owner segment.
+
+### Phase 2: IB AllReduce
+
+The cross-node phase is the replaceable part of the design. Its contract is to reduce each owner segment across nodes and leave the globally reduced segment in the owner's Phase 2 buffer. The current implementation uses a dual-tree IB phase.
+
+#### Current Tree Implementation
+
+When `nNodes > 1`, each active owner rank runs the dual-tree phase. One full CUDA block services both tree lanes cooperatively. The block creates two virtual IB transport groups:
+
+```text
+groupId(lane) = blockIdx.x * 2 + lane
+```
+
+Each lane has its own data half, staging slice, and transport group ID. The scheduler calls bounded progress functions for lane 0 and lane 1 in a uniform loop. If a lane is waiting on `NIC_DONE`, `SLOT_FREE`, or `DATA_READY`, that progress attempt returns immediately and the block tries the other lane. This avoids serial tree-lane scheduling while keeping all threads in the block on a uniform control path.
+
+Internal tree nodes receive from all children through transport-owned staging, reduce local and child inputs, and then forward the reduced data upward. Broadcast then flows from root to leaves.
+
+### Phase 3: NVL AllGather
+
+When `nLocalRanks > 1`, segment owners publish globally reduced segments to all local peers using Pipes NVL transport. Each block waits for both IB lanes for its tile before publishing that tile locally. When `nLocalRanks <= 1`, Phase 3 is skipped.
+
+## Launch and Tiling Policy
+
+The kernel uses `640` CUDA threads per block. `numBlocks` is capped at `16` for H100 and current GB200/GB300 use. The default policy starts at the cap and reduces blocks for small messages while:
+
+```text
+totalBytes < numBlocks * 640 * 64
+```
+
+`NCCL_CTRAN_MAX_NBLOCKS` controls the cap and defaults to `16`, which keeps the tree implementation below the NCCL Tree CTA count used on the current H100 and GB200/GB300 validation setups.
+
+The implementation uses phase-specific tile widths:
+
+- `kNvlTileElems = 15360`
+- `kIbTileElems = 5120`
+
+Both are selected to satisfy Pipes tile divisibility constraints with `640`-thread blocks and the vector widths used by supported datatypes.
+
+## Staging and Memory Lifetime
+
+The tree implementation does not allocate message-size-dependent AllReduce staging. NVL and IB receives use Pipes transport-owned staging buffers, and the tree path consumes those transient staging slices inside transport copy callbacks before the transport acknowledges and reuses the slots.
+
+The IBGDA send/recv transport data buffer is configured by per-communicator hint or `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` when provided. The current validation and tuning use the Pipes default `32MiB` per-peer IBGDA data buffer.
+
+## Correctness Invariants
+
+- No inter-block synchronization is required or assumed.
+- Each block owns disjoint data and transport group IDs.
+- `group.sync()` is used only for block-local phase transitions.
+- In-place and out-of-place reductions use the same block ownership model; a block finishes the reads needed for its tile before that tile can be overwritten by later local publication.
+- Tail elements are handled by tile bounds and byte-count checks; only valid user elements are read or written.
+- All remote lane progress uses device-visible signaling and memory ordering from Pipes transport primitives.
+
+## Validation
+
+The integration test is algorithm-agnostic and validates numerical correctness plus bitwise deterministic output across repeated runs, not trace shape. It covers `NVL_ONLY`, `IB_ONLY`, and `HYBRID` topologies; world sizes `1`, `2`, `3`, `4`, `7`, and `8` for local single-host topologies; and zero, small, medium, large, and tail message sizes in both in-place and out-of-place modes.
+
+Latest local and RE validation, benchmark commands, and 8-rank performance tables are recorded in:
+
+- https://www.internalfb.com/intern/paste/P2354738362/
+- https://pxl.cl/9ZhCc
+
+The primary benchmark comparison is forced NCCL Tree against CTREE using the third-party `nccl_allreduce_perf` target. The latest H100 8-rank `IB_ONLY` sweep covers `4B` through `1G` with `#wrong = 0` for CTREE.
+
+## Further Work
+
+- **Performance tuning**: continue tuning launch shape, tile sizing, transport progress, and tiny-message overhead.
+- **LL protocol for IB**: add a lower-latency IB protocol for small payloads.
+- **NVLS-based ReduceScatter**: replace the current Phase 1 implementation with an NVLS-based local ReduceScatter path.
+- **Ring-based IB implementation**: add a ring implementation for the IB phase so the cross-node phase can choose between Ring and Tree implementations.
+- **Wider reduction ops and datatypes**: add support beyond the current `commSum` scope, with correctness tests and benchmark coverage across all topologies.
+- **Uneven `pMin` topology coverage**: add targeted validation for mixed local-rank-count topologies where extra local ranks contribute to NVL phases but do not participate in IB.

--- a/comms/ctran/algos/topo/CtranTreeBuilder.h
+++ b/comms/ctran/algos/topo/CtranTreeBuilder.h
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+#include <glog/logging.h>
+
+#include "comms/ctran/algos/topo/TreeConstants.h"
+
+namespace ctran::algos::topo {
+
+struct TreeNeighbors {
+  int parent{-1};
+  std::array<int, kMaxTreeChildren> children;
+  int numChildren{0};
+
+  TreeNeighbors() {
+    children.fill(-1);
+  }
+
+  bool isRoot() const {
+    return parent == -1;
+  }
+
+  bool isLeaf() const {
+    return numChildren == 0;
+  }
+};
+
+// Build a single k-ary tree over numNodes using BFS level-order assignment.
+// fanOut must be in [1, kMaxTreeChildren], which keeps parent and child
+// relationships representable by TreeNeighbors.
+static inline TreeNeighbors
+buildKaryTree(int numNodes, int nodeRank, int fanOut) {
+  CHECK_GE(fanOut, 1);
+  CHECK_LE(fanOut, kMaxTreeChildren);
+
+  if (numNodes <= 1) {
+    return TreeNeighbors{};
+  }
+
+  TreeNeighbors result;
+
+  // BFS-order k-ary tree: node i has parent (i-1)/k, children k*i+1 .. k*i+k
+  // This gives a complete k-ary tree with level-order node assignment.
+  if (nodeRank == 0) {
+    result.parent = -1;
+  } else {
+    result.parent = (nodeRank - 1) / fanOut;
+  }
+
+  for (int c = 0; c < fanOut && c < kMaxTreeChildren; c++) {
+    int child = fanOut * nodeRank + 1 + c;
+    if (child < numNodes) {
+      result.children[result.numChildren++] = child;
+    }
+  }
+
+  return result;
+}
+
+// Build dual complementary k-ary trees.
+//
+// For k=2 (binary):
+//   Tree-0: standard binary tree in BFS order.
+//   Tree-1 (even N): mirror — build tree over mapping r' = N-1-r, remap back.
+//   Tree-1 (odd N): shift-by-1 — build tree over mapping r' = (r-1+N)%N, remap
+//   back. Property: leaves in Tree-0 are internal nodes in Tree-1
+//   (phase-complementary).
+//
+// For k>2:
+//   Tree-0: standard k-ary tree.
+//   Tree-1: k-ary tree with shifted root (root at node N/2).
+//   Phase-complementary property is NOT guaranteed for k>2.
+static inline std::pair<TreeNeighbors, TreeNeighbors>
+buildDualKaryTree(int numNodes, int nodeRank, int fanOut = 2) {
+  if (numNodes <= 1) {
+    TreeNeighbors single;
+    return {single, single};
+  }
+
+  // Tree-0: standard k-ary tree
+  TreeNeighbors tree0 = buildKaryTree(numNodes, nodeRank, fanOut);
+
+  // Tree-1: complementary tree
+  TreeNeighbors tree1;
+
+  if (fanOut == 2) {
+    // Binary dual tree: mirror/shift construction
+    int mappedRank;
+    if (numNodes % 2 == 0) {
+      // Even N: mirror r' = N-1-r
+      mappedRank = numNodes - 1 - nodeRank;
+    } else {
+      // Odd N: shift r' = (r-1+N) % N
+      mappedRank = (nodeRank - 1 + numNodes) % numNodes;
+    }
+
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    // Remap results back
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      if (numNodes % 2 == 0) {
+        return numNodes - 1 - r;
+      } else {
+        return (r + 1) % numNodes;
+      }
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  } else {
+    // k>2: shifted root construction
+    int shift = numNodes / 2;
+    int mappedRank = (nodeRank - shift + numNodes) % numNodes;
+    TreeNeighbors mapped = buildKaryTree(numNodes, mappedRank, fanOut);
+
+    auto remap = [&](int r) -> int {
+      if (r < 0)
+        return -1;
+      return (r + shift) % numNodes;
+    };
+
+    tree1.parent = remap(mapped.parent);
+    tree1.numChildren = mapped.numChildren;
+    for (int c = 0; c < mapped.numChildren; c++) {
+      tree1.children[c] = remap(mapped.children[c]);
+    }
+  }
+
+  return {tree0, tree1};
+}
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/TreeConstants.h
+++ b/comms/ctran/algos/topo/TreeConstants.h
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace ctran::algos::topo {
+
+inline constexpr int kMaxTreeChildren = 3;
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
+++ b/comms/ctran/algos/topo/tests/CtranTreeBuilderTest.cc
@@ -1,0 +1,394 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <queue>
+#include <set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/ctran/algos/topo/CtranTreeBuilder.h"
+
+namespace ctran::algos::topo {
+
+class CtranTreeBuilderTest : public ::testing::Test {};
+
+// Verify that BFS from the unique root reaches all nodes exactly once.
+static void verifyConnectivity(
+    const std::vector<TreeNeighbors>& nodes,
+    int expectedRoot = -1) {
+  const int numNodes = static_cast<int>(nodes.size());
+  int rootCount = 0;
+  int rootIdx = -1;
+  for (int i = 0; i < numNodes; i++) {
+    if (nodes[i].isRoot()) {
+      rootCount++;
+      rootIdx = i;
+    }
+  }
+  ASSERT_EQ(rootCount, 1) << "Exactly one root expected";
+  if (expectedRoot >= 0) {
+    ASSERT_EQ(rootIdx, expectedRoot);
+  }
+
+  std::set<int> visited;
+  std::queue<int> bfs;
+  bfs.push(rootIdx);
+  visited.insert(rootIdx);
+
+  while (!bfs.empty()) {
+    int cur = bfs.front();
+    bfs.pop();
+    for (int c = 0; c < nodes[cur].numChildren; c++) {
+      int child = nodes[cur].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      ASSERT_EQ(visited.count(child), 0)
+          << "Node " << child << " visited twice (cycle or shared child)";
+      visited.insert(child);
+      bfs.push(child);
+    }
+  }
+
+  ASSERT_EQ(static_cast<int>(visited.size()), numNodes)
+      << "BFS did not reach all nodes. Reached " << visited.size() << " out of "
+      << numNodes;
+}
+
+// Verify that BFS from root reaches all N nodes exactly once.
+static void verifyConnectivity(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  verifyConnectivity(nodes, 0);
+}
+
+// Verify parent-child consistency: if A lists B as child, B must list A as
+// parent.
+static void verifyParentChildConsistency(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < nodes[i].numChildren; c++) {
+      int child = nodes[i].children[c];
+      ASSERT_GE(child, 0);
+      ASSERT_LT(child, numNodes);
+      EXPECT_EQ(nodes[child].parent, i)
+          << "Node " << i << " lists " << child
+          << " as child, but child's parent is " << nodes[child].parent;
+    }
+    if (nodes[i].parent >= 0) {
+      int par = nodes[i].parent;
+      bool found = false;
+      for (int c = 0; c < nodes[par].numChildren; c++) {
+        if (nodes[par].children[c] == i) {
+          found = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(found) << "Node " << i << " has parent " << par
+                         << " but parent does not list it as a child";
+    }
+  }
+}
+
+// Verify leaf/root roles are derived from parent and child count.
+static void verifyDerivedRoles(int numNodes, int fanOut) {
+  std::vector<TreeNeighbors> nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    nodes[i] = buildKaryTree(numNodes, i, fanOut);
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    EXPECT_EQ(nodes[i].isLeaf(), nodes[i].numChildren == 0)
+        << "Node " << i << ": isLeaf inconsistent with numChildren";
+    EXPECT_EQ(nodes[i].isRoot(), nodes[i].parent == -1)
+        << "Node " << i << ": isRoot inconsistent with parent";
+  }
+}
+
+static void verifyUnusedChildSlotsAreSentinels(
+    const TreeNeighbors& node,
+    int nodeRank) {
+  for (int c = node.numChildren; c < kMaxTreeChildren; c++) {
+    EXPECT_EQ(node.children[c], -1) << "Node " << nodeRank << " child slot "
+                                    << c << " should keep the sentinel value";
+  }
+}
+
+static int expectedTree1Root(int numNodes, int fanOut) {
+  if (numNodes <= 1) {
+    return 0;
+  }
+  if (fanOut == 2) {
+    return numNodes % 2 == 0 ? numNodes - 1 : 1;
+  }
+  return numNodes / 2;
+}
+
+// --- Single K-ary Tree Tests ---
+
+class KaryTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(KaryTreeTest, Connectivity) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyConnectivity(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, ParentChildConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyParentChildConsistency(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, FlagConsistency) {
+  auto [numNodes, fanOut] = GetParam();
+  verifyDerivedRoles(numNodes, fanOut);
+}
+
+TEST_P(KaryTreeTest, MaxChildrenRespected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    auto node = buildKaryTree(numNodes, i, fanOut);
+    EXPECT_LE(node.numChildren, fanOut);
+    EXPECT_LE(node.numChildren, kMaxTreeChildren);
+  }
+}
+
+TEST_P(KaryTreeTest, UnusedChildSlotsAreSentinels) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    verifyUnusedChildSlotsAreSentinels(buildKaryTree(numNodes, i, fanOut), i);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BinaryAndTernary,
+    KaryTreeTest,
+    ::testing::Values(
+        // (numNodes, fanOut)
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(1, 3),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(7, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(15, 3),
+        std::make_pair(16, 3),
+        std::make_pair(27, 3),
+        std::make_pair(32, 3),
+        std::make_pair(64, 3)));
+
+// --- Dual Tree Tests ---
+
+class DualTreeTest : public CtranTreeBuilderTest,
+                     public ::testing::WithParamInterface<std::pair<int, int>> {
+};
+
+TEST_P(DualTreeTest, BothTreesConnected) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int r = 0; r < numNodes; r++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, r, fanOut);
+    // Both trees should produce valid nodes
+    EXPECT_GE(t0.parent, -1);
+    EXPECT_GE(t1.parent, -1);
+    EXPECT_LE(t0.numChildren, fanOut);
+    EXPECT_LE(t1.numChildren, fanOut);
+  }
+
+  // Verify full connectivity for both trees independently
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+  verifyConnectivity(t0Nodes, 0);
+  verifyConnectivity(t1Nodes);
+}
+
+TEST_P(DualTreeTest, Tree1Connectivity) {
+  auto [numNodes, fanOut] = GetParam();
+  std::vector<TreeNeighbors> t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t1Nodes[i] = t1;
+  }
+
+  verifyConnectivity(t1Nodes, expectedTree1Root(numNodes, fanOut));
+}
+
+TEST_P(DualTreeTest, UnusedChildSlotsAreSentinels) {
+  auto [numNodes, fanOut] = GetParam();
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    verifyUnusedChildSlotsAreSentinels(t0, i);
+    verifyUnusedChildSlotsAreSentinels(t1, i);
+  }
+}
+
+TEST_P(DualTreeTest, ParentChildConsistencyBothTrees) {
+  auto [numNodes, fanOut] = GetParam();
+
+  // Verify Tree-0 consistency
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    for (int c = 0; c < t0Nodes[i].numChildren; c++) {
+      int child = t0Nodes[i].children[c];
+      EXPECT_EQ(t0Nodes[child].parent, i)
+          << "Tree-0 inconsistency at node " << i;
+    }
+    for (int c = 0; c < t1Nodes[i].numChildren; c++) {
+      int child = t1Nodes[i].children[c];
+      EXPECT_EQ(t1Nodes[child].parent, i)
+          << "Tree-1 inconsistency at node " << i;
+    }
+  }
+}
+
+TEST_P(DualTreeTest, DifferentRoots) {
+  auto [numNodes, fanOut] = GetParam();
+  if (numNodes <= 1) {
+    return; // Single node — both trees are trivially the same
+  }
+
+  int root0 = -1, root1 = -1;
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, fanOut);
+    if (t0.isRoot())
+      root0 = i;
+    if (t1.isRoot())
+      root1 = i;
+  }
+  EXPECT_NE(root0, root1) << "Dual trees should have different roots";
+}
+
+// Phase-complementary property: leaves in tree-0 are internal in tree-1.
+// This is only guaranteed for binary (k=2) dual trees.
+class BinaryDualTreeComplementaryTest
+    : public CtranTreeBuilderTest,
+      public ::testing::WithParamInterface<int> {};
+
+TEST_P(BinaryDualTreeComplementaryTest, LeavesSwapWithInternal) {
+  int numNodes = GetParam();
+  if (numNodes <= 2) {
+    return; // Too small to have meaningful leaf/internal distinction
+  }
+
+  std::vector<TreeNeighbors> t0Nodes(numNodes), t1Nodes(numNodes);
+  for (int i = 0; i < numNodes; i++) {
+    auto [t0, t1] = buildDualKaryTree(numNodes, i, 2);
+    t0Nodes[i] = t0;
+    t1Nodes[i] = t1;
+  }
+
+  for (int i = 0; i < numNodes; i++) {
+    bool isLeaf0 = t0Nodes[i].isLeaf();
+    bool isLeaf1 = t1Nodes[i].isLeaf();
+    bool isRoot0 = t0Nodes[i].isRoot();
+    bool isRoot1 = t1Nodes[i].isRoot();
+
+    // Skip roots — root in one tree can be anything in the other
+    if (isRoot0 || isRoot1) {
+      continue;
+    }
+
+    EXPECT_NE(isLeaf0, isLeaf1)
+        << "Node " << i
+        << ": leaf in tree-0 should be internal in tree-1 (or vice versa). "
+        << "tree-0 isLeaf=" << isLeaf0 << " tree-1 isLeaf=" << isLeaf1;
+  }
+}
+
+// Phase-complementary property is only guaranteed for even N.
+// For odd N, one node must be leaf in both trees (unequal leaf/internal
+// counts).
+INSTANTIATE_TEST_SUITE_P(
+    BinaryComplementary,
+    BinaryDualTreeComplementaryTest,
+    ::testing::Values(4, 8, 16, 32, 64));
+
+INSTANTIATE_TEST_SUITE_P(
+    AllFanOuts,
+    DualTreeTest,
+    ::testing::Values(
+        std::make_pair(1, 2),
+        std::make_pair(2, 2),
+        std::make_pair(3, 2),
+        std::make_pair(4, 2),
+        std::make_pair(7, 2),
+        std::make_pair(8, 2),
+        std::make_pair(15, 2),
+        std::make_pair(16, 2),
+        std::make_pair(32, 2),
+        std::make_pair(64, 2),
+        std::make_pair(2, 3),
+        std::make_pair(3, 3),
+        std::make_pair(4, 3),
+        std::make_pair(8, 3),
+        std::make_pair(9, 3),
+        std::make_pair(27, 3),
+        std::make_pair(64, 3)));
+
+// --- Edge Case Tests ---
+
+TEST_F(CtranTreeBuilderTest, SingleNode) {
+  auto node = buildKaryTree(1, 0, 2);
+  EXPECT_TRUE(node.isRoot());
+  EXPECT_TRUE(node.isLeaf());
+  EXPECT_EQ(node.numChildren, 0);
+  EXPECT_EQ(node.parent, -1);
+}
+
+TEST_F(CtranTreeBuilderTest, TwoNodesBinary) {
+  auto n0 = buildKaryTree(2, 0, 2);
+  auto n1 = buildKaryTree(2, 1, 2);
+
+  EXPECT_TRUE(n0.isRoot());
+  EXPECT_FALSE(n0.isLeaf());
+  EXPECT_EQ(n0.numChildren, 1);
+  EXPECT_EQ(n0.children[0], 1);
+
+  EXPECT_FALSE(n1.isRoot());
+  EXPECT_TRUE(n1.isLeaf());
+  EXPECT_EQ(n1.parent, 0);
+}
+
+TEST_F(CtranTreeBuilderTest, DualSingleNode) {
+  auto [t0, t1] = buildDualKaryTree(1, 0, 2);
+  EXPECT_TRUE(t0.isRoot());
+  EXPECT_TRUE(t0.isLeaf());
+  EXPECT_TRUE(t1.isRoot());
+  EXPECT_TRUE(t1.isLeaf());
+}
+
+TEST_F(CtranTreeBuilderTest, InvalidFanOutRejected) {
+  EXPECT_DEATH(buildKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, 0), "fanOut");
+  EXPECT_DEATH(buildDualKaryTree(8, 0, kMaxTreeChildren + 1), "fanOut");
+}
+
+} // namespace ctran::algos::topo

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cu
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cu
@@ -1,0 +1,279 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+template <typename T>
+struct TestValueOps;
+
+template <>
+struct TestValueOps<float> {
+  using Word = uint32_t;
+
+  __device__ __forceinline__ static float fromFloat(float value) {
+    return value;
+  }
+
+  __device__ __forceinline__ static double toDouble(float value) {
+    return static_cast<double>(value);
+  }
+};
+
+template <>
+struct TestValueOps<__half> {
+  using Word = uint16_t;
+
+  __device__ __forceinline__ static __half fromFloat(float value) {
+    return __float2half(value);
+  }
+
+  __device__ __forceinline__ static double toDouble(__half value) {
+    return static_cast<double>(__half2float(value));
+  }
+};
+
+// Per-element value: 1.0f / (1.0f + (rep + rank + i) % 256)
+// This produces different values per element and per rank.
+__device__ static float elementValue(int rank, int rep, size_t i) {
+  return 1.0f / (1.0f + static_cast<float>((rep + rank + i) % 256));
+}
+
+template <typename T>
+__global__ void initDataKernel(T* buf, size_t count, int rank, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    buf[idx] = TestValueOps<T>::fromFloat(elementValue(rank, rep, idx));
+  }
+}
+
+template <typename T>
+__global__ void initExpectedKernel(T* buf, size_t count, int nranks, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    float sum = 0.0f;
+    for (int r = 0; r < nranks; r++) {
+      sum += elementValue(r, rep, idx);
+    }
+    buf[idx] = TestValueOps<T>::fromFloat(sum);
+  }
+}
+
+// Each block computes the max abs delta over its assigned elements, then
+// writes the per-block maximum into blockMaxes[blockIdx.x].
+template <typename T>
+__global__ void deltaKernel(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    double* blockMaxes) {
+  extern __shared__ double sdata[];
+
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  double localMax = 0.0;
+  if (idx < count) {
+    localMax = fabs(
+        TestValueOps<T>::toDouble(actual[idx]) -
+        TestValueOps<T>::toDouble(expected[idx]));
+  }
+
+  sdata[threadIdx.x] = localMax;
+  __syncthreads();
+
+  // Tree reduction within the block
+  for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (threadIdx.x < s) {
+      sdata[threadIdx.x] = fmax(sdata[threadIdx.x], sdata[threadIdx.x + s]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    blockMaxes[blockIdx.x] = sdata[0];
+  }
+}
+
+__device__ __forceinline__ uint64_t mixChecksum(uint64_t acc, uint64_t value) {
+  acc ^= value + 0x9e3779b97f4a7c15ULL + (acc << 6) + (acc >> 2);
+  return acc * 0x100000001b3ULL;
+}
+
+template <typename T>
+__global__ void
+rawBitsChecksumKernel(const T* data, size_t count, uint64_t* result) {
+  constexpr int kBlockSize = 256;
+  __shared__ uint64_t partials[kBlockSize];
+
+  using Word = typename TestValueOps<T>::Word;
+  const Word* words = reinterpret_cast<const Word*>(data);
+  uint64_t local = 0xcbf29ce484222325ULL ^
+      (static_cast<uint64_t>(threadIdx.x) << 32) ^ count ^
+      (static_cast<uint64_t>(sizeof(T)) << 56);
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    const uint64_t taggedValue =
+        (static_cast<uint64_t>(words[i]) << 32) ^ static_cast<uint64_t>(i);
+    local = mixChecksum(local, taggedValue);
+  }
+
+  partials[threadIdx.x] = local;
+  __syncthreads();
+
+  for (int stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      partials[threadIdx.x] =
+          mixChecksum(partials[threadIdx.x], partials[threadIdx.x + stride]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *result = partials[0];
+  }
+}
+
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+}
+
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+}
+
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+}
+
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+}
+
+template <typename T>
+double computeMaxDeltaTyped(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return 0.0;
+  }
+
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+
+  double* dBlockMaxes = nullptr;
+  cudaMalloc(&dBlockMaxes, numBlocks * sizeof(double));
+
+  size_t sharedBytes = kBlockSize * sizeof(double);
+  deltaKernel<<<numBlocks, kBlockSize, sharedBytes, stream>>>(
+      actual, expected, count, dBlockMaxes);
+
+  std::vector<double> hBlockMaxes(numBlocks);
+  cudaMemcpyAsync(
+      hBlockMaxes.data(),
+      dBlockMaxes,
+      numBlocks * sizeof(double),
+      cudaMemcpyDeviceToHost,
+      stream);
+  cudaStreamSynchronize(stream);
+
+  double maxDelta = 0.0;
+  for (int i = 0; i < numBlocks; i++) {
+    maxDelta = std::fmax(maxDelta, hBlockMaxes[i]);
+  }
+
+  cudaFree(dBlockMaxes);
+  return maxDelta;
+}
+
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+template <typename T>
+uint64_t
+computeRawBitsChecksumTyped(const T* data, size_t count, cudaStream_t stream) {
+  if (count == 0) {
+    return 0;
+  }
+
+  uint64_t* dChecksum = nullptr;
+  cudaMalloc(&dChecksum, sizeof(uint64_t));
+
+  constexpr int kBlockSize = 256;
+  rawBitsChecksumKernel<<<1, kBlockSize, 0, stream>>>(data, count, dChecksum);
+
+  uint64_t hChecksum = 0;
+  cudaMemcpyAsync(
+      &hChecksum, dChecksum, sizeof(uint64_t), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+
+  cudaFree(dChecksum);
+  return hChecksum;
+}
+
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}
+
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}

--- a/comms/ctran/tests/AllReduceTreeTestKernels.cuh
+++ b/comms/ctran/tests/AllReduceTreeTestKernels.cuh
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+// Initialize data buffer: each element = 1.0f / (1.0f + (rep + rank + i) % 256)
+// Produces different values per element AND per rank, avoiding uniform fill.
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+// Initialize expected buffer: expected[i] = sum over all ranks of
+// initData(rank, i) This is exactly what AllReduce(sum) should produce.
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+// Compute max |actual[i] - expected[i]| across all elements.
+// Returns the result synchronously (blocks on stream).
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream);
+
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream);
+
+// Compute a deterministic checksum of the raw output bits using a single CUDA
+// block. Returns synchronously after copying one uint64_t to host.
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream);
+
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream);

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -1,0 +1,478 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "CtranUtUtils.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+/**
+ * Distributed CTRAN AllReduce correctness fixture.
+ *
+ * The fixture is algorithm-parameterized and validates execution status plus
+ * the numerical reduction result. It intentionally avoids colltrace assertions
+ * so the same test can cover CTREE and future AllReduce algorithm variants.
+ */
+class CtranAllReduceTest : public ctran::CtranDistTestFixture,
+                           public CtranBaseTest {
+ public:
+  CtranAllReduceTest() = default;
+
+  /** Identical-input repeats used to check bitwise deterministic output. */
+  static constexpr int kDeterminismRepeats = 4;
+
+  static void* allocateDeviceBuffer(size_t bytes) {
+    void* ptr = nullptr;
+    COMMCHECK_TEST(
+        ctran::utils::commCuMemAlloc(
+            &ptr,
+            nullptr,
+            ctran::utils::getCuMemAllocHandleType(),
+            bytes,
+            nullptr,
+            "CtranAllReduceTest"));
+    return ptr;
+  }
+
+  static void releaseDeviceBuffer(void* ptr) {
+    COMMCHECK_TEST(ctran::utils::commCuMemFree(ptr));
+  }
+
+  static void launchInitData(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int rank,
+      int rep,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitDataKernel(
+            static_cast<float*>(buf), count, rank, rep, stream);
+        return;
+      case commFloat16:
+        launchInitDataKernel(
+            static_cast<__half*>(buf), count, rank, rep, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static void launchInitExpected(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int nranks,
+      int rep,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitExpectedKernel(
+            static_cast<float*>(buf), count, nranks, rep, stream);
+        return;
+      case commFloat16:
+        launchInitExpectedKernel(
+            static_cast<__half*>(buf), count, nranks, rep, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static double computeMaxDeltaForType(
+      const void* actual,
+      const void* expected,
+      commDataType_t datatype,
+      size_t count,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        return computeMaxDelta(
+            static_cast<const float*>(actual),
+            static_cast<const float*>(expected),
+            count,
+            stream);
+      case commFloat16:
+        return computeMaxDelta(
+            static_cast<const __half*>(actual),
+            static_cast<const __half*>(expected),
+            count,
+            stream);
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return DBL_MAX;
+    }
+  }
+
+  static uint64_t computeRawBitsChecksumForType(
+      const void* data,
+      commDataType_t datatype,
+      size_t count,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        return computeRawBitsChecksum(
+            static_cast<const float*>(data), count, stream);
+      case commFloat16:
+        return computeRawBitsChecksum(
+            static_cast<const __half*>(data), count, stream);
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return 0;
+    }
+  }
+
+  static double thresholdForDatatype(commDataType_t datatype, int nranks) {
+    const int rankScale = std::max(1, nranks - 1);
+    switch (datatype) {
+      case commFloat32:
+        return 1e-5 * rankScale;
+      case commFloat16:
+        return 5e-3 * rankScale;
+      default:
+        return 0.0;
+    }
+  }
+
+  /**
+   * Configure CTRAN AllReduce and Pipes before constructing the communicator.
+   */
+  void SetUp() override {
+#ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
+    setenv("NCCL_CTRAN_BACKENDS", "socket, nvl", 1);
+#endif
+    setenv("NCCL_ALLREDUCE_ALGO", "ctree", 1);
+    setenv("NCCL_CTRAN_USE_PIPES", "1", 1);
+    setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 1);
+    // Re-read CVAR-backed environment overrides before fixture setup.
+    ncclCvarInit();
+    ctran::CtranDistTestFixture::SetUp();
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    ctran::CtranDistTestFixture::TearDown();
+  }
+
+  /**
+   * Run one `commSum` AllReduce case and validate max absolute error.
+   */
+  void runCorrectnessTest(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      commDataType_t datatype,
+      size_t count,
+      bool inPlace) {
+    // Check support before the zero-count no-op so disabled algorithms skip
+    // consistently with non-empty cases.
+    if (!ctranAllReduceSupport(ctranComm.get(), algo)) {
+      GTEST_SKIP() << "ctranAllReduceSupport returns false for algo "
+                   << allReduceAlgoName(algo) << ", skip test";
+    }
+
+    // Zero-element case: no-op path
+    if (count == 0) {
+      auto res = runAllReduce(
+          algo,
+          nullptr,
+          nullptr,
+          0,
+          datatype,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+      return;
+    }
+
+    const size_t bytes = count * commTypeSize(datatype);
+    void* sendbuf = allocateDeviceBuffer(bytes);
+    void* recvbuf = inPlace ? sendbuf : allocateDeviceBuffer(bytes);
+    void* expectedBuf = allocateDeviceBuffer(bytes);
+
+    // Initialize expected: sum of initData across all ranks
+    launchInitExpected(
+        expectedBuf,
+        datatype,
+        count,
+        numRanks,
+        /*rep=*/0,
+        testStream);
+
+    std::array<uint64_t, kDeterminismRepeats> checksums{};
+    for (int repeat = 0; repeat < kDeterminismRepeats; ++repeat) {
+      // Reinitialize identical inputs for each repeat. This keeps in-place
+      // cases from feeding the previous reduction result into the next run.
+      launchInitData(
+          sendbuf,
+          datatype,
+          count,
+          globalRank,
+          /*rep=*/0,
+          testStream);
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      commResult_t res = runAllReduce(
+          algo,
+          sendbuf,
+          recvbuf,
+          count,
+          datatype,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      // Validate: max absolute error across all elements
+      const void* resultBuf = inPlace ? sendbuf : recvbuf;
+      double maxDelta = computeMaxDeltaForType(
+          resultBuf, expectedBuf, datatype, count, testStream);
+
+      double threshold = thresholdForDatatype(datatype, numRanks);
+      ASSERT_LT(maxDelta, threshold)
+          << "maxDelta=" << maxDelta << " threshold=" << threshold
+          << " count=" << count << " rank=" << globalRank
+          << " datatype=" << commDataTypeToString(datatype)
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+
+      checksums[repeat] =
+          computeRawBitsChecksumForType(resultBuf, datatype, count, testStream);
+    }
+
+    for (int repeat = 1; repeat < kDeterminismRepeats; ++repeat) {
+      ASSERT_EQ(checksums[0], checksums[repeat])
+          << "non-deterministic AllReduce output checksum for count=" << count
+          << " rank=" << globalRank
+          << " datatype=" << commDataTypeToString(datatype)
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+    }
+
+    verifyGpeLeak(ctranComm->ctran_.get());
+
+    if (!inPlace) {
+      releaseDeviceBuffer(recvbuf);
+    }
+    releaseDeviceBuffer(expectedBuf);
+    releaseDeviceBuffer(sendbuf);
+  }
+
+ protected:
+  /** Dispatch one AllReduce call for the algorithm under test. */
+  commResult_t runAllReduce(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      const void* sendbuf,
+      void* recvbuf,
+      size_t count,
+      commDataType_t datatype,
+      commRedOp_t redOp,
+      CtranComm* comm,
+      cudaStream_t stream,
+      std::optional<std::chrono::milliseconds> timeout) {
+    switch (algo) {
+      case NCCL_ALLREDUCE_ALGO::ctree:
+        return ctranAllReduceTree(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      default:
+        return commInvalidArgument;
+    }
+  }
+
+  /** CUDA stream used by buffer initialization, AllReduce, and validation. */
+  cudaStream_t testStream{0};
+  /** Communicator under test for this distributed rank. */
+  std::unique_ptr<CtranComm> ctranComm{nullptr};
+};
+
+using AllReduceParam =
+    std::tuple<enum NCCL_ALLREDUCE_ALGO, commDataType_t, size_t, bool>;
+
+const std::vector<size_t>& allReduceElementCounts() {
+  static const std::vector<size_t> counts{
+      // Zero
+      0,
+      // Tiny
+      1,
+      7,
+      16,
+      // Small
+      64,
+      256,
+      1024,
+      // Medium
+      4096,
+      16384,
+      65536,
+      // Large
+      262144,
+      1048576,
+      4194304,
+      // Large + tail
+      1048576 - 7,
+      1048576 + 7,
+      4194304 - 13,
+      4194304 + 13,
+  };
+  return counts;
+}
+
+const std::vector<commDataType_t>& allReduceDataTypes() {
+  static const std::vector<commDataType_t> datatypes{
+      commFloat32,
+      commFloat16,
+  };
+  return datatypes;
+}
+
+std::string dataTypeTestName(commDataType_t datatype) {
+  switch (datatype) {
+    case commFloat32:
+      return "FP32";
+    case commFloat16:
+      return "FP16";
+    default:
+      return "UnsupportedType";
+  }
+}
+
+std::string allReduceTestName(
+    enum NCCL_ALLREDUCE_ALGO algo,
+    commDataType_t datatype,
+    size_t count,
+    bool inPlace) {
+  return allReduceAlgoName(algo) + "_" + dataTypeTestName(datatype) + "_" +
+      std::to_string(count) + "elements_" +
+      (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+#if defined(CTRAN_ALLREDUCE_TEST_NVL_ONLY)
+/**
+ * NVL-only topology test using the default local topology.
+ */
+class NVL_ONLY : public CtranAllReduceTest,
+                 public ::testing::WithParamInterface<AllReduceParam> {};
+
+TEST_P(NVL_ONLY, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string nvlTestName(
+    const testing::TestParamInfo<NVL_ONLY::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    NVL_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    nvlTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY)
+/**
+ * IB-only topology test that disables local P2P and forces a no-local topology.
+ */
+class IB_ONLY : public CtranAllReduceTest,
+                public ::testing::WithParamInterface<AllReduceParam> {
+ public:
+  /**
+   * Force traffic through the inter-node path before communicator creation.
+   */
+  void SetUp() override {
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    setenv("NCCL_IGNORE_TOPO_LOAD_FAILURE", "1", 1);
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    CtranAllReduceTest::SetUp();
+  }
+
+  void TearDown() override {
+    unsetenv("NCCL_COMM_STATE_DEBUG_TOPO");
+    unsetenv("NCCL_IGNORE_TOPO_LOAD_FAILURE");
+    unsetenv("NCCL_P2P_DISABLE");
+    CtranAllReduceTest::TearDown();
+  }
+};
+
+TEST_P(IB_ONLY, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string ibTestName(
+    const testing::TestParamInfo<IB_ONLY::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    IB_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    ibTestName);
+#endif
+
+#if defined(CTRAN_ALLREDUCE_TEST_HYBRID)
+/**
+ * Hybrid topology test that exercises NVL and IB paths together.
+ */
+class HYBRID : public CtranAllReduceTest,
+               public ::testing::WithParamInterface<AllReduceParam> {};
+
+TEST_P(HYBRID, Correctness) {
+  auto [algo, datatype, count, inPlace] = GetParam();
+  runCorrectnessTest(algo, datatype, count, inPlace);
+}
+
+inline std::string hybridTestName(
+    const testing::TestParamInfo<HYBRID::ParamType>& info) {
+  auto [algo, datatype, count, inPlace] = info.param;
+  return allReduceTestName(algo, datatype, count, inPlace);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduce,
+    HYBRID,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    hybridTestName);
+#endif
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "CtranUtUtils.h"
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
 #include "comms/ctran/tests/AllReduceTreeTestKernels.cuh"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -293,6 +294,23 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       case NCCL_ALLREDUCE_ALGO::ctree:
         return ctranAllReduceTree(
             sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::ctring:
+        return ctranAllReduceRing(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::ctdirect:
+        return ctranAllReduceDirect(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::pipesflatring:
+        return ctranAllReduce(
+            sendbuf,
+            recvbuf,
+            count,
+            datatype,
+            redOp,
+            comm,
+            stream,
+            algo,
+            timeout);
       default:
         return commInvalidArgument;
     }
@@ -434,7 +452,9 @@ INSTANTIATE_TEST_SUITE_P(
     CtranAllReduce,
     IB_ONLY,
     ::testing::Combine(
-        ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
+        ::testing::Values(
+            NCCL_ALLREDUCE_ALGO::ctree,
+            NCCL_ALLREDUCE_ALGO::pipesflatring),
         ::testing::ValuesIn(allReduceDataTypes()),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -61,6 +61,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctdirect;
   } else if (str == "ctring") {
     val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else if (str == "ctree") {
+    val = NCCL_ALLREDUCE_ALGO::ctree;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -144,6 +146,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctdirect";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "ctring";
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      return "ctree";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -63,6 +63,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctring;
   } else if (str == "ctree") {
     val = NCCL_ALLREDUCE_ALGO::ctree;
+  } else if (str == "pipesflatring") {
+    val = NCCL_ALLREDUCE_ALGO::pipesflatring;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -148,6 +150,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctring";
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "ctree";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "pipesflatring";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -98,6 +98,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctree:
       str = "ctree";
       break;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      str = "pipesflatring";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -175,6 +178,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::pipesflatring);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -95,6 +95,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctring:
       str = "ctring";
       break;
+    case NCCL_ALLREDUCE_ALGO::ctree:
+      str = "ctree";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -171,6 +174,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctran);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctree);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -41,6 +41,40 @@ inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 // `PIPES_DEVICE_TRAP()` is defined in `comms/pipes/DeviceMacros.cuh` and
 // is intentionally available across all `comms/pipes` device headers.
 
+/** Result of one bounded send/recv progress attempt. */
+enum class IbgdaSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+};
+
+/** Internal stage for a resumable pipelined send or recv operation. */
+enum class IbgdaSendRecvProgressStage : uint8_t {
+  WaitNicDone,
+  WaitSlotFree,
+  WaitDataReady,
+  Done,
+};
+
+/**
+ * Resumable state for one transport-managed pipelined send or recv.
+ *
+ * The caller owns this state and repeatedly passes it to `progress*Once()`.
+ * Each progress call performs bounded work and returns immediately if the next
+ * signal/counter dependency is not ready.
+ */
+struct IbgdaSendRecvProgressState {
+  int groupId{0};
+  int activeBlocks{0};
+  std::size_t nbytes{0};
+  std::size_t maxSignalBytes{0};
+  std::size_t perBlockSlot{0};
+  std::size_t chunkSize{0};
+  std::size_t nextByte{0};
+  int64_t baseStep{0};
+  IbgdaSendRecvProgressStage stage{IbgdaSendRecvProgressStage::Done};
+};
+
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
 // constructed with no owned signal/counter buffer (numSlots == 0).
@@ -1179,6 +1213,378 @@ class P2pIbgdaTransportDevice {
   //     else
   //       transport->recv(sub, tiles.data(), tiles.bytes(), active_blocks);
   //   }
+
+ private:
+  struct ProgressChunk {
+    std::size_t stagingOff;
+    std::size_t dataOff;
+    std::size_t bytes;
+    uint64_t streamEnd;
+  };
+
+  __device__ __forceinline__ void init_progress_geometry(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.nbytes == 0) {
+      return;
+    }
+    if (state.groupId != static_cast<int>(group.group_id)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress state group_id=%d but group.group_id=%u\n",
+            state.groupId,
+            group.group_id);
+      }
+      __trap();
+    }
+    if (state.activeBlocks > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress active_blocks=%d > maxGroups=%d\n",
+            state.activeBlocks,
+            sendRecvState_.maxGroups);
+      }
+      __trap();
+    }
+    if (state.groupId < 0 || state.groupId >= state.activeBlocks) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%d >= active_blocks=%d\n",
+            state.groupId,
+            state.activeBlocks);
+      }
+      __trap();
+    }
+
+    state.perBlockSlot =
+        (sendRecvState_.dataBufferSize / state.activeBlocks) & ~15ULL;
+    if (state.perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            state.activeBlocks);
+      }
+      __trap();
+    }
+
+    state.chunkSize =
+        (state.maxSignalBytes > 0 && state.maxSignalBytes < state.perBlockSlot)
+        ? (state.maxSignalBytes & ~15ULL)
+        : state.perBlockSlot;
+    if (state.chunkSize == 0) {
+      state.chunkSize = state.perBlockSlot;
+    }
+#endif
+  }
+
+  __device__ __forceinline__ ProgressChunk
+  progress_chunk(const IbgdaSendRecvProgressState& state) const {
+    const uint64_t streamStart =
+        static_cast<uint64_t>(state.baseStep) + state.nextByte;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / state.perBlockSlot);
+    const std::size_t slotOff =
+        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+    const std::size_t chunkOff =
+        pipelineOff - static_cast<std::size_t>(slot) * state.perBlockSlot;
+    const std::size_t slotRemaining = state.perBlockSlot - chunkOff;
+    const std::size_t dataRemaining = state.nbytes - state.nextByte;
+    std::size_t bytes =
+        state.chunkSize < dataRemaining ? state.chunkSize : dataRemaining;
+    bytes = bytes < slotRemaining ? bytes : slotRemaining;
+    return ProgressChunk{
+        .stagingOff = slotOff +
+            static_cast<std::size_t>(state.groupId) * state.perBlockSlot +
+            chunkOff,
+        .dataOff = state.nextByte,
+        .bytes = bytes,
+        .streamEnd = streamStart + bytes,
+    };
+  }
+
+ public:
+  /**
+   * Initialize resumable state for one pipelined send operation.
+   *
+   * The returned state is independent of the source pointer. A caller may keep
+   * the state in its own scheduler and call `progress_send_once()` until it
+   * returns `Done`.
+   */
+  __device__ __forceinline__ IbgdaSendRecvProgressState init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    IbgdaSendRecvProgressState state{};
+    state.groupId = static_cast<int>(group.group_id);
+    state.activeBlocks =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    state.nbytes = nbytes;
+    state.maxSignalBytes = max_signal_bytes;
+    state.stage = nbytes == 0 ? IbgdaSendRecvProgressStage::Done
+                              : IbgdaSendRecvProgressStage::WaitNicDone;
+    init_progress_geometry(group, state);
+    if (nbytes != 0) {
+      state.baseStep = sendRecvState_.stepState[state.groupId];
+    }
+    return state;
+#else
+    return {};
+#endif
+  }
+
+  /**
+   * Initialize resumable state for one pipelined recv operation.
+   *
+   * The returned state is independent of the destination pointer. A caller may
+   * keep the state in its own scheduler and call `progress_recv_once()` until
+   * it returns `Done`.
+   */
+  __device__ __forceinline__ IbgdaSendRecvProgressState init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    IbgdaSendRecvProgressState state{};
+    state.groupId = static_cast<int>(group.group_id);
+    state.activeBlocks =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    state.nbytes = nbytes;
+    state.maxSignalBytes = max_signal_bytes;
+    state.stage = nbytes == 0 ? IbgdaSendRecvProgressStage::Done
+                              : IbgdaSendRecvProgressStage::WaitDataReady;
+    init_progress_geometry(group, state);
+    if (nbytes != 0) {
+      state.baseStep =
+          sendRecvState_.stepState[sendRecvState_.maxGroups + state.groupId];
+    }
+    return state;
+#else
+    return {};
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized send.
+   *
+   * This method never spins on NIC_DONE or SLOT_FREE. If either dependency is
+   * not ready, it returns `Waiting` immediately so a higher-level scheduler can
+   * try another independent lane.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state,
+      const void* __restrict__ src,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::progress_send_once() requires NVIDIA GPU");
+#endif
+    if (state.stage == IbgdaSendRecvProgressStage::Done ||
+        state.nextByte >= state.nbytes) {
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    bool progressed = false;
+    const std::size_t pipelineBytes = state.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+
+    if (state.stage == IbgdaSendRecvProgressStage::WaitNicDone) {
+      const ProgressChunk chunk = progress_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_counter(sendRecvState_.localCounterBuf.subBuffer(
+                  state.groupId * sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      CopyOp::send(
+          sendRecvState_.sendStagingPtr + chunk.stagingOff,
+          static_cast<const char*>(src) + chunk.dataOff,
+          chunk.bytes,
+          group,
+          chunk.dataOff,
+          args...);
+      group.sync();
+      state.stage = IbgdaSendRecvProgressStage::WaitSlotFree;
+      progressed = true;
+    }
+
+    if (state.stage == IbgdaSendRecvProgressStage::WaitSlotFree) {
+      const ProgressChunk chunk = progress_chunk(state);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                  (sendRecvState_.maxGroups + state.groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return progressed ? IbgdaSendRecvProgressStatus::Progressed
+                            : IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        put(solo,
+            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            chunk.bytes,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes,
+            sendRecvState_.localCounterBuf.subBuffer(
+                state.groupId * sizeof(uint64_t)),
+            chunk.bytes);
+      }
+      group.sync();
+
+      state.nextByte += chunk.bytes;
+      progressed = true;
+      if (state.nextByte >= state.nbytes) {
+        if (group.is_leader()) {
+          sendRecvState_.stepState[state.groupId] =
+              state.baseStep + static_cast<int64_t>(state.nbytes);
+        }
+        group.sync();
+        state.stage = IbgdaSendRecvProgressStage::Done;
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      state.stage = IbgdaSendRecvProgressStage::WaitNicDone;
+    }
+
+    return progressed ? IbgdaSendRecvProgressStatus::Progressed
+                      : IbgdaSendRecvProgressStatus::Waiting;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized recv.
+   *
+   * This method never spins on DATA_READY. If the sender has not signaled the
+   * next chunk yet, it returns `Waiting` immediately.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      IbgdaSendRecvProgressState& state,
+      void* __restrict__ dst,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        false,
+        "P2pIbgdaTransportDevice::progress_recv_once() requires NVIDIA GPU");
+#endif
+    if (state.stage == IbgdaSendRecvProgressStage::Done ||
+        state.nextByte >= state.nbytes) {
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    const ProgressChunk chunk = progress_chunk(state);
+    const uint64_t expected = chunk.streamEnd;
+    uint32_t ready = 1;
+    unsigned long long current = 0;
+    if (group.is_leader()) {
+      current = static_cast<unsigned long long>(
+          read_signal(sendRecvState_.localSignalBuf.subBuffer(
+              state.groupId * sizeof(uint64_t))));
+      ready = current >= expected ? 1U : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_recv_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            static_cast<unsigned long long>(expected),
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    CopyOp::recv(
+        static_cast<char*>(dst) + chunk.dataOff,
+        sendRecvState_.recvStagingPtr + chunk.stagingOff,
+        chunk.bytes,
+        group,
+        chunk.dataOff,
+        args...);
+    group.sync();
+
+    signal(
+        group,
+        sendRecvState_.remoteSignalBuf.subBuffer(
+            (sendRecvState_.maxGroups + state.groupId) * sizeof(uint64_t)),
+        chunk.bytes);
+
+    state.nextByte += chunk.bytes;
+    if (state.nextByte >= state.nbytes) {
+      if (group.is_leader()) {
+        sendRecvState_.stepState[sendRecvState_.maxGroups + state.groupId] =
+            state.baseStep + static_cast<int64_t>(state.nbytes);
+      }
+      group.sync();
+      state.stage = IbgdaSendRecvProgressStage::Done;
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    return IbgdaSendRecvProgressStatus::Progressed;
+#else
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
 
   /**
    * send — send one block's tile via pipelined RDMA.

--- a/comms/pipes/collectives/Ring.cuh
+++ b/comms/pipes/collectives/Ring.cuh
@@ -37,4 +37,15 @@ struct RingReduceScatterArgs {
   T* output{nullptr};
 };
 
+template <int NumRings, typename T>
+struct RingAllReduceArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  RingTopology rings[NumRings]{};
+  const T* input{nullptr};
+  T* output{nullptr};
+};
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -1,0 +1,153 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/RingAllReduce.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
+    const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_elems = chunk_elems / NumRings;
+  const std::size_t ring_elems = (ring_id < NumRings - 1)
+      ? base_ring_elems
+      : (chunk_elems - (NumRings - 1) * base_ring_elems);
+  const std::size_t ring_bytes = ring_elems * sizeof(T);
+  const std::size_t ring_offset = ring_id * base_ring_elems * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 1: REDUCE-SCATTER (TileReduce CopyOp)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    const char* input_base = reinterpret_cast<const char*>(args.input);
+    using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+
+    for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = io_tile_bytes - off;
+      const std::size_t window =
+          (remaining < pipeline_window) ? remaining : pipeline_window;
+
+      int current_rank = (my_rank + W - stride) % W;
+
+      const char* send_src = input_base + current_rank * chunk_bytes +
+          ring_offset + io_tile_offset + off;
+      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+      for (int step = 0; step < W - 1; step++) {
+        current_rank = (current_rank + W - stride) % W;
+        const char* local_input = input_base + current_rank * chunk_bytes +
+            ring_offset + io_tile_offset + off;
+
+        if (step < W - 2) {
+          prev.template forward<ReduceOp>(
+              group,
+              nullptr,
+              next,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout,
+              local_input);
+        } else {
+          char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+              io_tile_offset + off;
+          prev.template recv<ReduceOp>(
+              group,
+              dst,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout,
+              local_input);
+        }
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 2: ALL-GATHER (Memcpy CopyOp)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    char* output_base = reinterpret_cast<char*>(args.output);
+
+    // Local copy: reduced shard → correct position in output.
+    const char* own_src = output_base + ring_offset + io_tile_offset;
+    char* own_dst =
+        output_base + my_rank * chunk_bytes + ring_offset + io_tile_offset;
+    if (own_src != own_dst) {
+      memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
+    }
+    ring_group.sync();
+
+    for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = io_tile_bytes - off;
+      const std::size_t window =
+          (remaining < pipeline_window) ? remaining : pipeline_window;
+
+      char* send_src = output_base + my_rank * chunk_bytes + ring_offset +
+          io_tile_offset + off;
+      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+      int current_rank = my_rank;
+      for (int step = 0; step < W - 1; step++) {
+        current_rank = (current_rank + W - stride) % W;
+        char* dst = output_base + current_rank * chunk_bytes + ring_offset +
+            io_tile_offset + off;
+
+        if (step < W - 2) {
+          prev.forward(
+              group, dst, next, window, group.total_groups, max_sig, timeout);
+        } else {
+          prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+        }
+      }
+    }
+  }
+#endif
+}
+
+// Template instantiations
+template __global__ void ring_allreduce_kernel<1, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<1, float>,
+    Timeout);
+template __global__ void ring_allreduce_kernel<2, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<2, float>,
+    Timeout);
+template __global__ void ring_allreduce_kernel<4, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<4, float>,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -49,11 +49,11 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
   const int stride = (my_rank - topo.prev_rank + W) % W;
 
   // ═══════════════════════════════════════════════════════════════════
-  // PHASE 1: REDUCE-SCATTER (TileReduce CopyOp)
+  // PHASE 1: REDUCE-SCATTER (TileReduceStaged CopyOp)
   // ═══════════════════════════════════════════════════════════════════
   {
     const char* input_base = reinterpret_cast<const char*>(args.input);
-    using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+    using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
 
     for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
       const std::size_t remaining = io_tile_bytes - off;

--- a/comms/pipes/collectives/RingAllReduce.cuh
+++ b/comms/pipes/collectives/RingAllReduce.cuh
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/Ring.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
+    const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
+    Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -1,0 +1,130 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+RingTopology to_ring_topology(
+    const RingAllReduceLaunchParams::RingParams& src) {
+  return RingTopology{
+      .prev_rank = src.prev_rank,
+      .next_rank = src.next_rank,
+      .prev = src.prev,
+      .next = src.next,
+  };
+}
+
+void check_kernel_launch(const char* kernel_name) {
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(kernel_name) +
+        " kernel launch failed: " + cudaGetErrorString(err));
+  }
+}
+
+template <int NumRings>
+void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
+  const int my_rank = params.my_rank;
+  const int num_ranks = params.num_ranks;
+  const std::size_t chunk_elements = params.count / num_ranks;
+  const std::size_t chunk_bytes = chunk_elements * sizeof(float);
+
+  // Phase 1: ReduceScatter
+  // Writes reduced shard to output[my_rank * chunk_elements]
+  {
+    RingReduceScatterArgs<NumRings, float> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.chunk_elements = chunk_elements;
+    args.signaling_data_size = params.signaling_data_size;
+    args.input = params.input;
+    args.output = params.output + my_rank * chunk_elements;
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("ReduceScatter");
+  }
+
+  // Phase 2: AllGather
+  // Reads reduced shard from output[my_rank * chunk_bytes], gathers into output
+  {
+    RingAllgatherArgs<NumRings> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.sendcount = chunk_bytes;
+    args.signaling_data_size = params.signaling_data_size;
+    args.sendbuf =
+        reinterpret_cast<const char*>(params.output) + my_rank * chunk_bytes;
+    args.recvbuf = reinterpret_cast<char*>(params.output);
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_allgather_kernel<NumRings, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("AllGather");
+  }
+}
+
+} // namespace
+
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params) {
+  if (params.num_ranks == 0) {
+    throw std::runtime_error("num_ranks must be > 0");
+  }
+  if (params.count % params.num_ranks != 0) {
+    throw std::runtime_error(
+        "count (" + std::to_string(params.count) +
+        ") must be divisible by num_ranks (" +
+        std::to_string(params.num_ranks) + ")");
+  }
+
+  Timeout timeout;
+  if (params.timeout_ms > 0) {
+    int device = 0;
+    cudaError_t cudaErr = cudaGetDevice(&device);
+    if (cudaErr != cudaSuccess) {
+      throw std::runtime_error(
+          "Failed to get CUDA device: " +
+          std::string(cudaGetErrorString(cudaErr)));
+    }
+
+    timeout = makeTimeout(params.timeout_ms, device);
+  }
+
+  switch (params.num_rings) {
+    case 1:
+      launch_impl<1>(params, timeout);
+      break;
+    case 2:
+      launch_impl<2>(params, timeout);
+      break;
+    case 4:
+      launch_impl<4>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error(
+          "Unsupported num_rings=" + std::to_string(params.num_rings) +
+          " (supported: 1, 2, 4)");
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -9,8 +9,7 @@
 
 #include "comms/pipes/CopyOp.cuh"
 #include "comms/pipes/TimeoutUtils.h"
-#include "comms/pipes/collectives/RingAllgather.cuh"
-#include "comms/pipes/collectives/RingReduceScatter.cuh"
+#include "comms/pipes/collectives/RingAllReduce.cuh"
 
 namespace comms::pipes {
 
@@ -37,51 +36,23 @@ void check_kernel_launch(const char* kernel_name) {
 
 template <int NumRings>
 void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
-  const int my_rank = params.my_rank;
-  const int num_ranks = params.num_ranks;
-  const std::size_t chunk_elements = params.count / num_ranks;
-  const std::size_t chunk_bytes = chunk_elements * sizeof(float);
+  const std::size_t chunk_elements = params.count / params.num_ranks;
 
-  // Phase 1: ReduceScatter
-  // Writes reduced shard to output[my_rank * chunk_elements]
-  {
-    RingReduceScatterArgs<NumRings, float> args{};
-    args.my_rank = my_rank;
-    args.num_ranks = num_ranks;
-    args.chunk_elements = chunk_elements;
-    args.signaling_data_size = params.signaling_data_size;
-    args.input = params.input;
-    args.output = params.output + my_rank * chunk_elements;
+  RingAllReduceArgs<NumRings, float> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
 
-    for (int r = 0; r < NumRings; r++) {
-      args.rings[r] = to_ring_topology(params.rings[r]);
-    }
-
-    ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
-    check_kernel_launch("ReduceScatter");
+  for (int r = 0; r < NumRings; r++) {
+    args.rings[r] = to_ring_topology(params.rings[r]);
   }
 
-  // Phase 2: AllGather
-  // Reads reduced shard from output[my_rank * chunk_bytes], gathers into output
-  {
-    RingAllgatherArgs<NumRings> args{};
-    args.my_rank = my_rank;
-    args.num_ranks = num_ranks;
-    args.sendcount = chunk_bytes;
-    args.signaling_data_size = params.signaling_data_size;
-    args.sendbuf =
-        reinterpret_cast<const char*>(params.output) + my_rank * chunk_bytes;
-    args.recvbuf = reinterpret_cast<char*>(params.output);
-
-    for (int r = 0; r < NumRings; r++) {
-      args.rings[r] = to_ring_topology(params.rings[r]);
-    }
-
-    ring_allgather_kernel<NumRings, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
-    check_kernel_launch("AllGather");
-  }
+  ring_allreduce_kernel<NumRings, float, SumOp, 16384, 512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+  check_kernel_launch("RingAllReduce");
 }
 
 } // namespace

--- a/comms/pipes/collectives/RingAllReduceLauncher.h
+++ b/comms/pipes/collectives/RingAllReduceLauncher.h
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct RingAllReduceLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t count{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  int num_rings{1};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+
+  struct RingParams {
+    int prev_rank{0};
+    int next_rank{0};
+    P2pIbgdaTransportDevice* prev{nullptr};
+    P2pIbgdaTransportDevice* next{nullptr};
+  };
+  static constexpr int kMaxRings = 4;
+  RingParams rings[kMaxRings]{};
+};
+
+// Launches a ring allreduce on the specified stream.
+//
+// Preconditions:
+// - count must be divisible by num_ranks
+// - transport devices must be bound and connected
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgather.cu
+++ b/comms/pipes/collectives/RingAllgather.cu
@@ -1,9 +1,5 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/pipes/CopyOp.cuh"
-#include "comms/pipes/CopyUtils.cuh"
-#include "comms/pipes/ThreadGroup.cuh"
-#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/collectives/RingAllgather.cuh"
 
 namespace comms::pipes {
@@ -12,68 +8,7 @@ template <int NumRings, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     const __grid_constant__ RingAllgatherArgs<NumRings> args,
     Timeout timeout) {
-#ifdef __CUDA_ARCH__
-  timeout.start();
-
-  auto group = make_block_group();
-  auto [ring_id, ring_group] = group.partition(NumRings);
-  const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
-
-  const int W = args.num_ranks;
-  const std::size_t chunk_bytes = args.sendcount;
-  const std::size_t max_sig = args.signaling_data_size;
-
-  const std::size_t base_ring_bytes = chunk_bytes / NumRings;
-  const std::size_t ring_bytes = (ring_id < NumRings - 1)
-      ? base_ring_bytes
-      : (chunk_bytes - (NumRings - 1) * base_ring_bytes);
-  const std::size_t ring_offset = ring_id * base_ring_bytes;
-
-  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
-  const std::size_t io_tile_offset =
-      ring_group.group_id * ring_tile.tile_elements;
-  const std::size_t io_tile_bytes = ring_tile.bytes();
-
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
-
-  const int my_rank = args.my_rank;
-  const int stride = (my_rank - topo.prev_rank + W) % W;
-
-  // Local copy: own chunk from sendbuf to recvbuf.
-  const char* own_src = args.sendbuf + ring_offset + io_tile_offset;
-  char* own_dst =
-      args.recvbuf + my_rank * chunk_bytes + ring_offset + io_tile_offset;
-  memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
-  ring_group.sync();
-
-  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
-    const std::size_t remaining = io_tile_bytes - off;
-    const std::size_t window =
-        (remaining < pipeline_window) ? remaining : pipeline_window;
-
-    // Step 0: Send own chunk to next.
-    char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
-        io_tile_offset + off;
-    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
-
-    // Steps 1..W-1: receive and forward (or just receive on last step).
-    int current_rank = my_rank;
-    for (int step = 0; step < W - 1; step++) {
-      current_rank = (current_rank + W - stride) % W;
-      char* dst = args.recvbuf + current_rank * chunk_bytes + ring_offset +
-          io_tile_offset + off;
-
-      if (step < W - 2) {
-        prev.forward(
-            group, dst, next, window, group.total_groups, max_sig, timeout);
-      } else {
-        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
-      }
-    }
-  }
-#endif
+  ring_allgather_device<NumRings, kBlockSize>(args, timeout);
 }
 
 // Template instantiations

--- a/comms/pipes/collectives/RingAllgather.cuh
+++ b/comms/pipes/collectives/RingAllgather.cuh
@@ -2,10 +2,82 @@
 
 #pragma once
 
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/collectives/Ring.cuh"
 
 namespace comms::pipes {
+
+template <int NumRings, int kBlockSize>
+__device__ __forceinline__ void ring_allgather_device(
+    const RingAllgatherArgs<NumRings>& args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_bytes = args.sendcount;
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_bytes = chunk_bytes / NumRings;
+  const std::size_t ring_bytes = (ring_id < NumRings - 1)
+      ? base_ring_bytes
+      : (chunk_bytes - (NumRings - 1) * base_ring_bytes);
+  const std::size_t ring_offset = ring_id * base_ring_bytes;
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+
+  // Local copy: own chunk from sendbuf to recvbuf.
+  const char* own_src = args.sendbuf + ring_offset + io_tile_offset;
+  char* own_dst =
+      args.recvbuf + my_rank * chunk_bytes + ring_offset + io_tile_offset;
+  memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
+  ring_group.sync();
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    // Step 0: Send own chunk to next.
+    char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
+        io_tile_offset + off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    // Steps 1..W-1: receive and forward (or just receive on last step).
+    int current_rank = my_rank;
+    for (int step = 0; step < W - 1; step++) {
+      current_rank = (current_rank + W - stride) % W;
+      char* dst = args.recvbuf + current_rank * chunk_bytes + ring_offset +
+          io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.forward(
+            group, dst, next, window, group.total_groups, max_sig, timeout);
+      } else {
+        prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+      }
+    }
+  }
+#endif
+}
 
 template <int NumRings, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(

--- a/comms/pipes/collectives/RingReduceScatter.cu
+++ b/comms/pipes/collectives/RingReduceScatter.cu
@@ -1,9 +1,5 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "comms/pipes/CopyOp.cuh"
-#include "comms/pipes/CopyUtils.cuh"
-#include "comms/pipes/ThreadGroup.cuh"
-#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/collectives/RingReduceScatter.cuh"
 
 namespace comms::pipes {
@@ -17,83 +13,8 @@ template <
 __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
     const __grid_constant__ RingReduceScatterArgs<NumRings, T> args,
     Timeout timeout) {
-#ifdef __CUDA_ARCH__
-  timeout.start();
-
-  auto group = make_block_group();
-  auto [ring_id, ring_group] = group.partition(NumRings);
-  const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
-
-  const int W = args.num_ranks;
-  const std::size_t chunk_elems = args.chunk_elements;
-  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
-  const std::size_t max_sig = args.signaling_data_size;
-
-  const std::size_t base_ring_elems = chunk_elems / NumRings;
-  const std::size_t ring_elems = (ring_id < NumRings - 1)
-      ? base_ring_elems
-      : (chunk_elems - (NumRings - 1) * base_ring_elems);
-  const std::size_t ring_bytes = ring_elems * sizeof(T);
-  const std::size_t ring_offset = ring_id * base_ring_elems * sizeof(T);
-
-  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
-  const std::size_t io_tile_offset =
-      ring_group.group_id * ring_tile.tile_elements;
-  const std::size_t io_tile_bytes = ring_tile.bytes();
-
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
-
-  const int my_rank = args.my_rank;
-  const int stride = (my_rank - topo.prev_rank + W) % W;
-  const char* input_base = reinterpret_cast<const char*>(args.input);
-
-  using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
-
-  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
-    const std::size_t remaining = io_tile_bytes - off;
-    const std::size_t window =
-        (remaining < pipeline_window) ? remaining : pipeline_window;
-
-    int current_rank = (my_rank + W - stride) % W;
-
-    // Step 0: Send raw input chunk to next.
-    const char* send_src = input_base + current_rank * chunk_bytes +
-        ring_offset + io_tile_offset + off;
-    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
-
-    // W-1 receive steps: forward for intermediate, recv for final.
-    for (int step = 0; step < W - 1; step++) {
-      current_rank = (current_rank + W - stride) % W;
-      const char* local_input = input_base + current_rank * chunk_bytes +
-          ring_offset + io_tile_offset + off;
-
-      if (step < W - 2) {
-        prev.template forward<ReduceOp>(
-            group,
-            nullptr,
-            next,
-            window,
-            group.total_groups,
-            max_sig,
-            timeout,
-            local_input);
-      } else {
-        char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
-            io_tile_offset + off;
-        prev.template recv<ReduceOp>(
-            group,
-            dst,
-            window,
-            group.total_groups,
-            max_sig,
-            timeout,
-            local_input);
-      }
-    }
-  }
-#endif
+  ring_reduce_scatter_device<NumRings, T, AccumOp, kTileElems, kBlockSize>(
+      args, timeout);
 }
 
 // Template instantiations

--- a/comms/pipes/collectives/RingReduceScatter.cuh
+++ b/comms/pipes/collectives/RingReduceScatter.cuh
@@ -2,10 +2,102 @@
 
 #pragma once
 
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
 #include "comms/pipes/Timeout.cuh"
 #include "comms/pipes/collectives/Ring.cuh"
 
 namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__device__ __forceinline__ void ring_reduce_scatter_device(
+    const RingReduceScatterArgs<NumRings, T>& args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_elems = chunk_elems / NumRings;
+  const std::size_t ring_elems = (ring_id < NumRings - 1)
+      ? base_ring_elems
+      : (chunk_elems - (NumRings - 1) * base_ring_elems);
+  const std::size_t ring_bytes = ring_elems * sizeof(T);
+  const std::size_t ring_offset = ring_id * base_ring_elems * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+  const char* input_base = reinterpret_cast<const char*>(args.input);
+
+  using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
+
+  for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+    const std::size_t remaining = io_tile_bytes - off;
+    const std::size_t window =
+        (remaining < pipeline_window) ? remaining : pipeline_window;
+
+    int current_rank = (my_rank + W - stride) % W;
+
+    // Step 0: Send raw input chunk to next.
+    const char* send_src = input_base + current_rank * chunk_bytes +
+        ring_offset + io_tile_offset + off;
+    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+    // W-1 receive steps: forward for intermediate, recv for final.
+    for (int step = 0; step < W - 1; step++) {
+      current_rank = (current_rank + W - stride) % W;
+      const char* local_input = input_base + current_rank * chunk_bytes +
+          ring_offset + io_tile_offset + off;
+
+      if (step < W - 2) {
+        prev.template forward<ReduceOp>(
+            group,
+            nullptr,
+            next,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      } else {
+        char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+            io_tile_offset + off;
+        prev.template recv<ReduceOp>(
+            group,
+            dst,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            local_input);
+      }
+    }
+  }
+#endif
+}
 
 template <
     int NumRings,

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -1,0 +1,436 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+struct RingAllReduceBenchmarkConfig {
+  std::size_t total_elements;
+  int num_blocks;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct RingAllReduceBenchmarkResult {
+  std::string test_name;
+  std::size_t total_elements{};
+  std::size_t total_bytes{};
+  int num_rings{};
+  float nccl_bandwidth{};
+  float ring_bandwidth{};
+  float nccl_latency{};
+  float ring_latency{};
+  float speedup{};
+};
+
+class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id{};
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_bytes = config.total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(total_bytes);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total_bytes));
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclAllReduce(
+          send_buf.get(),
+          recv_buf.get(),
+          config.total_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclAllReduce(
+          send_buf.get(),
+          recv_buf.get(),
+          config.total_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_ring_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_bytes = config.total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(total_bytes);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total_bytes));
+
+    std::unique_ptr<MultipeerIbgdaTransport> transport;
+    try {
+      MultipeerIbgdaTransportConfig transport_config{
+          .cudaDevice = localRank,
+          .dataBufferSize = config.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * config.num_rings,
+                  .pipelineDepth = config.pipeline_depth,
+              },
+          .numQpsPerPeerPerNic = config.num_qps,
+      };
+      transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transport_config);
+      transport->exchange();
+    } catch (const std::exception& e) {
+      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    if (config.num_rings <= 0 ||
+        config.num_rings > RingAllReduceLaunchParams::kMaxRings) {
+      XLOGF(ERR, "Unsupported num_rings={}", config.num_rings);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, config.num_rings);
+    if (!rings_opt) {
+      XLOGF(
+          ERR,
+          "Cannot construct {} distinct rings for {} ranks",
+          config.num_rings,
+          worldSize);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+    auto& rings = *rings_opt;
+    if (rings.size() < static_cast<std::size_t>(config.num_rings)) {
+      XLOGF(
+          ERR,
+          "Constructed {} rings, expected {}",
+          rings.size(),
+          config.num_rings);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    RingAllReduceLaunchParams launch_params{};
+    launch_params.my_rank = globalRank;
+    launch_params.num_ranks = worldSize;
+    launch_params.count = config.total_elements;
+    launch_params.input = static_cast<const float*>(send_buf.get());
+    launch_params.output = static_cast<float*>(recv_buf.get());
+    launch_params.num_blocks = config.num_blocks * config.num_rings;
+    launch_params.num_rings = config.num_rings;
+    launch_params.stream = stream_;
+
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_ring_allreduce(launch_params);
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      launch_ring_allreduce(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(const std::vector<RingAllReduceBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    auto fmt_bytes = [](std::size_t bytes) -> std::string {
+      if (bytes >= 1024UL * 1024 * 1024) {
+        return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+      }
+      if (bytes >= 1024 * 1024) {
+        return std::to_string(bytes / (1024 * 1024)) + "MB";
+      }
+      if (bytes >= 1024) {
+        return std::to_string(bytes / 1024) + "KB";
+      }
+      return std::to_string(bytes) + "B";
+    };
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "         NCCL AllReduce vs Ring AllReduce (Pipes IBGDA) Benchmark\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(6) << "Rings" << std::right
+       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
+       << std::right << std::setw(10) << "Speedup" << std::right
+       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
+       << "Ring Lat\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(6) << "" << std::right << std::setw(10)
+       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
+       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "(us)\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
+         << std::setw(6) << r.num_rings << std::right << std::setw(10)
+         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
+         << std::setw(10) << std::fixed << std::setprecision(2)
+         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup << "x" << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.ring_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize << " ranks, total_elements = per-rank input/output size\n";
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Ring AllReduce (Pipes IBGDA) vs NCCL Comparison ===\n";
+  }
+
+  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+  int kNumQps = 4;
+
+  std::vector<RingAllReduceBenchmarkConfig> configs = {
+      {.total_elements = 64 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256KB_8B"},
+      {.total_elements = 256 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "1MB_16B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_16B"},
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_16B"},
+      {.total_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64MB_16B"},
+      {.total_elements = 32 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "128MB_16B"},
+      {.total_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256MB_32B"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "512MB_32B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_16B_2R"},
+      {.total_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64MB_16B_2R"},
+      {.total_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256MB_32B_2R"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "512MB_32B_2R"},
+  };
+
+  std::vector<RingAllReduceBenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    float nccl_lat = 0.0f;
+    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
+
+    float ring_lat = 0.0f;
+    float ring_bw = run_ring_benchmark(config, ring_lat);
+
+    if (globalRank == 0) {
+      results.push_back({
+          .test_name = config.name,
+          .total_elements = config.total_elements,
+          .total_bytes = config.total_elements * sizeof(float),
+          .num_rings = config.num_rings,
+          .nccl_bandwidth = nccl_bw,
+          .ring_bandwidth = ring_bw,
+          .nccl_latency = nccl_lat,
+          .ring_latency = ring_lat,
+          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
+
 #include "comms/pipes/MultipeerIbgdaTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/pipes/collectives/RingAllReduceLauncher.h"
@@ -38,10 +40,13 @@ struct RingAllReduceBenchmarkResult {
   std::size_t total_bytes{};
   int num_rings{};
   float nccl_bandwidth{};
+  float ctran_bandwidth{};
   float ring_bandwidth{};
   float nccl_latency{};
+  float ctran_latency{};
   float ring_latency{};
-  float speedup{};
+  float speedup_vs_nccl{};
+  float speedup_vs_ctran{};
 };
 
 class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
@@ -51,13 +56,17 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     setenv("NCCL_P2P_DISABLE", "1", 1);
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    setenv("NCCL_IGNORE_TOPO_LOAD_FAILURE", "true", 1);
     NCCL_CHECK_VOID(
-        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+        ncclCommInitRank(&comm_, worldSize, get_nccl_id(), globalRank));
+
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
-    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    NCCL_CHECK_VOID(ncclCommDestroy(comm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
     BenchmarkTestFixture::TearDown();
   }
@@ -88,6 +97,29 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float run_nccl_benchmark(
       const RingAllReduceBenchmarkConfig& config,
       float& latency_us) {
+    NCCL_CHECK(set_allreduce_algo("orig"));
+    return run_ncclx_benchmark(config, latency_us);
+  }
+
+  float run_ctran_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    NCCL_CHECK(set_allreduce_algo("ctring"));
+    float bw = run_ncclx_benchmark(config, latency_us);
+    NCCL_CHECK(set_allreduce_algo("orig"));
+    return bw;
+  }
+
+  ncclResult_t set_allreduce_algo(const std::string& algo) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allreduceAlgo", algo}});
+    config.hints = &hints;
+    return ncclx::commSetConfig(comm_, &config);
+  }
+
+  float run_ncclx_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
     const std::size_t total_bytes = config.total_elements * sizeof(float);
 
     DeviceBuffer send_buf(total_bytes);
@@ -107,7 +139,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          comm_,
           stream_));
     }
 
@@ -119,7 +151,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          comm_,
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
@@ -261,43 +293,46 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     std::stringstream ss;
     ss << "\n";
-    ss << "================================================================================\n";
-    ss << "         NCCL AllReduce vs Ring AllReduce (Pipes IBGDA) Benchmark\n";
-    ss << "================================================================================\n";
-    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
-       << "Size" << std::right << std::setw(6) << "Rings" << std::right
-       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
-       << std::right << std::setw(10) << "Speedup" << std::right
-       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
-       << "Ring Lat\n";
-    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
-       << std::right << std::setw(6) << "" << std::right << std::setw(10)
-       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
-       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
-       << std::right << std::setw(12) << "(us)\n";
-    ss << "--------------------------------------------------------------------------------\n";
+    ss << "====================================================================================================\n";
+    ss << "         NCCL vs Ctran (ctring) vs Pipes Ring AllReduce Benchmark\n";
+    ss << "====================================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(8)
+       << "Size" << std::setw(4) << "R" << std::setw(9) << "NCCL"
+       << std::setw(9) << "Ctran" << std::setw(9) << "Pipes" << std::setw(10)
+       << "vs NCCL" << std::setw(10) << "vs Ctran" << std::setw(10) << "NCCL us"
+       << std::setw(10) << "Ctran us" << std::setw(10) << "Pipes us\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(8) << ""
+       << std::setw(4) << "" << std::setw(9) << "(GB/s)" << std::setw(9)
+       << "(GB/s)" << std::setw(9) << "(GB/s)" << std::setw(10) << ""
+       << std::setw(10) << "" << std::setw(10) << "" << std::setw(10) << ""
+       << std::setw(10) << "\n";
+    ss << "----------------------------------------------------------------------------------------------------\n";
 
     for (const auto& r : results) {
       ss << std::left << std::setw(14) << r.test_name << std::right
-         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
-         << std::setw(6) << r.num_rings << std::right << std::setw(10)
-         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
-         << std::setw(10) << std::fixed << std::setprecision(2)
-         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.speedup << "x" << std::right
-         << std::setw(12) << std::fixed << std::setprecision(1)
-         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setw(8) << fmt_bytes(r.total_bytes) << std::setw(4)
+         << r.num_rings << std::setw(9) << std::fixed << std::setprecision(2)
+         << r.nccl_bandwidth << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.ctran_bandwidth << std::setw(9)
+         << std::fixed << std::setprecision(2) << r.ring_bandwidth
+         << std::setw(9) << std::fixed << std::setprecision(2)
+         << r.speedup_vs_nccl << "x" << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup_vs_ctran << "x" << std::setw(10)
+         << std::fixed << std::setprecision(1) << r.nccl_latency
+         << std::setw(10) << std::fixed << std::setprecision(1)
+         << r.ctran_latency << std::setw(10) << std::fixed
          << std::setprecision(1) << r.ring_latency << "\n";
     }
 
-    ss << "================================================================================\n";
-    ss << worldSize << " ranks, total_elements = per-rank input/output size\n";
-    ss << "================================================================================\n";
+    ss << "====================================================================================================\n";
+    ss << worldSize
+       << " ranks | NCCL=orig(auto) | Ctran=ctring(GPE) | Pipes=IBGDA(device-native)\n";
+    ss << "====================================================================================================\n";
 
     XLOG(INFO) << ss.str();
   }
 
-  ncclComm_t nccl_comm_{};
+  ncclComm_t comm_{};
   cudaStream_t stream_{};
 };
 
@@ -402,6 +437,9 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
     float nccl_lat = 0.0f;
     float nccl_bw = run_nccl_benchmark(config, nccl_lat);
 
+    float ctran_lat = 0.0f;
+    float ctran_bw = run_ctran_benchmark(config, ctran_lat);
+
     float ring_lat = 0.0f;
     float ring_bw = run_ring_benchmark(config, ring_lat);
 
@@ -412,10 +450,13 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
           .total_bytes = config.total_elements * sizeof(float),
           .num_rings = config.num_rings,
           .nccl_bandwidth = nccl_bw,
+          .ctran_bandwidth = ctran_bw,
           .ring_bandwidth = ring_bw,
           .nccl_latency = nccl_lat,
+          .ctran_latency = ctran_lat,
           .ring_latency = ring_lat,
-          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+          .speedup_vs_nccl = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+          .speedup_vs_ctran = (ctran_bw > 0) ? ring_bw / ctran_bw : 0.0f,
       });
     }
     bootstrap->barrierAll();

--- a/comms/pipes/collectives/tests/AllReduceTestHarness.h
+++ b/comms/pipes/collectives/tests/AllReduceTestHarness.h
@@ -1,0 +1,74 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::pipes::test {
+
+struct AllReduceTestConfig {
+  std::size_t total_elements;
+  int num_blocks;
+  std::string name;
+};
+
+class AllReduceTestBase : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void fill_input(float* input_d, std::size_t total_elements) {
+    std::vector<float> h_input(total_elements);
+    for (std::size_t i = 0; i < total_elements; i++) {
+      h_input[i] = static_cast<float>((globalRank * 7 + i) % 100) * 0.01f;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        input_d,
+        h_input.data(),
+        total_elements * sizeof(float),
+        cudaMemcpyHostToDevice));
+  }
+
+  void verify_allreduce(const float* output_d, std::size_t total_elements) {
+    std::vector<float> h_output(total_elements);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_output.data(),
+        output_d,
+        total_elements * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    int errors = 0;
+    for (std::size_t i = 0; i < total_elements; i++) {
+      float expected = 0.0f;
+      for (int rank = 0; rank < worldSize; rank++) {
+        expected += static_cast<float>((rank * 7 + i) % 100) * 0.01f;
+      }
+      float actual = h_output[i];
+      if (std::abs(actual - expected) > 1e-2f) {
+        if (errors < 10) {
+          EXPECT_NEAR(actual, expected, 1e-2f)
+              << "Mismatch at offset=" << i << " (my_rank=" << globalRank
+              << ")";
+        }
+        errors++;
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Total mismatches: " << errors << " out of "
+                         << total_elements
+                         << " elements (my_rank=" << globalRank << ")";
+  }
+};
+
+} // namespace comms::pipes::test

--- a/comms/pipes/collectives/tests/RingAllReduceTest.cc
+++ b/comms/pipes/collectives/tests/RingAllReduceTest.cc
@@ -1,0 +1,235 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/AllReduceTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct RingAllReduceTestParams {
+  AllReduceTestConfig config;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<RingAllReduceTestParams>& info) {
+  return info.param.config.name;
+}
+
+struct LaunchContext {
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  RingAllReduceLaunchParams params{};
+};
+
+class RingAllReduceTest
+    : public AllReduceTestBase,
+      public ::testing::WithParamInterface<RingAllReduceTestParams> {
+ protected:
+  std::optional<LaunchContext> setup_launch(
+      const RingAllReduceTestParams& params) {
+    const auto& config = params.config;
+
+    LaunchContext ctx;
+    try {
+      MultipeerIbgdaTransportConfig transportConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = params.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * params.num_rings,
+                  .pipelineDepth = params.pipeline_depth,
+              },
+      };
+      ctx.transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transportConfig);
+      ctx.transport->exchange();
+    } catch (const std::exception&) {
+      return std::nullopt;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, params.num_rings);
+    if (!rings_opt.has_value()) {
+      return std::nullopt;
+    }
+    auto& rings = *rings_opt;
+
+    ctx.params.my_rank = globalRank;
+    ctx.params.num_ranks = worldSize;
+    ctx.params.count = config.total_elements;
+    ctx.params.num_blocks = config.num_blocks * params.num_rings;
+    ctx.params.num_rings = params.num_rings;
+    ctx.params.timeout_ms = 30000.0f;
+
+    for (int r = 0; r < params.num_rings; r++) {
+      auto& rp = ctx.params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = ctx.transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = ctx.transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    return ctx;
+  }
+};
+
+TEST_P(RingAllReduceTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+  if (config.total_elements % worldSize != 0) {
+    GTEST_SKIP() << "total_elements must be divisible by worldSize";
+  }
+
+  auto ctx = setup_launch(params);
+  if (!ctx) {
+    GTEST_SKIP() << "Transport or ring setup unavailable";
+  }
+
+  DeviceBuffer inputBuf(config.total_elements * sizeof(float));
+  DeviceBuffer outputBuf(config.total_elements * sizeof(float));
+  CUDACHECK_TEST(
+      cudaMemset(outputBuf.get(), 0, config.total_elements * sizeof(float)));
+
+  fill_input(static_cast<float*>(inputBuf.get()), config.total_elements);
+
+  ctx->params.input = static_cast<const float*>(inputBuf.get());
+  ctx->params.output = static_cast<float*>(outputBuf.get());
+
+  bootstrap->barrierAll();
+  launch_ring_allreduce(ctx->params);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allreduce(
+      static_cast<const float*>(outputBuf.get()), config.total_elements);
+}
+
+TEST_P(RingAllReduceTest, InPlaceCorrectness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+  if (config.total_elements % worldSize != 0) {
+    GTEST_SKIP() << "total_elements must be divisible by worldSize";
+  }
+
+  auto ctx = setup_launch(params);
+  if (!ctx) {
+    GTEST_SKIP() << "Transport or ring setup unavailable";
+  }
+
+  DeviceBuffer buf(config.total_elements * sizeof(float));
+  fill_input(static_cast<float*>(buf.get()), config.total_elements);
+
+  ctx->params.input = static_cast<const float*>(buf.get());
+  ctx->params.output = static_cast<float*>(buf.get());
+
+  bootstrap->barrierAll();
+  launch_ring_allreduce(ctx->params);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allreduce(static_cast<const float*>(buf.get()), config.total_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 16 * 1024,
+                 .num_blocks = 4,
+                 .name = "64KB_4B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 256 * 1024,
+                 .num_blocks = 16,
+                 .name = "1MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 2 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "16MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 8 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2649,13 +2649,14 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring
+   choices     : orig, ctran, ctdirect, ctring, ctree
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
      ctran - Picks the best ctran-based algorithm
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - ctran-based ring algorithm
+     ctree - Ctran-based tree algorithm (Pipes-native)
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1806,6 +1806,19 @@ cvars:
      initialize MultiPeerTransport which provides unified NVLink and IBGDA
      transport for P2P communication.
 
+ - name        : NCCL_CTRAN_MAX_NBLOCKS
+   type        : int
+   default     : 16
+   description : |-
+     Maximum number of logical CUDA blocks used by CTRAN collectives that support message-size-based block tuning.
+
+ - name        : NCCL_CTRAN_TREE_FANOUT
+   type        : int
+   default     : 2
+   description : |-
+     Fanout used when building CTREE tree topologies for experimental benchmarking.
+     Valid values are 1 through the compile-time maximum tree children.
+
  - name        : NCCL_CTRAN_PIPES_TRACE_ENABLE
    type        : bool
    default     : false

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -2662,7 +2662,7 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring, ctree
+   choices     : orig, ctran, ctdirect, ctring, ctree, pipesflatring
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
@@ -2670,6 +2670,7 @@ cvars:
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - ctran-based ring algorithm
      ctree - Ctran-based tree algorithm (Pipes-native)
+     pipesflatring - Pipes-based device-native ring algorithm (IBGDA)
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3083,6 +3083,21 @@ cvars:
      Number of threads in each thread block used for the AllReduce
      kernel.
 
+ - name        : NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_RINGS
+   type        : int
+   default     : -1
+   description : |-
+     Number of rings for the pipesflatring AllReduce algorithm. Set to
+     -1 for automatic selection. Supported explicit values are 1, 2, and 4.
+
+ - name        : NCCL_CTRAN_ALLREDUCE_PIPES_FLAT_RING_NUM_BLOCKS
+   type        : int
+   default     : -1
+   description : |-
+     Total grid blocks for the pipesflatring AllReduce algorithm. Set to
+     -1 for automatic selection. This is the total grid size split across
+     all rings.
+
  - name        : NCCL_CTRAN_ALLREDUCE_RING_AUTO_TUNE_MAX_BDP
    type        : int
    default     : 0


### PR DESCRIPTION
Summary:

Switch the fused Ring AllReduce kernel's ReduceScatter phase from `TileReduce` to `TileReduceStaged` (introduced in D104600612). `TileReduceStaged` decouples the two memory load streams (staging buffer from IB + local GPU memory) from the accumulation step, giving the compiler more freedom to schedule loads in parallel. Measured +2-3% bandwidth improvement at 32-128MB for standalone `ReduceScatter`.

Differential Revision: D104758065
