### PR TITLE
Add NCCL Ring baseline and medium-size block sweep to AllReduce benchmark (#2708)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -215,6 +215,21 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           config.ibgdaConfig.dataBufferSize);
     }
 
+    if (NCCL_CTRAN_PIPES_SENDRECV_ENABLE) {
+      config.ibgdaConfig.sendRecv =
+          comms::pipes::MultipeerIbgdaTransportConfig::SendRecvConfig{
+              .maxGroups =
+                  static_cast<int>(NCCL_CTRAN_PIPES_SENDRECV_MAX_GROUPS),
+              .pipelineDepth =
+                  static_cast<int>(NCCL_CTRAN_PIPES_SENDRECV_PIPELINE_DEPTH),
+          };
+      CLOGF(
+          INFO,
+          "Pipes IBGDA send/recv enabled (maxGroups={}, pipelineDepth={})",
+          NCCL_CTRAN_PIPES_SENDRECV_MAX_GROUPS,
+          NCCL_CTRAN_PIPES_SENDRECV_PIPELINE_DEPTH);
+    }
+
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||
         NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal;

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -28,6 +28,18 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctran:
     case NCCL_ALLREDUCE_ALGO::ctdirect:
       return true;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+#if defined(ENABLE_PIPES)
+      if (comm->multiPeerTransport_ && NCCL_CTRAN_PIPES_SENDRECV_ENABLE &&
+          comm->statex_->nLocalRanks() == 1) {
+        return true;
+      }
+      CLOGF(
+          WARN,
+          "pipesflatring requires ENABLE_PIPES, NCCL_CTRAN_USE_PIPES=1, "
+          "NCCL_CTRAN_PIPES_SENDRECV_ENABLE=1, and nLocalRanks=1");
+#endif
+      return false;
     default: // invalid query
       return false;
   }
@@ -64,6 +76,13 @@ commResult_t ctranAllReduce(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       return ctranAllReduceRing(
+          sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      if (comm->statex_->nRanks() == 1) {
+        return ctranAllReduceDirect(
+            sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
+      }
+      return ctranAllReducePipesFlatRing(
           sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
     case NCCL_ALLREDUCE_ALGO::ctdirect:
     default:

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -26,6 +26,15 @@ commResult_t ctranAllReduceRing(
     CtranComm* comm,
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
 static inline const std::string allReduceAlgoName(
     enum NCCL_ALLREDUCE_ALGO algo) {
@@ -38,6 +47,8 @@ static inline const std::string allReduceAlgoName(
       return "Baseline";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "CtranAllReduceRing";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "PipesFlatRingAllReduce";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -1,0 +1,157 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <chrono>
+#include <optional>
+
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PIPES)
+
+#include "comms/pipes/MultiPeerTransport.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  if (!comm->multiPeerTransport_) {
+    CLOGF(
+        ERR,
+        "PipesFlatRingAllReduce requires MultiPeerTransport "
+        "(NCCL_CTRAN_USE_PIPES=1)");
+    return commInternalError;
+  }
+
+  if (datatype != commDataType_t::commFloat32) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce currently supports float32 only, got {}",
+        static_cast<int>(datatype));
+    return commInvalidArgument;
+  }
+
+  if (redOp != commRedOp_t::commSum) {
+    CLOGF(
+        WARN,
+        "PipesFlatRingAllReduce currently supports Sum only, got {}",
+        static_cast<int>(redOp));
+    return commInvalidArgument;
+  }
+
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  auto* statex = comm->statex_.get();
+  const int nRanks = statex->nRanks();
+  const int rank = statex->rank();
+
+  if (nRanks < 2) {
+    if (sendbuff != recvbuff) {
+      auto err = cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * sizeof(float),
+          cudaMemcpyDeviceToDevice,
+          stream);
+      if (err != cudaSuccess) {
+        CLOGF(
+            ERR,
+            "PipesFlatRingAllReduce cudaMemcpyAsync failed: {}",
+            cudaGetErrorString(err));
+        return commInternalError;
+      }
+    }
+    return commSuccess;
+  }
+
+  const size_t divisibleCount = (count / nRanks) * nRanks;
+  const size_t remainder = count - divisibleCount;
+
+  if (divisibleCount > 0) {
+    const int numRings = 1;
+
+    auto ringsOpt = comms::pipes::make_standard_rings(nRanks, rank, numRings);
+    if (!ringsOpt.has_value()) {
+      CLOGF(
+          ERR,
+          "PipesFlatRingAllReduce: failed to build {} rings for {} ranks",
+          numRings,
+          nRanks);
+      return commInvalidArgument;
+    }
+    const auto& rings = *ringsOpt;
+
+    auto* mpt = comm->multiPeerTransport_.get();
+
+    comms::pipes::RingAllReduceLaunchParams params{};
+    params.my_rank = rank;
+    params.num_ranks = nRanks;
+    params.count = divisibleCount;
+    params.signaling_data_size = 0;
+    params.input = static_cast<const float*>(sendbuff);
+    params.output = static_cast<float*>(recvbuff);
+    params.num_blocks = 16;
+    params.num_rings = numRings;
+    params.stream = stream;
+
+    if (timeout.has_value()) {
+      params.timeout_ms = static_cast<float>(timeout->count());
+    }
+
+    for (int r = 0; r < numRings; r++) {
+      params.rings[r].prev_rank = rings[r].prev_rank;
+      params.rings[r].next_rank = rings[r].next_rank;
+      params.rings[r].prev =
+          mpt->get_p2p_ibgda_transport_device(rings[r].prev_rank);
+      params.rings[r].next =
+          mpt->get_p2p_ibgda_transport_device(rings[r].next_rank);
+    }
+
+    comms::pipes::launch_ring_allreduce(params);
+  }
+
+  if (remainder > 0) {
+    const size_t elemSize = sizeof(float);
+    const void* remainderSendbuff =
+        static_cast<const char*>(sendbuff) + divisibleCount * elemSize;
+    void* remainderRecvbuff =
+        static_cast<char*>(recvbuff) + divisibleCount * elemSize;
+    return ctranAllReduceDirect(
+        remainderSendbuff,
+        remainderRecvbuff,
+        remainder,
+        datatype,
+        redOp,
+        comm,
+        stream,
+        timeout);
+  }
+
+  return commSuccess;
+}
+
+#else
+
+commResult_t ctranAllReducePipesFlatRing(
+    const void*,
+    void*,
+    size_t,
+    commDataType_t,
+    commRedOp_t,
+    CtranComm*,
+    cudaStream_t,
+    std::optional<std::chrono::milliseconds>) {
+  return commInternalError;
+}
+
+#endif // ENABLE_PIPES

--- a/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReducePipesFlatRing.cc
@@ -76,9 +76,42 @@ commResult_t ctranAllReducePipesFlatRing(
 
   const size_t divisibleCount = (count / nRanks) * nRanks;
   const size_t remainder = count - divisibleCount;
+  const size_t messageBytes = divisibleCount * sizeof(float);
 
   if (divisibleCount > 0) {
-    const int numRings = 1;
+    bool enableBidirAg = false;
+    if (nRanks > 2) {
+      int64_t bidirMinSize = NCCL_CTRAN_ALLREDUCE_PIPES_BIDIR_AG_MIN_SIZE;
+      if (bidirMinSize == -1) {
+        enableBidirAg = false;
+      } else if (bidirMinSize == 0) {
+        enableBidirAg = true;
+      } else if (bidirMinSize == -2) {
+        enableBidirAg = (messageBytes >= 16UL * 1024 * 1024);
+      } else if (bidirMinSize > 0) {
+        enableBidirAg = (static_cast<int64_t>(messageBytes) >= bidirMinSize);
+      }
+    }
+
+    int numRings;
+    int numBlocks;
+    if (NCCL_CTRAN_ALLREDUCE_PIPES_NUM_RINGS > 0) {
+      numRings = NCCL_CTRAN_ALLREDUCE_PIPES_NUM_RINGS;
+    } else if (messageBytes > 32UL * 1024 * 1024) {
+      numRings = 2;
+    } else {
+      numRings = 1;
+    }
+
+    if (NCCL_CTRAN_ALLREDUCE_PIPES_NUM_BLOCKS > 0) {
+      numBlocks = NCCL_CTRAN_ALLREDUCE_PIPES_NUM_BLOCKS;
+    } else if (messageBytes <= 1024 * 1024) {
+      numBlocks = 4;
+    } else if (messageBytes <= 32UL * 1024 * 1024) {
+      numBlocks = 8;
+    } else {
+      numBlocks = 16;
+    }
 
     auto ringsOpt = comms::pipes::make_standard_rings(nRanks, rank, numRings);
     if (!ringsOpt.has_value()) {
@@ -100,9 +133,10 @@ commResult_t ctranAllReducePipesFlatRing(
     params.signaling_data_size = 0;
     params.input = static_cast<const float*>(sendbuff);
     params.output = static_cast<float*>(recvbuff);
-    params.num_blocks = 16;
+    params.num_blocks = numBlocks;
     params.num_rings = numRings;
     params.stream = stream;
+    params.enable_bidir_ag = enableBidirAg;
 
     if (timeout.has_value()) {
       params.timeout_ms = static_cast<float>(timeout->count());

--- a/comms/ncclx/meta/algoconf/AlgoStrConv.h
+++ b/comms/ncclx/meta/algoconf/AlgoStrConv.h
@@ -61,6 +61,8 @@ inline void algoStrToVal(
     val = NCCL_ALLREDUCE_ALGO::ctdirect;
   } else if (str == "ctring") {
     val = NCCL_ALLREDUCE_ALGO::ctring;
+  } else if (str == "pipesflatring") {
+    val = NCCL_ALLREDUCE_ALGO::pipesflatring;
   } else {
     val = NCCL_ALLREDUCE_ALGO::orig;
   }
@@ -144,6 +146,8 @@ inline std::string algoValToStr(enum NCCL_ALLREDUCE_ALGO val) {
       return "ctdirect";
     case NCCL_ALLREDUCE_ALGO::ctring:
       return "ctring";
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      return "pipesflatring";
   }
   return "unknown";
 }

--- a/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
+++ b/comms/ncclx/meta/algoconf/tests/AlgoStrConvTest.cc
@@ -95,6 +95,9 @@ void checkAlgoStrToVal(enum NCCL_ALLREDUCE_ALGO algo) {
     case NCCL_ALLREDUCE_ALGO::ctring:
       str = "ctring";
       break;
+    case NCCL_ALLREDUCE_ALGO::pipesflatring:
+      str = "pipesflatring";
+      break;
   }
   enum NCCL_ALLREDUCE_ALGO result;
   algoStrToVal(str, result);
@@ -171,6 +174,7 @@ TEST(AlgoStrConvTest, AllReduceCompleteness) {
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctran);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctdirect);
   checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::ctring);
+  checkAlgoStrToVal(NCCL_ALLREDUCE_ALGO::pipesflatring);
 }
 
 TEST(AlgoStrConvTest, AllToAllVCompleteness) {

--- a/comms/pipes/P2pIbgdaTransportDevice.cuh
+++ b/comms/pipes/P2pIbgdaTransportDevice.cuh
@@ -34,6 +34,20 @@
 
 namespace comms::pipes {
 
+// Toggle release fences in the RDMA put path (send/forward).
+// __threadfence_system() ensures GPU stores are visible to PCIe/NIC devices.
+// __threadfence() is lighter (GPU-scope only) but may suffice if the NIC DMA
+// path snoops GPU L2 cache. Define to 1 to use device-scope fence; default 0
+// keeps system-scope fence.
+#ifndef PIPES_USE_DEVICE_SCOPE_RELEASE_FENCE
+#define PIPES_USE_DEVICE_SCOPE_RELEASE_FENCE 0
+#endif
+#if PIPES_USE_DEVICE_SCOPE_RELEASE_FENCE
+#define PIPES_RELEASE_FENCE() __threadfence()
+#else
+#define PIPES_RELEASE_FENCE() __threadfence_system()
+#endif
+
 struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
@@ -1338,10 +1352,10 @@ class P2pIbgdaTransportDevice {
             timeout);
       }
 
-      // (4) threadfence_system + leader-only single-WQE RDMA put with
+      // (4) Release fence + leader-only single-WQE RDMA put with
       //     fused signal+counter. All threads fence to ensure memcpy
       //     stores are visible to the NIC before the leader posts the WQE.
-      __threadfence_system();
+      PIPES_RELEASE_FENCE();
       group.sync();
       if (group.is_leader()) {
         ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
@@ -1759,8 +1773,8 @@ class P2pIbgdaTransportDevice {
             timeout);
       }
 
-      // (6) threadfence_system + RDMA put via fwd transport.
-      __threadfence_system();
+      // (6) Release fence + RDMA put via fwd transport.
+      PIPES_RELEASE_FENCE();
       group.sync();
       if (group.is_leader()) {
         ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};

--- a/comms/pipes/collectives/DirectCollectiveUtils.cuh
+++ b/comms/pipes/collectives/DirectCollectiveUtils.cuh
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 
-#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/CopyOp.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
 #include "comms/pipes/P2pNvlTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"

--- a/comms/pipes/collectives/Ring.cuh
+++ b/comms/pipes/collectives/Ring.cuh
@@ -37,4 +37,15 @@ struct RingReduceScatterArgs {
   T* output{nullptr};
 };
 
+template <int NumRings, typename T>
+struct RingAllReduceArgs {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t chunk_elements{0};
+  std::size_t signaling_data_size{0};
+  RingTopology rings[NumRings]{};
+  const T* input{nullptr};
+  T* output{nullptr};
+};
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/Ring.cuh
+++ b/comms/pipes/collectives/Ring.cuh
@@ -43,6 +43,8 @@ struct RingAllReduceArgs {
   int num_ranks{0};
   std::size_t chunk_elements{0};
   std::size_t signaling_data_size{0};
+  std::size_t ib_window_bytes{0};
+  bool skip_reduction{false};
   RingTopology rings[NumRings]{};
   const T* input{nullptr};
   T* output{nullptr};

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -1,0 +1,153 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/CopyUtils.cuh"
+#include "comms/pipes/ThreadGroup.cuh"
+#include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/RingAllReduce.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
+    const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
+    Timeout timeout) {
+#ifdef __CUDA_ARCH__
+  timeout.start();
+
+  auto group = make_block_group();
+  auto [ring_id, ring_group] = group.partition(NumRings);
+  const auto& topo = args.rings[ring_id];
+  auto& prev = *topo.prev;
+  auto& next = *topo.next;
+
+  const int W = args.num_ranks;
+  const std::size_t chunk_elems = args.chunk_elements;
+  const std::size_t chunk_bytes = chunk_elems * sizeof(T);
+  const std::size_t max_sig = args.signaling_data_size;
+
+  const std::size_t base_ring_elems = chunk_elems / NumRings;
+  const std::size_t ring_elems = (ring_id < NumRings - 1)
+      ? base_ring_elems
+      : (chunk_elems - (NumRings - 1) * base_ring_elems);
+  const std::size_t ring_bytes = ring_elems * sizeof(T);
+  const std::size_t ring_offset = ring_id * base_ring_elems * sizeof(T);
+
+  TiledBuffer<char> ring_tile(nullptr, ring_bytes, ring_group);
+  const std::size_t io_tile_offset =
+      ring_group.group_id * ring_tile.tile_elements;
+  const std::size_t io_tile_bytes = ring_tile.bytes();
+
+  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+
+  const int my_rank = args.my_rank;
+  const int stride = (my_rank - topo.prev_rank + W) % W;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 1: REDUCE-SCATTER (TileReduce CopyOp)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    const char* input_base = reinterpret_cast<const char*>(args.input);
+    using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+
+    for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = io_tile_bytes - off;
+      const std::size_t window =
+          (remaining < pipeline_window) ? remaining : pipeline_window;
+
+      int current_rank = (my_rank + W - stride) % W;
+
+      const char* send_src = input_base + current_rank * chunk_bytes +
+          ring_offset + io_tile_offset + off;
+      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+      for (int step = 0; step < W - 1; step++) {
+        current_rank = (current_rank + W - stride) % W;
+        const char* local_input = input_base + current_rank * chunk_bytes +
+            ring_offset + io_tile_offset + off;
+
+        if (step < W - 2) {
+          prev.template forward<ReduceOp>(
+              group,
+              nullptr,
+              next,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout,
+              local_input);
+        } else {
+          char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+              io_tile_offset + off;
+          prev.template recv<ReduceOp>(
+              group,
+              dst,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout,
+              local_input);
+        }
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 2: ALL-GATHER (Memcpy CopyOp)
+  // ═══════════════════════════════════════════════════════════════════
+  {
+    char* output_base = reinterpret_cast<char*>(args.output);
+
+    // Local copy: reduced shard → correct position in output.
+    const char* own_src = output_base + ring_offset + io_tile_offset;
+    char* own_dst =
+        output_base + my_rank * chunk_bytes + ring_offset + io_tile_offset;
+    if (own_src != own_dst) {
+      memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
+    }
+    ring_group.sync();
+
+    for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+      const std::size_t remaining = io_tile_bytes - off;
+      const std::size_t window =
+          (remaining < pipeline_window) ? remaining : pipeline_window;
+
+      char* send_src = output_base + my_rank * chunk_bytes + ring_offset +
+          io_tile_offset + off;
+      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+
+      int current_rank = my_rank;
+      for (int step = 0; step < W - 1; step++) {
+        current_rank = (current_rank + W - stride) % W;
+        char* dst = output_base + current_rank * chunk_bytes + ring_offset +
+            io_tile_offset + off;
+
+        if (step < W - 2) {
+          prev.forward(
+              group, dst, next, window, group.total_groups, max_sig, timeout);
+        } else {
+          prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+        }
+      }
+    }
+  }
+#endif
+}
+
+// Template instantiations
+template __global__ void ring_allreduce_kernel<1, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<1, float>,
+    Timeout);
+template __global__ void ring_allreduce_kernel<2, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<2, float>,
+    Timeout);
+template __global__ void ring_allreduce_kernel<4, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<4, float>,
+    Timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -49,11 +49,11 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
   const int stride = (my_rank - topo.prev_rank + W) % W;
 
   // ═══════════════════════════════════════════════════════════════════
-  // PHASE 1: REDUCE-SCATTER (TileReduce CopyOp)
+  // PHASE 1: REDUCE-SCATTER (TileReduceStaged CopyOp)
   // ═══════════════════════════════════════════════════════════════════
   {
     const char* input_base = reinterpret_cast<const char*>(args.input);
-    using ReduceOp = TileReduce<T, AccumOp, kTileElems, kBlockSize>;
+    using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
 
     for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
       const std::size_t remaining = io_tile_bytes - off;

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -13,7 +13,8 @@ template <
     typename T,
     typename AccumOp,
     int kTileElems,
-    int kBlockSize>
+    int kBlockSize,
+    bool EnableBidirAg>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
     const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
     Timeout timeout) {
@@ -112,6 +113,9 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
     }
     ring_group.sync();
 
+    const int num_fwd_recvs = EnableBidirAg ? (W - 1 + 1) / 2 : (W - 1);
+    const int num_rev_recvs = EnableBidirAg ? (W - 1) / 2 : 0;
+
     for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
       const std::size_t remaining = io_tile_bytes - off;
       const std::size_t window =
@@ -120,18 +124,53 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
       char* send_src = output_base + my_rank * chunk_bytes + ring_offset +
           io_tile_offset + off;
       next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+      if constexpr (EnableBidirAg) {
+        if (num_rev_recvs > 0) {
+          prev.send(
+              group, send_src, window, group.total_groups, max_sig, timeout);
+        }
+      }
 
-      int current_rank = my_rank;
-      for (int step = 0; step < W - 1; step++) {
-        current_rank = (current_rank + W - stride) % W;
-        char* dst = output_base + current_rank * chunk_bytes + ring_offset +
+      int fwd_current = my_rank;
+      int rev_current = my_rank;
+
+      for (int step = 0; step < num_fwd_recvs; step++) {
+        fwd_current = (fwd_current + W - stride) % W;
+        char* fwd_dst = output_base + fwd_current * chunk_bytes + ring_offset +
             io_tile_offset + off;
-
-        if (step < W - 2) {
+        if (step < num_fwd_recvs - 1) {
           prev.forward(
-              group, dst, next, window, group.total_groups, max_sig, timeout);
+              group,
+              fwd_dst,
+              next,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout);
         } else {
-          prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+          prev.recv(
+              group, fwd_dst, window, group.total_groups, max_sig, timeout);
+        }
+
+        if constexpr (EnableBidirAg) {
+          if (step < num_rev_recvs) {
+            rev_current = (rev_current + stride) % W;
+            char* rev_dst = output_base + rev_current * chunk_bytes +
+                ring_offset + io_tile_offset + off;
+            if (step < num_rev_recvs - 1) {
+              next.forward(
+                  group,
+                  rev_dst,
+                  prev,
+                  window,
+                  group.total_groups,
+                  max_sig,
+                  timeout);
+            } else {
+              next.recv(
+                  group, rev_dst, window, group.total_groups, max_sig, timeout);
+            }
+          }
         }
       }
     }
@@ -139,7 +178,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
 #endif
 }
 
