### PR TITLE
Use NCCL cvars for StagedRdma QP configuration

### DIFF
--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -57,20 +57,41 @@ void initEnvironment() {
 
 // RDMA port and addressing
 constexpr uint8_t kPortNum = 1; // Standard IB port number
-constexpr int kGidIndex = 3; // RoCEv2 GID index (Ethernet)
 
 // QP capacity
 constexpr int kTotalQps = 1; // 1 for H100; increase for GB200
 constexpr int kMaxMsgCntPerQp = 4; // Single-buffer protocol headroom
 constexpr int kMaxSge = 1; // One scatter-gather entry per WR
 
-// QP transport — aligned with NCCL_IB_* cvar defaults
-constexpr uint8_t kTimeout = 20; // ACK timeout (~4.2 s)
-constexpr uint8_t kRetryCnt = 7; // Transport retries (7 = infinite)
-constexpr uint8_t kRnrRetryCnt = 7; // RNR retries (7 = infinite)
+// QP transport — hardcoded defaults for params without NCCL cvars
+constexpr uint8_t kRnrRetryCnt = 7; // RNR retries (7 = max, no cvar)
 constexpr uint8_t kMinRnrTimer = 12; // RNR NAK timer
 constexpr uint8_t kMaxRdAtomic = 1; // Outstanding RDMA read/atomic
 constexpr uint8_t kHopLimit = 255; // GRH hop limit
+constexpr int kDefaultGidIndex = 3; // RoCEv2 GID index fallback
+
+// QP transport config read from NCCL cvars at runtime. Centralizes all
+// cvar reads so QP setup call sites don't scatter IB policy.
+struct QpTransportConfig {
+  uint8_t timeout;
+  uint8_t retryCnt;
+  uint8_t gidIndex;
+  uint8_t trafficClass;
+  uint8_t sl;
+  uint16_t pkeyIndex;
+
+  static QpTransportConfig fromNcclCvars() {
+    return QpTransportConfig{
+        .timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT),
+        .retryCnt = static_cast<uint8_t>(NCCL_IB_RETRY_CNT),
+        .gidIndex = static_cast<uint8_t>(
+            NCCL_IB_GID_INDEX >= 0 ? NCCL_IB_GID_INDEX : kDefaultGidIndex),
+        .trafficClass = static_cast<uint8_t>(NCCL_IB_TC),
+        .sl = static_cast<uint8_t>(NCCL_IB_SL),
+        .pkeyIndex = static_cast<uint16_t>(NCCL_IB_PKEY),
+    };
+  }
+};
 
 // Value the client writes to the server's readyToSendFlag_ via RDMA_WRITE
 // to signal that it has finished copying data out of its staging buffer.
@@ -411,7 +432,8 @@ void StagedRdmaTransportBase::initIbResources() {
   initQpAttr.qp_access_flags = static_cast<ibv_access_flags>(
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
       IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC);
-  initQpAttr.pkey_index = 0;
+  auto qpConfig = QpTransportConfig::fromNcclCvars();
+  initQpAttr.pkey_index = qpConfig.pkeyIndex;
   initQpAttr.port_num = kPortNum;
 
   auto initResult = vqp_->modifyVirtualQp(
@@ -440,6 +462,7 @@ void StagedRdmaTransportBase::ensureCudaStream() {
 
 void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   auto peer = deserializeConnectionInfo(peerConnInfo);
+  auto qpConfig = QpTransportConfig::fromNcclCvars();
 
   // Store peer's staging info for use in send/recv
   peerStaging_ = std::move(peer.staging);
@@ -456,10 +479,10 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   rtrAttr.ah_attr.grh.dgid.global.subnet_prefix = peer.subnetPrefix;
   rtrAttr.ah_attr.grh.dgid.global.interface_id = peer.interfaceId;
   rtrAttr.ah_attr.grh.flow_label = 0;
-  rtrAttr.ah_attr.grh.sgid_index = kGidIndex;
+  rtrAttr.ah_attr.grh.sgid_index = qpConfig.gidIndex;
   rtrAttr.ah_attr.grh.hop_limit = kHopLimit;
-  rtrAttr.ah_attr.grh.traffic_class = 0;
-  rtrAttr.ah_attr.sl = 0;
+  rtrAttr.ah_attr.grh.traffic_class = qpConfig.trafficClass;
+  rtrAttr.ah_attr.sl = qpConfig.sl;
   rtrAttr.ah_attr.src_path_bits = 0;
   rtrAttr.ah_attr.port_num = peer.port;
 
@@ -476,8 +499,8 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   // Transition QP: RTR → RTS
   ibv_qp_attr rtsAttr = {};
   rtsAttr.qp_state = IBV_QPS_RTS;
-  rtsAttr.timeout = kTimeout;
-  rtsAttr.retry_cnt = kRetryCnt;
+  rtsAttr.timeout = qpConfig.timeout;
+  rtsAttr.retry_cnt = qpConfig.retryCnt;
   rtsAttr.rnr_retry = kRnrRetryCnt;
   rtsAttr.sq_psn = 0;
   rtsAttr.max_rd_atomic = kMaxRdAtomic;
@@ -496,7 +519,8 @@ std::string StagedRdmaTransportBase::serializeConnInfo(
     const StagingRendezvousInfo& localStaging) {
   auto busCard = vqp_->getVirtualQpBusinessCard();
 
-  auto maybeGid = device_->queryGid(kPortNum, kGidIndex);
+  auto qpConfig = QpTransportConfig::fromNcclCvars();
+  auto maybeGid = device_->queryGid(kPortNum, qpConfig.gidIndex);
   if (!maybeGid) {
     throw std::runtime_error("Failed to query GID: " + maybeGid.error().errStr);
   }


### PR DESCRIPTION
Summary:
StagedRdmaTransport hardcodes QP transport parameters (timeout, retry count, GID index, traffic class, service level, partition key) as compile-time constants. These parameters control how the IB verbs layer handles RDMA operations — timeout and retry count determine how long the HCA waits for ACKs before declaring a path dead, GID index selects which RoCEv2 address to use, and traffic class and service level control QoS marking which determines how the fabric switches handle the traffic (PFC flow control, ECN, virtual lane assignment).

NCCL/CTRAN reads these from runtime environment variables (`NCCL_IB_TIMEOUT`, `NCCL_IB_RETRY_CNT`, `NCCL_IB_GID_INDEX`, `NCCL_IB_TC`, `NCCL_IB_SL`, `NCCL_IB_PKEY`) so that deployments can tune them per-cluster. StagedRdma bypasses CTRAN and creates QPs directly via ibverbx, but was not reading these cvars — it always used the compiled defaults regardless of what the deployment configured.

This change makes StagedRdma read the same NCCL cvars that CTRAN uses for QP setup, ensuring consistent QoS marking and transport behavior across all RDMA paths on the same host.

Differential Revision: D106958618


