### PR TITLE
Add JSON tuning config and sub-slot signaling for NVLink sendrecv

### DIFF
--- a/comms/pipes/triton/collectives/nvl/__init__.py
+++ b/comms/pipes/triton/collectives/nvl/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -94,10 +94,12 @@ _MODE_RECV_ONLY = 2
 def triton_nvl_sendrecv_kernel(  # noqa: C901
     send_ptr,
     recv_ptr,
-    buffer_ptrs,  # int64 device tensor, shape (world_size,)
-    signal_pad_ptrs,  # int64 device tensor, shape (world_size,)
-    sender_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
-    recver_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    remote_buf,  # direct tensor: peer's staging buffer
+    local_buf,  # direct tensor: own staging buffer
+    remote_sig,  # direct tensor: peer's signal pad (int64)
+    local_sig,  # direct tensor: own signal pad (int64)
+    sender_step_ptr,
+    recver_step_ptr,
     local_rank,
     peer_rank,
     send_numel,
@@ -118,6 +120,16 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
     path ``pid // 2`` and odd programs run receiver path ``pid // 2``.
     Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
     exactly one path.
+
+    Staging buffer and signal pad pointers are passed as direct typed
+    tensor arguments (via ``handle.get_buffer`` / ``handle.get_signal_pad``
+    on the host side) rather than loaded at runtime from a pointer-of-pointer
+    tensor. This is critical for Triton codegen: runtime-loaded store
+    destination pointers (``tl.load(...).to(pointer_type(...))``) trigger
+    the compiler's layout optimizer to emit scalar 16-bit stores
+    (``STG.E.U16``) instead of 128-bit vectorized stores (``STG.E.128``).
+    Direct tensor arguments avoid this, producing the same ``LDG.E.128 +
+    STG.E.128`` pattern that NCCL uses with ``uint4``.
     """
     TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
 
@@ -132,21 +144,8 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         is_sender = (pid % 2) == 0
         block_id = pid // 2
 
-    # ---- Buffer pointers ----
-    # Sender writes to peer rank's staging buffer; receiver reads its own.
-    buffer_ptrs_u64 = buffer_ptrs.to(tl.pointer_type(tl.uint64))
-    remote_buf = tl.load(buffer_ptrs_u64 + peer_rank).to(
-        tl.pointer_type(send_ptr.dtype.element_ty)
-    )
-    local_buf = tl.load(buffer_ptrs_u64 + local_rank).to(
-        tl.pointer_type(recv_ptr.dtype.element_ty)
-    )
-
-    # ---- Signal pad pointers ----
-    signal_pad_ptrs_u64 = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
-    remote_sig = tl.load(signal_pad_ptrs_u64 + peer_rank).to(tl.pointer_type(tl.int64))
-    local_sig = tl.load(signal_pad_ptrs_u64 + local_rank).to(tl.pointer_type(tl.int64))
-
+    # Buffer and signal pointers are already typed kernel arguments —
+    # no pointer-of-pointer load needed.
     HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
 
     flat_tid = get_flat_tid()

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -4,40 +4,47 @@
 
 """Triton NVLink-only copy-based send/recv kernel.
 
-Single peer-pair copy-based send, receive, or bidirectional sendrecv,
+N-rank group-aware copy-based send, receive, or bidirectional sendrecv,
 double-buffered staging, monotonic int64 head/tail signaling. CUDA-graph
 replayable via persistent step-state counters that advance across replays.
 
-Scope: 2-rank groups only. ``send_peer`` and ``recv_peer`` are the same
-rank (single ``peer_rank`` arg). This kernel is **not** directly usable
-for Ring AllGather on world_size > 2 — ring needs ``(send_peer,
-recv_peer) = ((rank+1)%N, (rank-1)%N)`` plus per-sender staging slots.
-See ``sendrecv_op.py`` module docstring for the planned API/protocol
-extension.
+Supports separate ``send_peer`` and ``recv_peer`` (e.g., for ring
+topology: ``send_peer = (rank+1) % N``, ``recv_peer = (rank-1) % N``).
+All pointer resolution is done on the host side — the kernel receives
+pre-sliced staging buffer, signal pad, and step state pointers for the
+specific ``(send_peer, recv_peer)`` pair. This preserves direct typed
+tensor arguments, avoiding the store scalarization (``STG.E.U16``) that
+pointer-of-pointer indirection causes.
 
 Architecture
 ------------
 
 ::
 
-    Rank A (sender)                        Rank B (receiver)
-    ┌─────────────┐                        ┌─────────────┐
-    │ src tensor  │──(1) read──→           │             │
-    │ (local HBM) │            │           │             │
-    └─────────────┘            │           │             │
-                               ▼           │             │
-                   ┌─────────────────────┐ │             │
-                   │ staging buffer      │ │             │
-                   │ (Rank B symm mem)   │─(2) read───→  │
-                   │ [slot 0 | slot 1]   │ │       ▼     │
-                   └─────────────────────┘ │  ┌─────────────┐
-                                           │  │ dst tensor  │
-                                           │  │ (local HBM) │
-                                           │  └─────────────┘
-                                           └────────────────┘
+    Rank A (sender → send_peer)          send_peer (receiver)
+    ┌─────────────┐                      ┌─────────────┐
+    │ src tensor  │──(1) read──→         │             │
+    │ (local HBM) │            │         │             │
+    └─────────────┘            │         │             │
+                               ▼         │             │
+                   ┌─────────────────────┐             │
+                   │ staging buffer      │─(2) read──→ │
+                   │ (send_peer symm mem │       ▼     │
+                   │  local_rank region) │  ┌─────────────┐
+                   └─────────────────────┘  │ dst tensor  │
+                                            └─────────────┘
 
-    (1) Sender reads local src, REMOTE-writes to peer's staging buffer
-    (2) Receiver LOCAL-reads its staging buffer, writes to local dst
+    recv_peer (sender)                   Rank A (receiver ← recv_peer)
+    ┌─────────────┐                      ┌─────────────┐
+    │ src tensor  │──(1) read──→         │             │
+    └─────────────┘            │         │             │
+                               ▼         │             │
+                   ┌─────────────────────┐             │
+                   │ staging buffer      │─(2) read──→ │
+                   │ (local_rank symm mem│       ▼     │
+                   │  recv_peer region)  │  ┌─────────────┐
+                   └─────────────────────┘  │ dst tensor  │
+                                            └─────────────┘
 
 All remote operations are NVLink fire-and-forget writes (zero NVLink reads).
 
@@ -48,14 +55,13 @@ Each block ``k`` owns a fixed staging-buffer region
 ``[k * BLOCK_STRIDE * PIPELINE_DEPTH, (k+1) * BLOCK_STRIDE * PIPELINE_DEPTH)``
 and a fixed ``(head[k], tail[k])`` signal pair. Sender block ``k`` and
 receiver block ``k`` use the SAME signal slot ``k`` and the SAME buffer
-region. The block→region mapping is determined by ``MAX_BLOCKS_PER_DIR``
+region. The block→region mapping is determined by ``MAX_BLOCKS_PER_PEER``
 (constant) and is independent of the runtime ``NUM_SEND_BLOCKS``, so
 back-to-back kernel launches with different block counts cannot race.
 
-Signal-pad layout per rank (int64 entries; ``MBPD = MAX_BLOCKS_PER_DIR``)::
-
-    [0 .. MBPD):       TAIL — written by remote sender, polled by local receiver
-    [MBPD .. 2*MBPD):  HEAD — written by remote receiver, polled by local sender
+Signal pointers are pre-resolved by the host into the N-rank per-(peer,
+block) layout. The kernel sees them as simple base pointers and indexes
+by ``block_id`` only.
 
 Memory ordering:
 
@@ -69,6 +75,25 @@ Memory ordering:
     ``sync_threads()`` execution barrier. Consumer uses
     :func:`wait_ge_volatile` (no acquire). The sender does not read any
     payload written by the receiver, so the fence is unnecessary.
+
+Intra-block synchronization pattern (used 4× below):
+
+  * ``if flat_tid == 0: <wait>`` + ``sync_threads()`` — only thread 0
+    polls the signal; the barrier publishes that result to the rest of
+    the block before any data thread observes the slot as ready.
+  * ``sync_threads()`` + ``if flat_tid == 0: <publish>`` — all data
+    threads must have committed their stores (or completed their loads)
+    before thread 0 advances the counter and releases the slot.
+
+Removing or reordering either ``sync_threads()`` call is a silent
+correctness bug — TLS / per-warp scheduling will break the producer/
+consumer ordering invariant.
+
+Specialization note: ``send_numel`` and ``recv_numel`` are intentionally
+specialized (no ``do_not_specialize``). Distinct ``(send_numel,
+recv_numel)`` pairs trigger Triton recompilation. For ring AllGather
+(single shard size per call) this is fine; callers driving many
+distinct sizes per process should reuse buffers.
 """
 
 from __future__ import annotations
@@ -90,30 +115,30 @@ _MODE_SEND_ONLY = 1
 _MODE_RECV_ONLY = 2
 
 
-@triton.jit(do_not_specialize=["local_rank", "peer_rank"])
+@triton.jit
 def triton_nvl_sendrecv_kernel(  # noqa: C901
     send_ptr,
     recv_ptr,
-    remote_buf,  # direct tensor: peer's staging buffer
-    local_buf,  # direct tensor: own staging buffer
-    remote_sig,  # direct tensor: peer's signal pad (int64)
-    local_sig,  # direct tensor: own signal pad (int64)
-    sender_step_ptr,
-    recver_step_ptr,
-    local_rank,
-    peer_rank,
+    send_staging_buf,  # pre-sliced: send_peer's staging at local_rank's region
+    recv_staging_buf,  # pre-sliced: local staging at recv_peer's region
+    send_tail_sig,  # pre-sliced: signal base for sender TAIL (int64)
+    send_head_sig,  # pre-sliced: signal base for sender HEAD (int64)
+    recv_tail_sig,  # pre-sliced: signal base for receiver TAIL (int64)
+    recv_head_sig,  # pre-sliced: signal base for receiver HEAD (int64)
+    sender_step_ptr,  # pre-sliced: step_state[send_peer, :] shape (MBPP,)
+    recver_step_ptr,  # pre-sliced: step_state[recv_peer, :] shape (MBPP,)
     send_numel,
     recv_numel,
     TILE_ROWS: tl.constexpr,
     TILE_COLS: tl.constexpr,
     BLOCK_STRIDE_ELEMS: tl.constexpr,
     PIPELINE_DEPTH: tl.constexpr,
-    MAX_BLOCKS_PER_DIR: tl.constexpr,
+    MAX_BLOCKS_PER_PEER: tl.constexpr,
     NUM_SEND_BLOCKS: tl.constexpr,
     MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
     MODE: tl.constexpr,
 ):
-    """NVLink copy-based send/recv kernel.
+    """NVLink copy-based send/recv kernel with pre-resolved N-rank pointers.
 
     Bidirectional mode launches grid ``(2 * NUM_SEND_BLOCKS,)`` and
     interleaves paired sender/receiver programs: even programs run sender
@@ -121,15 +146,9 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
     Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
     exactly one path.
 
-    Staging buffer and signal pad pointers are passed as direct typed
-    tensor arguments (via ``handle.get_buffer`` / ``handle.get_signal_pad``
-    on the host side) rather than loaded at runtime from a pointer-of-pointer
-    tensor. This is critical for Triton codegen: runtime-loaded store
-    destination pointers (``tl.load(...).to(pointer_type(...))``) trigger
-    the compiler's layout optimizer to emit scalar 16-bit stores
-    (``STG.E.U16``) instead of 128-bit vectorized stores (``STG.E.128``).
-    Direct tensor arguments avoid this, producing the same ``LDG.E.128 +
-    STG.E.128`` pattern that NCCL uses with ``uint4``.
+    All staging buffer and signal pad pointers are pre-resolved by the
+    host for the specific ``(send_peer, recv_peer)`` pair, so the kernel
+    indexes by ``block_id`` only — no world_size or peer_rank needed.
     """
     TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
 
@@ -144,20 +163,20 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         is_sender = (pid % 2) == 0
         block_id = pid // 2
 
-    # Buffer and signal pointers are already typed kernel arguments —
-    # no pointer-of-pointer load needed.
-    HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
-
     flat_tid = get_flat_tid()
 
     if is_sender:
         # ===== SENDER =====
         sender_id = block_id
 
+        # Signal pointers: host pre-resolved to the correct per-(peer, block) base.
+        # Buffer and signal pointers are already typed kernel arguments —
+        # no pointer-of-pointer load needed (preserves the STG.E.U16-free
+        # vectorized-store codegen pattern).
         # tail: REMOTE — written here, polled by remote receiver
-        # head: LOCAL — polled here, written by remote receiver
-        tail_remote_ptr = remote_sig + sender_id
-        head_local_ptr = local_sig + HEAD_OFFSET + sender_id
+        # head: LOCAL  — polled here, written by remote receiver
+        tail_remote_ptr = send_tail_sig + sender_id
+        head_local_ptr = send_head_sig + sender_id
 
         start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
 
@@ -206,17 +225,17 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
                 buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
                     tl.int64
                 )
-                tl.store(remote_buf + slot_base + buf_off, data, mask=mask)
+                tl.store(send_staging_buf + slot_base + buf_off, data, mask=mask)
 
                 send_tile_idx += NUM_SEND_BLOCKS
                 buf_tile_idx += 1
 
             sync_threads()
-            # ``bar.sync 0`` ensures all sender threads have finished issuing
-            # their staging stores before thread 0 issues the system fence.
-            # Without this barrier, thread 0's fence would only drain its own
-            # in-flight stores, leaving other threads' stores unsynchronized
-            # with the TAIL publish.
+            # ``bar.sync 0`` (sync_threads) above ensures all sender threads have
+            # finished issuing their staging stores before thread 0 issues the
+            # system fence. Without this barrier, thread 0's fence would only
+            # drain its own in-flight stores, leaving other threads' stores
+            # unsynchronized with the TAIL publish.
             if flat_tid == 0:
                 fence_and_remote_store_i64(
                     tail_remote_ptr, (send_step + 1).to(tl.int64)
@@ -230,10 +249,11 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         # ===== RECEIVER =====
         receiver_id = block_id
 
-        # tail: LOCAL — polled here, written by remote sender
+        # Signal pointers: host pre-resolved to the correct per-(peer, block) base.
+        # tail: LOCAL  — polled here, written by remote sender
         # head: REMOTE — written here, polled by remote sender
-        tail_local_ptr = local_sig + receiver_id
-        head_remote_ptr = remote_sig + HEAD_OFFSET + receiver_id
+        tail_local_ptr = recv_tail_sig + receiver_id
+        head_remote_ptr = recv_head_sig + receiver_id
 
         start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
 
@@ -274,7 +294,7 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
                 buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
                     tl.int64
                 )
-                data = tl.load(local_buf + slot_base + buf_off, mask=mask)
+                data = tl.load(recv_staging_buf + slot_base + buf_off, mask=mask)
                 tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
 
                 recv_tile_idx += NUM_SEND_BLOCKS

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -94,6 +94,19 @@ specialized (no ``do_not_specialize``). Distinct ``(send_numel,
 recv_numel)`` pairs trigger Triton recompilation. For ring AllGather
 (single shard size per call) this is fine; callers driving many
 distinct sizes per process should reuse buffers.
+
+Sub-slot signaling
+------------------
+
+The ``CHUNKS_PER_SLOT`` constexpr controls how many DATA_READY signals
+are issued per pipeline slot fill. When ``CHUNKS_PER_SLOT == 1``
+(the default, ``signal_bytes == BLOCK_STRIDE_BYTES``), behavior is
+identical to signaling once per slot — full backward compatibility.
+
+When ``CHUNKS_PER_SLOT > 1`` (``signal_bytes < BLOCK_STRIDE_BYTES``),
+each slot is divided into chunks of ``SIGNAL_STRIDE_ELEMS`` elements.
+The sender signals DATA_READY after each chunk. Backpressure (SLOT_FREE)
+fires only at slot boundaries.
 """
 
 from __future__ import annotations
@@ -119,36 +132,32 @@ _MODE_RECV_ONLY = 2
 def triton_nvl_sendrecv_kernel(  # noqa: C901
     send_ptr,
     recv_ptr,
-    send_staging_buf,  # pre-sliced: send_peer's staging at local_rank's region
-    recv_staging_buf,  # pre-sliced: local staging at recv_peer's region
-    send_tail_sig,  # pre-sliced: signal base for sender TAIL (int64)
-    send_head_sig,  # pre-sliced: signal base for sender HEAD (int64)
-    recv_tail_sig,  # pre-sliced: signal base for receiver TAIL (int64)
-    recv_head_sig,  # pre-sliced: signal base for receiver HEAD (int64)
-    sender_step_ptr,  # pre-sliced: step_state[send_peer, :] shape (MBPP,)
-    recver_step_ptr,  # pre-sliced: step_state[recv_peer, :] shape (MBPP,)
+    send_staging_buf,
+    recv_staging_buf,
+    send_tail_sig,
+    send_head_sig,
+    recv_tail_sig,
+    recv_head_sig,
+    sender_step_ptr,
+    recver_step_ptr,
     send_numel,
     recv_numel,
     TILE_ROWS: tl.constexpr,
     TILE_COLS: tl.constexpr,
     BLOCK_STRIDE_ELEMS: tl.constexpr,
+    SIGNAL_STRIDE_ELEMS: tl.constexpr,
     PIPELINE_DEPTH: tl.constexpr,
     MAX_BLOCKS_PER_PEER: tl.constexpr,
     NUM_SEND_BLOCKS: tl.constexpr,
-    MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
+    TILES_PER_SIGNAL: tl.constexpr,
+    CHUNKS_PER_SLOT: tl.constexpr,
     MODE: tl.constexpr,
 ):
     """NVLink copy-based send/recv kernel with pre-resolved N-rank pointers.
 