-// Template instantiations
+// Template instantiations: EnableBidirAg = false (default)
 template __global__ void ring_allreduce_kernel<1, float, SumOp, 16384, 512>(
     const __grid_constant__ RingAllReduceArgs<1, float>,
     Timeout);
@@ -147,6 +186,20 @@ template __global__ void ring_allreduce_kernel<2, float, SumOp, 16384, 512>(
     const __grid_constant__ RingAllReduceArgs<2, float>,
     Timeout);
 template __global__ void ring_allreduce_kernel<4, float, SumOp, 16384, 512>(
+    const __grid_constant__ RingAllReduceArgs<4, float>,
+    Timeout);
+
+// Template instantiations: EnableBidirAg = true
+template __global__ void
+ring_allreduce_kernel<1, float, SumOp, 16384, 512, true>(
+    const __grid_constant__ RingAllReduceArgs<1, float>,
+    Timeout);
+template __global__ void
+ring_allreduce_kernel<2, float, SumOp, 16384, 512, true>(
+    const __grid_constant__ RingAllReduceArgs<2, float>,
+    Timeout);
+template __global__ void
+ring_allreduce_kernel<4, float, SumOp, 16384, 512, true>(
     const __grid_constant__ RingAllReduceArgs<4, float>,
     Timeout);
 

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -4,6 +4,7 @@
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
 #include "comms/pipes/collectives/RingAllReduce.cuh"
 
 namespace comms::pipes {
@@ -104,13 +105,9 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
   {
     char* output_base = reinterpret_cast<char*>(args.output);
 
-    // Local copy: reduced shard → correct position in output.
     const char* own_src = output_base + ring_offset + io_tile_offset;
     char* own_dst =
         output_base + my_rank * chunk_bytes + ring_offset + io_tile_offset;
-    if (own_src != own_dst) {
-      memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
-    }
     ring_group.sync();
 
     const int num_fwd_recvs = EnableBidirAg ? (W - 1 + 1) / 2 : (W - 1);
@@ -121,13 +118,28 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
       const std::size_t window =
           (remaining < pipeline_window) ? remaining : pipeline_window;
 
-      char* send_src = output_base + my_rank * chunk_bytes + ring_offset +
-          io_tile_offset + off;
-      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+      if (own_src != own_dst) {
+        next.template send<MemcpyAndSelfCopy>(
+            group,
+            own_src + off,
+            window,
+            group.total_groups,
+            max_sig,
+            timeout,
+            own_dst + off);
+      } else {
+        next.send(
+            group, own_src + off, window, group.total_groups, max_sig, timeout);
+      }
       if constexpr (EnableBidirAg) {
         if (num_rev_recvs > 0) {
           prev.send(
-              group, send_src, window, group.total_groups, max_sig, timeout);
+              group,
+              own_src + off,
+              window,
+              group.total_groups,
+              max_sig,
+              timeout);
         }
       }
 

--- a/comms/pipes/collectives/RingAllReduce.cu
+++ b/comms/pipes/collectives/RingAllReduce.cu
@@ -45,55 +45,94 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
       ring_group.group_id * ring_tile.tile_elements;
   const std::size_t io_tile_bytes = ring_tile.bytes();
 
-  const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
+  const std::size_t transport_window = next.pipeline_window(group.total_groups);
+  const std::size_t pipeline_window = (args.ib_window_bytes > 0)
+      ? min(args.ib_window_bytes, transport_window)
+      : transport_window;
 
   const int my_rank = args.my_rank;
   const int stride = (my_rank - topo.prev_rank + W) % W;
 
   // ═══════════════════════════════════════════════════════════════════
-  // PHASE 1: REDUCE-SCATTER (TileReduceStaged CopyOp)
+  // PHASE 1: REDUCE-SCATTER (TileReduceStaged or Memcpy CopyOp)
   // ═══════════════════════════════════════════════════════════════════
   {
     const char* input_base = reinterpret_cast<const char*>(args.input);
-    using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
 
-    for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
-      const std::size_t remaining = io_tile_bytes - off;
-      const std::size_t window =
-          (remaining < pipeline_window) ? remaining : pipeline_window;
+    if (args.skip_reduction) {
+      for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+        const std::size_t remaining = io_tile_bytes - off;
+        const std::size_t window =
+            (remaining < pipeline_window) ? remaining : pipeline_window;
 
-      int current_rank = (my_rank + W - stride) % W;
+        int current_rank = (my_rank + W - stride) % W;
 
-      const char* send_src = input_base + current_rank * chunk_bytes +
-          ring_offset + io_tile_offset + off;
-      next.send(group, send_src, window, group.total_groups, max_sig, timeout);
-
-      for (int step = 0; step < W - 1; step++) {
-        current_rank = (current_rank + W - stride) % W;
-        const char* local_input = input_base + current_rank * chunk_bytes +
+        const char* send_src = input_base + current_rank * chunk_bytes +
             ring_offset + io_tile_offset + off;
+        next.send(
+            group, send_src, window, group.total_groups, max_sig, timeout);
 
-        if (step < W - 2) {
-          prev.template forward<ReduceOp>(
-              group,
-              nullptr,
-              next,
-              window,
-              group.total_groups,
-              max_sig,
-              timeout,
-              local_input);
-        } else {
-          char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
-              io_tile_offset + off;
-          prev.template recv<ReduceOp>(
-              group,
-              dst,
-              window,
-              group.total_groups,
-              max_sig,
-              timeout,
-              local_input);
+        for (int step = 0; step < W - 1; step++) {
+          current_rank = (current_rank + W - stride) % W;
+
+          if (step < W - 2) {
+            prev.forward(
+                group,
+                nullptr,
+                next,
+                window,
+                group.total_groups,
+                max_sig,
+                timeout);
+          } else {
+            char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+                io_tile_offset + off;
+            prev.recv(group, dst, window, group.total_groups, max_sig, timeout);
+          }
+        }
+      }
+    } else {
+      using ReduceOp = TileReduceStaged<T, AccumOp, kTileElems, kBlockSize>;
+
+      for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
+        const std::size_t remaining = io_tile_bytes - off;
+        const std::size_t window =
+            (remaining < pipeline_window) ? remaining : pipeline_window;
+
+        int current_rank = (my_rank + W - stride) % W;
+
+        const char* send_src = input_base + current_rank * chunk_bytes +
+            ring_offset + io_tile_offset + off;
+        next.send(
+            group, send_src, window, group.total_groups, max_sig, timeout);
+
+        for (int step = 0; step < W - 1; step++) {
+          current_rank = (current_rank + W - stride) % W;
+          const char* local_input = input_base + current_rank * chunk_bytes +
+              ring_offset + io_tile_offset + off;
+
+          if (step < W - 2) {
+            prev.template forward<ReduceOp>(
+                group,
+                nullptr,
+                next,
+                window,
+                group.total_groups,
+                max_sig,
+                timeout,
+                local_input);
+          } else {
+            char* dst = reinterpret_cast<char*>(args.output) + ring_offset +
+                io_tile_offset + off;
+            prev.template recv<ReduceOp>(
+                group,
+                dst,
+                window,
+                group.total_groups,
+                max_sig,
+                timeout,
+                local_input);
+          }
         }
       }
     }

--- a/comms/pipes/collectives/RingAllReduce.cuh
+++ b/comms/pipes/collectives/RingAllReduce.cuh
@@ -1,0 +1,20 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/pipes/Timeout.cuh"
+#include "comms/pipes/collectives/Ring.cuh"
+
+namespace comms::pipes {
+
+template <
+    int NumRings,
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize>
+__global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
+    const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
+    Timeout timeout);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduce.cuh
+++ b/comms/pipes/collectives/RingAllReduce.cuh
@@ -12,7 +12,8 @@ template <
     typename T,
     typename AccumOp,
     int kTileElems,
-    int kBlockSize>
+    int kBlockSize,
+    bool EnableBidirAg = false>
 __global__ __launch_bounds__(kBlockSize, 1) void ring_allreduce_kernel(
     const __grid_constant__ RingAllReduceArgs<NumRings, T> args,
     Timeout timeout);

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -43,6 +43,8 @@ void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
   args.num_ranks = params.num_ranks;
   args.chunk_elements = chunk_elements;
   args.signaling_data_size = params.signaling_data_size;
+  args.ib_window_bytes = params.ib_window_bytes;
+  args.skip_reduction = params.skip_reduction;
   args.input = params.input;
   args.output = params.output;
 

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -1,0 +1,130 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/pipes/CopyOp.cuh"
+#include "comms/pipes/TimeoutUtils.h"
+#include "comms/pipes/collectives/RingAllgather.cuh"
+#include "comms/pipes/collectives/RingReduceScatter.cuh"
+
+namespace comms::pipes {
+
+namespace {
+
+RingTopology to_ring_topology(
+    const RingAllReduceLaunchParams::RingParams& src) {
+  return RingTopology{
+      .prev_rank = src.prev_rank,
+      .next_rank = src.next_rank,
+      .prev = src.prev,
+      .next = src.next,
+  };
+}
+
+void check_kernel_launch(const char* kernel_name) {
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(kernel_name) +
+        " kernel launch failed: " + cudaGetErrorString(err));
+  }
+}
+
+template <int NumRings>
+void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
+  const int my_rank = params.my_rank;
+  const int num_ranks = params.num_ranks;
+  const std::size_t chunk_elements = params.count / num_ranks;
+  const std::size_t chunk_bytes = chunk_elements * sizeof(float);
+
+  // Phase 1: ReduceScatter
+  // Writes reduced shard to output[my_rank * chunk_elements]
+  {
+    RingReduceScatterArgs<NumRings, float> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.chunk_elements = chunk_elements;
+    args.signaling_data_size = params.signaling_data_size;
+    args.input = params.input;
+    args.output = params.output + my_rank * chunk_elements;
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("ReduceScatter");
+  }
+
+  // Phase 2: AllGather
+  // Reads reduced shard from output[my_rank * chunk_bytes], gathers into output
+  {
+    RingAllgatherArgs<NumRings> args{};
+    args.my_rank = my_rank;
+    args.num_ranks = num_ranks;
+    args.sendcount = chunk_bytes;
+    args.signaling_data_size = params.signaling_data_size;
+    args.sendbuf =
+        reinterpret_cast<const char*>(params.output) + my_rank * chunk_bytes;
+    args.recvbuf = reinterpret_cast<char*>(params.output);
+
+    for (int r = 0; r < NumRings; r++) {
+      args.rings[r] = to_ring_topology(params.rings[r]);
+    }
+
+    ring_allgather_kernel<NumRings, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+    check_kernel_launch("AllGather");
+  }
+}
+
+} // namespace
+
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params) {
+  if (params.num_ranks == 0) {
+    throw std::runtime_error("num_ranks must be > 0");
+  }
+  if (params.count % params.num_ranks != 0) {
+    throw std::runtime_error(
+        "count (" + std::to_string(params.count) +
+        ") must be divisible by num_ranks (" +
+        std::to_string(params.num_ranks) + ")");
+  }
+
+  Timeout timeout;
+  if (params.timeout_ms > 0) {
+    int device = 0;
+    cudaError_t cudaErr = cudaGetDevice(&device);
+    if (cudaErr != cudaSuccess) {
+      throw std::runtime_error(
+          "Failed to get CUDA device: " +
+          std::string(cudaGetErrorString(cudaErr)));
+    }
+
+    timeout = makeTimeout(params.timeout_ms, device);
+  }
+
+  switch (params.num_rings) {
+    case 1:
+      launch_impl<1>(params, timeout);
+      break;
+    case 2:
+      launch_impl<2>(params, timeout);
+      break;
+    case 4:
+      launch_impl<4>(params, timeout);
+      break;
+    default:
+      throw std::runtime_error(
+          "Unsupported num_rings=" + std::to_string(params.num_rings) +
+          " (supported: 1, 2, 4)");
+  }
+}
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -9,8 +9,7 @@
 
 #include "comms/pipes/CopyOp.cuh"
 #include "comms/pipes/TimeoutUtils.h"
