### PR TITLE
Constrain Pipes NVL peer discovery to CommStateX logical rank group

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -214,6 +214,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
     // Topology config: MNNVL mode and overrides
     config.topoConfig.mnnvlMode =
         static_cast<comms::pipes::MnnvlMode>(NCCL_MNNVL_ENABLE);
+    config.topoConfig.logicalNvlRanks = comm->statex_->localRankToRanks();
 
     // Guard against H100 Grand Teton returning NVML fabric info
     // (state=COMPLETED) without actual cross-node NVLink (MNNVL) capability.

--- a/comms/pipes/TopologyDiscovery.cc
+++ b/comms/pipes/TopologyDiscovery.cc
@@ -10,6 +10,7 @@
 #include <optional>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 
 #include <unistd.h>
 
@@ -96,6 +97,29 @@ TopologyResult TopologyDiscovery::classify(
   auto& myInfo = allInfo[myRank];
   const auto& peerAccessFn = peerAccessFn_;
 
+  std::optional<std::unordered_set<int>> logicalNvlRankSet;
+  if (topoConfig.logicalNvlRanks.has_value()) {
+    logicalNvlRankSet.emplace();
+    for (int rank : *topoConfig.logicalNvlRanks) {
+      if (rank < 0 || rank >= nRanks) {
+        throw std::runtime_error(
+            "TopologyDiscovery::classify: logicalNvlRanks contains rank " +
+            std::to_string(rank) + " outside [0, " + std::to_string(nRanks) +
+            ")");
+      }
+      logicalNvlRankSet->insert(rank);
+    }
+    if (logicalNvlRankSet->count(myRank) == 0) {
+      throw std::runtime_error(
+          "TopologyDiscovery::classify: logicalNvlRanks must include myRank " +
+          std::to_string(myRank));
+    }
+  }
+
+  auto isInLogicalNvlGroup = [&logicalNvlRankSet](int rank) {
+    return !logicalNvlRankSet.has_value() || logicalNvlRankSet->count(rank) > 0;
+  };
+
   // Handle MnnvlMode (following NCCL's NCCL_MNNVL_ENABLE semantics).
   // Env vars (NCCL_MNNVL_ENABLE, NCCL_P2P_DISABLE) are read by the caller
   // (e.g. CtranPipes) and passed via TopologyConfig fields.
@@ -155,6 +179,9 @@ TopologyResult TopologyDiscovery::classify(
     if (r == myRank) {
       continue;
     }
+    if (!isInLogicalNvlGroup(r)) {
+      continue;
+    }
 
     // Tier 1: MNNVL fabric match (GB200 cross-host NVLink).
     // Skipped when p2pDisable is true (NCCL_P2P_DISABLE=1 disables all
@@ -198,7 +225,9 @@ TopologyResult TopologyDiscovery::classify(
   LOG(INFO) << "TopologyDiscovery: rank " << myRank << " classified "
             << result.nvlPeerRanks.size() << " NVL peers from " << (nRanks - 1)
             << " total" << (topoConfig.p2pDisable ? " (p2p disabled)" : "")
-            << (myInfo.fabricInfo.available ? " (MNNVL)" : "");
+            << (myInfo.fabricInfo.available ? " (MNNVL)" : "")
+            << (logicalNvlRankSet.has_value() ? " (logical group constrained)"
+                                              : "");
 
   // Store fabric info in the result.
   if (myInfo.fabricInfo.available) {

--- a/comms/pipes/TopologyDiscovery.h
+++ b/comms/pipes/TopologyDiscovery.h
@@ -73,6 +73,14 @@ struct TopologyConfig {
   //     <clusterUuid, cliqueId> pair form an NVLink clique.
   std::optional<int> mnnvlCliqueId;
 
+  // Optional logical NVL rank group supplied by an upper layer.
+  //
+  // When set, both MNNVL fabric matching and same-host P2P discovery are
+  // constrained to this rank set. This lets CTRAN pass CommStateX's effective
+  // local/NVL group, which may be a virtual clique smaller than the raw MNNVL
+  // fabric domain.
+  std::optional<std::vector<int>> logicalNvlRanks;
+
   // Disable all P2P NVLink transport (both Tier 1 MNNVL and Tier 2 same-host).
   // Follows NCCL's NCCL_P2P_DISABLE semantics (PATH_LOC — self only):
   //   - false (default): use NVLink when available (MNNVL or peer access)
@@ -157,8 +165,10 @@ using LocalInfoFn = std::function<RankTopologyInfo(int deviceId)>;
  *   TopologyDiscovery topo(myPeerAccessFn, myLocalInfoFn);
  *   auto result = topo.discover(myRank, nRanks, deviceId, bootstrap);
  *
- * MNNVL Overrides (following NCCL's NCCL_MNNVL_ENABLE / NCCL_MNNVL_UUID /
- *   NCCL_MNNVL_CLIQUE_ID):
+ * TopologyConfig:
+ *
+ * MNNVL overrides (following NCCL's NCCL_MNNVL_ENABLE / NCCL_MNNVL_UUID /
+ * NCCL_MNNVL_CLIQUE_ID):
  *   These optional parameters override the hardware-reported fabric info
  *   from NVML. They only take effect when fabric info is available (i.e.,
  *   on MNNVL-capable hardware like GB200).
@@ -173,6 +183,11 @@ using LocalInfoFn = std::function<RankTopologyInfo(int deviceId)>;
  *   - std::nullopt (default): use hardware-reported clique ID
  *   - 32-bit integer: override clique ID. Ranks with the same
  *     <clusterUuid, cliqueId> pair form an NVLink clique.
+ *
+ *   logicalNvlRanks:
+ *   - std::nullopt (default): discover every NVLink-reachable peer
+ *   - rank set: restrict both MNNVL and same-host P2P discovery to the given
+ *     logical group, preserving the upper layer's local/NVL rank mapping.
  */
 class TopologyDiscovery {
  public:
@@ -208,7 +223,7 @@ class TopologyDiscovery {
    * @param nRanks      Total number of ranks.
    * @param deviceId    CUDA device index.
    * @param bootstrap   Bootstrap interface for allGather.
-   * @param topoConfig  Optional MNNVL overrides for UUID and clique ID.
+   * @param topoConfig  Optional MNNVL overrides and logical rank constraints.
    */
   TopologyResult discover(
       int myRank,
@@ -233,7 +248,7 @@ class TopologyDiscovery {
    * @param allInfo      Pre-populated per-rank topology info (size == nRanks).
    *                     allInfo[myRank] may be modified by TopologyConfig
    *                     overrides.
-   * @param topoConfig   MNNVL overrides.
+   * @param topoConfig   Optional MNNVL overrides and logical rank constraints.
    */
   TopologyResult classify(
       int myRank,

--- a/comms/pipes/tests/TopologyClassifyTest.cc
+++ b/comms/pipes/tests/TopologyClassifyTest.cc
@@ -160,6 +160,74 @@ TEST(TopologyClassifyTest, MnnvlMixedAvailability) {
   EXPECT_EQ(result.nvlPeerRanks[0], 1);
 }
 
+// A caller-provided logical NVL rank group constrains raw MNNVL discovery.
+TEST(TopologyClassifyTest, LogicalNvlRanksRestrictMnnvlTier1) {
+  constexpr int64_t kUuid = 0xAAAABBBBCCCCDDDD;
+  constexpr unsigned int kCliqueId = 1;
+
+  std::vector<RankTopologyInfo> allInfo = {
+      make_mnnvl_rank_info("host0", 0, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host0", 1, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host1", 0, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host1", 1, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host2", 0, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host2", 1, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host3", 0, kUuid, kCliqueId),
+      make_mnnvl_rank_info("host3", 1, kUuid, kCliqueId),
+  };
+
+  TopologyDiscovery topo;
+  TopologyConfig config;
+  config.logicalNvlRanks = std::vector<int>{4, 5, 6, 7};
+  auto result = topo.classify(/*myRank=*/4, /*nRanks=*/8, allInfo, config);
+
+  ASSERT_EQ(result.nvlPeerRanks.size(), 3u);
+  EXPECT_EQ(result.nvlPeerRanks[0], 5);
+  EXPECT_EQ(result.nvlPeerRanks[1], 6);
+  EXPECT_EQ(result.nvlPeerRanks[2], 7);
+  EXPECT_EQ(result.globalToNvlLocal.at(4), 0);
+  EXPECT_EQ(result.globalToNvlLocal.at(5), 1);
+  EXPECT_EQ(result.globalToNvlLocal.at(6), 2);
+  EXPECT_EQ(result.globalToNvlLocal.at(7), 3);
+  EXPECT_EQ(result.globalToNvlLocal.count(0), 0u);
+}
+
+// The same logical group constraint also applies to same-host Tier 2 peers.
+TEST(TopologyClassifyTest, LogicalNvlRanksRestrictSameHostTier2) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+      make_rank_info("host0", 2),
+      make_rank_info("host0", 3),
+  };
+
+  TopologyDiscovery topo(always_can_access);
+  TopologyConfig config;
+  config.logicalNvlRanks = std::vector<int>{2, 3};
+  auto result = topo.classify(/*myRank=*/2, /*nRanks=*/4, allInfo, config);
+
+  ASSERT_EQ(result.nvlPeerRanks.size(), 1u);
+  EXPECT_EQ(result.nvlPeerRanks[0], 3);
+  EXPECT_EQ(result.globalToNvlLocal.at(2), 0);
+  EXPECT_EQ(result.globalToNvlLocal.at(3), 1);
+  EXPECT_EQ(result.globalToNvlLocal.count(0), 0u);
+  EXPECT_EQ(result.globalToNvlLocal.count(1), 0u);
+}
+
+TEST(TopologyClassifyTest, LogicalNvlRanksMustIncludeSelf) {
+  std::vector<RankTopologyInfo> allInfo = {
+      make_rank_info("host0", 0),
+      make_rank_info("host0", 1),
+  };
+
+  TopologyDiscovery topo(always_can_access);
+  TopologyConfig config;
+  config.logicalNvlRanks = std::vector<int>{1};
+  EXPECT_THROW(
+      topo.classify(/*myRank=*/0, /*nRanks=*/2, allInfo, config),
+      std::runtime_error);
+}
+
 // =============================================================================
 // MnnvlMode tests
 // =============================================================================


### PR DESCRIPTION
Summary:
## Problem

Pipes `TopologyDiscovery` discovers NVL peers by scanning all ranks for MNNVL fabric matches (Tier 1) or same-host CUDA peer access (Tier 2). This discovers the *raw hardware* NVLink domain — every GPU reachable via NVLink fabric or local P2P.

However, `CommStateX` may expose a *logical* NVL group that is a strict subset of the hardware domain. This happens when `CommStateX` uses a virtual or deterministic MNNVL clique (e.g., a 2-node subset of a 4-node NVLink fabric). When Pipes discovers more NVL peers than `CommStateX` expects, `MultiPeerTransport`'s NVL-local rank mapping diverges from CTRAN's staging buffer layout, causing out-of-bounds accesses or silent data corruption.

## Solution

Add an optional `logicalNvlRanks` field to `TopologyConfig` that constrains peer discovery to only the ranks in the caller-supplied logical group. When set, both Tier 1 (MNNVL fabric match) and Tier 2 (same-host P2P) skip any rank not in the logical set. CTRAN populates this from `CommStateX::localRankToRanks()`.

## Data flow

```
CommStateX::localRankToRanks()
        │
        ▼
CtranPipes.cc: config.topoConfig.logicalNvlRanks = comm->statex_->localRankToRanks()
        │
        ▼
TopologyDiscovery::classify()
        │
        ├─ Build logicalNvlRankSet from logicalNvlRanks
        │
        ├─ For each candidate rank r:
        │     if r ∉ logicalNvlRankSet → skip
        │     else → proceed to Tier 1 / Tier 2 checks
        │
        ▼
TopologyResult (nvlPeerRanks, globalToNvlLocal)
  — now aligned with CommStateX's view
```

## Changes

**`TopologyDiscovery.h`** — Add `logicalNvlRanks` field to `TopologyConfig` struct; update doc comments for `discover()`, `classify()`, and the class-level TopologyConfig documentation.

**`TopologyDiscovery.cc`** — At the start of `classify()`, convert `logicalNvlRanks` to `std::unordered_set` for O(1) lookup, validate all ranks are in range and that `myRank` is included (throws `std::runtime_error` otherwise). In the peer loop, skip any rank not in the logical set. Append `(logical group constrained)` to the log line when active.

**`CtranPipes.cc`** — Wire `CommStateX::localRankToRanks()` into `config.topoConfig.logicalNvlRanks` during Pipes initialization.

**`TopologyClassifyTest.cc`** — Three new unit tests:
- `LogicalNvlRanksRestrictMnnvlTier1`: 8-rank 4-host MNNVL setup, logical group {4,5,6,7} — verifies only those ranks appear as NVL peers and `globalToNvlLocal` excludes ranks 0–3.
- `LogicalNvlRanksRestrictSameHostTier2`: 4 ranks on same host, logical group {2,3} — verifies Tier 2 is also constrained.
- `LogicalNvlRanksMustIncludeSelf`: logical group that omits `myRank` — verifies `std::runtime_error` is thrown.

Differential Revision: D106556911


