### PR TITLE
Fallback to hostname when ncclx topology file is missing

### DIFF
--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -1,4 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+#include <cstring>
 #include <unistd.h>
 #include <fstream>
 
@@ -13,6 +14,13 @@ namespace {
 constexpr std::string_view kDeviceName = "DEVICE_NAME";
 constexpr std::string_view kNetworkTopo = "DEVICE_BACKEND_NETWORK_TOPOLOGY";
 constexpr std::string_view kDeviceRackSerial = "DEVICE_RACK_SERIAL";
+
+template <size_t N>
+void copyStringToFixedBuffer(char (&dst)[N], const std::string& src) {
+  static_assert(N > 0);
+  std::strncpy(dst, src.c_str(), N - 1);
+  dst[N - 1] = '\0';
+}
 } // namespace
 
 // DEVICE_BACKEND_NETWORK_TOPOLOGY should be present in all T20 hosts with
@@ -135,13 +143,13 @@ std::optional<TopologyResult> loadTopology(
     }
   }
 
-  ncclx::RankTopology topo;
+  ncclx::RankTopology topo{};
   topo.rank = rank;
   topo.pid = getpid();
-  std::strncpy(topo.rackSerial, rackSerial.c_str(), ncclx::kMaxNameLen);
-  std::strncpy(topo.dc, dc.c_str(), ncclx::kMaxNameLen);
-  std::strncpy(topo.zone, zone.c_str(), ncclx::kMaxNameLen);
-  std::strncpy(topo.host, host.c_str(), ncclx::kMaxNameLen);
+  copyStringToFixedBuffer(topo.rackSerial, rackSerial);
+  copyStringToFixedBuffer(topo.dc, dc);
+  copyStringToFixedBuffer(topo.zone, zone);
+  copyStringToFixedBuffer(topo.host, host);
   return TopologyResult{topo, std::move(backendNetworkTopology)};
 }
 

--- a/comms/ctran/commstate/Topology.cc
+++ b/comms/ctran/commstate/Topology.cc
@@ -93,11 +93,32 @@ std::optional<TopologyResult> loadTopology(
     }
   }
 
