### PR TITLE
Add dma export abstraction. (#2768)

### DIFF
--- a/comms/uniflow/drivers/DeviceAdapter.h
+++ b/comms/uniflow/drivers/DeviceAdapter.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "comms/uniflow/Result.h"
@@ -10,6 +11,26 @@
 namespace uniflow {
 
 class CudaApi;
+class CudaDriverApi;
+
+/// Description of a DMA-BUF region exported from device memory and
+/// suitable for use with `ibv_reg_dmabuf_mr`.
+///
+struct DmaBuff {
+  /// dma-buf fd to pass to `ibv_reg_dmabuf_mr`. -1 means unset.
+  int fd{-1};
+  /// Byte offset of the buffer inside the dma-buf described by `fd`.
+  uint64_t offset{0};
+  /// Length of the registered region in bytes.
+  size_t len{0};
+  /// IOVA for the NIC. Per-export backends typically set this to the
+  /// original VA so the NIC can reference device memory directly;
+  /// pool-backed backends use 0.
+  uint64_t iova{0};
+  /// Registration bbase for this DmaBuff to be used when creating WQEs.
+  /// This is to be subtracted from a device pointer to form the WQE address.
+  uint64_t registrationBase{0};
+};
 
 /// DeviceAdapter abstracts device-specific host pinned memory allocation
 /// for use with DMA from a NIC or accelerator.
@@ -27,14 +48,51 @@ class DeviceAdapter {
   /// Return a device-accessible pointer for `hostPtr` (which must have been
   /// obtained from pinnedHostAlloc()).
   virtual Result<void*> hostGetDevicePointer(void* hostPtr) = 0;
+
+  /// Query whether DMA-BUF export is available for `deviceId`.
+  virtual Result<bool> isDmaBuffSupported(int deviceId) = 0;
+
+  /// Export a DMA-BUF descriptor for `[ptr, ptr + len)` on `deviceId`.
+  /// The caller must call `closeDmaBuff()` on the returned value once the
+  /// resulting MR has been registered.
+  virtual Result<DmaBuff>
+  exportDmaBuff(int deviceId, void* ptr, size_t len) = 0;
+
+  /// Translate a client-supplied device pointer (which may be an opaque
+  /// allocation handle / UID) to the bare device address the NIC needs to
+  /// subtract `registrationBase` from. Default: identity cast — backends
+  /// that have no separate UID representation (CPU, CUDA) do not need to
+  /// override this. Backends whose pointer encodes a device ordinal (or
+  /// other metadata) must strip it here before any wire-address arithmetic.
+  virtual uint64_t resolveDevicePointer(const void* ptr) const noexcept {
+    return reinterpret_cast<uint64_t>(ptr);
+  }
+
+  /// Whether a failed or unavailable DMA-BUF export may fall back to a plain
+  /// `ibv_reg_mr` over the segment's host pointer.
+  ///
+  /// True (default) for backends whose accelerator pointers are real process
+  /// virtual addresses (e.g. CUDA): there DMA-BUF is an optimization for GPU
+  /// Direct RDMA and a plain MR is a valid, if degraded, path.
+  ///
+  /// False for backends whose pointers are not host-registerable.
+  virtual bool allowsRegMrFallback() const noexcept {
+    return true;
+  }
+
+  /// Release any resources held by `buff`. For per-export backends this
+  /// closes the fd; for pool-backed backends it is a no-op because the
+  /// fd is owned by the device runtime and shared across pool members.
+  virtual Status closeDmaBuff(DmaBuff& buff) = 0;
 };
 
 /// Returns a DeviceAdapter for the current build configuration.
 ///
-/// The CUDA implementation accepts an optional CudaApi for dependency
-/// injection in tests; if null, a default CudaApi is constructed. The
-/// parameter is ignored by non-CUDA implementations.
+/// The CUDA implementation accepts an optional CudaApi and CudaDriverApi
+/// for dependency injection in tests; if null, default instances are
+/// constructed. These parameters are ignored by non-CUDA implementations.
 std::shared_ptr<DeviceAdapter> createDeviceAdapter(
-    std::shared_ptr<CudaApi> cudaApi = nullptr);
+    std::shared_ptr<CudaApi> cudaApi = nullptr,
+    std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr);
 
 } // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
@@ -2,7 +2,19 @@
 
 #include "comms/uniflow/drivers/cuda/CudaDeviceAdapter.h"
 
