### PR TITLE
Tolerate heterogeneous transport handles

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -51,44 +51,26 @@ Status MultiTransport::validateRequests(
   auto localMemType = requests.front().local.memType();
   auto remoteMemType = requests.front().remote.memType();
   auto localMemDeviceId = requests.front().local.deviceId();
-  auto localHandles = requests.front().local.handles_;
-  auto remoteHandles = requests.front().remote.handles_;
 
   for (size_t i = 1; i < requests.size(); ++i) {
-    auto& local = requests[i].local;
-    auto& remote = requests[i].remote;
+    const auto& local = requests[i].local;
+    const auto& remote = requests[i].remote;
     if (local.memType() != localMemType || remote.memType() != remoteMemType ||
         local.deviceId() != localMemDeviceId) {
       return Err(
           ErrCode::InvalidArgument,
           "all requests must have the same memory type and device id");
     }
-
-    if (localHandles.size() != local.handles_.size() ||
-        remoteHandles.size() != remote.handles_.size()) {
-      return Err(
-          ErrCode::InvalidArgument,
-          "all requests must have the same number of handles");
-    }
-
-    for (size_t j = 0; j < localHandles.size(); ++j) {
-      if (localHandles[j]->transportType() !=
-          local.handles_[j]->transportType()) {
-        return Err(
-            ErrCode::InvalidArgument,
-            "all requests must have the same handles type");
-      }
-    }
-
-    for (size_t j = 0; j < remoteHandles.size(); ++j) {
-      if (remoteHandles[j]->transportType() !=
-          remote.handles_[j]->transportType()) {
-        return Err(
-            ErrCode::InvalidArgument,
-            "all requests must have the same handles type");
-      }
-    }
   }
+
+  // Handle counts and transport types are intentionally not validated here.
+  // A segment's handles describe the transports that were usable when that
+  // specific segment was registered or imported; they are capabilities, not a
+  // batch schema. For example, a GPU cache segment may expose both NVLink and
+  // RDMA, while a peer process that cannot import the NVLink handle still has a
+  // valid RDMA handle. selectTransport() enforces the real transfer invariant:
+  // one common transport must be available on every local and remote segment in
+  // the batch.
   return Ok();
 }
 
