### PR TITLE
workaround to use DLE packages

### DIFF
--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -20,9 +20,16 @@ export USE_GLOO=OFF
 export USE_TRANSPORT=OFF
 export USE_SYSTEM_LIBS=1
 
-python3 -m pip install --pre torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir
+python3 -m pip install --no-deps --pre torch pytorch-triton-xpu --index-url https://download.pytorch.org/whl/nightly/xpu --force-reinstall --no-cache-dir
 
-cd torchcomms && pip install '.[dev]' --no-build-isolation && cd ..
+cd torchcomms && \
+    # Parse the base dev array directly out of setup.py
+    sed -n '/"dev": \[/,/\]/p' setup.py | grep -v -E '"dev"|\[|\]' | sed -e 's/[", ]//g' > requirements-xccl.txt && \
+    printf "%s\n" "typing-extensions" "sympy" >> requirements-xccl.txt
+    python3 -m pip install -r requirements-xccl.txt && \
+    # Install torchcomms package without additional dependencies
+    python3 -m pip install . --no-build-isolation --no-deps && \
+cd ..
 
 #Check Intel XPU visibility
 #Expose ZE_AFFINITY_MASK to explicitly expose the number of Intel GPUs assigned to the runner for all tests.


### PR DESCRIPTION
The removal of `--no-deps` causes DLE specific packages as dependencies to be installed during torch/torchcomms installation. 
However, due to an ongoing issue with `tcmlib` [here](https://github.com/pytorch/test-infra/issues/8115),pip package installation is currently unstable and there is a fix [here](https://github.com/pytorch/test-infra/pull/8120).  Since this change will be reflected only after the PR is merged and in the subsequent nightly wheel, in order to unblock ourselves, here is a workaround

This issue wasn't observed in the past as the packages were already made available via the `DLE_PATH` that is activated during torchcomms build and test process instead of using pip packages