+#include <unistd.h>
+
+#include "comms/uniflow/drivers/cuda/CudaDevicePtr.h"
+
 namespace uniflow {
+
+CudaDeviceAdapter::CudaDeviceAdapter(
+    std::shared_ptr<CudaApi> cudaApi,
+    std::shared_ptr<CudaDriverApi> cudaDriverApi)
+    : cudaApi_(std::move(cudaApi)), cudaDriverApi_(std::move(cudaDriverApi)) {
+  const long ps = ::sysconf(_SC_PAGESIZE);
+  pageSize_ = ps > 0 ? static_cast<size_t>(ps) : size_t{4096};
+}
 
 Result<void*> CudaDeviceAdapter::pinnedHostAlloc(size_t size) {
   return cudaApi_->hostAlloc(size, cudaHostAllocMapped | cudaHostAllocPortable);
@@ -16,12 +28,69 @@ Result<void*> CudaDeviceAdapter::hostGetDevicePointer(void* hostPtr) {
   return cudaApi_->hostGetDevicePointer(hostPtr);
 }
 
+Result<bool> CudaDeviceAdapter::isDmaBuffSupported(int deviceId) {
+  if (!cudaDriverApi_) {
+    return Err(
+        ErrCode::DriverError, "CudaDeviceAdapter: CudaDriverApi unavailable");
+  }
+  return cudaDriverApi_->isDmaBufSupported(deviceId);
+}
+
+Result<DmaBuff>
+CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
+  if (!cudaDriverApi_) {
+    return Err(
+        ErrCode::DriverError, "CudaDeviceAdapter: CudaDriverApi unavailable");
+  }
+  if (ptr == nullptr || len == 0) {
+    return Err(ErrCode::InvalidArgument, "exportDmaBuff: bad ptr or len");
+  }
+
+  // dma-buf registration requires a page-aligned base address. Align down
+  // and remember the offset so the caller can pass it to regDmabufMr.
+  const auto addr = reinterpret_cast<uint64_t>(ptr);
+  const uintptr_t alignedAddr = addr & ~(pageSize_ - 1);
+  const uint64_t dmaBufOffset = addr - alignedAddr;
+  const size_t dmaBufLen =
+      (len + dmaBufOffset + pageSize_ - 1) & ~(pageSize_ - 1);
+
+  DmaBuff out;
+  // TODO: set CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE if a data-direct
+  // link is available.
+  constexpr unsigned long long kFlags = 0;
+  auto status = cudaDriverApi_->cuMemGetHandleForAddressRange(
+      &out.fd,
+      toDevicePtr(alignedAddr),
+      dmaBufLen,
+      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+      kFlags);
+  CHECK_RETURN(status);
+
+  out.offset = dmaBufOffset;
+  out.len = len;
+  out.iova = static_cast<uint64_t>(addr);
+  return out;
+}
+
+Status CudaDeviceAdapter::closeDmaBuff(DmaBuff& buff) {
+  if (buff.fd >= 0) {
+    ::close(buff.fd);
+    buff.fd = -1;
+  }
+  return Ok();
+}
+
 std::shared_ptr<DeviceAdapter> createDeviceAdapter(
-    std::shared_ptr<CudaApi> cudaApi) {
+    std::shared_ptr<CudaApi> cudaApi,
+    std::shared_ptr<CudaDriverApi> cudaDriverApi) {
   if (!cudaApi) {
     cudaApi = std::make_shared<CudaApi>();
   }
-  return std::make_shared<CudaDeviceAdapter>(std::move(cudaApi));
+  if (!cudaDriverApi) {
+    cudaDriverApi = std::make_shared<CudaDriverApi>();
+  }
+  return std::make_shared<CudaDeviceAdapter>(
+      std::move(cudaApi), std::move(cudaDriverApi));
 }
 
 } // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.h
@@ -2,24 +2,33 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 
 namespace uniflow {
 
 class CudaDeviceAdapter : public DeviceAdapter {
  public:
-  explicit CudaDeviceAdapter(std::shared_ptr<CudaApi> cudaApi)
-      : cudaApi_(std::move(cudaApi)) {}
+  explicit CudaDeviceAdapter(
+      std::shared_ptr<CudaApi> cudaApi,
+      std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr);
 
   Result<void*> pinnedHostAlloc(size_t size) override;
   Status pinnedHostFree(void* ptr) override;
   Result<void*> hostGetDevicePointer(void* hostPtr) override;
 
+  Result<bool> isDmaBuffSupported(int deviceId) override;
+  Result<DmaBuff> exportDmaBuff(int deviceId, void* ptr, size_t len) override;
+  Status closeDmaBuff(DmaBuff& buff) override;
+
  private:
   std::shared_ptr<CudaApi> cudaApi_;
+  std::shared_ptr<CudaDriverApi> cudaDriverApi_;
+  size_t pageSize_{0};
 };
 
 } // namespace uniflow

