### PR TITLE
Add isendCtrl/irecvCtrl ctrl sockets for back-pressure (#2749)

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -1,4 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+#include <sys/socket.h>
+#include <thread>
+
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/profiler/Profiler.h"
@@ -109,6 +112,21 @@ void CtranTcpDm::bootstrapAccept() {
 
     auto transport = CtranTcpDmSingleton::getTransport();
 
+    // Negative rank = ctrl socket connection (bufSync)
+    if (peerRank < 0) {
+      int actualPeer = -(peerRank + 1);
+      int ctrlFd = socket.getFd();
+      std::lock_guard lock(mutex_);
+      ctrlSocks_.emplace(actualPeer, std::move(socket));
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-TCPDM: ctrl socket accepted from peer {} fd={}",
+          actualPeer,
+          ctrlFd);
+      continue;
+    }
+
     ::comms::tcp_devmem::Handle handle{};
     ::comms::tcp_devmem::ListenerInterface* listenComm{};
     COMMCHECKTHROW(transport->listen(netdev_, &handle, &listenComm));
@@ -126,8 +144,8 @@ void CtranTcpDm::bootstrapAccept() {
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "CTRAN-TC: Established connection: commHash {:x}, commDesc {}, "
-        "rank {}, peer {}",
+        "CTRAN-TCPDM: Established data connection: commHash {:x}, "
+        "commDesc {}, rank {}, peer {}",
         commHash_,
         commDesc_,
         rank_,
@@ -178,8 +196,8 @@ commResult_t CtranTcpDm::bootstrapConnect(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-TCPDM: Established connection: commHash {:x}, commDesc {}, pimpl {}, "
-      "rank {}, peer {}",
+      "CTRAN-TCPDM: Established data connection: commHash {:x}, "
+      "commDesc {}, pimpl {}, rank {}, peer {}",
       commHash_,
       commDesc_,
       (void*)this,
@@ -187,6 +205,34 @@ commResult_t CtranTcpDm::bootstrapConnect(
       peerRank);
 
   return res;
+}
+
+void CtranTcpDm::ensureCtrlSocket(int peerRank) {
+  {
+    std::lock_guard lock(mutex_);
+    if (ctrlSocks_.count(peerRank)) {
+      return;
+    }
+  }
+
+  folly::SocketAddress peerAddr;
+  peerAddr.setFromSockaddr(
+      reinterpret_cast<sockaddr_in6*>(&allListenSocketAddrs_[peerRank]));
+  ctran::bootstrap::Socket sock;
+  FB_SYSCHECKTHROW_EX(
+      sock.connect(
+          peerAddr,
+          NCCL_CLIENT_SOCKET_IFNAME,
+          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
+          NCCL_SOCKET_RETRY_CNT),
+      rank_,
+      commHash_,
+      commDesc_);
+  int marker = -(rank_ + 1);
+  FB_SYSCHECKTHROW_EX(
+      sock.send(&marker, sizeof(int)), rank_, commHash_, commDesc_);
+  std::lock_guard lock(mutex_);
+  ctrlSocks_.emplace(peerRank, std::move(sock));
 }
 
 CtranTcpDm::CtranTcpDm(
@@ -320,8 +366,66 @@ commResult_t CtranTcpDm::connectPeer(int peerRank) {
   return bootstrapConnect(peerRank, peerAddr);
 }
 
+void CtranTcpDm::ctrlSyncProgress() {
+  for (auto& [peerRank, sock] : ctrlSocks_) {
+    auto& pending = pendingSyncRecvs_[peerRank];
+    while (!pending.empty()) {
+      uint8_t sync;
+      int ret = ::recv(sock.getFd(), &sync, sizeof(sync), MSG_DONTWAIT);
+      if (ret <= 0) {
+        break;
+      }
+      syncRecvCount_[peerRank]++;
+      pending.front()->complete();
+      pending.pop_front();
+      CLOGF_SUBSYS(
+          INFO,
+          COLL,
+          "CTRAN-TCPDM: ctrlSyncProgress completed sync from peer {}, total={}, remaining={}, fd={}",
+          peerRank,
+          syncRecvCount_[peerRank],
+          pending.size(),
+          sock.getFd());
+    }
+  }
+}
+
+commResult_t CtranTcpDm::isendCtrlMsg(
+    const ControlMsg& msg,
+    int peerRank,
+    CtranTcpDmRequest& req) {
+  // only allow sync messages to be sent on the ctrl socket
+  if (msg.type != ControlMsgType::SYNC) {
+    req.complete();
+    return commSuccess;
+  }
+  // only sendeer can do lazy connect to avoid deadlock.
+  ensureCtrlSocket(peerRank);
+  std::lock_guard lock(mutex_);
+  auto& sock = ctrlSocks_.at(peerRank);
+  uint8_t sync = 1;
+  sock.send(&sync, sizeof(sync));
+  req.complete();
+  return commSuccess;
+}
+
+commResult_t CtranTcpDm::irecvCtrlMsg(
+    ControlMsg& msg,
+    int peerRank,
+    CtranTcpDmRequest& req) {
+  if (msg.type != ControlMsgType::SYNC) {
+    req.complete();
+    return commSuccess;
+  }
+  std::lock_guard lock(mutex_);
+  pendingSyncRecvs_[peerRank].push_back(&req);
+  return commSuccess;
+}
+
 commResult_t CtranTcpDm::progress() {
   std::unique_lock lock(mutex_);
+
+  ctrlSyncProgress();
 
   for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
     auto& recvReq = *it;

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <deque>
 #include <unordered_map>
 
 #include "comms/ctran/CtranComm.h"
@@ -58,27 +59,11 @@ class CtranTcpDm {
     return isend(peerRank, tcpdmRegElem, (void*)sbuf, len, *req);
   }
 
-  commResult_t irecvCtrlMsg(
-      [[maybe_unused]] ControlMsg& msg,
-      [[maybe_unused]] int peerRank,
-      CtranTcpDmRequest& req) {
-    // Don't share receiver's control information with the sender. Rely
-    // on the receiver buffering (TCP window) instead of explicit
-    // synchronization.
-    req.complete();
-    return commSuccess;
-  }
+  commResult_t
+  irecvCtrlMsg(ControlMsg& msg, int peerRank, CtranTcpDmRequest& req);
 
-  commResult_t isendCtrlMsg(
-      [[maybe_unused]] const ControlMsg& msg,
-      [[maybe_unused]] int peerRank,
-      CtranTcpDmRequest& req) {
-    // Don't share receiver's control information with the sender. Rely
-    // on the receiver buffering (TCP window) instead of explicit
-    // synchronization.
-    req.complete();
-    return commSuccess;
-  }
+  commResult_t
+  isendCtrlMsg(const ControlMsg& msg, int peerRank, CtranTcpDmRequest& req);
 
   void profilerStart();
   void profilerEnd();
@@ -138,6 +123,21 @@ class CtranTcpDm {
     void* unpackPool{nullptr};
   };
   std::list<std::unique_ptr<RecvRequest>> queuedRecv_;
+
+  // Lazy per-peer TCP connections for sync-only control messages.
+  // Created on-demand by ensureCtrlSocket() on first isendCtrlMsg/irecvCtrlMsg.
+  // Smaller rank initiates; larger rank's bootstrapAccept thread accepts.
+  std::unordered_map<int, ctran::bootstrap::Socket> ctrlSocks_;
+  void ensureCtrlSocket(int peerRank);
+
+  // Per-peer queue of pending sync recv requests (from irecvCtrlMsg).
+  // Completed in FIFO order as sync bytes arrive on ctrlSocks_.
+  std::unordered_map<int, std::deque<CtranTcpDmRequest*>> pendingSyncRecvs_;
+
+  // Per-peer count of received sync bytes (for debugging).
+  std::unordered_map<int, int> syncRecvCount_;
+
+  void ctrlSyncProgress();
 
   commResult_t connectPeer(int peerRank);
 

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -12,6 +13,7 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -155,7 +157,89 @@ TEST_F(CtranTcpTest, SendRecv) {
         ctranTcpDm->isend(recvRank, memHandle, &send, sizeof(send), req));
     COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
   }
-  COMMCHECK_TEST(CtranTcpDm::deregMem(memHandle));
+  // Ranks outside the sender/receiver pair never registered memory.
+  if (memHandle != nullptr) {
+    COMMCHECK_TEST(CtranTcpDm::deregMem(memHandle));
+  }
+}
+
+TEST_F(CtranTcpTest, SyncCtrlMsg) {
+  this->printTestDesc(
+      "SyncCtrlMsg",
+      "Expect CtranTcpDm to deliver a SYNC control message over a "
+      "lazily-established ctrl socket.");
+
+  if (this->numRanks < 2) {
+    GTEST_SKIP() << "Test requires at least 2 ranks. Skip test.";
+  }
+
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::SYNC);
+  CtranTcpDmRequest req{};
+
+  if (this->globalRank == sendRank) {
+    // Sender lazily connects the ctrl socket and pushes the sync byte; the
+    // send request completes synchronously.
+    COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, req));
+    EXPECT_TRUE(req.isComplete());
+  } else if (this->globalRank == recvRank) {
+    // Receiver queues the sync recv and drains it via progress().
+    COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, req));
+    COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
+  }
+}
+
+TEST_F(CtranTcpTest, SyncCtrlMsgBackPressure) {
+  this->printTestDesc(
+      "SyncCtrlMsgBackPressure",
+      "Expect CtranTcpDm to deliver multiple SYNC control messages in FIFO "
+      "order over a single ctrl socket.");
+
+  if (this->numRanks < 2) {
+    GTEST_SKIP() << "Test requires at least 2 ranks. Skip test.";
+  }
+
+  constexpr int kNumSyncs = 8;
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::SYNC);
+
+  if (this->globalRank == sendRank) {
+    for (int i = 0; i < kNumSyncs; i++) {
+      CtranTcpDmRequest req{};
+      COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, req));
+      EXPECT_TRUE(req.isComplete());
+    }
+  } else if (this->globalRank == recvRank) {
+    // Post all sync recvs up-front so they are completed from the pending
+    // queue in FIFO order as bytes arrive.
+    std::vector<CtranTcpDmRequest> reqs(kNumSyncs);
+    for (auto& req : reqs) {
+      COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, req));
+    }
+    for (auto& req : reqs) {
+      COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
+    }
+  }
+}
+
+TEST_F(CtranTcpTest, NonSyncCtrlMsgIsNoop) {
+  this->printTestDesc(
+      "NonSyncCtrlMsgIsNoop",
+      "Expect non-SYNC control messages to complete immediately without "
+      "establishing a ctrl socket.");
+
+  // Non-SYNC ctrl messages are a local no-op on the TCPDM backend, so every
+  // rank can exercise this independently without peer interaction.
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::UNSPECIFIED);
+
+  CtranTcpDmRequest sendReq{};
+  COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, sendReq));
+  EXPECT_TRUE(sendReq.isComplete());
+
+  CtranTcpDmRequest recvReq{};
+  COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, recvReq));
+  EXPECT_TRUE(recvReq.isComplete());
 }
 
 TEST_F(CtranTcpTest, getIfNames) {


### PR DESCRIPTION
Summary:

Add `isendCtrl`/`irecvCtrl` sync-only control message support to the TcpDm backend. Ctrl sockets are lightweight per-peer TCP connections (separate from the data path) used for synchronization signals like staging buffer back-pressure in AllReduceRing.


Ctrl sockets are established lazily on first use to any peer (no ring topology assumption). The smaller-rank peer initiates the TCP connection; the larger-rank peer accepts via the existing `bootstrapAccept` thread. `isendCtrlMsg` sends a 1-byte sync signal; `irecvCtrlMsg` queues the request for async completion in `ctrlSyncProgress`.

Reviewed By: fomichev

Differential Revision: D107115137


