### PR TITLE
Add warp-specialized bidirectional sendrecv with adaptive stride

### DIFF
--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -4,40 +4,47 @@
 
 """Triton NVLink-only copy-based send/recv kernel.
 
-Single peer-pair copy-based send, receive, or bidirectional sendrecv,
+N-rank group-aware copy-based send, receive, or bidirectional sendrecv,
 double-buffered staging, monotonic int64 head/tail signaling. CUDA-graph
 replayable via persistent step-state counters that advance across replays.
 
-Scope: 2-rank groups only. ``send_peer`` and ``recv_peer`` are the same
-rank (single ``peer_rank`` arg). This kernel is **not** directly usable
-for Ring AllGather on world_size > 2 — ring needs ``(send_peer,
-recv_peer) = ((rank+1)%N, (rank-1)%N)`` plus per-sender staging slots.
-See ``sendrecv_op.py`` module docstring for the planned API/protocol
-extension.
+Supports separate ``send_peer`` and ``recv_peer`` (e.g., for ring
+topology: ``send_peer = (rank+1) % N``, ``recv_peer = (rank-1) % N``).
+All pointer resolution is done on the host side — the kernel receives
+pre-sliced staging buffer, signal pad, and step state pointers for the
+specific ``(send_peer, recv_peer)`` pair. This preserves direct typed
+tensor arguments, avoiding the store scalarization (``STG.E.U16``) that
+pointer-of-pointer indirection causes.
 
 Architecture
 ------------
 
 ::
 
-    Rank A (sender)                        Rank B (receiver)
-    ┌─────────────┐                        ┌─────────────┐
-    │ src tensor  │──(1) read──→           │             │
-    │ (local HBM) │            │           │             │
-    └─────────────┘            │           │             │
-                               ▼           │             │
-                   ┌─────────────────────┐ │             │
-                   │ staging buffer      │ │             │
-                   │ (Rank B symm mem)   │─(2) read───→  │
-                   │ [slot 0 | slot 1]   │ │       ▼     │
-                   └─────────────────────┘ │  ┌─────────────┐
-                                           │  │ dst tensor  │
-                                           │  │ (local HBM) │
-                                           │  └─────────────┘
-                                           └────────────────┘
+    Rank A (sender → send_peer)          send_peer (receiver)
+    ┌─────────────┐                      ┌─────────────┐
+    │ src tensor  │──(1) read──→         │             │
+    │ (local HBM) │            │         │             │
+    └─────────────┘            │         │             │
+                               ▼         │             │
+                   ┌─────────────────────┐             │
+                   │ staging buffer      │─(2) read──→ │
+                   │ (send_peer symm mem │       ▼     │
+                   │  local_rank region) │  ┌─────────────┐
+                   └─────────────────────┘  │ dst tensor  │
+                                            └─────────────┘
 
-    (1) Sender reads local src, REMOTE-writes to peer's staging buffer
-    (2) Receiver LOCAL-reads its staging buffer, writes to local dst
+    recv_peer (sender)                   Rank A (receiver ← recv_peer)
+    ┌─────────────┐                      ┌─────────────┐
+    │ src tensor  │──(1) read──→         │             │
+    └─────────────┘            │         │             │
+                               ▼         │             │
+                   ┌─────────────────────┐             │
+                   │ staging buffer      │─(2) read──→ │
+                   │ (local_rank symm mem│       ▼     │
+                   │  recv_peer region)  │  ┌─────────────┐
+                   └─────────────────────┘  │ dst tensor  │
+                                            └─────────────┘
 
 All remote operations are NVLink fire-and-forget writes (zero NVLink reads).
 
@@ -48,14 +55,13 @@ Each block ``k`` owns a fixed staging-buffer region
 ``[k * BLOCK_STRIDE * PIPELINE_DEPTH, (k+1) * BLOCK_STRIDE * PIPELINE_DEPTH)``
 and a fixed ``(head[k], tail[k])`` signal pair. Sender block ``k`` and
 receiver block ``k`` use the SAME signal slot ``k`` and the SAME buffer
-region. The block→region mapping is determined by ``MAX_BLOCKS_PER_DIR``
+region. The block→region mapping is determined by ``MAX_BLOCKS_PER_PEER``
 (constant) and is independent of the runtime ``NUM_SEND_BLOCKS``, so
 back-to-back kernel launches with different block counts cannot race.
 
-Signal-pad layout per rank (int64 entries; ``MBPD = MAX_BLOCKS_PER_DIR``)::
-
-    [0 .. MBPD):       TAIL — written by remote sender, polled by local receiver
-    [MBPD .. 2*MBPD):  HEAD — written by remote receiver, polled by local sender
+Signal pointers are pre-resolved by the host into the N-rank per-(peer,
+block) layout. The kernel sees them as simple base pointers and indexes
+by ``block_id`` only.
 
 Memory ordering:
 
@@ -69,6 +75,25 @@ Memory ordering:
     ``sync_threads()`` execution barrier. Consumer uses
     :func:`wait_ge_volatile` (no acquire). The sender does not read any
     payload written by the receiver, so the fence is unnecessary.
+
+Intra-block synchronization pattern (used 4× below):
+
+  * ``if flat_tid == 0: <wait>`` + ``sync_threads()`` — only thread 0
+    polls the signal; the barrier publishes that result to the rest of
+    the block before any data thread observes the slot as ready.
+  * ``sync_threads()`` + ``if flat_tid == 0: <publish>`` — all data
+    threads must have committed their stores (or completed their loads)
+    before thread 0 advances the counter and releases the slot.
+
+Removing or reordering either ``sync_threads()`` call is a silent
+correctness bug — TLS / per-warp scheduling will break the producer/
+consumer ordering invariant.
+
+Specialization note: ``send_numel`` and ``recv_numel`` are intentionally
+specialized (no ``do_not_specialize``). Distinct ``(send_numel,
+recv_numel)`` pairs trigger Triton recompilation. For ring AllGather
+(single shard size per call) this is fine; callers driving many
+distinct sizes per process should reuse buffers.
 """
 
 from __future__ import annotations
@@ -90,30 +115,29 @@ _MODE_SEND_ONLY = 1
 _MODE_RECV_ONLY = 2
 
 
-@triton.jit(do_not_specialize=["local_rank", "peer_rank"])
+@triton.jit
 def triton_nvl_sendrecv_kernel(  # noqa: C901
     send_ptr,
     recv_ptr,
-    remote_buf,  # direct tensor: peer's staging buffer
-    local_buf,  # direct tensor: own staging buffer
-    remote_sig,  # direct tensor: peer's signal pad (int64)
-    local_sig,  # direct tensor: own signal pad (int64)
-    sender_step_ptr,
-    recver_step_ptr,
-    local_rank,
-    peer_rank,
+    send_staging_buf,  # pre-sliced: send_peer's staging at local_rank's region
+    recv_staging_buf,  # pre-sliced: local staging at recv_peer's region
+    send_tail_sig,  # pre-sliced: signal base for sender TAIL (int64)
+    send_head_sig,  # pre-sliced: signal base for sender HEAD (int64)
+    recv_tail_sig,  # pre-sliced: signal base for receiver TAIL (int64)
+    recv_head_sig,  # pre-sliced: signal base for receiver HEAD (int64)
+    sender_step_ptr,  # pre-sliced: step_state[send_peer, :] shape (MBPP,)
+    recver_step_ptr,  # pre-sliced: step_state[recv_peer, :] shape (MBPP,)
     send_numel,
     recv_numel,
     TILE_ROWS: tl.constexpr,
     TILE_COLS: tl.constexpr,
     BLOCK_STRIDE_ELEMS: tl.constexpr,
     PIPELINE_DEPTH: tl.constexpr,
-    MAX_BLOCKS_PER_DIR: tl.constexpr,
     NUM_SEND_BLOCKS: tl.constexpr,
     MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
     MODE: tl.constexpr,
 ):
-    """NVLink copy-based send/recv kernel.
+    """NVLink copy-based send/recv kernel with pre-resolved N-rank pointers.
 
     Bidirectional mode launches grid ``(2 * NUM_SEND_BLOCKS,)`` and
     interleaves paired sender/receiver programs: even programs run sender
@@ -121,15 +145,9 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
     Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
     exactly one path.
 
