### PR TITLE
CtranMapper::initNotifyImpl: support host-buffer recv via TCPDM (#2743)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1903,17 +1903,27 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       // receive operation. Once it does, it will mark tcpDmReq as complete,
       // allowing us to exit the loop.
 
-      if (kernElem == nullptr) {
-        CLOGF(ERR, "TCP Device Memory requires kernElem in the notifier");
-        return commInternalError;
-      }
-
-      const void* rbuff = kernElem->waitNotify.recvbuff;
-      size_t len = kernElem->waitNotify.nbytes;
-
-      if (rbuff == nullptr || len == 0) {
-        CLOGF(ERR, "TCP Device Memory requires recvbuff in the notifier");
-        return commInternalError;
+      const void* rbuff = nullptr;
+      size_t len = 0;
+      if (kernElem != nullptr) {
+        rbuff = kernElem->waitNotify.recvbuff;
+        len = kernElem->waitNotify.nbytes;
+        if (rbuff == nullptr || len == 0) {
+          CLOGF(ERR, "TCP Device Memory requires recvbuff in the notifier");
+          return commInternalError;
+        }
+      } else {
+        const DevMemType type = regElem->getType();
+        if (type != kHostUnregistered && type != kHostPinned) {
+          CLOGF(
+              ERR,
+              "TCP Device Memory requires kernElem in the notifier "
+              "(memType {})",
+              devMemTypeStr(type));
+          return commInternalError;
+        }
+        rbuff = regElem->buf;
+        len = regElem->len;
       }
 
       FB_COMMCHECK(this->ctranTcpDm->irecv(


### PR DESCRIPTION
Summary:

Host-buffer broadcasts (e.g., PAFT init's `broadcast_object` on tiny CPU tensors) over the TCPDM backend were dying on the receiver side with `[ctran] TCP Device Memory requires kernElem in the notifier` followed by `commInternalError` from `BroadcastBinomialTree.cc:266`. Repro: `sdf-mccl-tcp-paft_v11_tpp_600_HEALTH_TEST_PAFT-pmdxhhh5`.

`BroadcastBinomialTree` only populates `elem` (the NVL kernel signaling struct) when `op->isDevice && requiresRecvNotify(parent)` — i.e. for device-memory transfers between NVL peers. Host-buffer broadcasts have `op->isDevice == false`, so `elem` stays null. That null was then passed through to `CtranMapper::initNotifyImpl` as `kernElem`, and the TCPDM branch immediately errored on it because it sourced `rbuff`/`len` from `kernElem->waitNotify.recvbuff`/`nbytes`.

The receiver-side `irecv` call doesn't actually need the NVL signaling struct; it only needs the destination buffer and its length. For host-buffer transfers, the `regElem` itself already describes the registered host buffer (`buf`, `len`), so source `rbuff`/`len` from it when `kernElem == nullptr`. The defensive "TCP Device Memory requires kernElem in the notifier" error is preserved for the non-host case: if `kernElem == nullptr` and `regElem->getType()` is anything other than `kHostUnregistered`/`kHostPinned`, we still error out (with the `DevMemType` name included for triage). Device-buffer transfers continue to use the existing `kernElem->waitNotify` path unchanged.

This unblocks the host-buffer recv side of the TLV-over-ctrl-fd path that landed in the prior `tcp_devmem` chain (commit `9ff7826a60f8`). The sender-side `iput` (CtranMapper.h:1681) already takes `sbuf`/`dbuf` directly from the caller and didn't need a parallel change.

Differential Revision: D107023761