-#include "comms/pipes/collectives/RingAllgather.cuh"
-#include "comms/pipes/collectives/RingReduceScatter.cuh"
+#include "comms/pipes/collectives/RingAllReduce.cuh"
 
 namespace comms::pipes {
 
@@ -37,51 +36,23 @@ void check_kernel_launch(const char* kernel_name) {
 
 template <int NumRings>
 void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
-  const int my_rank = params.my_rank;
-  const int num_ranks = params.num_ranks;
-  const std::size_t chunk_elements = params.count / num_ranks;
-  const std::size_t chunk_bytes = chunk_elements * sizeof(float);
+  const std::size_t chunk_elements = params.count / params.num_ranks;
 
-  // Phase 1: ReduceScatter
-  // Writes reduced shard to output[my_rank * chunk_elements]
-  {
-    RingReduceScatterArgs<NumRings, float> args{};
-    args.my_rank = my_rank;
-    args.num_ranks = num_ranks;
-    args.chunk_elements = chunk_elements;
-    args.signaling_data_size = params.signaling_data_size;
-    args.input = params.input;
-    args.output = params.output + my_rank * chunk_elements;
+  RingAllReduceArgs<NumRings, float> args{};
+  args.my_rank = params.my_rank;
+  args.num_ranks = params.num_ranks;
+  args.chunk_elements = chunk_elements;
+  args.signaling_data_size = params.signaling_data_size;
+  args.input = params.input;
+  args.output = params.output;
 
-    for (int r = 0; r < NumRings; r++) {
-      args.rings[r] = to_ring_topology(params.rings[r]);
-    }
-
-    ring_reduce_scatter_kernel<NumRings, float, SumOp, 16384, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
-    check_kernel_launch("ReduceScatter");
+  for (int r = 0; r < NumRings; r++) {
+    args.rings[r] = to_ring_topology(params.rings[r]);
   }
 
-  // Phase 2: AllGather
-  // Reads reduced shard from output[my_rank * chunk_bytes], gathers into output
-  {
-    RingAllgatherArgs<NumRings> args{};
-    args.my_rank = my_rank;
-    args.num_ranks = num_ranks;
-    args.sendcount = chunk_bytes;
-    args.signaling_data_size = params.signaling_data_size;
-    args.sendbuf =
-        reinterpret_cast<const char*>(params.output) + my_rank * chunk_bytes;
-    args.recvbuf = reinterpret_cast<char*>(params.output);
-
-    for (int r = 0; r < NumRings; r++) {
-      args.rings[r] = to_ring_topology(params.rings[r]);
-    }
-
-    ring_allgather_kernel<NumRings, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
-    check_kernel_launch("AllGather");
-  }
+  ring_allreduce_kernel<NumRings, float, SumOp, 16384, 512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
+  check_kernel_launch("RingAllReduce");
 }
 
 } // namespace

--- a/comms/pipes/collectives/RingAllReduceLauncher.cu
+++ b/comms/pipes/collectives/RingAllReduceLauncher.cu
@@ -34,7 +34,7 @@ void check_kernel_launch(const char* kernel_name) {
   }
 }
 
-template <int NumRings>
+template <int NumRings, bool EnableBidirAg>
 void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
   const std::size_t chunk_elements = params.count / params.num_ranks;
 
@@ -50,7 +50,7 @@ void launch_impl(const RingAllReduceLaunchParams& params, Timeout timeout) {
     args.rings[r] = to_ring_topology(params.rings[r]);
   }
 
-  ring_allreduce_kernel<NumRings, float, SumOp, 16384, 512>
+  ring_allreduce_kernel<NumRings, float, SumOp, 16384, 512, EnableBidirAg>
       <<<params.num_blocks, 512, 0, params.stream>>>(args, timeout);
   check_kernel_launch("RingAllReduce");
 }
@@ -81,15 +81,26 @@ void launch_ring_allreduce(const RingAllReduceLaunchParams& params) {
     timeout = makeTimeout(params.timeout_ms, device);
   }
 
