### PR TITLE
Use algorithm-specific kernel names for AllGather GPE stubs

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cc
@@ -5,6 +5,11 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
+__global__ void ncclKernelAllGatherCtranBrucks(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allgather::KernelArgs args);
+
 static const auto myAlgo = NCCL_ALLGATHER_ALGO::ctbrucks;
 
 // # of steps is ceil(log2(p))
@@ -325,7 +330,7 @@ commResult_t ctranAllGatherBrucksFF(
       std::move(opGroup),
       impl,
       config,
-      reinterpret_cast<void*>(ncclKernelAllGatherCtranGpeStub)));
+      reinterpret_cast<void*>(ncclKernelAllGatherCtranBrucks)));
   if (extraCopyBuff != nullptr) {
     FB_CUDACHECK(cudaMemcpyAsync(
         recvbuff,

--- a/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
+++ b/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
@@ -5,7 +5,7 @@
 #include "comms/ctran/algos/common/GpeKernelDev.cuh"
 #include "comms/ctran/gpe/CtranGpeDev.h"
 
-__global__ void ncclKernelAllGatherCtranStreamedRd(
+__global__ void ncclKernelAllGatherCtranBrucks(
     int* flag,
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args) {

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -10,6 +10,11 @@
 #include "comms/ctran/profiler/Profiler.h"
 #include "comms/ctran/utils/DevUtils.cuh"
 
+__global__ void ncclKernelAllGatherCtranStreamedRd(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allgather::KernelArgs args);
+
 namespace {
 
 using ctran::algos::PersistPlanKey;
@@ -175,7 +180,7 @@ commResult_t ctranAllGatherStreamedRd(
       std::move(opGroup),
       impl,
       config,
-      reinterpret_cast<void*>(ncclKernelAllGatherCtranGpeStub)));
+      reinterpret_cast<void*>(ncclKernelAllGatherCtranStreamedRd)));
   if (extraCopyBuff != nullptr) {
     FB_CUDACHECK(cudaMemcpyAsync(
         recvbuff,

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -450,11 +450,6 @@ __global__ void ncclKernelAllGatherCtranRing(
     CtranAlgoDeviceState* devState,
     ctran::allgather::KernelArgs args);
 
-__global__ void ncclKernelAllGatherCtranGpeStub(
-    int* flag,
-    CtranAlgoDeviceState* devState,
-    ctran::allgather::KernelArgs args);
-
 template <typename T, commRedOp_t RedOp>
 __global__ void ncclKernelAllReduceCtranDirect(
     int* flag,

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -119,6 +119,7 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/PipelineImpl.cu

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -124,6 +124,7 @@ SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/AllToAllPImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherRing.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/StreamedRd/Impl.cu
+SRCS += ${BASE_DIR}/comms/ctran/algos/AllGather/AllGatherBrucksFF.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceShm.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/DirectImpl.cu
 SRCS += ${BASE_DIR}/comms/ctran/algos/AllGatherP/PipelineImpl.cu


### PR DESCRIPTION
Summary:
- Split `ncclKernelAllGatherCtranGpeStub` into `ncclKernelAllGatherCtranStreamedRd` and `ncclKernelAllGatherCtranBrucks` so users can identify the algorithm from Kineto traces
- Move kernel forward declarations from `CtranGpe.h` into each algorithm's `.cc` file
- Add new `AllGatherBrucksFF.cu` with the Brucks kernel stub
- Update BUCK and ncclx Makefiles (v2_29, v2_30) to include the new `.cu` file

Reviewed By: Regina8023

Differential Revision: D106559443


