### PR TITLE
add hang scenario to verify FR (#2723)

### DIFF
--- a/comms/torchcomms/HealthCheck.cpp
+++ b/comms/torchcomms/HealthCheck.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/HealthCheck.hpp"
+
+#include <torch/csrc/distributed/c10d/control_plane/Handlers.hpp>
+
+namespace torch::comms {
+namespace {
+
+// Static registration of the torchcomms_health_check control plane handler.
+// Returns {"healthy": true/false} based on whether any communicator's
+// watchdog has detected a timeout.
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+c10d::control_plane::RegisterHandler torchcommsHealthCheckRegistration(
+    "torchcomms_health_check",
+    [](const c10d::control_plane::Request& /* req */,
+       c10d::control_plane::Response& res) {
+      bool timed_out = TorchCommsHealthCheck::get()->isTimedOut();
+      std::string json =
+          timed_out ? R"({"healthy": false})" : R"({"healthy": true})";
+      res.setContent(std::move(json), "application/json");
+      res.setStatus(200);
+    });
+
+} // namespace
+} // namespace torch::comms

--- a/comms/torchcomms/HealthCheck.hpp
+++ b/comms/torchcomms/HealthCheck.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <atomic>
+
+namespace torch::comms {
+
+// Process-level singleton tracking whether any TorchComm communicator
+// has experienced a watchdog timeout. Used by the debug server's health
+// check endpoint to detect unhealthy ranks and trigger flight recorder dumps.
+class TorchCommsHealthCheck {
+ public:
+  static TorchCommsHealthCheck* get() {
+    // NOLINTNEXTLINE(facebook-hte-InlinedStaticLocalVariableWarning)
+    static auto* instance = new TorchCommsHealthCheck();
+    return instance;
+  }
+
+  void setTimedOut() {
+    timed_out_.store(true, std::memory_order_release);
+  }
+
+  bool isTimedOut() const {
+    return timed_out_.load(std::memory_order_acquire);
+  }
+
+ private:
+  TorchCommsHealthCheck() = default;
+  std::atomic<bool> timed_out_{false};
+};
+
+} // namespace torch::comms

--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -433,7 +433,12 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::createWork(
     return c10::make_intrusive<TorchWorkThread>(std::move(fn));
   }
 
-  fn();
+  try {
+    fn();
+  } catch (...) {
+    runAbortHooks();
+    throw;
+  }
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 

--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "comms/torchcomms/hooks/fr/FlightRecorder.hpp"
+#include "comms/torchcomms/HealthCheck.hpp"
 #include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
+#include "comms/torchcomms/utils/Utils.hpp"
 
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/ApproximateClock.h>
@@ -16,6 +18,7 @@
 #include <future>
 #include <mutex>
 #include <sstream>
+#include <thread>
 
 namespace torch {
 namespace comms {
@@ -997,7 +1000,8 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
         self->onPostHook(device, op_id, args);
       });
 
-  // Register abort hook - called before aborting to dump flight recorder data.
+  // Register abort hook - called before crashing to wait for health check
+  // that would request flight recorder dump.
   // Derive the global rank of this process from the comm's member ranks
   // (`getRanks()`) indexed by this process's rank-within-comm (`getRank()`).
   // This works for both the world comm and sub-PGs, so every registered
@@ -1006,7 +1010,18 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
   // well-formed comm, getRank() is always within bounds of getRanks().
   int rank = comm_ranks.at(comm->getRank());
   recorder_->setRank(rank);
-  comm->registerAbortHook([self, rank]() { self->dump_file(rank); });
+  comm->registerAbortHook([]() {
+    TorchCommsHealthCheck::get()->setTimedOut();
+    auto wait_ms = env_to_value("TORCHCOMM_HEALTH_CHECK_WAIT_MS", 15000);
+    LOG(ERROR)
+        << "Waiting " << wait_ms
+        << "ms for health check and flight recorder dump before aborting";
+    // Intentional wait before aborting: gives the health check poll and
+    // the FR dump (initiated by the control plane handler) time to fire.
+    // Not a test sleep — this code path runs only on the way to abort().
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+  });
 
   registrations_.emplace_back(comm, pg_id, pg_desc);
   enabled_ = true;

--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -12,6 +12,9 @@
 #include <torch/csrc/distributed/c10d/TraceUtils.h>
 #include <torch/csrc/distributed/c10d/control_plane/Handlers.hpp>
 #include <torch/csrc/jit/serialization/pickler.h>
+#include <atomic>
+#include <future>
+#include <mutex>
 #include <sstream>
 
 namespace torch {
@@ -107,6 +110,74 @@ c10d::control_plane::RegisterHandler torchcommsFrTraceJsonRegistration(
           processedParams[onlyActiveStr]);
       res.setContent(std::move(trace), "application/json");
       res.setStatus(200);
+    });
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+c10d::control_plane::RegisterHandler torchcommsFrDumpFileRegistration(
+    "torchcomms_fr_dump_file",
+    [](const c10d::control_plane::Request& /* req */,
+       c10d::control_plane::Response& res) {
+      auto* recorder = FlightRecorder::get();
+      int rank = recorder->getRank();
+      // Reject if no communicator has registered yet — getRank() would
+      // otherwise return the default sentinel (-1) and we would write a
+      // bogus per-rank file.
+      if (rank < 0) {
+        res.setStatus(503);
+        res.setContent(
+            "Flight Recorder has not been registered with any communicator yet",
+            "text/plain");
+        return;
+      }
+
+      // Single-flight guard: rapid/overlapping calls (e.g. from a health
+      // check loop) must not each spawn a fresh worker thread writing to
+      // the same per-rank file. Use the previous future's state itself as
+      // the single-flight signal — when wait_for(0) returns `ready`, the
+      // worker has fully exited and reassigning the future will not block
+      // on a thread join. If it is not ready, the worker is still running
+      // (or in the middle of exiting); coalesce by returning immediately
+      // without launching another task.
+      // NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+      static std::mutex dump_future_mutex;
+      // NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+      static std::future<void> dump_future;
+
+      {
+        std::lock_guard<std::mutex> lock(dump_future_mutex);
+        if (dump_future.valid() &&
+            dump_future.wait_for(std::chrono::seconds(0)) !=
+                std::future_status::ready) {
+          res.setStatus(200);
+          res.setContent(
+              "Flight Recorder dump already in progress for rank " +
+                  std::to_string(rank),
+              "text/plain");
+          return;
+        }
+        // Using std::async with std::launch::async means the future's
+        // destructor joins the worker thread instead of leaking it
+        // (no detach()). The dump writes through the global singleton
+        // recorder + DebugInfoWriter, so we don't need to instantiate a
+        // new FlightRecorderHook.
+        dump_future = std::async(std::launch::async, [rank, recorder]() {
+          LOG(INFO) << "Writing Flight Recorder debug info to file for rank "
+                    << rank;
+          std::string trace = recorder->dump(
+              std::unordered_map<
+                  std::string,
+                  std::unordered_map<std::string, std::string>>{},
+              /*includeCollectives=*/true,
+              /*includeStackTraces=*/false,
+              /*onlyActive=*/false);
+          DebugInfoWriter::getWriter(rank).write(trace);
+        });
+      }
+
+      res.setStatus(200);
+      res.setContent(
+          "Flight Recorder dump initiated for rank " + std::to_string(rank),
+          "text/plain");
     });
 
 } // namespace