--- a/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaDeviceAdapterTest.cpp
@@ -5,7 +5,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <memory>
+
 #include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+#include "comms/uniflow/drivers/cuda/mock/MockCudaDriverApi.h"
 
 namespace uniflow {
 
@@ -59,6 +63,74 @@ TEST(CudaDeviceAdapterTest, PinnedHostFreeDelegatesToCudaApi) {
   CudaDeviceAdapter adapter(mock);
 
   EXPECT_FALSE(adapter.pinnedHostFree(fakePtr).hasError());
+}
+
+TEST(CudaDeviceAdapterTest, IsDmaBuffSupportedDelegatesToDriverApi) {
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  EXPECT_CALL(*driverApi, isDmaBufSupported(3)).WillOnce(Return(true));
+
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  auto res = adapter.isDmaBuffSupported(3);
+  ASSERT_FALSE(res.hasError());
+  EXPECT_TRUE(res.value());
+}
+
+TEST(CudaDeviceAdapterTest, ExportDmaBuffPopulatesFdOffsetAndIova) {
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  constexpr int kFakeFd = 42;
+  EXPECT_CALL(
+      *driverApi,
+      cuMemGetHandleForAddressRange(
+          _, _, _, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0))
+      .WillOnce([&](void* handle,
+                    CUdeviceptr,
+                    size_t,
+                    CUmemRangeHandleType,
+                    unsigned long long) {
+        *static_cast<int*>(handle) = kFakeFd;
+        return Ok();
+      });
+
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  // Use a real heap-aligned allocation as the base, then offset into it to
+  // get a non-page-aligned pointer. posix_memalign + free keeps the
+  // allocate/free pair symmetric (mixing aligned `new[]` with default
+  // `delete[]` would be UB).
+  const size_t pageSize = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
+  void* backingRaw = nullptr;
+  ASSERT_EQ(::posix_memalign(&backingRaw, pageSize, pageSize * 2), 0);
+  std::unique_ptr<void, decltype(&::free)> backing(backingRaw, &::free);
+  void* ptr = static_cast<std::byte*>(backing.get()) + 128;
+
+  auto res = adapter.exportDmaBuff(/*deviceId=*/0, ptr, /*len=*/4096);
+  ASSERT_FALSE(res.hasError());
+  EXPECT_EQ(res->fd, kFakeFd);
+  EXPECT_EQ(res->offset, 128u);
+  EXPECT_EQ(res->len, 4096u);
+  EXPECT_EQ(res->iova, reinterpret_cast<uint64_t>(ptr));
+}
+
+TEST(CudaDeviceAdapterTest, ExportDmaBuffRejectsNullPtr) {
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  auto res = adapter.exportDmaBuff(/*deviceId=*/0, nullptr, /*len=*/4096);
+  EXPECT_TRUE(res.hasError());
+}
+
+TEST(CudaDeviceAdapterTest, CloseDmaBuffIsNoopForUnsetFd) {
+  auto cudaApi = std::make_shared<NiceMock<MockCudaApi>>();
+  auto driverApi = std::make_shared<NiceMock<MockCudaDriverApi>>();
+  CudaDeviceAdapter adapter(cudaApi, driverApi);
+
+  DmaBuff buff;
+  EXPECT_FALSE(adapter.closeDmaBuff(buff).hasError());
+  EXPECT_EQ(buff.fd, -1);
 }
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaRegistrationHandle.cpp
+++ b/comms/uniflow/transport/rdma/RdmaRegistrationHandle.cpp
@@ -4,6 +4,9 @@
 
 #include <cassert>
 #include <cstring>
+#include <stdexcept>
+
+#include "comms/uniflow/Result.h"
 
 namespace uniflow {
 
@@ -15,11 +18,24 @@ RdmaRegistrationHandle::RdmaRegistrationHandle(
     std::vector<ibv_mr*> mrs,
     std::shared_ptr<IbvApi> ibvApi,
     uint64_t domainId,
+    uint64_t registrationBase,
+    std::shared_ptr<DeviceAdapter> deviceAdapter,
+    int deviceId,
     int hostBufferNumaNode)
     : mrs_(std::move(mrs)),
       ibvApi_(std::move(ibvApi)),
       domainId_(domainId),
-      hostBufferNumaNode_(hostBufferNumaNode) {}
+      hostBufferNumaNode_(hostBufferNumaNode),
+      registrationBase_(registrationBase),
+      deviceAdapter_(std::move(deviceAdapter)),
+      deviceId_(deviceId) {
+  // toWireAddr() dereferences deviceAdapter_ whenever deviceId_ >= 0, so a
+  // device-backed handle must be given a non-null adapter. Enforced in release
+  // builds too: a null adapter here is a programming error, not a runtime
+  // input.
+  CHECK_THROW_EXCEPTION(
+      deviceId_ < 0 || deviceAdapter_ != nullptr, std::invalid_argument);
+}
 
 RdmaRegistrationHandle::~RdmaRegistrationHandle() {
   for (auto* mr : mrs_) {
@@ -36,6 +52,7 @@ std::vector<uint8_t> RdmaRegistrationHandle::serialize() const {
 
   Header header{
       .domainId = domainId_,
+      .registrationBase = registrationBase_,
       .numMrs = static_cast<uint8_t>(mrs_.size()),
   };
   std::memcpy(buf.data(), &header, sizeof(header));
@@ -50,6 +67,11 @@ std::vector<uint8_t> RdmaRegistrationHandle::serialize() const {
 
   return buf;
 }
+uint64_t RdmaRegistrationHandle::toWireAddr(const void* ptr) const {
+  auto devAddr = (deviceId_ >= 0) ? deviceAdapter_->resolveDevicePointer(ptr)
+                                  : reinterpret_cast<uint64_t>(ptr);
+  return devAddr - registrationBase_;
+}
 
 // ---------------------------------------------------------------------------
 // RdmaRemoteRegistrationHandle
@@ -57,7 +79,29 @@ std::vector<uint8_t> RdmaRegistrationHandle::serialize() const {
 
 RdmaRemoteRegistrationHandle::RdmaRemoteRegistrationHandle(
     std::vector<uint32_t> rkeys,
-    uint64_t domainId)
-    : rkeys_(std::move(rkeys)), domainId_(domainId) {}
+    uint64_t domainId,
+    uint64_t registrationBase,
+    std::shared_ptr<DeviceAdapter> deviceAdapter)
+    : rkeys_(std::move(rkeys)),
+      domainId_(domainId),
+      registrationBase_(registrationBase),
+      deviceAdapter_(std::move(deviceAdapter)) {
+  // toWireAddr() dereferences deviceAdapter_ whenever registrationBase_ != 0,
+  // so a translated handle must be given a non-null adapter. Enforced in
+  // release builds too: a null adapter here is a programming error, not a
+  // runtime input.
+  CHECK_THROW_EXCEPTION(
+      registrationBase_ == 0 || deviceAdapter_ != nullptr,
+      std::invalid_argument);
+}
+
+uint64_t RdmaRemoteRegistrationHandle::toWireAddr(const void* ptr) const {
+  /// Remote handles don't carry information on whether the target is a device
+  /// ptr or not So we use the fact that only targets that have a non-zero
+  /// registrationBase require pointer translation
+  auto devAddr = registrationBase_ ? deviceAdapter_->resolveDevicePointer(ptr)
+                                   : reinterpret_cast<uint64_t>(ptr);
+  return devAddr - registrationBase_;
+}
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaRegistrationHandle.h
+++ b/comms/uniflow/transport/rdma/RdmaRegistrationHandle.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "comms/uniflow/Segment.h"
+#include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/ibverbs/IbvApi.h"
 #include "comms/uniflow/transport/TransportType.h"
 
@@ -22,13 +23,15 @@ namespace uniflow {
 /// obtained from ibv_reg_mr. Each MR pins the same memory region but
 /// is associated with a different protection domain.
 ///
-/// The serialized payload contains a domain id and per-MR rkeys, which
-/// the peer needs to perform one-sided RDMA operations on this memory.
+/// The serialized payload contains a domain id, a registrationBase, and
+/// per-MR rkeys, which the peer needs to perform one-sided RDMA operations
+/// on this memory.
 class RdmaRegistrationHandle : public RegistrationHandle {
  public:
   /// Packed wire format for serialization.
   struct __attribute__((packed)) Header {
     uint64_t domainId{0}; // Factory instance key
+    uint64_t registrationBase{0}; // VA → wire-address offset
     uint8_t numMrs{0}; // Number of MRs (one per NIC)
     // Followed by numMrs uint32_t rkeys.
   };
@@ -39,6 +42,9 @@ class RdmaRegistrationHandle : public RegistrationHandle {
       std::vector<ibv_mr*> mrs,
       std::shared_ptr<IbvApi> ibvApi,
       uint64_t domainId,
+      uint64_t registrationBase = 0,
+      std::shared_ptr<DeviceAdapter> deviceAdapter = nullptr,
+      int deviceId = -1,
       int bufferNumaNode = -1);
 
   ~RdmaRegistrationHandle() override;
@@ -83,11 +89,26 @@ class RdmaRegistrationHandle : public RegistrationHandle {
     return hostBufferNumaNode_;
   }
 
+  /// Value to subtract from a VA to produce the address the NIC expects
+  /// on the wire (SGE.addr / wr.rdma.remote_addr). Zero for ordinary
+  /// single-buffer registrations; non-zero when the underlying MR covers
+  /// a larger containing region.
+  uint64_t registrationBase() const noexcept {
+    return registrationBase_;
+  }
+
+  /// Translate a client-supplied pointer to the wire address the NIC
+  /// expects in an SGE (`sge.addr`). Folds two platform-specific steps.
+  uint64_t toWireAddr(const void* ptr) const;
+
  private:
   std::vector<ibv_mr*> mrs_;
   std::shared_ptr<IbvApi> ibvApi_;
   uint64_t domainId_;
   int hostBufferNumaNode_{-1};
+  uint64_t registrationBase_{0};
+  std::shared_ptr<DeviceAdapter> deviceAdapter_;
+  int deviceId_{-1};
 };
 
 // ---------------------------------------------------------------------------
@@ -99,7 +120,11 @@ class RdmaRegistrationHandle : public RegistrationHandle {
 /// used in RDMA work requests posted on QPs belonging to that NIC.
 class RdmaRemoteRegistrationHandle : public RemoteRegistrationHandle {
  public:
-  RdmaRemoteRegistrationHandle(std::vector<uint32_t> rkeys, uint64_t domainId);
+  RdmaRemoteRegistrationHandle(
+      std::vector<uint32_t> rkeys,
+      uint64_t domainId,
+      uint64_t registrationBase = 0,
+      std::shared_ptr<DeviceAdapter> deviceAdapter = nullptr);
 
   ~RdmaRemoteRegistrationHandle() override = default;
 
@@ -123,9 +148,21 @@ class RdmaRemoteRegistrationHandle : public RemoteRegistrationHandle {
     return domainId_;
   }
 
+  /// Mirror of the sender's `RdmaRegistrationHandle::registrationBase()` —
+  /// subtract from remote VA to form `wr.rdma.remote_addr`.
+  uint64_t registrationBase() const noexcept {
+    return registrationBase_;
+  }
+
+  /// Translate a client-supplied pointer to the wire address the NIC
+  /// expects in an SGE (`sge.addr`). Folds two platform-specific steps.
+  uint64_t toWireAddr(const void* ptr) const;
+
  private:
   std::vector<uint32_t> rkeys_;
   uint64_t domainId_;
+  uint64_t registrationBase_{0};
+  std::shared_ptr<DeviceAdapter> deviceAdapter_;
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -10,7 +10,6 @@
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
 #include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 
-#include <unistd.h>
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -26,6 +25,29 @@ namespace uniflow {
 namespace {
 
 constexpr uint32_t kSlabIdxInvalid{0xFFFFFFFF};
+
+// RAII guard that releases a DmaBuff's resources on scope exit. Closing is
+// only attempted when an fd was actually exported (fd >= 0).
+class DmaBuffCloseGuard {
+ public:
+  DmaBuffCloseGuard(DeviceAdapter& adapter, DmaBuff& buff) noexcept
+      : adapter_{adapter}, buff_{buff} {}
+
+  ~DmaBuffCloseGuard() {
+    if (buff_.fd >= 0) {
+      (void)adapter_.closeDmaBuff(buff_);
+    }
+  }
+
+  DmaBuffCloseGuard(const DmaBuffCloseGuard&) = delete;
+  DmaBuffCloseGuard& operator=(const DmaBuffCloseGuard&) = delete;
+  DmaBuffCloseGuard(DmaBuffCloseGuard&&) = delete;
+  DmaBuffCloseGuard& operator=(DmaBuffCloseGuard&&) = delete;
+
+ private:
+  DeviceAdapter& adapter_;
+  DmaBuff& buff_;
+};
 
 struct __attribute__((packed)) RdmaTopologyInfo {
   uint8_t version{kRdmaVersion};
@@ -610,6 +632,14 @@ RdmaTransport::buildSendWrs(
     if (reqSize == 0) {
       continue;
     }
+    // preprocessRequest guarantees both handles are non-null; guard here to
+    // document the invariant and satisfy nullable-dereference analysis.
+    if (localHandle == nullptr || remoteHandle == nullptr) {
+      return Err(
+          ErrCode::InvalidArgument, "RDMA transfer: null registration handle");
+    }
+    const uint64_t localWireBase = localHandle->toWireAddr(req.local.data());
+    const uint64_t remoteWireBase = remoteHandle->toWireAddr(req.remote.data());
 
     // Split into fixed-size chunks. Each chunk becomes one SendWr.
     size_t offset = 0;
@@ -617,13 +647,12 @@ RdmaTransport::buildSendWrs(
       size_t len = std::min(reqSize - offset, kChunkSize);
       auto& sendWr = wrs->emplace_back();
 
-      sendWr.sge.addr = reinterpret_cast<uint64_t>(req.local.data()) + offset;
+      sendWr.sge.addr = localWireBase + offset;
       sendWr.sge.length = static_cast<uint32_t>(len);
       sendWr.wr.num_sge = 1;
       sendWr.wr.opcode = opcode;
       sendWr.wr.send_flags = 0; // Signaled only on the last WR per QP.
-      sendWr.wr.wr.rdma.remote_addr =
-          reinterpret_cast<uint64_t>(req.remote.data()) + offset;
+      sendWr.wr.wr.rdma.remote_addr = remoteWireBase + offset;
       sendWr.localHandle = localHandle;
       sendWr.remoteHandle = remoteHandle;
 
@@ -1835,11 +1864,11 @@ RdmaTransportFactory::RdmaTransportFactory(
     cudaApi_ = std::make_shared<CudaApi>();
   }
 
+  deviceAdapter_ = createDeviceAdapter(cudaApi_, cudaDriverApi_);
+
   // Generate a random domain id to identify handles from this factory.
   std::mt19937_64 rng{std::random_device{}()};
   domainId_ = rng();
-
-  pageSize_ = sysconf(_SC_PAGESIZE);
 
   int numDevices = 0;
   auto devListResult = ibvApi_->getDeviceList(&numDevices);
@@ -1890,64 +1919,65 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   int access =
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
 
-  // For VRAM, get DMA-BUF fd for GPU Direct RDMA (NIC reads/writes GPU
-  // memory directly). For DRAM, use standard ibv_reg_mr.
-  // RAII guard ensures the fd is closed when we leave this scope.
-  struct FdGuard {
-    int fd = -1;
-    ~FdGuard() {
-      if (fd >= 0) {
-        ::close(fd);
-      }
-    }
-  } fdGuard;
-
-  // dma buffers must be page aligned, the address must be page-aligned.
-  // Align down to page boundary and track the offset for regDmabufMr.
-  uint64_t dmaBufOffset = 0;
-  uintptr_t addr = reinterpret_cast<uintptr_t>(segment.mutable_data());
+  // For VRAM, ask the DeviceAdapter to export a DMA-BUF fd for GPU Direct
+  // RDMA (NIC reads/writes accelerator memory directly). For DRAM, fall
+  // back to standard ibv_reg_mr.
+  // RAII guard ensures closeDmaBuff() runs on every exit path.
+  DmaBuff dmaBuff;
+  DmaBuffCloseGuard closeGuard{*deviceAdapter_, dmaBuff};
+  uint64_t registrationBase = 0;
 
   if (segment.memType() == MemoryType::VRAM) {
     auto dmaBufSupported =
-        cudaDriverApi_->isDmaBufSupported(segment.deviceId());
+        deviceAdapter_->isDmaBuffSupported(segment.deviceId());
     CHECK_RETURN(dmaBufSupported);
     if (dmaBufSupported.value()) {
-      const uintptr_t alignedAddr = addr & ~(pageSize_ - 1);
-      dmaBufOffset = addr - alignedAddr;
-      const size_t dmaBufLen =
-          (segment.len() + dmaBufOffset + pageSize_ - 1) & ~(pageSize_ - 1);
-
-      int flags = 0;
-      // TODO: set CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE if data direct
-      // link is available.
-      auto dmaBufStatus = cudaDriverApi_->cuMemGetHandleForAddressRange(
-          &fdGuard.fd,
-          toDevicePtr(alignedAddr),
-          dmaBufLen,
-          CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-          flags);
-      if (!dmaBufStatus) {
-        fdGuard.fd = -1;
-        // DMA-BUF is the preferred GPU Direct RDMA registration path, but it
-        // is an optimization over a valid VRAM allocation rather than the only
-        // correctness path. Some CUDA allocation modes or driver states cannot
-        // export a DMA-BUF for an otherwise usable segment; fall back to normal
-        // MR registration so non-GDR-capable paths can still make progress.
+      auto exportRes = deviceAdapter_->exportDmaBuff(
+          segment.deviceId(), segment.mutable_data(), segment.len());
+      if (exportRes.hasValue()) {
+        dmaBuff = std::move(exportRes).value();
+        registrationBase = dmaBuff.registrationBase;
+      } else if (deviceAdapter_->allowsRegMrFallback()) {
         UNIFLOW_LOG_WARN(
-            "cuMemGetHandleForAddressRange failed for VRAM segment "
-            "(addr=0x{:x}, len={}, device={}): {}. "
-            "Falling back to ibv_reg_mr; this may disable GPU Direct RDMA. "
-            "For PyTorch expandable-segment allocations, "
-            "TORCH_CUDA_EXPANDABLE_SEGMENTS_IPC=1 can restore DMA-BUF export.",
-            addr,
-            dmaBufLen,
+            "registerSegment: exportDmaBuff failed for VRAM segment "
+            "(device={}, ptr=0x{:x}, len={}): {}. Falling back to ibv_reg_mr; "
+            "GPU Direct RDMA may be disabled for this segment.",
             segment.deviceId(),
-            dmaBufStatus.error().message());
+            reinterpret_cast<uint64_t>(segment.mutable_data()),
+            segment.len(),
+            exportRes.error().toString());
+      } else {
+        UNIFLOW_LOG_ERROR(
+            "registerSegment: exportDmaBuff failed for VRAM segment "
+            "(device={}, ptr=0x{:x}, len={}): {}. Backend does not allow "
+            "ibv_reg_mr fallback for accelerator memory (a plain registration "
+            "would be invalid, e.g. out-of-pool or wrong-device pointer); "
+            "failing registration.",
+            segment.deviceId(),
+            reinterpret_cast<uint64_t>(segment.mutable_data()),
+            segment.len(),
+            exportRes.error().toString());
+        return std::move(exportRes).error();
       }
+    } else if (!deviceAdapter_->allowsRegMrFallback()) {
+      // DMA-BUF is the only valid registration path for this backend's
+      // accelerator memory; a plain ibv_reg_mr would mis-register it.
+      UNIFLOW_LOG_ERROR(
+          "registerSegment: DMA-BUF unsupported for VRAM segment "
+          "(device={}, ptr=0x{:x}, len={}) and backend does not allow "
+          "ibv_reg_mr fallback; failing registration.",
+          segment.deviceId(),
+          reinterpret_cast<uint64_t>(segment.mutable_data()),
+          segment.len());
+      return Err(
+          ErrCode::DriverError,
+          "registerSegment: DMA-BUF unsupported and ibv_reg_mr fallback not "
+          "permitted for accelerator memory on device " +
+              std::to_string(segment.deviceId()));
     }
   }
   const bool useRegMrFallback =
-      segment.memType() == MemoryType::VRAM && fdGuard.fd < 0;
+      segment.memType() == MemoryType::VRAM && dmaBuff.fd < 0;
   if (useRegMrFallback) {
     dmaBufFallbackCount_.fetch_add(1, std::memory_order_relaxed);
   }
@@ -1958,14 +1988,14 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
   mrs.reserve(nicsHandle_->size());
   for (const auto& nic : *nicsHandle_) {
     Result<ibv_mr*> mrResult = Err(ErrCode::NotImplemented);
-    if (nic.dmaBufSupported && fdGuard.fd >= 0) {
-      // GPU memory: register via DMA-BUF for GPU Direct RDMA.
+    if (nic.dmaBufSupported && dmaBuff.fd >= 0) {
+      // Accelerator memory: register via DMA-BUF for GPU Direct RDMA.
       mrResult = ibvApi_->regDmabufMr(
           nic.pd,
-          dmaBufOffset,
-          segment.len(),
-          reinterpret_cast<uint64_t>(addr),
-          fdGuard.fd,
+          dmaBuff.offset,
+          dmaBuff.len,
+          dmaBuff.iova,
+          dmaBuff.fd,
           access);
     } else {
       // standard registration.
@@ -1987,7 +2017,13 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
       ? detectHostNumaNode(segment.mutable_data())
       : -1;
   return std::make_unique<RdmaRegistrationHandle>(
-      std::move(mrs), ibvApi_, domainId_, numaNode);
+      std::move(mrs),
+      ibvApi_,
+      domainId_,
+      registrationBase,
+      deviceAdapter_,
+      segment.deviceId(),
+      numaNode);
 }
 
 Result<std::unique_ptr<RemoteRegistrationHandle>>
@@ -2023,7 +2059,7 @@ RdmaTransportFactory::importSegment(
 
   uint64_t domainId = header.domainId;
   return std::make_unique<RdmaRemoteRegistrationHandle>(
-      std::move(rkeys), domainId);
+      std::move(rkeys), domainId, header.registrationBase, deviceAdapter_);
 }
 
 Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -22,7 +22,7 @@
 
 namespace uniflow {
 
-constexpr uint8_t kRdmaVersion{1};
+constexpr uint8_t kRdmaVersion{2};
 
 // Forward declarations.
 class RdmaRegistrationHandle;
@@ -679,9 +679,9 @@ class RdmaTransportFactory : public TransportFactory {
 
   EventBase* evb_{nullptr};
   uint64_t domainId_{0};
-  size_t pageSize_{0};
   std::atomic<uint64_t> dmaBufFallbackCount_{0};
   std::shared_ptr<std::vector<NicResources>> nicsHandle_;
+  std::shared_ptr<DeviceAdapter> deviceAdapter_;
   const RdmaTransportConfig config_;
   std::shared_ptr<RdmaSlabPool> slabPool_;
 };

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -134,7 +134,14 @@ TEST_F(RdmaRegistrationHandleTest, SerializeMultipleMrs) {
 
 TEST_F(RdmaRegistrationHandleTest, HostNumaNodeExplicit) {
   ibv_mr mr{};
-  RdmaRegistrationHandle handle({&mr}, ibv_, 42, 3);
+  RdmaRegistrationHandle handle(
+      {&mr},
+      ibv_,
+      42,
+      /*registrationBase=*/0,
+      /*deviceAdapter=*/nullptr,
+      /*deviceId=*/-1,
+      /*bufferNumaNode=*/3);
   EXPECT_EQ(handle.hostBufferNumaNode(), 3);
 }
 
@@ -192,11 +199,127 @@ TEST_F(RdmaRegistrationHandleTest, SerializeDeserializeRoundTrip) {
       header.numMrs * sizeof(uint32_t));
 
   // addr and length are provided by the caller, not from the wire.
-  RdmaRemoteRegistrationHandle remote(std::move(rkeys), header.domainId);
+  RdmaRemoteRegistrationHandle remote(
+      std::move(rkeys), header.domainId, header.registrationBase);
 
   EXPECT_EQ(remote.numMrs(), handle.numMrs());
   EXPECT_EQ(remote.rkey(0), handle.rkey(0));
   EXPECT_EQ(remote.rkey(1), handle.rkey(1));
+  EXPECT_EQ(remote.registrationBase(), handle.registrationBase());
+}
+
+TEST_F(RdmaRegistrationHandleTest, RegistrationBaseDefaultsToZero) {
+  ibv_mr mr{};
+  RdmaRegistrationHandle handle({&mr}, ibv_, 42);
+  EXPECT_EQ(handle.registrationBase(), 0u);
+}
+
+TEST_F(RdmaRegistrationHandleTest, RegistrationBaseRoundTripsNonZero) {
+  ibv_mr mr{};
+  mr.rkey = 0x77;
+  constexpr uint64_t kPoolBase = 0x7f0000000000ULL;
+  RdmaRegistrationHandle handle(
+      {&mr}, ibv_, 42, /*registrationBase=*/kPoolBase);
+  EXPECT_EQ(handle.registrationBase(), kPoolBase);
+
+  auto serialized = handle.serialize();
+  RdmaRegistrationHandle::Header header;
+  std::memcpy(&header, serialized.data(), sizeof(header));
+  EXPECT_EQ(header.domainId, 42u);
+  EXPECT_EQ(header.registrationBase, kPoolBase);
+  EXPECT_EQ(header.numMrs, 1u);
+}
+
+// --- toWireAddr tests ---
+
+namespace {
+// Minimal DeviceAdapter test double whose resolveDevicePointer returns a
+// fixed, caller-controlled address. Only resolveDevicePointer is exercised by
+// toWireAddr; the remaining methods are unused and return an error.
+class FakeDeviceAdapter : public DeviceAdapter {
+ public:
+  explicit FakeDeviceAdapter(uint64_t resolvedAddr) noexcept
+      : resolvedAddr_(resolvedAddr) {}
+
+  uint64_t resolveDevicePointer(const void* /*ptr*/) const noexcept override {
+    return resolvedAddr_;
+  }
+
+  Result<void*> pinnedHostAlloc(size_t) override {
+    return ErrCode::NotImplemented;
+  }
+  Status pinnedHostFree(void*) override {
+    return ErrCode::NotImplemented;
+  }
+  Result<void*> hostGetDevicePointer(void*) override {
+    return ErrCode::NotImplemented;
+  }
+  Result<bool> isDmaBuffSupported(int) override {
+    return ErrCode::NotImplemented;
+  }
+  Result<DmaBuff> exportDmaBuff(int, void*, size_t) override {
+    return ErrCode::NotImplemented;
+  }
+  Status closeDmaBuff(DmaBuff&) override {
+    return ErrCode::NotImplemented;
+  }
+
+ private:
+  uint64_t resolvedAddr_;
+};
+} // namespace
+
+// Host pointer (deviceId < 0) with zero base: wire address is the raw pointer.
+TEST_F(RdmaRegistrationHandleTest, ToWireAddrHostPointerNoBaseReturnsRawAddr) {
+  ibv_mr mr{};
+  char buf[16]{};
+  RdmaRegistrationHandle handle({&mr}, ibv_, 42);
+  EXPECT_EQ(handle.toWireAddr(buf), reinterpret_cast<uint64_t>(buf));
+}
+
+// Host pointer (deviceId < 0) with a non-zero base: base is subtracted.
+TEST_F(RdmaRegistrationHandleTest, ToWireAddrHostPointerSubtractsBase) {
+  ibv_mr mr{};
+  char buf[16]{};
+  constexpr uint64_t kBase = 0x1000;
+  RdmaRegistrationHandle handle({&mr}, ibv_, 42, /*registrationBase=*/kBase);
+  EXPECT_EQ(handle.toWireAddr(buf), reinterpret_cast<uint64_t>(buf) - kBase);
+}
+
+// Device pointer (deviceId >= 0): the adapter resolves the address, then base
+// is subtracted. The input pointer is opaque to the adapter.
+TEST_F(
+    RdmaRegistrationHandleTest,
+    ToWireAddrDevicePointerResolvesThenSubtractsBase) {
+  ibv_mr mr{};
+  char buf[16]{};
+  constexpr uint64_t kDevAddr = 0x7f0000005000ULL;
+  constexpr uint64_t kBase = 0x7f0000000000ULL;
+  auto adapter = std::make_shared<FakeDeviceAdapter>(kDevAddr);
+  RdmaRegistrationHandle handle(
+      {&mr}, ibv_, 42, /*registrationBase=*/kBase, adapter, /*deviceId=*/0);
+  EXPECT_EQ(handle.toWireAddr(buf), kDevAddr - kBase);
+}
+
+// Remote handle with zero base: wire address is the raw pointer (no adapter
+// dereference, so a null adapter is fine).
+TEST(RdmaRemoteRegistrationHandleTest, ToWireAddrZeroBaseReturnsRawAddr) {
+  char buf[16]{};
+  RdmaRemoteRegistrationHandle handle({0x1}, 42);
+  EXPECT_EQ(handle.toWireAddr(buf), reinterpret_cast<uint64_t>(buf));
+}
+
+// Remote handle with a non-zero base: the adapter resolves the address, then
+// base is subtracted.
+TEST(
+    RdmaRemoteRegistrationHandleTest,
+    ToWireAddrNonZeroBaseResolvesThenSubtractsBase) {
+  char buf[16]{};
+  constexpr uint64_t kDevAddr = 0x7f0000005000ULL;
+  constexpr uint64_t kBase = 0x7f0000000000ULL;
+  auto adapter = std::make_shared<FakeDeviceAdapter>(kDevAddr);
+  RdmaRemoteRegistrationHandle handle({0x1}, 42, kBase, adapter);
+  EXPECT_EQ(handle.toWireAddr(buf), kDevAddr - kBase);
 }
 
 // --- Factory registerSegment/importSegment tests ---

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -141,7 +141,7 @@ TEST(RdmaTransportInfoTest, DeserializeTruncatedHeader) {
 TEST(RdmaTransportInfoTest, DeserializeTruncatedPayload) {
   // Provide a full header but no NicInfo/QpInfo payload.
   RdmaTransportInfo info;
-  info.header.version = 1;
+  info.header.version = kRdmaVersion;
   info.header.numQps = 3;
   info.header.numNics = 2;
 
@@ -155,7 +155,7 @@ TEST(RdmaTransportInfoTest, DeserializeTruncatedPayload) {
 
 TEST(RdmaTransportInfoTest, SerializeZeroQps) {
   RdmaTransportInfo info;
-  info.header.version = 1;
+  info.header.version = kRdmaVersion;
   info.header.numQps = 0;
   info.header.numNics = 1;
   info.nicInfos = {{.lid = 1}};
@@ -530,7 +530,7 @@ TEST_F(RdmaTransportTest, ConnectTransitionsQPs) {
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
-  remoteInfo.header.version = 1;
+  remoteInfo.header.version = kRdmaVersion;
   remoteInfo.header.numQps = 1;
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 0x5678}};
@@ -560,7 +560,7 @@ TEST_F(RdmaTransportTest, ConnectRejectsQpCountMismatch) {
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
-  remoteInfo.header.version = 1;
+  remoteInfo.header.version = kRdmaVersion;
   remoteInfo.header.numQps = 2;
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 1}};
@@ -582,7 +582,7 @@ TEST_F(RdmaTransportTest, ConnectWithoutBindFails) {
 
   // Don't call bind() - go straight to connect()
   RdmaTransportInfo remoteInfo;
-  remoteInfo.header.version = 1;
+  remoteInfo.header.version = kRdmaVersion;
   remoteInfo.header.numQps = 1;
   remoteInfo.header.numNics = 1;
   remoteInfo.nicInfos = {{.lid = 1}};
@@ -982,7 +982,7 @@ class RdmaTransportDataPathTest : public ::testing::Test {
     transport_->bind();
 
     RdmaTransportInfo remoteInfo;
-    remoteInfo.header.version = 1;
+    remoteInfo.header.version = kRdmaVersion;
     remoteInfo.header.numQps = 1;
     remoteInfo.header.numNics = 1;
     remoteInfo.header.domainId = kRemoteDomainId;
@@ -1100,7 +1100,7 @@ TEST_P(RdmaTransportOpcodeTest, DisconnectedTransportReturnsError) {
 TEST_P(RdmaTransportOpcodeTest, EmptyRequestsReturnsOk) {
   std::vector<TransferRequest> reqs;
   auto status = transfer(reqs).get();
-  EXPECT_FALSE(status.hasError());
+  EXPECT_FALSE(status.hasError()) << status.error().message();
 }
 
 TEST_P(RdmaTransportOpcodeTest, MismatchedSpanSizesReturnsError) {
@@ -1296,7 +1296,7 @@ TEST_F(RdmaTransportTest, CompletionRoutingDisambiguatesDuplicateQpNumbers) {
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
-  remoteInfo.header.version = 1;
+  remoteInfo.header.version = kRdmaVersion;
   remoteInfo.header.numQps = 2;
   remoteInfo.header.numNics = 2;
   remoteInfo.header.domainId = kRemoteDomainId;


### PR DESCRIPTION
Summary:

Introduce an abstraction over dma buffs and registering them.

We add the following methods to DeviceAdapter:
- isDmaBuffSupported
- exportDmaBuff
- resolveDevicePointer
- allowsRegMrFallback
- closeDmaBuff

With this 5 methods we can support existing CUDA-like devices as is and alternative devices that require a different path for exporting VRAM.

Reviewed By: rmahidhar

Differential Revision: D106401097