-  if (!NCCL_IGNORE_TOPO_LOAD_FAILURE) {
-    if (host.empty()) {
-      CLOGF(ERR, "Failed to load hostname (DEVICE_NAME) from {}", filepath);
+  if (host.empty()) {
+    char hostname[256] = {};
+    if (gethostname(hostname, sizeof(hostname) - 1) == 0 && hostname[0] != '\0') {
+      host = hostname;
+      CLOGF(
+          WARN,
+          "DEVICE_NAME not found in {}. Falling back to gethostname()={}",
+          filepath,
+          host);
+    } else if (!NCCL_IGNORE_TOPO_LOAD_FAILURE) {
+      CLOGF(
+          ERR,
+          "Failed to load hostname (DEVICE_NAME) from {} and gethostname() fallback failed",
+          filepath);
       return std::nullopt;
-    } else if (!backendNetworkTopology.empty() && !isBackendTopologyValid) {
+    } else {
+      CLOGF(
+          WARN,
+          "DEVICE_NAME not found in {} and gethostname() fallback failed. "
+          "Continuing because NCCL_IGNORE_TOPO_LOAD_FAILURE=1",
+          filepath);
+    }
+  }
+
+  if (!NCCL_IGNORE_TOPO_LOAD_FAILURE) {
+    if (!backendNetworkTopology.empty() && !isBackendTopologyValid) {
       CLOGF(
           ERR,
           "CTRAN cannot be enabled due to missing topology information. "

--- a/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
+++ b/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <fstream>
+#include <unistd.h>
 
 #include "comms/ctran/commstate/Topology.h"
 
@@ -21,21 +22,41 @@ TEST(TopologyTest, LoadTopologySuccess) {
   EXPECT_EQ(topo->networkTopo, "/nha1.1D//rtsw098.c084.f00.nha1");
 }
 
-TEST(TopologyTest, LoadTopologyFailure) {
+TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenFileIsEmpty) {
   const std::string filepath = "/tmp/ut-topology.txt";
   std::ofstream file(filepath);
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
-  EXPECT_FALSE(topo);
+  ASSERT_TRUE(topo);
+  char hostname[256] = {};
+  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
+  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
+  EXPECT_EQ(topo->networkTopo, "");
 }
 
-TEST(TopologyTest, EmptyHostName) {
+TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenHostMissing) {
   const std::string filepath = "/tmp/mocked_fbwhoami.txt";
   std::ofstream file(filepath);
   file << "DEVICE_NAME=";
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
-  EXPECT_FALSE(topo);
+  ASSERT_TRUE(topo);
+  char hostname[256] = {};
+  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
+  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
+  EXPECT_EQ(topo->networkTopo, "");
+}
+
+TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenFileMissing) {
+  const std::string filepath = "/tmp/missing_fbwhoami.txt";
+  unlink(filepath.c_str());
+
+  auto topo = ctran::commstate::loadTopology(0, filepath);
+  ASSERT_TRUE(topo);
+  char hostname[256] = {};
+  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
+  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
+  EXPECT_EQ(topo->networkTopo, "");
 }
 
 TEST(TopologyTest, RailBasedTopology) {

--- a/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
+++ b/comms/ctran/commstate/tests/LoadTopologyUnitTest.cc
@@ -6,6 +6,19 @@
 
 #include "comms/ctran/commstate/Topology.h"
 
+namespace {
+
+void expectHostFromGethostname(
+    const std::optional<ctran::commstate::TopologyResult>& topo) {
+  ASSERT_TRUE(topo);
+  char hostname[256] = {};
+  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
+  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
+  EXPECT_EQ(topo->networkTopo, "");
+}
+
+} // namespace
+
 TEST(TopologyTest, LoadTopologySuccess) {
   const std::string filepath = "/tmp/ut-topology.txt";
   std::ofstream file(filepath);
@@ -25,25 +38,34 @@ TEST(TopologyTest, LoadTopologySuccess) {
 TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenFileIsEmpty) {
   const std::string filepath = "/tmp/ut-topology.txt";
   std::ofstream file(filepath);
+  file.close();
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
-  ASSERT_TRUE(topo);
-  char hostname[256] = {};
-  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
-  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
-  EXPECT_EQ(topo->networkTopo, "");
+  expectHostFromGethostname(topo);
 }
 
 TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenHostMissing) {
   const std::string filepath = "/tmp/mocked_fbwhoami.txt";
   std::ofstream file(filepath);
-  file << "DEVICE_NAME=";
+  file << "DEVICE_NAME=" << std::endl;
+  file.close();
+
+  auto topo = ctran::commstate::loadTopology(0, filepath);
+  expectHostFromGethostname(topo);
+}
+
+TEST(TopologyTest, LoadTopologyTruncatesLongHostNameSafely) {
+  const std::string filepath = "/tmp/ut-topology.txt";
+  const std::string longHost(ncclx::kMaxNameLen + 16, 'a');
+  std::ofstream file(filepath);
+  file << "DEVICE_NAME=" << longHost << std::endl;
+  file.close();
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
   ASSERT_TRUE(topo);
-  char hostname[256] = {};
-  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
-  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
+  const std::string host(topo->rankTopology.host);
+  EXPECT_EQ(host.size(), ncclx::kMaxNameLen - 1);
+  EXPECT_EQ(host, longHost.substr(0, ncclx::kMaxNameLen - 1));
   EXPECT_EQ(topo->networkTopo, "");
 }
 
@@ -52,11 +74,7 @@ TEST(TopologyTest, LoadTopologyFallsBackToHostnameWhenFileMissing) {
   unlink(filepath.c_str());
 
   auto topo = ctran::commstate::loadTopology(0, filepath);
-  ASSERT_TRUE(topo);
-  char hostname[256] = {};
-  ASSERT_EQ(gethostname(hostname, sizeof(hostname) - 1), 0);
-  EXPECT_EQ(std::string(topo->rankTopology.host), std::string(hostname));
-  EXPECT_EQ(topo->networkTopo, "");
+  expectHostFromGethostname(topo);
 }
 
 TEST(TopologyTest, RailBasedTopology) {


### PR DESCRIPTION
using `gethostname()` when `DEVICE_NAME` is missing from `NCCL_TOPO_FILE_PATH`, so ctran enabled ncclx can initialize on hosts without `/etc/fbwhoami`