### PR TITLE
: remove ctrd in AllGatherBench.cc

### DIFF
--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -181,9 +181,6 @@ enum NCCL_ALLGATHER_ALGO parseCtranAlgo(const std::string& algo) {
   if (algo == "ctdirect") {
     return NCCL_ALLGATHER_ALGO::ctdirect;
   }
-  if (algo == "ctrd") {
-    return NCCL_ALLGATHER_ALGO::ctrd;
-  }
   if (algo == "ctbrucks") {
     return NCCL_ALLGATHER_ALGO::ctbrucks;
   }


### PR DESCRIPTION
Summary: remove NCCL_ALLGATHER_ALGO::ctrd since it's removed from prod.

Reviewed By: snarayankh

Differential Revision: D106604206


