### PR TITLE
remove NCCL_COMM_STATE_DEBUG_TOPO=nolocal to test 4x2 case, and remove unnecessary BUCK flags

### DIFF
--- a/comms/ctran/benchmarks/AllGatherBench.cc
+++ b/comms/ctran/benchmarks/AllGatherBench.cc
@@ -197,7 +197,6 @@ class CtranAllGatherBenchmark : public ctran::CtranDistTestFixture {
     setenv("NCCL_CTRAN_USE_PIPES", "1", 0);
     setenv("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1", 0);
     setenv("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "8388608", 0);
-    setenv("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal", 0);
     setenv("NCCL_DEBUG", "WARN", 0);
 
     ctran::CtranDistTestFixture::SetUp();


### PR DESCRIPTION
Summary: remove NCCL_COMM_STATE_DEBUG_TOPO=nolocal to test 4x2 case, and remove unnecessary BUCK flags since they're configured in class CtranAllGatherBenchmark

Reviewed By: snarayankh

Differential Revision: D106865358