-    Bidirectional mode launches grid ``(2 * NUM_SEND_BLOCKS,)`` and
-    interleaves paired sender/receiver programs: even programs run sender
-    path ``pid // 2`` and odd programs run receiver path ``pid // 2``.
-    Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
-    exactly one path.
-
-    All staging buffer and signal pad pointers are pre-resolved by the
-    host for the specific ``(send_peer, recv_peer)`` pair, so the kernel
-    indexes by ``block_id`` only — no world_size or peer_rank needed.
+    The host passes peer-specific staging buffers, signal pads, and step-state
+    rows directly. That keeps the kernel simple and avoids pointer-of-pointer
+    loads that can pessimize Triton store codegen.
     """
     TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
 
@@ -190,26 +199,42 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         send_step = start_step
 
         while send_tile_idx < num_send_tiles:
-            slot = (send_step - start_step) % PIPELINE_DEPTH
-            slot_base = (
-                sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
-                + slot * BLOCK_STRIDE_ELEMS
-            )
-
-            # Wait for slot to be free. For the first PIPELINE_DEPTH steps
-            # of a non-first call, the slot may still hold data the remote
-            # receiver has not yet consumed — gate on start_step.
-            if send_step < start_step + PIPELINE_DEPTH:
-                wait_target = start_step
+            if CHUNKS_PER_SLOT == 1:
+                slot = (send_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+                # Wait for slot to be free. For the first PIPELINE_DEPTH steps
+                # of a non-first call, the slot may still hold data the remote
+                # receiver has not yet consumed — gate on start_step.
+                if send_step < start_step + PIPELINE_DEPTH:
+                    wait_target = start_step
+                else:
+                    wait_target = send_step - PIPELINE_DEPTH + 1
+                if flat_tid == 0:
+                    wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+                sync_threads()
             else:
-                wait_target = send_step - PIPELINE_DEPTH + 1
-            if flat_tid == 0:
-                wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
-            sync_threads()
+                chunk_in_slot = (send_step - start_step) % CHUNKS_PER_SLOT
+                slot = ((send_step - start_step) // CHUNKS_PER_SLOT) % PIPELINE_DEPTH
+                slot_base = (
+                    sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                    + chunk_in_slot * SIGNAL_STRIDE_ELEMS
+                )
+                if chunk_in_slot == 0:
+                    if send_step < start_step + CHUNKS_PER_SLOT * PIPELINE_DEPTH:
+                        wait_target = start_step
+                    else:
+                        wait_target = send_step - CHUNKS_PER_SLOT * PIPELINE_DEPTH + 1
+                    if flat_tid == 0:
+                        wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+                sync_threads()
 
             buf_tile_idx = 0
             tiles_to_send_this_step = min(
-                MAX_TILES_PER_BLOCK_PER_SLOT,
+                TILES_PER_SIGNAL,
                 tl.cdiv(num_send_tiles - send_tile_idx, NUM_SEND_BLOCKS),
             )
             for _i in range(tiles_to_send_this_step):
@@ -267,11 +292,20 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
         recv_step = start_step
 
         while recv_tile_idx < num_recv_tiles:
-            slot = (recv_step - start_step) % PIPELINE_DEPTH
-            slot_base = (
-                receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
-                + slot * BLOCK_STRIDE_ELEMS
-            )
+            if CHUNKS_PER_SLOT == 1:
+                slot = (recv_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+            else:
+                chunk_in_slot = (recv_step - start_step) % CHUNKS_PER_SLOT
+                slot = ((recv_step - start_step) // CHUNKS_PER_SLOT) % PIPELINE_DEPTH
+                slot_base = (
+                    receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                    + chunk_in_slot * SIGNAL_STRIDE_ELEMS
+                )
 
             if flat_tid == 0:
                 wait_ge(tail_local_ptr, (recv_step + 1).to(tl.int64))
@@ -279,7 +313,7 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
 
             buf_tile_idx = 0
             tiles_to_recv_this_step = min(
-                MAX_TILES_PER_BLOCK_PER_SLOT,
+                TILES_PER_SIGNAL,
                 tl.cdiv(num_recv_tiles - recv_tile_idx, NUM_SEND_BLOCKS),
             )
             for _i in range(tiles_to_recv_this_step):
@@ -301,8 +335,20 @@ def triton_nvl_sendrecv_kernel(  # noqa: C901
                 buf_tile_idx += 1
 
             sync_threads()
-            if flat_tid == 0:
-                remote_store_i64_relaxed(head_remote_ptr, (recv_step + 1).to(tl.int64))
+            if CHUNKS_PER_SLOT == 1:
+                if flat_tid == 0:
+                    remote_store_i64_relaxed(
+                        head_remote_ptr, (recv_step + 1).to(tl.int64)
+                    )
+            else:
+                last_in_slot = (chunk_in_slot == CHUNKS_PER_SLOT - 1) or (
+                    recv_tile_idx >= num_recv_tiles
+                )
+                if last_in_slot:
+                    if flat_tid == 0:
+                        remote_store_i64_relaxed(
+                            head_remote_ptr, (recv_step + 1).to(tl.int64)
+                        )
             recv_step += 1
 
         tl.store(recver_step_ptr + receiver_id, recv_step.to(tl.int64))

--- a/comms/pipes/triton/collectives/nvl/sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv.py
@@ -1,0 +1,289 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton NVLink-only copy-based send/recv kernel.
+
+Single peer-pair copy-based send, receive, or bidirectional sendrecv,
+double-buffered staging, monotonic int64 head/tail signaling. CUDA-graph
+replayable via persistent step-state counters that advance across replays.
+
+Scope: 2-rank groups only. ``send_peer`` and ``recv_peer`` are the same
+rank (single ``peer_rank`` arg). This kernel is **not** directly usable
+for Ring AllGather on world_size > 2 — ring needs ``(send_peer,
+recv_peer) = ((rank+1)%N, (rank-1)%N)`` plus per-sender staging slots.
+See ``sendrecv_op.py`` module docstring for the planned API/protocol
+extension.
+
+Architecture
+------------
+
+::
+
+    Rank A (sender)                        Rank B (receiver)
+    ┌─────────────┐                        ┌─────────────┐
+    │ src tensor  │──(1) read──→           │             │
+    │ (local HBM) │            │           │             │
+    └─────────────┘            │           │             │
+                               ▼           │             │
+                   ┌─────────────────────┐ │             │
+                   │ staging buffer      │ │             │
+                   │ (Rank B symm mem)   │─(2) read───→  │
+                   │ [slot 0 | slot 1]   │ │       ▼     │
+                   └─────────────────────┘ │  ┌─────────────┐
+                                           │  │ dst tensor  │
+                                           │  │ (local HBM) │
+                                           │  └─────────────┘
+                                           └────────────────┘
+
+    (1) Sender reads local src, REMOTE-writes to peer's staging buffer
+    (2) Receiver LOCAL-reads its staging buffer, writes to local dst
+
+All remote operations are NVLink fire-and-forget writes (zero NVLink reads).
+
+Block / signal / buffer mapping
+-------------------------------
+
+Each block ``k`` owns a fixed staging-buffer region
+``[k * BLOCK_STRIDE * PIPELINE_DEPTH, (k+1) * BLOCK_STRIDE * PIPELINE_DEPTH)``
+and a fixed ``(head[k], tail[k])`` signal pair. Sender block ``k`` and
+receiver block ``k`` use the SAME signal slot ``k`` and the SAME buffer
+region. The block→region mapping is determined by ``MAX_BLOCKS_PER_DIR``
+(constant) and is independent of the runtime ``NUM_SEND_BLOCKS``, so
+back-to-back kernel launches with different block counts cannot race.
+
+Signal-pad layout per rank (int64 entries; ``MBPD = MAX_BLOCKS_PER_DIR``)::
+
+    [0 .. MBPD):       TAIL — written by remote sender, polled by local receiver
+    [MBPD .. 2*MBPD):  HEAD — written by remote receiver, polled by local sender
+
+Memory ordering:
+
+  * **TAIL** (sender→receiver, publishes payload data): producer uses
+    :func:`fence_and_remote_store_i64` (release fence + relaxed store);
+    consumer uses :func:`wait_ge` (acquire poll). The fence guarantees the
+    receiver sees the staging-buffer data once it sees the new TAIL.
+
+  * **HEAD** (receiver→sender, only transfers slot ownership): producer
+    uses :func:`remote_store_i64_relaxed` (no fence) preceded by a local
+    ``sync_threads()`` execution barrier. Consumer uses
+    :func:`wait_ge_volatile` (no acquire). The sender does not read any
+    payload written by the receiver, so the fence is unnecessary.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from .utils import (
+    fence_and_remote_store_i64,
+    get_flat_tid,
+    remote_store_i64_relaxed,
+    sync_threads,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+_MODE_BIDIRECTIONAL = 0
+_MODE_SEND_ONLY = 1
+_MODE_RECV_ONLY = 2
+
+
+@triton.jit(do_not_specialize=["local_rank", "peer_rank"])
+def triton_nvl_sendrecv_kernel(  # noqa: C901
+    send_ptr,
+    recv_ptr,
+    buffer_ptrs,  # int64 device tensor, shape (world_size,)
+    signal_pad_ptrs,  # int64 device tensor, shape (world_size,)
+    sender_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    recver_step_ptr,  # int64 device tensor, shape (MAX_BLOCKS_PER_DIR,)
+    local_rank,
+    peer_rank,
+    send_numel,
+    recv_numel,
+    TILE_ROWS: tl.constexpr,
+    TILE_COLS: tl.constexpr,
+    BLOCK_STRIDE_ELEMS: tl.constexpr,
+    PIPELINE_DEPTH: tl.constexpr,
+    MAX_BLOCKS_PER_DIR: tl.constexpr,
+    NUM_SEND_BLOCKS: tl.constexpr,
+    MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
+    MODE: tl.constexpr,
+):
+    """NVLink copy-based send/recv kernel.
+
+    Bidirectional mode launches grid ``(2 * NUM_SEND_BLOCKS,)`` and
+    interleaves paired sender/receiver programs: even programs run sender
+    path ``pid // 2`` and odd programs run receiver path ``pid // 2``.
+    Send-only and recv-only modes launch grid ``(NUM_SEND_BLOCKS,)`` and run
+    exactly one path.
+    """
+    TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
+
+    pid = tl.program_id(0)
+    if MODE == _MODE_SEND_ONLY:
+        is_sender = True
+        block_id = pid
+    elif MODE == _MODE_RECV_ONLY:
+        is_sender = False
+        block_id = pid
+    else:
+        is_sender = (pid % 2) == 0
+        block_id = pid // 2
+
+    # ---- Buffer pointers ----
+    # Sender writes to peer rank's staging buffer; receiver reads its own.
+    buffer_ptrs_u64 = buffer_ptrs.to(tl.pointer_type(tl.uint64))
+    remote_buf = tl.load(buffer_ptrs_u64 + peer_rank).to(
+        tl.pointer_type(send_ptr.dtype.element_ty)
+    )
+    local_buf = tl.load(buffer_ptrs_u64 + local_rank).to(
+        tl.pointer_type(recv_ptr.dtype.element_ty)
+    )
+
+    # ---- Signal pad pointers ----
+    signal_pad_ptrs_u64 = signal_pad_ptrs.to(tl.pointer_type(tl.uint64))
+    remote_sig = tl.load(signal_pad_ptrs_u64 + peer_rank).to(tl.pointer_type(tl.int64))
+    local_sig = tl.load(signal_pad_ptrs_u64 + local_rank).to(tl.pointer_type(tl.int64))
+
+    HEAD_OFFSET: tl.constexpr = MAX_BLOCKS_PER_DIR
+
+    flat_tid = get_flat_tid()
+
+    if is_sender:
+        # ===== SENDER =====
+        sender_id = block_id
+
+        # tail: REMOTE — written here, polled by remote receiver
+        # head: LOCAL — polled here, written by remote receiver
+        tail_remote_ptr = remote_sig + sender_id
+        head_local_ptr = local_sig + HEAD_OFFSET + sender_id
+
+        start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
+
+        local_rows = tl.arange(0, TILE_ROWS)
+        local_cols = tl.arange(0, TILE_COLS)
+        num_send_tiles = tl.cdiv(send_numel, TILE_NUMEL)
+
+        # int64 tile index so `send_tile_idx * TILE_NUMEL` cannot overflow
+        # int32 for multi-GiB tensors.
+        send_tile_idx = sender_id.to(tl.int64)
+        send_step = start_step
+
+        while send_tile_idx < num_send_tiles:
+            slot = (send_step - start_step) % PIPELINE_DEPTH
+            slot_base = (
+                sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                + slot * BLOCK_STRIDE_ELEMS
+            )
+
+            # Wait for slot to be free. For the first PIPELINE_DEPTH steps
+            # of a non-first call, the slot may still hold data the remote
+            # receiver has not yet consumed — gate on start_step.
+            if send_step < start_step + PIPELINE_DEPTH:
+                wait_target = start_step
+            else:
+                wait_target = send_step - PIPELINE_DEPTH + 1
+            if flat_tid == 0:
+                wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+            sync_threads()
+
+            buf_tile_idx = 0
+            tiles_to_send_this_step = min(
+                MAX_TILES_PER_BLOCK_PER_SLOT,
+                tl.cdiv(num_send_tiles - send_tile_idx, NUM_SEND_BLOCKS),
+            )
+            for _i in range(tiles_to_send_this_step):
+                flat_idx = (
+                    send_tile_idx * TILE_NUMEL
+                    + local_rows[:, None] * TILE_COLS
+                    + local_cols[None, :]
+                )
+                mask = flat_idx < send_numel
+                data = tl.load(send_ptr + flat_idx.to(tl.int64), mask=mask)
+
+                buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                    tl.int64
+                )
+                tl.store(remote_buf + slot_base + buf_off, data, mask=mask)
+
+                send_tile_idx += NUM_SEND_BLOCKS
+                buf_tile_idx += 1
+
+            sync_threads()
+            # ``bar.sync 0`` ensures all sender threads have finished issuing
+            # their staging stores before thread 0 issues the system fence.
+            # Without this barrier, thread 0's fence would only drain its own
+            # in-flight stores, leaving other threads' stores unsynchronized
+            # with the TAIL publish.
+            if flat_tid == 0:
+                fence_and_remote_store_i64(
+                    tail_remote_ptr, (send_step + 1).to(tl.int64)
+                )
+            send_step += 1
+
+        # Persist for next launch's start_step.
+        tl.store(sender_step_ptr + sender_id, send_step.to(tl.int64))
+
+    else:
+        # ===== RECEIVER =====
+        receiver_id = block_id
+
+        # tail: LOCAL — polled here, written by remote sender
+        # head: REMOTE — written here, polled by remote sender
+        tail_local_ptr = local_sig + receiver_id
+        head_remote_ptr = remote_sig + HEAD_OFFSET + receiver_id
+
+        start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
+
+        local_rows = tl.arange(0, TILE_ROWS)
+        local_cols = tl.arange(0, TILE_COLS)
+        num_recv_tiles = tl.cdiv(recv_numel, TILE_NUMEL)
+
+        # int64 tile index so `recv_tile_idx * TILE_NUMEL` cannot overflow
+        # int32 for multi-GiB tensors.
+        recv_tile_idx = receiver_id.to(tl.int64)
+        recv_step = start_step
+
+        while recv_tile_idx < num_recv_tiles:
+            slot = (recv_step - start_step) % PIPELINE_DEPTH
+            slot_base = (
+                receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                + slot * BLOCK_STRIDE_ELEMS
+            )
+
+            if flat_tid == 0:
+                wait_ge(tail_local_ptr, (recv_step + 1).to(tl.int64))
+            sync_threads()
+
+            buf_tile_idx = 0
+            tiles_to_recv_this_step = min(
+                MAX_TILES_PER_BLOCK_PER_SLOT,
+                tl.cdiv(num_recv_tiles - recv_tile_idx, NUM_SEND_BLOCKS),
+            )
+            for _i in range(tiles_to_recv_this_step):
+                flat_idx = (
+                    recv_tile_idx * TILE_NUMEL
+                    + local_rows[:, None] * TILE_COLS
+                    + local_cols[None, :]
+                )
+                mask = flat_idx < recv_numel
+
+                buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                    tl.int64
+                )
+                data = tl.load(local_buf + slot_base + buf_off, mask=mask)
+                tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
+
+                recv_tile_idx += NUM_SEND_BLOCKS
+                buf_tile_idx += 1
+
+            sync_threads()
+            if flat_tid == 0:
+                remote_store_i64_relaxed(head_remote_ptr, (recv_step + 1).to(tl.int64))
+            recv_step += 1
+
+        tl.store(recver_step_ptr + receiver_id, recv_step.to(tl.int64))

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -31,6 +31,7 @@ Composing collectives from this primitive:
 from __future__ import annotations
 
 import logging
+import os
 from typing import NamedTuple
 
 import torch
@@ -39,6 +40,7 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch._C._distributed_c10d import _SymmetricMemory
 
 from .sendrecv import triton_nvl_sendrecv_kernel
+from .sendrecv_ws import triton_nvl_sendrecv_bidir_ws_kernel
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -49,11 +51,17 @@ logger: logging.Logger = logging.getLogger(__name__)
 # so back-to-back launches with different block counts cannot race.
 # ---------------------------------------------------------------------------
 
-_BLOCK_STRIDE_BYTES: int = 256 * 1024
-_PIPELINE_DEPTH: int = 2
+_BLOCK_STRIDE_BYTES: int = int(
+    os.environ.get("TRITON_NVL_BLOCK_STRIDE_BYTES", str(256 * 1024))
+)
+_PIPELINE_DEPTH: int = int(os.environ.get("TRITON_NVL_PIPELINE_DEPTH", "2"))
 _MAX_BLOCKS_PER_PEER: int = 32
 _DEFAULT_NUM_SEND_BLOCKS: int = 16
 _DEFAULT_NUM_WARPS: int = 8
+_DEFAULT_WS_SENDER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_SENDER_WARPS", "4"))
+_DEFAULT_WS_RECEIVER_WARPS: int = int(
+    os.environ.get("TRITON_NVL_WS_RECEIVER_WARPS", "4")
+)
 _MODE_BIDIRECTIONAL: int = 0
 _MODE_SEND_ONLY: int = 1
 _MODE_RECV_ONLY: int = 2
@@ -69,6 +77,15 @@ def _compute_config(element_size: int) -> _Config:
     return _Config(
         tile_rows=32,
         tile_cols=2048 // element_size,
+        num_stages=2,
+    )
+
+
+def _compute_ws_config(element_size: int) -> _Config:
+    tile_bytes = int(os.environ.get("TRITON_NVL_WS_TILE_BYTES", "2048"))
+    return _Config(
+        tile_rows=32,
+        tile_cols=tile_bytes // element_size,
         num_stages=2,
     )
 
@@ -230,6 +247,58 @@ def triton_nvl_sendrecv(
     )
 
 
+def triton_nvl_sendrecv_ws(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    send_peer: int,
+    recv_peer: int | None = None,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    sender_warps: int = _DEFAULT_WS_SENDER_WARPS,
+    receiver_warps: int = _DEFAULT_WS_RECEIVER_WARPS,
+) -> None:
+    """Warp-specialized bidirectional NVLink send/recv.
+
+    Each CTA runs sender and receiver as concurrent TLX async tasks,
+    allowing both NVLink directions to share the same SM. Default
+    configuration: 4 sender warps + 4 receiver warps = 8 total.
+
+    Limitations:
+        * TLX ``sync_threads()`` has an iteration-count-dependent
+          barrier bug — while-loops with >2 iterations hang. The host
+          launcher computes ``BLOCK_STRIDE_ELEMS`` adaptively to keep
+          the iter count <=2 and raises ``RuntimeError`` if that is not
+          achievable for the given (message size, ``num_blocks``,
+          ``TRITON_NVL_BLOCK_STRIDE_BYTES``) combination.
+          Empirically safe ranges (cap=4) with default 256KB stride:
+          messages up to ~16 MiB; with ``TRITON_NVL_BLOCK_STRIDE_BYTES=2 MiB``
+          up to ~64 MiB. For larger messages, fall back to
+          :func:`triton_nvl_sendrecv` (the stable kernel).
+        * ``sender_warps + receiver_warps`` must be a multiple of 4
+          (TLX warp-specialization codegen requires it).
+    """
+    if recv_peer is None:
+        recv_peer = send_peer
+    assert send_buf.is_cuda and recv_buf.is_cuda
+    assert send_buf.is_contiguous() and recv_buf.is_contiguous()
+    assert send_buf.dtype == recv_buf.dtype
+    assert send_buf.numel() == recv_buf.numel()
+    _launch(
+        send_buf,
+        recv_buf,
+        send_peer,
+        recv_peer,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=sender_warps + receiver_warps,
+        mode=_MODE_BIDIRECTIONAL,
+        warp_specialized=True,
+        sender_warps=sender_warps,
+        receiver_warps=receiver_warps,
+    )
+
+
 def triton_nvl_send(
     send_buf: torch.Tensor,
     send_peer: int,
@@ -292,6 +361,9 @@ def _launch(
     num_blocks: int,
     num_warps: int,
     mode: int,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> None:
     assert send_buf.dtype == recv_buf.dtype, (
         f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
@@ -299,9 +371,26 @@ def _launch(
     assert 0 < num_blocks <= _MAX_BLOCKS_PER_PEER, (
         f"num_blocks must be in (0, {_MAX_BLOCKS_PER_PEER}], got {num_blocks}"
     )
-    assert num_warps in (4, 8), (
-        f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
-    )
+    if warp_specialized:
+        assert 1 <= sender_warps <= 8, (
+            f"sender_warps must be in [1, 8], got {sender_warps}"
+        )
+        assert 1 <= receiver_warps <= 8, (
+            f"receiver_warps must be in [1, 8], got {receiver_warps}"
+        )
+        total = sender_warps + receiver_warps
+        # TLX requires `num_warps` to be a multiple of 4 for warp
+        # specialization. (1+1=2 and similar small splits are rejected
+        # downstream by the TritonTLXFixup MLIR pass.)
+        assert total % 4 == 0 and total <= 16, (
+            f"sender_warps + receiver_warps must be a multiple of 4 "
+            f"in [4, 16] (TLX warp-spec requirement), "
+            f"got {sender_warps} + {receiver_warps} = {total}"
+        )
+    else:
+        assert num_warps in (4, 8), (
+            f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
+        )
 
     world_size = dist.get_world_size(group)
     if world_size == 1:
@@ -319,14 +408,54 @@ def _launch(
         group, send_buf.device, world_size
     )
 
-    config = _compute_config(send_buf.element_size())
-    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
-    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
+    config = (
+        _compute_ws_config(send_buf.element_size())
+        if warp_specialized
+        else _compute_config(send_buf.element_size())
+    )
     tile_numel = config.tile_rows * config.tile_cols
     tile_bytes = tile_numel * send_buf.element_size()
-    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
 
-    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+    orig_block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    if warp_specialized:
+        # Adaptive stride: pick the smallest stride that keeps the
+        # while-loop iter count <= 2 (TLX `sync_threads()` bug).
+        # `max_ws_stride` caps per-block staging so the sum across all
+        # `num_blocks` blocks fits within the per-peer staging quota
+        # `_BLOCK_STRIDE_BYTES * _MAX_BLOCKS_PER_PEER` (and thus within
+        # `staging_elems` below); enforces no buffer overflow even when
+        # the requested stride to land iters<=2 is large.
+        max_ws_stride = _BLOCK_STRIDE_BYTES * _MAX_BLOCKS_PER_PEER // num_blocks
+        num_tiles = -(-send_buf.numel() // tile_numel)
+        tiles_per_block = -(-num_tiles // num_blocks)
+        target_tiles_per_step = -(-tiles_per_block // 2)
+        needed_stride = target_tiles_per_step * tile_bytes
+        ws_stride = max(min(needed_stride, max_ws_stride), _BLOCK_STRIDE_BYTES)
+        block_stride_elems = ws_stride // send_buf.element_size()
+        max_tiles_per_block_per_slot = max(ws_stride // tile_bytes, 1)
+        # Fail-loud on the TLX iteration bug: if the requested stride
+        # was capped below `needed_stride`, the achievable iters/block
+        # may exceed 2 and hang the kernel. Compute the realized iter
+        # count and refuse to launch if it exceeds the safe bound.
+        ws_iters_per_block = -(-tiles_per_block // max_tiles_per_block_per_slot)
+        if ws_iters_per_block > 2:
+            raise RuntimeError(
+                f"triton_nvl_sendrecv_ws would require "
+                f"{ws_iters_per_block} loop iterations per block (>2), "
+                f"which triggers a TLX `sync_threads()` barrier bug and "
+                f"hangs the kernel "
+                f"(numel={send_buf.numel()}, num_blocks={num_blocks}, "
+                f"BLOCK_STRIDE_BYTES={_BLOCK_STRIDE_BYTES}). Either reduce "
+                f"the message size, increase num_blocks, raise "
+                f"TRITON_NVL_BLOCK_STRIDE_BYTES, or fall back to "
+                f"triton_nvl_sendrecv() for large messages."
+            )
+    else:
+        block_stride_elems = orig_block_stride_elems
+        max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = orig_block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
 
     # --- Pre-resolve staging buffers for the specific peer pair ---
     # Sender writes to send_peer's staging area at local_rank's partition.
@@ -365,6 +494,38 @@ def _launch(
     # --- Pre-slice step state to the peer rows ---
     sender_step_ptr = sender_step_all[send_peer]
     recver_step_ptr = recver_step_all[recv_peer]
+
+    if warp_specialized:
+        grid = (num_blocks,)
+        # pyre-ignore[28]: triton's `kernel[grid](...)` launcher
+        triton_nvl_sendrecv_bidir_ws_kernel[grid](
+            send_ptr=send_buf,
+            recv_ptr=recv_buf,
+            send_staging_buf=send_staging_buf,
+            recv_staging_buf=recv_staging_buf,
+            send_tail_sig=send_tail_sig,
+            send_head_sig=send_head_sig,
+            recv_tail_sig=recv_tail_sig,
+            recv_head_sig=recv_head_sig,
+            sender_step_ptr=sender_step_ptr,
+            recver_step_ptr=recver_step_ptr,
+            send_numel=send_buf.numel(),
+            recv_numel=recv_buf.numel(),
+            TILE_ROWS=config.tile_rows,
+            TILE_COLS=config.tile_cols,
+            BLOCK_STRIDE_ELEMS=block_stride_elems,
+            PIPELINE_DEPTH=_PIPELINE_DEPTH,
+            MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
+            NUM_SEND_BLOCKS=num_blocks,
+            NUM_SENDER_WARPS=sender_warps,
+            NUM_RECEIVER_WARPS=receiver_warps,
+            num_warps=num_warps,
+            # WS uses TLX async_task for pipelining; disable Triton's
+            # software pipelining to avoid stage interleaving on top of
+            # the explicit sender/receiver task split.
+            num_stages=0,
+        )
+        return
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -7,22 +7,25 @@
 Allocates (and caches) the symmetric memory staging buffer plus the
 persistent step-state tensors, computes a kernel config, and launches.
 
-v1 scope (intentionally narrow):
+Supports **N-rank groups** with separate ``send_peer`` and ``recv_peer``
+arguments. Each rank's staging buffer is partitioned by sender rank,
+matching the layout used by ``all_to_all_single.py``. The signal pad
+uses a per-(peer, block) layout: TAIL at ``[peer * MBPP + block_id]``
+and HEAD at ``[HEAD_OFFSET + peer * MBPP + block_id]`` where
+``HEAD_OFFSET = world_size * MAX_BLOCKS_PER_PEER``.
 
-  * **2-rank groups only**. The staging buffer holds a single peer pair's
-    slot and the API takes a single ``peer_rank`` used for both directions
-    (sender → ``peer_rank``, receiver ← ``peer_rank``).
-  * Copy-based send-only, recv-only, and bidirectional sendrecv between
-    this rank and ``peer_rank``. Peer ranks must launch matching operations
-    simultaneously.
+Since ``send_peer`` and ``recv_peer`` are known at host launch time,
+the host pre-resolves all staging buffer, signal pad, and step state
+pointers for the specific peer pair. This preserves the direct typed
+tensor argument pattern in the kernel, avoiding the store scalarization
+(``STG.E.U16``) that pointer-of-pointer indirection causes.
 
-The bidirectional single-peer API is **not** directly composable into Ring AllGather on N>2 ranks —
-ring needs ``send_peer = (rank+1)%N`` paired with ``recv_peer =
-(rank-1)%N`` (different peers per direction), and the staging buffer
-needs per-sender slots like the MSL ``all_to_all_single_non_contig``
-kernel uses. The follow-up to add ring AllGather will introduce a
-``triton_nvl_sendrecv(send, recv, send_peer, recv_peer, ...)`` variant
-plus per-peer staging slots indexed by sender rank.
+Composing collectives from this primitive:
+
+  * **Ring AllGather**: call ``triton_nvl_sendrecv`` with
+    ``send_peer = (rank + 1) % N``, ``recv_peer = (rank - 1) % N``
+    in a host loop over N-1 ring steps.
+  * **Bidirectional exchange**: ``send_peer == recv_peer`` (the v1 API).
 """
 
 from __future__ import annotations
