### PR TITLE
Add DeviceHostQueue: bounded MPSC GPU/CPU proxy queue

### DIFF
--- a/comms/common/AtomicUtils.cuh
+++ b/comms/common/AtomicUtils.cuh
@@ -642,4 +642,34 @@ atomic_fetch_add_release_gpu_global(uint32_t* ptr, uint32_t val) {
 #endif
 }
 
+// =============================================================================
+// Compare-and-Swap
+// =============================================================================
+
+// Relaxed system-scope compare-and-swap. Returns the value previously at *ptr;
+// the swap succeeded iff the returned value == cmp. Mirrors PTX atom.cas so a
+// caller can build a portable CAS-retry loop (e.g. claiming a ring slot).
+__device__ __forceinline__ uint64_t
+atomic_cas_relaxed_sys_global(uint64_t* ptr, uint64_t cmp, uint64_t val) {
+#ifdef __CUDA_ARCH__
+  uint64_t old_val;
+  asm volatile("atom.relaxed.sys.global.cas.b64 %0, [%1], %2, %3;"
+               : "=l"(old_val)
+               : "l"(ptr), "l"(cmp), "l"(val)
+               : "memory");
+  return old_val;
+#else
+  // Strong CAS (weak=false) is required: we infer success from the returned
+  // value (== cmp), but a *weak* CAS may fail SPURIOUSLY with *ptr still ==
+  // cmp, leaving `cmp` unchanged -- indistinguishable from a real success, so
+  // two callers could "claim" the same slot. Strong CAS never fails spuriously,
+  // so "returned == cmp" iff the swap happened, matching PTX atom.cas. On a
+  // real failure __atomic_compare_exchange_n writes the actual prior value into
+  // `cmp`.
+  __atomic_compare_exchange_n(
+      ptr, &cmp, val, /*weak=*/false, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+  return cmp;
+#endif
+}
+
 } // namespace comms::device

