### PR TITLE
add python scripts to generate perfetto traces from pipes tracing logs (#2764)

### DIFF
--- a/comms/pipes/scripts/pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/pipestrace_to_perfetto.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""Convert `PipesTrace` log lines into Perfetto / Chrome Trace Event JSON.
+
+Design doc: fbsource/users/al/alvinyc/designdoc/pipes_trace_to_perfetto.md
+
+Consumes one or more launcher logs (mpirun --tag-output captures of the
+hierarchical allgather overlap kernel) and emits a single JSON timeline that
+can be opened at https://ui.perfetto.dev/. Stdlib-only, no BUCK target —
+matches the existing pipes/scripts/ layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import gzip
+import json
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Iterator, Sequence
+from typing import TextIO
+
+logger: logging.Logger = logging.getLogger("pipestrace_to_perfetto")
+
+# Event name strings emitted by pipesTraceEventTypeName() in PipesTrace.cc.
+AG_IB_BEGIN = "hier_ag_ib_chunk_begin"
+AG_IB_READY = "hier_ag_ib_chunk_ready"
+AG_NVL_WAIT_BEGIN = "hier_ag_nvl_wait_begin"
+AG_NVL_CHUNK_READY = "hier_ag_nvl_chunk_ready"
+AG_NVL_TASK_DONE = "hier_ag_nvl_task_done"
+IB_SEND_BEGIN = "ib_send_begin"
+IB_SEND_END = "ib_send_end"
+IB_RECV_BEGIN = "ib_recv_begin"
+IB_RECV_END = "ib_recv_end"
+IB_FORWARD_BEGIN = "ib_forward_begin"
+IB_FORWARD_END = "ib_forward_end"
+
+IB_SEND = "ib_send"
+IB_RECV = "ib_recv"
+IB_FORWARD = "ib_forward"
+
+IB_NAMES = frozenset(
+    {
+        AG_IB_BEGIN,
+        AG_IB_READY,
+        IB_SEND_BEGIN,
+        IB_SEND_END,
+        IB_RECV_BEGIN,
+        IB_RECV_END,
+        IB_FORWARD_BEGIN,
+        IB_FORWARD_END,
+    }
+)
+NVL_NAMES = frozenset({AG_NVL_WAIT_BEGIN, AG_NVL_CHUNK_READY, AG_NVL_TASK_DONE})
+KNOWN_EVENT_NAMES = IB_NAMES | NVL_NAMES
+
+# +100/+200 keep IB and NVL tracks visually grouped per process, with room
+# for additional virtual tracks without colliding.
+THREAD_OFFSET_IB = 100
+THREAD_OFFSET_NVL = 200
+
+_PREFIX = r"^\[1,(?P<mpi_rank>\d+)\]<(?:stderr|stdout)>:"
+
+# `[^\[]*?` forbids a stray "[" in the gap between rank prefix and "Pipes
+# trace ..." — that's how mpirun --tag-output splices another rank's prefix
+# mid-line under load. Without this, the regex would backtrack across the
+# splice and synthesize a wrong-rank event.
+EVENT_RE: re.Pattern[str] = re.compile(
+    _PREFIX + r"[^\[]*?Pipes trace event=(?P<name>\w+)"
+    r" step=(?P<step>\d+)"
+    r" rank=(?P<rank>-?\d+)"
+    r" detail=(?P<detail>\d+)"
+    r" slot=(?P<slot>\d+)"
+    r" wall_time_ns=(?P<ns>\d+)\s*$"
+)
+
+DRAIN_RE: re.Pattern[str] = re.compile(
+    _PREFIX + r"[^\[]*?Pipes trace drain entries_read=(?P<read>\d+)"
+    r" entries_lost=(?P<lost>\d+)"
+    r" last_read=(?P<last>\d+)\s*$"
+)
+
+# mpirun ... -host h1:p,h2:p,... — first ":p" is procs-per-node (= nvl_size).
+MPIRUN_HOST_RE: re.Pattern[str] = re.compile(
+    r"mpirun\s.*?-host\s+([\w\.\-]+:\d+(?:,[\w\.\-]+:\d+)*)"
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Event:
+    mpi_rank: int
+    name: str
+    step: int  # chunk id for AG events, byte offset for IB send/recv/forward
+    rank: int  # ib_rank (IB events) / ib_src (NVL events)
+    group: int  # detail = group.group_id
+    slot: int
+    ns: int
+
+
+@dataclasses.dataclass
+class ParseStats:
+    events: int = 0
+    drains: int = 0
+    dropped_lines: int = 0
+    lost_entries: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class Topology:
+    nvl_size: int
+    ib_size: int
+    auto_detected_nvl: bool
+
+
+@dataclasses.dataclass
+class Slice_:
+    pid: int
+    tid: int
+    cat: str
+    name: str
+    begin_ns: int
+    end_ns: int
+    args: dict[str, object]
+
+
+@dataclasses.dataclass
+class PairState:
+    """Per-rank state used while walking events in (ns, slot) order."""
+
+    mpi_rank: int
+    # (group, chunk) -> (begin_ns, begin_slot, self_ib_rank)
+    pending_ib: dict[tuple[int, int], tuple[int, int, int]] = dataclasses.field(
+        default_factory=dict
+    )
+    # (group, chunk, ib_src) -> (begin_ns, begin_slot)
+    pending_nvl_wait: dict[tuple[int, int, int], tuple[int, int]] = dataclasses.field(
+        default_factory=dict
+    )
+    pending_nvl_bcast: dict[tuple[int, int, int], tuple[int, int]] = dataclasses.field(
+        default_factory=dict
+    )
+    # (group, self_ib_rank) -> begin event
+    pending_ib_send: dict[tuple[int, int], Event] = dataclasses.field(
+        default_factory=dict
+    )
+    pending_ib_recv: dict[tuple[int, int], Event] = dataclasses.field(
+        default_factory=dict
+    )
+    pending_ib_forward: dict[tuple[int, int], Event] = dataclasses.field(
+        default_factory=dict
+    )
+
+
+def _open_log(path: str) -> TextIO:
+    if path == "-":
+        return sys.stdin
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def _detect_nvl_from_mpirun(line: str) -> int | None:
+    m = MPIRUN_HOST_RE.search(line)
+    if m is None:
+        return None
+    first = m.group(1).split(",", 1)[0]
+    try:
+        return int(first.split(":")[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _parse_event_line(line: str) -> Event | None:
+    m = EVENT_RE.fullmatch(line)
+    if m is None:
+        return None
+    name = m["name"]
+    if name not in KNOWN_EVENT_NAMES:
+        return None
+    return Event(
+        mpi_rank=int(m["mpi_rank"]),
+        name=name,
+        step=int(m["step"]),
+        rank=int(m["rank"]),
+        group=int(m["detail"]),
+        slot=int(m["slot"]),
+        ns=int(m["ns"]),
+    )
+
+
+def parse_events(
+    paths: Sequence[str], stats: ParseStats
+) -> tuple[list[Event], int | None]:
+    """Parse all log paths into Event records; also detect nvl_size from mpirun."""
+    events: list[Event] = []
+    nvl_hint: int | None = None
+    for path in paths:
+        with _open_log(path) as fh:
+            for line in fh:
+                if nvl_hint is None and "mpirun" in line and "-host" in line:
+                    nvl_hint = _detect_nvl_from_mpirun(line)
+
+                event = _parse_event_line(line)
+                if event is not None:
+                    events.append(event)
+                    stats.events += 1
+                    continue
+
+                drain = DRAIN_RE.fullmatch(line)
+                if drain is not None:
+                    stats.drains += 1
+                    stats.lost_entries += int(drain["lost"])
+                    continue
+
+                # Count only Pipes-trace lines that failed to parse — mpirun
+                # occasionally splices its rank prefix mid-line under load.
+                # Other log lines are not interesting.
+                if "Pipes trace" in line:
+                    stats.dropped_lines += 1
+    return events, nvl_hint
+
+
+def resolve_topology(
+    events: Sequence[Event],
+    nvl_size_arg: int | None,
+    ib_size_arg: int | None,
+    nvl_size_hint: int | None,
+) -> Topology:
+    auto_detected = False
+    if nvl_size_arg is not None:
+        nvl_size = nvl_size_arg
+    elif nvl_size_hint is not None:
+        nvl_size = nvl_size_hint
+        auto_detected = True
+    else:
+        logger.warning("Could not infer nvl_size from log; defaulting to 2")
+        nvl_size = 2
+
+    if ib_size_arg is not None:
+        ib_size = ib_size_arg
+    else:
+        max_rank = max((e.mpi_rank for e in events), default=0)
+        ib_size = max_rank // max(nvl_size, 1) + 1
+    return Topology(nvl_size=nvl_size, ib_size=ib_size, auto_detected_nvl=auto_detected)
+
+
+def filter_events(
+    events: Iterable[Event],
+    rank_filter: set[int] | None,
+    type_filter: set[str],
+    time_start: int | None,
+    time_end: int | None,
+) -> Iterator[Event]:
+    for e in events:
+        if rank_filter is not None and e.mpi_rank not in rank_filter:
+            continue
+        if "ib" not in type_filter and e.name in IB_NAMES:
+            continue
+        if "nvl" not in type_filter and e.name in NVL_NAMES:
+            continue
+        if time_start is not None and e.ns < time_start:
+            continue
+        if time_end is not None and e.ns >= time_end:
+            continue
+        yield e
+
+
+def group_by_rank(events: Iterable[Event]) -> dict[int, list[Event]]:
+    per_rank: dict[int, list[Event]] = defaultdict(list)
+    for e in events:
+        per_rank[e.mpi_rank].append(e)
+    for lst in per_rank.values():
+        lst.sort(key=lambda e: (e.ns, e.slot))
+    return per_rank
+
+
+def _ib_args(
+    chunk: int,
+    self_r: int,
+    group: int,
+    begin_ns: int,
+    end_ns: int,
+    begin_slot: int,
+    end_slot: int,
+) -> dict[str, object]:
+    return {
+        "chunk": chunk,
+        "ib_rank": self_r,
+        "block": group,
+        "slot_begin": begin_slot,
+        "slot_end": end_slot,
+        "begin_ns": begin_ns,
+        "end_ns": end_ns,
+        "dur_ns": end_ns - begin_ns,
+    }
+
+
+def _nvl_args(
+    chunk: int,
+    ib_src: int,
+    group: int,
+    begin_ns: int,
+    end_ns: int,
+    begin_slot: int,
+    end_slot: int,
+) -> dict[str, object]:
+    return {
+        "chunk": chunk,
+        "ib_src": ib_src,
+        "block": group,
+        "slot_begin": begin_slot,
+        "slot_end": end_slot,
+        "begin_ns": begin_ns,
+        "end_ns": end_ns,
+        "dur_ns": end_ns - begin_ns,
+    }
+
+
+def _ib_op_args(begin: Event, end: Event, op_name: str) -> dict[str, object]:
+    return {
+        "op": op_name,
+        "ib_rank": end.rank,
+        "block": end.group,
+        "byte_begin": begin.step,
+        "byte_end": end.step,
+        "bytes": end.step - begin.step,
+        "slot_begin": begin.slot,
+        "slot_end": end.slot,
+        "begin_ns": begin.ns,
+        "end_ns": end.ns,
+        "dur_ns": end.ns - begin.ns,
+    }
+
+
+def _handle_ib_op_begin(
+    pending: dict[tuple[int, int], Event],
+    e: Event,
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    key = (e.group, e.rank)
+    previous = pending.get(key)
+    if previous is not None:
+        unmatched.append((previous, f"{previous.name} without matching end"))
+    pending[key] = e
+
+
+def _handle_ib_op_end(
+    state: PairState,
+    pending: dict[tuple[int, int], Event],
+    e: Event,
+    op_name: str,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    key = (e.group, e.rank)
+    begin = pending.pop(key, None)
+    if begin is None:
+        unmatched.append((e, f"{e.name} without matching begin"))
+        return
+    slices.append(
+        Slice_(
+            pid=state.mpi_rank,
+            tid=THREAD_OFFSET_IB + e.group,
+            cat=op_name,
+            name=op_name,
+            begin_ns=begin.ns,
+            end_ns=e.ns,
+            args=_ib_op_args(begin, e, op_name),
+        )
+    )
+
+
+def _handle_ib_ready(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+) -> int:
+    key = (e.group, e.step)
+    pending = state.pending_ib.get(key)
+    if pending is not None and e.rank == pending[2]:
+        begin_ns, begin_slot, self_r = pending
+        slices.append(
+            Slice_(
+                pid=state.mpi_rank,
+                tid=THREAD_OFFSET_IB + e.group,
+                cat="ib",
+                name=f"IB chunk {e.step}",
+                begin_ns=begin_ns,
+                end_ns=e.ns,
+                args=_ib_args(
+                    e.step,
+                    self_r,
+                    e.group,
+                    begin_ns,
+                    e.ns,
+                    begin_slot,
+                    e.slot,
+                ),
+            )
+        )
+        del state.pending_ib[key]
+        return 0
+    # Forwarded ready (rank != self) or self-ready with missing begin used to
+    # become Perfetto instant events. Keep only the count now.
+    return 1
+
+
+def _handle_nvl_chunk_ready(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    key = (e.group, e.step, e.rank)
+    wait = state.pending_nvl_wait.pop(key, None)
+    if wait is not None:
+        begin_ns, begin_slot = wait
+        slices.append(
+            Slice_(
+                pid=state.mpi_rank,
+                tid=THREAD_OFFSET_NVL + e.group,
+                cat="nvl_wait",
+                name=f"NVL wait src={e.rank} chunk={e.step}",
+                begin_ns=begin_ns,
+                end_ns=e.ns,
+                args=_nvl_args(
+                    e.step,
+                    e.rank,
+                    e.group,
+                    begin_ns,
+                    e.ns,
+                    begin_slot,
+                    e.slot,
+                ),
+            )
+        )
+    else:
+        unmatched.append((e, "nvl_chunk_ready without matching wait_begin"))
+    state.pending_nvl_bcast[key] = (e.ns, e.slot)
+
+
+def _handle_nvl_task_done(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    key = (e.group, e.step, e.rank)
+    bcast = state.pending_nvl_bcast.pop(key, None)
+    if bcast is None:
+        unmatched.append((e, "nvl_task_done without matching chunk_ready"))
+        return
+    begin_ns, begin_slot = bcast
+    slices.append(
+        Slice_(
+            pid=state.mpi_rank,
+            tid=THREAD_OFFSET_NVL + e.group,
+            cat="nvl_bcast",
+            name=f"NVL bcast src={e.rank} chunk={e.step}",
+            begin_ns=begin_ns,
+            end_ns=e.ns,
+            args=_nvl_args(
+                e.step,
+                e.rank,
+                e.group,
+                begin_ns,
+                e.ns,
+                begin_slot,
+                e.slot,
+            ),
+        )
+    )
+
+
+def _drain_state(state: PairState, unmatched: list[tuple[Event, str]]) -> None:
+    for (group, chunk), (_, _, self_r) in state.pending_ib.items():
+        unmatched.append(
+            (
+                Event(
+                    mpi_rank=state.mpi_rank,
+                    name=AG_IB_BEGIN,
+                    step=chunk,
+                    rank=self_r,
+                    group=group,
+                    slot=-1,
+                    ns=-1,
+                ),
+                "ib_chunk_begin without matching ready",
+            )
+        )
+    for (group, chunk, src), _ in state.pending_nvl_wait.items():
+        unmatched.append(
+            (
+                Event(
+                    mpi_rank=state.mpi_rank,
+                    name=AG_NVL_WAIT_BEGIN,
+                    step=chunk,
+                    rank=src,
+                    group=group,
+                    slot=-1,
+                    ns=-1,
+                ),
+                "nvl_wait_begin without chunk_ready",
+            )
+        )
+    for (group, chunk, src), _ in state.pending_nvl_bcast.items():
+        unmatched.append(
+            (
+                Event(
+                    mpi_rank=state.mpi_rank,
+                    name=AG_NVL_CHUNK_READY,
+                    step=chunk,
+                    rank=src,
+                    group=group,
+                    slot=-1,
+                    ns=-1,
+                ),
+                "nvl_chunk_ready without task_done",
+            )
+        )
+    for _, event in state.pending_ib_send.items():
+        unmatched.append((event, f"{event.name} without matching end"))
+    for _, event in state.pending_ib_recv.items():
+        unmatched.append((event, f"{event.name} without matching end"))
+    for _, event in state.pending_ib_forward.items():
+        unmatched.append((event, f"{event.name} without matching end"))
+
+
+def _handle_ib_event(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> int:
+    if e.name == AG_IB_BEGIN:
+        state.pending_ib[(e.group, e.step)] = (e.ns, e.slot, e.rank)
+    elif e.name == AG_IB_READY:
+        return _handle_ib_ready(state, e, slices)
+    elif e.name == IB_SEND_BEGIN:
+        _handle_ib_op_begin(state.pending_ib_send, e, unmatched)
+    elif e.name == IB_SEND_END:
+        _handle_ib_op_end(state, state.pending_ib_send, e, IB_SEND, slices, unmatched)
+    elif e.name == IB_RECV_BEGIN:
+        _handle_ib_op_begin(state.pending_ib_recv, e, unmatched)
+    elif e.name == IB_RECV_END:
+        _handle_ib_op_end(state, state.pending_ib_recv, e, IB_RECV, slices, unmatched)
+    elif e.name == IB_FORWARD_BEGIN:
+        _handle_ib_op_begin(state.pending_ib_forward, e, unmatched)
+    elif e.name == IB_FORWARD_END:
+        _handle_ib_op_end(
+            state,
+            state.pending_ib_forward,
+            e,
+            IB_FORWARD,
+            slices,
+            unmatched,
+        )
+    else:
+        unmatched.append((e, f"unknown IB event name {e.name!r}"))
+    return 0
+
+
+def _handle_nvl_event(
+    state: PairState,
+    e: Event,
+    slices: list[Slice_],
+    unmatched: list[tuple[Event, str]],
+) -> None:
+    if e.name == AG_NVL_WAIT_BEGIN:
+        state.pending_nvl_wait[(e.group, e.step, e.rank)] = (
+            e.ns,
+            e.slot,
+        )
+    elif e.name == AG_NVL_CHUNK_READY:
+        _handle_nvl_chunk_ready(state, e, slices, unmatched)
+    elif e.name == AG_NVL_TASK_DONE:
+        _handle_nvl_task_done(state, e, slices, unmatched)
+    else:
+        unmatched.append((e, f"unknown NVL event name {e.name!r}"))
+
+
+def pair_events(
+    per_rank: dict[int, list[Event]],
+) -> tuple[list[Slice_], int, list[tuple[Event, str]]]:
+    slices: list[Slice_] = []
+    unpaired_instant_count = 0
+    unmatched: list[tuple[Event, str]] = []
+
+    for mpi_rank, evs in per_rank.items():
+        state = PairState(mpi_rank=mpi_rank)
+        for e in evs:
+            if e.name in IB_NAMES:
+                unpaired_instant_count += _handle_ib_event(state, e, slices, unmatched)
+            elif e.name in NVL_NAMES:
+                _handle_nvl_event(state, e, slices, unmatched)
+            else:
+                unmatched.append((e, f"unknown event name {e.name!r}"))
+        _drain_state(state, unmatched)
+    return slices, unpaired_instant_count, unmatched
+
+
+def _compute_used_tids(slices: Sequence[Slice_]) -> dict[int, set[int]]:
+    used: dict[int, set[int]] = defaultdict(set)
+    for s in slices:
+        used[s.pid].add(s.tid)
+    return used
+
+
+def _compute_min_ns(slices: Sequence[Slice_]) -> int:
+    candidates: list[int] = [s.begin_ns for s in slices]
+    return min(candidates) if candidates else 0
+
+
+def _emit_metadata(
+    pids: Sequence[int],
+    used_tids: dict[int, set[int]],
+    topology: Topology,
+) -> list[dict[str, object]]:
+    out: list[dict[str, object]] = []
+    nvl_size = max(topology.nvl_size, 1)
+    for pid in sorted(set(pids)):
+        ib_rank = pid // nvl_size
+        nvl_rank = pid % nvl_size
+        out.append(
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": pid,
+                "args": {"name": f"rank {pid} (ib={ib_rank} nvl={nvl_rank})"},
+            }
+        )
+        out.append(
+            {
+                "ph": "M",
+                "name": "process_sort_index",
+                "pid": pid,
+                "args": {"sort_index": pid},
+            }
+        )
+        for tid in sorted(used_tids.get(pid, set())):
+            if tid >= THREAD_OFFSET_NVL:
+                kind, block = "NVL", tid - THREAD_OFFSET_NVL
+            else:
+                kind, block = "IB", tid - THREAD_OFFSET_IB
+            out.append(
+                {
+                    "ph": "M",
+                    "name": "thread_name",
+                    "pid": pid,
+                    "tid": tid,
+                    "args": {"name": f"{kind} block {block}"},
+                }
+            )
+            out.append(
+                {
+                    "ph": "M",
+                    "name": "thread_sort_index",
+                    "pid": pid,
+                    "tid": tid,
+                    "args": {"sort_index": tid},
+                }
+            )
+    return out
+
+
+def build_trace(
+    slices: Sequence[Slice_],
+    topology: Topology,
+    pids: Sequence[int],
+) -> dict[str, object]:
+    used_tids = _compute_used_tids(slices)
+    min_ns = _compute_min_ns(slices)
+
+    trace_events: list[dict[str, object]] = _emit_metadata(pids, used_tids, topology)
+
+    for s in slices:
+        trace_events.append(
+            {
+                "ph": "X",
+                "name": s.name,
+                "cat": s.cat,
+                "pid": s.pid,
+                "tid": s.tid,
+                "ts": (s.begin_ns - min_ns) / 1000.0,
+                "dur": (s.end_ns - s.begin_ns) / 1000.0,
+                "args": s.args,
+            }
+        )
+
+    return {
+        "displayTimeUnit": "ns",
+        "traceEvents": trace_events,
+        "meta": {
+            "time_offset_ns": min_ns,
+            "nvl_size": topology.nvl_size,
+            "ib_size": topology.ib_size,
+            "nvl_size_auto_detected": topology.auto_detected_nvl,
+        },
+    }
+
+
+def write_json(trace: dict[str, object], out_path: str, gzip_: bool) -> str:
+    payload = json.dumps(trace, separators=(",", ":"))
+    if gzip_:
+        if not out_path.endswith(".gz"):
+            out_path += ".gz"
+        with gzip.open(out_path, "wt", encoding="utf-8") as fh:
+            fh.write(payload)
+    else:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+    return out_path
+
+
+def parse_csv_ints(value: str) -> set[int]:
+    return {int(x.strip()) for x in value.split(",") if x.strip()}
+
+
+def parse_csv_strs(value: str) -> set[str]:
+    return {x.strip() for x in value.split(",") if x.strip()}
+
+
+def default_output(first_log: str) -> str:
+    if first_log == "-":
+        return "pipestrace.perfetto.json"
+    base = os.path.basename(first_log)
+    if base.endswith(".log"):
+        base = base[:-4]
+    return f"{base}.perfetto.json"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pipestrace_to_perfetto",
+        description=(
+            "Convert PipesTrace log lines into a Perfetto / Chrome Trace "
+            "Event JSON timeline that can be opened at "
+            "https://ui.perfetto.dev/."
+        ),
+    )
+    p.add_argument(
+        "log_file",
+        nargs="+",
+        help="One or more captured launcher logs. '-' reads stdin.",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        help="Output JSON path. Default: <first log basename>.perfetto.json",
+    )
+    p.add_argument(
+        "--gzip",
+        action="store_true",
+        help="Write gzip-compressed JSON (.json.gz). Perfetto UI accepts gz.",
+    )
+    p.add_argument(
+        "--nvl-size",
+        type=int,
+        help=(
+            "Procs per node (= nvl_size). Default: auto-detect from the "
+            "mpirun -host h1:p,... line; fall back to 2 with a warning."
+        ),
+    )
+    p.add_argument(
+        "--ib-size",
+        type=int,
+        help="Number of IB nodes. Default: max_mpi_rank // nvl_size + 1.",
+    )
+    p.add_argument(
+        "--ranks",
+        type=parse_csv_ints,
+        help="Comma-list of MPI ranks to include. Default: all.",
+    )
+    p.add_argument(
+        "--types",
+        type=parse_csv_strs,
+        default={"ib", "nvl"},
+        help="Block kinds to include: ib,nvl. Default: ib,nvl.",
+    )
+    p.add_argument(
+        "--time-start",
+        type=int,
+        help="Drop events with wall_time_ns < NS.",
+    )
+    p.add_argument(
+        "--time-end",
+        type=int,
+        help="Drop events with wall_time_ns >= NS.",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log parse summary (counts, dropped, unmatched).",
+    )
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 2 on any unmatched begin/end pair or lost trace entries.",
+    )
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if "ib" not in args.types and "nvl" not in args.types:
+        logger.error("--types must include at least one of ib,nvl")
+        return 1
+
+    stats = ParseStats()
+    raw_events, nvl_hint = parse_events(args.log_file, stats)
+    if not raw_events:
+        logger.error("No Pipes trace events parsed from %s", args.log_file)
+        return 1
+
+    topology = resolve_topology(raw_events, args.nvl_size, args.ib_size, nvl_hint)
+    logger.debug(
+        "Topology: nvl_size=%d ib_size=%d auto_detected=%s",
+        topology.nvl_size,
+        topology.ib_size,
+        topology.auto_detected_nvl,
+    )
+
+    filtered = list(
+        filter_events(
+            raw_events,
+            rank_filter=args.ranks,
+            type_filter=args.types,
+            time_start=args.time_start,
+            time_end=args.time_end,
+        )
+    )
+    logger.debug("Filtered events: %d (from %d raw)", len(filtered), len(raw_events))
+
+    per_rank = group_by_rank(filtered)
+    slices, unpaired_instant_count, unmatched = pair_events(per_rank)
+    logger.debug(
+        "Parse stats: events=%d drains=%d lost_entries=%d dropped_lines=%d "
+        "unpaired_instants=%d",
+        stats.events,
+        stats.drains,
+        stats.lost_entries,
+        stats.dropped_lines,
+        unpaired_instant_count,
+    )
+    if stats.lost_entries:
+        logger.warning(
+            "Pipes trace reported %d lost trace entries across %d drain records",
+            stats.lost_entries,
+            stats.drains,
+        )
+    logger.debug(
+        "Pair results: slices=%d unpaired_instants=%d unmatched=%d",
+        len(slices),
+        unpaired_instant_count,
+        len(unmatched),
+    )
+    if args.verbose:
+        for ev, reason in unmatched[:50]:
+            logger.debug("unmatched: %s (%s)", reason, ev)
+        if len(unmatched) > 50:
+            logger.debug("... and %d more", len(unmatched) - 50)
+
+    pids = sorted({e.mpi_rank for e in filtered})
+    trace = build_trace(slices, topology, pids)
+    out_path = args.output or default_output(args.log_file[0])
+    written = write_json(trace, out_path, gzip_=args.gzip)
+    logger.warning(
+        "Wrote %s (%d slices, %d unpaired instants suppressed)",
+        written,
+        len(slices),
+        unpaired_instant_count,
+    )
+
+    if args.strict and (unmatched or stats.lost_entries):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
+++ b/comms/pipes/scripts/tests/test_pipestrace_to_perfetto.py
@@ -1,0 +1,319 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+"""Unit tests for pipestrace_to_perfetto.
+
+Run with:
+``buck2 test @fbcode//mode/opt -c hpc_comms.use_ncclx=stable //comms/pipes/scripts/tests:test_pipestrace_to_perfetto``
+or directly: ``python3 -m unittest`` from this directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+# Keep direct `python3 -m unittest` execution working outside Buck.
+_SCRIPT_DIR = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_SCRIPT_DIR))
+import pipestrace_to_perfetto as ptp  # noqa: E402
+
+
+def _event_line(
+    rank: int, name: str, step: int, r: int, detail: int, slot: int, ns: int
+) -> str:
+    return (
+        f"[1,{rank}]<stderr>:I0531 12:00:00.000000 1234 PipesTrace.cc:168] "
+        f"Pipes trace event={name} step={step} rank={r} detail={detail} "
+        f"slot={slot} wall_time_ns={ns}\n"
+    )
+
+
+def _drain_line(rank: int, read: int, lost: int, last: int) -> str:
+    return (
+        f"[1,{rank}]<stderr>:I0531 12:00:00.000100 1234 PipesTrace.cc:179] "
+        f"Pipes trace drain entries_read={read} entries_lost={lost} "
+        f"last_read={last}\n"
+    )
+
+
+class EventRegexTest(unittest.TestCase):
+    def test_matches_well_formed_event(self) -> None:
+        line = _event_line(7, ptp.AG_IB_BEGIN, 3, 3, 0, 0, 1780268274964010916)
+        match = ptp.EVENT_RE.match(line)
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual("7", match["mpi_rank"])
+        self.assertEqual(ptp.AG_IB_BEGIN, match["name"])
+        self.assertEqual("1780268274964010916", match["ns"])
+
+    def test_matches_drain(self) -> None:
+        match = ptp.DRAIN_RE.match(_drain_line(1, 68, 0, 68))
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual("68", match["read"])
+        self.assertEqual("0", match["lost"])
+
+    def test_negative_rank_field(self) -> None:
+        line = _event_line(0, ptp.AG_IB_BEGIN, 0, -1, 0, 0, 100)
+        event = ptp._parse_event_line(line)
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual(0, event.step)
+        self.assertEqual(-1, event.rank)
+
+
+class ParseEventsTest(unittest.TestCase):
+    def test_concatenated_tagged_events_are_dropped(self) -> None:
+        log = _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000).rstrip(
+            "\n"
+        ) + _event_line(0, ptp.AG_IB_READY, 0, 0, 0, 1, 1_000_000_100)
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            with open(log_path, "w") as f:
+                f.write(log)
+            stats = ptp.ParseStats()
+            events, _ = ptp.parse_events([log_path], stats)
+        self.assertEqual([], events)
+        self.assertEqual(0, stats.events)
+        self.assertEqual(1, stats.dropped_lines)
+
+    def test_drain_lost_entries_are_counted(self) -> None:
+        log = _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000)
+        log += _drain_line(0, read=8, lost=3, last=11)
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            with open(log_path, "w") as f:
+                f.write(log)
+            stats = ptp.ParseStats()
+            events, _ = ptp.parse_events([log_path], stats)
+        self.assertEqual(1, len(events))
+        self.assertEqual(1, stats.drains)
+        self.assertEqual(3, stats.lost_entries)
+
+
+class FilterEventsTest(unittest.TestCase):
+    def test_rank_and_type_and_time_filters(self) -> None:
+        events = [
+            ptp.Event(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 100),
+            ptp.Event(1, ptp.AG_IB_BEGIN, 0, 1, 0, 0, 200),
+            ptp.Event(0, ptp.AG_NVL_WAIT_BEGIN, 0, 0, 0, 1, 300),
+            ptp.Event(0, ptp.AG_IB_READY, 0, 0, 0, 2, 400),
+        ]
+        out = list(
+            ptp.filter_events(
+                events,
+                rank_filter={0},
+                type_filter={"ib"},
+                time_start=150,
+                time_end=500,
+            )
+        )
+        self.assertCountEqual([events[3]], out)
+
+
+class PairIbTest(unittest.TestCase):
+    def test_self_ready_closes_slice_forwarded_are_counted(self) -> None:
+        evs = [
+            ptp.Event(6, ptp.AG_IB_BEGIN, 0, 3, 0, 0, 100),
+            ptp.Event(6, ptp.AG_IB_READY, 0, 3, 0, 1, 200),  # self
+            ptp.Event(6, ptp.AG_IB_READY, 0, 2, 0, 2, 250),  # forwarded
+            ptp.Event(6, ptp.AG_IB_READY, 0, 1, 0, 3, 300),  # forwarded
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({6: evs})
+        self.assertEqual(1, len(slices))
+        self.assertEqual("IB chunk 0", slices[0].name)
+        self.assertEqual(100, slices[0].begin_ns)
+        self.assertEqual(200, slices[0].end_ns)
+        self.assertEqual(3, slices[0].args["ib_rank"])
+        self.assertEqual(2, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+
+    def test_missing_begin_is_counted_not_sliced(self) -> None:
+        evs = [ptp.Event(0, ptp.AG_IB_READY, 0, 0, 0, 1, 200)]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({0: evs})
+        self.assertEqual([], slices)
+        self.assertEqual(1, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+
+    def test_unmatched_begin_reported(self) -> None:
+        evs = [ptp.Event(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 100)]
+        _, _, unmatched = ptp.pair_events({0: evs})
+        self.assertEqual(1, len(unmatched))
+        self.assertIn("ib_chunk_begin", unmatched[0][1])
+
+    def test_ib_send_recv_forward_slices(self) -> None:
+        evs = [
+            ptp.Event(0, ptp.IB_SEND_BEGIN, 0, 1, 0, 0, 100),
+            ptp.Event(0, ptp.IB_SEND_END, 16, 1, 0, 1, 120),
+            ptp.Event(0, ptp.IB_RECV_BEGIN, 32, 2, 0, 2, 130),
+            ptp.Event(0, ptp.IB_RECV_END, 48, 2, 0, 3, 160),
+            ptp.Event(0, ptp.IB_FORWARD_BEGIN, 64, 3, 0, 4, 170),
+            ptp.Event(0, ptp.IB_FORWARD_END, 96, 3, 0, 5, 210),
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({0: evs})
+        self.assertEqual(0, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+        self.assertCountEqual(
+            [ptp.IB_SEND, ptp.IB_RECV, ptp.IB_FORWARD],
+            [s.cat for s in slices],
+        )
+        send = next(s for s in slices if s.cat == ptp.IB_SEND)
+        self.assertEqual((100, 120), (send.begin_ns, send.end_ns))
+        self.assertEqual(16, send.args["bytes"])
+
+
+class PairNvlTest(unittest.TestCase):
+    def test_wait_and_bcast_slices(self) -> None:
+        evs = [
+            ptp.Event(0, ptp.AG_NVL_WAIT_BEGIN, 0, 3, 0, 0, 100),
+            ptp.Event(0, ptp.AG_NVL_CHUNK_READY, 0, 3, 0, 1, 150),
+            ptp.Event(0, ptp.AG_NVL_TASK_DONE, 0, 3, 0, 2, 200),
+        ]
+        slices, unpaired_instant_count, unmatched = ptp.pair_events({0: evs})
+        wait = next(s for s in slices if s.cat == "nvl_wait")
+        bcast = next(s for s in slices if s.cat == "nvl_bcast")
+        self.assertEqual((100, 150), (wait.begin_ns, wait.end_ns))
+        self.assertEqual((150, 200), (bcast.begin_ns, bcast.end_ns))
+        self.assertEqual(3, wait.args["ib_src"])
+        self.assertEqual(0, unpaired_instant_count)
+        self.assertEqual([], unmatched)
+
+    def test_orphan_task_done_reported(self) -> None:
+        evs = [ptp.Event(0, ptp.AG_NVL_TASK_DONE, 0, 3, 0, 0, 100)]
+        slices, _, unmatched = ptp.pair_events({0: evs})
+        self.assertEqual([], slices)
+        self.assertEqual(1, len(unmatched))
+        self.assertIn("task_done", unmatched[0][1])
+
+
+class BuildTraceTest(unittest.TestCase):
+    def test_ts_dur_offset_and_metadata(self) -> None:
+        slices = [
+            ptp.Slice_(
+                pid=6,
+                tid=100,
+                cat="ib",
+                name="IB chunk 0",
+                begin_ns=1_000_000_000,
+                end_ns=1_000_017_296,
+                args={"chunk": 0, "ib_rank": 3, "block": 0},
+            )
+        ]
+        topo = ptp.Topology(nvl_size=2, ib_size=4, auto_detected_nvl=False)
+        trace = ptp.build_trace(slices, topo, pids=[6])
+
+        self.assertEqual("ns", trace["displayTimeUnit"])
+        meta = trace["meta"]
+        assert isinstance(meta, dict)
+        self.assertEqual(1_000_000_000, meta["time_offset_ns"])
+        self.assertEqual(2, meta["nvl_size"])
+
+        events = trace["traceEvents"]
+        assert isinstance(events, list)
+        # process_name reflects ib/nvl derivation: rank 6 / nvl_size 2 → ib=3, nvl=0
+        proc_name = next(
+            e for e in events if e.get("ph") == "M" and e.get("name") == "process_name"
+        )
+        self.assertEqual("rank 6 (ib=3 nvl=0)", proc_name["args"]["name"])
+
+        x = next(e for e in events if e.get("ph") == "X")
+        self.assertEqual(0.0, x["ts"])
+        self.assertAlmostEqual(17.296, x["dur"])
+        self.assertFalse(any(e.get("ph") == "i" for e in events))
+
+
+class EndToEndCliTest(unittest.TestCase):
+    def test_writes_well_formed_json(self) -> None:
+        log = (
+            "INFO:root:Running mpirun -np 1 -host h:1 --tag-output app\n"
+            + _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000)
+            + _event_line(0, ptp.AG_IB_READY, 0, 0, 0, 1, 1_000_000_100)
+            + _event_line(0, ptp.AG_NVL_WAIT_BEGIN, 0, 0, 0, 2, 1_000_000_200)
+            + _event_line(0, ptp.AG_NVL_CHUNK_READY, 0, 0, 0, 3, 1_000_000_300)
+            + _event_line(0, ptp.AG_NVL_TASK_DONE, 0, 0, 0, 4, 1_000_000_400)
+        )
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            rc = ptp.main([log_path, "-o", out_path])
+            self.assertEqual(0, rc)
+            with open(out_path) as f:
+                trace = json.load(f)
+        events = trace["traceEvents"]
+        x_phases = [e for e in events if e.get("ph") == "X"]
+        # Three slices: IB chunk + NVL wait + NVL bcast.
+        self.assertEqual(3, len(x_phases))
+
+    def test_logs_unpaired_instant_count(self) -> None:
+        log = (
+            _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000)
+            + _event_line(0, ptp.AG_IB_READY, 0, 0, 0, 1, 1_000_000_100)
+            + _event_line(0, ptp.AG_IB_READY, 0, 1, 0, 2, 1_000_000_200)
+        )
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            with self.assertLogs(ptp.logger, level="WARNING") as logs:
+                rc = ptp.main([log_path, "-o", out_path, "--nvl-size", "1"])
+            self.assertEqual(0, rc)
+        self.assertTrue(
+            any("1 unpaired instants suppressed" in message for message in logs.output)
+        )
+
+    def test_strict_returns_2_on_unmatched(self) -> None:
+        log = _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 100)  # no ready
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            rc = ptp.main([log_path, "-o", out_path, "--nvl-size", "1", "--strict"])
+            self.assertEqual(2, rc)
+
+    def test_no_events_returns_1(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write("no pipes trace here\n")
+            rc = ptp.main([log_path, "-o", out_path])
+            self.assertEqual(1, rc)
+
+    def test_warns_when_drain_reports_lost_entries(self) -> None:
+        log = (
+            _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000)
+            + _event_line(0, ptp.AG_IB_READY, 0, 0, 0, 1, 1_000_000_100)
+            + _drain_line(0, read=2, lost=5, last=7)
+        )
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            with self.assertLogs(ptp.logger, level="WARNING") as logs:
+                rc = ptp.main([log_path, "-o", out_path, "--nvl-size", "1"])
+            self.assertEqual(0, rc)
+        self.assertTrue(
+            any("reported 5 lost trace entries" in message for message in logs.output)
+        )
+
+    def test_strict_returns_2_on_lost_entries(self) -> None:
+        log = (
+            _event_line(0, ptp.AG_IB_BEGIN, 0, 0, 0, 0, 1_000_000_000)
+            + _event_line(0, ptp.AG_IB_READY, 0, 0, 0, 1, 1_000_000_100)
+            + _drain_line(0, read=2, lost=1, last=3)
+        )
+        with tempfile.TemporaryDirectory() as d:
+            log_path = os.path.join(d, "x.log")
+            out_path = os.path.join(d, "x.perfetto.json")
+            with open(log_path, "w") as f:
+                f.write(log)
+            rc = ptp.main([log_path, "-o", out_path, "--nvl-size", "1", "--strict"])
+            self.assertEqual(2, rc)

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -315,13 +315,15 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const std::size_t window =
             remaining < ib_window ? remaining : ib_window;
 
-        next.template send<MemcpyAndSelfCopy>(
+        next.template sendWithTrace<MemcpyAndSelfCopy>(
             group,
             send_src + chunk_off,
             window,
             args.ib_num_blocks,
             args.ib_signaling_data_size,
             timeout,
+            args.trace,
+            static_cast<uint8_t>(args.ib_rank),
             own_dst + chunk_off);
 
         int fwd_current_rank = args.ib_rank;
@@ -334,22 +336,26 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
               off + chunk_off;
 
           if (step < W - 2) {
-            prev.forward(
+            prev.forwardWithTrace(
                 group,
                 dst,
                 next,
                 window,
                 args.ib_num_blocks,
                 args.ib_signaling_data_size,
-                timeout);
+                timeout,
+                args.trace,
+                static_cast<uint8_t>(args.ib_rank));
           } else {
-            prev.recv(
+            prev.recvWithTrace(
                 group,
                 dst,
                 window,
                 args.ib_num_blocks,
                 args.ib_signaling_data_size,
-                timeout);
+                timeout,
+                args.trace,
+                static_cast<uint8_t>(args.ib_rank));
           }
         }
       }

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -326,6 +326,26 @@ void runTestPutCooperativePartitioningBlock(bool* d_success) {
 }
 
 // =============================================================================
+// trace_ibgda_event test kernel
+// =============================================================================
+
+__global__ void testTraceIbgdaEvent(PipesTraceHandle trace) {
+#if PIPES_IS_DEVICE_COMPILE
+  trace_ibgda_event(
+      trace,
+      /*self_rank=*/7,
+      PipesTraceEventType::kIbSendBegin,
+      /*step=*/0x12345678,
+      /*group_id=*/0x4321);
+#endif
+}
+
+void runTestTraceIbgdaEvent(PipesTraceHandle trace) {
+  testTraceIbgdaEvent<<<1, 1>>>(trace);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
 // wait_signal timeout test kernels
 // =============================================================================
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims::tests {
@@ -70,6 +71,9 @@ void runTestBroadcast64DoubleSafety(bool* d_success);
 
 // Test put_cooperative partitioning logic with block-sized groups
 void runTestPutCooperativePartitioningBlock(bool* d_success);
+
+// Test trace_ibgda_event writes the expected trace payload.
+void runTestTraceIbgdaEvent(PipesTraceHandle trace);
 
 // =============================================================================
 // wait_signal timeout tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -21,6 +21,8 @@
 #include "comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/utils/CudaRAII.h"
 #endif
@@ -269,6 +271,42 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, PutCooperativePartitioningBlock) {
     runTestPutCooperativePartitioningBlock(d_success);
   });
 }
+
+#ifndef __HIP_PLATFORM_AMD__
+TEST_F(P2pIbgdaTransportDeviceTestFixture, TraceIbgdaEventWritesEvent) {
+  cudaDeviceProp props{};
+  CUDACHECK_TEST(cudaGetDeviceProperties(&props, 0));
+  if (props.major < 9) {
+    GTEST_SKIP() << "HRDWRingBuffer trace writes require sm_90+";
+  }
+
+  ::hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent> traceBuffer(8);
+  ASSERT_TRUE(traceBuffer.valid());
+
+  auto deviceHandle = traceBuffer.deviceHandle();
+  runTestTraceIbgdaEvent(
+      PipesTraceHandle{
+          .ring = reinterpret_cast<PipesTraceEntry*>(deviceHandle.ring),
+          .writeIndex = deviceHandle.writeIndex,
+          .mask = deviceHandle.mask,
+          .shift = deviceHandle.shift});
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<PipesTraceEvent> events;
+  ::hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent> reader(traceBuffer);
+  const auto result = reader.poll(
+      [&](const auto& entry, uint64_t) { events.push_back(entry.data); });
+
+  EXPECT_EQ(result.entriesLost, 0u);
+  ASSERT_EQ(result.entriesRead, 1u);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].step, 0x12345678u);
+  EXPECT_EQ(events[0].detail, 0x4321u);
+  EXPECT_EQ(
+      events[0].type, static_cast<uint8_t>(PipesTraceEventType::kIbSendBegin));
+  EXPECT_EQ(events[0].rank, 7u);
+}
+#endif // !__HIP_PLATFORM_AMD__
 
 // =============================================================================
 // wait_signal Timeout Tests

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -31,6 +31,18 @@ const char* pipesTraceEventTypeName(uint8_t type) {
       return "hier_ag_nvl_chunk_ready";
     case Type::kHierAgNvlTaskDone:
       return "hier_ag_nvl_task_done";
+    case Type::kIbSendBegin:
+      return "ib_send_begin";
+    case Type::kIbSendEnd:
+      return "ib_send_end";
+    case Type::kIbRecvBegin:
+      return "ib_recv_begin";
+    case Type::kIbRecvEnd:
+      return "ib_recv_end";
+    case Type::kIbForwardBegin:
+      return "ib_forward_begin";
+    case Type::kIbForwardEnd:
+      return "ib_forward_end";
   }
   return "unknown";
 }
@@ -119,7 +131,12 @@ PipesTraceHandle PipesTrace::deviceHandle() const {
   if (buffer_ == nullptr) {
     return {};
   }
-  return buffer_->deviceHandle();
+  auto handle = buffer_->deviceHandle();
+  return PipesTraceHandle{
+      .ring = reinterpret_cast<PipesTraceEntry*>(handle.ring),
+      .writeIndex = handle.writeIndex,
+      .mask = handle.mask,
+      .shift = handle.shift};
 }
 
 void PipesTrace::drain() {

--- a/comms/prims/trace/PipesTraceTypes.h
+++ b/comms/prims/trace/PipesTraceTypes.h
@@ -4,7 +4,9 @@
 
 #include <cstdint>
 
-#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+#include <cuda/atomic>
+#endif
 
 namespace comms::prims {
 
@@ -15,6 +17,13 @@ enum class PipesTraceEventType : uint8_t {
   kHierAgNvlWaitBegin = 3,
   kHierAgNvlChunkReady = 4,
   kHierAgNvlTaskDone = 5,
+
+  kIbSendBegin = 6,
+  kIbSendEnd = 7,
+  kIbRecvBegin = 8,
+  kIbRecvEnd = 9,
+  kIbForwardBegin = 10,
+  kIbForwardEnd = 11,
 };
 
 struct PipesTraceEvent {
@@ -26,20 +35,86 @@ struct PipesTraceEvent {
 
 static_assert(sizeof(PipesTraceEvent) == 8);
 
-using PipesTraceHandle =
-    ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
+struct alignas(16) PipesTraceEntry {
+  uint32_t timestamp;
+  uint32_t epoch;
+  PipesTraceEvent data;
+};
+
+static_assert(sizeof(PipesTraceEntry) == 16);
+static_assert(alignof(PipesTraceEntry) == 16);
+
+struct PipesTraceHandle {
+  PipesTraceEntry* ring{nullptr};
+  uint64_t* writeIndex{nullptr};
+  uint32_t mask{0};
+  uint32_t shift{0};
+};
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
+__device__ __forceinline__ uint64_t read_pipes_trace_globaltimer() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  uint64_t timer;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(timer));
+  return timer;
+#else
+  return 0;
+#endif
+}
+
 __device__ __forceinline__ void write_pipes_trace(
     PipesTraceHandle trace,
     PipesTraceEventType type,
     uint32_t step,
     uint16_t detail,
     uint8_t rank) {
-  if (trace.ring == nullptr) {
+  if (trace.ring == nullptr || trace.writeIndex == nullptr) {
     return;
   }
-  trace.write(PipesTraceEvent{step, detail, static_cast<uint8_t>(type), rank});
+
+#if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 900)
+  // The backing ring uses 128-bit atomics, which are only available on
+  // Hopper+. Keep traced kernels buildable for other device targets.
+  (void)type;
+  (void)step;
+  (void)detail;
+  (void)rank;
+  return;
+#else
+  uint64_t slot =
+      cuda::atomic_ref<uint64_t, cuda::thread_scope_system>(*trace.writeIndex)
+          .fetch_add(1ULL, cuda::memory_order_relaxed);
+  uint64_t idx = slot & trace.mask;
+
+  PipesTraceEntry packed{};
+  packed.timestamp =
+      static_cast<uint32_t>(read_pipes_trace_globaltimer() >> 10);
+  packed.epoch = static_cast<uint32_t>(slot >> trace.shift) + 1u;
+  packed.data = PipesTraceEvent{
+      .step = step,
+      .detail = detail,
+      .type = static_cast<uint8_t>(type),
+      .rank = rank};
+
+  uint64_t packed_lo, packed_hi;
+  __builtin_memcpy(&packed_lo, &packed, sizeof(packed_lo));
+  __builtin_memcpy(
+      &packed_hi,
+      reinterpret_cast<const char*>(&packed) + sizeof(packed_lo),
+      sizeof(packed_hi));
+
+  [[maybe_unused]] uint64_t prev_lo, prev_hi;
+  asm volatile(
+      "{ .reg .b128 _src, _dst;\n\t"
+      "  mov.b128 _src, {%2, %3};\n\t"
+      "  atom.exch.relaxed.sys.b128 _dst, [%4], _src;\n\t"
+      "  mov.b128 {%0, %1}, _dst; }"
+      : "=l"(prev_lo), "=l"(prev_hi)
+      : "l"(packed_lo), "l"(packed_hi), "l"(&trace.ring[idx])
+      : "memory");
+#endif
 }
 #endif
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -30,6 +30,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
@@ -37,6 +38,24 @@ namespace comms::prims {
 struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
+
+#if PIPES_IS_DEVICE_COMPILE
+__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
+  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
+  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
+}
+
+__device__ __forceinline__ void trace_ibgda_event(
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    PipesTraceEventType type,
+    uint32_t step,
+    uint16_t group_id) {
+  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
+  // unconfigured handle has effectively no cost.
+  write_pipes_trace(trace, type, step, group_id, self_rank);
+}
+#endif
 
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
@@ -1731,6 +1750,40 @@ class P2pIbgdaTransportDevice {
     (void)max_signal_bytes;
     (void)timeout;
 #else
+    sendWithTrace<CopyOp>(
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+#endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void sendWithTrace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    (void)trace;
+    (void)self_rank;
+#else
     if (nbytes == 0) {
       return;
     }
@@ -1791,6 +1844,15 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Busy;
       state.activeBaseStep = static_cast<int64_t>(baseByte);
       state.activeNextByte = 0;
+    }
+
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbSendBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
     }
 
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
@@ -1867,6 +1929,12 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbSendEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif
@@ -1916,6 +1984,40 @@ class P2pIbgdaTransportDevice {
     (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
+#else
+    recvWithTrace<CopyOp>(
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+#endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recvWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    (void)trace;
+    (void)self_rank;
 #else
     if (nbytes == 0) {
       return;
@@ -1979,6 +2081,15 @@ class P2pIbgdaTransportDevice {
       state.activeNextByte = 0;
     }
 
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbRecvBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
+    }
+
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
@@ -2027,6 +2138,12 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbRecvEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif
@@ -2099,6 +2216,31 @@ class P2pIbgdaTransportDevice {
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
+      Args... args) {
+    forwardWithTrace<CopyOp>(
+        group,
+        dst,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forwardWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
       Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
@@ -2201,6 +2343,15 @@ class P2pIbgdaTransportDevice {
       fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
       fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
       fwdSlotState.activeNextByte = 0;
+    }
+
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbForwardBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
     }
 
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
@@ -2315,6 +2466,12 @@ class P2pIbgdaTransportDevice {
       fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
       fwdSlotState.activeBaseStep = 0;
       fwdSlotState.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbForwardEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif


### PR DESCRIPTION
Summary:

Adds `pipestrace_to_perfetto.py`, a stdlib-only utility for converting `PipesTrace` log lines from tagged launcher logs into Perfetto/Chrome Trace Event JSON.

The script parses IB and NVL trace events, optionally filters by rank, event type, and timestamp range, infers topology from `mpirun -host` output or explicit CLI args, and pairs begin/ready/done events into duration slices. Forwarded `ib_ready` events are emitted as instant markers by default, with `--no-instants` available to suppress them. The output can be written as plain JSON or gzip-compressed JSON for loading in Perfetto UI.

Adds unit tests covering log regex parsing, filtering, IB/NVL event pairing, Perfetto trace construction, strict unmatched-event handling, and end-to-end CLI JSON generation, plus a Buck unittest target for the test suite.

Differential Revision: D107277104