@@ -212,12 +194,9 @@ Result<Transport*> MultiTransport::selectTransport(
   auto localMemType = requests.front().local.memType();
   auto remoteMemType = requests.front().remote.memType();
   auto localDeviceId = requests.front().local.deviceId();
-  auto localHandles = requests.front().local.handles_;
-  auto remoteHandles = requests.front().remote.handles_;
 
-  // Helper to check if handles contain a given transport type.
-  auto hasHandleType = [](auto& handles, TransportType type) {
-    for (auto& h : handles) {
+  auto hasHandleType = [](const auto& handles, TransportType type) {
+    for (const auto& h : handles) {
       if (h->transportType() == type) {
         return true;
       }
@@ -225,29 +204,46 @@ Result<Transport*> MultiTransport::selectTransport(
     return false;
   };
 
-  // VRAM→VRAM on matching device: prefer NVLink if both sides have handles.
+  // A transport is eligible only if every request in the batch has a matching
+  // handle on both local and remote sides. This preserves the invariant that a
+  // single transport implementation executes the entire batch. Example use
+  // case: distributed KV-cache transfer can mix peers where NVLink is available
+  // with peers where RDMA is the only common capability; the batch should use
+  // NVLink only when all segments support it, otherwise fall back to RDMA.
+  auto allHaveTransport = [&](TransportType type) {
+    for (const auto& req : requests) {
+      if (!hasHandleType(req.local.handles_, type) ||
+          !hasHandleType(req.remote.handles_, type)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // VRAM→VRAM on matching device: prefer NVLink if ALL requests have it.
   if (localMemType == MemoryType::VRAM && remoteMemType == MemoryType::VRAM &&
       localDeviceId == deviceId_) {
-    if (hasHandleType(localHandles, TransportType::NVLink) &&
-        hasHandleType(remoteHandles, TransportType::NVLink)) {
+    if (allHaveTransport(TransportType::NVLink)) {
       if (auto* t = findTransport(TransportType::NVLink)) {
         return t;
       }
     }
   }
 
-  // Fallback priority: RDMA → TCP
+  // Fallback: RDMA → TCP, must be available in ALL requests.
   static constexpr TransportType kFallback[] = {
       TransportType::RDMA, TransportType::TCP};
   for (auto type : kFallback) {
-    if (auto* t = findTransport(type)) {
-      return t;
+    if (allHaveTransport(type)) {
+      if (auto* t = findTransport(type)) {
+        return t;
+      }
     }
   }
 
   return Err(
       ErrCode::NotConnected,
-      "no transport available for the given memory type and device id");
+      "no common transport available across all requests");
 }
 
 std::future<Status> MultiTransport::doTransfer(

--- a/comms/uniflow/Segment.cpp
+++ b/comms/uniflow/Segment.cpp
@@ -2,6 +2,8 @@
 
 #include "comms/uniflow/Segment.h"
 #include <cstring>
+#include <optional>
+#include "comms/uniflow/logging/Logger.h"
 
 namespace {
 
@@ -130,6 +132,8 @@ Result<RemoteRegisteredSegment> RemoteRegisteredSegment::from(
       memType,
       static_cast<int>(deviceId));
 
+  std::optional<Err> firstImportError;
+
   // handles data
   for (uint8_t i = 0; i < numHandles; ++i) {
     const size_t headerSize = sizeof(uint8_t) + sizeof(uint32_t);
@@ -165,8 +169,37 @@ Result<RemoteRegisteredSegment> RemoteRegisteredSegment::from(
     pos += handleSize;
 
     auto handleResult = getHandle(transportType, len, handleData);
-    CHECK_RETURN(handleResult);
+    if (handleResult.hasError()) {
+      if (!firstImportError.has_value()) {
+        firstImportError = handleResult.error();
+      }
+      // A serialized segment may carry handles for multiple alternative
+      // transports. One handle can be unusable in a given process or topology
+      // while another remains valid, so keep importing the rest and let
+      // MultiTransport choose the common transport for the transfer batch.
+      UNIFLOW_LOG_WARN(
+          "importSegment: transport {} handle {}/{} could not be imported "
+          "and will be ignored: {}",
+          transportType,
+          i + 1,
+          numHandles,
+          handleResult.error().message());
+      continue;
+    }
     segment.handles_.emplace_back(std::move(handleResult).value());
+  }
+
+  if (segment.handles_.empty()) {
+    if (firstImportError.has_value()) {
+      return Err(
+          firstImportError->code(),
+          "importSegment: no transport backend could import this segment; "
+          "first error: " +
+              firstImportError->message());
+    }
+    return Err(
+        ErrCode::InvalidArgument,
+        "importSegment: no transport backend could import this segment");
   }
 
   return segment;

--- a/comms/uniflow/tests/unit/MultiTransportTest.cpp
+++ b/comms/uniflow/tests/unit/MultiTransportTest.cpp
@@ -146,7 +146,7 @@ class MockTransportFactory : public TransportFactory {
       size_t /*segmentLength*/,
       std::span<const uint8_t> payload) override {
     if (failImport_) {
-      return Err(ErrCode::DriverError, "mock import failure");
+      return Err(importErrorCode_, "mock import failure");
     }
     return std::make_unique<MockRemoteRegistrationHandle>(
         transportType_, std::vector<uint8_t>(payload.begin(), payload.end()));
@@ -174,6 +174,9 @@ class MockTransportFactory : public TransportFactory {
   void setFailImport(bool fail) {
     failImport_ = fail;
   }
+  void setImportErrorCode(ErrCode code) {
+    importErrorCode_ = code;
+  }
   void setFailCreateTransport(bool fail) {
     failCreateTransport_ = fail;
   }
@@ -183,6 +186,7 @@ class MockTransportFactory : public TransportFactory {
   std::vector<uint8_t> topoData_;
   bool failRegister_{false};
   bool failImport_{false};
+  ErrCode importErrorCode_{ErrCode::DriverError};
   bool failCreateTransport_{false};
 };
 
@@ -533,6 +537,61 @@ TEST_F(MultiTransportFactoryTest, ImportSegmentPropagatesFactoryError) {
   EXPECT_EQ(importResult.error().code(), ErrCode::DriverError);
 }
 
+TEST_F(
+    MultiTransportFactoryTest,
+    ImportSegmentPreservesFirstErrorWhenAllHandlesFail) {
+  auto rdma = makeFactory(TransportType::RDMA, {0x01});
+  auto nvlink = makeFactory(TransportType::NVLink, {0x02});
+  MultiTransportFactory registerMtf = makeMultiTransportFactory({rdma, nvlink});
+
+  uint8_t buf[64];
+  Segment seg(buf, sizeof(buf), MemoryType::VRAM, 0);
+  auto regResult = registerMtf.registerSegment(seg);
+  ASSERT_TRUE(regResult.hasValue());
+  auto exported = regResult.value().exportId();
+  ASSERT_TRUE(exported.hasValue());
+
+  auto rdmaImport = makeFactory(TransportType::RDMA);
+  rdmaImport->setFailImport(true);
+  rdmaImport->setImportErrorCode(ErrCode::DriverError);
+  auto nvlinkImport = makeFactory(TransportType::NVLink);
+  nvlinkImport->setFailImport(true);
+  nvlinkImport->setImportErrorCode(ErrCode::InvalidArgument);
+  MultiTransportFactory importMtf =
+      makeMultiTransportFactory({rdmaImport, nvlinkImport});
+
+  auto importResult = importMtf.importSegment(exported.value());
+  ASSERT_TRUE(importResult.hasError());
+  EXPECT_EQ(importResult.error().code(), ErrCode::DriverError);
+}
+
+TEST_F(
+    MultiTransportFactoryTest,
+    ImportSegmentKeepsUsableHandlesWhenOptionalImportFails) {
+  auto rdma = makeFactory(TransportType::RDMA, {0x01});
+  auto nvlink = makeFactory(TransportType::NVLink, {0x02});
+  MultiTransportFactory registerMtf = makeMultiTransportFactory({rdma, nvlink});
+
+  uint8_t buf[64];
+  Segment seg(buf, sizeof(buf), MemoryType::VRAM, 0);
+  auto regResult = registerMtf.registerSegment(seg);
+  ASSERT_TRUE(regResult.hasValue());
+  auto exported = regResult.value().exportId();
+  ASSERT_TRUE(exported.hasValue());
+
+  auto rdmaImport = makeFactory(TransportType::RDMA);
+  auto nvlinkImport = makeFactory(TransportType::NVLink);
+  nvlinkImport->setFailImport(true);
+  MultiTransportFactory importMtf =
+      makeMultiTransportFactory({rdmaImport, nvlinkImport});
+
+  auto importResult = importMtf.importSegment(exported.value());
+  ASSERT_TRUE(importResult.hasValue()) << importResult.error().message();
+  auto& handles = getHandles(importResult.value());
+  ASSERT_EQ(handles.size(), 1u);
+  EXPECT_EQ(handles[0]->transportType(), TransportType::RDMA);
+}
+
 TEST_F(MultiTransportFactoryTest, RegisterSegmentZeroFactories) {
   MultiTransportFactory mtf = makeMultiTransportFactory({});
 
@@ -751,7 +810,7 @@ TEST_F(MultiTransportTest, VramPutRoutesToNvLink) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(nvlink->putCount, 1);
   EXPECT_EQ(rdma->putCount, 0);
@@ -769,7 +828,7 @@ TEST_F(MultiTransportTest, DramPutRoutesToRdma) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);
@@ -788,7 +847,7 @@ TEST_F(MultiTransportTest, VramGetRoutesToNvLink) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.get(std::move(reqs));
+  auto future = mt.get(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(nvlink->getCount, 1);
   EXPECT_EQ(rdma->getCount, 0);
@@ -805,7 +864,7 @@ TEST_F(MultiTransportTest, DramGetRoutesToRdma) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.get(std::move(reqs));
+  auto future = mt.get(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->getCount, 1);
   EXPECT_EQ(nvlink->getCount, 0);
@@ -822,7 +881,7 @@ TEST_F(MultiTransportTest, VramFallsBackToRdmaWhenNoNvLink) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
 }
@@ -848,9 +907,59 @@ TEST_F(MultiTransportTest, MultiplePutsBatchToSameTransport) {
       {v2.regSeg.span(size_t{0}, size_t{32}),
        vr2.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(nvlink->putCount, 2);
+  EXPECT_EQ(rdma->putCount, 0);
+}
+
+TEST_F(
+    MultiTransportTest,
+    BatchFallsBackToRdmaWhenNvLinkMissingFromOneRequest) {
+  MultiTransport mt(0);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments nvlinkCapableLocal(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  TestSegments nvlinkCapableRemote(
+      MemoryType::VRAM, 0, {TransportType::NVLink, TransportType::RDMA});
+  TestSegments rdmaOnlyLocal(MemoryType::VRAM, 0, {TransportType::RDMA});
+  TestSegments rdmaOnlyRemote(MemoryType::VRAM, 0, {TransportType::RDMA});
+
+  std::vector<TransferRequest> reqs = {
+      {nvlinkCapableLocal.regSeg.span(size_t{0}, size_t{32}),
+       nvlinkCapableRemote.remoteSeg.span(size_t{0}, size_t{32})},
+      {rdmaOnlyLocal.regSeg.span(size_t{0}, size_t{32}),
+       rdmaOnlyRemote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  EXPECT_TRUE(future.get().hasValue());
+  EXPECT_EQ(rdma->putCount, 2);
+  EXPECT_EQ(nvlink->putCount, 0);
+}
+
+TEST_F(MultiTransportTest, BatchFailsWhenNoTransportIsCommonToAllRequests) {
+  MultiTransport mt(0);
+  auto* nvlink = addMock(mt, TransportType::NVLink);
+  auto* rdma = addMock(mt, TransportType::RDMA);
+
+  TestSegments nvlinkOnlyLocal(MemoryType::VRAM, 0, {TransportType::NVLink});
+  TestSegments nvlinkOnlyRemote(MemoryType::VRAM, 0, {TransportType::NVLink});
+  TestSegments rdmaOnlyLocal(MemoryType::VRAM, 0, {TransportType::RDMA});
+  TestSegments rdmaOnlyRemote(MemoryType::VRAM, 0, {TransportType::RDMA});
+
+  std::vector<TransferRequest> reqs = {
+      {nvlinkOnlyLocal.regSeg.span(size_t{0}, size_t{32}),
+       nvlinkOnlyRemote.remoteSeg.span(size_t{0}, size_t{32})},
+      {rdmaOnlyLocal.regSeg.span(size_t{0}, size_t{32}),
+       rdmaOnlyRemote.remoteSeg.span(size_t{0}, size_t{32})}};
+
+  auto future = mt.put(reqs);
+  auto status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::NotConnected);
+  EXPECT_EQ(nvlink->putCount, 0);
   EXPECT_EQ(rdma->putCount, 0);
 }
 
@@ -859,7 +968,7 @@ TEST_F(MultiTransportTest, EmptyPutReturnsError) {
   addMock(mt, TransportType::RDMA);
 
   std::vector<TransferRequest> empty;
-  auto future = mt.put(std::move(empty));
+  auto future = mt.put(empty);
   auto status = future.get();
   EXPECT_TRUE(status.hasError());
   EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
@@ -874,7 +983,7 @@ TEST_F(MultiTransportTest, PutWithNoTransportsReturnsError) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   auto status = future.get();
   EXPECT_TRUE(status.hasError());
   EXPECT_EQ(status.error().code(), ErrCode::NotConnected);
@@ -899,7 +1008,7 @@ TEST_F(MultiTransportTest, MixedMemoryTypesRejected) {
       {dram1.regSeg.span(size_t{0}, size_t{32}),
        dramR.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   auto status = future.get();
   EXPECT_TRUE(status.hasError());
   EXPECT_EQ(status.error().code(), ErrCode::InvalidArgument);
@@ -919,7 +1028,7 @@ TEST_F(MultiTransportTest, VramWrongDeviceFallsBackToRdma) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);
@@ -938,7 +1047,7 @@ TEST_F(MultiTransportTest, CrossMemoryTypeFallsBackToRdma) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);
@@ -957,7 +1066,7 @@ TEST_F(MultiTransportTest, AsymmetricHandlesFallBackToRdma) {
       {local.regSeg.span(size_t{0}, size_t{32}),
        remote.remoteSeg.span(size_t{0}, size_t{32})}};
 
-  auto future = mt.put(std::move(reqs));
+  auto future = mt.put(reqs);
   EXPECT_TRUE(future.get().hasValue());
   EXPECT_EQ(rdma->putCount, 1);
   EXPECT_EQ(nvlink->putCount, 0);

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1901,15 +1901,36 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
       int flags = 0;
       // TODO: set CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE if data direct
       // link is available.
-      if (!cudaDriverApi_->cuMemGetHandleForAddressRange(
-              &fdGuard.fd,
-              static_cast<CUdeviceptr>(alignedAddr),
-              dmaBufLen,
-              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-              flags)) {
-        // TODO: WARNING LOG without exit, fallback to ibv_reg_mr.
+      auto dmaBufStatus = cudaDriverApi_->cuMemGetHandleForAddressRange(
+          &fdGuard.fd,
+          static_cast<CUdeviceptr>(alignedAddr),
+          dmaBufLen,
+          CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+          flags);
+      if (!dmaBufStatus) {
+        fdGuard.fd = -1;
+        // DMA-BUF is the preferred GPU Direct RDMA registration path, but it
+        // is an optimization over a valid VRAM allocation rather than the only
+        // correctness path. Some CUDA allocation modes or driver states cannot
+        // export a DMA-BUF for an otherwise usable segment; fall back to normal
+        // MR registration so non-GDR-capable paths can still make progress.
+        UNIFLOW_LOG_WARN(
+            "cuMemGetHandleForAddressRange failed for VRAM segment "
+            "(addr=0x{:x}, len={}, device={}): {}. "
+            "Falling back to ibv_reg_mr; this may disable GPU Direct RDMA. "
+            "For PyTorch expandable-segment allocations, "
+            "TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC=1 can restore DMA-BUF export.",
+            addr,
+            dmaBufLen,
+            segment.deviceId(),
+            dmaBufStatus.error().message());
       }
     }
+  }
+  const bool useRegMrFallback =
+      segment.memType() == MemoryType::VRAM && fdGuard.fd < 0;
+  if (useRegMrFallback) {
+    dmaBufFallbackCount_.fetch_add(1, std::memory_order_relaxed);
   }
 
   // Register with every NIC's protection domain so the region is usable

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -668,6 +668,10 @@ class RdmaTransportFactory : public TransportFactory {
   /* Return the topology information */
   std::vector<uint8_t> getTopology() override;
 
+  uint64_t dmaBufFallbackCount() const {
+    return dmaBufFallbackCount_.load(std::memory_order_relaxed);
+  }
+
  private:
   Status canConnect(std::span<const uint8_t> peerTopology) override;
 
@@ -677,6 +681,7 @@ class RdmaTransportFactory : public TransportFactory {
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
   size_t pageSize_{0};
+  std::atomic<uint64_t> dmaBufFallbackCount_{0};
   std::shared_ptr<std::vector<NicResources>> nicsHandle_;
   const RdmaTransportConfig config_;
 };

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -320,6 +320,7 @@ TEST_F(RdmaFactoryRegistrationTest, VramFallsBackToRegMrWhenDmaBufUnsupported) {
 
   auto result = factory_->registerSegment(segment);
   ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(factory_->dmaBufFallbackCount(), 1);
 }
 
 TEST_F(RdmaFactoryRegistrationTest, VramFallsBackToRegMrWhenGetHandleFails) {
@@ -343,6 +344,7 @@ TEST_F(RdmaFactoryRegistrationTest, VramFallsBackToRegMrWhenGetHandleFails) {
 
   auto result = factory_->registerSegment(segment);
   ASSERT_TRUE(result.hasValue());
+  EXPECT_EQ(factory_->dmaBufFallbackCount(), 1);
 }
 
 TEST_F(RdmaFactoryRegistrationTest, ImportSegmentSucceeds) {


### PR DESCRIPTION
Summary: Make Uniflow treat per-segment transport handles as capabilities instead of a batch schema. Segment import now keeps usable handles when one optional transport cannot be imported, preserves the first import error if no handle can be imported, and `MultiTransport` selects a single common transport across the whole batch. This is production behavior, not a benchmark workaround: for distributed KV-cache transfer, a peer may expose both `NVLink` and `RDMA` for most GPU cache segments while one process/topology can only import `RDMA`; the transfer should fall back to `RDMA` when it is common to every request and fail cleanly when no common transport exists. The RDMA DMA-BUF fallback comment also documents that DMA-BUF is the preferred GDR path while `ibv_reg_mr` remains the correctness fallback for valid VRAM allocations that cannot be exported as DMA-BUF.

Reviewed By: saifhhasan

Differential Revision: D106118519