+  const bool bidir = params.enable_bidir_ag && params.num_ranks > 2;
+
   switch (params.num_rings) {
     case 1:
-      launch_impl<1>(params, timeout);
+      if (bidir)
+        launch_impl<1, true>(params, timeout);
+      else
+        launch_impl<1, false>(params, timeout);
       break;
     case 2:
-      launch_impl<2>(params, timeout);
+      if (bidir)
+        launch_impl<2, true>(params, timeout);
+      else
+        launch_impl<2, false>(params, timeout);
       break;
     case 4:
-      launch_impl<4>(params, timeout);
+      if (bidir)
+        launch_impl<4, true>(params, timeout);
+      else
+        launch_impl<4, false>(params, timeout);
       break;
     default:
       throw std::runtime_error(

--- a/comms/pipes/collectives/RingAllReduceLauncher.h
+++ b/comms/pipes/collectives/RingAllReduceLauncher.h
@@ -20,6 +20,8 @@ struct RingAllReduceLaunchParams {
   int num_rings{1};
   float timeout_ms{0.0f};
   bool enable_bidir_ag{false};
+  std::size_t ib_window_bytes{0};
+  bool skip_reduction{false};
   cudaStream_t stream{nullptr};
 
   struct RingParams {

--- a/comms/pipes/collectives/RingAllReduceLauncher.h
+++ b/comms/pipes/collectives/RingAllReduceLauncher.h
@@ -19,6 +19,7 @@ struct RingAllReduceLaunchParams {
   int num_blocks{16};
   int num_rings{1};
   float timeout_ms{0.0f};
+  bool enable_bidir_ag{false};
   cudaStream_t stream{nullptr};
 
   struct RingParams {

--- a/comms/pipes/collectives/RingAllReduceLauncher.h
+++ b/comms/pipes/collectives/RingAllReduceLauncher.h
@@ -1,0 +1,41 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace comms::pipes {
+
+class P2pIbgdaTransportDevice;
+
+struct RingAllReduceLaunchParams {
+  int my_rank{0};
+  int num_ranks{0};
+  std::size_t count{0};
+  std::size_t signaling_data_size{0};
+  const float* input{nullptr};
+  float* output{nullptr};
+  int num_blocks{16};
+  int num_rings{1};
+  float timeout_ms{0.0f};
+  cudaStream_t stream{nullptr};
+
+  struct RingParams {
+    int prev_rank{0};
+    int next_rank{0};
+    P2pIbgdaTransportDevice* prev{nullptr};
+    P2pIbgdaTransportDevice* next{nullptr};
+  };
+  static constexpr int kMaxRings = 4;
+  RingParams rings[kMaxRings]{};
+};
+
+// Launches a ring allreduce on the specified stream.
+//
+// Preconditions:
+// - count must be divisible by num_ranks
+// - transport devices must be bound and connected
+void launch_ring_allreduce(const RingAllReduceLaunchParams& params);
+
+} // namespace comms::pipes

--- a/comms/pipes/collectives/RingAllgather.cu
+++ b/comms/pipes/collectives/RingAllgather.cu
@@ -4,6 +4,7 @@
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
+#include "comms/pipes/collectives/DirectCollectiveUtils.cuh"
 #include "comms/pipes/collectives/RingAllgather.cuh"
 
 namespace comms::pipes {
@@ -41,11 +42,9 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
   const int my_rank = args.my_rank;
   const int stride = (my_rank - topo.prev_rank + W) % W;
 
-  // Local copy: own chunk from sendbuf to recvbuf.
   const char* own_src = args.sendbuf + ring_offset + io_tile_offset;
   char* own_dst =
       args.recvbuf + my_rank * chunk_bytes + ring_offset + io_tile_offset;
-  memcpy_vectorized(own_dst, own_src, io_tile_bytes, ring_group);
   ring_group.sync();
 
   for (std::size_t off = 0; off < io_tile_bytes; off += pipeline_window) {
@@ -53,10 +52,14 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
     const std::size_t window =
         (remaining < pipeline_window) ? remaining : pipeline_window;
 
-    // Step 0: Send own chunk to next.
-    char* send_src = args.recvbuf + my_rank * chunk_bytes + ring_offset +
-        io_tile_offset + off;
-    next.send(group, send_src, window, group.total_groups, max_sig, timeout);
+    next.template send<MemcpyAndSelfCopy>(
+        group,
+        own_src + off,
+        window,
+        group.total_groups,
+        max_sig,
+        timeout,
+        own_dst + off);
 
     // Steps 1..W-1: receive and forward (or just receive on last step).
     int current_rank = my_rank;

--- a/comms/pipes/collectives/RingUtils.h
+++ b/comms/pipes/collectives/RingUtils.h
@@ -45,4 +45,26 @@ make_standard_rings(int world_size, int my_rank, int num_rings) {
   return rings;
 }
 
+/**
+ * Return a 2-ring {forward, reverse} topology for bi-directional
+ * communication. Ring 0 uses stride 1, ring 1 uses stride W-1
+ * (the reverse direction). Returns nullopt for world_size < 3
+ * where forward and reverse are identical.
+ */
+inline std::optional<std::vector<RingNeighbors>> make_bidir_rings(
+    int world_size,
+    int my_rank) {
+  if (world_size < 3) {
+    return std::nullopt;
+  }
+  int fwd_stride = 1;
+  int rev_stride = world_size - 1;
+  return std::vector<RingNeighbors>{
+      {.prev_rank = (my_rank - fwd_stride + world_size) % world_size,
+       .next_rank = (my_rank + fwd_stride) % world_size},
+      {.prev_rank = (my_rank - rev_stride + world_size) % world_size,
+       .next_rank = (my_rank + rev_stride) % world_size},
+  };
+}
+
 } // namespace comms::pipes

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -1,0 +1,436 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <nccl.h>
+
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/benchmarks/BenchmarkMacros.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::benchmark {
+
+namespace {
+
+struct RingAllReduceBenchmarkConfig {
+  std::size_t total_elements;
+  int num_blocks;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+  int num_qps;
+  std::string name;
+};
+
+struct RingAllReduceBenchmarkResult {
+  std::string test_name;
+  std::size_t total_elements{};
+  std::size_t total_bytes{};
+  int num_rings{};
+  float nccl_bandwidth{};
+  float ring_bandwidth{};
+  float nccl_latency{};
+  float ring_latency{};
+  float speedup{};
+};
+
+class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDA_CHECK_VOID(cudaSetDevice(localRank));
+
+    setenv("NCCL_P2P_DISABLE", "1", 1);
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+    CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
+    BenchmarkTestFixture::TearDown();
+  }
+
+  ncclUniqueId get_nccl_id() {
+    ncclUniqueId id{};
+    if (globalRank == 0) {
+      ncclResult_t res = ncclGetUniqueId(&id);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclGetUniqueId failed: {}", ncclGetErrorString(res));
+        std::abort();
+      }
+    }
+    std::vector<ncclUniqueId> all_ids(worldSize);
+    all_ids[globalRank] = id;
+    auto result =
+        bootstrap
+            ->allGather(
+                all_ids.data(), sizeof(ncclUniqueId), globalRank, worldSize)
+            .get();
+    if (result != 0) {
+      XLOG(ERR) << "Bootstrap allGather for NCCL ID failed";
+      std::abort();
+    }
+    return all_ids[0];
+  }
+
+  float run_nccl_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_bytes = config.total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(total_bytes);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total_bytes));
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      NCCL_CHECK(ncclAllReduce(
+          send_buf.get(),
+          recv_buf.get(),
+          config.total_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      NCCL_CHECK(ncclAllReduce(
+          send_buf.get(),
+          recv_buf.get(),
+          config.total_elements,
+          ncclFloat,
+          ncclSum,
+          nccl_comm_,
+          stream_));
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  float run_ring_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    const std::size_t total_bytes = config.total_elements * sizeof(float);
+
+    DeviceBuffer send_buf(total_bytes);
+    DeviceBuffer recv_buf(total_bytes);
+    CUDA_CHECK(cudaMemset(send_buf.get(), 0, total_bytes));
+    CUDA_CHECK(cudaMemset(recv_buf.get(), 0, total_bytes));
+
+    std::unique_ptr<MultipeerIbgdaTransport> transport;
+    try {
+      MultipeerIbgdaTransportConfig transport_config{
+          .cudaDevice = localRank,
+          .dataBufferSize = config.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * config.num_rings,
+                  .pipelineDepth = config.pipeline_depth,
+              },
+          .numQpsPerPeerPerNic = config.num_qps,
+      };
+      transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transport_config);
+      transport->exchange();
+    } catch (const std::exception& e) {
+      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    if (config.num_rings <= 0 ||
+        config.num_rings > RingAllReduceLaunchParams::kMaxRings) {
+      XLOGF(ERR, "Unsupported num_rings={}", config.num_rings);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, config.num_rings);
+    if (!rings_opt) {
+      XLOGF(
+          ERR,
+          "Cannot construct {} distinct rings for {} ranks",
+          config.num_rings,
+          worldSize);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+    auto& rings = *rings_opt;
+    if (rings.size() < static_cast<std::size_t>(config.num_rings)) {
+      XLOGF(
+          ERR,
+          "Constructed {} rings, expected {}",
+          rings.size(),
+          config.num_rings);
+      latency_us = 0.0f;
+      return 0.0f;
+    }
+
+    RingAllReduceLaunchParams launch_params{};
+    launch_params.my_rank = globalRank;
+    launch_params.num_ranks = worldSize;
+    launch_params.count = config.total_elements;
+    launch_params.input = static_cast<const float*>(send_buf.get());
+    launch_params.output = static_cast<float*>(recv_buf.get());
+    launch_params.num_blocks = config.num_blocks * config.num_rings;
+    launch_params.num_rings = config.num_rings;
+    launch_params.stream = stream_;
+
+    for (int r = 0; r < config.num_rings; r++) {
+      auto& rp = launch_params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    CudaEvent start, stop;
+    const int n_warmup = 5;
+    const int n_iter = 100;
+
+    bootstrap->barrierAll();
+    for (int i = 0; i < n_warmup; i++) {
+      launch_ring_allreduce(launch_params);
+      CUDA_CHECK(cudaStreamSynchronize(stream_));
+    }
+    bootstrap->barrierAll();
+
+    CUDA_CHECK(cudaEventRecord(start.get(), stream_));
+    for (int i = 0; i < n_iter; i++) {
+      launch_ring_allreduce(launch_params);
+    }
+    CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
+    CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+    float total_ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&total_ms, start.get(), stop.get()));
+    float avg_ms = total_ms / n_iter;
+    latency_us = avg_ms * 1000.0f;
+
+    float bw = (total_bytes / (1e9f)) / (avg_ms / 1e3f);
+    bootstrap->barrierAll();
+    return bw;
+  }
+
+  void print_results(const std::vector<RingAllReduceBenchmarkResult>& results) {
+    if (globalRank != 0) {
+      return;
+    }
+
+    auto fmt_bytes = [](std::size_t bytes) -> std::string {
+      if (bytes >= 1024UL * 1024 * 1024) {
+        return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+      }
+      if (bytes >= 1024 * 1024) {
+        return std::to_string(bytes / (1024 * 1024)) + "MB";
+      }
+      if (bytes >= 1024) {
+        return std::to_string(bytes / 1024) + "KB";
+      }
+      return std::to_string(bytes) + "B";
+    };
+
+    std::stringstream ss;
+    ss << "\n";
+    ss << "================================================================================\n";
+    ss << "         NCCL AllReduce vs Ring AllReduce (Pipes IBGDA) Benchmark\n";
+    ss << "================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
+       << "Size" << std::right << std::setw(6) << "Rings" << std::right
+       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
+       << std::right << std::setw(10) << "Speedup" << std::right
+       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
+       << "Ring Lat\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
+       << std::right << std::setw(6) << "" << std::right << std::setw(10)
+       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
+       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
+       << std::right << std::setw(12) << "(us)\n";
+    ss << "--------------------------------------------------------------------------------\n";
+
+    for (const auto& r : results) {
+      ss << std::left << std::setw(14) << r.test_name << std::right
+         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
+         << std::setw(6) << r.num_rings << std::right << std::setw(10)
+         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
+         << std::setw(10) << std::fixed << std::setprecision(2)
+         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup << "x" << std::right
+         << std::setw(12) << std::fixed << std::setprecision(1)
+         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setprecision(1) << r.ring_latency << "\n";
+    }
+
+    ss << "================================================================================\n";
+    ss << worldSize << " ranks, total_elements = per-rank input/output size\n";
+    ss << "================================================================================\n";
+
+    XLOG(INFO) << ss.str();
+  }
+
+  ncclComm_t nccl_comm_{};
+  cudaStream_t stream_{};
+};
+
+TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
+  if (globalRank == 0) {
+    XLOG(INFO) << "\n=== Ring AllReduce (Pipes IBGDA) vs NCCL Comparison ===\n";
+  }
+
+  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+  int kNumQps = 4;
+
+  std::vector<RingAllReduceBenchmarkConfig> configs = {
+      {.total_elements = 64 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256KB_8B"},
+      {.total_elements = 256 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "1MB_16B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_16B"},
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_16B"},
+      {.total_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64MB_16B"},
+      {.total_elements = 32 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "128MB_16B"},
+      {.total_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256MB_32B"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "512MB_32B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_16B_2R"},
+      {.total_elements = 16 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "64MB_16B_2R"},
+      {.total_elements = 64 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "256MB_32B_2R"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 32,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "512MB_32B_2R"},
+  };
+
+  std::vector<RingAllReduceBenchmarkResult> results;
+
+  for (const auto& config : configs) {
+    float nccl_lat = 0.0f;
+    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
+
+    float ring_lat = 0.0f;
+    float ring_bw = run_ring_benchmark(config, ring_lat);
+
+    if (globalRank == 0) {
+      results.push_back({
+          .test_name = config.name,
+          .total_elements = config.total_elements,
+          .total_bytes = config.total_elements * sizeof(float),
+          .num_rings = config.num_rings,
+          .nccl_bandwidth = nccl_bw,
+          .ring_bandwidth = ring_bw,
+          .nccl_latency = nccl_lat,
+          .ring_latency = ring_lat,
+          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+      });
+    }
+    bootstrap->barrierAll();
+  }
+
+  print_results(results);
+}
+
+} // namespace
+
+} // namespace comms::pipes::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -45,12 +45,15 @@ struct RingAllReduceBenchmarkResult {
   std::size_t total_bytes{};
   int num_rings{};
   float nccl_bandwidth{};
+  float nccl_ring_bandwidth{};
   float ctran_bandwidth{};
   float ring_bandwidth{};
   float nccl_latency{};
+  float nccl_ring_latency{};
   float ctran_latency{};
   float ring_latency{};
   float speedup_vs_nccl{};
+  float speedup_vs_nccl_ring{};
   float speedup_vs_ctran{};
 };
 
@@ -67,11 +70,19 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     NCCL_CHECK_VOID(
         ncclCommInitRank(&comm_, worldSize, get_nccl_id(), globalRank));
 
+    setenv("NCCL_ALGO", "Ring", 1);
+    setenv("NCCL_PROTO", "Simple", 1);
+    NCCL_CHECK_VOID(
+        ncclCommInitRank(&ring_comm_, worldSize, get_nccl_id(), globalRank));
+    unsetenv("NCCL_ALGO");
+    unsetenv("NCCL_PROTO");
+
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
     NCCL_CHECK_VOID(ncclCommDestroy(comm_));
+    NCCL_CHECK_VOID(ncclCommDestroy(ring_comm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
     BenchmarkTestFixture::TearDown();
   }
@@ -103,14 +114,20 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       const RingAllReduceBenchmarkConfig& config,
       float& latency_us) {
     NCCL_CHECK(set_allreduce_algo("orig"));
-    return run_ncclx_benchmark(config, latency_us);
+    return run_ncclx_benchmark(config, latency_us, comm_);
+  }
+
+  float run_nccl_ring_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    return run_ncclx_benchmark(config, latency_us, ring_comm_);
   }
 
   float run_ctran_benchmark(
       const RingAllReduceBenchmarkConfig& config,
       float& latency_us) {
     NCCL_CHECK(set_allreduce_algo("ctring"));
-    float bw = run_ncclx_benchmark(config, latency_us);
+    float bw = run_ncclx_benchmark(config, latency_us, comm_);
     NCCL_CHECK(set_allreduce_algo("orig"));
     return bw;
   }
@@ -124,7 +141,11 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
   float run_ncclx_benchmark(
       const RingAllReduceBenchmarkConfig& config,
-      float& latency_us) {
+      float& latency_us,
+      ncclComm_t nccl_comm = nullptr) {
+    if (nccl_comm == nullptr) {
+      nccl_comm = comm_;
+    }
     const std::size_t total_bytes = config.total_elements * sizeof(float);
 
     DeviceBuffer send_buf(total_bytes);
@@ -144,7 +165,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          comm_,
+          nccl_comm,
           stream_));
     }
 
