### PR TITLE
ctgraph: delegate to ctp2p instead of ctzcopy

### DIFF
--- a/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvCudagraphAware.cc
@@ -3,7 +3,7 @@
 // Cudagraph-aware SendRecv: when ctranGroupEndHook is called with
 // algo=ctgraph during CUDA graph capture, this module pre-registers all
 // send/recv buffers via globalRegisterWithPtr (local-persist pattern),
-// then delegates to ctranGroupEndHookImpl(ctzcopy) for the actual GPE
+// then delegates to ctranGroupEndHookImpl(ctp2p) for the actual GPE
 // dispatch. The GPE host-node callbacks are captured into the graph and
 // re-execute on replay with pre-registered buffers (searchRegHandle
 // hits the fast path).
@@ -67,9 +67,9 @@ commResult_t ctranSendRecvCudagraphAware(
     }
   });
 
-  // Dispatch to normal eager path with ctzcopy
+  // Dispatch to normal eager path with ctp2p
   FB_COMMCHECK(
-      ctranGroupEndHookImpl(opGroup, NCCL_SENDRECV_ALGO::ctzcopy, timeout));
+      ctranGroupEndHookImpl(opGroup, NCCL_SENDRECV_ALGO::ctp2p, timeout));
 
   // Success — transfer cleanup to deferred
   cleanupGuard.dismiss();


### PR DESCRIPTION
Summary:
ctgraph is IB-only today (gated by ctranSendRecvSupport). Switching
the underlying delegation from ctzcopy to ctp2p is a no-op for this
path because both share the same IB GPE submit path.

Reviewed By: minsii

Differential Revision: D106581886


