### PR TITLE
Cmake build break fixes (#2760)

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -161,6 +161,10 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/zstd.git" "v1.5.6" zstd
     build_automake_library "https://github.com/jedisct1/libsodium.git" "1.0.20-RELEASE" sodium
     build_fb_oss_library "https://github.com/fastfloat/fast_float.git" "v8.0.2" fast_float "-DFASTFLOAT_INSTALL=ON"
+    # Abseil provides absl::log / absl::check used by
+    # comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc, which is pulled into
+    # librccl via comms/pipes/PipesTrace.cc and comms/utils/colltrace/CollTrace.cc.
+    build_fb_oss_library "https://github.com/abseil/abseil-cpp.git" "20240722.0" abseil-cpp "-DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON -DABSL_BUILD_TESTING=OFF"
     # Build libevent as both static and shared (thrift needs .a, others may need .so)
     build_fb_oss_library "https://github.com/libevent/libevent.git" "release-2.1.12-stable" event "-DEVENT__LIBRARY_TYPE=BOTH"
     build_fb_oss_library "https://github.com/google/double-conversion.git" "v3.3.1" double-conversion
@@ -191,6 +195,7 @@ function build_third_party {
         conda-forge::zlib
         conda-forge::libopenssl-static
         conda-forge::folly
+        conda-forge::libabseil
         fmt
         pyyaml
       )
@@ -352,7 +357,10 @@ fi
 
 # hipify-perl (ROCm 7.0) doesn't map cudaEventWait/Record flags, so they pass
 # through unchanged into hipified source. Define them directly.
-export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -I${BASE_DIR} -DFOLLY_ASSUME_NO_JEMALLOC -DSO_INCOMING_NAPI_ID=56 -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
+# CUDART_CB (the CUDA host-callback calling-convention macro, empty on Linux)
+# is likewise not mapped by hipify; define it empty so callbacks like
+# drainPipesTraceCallback in comms/pipes/PipesTrace.cc parse correctly.
+export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -I${BASE_DIR} -DSO_INCOMING_NAPI_ID=56 -DCUDART_CB= -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
 
 # Create linker version script to hide gflags/glog symbols from librccl.so.
 # These get pulled in via static libs (libfolly.a, libthriftcpp2.a) but conflict
@@ -373,8 +381,10 @@ export LDFLAGS="${LDFLAGS:-} -Wl,--version-script=/tmp/rccl_hide_gflags.lds"
 
 mkdir -p "$BUILDDIR"
 pushd "${NCCL_HOME}"
-export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
-export CXX="${CXX:-${ROCM_PATH}/bin/amdclang++}"
+export ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0
+export CXX=/usr/local/fbcode/platform010/lib/rocm-7.0/lib/llvm/bin/amdclang++
+
+
 function build_rccl {
   ./install.sh \
     --prefix "$BUILDDIR" \

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -896,6 +896,11 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "GpuMemHandler\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")
+# Exclude comms/pipes/amd/ — the AMD GDA (GPUDirect Async) verbs backend
+# (pipes_gda, mlx5/bnxt nic backends) is only consumed by the excluded
+# MultipeerIbgdaTransport, and depends on mlx5dv/bnxt direct-verbs headers
+# (infiniband/mlx5dv.h, BnxtReDv.h) not available in this build.
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/pipes/amd/.*")
 
 # Run this command to get RCCLX_LIB_FILES:
 # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/lib/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" \) | sort
@@ -920,12 +925,18 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/lpcoll/low_precision_buffer_pool.cc
   comms/rcclx/develop/meta/lpcoll/low_precision_buffer_pool.h
   comms/rcclx/develop/meta/lpcoll/low_precision_common.h
+  comms/rcclx/develop/meta/lpcoll/low_precision_kernels.cu
   comms/rcclx/develop/meta/lpcoll/low_precision_kernels.h
   comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.cc
   comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.h
   comms/rcclx/develop/meta/lpcoll/low_precision_utility.h
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.cc
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.h
+  # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/relay/*" \( -name "*.cc" -o -name "*.h" -o -name "*.cu" \) | sort
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
 )
 
 # find comms/ctran/ -type f ! -path "*/tests/*" ! -path "*/benchmarks/*" ! -path "*/examples/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" -o -name "*.cuh" -o -name "*.cu" \) | sort
@@ -1238,6 +1249,11 @@ if (NOT Python3_FOUND)
   message(FATAL_ERROR "RCCL requires Python3 for generating host/device tables")
 endif()
 
+# Abseil (absl::log / absl::check) is used by
+# comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc, which is compiled into
+# librccl. Resolved from CONDA_PREFIX via CMAKE_PREFIX_PATH (env), same as fmt.
+find_package(absl CONFIG REQUIRED)
+
 set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 set(GEN_SYM_DIR "${GEN_DIR}/symmetric")
 
@@ -1311,6 +1327,14 @@ endforeach()
 
 # Find the generated files in the output directory
 file(GLOB_RECURSE GENERATED_FILES "${GEN_DIR}/*")