@@ -156,7 +177,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          comm_,
+          nccl_comm,
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
@@ -308,46 +329,45 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     std::stringstream ss;
     ss << "\n";
-    ss << "====================================================================================================\n";
-    ss << "         NCCL vs Ctran (ctring) vs Pipes Ring AllReduce Benchmark\n";
-    ss << "====================================================================================================\n";
-    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(8)
+    ss << "============================================================================================================================\n";
+    ss << "         NCCL (auto) vs NCCL (Ring) vs Ctran (ctring) vs Pipes Ring AllReduce Benchmark\n";
+    ss << "============================================================================================================================\n";
+    ss << std::left << std::setw(16) << "Test" << std::right << std::setw(8)
        << "Size" << std::setw(4) << "R" << std::setw(9) << "NCCL"
-       << std::setw(9) << "Ctran" << std::setw(9) << "Pipes" << std::setw(10)
-       << "vs NCCL" << std::setw(10) << "vs Ctran" << std::setw(10) << "NCCL us"
-       << std::setw(10) << "Ctran us" << std::setw(10) << "Pipes us\n";
-    ss << std::left << std::setw(14) << "" << std::right << std::setw(8) << ""
-       << std::setw(4) << "" << std::setw(9) << "(GB/s)" << std::setw(9)
-       << "(GB/s)" << std::setw(9) << "(GB/s)" << std::setw(10) << ""
-       << std::setw(10) << "" << std::setw(10) << "" << std::setw(10) << ""
-       << std::setw(10) << "\n";
-    ss << "----------------------------------------------------------------------------------------------------\n";
+       << std::setw(10) << "NCCLRing" << std::setw(9) << "Ctran" << std::setw(9)
+       << "Pipes" << std::setw(10) << "vs NCCL" << std::setw(10) << "vs Ring"
+       << std::setw(10) << "vs Ctran" << "\n";
+    ss << std::left << std::setw(16) << "" << std::right << std::setw(8) << ""
+       << std::setw(4) << "" << std::setw(9) << "(GB/s)" << std::setw(10)
+       << "(GB/s)" << std::setw(9) << "(GB/s)" << std::setw(9) << "(GB/s)"
+       << "\n";
+    ss << "----------------------------------------------------------------------------------------------------------------------------\n";
 
     for (const auto& r : results) {
-      ss << std::left << std::setw(14) << r.test_name << std::right
+      ss << std::left << std::setw(16) << r.test_name << std::right
          << std::setw(8) << fmt_bytes(r.total_bytes) << std::setw(4)
          << r.num_rings << std::setw(9) << std::fixed << std::setprecision(2)
-         << r.nccl_bandwidth << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.ctran_bandwidth << std::setw(9)
-         << std::fixed << std::setprecision(2) << r.ring_bandwidth
+         << r.nccl_bandwidth << std::setw(10) << std::fixed
+         << std::setprecision(2) << r.nccl_ring_bandwidth << std::setw(9)
+         << std::fixed << std::setprecision(2) << r.ctran_bandwidth
          << std::setw(9) << std::fixed << std::setprecision(2)
-         << r.speedup_vs_nccl << "x" << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.speedup_vs_ctran << "x" << std::setw(10)
-         << std::fixed << std::setprecision(1) << r.nccl_latency
-         << std::setw(10) << std::fixed << std::setprecision(1)
-         << r.ctran_latency << std::setw(10) << std::fixed
-         << std::setprecision(1) << r.ring_latency << "\n";
+         << r.ring_bandwidth << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup_vs_nccl << "x" << std::setw(9)
+         << std::fixed << std::setprecision(2) << r.speedup_vs_nccl_ring << "x"
+         << std::setw(9) << std::fixed << std::setprecision(2)
+         << r.speedup_vs_ctran << "x\n";
     }
 
-    ss << "====================================================================================================\n";
+    ss << "============================================================================================================================\n";
     ss << worldSize
-       << " ranks | NCCL=orig(auto) | Ctran=ctring(GPE) | Pipes=IBGDA(device-native)\n";
-    ss << "====================================================================================================\n";
+       << " ranks | NCCL=orig(auto) | NCCLRing=Ring/Simple | Ctran=ctring(GPE) | Pipes=IBGDA(device-native)\n";
+    ss << "============================================================================================================================\n";
 
     XLOG(INFO) << ss.str();
   }
 
   ncclComm_t comm_{};
+  ncclComm_t ring_comm_{};
   cudaStream_t stream_{};
 };
 
@@ -360,7 +380,88 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
   int kNumQps = 4;
 
   std::vector<RingAllReduceBenchmarkConfig> configs = {
-      // === Baselines ===
+      // === Medium-size optimization: block count sweep at 4MB/16MB/32MB ===
+      // 4MB baselines
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_16B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_8B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 4,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_4B"},
+      {.total_elements = 1024 * 1024,
+       .num_blocks = 2,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "4MB_2B"},
+      // 16MB baselines
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_16B"},
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_8B"},
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 4,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_4B"},
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 2,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "16MB_2B"},
+      // 32MB baselines
+      {.total_elements = 8 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "32MB_16B"},
+      {.total_elements = 8 * 1024 * 1024,
+       .num_blocks = 8,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "32MB_8B"},
+      {.total_elements = 8 * 1024 * 1024,
+       .num_blocks = 4,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "32MB_4B"},
+      // 64MB + 512MB reference points
       {.total_elements = 16 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
@@ -368,43 +469,6 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
        .pipeline_depth = 2,
        .num_qps = kNumQps,
        .name = "64MB_16B"},
-      {.total_elements = 32 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "128MB_16B"},
-      {.total_elements = 64 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256MB_32B"},
-      {.total_elements = 128 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "512MB_32B"},
-      // === 1GB baseline ===
-      {.total_elements = 256 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "1GB_32B"},
-      // === Block count sweep on GB200 ===
-      {.total_elements = 64 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256MB_16B"},
       {.total_elements = 128 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
@@ -412,42 +476,6 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
        .pipeline_depth = 2,
        .num_qps = kNumQps,
        .name = "512MB_16B"},
-      {.total_elements = 256 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "1GB_16B"},
-      // === QP count sweep (multi-QP striping) ===
-      {.total_elements = 128 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = 2,
-       .name = "512MB_16B_2q"},
-      {.total_elements = 128 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = 8,
-       .name = "512MB_16B_8q"},
-      {.total_elements = 256 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = 2,
-       .name = "1GB_16B_2q"},
-      {.total_elements = 256 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = 8,
-       .name = "1GB_16B_8q"},
   };
 
   std::vector<RingAllReduceBenchmarkResult> results;
@@ -455,6 +483,9 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
   for (const auto& config : configs) {
     float nccl_lat = 0.0f;
     float nccl_bw = run_nccl_benchmark(config, nccl_lat);
+
+    float nccl_ring_lat = 0.0f;
+    float nccl_ring_bw = run_nccl_ring_benchmark(config, nccl_ring_lat);
 
     float ctran_lat = 0.0f;
     float ctran_bw = run_ctran_benchmark(config, ctran_lat);
@@ -469,12 +500,16 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
           .total_bytes = config.total_elements * sizeof(float),
           .num_rings = config.num_rings,
           .nccl_bandwidth = nccl_bw,
+          .nccl_ring_bandwidth = nccl_ring_bw,
           .ctran_bandwidth = ctran_bw,
           .ring_bandwidth = ring_bw,
           .nccl_latency = nccl_lat,
+          .nccl_ring_latency = nccl_ring_lat,
           .ctran_latency = ctran_lat,
           .ring_latency = ring_lat,
           .speedup_vs_nccl = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+          .speedup_vs_nccl_ring =
+              (nccl_ring_bw > 0) ? ring_bw / nccl_ring_bw : 0.0f,
           .speedup_vs_ctran = (ctran_bw > 0) ? ring_bw / ctran_bw : 0.0f,
       });
     }

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -31,6 +31,8 @@ struct RingAllReduceBenchmarkConfig {
   std::size_t data_buffer_size;
   int pipeline_depth;
   int num_qps;
+  bool enable_bidir_ag{false};
+  bool use_reverse_ring{false};
   std::string name;
 };
 
@@ -198,19 +200,25 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       return 0.0f;
     }
 