--- a/comms/utils/device_host_queue/DeviceHostQueue.cuh
+++ b/comms/utils/device_host_queue/DeviceHostQueue.cuh
@@ -1,0 +1,437 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+
+#include "comms/common/AtomicUtils.cuh"
+
+// =============================================================================
+// DeviceHostQueue<T, Policy> — bounded multi-producer ring in shared
+// host-pinned memory for passing fixed-size proxy commands from GPU to CPU (the
+// GPU delegates work to a CPU/engine proxy that runs it).
+//
+// Data flows one way: GPU threads are the producers, the CPU (the host owner)
+// is the single consumer. Only ConsumerPolicy::Single is implemented: many
+// producer threads reserve and publish slots, and the one host consumer drains
+// them in sequence order. A future ConsumerPolicy::Multi would add multiple
+// consumers, keeping per-consumer state off this shared ring.
+//
+// Coordinates (plain integers in shared memory; atomicity applied at the access
+// site — see "Memory model"):
+//   pi         producer reservation sequence (fetch_add / CAS)
+//   readySeq  per-slot publish marker (== seq + 1 once published)
+//   ci         reuse credit: a producer may overwrite a slot only after ci
+//              passes it. read() advances ci as it copies each command out, so
+//              copy-out frees the slot.
+//
+// Memory model. The device producer uses system-scope atomics (comms::device);
+// the release store that publishes readySeq carries the barrier into the CPU
+// domain (it orders the payload writes before the marker). The host consumer
+// uses std::atomic_ref
+// release/acquire (inner-shareable on Grace); that suffices because the ring is
+// coherent host-pinned memory and the device peer issues the system-scope half.
+// This split is the GB200-validated convention in comms (cf. ctran MemFence.h /
+// GpeKernelSync).
+//
+// Minimal by design: no status/abort/timeout. The blocking variants spin with
+// no escape; bounded waits and teardown belong to the caller's progress loop.
+//
+// Portable across CUDA and HIP/ROCm: device-side atomics go through
+// comms::device (AtomicUtils.cuh), and the host-pinned mapped allocation uses
+// the CUDA runtime API (hipified 1:1 on AMD, with the coherent-mapped flag).
+// =============================================================================
+
+namespace meta::comms {
+
+/// Outcome of a (non-blocking) queue operation.
+enum class QueueOpStatus : uint32_t {
+  Ok,
+  Full, // write(): no credit
+  Empty, // read(): ordered head not yet published
+};
+
+/// Consumer cardinality. Only Single is implemented in the initial cut; Multi
+/// is reserved for a future specialization.
+enum class ConsumerPolicy : uint32_t {
+  Single,
+  Multi,
+};
+
+/// Data-flow direction. Only D2H (device produces, host consumes) is
+/// implemented. H2D (host produces, device consumes) would need a different
+/// host fence strategy -- a host system-scope release (DMB SY on aarch64), not
+/// the inner-shareable release std::atomic emits -- so it is rejected at
+/// compile time (see the static_assert in DeviceHostQueue) rather than silently
+/// mis- synchronizing across the GPU domain.
+enum class Direction : uint32_t {
+  D2H, // device producer -> host consumer
+  H2D, // host producer -> device consumer (not yet supported)
+};
+
+template <class T, Direction Dir, ConsumerPolicy Policy>
+class DeviceHostQueue;
+
+/// One ring slot: payload plus its publish marker. Per-consumer bookkeeping
+/// (for a future Multi policy) lives on the consumer side, never in this
+/// cross-domain ring.
+template <class T>
+struct alignas(64) DeviceHostQueueSlot {
+  alignas(alignof(T)) std::byte payload[sizeof(T)];
+  // Publish marker (system-scope atomic at the access site). MUST stay LAST: it
+  // is written strictly after the payload, via a system-scope release store.
+  uint64_t readySeq;
+};
+
+/// Shared control header. slots[] follows immediately in the same allocation
+/// (see slotsOf()); capacity/mask are carried by value in the device handle,
+/// not read from here.
+template <class T>
+struct alignas(64) DeviceHostQueueControl {
+  alignas(64) uint64_t pi; // producer reservation
+  alignas(64) uint64_t ci; // reuse credit
+};
+
+/// Pointer to the first slot, which lives immediately after the control header.
+template <class T>
+__host__ __device__ inline DeviceHostQueueSlot<T>* slotsOf(
+    DeviceHostQueueControl<T>* ctrl) {
+  return reinterpret_cast<DeviceHostQueueSlot<T>*>(
+      reinterpret_cast<std::byte*>(ctrl) + sizeof(DeviceHostQueueControl<T>));
+}
+
+/// Host-side relax hint for spin-wait loops: the YIELD instruction on
+/// aarch64/Grace, PAUSE on x86. It lets an SMT sibling make progress and draws
+/// less power while polling, but does NOT deschedule, so an always-busy
+/// consumer keeps its latency. A consumer that may idle or shares a core should
+/// instead loop on the non-blocking read() with its own backoff (e.g.
+/// std::this_thread::yield()).
+inline void cpuRelax() {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  // host-only helper; no-op if pulled into a device compile
+#elif defined(__aarch64__)
+  asm volatile("yield" ::: "memory");
+#elif defined(__x86_64__)
+  __builtin_ia32_pause();
+#endif
+}
+
+// =============================================================================
+// DeviceHostQueueProducer<T, Policy> — trivially-copyable, non-owning
+// device producer handle. Returned by
+// DeviceHostQueue::producerHandle() and passed BY VALUE into kernels.
+// It holds no cursor, so it is safe to broadcast to every producer thread;
+// write()/blockingWrite() may be called concurrently by any number of threads.
+// =============================================================================
+template <class T, ConsumerPolicy Policy = ConsumerPolicy::Single>
+class DeviceHostQueueProducer {
+ public:
+  static_assert(std::is_trivially_copyable_v<T>);
+  static_assert(std::is_trivially_destructible_v<T>);
+  static_assert(
+      Policy == ConsumerPolicy::Single,
+      "DeviceHostQueue: only ConsumerPolicy::Single is implemented");
+
+  DeviceHostQueueProducer() = default;
+
+  __host__ __device__ uint32_t capacity() const {
+    return capacity_;
+  }
+
+  /// Approximate number of in-flight (reserved-but-not-credited) slots. Clamped
+  /// to [0, capacity]; not exact under concurrency.
+  __device__ uint32_t sizeApprox() const {
+    uint64_t p = ::comms::device::ld_relaxed_sys_global(&ctrl_->pi);
+    uint64_t c = ::comms::device::ld_relaxed_sys_global(&ctrl_->ci);
+    uint64_t d = p > c ? p - c : 0;
+    return d > capacity_ ? capacity_ : static_cast<uint32_t>(d);
+  }
+
+  /// Non-blocking producer. Reserves a slot only if credit is available, so a
+  /// Full return never leaves an unpublished hole. Returns Ok or Full.
+  __device__ QueueOpStatus write(const T& value) {
+    uint64_t seq = ::comms::device::ld_relaxed_sys_global(&ctrl_->pi);
+    for (;;) {
+      uint64_t c = ::comms::device::ld_acquire_sys_global(&ctrl_->ci);
+      // `seq` may be a stale snapshot of pi here — other producers can advance
+      // pi and consumers can advance ci past it before this guard runs — so
+      // guard against unsigned underflow: only report Full when seq >= ci. When
+      // seq < ci, the CAS below fails and refreshes seq to the current pi.
+      if (seq >= c && seq - c >= capacity_) {
+        return QueueOpStatus::Full;
+      }
+      // Claim seq only if pi is unchanged; atomic_cas returns the prior value,
+      // so a mismatch refreshes seq and we retry. Nothing is claimed on Full.
+      uint64_t prev = ::comms::device::atomic_cas_relaxed_sys_global(
+          &ctrl_->pi, seq, seq + 1);
+      if (prev == seq) {
+        break;
+      }
+      seq = prev;
+    }
+    publish(seq, value);
+    return QueueOpStatus::Ok;
+  }
+
+  /// Blocking producer: reserve a slot, spin for reuse credit, then publish. No
+  /// escape — assumes the consumer keeps draining. Callers needing to bail out
+  /// (timeout/teardown) should loop on write() instead.
+  ///
+  /// Reserve-then-publish obligation: unlike write() (which CAS-claims pi only
+  /// when it is about to publish), blockingWrite reserves its sequence with an
+  /// unconditional fetch_add and is therefore committed to publishing it. A
+  /// thread that reserves a sequence and then never publishes (aborts mid-call)
+  /// leaves a permanent hole that wedges the in-order consumer at that
+  /// sequence. Do not abort between the reservation and publish().
+  __device__ void blockingWrite(const T& value) {
+    uint64_t seq = ::comms::device::atomic_fetch_add_relaxed_sys_global(
+        &ctrl_->pi, /*val=*/1);
+    // seq is exclusively owned and unpublished until publish() below, so it
+    // cannot be consumed while we spin; ci <= seq always holds here and the
+    // subtraction never underflows (unlike write(), which guards a stale seq).
+    while (seq - ::comms::device::ld_acquire_sys_global(&ctrl_->ci) >=
+           capacity_) {
+      // spin for reuse credit
+    }
+    publish(seq, value);
+  }
+
+ private:
+  friend class DeviceHostQueue<T, Direction::D2H, Policy>;
+
+  /// Publish the reserved slot `seq`: copy the payload in, then make it visible
+  /// with a single system-scope *release* store of the marker (readySeq ==
+  /// seq + 1). That release store orders the payload writes before the marker
+  /// becomes visible, so a consumer that acquire-loads readySeq == seq + 1
+  /// always sees the full payload. The release store alone carries this
+  /// ordering — a separate release fence would be redundant (one would be
+  /// needed only if the marker store were relaxed).
+  __device__ void publish(uint64_t seq, const T& value) {
+    DeviceHostQueueSlot<T>& slot = slots_[seq & mask_];
+    memcpy(slot.payload, &value, sizeof(T));
+    ::comms::device::st_release_sys_global(&slot.readySeq, seq + 1);
+  }
+
+  DeviceHostQueueControl<T>* ctrl_ = nullptr; // device pointer
+  DeviceHostQueueSlot<T>* slots_ = nullptr; // device pointer
+  uint32_t capacity_ = 0;
+  uint32_t mask_ =
+      0; // capacity - 1; slot index = seq & mask_ (capacity is a power of two)
+};
+
+// =============================================================================
+// DeviceHostQueue<T, Policy> — host RAII owner of the cudaHostAlloc
+// allocation, and the single (CPU) consumer. Non-copyable, non-movable. The
+// host consumer methods (read/blockingRead) mirror the device producer over
+// the same plain words via std::atomic_ref. Hand producerHandle() to the GPU.
+//
+// Teardown: the caller must quiesce all producers (abort flag + stream sync)
+// before destruction — freeing a live shared ring is undefined behavior.
+// =============================================================================
+template <
+    class T,
+    Direction Dir = Direction::D2H,
+    ConsumerPolicy Policy = ConsumerPolicy::Single>
+class DeviceHostQueue {
+ public:
+  static_assert(std::is_trivially_copyable_v<T>);
+  static_assert(std::is_trivially_destructible_v<T>);
+  static_assert(
+      Dir == Direction::D2H,
+      "DeviceHostQueue: only Direction::D2H (device producer -> host consumer) "
+      "is supported; H2D needs a host system-scope fence and is not yet "
+      "implemented");
+  static_assert(
+      Policy == ConsumerPolicy::Single,
+      "DeviceHostQueue: only ConsumerPolicy::Single is implemented");
+
+  using Producer = DeviceHostQueueProducer<T, Policy>;
+
+  struct ReadResult {
+    T value;
+    uint64_t seq;
+  };
+
+  /// Allocate and zero-initialize a queue. `capacity` must be a power of two.
+  explicit DeviceHostQueue(uint32_t capacity) {
+    if (capacity == 0 || (capacity & (capacity - 1)) != 0) {
+      throw std::runtime_error(
+          "DeviceHostQueue: capacity must be a power of two");
+    }
+    capacity_ = capacity;
+    mask_ = capacity - 1;
+    static_assert(
+        sizeof(DeviceHostQueueControl<T>) % alignof(DeviceHostQueueSlot<T>) ==
+            0,
+        "slots[] must start on its natural alignment after the control header");
+    static_assert(
+        offsetof(DeviceHostQueueSlot<T>, readySeq) >
+            offsetof(DeviceHostQueueSlot<T>, payload),
+        "readySeq must remain the last field, after the payload");
+
+    const size_t bytes = sizeof(DeviceHostQueueControl<T>) +
+        static_cast<size_t>(capacity) * sizeof(DeviceHostQueueSlot<T>);
+
+    void* host = nullptr;
+#if defined(__HIP_PLATFORM_AMD__)
+    // Fine-grained (coherent) + mapped so a GPU system-scope release store is
+    // visible to a concurrently-polling CPU consumer mid-kernel, with no manual
+    // cache flush. cudaHostAlloc below hipifies to hipHostMalloc.
+    const unsigned kHostAllocFlags =
+        hipHostMallocMapped | hipHostMallocCoherent;
+#else
+    const unsigned kHostAllocFlags = cudaHostAllocMapped;
+#endif
+    if (cudaError_t e = cudaHostAlloc(&host, bytes, kHostAllocFlags);
+        e != cudaSuccess) {
+      throw std::runtime_error(
+          std::string("DeviceHostQueue: cudaHostAlloc: ") +
+          cudaGetErrorString(e));
+    }
+    // cudaHostAlloc does not zero; this establishes pi=ci=0 and readySeq=0 so
+    // the readySeq==seq+1 scheme is unambiguous from seq 0.
+    std::memset(host, 0, bytes);
+    void* dev = nullptr;
+    if (cudaError_t e = cudaHostGetDevicePointer(&dev, host, 0);
+        e != cudaSuccess) {
+      // ctrlHost_ is still null here, so the destructor would not free `host`;
+      // release it on this error path to avoid leaking the pinned allocation.
+      cudaFreeHost(host);
+      throw std::runtime_error(
+          std::string("DeviceHostQueue: cudaHostGetDevicePointer: ") +
+          cudaGetErrorString(e));
+    }
+    ctrlHost_ = reinterpret_cast<DeviceHostQueueControl<T>*>(host);
+    ctrlDev_ = reinterpret_cast<DeviceHostQueueControl<T>*>(dev);
+    slotsHost_ = slotsOf(ctrlHost_);
+    slotsDev_ = slotsOf(ctrlDev_);
+  }
+
+  ~DeviceHostQueue() {
+    // Precondition: producers already quiesced; freeing a live ring is
+    // undefined behavior.
+    if (ctrlHost_ != nullptr) {
+      cudaFreeHost(ctrlHost_);
+    }
+  }
+
+  DeviceHostQueue(const DeviceHostQueue&) = delete;
+  DeviceHostQueue& operator=(const DeviceHostQueue&) = delete;
+  DeviceHostQueue(DeviceHostQueue&&) = delete;
+  DeviceHostQueue& operator=(DeviceHostQueue&&) = delete;
+
+  uint32_t capacity() const {
+    return capacity_;
+  }
+
+  /// Approximate backlog (published-but-not-yet-consumed slots). Clamped to
+  /// [0, capacity]; not exact under concurrency.
+  size_t sizeApprox() const {
+    uint64_t p = std::atomic_ref<uint64_t>(ctrlHost_->pi)
+                     .load(std::memory_order_relaxed);
+    uint64_t c = std::atomic_ref<uint64_t>(ctrlHost_->ci)
+                     .load(std::memory_order_relaxed);
+    uint64_t d = p > c ? p - c : 0;
+    return d > capacity_ ? capacity_ : static_cast<size_t>(d);
+  }
+
+  /// Single-owner host consumer dequeue: copies the next published command out
+  /// and releases its slot (advances ci) for producer reuse. Returns the
+  /// payload and its sequence via `out`. Returns Ok or Empty.
+  QueueOpStatus read(ReadResult& out) {
+    DeviceHostQueueSlot<T>& slot = slotsHost_[nextToRead_ & mask_];
+    uint64_t ready = std::atomic_ref<uint64_t>(slot.readySeq)
+                         .load(std::memory_order_acquire);
+    if (ready != nextToRead_ + 1) {
+      return QueueOpStatus::Empty;
+    }
+    memcpy(
+        &out.value, slot.payload, sizeof(T)); // copy out: slot no longer needed
+    out.seq = nextToRead_;
+    ++nextToRead_;
+    // Publish reuse credit; release pairs with the producer's acquire of ci.
+    std::atomic_ref<uint64_t>(ctrlHost_->ci)
+        .store(nextToRead_, std::memory_order_release);
+    return QueueOpStatus::Ok;
+  }
+
+  /// Batched MPSC dequeue: copies up to `max` contiguous published commands
+  /// into out[0..n) in sequence order, then releases all n slots with a SINGLE
+  /// ci release store (vs one per command in read()). That store is the
+  /// cross-domain write that bounds drain throughput, so batching it is the
+  /// main consumer-side perf lever; prefer this over read() in a drain loop.
+  /// Returns n; n == 0 means the head is not yet published. MPSC only.
+  size_t readMulti(ReadResult* out, size_t max) {
+    static_assert(
+        Policy == ConsumerPolicy::Single,
+        "readMulti is MPSC-only; with ConsumerPolicy::Multi each consumer "
+        "claims via read()");
+    size_t n = 0;
+    uint64_t seq = nextToRead_;
+    while (n < max) {
+      DeviceHostQueueSlot<T>& slot = slotsHost_[seq & mask_];
+      // Per-slot acquire pairs with the producer's release of readySeq, so the
+      // payload copied just below is fully visible.
+      uint64_t ready = std::atomic_ref<uint64_t>(slot.readySeq)
+                           .load(std::memory_order_acquire);
+      if (ready != seq + 1) {
+        break; // first unpublished slot ends the contiguous batch
+      }
+      memcpy(&out[n].value, slot.payload, sizeof(T));
+      out[n].seq = seq;
+      ++n;
+      ++seq;
+    }
+    if (n > 0) {
+      nextToRead_ = seq;
+      // One release store frees the whole batch and orders the n copy-outs
+      // before the credit; pairs with the producer's acquire of ci.
+      std::atomic_ref<uint64_t>(ctrlHost_->ci)
+          .store(seq, std::memory_order_release);
+    }
+    return n;
+  }
+
+  /// Blocking host consumer dequeue: spins until the head is published, then
+  /// copies it out and releases its slot. Each empty poll issues a cpuRelax()
+  /// hint (YIELD on aarch64/Grace, PAUSE on x86) so it does not burn the core
+  /// hot. No escape (assumes a producer makes progress); a consumer that may
+  /// idle, shares a core, or must also poll other things should loop on the
+  /// non-blocking read() with its own backoff instead.
+  void blockingRead(ReadResult& out) {
+    while (read(out) == QueueOpStatus::Empty) {
+      cpuRelax();
+    }
+  }
+
+  /// Device producer handle for kernels — cursor-free and trivially copyable,
+  /// so it is safe to pass BY VALUE to every producer thread. Idempotent.
+  Producer producerHandle() const {
+    Producer h;
+    h.ctrl_ = ctrlDev_;
+    h.slots_ = slotsDev_;
+    h.capacity_ = capacity_;
+    h.mask_ = mask_;
+    return h;
+  }
+
+ private:
+  DeviceHostQueueControl<T>* ctrlHost_ = nullptr;
+  DeviceHostQueueControl<T>* ctrlDev_ = nullptr;
+  DeviceHostQueueSlot<T>* slotsHost_ = nullptr;
+  DeviceHostQueueSlot<T>* slotsDev_ = nullptr;
+  uint32_t capacity_ = 0;
+  uint32_t mask_ =
+      0; // capacity - 1; slot index = seq & mask_ (capacity is a power of two)
+  uint64_t nextToRead_ = 0; // host consumer cursor (single consumer)
+};
+
+} // namespace meta::comms

