### PR TITLE
Add `cliqueSize` and `algoStat` to commDump output

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -145,7 +145,7 @@ commResult_t ctranInit(
 
   for (const auto& opt : NCCL_COLLTRACE) {
     if (opt == "algostat") {
-      comm->algoStats_ = std::make_unique<meta::comms::colltrace::AlgoStats>(
+      comm->algoStats_ = meta::comms::colltrace::AlgoStats::getOrCreate(
           comm->statex_->commHash(), comm->statex_->commDesc());
       break;
     }

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -227,7 +227,7 @@ class CtranComm {
   friend commResult_t ctranInit(
       CtranComm* comm,
       std::unique_ptr<ctran::IProfilerReporter> reporter);
-  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats_;
   // TODO: define proper constructor to make CtranComm be independent of
   // ncclComm.
   // While doing refactoring we always create CtranComm from ncclComm and it

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -311,7 +311,7 @@ ncclResult_t newCollTraceInit(ncclComm* comm) {
   // Initialize standalone AlgoStats if algostat mode enabled
   // This is independent of which colltrace implementation is used
   if (algoStatEnabled) {
-    comm->algoStats = std::make_unique<meta::comms::colltrace::AlgoStats>(
+    comm->algoStats = meta::comms::colltrace::AlgoStats::getOrCreate(
         comm->logMetaData.commHash, comm->logMetaData.commDesc);
   }
 
@@ -475,22 +475,10 @@ __attribute__((visibility("default"))) void dumpAlgoStat(
     return;
   }
 
-  // Dump baseline (ncclx) algo stats
+  // Baseline and ctran share the same AlgoStats instance via getOrCreate.
   if (comm->algoStats) {
     auto dump = comm->algoStats->dump();
     map.swap(dump.counts);
-  }
-
-  // Merge ctran algo stats
-  if (comm->ctranComm_) {
-    auto ctranDump = comm->ctranComm_->dumpAlgoStats();
-    if (ctranDump.has_value()) {
-      for (auto& [opName, algoMap] : ctranDump->counts) {
-        for (auto& [algoName, count] : algoMap) {
-          map[opName][algoName] += count;
-        }
-      }
-    }
   }
 }
 

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -164,6 +164,7 @@ static void dumpCommInfo(
   map["nRanks"] = std::to_string(comm->nRanks);
   map["localRanks"] = std::to_string(comm->localRanks);
   map["nNodes"] = std::to_string(comm->nNodes);
+  map["cliqueSize"] = std::to_string(comm->clique.size);
   map["commDesc"] = toQuotedString(NCCLX_CONFIG_FIELD(comm->config, commDesc));
 }
 
@@ -201,6 +202,9 @@ static void dumpCommInfo(
   }
   if (isKeyRequested(requestFields, "nNodes")) {
     map["nNodes"] = std::to_string(stateInfo.nNodes);
+  }
+  if (isKeyRequested(requestFields, "cliqueSize")) {
+    map["cliqueSize"] = std::to_string(stateInfo.cliqueSize);
   }
 }
 
@@ -272,6 +276,28 @@ static void dumpMemoryTrace(
   }
 }
 
+static void dumpAlgoStatToMap(
+    const std::shared_ptr<meta::comms::colltrace::AlgoStats>& algoStats,
+    std::unordered_map<std::string, std::string>& map,
+    const DumpFieldSet& requestFields = {}) {
+  if (!isKeyRequested(requestFields, "algoStat") || !algoStats) {
+    return;
+  }
+  auto dump = algoStats->dump();
+  if (dump.counts.empty()) {
+    return;
+  }
+  folly::dynamic obj = folly::dynamic::object();
+  for (const auto& [opName, algoMap] : dump.counts) {
+    folly::dynamic algoObj = folly::dynamic::object();
+    for (const auto& [algoName, count] : algoMap) {
+      algoObj[algoName] = count;
+    }
+    obj[opName] = std::move(algoObj);
+  }
+  map["algoStat"] = folly::toJson(obj);
+}
+
 std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     const ncclx::comms_monitor::NcclCommMonitorInfo& info,
     const std::unordered_set<std::string>& requestFields) {
@@ -286,6 +312,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
            "nRanks",
            "localRanks",
            "nNodes",
+           "cliqueSize",
            "commDesc"})) {
     dumpCommInfo(&info.logMetaData, info.stateInfo, map, requestFields);
   }