-    Staging buffer and signal pad pointers are passed as direct typed
-    tensor arguments (via ``handle.get_buffer`` / ``handle.get_signal_pad``
-    on the host side) rather than loaded at runtime from a pointer-of-pointer
-    tensor. This is critical for Triton codegen: runtime-loaded store
-    destination pointers (``tl.load(...).to(pointer_type(...))``) trigger
-    the compiler's layout optimizer to emit scalar 16-bit stores
-    (``STG.E.U16``) instead of 128-bit vectorized stores (``STG.E.128``).
-    Direct tensor arguments avoid this, producing the same ``LDG.E.128 +
-    STG.E.128`` pattern that NCCL uses with ``uint4``.
+    All staging buffer and signal pad pointers are pre-resolved by the
+    host for the specific ``(send_peer, recv_peer)`` pair, so the kernel
+    indexes by ``block_id`` only — no world_size or peer_rank needed.
     """
     TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
 
@@ -144,20 +162,20 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         is_sender = (pid % 2) == 0
         block_id = pid // 2
 
-    # Buffer and signal pointers are already typed kernel arguments —
-    # no pointer-of-pointer load needed.
-    HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
-
     flat_tid = get_flat_tid()
 
     if is_sender:
         # ===== SENDER =====
         sender_id = block_id
 
+        # Signal pointers: host pre-resolved to the correct per-(peer, block) base.
+        # Buffer and signal pointers are already typed kernel arguments —
+        # no pointer-of-pointer load needed (preserves the STG.E.U16-free
+        # vectorized-store codegen pattern).
         # tail: REMOTE — written here, polled by remote receiver
-        # head: LOCAL — polled here, written by remote receiver
-        tail_remote_ptr = remote_sig + sender_id
-        head_local_ptr = local_sig + HEAD_OFFSET + sender_id
+        # head: LOCAL  — polled here, written by remote receiver
+        tail_remote_ptr = send_tail_sig + sender_id
+        head_local_ptr = send_head_sig + sender_id
 
         start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
 
@@ -206,17 +224,17 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
                 buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
                     tl.int64
                 )
-                tl.store(remote_buf + slot_base + buf_off, data, mask=mask)
+                tl.store(send_staging_buf + slot_base + buf_off, data, mask=mask)
 
                 send_tile_idx += NUM_SEND_BLOCKS
                 buf_tile_idx += 1
 
             sync_threads()
-            # ``bar.sync 0`` ensures all sender threads have finished issuing
-            # their staging stores before thread 0 issues the system fence.
-            # Without this barrier, thread 0's fence would only drain its own
-            # in-flight stores, leaving other threads' stores unsynchronized
-            # with the TAIL publish.
+            # ``bar.sync 0`` (sync_threads) above ensures all sender threads have
+            # finished issuing their staging stores before thread 0 issues the
+            # system fence. Without this barrier, thread 0's fence would only
+            # drain its own in-flight stores, leaving other threads' stores
+            # unsynchronized with the TAIL publish.
             if flat_tid == 0:
                 fence_and_remote_store_i64(
                     tail_remote_ptr, (send_step + 1).to(tl.int64)
@@ -230,10 +248,11 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         # ===== RECEIVER =====
         receiver_id = block_id
 
-        # tail: LOCAL — polled here, written by remote sender
+        # Signal pointers: host pre-resolved to the correct per-(peer, block) base.
+        # tail: LOCAL  — polled here, written by remote sender
         # head: REMOTE — written here, polled by remote sender
-        tail_local_ptr = local_sig + receiver_id
-        head_remote_ptr = remote_sig + HEAD_OFFSET + receiver_id
+        tail_local_ptr = recv_tail_sig + receiver_id
+        head_remote_ptr = recv_head_sig + receiver_id
 
         start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
 
@@ -274,7 +293,7 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
                 buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
                     tl.int64
                 )
-                data = tl.load(local_buf + slot_base + buf_off, mask=mask)
+                data = tl.load(recv_staging_buf + slot_base + buf_off, mask=mask)
                 tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
 
                 recv_tile_idx += NUM_SEND_BLOCKS

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -45,6 +45,7 @@ Usage patterns:
 from __future__ import annotations
 
 import logging
+import os
 from typing import NamedTuple
 
 import torch
@@ -53,6 +54,7 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch._C._distributed_c10d import _SymmetricMemory
 
 from .sendrecv import triton_nvl_sendrecv_kernel
+from .sendrecv_ws import triton_nvl_sendrecv_bidir_ws_kernel
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -63,11 +65,17 @@ logger: logging.Logger = logging.getLogger(__name__)
 # so back-to-back launches with different block counts cannot race.
 # ---------------------------------------------------------------------------
 
-_BLOCK_STRIDE_BYTES: int = 256 * 1024
-_PIPELINE_DEPTH: int = 2
+_BLOCK_STRIDE_BYTES: int = int(
+    os.environ.get("TRITON_NVL_BLOCK_STRIDE_BYTES", str(256 * 1024))
+)
+_PIPELINE_DEPTH: int = int(os.environ.get("TRITON_NVL_PIPELINE_DEPTH", "2"))
 _MAX_BLOCKS_PER_PEER: int = 32
 _DEFAULT_NUM_SEND_BLOCKS: int = 16
 _DEFAULT_NUM_WARPS: int = 8
+_DEFAULT_WS_SENDER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_SENDER_WARPS", "4"))
+_DEFAULT_WS_RECEIVER_WARPS: int = int(
+    os.environ.get("TRITON_NVL_WS_RECEIVER_WARPS", "4")
+)
 _MODE_BIDIRECTIONAL: int = 0
 _MODE_SEND_ONLY: int = 1
 _MODE_RECV_ONLY: int = 2
@@ -83,6 +91,15 @@ def _compute_config(element_size: int) -> _Config:
     return _Config(
         tile_rows=32,
         tile_cols=2048 // element_size,
+        num_stages=2,
+    )
+
+
+def _compute_ws_config(element_size: int) -> _Config:
+    tile_bytes = int(os.environ.get("TRITON_NVL_WS_TILE_BYTES", "2048"))
+    return _Config(
+        tile_rows=32,
+        tile_cols=tile_bytes // element_size,
         num_stages=2,
     )
 
@@ -286,6 +303,54 @@ def triton_nvl_sendrecv(
     )
 
 
+def triton_nvl_sendrecv_ws(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    send_peer: int,
+    recv_peer: int | None = None,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    sender_warps: int = _DEFAULT_WS_SENDER_WARPS,
+    receiver_warps: int = _DEFAULT_WS_RECEIVER_WARPS,
+) -> None:
+    """Warp-specialized bidirectional NVLink send/recv.
+
+    Each CTA runs sender and receiver as concurrent TLX async tasks,
+    allowing both NVLink directions to share the same SM. Default
+    configuration: 4 sender warps + 4 receiver warps = 8 total.
+
+    Notes:
+        * ``sender_warps`` and ``receiver_warps`` must each be a power of
+          two and sum to a power of two in ``[2, 16]`` (TLX warp-spec +
+          Triton ``num_warps`` requirement, which forces
+          ``sender_warps == receiver_warps``).
+        * The host launcher raises ``BLOCK_STRIDE_ELEMS`` adaptively to
+          lower the while-loop iteration count. This is a perf
+          optimization only (fewer ``fence.acq_rel.sys`` ops, a few % at
+          large messages); the kernel is correct at any iteration count.
+    """
+    if recv_peer is None:
+        recv_peer = send_peer
+    assert send_buf.is_cuda and recv_buf.is_cuda
+    assert send_buf.is_contiguous() and recv_buf.is_contiguous()
+    assert send_buf.dtype == recv_buf.dtype
+    assert send_buf.numel() == recv_buf.numel()
+    _launch(
+        send_buf,
+        recv_buf,
+        send_peer,
+        recv_peer,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=sender_warps + receiver_warps,
+        mode=_MODE_BIDIRECTIONAL,
+        warp_specialized=True,
+        sender_warps=sender_warps,
+        receiver_warps=receiver_warps,
+    )
+
+
 def triton_nvl_send(
     send_buf: torch.Tensor,
     send_peer: int,
@@ -352,6 +417,9 @@ def _launch(
     num_blocks: int,
     num_warps: int,
     mode: int,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> None:
     assert send_buf.dtype == recv_buf.dtype, (
         f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
@@ -359,9 +427,35 @@ def _launch(
     assert 0 < num_blocks <= _MAX_BLOCKS_PER_PEER, (
         f"num_blocks must be in (0, {_MAX_BLOCKS_PER_PEER}], got {num_blocks}"
     )
-    assert num_warps in (4, 8), (
-        f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
-    )
+    if warp_specialized:
+        # TLX warp specialization requires EACH partition's warp count to be a
+        # power of two (verified by `ttg.warp_specialize`: "number of warps
+        # must be a power of 2"), and Triton requires the kernel's total
+        # `num_warps` to be a power of two as well. Two powers of two sum to a
+        # power of two only when they are equal, so this effectively requires
+        # `sender_warps == receiver_warps` drawn from {1, 2, 4, 8}. The old
+        # `total % 4 == 0` check wrongly accepted splits like (3, 5), which
+        # then crashed deep in the TritonTLXFixup MLIR pass.
+        def _is_pow2(x: int) -> bool:
+            return x >= 1 and (x & (x - 1)) == 0
+
+        total = sender_warps + receiver_warps
+        assert _is_pow2(sender_warps) and sender_warps <= 8, (
+            f"sender_warps must be a power of 2 in [1, 8], got {sender_warps}"
+        )
+        assert _is_pow2(receiver_warps) and receiver_warps <= 8, (
+            f"receiver_warps must be a power of 2 in [1, 8], got {receiver_warps}"
+        )
+        assert _is_pow2(total) and total <= 16, (
+            f"sender_warps + receiver_warps must be a power of 2 in [2, 16] "
+            f"(TLX warp-spec + Triton num_warps requirement, which forces "
+            f"sender_warps == receiver_warps); got {sender_warps} + "
+            f"{receiver_warps} = {total}"
+        )
+    else:
+        assert num_warps in (4, 8), (
+            f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
+        )
 
     world_size = dist.get_world_size(group)
     if world_size == 1:
@@ -390,14 +484,55 @@ def _launch(
         group, send_buf.device, world_size
     )
 
-    config = _compute_config(send_buf.element_size())
-    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
-    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
+    config = (
+        _compute_ws_config(send_buf.element_size())
+        if warp_specialized
+        else _compute_config(send_buf.element_size())
+    )
     tile_numel = config.tile_rows * config.tile_cols
     tile_bytes = tile_numel * send_buf.element_size()
-    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
 
-    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+    orig_block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    if warp_specialized:
+        # Adaptive stride (PERF optimization only). The WS kernel is now
+        # correct at any loop-iteration count (per-task compiler-sized
+        # barriers via tl.debug_barrier(); see sendrecv_ws.py). Raising the
+        # per-block stride lowers the iteration count, which reduces the
+        # number of `fence.acq_rel.sys` operations (one per step) and buys a
+        # few % at large messages (e.g. 64 MiB: ~1.07x at default 256 KiB
+        # stride vs ~1.12x at 2 MiB stride). It is NOT required for
+        # correctness, so there is no fail-loud guard here anymore.
+        # `max_ws_stride` caps per-block staging so the sum across all
+        # `num_blocks` blocks fits within the per-peer staging quota
+        # `_BLOCK_STRIDE_BYTES * _MAX_BLOCKS_PER_PEER` (and thus within
+        # `staging_elems` below); enforces no buffer overflow even when
+        # the requested stride to land a low iter count is large.
+        max_ws_stride = _BLOCK_STRIDE_BYTES * _MAX_BLOCKS_PER_PEER // num_blocks
+        num_tiles = -(-send_buf.numel() // tile_numel)
+        tiles_per_block = -(-num_tiles // num_blocks)
+        target_tiles_per_step = -(-tiles_per_block // 2)
+        needed_stride = target_tiles_per_step * tile_bytes
+        ws_stride = max(min(needed_stride, max_ws_stride), _BLOCK_STRIDE_BYTES)
+        block_stride_elems = ws_stride // send_buf.element_size()
+        max_tiles_per_block_per_slot = max(ws_stride // tile_bytes, 1)
+    else:
+        block_stride_elems = orig_block_stride_elems
+        max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = orig_block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+
+    # Buffer-overflow guard: the kernel writes at most
+    # `num_blocks * block_stride_elems * PIPELINE_DEPTH` elements into the
+    # per-peer staging region. The WS adaptive stride can raise
+    # `block_stride_elems` above the default, so make the (otherwise implicit)
+    # bound explicit instead of relying on the `max_ws_stride` floor-division
+    # arithmetic alone.
+    assert num_blocks * block_stride_elems * _PIPELINE_DEPTH <= staging_elems, (
+        f"staging overflow: num_blocks={num_blocks} * "
+        f"block_stride_elems={block_stride_elems} * depth={_PIPELINE_DEPTH} "
+        f"> staging_elems={staging_elems}"
+    )
 
     # --- Pre-resolve staging buffers for the specific peer pair ---
     # Sender writes to send_peer's staging area at local_rank's partition.
@@ -446,6 +581,38 @@ def _launch(
     # --- Pre-slice step state to the peer rows ---
     sender_step_ptr = sender_step_all[send_peer]
     recver_step_ptr = recver_step_all[recv_peer]
+
+    if warp_specialized:
+        grid = (num_blocks,)
+        # pyre-ignore[28]: triton's `kernel[grid](...)` launcher
+        triton_nvl_sendrecv_bidir_ws_kernel[grid](
+            send_ptr=send_buf,
+            recv_ptr=recv_buf,
+            send_staging_buf=send_staging_buf,
+            recv_staging_buf=recv_staging_buf,
+            send_tail_sig=send_tail_sig,
+            send_head_sig=send_head_sig,
+            recv_tail_sig=recv_tail_sig,
+            recv_head_sig=recv_head_sig,
+            sender_step_ptr=sender_step_ptr,
+            recver_step_ptr=recver_step_ptr,
+            send_numel=send_buf.numel(),
+            recv_numel=recv_buf.numel(),
+            TILE_ROWS=config.tile_rows,
+            TILE_COLS=config.tile_cols,
+            BLOCK_STRIDE_ELEMS=block_stride_elems,
+            PIPELINE_DEPTH=_PIPELINE_DEPTH,
+            MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
+            NUM_SEND_BLOCKS=num_blocks,
+            NUM_SENDER_WARPS=sender_warps,
+            NUM_RECEIVER_WARPS=receiver_warps,
+            num_warps=num_warps,
+            # WS uses TLX async_task for pipelining; disable Triton's
+            # software pipelining to avoid stage interleaving on top of
+            # the explicit sender/receiver task split.
+            num_stages=0,
+        )
+        return
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -7,22 +7,39 @@
 Allocates (and caches) the symmetric memory staging buffer plus the
 persistent step-state tensors, computes a kernel config, and launches.
 
-v1 scope (intentionally narrow):
+Supports **N-rank groups** with separate ``send_peer`` and ``recv_peer``
+arguments. Each rank's staging buffer is partitioned by sender rank,
+matching the layout used by ``all_to_all_single.py``. The signal pad
+uses a per-(peer, block) layout: TAIL at ``[peer * MBPP + block_id]``
+and HEAD at ``[HEAD_OFFSET + peer * MBPP + block_id]`` where
+``HEAD_OFFSET = world_size * MAX_BLOCKS_PER_PEER``.
 
-  * **2-rank groups only**. The staging buffer holds a single peer pair's
-    slot and the API takes a single ``peer_rank`` used for both directions
-    (sender → ``peer_rank``, receiver ← ``peer_rank``).
-  * Copy-based send-only, recv-only, and bidirectional sendrecv between
-    this rank and ``peer_rank``. Peer ranks must launch matching operations
-    simultaneously.
+Since ``send_peer`` and ``recv_peer`` are known at host launch time,
+the host pre-resolves all staging buffer, signal pad, and step state
+pointers for the specific peer pair. This preserves the direct typed
+tensor argument pattern in the kernel, avoiding the store scalarization
+(``STG.E.U16``) that pointer-of-pointer indirection causes.
 
-The bidirectional single-peer API is **not** directly composable into Ring AllGather on N>2 ranks —
-ring needs ``send_peer = (rank+1)%N`` paired with ``recv_peer =
-(rank-1)%N`` (different peers per direction), and the staging buffer
-needs per-sender slots like the MSL ``all_to_all_single_non_contig``
-kernel uses. The follow-up to add ring AllGather will introduce a
-``triton_nvl_sendrecv(send, recv, send_peer, recv_peer, ...)`` variant
-plus per-peer staging slots indexed by sender rank.
+Composing collectives from this primitive:
+
+  * **Ring AllGather**: call ``triton_nvl_sendrecv`` with
+    ``send_peer = (rank + 1) % N``, ``recv_peer = (rank - 1) % N``
+    in a host loop over N-1 ring steps.
+  * **Bidirectional exchange**: ``send_peer == recv_peer`` (the v1 API).
+
+Usage patterns:
+
+  * **2-rank P2P group**: ``triton_nvl_send``/``triton_nvl_recv`` may
+    initialize lazily because the matching peers are also all ranks in the
+    group.
+  * **N-rank collective schedule**: ``triton_nvl_sendrecv`` may initialize
+    lazily when every rank in ``group`` enters the same collective step, such
+    as Ring AllGather.
+  * **N-rank sparse P2P**: call ``triton_nvl_sendrecv_prepare`` on all ranks
+    in ``group`` before only a subset calls ``triton_nvl_send``,
+    ``triton_nvl_recv``, or ``triton_nvl_sendrecv``. The symmetric-memory
+    arena is collective over ``group`` even when a later operation only uses a
+    peer pair.
 """
 
 from __future__ import annotations
