### PR TITLE
Guard NCCLX FP8 dtype mapping on `HAVE_FP8` (#2752)

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -33,10 +33,12 @@ ncclDataType_t getNcclDataTypeInternal(const at::ScalarType scalar_type) {
       return ncclUint8;
     case at::ScalarType::BFloat16:
       return ncclBfloat16;
+#if HAVE_FP8
     case at::ScalarType::Float8_e5m2:
       return ncclFloat8e5m2;
     case at::ScalarType::Float8_e4m3fn:
       return ncclFloat8e4m3;
+#endif
     case at::ScalarType::UInt32:
       return ncclUint32;
     case at::ScalarType::UInt64:


### PR DESCRIPTION
Summary:

Keep the NCCLX TorchComm dtype mapping compatible with NCCL headers that do not expose FP8 enum values:
- Wrap `at::ScalarType::Float8_e5m2` and `at::ScalarType::Float8_e4m3fn` mappings in `#if HAVE_FP8`.
- Without `HAVE_FP8`, FP8 tensors now fall through to the existing unsupported dtype error instead of failing compile against dummy or older NCCL headers.

Differential Revision: D107127761