-    if (config.num_rings <= 0 ||
-        config.num_rings > RingAllReduceLaunchParams::kMaxRings) {
-      XLOGF(ERR, "Unsupported num_rings={}", config.num_rings);
+    if (config.use_reverse_ring && config.num_rings != 2) {
+      XLOGF(
+          ERR,
+          "use_reverse_ring requires num_rings=2, got {}",
+          config.num_rings);
       latency_us = 0.0f;
       return 0.0f;
     }
 
-    auto rings_opt =
-        make_standard_rings(worldSize, globalRank, config.num_rings);
+    std::optional<std::vector<RingNeighbors>> rings_opt;
+    if (config.use_reverse_ring) {
+      rings_opt = make_bidir_rings(worldSize, globalRank);
+    } else {
+      rings_opt = make_standard_rings(worldSize, globalRank, config.num_rings);
+    }
     if (!rings_opt) {
       XLOGF(
           ERR,
-          "Cannot construct {} distinct rings for {} ranks",
+          "Cannot construct {} rings for {} ranks",
           config.num_rings,
           worldSize);
       latency_us = 0.0f;
@@ -236,6 +244,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     launch_params.num_blocks = config.num_blocks * config.num_rings;
     launch_params.num_rings = config.num_rings;
     launch_params.stream = stream_;
+    launch_params.enable_bidir_ag = config.enable_bidir_ag;
 
     for (int r = 0; r < config.num_rings; r++) {
       auto& rp = launch_params.rings[r];
@@ -345,6 +354,7 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
   int kNumQps = 4;
 
   std::vector<RingAllReduceBenchmarkConfig> configs = {
+      // Baselines: full sweep for first real Ctran comparison
       {.total_elements = 64 * 1024,
        .num_blocks = 8,
        .num_rings = 1,
@@ -373,6 +383,13 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
        .pipeline_depth = 2,
        .num_qps = kNumQps,
        .name = "16MB_16B"},
+      {.total_elements = 8 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .name = "32MB_16B"},
       {.total_elements = 16 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
@@ -401,34 +418,58 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
        .pipeline_depth = 2,
        .num_qps = kNumQps,
        .name = "512MB_32B"},
-      {.total_elements = 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4MB_16B_2R"},
-      {.total_elements = 16 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "64MB_16B_2R"},
+      // Bidir at key sizes
       {.total_elements = 64 * 1024 * 1024,
        .num_blocks = 32,
-       .num_rings = 2,
+       .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .name = "256MB_32B_2R"},
+       .enable_bidir_ag = true,
+       .name = "256MB_32B_bd"},
       {.total_elements = 128 * 1024 * 1024,
        .num_blocks = 32,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .enable_bidir_ag = true,
+       .name = "512MB_32B_bd"},
+      // === Fair comparison: same total grid (perBlockSlot=1MB) ===
+      // Reverse ring: num_blocks halved so total grid matches baseline
+      {.total_elements = 64 * 1024 * 1024,
+       .num_blocks = 16,
        .num_rings = 2,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .name = "512MB_32B_2R"},
+       .use_reverse_ring = true,
+       .name = "256MB_16B_rv"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 2,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .use_reverse_ring = true,
+       .name = "512MB_16B_rv"},
+      // === Bidir at medium sizes (link not yet saturated) ===
+      {.total_elements = 4 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .enable_bidir_ag = true,
+       .name = "16MB_16B_bd"},
+      {.total_elements = 8 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = kNumQps,
+       .enable_bidir_ag = true,
+       .name = "32MB_16B_bd"},
   };
 
   std::vector<RingAllReduceBenchmarkResult> results;

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -33,6 +33,9 @@ struct RingAllReduceBenchmarkConfig {
   int num_qps;
   bool enable_bidir_ag{false};
   bool use_reverse_ring{false};
+  std::size_t signaling_data_size{0};
+  std::size_t ib_window_bytes{0};
+  bool skip_reduction{false};
   std::string name;
 };
 
@@ -245,6 +248,9 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     launch_params.num_rings = config.num_rings;
     launch_params.stream = stream_;
     launch_params.enable_bidir_ag = config.enable_bidir_ag;
+    launch_params.signaling_data_size = config.signaling_data_size;
+    launch_params.ib_window_bytes = config.ib_window_bytes;
+    launch_params.skip_reduction = config.skip_reduction;
 
     for (int r = 0; r < config.num_rings; r++) {
       auto& rp = launch_params.rings[r];
@@ -354,42 +360,7 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
   int kNumQps = 4;
 
   std::vector<RingAllReduceBenchmarkConfig> configs = {
-      // Baselines: full sweep for first real Ctran comparison
-      {.total_elements = 64 * 1024,
-       .num_blocks = 8,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256KB_8B"},
-      {.total_elements = 256 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "1MB_16B"},
-      {.total_elements = 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4MB_16B"},
-      {.total_elements = 4 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "16MB_16B"},
-      {.total_elements = 8 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "32MB_16B"},
+      // === Baselines ===
       {.total_elements = 16 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
@@ -418,58 +389,65 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
        .pipeline_depth = 2,
        .num_qps = kNumQps,
        .name = "512MB_32B"},
-      // Bidir at key sizes
-      {.total_elements = 64 * 1024 * 1024,
+      // === 1GB baseline ===
+      {.total_elements = 256 * 1024 * 1024,
        .num_blocks = 32,
        .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .enable_bidir_ag = true,
-       .name = "256MB_32B_bd"},
-      {.total_elements = 128 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .enable_bidir_ag = true,
-       .name = "512MB_32B_bd"},
-      // === Fair comparison: same total grid (perBlockSlot=1MB) ===
-      // Reverse ring: num_blocks halved so total grid matches baseline
+       .name = "1GB_32B"},
+      // === Block count sweep on GB200 ===
       {.total_elements = 64 * 1024 * 1024,
        .num_blocks = 16,
-       .num_rings = 2,
+       .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .use_reverse_ring = true,
-       .name = "256MB_16B_rv"},
+       .name = "256MB_16B"},
       {.total_elements = 128 * 1024 * 1024,
        .num_blocks = 16,
-       .num_rings = 2,
+       .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .use_reverse_ring = true,
-       .name = "512MB_16B_rv"},
-      // === Bidir at medium sizes (link not yet saturated) ===
-      {.total_elements = 4 * 1024 * 1024,
+       .name = "512MB_16B"},
+      {.total_elements = 256 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
        .num_qps = kNumQps,
-       .enable_bidir_ag = true,
-       .name = "16MB_16B_bd"},
-      {.total_elements = 8 * 1024 * 1024,
+       .name = "1GB_16B"},
+      // === QP count sweep (multi-QP striping) ===
+      {.total_elements = 128 * 1024 * 1024,
        .num_blocks = 16,
        .num_rings = 1,
        .data_buffer_size = kDataBufferSize,
        .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .enable_bidir_ag = true,
-       .name = "32MB_16B_bd"},
+       .num_qps = 2,
+       .name = "512MB_16B_2q"},
+      {.total_elements = 128 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = 8,
+       .name = "512MB_16B_8q"},
+      {.total_elements = 256 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = 2,
+       .name = "1GB_16B_2q"},
+      {.total_elements = 256 * 1024 * 1024,
+       .num_blocks = 16,
+       .num_rings = 1,
+       .data_buffer_size = kDataBufferSize,
+       .pipeline_depth = 2,
+       .num_qps = 8,
+       .name = "1GB_16B_8q"},
   };
 
   std::vector<RingAllReduceBenchmarkResult> results;

--- a/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
+++ b/comms/pipes/collectives/benchmarks/RingAllReduceBenchmark.cc
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <vector>
 
+#include "comms/utils/cvars/nccl_cvars.h"
+
 #include "comms/pipes/MultipeerIbgdaTransport.h"
 #include "comms/pipes/benchmarks/BenchmarkMacros.h"
 #include "comms/pipes/collectives/RingAllReduceLauncher.h"
@@ -38,10 +40,13 @@ struct RingAllReduceBenchmarkResult {
   std::size_t total_bytes{};
   int num_rings{};
   float nccl_bandwidth{};
+  float ctran_bandwidth{};
   float ring_bandwidth{};
   float nccl_latency{};
+  float ctran_latency{};
   float ring_latency{};
-  float speedup{};
+  float speedup_vs_nccl{};
+  float speedup_vs_ctran{};
 };
 
 class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
@@ -51,13 +56,17 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     setenv("NCCL_P2P_DISABLE", "1", 1);
+    setenv("NCCL_CTRAN_ENABLE", "1", 1);
+    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 1);
+    setenv("NCCL_IGNORE_TOPO_LOAD_FAILURE", "true", 1);
     NCCL_CHECK_VOID(
-        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
+        ncclCommInitRank(&comm_, worldSize, get_nccl_id(), globalRank));
+
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
-    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
+    NCCL_CHECK_VOID(ncclCommDestroy(comm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
     BenchmarkTestFixture::TearDown();
   }
@@ -88,6 +97,29 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
   float run_nccl_benchmark(
       const RingAllReduceBenchmarkConfig& config,
       float& latency_us) {
+    NCCL_CHECK(set_allreduce_algo("orig"));
+    return run_ncclx_benchmark(config, latency_us);
+  }
+
+  float run_ctran_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
+    NCCL_CHECK(set_allreduce_algo("ctring"));
+    float bw = run_ncclx_benchmark(config, latency_us);
+    NCCL_CHECK(set_allreduce_algo("orig"));
+    return bw;
+  }
+
+  ncclResult_t set_allreduce_algo(const std::string& algo) {
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    ncclx::Hints hints({{"allreduceAlgo", algo}});
+    config.hints = &hints;
+    return ncclx::commSetConfig(comm_, &config);
+  }
+
+  float run_ncclx_benchmark(
+      const RingAllReduceBenchmarkConfig& config,
+      float& latency_us) {
     const std::size_t total_bytes = config.total_elements * sizeof(float);
 
     DeviceBuffer send_buf(total_bytes);
@@ -107,7 +139,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          comm_,
           stream_));
     }
 
@@ -119,7 +151,7 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           config.total_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          comm_,
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
@@ -261,43 +293,46 @@ class RingAllReduceBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     std::stringstream ss;
     ss << "\n";
-    ss << "================================================================================\n";
-    ss << "         NCCL AllReduce vs Ring AllReduce (Pipes IBGDA) Benchmark\n";
-    ss << "================================================================================\n";
-    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
-       << "Size" << std::right << std::setw(6) << "Rings" << std::right
-       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
-       << std::right << std::setw(10) << "Speedup" << std::right
-       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
-       << "Ring Lat\n";
-    ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
-       << std::right << std::setw(6) << "" << std::right << std::setw(10)
-       << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
-       << std::setw(10) << "" << std::right << std::setw(12) << "(us)"
-       << std::right << std::setw(12) << "(us)\n";
-    ss << "--------------------------------------------------------------------------------\n";
+    ss << "====================================================================================================\n";
+    ss << "         NCCL vs Ctran (ctring) vs Pipes Ring AllReduce Benchmark\n";
+    ss << "====================================================================================================\n";
+    ss << std::left << std::setw(14) << "Test" << std::right << std::setw(8)
+       << "Size" << std::setw(4) << "R" << std::setw(9) << "NCCL"
+       << std::setw(9) << "Ctran" << std::setw(9) << "Pipes" << std::setw(10)
+       << "vs NCCL" << std::setw(10) << "vs Ctran" << std::setw(10) << "NCCL us"
+       << std::setw(10) << "Ctran us" << std::setw(10) << "Pipes us\n";
+    ss << std::left << std::setw(14) << "" << std::right << std::setw(8) << ""
+       << std::setw(4) << "" << std::setw(9) << "(GB/s)" << std::setw(9)
+       << "(GB/s)" << std::setw(9) << "(GB/s)" << std::setw(10) << ""
+       << std::setw(10) << "" << std::setw(10) << "" << std::setw(10) << ""
+       << std::setw(10) << "\n";
+    ss << "----------------------------------------------------------------------------------------------------\n";
 
     for (const auto& r : results) {
       ss << std::left << std::setw(14) << r.test_name << std::right
-         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
-         << std::setw(6) << r.num_rings << std::right << std::setw(10)
-         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
-         << std::setw(10) << std::fixed << std::setprecision(2)
-         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.speedup << "x" << std::right
-         << std::setw(12) << std::fixed << std::setprecision(1)
-         << r.nccl_latency << std::right << std::setw(12) << std::fixed
+         << std::setw(8) << fmt_bytes(r.total_bytes) << std::setw(4)
+         << r.num_rings << std::setw(9) << std::fixed << std::setprecision(2)
+         << r.nccl_bandwidth << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.ctran_bandwidth << std::setw(9)
+         << std::fixed << std::setprecision(2) << r.ring_bandwidth
+         << std::setw(9) << std::fixed << std::setprecision(2)
+         << r.speedup_vs_nccl << "x" << std::setw(9) << std::fixed
+         << std::setprecision(2) << r.speedup_vs_ctran << "x" << std::setw(10)
+         << std::fixed << std::setprecision(1) << r.nccl_latency
+         << std::setw(10) << std::fixed << std::setprecision(1)
+         << r.ctran_latency << std::setw(10) << std::fixed
          << std::setprecision(1) << r.ring_latency << "\n";
     }
 
