### PR TITLE
Log globalDeregister only for registered memory (#2750)

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -406,6 +406,7 @@ commResult_t ctran::RegCache::globalDeregister(
 
   // Free each segment
   size_t totalSegmentsFreed = 0;
+  size_t totalRegElemsFreed = 0;
   for (auto segHdl : segHdls) {
     bool freed = false;
     bool ncclManaged = false;
@@ -415,10 +416,11 @@ commResult_t ctran::RegCache::globalDeregister(
     if (freed) {
       totalSegmentsFreed++;
     }
+    totalRegElemsFreed += regElemsFreed.size();
   }
 
-  // Log a single memory event for the entire deregistration
-  if (totalSegmentsFreed > 0) {
+  // Only log when a real registration was torn down.
+  if (totalRegElemsFreed > 0) {
     CommLogData globalLogData{};
     globalLogData.commDesc = "global";
     meta::comms::memtrace::recordReg(


### PR DESCRIPTION
Summary:

`globalDeregister` logged a `globalDeregister` event to the `nccl_memory_logging` Scuba table on every cached-segment teardown — even for memory that was only cached and never used in a collective. The register side only logs real registrations, so the two were asymmetric.

Now we only log when a `RegElem` (backend registration) was actually freed. Cache-only buffers have no `RegElem`, so they no longer emit the event. The cache is still freed regardless; only the log is gated.

Reviewed By: elvinlife

Differential Revision: D107156247