@@ -48,7 +65,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 _BLOCK_STRIDE_BYTES: int = 256 * 1024
 _PIPELINE_DEPTH: int = 2
-_MAX_BLOCKS_PER_DIR: int = 32
+_MAX_BLOCKS_PER_PEER: int = 32
 _DEFAULT_NUM_SEND_BLOCKS: int = 16
 _DEFAULT_NUM_WARPS: int = 8
 _MODE_BIDIRECTIONAL: int = 0
@@ -70,8 +87,8 @@ def _compute_config(element_size: int) -> _Config:
     )
 
 
-def _per_pair_bytes() -> int:
-    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_DIR
+def _per_peer_bytes() -> int:
+    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_PEER
 
 
 # ---------------------------------------------------------------------------
@@ -84,37 +101,60 @@ def _per_pair_bytes() -> int:
 # caller multiplexes threads onto a single PG, wrap these in a lock.
 # ---------------------------------------------------------------------------
 
-_HANDLE_CACHE: dict[dist.ProcessGroup, _SymmetricMemory] = {}
+_HANDLE_CACHE: dict[tuple[dist.ProcessGroup, torch.device], _SymmetricMemory] = {}
 
 _STEP_STATE_CACHE: dict[
-    dist.ProcessGroup,
+    tuple[dist.ProcessGroup, torch.device],
     tuple[torch.Tensor, torch.Tensor],
 ] = {}
+
+
+def _required_signal_pad_bytes(world_size: int) -> int:
+    return 2 * world_size * _MAX_BLOCKS_PER_PEER * 8  # int64 = 8 bytes
+
+
+def _is_prepared(group: dist.ProcessGroup, device: torch.device) -> bool:
+    return (group, device) in _HANDLE_CACHE
 
 
 def _get_staging_buffer(
     group: dist.ProcessGroup,
     device: torch.device,
+    world_size: int,
 ) -> _SymmetricMemory:
     """Get or create the symmetric memory handle for ``group``.
 
-    The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
-    on each block. ``symm_mem.empty`` zeroes the entire allocation including
-    the signal pad (via ``cudaMemset`` in CUDASymmetricMemory.cu's
-    ``allocate``), so the first launch is safe. We additionally zero the
-    signal pad explicitly + barrier so the invariant holds even if the
-    underlying allocator behaviour changes in a future torch release.
+    Staging is sized for N-rank: ``per_peer_bytes * world_size``.
+
+    The signal-pad sufficiency check runs only on the first allocation
+    for a given ``(group, device)``. Callers must call
+    ``symm_mem.set_signal_pad_size()`` before the first launch on any
+    process group; lazy reconfiguration after the first launch will not
+    be re-validated for already-cached groups.
     """
-    cached = _HANDLE_CACHE.get(group)
+    cache_key = (group, device)
+    cached = _HANDLE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
-    num_bytes = _per_pair_bytes()
+    num_bytes = _per_peer_bytes() * world_size
     logger.info(
-        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes",
+        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes (%d ranks)",
         group.group_desc,
         num_bytes,
+        world_size,
     )
+
+    required_sig = _required_signal_pad_bytes(world_size)
+    current_sig = symm_mem.get_signal_pad_size()
+    if current_sig < required_sig:
+        raise RuntimeError(
+            f"Signal pad too small for {world_size}-rank group with "
+            f"{_MAX_BLOCKS_PER_PEER} blocks per peer: need {required_sig} bytes, "
+            f"have {current_sig}. Call symm_mem.set_signal_pad_size() before "
+            f"first allocation."
+        )
+
     raw = symm_mem.empty(num_bytes, dtype=torch.uint8, device=device)
     handle = symm_mem.rendezvous(raw, group=group)
     # Defensive: explicitly zero the signal pad before any block can poll it.
