### PR TITLE
Add online accuracy/perf test assets

### DIFF
--- a/comms/uniflow/benchmarks/disagg_accuracy_test.py
+++ b/comms/uniflow/benchmarks/disagg_accuracy_test.py
@@ -1,0 +1,761 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""
+Disaggregated serving accuracy and performance test.
+
+Replicates vLLM's production test methodology:
+  1. Standalone baseline server (no disagg) → reference outputs
+  2. Disagg pipeline (prefill + decode + proxy) → exact match
+  3. Performance benchmark through disagg proxy
+
+Usage:
+  torchx run fb.dist.ddp -j 1x2 -m comms.uniflow.benchmarks.disagg_accuracy_test \
+    -- --connector UniflowConnector --model meta-llama/Llama-3.1-8B-Instruct
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _log(msg: str) -> None:
+    logger.info(msg)
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+# ── Configuration ──────────────────────────────────────────────────────
+
+
+@dataclass
+class ServerConfig:
+    """Configuration for a single vLLM server instance."""
+
+    model_path: str
+    port: int
+    gpu_id: str
+    block_size: int = 128
+    gpu_memory_utilization: float = 0.45
+    max_model_len: int = 2048
+    kv_transfer_config: str | None = None
+    side_channel_port: int | None = None
+    host_ip: str = "127.0.0.1"
+
+    def to_cmd(self) -> list[str]:
+        # In MAST PAR environment, use the PAR's Python to invoke
+        # vllm.entrypoints.openai.api_server. On devservers, use vllm CLI.
+        par_path = os.environ.get("FBPKG_ROOT", "")
+        if par_path and (Path(par_path) / "penv.par").exists():
+            python = str(Path(par_path) / "penv.par")
+            cmd = [python, "-m", "vllm.entrypoints.openai.api_server"]
+        else:
+            cmd = ["vllm", "serve"]
+        cmd += [
+            self.model_path,
+            "--port",
+            str(self.port),
+            "--block-size",
+            str(self.block_size),
+            "--gpu-memory-utilization",
+            str(self.gpu_memory_utilization),
+            "--max-model-len",
+            str(self.max_model_len),
+            "--enforce-eager",
+            "--seed",
+            "42",
+        ]
+        if self.kv_transfer_config:
+            cmd += ["--kv-transfer-config", self.kv_transfer_config]
+        return cmd
+
+    def to_env(self) -> dict[str, str]:
+        env = {
+            "CUDA_VISIBLE_DEVICES": self.gpu_id,
+            "VLLM_HOST_IP": self.host_ip,
+        }
+        if self.side_channel_port:
+            env["VLLM_UNIFLOW_SIDE_CHANNEL_PORT"] = str(self.side_channel_port)
+            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.side_channel_port)
+        return env
+
+
+class ProcessStderrLog:
+    """Owns a child process stderr file without risking pipe backpressure."""
+
+    def __init__(self, prefix: str):
+        self._prefix = prefix
+        self._file = None
+        self.path: Path | None = None
+
+    def open(self):
+        self._file = tempfile.NamedTemporaryFile(
+            prefix=self._prefix,
+            suffix=".stderr.log",
+            delete=False,
+        )
+        self.path = Path(self._file.name)
+        return self._file
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def tail(self, max_bytes: int = 4096) -> str:
+        if self._file is not None:
+            self._file.flush()
+        if self.path is None or not self.path.exists():
+            return ""
+        with self.path.open("rb") as log_file:
+            log_file.seek(0, os.SEEK_END)
+            size = log_file.tell()
+            log_file.seek(max(0, size - max_bytes))
+            return log_file.read().decode(errors="replace")
+
+
+@dataclass
+class TestConfig:
+    """Top-level test configuration."""
+
+    connector: str = "UniflowConnector"
+    model: str = "meta-llama/Llama-3.1-8B-Instruct"
+    block_size: int = 128
+    gpu_memory_utilization: float = 0.45
+    max_model_len: int = 2048
+    num_perf_prompts: int = 250
+    output_len: int = 32
+    perf_warmup: int = 3
+    perf_iterations: int = 5
+    skip_perf: bool = False
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> TestConfig:
+        return cls(
+            connector=args.connector,
+            model=args.model,
+            block_size=args.block_size,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            max_model_len=args.max_model_len,
+            num_perf_prompts=args.num_prompts,
+            output_len=args.output_len,
+            perf_warmup=args.perf_warmup,
+            perf_iterations=args.perf_iterations,
+            skip_perf=args.skip_perf,
+        )
+
+    def kv_transfer_config(self) -> str:
+        if self.connector == "UniflowConnector":
+            return json.dumps(
+                {
+                    "kv_connector": "UniflowConnector",
+                    "kv_role": "kv_both",
+                    "kv_connector_module_path": "vllm.fb.distributed.vllm_kv_connector.uniflow_connector",
+                }
+            )
+        return json.dumps(
+            {
+                "kv_connector": "NixlConnector",
+                "kv_role": "kv_both",
+            }
+        )
+
+
+# ── Server Lifecycle ───────────────────────────────────────────────────
+
+
+class VLLMServer:
+    """Manages the lifecycle of a single vLLM server process."""
+
+    def __init__(self, config: ServerConfig, label: str):
+        self._config = config
+        self._label = label
+        self._process: subprocess.Popen | None = None
+        self._stderr_log = ProcessStderrLog(f"disagg_{label}_")
+
+    def start(self) -> None:
+        env = {**os.environ, **self._config.to_env()}
+        cmd = self._config.to_cmd()
+        stderr_file = self._stderr_log.open()
+        _log(
+            f"[{self._label}] Starting: CUDA_VISIBLE_DEVICES={self._config.gpu_id} "
+            f"port={self._config.port} stderr={self._stderr_log.path}"
+        )
+        self._process = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_file,
+        )
+
+    def wait_until_ready(self, timeout: int = 300) -> None:
+        url = f"http://localhost:{self._config.port}/health"
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                urllib.request.urlopen(url, timeout=5)
+                _log(f"[{self._label}] Ready on port {self._config.port}")
+                return
+            except (OSError, urllib.error.URLError):
+                if self._process and self._process.poll() is not None:
+                    raise RuntimeError(
+                        f"[{self._label}] Server exited with code "
+                        f"{self._process.returncode}:\n{self._stderr_log.tail()}"
+                    )
+                time.sleep(1)
+        raise TimeoutError(f"[{self._label}] Not ready after {timeout}s")
+
+    def stop(self) -> None:
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            _log(f"[{self._label}] Stopped")
+        self._process = None
+        self._stderr_log.close()
+
+
+class ProxyServer:
+    """Routes requests: client → prefill → decode."""
+
+    def __init__(self, prefill_port: int, decode_port: int, proxy_port: int = 8192):
+        self._prefill_port = prefill_port
+        self._decode_port = decode_port
+        self._proxy_port = proxy_port
+        self._process: subprocess.Popen | None = None
+        self._stderr_log = ProcessStderrLog("disagg_proxy_")
+
+    @property
+    def url(self) -> str:
+        return f"http://localhost:{self._proxy_port}"
+
+    def start(self) -> None:
+        # Find the proxy script in the fbpkg
+        proxy_script = self._find_proxy_script()
+        par_path = os.environ.get("FBPKG_ROOT", "")
+        if par_path and (Path(par_path) / "penv.par").exists():
+            python = str(Path(par_path) / "penv.par")
+        else:
+            python = sys.executable
+        cmd = [
+            python,
+            proxy_script,
+            "--prefiller-host",
+            "localhost",
+            "--prefiller-port",
+            str(self._prefill_port),
+            "--decoder-host",
+            "localhost",
+            "--decoder-port",
+            str(self._decode_port),
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(self._proxy_port),
+        ]
+        stderr_file = self._stderr_log.open()
+        _log(
+            f"[proxy] Starting on port {self._proxy_port} "
+            f"stderr={self._stderr_log.path}"
+        )
+        self._process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_file,
+        )
+        self.wait_until_ready()
+
+    def wait_until_ready(self, timeout: int = 60) -> None:
+        url = f"http://localhost:{self._proxy_port}/healthcheck"
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                urllib.request.urlopen(url, timeout=5)
+                _log(f"[proxy] Ready on port {self._proxy_port}")
+                return
+            except (OSError, urllib.error.URLError):
+                if self._process and self._process.poll() is not None:
+                    raise RuntimeError(
+                        "[proxy] Server exited with code "
+                        f"{self._process.returncode}:\n{self._stderr_log.tail()}"
+                    )
+                time.sleep(1)
+        raise TimeoutError(f"[proxy] Not ready after {timeout}s")
+
+    def stop(self) -> None:
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+            _log("[proxy] Stopped")
+        self._process = None
+        self._stderr_log.close()
+
+    def _find_proxy_script(self) -> str:
+        candidates = [
+            Path(__file__).parent / "toy_proxy_server.py",
+        ]
+        par_path = os.environ.get("FBPKG_ROOT", "")
+        if par_path:
+            candidates.append(Path(par_path) / "toy_proxy_server.py")
+        for p in Path("/packages").glob("*/toy_proxy_server.py"):
+            candidates.append(p)
+        for p in candidates:
+            if p.exists():
+                return str(p)
+        raise FileNotFoundError("toy_proxy_server.py not found")
+
+
+# ── Test Client ────────────────────────────────────────────────────────
+
+
+class TestClient:
+    """Sends requests to a vLLM-compatible endpoint and collects outputs."""
+
+    # Same prompts as vLLM's test_disagg_accuracy.py
+    CORRECTNESS_PROMPTS = [
+        "Red Hat is the best company in the world to work for because it works "
+        "on open source software, which means that all the contributions are "
+        "delivered to the community. As a result, when working on projects like "
+        "vLLM we are able to meet many amazing people from various organizations "
+        "like AMD, Google, NVIDIA, ",
+        "We hold these truths to be self-evident, that all men are created "
+        "equal, that they are endowed by their Creator with certain unalienable "
+        "Rights, that among these are Life, Liberty and the pursuit of "
+        "Happiness.--That to secure these rights, Governments are instituted "
+        "among Men, deriving their just powers from the consent of the "
+        "governed, ",
+    ]
+
+    def __init__(self, base_url: str, model: str):
+        self._url = f"{base_url}/v1/completions"
+        self._model = model
+
+    def generate(self, prompt: str, max_tokens: int = 30) -> str:
+        body = json.dumps(
+            {
+                "model": self._model,
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": 0.0,
+                "seed": 42,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            self._url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read())["choices"][0]["text"]
+
+    def generate_batch(self, prompts: list[str], max_tokens: int = 30) -> list[str]:
+        return [self.generate(p, max_tokens) for p in prompts]
+
+
+# ── Test Phases ────────────────────────────────────────────────────────
+
+
+class CorrectnessTest:
+    """Exact-match check between captured baseline and disagg outputs."""
+
+    def __init__(self, baseline_outputs: dict[str, str], client_disagg: TestClient):
+        self._baseline_outputs = baseline_outputs
+        self._disagg = client_disagg
+
+    @staticmethod
+    def collect_baseline(client_baseline: TestClient) -> dict[str, str]:
+        prompts = TestClient.CORRECTNESS_PROMPTS
+        _log("── Correctness: generating baseline outputs ──")
+        baseline_outputs = {}
+        for i, prompt in enumerate(prompts):
+            text = client_baseline.generate(prompt)
+            baseline_outputs[prompt] = text
+            _log(f"  [baseline] prompt {i}: {text[:60]!r}")
+        return baseline_outputs
+
+    def run(self) -> bool:
+        prompts = TestClient.CORRECTNESS_PROMPTS
+        _log("── Correctness: generating disagg outputs ──")
+        mismatches = 0
+        for i, p in enumerate(prompts):
+            text = self._disagg.generate(p)
+            expected = self._baseline_outputs[p]
+            match = text == expected
+            _log(f"  [disagg]   prompt {i}: match={match} {text[:60]!r}")
+            if not match:
+                _log(f"    EXPECTED: {expected[:60]!r}")
+                mismatches += 1
+
+        if mismatches == 0:
+            _log(f"CORRECTNESS PASSED: {len(prompts)}/{len(prompts)} exact match")
+            return True
+        _log(f"CORRECTNESS FAILED: {mismatches}/{len(prompts)} mismatches")
+        return False
+
+
+@dataclass
+class PerfResult:
+    """Performance measurement result."""
+
+    num_prompts: int
+    output_len: int
+    times_s: list[float]
+    median_s: float = 0.0
+    mean_s: float = 0.0
+    req_per_s: float = 0.0
+
+    def __post_init__(self):
+        if self.times_s:
+            self.median_s = statistics.median(self.times_s)
+            self.mean_s = statistics.mean(self.times_s)
+            self.req_per_s = self.num_prompts / self.median_s if self.median_s else 0
+
+
+class PerformanceBenchmark:
+    """Phase 2: Throughput measurement through disagg proxy."""
+
+    def __init__(self, client: TestClient, config: TestConfig):
+        self._client = client
+        self._config = config
+
+    def run(self) -> PerfResult:
+        n = self._config.num_perf_prompts
+        out_len = self._config.output_len
+        base = "The quick brown fox jumps over the lazy dog. "
+        text = (base * 17)[:512]
+        prompts = [f"{text} Question {i}: What comes next?" for i in range(n)]
+
+        _log(f"── Performance: {n} prompts, {out_len} output tokens ──")
+
+        _log("  Warmup...")
+        for p in prompts[: min(self._config.perf_warmup, n)]:
+            self._client.generate(p, out_len)
+
+        times: list[float] = []
+        for iteration in range(self._config.perf_iterations):
+            t0 = time.perf_counter()
+            for p in prompts:
+                self._client.generate(p, out_len)
+            elapsed = time.perf_counter() - t0
+            times.append(elapsed)
+            _log(f"  Iter {iteration}: {elapsed:.2f}s ({n / elapsed:.1f} req/s)")
+
+        result = PerfResult(num_prompts=n, output_len=out_len, times_s=times)
+        _log(
+            f"PERFORMANCE: median={result.median_s:.2f}s "
+            f"mean={result.mean_s:.2f}s "
+            f"({result.req_per_s:.1f} req/s)"
+        )
+        return result
+
+
+# ── Orchestrator ───────────────────────────────────────────────────────
+
+
+class Topology:
+    """Detects the MAST rank topology for GPU assignment."""
+
+    def __init__(self):
+        self.rank = int(os.environ.get("RANK", 0))
+        self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
+        self.world_size = int(os.environ.get("WORLD_SIZE", 2))
+        self.local_world_size = int(
+            os.environ.get("LOCAL_WORLD_SIZE", str(self.world_size))
+        )
+        self.num_nodes = self.world_size // self.local_world_size
+        self.gpu_id = os.environ.get("CUDA_VISIBLE_DEVICES", str(self.local_rank))
+
+    @property
+    def is_same_node(self) -> bool:
+        return self.num_nodes == 1
+
+    @property
+    def is_driver(self) -> bool:
+        return self.rank == 0
+
+    def detect_ip(self) -> str:
+        try:
+            with socket.socket(socket.AF_INET6, socket.SOCK_DGRAM) as sock:
+                sock.connect(("2001:4860:4860::8888", 80))
+                return sock.getsockname()[0]
+        except OSError:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(("8.8.8.8", 80))
+                return sock.getsockname()[0]
+
+
+class DisaggAccuracyTest:
+    """Main orchestrator — runs correctness + performance tests.
+
+    Flow:
+      1. Download model
+      2. Start standalone baseline server → generate reference outputs → stop
+      3. Start disagg pipeline (prefill + decode + proxy)
+      4. Correctness: exact match against baseline
+      5. Performance: throughput measurement
+      6. Cleanup
+    """
+
+    BASELINE_PORT = 8000
+    PREFILL_PORT = 8100
+    DECODE_PORT = 8200
+    PROXY_PORT = 8192
+
+    def __init__(self, config: TestConfig, topo: Topology):
+        self._config = config
+        self._topo = topo
+        self._servers: list[VLLMServer] = []
+        self._proxy: ProxyServer | None = None
+        self._model_path: str = ""
+
+    def run(self) -> bool:
+        if not self._topo.is_driver:
+            return self._idle_non_driver_rank()
+        if not self._topo.is_same_node:
+            _log(
+                "Cross-node online accuracy orchestration is not supported by this "
+                "single-process test harness; use `run_mast_benchmarks.py` for "
+                "cross-node MAST validation."
+            )
+            return False
+
+        try:
+            self._model_path = self._download_model()
+            gpu_baseline, gpu_prefill, gpu_decode = self._assign_gpus()
+            host_ip = (
+                self._topo.detect_ip() if not self._topo.is_same_node else "127.0.0.1"
+            )
+            self._log_header()
+
+            baseline_outputs = self._run_baseline_phase(gpu_baseline)
+            disagg_client = self._start_disagg_phase(
+                gpu_prefill,
+                gpu_decode,
+                host_ip,
+            )
+
+            _log("\n── Phase 2: Correctness Test ──")
+            correctness = CorrectnessTest(baseline_outputs, disagg_client)
+            passed = correctness.run()
+            if not passed:
+                _log("ABORTING: correctness test failed")
+                return False
+
+            if not self._config.skip_perf:
+                self._run_performance_phase(disagg_client)
+
+            _log("\n" + "=" * 60)
+            _log("ALL TESTS PASSED")
+            _log("=" * 60)
+            return True
+
+        finally:
+            self._stop_all()
+
+    def _idle_non_driver_rank(self) -> bool:
+        _log(f"Rank {self._topo.rank}: idle (driver is rank 0)")
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+        signal.pause()
+        return True
+
+    def _log_header(self) -> None:
+        _log("=" * 60)
+        _log(f"DISAGG ACCURACY TEST — {self._config.connector}")
+        _log(f"  Model: {self._config.model}")
+        _log(f"  Topology: {'same-node' if self._topo.is_same_node else 'cross-node'}")
+        _log("=" * 60)
+
+    def _run_baseline_phase(self, gpu_baseline: str) -> dict[str, str]:
+        _log("\n── Phase 1a: Standalone Baseline ──")
+        self._start_server(
+            "baseline",
+            ServerConfig(
+                model_path=self._model_path,
+                port=self.BASELINE_PORT,
+                gpu_id=gpu_baseline,
+                block_size=self._config.block_size,
+                gpu_memory_utilization=self._config.gpu_memory_utilization,
+                max_model_len=self._config.max_model_len,
+            ),
+        )
+        baseline_client = TestClient(
+            f"http://localhost:{self.BASELINE_PORT}", self._model_path
+        )
+        baseline_outputs = CorrectnessTest.collect_baseline(baseline_client)
+        self._stop_all()
+        return baseline_outputs
+
+    def _start_disagg_phase(
+        self,
+        gpu_prefill: str,
+        gpu_decode: str,
+        host_ip: str,
+    ) -> TestClient:
+        _log("\n── Phase 1b: Disagg Pipeline ──")
+        kv_config = self._config.kv_transfer_config()
+        self._start_server(
+            "prefill",
+            ServerConfig(
+                model_path=self._model_path,
+                port=self.PREFILL_PORT,
+                gpu_id=gpu_prefill,
+                block_size=self._config.block_size,
+                gpu_memory_utilization=self._config.gpu_memory_utilization,
+                max_model_len=self._config.max_model_len,
+                kv_transfer_config=kv_config,
+                side_channel_port=15580,
+                host_ip=host_ip,
+            ),
+        )
+        self._start_server(
+            "decode",
+            ServerConfig(
+                model_path=self._model_path,
+                port=self.DECODE_PORT,
+                gpu_id=gpu_decode,
+                block_size=self._config.block_size,
+                gpu_memory_utilization=self._config.gpu_memory_utilization,
+                max_model_len=self._config.max_model_len,
+                kv_transfer_config=kv_config,
+                side_channel_port=15680,
+                host_ip=host_ip,
+            ),
+        )
+
+        self._proxy = ProxyServer(self.PREFILL_PORT, self.DECODE_PORT, self.PROXY_PORT)
+        self._proxy.start()
+        return TestClient(f"http://localhost:{self.PROXY_PORT}", self._model_path)
+
+    def _run_performance_phase(self, disagg_client: TestClient) -> None:
+        _log("\n── Phase 3: Performance Benchmark ──")
+        perf = PerformanceBenchmark(disagg_client, self._config)
+        result = perf.run()
+        _log(f"\nFinal: {result.req_per_s:.1f} req/s (median={result.median_s:.2f}s)")
+
+    def _download_model(self) -> str:
+        model_dir = Path("/tmp/disagg_models") / Path(self._config.model).name
+        _log(f"Downloading {self._config.model}...")
+        # Use the existing download infrastructure from disagg_entry
+        try:
+            from vllm.fb.standalone_benchmark.disagg_entry import download_model
+
+            return download_model(self._config.model, 0)
+        except ImportError:
+            from mast_utils import download_model_from_manifold
+
+            if model_dir.exists() and any(model_dir.iterdir()):
+                _log(f"Model cached: {model_dir}")
+                return str(model_dir)
+            download_model_from_manifold(self._config.model, str(model_dir))
+            return str(model_dir)
+
+    def _assign_gpus(self) -> tuple[str, str, str]:
+        if self._topo.is_same_node:
+            return "0", "0", "1"
+        raise RuntimeError("cross-node online accuracy orchestration is unsupported")
+
+    def _start_server(self, label: str, config: ServerConfig) -> VLLMServer:
+        server = VLLMServer(config, label)
+        server.start()
+        server.wait_until_ready()
+        self._servers.append(server)
+        return server
+
+    def _stop_all(self) -> None:
+        if self._proxy:
+            self._proxy.stop()
+            self._proxy = None
+        for s in self._servers:
+            s.stop()
+        self._servers.clear()
+        time.sleep(2)
+
+
+# ── Entry Point ────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Disaggregated serving accuracy + performance test",
+    )
+    p.add_argument(
+        "--connector",
+        type=str,
+        default=os.environ.get("CONNECTOR", "UniflowConnector"),
+        choices=["UniflowConnector", "NixlConnector"],
+    )
+    p.add_argument(
+        "--model",
+        type=str,
+        default=os.environ.get("MODEL", "meta-llama/Llama-3.1-8B-Instruct"),
+    )
+    p.add_argument(
+        "--block-size", type=int, default=int(os.environ.get("BLOCK_SIZE", "128"))
+    )
+    p.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=float(os.environ.get("GPU_MEM_UTIL", "0.45")),
+    )
+    p.add_argument(
+        "--max-model-len",
+        type=int,
+        default=int(os.environ.get("MAX_MODEL_LEN", "2048")),
+    )
+    p.add_argument(
+        "--num-prompts", type=int, default=int(os.environ.get("NUM_PROMPTS", "250"))
+    )
+    p.add_argument(
+        "--output-len", type=int, default=int(os.environ.get("OUTPUT_LEN", "32"))
+    )
+    p.add_argument(
+        "--perf-warmup", type=int, default=int(os.environ.get("PERF_WARMUP", "3"))
+    )
+    p.add_argument(
+        "--perf-iterations",
+        type=int,
+        default=int(os.environ.get("PERF_ITERATIONS", "5")),
+    )
+    p.add_argument("--skip-perf", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    configure_logging()
+    args = parse_args(argv)
+    config = TestConfig.from_args(args)
+    topo = Topology()
+
+    test = DisaggAccuracyTest(config, topo)
+    success = test.run()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/comms/uniflow/benchmarks/disagg_online_test.py
+++ b/comms/uniflow/benchmarks/disagg_online_test.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+from __future__ import annotations
+
+import sys
+
+try:
+    from comms.uniflow.benchmarks.disagg_accuracy_test import main as accuracy_main
+except ImportError:
+    from disagg_accuracy_test import main as accuracy_main
+
+
+def main(argv: list[str] | None = None) -> None:
+    accuracy_main(argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/comms/uniflow/benchmarks/disagg_online_test.sh
+++ b/comms/uniflow/benchmarks/disagg_online_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Compatibility wrapper for the Python online accuracy/performance runner.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PYTHON=${PYTHON:-python3}
+
+if [[ -n "${FBPKG_ROOT:-}" && -x "${FBPKG_ROOT}/penv.par" ]]; then
+  PYTHON="${FBPKG_ROOT}/penv.par"
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/disagg_online_test.py" "$@"

--- a/comms/uniflow/benchmarks/run_mast_benchmarks.py
+++ b/comms/uniflow/benchmarks/run_mast_benchmarks.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TARGET = "fbcode//comms/uniflow/benchmarks:uniflow_disagg_bench_mast"
+DEFAULT_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+DEFAULT_WORKSPACE = Path("/tmp/mast_empty_workspace")
+DEFAULT_BHA_CONFIG = Path("/tmp/bha_uniflow_split_2x8.json")
+RESULT_LOG_REGEX = (
+    "CORRECTNESS|PERFORMANCE|ALL ACCURACY|FAILED|Traceback|RuntimeError|"
+    "Exception|ValueError"
+)
+TERMINAL_STATES = {"SUCCEEDED", "FAILED", "CANCELLED"}
+FAILURE_STATES = {"FAILED", "CANCELLED"}
+
+
+CONNECTORS = {
+    "uniflow": "UniflowConnector",
+    "nixl": "NixlConnector",
+}
+
+
+@dataclass(frozen=True)
+class Workload:
+    model: str
+    tp: int
+    warmup_iters: int
+    measure_iters: int
+    prompt_len: int
+    num_prompts: int
+    output_len: int
+    gpu_memory_utilization: float
+    mode: str
+    timeout: int
+
+
+@dataclass(frozen=True)
+class MastConfig:
+    workspace: Path
+    bha_config_path: Path
+    hpc_identity: str
+    hpc_cluster_uuid: str
+    rm_attribution: str
+    hpc_job_oncall: str
+    locality_constraints: str
+    model_type_name: str
+    opec_tag: str
+    host_type: str
+    presto_identity: str
+    poll_interval_sec: int
+    job_timeout_sec: int
+
+    @property
+    def scheduler_args(self) -> str:
+        values = {
+            "hpcIdentity": self.hpc_identity,
+            "hpcClusterUuid": self.hpc_cluster_uuid,
+            "rmAttribution": self.rm_attribution,
+            "hpcJobOncall": self.hpc_job_oncall,
+            "localityConstraints": self.locality_constraints,
+            "modelTypeName": self.model_type_name,
+            "enableGracefulPreemption": "false",
+            "maxJobFailures": "0",
+            "opecTag": self.opec_tag,
+        }
+        return ",".join(f"{key}={value}" for key, value in values.items())
+
+    @property
+    def common_env(self) -> str:
+        values = {
+            "HYDRA_MAIN_MODULE": "vllm.fb.standalone_benchmark.disagg_entry",
+            "LOGLEVEL": "WARNING",
+            "PRESTO_CLIENT_IDENTITY": self.presto_identity,
+            "PROCESS_MEMORY_AUTO_MEASUREMENT": "1",
+            "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+        }
+        return ",".join(f"{key}={value}" for key, value in values.items())
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    connector_key: str
+    connector_class: str
+    layout: str
+    name: str
+    session_id: str
+
+    @property
+    def is_cross_node(self) -> bool:
+        return self.layout == "cn"
+
+
+@dataclass
+class JobResult:
+    spec: JobSpec
+    app_uri: str
+    state: str
+    log_lines: list[str]
+
+    @property
+    def passed(self) -> bool:
+        output = "\n".join(self.log_lines)
+        return (
+            self.state == "SUCCEEDED"
+            and "CORRECTNESS PASSED" in output
+            and "ALL ACCURACY TESTS PASSED" in output
+            and "PERFORMANCE:" in output
+            and "Traceback" not in output
+            and "RuntimeError" not in output
+            and "ValueError" not in output
+        )
+
+
+class CommandRunner:
+    def __init__(self, *, quiet_warnings: bool) -> None:
+        self.quiet_warnings = quiet_warnings
+
+    def run_capture(
+        self,
+        cmd: Sequence[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        suppress_stderr: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        stderr = subprocess.DEVNULL if suppress_stderr else subprocess.PIPE
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=stderr,
+            check=False,
+        )
+
+    def run_stream(
+        self,
+        cmd: Sequence[str],
+        *,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, list[str]]:
+        process = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            errors="replace",
+        )
+        assert process.stdout is not None
+        lines: list[str] = []
+        for line in process.stdout:
+            line = line.rstrip()
+            lines.append(line)
+            if self._should_print(line):
+                logger.info("%s", line)
+        return process.wait(), lines
+
+    def _should_print(self, line: str) -> bool:
+        if not self.quiet_warnings:
+            return True
+        noisy_tokens = (
+            "ThriftPyDeprecatedWarning",
+            "Future automatic thrift-py-deprecated",
+            "NumExpr",
+        )
+        return not any(token in line for token in noisy_tokens)
+
+
+class FbpkgBuilder:
+    def __init__(self, runner: CommandRunner, fbcode_dir: Path, target: str) -> None:
+        self.runner = runner
+        self.fbcode_dir = fbcode_dir
+        self.target = target
+
+    def build(self) -> str:
+        logger.info("Building fbpkg target: %s", self.target)
+        code, lines = self.runner.run_stream(
+            ["fbpkg", "build", self.target], cwd=self.fbcode_dir
+        )
+        if code != 0:
+            raise RuntimeError(
+                f"`fbpkg build {self.target}` failed with exit code {code}"
+            )
+        package = self._extract_package(lines)
+        logger.info("Built package: %s", package)
+        return package
+
+    @staticmethod
+    def _extract_package(lines: Sequence[str]) -> str:
+        pattern = re.compile(r"\b(uniflow_disagg_bench_mast:[0-9a-f]{32})\b")
+        for line in reversed(lines):
+            match = pattern.search(line)
+            if match:
+                return match.group(1)
+        raise RuntimeError(
+            "Unable to find `uniflow_disagg_bench_mast:<hash>` in fbpkg output"
+        )
+
+
+class MastBenchmarkRunner:
+    def __init__(
+        self,
+        runner: CommandRunner,
+        config: MastConfig,
+        workload: Workload,
+        package: str,
+    ) -> None:
+        self.runner = runner
+        self.config = config
+        self.workload = workload
+        self.package = package
+
+    def launch(self, spec: JobSpec) -> str:
+        self._prepare_workspace()
+        cmd = self._launch_command(spec)
+        logger.info(
+            "Launching %s %s: %s",
+            spec.layout.upper(),
+            spec.connector_class,
+            spec.name,
+        )
+        code, lines = self.runner.run_stream(
+            cmd, cwd=self.config.workspace, env=self._torchx_env()
+        )
+        if code != 0:
+            raise RuntimeError(
+                f"`torchx run` failed for {spec.name} with exit code {code}"
+            )
+        app_uri = self._extract_app_uri(lines)
+        logger.info("Launched %s: %s", spec.name, app_uri)
+        return app_uri
+
+    def wait_for_result(self, spec: JobSpec, app_uri: str) -> JobResult:
+        deadline = time.monotonic() + self.config.job_timeout_sec
+        last_state = "UNKNOWN"
+        while time.monotonic() < deadline:
+            state = self._status(app_uri)
+            if state != last_state:
+                logger.info("%s: %s", spec.name, state)
+                last_state = state
+            if state in TERMINAL_STATES:
+                return JobResult(
+                    spec=spec,
+                    app_uri=app_uri,
+                    state=state,
+                    log_lines=self._collect_logs(spec, app_uri),
+                )
+            time.sleep(self.config.poll_interval_sec)
+        return JobResult(
+            spec=spec,
+            app_uri=app_uri,
+            state=f"TIMEOUT_AFTER_{self.config.job_timeout_sec}s",
+            log_lines=self._collect_logs(spec, app_uri),
+        )
+
+    def _launch_command(self, spec: JobSpec) -> list[str]:
+        layout = "2x8" if spec.is_cross_node else "1x2"
+        rdzv_backend = "zeus" if spec.is_cross_node else "c10d"
+        env = f"{self.config.common_env},TORCHX_INTERNAL_SESSION_ID={spec.session_id}"
+        cmd = [
+            "torchx",
+            "run",
+            "--no-repro-info",
+            "-s",
+            "mast",
+            "--scheduler_args",
+            self.config.scheduler_args,
+            "fb.dist.ddp",
+            "--name",
+            spec.name,
+            "--img",
+            self.package,
+            "-h",
+            self.config.host_type,
+            "-j",
+            layout,
+            "--env",
+            env,
+            "--rdzv_backend",
+            rdzv_backend,
+            "-m",
+            "vllm.fb.standalone_benchmark.disagg_entry",
+            "--",
+            "--connector",
+            spec.connector_class,
+            "--tp",
+            str(self.workload.tp),
+            "--model",
+            self.workload.model,
+            "--gpu-memory-utilization",
+            str(self.workload.gpu_memory_utilization),
+            "--warmup-iters",
+            str(self.workload.warmup_iters),
+            "--measure-iters",
+            str(self.workload.measure_iters),
+            "--prompt-len",
+            str(self.workload.prompt_len),
+            "--num-prompts",
+            str(self.workload.num_prompts),
+            "--output-len",
+            str(self.workload.output_len),
+            "--mode",
+            self.workload.mode,
+            "--timeout",
+            str(self.workload.timeout),
+        ]
+        if spec.is_cross_node:
+            cmd.insert(cmd.index("--env"), "--bha_config_path")
+            cmd.insert(cmd.index("--env"), str(self.config.bha_config_path))
+        return cmd
+
+    def _prepare_workspace(self) -> None:
+        self.config.workspace.mkdir(parents=True, exist_ok=True)
+        if not self.config.bha_config_path.exists():
+            self.config.bha_config_path.write_text(
+                '{\n  "trainer": [\n    {\n      "domain": {\n        "multiple": 2,\n'
+                '        "maxGroupCount": 1\n      }\n    }\n  ]\n}\n'
+            )
+
+    def _status(self, app_uri: str) -> str:
+        result = self.runner.run_capture(
+            ["torchx", "status", app_uri],
+            cwd=self.config.workspace,
+            env=self._torchx_env(),
+            suppress_stderr=True,
+        )
+        if result.returncode != 0:
+            return "STATUS_ERROR"
+        match = re.search(r"State:\s+([A-Z_]+)", result.stdout)
+        return match.group(1) if match else "UNKNOWN"
+
+    def _collect_logs(self, spec: JobSpec, app_uri: str) -> list[str]:
+        logs: list[str] = []
+        for role in self._trainer_roles(spec):
+            result = self.runner.run_capture(
+                ["torchx", "log", "--regex", RESULT_LOG_REGEX, f"{app_uri}/{role}"],
+                cwd=self.config.workspace,
+                env=self._torchx_env(),
+                suppress_stderr=True,
+            )
+            if result.stdout:
+                logs.extend(line for line in result.stdout.splitlines() if line)
+        return logs
+
+    @staticmethod
+    def _trainer_roles(spec: JobSpec) -> list[str]:
+        return ["trainer/0", "trainer/1"] if spec.is_cross_node else ["trainer/0"]
+
+    @staticmethod
+    def _extract_app_uri(lines: Sequence[str]) -> str:
+        for line in lines:
+            match = re.search(r"(mast://torchx/\S+)", line)
+            if match:
+                return match.group(1)
+        raise RuntimeError("Unable to find launched `mast://torchx/...` app URI")
+
+    @staticmethod
+    def _torchx_env() -> dict[str, str]:
+        env = os.environ.copy()
+        env["PYTHONWARNINGS"] = "ignore"
+        env["PYTHON_EXEC"] = "./mast_wrapper.sh"
+        return env
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build the uniflow benchmark fbpkg, launch MAST jobs, poll status, and summarize results."
+    )
+    parser.add_argument(
+        "--connector", choices=["uniflow", "nixl", "both"], default="both"
+    )
+    parser.add_argument("--layout", choices=["sn", "cn", "both"], default="both")
+    parser.add_argument(
+        "--package",
+        help="Existing `uniflow_disagg_bench_mast:<hash>` package. Skips build when set.",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Require --package and skip fbpkg build.",
+    )
+    parser.add_argument("--target", default=DEFAULT_TARGET)
+    parser.add_argument(
+        "--fbcode-dir", type=Path, default=Path(__file__).resolve().parents[3]
+    )
+    parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
+    parser.add_argument("--bha-config-path", type=Path, default=DEFAULT_BHA_CONFIG)
+    parser.add_argument("--job-prefix", default="acc-h100")
+    parser.add_argument("--poll-interval-sec", type=int, default=30)
+    parser.add_argument("--job-timeout-sec", type=int, default=3600)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--warmup-iters", type=int, default=3)
+    parser.add_argument("--measure-iters", type=int, default=3)
+    parser.add_argument("--prompt-len", type=int, default=128)
+    parser.add_argument("--num-prompts", type=int, default=250)
+    parser.add_argument("--output-len", type=int, default=32)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--mode", default="accuracy")
+    parser.add_argument("--timeout", type=int, default=0)
+    parser.add_argument("--host-type", default="grandteton_80g_roce")
+    parser.add_argument("--hpc-identity", default="networkai_mast_job_identity")
+    parser.add_argument("--hpc-cluster-uuid", default="MastGenAICluster")
+    parser.add_argument("--rm-attribution", default="msl_infra_optimization")
+    parser.add_argument("--hpc-job-oncall", default="ncclx")
+    parser.add_argument("--locality-constraints", default="region;eag")
+    parser.add_argument("--model-type-name", default="gen_ai_default")
+    parser.add_argument("--opec-tag", default="DEDICATED_ONLY")
+    parser.add_argument(
+        "--presto-identity", default="svc:chronos_secgrp_networkai_mast_job_identity"
+    )
+    parser.add_argument(
+        "--quiet-warnings", action=argparse.BooleanOptionalAction, default=True
+    )
+    return parser.parse_args()
+
+
+def make_job_specs(args: argparse.Namespace, package: str) -> list[JobSpec]:
+    connectors = list(CONNECTORS) if args.connector == "both" else [args.connector]
+    layouts = ["sn", "cn"] if args.layout == "both" else [args.layout]
+    package_suffix = package_hash_suffix(package)
+    run_suffix = time.strftime("%m%d%H%M%S")
+    specs: list[JobSpec] = []
+    for connector in connectors:
+        for layout in layouts:
+            connector_short = "uni" if connector == "uniflow" else "nixl"
+            name = f"{args.job_prefix}-{layout}-{connector_short}-{package_suffix}-{run_suffix}"
+            session_id = f"codex-{package_suffix}-{layout}-{connector}"
+            specs.append(
+                JobSpec(
+                    connector_key=connector,
+                    connector_class=CONNECTORS[connector],
+                    layout=layout,
+                    name=name,
+                    session_id=session_id,
+                )
+            )
+    return specs
+
+
+def package_hash_suffix(package: str) -> str:
+    parts = package.split(":", 1)
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"--package must use the fbpkg `name:hash` format, got {package!r}"
+        )
+    return parts[1][:7]
+
+
+def print_summary(package: str, results: Sequence[JobResult]) -> None:
+    logger.info("\nSummary")
+    logger.info("Package: %s", package)
+    for result in results:
+        status = "PASS" if result.passed else "FAIL"
+        logger.info(
+            "%s: %s %s %s %s",
+            status,
+            result.spec.layout.upper(),
+            result.spec.connector_class,
+            result.state,
+            result.app_uri,
+        )
+        for line in result.log_lines:
+            logger.info("  %s", line)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = parse_args()
+    if args.skip_build and not args.package:
+        raise SystemExit("--skip-build requires --package")
+
+    runner = CommandRunner(quiet_warnings=args.quiet_warnings)
+    package = args.package or FbpkgBuilder(runner, args.fbcode_dir, args.target).build()
+    workload = Workload(
+        model=args.model,
+        tp=args.tp,
+        warmup_iters=args.warmup_iters,
+        measure_iters=args.measure_iters,
+        prompt_len=args.prompt_len,
+        num_prompts=args.num_prompts,
+        output_len=args.output_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        mode=args.mode,
+        timeout=args.timeout,
+    )
+    mast_config = MastConfig(
+        workspace=args.workspace,
+        bha_config_path=args.bha_config_path,
+        hpc_identity=args.hpc_identity,
+        hpc_cluster_uuid=args.hpc_cluster_uuid,
+        rm_attribution=args.rm_attribution,
+        hpc_job_oncall=args.hpc_job_oncall,
+        locality_constraints=args.locality_constraints,
+        model_type_name=args.model_type_name,
+        opec_tag=args.opec_tag,
+        host_type=args.host_type,
+        presto_identity=args.presto_identity,
+        poll_interval_sec=args.poll_interval_sec,
+        job_timeout_sec=args.job_timeout_sec,
+    )
+    mast = MastBenchmarkRunner(runner, mast_config, workload, package)
+
+    launched: list[tuple[JobSpec, str]] = []
+    for spec in make_job_specs(args, package):
+        launched.append((spec, mast.launch(spec)))
+
+    results = [mast.wait_for_result(spec, app_uri) for spec, app_uri in launched]
+    print_summary(package, results)
+    return 0 if all(result.passed for result in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/comms/uniflow/benchmarks/toy_proxy_server.py
+++ b/comms/uniflow/benchmarks/toy_proxy_server.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import logging
+import os
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BackendInstance:
+    host: str
+    port: int
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}/v1"
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    host: str
+    port: int
+    prefiller_instances: list[BackendInstance]
+    decoder_instances: list[BackendInstance]
+
+
+class BackendClient:
+    """HTTP client for one prefill or decode vLLM backend."""
+
+    def __init__(self, instance: BackendInstance, backend_id: int) -> None:
+        self.instance = instance
+        self.backend_id = backend_id
+        self._client = httpx.AsyncClient(
+            timeout=None,
+            base_url=instance.base_url,
+            limits=httpx.Limits(
+                max_connections=None,
+                max_keepalive_connections=None,
+            ),
+        )
+
+    async def post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+    ) -> httpx.Response:
+        response = await self._client.post(endpoint, json=payload, headers=headers)
+        response.raise_for_status()
+        await response.aread()
+        return response
+
+    async def stream_json(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+        headers: dict[str, str],
+    ) -> AsyncIterator[bytes]:
+        async with self._client.stream(
+            "POST",
+            endpoint,
+            json=payload,
+            headers=headers,
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                yield chunk
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def __repr__(self) -> str:
+        return (
+            f"BackendClient(id={self.backend_id}, "
+            f"host={self.instance.host!r}, port={self.instance.port})"
+        )
+
+
+class BackendPool:
+    """Round-robin pool for one backend role."""
+
+    def __init__(self, role: str, instances: list[BackendInstance]) -> None:
+        if not instances:
+            raise ValueError(f"{role} backend pool requires at least one instance")
+        self._role = role
+        self._instances = instances
+        self._clients: list[BackendClient] = []
+        self._iterator: itertools.cycle[int] | None = None
+
+    @property
+    def size(self) -> int:
+        return len(self._clients)
+
+    def start(self) -> None:
+        self._clients = [
+            BackendClient(instance, backend_id)
+            for backend_id, instance in enumerate(self._instances)
+        ]
+        self._iterator = itertools.cycle(range(len(self._clients)))
+        logger.info("Initialized %s %s backend clients", self.size, self._role)
+
+    async def close(self) -> None:
+        for client in self._clients:
+            await client.close()
+        self._clients = []
+        self._iterator = None
+
+    def next_client(self) -> BackendClient:
+        if self._iterator is None:
+            raise RuntimeError(f"{self._role} backend pool is not initialized")
+        return self._clients[next(self._iterator)]
+
+
+class CompletionRequestBuilder:
+    """Builds the two requests used by the disaggregated prefill/decode flow."""
+
+    @staticmethod
+    def headers(request_id: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+            "X-Request-Id": request_id,
+        }
+
+    @staticmethod
+    def prefill_payload(request_data: dict[str, Any]) -> dict[str, Any]:
+        payload = request_data.copy()
+        payload["kv_transfer_params"] = {
+            "do_remote_decode": True,
+            "do_remote_prefill": False,
+            "remote_engine_id": None,
+            "remote_block_ids": None,
+            "remote_host": None,
+            "remote_port": None,
+        }
+        payload["stream"] = False
+        payload["max_tokens"] = 1
+        if "max_completion_tokens" in payload:
+            payload["max_completion_tokens"] = 1
+        payload.pop("stream_options", None)
+        return payload
+
+    @staticmethod
+    def decode_payload(
+        request_data: dict[str, Any],
+        kv_transfer_params: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload = request_data.copy()
+        if kv_transfer_params:
+            payload["kv_transfer_params"] = kv_transfer_params
+        return payload
+
+
+class DisaggProxyService:
+    """Coordinates prefill and decode requests for OpenAI-compatible endpoints."""
+
+    def __init__(self, config: ProxyConfig) -> None:
+        self._prefill_pool = BackendPool("prefill", config.prefiller_instances)
+        self._decode_pool = BackendPool("decode", config.decoder_instances)
+        self._builder = CompletionRequestBuilder()
+
+    def start(self) -> None:
+        self._prefill_pool.start()
+        self._decode_pool.start()
+
+    async def close(self) -> None:
+        await self._prefill_pool.close()
+        await self._decode_pool.close()
+
+    def health(self) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "prefill_instances": self._prefill_pool.size,
+            "decode_instances": self._decode_pool.size,
+        }
+
+    async def handle_completion(
+        self,
+        endpoint: str,
+        request_data: dict[str, Any],
+    ) -> StreamingResponse:
+        request_id = str(uuid.uuid4())
+        headers = self._builder.headers(request_id)
+
+        prefill_client = self._prefill_pool.next_client()
+        prefill_response = await prefill_client.post_json(
+            endpoint,
+            self._builder.prefill_payload(request_data),
+            headers,
+        )
+        try:
+            response_payload = prefill_response.json()
+            kv_transfer_params = response_payload.get("kv_transfer_params")
+            if not kv_transfer_params:
+                raise ValueError("prefill response did not include kv_transfer_params")
+        finally:
+            await prefill_response.aclose()
+
+        decode_client = self._decode_pool.next_client()
+        decode_payload = self._builder.decode_payload(
+            request_data,
+            kv_transfer_params,
+        )
+        logger.debug(
+            "Routing request %s via %s -> %s", request_id, prefill_client, decode_client
+        )
+
+        async def stream_decode_response() -> AsyncIterator[bytes]:
+            async for chunk in decode_client.stream_json(
+                endpoint,
+                decode_payload,
+                headers,
+            ):
+                yield chunk
+
+        return StreamingResponse(
+            stream_decode_response(),
+            media_type="application/json",
+        )
+
+
+def _get_service(request: Request) -> DisaggProxyService:
+    return request.app.state.proxy_service
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    service: DisaggProxyService = app.state.proxy_service
+    service.start()
+    try:
+        yield
+    finally:
+        await service.close()
+
+
+def create_app(config: ProxyConfig) -> FastAPI:
+    app = FastAPI(lifespan=lifespan)
+    app.state.proxy_service = DisaggProxyService(config)
+    app.add_api_route("/v1/completions", handle_completions, methods=["POST"])
+    app.add_api_route(
+        "/v1/chat/completions",
+        handle_chat_completions,
+        methods=["POST"],
+    )
+    app.add_api_route("/healthcheck", healthcheck, methods=["GET"])
+    return app
+
+
+def parse_args(argv: list[str] | None = None) -> ProxyConfig:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--port", type=int, default=8000)
+    # Always use 127.0.0.1 as localhost binds to IPv6 which is blocked on CI
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+
+    parser.add_argument(
+        "--prefiller-hosts",
+        "--prefiller-host",
+        type=str,
+        nargs="+",
+        default=["localhost"],
+    )
+    parser.add_argument(
+        "--prefiller-ports", "--prefiller-port", type=int, nargs="+", default=[8100]
+    )
+
+    parser.add_argument(
+        "--decoder-hosts", "--decoder-host", type=str, nargs="+", default=["localhost"]
+    )
+    parser.add_argument(
+        "--decoder-ports", "--decoder-port", type=int, nargs="+", default=[8200]
+    )
+
+    args = parser.parse_args(argv)
+
+    if len(args.prefiller_hosts) != len(args.prefiller_ports):
+        raise ValueError(
+            "Number of prefiller hosts must match number of prefiller ports"
+        )
+
+    if len(args.decoder_hosts) != len(args.decoder_ports):
+        raise ValueError("Number of decoder hosts must match number of decoder ports")
+
+    return ProxyConfig(
+        host=args.host,
+        port=args.port,
+        prefiller_instances=[
+            BackendInstance(host, port)
+            for host, port in zip(args.prefiller_hosts, args.prefiller_ports)
+        ],
+        decoder_instances=[
+            BackendInstance(host, port)
+            for host, port in zip(args.decoder_hosts, args.decoder_ports)
+        ],
+    )
+
+
+async def _handle_completions(endpoint: str, request: Request) -> StreamingResponse:
+    try:
+        return await _get_service(request).handle_completion(
+            endpoint,
+            await request.json(),
+        )
+    except httpx.HTTPError:
+        logger.exception("HTTP error in disagg proxy for %s endpoint", endpoint)
+        raise
+    except (KeyError, ValueError, RuntimeError):
+        logger.exception(
+            "Request handling error in disagg proxy for %s endpoint",
+            endpoint,
+        )
+        raise
+
+
+async def handle_completions(request: Request) -> StreamingResponse:
+    return await _handle_completions("/completions", request)
+
+
+async def handle_chat_completions(request: Request) -> StreamingResponse:
+    return await _handle_completions("/chat/completions", request)
+
+
+async def healthcheck(request: Request) -> dict[str, Any]:
+    return _get_service(request).health()
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
+    config = parse_args(argv)
+
+    import uvicorn
+
+    uvicorn.run(create_app(config), host=config.host, port=config.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary: Add online accuracy/performance benchmark assets for disaggregated prefill/decode validation. This includes the accuracy driver, online proxy/test entry points, toy proxy server, Buck packaging, and `run_mast_benchmarks.py`, which automates the reviewer-facing validation flow by building or accepting a benchmark fbpkg, launching same-node and cross-node MAST jobs for Uniflow, NIXL, or both, polling terminal status, collecting result logs, and returning nonzero when any job fails or lacks correctness/performance pass signals.

Reviewed By: saifhhasan

Differential Revision: D106118514


