### PR TITLE
Drain Pipes HRDW trace from a background poll thread instead of a stream callback

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -3,6 +3,7 @@
 #include "comms/ctran/CtranPipes.h"
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <set>
 
@@ -43,16 +44,11 @@ commResult_t ctran::ctranPreparePipesTrace(
   if (comm->pipesTrace_ == nullptr) {
     comm->pipesTrace_ = std::make_unique<comms::pipes::PipesTrace>();
   }
-  comm->pipesTrace_->ensure(ringSize);
+  comm->pipesTrace_->ensure(
+      ringSize,
+      std::chrono::milliseconds(NCCL_CTRAN_PIPES_TRACE_POLL_INTERVAL_MS));
   trace = comm->pipesTrace_->deviceHandle();
   return commSuccess;
-}
-
-void ctran::ctranEnqueuePipesTraceDrain(CtranComm* comm, cudaStream_t stream) {
-  if (!ctranPipesTraceEnabled() || comm->pipesTrace_ == nullptr) {
-    return;
-  }
-  comm->pipesTrace_->enqueueDrain(stream);
 }
 
 commResult_t ctranInitializePipes(CtranComm* comm) {

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -7,10 +7,6 @@
 #include <cstdint>
 
 #if defined(ENABLE_PIPES)
-#include <cuda_runtime.h>
-#endif // defined(ENABLE_PIPES)
-
-#if defined(ENABLE_PIPES)
 #include "comms/pipes/PipesTraceTypes.h"
 #endif // defined(ENABLE_PIPES)
 #include "comms/utils/commSpecs.h"
@@ -43,7 +39,6 @@ namespace ctran {
 commResult_t ctranPreparePipesTrace(
     CtranComm* comm,
     comms::pipes::PipesTraceHandle& trace);
-void ctranEnqueuePipesTraceDrain(CtranComm* comm, cudaStream_t stream);
 
 } // namespace ctran
 #endif // defined(ENABLE_PIPES)

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -400,7 +400,6 @@ commResult_t ctranAllGatherHierarchicalRing(
     overlapParams.ready_counters = comm->hierarchicalAgReadyCounters_;
     FB_COMMCHECK(ctran::ctranPreparePipesTrace(comm, overlapParams.trace));
     comms::pipes::launch_hierarchical_allgather_overlap(overlapParams);
-    ctran::ctranEnqueuePipesTraceDrain(comm, overlapParams.stream);
   } else {
     comms::pipes::launch_hierarchical_allgather_fused(params);
   }

--- a/comms/pipes/PipesTrace.cc
+++ b/comms/pipes/PipesTrace.cc
@@ -2,6 +2,8 @@
 
 #include "comms/pipes/PipesTrace.h"
 
+#include <pthread.h>
+
 #include <chrono>
 #include <exception>
 #include <memory>
@@ -33,24 +35,23 @@ const char* pipesTraceEventTypeName(uint8_t type) {
   return "unknown";
 }
 
-void CUDART_CB drainPipesTraceCallback(void* userData) {
-  static_cast<PipesTrace*>(userData)->drainFromCallback();
-}
-
 } // namespace
 
 PipesTrace::~PipesTrace() {
-  {
-    std::unique_lock<std::mutex> lock(callbacksMutex_);
-    shuttingDown_ = true;
-    // Drain callbacks are stream-ordered after traced kernels, so this keeps
-    // the ring alive until outstanding kernel writes and callback users finish.
-    callbacksDone_.wait(lock, [&] { return pendingCallbacks_ == 0; });
+  // CTRAN teardown relies on the same lifetime contract as other comm-owned
+  // device resources; see deviceHandle(). Teardown here only stops the poller
+  // and drains, without synchronizing the device itself.
+  stopPollThread();
+  // The poller is stopped, so this is now the only reader: flush and log
+  // whatever the kernels wrote since the last poll tick before the ring is
+  // torn down.
+  try {
+    drain();
+  } catch (const std::exception& ex) {
+    CLOGF(WARN, "Pipes trace final drain failed: {}", ex.what());
+  } catch (...) {
+    CLOGF(WARN, "Pipes trace final drain failed with unknown exception");
   }
-  {
-    std::lock_guard<std::mutex> lock(drainMutex_);
-  }
-  stopLogThread();
 }
 
 uint32_t PipesTrace::normalizeRingSize(uint64_t ringSize) {
@@ -70,15 +71,12 @@ uint32_t PipesTrace::normalizeRingSize(uint64_t ringSize) {
   return static_cast<uint32_t>(ringSize);
 }
 
-void PipesTrace::ensure(uint32_t ringSize) {
+void PipesTrace::ensure(
+    uint32_t ringSize,
+    std::chrono::milliseconds pollInterval,
+    EventCallback eventCallback) {
   if (ringSize == 0) {
     return;
-  }
-  {
-    std::lock_guard<std::mutex> lock(callbacksMutex_);
-    if (shuttingDown_) {
-      return;
-    }
   }
 
   std::lock_guard<std::mutex> lock(drainMutex_);
@@ -104,8 +102,16 @@ void PipesTrace::ensure(uint32_t ringSize) {
 
   reader_ = std::make_unique<Reader>(*buffer_);
   ::hrdw_ring_buffer::GlobaltimerCalibration::get();
-  startLogThread();
-  CLOGF(INFO, "Pipes trace buffer ready ring_size={}", buffer_->size());
+  // Set before starting the poller; the poll thread reads pollInterval_ only
+  // after this store and it is never mutated again for this ring.
+  pollInterval_ = pollInterval;
+  eventCallback_ = std::move(eventCallback);
+  startPollThread();
+  CLOGF(
+      INFO,
+      "Pipes trace buffer ready ring_size={} poll_interval_ms={}",
+      buffer_->size(),
+      static_cast<long long>(pollInterval_.count()));
 }
 
 PipesTraceHandle PipesTrace::deviceHandle() const {
@@ -124,27 +130,16 @@ void PipesTrace::drain() {
       return;
     }
 
-    // Keep CUDA host callbacks short: poll and copy entries here, then let the
-    // logger thread do per-entry timestamp conversion and formatting.
+    // Poll and copy entries under the lock, then format and log them outside
+    // it. The trace is low-rate and the poll thread is our own (it blocks no
+    // CUDA stream), so logging inline is cheap and keeps the design single-
+    // threaded.
     auto result = reader_->poll([&](const auto& entry, uint64_t slot) {
       batch.entries.push_back(PendingLogEntry{entry, slot});
     });
-    batch.entriesRead = result.entriesRead;
     batch.entriesLost = result.entriesLost;
-    batch.lastRead = reader_->lastReadIndex();
   }
-  enqueueLogBatch(std::move(batch));
-}
-
-void PipesTrace::enqueueLogBatch(PendingLogBatch batch) {
-  {
-    std::lock_guard<std::mutex> lock(logMutex_);
-    if (stopLogging_) {
-      return;
-    }
-    pendingLogBatches_.push_back(std::move(batch));
-  }
-  logAvailable_.notify_one();
+  logBatch(batch);
 }
 
 void PipesTrace::logBatch(const PendingLogBatch& batch) const {
@@ -166,117 +161,58 @@ void PipesTrace::logBatch(const PendingLogBatch& batch) const {
         event.detail,
         pendingEntry.slot,
         wallTimeNs);
+    if (eventCallback_ != nullptr) {
+      eventCallback_(event, pendingEntry.slot);
+    }
   }
 
   if (batch.entriesLost != 0) {
     CLOGF(WARN, "Pipes trace lost {} entries", batch.entriesLost);
   }
-  CLOGF(
-      INFO,
-      "Pipes trace drain entries_read={} entries_lost={} last_read={}",
-      batch.entriesRead,
-      batch.entriesLost,
-      batch.lastRead);
 }
 
-void PipesTrace::logLoop() {
+void PipesTrace::pollLoop() {
+  pthread_setname_np(pthread_self(), "PipesTracePoll");
   while (true) {
-    PendingLogBatch batch;
     {
-      std::unique_lock<std::mutex> lock(logMutex_);
-      logAvailable_.wait(
-          lock, [&] { return stopLogging_ || !pendingLogBatches_.empty(); });
-      if (pendingLogBatches_.empty()) {
-        if (stopLogging_) {
-          return;
-        }
-        continue;
+      std::unique_lock<std::mutex> lock(pollMutex_);
+      // Wake early on shutdown; otherwise drain once per interval.
+      if (pollWake_.wait_for(
+              lock, pollInterval_, [&] { return stopPolling_; })) {
+        return;
       }
-      batch = std::move(pendingLogBatches_.front());
-      pendingLogBatches_.pop_front();
     }
-    logBatch(batch);
-  }
-}
-
-void PipesTrace::startLogThread() {
-  std::lock_guard<std::mutex> lock(logMutex_);
-  if (logThread_.joinable()) {
-    return;
-  }
-  stopLogging_ = false;
-  logThread_ = std::thread([this] { logLoop(); });
-}
-
-void PipesTrace::stopLogThread() {
-  {
-    std::lock_guard<std::mutex> lock(logMutex_);
-    stopLogging_ = true;
-  }
-  logAvailable_.notify_one();
-  if (logThread_.joinable()) {
-    logThread_.join();
-  }
-}
-
-void PipesTrace::enqueueDrain(cudaStream_t stream) {
-  {
-    std::lock_guard<std::mutex> lock(drainMutex_);
-    if (reader_ == nullptr) {
-      return;
+    try {
+      drain();
+    } catch (const std::exception& ex) {
+      CLOGF(WARN, "Pipes trace poll drain failed: {}", ex.what());
+    } catch (...) {
+      CLOGF(WARN, "Pipes trace poll drain failed with unknown exception");
     }
   }
-
-  cudaStreamCaptureStatus captureStatus = cudaStreamCaptureStatusNone;
-  auto captureErr = cudaStreamIsCapturing(stream, &captureStatus);
-  if (captureErr != cudaSuccess) {
-    CLOGF(
-        WARN,
-        "Pipes trace failed to query stream capture status: {}",
-        cudaGetErrorString(captureErr));
-    return;
-  }
-  if (captureStatus != cudaStreamCaptureStatusNone) {
-    return;
-  }
-
-  if (!beginDrainCallback()) {
-    return;
-  }
-  auto launchErr = cudaLaunchHostFunc(stream, drainPipesTraceCallback, this);
-  if (launchErr != cudaSuccess) {
-    finishDrainCallback();
-    CLOGF(
-        WARN,
-        "Pipes trace failed to enqueue drain callback: {}",
-        cudaGetErrorString(launchErr));
-  }
 }
 
-void PipesTrace::drainFromCallback() {
-  try {
-    drain();
-  } catch (const std::exception& ex) {
-    CLOGF(WARN, "Pipes trace callback drain failed: {}", ex.what());
-  } catch (...) {
-    CLOGF(WARN, "Pipes trace callback drain failed with unknown exception");
+void PipesTrace::startPollThread() {
+  if (pollInterval_.count() <= 0) {
+    return;
   }
-  finishDrainCallback();
+  std::lock_guard<std::mutex> lock(pollMutex_);
+  if (pollThread_.joinable()) {
+    return;
+  }
+  stopPolling_ = false;
+  pollThread_ = std::thread([this] { pollLoop(); });
 }
 
-bool PipesTrace::beginDrainCallback() {
-  std::lock_guard<std::mutex> lock(callbacksMutex_);
-  if (shuttingDown_) {
-    return false;
+void PipesTrace::stopPollThread() {
+  {
+    std::lock_guard<std::mutex> lock(pollMutex_);
+    stopPolling_ = true;
   }
-  ++pendingCallbacks_;
-  return true;
-}
-
-void PipesTrace::finishDrainCallback() {
-  std::lock_guard<std::mutex> lock(callbacksMutex_);
-  --pendingCallbacks_;
-  callbacksDone_.notify_one();
+  pollWake_.notify_one();
+  if (pollThread_.joinable()) {
+    pollThread_.join();
+  }
 }
 
 } // namespace comms::pipes

--- a/comms/pipes/PipesTrace.h
+++ b/comms/pipes/PipesTrace.h
@@ -4,10 +4,11 @@
 
 #include <cuda_runtime.h>
 
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -36,11 +37,24 @@ class PipesTrace {
 
   static uint32_t normalizeRingSize(uint64_t ringSize);
 
-  void ensure(uint32_t ringSize);
+  using EventCallback =
+      std::function<void(const PipesTraceEvent& event, uint64_t slot)>;
+
+  // Allocate the ring (if needed) and start the background poll thread.
+  void ensure(
+      uint32_t ringSize,
+      std::chrono::milliseconds pollInterval,
+      EventCallback eventCallback = nullptr);
+
+  // Device-side handle into the ring.
+  //
+  // Lifetime contract: traced kernels write directly through this handle, so
+  // the ring it points at must outlive every kernel that was handed it. This is
+  // the same lifetime contract as other CTRAN comm-owned device resources:
+  // callers must not destroy the communicator until all CTRAN work that may
+  // reference those resources has completed. ~PipesTrace() follows that
+  // contract and does not synchronize the device itself.
   PipesTraceHandle deviceHandle() const;
-  void drain();
-  void enqueueDrain(cudaStream_t stream);
-  void drainFromCallback();
 
  private:
   struct PendingLogEntry {
@@ -50,31 +64,24 @@ class PipesTrace {
 
   struct PendingLogBatch {
     std::vector<PendingLogEntry> entries;
-    uint64_t entriesRead{0};
     uint64_t entriesLost{0};
-    uint64_t lastRead{0};
   };
 
-  void enqueueLogBatch(PendingLogBatch batch);
   void logBatch(const PendingLogBatch& batch) const;
-  void logLoop();
-  void startLogThread();
-  void stopLogThread();
-  bool beginDrainCallback();
-  void finishDrainCallback();
+  void drain();
+  void pollLoop();
+  void startPollThread();
+  void stopPollThread();
 
   std::unique_ptr<Buffer> buffer_;
   std::unique_ptr<Reader> reader_;
   mutable std::mutex drainMutex_;
-  std::mutex logMutex_;
-  std::condition_variable logAvailable_;
-  std::deque<PendingLogBatch> pendingLogBatches_;
-  std::thread logThread_;
-  std::mutex callbacksMutex_;
-  std::condition_variable callbacksDone_;
-  std::size_t pendingCallbacks_{0};
-  bool stopLogging_{false};
-  bool shuttingDown_{false};
+  std::thread pollThread_;
+  std::mutex pollMutex_;
+  std::condition_variable pollWake_;
+  std::chrono::milliseconds pollInterval_{0};
+  EventCallback eventCallback_;
+  bool stopPolling_{false};
 };
 
 } // namespace comms::pipes

--- a/comms/pipes/tests/PipesTraceTest.cc
+++ b/comms/pipes/tests/PipesTraceTest.cc
@@ -1,0 +1,585 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/pipes/PipesTrace.h"
+#include "comms/pipes/PipesTraceTypes.h"
+#include "comms/pipes/tests/PipesTraceTest.cuh"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
+
+using comms::pipes::PipesTrace;
+using comms::pipes::PipesTraceEvent;
+
+namespace {
+
+constexpr auto kPollInterval = std::chrono::milliseconds{1};
+constexpr auto kWaitTimeout = std::chrono::seconds{10};
+
+class MappedSpinFlag {
+ public:
+  explicit MappedSpinFlag(cudaStream_t stream) : stream_(stream) {}
+
+  ~MappedSpinFlag() {
+    release();
+  }
+
+  cudaError_t init() {
+    auto err = cudaHostAlloc(
+        reinterpret_cast<void**>(&hostFlag_), sizeof(int), cudaHostAllocMapped);
+    if (err != cudaSuccess) {
+      return err;
+    }
+    if (hostFlag_ == nullptr) {
+      return cudaErrorMemoryAllocation;
+    }
+    *hostFlag_ = 0;
+
+    err = cudaHostGetDevicePointer(
+        reinterpret_cast<void**>(&deviceFlag_), hostFlag_, 0);
+    if (err != cudaSuccess) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaFreeHost(hostFlag_);
+      hostFlag_ = nullptr;
+      deviceFlag_ = nullptr;
+    }
+    return err;
+  }
+
+  volatile int* device() const {
+    return deviceFlag_;
+  }
+
+  void release() {
+    if (hostFlag_ == nullptr) {
+      return;
+    }
+    *hostFlag_ = 1;
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaStreamSynchronize(stream_);
+    // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+    cudaFreeHost(hostFlag_);
+    hostFlag_ = nullptr;
+    deviceFlag_ = nullptr;
+  }
+
+ private:
+  cudaStream_t stream_{nullptr};
+  int* hostFlag_{nullptr};
+  int* deviceFlag_{nullptr};
+};
+
+class PipesTraceCudaTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int deviceCount = 0;
+    auto err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess || deviceCount == 0) {
+      GTEST_SKIP() << "No CUDA device available";
+    }
+
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+    int major = 0;
+    ASSERT_EQ(
+        cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, 0),
+        cudaSuccess);
+    if (major < 9) {
+      GTEST_SKIP() << "HRDW ring buffer requires sm_90+";
+    }
+
+    ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+  }
+
+  void TearDown() override {
+    if (stream_ != nullptr) {
+      // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  cudaStream_t stream_{nullptr};
+};
+
+void waitForReceivedEvents(
+    std::mutex& mu,
+    const std::vector<PipesTraceEvent>& received,
+    size_t expected,
+    const char* timeoutMessage) {
+  auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
+  while (true) {
+    {
+      std::lock_guard<std::mutex> lock(mu);
+      if (received.size() >= expected) {
+        return;
+      }
+    }
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline) << timeoutMessage;
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(kPollInterval);
+  }
+}
+
+} // namespace
+
+TEST(PipesTraceTest, NormalizeRingSizeZero) {
+  EXPECT_EQ(PipesTrace::normalizeRingSize(0), 0u);
+}
+
+TEST(PipesTraceTest, NormalizeRingSizeClampsLarge) {
+  EXPECT_EQ(
+      PipesTrace::normalizeRingSize(1ULL << 32),
+      static_cast<uint32_t>(1ULL << 31));
+}
+
+TEST(PipesTraceTest, NormalizeRingSizePassthrough) {
+  EXPECT_EQ(PipesTrace::normalizeRingSize(1024), 1024u);
+}
+
+TEST_F(PipesTraceCudaTest, EnsureCreatesBuffer) {
+  PipesTrace trace;
+  trace.ensure(64, kPollInterval);
+  auto handle = trace.deviceHandle();
+  EXPECT_NE(handle.ring, nullptr);
+  EXPECT_NE(handle.writeIndex, nullptr);
+}
+
+TEST_F(PipesTraceCudaTest, EnsureZeroSizeIsNoOp) {
+  PipesTrace trace;
+  trace.ensure(0, kPollInterval);
+  auto handle = trace.deviceHandle();
+  EXPECT_EQ(handle.ring, nullptr);
+}
+
+TEST_F(PipesTraceCudaTest, DeviceHandleNullBeforeEnsure) {
+  PipesTrace trace;
+  auto handle = trace.deviceHandle();
+  EXPECT_EQ(handle.ring, nullptr);
+}
+
+TEST_F(PipesTraceCudaTest, DestructionAfterEnsure) {
+  auto trace = std::make_unique<PipesTrace>();
+  trace->ensure(64, kPollInterval);
+  auto handle = trace->deviceHandle();
+  EXPECT_NE(handle.ring, nullptr);
+  trace.reset();
+}
+
+TEST_F(PipesTraceCudaTest, EnsureIdempotent) {
+  PipesTrace trace;
+  trace.ensure(64, kPollInterval);
+  auto handle1 = trace.deviceHandle();
+
+  trace.ensure(64, kPollInterval);
+  auto handle2 = trace.deviceHandle();
+
+  EXPECT_EQ(handle1.ring, handle2.ring);
+  EXPECT_EQ(handle1.writeIndex, handle2.writeIndex);
+}
+
+TEST_F(PipesTraceCudaTest, WriteAndReadEvents) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  constexpr int kNumEvents = 10;
+  Buffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  comms::pipes::test::launchWriteEvents(handle, kNumEvents, stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  Reader reader(buf);
+  uint64_t eventsRead = 0;
+  auto result = reader.poll([&](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u);
+    EXPECT_EQ(
+        entry.data.type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+    ++eventsRead;
+  });
+
+  EXPECT_EQ(result.entriesRead, kNumEvents);
+  EXPECT_EQ(eventsRead, kNumEvents);
+  EXPECT_EQ(result.entriesLost, 0u);
+}
+
+TEST_F(PipesTraceCudaTest, EventsVisibleBeforeKernelCompletes) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  constexpr int kNumEvents = 10;
+  Buffer buf(64);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  MappedSpinFlag releaseFlag(stream_);
+  ASSERT_EQ(releaseFlag.init(), cudaSuccess);
+
+  comms::pipes::test::launchWriteAndSpin(
+      handle, releaseFlag.device(), kNumEvents, stream_);
+
+  Reader reader(buf);
+  uint64_t totalRead = 0;
+  auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
+  while (totalRead < static_cast<uint64_t>(kNumEvents)) {
+    reader.poll([&](const auto& entry, uint64_t) {
+      EXPECT_NE(entry.timestamp, 0u);
+      ++totalRead;
+    });
+
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "Timed out waiting for events while kernel is still running. Got "
+        << totalRead << "/" << kNumEvents << " events.";
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(kPollInterval);
+  }
+
+  EXPECT_EQ(totalRead, static_cast<uint64_t>(kNumEvents));
+  EXPECT_EQ(cudaStreamQuery(stream_), cudaErrorNotReady)
+      << "Kernel should still be spinning on the flag";
+
+  releaseFlag.release();
+}
+
+TEST_F(PipesTraceCudaTest, PollThreadPicksUpEventsBeforeKernelEnds) {
+  constexpr int kNumEvents = 10;
+
+  std::mutex mu;
+  std::vector<PipesTraceEvent> received;
+
+  PipesTrace trace;
+  trace.ensure(64, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
+    std::lock_guard<std::mutex> lock(mu);
+    received.push_back(event);
+  });
+  auto handle = trace.deviceHandle();
+  ASSERT_NE(handle.ring, nullptr);
+
+  MappedSpinFlag releaseFlag(stream_);
+  ASSERT_EQ(releaseFlag.init(), cudaSuccess);
+
+  comms::pipes::test::launchWriteAndSpin(
+      handle, releaseFlag.device(), kNumEvents, stream_);
+
+  waitForReceivedEvents(
+      mu,
+      received,
+      kNumEvents,
+      "Timed out waiting for poll thread to deliver events");
+
+  EXPECT_EQ(cudaStreamQuery(stream_), cudaErrorNotReady)
+      << "Kernel should still be spinning on the flag";
+
+  releaseFlag.release();
+
+  std::lock_guard<std::mutex> lock(mu);
+  ASSERT_EQ(received.size(), static_cast<size_t>(kNumEvents));
+  for (int i = 0; i < kNumEvents; i++) {
+    EXPECT_EQ(received[i].step, static_cast<uint32_t>(i));
+    EXPECT_EQ(received[i].detail, static_cast<uint16_t>(i));
+    EXPECT_EQ(
+        received[i].type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+  }
+}
+
+TEST_F(PipesTraceCudaTest, PollThreadConsumesEagerEvents) {
+  constexpr int kNumEvents = 20;
+
+  std::mutex mu;
+  std::vector<PipesTraceEvent> received;
+
+  PipesTrace trace;
+  trace.ensure(64, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
+    std::lock_guard<std::mutex> lock(mu);
+    received.push_back(event);
+  });
+  auto handle = trace.deviceHandle();
+  ASSERT_NE(handle.ring, nullptr);
+
+  comms::pipes::test::launchWriteEvents(handle, kNumEvents, stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  waitForReceivedEvents(
+      mu,
+      received,
+      kNumEvents,
+      "Timed out waiting for poll thread to deliver events");
+
+  std::lock_guard<std::mutex> lock(mu);
+  ASSERT_EQ(received.size(), static_cast<size_t>(kNumEvents));
+  for (int i = 0; i < kNumEvents; i++) {
+    EXPECT_EQ(received[i].step, static_cast<uint32_t>(i));
+    EXPECT_EQ(received[i].detail, static_cast<uint16_t>(i));
+    EXPECT_EQ(
+        received[i].type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+  }
+}
+
+TEST_F(PipesTraceCudaTest, MultipleKernelLaunches) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  Buffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  constexpr int kLaunches = 5;
+  constexpr int kEventsPerLaunch = 10;
+
+  for (int i = 0; i < kLaunches; i++) {
+    comms::pipes::test::launchWriteEvents(handle, kEventsPerLaunch, stream_);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  Reader reader(buf);
+  uint64_t totalRead = 0;
+  auto result = reader.poll([&](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u);
+    ++totalRead;
+  });
+
+  EXPECT_EQ(totalRead, static_cast<uint64_t>(kLaunches * kEventsPerLaunch));
+  EXPECT_EQ(result.entriesLost, 0u);
+}
+
+TEST_F(PipesTraceCudaTest, GraphCaptureAndReplay) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  constexpr int kNumEvents = 10;
+  Buffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t instance = nullptr;
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  comms::pipes::test::launchWriteEvents(handle, kNumEvents, stream_);
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0), cudaSuccess);
+
+  Reader reader(buf);
+  auto captureResult = reader.poll([](const auto&, uint64_t) {});
+  EXPECT_EQ(captureResult.entriesRead, 0u);
+
+  ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  uint64_t totalRead = 0;
+  auto replayResult = reader.poll([&](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u);
+    EXPECT_EQ(
+        entry.data.type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+    ++totalRead;
+  });
+
+  EXPECT_EQ(totalRead, static_cast<uint64_t>(kNumEvents));
+  EXPECT_EQ(replayResult.entriesLost, 0u);
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+TEST_F(PipesTraceCudaTest, GraphMultipleReplays) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  constexpr int kNumEvents = 5;
+  constexpr int kReplays = 10;
+  Buffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t instance = nullptr;
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  comms::pipes::test::launchWriteEvents(handle, kNumEvents, stream_);
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0), cudaSuccess);
+
+  for (int i = 0; i < kReplays; i++) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  Reader reader(buf);
+  uint64_t totalRead = 0;
+  auto result = reader.poll([&](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u);
+    ++totalRead;
+  });
+
+  EXPECT_EQ(
+      totalRead + result.entriesLost,
+      static_cast<uint64_t>(kNumEvents * kReplays));
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+TEST_F(PipesTraceCudaTest, PollThreadWithGraphReplay) {
+  constexpr int kNumEvents = 10;
+  constexpr int kReplays = 3;
+  constexpr uint64_t kTotalEvents = kNumEvents * kReplays;
+
+  std::mutex mu;
+  std::vector<PipesTraceEvent> received;
+
+  PipesTrace trace;
+  trace.ensure(256, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
+    std::lock_guard<std::mutex> lock(mu);
+    received.push_back(event);
+  });
+  auto handle = trace.deviceHandle();
+  ASSERT_NE(handle.ring, nullptr);
+
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t instance = nullptr;
+
+  ASSERT_EQ(
+      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
+      cudaSuccess);
+  comms::pipes::test::launchWriteEvents(handle, kNumEvents, stream_);
+  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
+  ASSERT_NE(graph, nullptr);
+  ASSERT_EQ(
+      cudaGraphInstantiate(&instance, graph, nullptr, nullptr, 0), cudaSuccess);
+
+  {
+    std::lock_guard<std::mutex> lock(mu);
+    EXPECT_EQ(received.size(), 0u);
+  }
+
+  for (int i = 0; i < kReplays; i++) {
+    ASSERT_EQ(cudaGraphLaunch(instance, stream_), cudaSuccess);
+  }
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  waitForReceivedEvents(
+      mu,
+      received,
+      kTotalEvents,
+      "Timed out waiting for poll thread to deliver graph replay events");
+
+  {
+    std::lock_guard<std::mutex> lock(mu);
+    ASSERT_EQ(received.size(), static_cast<size_t>(kTotalEvents));
+    for (size_t i = 0; i < received.size(); i++) {
+      EXPECT_EQ(received[i].step, static_cast<uint32_t>(i % kNumEvents));
+      EXPECT_EQ(
+          received[i].type,
+          static_cast<uint8_t>(
+              comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+    }
+  }
+
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphExecDestroy(instance);
+  // NOLINTNEXTLINE(facebook-cuda-safe-api-call-check)
+  cudaGraphDestroy(graph);
+}
+
+TEST_F(PipesTraceCudaTest, MultiBlockWriteAndRead) {
+  using Buffer = hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent>;
+  using Reader = hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent>;
+
+  constexpr int kNumBlocks = 8;
+  constexpr int kEventsPerBlock = 10;
+  constexpr uint64_t kTotalEvents = kNumBlocks * kEventsPerBlock;
+
+  Buffer buf(256);
+  ASSERT_TRUE(buf.valid());
+  auto handle = buf.deviceHandle();
+
+  comms::pipes::test::launchWriteEventsMultiBlock(
+      handle, kNumBlocks, kEventsPerBlock, stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  Reader reader(buf);
+  uint64_t totalRead = 0;
+  auto result = reader.poll([&](const auto& entry, uint64_t) {
+    EXPECT_NE(entry.timestamp, 0u);
+    EXPECT_EQ(
+        entry.data.type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+    EXPECT_LT(entry.data.rank, kNumBlocks);
+    ++totalRead;
+  });
+
+  EXPECT_EQ(totalRead + result.entriesLost, kTotalEvents);
+  EXPECT_EQ(totalRead, result.entriesRead);
+}
+
+TEST_F(PipesTraceCudaTest, PollThreadMultiBlockEvents) {
+  constexpr int kNumBlocks = 8;
+  constexpr int kEventsPerBlock = 10;
+  constexpr uint64_t kTotalEvents = kNumBlocks * kEventsPerBlock;
+
+  std::mutex mu;
+  std::vector<PipesTraceEvent> received;
+
+  PipesTrace trace;
+  trace.ensure(256, kPollInterval, [&](const PipesTraceEvent& event, uint64_t) {
+    std::lock_guard<std::mutex> lock(mu);
+    received.push_back(event);
+  });
+  auto handle = trace.deviceHandle();
+  ASSERT_NE(handle.ring, nullptr);
+
+  comms::pipes::test::launchWriteEventsMultiBlock(
+      handle, kNumBlocks, kEventsPerBlock, stream_);
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+  waitForReceivedEvents(
+      mu,
+      received,
+      kTotalEvents,
+      "Timed out waiting for poll thread to deliver multi-block events");
+
+  std::lock_guard<std::mutex> lock(mu);
+  ASSERT_EQ(received.size(), static_cast<size_t>(kTotalEvents));
+
+  std::set<uint8_t> seenBlocks;
+  for (const auto& event : received) {
+    EXPECT_EQ(
+        event.type,
+        static_cast<uint8_t>(
+            comms::pipes::PipesTraceEventType::kHierAgNvlTaskDone));
+    EXPECT_LT(event.rank, kNumBlocks);
+    seenBlocks.insert(event.rank);
+  }
+  EXPECT_EQ(seenBlocks.size(), static_cast<size_t>(kNumBlocks));
+}

--- a/comms/pipes/tests/PipesTraceTest.cu
+++ b/comms/pipes/tests/PipesTraceTest.cu
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/pipes/tests/PipesTraceTest.cuh"
+
+#include "comms/pipes/PipesTraceTypes.h"
+
+namespace comms::pipes::test {
+
+__global__ void writeAndSpinKernel(
+    PipesTraceHandle trace,
+    volatile int* releaseFlag,
+    int numEvents) {
+  for (int i = 0; i < numEvents; i++) {
+    write_pipes_trace(
+        trace,
+        PipesTraceEventType::kHierAgNvlTaskDone,
+        static_cast<uint32_t>(i),
+        static_cast<uint16_t>(i),
+        0);
+  }
+  __syncthreads();
+  __threadfence_system();
+  while (*releaseFlag == 0) {
+    // Spin until the host releases the kernel.
+  }
+}
+
+__global__ void writeEventsKernel(PipesTraceHandle trace, int numEvents) {
+  for (int i = 0; i < numEvents; i++) {
+    write_pipes_trace(
+        trace,
+        PipesTraceEventType::kHierAgNvlTaskDone,
+        static_cast<uint32_t>(i),
+        static_cast<uint16_t>(i),
+        0);
+  }
+}
+
+__global__ void writeEventsMultiBlockKernel(
+    PipesTraceHandle trace,
+    int eventsPerBlock) {
+  int blockId = static_cast<int>(blockIdx.x);
+  for (int i = 0; i < eventsPerBlock; i++) {
+    write_pipes_trace(
+        trace,
+        PipesTraceEventType::kHierAgNvlTaskDone,
+        static_cast<uint32_t>(i),
+        static_cast<uint16_t>(blockId),
+        static_cast<uint8_t>(blockId));
+  }
+}
+
+void launchWriteAndSpin(
+    PipesTraceHandle trace,
+    volatile int* releaseFlag,
+    int numEvents,
+    cudaStream_t stream) {
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  writeAndSpinKernel<<<1, 1, 0, stream>>>(trace, releaseFlag, numEvents);
+}
+
+void launchWriteEvents(
+    PipesTraceHandle trace,
+    int numEvents,
+    cudaStream_t stream) {
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  writeEventsKernel<<<1, 1, 0, stream>>>(trace, numEvents);
+}
+
+void launchWriteEventsMultiBlock(
+    PipesTraceHandle trace,
+    int numBlocks,
+    int eventsPerBlock,
+    cudaStream_t stream) {
+  // NOLINTNEXTLINE(facebook-cuda-safe-kernel-call-check)
+  writeEventsMultiBlockKernel<<<numBlocks, 1, 0, stream>>>(
+      trace, eventsPerBlock);
+}
+
+} // namespace comms::pipes::test

--- a/comms/pipes/tests/PipesTraceTest.cuh
+++ b/comms/pipes/tests/PipesTraceTest.cuh
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include "comms/pipes/PipesTraceTypes.h"
+
+namespace comms::pipes::test {
+
+void launchWriteAndSpin(
+    PipesTraceHandle trace,
+    volatile int* releaseFlag,
+    int numEvents,
+    cudaStream_t stream);
+
+void launchWriteEvents(
+    PipesTraceHandle trace,
+    int numEvents,
+    cudaStream_t stream);
+
+void launchWriteEventsMultiBlock(
+    PipesTraceHandle trace,
+    int numBlocks,
+    int eventsPerBlock,
+    cudaStream_t stream);
+
+} // namespace comms::pipes::test

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1811,8 +1811,9 @@ cvars:
    default     : false
    description : |-
      Enable generic Pipes algorithm tracing. When enabled, CTA leaders write
-     compact per-phase events to an HRDW ring buffer and the host logs them
-     after the collective stream reaches the kernel.
+     compact per-phase events to an HRDW ring buffer and a host background
+     thread polls the buffer on an interval, so breadcrumbs are logged while
+     the kernel is still running (including when it hangs).
 
  - name        : NCCL_CTRAN_PIPES_TRACE_RING_SIZE
    type        : uint64_t
@@ -1820,6 +1821,15 @@ cvars:
    description : |-
      Number of HRDW ring-buffer entries reserved per communicator for
      NCCL_CTRAN_PIPES_TRACE_ENABLE.
+
+ - name        : NCCL_CTRAN_PIPES_TRACE_POLL_INTERVAL_MS
+   type        : uint64_t
+   default     : 50
+   description : |-
+     Interval in milliseconds at which the host background thread polls the
+     HRDW ring buffer for NCCL_CTRAN_PIPES_TRACE_ENABLE. Smaller values reduce
+     the chance of losing events to ring wraparound on high-rate kernels at the
+     cost of more frequent polling; a final drain always runs on teardown.
 
  - name        : NCCL_CTRAN_PIPES_NVL_CHUNK_SIZE
    type        : uint64_t


### PR DESCRIPTION
Summary:
The original Pipes HRDW trace drain (D105712071) flushed the ring from a stream-ordered `cudaLaunchHostFunc` callback and formatted entries on a separate logger thread. The callback only fires once the stream reaches it, so a hung or deadlocked kernel — the exact case the trace exists to debug — never drains. But the breadcrumbs are already live in pinned, CPU-visible host memory the moment they are written, so all that is missing is a trigger to read them while the kernel is still running.

This replaces the callback and logger thread with a single background poll thread. `ensure()` now takes a poll interval and starts a `pollLoop` that drains the ring every `NCCL_CTRAN_PIPES_TRACE_POLL_INTERVAL_MS` (default 50ms) and logs the entries inline. The reader reads the pinned mapping directly — lock-free and stream-independent — so it captures breadcrumbs concurrently with a running or hung kernel, a mode already covered by the `ConcurrentWriteAndPoll` stress test. The logger thread is dropped since the poll thread blocks no stream, and the destructor stops the poller then runs one final `drain()` to flush the tail. Adds the `NCCL_CTRAN_PIPES_TRACE_POLL_INTERVAL_MS` cvar.

Ring sizing is now interval-driven rather than needing to hold a whole collective's worth of events; `poll()` still reports `entries_lost` on wraparound so any loss stays visible. Tradeoff: if the log sink stalls, draining stalls with it and the ring can wrap instead of queueing batches in memory — not a concern at this event rate.

Reviewed By: snarayankh

Differential Revision: D106848328


