### PR TITLE
Add slab pool to rdma factory (#2754)

### DIFF
--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1826,6 +1826,11 @@ RdmaTransportFactory::RdmaTransportFactory(
 
     nicsHandle_->emplace_back(targetDevice, ibvApi_, config_.gidIndex, portNum);
   }
+
+  if (config_.slabPoolConfig.slabNum > 0) {
+    slabPool_ = std::make_shared<RdmaSlabPool>(
+        config_.slabPoolConfig, cudaApi_, ibvApi_, nicsHandle_);
+  }
 }
 
 Result<std::unique_ptr<RegistrationHandle>>
@@ -1974,6 +1979,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
   auto peerTopo = RdmaTopologyInfo::deserialize(peerTopology).value();
   auto config = config_;
   config.numQps = std::min(peerTopo.numQps, config.numQps);
+
   return std::make_unique<RdmaTransport>(
       ibvApi_,
       cudaApi_,
@@ -1982,7 +1988,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
       nicsHandle_,
       domainId_,
       config,
-      nullptr);
+      slabPool_);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "comms/uniflow/transport/rdma/CopyEngine.h"
+#include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 
 #include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
@@ -58,6 +59,7 @@ struct RdmaTransportConfig {
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
   uint16_t pipelineDepth{2}; /* Send/recv pipeline depth (D staging slabs). */
+  RdmaSlabPoolConfig slabPoolConfig{.slabNum = 0}; /* Disabled by default. */
 };
 
 /*
@@ -675,6 +677,7 @@ class RdmaTransportFactory : public TransportFactory {
   std::atomic<uint64_t> dmaBufFallbackCount_{0};
   std::shared_ptr<std::vector<NicResources>> nicsHandle_;
   const RdmaTransportConfig config_;
+  std::shared_ptr<RdmaSlabPool> slabPool_;
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -714,6 +714,26 @@ TEST_F(RdmaTransportFactoryTest, GetTopologyReflectsConfiguredQps) {
   EXPECT_EQ(topo1[0], topo4[0]);
 }
 
+// --- Slab pool ownership tests ---
+
+TEST_F(RdmaTransportFactoryTest, DefaultConfigSkipsSlabPool) {
+  setupSingleDevice();
+  RdmaTransportFactory factory(
+      {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
+}
+
+TEST_F(RdmaTransportFactoryTest, SlabPoolFailurePropagates) {
+  setupSingleDevice();
+  ON_CALL(*mockApi_, regMr(_, _, _, _))
+      .WillByDefault(
+          Return(Err(ErrCode::DriverError, "simulated regMr failure")));
+  RdmaTransportConfig config{.slabPoolConfig = {.slabNum = 4}};
+  EXPECT_THROW(
+      RdmaTransportFactory(
+          {"mlx5_0"}, evbThread_.getEventBase(), config, mockApi_),
+      std::runtime_error);
+}
+
 // --- supported() tests ---
 
 TEST_F(RdmaTransportFactoryTest, SupportedReturnsTrueWithActiveDevice) {


### PR DESCRIPTION
Summary:


As title, let factory create the slab pool in ctor and share it with all transports instance.

Reviewed By: rmahidhar

Differential Revision: D107257890