@@ -48,7 +51,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 _BLOCK_STRIDE_BYTES: int = 256 * 1024
 _PIPELINE_DEPTH: int = 2
-_MAX_BLOCKS_PER_DIR: int = 32
+_MAX_BLOCKS_PER_PEER: int = 32
 _DEFAULT_NUM_SEND_BLOCKS: int = 16
 _DEFAULT_NUM_WARPS: int = 8
 _MODE_BIDIRECTIONAL: int = 0
@@ -70,8 +73,8 @@ def _compute_config(element_size: int) -> _Config:
     )
 
 
-def _per_pair_bytes() -> int:
-    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_DIR
+def _per_peer_bytes() -> int:
+    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_PEER
 
 
 # ---------------------------------------------------------------------------
@@ -84,37 +87,56 @@ def _per_pair_bytes() -> int:
 # caller multiplexes threads onto a single PG, wrap these in a lock.
 # ---------------------------------------------------------------------------
 
-_HANDLE_CACHE: dict[dist.ProcessGroup, _SymmetricMemory] = {}
+_HANDLE_CACHE: dict[tuple[dist.ProcessGroup, torch.device], _SymmetricMemory] = {}
 
 _STEP_STATE_CACHE: dict[
-    dist.ProcessGroup,
+    tuple[dist.ProcessGroup, torch.device],
     tuple[torch.Tensor, torch.Tensor],
 ] = {}
+
+
+def _required_signal_pad_bytes(world_size: int) -> int:
+    return 2 * world_size * _MAX_BLOCKS_PER_PEER * 8  # int64 = 8 bytes
 
 
 def _get_staging_buffer(
     group: dist.ProcessGroup,
     device: torch.device,
+    world_size: int,
 ) -> _SymmetricMemory:
     """Get or create the symmetric memory handle for ``group``.
 
-    The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
-    on each block. ``symm_mem.empty`` zeroes the entire allocation including
-    the signal pad (via ``cudaMemset`` in CUDASymmetricMemory.cu's
-    ``allocate``), so the first launch is safe. We additionally zero the
-    signal pad explicitly + barrier so the invariant holds even if the
-    underlying allocator behaviour changes in a future torch release.
+    Staging is sized for N-rank: ``per_peer_bytes * world_size``.
+
+    The signal-pad sufficiency check runs only on the first allocation
+    for a given ``(group, device)``. Callers must call
+    ``symm_mem.set_signal_pad_size()`` before the first launch on any
+    process group; lazy reconfiguration after the first launch will not
+    be re-validated for already-cached groups.
     """
-    cached = _HANDLE_CACHE.get(group)
+    cache_key = (group, device)
+    cached = _HANDLE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
-    num_bytes = _per_pair_bytes()
+    num_bytes = _per_peer_bytes() * world_size
     logger.info(
-        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes",
+        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes (%d ranks)",
         group.group_desc,
         num_bytes,
+        world_size,
     )
+
+    required_sig = _required_signal_pad_bytes(world_size)
+    current_sig = symm_mem.get_signal_pad_size()
+    if current_sig < required_sig:
+        raise RuntimeError(
+            f"Signal pad too small for {world_size}-rank group with "
+            f"{_MAX_BLOCKS_PER_PEER} blocks per peer: need {required_sig} bytes, "
+            f"have {current_sig}. Call symm_mem.set_signal_pad_size() before "
+            f"first allocation."
+        )
+
     raw = symm_mem.empty(num_bytes, dtype=torch.uint8, device=device)
     handle = symm_mem.rendezvous(raw, group=group)
     # Defensive: explicitly zero the signal pad before any block can poll it.