--- a/comms/utils/device_host_queue/doc/mpsc_proxy_queue_design.md
+++ b/comms/utils/device_host_queue/doc/mpsc_proxy_queue_design.md
@@ -1,0 +1,399 @@
+# DeviceHostQueue Design (MPSC / MPMC)
+
+## Summary
+
+`DeviceHostQueue<T, Direction, ConsumerPolicy>` is a bounded, lock-free typed ring in host-pinned mapped memory for passing fixed-size proxy commands **one way from GPU to CPU**: the GPU delegates work to a CPU/engine proxy that executes it. GPU threads are the producers; the CPU is the consumer.
+
+The queue is intentionally independent of IBRC, copy-engine, or UniFlow descriptors. Backends provide the payload type `T` and decide what a consumed item means. (The IBRC proxy descriptor ring in `ibrc_proxy_design.md` is a specialization of this same protocol with `T = IbrcProxyDesc`.)
+
+It is header-only and lives at `comms/utils/device_host_queue/DeviceHostQueue.cuh`. It is portable across CUDA and HIP/ROCm (see Portability).
+
+Data flow:
+
+```text
+GPU/device producers -> host CPU consumer(s)
+```
+
+Two consumer policies are selected at compile time via the `ConsumerPolicy` template parameter:
+
+- **`Single` (MPSC)** — one CPU consumer drains in strict sequence order via a private cursor.
+- **`Multi` (MPMC)** — several CPU consumer threads drain concurrently; each published command is delivered to exactly one consumer, claimed in FIFO order. Processing across consumers is not globally ordered, but there is no loss or duplication.
+
+The GPU producer protocol is identical for both policies.
+
+> **Before you pick `Multi`, read "MPSC vs MPMC — the throughput inversion" below.** On a fast cross-domain link (GB200/NVLink-C2C) `Multi` is *slower* than `Single` for pure dequeue; it is for *processing*-bound consumers, not for higher dequeue throughput.
+
+## Goals
+
+- Provide a typed bounded queue in host-pinned mapped memory.
+- Support many GPU producers reserving slots concurrently.
+- Support either one CPU consumer (`Single`) or many concurrent CPU consumers (`Multi`).
+- Preserve FIFO by logical sequence number (claim order under `Multi`).
+- Keep the queue payload independent from backend protocol fields.
+- Keep the GPU producer protocol policy-independent.
+- Keep all consumer claim/completion bookkeeping off the cross-domain ring.
+- Run on both NVIDIA (CUDA) and AMD (HIP/ROCm).
+
+## Non-Goals
+
+- Host producers or device consumers — the data path is strictly GPU → CPU. This is enforced by the `Direction` template parameter: only `Direction::D2H` (device producer → host consumer) is implemented; `Direction::H2D` is rejected at compile time via `static_assert`. H2D is not a drop-in: the host would become the publisher and would have to carry the system-scope half of the fence with an explicit `dmb sy` (aarch64), which `std::atomic`'s inner-shareable release does not provide — see Memory Model.
+- Dynamic resizing.
+- Non-trivially-copyable payloads.
+- Cross-process queue sharing.
+- A status/abort/timeout/heartbeat machinery. The queue is minimal by design: the blocking variants spin (with a relax hint, see Blocking variants) with no escape; bounded waits, abort, and teardown belong to the caller's progress loop / lifecycle, not to the FIFO.
+- A generic replacement for backend completion queues or token/resource pools.
+
+## When To Use This
+
+Reach for `DeviceHostQueue` when a GPU kernel must hand work to a CPU/host agent *while the kernel keeps running*, and you want a typed, bounded, allocation-free, lock-free hand-off:
+
+- **vs `cudaLaunchHostFunc` / stream callbacks** — those are stream-ordered, one-shot, coarse-grained, and cannot deliver work mid-kernel; this queue streams many fine-grained commands from a live kernel.
+- **vs a hand-rolled flag in unified/managed memory** — this gives you a real bounded FIFO with credit-based backpressure, a torn-publish-safe publish protocol, and FIFO/exactly-once semantics, instead of a single ad-hoc flag.
+- **vs a backend completion queue** — this is the generic transport; the backend layers its own descriptor type and completion accounting on top (see IBRC proxy).
+
+## Type Requirements
+
+`T` must be plain data:
+
+```cpp
+static_assert(std::is_trivially_copyable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+```
+
+Payloads should be fixed-size and cacheline-conscious. Recommended payload sizes for proxy commands are 16B–256B; throughput is ops-bound across that range (see Performance), so larger payloads cost little extra until you hit link bandwidth.
+
+`T` carries only the backend payload; it MUST NOT carry queue mechanics. The publish marker `readySeq` is owned by the queue and lives in the slot (`DeviceHostQueueSlot::readySeq`), never inside `T`. Publication writes the payload, then performs a *separate, system-scope release* store of the marker (see Sequence Protocol). A marker embedded in `T` could not implement that protocol — it would be copied as part of the payload blob with no ordering between payload and marker, and as a plain (non-atomic) field, so it could be observed torn or out of order.
+
+## API
+
+Device producer handle — returned by `producerHandle()`, passed BY VALUE into kernels. It holds no cursor, so it is safe to broadcast to every producer thread; `write()`/`blockingWrite()` may be called concurrently by any number of threads.
+
+```cpp
+template <class T, ConsumerPolicy Policy = ConsumerPolicy::Single>
+class DeviceHostQueueProducer {
+ public:
+  __host__ __device__ uint32_t capacity() const;
+  __device__ uint32_t sizeApprox() const;
+
+  // Reserves a slot only if credit is available, so a Full return never leaves
+  // an unpublished hole. Returns Ok or Full.
+  __device__ QueueOpStatus write(const T& value);
+
+  // Reserve a slot, spin for reuse credit, then publish. No escape.
+  __device__ void blockingWrite(const T& value);
+};
+```
+
+Host owner / CPU consumer — the RAII owner of the allocation and the consumer side.
+
+```cpp
+template <
+    class T,
+    Direction Dir = Direction::D2H,
+    ConsumerPolicy Policy = ConsumerPolicy::Single>
+class DeviceHostQueue {
+ public:
+  explicit DeviceHostQueue(uint32_t capacity); // power of two
+
+  uint32_t capacity() const;
+  size_t sizeApprox() const;
+
+  struct ReadResult { T value; uint64_t seq; };
+
+  // Copies the next published command out and releases its slot (advances ci)
+  // for producer reuse — copy-out frees the slot. Returns Ok or Empty.
+  // Single: call from one consumer only. Multi: safe from many threads; each
+  // command is returned to exactly one caller, claimed in FIFO order.
+  QueueOpStatus read(ReadResult& out);
+
+  // Batched MPSC dequeue: copies up to `max` contiguous published commands into
+  // out[0..n) and returns n, releasing the whole batch with a SINGLE ci store.
+  // MPSC only (compile error under Multi). See "Batched dequeue".
+  size_t readMulti(ReadResult* out, size_t max);  // Policy == Single only
+
+  void blockingRead(ReadResult& out);  // spins with a cpuRelax() hint
+
+  // Cursor-free, trivially-copyable device producer handle. Pass BY VALUE.
+  Producer producerHandle() const;
+};
+```
+
+Device `read` is not exposed: the consumer is always the CPU owner. `read()` writes the payload through `ReadResult` rather than returning `std::optional<T>`, keeping the contract uniform and copy-free.
+
+Ownership contract:
+
+```text
+producerHandle().write()/blockingWrite():
+  may be called by many GPU producer threads concurrently
+
+read()/readMulti()/blockingRead():
+  Single: exactly one CPU consumer
+  Multi:  read()/blockingRead() from any number of CPU consumer threads;
+          readMulti() is MPSC-only
+```
+
+## Memory Layout
+
+Queue storage lives in one contiguous host-pinned mapped allocation:
+
+```cpp
+// flags = cudaHostAllocMapped on CUDA;
+//       = hipHostMallocMapped | hipHostMallocCoherent on HIP/AMD (see Portability)
+cudaHostAlloc(&host_ptr, bytes, flags);
+cudaHostGetDevicePointer(&device_ptr, host_ptr, 0);
+```
+
+Shared, CPU↔GPU-mapped layout. Every word touched across the boundary is a PLAIN integer; atomicity and ordering are applied at the access site (see Memory Model).
+
+```cpp
+template <class T>
+struct alignas(64) DeviceHostQueueSlot {
+  alignas(alignof(T)) std::byte payload[sizeof(T)];
+  uint64_t readySeq; // publish marker; MUST stay LAST (written after payload)
+};
+
+template <class T>
+struct alignas(64) DeviceHostQueueControl {
+  alignas(64) uint64_t pi; // producer reservation
+  alignas(64) uint64_t ci; // reuse credit
+};
+// slots[] follows immediately after the control header in the same allocation.
+```
+
+`capacity` must be a power of two, so `slot = seq & mask`. `pi`, `ci`, and `readySeq` are 64-bit absolute logical sequence numbers — do not reduce them to 32-bit (the `readySeq == seq + 1` scheme and ABA-freedom depend on absolute sequences).
+
+The cross-domain ring carries only `pi`, `ci`, and per-slot `readySeq`. **All consumer claim/completion bookkeeping lives on the host side, never in the ring:**
+
+```text
+Single: a private uint64_t cursor (nextToRead), owned by the one consumer.
+Multi:  a shared std::atomic head (FIFO claim counter) plus a host-side done[]
+        array of absolute completion markers (one per slot), each padded to its
+        own cache line (alignas(64)) so consumers completing nearby seqs do not
+        false-share. Both are ordinary host atomics, since all consumers are CPU
+        threads.
+```
+
+## Memory Model
+
+The device producer uses **system-scope atomics** via `comms::device` (`comms/common/AtomicUtils.cuh`): `ld_relaxed_sys_global` / `ld_acquire_sys_global` for `pi`/`ci`, `atomic_fetch_add_relaxed_sys_global` / `atomic_cas_relaxed_sys_global` to reserve `pi`, and `st_release_sys_global` to publish `readySeq`. These lower to `ld/st.{relaxed,acquire,release}.sys.global` + `atom.relaxed.sys` PTX on NVIDIA and to `__atomic_*` / `__hip_atomic_*` on AMD. Using these lean primitives instead of `cuda::atomic_ref<…, thread_scope_system>` is also a large throughput win on H100/PCIe (see Performance).
+
+The host consumer uses `std::atomic_ref<uint64_t>` release/acquire, which is **inner-shareable** on aarch64/Grace. That suffices — not a gap — because (a) the ring is coherent host-pinned mapped memory and (b) the device peer always issues the system-scope half. The host fence only has to order the host's own loads/stores. This "host std-atomic + device system-scope over coherent pinned memory" split is the GB200-validated convention used elsewhere in comms (cf. ctran `MemFence.h` / `GpeKernelSync`). A host-side `dmb sy` is intentionally NOT emitted. This asymmetry is exactly why the queue is D2H-only (see Non-Goals): in a hypothetical H2D direction the host would be the *publisher*, so it would have to carry the system-scope half itself with an explicit `dmb sy` — `std::atomic`'s inner-shareable release would silently fail to order the payload into the GPU domain (and x86 would mask the bug). `Direction::H2D` is therefore a compile error rather than a footgun.
+
+**No separate publish fence.** The marker store is a system-scope *release* store, which by itself orders all prior writes in the producer thread (the payload memcpy) before the marker becomes visible to a consumer that acquire-loads it. An explicit `__threadfence_system()` before the release store would be redundant (it would be needed only if the marker store were *relaxed*). Dropping it removes one system-scope op from every publish — a ~13–20% publish-latency reduction (see Performance) — and the torn-publish stress test confirms correctness without it on H100, GB200/Grace, and AMD MI300.
+
+| word | device access | host access |
+| ---- | ------------- | ----------- |
+| `pi` (RMW) | `atomic_fetch_add_relaxed_sys_global` / `atomic_cas_relaxed_sys_global` | n/a (producers are GPU) |
+| `ci` (load on device, store/CAS on host) | `ld_acquire_sys_global` | `std::atomic_ref` release store (Single) / release CAS (Multi) |
+| `readySeq` | `st_release_sys_global` (release) | `std::atomic_ref` acquire load |
+
+Multi-consumer coordination (`head`, `done[]`) is host-only (CPU↔CPU) and uses ordinary `std::atomic`. The cross-domain 64-bit host atomics must be lock-free for the torn-publish protection to hold; this is asserted with `static_assert(... is_always_lock_free)` and is always true on the targeted host ABIs (x86-64, aarch64/Grace).
+
+Ordering contract:
+
+- **Publish/consume:** producer writes the payload, then release-stores `readySeq`; the consumer acquire-loads `readySeq` and, only on match, reads the payload. The release store — paired with the consumer's acquire — orders all payload writes before the marker becomes visible, for any payload size.
+- **Credit:** the producer acquire-loads `ci`; the consumer release-advances it after copy-out. This guarantees the consumer has finished copying a slot's previous occupant before any producer overwrites it.
+
+## Initialization
+
+`cudaHostAlloc` returns **uninitialized** memory, so the region MUST be explicitly zeroed before any producer can run.
+
+```text
+1. require capacity is a power of two; mask = capacity - 1
+2. bytes = sizeof(DeviceHostQueueControl<T>) + capacity * sizeof(DeviceHostQueueSlot<T>)
+3. cudaHostAlloc(&host_ptr, bytes, <mapped[/coherent on HIP]>)
+   cudaHostGetDevicePointer(&device_ptr, host_ptr, 0)  # free host_ptr if this fails
+4. memset(host_ptr, 0, bytes)                           # cudaHostAlloc does NOT zero
+5. publish the device handle / launch producer kernels only AFTER steps 1-4
+```
+
+Zeroing establishes `pi = ci = 0` and every slot's `readySeq = 0`. Why that is correct (the `readySeq == seq + 1` scheme):
+
+```text
+- pi starts its fetch_add at 0, so the first command is seq = 0.
+- The producer publishes readySeq = seq + 1, so the first marker is 1.
+- The consumer at the head (seq 0) treats a slot ready iff readySeq == seq + 1.
+- A zero-initialized slot has readySeq == 0 != 1, so it reads as "not ready"
+  until actually published. pi = ci = 0 also make the credit test
+  (seq - ci < capacity) and the slot map (seq & mask) well-defined from step 0.
+```
+
+Physical slot `s` is reused by sequences `s, s+capacity, s+2*capacity, …`; the marker for occupant `seq` is `seq + 1`, which differs from the previous occupant's marker by `capacity` and from the zero sentinel by at least 1. With 64-bit absolute sequences the exact-match test is unambiguous (ABA-free).
+
+## Sequence Protocol
+
+`pi` is the producer reservation sequence. `ci` is the producer-visible reuse-credit prefix: a producer may overwrite a slot only once `ci` has advanced past it. Under copy-out semantics the consumer advances `ci` as part of `read()` — dequeuing a command frees its slot — so there is no separate `advance_ci` step.
+
+Producer (both policies):
+
+```text
+# non-blocking write(): claim only if credit is available
+seq = ld_relaxed(pi)
+loop:
+  if seq >= ci and seq - ci.load(acquire) >= capacity: return Full   # underflow-safe guard
+  prev = atomic_cas_relaxed(pi, seq, seq + 1)        # claim; returns prior value
+  if prev == seq: break                              # no hole on Full
+  seq = prev                                         # refresh and retry
+
+# blockingWrite(): unconditional reservation, then spin for credit
+seq = atomic_fetch_add_relaxed(pi, 1)
+while seq - ci.load(acquire) >= capacity: spin
+publish(seq, value)
+
+publish(seq, value):
+  copy payload into slot[seq & mask]
+  st_release_sys_global(readySeq[seq & mask], seq + 1)   # release store; no separate fence
+```
+
+The Full guard is `seq >= c && seq - c >= capacity`: `seq` (a relaxed snapshot of `pi`) can be stale because other producers advance `pi` and the consumer advances `ci`, so the explicit `seq >= c` check prevents an unsigned underflow that would spuriously report Full; when `seq < c` the CAS simply fails and refreshes `seq`. This path is contention-tested (256 threads racing for 8 slots — exactly `capacity` claim Ok, the rest Full, no holes).
+
+Reserve-then-publish obligation: `blockingWrite` reserves with an unconditional `fetch_add` and is therefore committed to publishing. A thread that reserves and then never publishes (aborts mid-call) leaves a permanent hole that wedges the in-order consumer. `write()` has no such obligation — it claims `pi` only when it is about to publish.
+
+Single consumer (private `nextToRead` cursor):
+
+```text
+read(out):
+  seq = nextToRead
+  if readySeq[seq & mask].load(acquire) != seq + 1: return Empty
+  copy payload out
+  nextToRead = seq + 1
+  ci.store(seq + 1, release)        # copy-out frees the slot
+  return Ok (seq)
+```
+
+Multi consumer (shared `head` + host `done[]`):
+
+```text
+read(out):
+  loop:
+    h = head.load(acquire)
+    if readySeq[h & mask].load(acquire) != h + 1: return Empty   # head not published
+    if not head.compare_exchange_weak(h, h + 1): continue          # lost the claim; retry
+    # exclusive owner of seq h
+    copy payload out
+    done[h & mask].store(h + 1, release)     # mark consumed (absolute seq)
+    advance_reuse_credit()
+    return Ok (h)
+
+advance_reuse_credit():               # advance ci over the contiguous consumed prefix
+  loop:
+    c = ci.load(relaxed)
+    if done[c & mask].load(acquire) != c + 1: break   # end of contiguous freed prefix
+    if ci.compare_exchange_weak(c, c + 1, release): continue
+```
+
+`advance_reuse_credit` is **opportunistic, not cooperative**: whoever wins the `ci` CAS walks the whole contiguous prefix; a consumer that loses just reloads, finds the winner has already drained to the last visible marker, and bails via the `break`. So one consumer drains `ci` at a time while the others fall through — this is **not a livelock** (each pass either advances `ci` or breaks, and `ci` is monotonic and bounded by the published markers). Reclaim is therefore eventually-consistent: `ci` may briefly lag a just-completed consume until a later advance observes the marker, which never corrupts and never deadlocks a producer (a producer blocks only on a full ring, i.e. commands are waiting, so consumers keep draining).
+
+## Batched Dequeue (`readMulti`, MPSC)
+
+`readMulti(out, max)` scans `readySeq` from `nextToRead` until the first unpublished slot or `max`, copies the N contiguous published commands into `out[0..N)`, then advances `ci` with a **single** release store for the whole batch (instead of one per command in `read()`). It returns N (0 if the head is unpublished) and is MPSC-only (`static_assert(Policy == Single)`).
+
+Why it matters: the per-item `ci` release store is the cross-domain write that bounds drain throughput; amortizing it over a batch is the main consumer-side perf lever. On GB200 (where that store is the bottleneck) `readMulti` is ~1.7× faster than per-item `read()` at small payloads; on H100 it is neutral because the producer-side publish, not the consumer `ci` store, is the limiter there (see Performance). Per-slot `readySeq` acquire loads remain per item — those are cheap reads — only the credit store is batched.
+
+`readMulti` is **not** provided for `Multi`: MPMC's bottleneck is the shared `head` CAS, not the `ci` store, and a batched multi-consumer claim is a separate, more complex design. Multi consumers should use per-item `read()` (see the inversion note).
+
+## MPSC vs MPMC — the throughput inversion
+
+**`Multi` is not "MPSC plus more throughput".** Measured on GB200/NVLink-C2C, a single `Single` consumer reaches ~50–80 Mops/s, while 2/4/8 `Multi` consumers each land at ~15–19 Mops/s aggregate — adding consumers *reduces* aggregate dequeue throughput. Once the cross-domain coherence is cheap (NVLink-C2C), the shared `head` CAS plus per-slot `done[]` markers become the limiter, and more consumers means more contention on those. On H100/PCIe the effect is hidden — both sit at ~16 Mops/s — because the PCIe round-trip dominates either way.
+
+Guidance:
+
+- **Dequeue-bound** (cheap per-command work, you just want commands off the GPU fast) → use **`Single` + `readMulti`**. Do not reach for `Multi` for throughput.
+- **Processing-bound** (each command triggers real CPU work that one thread can't keep up with) → use **`Multi`** to parallelize the *processing*. The dequeue contention is then amortized by the per-command work, which is the regime `Multi` is designed for.
+
+Picking `Multi` to "go faster" on a pure hand-off path will regress you.
+
+## Blocking Variants And Spin Policy
+
+`blockingWrite` (device) spins for reuse credit; `blockingRead` (host) spins until the head is published. Neither has an escape — they assume the peer makes progress.
+
+`blockingRead` issues a `cpuRelax()` hint on each empty poll: the `YIELD` instruction on aarch64/Grace, `PAUSE` on x86. This relaxes the core (lets an SMT sibling progress, saves power) **without descheduling**, so an always-busy proxy consumer keeps its latency. It does *not* yield the core to the scheduler — backoff policy is the caller's, by design. A consumer that may idle, shares a core, or must also poll other things should loop on the non-blocking `read()` / `readMulti()` with its own backoff:
+
+```cpp
+ReadResult r;
+while (q.read(r) == QueueOpStatus::Empty) {
+  // caller's policy: cpuRelax(), std::this_thread::yield(), exponential backoff, ...
+}
+```
+
+## Capacity Sizing
+
+`capacity` (power of two) sets how many commands can be in flight before `write()` returns Full / `blockingWrite` spins. Size it from the producer/consumer rate gap and the consumer's drain batch:
+
+- Steady state needs `capacity >= producer_burst` so producers don't stall on a transient consumer hiccup. As a starting point, pick `capacity` a few × the consumer's `readMulti` `max` batch.
+- At ~16–80 Mops/s (see Performance) one slot frees every ~12–60 ns, so even a 1024-slot ring (≈12–60 µs of buffering at 64–128 B/slot) is small; start at 1024 and tune. Memory is `sizeof(Control) + capacity * sizeof(Slot)` of pinned mapped memory.
+- Larger rings hide consumer jitter but cost pinned memory and can hurt cache locality of the `readySeq` scan; do not oversize blindly.
+
+## Teardown And Lifetime
+
+`DeviceHostQueue<T>` is a host RAII owner (non-copyable, non-movable) of the `cudaHostAlloc` allocation. `producerHandle()` returns a trivially-copyable, non-owning device handle passed by value into kernels; it holds only device-resolved pointers and frees nothing.
+
+Destroying the queue while a device producer is still running is a use-after-free: a kernel may be spinning in `blockingWrite` (or mid `pi.fetch_add` / payload copy) holding device pointers into the ring, and `cudaFreeHost` on that memory while a kernel still touches it is undefined behavior.
+
+Teardown protocol (caller-driven, since the queue has no abort word):
+
+```text
+1. signal producers to stop (caller's own abort flag) and stop issuing writes
+2. quiesce every producer stream (cudaStreamSynchronize / cudaDeviceSynchronize)
+3. ensure consumers have stopped calling read()
+4. destroy the queue (frees control + slots)
+```
+
+The owner must outlive every kernel handed a producer handle.
+
+## Portability (CUDA + HIP/ROCm)
+
+The queue compiles and runs on both NVIDIA and AMD:
+
+- **Device atomics** route through `comms::device` (`AtomicUtils.cuh`), which is `#if defined(__HIP_PLATFORM_AMD__)`-branched to `__atomic_*`/`__hip_atomic_*` on AMD and PTX on NVIDIA. There is no `<cuda/atomic>` / `cuda::atomic_ref` dependency.
+- **Host allocation** uses the CUDA runtime API, which hipifies 1:1 (`cudaHostAlloc → hipHostMalloc`, etc.). On AMD the flags are `hipHostMallocMapped | hipHostMallocCoherent` — the **coherent (fine-grained)** flag is mandatory so a GPU system-scope release store is visible to a concurrently-polling CPU consumer mid-kernel with no manual cache flush; on a non-coherent allocation the consumer would only see writes at kernel completion.
+- **BUCK**: the lib/tests are `comms_gpu_cpp_library` / `comms_gpu_cpp_unittest` with `hip_compatible = True`; the lib depends on `//comms/common:atomic_utils`.
+
+Validated build + run on NVIDIA H100, AMD MI300, and (build) aarch64/Grace for GB200.
+
+## Performance
+
+Representative numbers, **median of 7 runs** per point (256 GPU producers; throughput is steady-state; latency is host-request → publish → host-read round trip). The GB200 fast path carries real run-to-run variance — the benchmark prints a stddev column per throughput point.
+
+| (64 B) | H100 (x86 / PCIe) | GB200 (aarch64 / C2C) | MI300X (AMD / ROCm) |
+| --- | --- | --- | --- |
+| MPSC throughput | ~16 Mops/s | ~52 Mops/s | ~8 Mops/s |
+| MPSC `readMulti` | ~17 Mops/s (neutral) | ~93 Mops/s (~1.8×) | ~9 Mops/s |
+| MPMC (4 consumers) | ~13 Mops/s | ~15 Mops/s (< MPSC) | ~6 Mops/s |
+| MPSC p50 latency | ~6.2 µs | ~3.9 µs | ~5.8 µs |
+| Contention p50 (1/32/256 producers) | 6.0 / 7.0 / 18 µs | 3.9 / 3.9 / 6.4 µs | 5.4 / 5.6 / 8.4 µs |
+
+Reading the data:
+
+- **Ops-bound, not bandwidth-bound.** Mops/s is roughly flat across payload size while GB/s scales linearly — the limiter is the per-publish cross-domain coordination (system-scope release store + `pi` RMW), not the link. Even at 256 B on GB200 the NVLink-C2C link is only a few percent utilized.
+- **`readMulti` helps where the consumer is the bottleneck.** On GB200 it is ~1.8× MPSC (the per-item `ci` store dominates there); on H100 it is neutral (the producer-side publish over PCIe is the limiter).
+- **Capacity matters.** Throughput plateaus once the ring is a few hundred slots; a too-small ring starves it — 64-slot 64 B MPSC is ~2 Mops/s on H100 (~14 on GB200, ~3 on MI300) vs the plateau at cap ≥ 256. Start at ~1024 and tune (see Capacity Sizing).
+- **MPMC is slower than MPSC for pure dequeue** on every architecture (head-CAS + `done[]` contention); the consumer-scaling sweep drops monotonically. Use `Multi` for processing parallelism, not dequeue throughput.
+- **Latency degrades gracefully under producer contention** — p50 rises from the empty-queue path to the backlogged path as producers go 1 → 256 (e.g. GB200 3.9 → 6.4 µs); the queue does not fall over.
+- **The `comms::device` PTX atomics matter on H100:** they took H100 throughput from ~1 → ~16 Mops/s versus libcu++ `cuda::atomic_ref<system>`. GB200 was already fast either way (cheap C2C coherence).
+- **Dropping the publish fence** lowered p50 latency ~13–20% and was throughput-neutral.
+
+## Tests
+
+`comms/utils/device_host_queue/tests/DeviceHostQueueUT.cu`:
+
+```text
+capacity is power-of-two validated
+empty read returns Empty (Single and Multi)
+device-write / host-read round trip
+producer Full/credit path (non-blocking write returns Full, then Ok after a read)
+concurrent write() under contention (256 threads, cap 8): exactly `cap` Ok, every
+  attempt Ok-or-Full, exactly `cap` drain back (CAS credit guard, no holes)
+single-producer wraparound FIFO across many capacity cycles
+readMulti batched drain: same sequence/values as per-item read(), no loss/dup
+sizeApprox backlog
+many GPU producers -> single host consumer: strict global sequence, per-producer
+  FIFO, no loss/duplication, and a per-command guard-word torn-publish check
+many GPU producers -> many concurrent host consumers (Multi): exactly-once
+  delivery (every sequence and every (producer,value) once) plus torn-publish
+```
+
+The torn-publish guard fills the rest of the payload cache line with the command's value and verifies it on consume, so a publish observed without all payload writes visible (a weak-memory ordering bug) is detected. It is run on **H100 (NVIDIA), MI300 (AMD — relaxed memory), and aarch64/Grace** to exercise the actual weak-memory ordering of the GPU→CPU publish path and the `Multi` `done[]`/`ci` release-acquire chain — the strongest evidence that the release-store-only publish (no fence) is correct.
+
+IBRC-specific tests (QP post order follows queue sequence order; credit advances only after the backend no longer needs the slot) belong with the IBRC backend, not this queue primitive.
+```

--- a/comms/utils/device_host_queue/tests/DeviceHostQueueUT.cu
+++ b/comms/utils/device_host_queue/tests/DeviceHostQueueUT.cu
@@ -1,0 +1,306 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "comms/utils/device_host_queue/DeviceHostQueue.cuh"
+
+using meta::comms::DeviceHostQueue;
+using meta::comms::QueueOpStatus;
+
+namespace {
+
+#define CUDACHECK(cmd)                                                    \
+  do {                                                                    \
+    cudaError_t e = (cmd);                                                \
+    ASSERT_EQ(e, cudaSuccess) << "CUDA error: " << cudaGetErrorString(e); \
+  } while (0)
+
+// Torn-publish detector payload. `guard[]` is filled with `value` on every
+// publish and spans the rest of a 64B cache line, so a consistently-published
+// command has guard[j] == value for all j. If the consumer ever observes the
+// readySeq marker without all payload writes being visible (a publish-ordering
+// bug — possible on weak memory, e.g. aarch64/Grace, if the release/acquire
+// pairing were wrong), some guard words would still hold a prior occupant's
+// value and the check below would fire.
+struct Cmd {
+  uint32_t producer;
+  uint32_t value;
+  uint32_t guard[14]; // == value on a consistent publish; sizeof(Cmd) == 64
+};
+static_assert(sizeof(Cmd) == 64);
+
+using IntQueue = DeviceHostQueue<uint64_t>;
+using CmdQueue = DeviceHostQueue<Cmd>;
+
+// Each thread is a producer that publishes `perThread` commands, tagged with
+// its global thread id and an increasing per-thread value.
+__global__ void producerKernel(CmdQueue::Producer q, uint32_t perThread) {
+  uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  for (uint32_t i = 0; i < perThread; ++i) {
+    Cmd c;
+    c.producer = tid;
+    c.value = i;
+    for (int j = 0; j < 14; ++j) {
+      c.guard[j] = i; // all guard words mirror value
+    }
+    q.blockingWrite(c);
+  }
+}
+
+// Single-thread producer: blocking-writes values base..base+n-1 in order.
+__global__ void
+intBlockingWriteKernel(IntQueue::Producer q, uint32_t n, uint64_t base) {
+  for (uint32_t i = 0; i < n; ++i) {
+    q.blockingWrite(base + i);
+  }
+}
+
+// Single-thread producer using the non-blocking write(); records each call's
+// status into st[] so the host can assert Ok/Full behaviour.
+__global__ void intWriteStatusKernel(
+    IntQueue::Producer q,
+    uint32_t n,
+    uint64_t base,
+    QueueOpStatus* st) {
+  for (uint32_t i = 0; i < n; ++i) {
+    st[i] = q.write(base + i);
+  }
+}
+
+// N producer threads each attempt exactly one non-blocking write(); st[tid]
+// records Ok/Full so the host can verify the credit guard under real
+// contention.
+__global__ void concurrentWriteKernel(IntQueue::Producer q, QueueOpStatus* st) {
+  uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  st[tid] = q.write(tid);
+}
+
+} // namespace
+
+TEST(DeviceHostQueueTest, CapacityMustBePowerOfTwo) {
+  EXPECT_THROW(IntQueue(0), std::runtime_error);
+  EXPECT_THROW(IntQueue(3), std::runtime_error);
+  EXPECT_NO_THROW(IntQueue(1));
+  EXPECT_NO_THROW(IntQueue(8));
+}
+
+TEST(DeviceHostQueueTest, EmptyReadReturnsEmpty) {
+  IntQueue q(8);
+  IntQueue::ReadResult r;
+  EXPECT_EQ(q.read(r), QueueOpStatus::Empty);
+}
+
+TEST(DeviceHostQueueTest, DeviceWriteHostReadRoundTrip) {
+  IntQueue q(8);
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+  // One device producer writes a single value 42.
+  intBlockingWriteKernel<<<1, 1, 0, stream>>>(q.producerHandle(), 1, 42);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaStreamSynchronize(stream));
+
+  IntQueue::ReadResult r;
+  ASSERT_EQ(q.read(r), QueueOpStatus::Ok);
+  EXPECT_EQ(r.value, 42u);
+  EXPECT_EQ(r.seq, 0u);
+  EXPECT_EQ(q.read(r), QueueOpStatus::Empty);
+  CUDACHECK(cudaStreamDestroy(stream));
+}
+
+TEST(DeviceHostQueueTest, FullReturnsFullUntilCreditAdvances) {
+  IntQueue q(4);
+  QueueOpStatus* st = nullptr;
+  CUDACHECK(cudaMallocManaged(&st, sizeof(QueueOpStatus) * 5));
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+
+  // Five non-blocking writes into a capacity-4 ring with nothing consumed yet:
+  // the first four claim credit (Ok), the fifth finds the ring full (Full).
+  intWriteStatusKernel<<<1, 1, 0, stream>>>(q.producerHandle(), 5, 0, st);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaStreamSynchronize(stream));
+  for (int i = 0; i < 4; ++i) {
+    EXPECT_EQ(st[i], QueueOpStatus::Ok) << "i=" << i;
+  }
+  EXPECT_EQ(st[4], QueueOpStatus::Full);
+
+  // Consume one (frees its slot); one more write now fits.
+  IntQueue::ReadResult r;
+  ASSERT_EQ(q.read(r), QueueOpStatus::Ok);
+  intWriteStatusKernel<<<1, 1, 0, stream>>>(q.producerHandle(), 1, 99, st);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaStreamSynchronize(stream));
+  EXPECT_EQ(st[0], QueueOpStatus::Ok);
+
+  CUDACHECK(cudaStreamDestroy(stream));
+  CUDACHECK(cudaFree(st));
+}
+
+TEST(DeviceHostQueueTest, ConcurrentWriteRespectsCapacity) {
+  const uint32_t cap = 8;
+  const uint32_t nThreads = 256; // >> cap: heavy contention on the credit guard
+  IntQueue q(cap);
+  QueueOpStatus* st = nullptr;
+  CUDACHECK(cudaMallocManaged(&st, sizeof(QueueOpStatus) * nThreads));
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+
+  // nThreads producers race on write() into a cap-8 ring with nothing consumed.
+  concurrentWriteKernel<<<nThreads / 32, 32, 0, stream>>>(
+      q.producerHandle(), st);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaStreamSynchronize(stream));
+
+  uint32_t ok = 0, full = 0;
+  for (uint32_t i = 0; i < nThreads; ++i) {
+    if (st[i] == QueueOpStatus::Ok) {
+      ++ok;
+    } else if (st[i] == QueueOpStatus::Full) {
+      ++full;
+    }
+  }
+  EXPECT_EQ(ok, cap); // exactly `cap` slots claimed: the guard admits no more
+  EXPECT_EQ(ok + full, nThreads); // every attempt resolved to Ok or Full
+
+  // Every Full claimed nothing (no hole), so exactly the `cap` Ok writes are
+  // published and drain back.
+  IntQueue::ReadResult r;
+  uint32_t drained = 0;
+  while (q.read(r) == QueueOpStatus::Ok) {
+    ++drained;
+  }
+  EXPECT_EQ(drained, cap);
+
+  CUDACHECK(cudaStreamDestroy(stream));
+  CUDACHECK(cudaFree(st));
+}
+
+TEST(DeviceHostQueueTest, WraparoundPreservesFifo) {
+  IntQueue q(4);
+  const uint64_t kIters = 1000; // many capacity cycles through a small ring
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+
+  // One device producer streams values 1..kIters; the host drains concurrently
+  // so the capacity-4 ring wraps ~250 times. blockingWrite spins for credit,
+  // so the producer cannot outrun the consumer.
+  intBlockingWriteKernel<<<1, 1, 0, stream>>>(
+      q.producerHandle(), static_cast<uint32_t>(kIters), /*base=*/1);
+  CUDACHECK(cudaGetLastError());
+
+  IntQueue::ReadResult r;
+  for (uint64_t i = 0; i < kIters; ++i) {
+    while (q.read(r) == QueueOpStatus::Empty) {
+      // spin until the producer publishes the next item
+    }
+    EXPECT_EQ(r.value, i + 1); // values are 1..kIters in order
+    EXPECT_EQ(r.seq, i);
+  }
+
+  CUDACHECK(cudaStreamSynchronize(stream));
+  CUDACHECK(cudaStreamDestroy(stream));
+}
+
+TEST(DeviceHostQueueTest, ReadMultiDrainsInOrder) {
+  IntQueue q(4);
+  const uint64_t kIters = 1000; // wraps the capacity-4 ring many times
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+
+  // One device producer streams 1..kIters; the host drains in batches via
+  // readMulti (max 4 per call). batch == capacity exercises full and partial
+  // batches and the single-ci-store reuse path under wraparound.
+  intBlockingWriteKernel<<<1, 1, 0, stream>>>(
+      q.producerHandle(), static_cast<uint32_t>(kIters), /*base=*/1);
+  CUDACHECK(cudaGetLastError());
+
+  IntQueue::ReadResult batch[4];
+  uint64_t got = 0;
+  while (got < kIters) {
+    size_t n = q.readMulti(batch, 4);
+    for (size_t i = 0; i < n; ++i) {
+      EXPECT_EQ(batch[i].seq, got); // strict sequence order, no loss/dup
+      EXPECT_EQ(batch[i].value, got + 1); // values are 1..kIters
+      ++got;
+    }
+  }
+
+  CUDACHECK(cudaStreamSynchronize(stream));
+  CUDACHECK(cudaStreamDestroy(stream));
+}
+
+TEST(DeviceHostQueueTest, SizeApprox) {
+  IntQueue q(8);
+  EXPECT_EQ(q.sizeApprox(), 0u);
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+  // Three published, none consumed -> backlog of 3.
+  intBlockingWriteKernel<<<1, 1, 0, stream>>>(q.producerHandle(), 3, 1);
+  CUDACHECK(cudaGetLastError());
+  CUDACHECK(cudaStreamSynchronize(stream));
+  EXPECT_EQ(q.sizeApprox(), 3u);
+  CUDACHECK(cudaStreamDestroy(stream));
+}
+
+// Many GPU producers -> single host consumer. Verifies: no loss/duplication
+// (each producer's commands all arrive), global FIFO by sequence, each
+// producer's values arrive in its publish order, and — via the guard words —
+// that no publish is ever observed torn (payload inconsistent with the
+// readySeq marker). The last check is what actually exercises the publish
+// release / consume acquire ordering on weak memory (aarch64/Grace); a large
+// command count widens the window for any ordering bug to surface.
+TEST(DeviceHostQueueTest, DeviceProducersHostConsumer) {
+  const uint32_t blocks = 8;
+  const uint32_t threads = 32;
+  const uint32_t perThread = 2000;
+  const uint32_t producers = blocks * threads;
+  const uint64_t total = uint64_t(producers) * perThread;
+
+  CmdQueue q(1024);
+  cudaStream_t stream;
+  CUDACHECK(cudaStreamCreate(&stream));
+
+  producerKernel<<<blocks, threads, 0, stream>>>(q.producerHandle(), perThread);
+  CUDACHECK(cudaGetLastError());
+
+  std::vector<uint32_t> counts(producers, 0);
+  std::vector<uint32_t> nextValue(producers, 0);
+  uint64_t consumed = 0;
+  uint64_t expectedSeq = 0;
+  uint64_t tornPublishes = 0;
+  CmdQueue::ReadResult r;
+  while (consumed < total) {
+    if (q.read(r) == QueueOpStatus::Ok) {
+      ASSERT_LT(r.value.producer, producers);
+      EXPECT_EQ(r.seq, expectedSeq); // host reads in strict sequence order
+      EXPECT_EQ(
+          r.value.value, nextValue[r.value.producer]); // per-producer FIFO
+      // Torn-publish check: every guard word must equal value.
+      for (int j = 0; j < 14; ++j) {
+        if (r.value.guard[j] != r.value.value) {
+          ++tornPublishes;
+          break; // count once per command
+        }
+      }
+      ++nextValue[r.value.producer];
+      ++counts[r.value.producer];
+      ++consumed;
+      ++expectedSeq;
+    }
+  }
+
+  CUDACHECK(cudaStreamSynchronize(stream));
+  EXPECT_EQ(tornPublishes, 0u)
+      << tornPublishes << " of " << total
+      << " commands were observed torn (payload visible before/without the "
+         "readySeq marker it was published under)";
+  for (uint32_t p = 0; p < producers; ++p) {
+    EXPECT_EQ(counts[p], perThread) << "producer " << p;
+  }
+  CUDACHECK(cudaStreamDestroy(stream));
+}


### PR DESCRIPTION
Summary:
Adds `meta::comms::DeviceHostQueue<T, Direction, ConsumerPolicy>`, a header-only bounded lock-free ring in host-pinned mapped memory for passing fixed-size proxy commands one way from GPU to CPU (the GPU delegates work to a CPU/engine proxy that executes it). GPU threads are the producers; the CPU (the host owner) is the single consumer. Lives at `comms/utils/device_host_queue`; design doc at `comms/utils/device_host_queue/doc/mpsc_proxy_queue_design.md`.

Coordinates are plain integers in mapped memory with atomicity applied at the access site: `pi` (producer reservation), per-slot `readySeq` (publish marker, `seq+1`), and `ci` (reuse credit). The device producer uses system-scope atomics via `comms::device` (`comms/common/AtomicUtils.cuh`) — lowering to `ld/st/atom.*.sys` PTX on NVIDIA and `__atomic_*`/`__hip_atomic_*` on AMD; the system-scope release store that publishes `readySeq` orders the payload writes before the marker, so no separate publish fence is needed. The host consumer uses `std::atomic_ref` release/acquire (inner-shareable on Grace), which is sufficient over coherent host-pinned memory because the device peer carries the system-scope half. This split is the GB200-validated convention in comms (cf. ctran `MemFence.h` / `GpeKernelSync`) and is documented inline in the header.

GPU producers take a cursor-free `producerHandle()` (trivially copyable, safe to broadcast to every thread) and call `write()` (CAS-claim, returns `Ok`/`Full`) or `blockingWrite()` (spin on credit). The non-blocking `write()` credit check is underflow-safe against a stale `pi` snapshot; `blockingWrite` documents its reserve-then-publish obligation. The host owner is the single consumer: `read()` copies one command out and frees the slot (copy-out semantics, advances `ci`); `readMulti()` drains a contiguous batch of published commands with a single `ci` store; `blockingRead()` spins with a `cpuRelax()` hint (YIELD on aarch64/Grace, PAUSE on x86). There is no host producer and no device consumer — the data path is strictly GPU to CPU, and that direction is explicit in the type: only `Direction::D2H` is implemented, while `Direction::H2D` (host producer → device consumer) is rejected at compile time via `static_assert` because it would need a host system-scope release fence (`DMB SY` on aarch64), not the inner-shareable release `std::atomic` emits. The constructor frees the pinned allocation if `cudaHostGetDevicePointer` fails. Power-of-two capacity, 64-bit absolute sequences, zero-init sentinel. `ConsumerPolicy::Single` is implemented; `ConsumerPolicy::Multi` is reserved behind a `static_assert`.

Portable across CUDA and HIP/ROCm: device-side atomics route through `comms::device` (no `<cuda/atomic>` dependency), and the host-pinned mapped allocation uses the CUDA runtime API, which hipifies 1:1 (`cudaHostAlloc` → `hipHostMalloc`), with the coherent-mapped flags (`hipHostMallocMapped | hipHostMallocCoherent`) on AMD so a GPU system-scope release store is visible to a concurrently-polling CPU consumer mid-kernel.

Differential Revision: D106964653