@@ -321,6 +348,7 @@ std::unordered_map<std::string, std::string> commDumpByMonitorInfo(
     }
   }
 
+  dumpAlgoStatToMap(info.algoStats, map, requestFields);
   dumpProcessGlobalErrors(map, requestFields);
   dumpMemoryTrace(info.memTracer, map, requestFields);
 

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.cc
@@ -85,13 +85,15 @@ folly::Singleton<CommsMonitor, CommsMonitorSingletonTag>
               .localRank = comm->localRank,
               .node = comm->rankToNode ? comm->rankToNode[comm->rank] : 0,
               .nLocalRanks = comm->localRanks,
-              .nNodes = comm->nNodes},
+              .nNodes = comm->nNodes,
+              .cliqueSize = comm->clique.size},
       .topoInfo = getTopoInfoFromNcclComm(comm),
       .mapperTrace = mapperTrace,
       .proxyTrace = proxyTrace,
       .newCollTrace = comm->newCollTrace,
       .memTracer = meta::comms::memtrace::MemoryTrace::getOrCreate(
-          comm->logMetaData.commHash)};
+          comm->logMetaData.commHash),
+      .algoStats = comm->algoStats};
 }
 
 bool CommsMonitor::deregisterCommImpl(ncclComm_t comm) {

--- a/comms/ncclx/meta/comms-monitor/CommsMonitor.h
+++ b/comms/ncclx/meta/comms-monitor/CommsMonitor.h
@@ -22,6 +22,7 @@ struct CommStateInfo {
   int node{0};
   int nLocalRanks{1};
   int nNodes{1};
+  int cliqueSize{0};
 };
 
 struct NcclCommMonitorInfo {
@@ -41,6 +42,10 @@ struct NcclCommMonitorInfo {
   // Adopted from MemoryTrace::getOrCreate() at registerComm time.
   // See MemoryTrace::getOrCreate() for dual ownership rationale.
   std::shared_ptr<meta::comms::memtrace::MemoryTrace> memTracer;
+
+  // Shared ownership of AlgoStats so it survives comm destruction.
+  // Baseline and ctran share the same instance via AlgoStats::getOrCreate.
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
 
   static NcclCommMonitorInfo fromNcclComm(ncclComm_t comm);
 };

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -151,6 +151,8 @@ TEST_F(CommDumpTest, SingleComm) {
   EXPECT_EQ(dump["localRanks"], std::to_string(this->comm->localRanks));
   EXPECT_EQ(dump.count("nNodes"), 1);
   EXPECT_EQ(dump["nNodes"], std::to_string(this->comm->nNodes));
+  EXPECT_EQ(dump.count("cliqueSize"), 1);
+  EXPECT_EQ(dump["cliqueSize"], std::to_string(this->comm->clique.size));
 
   EXPECT_EQ(dump.count("CT_pastColls"), 1);
   EXPECT_EQ(dump.count("CT_pendingColls"), 1);
@@ -943,6 +945,45 @@ TEST_F(CommDumpTest, DumpAfterCollNewCollTraceWithCommsMonitor) {
     auto ptActiveOpsObjs = folly::parseJson(dump["PT_activeOps"]);
     EXPECT_EQ(ptActiveOpsObjs.size(), 0);
   }
+}
+
+TEST_F(CommDumpTest, AlgoStatInCommDump) {
+  ncclx::comms_monitor::CommsMonitor::testOnlyClearComms();
+  auto reduceGuard = EnvRAII{NCCL_ALLREDUCE_ALGO, NCCL_ALLREDUCE_ALGO::orig};
+  auto traceGuard = EnvRAII(NCCL_COLLTRACE, {"trace", "algostat"});
+  auto commsMonitorGuard = EnvRAII(NCCL_COMMSMONITOR_ENABLE, true);
+
+  ncclx::test::NcclCommRAII comm{
+      globalRank, numRanks, localRank, bootstrap_.get()};
+
+  constexpr int numColls = 5;
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+
+  std::unordered_map<std::string, std::string> dump;
+  auto res = ncclCommDump(comm, dump);
+  ASSERT_EQ(res, ncclSuccess);
+
+  ASSERT_EQ(dump.count("algoStat"), 1);
+  auto algoStatObj = folly::parseJson(dump["algoStat"]);
+  ASSERT_TRUE(algoStatObj.count("AllReduce"));
+
+  int totalCalls = 0;
+  for (const auto& [algoName, count] : algoStatObj["AllReduce"].items()) {
+    EXPECT_GT(count.asInt(), 0);
+    totalCalls += count.asInt();
+  }
+  EXPECT_EQ(totalCalls, numColls);
 }
 
 TEST_F(CommDumpTest, DISABLED_DumpWhileCommsInDestruct) {

--- a/comms/ncclx/v2_29/src/include/comm.h
+++ b/comms/ncclx/v2_29/src/include/comm.h
@@ -826,7 +826,7 @@ struct ncclComm {
    */
   struct CommLogData logMetaData;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
-  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats;
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
   std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;

--- a/comms/ncclx/v2_30/src/include/comm.h
+++ b/comms/ncclx/v2_30/src/include/comm.h
@@ -840,7 +840,7 @@ struct ncclComm {
    */
   struct CommLogData logMetaData;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> newCollTrace;
-  std::unique_ptr<meta::comms::colltrace::AlgoStats> algoStats;
+  std::shared_ptr<meta::comms::colltrace::AlgoStats> algoStats;
   std::shared_ptr<meta::comms::IBootstrap> ctranBootstrap;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache{nullptr};
   std::vector<std::string> connSetupBufKeys;

--- a/comms/utils/colltrace/AlgoStats.cc
+++ b/comms/utils/colltrace/AlgoStats.cc
@@ -2,7 +2,27 @@
 
 #include "comms/utils/colltrace/AlgoStats.h"
 
+#include <folly/Synchronized.h>
+
 namespace meta::comms::colltrace {
+
+namespace {
+folly::Synchronized<std::unordered_map<uint64_t, std::shared_ptr<AlgoStats>>>
+    algoStatsInstances;
+} // namespace
+
+std::shared_ptr<AlgoStats> AlgoStats::getOrCreate(
+    uint64_t commHash,
+    const std::string& commDesc) {
+  auto locked = algoStatsInstances.wlock();
+  auto it = locked->find(commHash);
+  if (it != locked->end()) {
+    return it->second;
+  }
+  auto stats = std::make_shared<AlgoStats>(commHash, commDesc);
+  locked->emplace(commHash, stats);
+  return stats;
+}
 
 void AlgoStats::record(const std::string& opName, const std::string& algoName) {
   algoCounters_.withWLock(

--- a/comms/utils/colltrace/AlgoStats.h
+++ b/comms/utils/colltrace/AlgoStats.h
@@ -29,6 +29,12 @@ class AlgoStats {
   AlgoStats(uint64_t commHash, const std::string& commDesc)
       : commHash_(commHash), commDesc_(commDesc) {}
 
+  // Get or create a shared AlgoStats instance for a communicator.
+  // Both baseline and ctran record into the same instance keyed by commHash.
+  static std::shared_ptr<AlgoStats> getOrCreate(
+      uint64_t commHash,
+      const std::string& commDesc);
+
   // Record a collective execution with the given algorithm.
   // Thread-safe: can be called concurrently from multiple threads.
   void record(const std::string& opName, const std::string& algoName);


### PR DESCRIPTION
Summary:
- Add `cliqueSize` field to commDump, reporting `comm->clique.size` so MNNVL clique partition can be verified from commDump without reading NCCL init logs
- Consolidate `ncclx::colltrace::dumpAlgoStat` into commDump as `algoStat` field, serialized as JSON with per-collective algorithm call counts
- Migrate `AlgoStats` ownership from `unique_ptr` to `shared_ptr` with `AlgoStats::getOrCreate(commHash)` singleton factory (same pattern as `MemoryTrace`), so baseline and ctran share the same instance and algoStat survives comm destruction in CommsMonitor
- Simplify `dumpAlgoStat` in `CollTraceWrapper.cc` — no merge needed since baseline and ctran now record into the same `AlgoStats` instance
- Add `AlgoStatInCommDump` test validating algoStat appears in commDump output with correct call counts

Differential Revision: D106734544