-    ss << "================================================================================\n";
-    ss << worldSize << " ranks, total_elements = per-rank input/output size\n";
-    ss << "================================================================================\n";
+    ss << "====================================================================================================\n";
+    ss << worldSize
+       << " ranks | NCCL=orig(auto) | Ctran=ctring(GPE) | Pipes=IBGDA(device-native)\n";
+    ss << "====================================================================================================\n";
 
     XLOG(INFO) << ss.str();
   }
 
-  ncclComm_t nccl_comm_{};
+  ncclComm_t comm_{};
   cudaStream_t stream_{};
 };
 
@@ -402,6 +437,9 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
     float nccl_lat = 0.0f;
     float nccl_bw = run_nccl_benchmark(config, nccl_lat);
 
+    float ctran_lat = 0.0f;
+    float ctran_bw = run_ctran_benchmark(config, ctran_lat);
+
     float ring_lat = 0.0f;
     float ring_bw = run_ring_benchmark(config, ring_lat);
 
@@ -412,10 +450,13 @@ TEST_F(RingAllReduceBenchmarkFixture, VsNccl) {
           .total_bytes = config.total_elements * sizeof(float),
           .num_rings = config.num_rings,
           .nccl_bandwidth = nccl_bw,
+          .ctran_bandwidth = ctran_bw,
           .ring_bandwidth = ring_bw,
           .nccl_latency = nccl_lat,
+          .ctran_latency = ctran_lat,
           .ring_latency = ring_lat,
-          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+          .speedup_vs_nccl = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
+          .speedup_vs_ctran = (ctran_bw > 0) ? ring_bw / ctran_bw : 0.0f,
       });
     }
     bootstrap->barrierAll();

--- a/comms/pipes/collectives/tests/AllReduceTestHarness.h
+++ b/comms/pipes/collectives/tests/AllReduceTestHarness.h
@@ -1,0 +1,74 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::pipes::test {
+
+struct AllReduceTestConfig {
+  std::size_t total_elements;
+  int num_blocks;
+  std::string name;
+};
+
+class AllReduceTestBase : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void fill_input(float* input_d, std::size_t total_elements) {
+    std::vector<float> h_input(total_elements);
+    for (std::size_t i = 0; i < total_elements; i++) {
+      h_input[i] = static_cast<float>((globalRank * 7 + i) % 100) * 0.01f;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        input_d,
+        h_input.data(),
+        total_elements * sizeof(float),
+        cudaMemcpyHostToDevice));
+  }
+
+  void verify_allreduce(const float* output_d, std::size_t total_elements) {
+    std::vector<float> h_output(total_elements);
+    CUDACHECK_TEST(cudaMemcpy(
+        h_output.data(),
+        output_d,
+        total_elements * sizeof(float),
+        cudaMemcpyDeviceToHost));
+
+    int errors = 0;
+    for (std::size_t i = 0; i < total_elements; i++) {
+      float expected = 0.0f;
+      for (int rank = 0; rank < worldSize; rank++) {
+        expected += static_cast<float>((rank * 7 + i) % 100) * 0.01f;
+      }
+      float actual = h_output[i];
+      if (std::abs(actual - expected) > 1e-2f) {
+        if (errors < 10) {
+          EXPECT_NEAR(actual, expected, 1e-2f)
+              << "Mismatch at offset=" << i << " (my_rank=" << globalRank
+              << ")";
+        }
+        errors++;
+      }
+    }
+    EXPECT_EQ(errors, 0) << "Total mismatches: " << errors << " out of "
+                         << total_elements
+                         << " elements (my_rank=" << globalRank << ")";
+  }
+};
+
+} // namespace comms::pipes::test

--- a/comms/pipes/collectives/tests/RingAllReduceTest.cc
+++ b/comms/pipes/collectives/tests/RingAllReduceTest.cc
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <algorithm>
+
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
@@ -19,6 +21,7 @@ struct RingAllReduceTestParams {
   int num_rings;
   std::size_t data_buffer_size;
   int pipeline_depth;
+  bool enable_bidir_ag{false};
 };
 
 std::string param_name(
@@ -70,6 +73,7 @@ class RingAllReduceTest
     ctx.params.num_blocks = config.num_blocks * params.num_rings;
     ctx.params.num_rings = params.num_rings;
     ctx.params.timeout_ms = 30000.0f;
+    ctx.params.enable_bidir_ag = params.enable_bidir_ag;
 
     for (int r = 0; r < params.num_rings; r++) {
       auto& rp = ctx.params.rings[r];
@@ -148,6 +152,161 @@ TEST_P(RingAllReduceTest, InPlaceCorrectness) {
   verify_allreduce(static_cast<const float*>(buf.get()), config.total_elements);
 }
 
+TEST_P(RingAllReduceTest, MultiInvocationCorrectness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+  if (config.total_elements % worldSize != 0) {
+    GTEST_SKIP() << "total_elements must be divisible by worldSize";
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = params.data_buffer_size,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = config.num_blocks * params.num_rings,
+                .pipelineDepth = params.pipeline_depth,
+            },
+    };
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, transportConfig);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  DeviceBuffer inputBuf(config.total_elements * sizeof(float));
+  DeviceBuffer outputBuf(config.total_elements * sizeof(float));
+
+  auto rings_opt = make_standard_rings(worldSize, globalRank, params.num_rings);
+  if (!rings_opt.has_value()) {
+    GTEST_SKIP() << "Cannot construct " << params.num_rings
+                 << " distinct rings for " << worldSize << " ranks";
+  }
+  auto& rings = *rings_opt;
+
+  RingAllReduceLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.count = config.total_elements;
+  launchParams.signaling_data_size = 0;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.num_blocks = config.num_blocks * params.num_rings;
+  launchParams.num_rings = params.num_rings;
+  launchParams.timeout_ms = 30000.0f;
+  launchParams.enable_bidir_ag = params.enable_bidir_ag;
+
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev_rank = rings[r].prev_rank;
+    ringParams.next_rank = rings[r].next_rank;
+    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+  }
+
+  const int num_invocations = 5;
+  for (int iter = 0; iter < num_invocations; iter++) {
+    fill_input(static_cast<float*>(inputBuf.get()), config.total_elements);
+    CUDACHECK_TEST(
+        cudaMemset(outputBuf.get(), 0, config.total_elements * sizeof(float)));
+    bootstrap->barrierAll();
+    launch_ring_allreduce(launchParams);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+    verify_allreduce(
+        static_cast<const float*>(outputBuf.get()), config.total_elements);
+  }
+}
+
+TEST_P(RingAllReduceTest, TailCorrectness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+
+  // Mirror the split strategy from AllReducePipesFlatRing.cc
+  const std::size_t divisibleCount =
+      (config.total_elements / worldSize) * worldSize;
+  if (divisibleCount == 0) {
+    GTEST_SKIP() << "total_elements < worldSize, not enough for ring";
+  }
+
+  const int chunkElements = static_cast<int>(divisibleCount / worldSize);
+  const int requestedBlocks = config.num_blocks * params.num_rings;
+  const int safeBlocks = std::min(requestedBlocks, chunkElements);
+  if (safeBlocks == 0) {
+    GTEST_SKIP() << "Not enough elements for even 1 block";
+  }
+
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = params.data_buffer_size,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = safeBlocks,
+                .pipelineDepth = params.pipeline_depth,
+            },
+    };
+    transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, worldSize, bootstrap, transportConfig);
+    transport->exchange();
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  DeviceBuffer inputBuf(config.total_elements * sizeof(float));
+  DeviceBuffer outputBuf(config.total_elements * sizeof(float));
+  CUDACHECK_TEST(
+      cudaMemset(outputBuf.get(), 0, divisibleCount * sizeof(float)));
+
+  fill_input(static_cast<float*>(inputBuf.get()), config.total_elements);
+
+  auto rings_opt = make_standard_rings(worldSize, globalRank, params.num_rings);
+  if (!rings_opt.has_value()) {
+    GTEST_SKIP() << "Cannot construct " << params.num_rings
+                 << " distinct rings for " << worldSize << " ranks";
+  }
+  auto& rings = *rings_opt;
+
+  RingAllReduceLaunchParams launchParams{};
+  launchParams.my_rank = globalRank;
+  launchParams.num_ranks = worldSize;
+  launchParams.count = divisibleCount;
+  launchParams.signaling_data_size = 0;
+  launchParams.input = static_cast<const float*>(inputBuf.get());
+  launchParams.output = static_cast<float*>(outputBuf.get());
+  launchParams.num_blocks = safeBlocks;
+  launchParams.num_rings = params.num_rings;
+  launchParams.timeout_ms = 30000.0f;
+  launchParams.enable_bidir_ag = params.enable_bidir_ag;
+
+  for (int r = 0; r < params.num_rings; r++) {
+    auto& ringParams = launchParams.rings[r];
+    ringParams.prev_rank = rings[r].prev_rank;
+    ringParams.next_rank = rings[r].next_rank;
+    ringParams.prev = transport->getP2pTransportDevice(rings[r].prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(rings[r].next_rank);
+  }
+
+  bootstrap->barrierAll();
+  launch_ring_allreduce(launchParams);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allreduce(static_cast<const float*>(outputBuf.get()), divisibleCount);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     Ring1,
     RingAllReduceTest,
@@ -217,6 +376,163 @@ INSTANTIATE_TEST_SUITE_P(
                 {.total_elements = 1024 * 1024,
                  .num_blocks = 16,
                  .name = "4MB_16B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1Bidir,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 16 * 1024,
+                 .num_blocks = 4,
+                 .name = "64KB_4B_bidir"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_bidir"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 256 * 1024,
+                 .num_blocks = 16,
+                 .name = "1MB_16B_bidir"},
+            .num_rings = 1,
+            .data_buffer_size = 2 * 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_bidir"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "16MB_16B_bidir"},
+            .num_rings = 1,
+            .data_buffer_size = 8 * 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2Bidir,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_2R_bidir"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_2R_bidir"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+            .enable_bidir_ag = true,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1Tail,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 33,
+                 .num_blocks = 1,
+                 .name = "33elem_1B_tail1"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1025,
+                 .num_blocks = 4,
+                 .name = "1025elem_4B_tail1"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 16385,
+                 .num_blocks = 4,
+                 .name = "16Kp1_4B_tail1"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 65537,
+                 .num_blocks = 8,
+                 .name = "64Kp1_8B_tail1"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1048577,
+                 .num_blocks = 16,
+                 .name = "1Mp1_16B_tail1"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2Tail,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 65537,
+                 .num_blocks = 8,
+                 .name = "64Kp1_8B_2R_tail1"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1048577,
+                 .num_blocks = 16,
+                 .name = "1Mp1_16B_2R_tail1"},
             .num_rings = 2,
             .data_buffer_size = 4 * 1024 * 1024,
             .pipeline_depth = 2,

--- a/comms/pipes/collectives/tests/RingAllReduceTest.cc
+++ b/comms/pipes/collectives/tests/RingAllReduceTest.cc
@@ -1,0 +1,235 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+
+#include "comms/pipes/MultipeerIbgdaTransport.h"
+#include "comms/pipes/collectives/RingAllReduceLauncher.h"
+#include "comms/pipes/collectives/RingUtils.h"
+#include "comms/pipes/collectives/tests/AllReduceTestHarness.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::pipes::test {
+
+namespace {
+
+struct RingAllReduceTestParams {
+  AllReduceTestConfig config;
+  int num_rings;
+  std::size_t data_buffer_size;
+  int pipeline_depth;
+};
+
+std::string param_name(
+    const ::testing::TestParamInfo<RingAllReduceTestParams>& info) {
+  return info.param.config.name;
+}
+
+struct LaunchContext {
+  std::unique_ptr<MultipeerIbgdaTransport> transport;
+  RingAllReduceLaunchParams params{};
+};
+
+class RingAllReduceTest
+    : public AllReduceTestBase,
+      public ::testing::WithParamInterface<RingAllReduceTestParams> {
+ protected:
+  std::optional<LaunchContext> setup_launch(
+      const RingAllReduceTestParams& params) {
+    const auto& config = params.config;
+
+    LaunchContext ctx;
+    try {
+      MultipeerIbgdaTransportConfig transportConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = params.data_buffer_size,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = config.num_blocks * params.num_rings,
+                  .pipelineDepth = params.pipeline_depth,
+              },
+      };
+      ctx.transport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transportConfig);
+      ctx.transport->exchange();
+    } catch (const std::exception&) {
+      return std::nullopt;
+    }
+
+    auto rings_opt =
+        make_standard_rings(worldSize, globalRank, params.num_rings);
+    if (!rings_opt.has_value()) {
+      return std::nullopt;
+    }
+    auto& rings = *rings_opt;
+
+    ctx.params.my_rank = globalRank;
+    ctx.params.num_ranks = worldSize;
+    ctx.params.count = config.total_elements;
+    ctx.params.num_blocks = config.num_blocks * params.num_rings;
+    ctx.params.num_rings = params.num_rings;
+    ctx.params.timeout_ms = 30000.0f;
+
+    for (int r = 0; r < params.num_rings; r++) {
+      auto& rp = ctx.params.rings[r];
+      rp.prev_rank = rings[r].prev_rank;
+      rp.next_rank = rings[r].next_rank;
+      rp.prev = ctx.transport->getP2pTransportDevice(rings[r].prev_rank);
+      rp.next = ctx.transport->getP2pTransportDevice(rings[r].next_rank);
+    }
+
+    return ctx;
+  }
+};
+
+TEST_P(RingAllReduceTest, Correctness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+  if (config.total_elements % worldSize != 0) {
+    GTEST_SKIP() << "total_elements must be divisible by worldSize";
+  }
+
+  auto ctx = setup_launch(params);
+  if (!ctx) {
+    GTEST_SKIP() << "Transport or ring setup unavailable";
+  }
+
+  DeviceBuffer inputBuf(config.total_elements * sizeof(float));
+  DeviceBuffer outputBuf(config.total_elements * sizeof(float));
+  CUDACHECK_TEST(
+      cudaMemset(outputBuf.get(), 0, config.total_elements * sizeof(float)));
+
+  fill_input(static_cast<float*>(inputBuf.get()), config.total_elements);
+
+  ctx->params.input = static_cast<const float*>(inputBuf.get());
+  ctx->params.output = static_cast<float*>(outputBuf.get());
+
+  bootstrap->barrierAll();
+  launch_ring_allreduce(ctx->params);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allreduce(
+      static_cast<const float*>(outputBuf.get()), config.total_elements);
+}
+
+TEST_P(RingAllReduceTest, InPlaceCorrectness) {
+  const auto& params = GetParam();
+  const auto& config = params.config;
+
+  if (worldSize < 2) {
+    GTEST_SKIP() << "Ring allreduce requires at least 2 ranks";
+  }
+  if (config.total_elements % worldSize != 0) {
+    GTEST_SKIP() << "total_elements must be divisible by worldSize";
+  }
+
+  auto ctx = setup_launch(params);
+  if (!ctx) {
+    GTEST_SKIP() << "Transport or ring setup unavailable";
+  }
+
+  DeviceBuffer buf(config.total_elements * sizeof(float));
+  fill_input(static_cast<float*>(buf.get()), config.total_elements);
+
+  ctx->params.input = static_cast<const float*>(buf.get());
+  ctx->params.output = static_cast<float*>(buf.get());
+
+  bootstrap->barrierAll();
+  launch_ring_allreduce(ctx->params);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  bootstrap->barrierAll();
+
+  verify_allreduce(static_cast<const float*>(buf.get()), config.total_elements);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring1,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 16 * 1024,
+                 .num_blocks = 4,
+                 .name = "64KB_4B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B"},
+            .num_rings = 1,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 256 * 1024,
+                 .num_blocks = 16,
+                 .name = "1MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 2 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 4 * 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "16MB_16B"},
+            .num_rings = 1,
+            .data_buffer_size = 8 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+INSTANTIATE_TEST_SUITE_P(
+    Ring2,
+    RingAllReduceTest,
+    ::testing::Values(
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 64 * 1024,
+                 .num_blocks = 8,
+                 .name = "256KB_8B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 1024 * 1024,
+            .pipeline_depth = 2,
+        },
+        RingAllReduceTestParams{
+            .config =
+                {.total_elements = 1024 * 1024,
+                 .num_blocks = 16,
+                 .name = "4MB_16B_2R"},
+            .num_rings = 2,
+            .data_buffer_size = 4 * 1024 * 1024,
+            .pipeline_depth = 2,
+        }),
+    param_name);
+
+} // namespace
+
+} // namespace comms::pipes::test
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/pipes/collectives/tests/RingUtilsTest.cc
+++ b/comms/pipes/collectives/tests/RingUtilsTest.cc
@@ -123,4 +123,38 @@ TEST(MakeStandardRings, IterativeRankWalkMatchesRingTraversal) {
   }
 }
 
