### PR TITLE
Select PyTorch pybind11 headers in iter builds (#2709)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,32 @@ endif()
 
 find_package(Torch REQUIRED)
 
+function(torchcomms_use_torch_pybind11 target)
+    set(include_root "${TORCHCOMMS_PYBIND11_INCLUDE_DIR}")
+    if(NOT include_root)
+        # No setup.py-supplied path (e.g. a direct `cmake -B build` invocation).
+        # Fall back to PyTorch's bundled pybind11, exposed through a unique
+        # build-dir symlink so CMake does not dedup it against Torch::Torch's
+        # INTERFACE_SYSTEM include.
+        set(_torch_pybind11 "${TORCH_INSTALL_PREFIX}/include/pybind11")
+        if(NOT EXISTS "${_torch_pybind11}/pybind11.h")
+            message(FATAL_ERROR
+                "PyTorch bundled pybind11 not found at ${_torch_pybind11}")
+        endif()
+        set(include_root
+            "${CMAKE_CURRENT_BINARY_DIR}/_torch_pybind11_for_${target}")
+        file(MAKE_DIRECTORY "${include_root}")
+        file(CREATE_LINK
+            "${_torch_pybind11}" "${include_root}/pybind11" SYMBOLIC)
+    endif()
+    if(NOT EXISTS "${include_root}/pybind11/pybind11.h")
+        message(FATAL_ERROR
+            "torchcomms_use_torch_pybind11: ${include_root} does not contain "
+            "pybind11/pybind11.h")
+    endif()
+    target_include_directories(${target} BEFORE PRIVATE "${include_root}")
+endfunction()
+
 # Helper to glob sources
 file(GLOB TORCHCOMMS_SOURCES "comms/torchcomms/*.cpp")
 file(GLOB TORCHCOMMS_FAKE_SOURCES "comms/torchcomms/fake/*.cpp")
@@ -167,6 +193,7 @@ target_include_directories(torchcomms PRIVATE
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms)
 target_compile_features(torchcomms PRIVATE cxx_std_20)
 target_link_directories(torchcomms PRIVATE ${CONDA_LIB})
 # glog/gflags/fmt must come before TORCH_LIBRARIES so our headers are found
@@ -211,6 +238,7 @@ target_include_directories(torchcomms_comms PRIVATE
     ${TORCH_INSTALL_PREFIX}/include
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms_comms)
 target_compile_features(torchcomms_comms PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms PRIVATE

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ from setuptools.command.build_ext import build_ext as build_ext_orig
 
 try:
     import torch
-    from torch.utils.cpp_extension import _get_pybind11_abi_build_flags
 except ModuleNotFoundError:
     # Fail with a helpful message — torch is required for all torchcomms builds.
     print(
@@ -56,6 +55,26 @@ def flag_str(val: bool):
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 TORCH_ROOT = os.path.dirname(torch.__file__)
+
+
+def get_torch_pybind11_include_root(build_temp: pathlib.Path) -> pathlib.Path:
+    torch_include = pathlib.Path(torch.__file__).resolve().parent / "include"
+    torch_pybind11 = torch_include / "pybind11"
+    if not (torch_pybind11 / "pybind11.h").exists():
+        raise RuntimeError(
+            f"PyTorch pybind11 headers were not found under {torch_pybind11}."
+        )
+
+    include_root = build_temp / "torch_pybind11_include"
+    include_root.mkdir(parents=True, exist_ok=True)
+    link = include_root / "pybind11"
+    if link.exists() or link.is_symlink():
+        if link.is_dir() and not link.is_symlink():
+            raise RuntimeError(f"Expected {link} to be a symlink.")
+        link.unlink()
+    link.symlink_to(torch_pybind11, target_is_directory=True)
+    return include_root
+
 
 print("Configuration:")
 USE_NCCL = flag_enabled("USE_NCCL", True)
@@ -126,14 +145,14 @@ class build_ext(build_ext_orig):
 
         # these dirs will be created in build_py, so if you don't have
         # any python sources to bundle, the dirs will be missing
-        build_temp = pathlib.Path(self.build_temp)
+        build_temp = pathlib.Path(self.build_temp).absolute()
         build_temp.mkdir(parents=True, exist_ok=True)
         extdir = pathlib.Path(self.get_ext_fullpath(ext.name))
 
         build_flags = []
-        build_flags += _get_pybind11_abi_build_flags()
         if detect_hipify_v2():
             build_flags += ["-DHIPIFY_V2"]
+        pybind11_include_root = get_torch_pybind11_include_root(build_temp)
 
         cfg = os.environ.get("CMAKE_BUILD_TYPE", "RelWithDebInfo")
         print(f"- Building with {cfg} configuration")
@@ -145,6 +164,7 @@ class build_ext(build_ext_orig):
             f"-DCMAKE_INSTALL_PREFIX={extdir.parent.absolute()}",
             f"-DCMAKE_INSTALL_DIR={extdir.parent.absolute()}",
             f"-DCMAKE_PREFIX_PATH={TORCH_ROOT}",
+            f"-DTORCHCOMMS_PYBIND11_INCLUDE_DIR={pybind11_include_root}",
             f"-DCMAKE_CXX_FLAGS={shlex.quote(' '.join(build_flags))}",
             f"-DPython3_EXECUTABLE={sys.executable}",
             f"-DLIB_SUFFIX={os.environ.get('LIB_SUFFIX', 'lib')}",


### PR DESCRIPTION
Summary:

Iter rebuilds of torchcomms / torchcomms_mccl against shared conda envs (e.g. `xlformers_*_conda`) produce ABI-incompatible artifacts when the env ships a system pybind11 v2 alongside PyTorch's bundled v3. The build picks up v2 (`pybind11_internals_v5`) while PyTorch and the feedstock `.so` files use v11; import then fails with `type "RedOpType" is already registered` or `unknown base type "c10d::Backend"`.

Have setup.py discover `torch/include/pybind11`, expose it through a unique build-temp symlink, and pass `-DTORCHCOMMS_PYBIND11_INCLUDE_DIR=...` to CMake. A small `torchcomms_use_torch_pybind11(target)` helper prepends it via `target_include_directories(BEFORE PRIVATE ...)` on the three native pybind targets (`torchcomms`, `torchcomms_comms`, `torchcomms_comms_mccl`). Also drops the deprecated `_get_pybind11_abi_build_flags()` call (no-op since PyTorch 2.9).

The helper falls back to discovering torch's pybind11 directly from `${TORCH_INSTALL_PREFIX}` if `TORCHCOMMS_PYBIND11_INCLUDE_DIR` isn't set, so direct `cmake -B build` invocations (the C++-only OSS path) keep working without setup.py.

Feedstock and OSS `pip install` builds aren't affected — those envs ship no system pybind11, so the build already finds torch's bundled one first; we just make that explicit.

Reviewed By: function47

Differential Revision: D106414106