@@ -926,8 +997,15 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
         self->onPostHook(device, op_id, args);
       });
 
-  // Register abort hook - called before aborting to dump flight recorder data
-  int rank = comm->getRank();
+  // Register abort hook - called before aborting to dump flight recorder data.
+  // Derive the global rank of this process from the comm's member ranks
+  // (`getRanks()`) indexed by this process's rank-within-comm (`getRank()`).
+  // This works for both the world comm and sub-PGs, so every registered
+  // communicator yields the same stable global identifier.
+  // Use .at() to satisfy facebook-hte-LocalUncheckedArrayBounds; for a
+  // well-formed comm, getRank() is always within bounds of getRanks().
+  int rank = comm_ranks.at(comm->getRank());
+  recorder_->setRank(rank);
   comm->registerAbortHook([self, rank]() { self->dump_file(rank); });
 
   registrations_.emplace_back(comm, pg_id, pg_desc);

--- a/comms/torchcomms/hooks/fr/FlightRecorder.cpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.cpp
@@ -3,6 +3,7 @@
 #include "comms/torchcomms/hooks/fr/FlightRecorder.hpp"
 #include "comms/torchcomms/hooks/common/OpNameHelper.hpp"
 
+#include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/util/ApproximateClock.h>
 #include <c10/util/WaitCounter.h>
 #include <c10/util/irange.h>