+
+# Exclude the per-function "specialized" kernel files (gensrc/specialized/*.cpp
+# and gensrc/specialized_files.txt). They are an alternative parallel-build code
+# path that re-emits DEFINE_ncclDevFunc for the same ncclDevFunc_* symbols
+# already defined by the grouped impl files above; compiling both causes
+# "duplicate symbol" errors at device (amdgcn) link time. The grouped impl
+# files plus device_table.cpp are the complete, referenced set.
+list(FILTER GENERATED_FILES EXCLUDE REGEX "/specialized")
 
 # Append all found generated files to the list
 foreach(file ${GENERATED_FILES})
@@ -1784,6 +1808,7 @@ target_link_libraries(rccl PRIVATE   hip::device)
 target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
 target_link_libraries(rccl PRIVATE fmt::fmt-header-only)
+target_link_libraries(rccl PRIVATE absl::log absl::check)  # GpuClockCalibration.cc
 if(ENABLE_MSCCLPP)
   target_link_libraries(rccl PRIVATE mscclpp_nccl)
 endif()

--- a/rcclx_builder.sh
+++ b/rcclx_builder.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+set -x # print commands before running them
+set -euo pipefail # exit script on errors
+
+# Initialize conda if not available in this shell
+if ! command -v conda &> /dev/null; then
+    conda_init=""
+    if [ -n "${CONDA_EXE:-}" ]; then
+        conda_init="${CONDA_EXE%/bin/conda}/etc/profile.d/conda.sh"
+    fi
+    for conda_path in "$conda_init" "$HOME/miniconda3/etc/profile.d/conda.sh" "$HOME/anaconda3/etc/profile.d/conda.sh" "$HOME/miniforge3/etc/profile.d/conda.sh" "/opt/conda/etc/profile.d/conda.sh" "/usr/etc/profile.d/conda.sh" "/etc/profile.d/conda.sh"; do
+        if [ -n "$conda_path" ] && [ -f "$conda_path" ]; then
+            source "$conda_path"
+            break
+        fi
+    done
+    if ! command -v conda &> /dev/null; then
+        echo "Error: conda not found. Install miniconda and try again." >&2
+        exit 1
+    fi
+fi
+
+# Activate conda environment if CONDA_DEFAULT_ENV is set but not active
+if [ -n "${CONDA_DEFAULT_ENV:-}" ] && [ "${CONDA_PREFIX:-}" = "" ]; then
+    conda activate "$CONDA_DEFAULT_ENV"
+fi
+
+python3 -m ensurepip --upgrade
+python3 -m pip install --upgrade pip
+conda install conda-forge::libopenssl-static conda-forge::rsync -y
+conda install conda-forge::glog=0.4.0 conda-forge::gflags conda-forge::fmt -y
+
+ONLY_FUNCS="AllReduce * * Sum f32" ./comms/github/build_rcclx.sh


### PR DESCRIPTION
Summary:

Fixes a series of CMake/build breaks hit when building RCCLX out-of-tree via build_rcclx.sh against a conda environment. Each fix is independent; together they get the build through third-party deps, source globbing, code generation, compilation, and device link.

comms/github/build_rcclx.sh
1. Add Abseil as a third-party dependency. comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc uses absl::log / absl::check, and it gets pulled into librccl via comms/pipes/PipesTrace.cc and comms/utils/colltrace/CollTrace.cc. Builds abseil-cpp (20240722.0) from source in the source-build path and adds conda-forge::libabseil to the USE_SYSTEM_LIBS conda dep list.

2. Define CUDART_CB empty in CXXFLAGS. hipify (ROCm 7.0) doesn't map the CUDA host-callback calling-convention macro, so it passes through unchanged into hipified source; defining it empty lets callbacks like drainPipesTraceCallback parse. Also drops the no-longer-needed -DFOLLY_ASSUME_NO_JEMALLOC.

3. Pin ROCM_PATH / CXX to the platform010 ROCm 7.0 amdclang++. Points CXX at .../rocm-7.0/lib/llvm/bin/amdclang++ so the build uses the correct ROCm toolchain.

comms/rcclx/develop/projects/rccl/CMakeLists.txt

1. Exclude comms/pipes/amd/ sources. The AMD GDA (GPUDirect Async) verbs backend is only consumed by the already-excluded MultipeerIbgdaTransport and depends on direct-verbs headers (infiniband/mlx5dv.h, BnxtReDv.h) not available in this build.

2. Add missing lpcoll / relay sources. Adds meta/lpcoll/low_precision_kernels.cu and the meta/relay/sharded_relay_allreduce* (.cc/.h/.cu) files to the RCCLX source list.

3. Wire up Abseil. Adds find_package(absl CONFIG REQUIRED) (resolved from CONDA_PREFIX via CMAKE_PREFIX_PATH, same as fmt) and links absl::log absl::check into the rccl target.

4. Exclude generated gensrc/specialized/* files. They are an alternative parallel-build path that re-emits DEFINE_ncclDevFunc for the same ncclDevFunc_* symbols already defined by the grouped impl files, causing duplicate-symbol errors at device (amdgcn) link time.

Reviewed By: sudharssun

Differential Revision: D107300460


