### PR TITLE
fix singleton-leak FATAL at process exit in paft

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -106,16 +106,18 @@ void CtranTcpDm::bootstrapAccept() {
     FB_SYSCHECKTHROW_EX(
         socket.recv(&peerRank, sizeof(int)), rank_, commHash_, commDesc_);
 
+    auto transport = CtranTcpDmSingleton::getTransport();
+
     ::comms::tcp_devmem::Handle handle{};
     ::comms::tcp_devmem::ListenerInterface* listenComm{};
-    COMMCHECKTHROW(transport_->listen(netdev_, &handle, &listenComm));
+    COMMCHECKTHROW(transport->listen(netdev_, &handle, &listenComm));
 
     FB_SYSCHECKTHROW_EX(
         socket.send(&handle, sizeof(handle)), rank_, commHash_, commDesc_);
 
     ::comms::tcp_devmem::CommunicatorInterface* recvComm;
-    COMMCHECKTHROW(transport_->accept(listenComm, &recvComm));
-    COMMCHECKTHROW(transport_->closeListen(listenComm));
+    COMMCHECKTHROW(transport->accept(listenComm, &recvComm));
+    COMMCHECKTHROW(transport->closeListen(listenComm));
 
     bootstrapAddRecvPeer(peerRank, recvComm);
 
@@ -164,7 +166,9 @@ commResult_t CtranTcpDm::bootstrapConnect(
   FB_SYSCHECKRETURN(sock.recv(&handle, sizeof(handle)), commInternalError);
 
   ::comms::tcp_devmem::CommunicatorInterface* sendComm{};
-  COMMCHECKTHROW(transport_->connect(netdev_, &handle, &sendComm));
+  COMMCHECKTHROW(
+      CtranTcpDmSingleton::getTransport()->connect(
+          netdev_, &handle, &sendComm));
 
   bootstrapAddSendPeer(peerRank, sendComm);
 
@@ -183,16 +187,15 @@ commResult_t CtranTcpDm::bootstrapConnect(
 }
 
 CtranTcpDm::CtranTcpDm([[maybe_unused]] CtranComm* comm) {
-  transport_ = CtranTcpDmSingleton::getTransport();
-
   cudaDev_ = comm->statex_->cudaDev();
   rank_ = comm->statex_->rank();
   nRanks_ = comm->statex_->nRanks();
   commHash_ = comm->statex_->commHash();
   commDesc_ = comm->statex_->commDesc();
-  netdev_ = transport_->getDeviceFor(cudaDev_);
 
-  transport_->open(netdev_);
+  auto transport = CtranTcpDmSingleton::getTransport();
+  netdev_ = transport->getDeviceFor(cudaDev_);
+  transport->open(netdev_);
 
   bootstrapPrepare(comm->bootstrap_.get());
 
@@ -209,18 +212,17 @@ CtranTcpDm::~CtranTcpDm() {
   listenSocket_.shutdown();
   listenThread_.join();
 
+  auto transport = CtranTcpDmSingleton::getTransport();
   for (auto comm : sendComms_) {
-    transport_->closeSend(comm.second);
+    transport->closeSend(comm.second);
   }
   for (auto comm : recvComms_) {
-    transport_->closeRecv(comm.second);
+    transport->closeRecv(comm.second);
   }
 
-  // shutdown the transport if this is the last CtranTcpDm instance
-  // cudaFreeHost() will fail if wait until Singleton is destroyed
-  if (transport_.use_count() <= 2) {
-    transport_->shutdown(false);
-  }
+  // Always request shutdown; Transport self-gates on `comms_ > 0` so only
+  // the last CtranTcpDm actually tears down, while CUDA is still alive.
+  transport->shutdown(false);
 }
 
 commResult_t CtranTcpDm::preConnect(const std::unordered_set<int>& peerRanks) {
@@ -273,15 +275,16 @@ commResult_t CtranTcpDm::isend(
 
   ::comms::tcp_devmem::CommunicatorInterface* comm = sendComms_.at(peerRank);
 
+  auto transport = CtranTcpDmSingleton::getTransport();
   ::comms::tcp_devmem::RequestInterface* request{nullptr};
-  COMMCHECK_TCP(transport_->queueRequest(
+  COMMCHECK_TCP(transport->queueRequest(
       comm,
       ::comms::tcp_devmem::Transport::Op::Send,
       data,
       size,
       handle,
       &request));
-  req.track(transport_.get(), request);
+  req.track(transport.get(), request);
 
   return commSuccess;
 }
@@ -363,8 +366,9 @@ commResult_t CtranTcpDm::irecvConnected(
     return commInternalError;
   }
 
+  auto transport = CtranTcpDmSingleton::getTransport();
   ::comms::tcp_devmem::RequestInterface* request{nullptr};
-  COMMCHECK_TCP(transport_->queueRequest(
+  COMMCHECK_TCP(transport->queueRequest(
       comm,
       ::comms::tcp_devmem::Transport::Op::Recv,
       data,
@@ -373,19 +377,23 @@ commResult_t CtranTcpDm::irecvConnected(
       &request,
       unpackPool));
 
-  req.track(transport_.get(), request);
+  req.track(transport.get(), request);
 
   return commSuccess;
 }
 
 commResult_t
 CtranTcpDm::prepareUnpackConsumer(SQueues* sqs, size_t blocks, void** pool) {
-  COMMCHECK_TCP(transport_->prepareUnpackConsumer(netdev_, sqs, blocks, pool));
+  COMMCHECK_TCP(
+      CtranTcpDmSingleton::getTransport()->prepareUnpackConsumer(
+          netdev_, sqs, blocks, pool));
   return commSuccess;
 }
 
 commResult_t CtranTcpDm::teardownUnpackConsumer(void* pool) {
-  COMMCHECK_TCP(transport_->teardownUnpackConsumer(netdev_, pool));
+  COMMCHECK_TCP(
+      CtranTcpDmSingleton::getTransport()->teardownUnpackConsumer(
+          netdev_, pool));
   return commSuccess;
 }
 

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -90,7 +90,12 @@ class CtranTcpDm {
   commResult_t teardownUnpackConsumer(void* pool);
 
  private:
-  std::shared_ptr<::comms::tcp_devmem::TransportInterface> transport_;
+  // The Transport singleton is fetched via CtranTcpDmSingleton::getTransport()
+  // at each use site rather than held as a shared_ptr member. Holding it as a
+  // member kept the singleton ref-count elevated for the lifetime of every
+  // CtranTcpDm and prevented folly::Singleton's destroyInstances from running
+  // cleanly at process exit (FATAL "living references"). Mirrors what
+  // CtranIb does with CtranIbSingleton::getInstance().
   ctran::bootstrap::ServerSocket listenSocket_{
       static_cast<int>(NCCL_SOCKET_RETRY_CNT)};
   std::vector<sockaddr_storage> allListenSocketAddrs_{};

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1903,17 +1903,27 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       // receive operation. Once it does, it will mark tcpDmReq as complete,
       // allowing us to exit the loop.
 
-      if (kernElem == nullptr) {
-        CLOGF(ERR, "TCP Device Memory requires kernElem in the notifier");
-        return commInternalError;
-      }
-
-      const void* rbuff = kernElem->waitNotify.recvbuff;
-      size_t len = kernElem->waitNotify.nbytes;
-
-      if (rbuff == nullptr || len == 0) {
-        CLOGF(ERR, "TCP Device Memory requires recvbuff in the notifier");
-        return commInternalError;
+      const void* rbuff = nullptr;
+      size_t len = 0;
+      if (kernElem != nullptr) {
+        rbuff = kernElem->waitNotify.recvbuff;
+        len = kernElem->waitNotify.nbytes;
+        if (rbuff == nullptr || len == 0) {
+          CLOGF(ERR, "TCP Device Memory requires recvbuff in the notifier");
+          return commInternalError;
+        }
+      } else {
+        const DevMemType type = regElem->getType();
+        if (type != kHostUnregistered && type != kHostPinned) {
+          CLOGF(
+              ERR,
+              "TCP Device Memory requires kernElem in the notifier "
+              "(memType {})",
+              devMemTypeStr(type));
+          return commInternalError;
+        }
+        rbuff = regElem->buf;
+        len = regElem->len;
       }
 
       FB_COMMCHECK(this->ctranTcpDm->irecv(


### PR DESCRIPTION
Summary:
paft training hits a FATAL "Singleton of type comms::tcp_devmem::TransportInterface has a living reference" + SIGABRT at process exit (`folly::FatalHelper::~FatalHelper()` -> `__run_exit_handlers`). Training completes correctly through all steps; the abort fires only during shutdown.

Two related issues, fixed together:

1. `CtranTcpDm` held `shared_ptr<TransportInterface> transport_` as a member, keeping the Transport singleton's ref-count elevated for every comm's lifetime. In multi-comm scenarios (paft: world MCCL + HSDP_REPLICATE + per-shard groups) folly::Singleton's `destroyInstances` then finds living references and aborts. `CtranIb` (the RDMA counterpart) avoids this by fetching `CtranIbSingleton::getInstance()` as a stack-local in each method instead of holding it as a member. Mirror that pattern: drop the `transport_` member and fetch via `CtranTcpDmSingleton::getTransport()` per call. Hot-path send/recv each create one short-lived shared_ptr (atomic refcount bump); negligible vs the TCP work.

2. D105644598's `transport_.use_count() <= 2` guard around `transport->shutdown(false)` in `~CtranTcpDm` was too restrictive. The intent was "only the last CtranTcpDm fires shutdown", but in paft extra non-CtranTcpDm holders of the singleton kept `use_count` at 3-4 throughout teardown, so the guarded shutdown never fired. Drop the guard: `Transport::shutdown(false)` already self-gates on `comms_ > 0` (see `transport.cc:1951`); `comms_` is the authoritative counter and is decremented by the `closeSend`/`closeRecv` calls just above. Calling `shutdown(false)` unconditionally is safe — it's a no-op until the final CtranTcpDm drops `comms_` to 0, then performs the actual teardown while CUDA is still alive.

Reviewed By: function47

Differential Revision: D107289126