@@ -122,23 +162,30 @@ def _get_staging_buffer(
     # rendezvous-then-barrier sequence below guarantees that.
     handle.get_signal_pad(handle.rank).zero_()
     dist.barrier(group)
-    _HANDLE_CACHE[group] = handle
+    _HANDLE_CACHE[cache_key] = handle
     return handle
 
 
 def _get_step_state(
     group: dist.ProcessGroup,
     device: torch.device,
+    world_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Get or create persistent monotonic step counters for ``group``."""
-    cached = _STEP_STATE_CACHE.get(group)
+    """Get or create persistent monotonic step counters for ``group``.
+
+    Shape: ``(world_size, MAX_BLOCKS_PER_PEER)`` — one counter per
+    (peer, block) pair.
+    """
+    cache_key = (group, device)
+    cached = _STEP_STATE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
-    sender_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
-    recver_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
-    _STEP_STATE_CACHE[group] = (sender_step, recver_step)
-    return _STEP_STATE_CACHE[group]
+    shape = (world_size, _MAX_BLOCKS_PER_PEER)
+    sender_step = torch.zeros(shape, dtype=torch.int64, device=device)
+    recver_step = torch.zeros(shape, dtype=torch.int64, device=device)
+    _STEP_STATE_CACHE[cache_key] = (sender_step, recver_step)
+    return _STEP_STATE_CACHE[cache_key]
 
 
 # ---------------------------------------------------------------------------
@@ -146,49 +193,92 @@ def _get_step_state(
 # ---------------------------------------------------------------------------
 
 
+def triton_nvl_sendrecv_prepare(
+    *,
+    group: dist.ProcessGroup,
+    device: torch.device,
+) -> None:
+    """Collectively initialize NVLink sendrecv state for ``group``.
+
+    All ranks in ``group`` must call this before sparse N-rank
+    ``triton_nvl_send``/``triton_nvl_recv`` first use. Ring-style
+    ``triton_nvl_sendrecv`` schedules where every rank participates may still
+    initialize lazily on the first collective step.
+    """
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        return
+    _get_staging_buffer(group, device, world_size)
+    _get_step_state(group, device, world_size)
+
+
 def triton_nvl_sendrecv(
     send_buf: torch.Tensor,
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
+    recv_peer: int | None = None,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Bidirectional NVLink copy-based send/recv between this rank and ``peer_rank``.
+    """Bidirectional NVLink copy-based send/recv.
 
-    Both ranks in the (sender, receiver) pair must call this function
-    simultaneously. ``send_buf`` and ``recv_buf`` must have the same shape
-    and dtype on both ranks.
+    Sends ``send_buf`` to ``send_peer`` and receives into ``recv_buf``
+    from ``recv_peer`` (defaults to ``send_peer`` if not given).
+
+    Both peers must issue matching operations simultaneously:
+    ``send_peer`` must recv from this rank, and ``recv_peer`` must
+    send to this rank.
+
+    This API is intended as an N-rank collective step primitive. If only a
+    sparse peer pair will call into this module on first use, call
+    ``triton_nvl_sendrecv_prepare`` on all ranks in ``group`` first.
 
     .. warning::
-        ``dtype`` and ``numel`` of ``send_buf`` / ``recv_buf`` MUST match
-        between the two ranks. There is no cross-rank validation; a
-        mismatch silently produces wrong staging slot offsets and
-        corrupts data.
+        On a ``world_size > 2`` group, the first call lazily performs a
+        symmetric-memory rendezvous that is **collective over** ``group``.
+        Unlike the send-only / recv-only paths, this bidirectional entry is
+        **not** guarded against sparse first use: if only a subset of ranks
+        call it before any ``triton_nvl_sendrecv_prepare``, the absent ranks
+        never reach the rendezvous and the participating ranks **hang** (no
+        error is raised). Ring-style schedules where every rank enters the
+        same step are safe; for any sparse pattern, call
+        ``triton_nvl_sendrecv_prepare`` on all ranks first.
 
     Args:
-        send_buf: Source tensor to send to ``peer_rank``. Contiguous, CUDA.
-        recv_buf: Destination tensor to receive from ``peer_rank``. Contiguous, CUDA.
-        peer_rank: Rank in ``group`` to exchange with. ``send_peer`` and
-            ``recv_peer`` are the same rank in v1; see the module docstring
-            for why this is **not** directly extensible to Ring AllGather.
-        group: Process group used for symm-mem rendezvous. **v1 requires
-            size 2** — the assertion below is the enforcement point.
-        num_blocks: Thread blocks per direction. Defaults to 16. The actual
-            grid is ``2 * num_blocks`` for bidirectional mode (so default
-            gives a 32-block grid, apple-to-apple with NCCL's 32 channels)
-            and ``num_blocks`` for send-only / recv-only.
-        num_warps: Triton warps per block. Defaults to 8.
+        send_buf: Source tensor to send. Contiguous, CUDA.
+        recv_buf: Destination tensor to receive into. Contiguous, CUDA.
+        send_peer: Rank in ``group`` to send to.
+        recv_peer: Rank in ``group`` to receive from. Defaults to
+            ``send_peer`` for bidirectional exchange with a single peer.
+        group: Process group. Supports any world_size >= 2.
+        num_blocks: Thread blocks per direction.
+        num_warps: Triton warps per block.
+
+    Note: the lower-level launch path specializes ``send_buf.numel()`` and
+    ``recv_buf.numel()`` independently, but this public v1 API intentionally
+    releases only symmetric bidirectional exchange. If that constraint is
+    lifted later, each distinct ``(send_numel, recv_numel)`` pair will trigger
+    a kernel recompile. Ring AllGather (single shard size per process) is
+    unaffected; callers driving many distinct sizes per process should consider
+    reusing fixed-size scratch buffers.
     """
+    if recv_peer is None:
+        recv_peer = send_peer
     assert send_buf.is_cuda and recv_buf.is_cuda
     assert send_buf.is_contiguous() and recv_buf.is_contiguous()
     assert send_buf.dtype == recv_buf.dtype
+    # The kernel/launch path is shaped for independent send/recv numel, but
+    # asymmetric bidirectional exchange is not part of the released v1 API.
+    # Lifting this requires explicit asymmetric matching, graph, and
+    # back-to-back slot-reuse tests.
     assert send_buf.numel() == recv_buf.numel()
     _launch(
         send_buf,
         recv_buf,
-        peer_rank,
+        send_peer,
+        recv_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -198,23 +288,25 @@ def triton_nvl_sendrecv(
 
 def triton_nvl_send(
     send_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Send ``send_buf`` to ``peer_rank`` over NVLink using copy-based staging.
+    """Send ``send_buf`` to ``send_peer`` over NVLink using copy-based staging.
 
     Caller is responsible for ensuring the peer rank issues a matching
-    ``triton_nvl_recv`` with the same ``dtype`` and ``numel`` — there is
-    no cross-rank validation.
+    ``triton_nvl_recv`` with the same ``dtype`` and ``numel``. For sparse
+    N-rank first use, all ranks in ``group`` must first call
+    ``triton_nvl_sendrecv_prepare``.
     """
     assert send_buf.is_cuda and send_buf.is_contiguous()
     _launch(
         send_buf,
         send_buf,
-        peer_rank,
+        send_peer,
+        send_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -224,23 +316,25 @@ def triton_nvl_send(
 
 def triton_nvl_recv(
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    recv_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Receive into ``recv_buf`` from ``peer_rank`` over NVLink.
+    """Receive into ``recv_buf`` from ``recv_peer`` over NVLink.
 
     Caller is responsible for ensuring the peer rank issues a matching
-    ``triton_nvl_send`` with the same ``dtype`` and ``numel`` — there is
-    no cross-rank validation.
+    ``triton_nvl_send`` with the same ``dtype`` and ``numel``. For sparse
+    N-rank first use, all ranks in ``group`` must first call
+    ``triton_nvl_sendrecv_prepare``.
     """
     assert recv_buf.is_cuda and recv_buf.is_contiguous()
     _launch(
         recv_buf,
         recv_buf,
-        peer_rank,
+        recv_peer,
+        recv_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -251,7 +345,8 @@ def triton_nvl_recv(
 def _launch(
     send_buf: torch.Tensor,
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
+    recv_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int,
@@ -261,8 +356,8 @@ def _launch(
     assert send_buf.dtype == recv_buf.dtype, (
         f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
     )
-    assert 0 < num_blocks <= _MAX_BLOCKS_PER_DIR, (
-        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_DIR}], got {num_blocks}"
+    assert 0 < num_blocks <= _MAX_BLOCKS_PER_PEER, (
+        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_PEER}], got {num_blocks}"
     )
     assert num_warps in (4, 8), (
         f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
@@ -273,64 +368,111 @@ def _launch(
         recv_buf.copy_(send_buf)
         return
 
-    # v1 limit: single peer-pair staging buffer means we cannot service more
-    # than one (sender, receiver) pair per group. Lift this restriction in
-    # the follow-up that adds per-peer staging slots for Ring AllGather.
-    assert world_size == 2, (
-        f"triton_nvl_sendrecv v1 supports only 2-rank groups, got world_size={world_size}. "
-        "See module docstring for the planned per-peer slot API."
-    )
+    if (
+        mode != _MODE_BIDIRECTIONAL
+        and world_size > 2
+        and not _is_prepared(group, send_buf.device)
+    ):
+        raise RuntimeError(
+            "Sparse triton_nvl_send/triton_nvl_recv first use on an N-rank "
+            "group requires triton_nvl_sendrecv_prepare(group=..., "
+            "device=...) to be called by all ranks first."
+        )
 
     local_rank = dist.get_rank(group)
-    assert peer_rank != local_rank
-    assert 0 <= peer_rank < world_size
+    assert send_peer != local_rank, "send_peer must differ from local rank"
+    assert recv_peer != local_rank, "recv_peer must differ from local rank"
+    assert 0 <= send_peer < world_size
+    assert 0 <= recv_peer < world_size
+
+    handle = _get_staging_buffer(group, send_buf.device, world_size)
+    sender_step_all, recver_step_all = _get_step_state(
+        group, send_buf.device, world_size
+    )
+
+    config = _compute_config(send_buf.element_size())
+    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
+    tile_numel = config.tile_rows * config.tile_cols
+    tile_bytes = tile_numel * send_buf.element_size()
+    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+
+    # --- Pre-resolve staging buffers for the specific peer pair ---
+    # Sender writes to send_peer's staging area at local_rank's partition.
+    # Receiver reads from local staging area at recv_peer's partition.
+    send_staging_buf = handle.get_buffer(
+        send_peer,
+        sizes=[staging_elems],
+        dtype=send_buf.dtype,
+        storage_offset=local_rank * per_peer_elems,
+    )
+    recv_staging_buf = handle.get_buffer(
+        local_rank,
+        sizes=[staging_elems],
+        dtype=recv_buf.dtype,
+        storage_offset=recv_peer * per_peer_elems,
+    )
+
+    # --- Pre-resolve signal pad pointers for the specific peer pair ---
+    # Signal layout per rank (int64 entries):
+    #   [0 .. W*MBPP):       TAIL[peer * MBPP + block_id]
+    #   [W*MBPP .. 2*W*MBPP): HEAD[peer * MBPP + block_id]
+    head_offset = world_size * _MAX_BLOCKS_PER_PEER
+
+    send_peer_sig = handle.get_signal_pad(send_peer).view(torch.int64)
+    recv_peer_sig = handle.get_signal_pad(recv_peer).view(torch.int64)
+    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
+
+    # Each slice is bounded to exactly MBPP int64 entries (one (peer, block)
+    # row). The kernel only indexes ``block_id < num_blocks <= MBPP``, so an
+    # unbounded ``[start:]`` slice would silently overlap the neighbouring
+    # peer's row if a future kernel change indexed past MBPP. The explicit
+    # upper bound makes that a hard error instead.
+    def _sig_row(pad: torch.Tensor, start: int) -> torch.Tensor:
+        return pad[start : start + _MAX_BLOCKS_PER_PEER]
+
+    # Sender: tail on send_peer written by local_rank, head on local polled for send_peer
+    send_tail_sig = _sig_row(send_peer_sig, local_rank * _MAX_BLOCKS_PER_PEER)
+    send_head_sig = _sig_row(local_sig, head_offset + send_peer * _MAX_BLOCKS_PER_PEER)
+
+    # Receiver: tail on local polled for recv_peer, head on recv_peer written by local_rank
+    recv_tail_sig = _sig_row(local_sig, recv_peer * _MAX_BLOCKS_PER_PEER)
+    recv_head_sig = _sig_row(
+        recv_peer_sig, head_offset + local_rank * _MAX_BLOCKS_PER_PEER
+    )
+
+    # --- Pre-slice step state to the peer rows ---
+    sender_step_ptr = sender_step_all[send_peer]
+    recver_step_ptr = recver_step_all[recv_peer]
+
+    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
     # Buffer and signal pad pointers are passed as direct typed tensors
     # (not pointer-of-pointer int64 tensors) so Triton emits 128-bit
     # vectorized stores instead of 16-bit scalar stores. See the kernel
     # docstring in sendrecv.py for the codegen rationale.
-    handle = _get_staging_buffer(group, send_buf.device)
-    sender_step, recver_step = _get_step_state(group, send_buf.device)
-
-    config = _compute_config(send_buf.element_size())
-    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
-    tile_numel = config.tile_rows * config.tile_cols
-    tile_bytes = tile_numel * send_buf.element_size()
-    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
-
-    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_DIR * _PIPELINE_DEPTH
-    remote_buf = handle.get_buffer(
-        peer_rank, sizes=[staging_elems], dtype=send_buf.dtype
-    )
-    local_buf = handle.get_buffer(
-        local_rank, sizes=[staging_elems], dtype=recv_buf.dtype
-    )
-    remote_sig = handle.get_signal_pad(peer_rank).view(torch.int64)
-    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
-
-    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
-
     # pyre-ignore[28]: triton's `kernel[grid](...)` launcher accepts JIT-special
     # kwargs (`num_warps`, `num_stages`) that pyre can't see in the kernel
     # function's own signature. Not a real type error.
     triton_nvl_sendrecv_kernel[grid](
         send_ptr=send_buf,
         recv_ptr=recv_buf,
-        remote_buf=remote_buf,
-        local_buf=local_buf,
-        remote_sig=remote_sig,
-        local_sig=local_sig,
-        sender_step_ptr=sender_step,
-        recver_step_ptr=recver_step,
-        local_rank=local_rank,
-        peer_rank=peer_rank,
+        send_staging_buf=send_staging_buf,
+        recv_staging_buf=recv_staging_buf,
+        send_tail_sig=send_tail_sig,
+        send_head_sig=send_head_sig,
+        recv_tail_sig=recv_tail_sig,
+        recv_head_sig=recv_head_sig,
+        sender_step_ptr=sender_step_ptr,
+        recver_step_ptr=recver_step_ptr,
         send_numel=send_buf.numel(),
         recv_numel=recv_buf.numel(),
         TILE_ROWS=config.tile_rows,
         TILE_COLS=config.tile_cols,
         BLOCK_STRIDE_ELEMS=block_stride_elems,
         PIPELINE_DEPTH=_PIPELINE_DEPTH,
-        MAX_BLOCKS_PER_DIR=_MAX_BLOCKS_PER_DIR,
         NUM_SEND_BLOCKS=num_blocks,
         MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
         MODE=mode,

--- a/comms/pipes/triton/collectives/nvl/sendrecv_ws.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_ws.py
@@ -1,0 +1,206 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Warp-specialized bidirectional Triton NVLink send/recv kernel.
+
+Single CTA runs sender and receiver as concurrent TLX async tasks
+(default: 4 sender warps + 4 receiver warps). Both NVLink directions
+share the SM, mirroring NCCL's per-channel send/recv split.
+
+Staging-buffer / signal layout / monotonic step-state protocol are
+inherited from :mod:`sendrecv` — see that module's docstring for the
+pre-resolved per-(peer, block) signal layout and the
+``fence_and_remote_store_i64`` / ``wait_ge`` ordering invariants.
+
+Intra-task synchronization — compiler-rewritten warp-group barriers
+------------------------------------------------------------------
+
+The sender and receiver run as two separate ``tlx.async_task`` regions,
+each owning a DISJOINT subset of the CTA's warps. A full-CTA barrier is
+therefore the WRONG primitive inside either task: it blocks until *all*
+CTA threads arrive, but the two tasks run independent while-loops, so
+their arrivals only pair up by luck — they stay aligned for a couple of
+iterations and then desync and hang. The "iteration-count-dependent TLX
+codegen bug" originally blamed for this was actually a self-inflicted
+full-CTA barrier: the kernel emitted a raw inline-asm ``bar.sync 0;``
+(``utils.sync_threads``) which the TLX warp-spec lowering does NOT see
+(it only rewrites compiler-visible barrier ops), so it stayed full-CTA.
+
+The fix: use Triton's compiler-visible barrier ``tl.debug_barrier()``
+(an ``nvvm.barrier0``). Inside a warp-specialized region the TLX lowering
+(``ConvertWarpSpecializeToLLVM``) automatically rewrites each such
+barrier into a per-warp-group NAMED barrier, sized to *that* region's
+warp count (default region -> barrier 0; each partition -> barrier 2+idx).
+This keeps each task synchronizing ONLY its own warps, with the compiler
+choosing both the barrier id and the participant count (no hand-rolled
+ids/sizes to get wrong). It fixes both the deterministic deadlock AND the
+data race / high-iteration hang that the wrong barrier caused: validated
+deterministically correct and hang-free across the full size sweep up to
+1 GiB (~128 while-loop iterations) at the default stride.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx  # @manual=//triton:triton
+
+from .utils import (
+    fence_and_remote_store_i64,
+    remote_store_i64_relaxed,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+@triton.jit
+def triton_nvl_sendrecv_bidir_ws_kernel(  # noqa: C901
+    send_ptr,
+    recv_ptr,
+    send_staging_buf,
+    recv_staging_buf,
+    send_tail_sig,
+    send_head_sig,
+    recv_tail_sig,
+    recv_head_sig,
+    sender_step_ptr,
+    recver_step_ptr,
+    send_numel,
+    recv_numel,
+    TILE_ROWS: tl.constexpr,
+    TILE_COLS: tl.constexpr,
+    BLOCK_STRIDE_ELEMS: tl.constexpr,
+    PIPELINE_DEPTH: tl.constexpr,
+    MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
+    NUM_SEND_BLOCKS: tl.constexpr,
+    NUM_SENDER_WARPS: tl.constexpr,
+    NUM_RECEIVER_WARPS: tl.constexpr,
+):
+    TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
+    block_id = tl.program_id(0)
+
+    with tlx.async_tasks():
+        with tlx.async_task("default", num_warps=NUM_SENDER_WARPS):
+            sender_id = block_id
+            tail_remote_ptr = send_tail_sig + sender_id
+            head_local_ptr = send_head_sig + sender_id
+            start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
+            local_rows = tl.arange(0, TILE_ROWS)
+            local_cols = tl.arange(0, TILE_COLS)
+            num_send_tiles = tl.cdiv(send_numel, TILE_NUMEL)
+            send_tile_idx = sender_id.to(tl.int64)
+            send_step = start_step
+
+            while send_tile_idx < num_send_tiles:
+                slot = (send_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+                if send_step < start_step + PIPELINE_DEPTH:
+                    wait_target = start_step
+                else:
+                    wait_target = send_step - PIPELINE_DEPTH + 1
+                # Every sender warp polls the HEAD credit (idempotent
+                # acquire spin). ``tlx.thread_id()`` returns the CTA-GLOBAL
+                # tid, not a task-local one, so an ``if tid == 0`` elect would
+                # never fire for whichever task is not placed at tid 0 (it
+                # silently skipped the wait and raced on the staging buffer).
+                # Letting every thread poll is correct and layout-independent.
+                wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+
+                # Sender-task barrier: order the credit poll before all sender
+                # warps fill the staging slot. tl.debug_barrier() is rewritten
+                # by the TLX warp-spec lowering into a named barrier scoped to
+                # this task's warps (NOT a full-CTA barrier).
+                tl.debug_barrier()
+
+                buf_tile_idx = 0
+                tiles_to_send_this_step = min(
+                    MAX_TILES_PER_BLOCK_PER_SLOT,
+                    tl.cdiv(num_send_tiles - send_tile_idx, NUM_SEND_BLOCKS),
+                )
+                for _i in range(tiles_to_send_this_step):
+                    flat_idx = (
+                        send_tile_idx * TILE_NUMEL
+                        + local_rows[:, None] * TILE_COLS
+                        + local_cols[None, :]
+                    )
+                    mask = flat_idx < send_numel
+                    data = tl.load(send_ptr + flat_idx.to(tl.int64), mask=mask)
+                    buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                    buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                        tl.int64
+                    )
+                    tl.store(send_staging_buf + slot_base + buf_off, data, mask=mask)
+                    send_tile_idx += NUM_SEND_BLOCKS
+                    buf_tile_idx += 1
+
+                # Sender-task barrier: ensure every sender warp has finished
+                # writing the staging slot before the TAIL credit is posted
+                # (release publish). Rewritten to a task-scoped named barrier.
+                tl.debug_barrier()
+                fence_and_remote_store_i64(
+                    tail_remote_ptr, (send_step + 1).to(tl.int64)
+                )
+                send_step += 1
+
+            tl.store(sender_step_ptr + sender_id, send_step.to(tl.int64))
+
+        with tlx.async_task(num_warps=NUM_RECEIVER_WARPS):
+            receiver_id = block_id
+            tail_local_ptr = recv_tail_sig + receiver_id
+            head_remote_ptr = recv_head_sig + receiver_id
+            start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
+            local_rows = tl.arange(0, TILE_ROWS)
+            local_cols = tl.arange(0, TILE_COLS)
+            num_recv_tiles = tl.cdiv(recv_numel, TILE_NUMEL)
+            recv_tile_idx = receiver_id.to(tl.int64)
+            recv_step = start_step
+
+            while recv_tile_idx < num_recv_tiles:
+                slot = (recv_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+                # Every receiver warp polls the TAIL credit (idempotent
+                # acquire spin) for the layout-independence reason documented
+                # in the sender task above.
+                wait_ge(tail_local_ptr, (recv_step + 1).to(tl.int64))
+
+                # Receiver-task barrier: order the TAIL acquire-poll before
+                # all receiver warps read the staging slot. Rewritten to a
+                # task-scoped named barrier.
+                tl.debug_barrier()
+
+                buf_tile_idx = 0
+                tiles_to_recv_this_step = min(
+                    MAX_TILES_PER_BLOCK_PER_SLOT,
+                    tl.cdiv(num_recv_tiles - recv_tile_idx, NUM_SEND_BLOCKS),
+                )
+                for _i in range(tiles_to_recv_this_step):
+                    flat_idx = (
+                        recv_tile_idx * TILE_NUMEL
+                        + local_rows[:, None] * TILE_COLS
+                        + local_cols[None, :]
+                    )
+                    mask = flat_idx < recv_numel
+                    buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                    buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                        tl.int64
+                    )
+                    data = tl.load(recv_staging_buf + slot_base + buf_off, mask=mask)
+                    tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
+                    recv_tile_idx += NUM_SEND_BLOCKS
+                    buf_tile_idx += 1
+
+                # Receiver-task barrier: ensure every receiver warp has
+                # finished draining the staging slot before the HEAD credit
+                # is posted. Rewritten to a task-scoped named barrier.
+                tl.debug_barrier()
+                remote_store_i64_relaxed(head_remote_ptr, (recv_step + 1).to(tl.int64))
+                recv_step += 1
+
+            tl.store(recver_step_ptr + receiver_id, recv_step.to(tl.int64))

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -74,6 +74,7 @@ from comms.pipes.triton.collectives.nvl.sendrecv_op import (
     triton_nvl_recv,
     triton_nvl_send,
     triton_nvl_sendrecv,
+    triton_nvl_sendrecv_ws,
 )
 
 
@@ -95,11 +96,22 @@ _MSG_SIZES_BYTES: list[int] = [
 ]
 
 
+_WS_SENDER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_SENDER_WARPS", "4"))
+_WS_RECEIVER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_RECEIVER_WARPS", "4"))
+
+
 # NCCL ``NCCL_{MIN,MAX}_NCHANNELS`` allocation values to sweep.
 # At each cap we compare against NCCL with that allocation, and Triton
 # with ``num_blocks`` matched to NCCL's actual runtime grid (see table
 # in module docstring).
 _CAPS: list[int] = [4, 8, 16, 32]
+
+
+def _env_int_list(name: str, default: list[int]) -> list[int]:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return [int(x.strip()) for x in raw.split(",") if x.strip()]
 
 
 # Hardcoded NCCL P2P kernel runtime grid table, keyed by
@@ -270,6 +282,7 @@ def _bench_triton(
     *,
     bidirectional: bool,
     num_blocks: int,
+    warp_specialized: bool = False,
 ) -> tuple[float, float]:
     """Bench Triton send/recv via CUDA-graph replay. Returns (μs, GB/s)."""
     device = torch.device(f"cuda:{local_rank}")
@@ -279,13 +292,24 @@ def _bench_triton(
 
     def fn() -> None:
         if bidirectional:
-            triton_nvl_sendrecv(
-                send,
-                recv,
-                peer_rank,
-                group=group,
-                num_blocks=num_blocks,
-            )
+            if warp_specialized:
+                triton_nvl_sendrecv_ws(
+                    send,
+                    recv,
+                    peer_rank,
+                    group=group,
+                    num_blocks=num_blocks,
+                    sender_warps=_WS_SENDER_WARPS,
+                    receiver_warps=_WS_RECEIVER_WARPS,
+                )
+            else:
+                triton_nvl_sendrecv(
+                    send,
+                    recv,
+                    peer_rank,
+                    group=group,
+                    num_blocks=num_blocks,
+                )
         elif local_rank == 0:
             triton_nvl_send(
                 send,
@@ -406,14 +430,20 @@ def _print_row(
     triton_bw: float,
     nccl_us: float,
     nccl_bw: float,
+    ws_us: float | None = None,
+    ws_bw: float | None = None,
 ) -> None:
     if rank != 0:
         return
     speedup = nccl_us / triton_us if triton_us > 0 else 0.0
+    extra = ""
+    if ws_us is not None and ws_bw is not None:
+        ws_speedup = nccl_us / ws_us if ws_us > 0 else 0.0
+        extra = f" | ws {ws_us:>10.2f} {ws_bw:>12.3f} {ws_speedup:>7.2f}x"
     print(
         f"{_fmt_size(msg_bytes):>10} | {iters:>6} | {triton_num_blocks:>6} {nccl_grid:>9} | "
         f"{triton_us:>10.2f} {triton_bw:>12.3f} | "
-        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x"
+        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x{extra}"
     )
 
 
@@ -432,13 +462,15 @@ def _run_table(
     )
     title = f"{direction} | NCCL_NCHANNELS=cap={cap} (Triton num_blocks tracks NCCL runtime grid)"
     _print_header(local_rank, title)
-    for msg_bytes in _MSG_SIZES_BYTES:
+    for msg_bytes in _env_int_list("TRITON_NVL_BENCH_MSGS", _MSG_SIZES_BYTES):
         nccl_grid = _NCCL_GRID_TABLE[(msg_bytes, cap)]
         if bidirectional:
             triton_nb = _triton_num_blocks_bi(msg_bytes, cap)
         else:
             triton_nb = _triton_num_blocks_uni(msg_bytes, cap)
 
+        ws_us: float | None = None
+        ws_bw: float | None = None
         triton_us, triton_bw = _bench_triton(
             msg_bytes,
             local_rank,
@@ -447,6 +479,19 @@ def _run_table(
             bidirectional=bidirectional,
             num_blocks=triton_nb,
         )
+        dist.barrier(group)
+        if bidirectional:
+            # Warp-specialized (WS) kernel as an extra column. WS is correct
+            # at all sizes, so it runs across the whole sweep (no size cap).
+            ws_us, ws_bw = _bench_triton(
+                msg_bytes,
+                local_rank,
+                peer_rank,
+                group,
+                bidirectional=True,
+                num_blocks=nccl_grid,
+                warp_specialized=True,
+            )
         dist.barrier(group)
         nccl_us, nccl_bw = _bench_nccl(
             msg_bytes, local_rank, peer_rank, group, bidirectional=bidirectional
@@ -462,6 +507,8 @@ def _run_table(
             triton_bw,
             nccl_us,
             nccl_bw,
+            ws_us,
+            ws_bw,
         )
 
 
@@ -493,6 +540,10 @@ def _worker(local_rank: int, master_port: int, cap: int) -> None:
             "Triton bi: num_blocks = max(NCCL runtime grid // 2, 1)."
         )
         print("# BW = unidirectional payload bytes / latency.")
+        print(
+            f"# WS config: sender_warps={_WS_SENDER_WARPS}, "
+            f"receiver_warps={_WS_RECEIVER_WARPS}"
+        )
         print("#" * 100)
 
     _run_table(local_rank, peer_rank, group, bidirectional=False, cap=cap)
@@ -511,7 +562,7 @@ def main() -> None:
         f"(see _NCCL_GRID_TABLE); cap sweep: {_CAPS}"
     )
 
-    for cap in _CAPS:
+    for cap in _env_int_list("TRITON_NVL_BENCH_CAPS", _CAPS):
         os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
         os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
         port = _find_free_port()

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -10,14 +10,17 @@ import os
 import socket
 import sys
 from collections.abc import Callable
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 import torch.multiprocessing as mp
 from comms.pipes.triton.collectives.nvl.sendrecv_op import (
     triton_nvl_recv,
     triton_nvl_send,
     triton_nvl_sendrecv,
+    triton_nvl_sendrecv_prepare,
 )
 
 
@@ -347,11 +350,463 @@ def _worker(local_rank: int, master_port: int) -> None:
         sys.exit(1)
 
 
+def _run_ring_sendrecv(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+    num_warps: int = 8,
+) -> bool:
+    """Ring topology: each rank sends to (rank+1)%N, receives from (rank-1)%N."""
+    send_peer = (local_rank + 1) % world_size
+    recv_peer = (local_rank - 1 + world_size) % world_size
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    send = _make_pattern(local_rank, numel, dtype, device)
+    recv = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(recv_peer, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send,
+        recv,
+        send_peer,
+        recv_peer,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+    )
+    torch.cuda.synchronize(device)
+
+    ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_nrank_unidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    src_rank: int,
+    dst_rank: int,
+    local_rank: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Send from src_rank to dst_rank in an N-rank group."""
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    if local_rank == src_rank:
+        send = _make_pattern(local_rank, numel, dtype, device)
+        triton_nvl_send(send, dst_rank, group=group)
+        local_ok = True
+    elif local_rank == dst_rank:
+        recv = torch.zeros(numel, dtype=dtype, device=device)
+        expected = _make_pattern(src_rank, numel, dtype, device)
+        triton_nvl_recv(recv, src_rank, group=group)
+        torch.cuda.synchronize(device)
+        local_ok = _check_equal(recv, expected, name, local_rank)
+    else:
+        local_ok = True
+
+    torch.cuda.synchronize(device)
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_ring_back_to_back_pattern(
+    name: str,
+    configs: list[tuple[int, int]],
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Back-to-back ring sendrecv calls to verify step state persistence."""
+    send_peer = (local_rank + 1) % world_size
+    recv_peer = (local_rank - 1 + world_size) % world_size
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+
+    sends: list[torch.Tensor] = []
+    recvs: list[torch.Tensor] = []
+    expected: list[torch.Tensor] = []
+    for msg_bytes, _ in configs:
+        numel = _numel(msg_bytes, dtype)
+        sends.append(_make_pattern(local_rank, numel, dtype, device))
+        recvs.append(torch.zeros(numel, dtype=dtype, device=device))
+        expected.append(_make_pattern(recv_peer, numel, dtype, device))
+
+    for i, (_, num_blocks) in enumerate(configs):
+        triton_nvl_sendrecv(
+            sends[i],
+            recvs[i],
+            send_peer,
+            recv_peer,
+            group=group,
+            num_blocks=num_blocks,
+        )
+    torch.cuda.synchronize(device)
+
+    local_ok = all(
+        _check_equal(actual, exp, name, local_rank)
+        for actual, exp in zip(recvs, expected)
+    )
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_ring_back_to_back(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    return _run_ring_back_to_back_pattern(
+        "ring_back_to_back",
+        [
+            (64 * 1024, 4),
+            (1024 * 1024, 16),
+            (256 * 1024, 8),
+        ],
+        local_rank,
+        world_size,
+        group,
+    )
+
+
+def _run_ring_back_to_back_large_small(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    return _run_ring_back_to_back_pattern(
+        "ring_back_to_back_large_small",
+        [
+            (16 * 1024 * 1024, 32),
+            (64 * 1024, 4),
+            (16 * 1024 * 1024, 32),
+        ],
+        local_rank,
+        world_size,
+        group,
+    )
+
+
+def _run_ring_graph_case(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Capture and replay forward/reverse N-rank ring steps in a CUDA graph.
+
+    The two passes use distinct ``num_blocks`` (16, 4) so the captured graph
+    exercises per-(peer, block) step-state persistence under varying grids,
+    not just the eager path.
+    """
+    if world_size < 3:
+        return True
+
+    fwd_send: int = (local_rank + 1) % world_size
+    fwd_recv: int = (local_rank - 1 + world_size) % world_size
+    rev_send: int = fwd_recv
+    rev_recv: int = fwd_send
+
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+    numel = _numel(256 * 1024, dtype)
+
+    send_pass1: torch.Tensor = _make_pattern(local_rank, numel, dtype, device)
+    send_pass2: torch.Tensor = _make_pattern(local_rank + 1000, numel, dtype, device)
+    recv_pass1: torch.Tensor = torch.zeros(numel, dtype=dtype, device=device)
+    recv_pass2: torch.Tensor = torch.zeros(numel, dtype=dtype, device=device)
+    expected_pass1 = _make_pattern(fwd_recv, numel, dtype, device)
+    expected_pass2 = _make_pattern(rev_recv + 1000, numel, dtype, device)
+
+    def sequence() -> None:
+        triton_nvl_sendrecv(
+            send_pass1, recv_pass1, fwd_send, fwd_recv, group=group, num_blocks=16
+        )
+        triton_nvl_sendrecv(
+            send_pass2, recv_pass2, rev_send, rev_recv, group=group, num_blocks=4
+        )
+
+    sequence()
+    torch.cuda.synchronize(device)
+
+    graph_obj = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph_obj):
+        sequence()
+
+    local_ok = True
+    for _ in range(5):
+        recv_pass1.zero_()
+        recv_pass2.zero_()
+        graph_obj.replay()
+        torch.cuda.synchronize(device)
+        local_ok = local_ok and _check_equal(
+            recv_pass1, expected_pass1, "ring_cuda_graph_pass1", local_rank
+        )
+        local_ok = local_ok and _check_equal(
+            recv_pass2, expected_pass2, "ring_cuda_graph_pass2", local_rank
+        )
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: ring_cuda_graph")
+    return ok
+
+
+def _run_cross_peer_back_to_back(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Back-to-back launches that change ``send_peer``/``recv_peer`` across
+    calls. Verifies that the ``(world_size, MBPP)`` step-state matrix is
+    indexed by peer-row correctly — i.e. progress against peer A does not
+    leak into the slot ledger for peer B.
+
+    Each rank pairs with two distinct peers in sequence:
+      * pass 1: send→(rank+1)%N, recv←(rank-1+N)%N    (forward ring)
+      * pass 2: send→(rank-1+N)%N, recv←(rank+1)%N    (reverse ring)
+    """
+    if world_size < 3:
+        return True
+
+    fwd_send = (local_rank + 1) % world_size
+    fwd_recv = (local_rank - 1 + world_size) % world_size
+    rev_send = fwd_recv
+    rev_recv = fwd_send
+
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+    numel = _numel(256 * 1024, dtype)
+
+    # Two passes share send tensors but use independent recv buffers so
+    # we can verify each peer's payload landed in the right place.
+    send_pass1 = _make_pattern(local_rank, numel, dtype, device)
+    send_pass2 = _make_pattern(local_rank + 1000, numel, dtype, device)
+    recv_pass1 = torch.zeros(numel, dtype=dtype, device=device)
+    recv_pass2 = torch.zeros(numel, dtype=dtype, device=device)
+
+    expected_pass1 = _make_pattern(fwd_recv, numel, dtype, device)
+    expected_pass2 = _make_pattern(rev_recv + 1000, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send_pass1, recv_pass1, fwd_send, fwd_recv, group=group, num_blocks=8
+    )
+    triton_nvl_sendrecv(
+        send_pass2, recv_pass2, rev_send, rev_recv, group=group, num_blocks=8
+    )
+    torch.cuda.synchronize(device)
+
+    local_ok = _check_equal(
+        recv_pass1, expected_pass1, "cross_peer_pass1", local_rank
+    ) and _check_equal(recv_pass2, expected_pass2, "cross_peer_pass2", local_rank)
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: cross_peer_back_to_back")
+    return ok
+
+
+def _nrank_worker(local_rank: int, world_size: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+    device = torch.device(f"cuda:{local_rank}")
+
+    triton_nvl_sendrecv_prepare(group=group, device=device)
+    dist.barrier(group)
+
+    # Run sparse P2P before any ring sendrecv warms the launch path. The
+    # explicit prepare above covers the group-wide symmetric-memory rendezvous.
+    _record(
+        results,
+        lambda: _run_nrank_unidirectional(
+            "nrank_sparse_prepared_send_0_to_1",
+            1024 * 1024,
+            torch.int32,
+            0,
+            1,
+            local_rank,
+            group,
+        ),
+        group,
+    )
+
+    for name, msg_bytes in _BASE_CASES:
+        _record(
+            results,
+            lambda name=name, msg_bytes=msg_bytes: _run_ring_sendrecv(
+                f"ring_{name}_int32",
+                msg_bytes,
+                torch.int32,
+                local_rank,
+                world_size,
+                group,
+            ),
+            group,
+        )
+
+    for dtype in (torch.bfloat16, torch.float32):
+        _record(
+            results,
+            lambda dtype=dtype: _run_ring_sendrecv(
+                f"ring_64KB_{dtype}_smoke",
+                64 * 1024,
+                dtype,
+                local_rank,
+                world_size,
+                group,
+            ),
+            group,
+        )
+
+    # num_warps=4 variant: the 2-rank suite sweeps warp counts but the N-rank
+    # cases otherwise all run the default 8 warps. Cover the 4-warp config so
+    # warp-scheduling-dependent barrier bugs surface on the ring path too.
+    _record(
+        results,
+        lambda: _run_ring_sendrecv(
+            "ring_1MB_int32_warps4",
+            1024 * 1024,
+            torch.int32,
+            local_rank,
+            world_size,
+            group,
+            num_warps=4,
+        ),
+        group,
+    )
+
+    if world_size > 2:
+        _record(
+            results,
+            lambda: _run_nrank_unidirectional(
+                f"nrank_send_0_to_{world_size - 1}",
+                1024 * 1024,
+                torch.int32,
+                0,
+                world_size - 1,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    _record(
+        results,
+        lambda: _run_ring_back_to_back(local_rank, world_size, group),
+        group,
+    )
+
+    _record(
+        results,
+        lambda: _run_ring_back_to_back_large_small(local_rank, world_size, group),
+        group,
+    )
+
+    _record(
+        results,
+        lambda: _run_ring_graph_case(local_rank, world_size, group),
+        group,
+    )
+
+    _record(
+        results,
+        lambda: _run_cross_peer_back_to_back(local_rank, world_size, group),
+        group,
+    )
+
+    if local_rank == 0:
+        n_pass = sum(1 for ok in results if ok)
+        print(f"\nN-rank Results ({world_size} GPUs): {n_pass}/{len(results)} passed")
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+    if local_rank == 0 and not all(results):
+        sys.exit(1)
+
+
+def _signal_pad_failure_worker(local_rank: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    device = torch.device(f"cuda:{local_rank}")
+    local_ok = False
+    try:
+        with patch.object(symm_mem, "get_signal_pad_size", return_value=0):
+            triton_nvl_sendrecv_prepare(group=group, device=device)
+    except RuntimeError as error:
+        message = str(error)
+        local_ok = (
+            "Signal pad too small" in message
+            and "Call symm_mem.set_signal_pad_size() before first allocation" in message
+        )
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: signal_pad_first_allocation_failure")
+    dist.destroy_process_group()
+    if local_rank == 0 and not ok:
+        sys.exit(1)
+
+
 def main() -> None:
     port = _find_free_port()
+    num_gpus = torch.cuda.device_count()
+
     print("Running Triton NVLink SendRecv Correctness Tests")
     print("=" * 52)
+
+    print("\n--- signal-pad first-allocation failure test ---")
+    mp.spawn(_signal_pad_failure_worker, args=(port,), nprocs=2, join=True)
+
+    port = _find_free_port()
+    print("\n--- 2-rank tests ---")
     mp.spawn(_worker, args=(port,), nprocs=2, join=True)
+
+    if num_gpus >= 3:
+        port = _find_free_port()
+        print("\n--- 3-rank tests (minimal asymmetric topology) ---")
+        mp.spawn(_nrank_worker, args=(3, port), nprocs=3, join=True)
+    else:
+        print(f"\nSkipping 3-rank tests: need >= 3 GPUs, have {num_gpus}")
+
+    if num_gpus >= 4:
+        port = _find_free_port()
+        nprocs = min(num_gpus, 8)
+        print(f"\n--- {nprocs}-rank tests (ring topology) ---")
+        mp.spawn(_nrank_worker, args=(nprocs, port), nprocs=nprocs, join=True)
+    else:
+        print(f"\nSkipping N-rank tests: need >= 4 GPUs, have {num_gpus}")
 
 
 if __name__ == "__main__":

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -21,7 +21,31 @@ from comms.pipes.triton.collectives.nvl.sendrecv_op import (
     triton_nvl_send,
     triton_nvl_sendrecv,
     triton_nvl_sendrecv_prepare,
+    triton_nvl_sendrecv_ws,
 )
+
+
+# ---------------------------------------------------------------------------
+# Warp-specialized (WS) test gate (ON by default).
+#
+# The WS path uses TLX `async_tasks` / `async_task` warp-specialization.
+# Earlier this kernel hung after >2 while-loop iterations (blamed on an
+# upstream `tlx.sync_threads()` codegen bug) and intermittently corrupted
+# data. The real cause was a raw inline-asm `bar.sync 0` (`sync_threads()`)
+# inside the async_tasks: it is invisible to the TLX warp-spec lowering, so
+# it stayed a full-CTA barrier across the two independent tasks (deadlock at
+# higher iteration counts) and its hardcoded size corrupted data at small
+# warp counts. The kernel now uses `tl.debug_barrier()`, which the lowering
+# rewrites into a per-task, correctly-sized named barrier; combined with an
+# all-warps credit poll this makes the path deterministically correct and
+# hang-free at ANY iteration count (validated to 1 GiB / ~128 iters).
+#
+# The test binary pins `//triton:triton` directly (see tests/BUCK) so it uses
+# the real TLX runtime, not torch's bundled shim. The sweep needs multi-GPU
+# NVLink hardware, like the rest of this suite. Set
+# `TRITON_NVL_WS_TESTS_ENABLED=0` to skip it.
+# ---------------------------------------------------------------------------
+_WS_TESTS_ENABLED: bool = os.environ.get("TRITON_NVL_WS_TESTS_ENABLED", "1") == "1"
 
 
 _BASE_CASES: list[tuple[str, int]] = [
@@ -118,6 +142,9 @@ def _run_bidirectional(
     *,
     num_blocks: int = 16,
     num_warps: int = 8,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> bool:
     peer_rank = 1 - local_rank
     device = torch.device(f"cuda:{local_rank}")
@@ -126,9 +153,25 @@ def _run_bidirectional(
     recv = torch.zeros(numel, dtype=dtype, device=device)
     expected = _make_pattern(peer_rank, numel, dtype, device)
 
-    triton_nvl_sendrecv(
-        send, recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
-    )
+    if warp_specialized:
+        triton_nvl_sendrecv_ws(
+            send,
+            recv,
+            peer_rank,
+            group=group,
+            num_blocks=num_blocks,
+            sender_warps=sender_warps,
+            receiver_warps=receiver_warps,
+        )
+    else:
+        triton_nvl_sendrecv(
+            send,
+            recv,
+            peer_rank,
+            group=group,
+            num_blocks=num_blocks,
+            num_warps=num_warps,
+        )
     torch.cuda.synchronize(device)
 
     ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
@@ -209,6 +252,9 @@ def _run_graph_case(
     group: dist.ProcessGroup,
     *,
     bidirectional: bool,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> bool:
     peer_rank: int = 1 - local_rank
     device = torch.device(f"cuda:{local_rank}")
@@ -219,7 +265,16 @@ def _run_graph_case(
     expected = _make_pattern(peer_rank, numel, dtype, device)
 
     def fn() -> None:
-        if bidirectional:
+        if warp_specialized:
+            triton_nvl_sendrecv_ws(
+                send,
+                recv,
+                peer_rank,
+                group=group,
+                sender_warps=sender_warps,
+                receiver_warps=receiver_warps,
+            )
+        elif bidirectional:
             triton_nvl_sendrecv(send, recv, peer_rank, group=group)
         elif local_rank == 0:
             triton_nvl_send(send, peer_rank, group=group)
@@ -242,7 +297,7 @@ def _run_graph_case(
                 recv, expected, "cuda_graph", local_rank
             )
 
-    label = f"{'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
+    label = f"{'bidirectional_ws' if warp_specialized else 'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
     ok = _all_ok(local_ok, device, group)
     if local_rank == 0:
         print(f"  {'PASS' if ok else 'FAIL'}: {label}")
@@ -256,19 +311,9 @@ def _record(
     dist.barrier(group)
 
 
-def _worker(local_rank: int, master_port: int) -> None:
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = str(master_port)
-    os.environ["RANK"] = str(local_rank)
-    os.environ["LOCAL_RANK"] = str(local_rank)
-    os.environ["WORLD_SIZE"] = "2"
-
-    torch.cuda.set_device(local_rank)
-    dist.init_process_group("nccl")
-    group = dist.group.WORLD
-    assert group is not None
-
-    results: list[bool] = []
+def _record_base_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for name, msg_bytes in _BASE_CASES:
         _record(
             results,
@@ -278,6 +323,10 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_dtype_smoke_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for dtype in (torch.bfloat16, torch.float32):
         _record(
             results,
@@ -291,6 +340,69 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_ws_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
+    if not _WS_TESTS_ENABLED:
+        return
+
+    # TLX warp specialization requires each partition's warp count AND their
+    # sum to be powers of two, which forces sender_warps == receiver_warps
+    # (drawn from {2, 4, 8}). Non-pow2 splits like (3, 5) crash the
+    # TritonTLXFixup pass; the host launcher now rejects them up front.
+    for sw, rw in [(2, 2), (4, 4), (8, 8)]:
+        for msg_label, msg_bytes in [("256KB", 256 * 1024), ("1MB", 1024 * 1024)]:
+            _record(
+                results,
+                lambda sw=sw, rw=rw, mb=msg_bytes, ml=msg_label: _run_bidirectional(
+                    f"bidirectional_ws_{sw}s{rw}r_{ml}_int32",
+                    mb,
+                    torch.int32,
+                    local_rank,
+                    group,
+                    num_blocks=16,
+                    warp_specialized=True,
+                    sender_warps=sw,
+                    receiver_warps=rw,
+                ),
+                group,
+            )
+
+    # ---- Regression: asymmetric per-block tiles across the iteration range ----
+    # Locks in the barrier fix that the WS path needed: the kernel used a raw
+    # inline-asm `bar.sync 0` (invisible to the TLX warp-spec lowering) which
+    # stayed full-CTA across the two async_tasks and caused both a data race
+    # and an iteration-count-dependent hang. Switching to tl.debug_barrier()
+    # (compiler-rewritten to a per-task, correctly-sized named barrier) fixes
+    # both, so the kernel is now correct at ANY iteration count.
+    #
+    # Two sizes, both with non-tile-multiple numel (partial-tile mask) and
+    # num_tiles not divisible by num_blocks (asymmetric per-block tiles):
+    #   * 5 MB  (int32) -> 77 tiles  -> ~2 iters/block (boundary of old guard)
+    #   * 64 MB (int32) -> ~1024 tiles -> ~8 iters/block (formerly hung)
+    for label, msg_bytes in [("5MB", 5 * 1000 * 1000), ("64MB", 64 * 1000 * 1000)]:
+        for sw, rw in [(4, 4), (8, 8)]:
+            _record(
+                results,
+                lambda sw=sw, rw=rw, mb=msg_bytes, lbl=label: _run_bidirectional(
+                    f"bidirectional_ws_{sw}s{rw}r_{lbl}_asym_int32",
+                    mb,
+                    torch.int32,
+                    local_rank,
+                    group,
+                    num_blocks=16,
+                    warp_specialized=True,
+                    sender_warps=sw,
+                    receiver_warps=rw,
+                ),
+                group,
+            )
+
+
+def _record_unidirectional_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for src_rank in (0, 1):
         _record(
             results,
@@ -305,6 +417,10 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_config_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for num_blocks in (2, 16, 32):
         for num_warps in (4, 8):
             _record(
@@ -321,6 +437,10 @@ def _worker(local_rank: int, master_port: int) -> None:
                 group,
             )
 
+
+def _record_back_to_back_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for bidirectional in (False, True):
         for graph in (False, True):
             _record(
@@ -331,6 +451,10 @@ def _worker(local_rank: int, master_port: int) -> None:
                 group,
             )
 
+
+def _record_graph_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for bidirectional in (False, True):
         _record(
             results,
@@ -339,6 +463,37 @@ def _worker(local_rank: int, master_port: int) -> None:
             ),
             group,
         )
+
+    if _WS_TESTS_ENABLED:
+        _record(
+            results,
+            lambda: _run_graph_case(
+                local_rank, group, bidirectional=True, warp_specialized=True
+            ),
+            group,
+        )
+
+
+def _worker(local_rank: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+    _record_base_cases(results, local_rank, group)
+    _record_dtype_smoke_cases(results, local_rank, group)
+    _record_ws_cases(results, local_rank, group)
+    _record_unidirectional_cases(results, local_rank, group)
+    _record_config_cases(results, local_rank, group)
+    _record_back_to_back_cases(results, local_rank, group)
+    _record_graph_cases(results, local_rank, group)
 
     if local_rank == 0:
         n_pass = sum(1 for ok in results if ok)


### PR DESCRIPTION
Summary:
Adds a TLX warp-specialized (WS) bidirectional sendrecv kernel: each CTA runs sender and receiver as concurrent async_tasks, matching NCCL's per-channel send/recv structure. At runtime-SM-matched comparison (cap=4, H100) it is the top performer among the Triton variants at large messages: 1.10x-1.13x vs NCCL across 8MB-1GB, and 1.4x-1.7x at small sizes.

Intra-task synchronization uses tl.debug_barrier(), which the TLX warp-spec lowering rewrites into a per-task, correctly-sized named barrier (default region -> barrier 0; each partition -> barrier 2+idx, sized to that partition's warp count). This is the crux: a raw inline-asm bar.sync 0 (the original approach) is invisible to that lowering, so it stays a full-CTA barrier across the two independent async_tasks -- which deadlocks at higher loop-iteration counts and corrupts data at small warp counts. Switching to a compiler-visible barrier fixes both; the kernel is now deterministically correct and hang-free at any iteration count (validated to 1GB / ~128 iters).

Host-side validation: sender_warps and receiver_warps must each be a power of two and sum to a power of two in [2,16] (TLX warp-spec + Triton num_warps requirement, which forces sender_warps == receiver_warps).

Adaptive block stride is a performance optimization only (it lowers the loop-iteration count, reducing fence.acq_rel.sys operations -- a few % at large messages); it is NOT required for correctness, so there is no fail-loud iteration guard.

Differential Revision: D106331816