@@ -122,23 +144,30 @@ def _get_staging_buffer(
     # rendezvous-then-barrier sequence below guarantees that.
     handle.get_signal_pad(handle.rank).zero_()
     dist.barrier(group)
-    _HANDLE_CACHE[group] = handle
+    _HANDLE_CACHE[cache_key] = handle
     return handle
 
 
 def _get_step_state(
     group: dist.ProcessGroup,
     device: torch.device,
+    world_size: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Get or create persistent monotonic step counters for ``group``."""
-    cached = _STEP_STATE_CACHE.get(group)
+    """Get or create persistent monotonic step counters for ``group``.
+
+    Shape: ``(world_size, MAX_BLOCKS_PER_PEER)`` — one counter per
+    (peer, block) pair.
+    """
+    cache_key = (group, device)
+    cached = _STEP_STATE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
-    sender_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
-    recver_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
-    _STEP_STATE_CACHE[group] = (sender_step, recver_step)
-    return _STEP_STATE_CACHE[group]
+    shape = (world_size, _MAX_BLOCKS_PER_PEER)
+    sender_step = torch.zeros(shape, dtype=torch.int64, device=device)
+    recver_step = torch.zeros(shape, dtype=torch.int64, device=device)
+    _STEP_STATE_CACHE[cache_key] = (sender_step, recver_step)
+    return _STEP_STATE_CACHE[cache_key]
 
 
 # ---------------------------------------------------------------------------
@@ -149,38 +178,42 @@ def _get_step_state(
 def triton_nvl_sendrecv(
     send_buf: torch.Tensor,
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
+    recv_peer: int | None = None,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Bidirectional NVLink copy-based send/recv between this rank and ``peer_rank``.
+    """Bidirectional NVLink copy-based send/recv.
 
-    Both ranks in the (sender, receiver) pair must call this function
-    simultaneously. ``send_buf`` and ``recv_buf`` must have the same shape
-    and dtype on both ranks.
+    Sends ``send_buf`` to ``send_peer`` and receives into ``recv_buf``
+    from ``recv_peer`` (defaults to ``send_peer`` if not given).
 
-    .. warning::
-        ``dtype`` and ``numel`` of ``send_buf`` / ``recv_buf`` MUST match
-        between the two ranks. There is no cross-rank validation; a
-        mismatch silently produces wrong staging slot offsets and
-        corrupts data.
+    Both peers must issue matching operations simultaneously:
+    ``send_peer`` must recv from this rank, and ``recv_peer`` must
+    send to this rank.
 
     Args:
-        send_buf: Source tensor to send to ``peer_rank``. Contiguous, CUDA.
-        recv_buf: Destination tensor to receive from ``peer_rank``. Contiguous, CUDA.
-        peer_rank: Rank in ``group`` to exchange with. ``send_peer`` and
-            ``recv_peer`` are the same rank in v1; see the module docstring
-            for why this is **not** directly extensible to Ring AllGather.
-        group: Process group used for symm-mem rendezvous. **v1 requires
-            size 2** — the assertion below is the enforcement point.
-        num_blocks: Thread blocks per direction. Defaults to 16. The actual
-            grid is ``2 * num_blocks`` for bidirectional mode (so default
-            gives a 32-block grid, apple-to-apple with NCCL's 32 channels)
-            and ``num_blocks`` for send-only / recv-only.
-        num_warps: Triton warps per block. Defaults to 8.
+        send_buf: Source tensor to send. Contiguous, CUDA.
+        recv_buf: Destination tensor to receive into. Contiguous, CUDA.
+        send_peer: Rank in ``group`` to send to.
+        recv_peer: Rank in ``group`` to receive from. Defaults to
+            ``send_peer`` for bidirectional exchange with a single peer.
+        group: Process group. Supports any world_size >= 2.
+        num_blocks: Thread blocks per direction.
+        num_warps: Triton warps per block.
+
+    Note: ``send_buf.numel()`` and ``recv_buf.numel()`` are passed as
+    Triton specialization constants. Each distinct ``(send_numel,
+    recv_numel)`` pair triggers a kernel recompile, which is the
+    intentional cost of preserving ~8.8 ms launch perf at 1 GiB. Ring
+    AllGather (single shard size per process) is unaffected; callers
+    driving many distinct sizes per process should consider reusing
+    fixed-size scratch buffers.
     """
+    if recv_peer is None:
+        recv_peer = send_peer
     assert send_buf.is_cuda and recv_buf.is_cuda
     assert send_buf.is_contiguous() and recv_buf.is_contiguous()
     assert send_buf.dtype == recv_buf.dtype
@@ -188,7 +221,8 @@ def triton_nvl_sendrecv(
     _launch(
         send_buf,
         recv_buf,
-        peer_rank,
+        send_peer,
+        recv_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -198,23 +232,23 @@ def triton_nvl_sendrecv(
 
 def triton_nvl_send(
     send_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Send ``send_buf`` to ``peer_rank`` over NVLink using copy-based staging.
+    """Send ``send_buf`` to ``send_peer`` over NVLink using copy-based staging.
 
     Caller is responsible for ensuring the peer rank issues a matching
-    ``triton_nvl_recv`` with the same ``dtype`` and ``numel`` — there is
-    no cross-rank validation.
+    ``triton_nvl_recv`` with the same ``dtype`` and ``numel``.
     """
     assert send_buf.is_cuda and send_buf.is_contiguous()
     _launch(
         send_buf,
         send_buf,
-        peer_rank,
+        send_peer,
+        send_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -224,23 +258,23 @@ def triton_nvl_send(
 
 def triton_nvl_recv(
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    recv_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
 ) -> None:
-    """Receive into ``recv_buf`` from ``peer_rank`` over NVLink.
+    """Receive into ``recv_buf`` from ``recv_peer`` over NVLink.
 
     Caller is responsible for ensuring the peer rank issues a matching
-    ``triton_nvl_send`` with the same ``dtype`` and ``numel`` — there is
-    no cross-rank validation.
+    ``triton_nvl_send`` with the same ``dtype`` and ``numel``.
     """
     assert recv_buf.is_cuda and recv_buf.is_contiguous()
     _launch(
         recv_buf,
         recv_buf,
-        peer_rank,
+        recv_peer,
+        recv_peer,
         group=group,
         num_blocks=num_blocks,
         num_warps=num_warps,
@@ -251,7 +285,8 @@ def triton_nvl_recv(
 def _launch(
     send_buf: torch.Tensor,
     recv_buf: torch.Tensor,
-    peer_rank: int,
+    send_peer: int,
+    recv_peer: int,
     *,
     group: dist.ProcessGroup,
     num_blocks: int,
@@ -261,8 +296,8 @@ def _launch(
     assert send_buf.dtype == recv_buf.dtype, (
         f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
     )
-    assert 0 < num_blocks <= _MAX_BLOCKS_PER_DIR, (
-        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_DIR}], got {num_blocks}"
+    assert 0 < num_blocks <= _MAX_BLOCKS_PER_PEER, (
+        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_PEER}], got {num_blocks}"
     )
     assert num_warps in (4, 8), (
         f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
@@ -273,64 +308,91 @@ def _launch(
         recv_buf.copy_(send_buf)
         return
 
-    # v1 limit: single peer-pair staging buffer means we cannot service more
-    # than one (sender, receiver) pair per group. Lift this restriction in
-    # the follow-up that adds per-peer staging slots for Ring AllGather.
-    assert world_size == 2, (
-        f"triton_nvl_sendrecv v1 supports only 2-rank groups, got world_size={world_size}. "
-        "See module docstring for the planned per-peer slot API."
+    local_rank = dist.get_rank(group)
+    assert send_peer != local_rank, "send_peer must differ from local rank"
+    assert recv_peer != local_rank, "recv_peer must differ from local rank"
+    assert 0 <= send_peer < world_size
+    assert 0 <= recv_peer < world_size
+
+    handle = _get_staging_buffer(group, send_buf.device, world_size)
+    sender_step_all, recver_step_all = _get_step_state(
+        group, send_buf.device, world_size
     )
 
-    local_rank = dist.get_rank(group)
-    assert peer_rank != local_rank
-    assert 0 <= peer_rank < world_size
+    config = _compute_config(send_buf.element_size())
+    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
+    tile_numel = config.tile_rows * config.tile_cols
+    tile_bytes = tile_numel * send_buf.element_size()
+    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+
+    # --- Pre-resolve staging buffers for the specific peer pair ---
+    # Sender writes to send_peer's staging area at local_rank's partition.
+    # Receiver reads from local staging area at recv_peer's partition.
+    send_staging_buf = handle.get_buffer(
+        send_peer,
+        sizes=[staging_elems],
+        dtype=send_buf.dtype,
+        storage_offset=local_rank * per_peer_elems,
+    )
+    recv_staging_buf = handle.get_buffer(
+        local_rank,
+        sizes=[staging_elems],
+        dtype=recv_buf.dtype,
+        storage_offset=recv_peer * per_peer_elems,
+    )
+
+    # --- Pre-resolve signal pad pointers for the specific peer pair ---
+    # Signal layout per rank (int64 entries):
+    #   [0 .. W*MBPP):       TAIL[peer * MBPP + block_id]
+    #   [W*MBPP .. 2*W*MBPP): HEAD[peer * MBPP + block_id]
+    head_offset = world_size * _MAX_BLOCKS_PER_PEER
+
+    send_peer_sig = handle.get_signal_pad(send_peer).view(torch.int64)
+    recv_peer_sig = handle.get_signal_pad(recv_peer).view(torch.int64)
+    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
+
+    # Sender: tail on send_peer written by local_rank, head on local polled for send_peer
+    send_tail_sig = send_peer_sig[local_rank * _MAX_BLOCKS_PER_PEER :]
+    send_head_sig = local_sig[head_offset + send_peer * _MAX_BLOCKS_PER_PEER :]
+
+    # Receiver: tail on local polled for recv_peer, head on recv_peer written by local_rank
+    recv_tail_sig = local_sig[recv_peer * _MAX_BLOCKS_PER_PEER :]
+    recv_head_sig = recv_peer_sig[head_offset + local_rank * _MAX_BLOCKS_PER_PEER :]
+
+    # --- Pre-slice step state to the peer rows ---
+    sender_step_ptr = sender_step_all[send_peer]
+    recver_step_ptr = recver_step_all[recv_peer]
+
+    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
     # Buffer and signal pad pointers are passed as direct typed tensors
     # (not pointer-of-pointer int64 tensors) so Triton emits 128-bit
     # vectorized stores instead of 16-bit scalar stores. See the kernel
     # docstring in sendrecv.py for the codegen rationale.
-    handle = _get_staging_buffer(group, send_buf.device)
-    sender_step, recver_step = _get_step_state(group, send_buf.device)
-
-    config = _compute_config(send_buf.element_size())
-    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
-    tile_numel = config.tile_rows * config.tile_cols
-    tile_bytes = tile_numel * send_buf.element_size()
-    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
-
-    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_DIR * _PIPELINE_DEPTH
-    remote_buf = handle.get_buffer(
-        peer_rank, sizes=[staging_elems], dtype=send_buf.dtype
-    )
-    local_buf = handle.get_buffer(
-        local_rank, sizes=[staging_elems], dtype=recv_buf.dtype
-    )
-    remote_sig = handle.get_signal_pad(peer_rank).view(torch.int64)
-    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
-
-    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
-
     # pyre-ignore[28]: triton's `kernel[grid](...)` launcher accepts JIT-special
     # kwargs (`num_warps`, `num_stages`) that pyre can't see in the kernel
     # function's own signature. Not a real type error.
     triton_nvl_sendrecv_kernel[grid](
         send_ptr=send_buf,
         recv_ptr=recv_buf,
-        remote_buf=remote_buf,
-        local_buf=local_buf,
-        remote_sig=remote_sig,
-        local_sig=local_sig,
-        sender_step_ptr=sender_step,
-        recver_step_ptr=recver_step,
-        local_rank=local_rank,
-        peer_rank=peer_rank,
+        send_staging_buf=send_staging_buf,
+        recv_staging_buf=recv_staging_buf,
+        send_tail_sig=send_tail_sig,
+        send_head_sig=send_head_sig,
+        recv_tail_sig=recv_tail_sig,
+        recv_head_sig=recv_head_sig,
+        sender_step_ptr=sender_step_ptr,
+        recver_step_ptr=recver_step_ptr,
         send_numel=send_buf.numel(),
         recv_numel=recv_buf.numel(),
         TILE_ROWS=config.tile_rows,
         TILE_COLS=config.tile_cols,
         BLOCK_STRIDE_ELEMS=block_stride_elems,
         PIPELINE_DEPTH=_PIPELINE_DEPTH,
-        MAX_BLOCKS_PER_DIR=_MAX_BLOCKS_PER_DIR,
+        MAX_BLOCKS_PER_PEER=_MAX_BLOCKS_PER_PEER,
         NUM_SEND_BLOCKS=num_blocks,
         MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
         MODE=mode,

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -33,6 +33,7 @@ from typing import NamedTuple
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
 
 from .sendrecv import triton_nvl_sendrecv_kernel
 
@@ -83,10 +84,7 @@ def _per_pair_bytes() -> int:
 # caller multiplexes threads onto a single PG, wrap these in a lock.
 # ---------------------------------------------------------------------------
 
-_BUFFER_CACHE: dict[
-    dist.ProcessGroup,
-    tuple[object, torch.Tensor, torch.Tensor],  # (handle, buf_ptrs, sig_ptrs)
-] = {}
+_HANDLE_CACHE: dict[dist.ProcessGroup, _SymmetricMemory] = {}
 
 _STEP_STATE_CACHE: dict[
     dist.ProcessGroup,
@@ -97,8 +95,8 @@ _STEP_STATE_CACHE: dict[
 def _get_staging_buffer(
     group: dist.ProcessGroup,
     device: torch.device,
-) -> tuple[object, torch.Tensor, torch.Tensor]:
-    """Get or create the symmetric memory staging buffer for ``group``.
+) -> _SymmetricMemory:
+    """Get or create the symmetric memory handle for ``group``.
 
     The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
     on each block. ``symm_mem.empty`` zeroes the entire allocation including
@@ -107,7 +105,7 @@ def _get_staging_buffer(
     signal pad explicitly + barrier so the invariant holds even if the
     underlying allocator behaviour changes in a future torch release.
     """
-    cached = _BUFFER_CACHE.get(group)
+    cached = _HANDLE_CACHE.get(group)
     if cached is not None:
         return cached
 
@@ -124,10 +122,8 @@ def _get_staging_buffer(
     # rendezvous-then-barrier sequence below guarantees that.
     handle.get_signal_pad(handle.rank).zero_()
     dist.barrier(group)
-    buf_ptrs = torch.tensor(handle.buffer_ptrs, device=device, dtype=torch.int64)
-    sig_ptrs = torch.tensor(handle.signal_pad_ptrs, device=device, dtype=torch.int64)
-    _BUFFER_CACHE[group] = (handle, buf_ptrs, sig_ptrs)
-    return _BUFFER_CACHE[group]
+    _HANDLE_CACHE[group] = handle
+    return handle
 
 
 def _get_step_state(
@@ -289,7 +285,11 @@ def _launch(
     assert peer_rank != local_rank
     assert 0 <= peer_rank < world_size
 
-    _, buf_ptrs, sig_ptrs = _get_staging_buffer(group, send_buf.device)
+    # Buffer and signal pad pointers are passed as direct typed tensors
+    # (not pointer-of-pointer int64 tensors) so Triton emits 128-bit
+    # vectorized stores instead of 16-bit scalar stores. See the kernel
+    # docstring in sendrecv.py for the codegen rationale.
+    handle = _get_staging_buffer(group, send_buf.device)
     sender_step, recver_step = _get_step_state(group, send_buf.device)
 
     config = _compute_config(send_buf.element_size())
@@ -297,6 +297,16 @@ def _launch(
     tile_numel = config.tile_rows * config.tile_cols
     tile_bytes = tile_numel * send_buf.element_size()
     max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_DIR * _PIPELINE_DEPTH
+    remote_buf = handle.get_buffer(
+        peer_rank, sizes=[staging_elems], dtype=send_buf.dtype
+    )
+    local_buf = handle.get_buffer(
+        local_rank, sizes=[staging_elems], dtype=recv_buf.dtype
+    )
+    remote_sig = handle.get_signal_pad(peer_rank).view(torch.int64)
+    local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
@@ -306,8 +316,10 @@ def _launch(
     triton_nvl_sendrecv_kernel[grid](
         send_ptr=send_buf,
         recv_ptr=recv_buf,
-        buffer_ptrs=buf_ptrs,
-        signal_pad_ptrs=sig_ptrs,
+        remote_buf=remote_buf,
+        local_buf=local_buf,
+        remote_sig=remote_sig,
+        local_sig=local_sig,
         sender_step_ptr=sender_step,
         recver_step_ptr=recver_step,
         local_rank=local_rank,

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -20,6 +20,18 @@ pointers for the specific peer pair. This preserves the direct typed
 tensor argument pattern in the kernel, avoiding the store scalarization
 (``STG.E.U16``) that pointer-of-pointer indirection causes.
 
+Tuning parameters are loaded from a per-kernel JSON config file
+(``tuning_sendrecv.json``) keyed by ``(hardware, num_peers, msg_size)``.
+Environment variables override JSON config for debugging.
+
+Two kernel variants:
+
+- **Stable kernel** (``sendrecv.py``): supports sub-slot signaling via
+  ``signal_bytes`` for latency vs throughput trade-off.
+- **WS kernel** (``sendrecv_ws.py``): warp-specialized bidirectional with
+  concurrent sender/receiver TLX async tasks. No sub-slot signaling
+  (TLX barrier limitation). Adaptive stride as safety clamp.
+
 Composing collectives from this primitive:
 
   * **Ring AllGather**: call ``triton_nvl_sendrecv`` with
@@ -41,6 +53,7 @@ from torch._C._distributed_c10d import _SymmetricMemory
 
 from .sendrecv import triton_nvl_sendrecv_kernel
 from .sendrecv_ws import triton_nvl_sendrecv_bidir_ws_kernel
+from .tuning_config import _detect_hardware, get_sendrecv_config
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -54,40 +67,21 @@ logger: logging.Logger = logging.getLogger(__name__)
 _BLOCK_STRIDE_BYTES: int = int(
     os.environ.get("TRITON_NVL_BLOCK_STRIDE_BYTES", str(256 * 1024))
 )
-_PIPELINE_DEPTH: int = int(os.environ.get("TRITON_NVL_PIPELINE_DEPTH", "2"))
+_PIPELINE_DEPTH: int = 2
 _MAX_BLOCKS_PER_PEER: int = 32
-_DEFAULT_NUM_SEND_BLOCKS: int = 16
-_DEFAULT_NUM_WARPS: int = 8
-_DEFAULT_WS_SENDER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_SENDER_WARPS", "4"))
-_DEFAULT_WS_RECEIVER_WARPS: int = int(
-    os.environ.get("TRITON_NVL_WS_RECEIVER_WARPS", "4")
-)
 _MODE_BIDIRECTIONAL: int = 0
 _MODE_SEND_ONLY: int = 1
 _MODE_RECV_ONLY: int = 2
+
+# Sentinel defaults — when these are passed, JSON config is used instead.
+_SENTINEL_NUM_BLOCKS: int = -1
+_SENTINEL_NUM_WARPS: int = -1
 
 
 class _Config(NamedTuple):
     tile_rows: int
     tile_cols: int
     num_stages: int
-
-
-def _compute_config(element_size: int) -> _Config:
-    return _Config(
-        tile_rows=32,
-        tile_cols=2048 // element_size,
-        num_stages=2,
-    )
-
-
-def _compute_ws_config(element_size: int) -> _Config:
-    tile_bytes = int(os.environ.get("TRITON_NVL_WS_TILE_BYTES", "2048"))
-    return _Config(
-        tile_rows=32,
-        tile_cols=tile_bytes // element_size,
-        num_stages=2,
-    )
 
 
 def _per_peer_bytes() -> int:
@@ -113,7 +107,7 @@ _STEP_STATE_CACHE: dict[
 
 
 def _required_signal_pad_bytes(world_size: int) -> int:
-    return 2 * world_size * _MAX_BLOCKS_PER_PEER * 8  # int64 = 8 bytes
+    return 2 * world_size * _MAX_BLOCKS_PER_PEER * 8
 
 
 def _get_staging_buffer(
@@ -138,7 +132,8 @@ def _get_staging_buffer(
 
     num_bytes = _per_peer_bytes() * world_size
     logger.info(
-        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes (%d ranks)",
+        "triton_nvl_sendrecv staging cache miss on PG %s: "
+        "allocating %d bytes (%d ranks)",
         group.group_desc,
         num_bytes,
         world_size,
@@ -149,9 +144,9 @@ def _get_staging_buffer(
     if current_sig < required_sig:
         raise RuntimeError(
             f"Signal pad too small for {world_size}-rank group with "
-            f"{_MAX_BLOCKS_PER_PEER} blocks per peer: need {required_sig} bytes, "
-            f"have {current_sig}. Call symm_mem.set_signal_pad_size() before "
-            f"first allocation."
+            f"{_MAX_BLOCKS_PER_PEER} blocks per peer: need {required_sig} "
+            f"bytes, have {current_sig}. Call symm_mem.set_signal_pad_size() "
+            f"before first allocation."
         )
 
     raw = symm_mem.empty(num_bytes, dtype=torch.uint8, device=device)
@@ -199,8 +194,8 @@ def triton_nvl_sendrecv(
     recv_peer: int | None = None,
     *,
     group: dist.ProcessGroup,
-    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
-    num_warps: int = _DEFAULT_NUM_WARPS,
+    num_blocks: int = _SENTINEL_NUM_BLOCKS,
+    num_warps: int = _SENTINEL_NUM_WARPS,
 ) -> None:
     """Bidirectional NVLink copy-based send/recv.
 
@@ -254,9 +249,9 @@ def triton_nvl_sendrecv_ws(
     recv_peer: int | None = None,
     *,
     group: dist.ProcessGroup,
-    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
-    sender_warps: int = _DEFAULT_WS_SENDER_WARPS,
-    receiver_warps: int = _DEFAULT_WS_RECEIVER_WARPS,
+    num_blocks: int = _SENTINEL_NUM_BLOCKS,
+    sender_warps: int = -1,
+    receiver_warps: int = -1,
 ) -> None:
     """Warp-specialized bidirectional NVLink send/recv.
 
@@ -291,7 +286,7 @@ def triton_nvl_sendrecv_ws(
         recv_peer,
         group=group,
         num_blocks=num_blocks,
-        num_warps=sender_warps + receiver_warps,
+        num_warps=0,
         mode=_MODE_BIDIRECTIONAL,
         warp_specialized=True,
         sender_warps=sender_warps,
@@ -304,8 +299,8 @@ def triton_nvl_send(
     send_peer: int,
     *,
     group: dist.ProcessGroup,
-    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
-    num_warps: int = _DEFAULT_NUM_WARPS,
+    num_blocks: int = _SENTINEL_NUM_BLOCKS,
+    num_warps: int = _SENTINEL_NUM_WARPS,
 ) -> None:
     """Send ``send_buf`` to ``send_peer`` over NVLink using copy-based staging.
 
@@ -330,8 +325,8 @@ def triton_nvl_recv(
     recv_peer: int,
     *,
     group: dist.ProcessGroup,
-    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
-    num_warps: int = _DEFAULT_NUM_WARPS,
+    num_blocks: int = _SENTINEL_NUM_BLOCKS,
+    num_warps: int = _SENTINEL_NUM_WARPS,
 ) -> None:
     """Receive into ``recv_buf`` from ``recv_peer`` over NVLink.
 
@@ -362,12 +357,55 @@ def _launch(
     num_warps: int,
     mode: int,
     warp_specialized: bool = False,
-    sender_warps: int = 4,
-    receiver_warps: int = 4,
+    sender_warps: int = -1,
+    receiver_warps: int = -1,
 ) -> None:
-    assert send_buf.dtype == recv_buf.dtype, (
-        f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
+    assert send_buf.dtype == recv_buf.dtype
+
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        recv_buf.copy_(send_buf)
+        return
+
+    local_rank = dist.get_rank(group)
+    assert send_peer != local_rank
+    assert recv_peer != local_rank
+    assert 0 <= send_peer < world_size
+    assert 0 <= recv_peer < world_size
+
+    # --- JSON config lookup ---
+    msg_bytes = send_buf.numel() * send_buf.element_size()
+    config = get_sendrecv_config(
+        msg_bytes=msg_bytes,
+        element_size=send_buf.element_size(),
+        num_peers=1,
     )
+
+    if warp_specialized:
+        if config.ws is None:
+            raise RuntimeError(
+                f"Warp-specialized variant requested but tuning JSON has no "
+                f"`ws` config for (hardware={_detect_hardware()!r}, "
+                f"num_peers=1, msg_bytes={msg_bytes}). Either populate "
+                f"`tuning_sendrecv.json` with a matching entry, set "
+                f"`default_ws`, or call triton_nvl_sendrecv() (stable kernel) "
+                f"instead."
+            )
+        ws_cfg = config.ws
+        if num_blocks == _SENTINEL_NUM_BLOCKS:
+            num_blocks = ws_cfg.num_blocks
+        if sender_warps < 0:
+            sender_warps = ws_cfg.sender_warps
+        if receiver_warps < 0:
+            receiver_warps = ws_cfg.receiver_warps
+
+    if not warp_specialized:
+        stable_cfg = config.stable
+        if num_blocks == _SENTINEL_NUM_BLOCKS:
+            num_blocks = stable_cfg.num_blocks
+        if num_warps == _SENTINEL_NUM_WARPS:
+            num_warps = stable_cfg.num_warps
+
     assert 0 < num_blocks <= _MAX_BLOCKS_PER_PEER, (
         f"num_blocks must be in (0, {_MAX_BLOCKS_PER_PEER}], got {num_blocks}"
     )
@@ -378,47 +416,37 @@ def _launch(
         assert 1 <= receiver_warps <= 8, (
             f"receiver_warps must be in [1, 8], got {receiver_warps}"
         )
-        total = sender_warps + receiver_warps
+        total_warps = sender_warps + receiver_warps
         # TLX requires `num_warps` to be a multiple of 4 for warp
         # specialization. (1+1=2 and similar small splits are rejected
         # downstream by the TritonTLXFixup MLIR pass.)
-        assert total % 4 == 0 and total <= 16, (
+        assert total_warps % 4 == 0 and total_warps <= 16, (
             f"sender_warps + receiver_warps must be a multiple of 4 "
             f"in [4, 16] (TLX warp-spec requirement), "
-            f"got {sender_warps} + {receiver_warps} = {total}"
+            f"got {sender_warps} + {receiver_warps} = {total_warps}"
         )
+        num_warps = total_warps
     else:
         assert num_warps in (4, 8), (
             f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
         )
-
-    world_size = dist.get_world_size(group)
-    if world_size == 1:
-        recv_buf.copy_(send_buf)
-        return
-
-    local_rank = dist.get_rank(group)
-    assert send_peer != local_rank, "send_peer must differ from local rank"
-    assert recv_peer != local_rank, "recv_peer must differ from local rank"
-    assert 0 <= send_peer < world_size
-    assert 0 <= recv_peer < world_size
 
     handle = _get_staging_buffer(group, send_buf.device, world_size)
     sender_step_all, recver_step_all = _get_step_state(
         group, send_buf.device, world_size
     )
 
-    config = (
-        _compute_ws_config(send_buf.element_size())
-        if warp_specialized
-        else _compute_config(send_buf.element_size())
-    )
-    tile_numel = config.tile_rows * config.tile_cols
-    tile_bytes = tile_numel * send_buf.element_size()
-    per_peer_elems = _per_peer_bytes() // send_buf.element_size()
+    element_size = send_buf.element_size()
+    per_peer_elems = _per_peer_bytes() // element_size
+    block_stride_elems = _BLOCK_STRIDE_BYTES // element_size
 
-    orig_block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
     if warp_specialized:
+        assert config.ws is not None
+        tile_rows = config.ws.tile_rows
+        tile_cols = config.ws.tile_cols
+        tile_numel = tile_rows * tile_cols
+        tile_bytes = tile_numel * element_size
+
         # Adaptive stride: pick the smallest stride that keeps the
         # while-loop iter count <= 2 (TLX `sync_threads()` bug).
         # `max_ws_stride` caps per-block staging so the sum across all
@@ -432,7 +460,7 @@ def _launch(
         target_tiles_per_step = -(-tiles_per_block // 2)
         needed_stride = target_tiles_per_step * tile_bytes
         ws_stride = max(min(needed_stride, max_ws_stride), _BLOCK_STRIDE_BYTES)
-        block_stride_elems = ws_stride // send_buf.element_size()
+        ws_block_stride_elems = ws_stride // element_size
         max_tiles_per_block_per_slot = max(ws_stride // tile_bytes, 1)
         # Fail-loud on the TLX iteration bug: if the requested stride
         # was capped below `needed_stride`, the achievable iters/block
@@ -452,10 +480,46 @@ def _launch(
                 f"triton_nvl_sendrecv() for large messages."
             )
     else:
-        block_stride_elems = orig_block_stride_elems
-        max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+        tile_rows = config.stable.tile_rows
+        tile_cols = config.stable.tile_cols
+        tile_numel = tile_rows * tile_cols
+        tile_bytes = tile_numel * element_size
 
-    staging_elems = orig_block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
+        signal_bytes = config.stable.signal_bytes
+        if signal_bytes > _BLOCK_STRIDE_BYTES:
+            # Sweep tooling that picks `signal_bytes > _BLOCK_STRIDE_BYTES`
+            # would silently lose its choice if we did not surface this.
+            # Clamp + warn-once so the sweep entry can be re-tuned (or the
+            # block stride raised) without producing wrong perf attribution.
+            logger.warning(
+                "tuning_config requested signal_bytes=%d but "
+                "_BLOCK_STRIDE_BYTES=%d; clamping signal_bytes to the "
+                "stride. The sweep entry under "
+                "(hardware, num_peers, msg_bytes) is effectively useless "
+                "until the block stride is raised.",
+                signal_bytes,
+                _BLOCK_STRIDE_BYTES,
+            )
+        signal_bytes = min(signal_bytes, _BLOCK_STRIDE_BYTES)
+        # Sub-slot signaling invariants (avoid silent staging-buffer
+        # corruption). The kernel writes one full tile per chunk into
+        # `slot_base + chunk_in_slot * SIGNAL_STRIDE_ELEMS`; if a tile
+        # is larger than a chunk, the write spills into the next chunk
+        # region while that chunk may still be in-flight on the wire.
+        assert signal_bytes >= tile_bytes, (
+            f"signal_bytes ({signal_bytes}) must be >= tile_bytes "
+            f"({tile_bytes}); a sub-slot chunk smaller than one tile "
+            f"causes staging-buffer overrun across chunks."
+        )
+        # `chunks_per_slot` is computed as floor(stride / signal_bytes);
+        # a non-divisor leaves a wasted tail in each slot (functionally
+        # safe but wasteful and an indicator of bad sweep input).
+        assert _BLOCK_STRIDE_BYTES % signal_bytes == 0, (
+            f"_BLOCK_STRIDE_BYTES ({_BLOCK_STRIDE_BYTES}) must be an "
+            f"integer multiple of signal_bytes ({signal_bytes})."
+        )
+
+    staging_elems = block_stride_elems * _MAX_BLOCKS_PER_PEER * _PIPELINE_DEPTH
 
     # --- Pre-resolve staging buffers for the specific peer pair ---
     # Sender writes to send_peer's staging area at local_rank's partition.
@@ -478,7 +542,6 @@ def _launch(
     #   [0 .. W*MBPP):       TAIL[peer * MBPP + block_id]
     #   [W*MBPP .. 2*W*MBPP): HEAD[peer * MBPP + block_id]
     head_offset = world_size * _MAX_BLOCKS_PER_PEER
-
     send_peer_sig = handle.get_signal_pad(send_peer).view(torch.int64)
     recv_peer_sig = handle.get_signal_pad(recv_peer).view(torch.int64)
     local_sig = handle.get_signal_pad(local_rank).view(torch.int64)
@@ -511,9 +574,9 @@ def _launch(
             recver_step_ptr=recver_step_ptr,
             send_numel=send_buf.numel(),
             recv_numel=recv_buf.numel(),
-            TILE_ROWS=config.tile_rows,
-            TILE_COLS=config.tile_cols,
-            BLOCK_STRIDE_ELEMS=block_stride_elems,
+            TILE_ROWS=tile_rows,
+            TILE_COLS=tile_cols,
+            BLOCK_STRIDE_ELEMS=ws_block_stride_elems,
             PIPELINE_DEPTH=_PIPELINE_DEPTH,
             MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
             NUM_SEND_BLOCKS=num_blocks,
@@ -526,6 +589,11 @@ def _launch(
             num_stages=0,
         )
         return
+
+    # --- Stable kernel with sub-slot signaling ---
+    tiles_per_signal = max(signal_bytes // tile_bytes, 1)
+    chunks_per_slot = max(_BLOCK_STRIDE_BYTES // signal_bytes, 1)
+    signal_stride_elems = signal_bytes // element_size
 
     grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
 
@@ -549,14 +617,16 @@ def _launch(
         recver_step_ptr=recver_step_ptr,
         send_numel=send_buf.numel(),
         recv_numel=recv_buf.numel(),
-        TILE_ROWS=config.tile_rows,
-        TILE_COLS=config.tile_cols,
+        TILE_ROWS=tile_rows,
+        TILE_COLS=tile_cols,
         BLOCK_STRIDE_ELEMS=block_stride_elems,
+        SIGNAL_STRIDE_ELEMS=signal_stride_elems,
         PIPELINE_DEPTH=_PIPELINE_DEPTH,
         MAX_BLOCKS_PER_PEER=_MAX_BLOCKS_PER_PEER,
         NUM_SEND_BLOCKS=num_blocks,
-        MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
+        TILES_PER_SIGNAL=tiles_per_signal,
+        CHUNKS_PER_SLOT=chunks_per_slot,
         MODE=mode,
         num_warps=num_warps,
-        num_stages=config.num_stages,
+        num_stages=2,
     )

--- a/comms/pipes/triton/collectives/nvl/sendrecv_op.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_op.py
@@ -1,0 +1,327 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Host-side wrapper for the NVLink copy-based Triton send/recv kernel.
+
+Allocates (and caches) the symmetric memory staging buffer plus the
+persistent step-state tensors, computes a kernel config, and launches.
+
+v1 scope (intentionally narrow):
+
+  * **2-rank groups only**. The staging buffer holds a single peer pair's
+    slot and the API takes a single ``peer_rank`` used for both directions
+    (sender → ``peer_rank``, receiver ← ``peer_rank``).
+  * Copy-based send-only, recv-only, and bidirectional sendrecv between
+    this rank and ``peer_rank``. Peer ranks must launch matching operations
+    simultaneously.
+
+The bidirectional single-peer API is **not** directly composable into Ring AllGather on N>2 ranks —
+ring needs ``send_peer = (rank+1)%N`` paired with ``recv_peer =
+(rank-1)%N`` (different peers per direction), and the staging buffer
+needs per-sender slots like the MSL ``all_to_all_single_non_contig``
+kernel uses. The follow-up to add ring AllGather will introduce a
+``triton_nvl_sendrecv(send, recv, send_peer, recv_peer, ...)`` variant
+plus per-peer staging slots indexed by sender rank.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import NamedTuple
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from .sendrecv import triton_nvl_sendrecv_kernel
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables (powers of 2). These match the analogous constants in
+# all_to_all_single_non_contig.py and are deliberately shape-independent
+# so back-to-back launches with different block counts cannot race.
+# ---------------------------------------------------------------------------
+
+_BLOCK_STRIDE_BYTES: int = 256 * 1024
+_PIPELINE_DEPTH: int = 2
+_MAX_BLOCKS_PER_DIR: int = 32
+_DEFAULT_NUM_SEND_BLOCKS: int = 16
+_DEFAULT_NUM_WARPS: int = 8
+_MODE_BIDIRECTIONAL: int = 0
+_MODE_SEND_ONLY: int = 1
+_MODE_RECV_ONLY: int = 2
+
+
+class _Config(NamedTuple):
+    tile_rows: int
+    tile_cols: int
+    num_stages: int
+
+
+def _compute_config(element_size: int) -> _Config:
+    return _Config(
+        tile_rows=32,
+        tile_cols=2048 // element_size,
+        num_stages=2,
+    )
+
+
+def _per_pair_bytes() -> int:
+    return _BLOCK_STRIDE_BYTES * _PIPELINE_DEPTH * _MAX_BLOCKS_PER_DIR
+
+
+# ---------------------------------------------------------------------------
+# Per-group caches
+#
+# These dicts are not thread-safe: a multi-threaded caller racing on the
+# first use of a given ``group`` could double-allocate the staging buffer
+# or step state. PyTorch's torch.distributed call sites are single-threaded
+# per rank in practice, so we accept the simpler dict here. If a future
+# caller multiplexes threads onto a single PG, wrap these in a lock.
+# ---------------------------------------------------------------------------
+
+_BUFFER_CACHE: dict[
+    dist.ProcessGroup,
+    tuple[object, torch.Tensor, torch.Tensor],  # (handle, buf_ptrs, sig_ptrs)
+] = {}
+
+_STEP_STATE_CACHE: dict[
+    dist.ProcessGroup,
+    tuple[torch.Tensor, torch.Tensor],
+] = {}
+
+
+def _get_staging_buffer(
+    group: dist.ProcessGroup,
+    device: torch.device,
+) -> tuple[object, torch.Tensor, torch.Tensor]:
+    """Get or create the symmetric memory staging buffer for ``group``.
+
+    The signal pad must be zero on entry to the first ``wait_ge(_, 0)`` call
+    on each block. ``symm_mem.empty`` zeroes the entire allocation including
+    the signal pad (via ``cudaMemset`` in CUDASymmetricMemory.cu's
+    ``allocate``), so the first launch is safe. We additionally zero the
+    signal pad explicitly + barrier so the invariant holds even if the
+    underlying allocator behaviour changes in a future torch release.
+    """
+    cached = _BUFFER_CACHE.get(group)
+    if cached is not None:
+        return cached
+
+    num_bytes = _per_pair_bytes()
+    logger.info(
+        "triton_nvl_sendrecv staging cache miss on PG %s: allocating %d bytes",
+        group.group_desc,
+        num_bytes,
+    )
+    raw = symm_mem.empty(num_bytes, dtype=torch.uint8, device=device)
+    handle = symm_mem.rendezvous(raw, group=group)
+    # Defensive: explicitly zero the signal pad before any block can poll it.
+    # Both ranks must complete the zero before either issues a wait_ge — the
+    # rendezvous-then-barrier sequence below guarantees that.
+    handle.get_signal_pad(handle.rank).zero_()
+    dist.barrier(group)
+    buf_ptrs = torch.tensor(handle.buffer_ptrs, device=device, dtype=torch.int64)
+    sig_ptrs = torch.tensor(handle.signal_pad_ptrs, device=device, dtype=torch.int64)
+    _BUFFER_CACHE[group] = (handle, buf_ptrs, sig_ptrs)
+    return _BUFFER_CACHE[group]
+
+
+def _get_step_state(
+    group: dist.ProcessGroup,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Get or create persistent monotonic step counters for ``group``."""
+    cached = _STEP_STATE_CACHE.get(group)
+    if cached is not None:
+        return cached
+
+    sender_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
+    recver_step = torch.zeros(_MAX_BLOCKS_PER_DIR, dtype=torch.int64, device=device)
+    _STEP_STATE_CACHE[group] = (sender_step, recver_step)
+    return _STEP_STATE_CACHE[group]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def triton_nvl_sendrecv(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Bidirectional NVLink copy-based send/recv between this rank and ``peer_rank``.
+
+    Both ranks in the (sender, receiver) pair must call this function
+    simultaneously. ``send_buf`` and ``recv_buf`` must have the same shape
+    and dtype on both ranks.
+
+    .. warning::
+        ``dtype`` and ``numel`` of ``send_buf`` / ``recv_buf`` MUST match
+        between the two ranks. There is no cross-rank validation; a
+        mismatch silently produces wrong staging slot offsets and
+        corrupts data.
+
+    Args:
+        send_buf: Source tensor to send to ``peer_rank``. Contiguous, CUDA.
+        recv_buf: Destination tensor to receive from ``peer_rank``. Contiguous, CUDA.
+        peer_rank: Rank in ``group`` to exchange with. ``send_peer`` and
+            ``recv_peer`` are the same rank in v1; see the module docstring
+            for why this is **not** directly extensible to Ring AllGather.
+        group: Process group used for symm-mem rendezvous. **v1 requires
+            size 2** — the assertion below is the enforcement point.
+        num_blocks: Thread blocks per direction. Defaults to 16. The actual
+            grid is ``2 * num_blocks`` for bidirectional mode (so default
+            gives a 32-block grid, apple-to-apple with NCCL's 32 channels)
+            and ``num_blocks`` for send-only / recv-only.
+        num_warps: Triton warps per block. Defaults to 8.
+    """
+    assert send_buf.is_cuda and recv_buf.is_cuda
+    assert send_buf.is_contiguous() and recv_buf.is_contiguous()
+    assert send_buf.dtype == recv_buf.dtype
+    assert send_buf.numel() == recv_buf.numel()
+    _launch(
+        send_buf,
+        recv_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_BIDIRECTIONAL,
+    )
+
+
+def triton_nvl_send(
+    send_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Send ``send_buf`` to ``peer_rank`` over NVLink using copy-based staging.
+
+    Caller is responsible for ensuring the peer rank issues a matching
+    ``triton_nvl_recv`` with the same ``dtype`` and ``numel`` — there is
+    no cross-rank validation.
+    """
+    assert send_buf.is_cuda and send_buf.is_contiguous()
+    _launch(
+        send_buf,
+        send_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_SEND_ONLY,
+    )
+
+
+def triton_nvl_recv(
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int = _DEFAULT_NUM_SEND_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+) -> None:
+    """Receive into ``recv_buf`` from ``peer_rank`` over NVLink.
+
+    Caller is responsible for ensuring the peer rank issues a matching
+    ``triton_nvl_send`` with the same ``dtype`` and ``numel`` — there is
+    no cross-rank validation.
+    """
+    assert recv_buf.is_cuda and recv_buf.is_contiguous()
+    _launch(
+        recv_buf,
+        recv_buf,
+        peer_rank,
+        group=group,
+        num_blocks=num_blocks,
+        num_warps=num_warps,
+        mode=_MODE_RECV_ONLY,
+    )
+
+
+def _launch(
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    peer_rank: int,
+    *,
+    group: dist.ProcessGroup,
+    num_blocks: int,
+    num_warps: int,
+    mode: int,
+) -> None:
+    assert send_buf.dtype == recv_buf.dtype, (
+        f"send/recv dtype mismatch: {send_buf.dtype} vs {recv_buf.dtype}"
+    )
+    assert 0 < num_blocks <= _MAX_BLOCKS_PER_DIR, (
+        f"num_blocks must be in (0, {_MAX_BLOCKS_PER_DIR}], got {num_blocks}"
+    )
+    assert num_warps in (4, 8), (
+        f"num_warps must be 4 or 8 (only configs covered by tests); got {num_warps}"
+    )
+
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        recv_buf.copy_(send_buf)
+        return
+
+    # v1 limit: single peer-pair staging buffer means we cannot service more
+    # than one (sender, receiver) pair per group. Lift this restriction in
+    # the follow-up that adds per-peer staging slots for Ring AllGather.
+    assert world_size == 2, (
+        f"triton_nvl_sendrecv v1 supports only 2-rank groups, got world_size={world_size}. "
+        "See module docstring for the planned per-peer slot API."
+    )
+
+    local_rank = dist.get_rank(group)
+    assert peer_rank != local_rank
+    assert 0 <= peer_rank < world_size
+
+    _, buf_ptrs, sig_ptrs = _get_staging_buffer(group, send_buf.device)
+    sender_step, recver_step = _get_step_state(group, send_buf.device)
+
+    config = _compute_config(send_buf.element_size())
+    block_stride_elems = _BLOCK_STRIDE_BYTES // send_buf.element_size()
+    tile_numel = config.tile_rows * config.tile_cols
+    tile_bytes = tile_numel * send_buf.element_size()
+    max_tiles_per_block_per_slot = max(_BLOCK_STRIDE_BYTES // tile_bytes, 1)
+
+    grid = (2 * num_blocks,) if mode == _MODE_BIDIRECTIONAL else (num_blocks,)
+
+    # pyre-ignore[28]: triton's `kernel[grid](...)` launcher accepts JIT-special
+    # kwargs (`num_warps`, `num_stages`) that pyre can't see in the kernel
+    # function's own signature. Not a real type error.
+    triton_nvl_sendrecv_kernel[grid](
+        send_ptr=send_buf,
+        recv_ptr=recv_buf,
+        buffer_ptrs=buf_ptrs,
+        signal_pad_ptrs=sig_ptrs,
+        sender_step_ptr=sender_step,
+        recver_step_ptr=recver_step,
+        local_rank=local_rank,
+        peer_rank=peer_rank,
+        send_numel=send_buf.numel(),
+        recv_numel=recv_buf.numel(),
+        TILE_ROWS=config.tile_rows,
+        TILE_COLS=config.tile_cols,
+        BLOCK_STRIDE_ELEMS=block_stride_elems,
+        PIPELINE_DEPTH=_PIPELINE_DEPTH,
+        MAX_BLOCKS_PER_DIR=_MAX_BLOCKS_PER_DIR,
+        NUM_SEND_BLOCKS=num_blocks,
+        MAX_TILES_PER_BLOCK_PER_SLOT=max_tiles_per_block_per_slot,
+        MODE=mode,
+        num_warps=num_warps,
+        num_stages=config.num_stages,
+    )

--- a/comms/pipes/triton/collectives/nvl/sendrecv_ws.py
+++ b/comms/pipes/triton/collectives/nvl/sendrecv_ws.py
@@ -1,0 +1,183 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Warp-specialized bidirectional Triton NVLink send/recv kernel.
+
+Single CTA runs sender and receiver as concurrent TLX async tasks
+(default: 4 sender warps + 4 receiver warps). Both NVLink directions
+share the SM, mirroring NCCL's per-channel send/recv split.
+
+Staging-buffer / signal layout / monotonic step-state protocol are
+inherited from :mod:`sendrecv` — see that module's docstring for the
+pre-resolved per-(peer, block) signal layout and the
+``fence_and_remote_store_i64`` / ``wait_ge`` ordering invariants.
+
+Known limitation — TLX `sync_threads()` iteration bug
+-----------------------------------------------------
+
+``tlx.sync_threads()`` inside a multi-warp ``async_task`` has an
+iteration-count-dependent barrier bug: while-loops that execute more
+than 2 iterations hang on the second-pass barrier. This kernel relies
+on the host launcher (:func:`sendrecv_op._launch`) computing
+``BLOCK_STRIDE_ELEMS`` adaptively so that
+``ceil(tiles_per_block / max_tiles_per_block_per_slot) <= 2``. The
+launcher fail-loud raises if that bound cannot be satisfied — DO NOT
+remove that guard. See ``TLX_BARRIER_BUG.md`` for upstream tracking.
+
+Each ``sync_threads()`` call below is annotated with
+``TLX-BARRIER-BUG`` to flag the trigger sites for future maintainers.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+import triton.language.extra.tlx as tlx  # @manual=//triton:triton
+
+from .utils import (
+    fence_and_remote_store_i64,
+    remote_store_i64_relaxed,
+    sync_threads,
+    wait_ge,
+    wait_ge_volatile,
+)
+
+
+@triton.jit
+def triton_nvl_sendrecv_bidir_ws_kernel(  # noqa: C901
+    send_ptr,
+    recv_ptr,
+    send_staging_buf,
+    recv_staging_buf,
+    send_tail_sig,
+    send_head_sig,
+    recv_tail_sig,
+    recv_head_sig,
+    sender_step_ptr,
+    recver_step_ptr,
+    send_numel,
+    recv_numel,
+    TILE_ROWS: tl.constexpr,
+    TILE_COLS: tl.constexpr,
+    BLOCK_STRIDE_ELEMS: tl.constexpr,
+    PIPELINE_DEPTH: tl.constexpr,
+    MAX_TILES_PER_BLOCK_PER_SLOT: tl.constexpr,
+    NUM_SEND_BLOCKS: tl.constexpr,
+    NUM_SENDER_WARPS: tl.constexpr,
+    NUM_RECEIVER_WARPS: tl.constexpr,
+):
+    TILE_NUMEL: tl.constexpr = TILE_ROWS * TILE_COLS
+    block_id = tl.program_id(0)
+
+    with tlx.async_tasks():
+        with tlx.async_task("default", num_warps=NUM_SENDER_WARPS):
+            task_tid = tlx.thread_id(axis=0)
+            sender_id = block_id
+            tail_remote_ptr = send_tail_sig + sender_id
+            head_local_ptr = send_head_sig + sender_id
+            start_step = tl.load(sender_step_ptr + sender_id).to(tl.int64)
+            local_rows = tl.arange(0, TILE_ROWS)
+            local_cols = tl.arange(0, TILE_COLS)
+            num_send_tiles = tl.cdiv(send_numel, TILE_NUMEL)
+            send_tile_idx = sender_id.to(tl.int64)
+            send_step = start_step
+
+            while send_tile_idx < num_send_tiles:
+                slot = (send_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    sender_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+                if send_step < start_step + PIPELINE_DEPTH:
+                    wait_target = start_step
+                else:
+                    wait_target = send_step - PIPELINE_DEPTH + 1
+                if task_tid == 0:
+                    wait_ge_volatile(head_local_ptr, wait_target.to(tl.int64))
+
+                # TLX-BARRIER-BUG: hangs after >2 while-loop iters; host
+                # adaptive-stride math caps the iter count to <=2.
+                sync_threads()
+
+                buf_tile_idx = 0
+                tiles_to_send_this_step = min(
+                    MAX_TILES_PER_BLOCK_PER_SLOT,
+                    tl.cdiv(num_send_tiles - send_tile_idx, NUM_SEND_BLOCKS),
+                )
+                for _i in range(tiles_to_send_this_step):
+                    flat_idx = (
+                        send_tile_idx * TILE_NUMEL
+                        + local_rows[:, None] * TILE_COLS
+                        + local_cols[None, :]
+                    )
+                    mask = flat_idx < send_numel
+                    data = tl.load(send_ptr + flat_idx.to(tl.int64), mask=mask)
+                    buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                    buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                        tl.int64
+                    )
+                    tl.store(send_staging_buf + slot_base + buf_off, data, mask=mask)
+                    send_tile_idx += NUM_SEND_BLOCKS
+                    buf_tile_idx += 1
+
+                # TLX-BARRIER-BUG: see file docstring.
+                sync_threads()
+                fence_and_remote_store_i64(
+                    tail_remote_ptr, (send_step + 1).to(tl.int64)
+                )
+                send_step += 1
+
+            tl.store(sender_step_ptr + sender_id, send_step.to(tl.int64))
+
+        with tlx.async_task(num_warps=NUM_RECEIVER_WARPS):
+            task_tid = tlx.thread_id(axis=0)
+            receiver_id = block_id
+            tail_local_ptr = recv_tail_sig + receiver_id
+            head_remote_ptr = recv_head_sig + receiver_id
+            start_step = tl.load(recver_step_ptr + receiver_id).to(tl.int64)
+            local_rows = tl.arange(0, TILE_ROWS)
+            local_cols = tl.arange(0, TILE_COLS)
+            num_recv_tiles = tl.cdiv(recv_numel, TILE_NUMEL)
+            recv_tile_idx = receiver_id.to(tl.int64)
+            recv_step = start_step
+
+            while recv_tile_idx < num_recv_tiles:
+                slot = (recv_step - start_step) % PIPELINE_DEPTH
+                slot_base = (
+                    receiver_id * BLOCK_STRIDE_ELEMS * PIPELINE_DEPTH
+                    + slot * BLOCK_STRIDE_ELEMS
+                )
+                if task_tid == 0:
+                    wait_ge(tail_local_ptr, (recv_step + 1).to(tl.int64))
+
+                # TLX-BARRIER-BUG: see file docstring.
+                sync_threads()
+
+                buf_tile_idx = 0
+                tiles_to_recv_this_step = min(
+                    MAX_TILES_PER_BLOCK_PER_SLOT,
+                    tl.cdiv(num_recv_tiles - recv_tile_idx, NUM_SEND_BLOCKS),
+                )
+                for _i in range(tiles_to_recv_this_step):
+                    flat_idx = (
+                        recv_tile_idx * TILE_NUMEL
+                        + local_rows[:, None] * TILE_COLS
+                        + local_cols[None, :]
+                    )
+                    mask = flat_idx < recv_numel
+                    buf_t = buf_tile_idx * TILE_ROWS + local_rows
+                    buf_off = (buf_t[:, None] * TILE_COLS + local_cols[None, :]).to(
+                        tl.int64
+                    )
+                    data = tl.load(recv_staging_buf + slot_base + buf_off, mask=mask)
+                    tl.store(recv_ptr + flat_idx.to(tl.int64), data, mask=mask)
+                    recv_tile_idx += NUM_SEND_BLOCKS
+                    buf_tile_idx += 1
+
+                # TLX-BARRIER-BUG: see file docstring.
+                sync_threads()
+                remote_store_i64_relaxed(head_remote_ptr, (recv_step + 1).to(tl.int64))
+                recv_step += 1
+
+            tl.store(recver_step_ptr + receiver_id, recv_step.to(tl.int64))

--- a/comms/pipes/triton/collectives/nvl/tests/__init__.py
+++ b/comms/pipes/triton/collectives/nvl/tests/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -280,12 +280,26 @@ def _bench_triton(
     def fn() -> None:
         if bidirectional:
             triton_nvl_sendrecv(
-                send, recv, peer_rank, group=group, num_blocks=num_blocks
+                send,
+                recv,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
             )
         elif local_rank == 0:
-            triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+            triton_nvl_send(
+                send,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
+            )
         else:
-            triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+            triton_nvl_recv(
+                recv,
+                peer_rank,
+                group=group,
+                num_blocks=num_blocks,
+            )
 
     fn()
     dist.barrier(group)

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -1,0 +1,512 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Benchmark for the NVLink copy-based Triton send/recv vs NCCL baseline.
+
+**Runtime-SM-matched** apples-to-apples unidirectional and bidirectional
+sendrecv between rank 0 and rank 1 on a single node, NVLink-only.
+
+Key point: ``NCCL_{MIN,MAX}_NCHANNELS`` only controls *allocation*. NCCL's
+in-kernel adaptive policy decides how many of those allocated channels
+(= CTAs = SMs) to actually launch per call. Therefore we **first measure
+NCCL's runtime grid for every (msg_size, allocation_cap)** via nsys (see
+``_nccl_grid_probe.py`` companion target) and then pin Triton's
+``num_blocks`` to that runtime grid — guaranteeing that the per-cell
+comparison reflects identical SM usage on both kernels.
+
+Measured NCCL P2P kernel grid (= active SM count) on H100, NCCLX 2.29::
+
+      size   cap=4  cap=8  cap=16  cap=32
+       32 B    1      1      1       1
+       64 B    1      1      1       1
+       1 KB    1      1      1       1
+       8 KB    1      1      1       1
+      64 KB    1      1      1       1
+       1 MB    2      4      8      16
+       8 MB    2      4      8      16
+      64 MB    4      4      8      16
+     256 MB    4      8     16      16
+       1 GB    4      8     16      32
+
+Both unidirectional and bidirectional ``batch_isend_irecv`` produce the
+same NCCL grid (channels shared across the op set). Triton bidirectional
+uses a 2*num_blocks grid by construction, so for bidirectional we set
+``num_blocks = max(nccl_grid // 2, 1)`` (resulting Triton grid =
+``max(nccl_grid, 2)``); the only mismatch is at small-msg bi where
+NCCL=1 but Triton=2 — disclosed in commit summary.
+
+Both calls are captured into CUDA graphs and timed via ``graph.replay()``
+to remove the per-iteration Python and host launcher overhead.
+
+Fairness caveats:
+  * **Dtype**: bf16 only (representative ML-training payload dtype).
+  * **NCCL P2P + CUDA graph**: requires PyTorch + a NCCL build with
+    graph-aware P2P (NCCL 2.18+ or fbsource ``hpc_comms.use_ncclx=stable``).
+  * **NCCL P2P uses Simple protocol only.** ``NCCL_PROTO=LL`` only
+    affects collectives (verified via ``NCCL_DEBUG=INFO`` — AllReduce
+    shows ``proto LL``, but ``batch_isend_irecv`` allocates Simple-style
+    10 MB proxy buffers). NCCL has no LL/LL128 P2P path, so the small-
+    msg comparison is Triton-Simple-vs-NCCL-Simple.
+  * **Bidirectional minimum grid asymmetry**: Triton bidirectional grid
+    is always ``2 * num_blocks >= 2``; NCCL bidirectional grid drops to
+    1 at small msg. At cells where the table prescribes Triton
+    num_blocks=1 (=>grid=2) vs NCCL grid=1, Triton uses 2× SMs, which
+    we explicitly disclose.
+
+Run::
+
+    buck2 run @mode/opt -c hpc_comms.use_ncclx=stable \\
+        //comms/pipes/triton/collectives/nvl/tests:benchmark_sendrecv
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.pipes.triton.collectives.nvl.sendrecv_op import (
+    triton_nvl_recv,
+    triton_nvl_send,
+    triton_nvl_sendrecv,
+)
+
+
+# Message sizes to sweep (in bytes). 8 B and 16 B are excluded:
+# they are not target cases, and the current Triton codegen hits a
+# tiny-message divisibility cliff there that is not representative of
+# the copy-based path.
+_MSG_SIZES_BYTES: list[int] = [
+    32,
+    64,
+    1024,
+    8 * 1024,
+    64 * 1024,
+    1 * 1024 * 1024,
+    8 * 1024 * 1024,
+    64 * 1024 * 1024,
+    256 * 1024 * 1024,
+    1024 * 1024 * 1024,
+]
+
+
+# NCCL ``NCCL_{MIN,MAX}_NCHANNELS`` allocation values to sweep.
+# At each cap we compare against NCCL with that allocation, and Triton
+# with ``num_blocks`` matched to NCCL's actual runtime grid (see table
+# in module docstring).
+_CAPS: list[int] = [4, 8, 16, 32]
+
+
+# Hardcoded NCCL P2P kernel runtime grid table, keyed by
+# (msg_bytes, cap) -> grid count. Generated via nsys profiling of
+# ``ncclDevKernel_SendRecv`` on H100, NCCLX 2.29 (see
+# ``_nccl_grid_probe.py``). ``ncclDevKernelArgs`` is the same for uni
+# and bi; both directions share the channel pool, so the runtime grid
+# is identical regardless of P2POp count.
+_NCCL_GRID_TABLE: dict[tuple[int, int], int] = {
+    (32, 4): 1,
+    (32, 8): 1,
+    (32, 16): 1,
+    (32, 32): 1,
+    (64, 4): 1,
+    (64, 8): 1,
+    (64, 16): 1,
+    (64, 32): 1,
+    (1024, 4): 1,
+    (1024, 8): 1,
+    (1024, 16): 1,
+    (1024, 32): 1,
+    (8 * 1024, 4): 1,
+    (8 * 1024, 8): 1,
+    (8 * 1024, 16): 1,
+    (8 * 1024, 32): 1,
+    (64 * 1024, 4): 1,
+    (64 * 1024, 8): 1,
+    (64 * 1024, 16): 1,
+    (64 * 1024, 32): 1,
+    (1 * 1024 * 1024, 4): 2,
+    (1 * 1024 * 1024, 8): 4,
+    (1 * 1024 * 1024, 16): 8,
+    (1 * 1024 * 1024, 32): 16,
+    (8 * 1024 * 1024, 4): 2,
+    (8 * 1024 * 1024, 8): 4,
+    (8 * 1024 * 1024, 16): 8,
+    (8 * 1024 * 1024, 32): 16,
+    (64 * 1024 * 1024, 4): 4,
+    (64 * 1024 * 1024, 8): 4,
+    (64 * 1024 * 1024, 16): 8,
+    (64 * 1024 * 1024, 32): 16,
+    (256 * 1024 * 1024, 4): 4,
+    (256 * 1024 * 1024, 8): 8,
+    (256 * 1024 * 1024, 16): 16,
+    (256 * 1024 * 1024, 32): 16,
+    (1024 * 1024 * 1024, 4): 4,
+    (1024 * 1024 * 1024, 8): 8,
+    (1024 * 1024 * 1024, 16): 16,
+    (1024 * 1024 * 1024, 32): 32,
+}
+
+
+def _triton_num_blocks_uni(msg_bytes: int, cap: int) -> int:
+    """Triton uni grid = num_blocks. Match NCCL runtime grid exactly."""
+    return _NCCL_GRID_TABLE[(msg_bytes, cap)]
+
+
+def _triton_num_blocks_bi(msg_bytes: int, cap: int) -> int:
+    """Triton bi grid = 2 * num_blocks. Half the NCCL grid; minimum 1.
+
+    At cells where NCCL bi grid = 1, Triton bi grid = 2 (slight
+    Triton-side over-provision; disclosed in module docstring).
+    """
+    return max(_NCCL_GRID_TABLE[(msg_bytes, cap)] // 2, 1)
+
+
+# Per-message iteration counts. The 64 KB / 64 MiB thresholds split the
+# sweep into three latency regimes:
+#   * <= 64 KB: copy time is microseconds; per-replay timing variance is
+#     a meaningful fraction of the signal, so 500 replays drives stderr
+#     down without inflating wall clock.
+#   * 64 KB – 64 MiB: bandwidth-bound regime; 200 replays is enough for
+#     stable means.
+#   * > 64 MiB: each replay is milliseconds, 50 replays keeps the full
+#     sweep under a couple of minutes per cap.
+def _iters_for_size(msg_bytes: int) -> int:
+    if msg_bytes <= 64 * 1024:
+        return 500
+    if msg_bytes <= 64 * 1024 * 1024:
+        return 200
+    return 50
+
+
+# Empirically chosen on H100: 20 replays is enough for steady-state SM
+# clock / cache state on the timed graph, and 3 capture-warmup replays
+# is enough to populate any first-call lazy state inside ``fn`` (e.g.,
+# Triton autotune cache, NCCL communicator hot path) before capture.
+_WARMUP_ITERS: int = 20
+_CAPTURE_WARMUP_ITERS: int = 3
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _capture_one_call(fn: Callable[[], None]) -> torch.cuda.CUDAGraph:
+    """Warm up ``fn`` on a side stream, then capture a single call into a graph.
+
+    Standard PyTorch CUDA-graph capture pattern (see
+    https://pytorch.org/docs/stable/notes/cuda.html#cuda-graphs):
+
+      1. Warm up on a non-default stream so the kernel's JIT compile,
+         allocator, and any communicator setup happens before capture.
+      2. Make the current stream wait for the warmup to finish.
+      3. Capture a single ``fn`` call into the graph using the same
+         non-default stream.
+
+    The caller is responsible for ensuring ``fn`` does no Python-level
+    allocation that hasn't already happened by the time this helper
+    returns — graph replay only re-runs the recorded GPU ops.
+    """
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        for _ in range(_CAPTURE_WARMUP_ITERS):
+            fn()
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g, stream=side_stream):
+        fn()
+    return g
+
+
+def _time_replays(
+    g: torch.cuda.CUDAGraph,
+    iters: int,
+    device: torch.device,
+    group: dist.ProcessGroup,
+) -> float:
+    """Time ``iters`` replays of ``g`` using CUDA events. Returns μs/iter."""
+    for _ in range(_WARMUP_ITERS):
+        g.replay()
+    torch.cuda.synchronize(device)
+    # Align ranks at the start of the timed window so warmup skew on either
+    # side does not inflate the first few timed replays.
+    dist.barrier(group)
+    torch.cuda.synchronize(device)
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        g.replay()
+    end.record()
+    torch.cuda.synchronize(device)
+    elapsed_ms = start.elapsed_time(end)
+    return (elapsed_ms * 1000.0) / iters
+
+
+def _max_rank_latency(
+    lat_us: float,
+    device: torch.device,
+    group: dist.ProcessGroup,
+) -> float:
+    latency = torch.tensor([lat_us], dtype=torch.float64, device=device)
+    dist.all_reduce(latency, op=dist.ReduceOp.MAX, group=group)
+    return float(latency.item())
+
+
+def _bench_triton(
+    msg_bytes: int,
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    num_blocks: int,
+) -> tuple[float, float]:
+    """Bench Triton send/recv via CUDA-graph replay. Returns (μs, GB/s)."""
+    device = torch.device(f"cuda:{local_rank}")
+    numel = max(msg_bytes // torch.bfloat16.itemsize, 1)
+    send: torch.Tensor = torch.ones(numel, dtype=torch.bfloat16, device=device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=torch.bfloat16, device=device)
+
+    def fn() -> None:
+        if bidirectional:
+            triton_nvl_sendrecv(
+                send, recv, peer_rank, group=group, num_blocks=num_blocks
+            )
+        elif local_rank == 0:
+            triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+        else:
+            triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+
+    fn()
+    dist.barrier(group)
+
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat_us = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    bw_gbps = (msg_bytes / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+    if bidirectional or local_rank == 1:
+        torch.cuda.synchronize(device)
+        expected = torch.ones(numel, dtype=torch.bfloat16, device=device)
+        assert torch.equal(recv, expected), (
+            f"Triton bench correctness check failed at msg_bytes={msg_bytes}, "
+            f"bidirectional={bidirectional}, num_blocks={num_blocks}"
+        )
+    return lat_us, bw_gbps
+
+
+def _bench_nccl(
+    msg_bytes: int,
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+) -> tuple[float, float]:
+    """Bench NCCL ``batch_isend_irecv`` via CUDA-graph replay. Returns (μs, GB/s).
+
+    NCCL channel allocation is set by ``NCCL_{MIN,MAX}_NCHANNELS`` in
+    the parent ``main()`` before ``mp.spawn``; per-call runtime grid is
+    NCCL's adaptive choice (captured in ``_NCCL_GRID_TABLE``).
+    """
+    device = torch.device(f"cuda:{local_rank}")
+    numel = max(msg_bytes // torch.bfloat16.itemsize, 1)
+    send: torch.Tensor = torch.ones(numel, dtype=torch.bfloat16, device=device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=torch.bfloat16, device=device)
+
+    def fn() -> None:
+        if bidirectional:
+            ops = [
+                dist.P2POp(dist.isend, send, peer_rank, group=group),
+                dist.P2POp(dist.irecv, recv, peer_rank, group=group),
+            ]
+        elif local_rank == 0:
+            ops = [dist.P2POp(dist.isend, send, peer_rank, group=group)]
+        else:
+            ops = [dist.P2POp(dist.irecv, recv, peer_rank, group=group)]
+        reqs = dist.batch_isend_irecv(ops)
+        for r in reqs:
+            r.wait()
+
+    fn()
+    dist.barrier(group)
+
+    g = _capture_one_call(fn)
+    dist.barrier(group)
+
+    iters = _iters_for_size(msg_bytes)
+    lat_us = _max_rank_latency(_time_replays(g, iters, device, group), device, group)
+    bw_gbps = (msg_bytes / 1e9) / (lat_us / 1e6) if lat_us > 0 else 0.0
+
+    if bidirectional or local_rank == 1:
+        torch.cuda.synchronize(device)
+        expected = torch.ones(numel, dtype=torch.bfloat16, device=device)
+        assert torch.equal(recv, expected), (
+            f"NCCL bench correctness check failed at msg_bytes={msg_bytes}, "
+            f"bidirectional={bidirectional}"
+        )
+    return lat_us, bw_gbps
+
+
+def _fmt_size(b: int) -> str:
+    units = [("B", 1), ("KB", 1024), ("MB", 1024**2), ("GB", 1024**3)]
+    for name, scale in reversed(units):
+        if b >= scale:
+            return f"{b // scale}{name}" if b % scale == 0 else f"{b / scale:.1f}{name}"
+    return f"{b}B"
+
+
+def _print_header(rank: int, title: str) -> None:
+    if rank != 0:
+        return
+    print()
+    print("=" * 100)
+    print(title)
+    print(
+        f"{'msg_size':>10} | {'iters':>6} | {'tri_nb':>6} {'nccl_grid':>9} | "
+        f"{'triton_us':>10} {'triton_GB/s':>12} | "
+        f"{'nccl_us':>10} {'nccl_GB/s':>12} | {'speedup':>8}"
+    )
+    print("-" * 100)
+
+
+def _print_row(
+    rank: int,
+    msg_bytes: int,
+    iters: int,
+    triton_num_blocks: int,
+    nccl_grid: int,
+    triton_us: float,
+    triton_bw: float,
+    nccl_us: float,
+    nccl_bw: float,
+) -> None:
+    if rank != 0:
+        return
+    speedup = nccl_us / triton_us if triton_us > 0 else 0.0
+    print(
+        f"{_fmt_size(msg_bytes):>10} | {iters:>6} | {triton_num_blocks:>6} {nccl_grid:>9} | "
+        f"{triton_us:>10.2f} {triton_bw:>12.3f} | "
+        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x"
+    )
+
+
+def _run_table(
+    local_rank: int,
+    peer_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    cap: int,
+) -> None:
+    direction = (
+        "Bidirectional sendrecv"
+        if bidirectional
+        else "Unidirectional rank0->rank1 send/recv"
+    )
+    title = f"{direction} | NCCL_NCHANNELS=cap={cap} (Triton num_blocks tracks NCCL runtime grid)"
+    _print_header(local_rank, title)
+    for msg_bytes in _MSG_SIZES_BYTES:
+        nccl_grid = _NCCL_GRID_TABLE[(msg_bytes, cap)]
+        if bidirectional:
+            triton_nb = _triton_num_blocks_bi(msg_bytes, cap)
+        else:
+            triton_nb = _triton_num_blocks_uni(msg_bytes, cap)
+
+        triton_us, triton_bw = _bench_triton(
+            msg_bytes,
+            local_rank,
+            peer_rank,
+            group,
+            bidirectional=bidirectional,
+            num_blocks=triton_nb,
+        )
+        dist.barrier(group)
+        nccl_us, nccl_bw = _bench_nccl(
+            msg_bytes, local_rank, peer_rank, group, bidirectional=bidirectional
+        )
+        dist.barrier(group)
+        _print_row(
+            local_rank,
+            msg_bytes,
+            _iters_for_size(msg_bytes),
+            triton_nb,
+            nccl_grid,
+            triton_us,
+            triton_bw,
+            nccl_us,
+            nccl_bw,
+        )
+
+
+def _worker(local_rank: int, master_port: int, cap: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+    # Pin NCCL channel allocation to ``cap`` for the lifetime of this
+    # process. Note: this only sets the allocation cap; NCCL's adaptive
+    # in-kernel grid policy decides how many of those channels to
+    # actually use per call (captured in ``_NCCL_GRID_TABLE``).
+    os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
+    os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+    peer_rank = 1 - local_rank
+
+    if local_rank == 0:
+        print()
+        print("#" * 100)
+        print(f"# NCCL_{{MIN,MAX}}_NCHANNELS = {cap}")
+        print(
+            "# Triton uni: num_blocks = NCCL runtime grid; "
+            "Triton bi: num_blocks = max(NCCL runtime grid // 2, 1)."
+        )
+        print("# BW = unidirectional payload bytes / latency.")
+        print("#" * 100)
+
+    _run_table(local_rank, peer_rank, group, bidirectional=False, cap=cap)
+    dist.barrier(group)
+    _run_table(local_rank, peer_rank, group, bidirectional=True, cap=cap)
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+
+
+def main() -> None:
+    print("Triton NVLink Copy-Based SendRecv vs NCCL batch_isend_irecv")
+    print("Runtime-SM-matched 2-rank sweep via CUDA-graph replay.")
+    print(
+        "Triton num_blocks set per-cell to match NCCL adaptive runtime grid "
+        f"(see _NCCL_GRID_TABLE); cap sweep: {_CAPS}"
+    )
+
+    for cap in _CAPS:
+        os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
+        os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
+        port = _find_free_port()
+        try:
+            mp.spawn(_worker, args=(port, cap), nprocs=2, join=True)
+        except Exception as e:
+            print(f"benchmark failed at cap={cap}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/benchmark_sendrecv.py
@@ -74,6 +74,7 @@ from comms.pipes.triton.collectives.nvl.sendrecv_op import (
     triton_nvl_recv,
     triton_nvl_send,
     triton_nvl_sendrecv,
+    triton_nvl_sendrecv_ws,
 )
 
 
@@ -95,11 +96,25 @@ _MSG_SIZES_BYTES: list[int] = [
 ]
 
 
+_WS_SENDER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_SENDER_WARPS", "4"))
+_WS_RECEIVER_WARPS: int = int(os.environ.get("TRITON_NVL_WS_RECEIVER_WARPS", "4"))
+_WS_MAX_BYTES: int = int(
+    os.environ.get("TRITON_NVL_WS_MAX_BYTES", str(64 * 1024 * 1024))
+)
+
+
 # NCCL ``NCCL_{MIN,MAX}_NCHANNELS`` allocation values to sweep.
 # At each cap we compare against NCCL with that allocation, and Triton
 # with ``num_blocks`` matched to NCCL's actual runtime grid (see table
 # in module docstring).
 _CAPS: list[int] = [4, 8, 16, 32]
+
+
+def _env_int_list(name: str, default: list[int]) -> list[int]:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return [int(x.strip()) for x in raw.split(",") if x.strip()]
 
 
 # Hardcoded NCCL P2P kernel runtime grid table, keyed by
@@ -270,6 +285,7 @@ def _bench_triton(
     *,
     bidirectional: bool,
     num_blocks: int,
+    warp_specialized: bool = False,
 ) -> tuple[float, float]:
     """Bench Triton send/recv via CUDA-graph replay. Returns (μs, GB/s)."""
     device = torch.device(f"cuda:{local_rank}")
@@ -279,13 +295,24 @@ def _bench_triton(
 
     def fn() -> None:
         if bidirectional:
-            triton_nvl_sendrecv(
-                send,
-                recv,
-                peer_rank,
-                group=group,
-                num_blocks=num_blocks,
-            )
+            if warp_specialized:
+                triton_nvl_sendrecv_ws(
+                    send,
+                    recv,
+                    peer_rank,
+                    group=group,
+                    num_blocks=num_blocks,
+                    sender_warps=_WS_SENDER_WARPS,
+                    receiver_warps=_WS_RECEIVER_WARPS,
+                )
+            else:
+                triton_nvl_sendrecv(
+                    send,
+                    recv,
+                    peer_rank,
+                    group=group,
+                    num_blocks=num_blocks,
+                )
         elif local_rank == 0:
             triton_nvl_send(
                 send,
@@ -406,14 +433,20 @@ def _print_row(
     triton_bw: float,
     nccl_us: float,
     nccl_bw: float,
+    ws_us: float | None = None,
+    ws_bw: float | None = None,
 ) -> None:
     if rank != 0:
         return
     speedup = nccl_us / triton_us if triton_us > 0 else 0.0
+    extra = ""
+    if ws_us is not None and ws_bw is not None:
+        ws_speedup = nccl_us / ws_us if ws_us > 0 else 0.0
+        extra = f" | ws {ws_us:>10.2f} {ws_bw:>12.3f} {ws_speedup:>7.2f}x"
     print(
         f"{_fmt_size(msg_bytes):>10} | {iters:>6} | {triton_num_blocks:>6} {nccl_grid:>9} | "
         f"{triton_us:>10.2f} {triton_bw:>12.3f} | "
-        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x"
+        f"{nccl_us:>10.2f} {nccl_bw:>12.3f} | {speedup:>7.2f}x{extra}"
     )
 
 
@@ -425,43 +458,73 @@ def _run_table(
     bidirectional: bool,
     cap: int,
 ) -> None:
+    ws_only = os.environ.get("TRITON_NVL_BENCH_WS_ONLY") == "1"
     direction = (
-        "Bidirectional sendrecv"
+        "Bidirectional WS sendrecv"
+        if bidirectional and ws_only
+        else "Bidirectional sendrecv"
         if bidirectional
         else "Unidirectional rank0->rank1 send/recv"
     )
     title = f"{direction} | NCCL_NCHANNELS=cap={cap} (Triton num_blocks tracks NCCL runtime grid)"
     _print_header(local_rank, title)
-    for msg_bytes in _MSG_SIZES_BYTES:
+    for msg_bytes in _env_int_list("TRITON_NVL_BENCH_MSGS", _MSG_SIZES_BYTES):
         nccl_grid = _NCCL_GRID_TABLE[(msg_bytes, cap)]
         if bidirectional:
             triton_nb = _triton_num_blocks_bi(msg_bytes, cap)
         else:
             triton_nb = _triton_num_blocks_uni(msg_bytes, cap)
 
-        triton_us, triton_bw = _bench_triton(
-            msg_bytes,
-            local_rank,
-            peer_rank,
-            group,
-            bidirectional=bidirectional,
-            num_blocks=triton_nb,
-        )
+        ws_us: float | None = None
+        ws_bw: float | None = None
+        if bidirectional and ws_only and msg_bytes <= _WS_MAX_BYTES:
+            triton_us, triton_bw = _bench_triton(
+                msg_bytes,
+                local_rank,
+                peer_rank,
+                group,
+                bidirectional=True,
+                num_blocks=nccl_grid,
+                warp_specialized=True,
+            )
+        else:
+            triton_us, triton_bw = _bench_triton(
+                msg_bytes,
+                local_rank,
+                peer_rank,
+                group,
+                bidirectional=bidirectional,
+                num_blocks=triton_nb,
+            )
+            dist.barrier(group)
+            if bidirectional and msg_bytes <= _WS_MAX_BYTES:
+                ws_us, ws_bw = _bench_triton(
+                    msg_bytes,
+                    local_rank,
+                    peer_rank,
+                    group,
+                    bidirectional=True,
+                    num_blocks=nccl_grid,
+                    warp_specialized=True,
+                )
         dist.barrier(group)
         nccl_us, nccl_bw = _bench_nccl(
             msg_bytes, local_rank, peer_rank, group, bidirectional=bidirectional
         )
         dist.barrier(group)
+        display_nb = nccl_grid if bidirectional and ws_only else triton_nb
         _print_row(
             local_rank,
             msg_bytes,
             _iters_for_size(msg_bytes),
-            triton_nb,
+            display_nb,
             nccl_grid,
             triton_us,
             triton_bw,
             nccl_us,
             nccl_bw,
+            ws_us,
+            ws_bw,
         )
 
 
@@ -493,6 +556,10 @@ def _worker(local_rank: int, master_port: int, cap: int) -> None:
             "Triton bi: num_blocks = max(NCCL runtime grid // 2, 1)."
         )
         print("# BW = unidirectional payload bytes / latency.")
+        print(
+            f"# WS config: sender_warps={_WS_SENDER_WARPS}, "
+            f"receiver_warps={_WS_RECEIVER_WARPS}"
+        )
         print("#" * 100)
 
     _run_table(local_rank, peer_rank, group, bidirectional=False, cap=cap)
@@ -511,7 +578,7 @@ def main() -> None:
         f"(see _NCCL_GRID_TABLE); cap sweep: {_CAPS}"
     )
 
-    for cap in _CAPS:
+    for cap in _env_int_list("TRITON_NVL_BENCH_CAPS", _CAPS):
         os.environ["NCCL_MIN_NCHANNELS"] = str(cap)
         os.environ["NCCL_MAX_NCHANNELS"] = str(cap)
         port = _find_free_port()

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -18,7 +18,28 @@ from comms.pipes.triton.collectives.nvl.sendrecv_op import (
     triton_nvl_recv,
     triton_nvl_send,
     triton_nvl_sendrecv,
+    triton_nvl_sendrecv_ws,
 )
+
+
+# ---------------------------------------------------------------------------
+# Warp-specialized (WS) test gate.
+#
+# The WS path uses TLX `async_tasks` / `async_task` warp-specialization
+# codegen. In the current `//triton:triton` (in-tree TLX) build, the WS
+# kernel hits a runtime hang / barrier issue (see TLX_BARRIER_BUG.md and
+# the original D106331816 commit message: "tlx.sync_threads() has an
+# iteration-count-dependent barrier bug — hangs after >2 while-loop
+# iterations"). The kernel logic itself is correct — the failure is in
+# upstream TLX codegen.
+#
+# Until upstream TLX is fixed, we DO NOT run the WS test cases by default
+# (they would hang the entire test binary). The cases are kept inline so
+# they re-activate automatically once `TRITON_NVL_WS_TESTS_ENABLED=1` is
+# set, e.g. when a developer wants to validate WS against a fixed TLX
+# build, or once the upstream fix lands and we can flip the default.
+# ---------------------------------------------------------------------------
+_WS_TESTS_ENABLED: bool = os.environ.get("TRITON_NVL_WS_TESTS_ENABLED", "0") == "1"
 
 
 _BASE_CASES: list[tuple[str, int]] = [
@@ -115,6 +136,9 @@ def _run_bidirectional(
     *,
     num_blocks: int = 16,
     num_warps: int = 8,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> bool:
     peer_rank = 1 - local_rank
     device = torch.device(f"cuda:{local_rank}")
@@ -123,9 +147,25 @@ def _run_bidirectional(
     recv = torch.zeros(numel, dtype=dtype, device=device)
     expected = _make_pattern(peer_rank, numel, dtype, device)
 
-    triton_nvl_sendrecv(
-        send, recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
-    )
+    if warp_specialized:
+        triton_nvl_sendrecv_ws(
+            send,
+            recv,
+            peer_rank,
+            group=group,
+            num_blocks=num_blocks,
+            sender_warps=sender_warps,
+            receiver_warps=receiver_warps,
+        )
+    else:
+        triton_nvl_sendrecv(
+            send,
+            recv,
+            peer_rank,
+            group=group,
+            num_blocks=num_blocks,
+            num_warps=num_warps,
+        )
     torch.cuda.synchronize(device)
 
     ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
@@ -206,6 +246,9 @@ def _run_graph_case(
     group: dist.ProcessGroup,
     *,
     bidirectional: bool,
+    warp_specialized: bool = False,
+    sender_warps: int = 4,
+    receiver_warps: int = 4,
 ) -> bool:
     peer_rank: int = 1 - local_rank
     device = torch.device(f"cuda:{local_rank}")
@@ -216,7 +259,16 @@ def _run_graph_case(
     expected = _make_pattern(peer_rank, numel, dtype, device)
 
     def fn() -> None:
-        if bidirectional:
+        if warp_specialized:
+            triton_nvl_sendrecv_ws(
+                send,
+                recv,
+                peer_rank,
+                group=group,
+                sender_warps=sender_warps,
+                receiver_warps=receiver_warps,
+            )
+        elif bidirectional:
             triton_nvl_sendrecv(send, recv, peer_rank, group=group)
         elif local_rank == 0:
             triton_nvl_send(send, peer_rank, group=group)
@@ -239,7 +291,7 @@ def _run_graph_case(
                 recv, expected, "cuda_graph", local_rank
             )
 
-    label = f"{'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
+    label = f"{'bidirectional_ws' if warp_specialized else 'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
     ok = _all_ok(local_ok, device, group)
     if local_rank == 0:
         print(f"  {'PASS' if ok else 'FAIL'}: {label}")
@@ -253,19 +305,9 @@ def _record(
     dist.barrier(group)
 
 
-def _worker(local_rank: int, master_port: int) -> None:
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = str(master_port)
-    os.environ["RANK"] = str(local_rank)
-    os.environ["LOCAL_RANK"] = str(local_rank)
-    os.environ["WORLD_SIZE"] = "2"
-
-    torch.cuda.set_device(local_rank)
-    dist.init_process_group("nccl")
-    group = dist.group.WORLD
-    assert group is not None
-
-    results: list[bool] = []
+def _record_base_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for name, msg_bytes in _BASE_CASES:
         _record(
             results,
@@ -275,6 +317,10 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_dtype_smoke_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for dtype in (torch.bfloat16, torch.float32):
         _record(
             results,
@@ -288,6 +334,35 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_ws_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
+    if not _WS_TESTS_ENABLED:
+        return
+
+    for sw, rw in [(2, 2), (4, 4), (3, 5)]:
+        for msg_label, msg_bytes in [("256KB", 256 * 1024), ("1MB", 1024 * 1024)]:
+            _record(
+                results,
+                lambda sw=sw, rw=rw, mb=msg_bytes, ml=msg_label: _run_bidirectional(
+                    f"bidirectional_ws_{sw}s{rw}r_{ml}_int32",
+                    mb,
+                    torch.int32,
+                    local_rank,
+                    group,
+                    num_blocks=16,
+                    warp_specialized=True,
+                    sender_warps=sw,
+                    receiver_warps=rw,
+                ),
+                group,
+            )
+
+
+def _record_unidirectional_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for src_rank in (0, 1):
         _record(
             results,
@@ -302,6 +377,10 @@ def _worker(local_rank: int, master_port: int) -> None:
             group,
         )
 
+
+def _record_config_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for num_blocks in (2, 16, 32):
         for num_warps in (4, 8):
             _record(
@@ -318,6 +397,10 @@ def _worker(local_rank: int, master_port: int) -> None:
                 group,
             )
 
+
+def _record_back_to_back_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for bidirectional in (False, True):
         for graph in (False, True):
             _record(
@@ -328,6 +411,10 @@ def _worker(local_rank: int, master_port: int) -> None:
                 group,
             )
 
+
+def _record_graph_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
     for bidirectional in (False, True):
         _record(
             results,
@@ -336,6 +423,37 @@ def _worker(local_rank: int, master_port: int) -> None:
             ),
             group,
         )
+
+    if _WS_TESTS_ENABLED:
+        _record(
+            results,
+            lambda: _run_graph_case(
+                local_rank, group, bidirectional=True, warp_specialized=True
+            ),
+            group,
+        )
+
+
+def _worker(local_rank: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+    _record_base_cases(results, local_rank, group)
+    _record_dtype_smoke_cases(results, local_rank, group)
+    _record_ws_cases(results, local_rank, group)
+    _record_unidirectional_cases(results, local_rank, group)
+    _record_config_cases(results, local_rank, group)
+    _record_back_to_back_cases(results, local_rank, group)
+    _record_graph_cases(results, local_rank, group)
 
     if local_rank == 0:
         n_pass = sum(1 for ok in results if ok)

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -174,6 +174,185 @@ def _run_bidirectional(
     return ok
 
 
+def _run_with_signal_bytes_override(
+    name: str,
+    signal_bytes: int,
+    local_rank: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Run a small bidirectional case with a forced ``signal_bytes`` override.
+
+    Drops a temporary tuning JSON whose ``default_stable.signal_bytes`` is
+    smaller than ``_BLOCK_STRIDE_BYTES``, so the host sets
+    ``CHUNKS_PER_SLOT = _BLOCK_STRIDE_BYTES // signal_bytes > 1`` and the
+    kernel exercises the sub-slot signaling branch (per-chunk DATA_READY,
+    slot-boundary backpressure). Verifies functional equivalence vs the
+    ``CHUNKS_PER_SLOT == 1`` fast path on the same message size.
+    """
+    import json as _json
+    import tempfile as _tempfile
+
+    from comms.pipes.triton.collectives.nvl import tuning_config as _tc
+
+    msg_bytes = 256 * 1024
+    f = _tempfile.NamedTemporaryFile(  # noqa: SIM115
+        mode="w", suffix=".json", delete=False
+    )
+    _json.dump(
+        {
+            "default_stable": {
+                "tile_rows": 32,
+                "tile_row_bytes": 2048,
+                "signal_bytes": signal_bytes,
+                "num_blocks": 16,
+                "num_warps": 8,
+            },
+            "configs": [],
+        },
+        f,
+    )
+    f.close()
+    prev = os.environ.get("TRITON_NVL_TUNING_JSON")
+    os.environ["TRITON_NVL_TUNING_JSON"] = f.name
+    _tc._JSON_CACHE = None
+    _tc._CONFIG_CACHE.clear()
+    try:
+        return _run_bidirectional(
+            name, msg_bytes, torch.int32, local_rank, group, num_blocks=16
+        )
+    finally:
+        if prev is None:
+            os.environ.pop("TRITON_NVL_TUNING_JSON", None)
+        else:
+            os.environ["TRITON_NVL_TUNING_JSON"] = prev
+        _tc._JSON_CACHE = None
+        _tc._CONFIG_CACHE.clear()
+        os.unlink(f.name)
+
+
+def _run_back_to_back_across_chunks_per_slot(
+    name: str,
+    local_rank: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Three back-to-back launches with three distinct CHUNKS_PER_SLOT layouts.
+
+    The persistent ``sender_step_ptr`` / ``recver_step_ptr`` state survives
+    across launches and across CHUNKS_PER_SLOT changes. Argument is that
+    the signal counter is sender-published TAIL (``send_step + 1``) opaque
+    to the in-slot chunk layout, so the receiver only needs to see TAIL ≥
+    its expected step. This test pins the invariant: launch A with
+    ``signal_bytes = _BLOCK_STRIDE_BYTES`` (CHUNKS_PER_SLOT=1, fast path),
+    launch B with ``signal_bytes = 64KB`` (CHUNKS_PER_SLOT=4, sub-slot),
+    launch C back to ``signal_bytes = _BLOCK_STRIDE_BYTES``. All three
+    must produce correct receiver output despite reusing the same
+    persistent step counters.
+    """
+    import json as _json
+    import tempfile as _tempfile
+
+    from comms.pipes.triton.collectives.nvl import (
+        sendrecv_op as _so,
+        tuning_config as _tc,
+    )
+
+    def _write_json(signal_bytes: int) -> str:
+        f = _tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w", suffix=".json", delete=False
+        )
+        _json.dump(
+            {
+                "default_stable": {
+                    "tile_rows": 32,
+                    "tile_row_bytes": 2048,
+                    "signal_bytes": signal_bytes,
+                    "num_blocks": 16,
+                    "num_warps": 8,
+                },
+                "configs": [],
+            },
+            f,
+        )
+        f.close()
+        return f.name
+
+    msg_bytes = 256 * 1024
+    elements = msg_bytes // 4
+    fast_signal = _so._BLOCK_STRIDE_BYTES  # CHUNKS_PER_SLOT == 1
+    subslot_signal = 64 * 1024  # CHUNKS_PER_SLOT == _BLOCK_STRIDE_BYTES // 64KB
+    layouts = [
+        ("fast0", fast_signal, 1),
+        ("subslot", subslot_signal, fast_signal // subslot_signal),
+        ("fast1", fast_signal, 1),
+    ]
+    paths: list[str] = []
+    prev = os.environ.get("TRITON_NVL_TUNING_JSON")
+    rank = dist.get_rank(group=group)
+    peer = 1 - rank
+    try:
+        for stage_name, signal_bytes, expected_chunks_per_slot in layouts:
+            path = _write_json(signal_bytes)
+            paths.append(path)
+            os.environ["TRITON_NVL_TUNING_JSON"] = path
+            _tc._JSON_CACHE = None
+            _tc._CONFIG_CACHE.clear()
+
+            cfg = _tc.get_sendrecv_config(
+                msg_bytes=msg_bytes,
+                element_size=4,
+                num_peers=1,
+            )
+            if cfg.stable.signal_bytes != signal_bytes:
+                print(
+                    f"FAIL {name}/{stage_name}: JSON config inactive; "
+                    f"expected signal_bytes={signal_bytes}, "
+                    f"got {cfg.stable.signal_bytes}"
+                )
+                return False
+            chunks_per_slot = _so._BLOCK_STRIDE_BYTES // cfg.stable.signal_bytes
+            if chunks_per_slot != expected_chunks_per_slot:
+                print(
+                    f"FAIL {name}/{stage_name}: expected CHUNKS_PER_SLOT="
+                    f"{expected_chunks_per_slot}, got {chunks_per_slot}"
+                )
+                return False
+
+            send_buf = torch.full(
+                (elements,),
+                rank * 100 + len(paths),
+                dtype=torch.int32,
+                device=f"cuda:{local_rank}",
+            )
+            recv_buf = torch.empty_like(send_buf)
+            triton_nvl_sendrecv(
+                send_buf,
+                recv_buf,
+                send_peer=peer,
+                recv_peer=peer,
+                group=group,
+                num_blocks=16,
+            )
+            torch.cuda.synchronize()
+            expected = torch.full_like(recv_buf, peer * 100 + len(paths))
+            if not torch.equal(recv_buf, expected):
+                print(
+                    f"FAIL {name}/{stage_name}: rank={rank} signal_bytes={signal_bytes}"
+                )
+                return False
+        if rank == 0:
+            print(f"  PASS: {name}")
+        return True
+    finally:
+        if prev is None:
+            os.environ.pop("TRITON_NVL_TUNING_JSON", None)
+        else:
+            os.environ["TRITON_NVL_TUNING_JSON"] = prev
+        _tc._JSON_CACHE = None
+        _tc._CONFIG_CACHE.clear()
+        for path in paths:
+            os.unlink(path)
+
+
 def _run_back_to_back(
     local_rank: int,
     group: dist.ProcessGroup,
@@ -360,6 +539,33 @@ def _record_ws_cases(
             )
 
 
+def _record_subslot_cases(
+    results: list[bool], local_rank: int, group: dist.ProcessGroup
+) -> None:
+    # Force `signal_bytes < _BLOCK_STRIDE_BYTES` so the kernel exercises
+    # multiple DATA_READY signals per slot fill.
+    _record(
+        results,
+        lambda: _run_with_signal_bytes_override(
+            "bidirectional_subslot_chunks_per_slot_4_256KB_int32",
+            64 * 1024,  # signal_bytes -> chunks_per_slot = 256K/64K = 4
+            local_rank,
+            group,
+        ),
+        group,
+    )
+
+    _record(
+        results,
+        lambda: _run_back_to_back_across_chunks_per_slot(
+            "back_to_back_across_chunks_per_slot",
+            local_rank,
+            group,
+        ),
+        group,
+    )
+
+
 def _record_unidirectional_cases(
     results: list[bool], local_rank: int, group: dist.ProcessGroup
 ) -> None:
@@ -450,6 +656,7 @@ def _worker(local_rank: int, master_port: int) -> None:
     _record_base_cases(results, local_rank, group)
     _record_dtype_smoke_cases(results, local_rank, group)
     _record_ws_cases(results, local_rank, group)
+    _record_subslot_cases(results, local_rank, group)
     _record_unidirectional_cases(results, local_rank, group)
     _record_config_cases(results, local_rank, group)
     _record_back_to_back_cases(results, local_rank, group)

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -347,11 +347,286 @@ def _worker(local_rank: int, master_port: int) -> None:
         sys.exit(1)
 
 
+def _run_ring_sendrecv(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+) -> bool:
+    """Ring topology: each rank sends to (rank+1)%N, receives from (rank-1)%N."""
+    send_peer = (local_rank + 1) % world_size
+    recv_peer = (local_rank - 1 + world_size) % world_size
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    send = _make_pattern(local_rank, numel, dtype, device)
+    recv = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(recv_peer, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send,
+        recv,
+        send_peer,
+        recv_peer,
+        group=group,
+        num_blocks=num_blocks,
+    )
+    torch.cuda.synchronize(device)
+
+    ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_nrank_unidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    src_rank: int,
+    dst_rank: int,
+    local_rank: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Send from src_rank to dst_rank in an N-rank group."""
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    if local_rank == src_rank:
+        send = _make_pattern(local_rank, numel, dtype, device)
+        triton_nvl_send(send, dst_rank, group=group)
+        local_ok = True
+    elif local_rank == dst_rank:
+        recv = torch.zeros(numel, dtype=dtype, device=device)
+        expected = _make_pattern(src_rank, numel, dtype, device)
+        triton_nvl_recv(recv, src_rank, group=group)
+        torch.cuda.synchronize(device)
+        local_ok = _check_equal(recv, expected, name, local_rank)
+    else:
+        local_ok = True
+
+    torch.cuda.synchronize(device)
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_ring_back_to_back(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Back-to-back ring sendrecv calls to verify step state persistence."""
+    send_peer = (local_rank + 1) % world_size
+    recv_peer = (local_rank - 1 + world_size) % world_size
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+
+    configs: list[tuple[int, int]] = [
+        (64 * 1024, 4),
+        (1024 * 1024, 16),
+        (256 * 1024, 8),
+    ]
+    sends: list[torch.Tensor] = []
+    recvs: list[torch.Tensor] = []
+    expected: list[torch.Tensor] = []
+    for msg_bytes, _ in configs:
+        numel = _numel(msg_bytes, dtype)
+        sends.append(_make_pattern(local_rank, numel, dtype, device))
+        recvs.append(torch.zeros(numel, dtype=dtype, device=device))
+        expected.append(_make_pattern(recv_peer, numel, dtype, device))
+
+    for i, (_, num_blocks) in enumerate(configs):
+        triton_nvl_sendrecv(
+            sends[i],
+            recvs[i],
+            send_peer,
+            recv_peer,
+            group=group,
+            num_blocks=num_blocks,
+        )
+    torch.cuda.synchronize(device)
+
+    local_ok = all(
+        _check_equal(actual, exp, "ring_back_to_back", local_rank)
+        for actual, exp in zip(recvs, expected)
+    )
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: ring_back_to_back")
+    return ok
+
+
+def _run_cross_peer_back_to_back(
+    local_rank: int,
+    world_size: int,
+    group: dist.ProcessGroup,
+) -> bool:
+    """Back-to-back launches that change ``send_peer``/``recv_peer`` across
+    calls. Verifies that the ``(world_size, MBPP)`` step-state matrix is
+    indexed by peer-row correctly — i.e. progress against peer A does not
+    leak into the slot ledger for peer B.
+
+    Each rank pairs with two distinct peers in sequence:
+      * pass 1: send→(rank+1)%N, recv←(rank-1+N)%N    (forward ring)
+      * pass 2: send→(rank-1+N)%N, recv←(rank+1)%N    (reverse ring)
+    """
+    if world_size < 3:
+        return True
+
+    fwd_send = (local_rank + 1) % world_size
+    fwd_recv = (local_rank - 1 + world_size) % world_size
+    rev_send = fwd_recv
+    rev_recv = fwd_send
+
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+    numel = _numel(256 * 1024, dtype)
+
+    # Two passes share send tensors but use independent recv buffers so
+    # we can verify each peer's payload landed in the right place.
+    send_pass1 = _make_pattern(local_rank, numel, dtype, device)
+    send_pass2 = _make_pattern(local_rank + 1000, numel, dtype, device)
+    recv_pass1 = torch.zeros(numel, dtype=dtype, device=device)
+    recv_pass2 = torch.zeros(numel, dtype=dtype, device=device)
+
+    expected_pass1 = _make_pattern(fwd_recv, numel, dtype, device)
+    expected_pass2 = _make_pattern(rev_recv + 1000, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send_pass1, recv_pass1, fwd_send, fwd_recv, group=group, num_blocks=8
+    )
+    triton_nvl_sendrecv(
+        send_pass2, recv_pass2, rev_send, rev_recv, group=group, num_blocks=8
+    )
+    torch.cuda.synchronize(device)
+
+    local_ok = _check_equal(
+        recv_pass1, expected_pass1, "cross_peer_pass1", local_rank
+    ) and _check_equal(recv_pass2, expected_pass2, "cross_peer_pass2", local_rank)
+
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: cross_peer_back_to_back")
+    return ok
+
+
+def _nrank_worker(local_rank: int, world_size: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+
+    for name, msg_bytes in _BASE_CASES:
+        _record(
+            results,
+            lambda name=name, msg_bytes=msg_bytes: _run_ring_sendrecv(
+                f"ring_{name}_int32",
+                msg_bytes,
+                torch.int32,
+                local_rank,
+                world_size,
+                group,
+            ),
+            group,
+        )
+
+    for dtype in (torch.bfloat16, torch.float32):
+        _record(
+            results,
+            lambda dtype=dtype: _run_ring_sendrecv(
+                f"ring_64KB_{dtype}_smoke",
+                64 * 1024,
+                dtype,
+                local_rank,
+                world_size,
+                group,
+            ),
+            group,
+        )
+
+    _record(
+        results,
+        lambda: _run_nrank_unidirectional(
+            "nrank_send_0_to_1",
+            1024 * 1024,
+            torch.int32,
+            0,
+            1,
+            local_rank,
+            group,
+        ),
+        group,
+    )
+
+    if world_size > 2:
+        _record(
+            results,
+            lambda: _run_nrank_unidirectional(
+                f"nrank_send_0_to_{world_size - 1}",
+                1024 * 1024,
+                torch.int32,
+                0,
+                world_size - 1,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    _record(
+        results,
+        lambda: _run_ring_back_to_back(local_rank, world_size, group),
+        group,
+    )
+
+    _record(
+        results,
+        lambda: _run_cross_peer_back_to_back(local_rank, world_size, group),
+        group,
+    )
+
+    if local_rank == 0:
+        n_pass = sum(1 for ok in results if ok)
+        print(f"\nN-rank Results ({world_size} GPUs): {n_pass}/{len(results)} passed")
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+    if local_rank == 0 and not all(results):
+        sys.exit(1)
+
+
 def main() -> None:
     port = _find_free_port()
+    num_gpus = torch.cuda.device_count()
+
     print("Running Triton NVLink SendRecv Correctness Tests")
     print("=" * 52)
+
+    print("\n--- 2-rank tests ---")
     mp.spawn(_worker, args=(port,), nprocs=2, join=True)
+
+    if num_gpus >= 4:
+        port = _find_free_port()
+        nprocs = min(num_gpus, 8)
+        print(f"\n--- {nprocs}-rank tests (ring topology) ---")
+        mp.spawn(_nrank_worker, args=(nprocs, port), nprocs=nprocs, join=True)
+    else:
+        print(f"\nSkipping N-rank tests: need >= 4 GPUs, have {num_gpus}")
 
 
 if __name__ == "__main__":

--- a/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_sendrecv.py
@@ -1,0 +1,358 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Correctness tests for NVLink copy-based Triton send/recv."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from collections.abc import Callable
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from comms.pipes.triton.collectives.nvl.sendrecv_op import (
+    triton_nvl_recv,
+    triton_nvl_send,
+    triton_nvl_sendrecv,
+)
+
+
+_BASE_CASES: list[tuple[str, int]] = [
+    ("small_64KB", 64 * 1024),
+    ("medium_1MB", 1024 * 1024),
+    ("large_16MB", 16 * 1024 * 1024),
+]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _numel(msg_bytes: int, dtype: torch.dtype) -> int:
+    return max(msg_bytes // dtype.itemsize, 1)
+
+
+def _make_pattern(
+    rank: int, numel: int, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    if dtype == torch.int32:
+        idx = torch.arange(numel, dtype=torch.int32, device=device)
+        return (idx & 0x00FFFFFF) | (int(rank) << 24)
+    return torch.full((numel,), float(rank + 1), dtype=dtype, device=device)
+
+
+def _all_ok(local_ok: bool, device: torch.device, group: dist.ProcessGroup) -> bool:
+    status = torch.tensor([1 if local_ok else 0], dtype=torch.int32, device=device)
+    dist.all_reduce(status, op=dist.ReduceOp.MIN, group=group)
+    return bool(status.item())
+
+
+def _check_equal(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    label: str,
+    local_rank: int,
+) -> bool:
+    ok = torch.equal(actual, expected)
+    if not ok:
+        n_wrong = (actual != expected).sum().item()
+        print(
+            f"  FAIL(rank {local_rank}): {label} — {n_wrong}/{actual.numel()} mismatched, "
+            f"first-10 expected={expected[:10].tolist()} got={actual[:10].tolist()}"
+        )
+    return ok
+
+
+def _run_unidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    src_rank: int,
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+    num_warps: int = 8,
+) -> bool:
+    peer_rank = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+
+    if local_rank == src_rank:
+        send = _make_pattern(local_rank, numel, dtype, device)
+        triton_nvl_send(
+            send, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+        )
+        local_ok = True
+    else:
+        recv = torch.zeros(numel, dtype=dtype, device=device)
+        expected = _make_pattern(peer_rank, numel, dtype, device)
+        triton_nvl_recv(
+            recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+        )
+        torch.cuda.synchronize(device)
+        local_ok = _check_equal(recv, expected, name, local_rank)
+
+    torch.cuda.synchronize(device)
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_bidirectional(
+    name: str,
+    msg_bytes: int,
+    dtype: torch.dtype,
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    num_blocks: int = 16,
+    num_warps: int = 8,
+) -> bool:
+    peer_rank = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    numel = _numel(msg_bytes, dtype)
+    send = _make_pattern(local_rank, numel, dtype, device)
+    recv = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(peer_rank, numel, dtype, device)
+
+    triton_nvl_sendrecv(
+        send, recv, peer_rank, group=group, num_blocks=num_blocks, num_warps=num_warps
+    )
+    torch.cuda.synchronize(device)
+
+    ok = _all_ok(_check_equal(recv, expected, name, local_rank), device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {name}")
+    return ok
+
+
+def _run_back_to_back(
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+    graph: bool,
+) -> bool:
+    peer_rank: int = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    configs: list[tuple[int, int]] = [
+        (64 * 1024, 2),
+        (16 * 1024 * 1024, 32),
+        (256 * 1024, 16),
+    ]
+    dtype = torch.int32
+    sends: list[torch.Tensor] = []
+    recvs: list[torch.Tensor] = []
+    expected: list[torch.Tensor] = []
+    for msg_bytes, _ in configs:
+        numel = _numel(msg_bytes, dtype)
+        sends.append(_make_pattern(local_rank, numel, dtype, device))
+        recvs.append(torch.zeros(numel, dtype=dtype, device=device))
+        expected.append(_make_pattern(peer_rank, numel, dtype, device))
+
+    def sequence() -> None:
+        for i, (_, num_blocks) in enumerate(configs):
+            send = sends[i]
+            recv = recvs[i]
+            if bidirectional:
+                triton_nvl_sendrecv(
+                    send, recv, peer_rank, group=group, num_blocks=num_blocks
+                )
+            elif local_rank == 0:
+                triton_nvl_send(send, peer_rank, group=group, num_blocks=num_blocks)
+            else:
+                triton_nvl_recv(recv, peer_rank, group=group, num_blocks=num_blocks)
+
+    if graph:
+        sequence()
+        torch.cuda.synchronize(device)
+        graph_obj = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph_obj):
+            sequence()
+        for _ in range(5):
+            graph_obj.replay()
+    else:
+        sequence()
+    torch.cuda.synchronize(device)
+
+    if bidirectional or local_rank == 1:
+        local_ok = all(
+            _check_equal(actual, exp, "back_to_back", local_rank)
+            for actual, exp in zip(recvs, expected)
+        )
+    else:
+        local_ok = True
+
+    label = (
+        f"{'bidirectional' if bidirectional else 'unidirectional'}_"
+        f"back_to_back_{'graph' if graph else 'eager'}"
+    )
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {label}")
+    return ok
+
+
+def _run_graph_case(
+    local_rank: int,
+    group: dist.ProcessGroup,
+    *,
+    bidirectional: bool,
+) -> bool:
+    peer_rank: int = 1 - local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    dtype = torch.int32
+    numel = _numel(256 * 1024, dtype)
+    send: torch.Tensor = _make_pattern(local_rank, numel, dtype, device)
+    recv: torch.Tensor = torch.zeros(numel, dtype=dtype, device=device)
+    expected = _make_pattern(peer_rank, numel, dtype, device)
+
+    def fn() -> None:
+        if bidirectional:
+            triton_nvl_sendrecv(send, recv, peer_rank, group=group)
+        elif local_rank == 0:
+            triton_nvl_send(send, peer_rank, group=group)
+        else:
+            triton_nvl_recv(recv, peer_rank, group=group)
+
+    fn()
+    torch.cuda.synchronize(device)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        fn()
+
+    local_ok = True
+    for _ in range(5):
+        recv.zero_()
+        g.replay()
+        torch.cuda.synchronize(device)
+        if bidirectional or local_rank == 1:
+            local_ok = local_ok and _check_equal(
+                recv, expected, "cuda_graph", local_rank
+            )
+
+    label = f"{'bidirectional' if bidirectional else 'unidirectional'}_cuda_graph"
+    ok = _all_ok(local_ok, device, group)
+    if local_rank == 0:
+        print(f"  {'PASS' if ok else 'FAIL'}: {label}")
+    return ok
+
+
+def _record(
+    results: list[bool], fn: Callable[[], bool], group: dist.ProcessGroup
+) -> None:
+    results.append(fn())
+    dist.barrier(group)
+
+
+def _worker(local_rank: int, master_port: int) -> None:
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(local_rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = "2"
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = dist.group.WORLD
+    assert group is not None
+
+    results: list[bool] = []
+    for name, msg_bytes in _BASE_CASES:
+        _record(
+            results,
+            lambda name=name, msg_bytes=msg_bytes: _run_bidirectional(
+                f"bidirectional_{name}_int32", msg_bytes, torch.int32, local_rank, group
+            ),
+            group,
+        )
+
+    for dtype in (torch.bfloat16, torch.float32):
+        _record(
+            results,
+            lambda dtype=dtype: _run_bidirectional(
+                f"bidirectional_64KB_{dtype}_smoke",
+                64 * 1024,
+                dtype,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    for src_rank in (0, 1):
+        _record(
+            results,
+            lambda src_rank=src_rank: _run_unidirectional(
+                f"unidirectional_{src_rank}_to_{1 - src_rank}_1MB",
+                1024 * 1024,
+                torch.int32,
+                src_rank,
+                local_rank,
+                group,
+            ),
+            group,
+        )
+
+    for num_blocks in (2, 16, 32):
+        for num_warps in (4, 8):
+            _record(
+                results,
+                lambda num_blocks=num_blocks, num_warps=num_warps: _run_bidirectional(
+                    f"config_blocks_{num_blocks}_warps_{num_warps}",
+                    256 * 1024,
+                    torch.int32,
+                    local_rank,
+                    group,
+                    num_blocks=num_blocks,
+                    num_warps=num_warps,
+                ),
+                group,
+            )
+
+    for bidirectional in (False, True):
+        for graph in (False, True):
+            _record(
+                results,
+                lambda bidirectional=bidirectional, graph=graph: _run_back_to_back(
+                    local_rank, group, bidirectional=bidirectional, graph=graph
+                ),
+                group,
+            )
+
+    for bidirectional in (False, True):
+        _record(
+            results,
+            lambda bidirectional=bidirectional: _run_graph_case(
+                local_rank, group, bidirectional=bidirectional
+            ),
+            group,
+        )
+
+    if local_rank == 0:
+        n_pass = sum(1 for ok in results if ok)
+        print(f"\nResults: {n_pass}/{len(results)} passed")
+
+    dist.barrier(group)
+    dist.destroy_process_group()
+    if local_rank == 0 and not all(results):
+        sys.exit(1)
+
+
+def main() -> None:
+    port = _find_free_port()
+    print("Running Triton NVLink SendRecv Correctness Tests")
+    print("=" * 52)
+    mp.spawn(_worker, args=(port,), nprocs=2, join=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/pipes/triton/collectives/nvl/tests/test_tuning_config.py
+++ b/comms/pipes/triton/collectives/nvl/tests/test_tuning_config.py
@@ -1,0 +1,302 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Unit tests for ``tuning_config`` JSON lookup.
+
+CPU-only — no GPU / multi-process required. Exercises:
+  * ``_detect_hardware`` branch coverage via mocked
+    ``torch.cuda.get_device_name``.
+  * ``get_sendrecv_config`` lookup hit, miss-fallback, hardware
+    filtering, msg-byte range filtering, and result caching.
+  * ``_parse_stable`` / ``_parse_ws`` defaults + tile_cols derivation
+    from ``tile_row_bytes / element_size``.
+  * Empty JSON / missing-section fallback behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from typing import Any
+from unittest import mock
+
+from comms.pipes.triton.collectives.nvl import tuning_config
+
+
+def _reset_caches() -> None:
+    tuning_config._CONFIG_CACHE.clear()
+    tuning_config._JSON_CACHE = None
+
+
+def _write_json(d: dict[str, Any]) -> str:
+    f = tempfile.NamedTemporaryFile(  # noqa: SIM115
+        mode="w", suffix=".json", delete=False
+    )
+    json.dump(d, f)
+    f.close()
+    return f.name
+
+
+class DetectHardwareTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_caches()
+
+    def test_h100(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda,
+                "get_device_name",
+                return_value="NVIDIA H100 80GB HBM3",
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "H100")
+
+    def test_h200(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda, "get_device_name", return_value="NVIDIA H200"
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "H100")
+
+    def test_b200(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda, "get_device_name", return_value="NVIDIA B200"
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "B200")
+
+    def test_gb200_superchip(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda,
+                "get_device_name",
+                return_value="NVIDIA GB200",
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "GB200")
+
+    def test_a100(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda,
+                "get_device_name",
+                return_value="NVIDIA A100-SXM4-80GB",
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "A100")
+
+    def test_unknown_passthrough(self) -> None:
+        with (
+            mock.patch.object(
+                tuning_config.torch.cuda, "is_available", return_value=True
+            ),
+            mock.patch.object(
+                tuning_config.torch.cuda, "get_device_name", return_value="L40S"
+            ),
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "L40S")
+
+    def test_no_cuda(self) -> None:
+        with mock.patch.object(
+            tuning_config.torch.cuda, "is_available", return_value=False
+        ):
+            self.assertEqual(tuning_config._detect_hardware(), "unknown")
+
+
+class GetSendrecvConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _reset_caches()
+        self._json_path: str | None = None
+
+    def tearDown(self) -> None:
+        if self._json_path is not None and os.path.exists(self._json_path):
+            os.unlink(self._json_path)
+        os.environ.pop("TRITON_NVL_TUNING_JSON", None)
+        _reset_caches()
+
+    def _install_json(self, data: dict[str, Any]) -> None:
+        self._json_path = _write_json(data)
+        os.environ["TRITON_NVL_TUNING_JSON"] = self._json_path
+        _reset_caches()
+
+    def test_default_fallback_when_no_configs(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {
+                    "tile_rows": 32,
+                    "tile_row_bytes": 2048,
+                    "signal_bytes": 262144,
+                    "num_blocks": 16,
+                    "num_warps": 8,
+                },
+                "configs": [],
+            }
+        )
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertEqual(cfg.stable.signal_bytes, 262144)
+        self.assertEqual(cfg.stable.num_warps, 8)
+        # tile_cols = tile_row_bytes / element_size
+        self.assertEqual(cfg.stable.tile_cols, 2048 // 4)
+        self.assertIsNone(cfg.ws)
+
+    def test_default_fallback_with_default_ws(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {"signal_bytes": 262144, "num_warps": 8},
+                "default_ws": {"sender_warps": 4, "receiver_warps": 4},
+                "configs": [],
+            }
+        )
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024, element_size=2, num_peers=1, hardware="H100"
+        )
+        self.assertIsNotNone(cfg.ws)
+        # pyre-ignore[16]: just asserted not-None
+        self.assertEqual(cfg.ws.sender_warps, 4)
+        self.assertEqual(cfg.ws.tile_cols, 2048 // 2)
+
+    def test_lookup_hits_msg_range(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {"signal_bytes": 262144, "num_warps": 8},
+                "configs": [
+                    {
+                        "hardware": "H100",
+                        "num_peers": 1,
+                        "msg_bytes_min": 0,
+                        "msg_bytes_max": 1024 * 1024 - 1,
+                        "stable": {"signal_bytes": 65536, "num_warps": 4},
+                    },
+                    {
+                        "hardware": "H100",
+                        "num_peers": 1,
+                        "msg_bytes_min": 1024 * 1024,
+                        "msg_bytes_max": 2**40,
+                        "stable": {"signal_bytes": 524288, "num_warps": 16},
+                    },
+                ],
+            }
+        )
+        small = tuning_config.get_sendrecv_config(
+            msg_bytes=512 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        large = tuning_config.get_sendrecv_config(
+            msg_bytes=64 * 1024 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertEqual(small.stable.signal_bytes, 65536)
+        self.assertEqual(small.stable.num_warps, 4)
+        self.assertEqual(large.stable.signal_bytes, 524288)
+        self.assertEqual(large.stable.num_warps, 16)
+
+    def test_lookup_falls_back_when_hardware_mismatches(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {"signal_bytes": 262144, "num_warps": 8},
+                "configs": [
+                    {
+                        "hardware": "GB200",
+                        "stable": {"signal_bytes": 999, "num_warps": 99},
+                    },
+                ],
+            }
+        )
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertEqual(cfg.stable.signal_bytes, 262144)
+        self.assertEqual(cfg.stable.num_warps, 8)
+
+    def test_lookup_falls_back_when_num_peers_mismatches(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {"signal_bytes": 262144, "num_warps": 8},
+                "configs": [
+                    {
+                        "hardware": "H100",
+                        "num_peers": 7,
+                        "stable": {"signal_bytes": 999},
+                    },
+                ],
+            }
+        )
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertEqual(cfg.stable.signal_bytes, 262144)
+
+    def test_result_cached_per_key(self) -> None:
+        self._install_json(
+            {
+                "default_stable": {"signal_bytes": 262144, "num_warps": 8},
+                "configs": [],
+            }
+        )
+        a = tuning_config.get_sendrecv_config(
+            msg_bytes=1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        b = tuning_config.get_sendrecv_config(
+            msg_bytes=1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertIs(a, b)
+        # Different msg_bytes -> different cache key, but same JSON-derived values.
+        c = tuning_config.get_sendrecv_config(
+            msg_bytes=2048, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertIsNot(a, c)
+        self.assertEqual(a.stable, c.stable)
+
+    def test_empty_default_stable_uses_hardcoded_defaults(self) -> None:
+        self._install_json({"configs": []})
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        # Hardcoded defaults from _parse_stable: tile_rows=32, row_bytes=2048,
+        # signal_bytes=262144, num_blocks=16, num_warps=8.
+        self.assertEqual(cfg.stable.tile_rows, 32)
+        self.assertEqual(cfg.stable.tile_cols, 2048 // 4)
+        self.assertEqual(cfg.stable.signal_bytes, 262144)
+        self.assertEqual(cfg.stable.num_blocks, 16)
+        self.assertEqual(cfg.stable.num_warps, 8)
+
+    def test_repo_default_json_loads(self) -> None:
+        # Sanity check: the in-tree tuning_sendrecv.json is well-formed and
+        # loads. This catches accidental commit of a broken JSON.
+        os.environ.pop("TRITON_NVL_TUNING_JSON", None)
+        _reset_caches()
+        # Should not raise even without GPUs (hardware="H100" forces the path
+        # without calling _detect_hardware).
+        cfg = tuning_config.get_sendrecv_config(
+            msg_bytes=1024 * 1024, element_size=4, num_peers=1, hardware="H100"
+        )
+        self.assertGreater(cfg.stable.signal_bytes, 0)
+        self.assertGreater(cfg.stable.num_warps, 0)
+
+
+def main() -> None:
+    unittest.main(module=__name__, argv=["test_tuning_config", "-v"], exit=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/pipes/triton/collectives/nvl/tuning_config.py
+++ b/comms/pipes/triton/collectives/nvl/tuning_config.py
@@ -1,0 +1,189 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""JSON-based tuning config for NVLink sendrecv kernels.
+
+Each kernel launch looks up optimal parameters from a JSON config file
+keyed by ``(hardware, num_peers, msg_size_range)``. This replaces
+environment-variable-based tuning with a declarative, per-kernel config
+that can be populated by a sweep script.
+
+Two kernel variants have separate config sections:
+
+- **Stable kernel** (``sendrecv.py``): supports ``signal_bytes`` for
+  sub-slot signaling (latency vs throughput trade-off).
+- **WS kernel** (``sendrecv_ws.py``): no sub-slot signaling (TLX barrier
+  limitation), but has ``sender_warps`` / ``receiver_warps`` split.
+
+Failure semantics:
+  * Malformed or missing JSON → ``json.JSONDecodeError`` /
+    ``FileNotFoundError`` propagates from ``_load_json``. This is
+    deliberately fail-loud: silent fallback would hide bad sweep
+    output. If you need a recoverable load path, wrap callers, do not
+    add a try/except here.
+  * Schema mismatch (missing keys, wrong types) → the per-section
+    ``_parse_*`` functions fall back to hardcoded defaults via
+    ``dict.get(..., default)``. Sweep tooling should validate JSON
+    upstream rather than rely on this fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_TUNING_JSON_PATH: Path = Path(__file__).parent / "tuning_sendrecv.json"
+
+
+@dataclass(frozen=True)
+class StableTuningConfig:
+    tile_rows: int
+    tile_cols: int
+    signal_bytes: int
+    num_blocks: int
+    num_warps: int
+
+
+@dataclass(frozen=True)
+class WsTuningConfig:
+    tile_rows: int
+    tile_cols: int
+    num_blocks: int
+    sender_warps: int
+    receiver_warps: int
+
+
+@dataclass(frozen=True)
+class SendRecvTuningConfig:
+    stable: StableTuningConfig
+    ws: WsTuningConfig | None
+
+
+def _detect_hardware() -> str:
+    """Bucket the local GPU into a coarse hardware family.
+
+    Note: this inspects ``cuda:0`` only. On heterogeneous hosts (rare
+    in current production) the per-device family is not honored and
+    callers may receive a tuning config that does not match the device
+    actually used by the process.
+    """
+    if not torch.cuda.is_available():
+        return "unknown"
+    name = torch.cuda.get_device_name(0)
+    if "H100" in name or "H200" in name:
+        return "H100"
+    # GB200 NVL72 (Grace+B200 superchip, NVLink fabric across superchips)
+    # has substantially different NVLink topology vs standalone B200 PCIe
+    # (8x B200 + discrete NVLink switch in one host). Tuning sweet spots
+    # diverge — keep them in separate buckets so the sweep can populate
+    # them independently.
+    if "GB200" in name:
+        return "GB200"
+    if "B200" in name:
+        return "B200"
+    if "A100" in name:
+        return "A100"
+    return name
+
+
+_CONFIG_CACHE: dict[tuple[str, int, int], SendRecvTuningConfig] = {}
+
+_JSON_CACHE: dict[str, object] | None = None
+
+
+def _load_json() -> dict[str, object]:
+    global _JSON_CACHE
+    if _JSON_CACHE is not None:
+        return _JSON_CACHE
+
+    override = os.environ.get("TRITON_NVL_TUNING_JSON")
+    path = Path(override) if override else _TUNING_JSON_PATH
+
+    with open(path) as f:
+        data = json.load(f)
+
+    _JSON_CACHE = data
+    return data
+
+
+def _parse_stable(d: dict[str, object], element_size: int) -> StableTuningConfig:
+    tile_rows = int(d.get("tile_rows", 32))
+    row_bytes = int(d.get("tile_row_bytes", 2048))
+    return StableTuningConfig(
+        tile_rows=tile_rows,
+        tile_cols=row_bytes // element_size,
+        signal_bytes=int(d.get("signal_bytes", d.get("block_stride_bytes", 262144))),
+        num_blocks=int(d.get("num_blocks", 16)),
+        num_warps=int(d.get("num_warps", 8)),
+    )
+
+
+def _parse_ws(d: dict[str, object] | None, element_size: int) -> WsTuningConfig | None:
+    if d is None:
+        return None
+    tile_rows = int(d.get("tile_rows", 32))
+    row_bytes = int(d.get("tile_row_bytes", 2048))
+    return WsTuningConfig(
+        tile_rows=tile_rows,
+        tile_cols=row_bytes // element_size,
+        num_blocks=int(d.get("num_blocks", 16)),
+        sender_warps=int(d.get("sender_warps", 4)),
+        receiver_warps=int(d.get("receiver_warps", 4)),
+    )
+
+
+def get_sendrecv_config(
+    msg_bytes: int,
+    element_size: int = 4,
+    num_peers: int = 1,
+    hardware: str | None = None,
+) -> SendRecvTuningConfig:
+    """Lookup optimal tuning config for given parameters.
+
+    Falls back to defaults if no matching config entry is found.
+    """
+    if hardware is None:
+        hardware = _detect_hardware()
+
+    cache_key = (hardware, num_peers, msg_bytes)
+    cached = _CONFIG_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    data = _load_json()
+    configs = data.get("configs", [])
+
+    best: dict[str, object] | None = None
+    for entry in configs:
+        if entry.get("hardware", hardware) != hardware:
+            continue
+        if entry.get("num_peers", num_peers) != num_peers:
+            continue
+        lo = int(entry.get("msg_bytes_min", 0))
+        hi = int(entry.get("msg_bytes_max", 2**63))
+        if lo <= msg_bytes <= hi:
+            best = entry
+            break
+
+    if best is not None:
+        stable_d = best.get("stable", data.get("default_stable", {}))
+        ws_d = best.get("ws", data.get("default_ws"))
+    else:
+        stable_d = data.get("default_stable", {})
+        ws_d = data.get("default_ws")
+
+    result = SendRecvTuningConfig(
+        stable=_parse_stable(stable_d, element_size),
+        ws=_parse_ws(ws_d, element_size),
+    )
+
+    _CONFIG_CACHE[cache_key] = result
+    return result

--- a/comms/pipes/triton/collectives/nvl/tuning_sendrecv.json
+++ b/comms/pipes/triton/collectives/nvl/tuning_sendrecv.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "default_stable": {
+    "tile_rows": 32,
+    "tile_row_bytes": 2048,
+    "signal_bytes": 262144,
+    "num_blocks": 16,
+    "num_warps": 8
+  },
+  "default_ws": {
+    "tile_rows": 32,
+    "tile_row_bytes": 2048,
+    "num_blocks": 16,
+    "sender_warps": 4,
+    "receiver_warps": 4
+  },
+  "configs": [
+  ]
+}

--- a/comms/pipes/triton/collectives/nvl/utils.py
+++ b/comms/pipes/triton/collectives/nvl/utils.py
@@ -1,0 +1,174 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton device-side helpers for NVLink copy-based collectives."""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def get_tid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %tid.x;
+        mov.u32 $1, %tid.y;
+        mov.u32 $2, %tid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_ntid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %ntid.x;
+        mov.u32 $1, %ntid.y;
+        mov.u32 $2, %ntid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_flat_tid():
+    tid_x, tid_y, tid_z = get_tid()
+    ntid_x, ntid_y, _ = get_ntid()
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def sync_threads():
+    """Block-scope barrier (``bar.sync 0``).
+
+    Triton's implicit ``__syncthreads`` is not always emitted around inline
+    asm sections, so we emit one explicitly when the protocol requires
+    cross-warp ordering inside a block.
+    """
+    tl.inline_asm_elementwise(
+        "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+    )
+
+
+@triton.jit
+def wait_ge(addr, target):
+    """Acquire-poll int64 until ``*addr >= target``.
+
+    All reads are LOCAL (no NVLink load). Used by the **receiver** to poll the
+    local TAIL counter — the acquire memory order pairs with the sender's
+    ``fence_and_remote_store_i64`` (release) so the receiver's subsequent
+    staging-buffer reads observe the sender's writes.
+
+    The sender's HEAD poll uses the volatile-only :func:`wait_ge_volatile`
+    instead, because the receiver's HEAD update does not publish payload data
+    (see :func:`remote_store_i64_relaxed`).
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u64   %tmp64_<1>;
+            .reg .pred  %p<1>;
+
+            wait_ge:
+                ld.global.acquire.sys.b64 %tmp64_0, [$1];
+                setp.lt.u64 %p0, %tmp64_0, $2;
+                @%p0 bra wait_ge;
+        }
+        """,
+        "=r, l, l",
+        [addr, target],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def wait_ge_volatile(addr, target):
+    """Volatile-poll int64 until ``*addr >= target``.
+
+    Use for credit counters that only transfer staging-slot ownership. The
+    counter does not publish payload data, so the polling load does not need
+    acquire semantics.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u64   %tmp64_<1>;
+            .reg .pred  %p<1>;
+
+            wait_ge_volatile:
+                ld.volatile.global.u64 %tmp64_0, [$1];
+                setp.lt.u64 %p0, %tmp64_0, $2;
+                @%p0 bra wait_ge_volatile;
+        }
+        """,
+        "=r, l, l",
+        [addr, target],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def fence_and_remote_store_i64(addr, val):
+    """System fence + REMOTE int64 store for monotonic counter advancement.
+
+    Drains all prior writes (staging buffer data) so the remote rank's
+    acquire-load of the counter sees the data. The store itself is
+    relaxed because the fence has already provided release ordering.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            fence.acq_rel.sys;
+            st.global.relaxed.sys.b64 [$1], $2;
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r, l, l",
+        [addr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def remote_store_i64_relaxed(addr, val):
+    """REMOTE relaxed int64 store **without** a preceding system fence.
+
+    For credit signals that only transfer staging-slot ownership, where the
+    consumer side does not read any payload published by the producer of the
+    signal.
+
+    A local execution barrier (e.g. ``sync_threads``) before this store is
+    sufficient to ensure all prior reads inside the producer block have
+    completed before the credit is posted. Do **not** use this for signals
+    that publish payload data (e.g. sender→receiver TAIL); use
+    :func:`fence_and_remote_store_i64` for those.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            st.global.relaxed.sys.b64 [$1], $2;
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r, l, l",
+        [addr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )


### PR DESCRIPTION
Summary:
Replace environment-variable-based kernel tuning with a declarative JSON config system. Add sub-slot signaling support to the stable sendrecv kernel for per-message-size latency vs throughput trade-off.

**JSON tuning config** (`tuning_config.py` + `tuning_sendrecv.json`):
- `get_sendrecv_config(msg_bytes, element_size, num_peers, hardware)` looks up optimal `{tile_size, signal_bytes, num_blocks, num_warps, sender_warps, receiver_warps}` from a JSON file
- Two config dataclasses: `StableTuningConfig` (with `signal_bytes`) and `WsTuningConfig` (with warp split)
- Hardware auto-detect via `torch.cuda.get_device_name()`. The `_detect_hardware()` helper inspects `cuda:0` only; documented in the docstring (heterogeneous-host caveat).
- Falls back to defaults matching current hardcoded behavior (zero regression)
- JSON entries keyed by `(hardware, num_peers, msg_bytes_range)` — populate via sweep script
- Env vars (`TRITON_NVL_BLOCK_STRIDE_BYTES` etc.) still work as debug overrides
- `TRITON_NVL_TUNING_JSON` env var allows overriding the JSON path (used in tests)

**Sub-slot signaling** (`sendrecv.py`):
- New constexprs: `TILES_PER_SIGNAL`, `CHUNKS_PER_SLOT`, `SIGNAL_STRIDE_ELEMS`
- When `CHUNKS_PER_SLOT == 1` (default): identical behavior to v1 (one signal per slot fill)
- When `CHUNKS_PER_SLOT > 1` (`signal_bytes < BLOCK_STRIDE_BYTES`): sender signals DATA_READY after each chunk, enabling earlier receiver consumption. Backpressure (SLOT_FREE) fires only at slot boundaries
- Constexpr if separates fast path (`CHUNKS_PER_SLOT == 1`) from sub-slot path — verified via PTX dump that `CHUNKS_PER_SLOT=1` produces identical codegen to the old kernel (998 lines, 16x `st.global.v4.b32`)

**Host integration** (`sendrecv_op.py`):
- `_launch()` reads tuning config from JSON, computes `TILES_PER_SIGNAL` and `CHUNKS_PER_SLOT` from `signal_bytes`
- WS adaptive stride retained as runtime safety clamp (not replaced by JSON — correctness workaround for TLX barrier bug)
- Sentinel defaults (`_SENTINEL_NUM_BLOCKS = -1`): when callers omit `num_blocks`/`num_warps`, JSON config values are used; explicit values override
- Fail-loud guards added during review:
  * Caller requests warp_specialized=True but JSON has no `ws` config → raise RuntimeError instead of silently downgrading to stable.
  * `signal_bytes >= tile_bytes` and `_BLOCK_STRIDE_BYTES % signal_bytes == 0` invariants asserted to prevent silent staging-buffer overrun across sub-slot chunk boundaries.
  * Restored informative assertion messages on `num_blocks`, `sender_warps`/`receiver_warps`, `total_warps` checks (production stack-trace context).

**Key finding during development**: `triton.jit(do_not_specialize=["send_numel", "recv_numel"])` causes 15x throughput regression (122 -> 8 GB/s) because Triton cannot specialize on data size, disabling loop unrolling and mask constant-folding. PTX investigation confirmed the sub-slot signaling constexprs themselves have zero codegen impact. The decorator was removed.

Differential Revision: D106331826