@@ -145,8 +146,8 @@ void FlightRecorder::record(
     std::string profiling_name,
     const std::vector<at::Tensor>& inputs,
     const std::vector<at::Tensor>& outputs,
-    c10::Event* start,
-    c10::Event* end,
+    std::unique_ptr<c10::Event> start,
+    std::unique_ptr<c10::Event> end,
     std::chrono::milliseconds timeout_ms,
     std::shared_ptr<ProcessGroupStatus> pg_status) {
   if (!enabled_) {
@@ -156,7 +157,14 @@ void FlightRecorder::record(
   auto traceback =
       torch::CapturedTraceback::gather(true, true, capture_cpp_stack_);
 
+  c10::Event* start_ptr = start.get();
+  c10::Event* end_ptr = end.get();
+
   std::lock_guard<std::mutex> guard(mutex_);
+
+  if (start) {
+    pending_events_[op_id] = EventPair{std::move(start), std::move(end)};
+  }
 
   if (all_pg_status_.find(pg_id) == all_pg_status_.end()) {
     // Current pg_status is not in FR.
@@ -178,8 +186,8 @@ void FlightRecorder::record(
       op_id,
       std::move(profiling_name),
       std::move(traceback),
-      start,
-      end,
+      start_ptr,
+      end_ptr,
       c10::getTime(),
       timeout_ms.count(),
       std::nullopt,
@@ -323,59 +331,124 @@ std::optional<FlightRecorder::Entry> FlightRecorder::getEntry(
 
 void FlightRecorder::retire_id(
     std::optional<size_t> id,
+    const at::Device& device,
     bool compute_duration) {
   if (!enabled_ || !id) {
     return;
   }
 
-  bool can_compute_duration = false;
-  c10::Event* startEvent = nullptr;
-  c10::Event* endEvent = nullptr;
-  std::optional<float> duration = std::nullopt;
+  // Move the EventPair out of pending_events_ into a local so that the
+  // events outlive any concurrent record() that may overwrite
+  // pending_events_[*id] while we release the lock below. This also
+  // serves as a single cleanup point: when this function returns (normal
+  // or via exception), the local `events` is destroyed and the map no
+  // longer holds the entry — preventing leaks on all paths.
+  EventPair events;
+  {
+    std::lock_guard<std::mutex> extract_guard(mutex_);
+    auto events_it = pending_events_.find(*id);
+    if (events_it != pending_events_.end()) {
+      events = std::move(events_it->second);
+      pending_events_.erase(events_it);
+    }
+  }
+
+  // Record end event if available. Only attempt for CUDA devices to match
+  // the gating in onPreHook; other backends never populate pending_events_.
+  //
+  // Performed WITHOUT holding mutex_: CUDA event record() and
+  // getDeviceGuardImpl() can block (stream contention, queue back-pressure,
+  // device issues) and we never want a stalled CUDA call to also stall
+  // dump() and other callers waiting on mutex_.
+  bool events_invalid = false;
+  if (events.end && device.type() == c10::DeviceType::CUDA) {
+    try {
+      auto* guard_impl = c10::impl::getDeviceGuardImpl(device.type());
+      events.end->record(guard_impl->getStream(device));
+    } catch (const std::exception&) {
+      // Device record failed; the events are unusable for timing. Reset
+      // them so the raw pointers stored on the entry (which alias them)
+      // don't get dereferenced below.
+      events.start.reset();
+      events.end.reset();
+      events_invalid = true;
+    }
+  }
 
   std::unique_lock<std::mutex> guard(mutex_);
 
   // Look up the (id_, reset_epoch_) pair for this op_id
   auto it = op_id_to_id_and_epoch_.find(*id);
   if (it == op_id_to_id_and_epoch_.end()) {
-    return; // op_id not found
+    return; // op_id not found — `events` is destroyed via RAII
   }
   auto [internal_id, reset_epoch] = it->second;
   op_id_to_id_and_epoch_.erase(it);
 
+  bool can_compute_duration = false;
   Entry* entry = &entries_.at(getIdxFromId(internal_id, reset_epoch));
   if (entry->id_ == internal_id && entry->reset_epoch_ == reset_epoch) {
+    // If we destroyed the events due to a record-time exception, the
+    // entry's raw start_/end_ pointers now reference destroyed memory.
+    // Null them out before update_state to avoid use-after-free.
+    if (events_invalid) {
+      entry->start_ = entry->end_ = nullptr;
+    }
     update_state(*entry);
 
     if (compute_duration) {
       can_compute_duration = entry->time_discovered_completed_.has_value() &&
           entry->start_ && entry->end_;
-      startEvent = entry->start_;
-      endEvent = entry->end_;
+
+      // CPU-observed elapsed-time fallback. Used when device events are
+      // unavailable (CPU backends, backends without DeviceGuardImpl) or
+      // when events exist but have not yet been observed completed.
+      //
+      // NOTE: this is NOT a device-measured kernel duration. It measures
+      // wall-clock time between when `record()` ran on the pre-hook
+      // thread and `retire_id()` ran on the post-hook thread, which
+      // includes CPU scheduling, queueing, and post-hook dispatch
+      // latency. Treat `duration_ms` in this fallback as an upper bound
+      // on the actual collective runtime, not the runtime itself.
+      if (!can_compute_duration) {
+        auto now = c10::getTime();
+        entry->duration_ =
+            static_cast<float>(now - entry->time_created_) / 1e6f; // ns to ms
+      }
     }
     entry->retired_ = true;
     entry->start_ = entry->end_ = nullptr;
   }
 
   if (can_compute_duration) {
-    // Compute duration without without holding the lock, because
+    // Compute duration without holding the lock, because
     // cudaEventDuration() can hang, and we need to acquire the lock before we
     // can dump(), which we never want to block.
+    //
+    // The events are owned by the local `events`, so they survive any
+    // concurrent record() that may have rewritten pending_events_[*id].
     guard.unlock();
-    duration = getDurationFromEvent(*startEvent, *endEvent);
+    std::optional<float> duration;
+    try {
+      duration = getDurationFromEvent(*events.start, *events.end);
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Failed to compute duration for op_id " << *id << ": "
+                 << e.what();
+    }
     guard.lock();
 
-    // Refresh the entry pointer, see if the entry has been overwritten
-    entry = &entries_.at(getIdxFromId(*id, reset_epoch));
-    if (!(entry->id_ == *id && entry->reset_epoch_ == reset_epoch)) {
+    // Refresh the entry pointer in case it was overwritten while unlocked.
+    entry = &entries_.at(getIdxFromId(internal_id, reset_epoch));
+    if (entry->id_ == internal_id && entry->reset_epoch_ == reset_epoch) {
+      if (duration.has_value()) {
+        entry->duration_ = duration;
+      }
+    } else {
       LOG(INFO) << "retire_id abandoned for id " << *id
                 << ", event was overwritten while waiting to compute duration.";
-      return;
-    }
-    if (duration.has_value()) {
-      entry->duration_ = duration;
     }
   }
+  // `events` destroyed here — single cleanup point for pending_events_.
 }
 
 void FlightRecorder::reset_all() {
@@ -786,10 +859,11 @@ void DebugInfoWriter::registerWriter(std::unique_ptr<DebugInfoWriter> writer) {
 std::unique_ptr<DebugInfoWriter> DebugInfoWriter::writer_ = nullptr;
 std::atomic<bool> DebugInfoWriter::hasWriterRegistered_(false);
 
-float getDurationFromEvent(
-    [[maybe_unused]] c10::Event& startEvent,
-    [[maybe_unused]] c10::Event& endEvent) {
-  TORCH_CHECK(false, "getDuration not supported by c10::Event.");
+float getDurationFromEvent(c10::Event& startEvent, c10::Event& endEvent) {
+  TORCH_CHECK(
+      endEvent.query(),
+      "getDurationFromEvent can only be called after the end event has completed.");
+  return static_cast<float>(startEvent.elapsedTime(endEvent));
 }
 
 // ============================================================================
@@ -836,17 +910,20 @@ void FlightRecorderHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
 
   auto self = shared_from_this();
 
+  auto device = comm->getDevice();
+
   // Register pre-hook - records the operation
-  auto pre_hook_handle = comm->registerPreHook(
-      [self, comm_name, pg_id, pg_desc](size_t op_id, const PreHookArgs& args) {
-        self->onPreHook(comm_name, pg_id, pg_desc, op_id, args);
+  auto pre_hook_handle =
+      comm->registerPreHook([self, comm_name, pg_id, pg_desc, device](
+                                size_t op_id, const PreHookArgs& args) {
+        self->onPreHook(comm_name, pg_id, pg_desc, device, op_id, args);
       });
 
   // Register post-hook - called via work callback when work completes
   // The post-hook is invoked by TorchComm when the work's callback fires
-  auto post_hook_handle =
-      comm->registerPostHook([self](size_t op_id, const PostHookArgs& args) {
-        self->onPostHook(op_id, args);
+  auto post_hook_handle = comm->registerPostHook(
+      [self, device](size_t op_id, const PostHookArgs& args) {
+        self->onPostHook(device, op_id, args);
       });
 
   // Register abort hook - called before aborting to dump flight recorder data
@@ -861,6 +938,7 @@ void FlightRecorderHook::onPreHook(
     const std::string& comm_name,
     size_t pg_id,
     const std::string& pg_desc,
+    const at::Device& device,
     size_t op_id,
     const PreHookArgs& args) {
   auto name = getOpName(args);
@@ -927,8 +1005,26 @@ void FlightRecorderHook::onPreHook(
   std::string profiling_name =
       std::string(pg_desc) + ":" + std::string(opToString(name));
 
-  // TODO: Create start/end events for accurate timing
-  // For now, pass nullptr - timing will be based on CPU timestamps
+  // Create events for GPU-accurate timing on CUDA devices only.
+  // Other accelerator backends (XPU, MTIA) may not handle per-collective
+  // event creation gracefully; for those, fall back to wall-clock duration.
+  std::unique_ptr<c10::Event> start_event;
+  std::unique_ptr<c10::Event> end_event;
+  if (device.type() == c10::DeviceType::CUDA) {
+    try {
+      auto* guard_impl = c10::impl::getDeviceGuardImpl(device.type());
+      start_event = std::make_unique<c10::Event>(
+          device.type(), c10::EventFlag::BACKEND_DEFAULT);
+      end_event = std::make_unique<c10::Event>(
+          device.type(), c10::EventFlag::BACKEND_DEFAULT);
+      start_event->record(guard_impl->getStream(device));
+    } catch (const std::exception&) {
+      // Backend does not support DeviceGuardImpl or events.
+      // Fall back to no event tracking — duration will use wall-clock.
+      start_event.reset();
+      end_event.reset();
+    }
+  }
 
   recorder_->record(
       pg_id,
@@ -937,21 +1033,25 @@ void FlightRecorderHook::onPreHook(
       std::move(profiling_name),
       inputs,
       outputs,
-      nullptr, // start event
-      nullptr, // end event
+      std::move(start_event),
+      std::move(end_event),
       std::chrono::milliseconds(600000), // 10 minute default timeout
       nullptr // pg_status
   );
 }
 
-void FlightRecorderHook::onPostHook(size_t op_id, const PostHookArgs& args) {
+void FlightRecorderHook::onPostHook(
+    const at::Device& device,
+    size_t op_id,
+    const PostHookArgs& args) {
   if (!enabled_) {
     return;
   }
+
   if (std::get_if<FinalizePostHookArgs>(&args)) {
     return;
   }
-  recorder_->retire_id(op_id, false);
+  recorder_->retire_id(op_id, device, /*compute_duration=*/true);
 
   // Handle split operations - register the new communicator with flight
   // recorder

--- a/comms/torchcomms/hooks/fr/FlightRecorder.hpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.hpp
@@ -236,8 +236,8 @@ class FlightRecorder {
       std::string profiling_name,
       const std::vector<at::Tensor>& inputs,
       const std::vector<at::Tensor>& outputs,
-      c10::Event* start,
-      c10::Event* end,
+      std::unique_ptr<c10::Event> start,
+      std::unique_ptr<c10::Event> end,
       std::chrono::milliseconds timeout_ms,
       std::shared_ptr<ProcessGroupStatus> pg_status);
 
@@ -249,17 +249,18 @@ class FlightRecorder {
 
   std::vector<Entry> dump_entries();
 
-  /*
-  Mark an Event as completed and free its events.
-  This is called by the watchdog thread, and is asynchronous from the
-  perspective of the main thread.
-  compute_duration defaults to true since retire_id is only called in the
-  watchdog thread, which is currently a place we call cuda APIs which may hang,
-  but care should be taken to avoid computing duration in any function that must
-  never hang. (timing must also be enabled for compute_duration - see
-  TORCH_NCCL_ENABLE_TIMING).
-  */
-  void retire_id(std::optional<size_t> id, bool compute_duration = true);
+  // Stores start/end events per op_id for GPU-accurate timing.
+  struct EventPair {
+    std::unique_ptr<c10::Event> start;
+    std::unique_ptr<c10::Event> end;
+  };
+
+  // Record end event on the device stream, retire the entry, and cleanup
+  // stored events. Acquires mutex_ internally.
+  void retire_id(
+      std::optional<size_t> id,
+      const at::Device& device,
+      bool compute_duration = true);
 
   void reset_all();
 
@@ -329,6 +330,9 @@ class FlightRecorder {
   std::string comm_lib_version_;
   // Map from op_id to (id_, reset_epoch_) to pass correct values when retiring
   std::unordered_map<size_t, std::pair<size_t, size_t>> op_id_to_id_and_epoch_;
+
+  // Pending events for GPU-accurate timing, keyed by op_id.
+  std::unordered_map<size_t, EventPair> pending_events_;
 };
 
 // ============================================================================
@@ -418,14 +422,17 @@ class FlightRecorderHook
       const std::string& comm_name,
       size_t pg_id,
       const std::string& pg_desc,
+      const at::Device& device,
       size_t op_id,
       const PreHookArgs& args);
 
-  void onPostHook(size_t op_id, const PostHookArgs& args);
+  void
+  onPostHook(const at::Device& device, size_t op_id, const PostHookArgs& args);
 
   FlightRecorder* recorder_;
   bool owns_recorder_{false}; // True when using isolated instance
 
+  // Track registered communicators
   struct CommRegistration {
     std::weak_ptr<TorchComm> comm;
     size_t pg_id;

--- a/comms/torchcomms/hooks/fr/FlightRecorder.hpp
+++ b/comms/torchcomms/hooks/fr/FlightRecorder.hpp
@@ -11,6 +11,7 @@
 #include <comms/torchcomms/TorchComm.hpp>
 #include <comms/torchcomms/utils/Utils.hpp>
 #include <torch/csrc/profiler/combined_traceback.h>
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <optional>
@@ -284,6 +285,24 @@ class FlightRecorder {
    */
   size_t size() const;
 
+  /**
+   * Set the global rank for this process.
+   * Called during registerWithComm with the global rank derived from
+   * `comm->getRanks()[comm->getRank()]`, which yields the same value
+   * for every registered communicator (world comm or sub-PG). The
+   * dump_file handler uses this rank to name the per-rank trace file.
+   */
+  void setRank(int rank) {
+    rank_.store(rank, std::memory_order_relaxed);
+  }
+
+  /**
+   * Get the global rank, or -1 if not yet set.
+   */
+  int getRank() const {
+    return rank_.load(std::memory_order_relaxed);
+  }
+
  private:
   // Returns the entry with the given id and reset_epoch, if it exists.
   // Otherwise, returns std::nullopt.
@@ -315,6 +334,7 @@ class FlightRecorder {
 
   bool enabled_ = false;
   bool capture_cpp_stack_ = false;
+  std::atomic<int> rank_{-1};
   mutable std::mutex mutex_;
   std::vector<Entry> entries_;
   size_t max_entries_ = 0;

--- a/comms/torchcomms/hooks/fr/scripts/verify_flight_recorder.py
+++ b/comms/torchcomms/hooks/fr/scripts/verify_flight_recorder.py
@@ -8,33 +8,54 @@
 # pyre-strict
 
 """
-Flight Recorder Verification Script with Debug Server Integration
+Flight Recorder Hang Debugging Demo
 
-This script demonstrates how to use the FlightRecorderHook with torchcomms
-to record collective operations and dump traces for debugging, along with
-the PyTorch debug server for real-time debugging capabilities.
+Demonstrates debugging a rank-hang scenario
 
-The traces can be analyzed using the PyTorch flight_recorder trace analyzer:
-    python -m torch.distributed.flight_recorder.fr_trace <trace_dir>
+Scenario
+--------
+  - All ranks complete initial collectives together (baseline)
+  - One rank enters a long sleep (simulating a compute hang)
+  - Other ranks attempt another collective and eventually timeout
+  - The abort hook marks the timed-out rank as unhealthy
+  - The debug server's health check detects the unhealthy rank and
+    triggers per-rank pickle dumps automatically
+  - Periodic aggregated text dumps capture the divergent state
+  - The FR CLI performs cross-rank mismatch detection on the pickle files
 
-Debug server endpoints available at http://localhost:<DEBUG_SERVER_PORT>:
-    /torchcomms_fr_trace   - Flight recorder trace viewer
-    /torchcomms_fr_trace_json - Flight recorder trace as JSON
+Usage
+-----
+  # Basic run (last rank hangs, 30s timeout):
+  torchrun --nproc_per_node=2 verify_flight_recorder.py
 
-Usage:
-    # Set the dump directory (traces will be written as <prefix><rank>)
-    export TORCHCOMM_FR_DUMP_TEMP_FILE=/tmp/flight_recorder_traces/rank_
+  # Customise dump directory, timeout, and which rank hangs:
+  FR_DUMP_DIR=/tmp/fr_hang_debug \\
+  COMM_TIMEOUT=20 \\
+  HANGING_RANK=0 \\
+  torchrun --nproc_per_node=4 verify_flight_recorder.py
 
-    torchrun --nproc_per_node=2 verify_flight_recorder.py
+  # After the job fails, analyse the per-rank pickle traces:
+  python -m torch.distributed.flight_recorder.fr_trace \\
+      /tmp/fr_hang_debug/per_rank -p rank_
 
-    Or with a specific backend:
-    TEST_BACKEND=nccl torchrun --nproc_per_node=2 verify_flight_recorder.py
+Environment Variables
+---------------------
+  FR_DUMP_DIR         Root dump directory (default: /tmp/fr_hang_debug)
+  FR_DUMP_INTERVAL    Seconds between periodic dumps (default: 5)
+  COMM_TIMEOUT        Communicator timeout in seconds (default: 30)
+  HANGING_RANK        Which rank to hang; -1 = last rank (default: -1)
+  TEST_BACKEND        Communication backend (default: gloo)
+  TEST_DEVICE         Tensor device (default: cuda)
 
-    Enable debug server (rank 0 only by default):
-    TEST_DEBUG_SERVER=1 torchrun --nproc_per_node=2 verify_flight_recorder.py
-
-    Specify debug server port:
-    TEST_DEBUG_SERVER=1 DEBUG_SERVER_PORT=25999 torchrun --nproc_per_node=2 verify_flight_recorder.py
+Output Layout
+-------------
+  FR_DUMP_DIR/
+  ├── torchcomms_fr_trace_<ts>.txt        ← aggregated text dumps
+  ├── torchcomms_health_check_<ts>.txt    ← health check status
+  ├── stacks_<ts>.txt                     ← Python stack dumps
+  └── per_rank/                           ← per-rank pickle dumps (triggered by health check)
+      ├── rank_0
+      └── rank_1
 """
 
 import os
@@ -48,48 +69,79 @@ from torchcomms.hooks import FlightRecorderHook
 
 
 def main() -> None:
-    # Get backend from environment or default to gloo
     backend = os.environ.get("TEST_BACKEND", "gloo")
     device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
 
-    # Debug server configuration
-    enable_debug_server = os.environ.get("TEST_DEBUG_SERVER", "0") == "1"
-    debug_server_port = int(os.environ.get("DEBUG_SERVER_PORT", "25999"))
+    dump_dir = os.environ.get("FR_DUMP_DIR", "/tmp/fr_hang_debug")
+    dump_interval = float(os.environ.get("FR_DUMP_INTERVAL", "5"))
+    timeout_seconds = int(os.environ.get("COMM_TIMEOUT", "30"))
+    hanging_rank = int(os.environ.get("HANGING_RANK", "-1"))
 
-    # Initialize TorchComm (this starts the distributed backend)
+    # The abort hook waits this long for the health check to trigger
+    # FR dumps before the exception propagates.  Default to 3× the dump
+    # interval so at least one dump cycle can detect the unhealthy state.
+    health_check_wait = int(
+        os.environ.get(
+            "TORCHCOMM_HEALTH_CHECK_WAIT_SECONDS", str(int(dump_interval) * 3)
+        )
+    )
+    os.environ.setdefault("TORCHCOMM_HEALTH_CHECK_WAIT_SECONDS", str(health_check_wait))
+
+    os.makedirs(dump_dir, exist_ok=True)
+
+    # Per-rank pickle dumps go into a dedicated subdirectory so that the
+    # FR CLI can operate on a clean folder containing only rank_<N> files,
+    # separate from the debug-server's aggregated text dumps.
+    per_rank_dir = os.path.join(dump_dir, "per_rank")
+    os.makedirs(per_rank_dir, exist_ok=True)
+    dump_prefix = os.path.join(per_rank_dir, "rank_")
+    os.environ["TORCHCOMM_FR_DUMP_TEMP_FILE"] = dump_prefix
+
     comm = new_comm(
         backend=backend,
         device=device,
         name="main_comm",
-        timeout=timedelta(seconds=300),
+        timeout=timedelta(seconds=timeout_seconds),
     )
 
     rank = comm.get_rank()
     world_size = comm.get_size()
 
-    # Calculate device ID
+    if hanging_rank < 0:
+        hanging_rank = world_size - 1
+
     num_devices = torch.accelerator.device_count()
     device_id = rank % num_devices
     target_device = torch.device(f"{device.type}:{device_id}")
 
-    print(f"Rank {rank}/{world_size}: Running on device {device_id}")
+    print(
+        f"[Rank {rank}/{world_size}] device={device_id}, "
+        f"hanging_rank={hanging_rank}, timeout={timeout_seconds}s"
+    )
 
-    # Start debug server on ALL ranks
-    # The frontend HTTP server runs on rank 0, but the backend worker
-    # must run on every rank to register with the store
-    if enable_debug_server:
-        print(f"Rank {rank}: Starting debug server (port {debug_server_port})")
-        start_debug_server(port=debug_server_port)
-        if rank == 0:
-            print(
-                f"Rank {rank}: Debug server frontend at http://localhost:{debug_server_port}"
-            )
+    # ── Debug Server with Periodic Dumps ──────────────────────────────
+    # The debug server runs three periodic dump handlers:
+    #   1) torchcomms_fr_trace  → aggregated text tables in dump_dir
+    #   2) torchcomms_health_check → detects unhealthy ranks (watchdog
+    #      timeouts) and triggers per-rank pickle dumps → per_rank/rank_<N>.
+    #      These pickles are consumed by the FR CLI for automated
+    #      cross-rank mismatch analysis.
+    #   3) stacks → Python stack traces for every rank
+    start_debug_server(
+        port=25999,
+        dump_dir=dump_dir,
+        dump_interval=dump_interval,
+        enabled_dumps={"torchcomms_fr_trace", "torchcomms_health_check", "stacks"},
+    )
+    if rank == 0:
+        print(f"[Rank {rank}] Debug server: http://localhost:25999")
+        print(f"[Rank {rank}] Periodic dumps every {dump_interval}s → {dump_dir}")
+        print(f"[Rank {rank}] Health check triggers per-rank pickles → {per_rank_dir}")
 
-    # Create FlightRecorderHook
+    # ── Flight Recorder Hook ─────────────────────────────────────────
     recorder = FlightRecorderHook(max_entries=100)
     recorder.register_with_comm(comm)
 
-    # Create a tensor with rank-specific data
     tensor = torch.full(
         (1024,),
         float(rank + 1),
@@ -97,51 +149,77 @@ def main() -> None:
         device=target_device,
     )
 
-    print(f"Rank {rank}: Before AllReduce: {tensor[0].item()}")
-
-    # Perform multiple collective operations
-    for _ in range(5):
+    # ── Phase 1: Successful collectives (all ranks) ──────────────────
+    print(f"[Rank {rank}] Phase 1: Running 3 all_reduce + 1 broadcast")
+    for _i in range(3):
         comm.all_reduce(tensor, ReduceOp.SUM, async_op=False)
-
-    # Broadcast from rank 0
     comm.broadcast(tensor, root=0, async_op=False)
-
-    # Synchronize CUDA stream
     torch.accelerator.current_stream().synchronize()
+    print(f"[Rank {rank}] Phase 1 complete")
 
-    print(f"Rank {rank}: After AllReduce: {tensor[0].item()}")
-
-    # Dump traces using dump_file API
-    # The output location is controlled by TORCHCOMM_FR_DUMP_TEMP_FILE env var
-    # Files are written as <TORCHCOMM_FR_DUMP_TEMP_FILE><rank>
-    recorder.dump_file(rank)
-
-    dump_prefix = os.environ.get(
-        "TORCHCOMM_FR_DUMP_TEMP_FILE", "~/.cache/torchcomm_fr_trace_"
-    )
-    trace_file = f"{dump_prefix}{rank}"
-    print(f"Rank {rank}: Flight recorder trace dumped to {trace_file}")
-
-    if rank == 0:
-        dump_dir = os.path.dirname(dump_prefix) or "."
-        print(f"\n=== Flight Recorder traces saved to: {dump_dir} ===")
-        print("To analyze the traces, run:")
-        print(f"  python -m torch.distributed.flight_recorder.fr_trace -j {dump_dir}")
-
-    # Keep debug server running for manual verification
-    if enable_debug_server:
+    # ── Phase 2: One rank hangs ──────────────────────────────────────
+    # The hanging rank sleeps long enough for the other ranks' abort
+    # hook to fire and the health check to trigger dumps.
+    hang_duration = timeout_seconds + health_check_wait + int(dump_interval)
+    if rank == hanging_rank:
+        print(f"[Rank {rank}] >>> HANGING – sleeping {hang_duration}s <<<")
         print(
-            f"\nRank {rank}: Debug server running at http://localhost:{debug_server_port}"
+            f"[Rank {rank}] Periodic dumps will show this rank's ops stuck at "
+            "collective_seq_id=4 while others advance."
         )
-        print("Press Ctrl+C to stop the server and exit...")
-        try:
-            while True:
-                time.sleep(1)
-        except KeyboardInterrupt:
-            print(f"\nRank {rank}: Stopping debug server...")
+        time.sleep(hang_duration)
+        print(f"[Rank {rank}] Hang period over, exiting.")
+        comm.finalize()
+        return
 
-    # Cleanup
+    print(
+        f"[Rank {rank}] Phase 2: all_reduce (rank {hanging_rank} will NOT participate)"
+    )
+    print(f"[Rank {rank}] Expecting timeout in ~{timeout_seconds}s ...")
+
+    # When the collective times out, the abort hook fires: it calls
+    # setTimedOut() and sleeps for TORCHCOMM_HEALTH_CHECK_WAIT_SECONDS,
+    # giving the health check time to detect the unhealthy rank and
+    # trigger per-rank pickle dumps.  The exception then propagates here.
+    try:
+        comm.all_reduce(tensor, ReduceOp.SUM, async_op=False)
+    except RuntimeError as e:
+        # torchcomms raises RuntimeError on collective timeout (the case
+        # this script is intentionally exercising). Print analysis hints
+        # and continue to finalize() so the rank exits cleanly. Any other
+        # exception type indicates a real bug and should propagate.
+        print(f"[Rank {rank}] Caught timeout: {type(e).__name__}: {e}")
+        _print_analysis_instructions(rank, dump_dir, per_rank_dir)
+
     comm.finalize()
+
+
+def _print_analysis_instructions(rank: int, dump_dir: str, per_rank_dir: str) -> None:
+    if rank != 0:
+        return
+    print()
+    print("=" * 70)
+    print("  HOW TO DEBUG THIS HANG")
+    print("=" * 70)
+    print()
+    print("  1) Aggregated text dumps (human-readable):")
+    print(f"     ls {dump_dir}/torchcomms_fr_trace_*.txt")
+    print()
+    print("  2) Health check status (triggers per-rank pickle dumps):")
+    print(f"     ls {dump_dir}/torchcomms_health_check_*.txt")
+    print()
+    print("  3) Per-rank pickle dumps (FR CLI cross-rank analysis):")
+    print(
+        f"     python -m torch.distributed.flight_recorder.fr_trace"
+        f" {per_rank_dir} -p rank_"
+    )
+    print()
+    print("  Detailed per-entry output with stack traces:")
+    print(
+        f"     python -m torch.distributed.flight_recorder.fr_trace"
+        f" {per_rank_dir} -p rank_ -j --print_stack_trace"
+    )
+    print("=" * 70)
 
 
 if __name__ == "__main__":

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
@@ -6,10 +6,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import glob
 import json
 import os
 import pickle
+import shutil
 import tempfile
+import threading
 import typing
 import unittest
 from datetime import timedelta
@@ -29,6 +32,10 @@ from torch.distributed.flight_recorder.components.types import (
 )
 from torchcomms.hooks import FlightRecorderHook
 from torchcomms.objcol import all_gather_object
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    get_rank_and_size,
+    skip_backend,
+)
 
 
 class TestFlightRecorderHook(unittest.TestCase):
@@ -853,6 +860,128 @@ class TestFlightRecorderHook(unittest.TestCase):
                     del os.environ["TORCHCOMM_FR_DUMP_TEMP_FILE"]
 
         comm.finalize()
+
+    @skip_backend("xccl", "XCCL backend does not support comm abort")
+    def test_fr_abort_hook_writes_traces_on_simulated_rank_failure(self) -> None:
+        """Test abort hook writes traces when simulating a rank failure with threads.
+
+        This test uses threads to simulate a rank crash:
+        - Each rank spawns a thread that runs a collective
+        - On rank 0, the thread exits early (simulating a crash)
+        - On other ranks, the collective times out waiting for rank 0
+        - The timeout triggers the abort hook
+
+        Note: Uses abort_process_on_timeout_or_error=False so the process doesn't
+        actually exit, allowing us to verify the traces were written.
+        TORCHCOMM_HEALTH_CHECK_WAIT_MS=0 prevents the abort hook from sleeping.
+        """
+        rank, size = get_rank_and_size()
+        if size < 2:
+            self.skipTest("This test requires at least 2 ranks")
+
+        trace_dir = tempfile.mkdtemp(prefix="fr_thread_crash_test_")
+        self.addCleanup(lambda: shutil.rmtree(trace_dir, ignore_errors=True))
+        expected_trace_file = os.path.join(trace_dir, f"fr_crash_trace_{rank}")
+
+        original_dump_file = os.environ.get("TORCHCOMM_FR_DUMP_TEMP_FILE")
+        os.environ["TORCHCOMM_FR_DUMP_TEMP_FILE"] = expected_trace_file
+
+        original_health_check_wait = os.environ.get("TORCHCOMM_HEALTH_CHECK_WAIT_MS")
+        os.environ["TORCHCOMM_HEALTH_CHECK_WAIT_MS"] = "0"
+
+        collective_exception: list[Exception] = []
+
+        def run_collective_in_thread(
+            comm: torchcomms.TorchComm,
+            should_exit_early: bool,
+        ) -> None:
+            """Run a collective in a thread, optionally exiting early to simulate crash."""
+            try:
+                t = torch.rand(10, 10, device=self.device)
+                if should_exit_early:
+                    return
+                comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+            except Exception as e:
+                collective_exception.append(e)
+
+        try:
+            comm = torchcomms.new_comm(
+                backend=self.backend,
+                device=self.device,
+                name="test_comm_thread_crash",
+                timeout=timedelta(milliseconds=2000),
+                abort_process_on_timeout_or_error=False,
+            )
+
+            recorder = FlightRecorderHook(max_entries=100, isolated=True)
+            recorder.register_with_comm(comm)
+
+            t = torch.rand(10, 10, device=self.device)
+            comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+            should_crash = rank == 0
+            collective_thread = threading.Thread(
+                target=run_collective_in_thread,
+                args=(comm, should_crash),
+                name=f"collective-thread-rank-{rank}",
+            )
+            collective_thread.start()
+            collective_thread.join(timeout=10)
+
+            if rank != 0:
+                self.assertGreater(
+                    len(collective_exception),
+                    0,
+                    "Non-rank-0 should have experienced a timeout/error",
+                )
+
+            recorder.dump_file(rank)
+
+            self.assertTrue(
+                os.path.exists(expected_trace_file),
+                f"Expected trace file {expected_trace_file} was not created",
+            )
+
+            with open(expected_trace_file, "rb") as f:
+                data = pickle.load(f)
+
+            self.assertIn("version", data)
+            self.assertEqual(data["version"], "2.10")
+            self.assertIn("entries", data)
+
+            entries = data.get("entries", [])
+            self.assertGreater(
+                len(entries),
+                0,
+                f"Trace file for rank {rank} should have entries",
+            )
+
+            has_all_reduce = any(
+                entry.get("profiling_name") == f"{self.backend}:all_reduce"
+                for entry in entries
+            )
+            self.assertTrue(has_all_reduce, "Trace should contain all_reduce entry")
+
+            comm.finalize()
+
+        finally:
+            if original_dump_file is not None:
+                os.environ["TORCHCOMM_FR_DUMP_TEMP_FILE"] = original_dump_file
+            elif "TORCHCOMM_FR_DUMP_TEMP_FILE" in os.environ:
+                del os.environ["TORCHCOMM_FR_DUMP_TEMP_FILE"]
+
+            if original_health_check_wait is not None:
+                os.environ["TORCHCOMM_HEALTH_CHECK_WAIT_MS"] = (
+                    original_health_check_wait
+                )
+            elif "TORCHCOMM_HEALTH_CHECK_WAIT_MS" in os.environ:
+                del os.environ["TORCHCOMM_HEALTH_CHECK_WAIT_MS"]
+
+            for trace_file in glob.glob(f"{expected_trace_file}*"):
+                try:
+                    os.remove(trace_file)
+                except OSError:
+                    pass
 
     def test_only_active_excludes_completed_collectives(self) -> None:
         """Test that completed collectives are excluded when include_completed=False.

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderTest.py
@@ -1188,6 +1188,129 @@ class TestFlightRecorderHook(unittest.TestCase):
         level1_comm.finalize()
         comm.finalize()
 
+    def test_duration_recorded_for_collective(self) -> None:
+        """Test that duration_ms is recorded for collective operations.
+
+        For CPU backends, duration is computed from wall-clock timestamps.
+        For device backends, duration is computed from device events.
+        In both cases, retired entries should have a positive duration_ms.
+        """
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        # Run a collective operation
+        t = torch.rand(10, 10, device=device)
+        comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Wait for the work to complete so postHook fires
+        # (for CPU backends this is synchronous, for CUDA we need to sync)
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        # Parse JSON and check duration
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertGreater(len(entries), 0, "Should have at least one entry")
+
+        entry = entries[0]
+        self._validate_entry_format(entry)
+        self.assertTrue(entry["retired"], "Entry should be retired")
+        self.assertIn("duration_ms", entry, "Retired entry should have duration_ms")
+        self.assertGreater(entry["duration_ms"], 0, "duration_ms should be positive")
+
+        comm.finalize()
+
+    def test_duration_recorded_for_multiple_operations(self) -> None:
+        """Test that duration_ms is recorded for multiple different operations."""
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration_multi",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        t = torch.rand(10, 10, device=device)
+
+        # Run several different collective operations
+        comm.all_reduce(t, op=torchcomms.ReduceOp.SUM, async_op=False)
+        comm.broadcast(t, root=0, async_op=False)
+        comm.barrier(async_op=False)
+
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertGreaterEqual(len(entries), 3, "Should have at least 3 entries")
+
+        for entry in entries:
+            self._validate_entry_format(entry)
+            self.assertTrue(entry["retired"], "Entry should be retired")
+            self.assertIn(
+                "duration_ms",
+                entry,
+                f"Entry {entry['profiling_name']} missing duration",
+            )
+            self.assertGreater(
+                entry["duration_ms"],
+                0,
+                f"duration_ms should be positive for {entry['profiling_name']}",
+            )
+
+        comm.finalize()
+
+    def test_duration_ordering(self) -> None:
+        """Test that a longer operation has greater or equal duration."""
+        backend = os.environ["TEST_BACKEND"]
+        device = torch.device(os.environ.get("TEST_DEVICE", "cuda"))
+        comm = torchcomms.new_comm(
+            backend=backend,
+            device=device,
+            name="test_duration_order",
+            timeout=timedelta(seconds=300),
+        )
+
+        recorder = FlightRecorderHook(max_entries=100, isolated=True)
+        recorder.register_with_comm(comm)
+
+        # Small tensor - should be fast
+        t_small = torch.rand(1, device=device)
+        comm.all_reduce(t_small, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        # Large tensor - should take longer (or at least not less)
+        t_large = torch.rand(1000, 1000, device=device)
+        comm.all_reduce(t_large, op=torchcomms.ReduceOp.SUM, async_op=False)
+
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+
+        json_str = recorder.dump_json()
+        data = json.loads(json_str)
+        entries = data.get("entries", [])
+        self.assertEqual(len(entries), 2, "Should have exactly 2 entries")
+
+        for entry in entries:
+            self.assertIn("duration_ms", entry)
+            self.assertGreater(entry["duration_ms"], 0)
+
+        comm.finalize()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -333,10 +333,6 @@ void TorchCommNCCL::finalize() {
 }
 
 void TorchCommNCCL::abortNcclComm() {
-  // Call abort hooks before aborting to allow users to capture debug info
-  TC_LOG(INFO, this) << "Calling abort hooks before aborting.";
-  runAbortHooks();
-
   detachMemoryHook();
   if (nccl_comm_) {
     NCCL_CHECK(
@@ -348,6 +344,7 @@ void TorchCommNCCL::abortNcclComm() {
   }
   if (options_.abort_process_on_timeout_or_error) {
     TC_LOG(ERROR, this) << "Aborting process due to timeout";
+    runAbortHooks();
     ::abort();
   }
 }

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -246,6 +246,9 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
                             << " - timeout watchdog detected operation error. ";
       }
+
+      runAbortHooks();
+
       ::abort();
     }
 
@@ -262,6 +265,9 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this)
             << "Aborting process due to error on rank " << rank_
             << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
+
+        runAbortHooks();
+
         abort();
       }
     }
@@ -293,6 +299,7 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
       abortNcclComm();
       if (options_.abort_process_on_timeout_or_error) {
         TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        runAbortHooks();
         ::abort();
       } else {
         throw std::runtime_error("NCCL operation timed out");
@@ -311,6 +318,7 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "
                           << ncclException.what();
+      runAbortHooks();
       ::abort();
     } else {
       throw ncclException;

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -285,6 +285,9 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this) << "Aborting process due to error on rank " << rank_
                             << " - timeout watchdog detected operation error. ";
       }
+
+      runAbortHooks();
+
       std::abort();
     }
 
@@ -301,6 +304,9 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this)
             << "Aborting process due to error on rank " << rank_
             << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
+
+        runAbortHooks();
+
         std::abort();
       }
     }
@@ -335,6 +341,7 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
       abortNcclComm();
       if (options_.abort_process_on_timeout_or_error) {
         TC_LOG(ERROR, this) << "Aborting process due to timeout";
+        runAbortHooks();
         std::abort();
       } else {
         throw std::runtime_error("NCCLX operation timed out");
@@ -353,6 +360,7 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "
                           << ncclException.what();
+      runAbortHooks();
       std::abort();
     } else {
       throw ncclException;

--- a/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCLUtils.cpp
@@ -248,6 +248,9 @@ void TorchCommRCCL::timeoutWatchdog() noexcept {
       } else if (comm_state_ == CommState::ERROR) {
         TC_LOG(ERROR, this) << "Aborting process due to error";
       }
+
+      runAbortHooks();
+
       abort();
     }
 
@@ -264,6 +267,9 @@ void TorchCommRCCL::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this)
             << "Aborting process due to error on rank " << rank_
             << " - rccl hit async error: " << ncclGetErrorString(asyncErr);
+
+        runAbortHooks();
+
         abort();
       }
     }

--- a/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLXUtils.cpp
@@ -248,6 +248,9 @@ void TorchCommRCCLX::timeoutWatchdog() noexcept {
       } else if (comm_state_ == CommState::ERROR) {
         TC_LOG(ERROR, this) << "Aborting process due to error";
       }
+
+      runAbortHooks();
+
       abort();
     }
 
@@ -264,6 +267,9 @@ void TorchCommRCCLX::timeoutWatchdog() noexcept {
         TC_LOG(ERROR, this)
             << "Aborting process due to error on rank " << rank_
             << " - rcclx hit async error: " << ncclGetErrorString(asyncErr);
+
+        runAbortHooks();
+
         abort();
       }
     }

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -482,6 +482,7 @@ void TorchCommXCCL::abortXcclComm() {
   }
   if (options_.abort_process_on_timeout_or_error) {
     TC_LOG(ERROR, this) << "Aborting process due to timeout";
+    runAbortHooks();
     abort();
   }
 }

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -211,6 +211,9 @@ void TorchCommXCCL::timeoutWatchdog() noexcept {
         TC_LOG(ERROR) << "Aborting process due to error on rank " << rank_
                       << " - timeout watchdog detected operation error. ";
       }
+
+      runAbortHooks();
+
       abort();
     }
   }
@@ -232,6 +235,7 @@ void TorchCommXCCL::checkAndAbortIfTimedOutOrError() {
     //    abortXcclComm(); // cannot abort oneCCL communicator
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR) << "Aborting process due to timeout";
+      runAbortHooks();
       abort();
     } else {
       throw std::runtime_error("XCCL operation timed out");
@@ -244,6 +248,7 @@ void TorchCommXCCL::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR) << "Aborting process due to error: "
                     << xcclException.what();
+      runAbortHooks();
       abort();
     } else {
       throw xcclException;


### PR DESCRIPTION
Summary:

Rework the Flight Recorder verification script to demonstrate debugging a rank-hang scenario. Instead of simply running collectives and dumping traces, the script now simulates a real hang (one rank enters infinite sleep) so periodic dumps from the debug server and per-rank pickle traces capture divergent state. This enables validating both aggregated text dumps and FR CLI cross-rank mismatch detection against realistic failure conditions.

Reviewed By: d4l3k

Differential Revision: D99308229


