### PR TITLE
Record per-collective message sizes in AlgoStats (#2731)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -125,9 +125,10 @@ std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
 
 void CtranComm::recordAlgoStats(
     const std::string& opName,
-    const std::string& algoName) {
+    const std::string& algoName,
+    const size_t msgSize) {
   if (algoStats_) {
-    algoStats_->record(opName, algoName);
+    algoStats_->record(opName, algoName, msgSize);
   }
 }
 

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -161,13 +161,17 @@ class CtranComm {
   // disabled.
   std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;
 
-  void recordAlgoStats(const std::string& opName, const std::string& algoName);
+  void recordAlgoStats(
+      const std::string& opName,
+      const std::string& algoName,
+      const size_t msgSize = 0);
 
   // Record a collective algorithm invocation. No-op if algoStats is disabled.
   inline void recordAlgoStat(
       const std::string& opName,
-      const std::string& algoName) {
-    recordAlgoStats(opName, algoName);
+      const std::string& algoName,
+      const size_t msgSize = 0) {
+    recordAlgoStats(opName, algoName, msgSize);
   }
 
   // fields are public to allow access from external code and tests

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -341,7 +341,10 @@ commResult_t ctranAllGatherHierarchicalRing(
   if (colltraceHandle != nullptr) {
     colltraceHandle->trigger(CollTraceHandleTriggerState::BeforeEnqueueKernel);
   }
-  comm->recordAlgoStats("AllGather", allGatherAlgoName(myAlgo));
+  comm->recordAlgoStats(
+      "AllGather",
+      allGatherAlgoName(myAlgo),
+      sendcount * commTypeSize(datatype));
 
   if (useOverlap) {
     comms::pipes::HierarchicalAllgatherOverlapLaunchParams overlapParams{};

--- a/comms/ctran/gpe/CtranGpe.cc
+++ b/comms/ctran/gpe/CtranGpe.cc
@@ -362,6 +362,29 @@ CtranGpe::~CtranGpe() {
   this->pimpl->terminate();
 }
 
+namespace {
+inline size_t getMsgSizeFromOpGroup(
+    const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
+  if (opGroup.empty()) {
+    return 0;
+  }
+  const auto& op = *opGroup.front();
+  switch (op.type) {
+    case OpElem::ALLGATHER:
+      return op.allgather.sendcount * commTypeSize(op.allgather.datatype);
+    case OpElem::ALLREDUCE:
+      return op.allreduce.count * commTypeSize(op.allreduce.datatype);
+    case OpElem::REDUCESCATTER:
+      return op.reducescatter.recvcount *
+          commTypeSize(op.reducescatter.datatype);
+    case OpElem::ALLTOALL:
+      return op.alltoall.count * commTypeSize(op.alltoall.datatype);
+    default:
+      return 0;
+  }
+}
+} // namespace
+
 commResult_t CtranGpe::submit(
     std::vector<std::unique_ptr<struct OpElem>> opGroup,
     opFunc func,
@@ -370,7 +393,9 @@ commResult_t CtranGpe::submit(
     std::optional<std::chrono::milliseconds> timeout,
     PreLaunchGraphPrepareFn graphPrepareFn) {
   this->pimpl->comm->recordAlgoStat(
-      kernelTypeToOpName(kernelConfig.type), kernelConfig.algoName);
+      kernelTypeToOpName(kernelConfig.type),
+      kernelConfig.algoName,
+      getMsgSizeFromOpGroup(opGroup));
   return this->pimpl->submit(
       CtranGpeCmd::TypeEnum::GRAPH_ENQUEUE,
       std::move(opGroup),

--- a/comms/ctran/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ctran/tests/VerifyAlgoStatsUtil.cc
@@ -42,13 +42,18 @@ void VerifyAlgoStatsHelper::enable() {
 
 namespace {
 
-std::string formatStats(const std::unordered_map<std::string, int64_t>& stats) {
+std::string formatStats(
+    const std::unordered_map<std::string, std::map<size_t, int64_t>>& stats) {
   std::string result;
-  for (const auto& [name, count] : stats) {
+  for (const auto& [name, sizeMap] : stats) {
+    int64_t total = 0;
+    for (const auto& [sz, count] : sizeMap) {
+      total += count;
+    }
     if (!result.empty()) {
       result += ", ";
     }
-    result += fmt::format("{}({})", name, count);
+    result += fmt::format("{}({})", name, total);
   }
   return result;
 }
@@ -62,15 +67,21 @@ void VerifyAlgoStatsHelper::verify(
   auto statDumpOpt = comm->dumpAlgoStats();
   ASSERT_TRUE(statDumpOpt.has_value());
   auto statDump = std::move(*statDumpOpt);
-  auto it = statDump.counts.find(collective);
-  ASSERT_NE(it, statDump.counts.end())
+  auto it = statDump.entries.find(collective);
+  ASSERT_NE(it, statDump.entries.end())
       << collective << " not found in AlgoStats";
   bool found = false;
-  for (const auto& [algoName, callCount] : it->second) {
-    if (algoName.find(expectedAlgoSubstr) != std::string::npos &&
-        callCount > 0) {
-      found = true;
-      break;
+  for (const auto& [algoName, sizeMap] : it->second) {
+    if (algoName.find(expectedAlgoSubstr) != std::string::npos) {
+      for (const auto& [sz, count] : sizeMap) {
+        if (count > 0) {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        break;
+      }
     }
   }
   EXPECT_TRUE(found) << "Expected algorithm containing '" << expectedAlgoSubstr
@@ -85,15 +96,18 @@ void VerifyAlgoStatsHelper::verifyNot(
   auto statDumpOpt = comm->dumpAlgoStats();
   ASSERT_TRUE(statDumpOpt.has_value());
   auto statDump = std::move(*statDumpOpt);
-  auto it = statDump.counts.find(collective);
-  if (it == statDump.counts.end()) {
+  auto it = statDump.entries.find(collective);
+  if (it == statDump.entries.end()) {
     return;
   }
-  for (const auto& [algoName, callCount] : it->second) {
+  for (const auto& [algoName, sizeMap] : it->second) {
+    int64_t total = 0;
+    for (const auto& [sz, count] : sizeMap) {
+      total += count;
+    }
     EXPECT_FALSE(
-        algoName.find(unexpectedAlgoSubstr) != std::string::npos &&
-        callCount > 0)
-        << "Unexpected algorithm '" << algoName << "' with count " << callCount
+        algoName.find(unexpectedAlgoSubstr) != std::string::npos && total > 0)
+        << "Unexpected algorithm '" << algoName << "' with count " << total
         << " found in " << collective;
   }
 }
@@ -105,8 +119,8 @@ void VerifyAlgoStatsHelper::dump(CtranComm* comm, const std::string& collective)
     return;
   }
   auto statDump = std::move(*statDumpOpt);
-  auto it = statDump.counts.find(collective);
-  if (it != statDump.counts.end()) {
+  auto it = statDump.entries.find(collective);
+  if (it != statDump.entries.end()) {
     fmt::print(
         stderr, "AlgoStats[{}]: [{}]\n", collective, formatStats(it->second));
   }

--- a/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
+++ b/comms/ncclx/meta/colltrace/CollTraceWrapper.cc
@@ -478,7 +478,13 @@ __attribute__((visibility("default"))) void dumpAlgoStat(
   // Baseline and ctran share the same AlgoStats instance via getOrCreate.
   if (comm->algoStats) {
     auto dump = comm->algoStats->dump();
-    map.swap(dump.counts);
+    for (const auto& [opName, algoMap] : dump.entries) {
+      for (const auto& [algoName, sizeMap] : algoMap) {
+        for (const auto& [sz, count] : sizeMap) {
+          map[opName][algoName] += count;
+        }
+      }
+    }
   }
 }
 
@@ -487,6 +493,7 @@ namespace {
 struct AlgoInfo {
   std::string opName;
   std::string algoName;
+  size_t msgSize{0};
 };
 
 std::optional<AlgoInfo> parseAlgoInfoFromNcclKernelPlan(ncclKernelPlan& plan) {
@@ -510,6 +517,7 @@ std::optional<AlgoInfo> parseAlgoInfoFromNcclKernelPlan(ncclKernelPlan& plan) {
             ncclProtoToString(collTaskHead->protocol),
             ncclAlgoToString(collTaskHead->algorithm),
             static_cast<int>(collTaskHead->nMaxChannels)),
+        .msgSize = collTaskHead->count * ncclTypeSize(collTaskHead->datatype),
     };
   }
 
@@ -550,7 +558,8 @@ collTraceBaselineGetHandle(ncclKernelPlan* plan, cudaStream_t stream) {
   if (plan->comm->algoStats) {
     auto algoInfo = parseAlgoInfoFromNcclKernelPlan(*plan);
     if (algoInfo.has_value()) {
-      plan->comm->algoStats->record(algoInfo->opName, algoInfo->algoName);
+      plan->comm->algoStats->record(
+          algoInfo->opName, algoInfo->algoName, algoInfo->msgSize);
     }
   }
 

--- a/comms/ncclx/meta/colltrace/tests/AlgoStatsTest.cpp
+++ b/comms/ncclx/meta/colltrace/tests/AlgoStatsTest.cpp
@@ -21,9 +21,9 @@ TEST(AlgoStatsTest, BasicRecordAndDump) {
 
   EXPECT_EQ(dump.commHash, 0x12345678);
   EXPECT_EQ(dump.commDesc, "TP_PG");
-  EXPECT_EQ(dump.counts["ReduceScatter"]["PAT"], 2);
-  EXPECT_EQ(dump.counts["ReduceScatter"]["RING"], 1);
-  EXPECT_EQ(dump.counts["AllReduce"]["TREE"], 1);
+  EXPECT_EQ(dump.entries["ReduceScatter"]["PAT"][0], 2);
+  EXPECT_EQ(dump.entries["ReduceScatter"]["RING"][0], 1);
+  EXPECT_EQ(dump.entries["AllReduce"]["TREE"][0], 1);
 }
 
 TEST(AlgoStatsTest, Reset) {
@@ -33,12 +33,12 @@ TEST(AlgoStatsTest, Reset) {
   stats.record("AllGather", "RING");
 
   auto dumpBefore = stats.dump();
-  EXPECT_EQ(dumpBefore.counts["AllGather"]["RING"], 2);
+  EXPECT_EQ(dumpBefore.entries["AllGather"]["RING"][0], 2);
 
   stats.reset();
 
   auto dumpAfter = stats.dump();
-  EXPECT_TRUE(dumpAfter.counts.empty());
+  EXPECT_TRUE(dumpAfter.entries.empty());
   // Comm info should be preserved after reset
   EXPECT_EQ(dumpAfter.commHash, 0xABCD);
   EXPECT_EQ(dumpAfter.commDesc, "test_comm");
@@ -65,7 +65,8 @@ TEST(AlgoStatsTest, ConcurrentRecording) {
   }
 
   auto dump = stats.dump();
-  EXPECT_EQ(dump.counts["AllReduce"]["PAT"], kNumThreads * kRecordsPerThread);
+  EXPECT_EQ(
+      dump.entries["AllReduce"]["PAT"][0], kNumThreads * kRecordsPerThread);
 }
 
 TEST(AlgoStatsTest, MultipleCollectivesAndAlgorithms) {
@@ -87,12 +88,12 @@ TEST(AlgoStatsTest, MultipleCollectivesAndAlgorithms) {
 
   auto dump = stats.dump();
 
-  EXPECT_EQ(dump.counts.size(), 3); // 3 collectives
-  EXPECT_EQ(dump.counts["ReduceScatter"].size(), 2); // 2 algorithms
-  EXPECT_EQ(dump.counts["ReduceScatter"]["PAT"], 30);
-  EXPECT_EQ(dump.counts["ReduceScatter"]["RING"], 5);
-  EXPECT_EQ(dump.counts["AllReduce"]["TREE"], 50);
-  EXPECT_EQ(dump.counts["AllGather"]["RING"], 10);
+  EXPECT_EQ(dump.entries.size(), 3); // 3 collectives
+  EXPECT_EQ(dump.entries["ReduceScatter"].size(), 2); // 2 algorithms
+  EXPECT_EQ(dump.entries["ReduceScatter"]["PAT"][0], 30);
+  EXPECT_EQ(dump.entries["ReduceScatter"]["RING"][0], 5);
+  EXPECT_EQ(dump.entries["AllReduce"]["TREE"][0], 50);
+  EXPECT_EQ(dump.entries["AllGather"]["RING"][0], 10);
 }
 
 TEST(AlgoStatsTest, EmptyDump) {
@@ -102,5 +103,5 @@ TEST(AlgoStatsTest, EmptyDump) {
 
   EXPECT_EQ(dump.commHash, 0x9999);
   EXPECT_EQ(dump.commDesc, "empty_test");
-  EXPECT_TRUE(dump.counts.empty());
+  EXPECT_TRUE(dump.entries.empty());
 }

--- a/comms/ncclx/meta/commDump.cc
+++ b/comms/ncclx/meta/commDump.cc
@@ -284,14 +284,18 @@ static void dumpAlgoStatToMap(
     return;
   }
   auto dump = algoStats->dump();
-  if (dump.counts.empty()) {
+  if (dump.entries.empty()) {
     return;
   }
   folly::dynamic obj = folly::dynamic::object();
-  for (const auto& [opName, algoMap] : dump.counts) {
+  for (const auto& [opName, algoMap] : dump.entries) {
     folly::dynamic algoObj = folly::dynamic::object();
-    for (const auto& [algoName, count] : algoMap) {
-      algoObj[algoName] = count;
+    for (const auto& [algoName, sizeMap] : algoMap) {
+      folly::dynamic sizeObj = folly::dynamic::object();
+      for (const auto& [sz, count] : sizeMap) {
+        sizeObj[std::to_string(sz)] = count;
+      }
+      algoObj[algoName] = std::move(sizeObj);
     }
     obj[opName] = std::move(algoObj);
   }

--- a/comms/ncclx/meta/tests/CommDumpTest.cc
+++ b/comms/ncclx/meta/tests/CommDumpTest.cc
@@ -979,9 +979,13 @@ TEST_F(CommDumpTest, AlgoStatInCommDump) {
   ASSERT_TRUE(algoStatObj.count("AllReduce"));
 
   int totalCalls = 0;
-  for (const auto& [algoName, count] : algoStatObj["AllReduce"].items()) {
-    EXPECT_GT(count.asInt(), 0);
-    totalCalls += count.asInt();
+  for (const auto& [algoName, sizeMap] : algoStatObj["AllReduce"].items()) {
+    ASSERT_TRUE(sizeMap.isObject());
+    for (const auto& [sizeStr, count] : sizeMap.items()) {
+      EXPECT_GT(count.asInt(), 0);
+      EXPECT_GT(folly::to<size_t>(sizeStr.asString()), 0);
+      totalCalls += count.asInt();
+    }
   }
   EXPECT_EQ(totalCalls, numColls);
 }

--- a/comms/utils/colltrace/AlgoStats.cc
+++ b/comms/utils/colltrace/AlgoStats.cc
@@ -24,9 +24,12 @@ std::shared_ptr<AlgoStats> AlgoStats::getOrCreate(
   return stats;
 }
 
-void AlgoStats::record(const std::string& opName, const std::string& algoName) {
+void AlgoStats::record(
+    const std::string& opName,
+    const std::string& algoName,
+    const std::size_t msgSize) {
   algoCounters_.withWLock(
-      [&](auto& counters) { ++counters[AlgoKey{opName, algoName}]; });
+      [&](auto& counters) { ++counters[AlgoKey{opName, algoName, msgSize}]; });
 }
 
 AlgoStatDump AlgoStats::dump() const {
@@ -36,7 +39,8 @@ AlgoStatDump AlgoStats::dump() const {
 
   algoCounters_.withRLock([&](const auto& counters) {
     for (const auto& [key, count] : counters) {
-      result.counts[key.first][key.second] = count;
+      result.entries[std::get<0>(key)][std::get<1>(key)][std::get<2>(key)] =
+          count;
     }
   });
 

--- a/comms/utils/colltrace/AlgoStats.h
+++ b/comms/utils/colltrace/AlgoStats.h
@@ -1,9 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <map>
 #include <string>
+#include <tuple>
 #include <unordered_map>
-#include <utility>
 
 #include <folly/Synchronized.h>
 #include <folly/container/F14Map.h>
@@ -12,12 +13,14 @@
 namespace meta::comms::colltrace {
 
 // Result of algorithm statistics dump, per communicator.
+// Map: op -> algo -> msgSize -> count
 struct AlgoStatDump {
   uint64_t commHash{0};
   std::string commDesc;
-  // Map: collective name -> algorithm name -> call count
-  std::unordered_map<std::string, std::unordered_map<std::string, int64_t>>
-      counts;
+  std::unordered_map<
+      std::string,
+      std::unordered_map<std::string, std::map<std::size_t, int64_t>>>
+      entries;
 };
 
 // Thread-safe algorithm statistics tracker.
@@ -35,9 +38,12 @@ class AlgoStats {
       uint64_t commHash,
       const std::string& commDesc);
 
-  // Record a collective execution with the given algorithm.
+  // Record a collective execution with the given algorithm and message size.
   // Thread-safe: can be called concurrently from multiple threads.
-  void record(const std::string& opName, const std::string& algoName);
+  void record(
+      const std::string& opName,
+      const std::string& algoName,
+      const std::size_t msgSize = 0);
 
   // Get aggregated counts with communicator info.
   AlgoStatDump dump() const;
@@ -49,11 +55,11 @@ class AlgoStats {
   uint64_t commHash_{0};
   std::string commDesc_;
 
-  // Key: (opName, algoName), Value: count
-  using AlgoKey = std::pair<std::string, std::string>;
+  using AlgoKey = std::tuple<std::string, std::string, std::size_t>;
   struct AlgoKeyHash {
     std::size_t operator()(const AlgoKey& key) const noexcept {
-      return folly::hash::hash_combine(key.first, key.second);
+      return folly::hash::hash_combine(
+          std::get<0>(key), std::get<1>(key), std::get<2>(key));
     }
   };
 


### PR DESCRIPTION
Summary:

- Add `msgSize` parameter to `AlgoStats::record()` and count per `(opName, algoName, msgSize)` triple, so each message size has its own counter
- commDump `algoStat` JSON format: `{op: {algo: {size: count, ...}, ...}, ...}` — shows which algorithm was selected for each message size
- Pass message size from baseline path (`ncclTaskColl::count * ncclTypeSize`) and CTRAN paths (GPE `getMsgSizeFromOpGroup`, AllGatherHierarchicalRing)
- Preserve backward-compatible `dumpAlgoStat()` API (aggregates counts across sizes)
- Update ctran `VerifyAlgoStatsUtil` to handle new `AlgoStatDump` structure

Reviewed By: YulunW

Differential Revision: D106745988