+TEST(MakeBidirRings, W8Rank0) {
+  auto rings = make_bidir_rings(8, 0);
+  ASSERT_TRUE(rings.has_value());
+  ASSERT_EQ(rings->size(), 2);
+  EXPECT_EQ((*rings)[0].next_rank, 1);
+  EXPECT_EQ((*rings)[0].prev_rank, 7);
+  EXPECT_EQ((*rings)[1].next_rank, 7);
+  EXPECT_EQ((*rings)[1].prev_rank, 1);
+}
+
+TEST(MakeBidirRings, W2ReturnsNullopt) {
+  EXPECT_FALSE(make_bidir_rings(2, 0).has_value());
+}
+
+TEST(MakeBidirRings, W3Rank1) {
+  auto rings = make_bidir_rings(3, 1);
+  ASSERT_TRUE(rings.has_value());
+  ASSERT_EQ(rings->size(), 2);
+  EXPECT_EQ((*rings)[0].next_rank, 2);
+  EXPECT_EQ((*rings)[0].prev_rank, 0);
+  EXPECT_EQ((*rings)[1].next_rank, 0);
+  EXPECT_EQ((*rings)[1].prev_rank, 2);
+}
+
+TEST(MakeBidirRings, ReverseRingIsInverseOfForward) {
+  int W = 8;
+  for (int rank = 0; rank < W; rank++) {
+    auto rings = make_bidir_rings(W, rank);
+    ASSERT_TRUE(rings.has_value());
+    EXPECT_EQ((*rings)[0].next_rank, (*rings)[1].prev_rank) << "rank=" << rank;
+    EXPECT_EQ((*rings)[0].prev_rank, (*rings)[1].next_rank) << "rank=" << rank;
+  }
+}
+
 } // namespace comms::pipes::test

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1874,6 +1874,21 @@ cvars:
      pipelineDepth * dataBufferSize. Deeper pipeline hides more latency
      at the cost of more memory.
 
+ - name        : NCCL_CTRAN_ALLREDUCE_PIPES_NUM_RINGS
+   type        : int
+   default     : -1
+   description : |-
+     Number of rings for the pipesflatring AllReduce algorithm. Set to -1
+     for automatic selection based on message size.
+
+ - name        : NCCL_CTRAN_ALLREDUCE_PIPES_NUM_BLOCKS
+   type        : int
+   default     : -1
+   description : |-
+     Total grid blocks for the pipesflatring AllReduce algorithm. Set to -1
+     for automatic selection based on message size. This is the total
+     grid size (split across all rings).
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1845,6 +1845,35 @@ cvars:
      to be NVL-connected. All data movement and sync operations go over
      NVLink. Requires that all ranks are in the same NVL domain.
 
+ - name        : NCCL_CTRAN_PIPES_SENDRECV_ENABLE
+   type        : bool
+   default     : false
+   description : |-
+     Enable pipelined send/recv staging buffers on the IBGDA transport in
+     Pipes MultiPeerTransport. Required for ring-based collectives
+     (pipesflatring AllReduce, Ring ReduceScatter, Ring AllGather) that use
+     the send()/recv()/forward() protocol. When false, only the raw
+     put/signal APIs are available on the transport handles.
+
+ - name        : NCCL_CTRAN_PIPES_SENDRECV_MAX_GROUPS
+   type        : uint64_t
+   default     : 128
+   description : |-
+     Maximum number of block-groups that may participate in a single
+     send()/recv() call on the IBGDA transport. This sizes the per-peer
+     signal, counter, and step-state arrays. Must be >= the total grid
+     blocks (num_blocks) launched by any ring collective kernel using
+     this transport. Default 128 matches SendRecvConfig's own default.
+
+ - name        : NCCL_CTRAN_PIPES_SENDRECV_PIPELINE_DEPTH
+   type        : uint64_t
+   default     : 2
+   description : |-
+     Number of logical slots in the send/recv staging ring on the IBGDA
+     transport. Total staging memory per peer per direction is
+     pipelineDepth * dataBufferSize. Deeper pipeline hides more latency
+     at the cost of more memory.
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024
@@ -2649,13 +2678,14 @@ cvars:
  - name        : NCCL_ALLREDUCE_ALGO
    type        : enum
    default     : orig
-   choices     : orig, ctran, ctdirect, ctring
+   choices     : orig, ctran, ctdirect, ctring, pipesflatring
    description : |-
      The algorithm to use for Allreduce communication
      orig - Copy-based algorithm
      ctran - Picks the best ctran-based algorithm
      ctdirect - Ctran-based direct point-to-point algorithm
      ctring - ctran-based ring algorithm
+     pipesflatring - Pipes-based device-native ring algorithm (IBGDA)
 
  - name        : NCCL_ALLREDUCE_TYPE
    type        : enum

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1889,6 +1889,20 @@ cvars:
      for automatic selection based on message size. This is the total
      grid size (split across all rings).
 
+ - name        : NCCL_CTRAN_ALLREDUCE_PIPES_BIDIR_AG_MIN_SIZE
+   type        : int64_t
+   default     : -1
+   description : |-
+     Minimum message size in bytes for bi-directional AllGather optimization
+     in the Pipes ring AllReduce. Bi-directional AG sends data in both
+     directions simultaneously during the AllGather phase, reducing total
+     steps from W-1 to ceil((W-1)/2). This optimization benefits large
+     messages where the step reduction outweighs per-step overhead.
+     Set to 0 to enable for all message sizes.
+     Set to -1 to disable bi-directional AG entirely (default).
+     Set to -2 to auto-tune per GPU architecture.
+     Set to a positive value to enable only for messages at or above that size.
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024


### PR DESCRIPTION
Summary:

Add a forced NCCL Ring/Simple baseline column and medium-size block count sweep configs to the Ring AllReduce benchmark, enabling true ring-vs-ring performance comparison across all message sizes.

**NCCL Ring baseline:**
Creates a second NCCL communicator with `NCCL_ALGO=Ring` and `NCCL_PROTO=Simple` forced via env vars before `ncclCommInitRank`. This produces a 4-column comparison: NCCL (auto) vs NCCL Ring vs Ctran (ctring) vs Pipes (IBGDA). The NCCL Ring column confirms that NCCL auto uses tree (not ring) at small/medium sizes; the apparent "gap" to NCCL at 4-16MB was mostly ring-vs-tree, not a Pipes deficiency.

**Medium-size block count sweep:**
Tests block counts 2, 4, 8, 16 at 4MB, 16MB, and 32MB to find optimal configurations at medium sizes. At 16MB with 16 blocks, each block only has 128KB of data per ring step — too small to amortize the per-WQE overhead (QP slot reservation, mark_wqes_ready, NIC doorbell). Fewer blocks give more data per WQE.

**GB200 NCCL Ring results (Run 11, 4n×2g=8 ranks, IB-only):**

```
Size      NCCL(auto)  NCCLRing   Ctran        Pipes   Pipes vs Ring  Pipes vs Ctran
256KB           1.77      0.45    0.63         0.45           1.02x           0.73x
1MB             3.65      1.71    2.53         1.55           0.91x           0.61x
4MB            12.90      5.88    9.01     6.23(8B)           1.06x           0.69x
16MB           35.80     21.70   22.63   18.91(16B)           0.87x           0.83x
32MB           40.90     37.29   29.83   31.19(16B)           0.84x           1.05x
64MB           45.82     45.72   43.73   43.28(16B)           0.95x           0.99x
128MB          49.94     49.83   52.15   49.16(16B)           0.99x           0.94x
256MB          51.27     51.17   53.84   51.95(32B)           1.02x           0.96x
512MB          52.44     52.46   53.91   53.13(16B)           1.01x           0.99x
1GB            53.48     53.49   53.92   53.64(16B)           1.00x           0.99x
```

Key findings:
- NCCL auto uses tree at <64MB (up to 2.2x faster than NCCL Ring at 4MB)
- Pipes matches NCCL Ring at 256KB and beats it at 256MB+ (1.00-1.02x)
- Pipes is 0.87-0.95x of NCCL Ring at 4-16MB — block count optimization may close this
- The "0.53x NCCL" gap at 16MB was mostly ring-vs-tree, not a Pipes problem (vs Ring it's 0.87x)

Differential Revision: D105618089
