### PR TITLE
Fix flaky colltrace_graph_watchdog_test by removing unreliable log assertion

### DIFF
--- a/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
+++ b/comms/torchcomms/ncclx/tests/integration/cpp/ColltraceGraphWatchdogTest.cpp
@@ -6,7 +6,6 @@
 // tryEnableColltraceTimeoutWatchdog(), and that it correctly detects timeouts.
 
 #include <folly/Conv.h>
-#include <folly/FileUtil.h>
 #include <folly/Random.h>
 #include <folly/stop_watch.h>
 #include <folly/testing/TestUtil.h>
@@ -110,19 +109,10 @@ class ColltraceGraphWatchdogTest : public mccl::CollectiveIntegrationTestMixin,
     EXPECT_THAT(
         testDriverState.workerExitCodes, ::testing::Each(::testing::Ne(0)));
 
-    // Verify at least one NCCL debug log contains the colltrace watchdog
-    // timeout. Ranks 1-3 crash via XLOG(FATAL) in the test body (goes to
-    // stderr), so only rank 0's NCCL log will have the watchdog message.
-    bool foundWatchdogTimeout = false;
-    for (const auto& entry : folly::fs::directory_iterator(tmpDir_.path())) {
-      std::string fileContents;
-      if (folly::readFile(entry.path().c_str(), fileContents) &&
-          fileContents.find("watchdog timeout") != std::string::npos) {
-        foundWatchdogTimeout = true;
-      }
-    }
-    EXPECT_TRUE(foundWatchdogTimeout)
-        << "Expected at least one NCCL log to contain 'watchdog timeout'";
+    // Note: The watchdog's "watchdog timeout" message is logged via
+    // XLOG(FATAL) (folly logging -> stderr), not via NCCL's debug logging
+    // system (NCCL_DEBUG_FILE). Checking exit codes above is sufficient to
+    // validate the watchdog fired and crashed the workers.
   }
 };
 


### PR DESCRIPTION
Summary: The `testDriverCheckCrashedWithWatchdog()` method was searching for "watchdog timeout" in NCCL_DEBUG_FILE, but the WatchdogPlugin logs that message via folly XLOG(FATAL) (stderr), not NCCL's debug file system. This caused the assertion to fail ~97% of the time. The exit code check (all workers crashed with non-zero) already validates the watchdog behavior correctly.

Differential Revision: D106600065


