### PR TITLE
add NCCL sendrecv benchmark for comparison (#2776)

### DIFF
--- a/comms/uniflow/benchmarks/BenchmarkResult.h
+++ b/comms/uniflow/benchmarks/BenchmarkResult.h
@@ -21,6 +21,7 @@ struct BenchmarkResult {
   Stats latency{}; // in microseconds
   double messageRateMops{0};
   int numStreams{0};
+  int numPeers{0};
 };
 
 } // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -27,6 +27,7 @@ struct BenchmarkConfig {
   std::string direction{"both"};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"}; // "fanout", "fanin"
+  int pipelineDepth{2}; // send/recv staging pipeline depth
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -26,6 +26,7 @@ struct BenchmarkConfig {
   bool bidirectional{false};
   std::string direction{"both"};
   std::vector<int> numStreams{1, 2, 4, 8};
+  std::string topology{"fanout"}; // "fanout", "fanin"
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/BenchmarkRunner.h
+++ b/comms/uniflow/benchmarks/BenchmarkRunner.h
@@ -28,6 +28,8 @@ struct BenchmarkConfig {
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"}; // "fanout", "fanin"
   int pipelineDepth{2}; // send/recv staging pipeline depth
+  size_t slabSize{0}; // 0 = use chunk-size
+  int slabNum{0}; // 0 = use pipeline-depth
 };
 
 class Benchmark {

--- a/comms/uniflow/benchmarks/Reporter.cpp
+++ b/comms/uniflow/benchmarks/Reporter.cpp
@@ -119,7 +119,7 @@ void Reporter::printCSV(
   os << "benchmark,transport,direction,size_bytes,iterations,"
         "batch_size,tx_depth,chunk_size,"
         "bw_gbps,lat_avg_us,lat_p50_us,lat_p99_us,"
-        "lat_min_us,lat_max_us,msg_rate_mops,num_streams\n";
+        "lat_min_us,lat_max_us,msg_rate_mops,num_streams,num_peers\n";
 
   for (const auto& r : results) {
     os << r.benchmarkName << "," << r.transport << "," << r.direction << ","
@@ -128,7 +128,7 @@ void Reporter::printCSV(
        << std::setprecision(4) << r.bandwidthGBs << "," << r.latency.avg << ","
        << r.latency.p50 << "," << r.latency.p99 << "," << r.latency.min << ","
        << r.latency.max << "," << r.messageRateMops << "," << r.numStreams
-       << "\n";
+       << "," << r.numPeers << "\n";
   }
 }
 

--- a/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.cpp
@@ -1,0 +1,291 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+#include "nccl.h" // @manual
+
+#include "comms/uniflow/benchmarks/Rendezvous.h"
+#include "comms/uniflow/logging/Logger.h"
+
+namespace uniflow::benchmark {
+
+namespace {
+
+#define CUDACHECK(cmd)                                            \
+  do {                                                            \
+    cudaError_t e = (cmd);                                        \
+    if (e != cudaSuccess) {                                       \
+      UNIFLOW_LOG_ERROR("CUDA error: {}", cudaGetErrorString(e)); \
+      return {};                                                  \
+    }                                                             \
+  } while (0)
+
+#define NCCLCHECK(cmd)                                                  \
+  do {                                                                  \
+    ncclResult_t r = (cmd);                                             \
+    if (r != ncclSuccess) {                                             \
+      UNIFLOW_LOG_ERROR("NCCL error {}: {}", r, ncclGetErrorString(r)); \
+      return {};                                                        \
+    }                                                                   \
+  } while (0)
+
+#define CUDACHECK_THROW(cmd)                                    \
+  do {                                                          \
+    cudaError_t e = (cmd);                                      \
+    if (e != cudaSuccess) {                                     \
+      throw std::runtime_error(                                 \
+          std::string("CUDA error: ") + cudaGetErrorString(e)); \
+    }                                                           \
+  } while (0)
+
+struct NcclResources {
+  void* sendbuf{nullptr};
+  void* recvbuf{nullptr};
+  cudaStream_t stream{nullptr};
+  ncclComm_t comm{nullptr};
+  bool useGpu{false};
+
+  NcclResources(ncclComm_t comm, bool useGpu, size_t sendSize, size_t recvSize)
+      : comm(comm), useGpu(useGpu) {
+    if (useGpu) {
+      CUDACHECK_THROW(cudaMalloc(&sendbuf, sendSize));
+      CUDACHECK_THROW(cudaMalloc(&recvbuf, recvSize));
+      CUDACHECK_THROW(cudaMemset(sendbuf, 0xAB, sendSize));
+      CUDACHECK_THROW(cudaMemset(recvbuf, 0x00, recvSize));
+    } else {
+      CUDACHECK_THROW(cudaMallocHost(&sendbuf, sendSize));
+      CUDACHECK_THROW(cudaMallocHost(&recvbuf, recvSize));
+      std::memset(sendbuf, 0xAB, sendSize);
+      std::memset(recvbuf, 0x00, recvSize);
+    }
+    CUDACHECK_THROW(cudaStreamCreate(&stream));
+  }
+
+  ~NcclResources() {
+    if (stream) {
+      cudaStreamDestroy(stream);
+    }
+    if (useGpu) {
+      if (recvbuf) {
+        cudaFree(recvbuf);
+      }
+      if (sendbuf) {
+        cudaFree(sendbuf);
+      }
+    } else {
+      if (recvbuf) {
+        cudaFreeHost(recvbuf);
+      }
+      if (sendbuf) {
+        cudaFreeHost(sendbuf);
+      }
+    }
+    if (comm) {
+      ncclCommDestroy(comm);
+    }
+  }
+
+  NcclResources(const NcclResources&) = delete;
+  NcclResources& operator=(const NcclResources&) = delete;
+  NcclResources(NcclResources&&) = delete;
+  NcclResources& operator=(NcclResources&&) = delete;
+};
+
+} // namespace
+
+std::vector<BenchmarkResult> NcclSendRecvBenchmark::run(
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  const int rank = bootstrap.rank;
+  const int worldSize = bootstrap.worldSize;
+  const bool useGpu = config.cudaDevice >= 0;
+  const auto& topology = config.topology;
+
+  std::vector<int> sendPeers;
+  std::vector<int> recvPeers;
+  if (topology == "fanout") {
+    if (bootstrap.isRank0()) {
+      for (int r = 1; r < worldSize; ++r) {
+        sendPeers.push_back(r);
+      }
+    } else {
+      recvPeers.push_back(0);
+    }
+  } else if (topology == "fanin") {
+    if (bootstrap.isRank0()) {
+      for (int r = 1; r < worldSize; ++r) {
+        recvPeers.push_back(r);
+      }
+    } else {
+      sendPeers.push_back(0);
+    }
+  } else {
+    if (bootstrap.isRank0()) {
+      for (int r = 1; r < worldSize; ++r) {
+        sendPeers.push_back(r);
+        recvPeers.push_back(r);
+      }
+    } else {
+      recvPeers.push_back(0);
+      sendPeers.push_back(0);
+    }
+  }
+  const int numPeers =
+      static_cast<int>(std::max(sendPeers.size(), recvPeers.size()));
+
+  // NCCL requires a CUDA context even for host memory transfers.
+  CUDACHECK(cudaSetDevice(useGpu ? config.cudaDevice : rank));
+
+  // --- Initialize NCCL communicator ---
+  // Rank 0 generates unique ID, broadcasts to all peers via TCP control.
+  ncclUniqueId ncclId;
+  if (bootstrap.isRank0()) {
+    NCCLCHECK(ncclGetUniqueId(&ncclId));
+    std::vector<uint8_t> idBytes(sizeof(ncclId));
+    std::memcpy(idBytes.data(), &ncclId, sizeof(ncclId));
+    for (auto& peer : peers) {
+      auto res = exchangeMetadata(*peer.ctrl, idBytes, true);
+      if (!res) {
+        UNIFLOW_LOG_ERROR(
+            "NcclSendRecvBenchmark: failed to send NCCL ID to peer {}",
+            peer.peerRank);
+        return {};
+      }
+    }
+  } else {
+    if (peers.empty()) {
+      UNIFLOW_LOG_ERROR(
+          "NcclSendRecvBenchmark: rank {} has no control peer for NCCL ID exchange",
+          rank);
+      return {};
+    }
+    auto res = exchangeMetadata(
+        *peers[0].ctrl, std::vector<uint8_t>(sizeof(ncclId)), false);
+    if (!res) {
+      UNIFLOW_LOG_ERROR("NcclSendRecvBenchmark: failed to recv NCCL ID");
+      return {};
+    }
+    std::memcpy(&ncclId, res.value().data(), sizeof(ncclId));
+  }
+
+  ncclComm_t comm;
+  NCCLCHECK(ncclCommInitRank(&comm, worldSize, ncclId, rank));
+
+  UNIFLOW_LOG_WARN(
+      "NcclSendRecvBenchmark: rank {} initialized (worldSize={}, "
+      "topology={}, sends={}, recvs={}, memory={})",
+      rank,
+      worldSize,
+      topology,
+      sendPeers.size(),
+      recvPeers.size(),
+      useGpu ? "GPU" : "CPU");
+
+  const size_t numRecvPeers = std::max(size_t{1}, recvPeers.size());
+  const size_t recvBufSize = config.maxSize * numRecvPeers;
+
+  NcclResources res(comm, useGpu, config.maxSize, recvBufSize);
+
+  // --- Benchmark loop ---
+  using Clock = std::chrono::steady_clock;
+  auto sizes = generateSizes(config.minSize, config.maxSize);
+  std::vector<BenchmarkResult> results;
+
+  for (auto size : sizes) {
+    auto barrierStatus = barrier(peers, bootstrap);
+    if (!barrierStatus) {
+      UNIFLOW_LOG_ERROR(
+          "NcclSendRecvBenchmark: barrier failed: {}",
+          barrierStatus.error().toString());
+      break;
+    }
+
+    size_t count = size; // ncclChar = 1 byte
+
+    // Warmup
+    for (int w = 0; w < config.warmupIterations; ++w) {
+      NCCLCHECK(ncclGroupStart());
+      for (int p : sendPeers) {
+        NCCLCHECK(
+            ncclSend(res.sendbuf, count, ncclChar, p, res.comm, res.stream));
+      }
+      for (size_t i = 0; i < recvPeers.size(); ++i) {
+        auto* dst = static_cast<char*>(res.recvbuf) + i * config.maxSize;
+        NCCLCHECK(
+            ncclRecv(dst, count, ncclChar, recvPeers[i], res.comm, res.stream));
+      }
+      NCCLCHECK(ncclGroupEnd());
+      CUDACHECK(cudaStreamSynchronize(res.stream));
+    }
+
+    // Timed iterations
+    CUDACHECK(cudaStreamSynchronize(res.stream));
+    auto overallStart = Clock::now();
+
+    for (int iter = 0; iter < config.iterations; ++iter) {
+      NCCLCHECK(ncclGroupStart());
+      for (int p : sendPeers) {
+        NCCLCHECK(
+            ncclSend(res.sendbuf, count, ncclChar, p, res.comm, res.stream));
+      }
+      for (size_t i = 0; i < recvPeers.size(); ++i) {
+        auto* dst = static_cast<char*>(res.recvbuf) + i * config.maxSize;
+        NCCLCHECK(
+            ncclRecv(dst, count, ncclChar, recvPeers[i], res.comm, res.stream));
+      }
+      NCCLCHECK(ncclGroupEnd());
+    }
+
+    CUDACHECK(cudaStreamSynchronize(res.stream));
+    auto overallEnd = Clock::now();
+
+    double totalTimeSec =
+        std::chrono::duration<double>(overallEnd - overallStart).count();
+
+    double totalBytes =
+        static_cast<double>(size) * config.iterations * numPeers;
+    double bandwidthGBs =
+        (totalTimeSec > 0) ? (totalBytes / totalTimeSec) / 1e9 : 0;
+    double avgLatencyUs =
+        (totalTimeSec > 0) ? (totalTimeSec * 1e6) / config.iterations : 0;
+
+    results.push_back({
+        .benchmarkName = name(),
+        .transport = "nccl",
+        .direction = topology,
+        .messageSize = size,
+        .iterations = config.iterations,
+        .batchSize = 1,
+        .bandwidthGBs = bandwidthGBs,
+        .latency =
+            {.min = avgLatencyUs,
+             .max = avgLatencyUs,
+             .avg = avgLatencyUs,
+             .p50 = avgLatencyUs,
+             .p99 = avgLatencyUs},
+        .numPeers = numPeers,
+    });
+
+    UNIFLOW_LOG_WARN(
+        "[rank {}] nccl_{} peers={} size={:<10} iters={:<6} "
+        "aggBw={:.2f} GB/s  perLink={:.2f} GB/s  avg={:.1f} us",
+        rank,
+        topology,
+        numPeers,
+        size,
+        config.iterations,
+        bandwidthGBs,
+        numPeers > 0 ? bandwidthGBs / numPeers : 0.0,
+        avgLatencyUs);
+  }
+
+  return results;
+}
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "comms/uniflow/benchmarks/BenchmarkRunner.h"
+
+namespace uniflow::benchmark {
+
+/// NCCL send/recv benchmark for direct comparison with the uniflow
+/// copy-based send/recv benchmark under the same framework.
+/// Uses ncclSend/ncclRecv in a ring pattern (same as nccl-tests sendrecv).
+class NcclSendRecvBenchmark : public Benchmark {
+ public:
+  std::string name() const override {
+    return "nccl_sendrecv";
+  }
+
+  std::vector<BenchmarkResult> run(
+      const BenchmarkConfig& config,
+      std::vector<PeerConnection>& peers,
+      const BootstrapConfig& bootstrap) override;
+};
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
@@ -1,0 +1,590 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <future>
+#include <optional>
+#include <utility>
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/benchmarks/Rendezvous.h"
+#include "comms/uniflow/benchmarks/Stats.h"
+#include "comms/uniflow/drivers/TopologyDiscovery.h"
+#include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
+#include "comms/uniflow/drivers/ibverbs/IbvApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/logging/Logger.h"
+#include "comms/uniflow/transport/rdma/RdmaTransport.h"
+
+namespace uniflow::benchmark {
+
+namespace {
+
+std::vector<std::string> discoverRdmaDevices(
+    const std::shared_ptr<IbvApi>& ibvApi) {
+  int numDevices = 0;
+  auto devResult = ibvApi->getDeviceList(&numDevices);
+  if (!devResult.hasValue() || numDevices == 0) {
+    return {};
+  }
+  auto* deviceList = devResult.value();
+  std::vector<std::string> names;
+  for (int i = 0; i < numDevices; ++i) {
+    auto nameResult = ibvApi->getDeviceName(deviceList[i]);
+    if (nameResult.hasValue()) {
+      names.emplace_back(nameResult.value());
+    }
+  }
+  ibvApi->freeDeviceList(deviceList);
+  return names;
+}
+
+struct Buffers {
+  void* src{nullptr};
+  void* dst{nullptr};
+  bool useGpu{false};
+  MemoryType memType{MemoryType::DRAM};
+  int gpuDevice{0};
+
+  Buffers() = default;
+  ~Buffers() {
+    release();
+  }
+
+  Buffers(Buffers&& o) noexcept
+      : src(std::exchange(o.src, nullptr)),
+        dst(std::exchange(o.dst, nullptr)),
+        useGpu(o.useGpu),
+        memType(o.memType),
+        gpuDevice(o.gpuDevice) {}
+
+  Buffers(const Buffers&) = delete;
+  Buffers& operator=(const Buffers&) = delete;
+  Buffers& operator=(Buffers&&) = delete;
+
+ private:
+  void release() noexcept {
+    auto freeOne = [this](void* p) {
+      if (p) {
+        if (useGpu) {
+          cudaFree(p);
+        } else {
+          std::free(p);
+        }
+      }
+    };
+    freeOne(src);
+    freeOne(dst);
+    src = nullptr;
+    dst = nullptr;
+  }
+};
+
+std::optional<Buffers>
+allocateBuffers(size_t maxSize, int cudaDevice, int rank) {
+  Buffers bufs;
+  bufs.useGpu = cudaDevice >= 0;
+  bufs.memType = bufs.useGpu ? MemoryType::VRAM : MemoryType::DRAM;
+  bufs.gpuDevice = bufs.useGpu ? cudaDevice : 0;
+
+  auto allocOne = [&](void** out, uint8_t fill) -> bool {
+    if (bufs.useGpu) {
+      auto ret = cudaMalloc(out, maxSize);
+      if (ret != cudaSuccess || *out == nullptr) {
+        UNIFLOW_LOG_ERROR("SendRecvBandwidthBenchmark: cudaMalloc failed");
+        return false;
+      }
+      ret = cudaMemset(*out, fill, maxSize);
+      if (ret != cudaSuccess) {
+        UNIFLOW_LOG_ERROR(
+            "SendRecvBandwidthBenchmark: cudaMemset failed: {}",
+            cudaGetErrorString(ret));
+        cudaFree(*out);
+        *out = nullptr;
+        return false;
+      }
+    } else {
+      *out = std::malloc(maxSize);
+      if (*out == nullptr) {
+        UNIFLOW_LOG_ERROR("SendRecvBandwidthBenchmark: malloc failed");
+        return false;
+      }
+      std::memset(*out, fill, maxSize);
+    }
+    return true;
+  };
+
+  if (bufs.useGpu) {
+    auto cudaRet = cudaSetDevice(bufs.gpuDevice);
+    if (cudaRet != cudaSuccess) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: cudaSetDevice({}) failed: {}",
+          bufs.gpuDevice,
+          cudaGetErrorString(cudaRet));
+      return std::nullopt;
+    }
+  }
+
+  if (!allocOne(&bufs.src, 0xAB) || !allocOne(&bufs.dst, 0x00)) {
+    return std::nullopt;
+  }
+
+  if (bufs.useGpu) {
+    auto cudaRet = cudaDeviceSynchronize();
+    if (cudaRet != cudaSuccess) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: cudaDeviceSynchronize failed: {}",
+          cudaGetErrorString(cudaRet));
+      return std::nullopt;
+    }
+  }
+
+  UNIFLOW_LOG_INFO(
+      "SendRecvBandwidthBenchmark: rank {} allocated buffers ({} memory)",
+      rank,
+      bufs.useGpu ? "GPU" : "CPU");
+  return bufs;
+}
+
+// --- Multi-transport session: one factory, N peer transports ---
+
+struct PeerTransport {
+  std::unique_ptr<Transport> transport;
+  cudaStream_t stream{nullptr};
+  RequestOptions opts;
+};
+
+struct MultiTransportSession {
+  // Factory must be declared BEFORE transports so it is destroyed AFTER them.
+  std::unique_ptr<RdmaTransportFactory> factory;
+  std::vector<PeerTransport> peerTransports;
+
+  MultiTransportSession() = default;
+  MultiTransportSession(MultiTransportSession&&) = default;
+  MultiTransportSession(const MultiTransportSession&) = delete;
+  MultiTransportSession& operator=(const MultiTransportSession&) = delete;
+  MultiTransportSession& operator=(MultiTransportSession&&) = delete;
+
+  ~MultiTransportSession() {
+    for (auto& pt : peerTransports) {
+      if (pt.transport) {
+        pt.transport->shutdown();
+      }
+      if (pt.stream) {
+        cudaStreamDestroy(pt.stream);
+      }
+    }
+  }
+};
+
+std::optional<MultiTransportSession> setupMultiTransport(
+    const std::vector<std::string>& devices,
+    ScopedEventBaseThread& evbThread,
+    const std::shared_ptr<IbvApi>& ibvApi,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap,
+    size_t chunkSize,
+    bool useGpu) {
+  RdmaTransportConfig rdmaConfig{};
+  rdmaConfig.chunkSize = chunkSize;
+  rdmaConfig.numQps = static_cast<uint32_t>(devices.size());
+
+  auto cudaDriverApi = std::make_shared<CudaDriverApi>();
+  auto factory = std::make_unique<RdmaTransportFactory>(
+      devices, evbThread.getEventBase(), rdmaConfig, ibvApi, cudaDriverApi);
+
+  auto localTopology = factory->getTopology();
+
+  MultiTransportSession session;
+  session.peerTransports.reserve(peers.size());
+
+  for (size_t i = 0; i < peers.size(); ++i) {
+    auto& peer = peers[i];
+    auto remoteTopoResult =
+        exchangeMetadata(*peer.ctrl, localTopology, bootstrap.isRank0());
+    if (!remoteTopoResult) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: topology exchange with peer {} "
+          "failed: {}",
+          peer.peerRank,
+          remoteTopoResult.error().toString());
+      return std::nullopt;
+    }
+
+    auto transportResult =
+        factory->createTransport(std::move(remoteTopoResult).value());
+    if (!transportResult) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: createTransport for peer {} "
+          "failed: {}",
+          peer.peerRank,
+          transportResult.error().toString());
+      return std::nullopt;
+    }
+    auto transport = std::move(transportResult).value();
+
+    auto localInfo = transport->bind();
+    auto remoteInfoResult =
+        exchangeMetadata(*peer.ctrl, localInfo, bootstrap.isRank0());
+    if (!remoteInfoResult) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: info exchange with peer {} "
+          "failed: {}",
+          peer.peerRank,
+          remoteInfoResult.error().toString());
+      transport->shutdown();
+      return std::nullopt;
+    }
+
+    auto connectStatus =
+        transport->connect(std::move(remoteInfoResult).value());
+    if (!connectStatus) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: connect to peer {} failed: {}",
+          peer.peerRank,
+          connectStatus.error().toString());
+      transport->shutdown();
+      return std::nullopt;
+    }
+
+    PeerTransport pt;
+    pt.transport = std::move(transport);
+    if (useGpu) {
+      auto ret = cudaStreamCreate(&pt.stream);
+      if (ret != cudaSuccess) {
+        UNIFLOW_LOG_ERROR(
+            "SendRecvBandwidthBenchmark: cudaStreamCreate failed for peer {}",
+            peer.peerRank);
+        pt.transport->shutdown();
+        return std::nullopt;
+      }
+      pt.opts.stream = static_cast<void*>(pt.stream);
+    }
+
+    UNIFLOW_LOG_INFO(
+        "SendRecvBandwidthBenchmark: rank {} connected to peer {}",
+        bootstrap.rank,
+        peer.peerRank);
+    session.peerTransports.push_back(std::move(pt));
+  }
+
+  session.factory = std::move(factory);
+  return session;
+}
+
+// --- Benchmark loop: fan-out (rank 0 sends, others recv) ---
+
+std::vector<BenchmarkResult> runBenchmarkLoop(
+    MultiTransportSession& session,
+    const Buffers& bufs,
+    size_t maxSize,
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap,
+    const std::string& benchmarkName) {
+  using Clock = std::chrono::steady_clock;
+
+  auto sizes = generateSizes(config.minSize, config.maxSize);
+  std::vector<BenchmarkResult> results;
+  const int txDepth = std::max(1, config.txDepth);
+  const int numPeers = static_cast<int>(session.peerTransports.size());
+  if (numPeers == 0) {
+    UNIFLOW_LOG_ERROR("SendRecvBandwidthBenchmark: numPeers == 0");
+    return {};
+  }
+
+  // Fan-out: rank 0 sends, non-zero ranks receive.
+  bool doSend = bootstrap.isRank0();
+  bool doRecv = !bootstrap.isRank0();
+
+  Segment srcSeg(bufs.src, maxSize, bufs.memType, bufs.gpuDevice);
+  Segment dstSeg(bufs.dst, maxSize, bufs.memType, bufs.gpuDevice);
+
+  struct InflightOp {
+    std::future<Status> fut;
+  };
+  struct PeerState {
+    std::deque<InflightOp> inflight;
+  };
+
+  for (auto size : sizes) {
+    auto barrierStatus = barrier(peers, bootstrap);
+    if (!barrierStatus) {
+      UNIFLOW_LOG_ERROR(
+          "SendRecvBandwidthBenchmark: barrier failed: {}",
+          barrierStatus.error().toString());
+      break;
+    }
+
+    auto srcSpan = srcSeg.span(size_t{0}, size);
+    auto dstSpan = dstSeg.span(size_t{0}, size);
+
+    // Warmup — launch ops on all peers, wait for all.
+    bool warmupFailed = false;
+    for (int w = 0; w < config.warmupIterations && !warmupFailed; ++w) {
+      std::vector<std::future<Status>> futs;
+      for (int p = 0; p < numPeers; ++p) {
+        auto& pt = session.peerTransports[p];
+        if (doSend) {
+          futs.push_back(pt.transport->send(srcSpan, pt.opts));
+        }
+        if (doRecv) {
+          futs.push_back(pt.transport->recv(dstSpan, pt.opts));
+        }
+      }
+      for (auto& f : futs) {
+        auto st = f.get();
+        if (st.hasError()) {
+          UNIFLOW_LOG_ERROR(
+              "SendRecvBandwidthBenchmark: warmup failed at size {}: {}",
+              size,
+              st.error().message());
+          warmupFailed = true;
+        }
+      }
+    }
+    if (warmupFailed) {
+      break;
+    }
+
+    // Per-peer pipelining state.
+    std::vector<PeerState> peerStates(numPeers);
+    bool hadError = false;
+
+    auto drainAll = [&]() {
+      for (auto& ps : peerStates) {
+        for (auto& op : ps.inflight) {
+          op.fut.wait();
+        }
+        ps.inflight.clear();
+      }
+    };
+
+    auto completePeer = [&](int p) -> bool {
+      auto& ps = peerStates[p];
+      auto st = ps.inflight.front().fut.get();
+      if (st.hasError()) {
+        UNIFLOW_LOG_ERROR(
+            "SendRecvBandwidthBenchmark: op for peer {} failed at "
+            "size {}: {}",
+            p,
+            size,
+            st.error().message());
+        ps.inflight.pop_front();
+        drainAll();
+        return false;
+      }
+      ps.inflight.pop_front();
+      return true;
+    };
+
+    auto overallStart = Clock::now();
+
+    for (int iter = 0; iter < config.iterations && !hadError; ++iter) {
+      for (int p = 0; p < numPeers && !hadError; ++p) {
+        auto& ps = peerStates[p];
+        if (static_cast<int>(ps.inflight.size()) >= txDepth) {
+          if (!completePeer(p)) {
+            hadError = true;
+            break;
+          }
+        }
+        auto& pt = session.peerTransports[p];
+        InflightOp op;
+        if (doSend) {
+          op.fut = pt.transport->send(srcSpan, pt.opts);
+        } else {
+          op.fut = pt.transport->recv(dstSpan, pt.opts);
+        }
+        ps.inflight.push_back(std::move(op));
+      }
+    }
+
+    for (int p = 0; p < numPeers && !hadError; ++p) {
+      while (!peerStates[p].inflight.empty()) {
+        if (!completePeer(p)) {
+          hadError = true;
+        }
+      }
+    }
+
+    if (hadError) {
+      break;
+    }
+
+    auto overallEnd = Clock::now();
+
+    double totalTimeSec =
+        std::chrono::duration<double>(overallEnd - overallStart).count();
+    double totalBytes = static_cast<double>(size) *
+        static_cast<double>(config.iterations) * numPeers;
+    double bandwidthGBs =
+        (totalTimeSec > 0) ? (totalBytes / totalTimeSec) / 1e9 : 0;
+    double msgRateMops = (totalTimeSec > 0)
+        ? (static_cast<double>(config.iterations) * numPeers / totalTimeSec) /
+            1e6
+        : 0;
+    double avgLatencyUs =
+        (totalTimeSec > 0) ? (totalTimeSec * 1e6) / config.iterations : 0;
+
+    results.push_back({
+        .benchmarkName = benchmarkName,
+        .transport = "rdma",
+        .direction = "fanout",
+        .messageSize = size,
+        .iterations = config.iterations,
+        .batchSize = 1,
+        .txDepth = txDepth,
+        .chunkSize = config.chunkSize,
+        .bandwidthGBs = bandwidthGBs,
+        .latency =
+            {.min = avgLatencyUs,
+             .max = avgLatencyUs,
+             .avg = avgLatencyUs,
+             .p50 = avgLatencyUs,
+             .p99 = avgLatencyUs},
+        .messageRateMops = msgRateMops,
+        .numPeers = numPeers,
+    });
+
+    UNIFLOW_LOG_WARN(
+        "[rank {}] fanout peers={} size={:<10} txdepth={:<3} iters={:<6} "
+        "aggBw={:.2f} GB/s  perLink={:.2f} GB/s  avg={:.1f} us",
+        bootstrap.rank,
+        numPeers,
+        size,
+        txDepth,
+        config.iterations,
+        bandwidthGBs,
+        numPeers > 0 ? bandwidthGBs / numPeers : 0.0,
+        avgLatencyUs);
+  }
+
+  return results;
+}
+
+} // anonymous namespace
+
+std::vector<BenchmarkResult> SendRecvBandwidthBenchmark::run(
+    const BenchmarkConfig& config,
+    std::vector<PeerConnection>& peers,
+    const BootstrapConfig& bootstrap) {
+  if (peers.empty()) {
+    UNIFLOW_LOG_WARN("SendRecvBandwidthBenchmark: no peers, skipping");
+    return {};
+  }
+
+  if (config.topology != "fanout") {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: unsupported topology '{}' "
+        "(only 'fanout' is currently implemented)",
+        config.topology);
+    return {};
+  }
+
+  auto ibvApi = std::make_shared<IbvApi>();
+  auto initStatus = ibvApi->init();
+  if (initStatus.hasError()) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: IbvApi init failed: {}",
+        initStatus.error().message());
+    return {};
+  }
+
+  std::vector<std::string> deviceNames = rdmaDevices_;
+  if (deviceNames.empty()) {
+    deviceNames = discoverRdmaDevices(ibvApi);
+  }
+  if (deviceNames.empty()) {
+    UNIFLOW_LOG_ERROR("SendRecvBandwidthBenchmark: no RDMA devices found");
+    return {};
+  }
+
+  std::vector<std::string> myDevices;
+  const char* nicSelectionPolicy = "unknown";
+  if (!rdmaDevices_.empty()) {
+    myDevices = rdmaDevices_;
+    nicSelectionPolicy = "explicit (--rdma-devices)";
+  } else {
+    auto& topo = sharedTopology();
+    if (topo.available()) {
+      if (config.cudaDevice < 0) {
+        myDevices = topo.selectCpuNics();
+        nicSelectionPolicy = "topology CPU-local";
+      } else {
+        myDevices = topo.selectGpuNics(config.cudaDevice);
+        nicSelectionPolicy = "topology GPU-local";
+      }
+    }
+    if (myDevices.empty()) {
+      myDevices = deviceNames;
+      nicSelectionPolicy = "fallback (all devices)";
+    }
+    if (config.numNics > 0 &&
+        config.numNics < static_cast<int>(myDevices.size())) {
+      myDevices.resize(config.numNics);
+    }
+  }
+  {
+    std::string devList;
+    for (const auto& d : myDevices) {
+      if (!devList.empty()) {
+        devList += ", ";
+      }
+      devList += d;
+    }
+    UNIFLOW_LOG_WARN(
+        "SendRecvBandwidthBenchmark: rank {} using {} RDMA device(s): {} "
+        "[selection={}] with {} peer(s), topology={}",
+        bootstrap.rank,
+        myDevices.size(),
+        devList,
+        nicSelectionPolicy,
+        peers.size(),
+        config.topology);
+  }
+
+  bool useGpu = config.cudaDevice >= 0;
+  auto bufs =
+      allocateBuffers(config.maxSize, config.cudaDevice, bootstrap.rank);
+  if (!bufs) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: buffer allocation failed on rank {}",
+        bootstrap.rank);
+    return {};
+  }
+
+  ScopedEventBaseThread evbThread("bench-evb");
+  auto session = setupMultiTransport(
+      myDevices, evbThread, ibvApi, peers, bootstrap, config.chunkSize, useGpu);
+  if (!session) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: transport setup failed on rank {}",
+        bootstrap.rank);
+    return {};
+  }
+
+  UNIFLOW_LOG_INFO(
+      "SendRecvBandwidthBenchmark: rank {} set up {} transport(s)",
+      bootstrap.rank,
+      session->peerTransports.size());
+
+  auto results = runBenchmarkLoop(
+      *session, *bufs, config.maxSize, config, peers, bootstrap, name());
+
+  auto finalBarrier = barrier(peers, bootstrap);
+  if (!finalBarrier) {
+    UNIFLOW_LOG_WARN(
+        "SendRecvBandwidthBenchmark: final barrier failed: {}",
+        finalBarrier.error().toString());
+  }
+  return results;
+}
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
@@ -251,8 +251,10 @@ std::optional<MultiTransportSession> setupMultiTransport(
   const auto numPeers = std::max(size_t{1}, peers.size());
   const auto pipelineDepth =
       static_cast<size_t>(std::max(1, config.pipelineDepth));
-  rdmaConfig.slabPoolConfig.slabSize = config.chunkSize;
-  rdmaConfig.slabPoolConfig.slabNum = pipelineDepth * numPeers;
+  rdmaConfig.slabPoolConfig.slabSize =
+      config.slabSize > 0 ? config.slabSize : config.chunkSize;
+  rdmaConfig.slabPoolConfig.slabNum =
+      config.slabNum > 0 ? config.slabNum : pipelineDepth * numPeers;
   auto cudaDriverApi = std::make_shared<CudaDriverApi>();
 
   MultiTransportSession session;

--- a/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.cpp
@@ -161,7 +161,8 @@ struct PeerTransport {
 };
 
 struct MultiTransportSession {
-  // Factory must be declared BEFORE transports so it is destroyed AFTER them.
+  // EventBase thread must outlive factory which must outlive transports.
+  std::unique_ptr<ScopedEventBaseThread> evbThread;
   std::unique_ptr<RdmaTransportFactory> factory;
   std::vector<PeerTransport> peerTransports;
 
@@ -183,84 +184,105 @@ struct MultiTransportSession {
   }
 };
 
+std::optional<std::unique_ptr<Transport>> connectOneTransport(
+    RdmaTransportFactory& factory,
+    controller::Conn& ctrl,
+    bool isRank0,
+    int peerRank) {
+  auto localTopology = factory.getTopology();
+  auto remoteTopoResult = exchangeMetadata(ctrl, localTopology, isRank0);
+  if (!remoteTopoResult) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: topology exchange with peer {} "
+        "failed: {}",
+        peerRank,
+        remoteTopoResult.error().toString());
+    return std::nullopt;
+  }
+
+  auto transportResult =
+      factory.createTransport(std::move(remoteTopoResult).value());
+  if (!transportResult) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: createTransport for peer {} "
+        "failed: {}",
+        peerRank,
+        transportResult.error().toString());
+    return std::nullopt;
+  }
+  auto transport = std::move(transportResult).value();
+
+  auto localInfo = transport->bind();
+  auto remoteInfoResult = exchangeMetadata(ctrl, localInfo, isRank0);
+  if (!remoteInfoResult) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: info exchange with peer {} "
+        "failed: {}",
+        peerRank,
+        remoteInfoResult.error().toString());
+    transport->shutdown();
+    return std::nullopt;
+  }
+
+  auto connectStatus = transport->connect(std::move(remoteInfoResult).value());
+  if (!connectStatus) {
+    UNIFLOW_LOG_ERROR(
+        "SendRecvBandwidthBenchmark: connect to peer {} failed: {}",
+        peerRank,
+        connectStatus.error().toString());
+    transport->shutdown();
+    return std::nullopt;
+  }
+
+  return transport;
+}
+
 std::optional<MultiTransportSession> setupMultiTransport(
     const std::vector<std::string>& devices,
-    ScopedEventBaseThread& evbThread,
     const std::shared_ptr<IbvApi>& ibvApi,
     std::vector<PeerConnection>& peers,
     const BootstrapConfig& bootstrap,
-    size_t chunkSize,
+    const BenchmarkConfig& config,
     bool useGpu) {
   RdmaTransportConfig rdmaConfig{};
-  rdmaConfig.chunkSize = chunkSize;
+  rdmaConfig.chunkSize = config.chunkSize;
   rdmaConfig.numQps = static_cast<uint32_t>(devices.size());
-
+  rdmaConfig.pipelineDepth = static_cast<uint16_t>(config.pipelineDepth);
+  const auto numPeers = std::max(size_t{1}, peers.size());
+  const auto pipelineDepth =
+      static_cast<size_t>(std::max(1, config.pipelineDepth));
+  rdmaConfig.slabPoolConfig.slabSize = config.chunkSize;
+  rdmaConfig.slabPoolConfig.slabNum = pipelineDepth * numPeers;
   auto cudaDriverApi = std::make_shared<CudaDriverApi>();
-  auto factory = std::make_unique<RdmaTransportFactory>(
-      devices, evbThread.getEventBase(), rdmaConfig, ibvApi, cudaDriverApi);
-
-  auto localTopology = factory->getTopology();
 
   MultiTransportSession session;
+  session.evbThread = std::make_unique<ScopedEventBaseThread>("bench-evb");
+  session.factory = std::make_unique<RdmaTransportFactory>(
+      devices,
+      session.evbThread->getEventBase(),
+      rdmaConfig,
+      ibvApi,
+      cudaDriverApi);
+
   session.peerTransports.reserve(peers.size());
 
   for (size_t i = 0; i < peers.size(); ++i) {
     auto& peer = peers[i];
-    auto remoteTopoResult =
-        exchangeMetadata(*peer.ctrl, localTopology, bootstrap.isRank0());
-    if (!remoteTopoResult) {
-      UNIFLOW_LOG_ERROR(
-          "SendRecvBandwidthBenchmark: topology exchange with peer {} "
-          "failed: {}",
-          peer.peerRank,
-          remoteTopoResult.error().toString());
-      return std::nullopt;
-    }
-
-    auto transportResult =
-        factory->createTransport(std::move(remoteTopoResult).value());
-    if (!transportResult) {
-      UNIFLOW_LOG_ERROR(
-          "SendRecvBandwidthBenchmark: createTransport for peer {} "
-          "failed: {}",
-          peer.peerRank,
-          transportResult.error().toString());
-      return std::nullopt;
-    }
-    auto transport = std::move(transportResult).value();
-
-    auto localInfo = transport->bind();
-    auto remoteInfoResult =
-        exchangeMetadata(*peer.ctrl, localInfo, bootstrap.isRank0());
-    if (!remoteInfoResult) {
-      UNIFLOW_LOG_ERROR(
-          "SendRecvBandwidthBenchmark: info exchange with peer {} "
-          "failed: {}",
-          peer.peerRank,
-          remoteInfoResult.error().toString());
-      transport->shutdown();
-      return std::nullopt;
-    }
-
-    auto connectStatus =
-        transport->connect(std::move(remoteInfoResult).value());
-    if (!connectStatus) {
-      UNIFLOW_LOG_ERROR(
-          "SendRecvBandwidthBenchmark: connect to peer {} failed: {}",
-          peer.peerRank,
-          connectStatus.error().toString());
-      transport->shutdown();
+    auto t = connectOneTransport(
+        *session.factory, *peer.ctrl, bootstrap.isRank0(), peer.peerRank);
+    if (!t) {
       return std::nullopt;
     }
 
     PeerTransport pt;
-    pt.transport = std::move(transport);
+    pt.transport = std::move(*t);
     if (useGpu) {
       auto ret = cudaStreamCreate(&pt.stream);
       if (ret != cudaSuccess) {
         UNIFLOW_LOG_ERROR(
-            "SendRecvBandwidthBenchmark: cudaStreamCreate failed for peer {}",
-            peer.peerRank);
+            "SendRecvBandwidthBenchmark: cudaStreamCreate failed for peer {}: {}",
+            peer.peerRank,
+            cudaGetErrorString(ret));
         pt.transport->shutdown();
         return std::nullopt;
       }
@@ -274,11 +296,10 @@ std::optional<MultiTransportSession> setupMultiTransport(
     session.peerTransports.push_back(std::move(pt));
   }
 
-  session.factory = std::move(factory);
   return session;
 }
 
-// --- Benchmark loop: fan-out (rank 0 sends, others recv) ---
+// --- Benchmark loop: topology-driven concurrent send/recv ---
 
 std::vector<BenchmarkResult> runBenchmarkLoop(
     MultiTransportSession& session,
@@ -294,14 +315,15 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
   std::vector<BenchmarkResult> results;
   const int txDepth = std::max(1, config.txDepth);
   const int numPeers = static_cast<int>(session.peerTransports.size());
+  const auto& topology = config.topology;
+
   if (numPeers == 0) {
     UNIFLOW_LOG_ERROR("SendRecvBandwidthBenchmark: numPeers == 0");
     return {};
   }
 
-  // Fan-out: rank 0 sends, non-zero ranks receive.
-  bool doSend = bootstrap.isRank0();
-  bool doRecv = !bootstrap.isRank0();
+  bool doSend = (topology == "fanout" && bootstrap.isRank0()) ||
+      (topology == "fanin" && !bootstrap.isRank0());
 
   Segment srcSeg(bufs.src, maxSize, bufs.memType, bufs.gpuDevice);
   Segment dstSeg(bufs.dst, maxSize, bufs.memType, bufs.gpuDevice);
@@ -333,8 +355,7 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
         auto& pt = session.peerTransports[p];
         if (doSend) {
           futs.push_back(pt.transport->send(srcSpan, pt.opts));
-        }
-        if (doRecv) {
+        } else {
           futs.push_back(pt.transport->recv(dstSpan, pt.opts));
         }
       }
@@ -436,7 +457,7 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
     results.push_back({
         .benchmarkName = benchmarkName,
         .transport = "rdma",
-        .direction = "fanout",
+        .direction = topology,
         .messageSize = size,
         .iterations = config.iterations,
         .batchSize = 1,
@@ -454,9 +475,10 @@ std::vector<BenchmarkResult> runBenchmarkLoop(
     });
 
     UNIFLOW_LOG_WARN(
-        "[rank {}] fanout peers={} size={:<10} txdepth={:<3} iters={:<6} "
+        "[rank {}] {} peers={} size={:<10} txdepth={:<3} iters={:<6} "
         "aggBw={:.2f} GB/s  perLink={:.2f} GB/s  avg={:.1f} us",
         bootstrap.rank,
+        topology,
         numPeers,
         size,
         txDepth,
@@ -560,9 +582,8 @@ std::vector<BenchmarkResult> SendRecvBandwidthBenchmark::run(
     return {};
   }
 
-  ScopedEventBaseThread evbThread("bench-evb");
-  auto session = setupMultiTransport(
-      myDevices, evbThread, ibvApi, peers, bootstrap, config.chunkSize, useGpu);
+  auto session =
+      setupMultiTransport(myDevices, ibvApi, peers, bootstrap, config, useGpu);
   if (!session) {
     UNIFLOW_LOG_ERROR(
         "SendRecvBandwidthBenchmark: transport setup failed on rank {}",

--- a/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h
+++ b/comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "comms/uniflow/benchmarks/BenchmarkRunner.h"
+
+namespace uniflow::benchmark {
+
+/// Measures copy-based send/recv bandwidth across message sizes with
+/// multi-peer support.  One RdmaTransportFactory creates N-1 transports
+/// (one per peer), all sharing NicResources and SlabPool.
+///
+/// Topologies (--topology):
+///   fanout  — rank 0 sends to all peers, others receive
+///
+/// fanin support will be added in a follow-up diff.
+///
+/// Bandwidth is aggregate: size * numPeers * iters / time, busBw factor = 1.
+class SendRecvBandwidthBenchmark : public Benchmark {
+ public:
+  explicit SendRecvBandwidthBenchmark(std::vector<std::string> rdmaDevices)
+      : rdmaDevices_(std::move(rdmaDevices)) {}
+
+  std::string name() const override {
+    return "sendrecv_bandwidth";
+  }
+
+  std::vector<BenchmarkResult> run(
+      const BenchmarkConfig& config,
+      std::vector<PeerConnection>& peers,
+      const BootstrapConfig& bootstrap) override;
+
+ private:
+  std::vector<std::string> rdmaDevices_;
+};
+
+} // namespace uniflow::benchmark

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -39,6 +39,7 @@ struct CliOptions {
   bool bidirectional{false};
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
+  int pipelineDepth{2};
   std::vector<std::string> rdmaDevices;
 };
 
@@ -93,6 +94,7 @@ void printUsage(const char* prog) {
       << "  --chunk-size <bytes>   RDMA transfer chunk size in bytes (default: 524288)\n"
       << "  --cuda-device <id>     GPU device index for buffer allocation (default: CPU memory)\n"
       << "  --topology <type>      Send/recv pattern: fanout|fanin (default: fanout)\n"
+      << "  --pipeline-depth <n>   Send/recv staging pipeline depth (default: 2)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -128,6 +130,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"chunk-size", required_argument, nullptr, 256},
       {"cuda-device", required_argument, nullptr, 'c'},
       {"topology", required_argument, nullptr, 259},
+      {"pipeline-depth", required_argument, nullptr, 260},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0},
@@ -267,6 +270,20 @@ CliOptions parseArgs(int argc, char** argv) {
           std::exit(1);
         }
         break;
+      case 260:
+        try {
+          opts.pipelineDepth = std::stoi(optarg);
+          if (opts.pipelineDepth < 1 || opts.pipelineDepth > 65535) {
+            std::cerr
+                << "Invalid value for --pipeline-depth: must be in [1, 65535]\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --pipeline-depth: '" << optarg
+                    << "'\n";
+          std::exit(1);
+        }
+        break;
       case 'l':
         listMode = true;
         break;
@@ -338,6 +355,7 @@ int main(int argc, char** argv) {
   config.cudaDevice = opts.cudaDevice;
   config.numStreams = opts.numStreams;
   config.topology = opts.topology;
+  config.pipelineDepth = opts.pipelineDepth;
 
   UNIFLOW_LOG_INFO(
       "Rank {}/{} starting benchmark (transport={})",

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -37,6 +37,7 @@ struct CliOptions {
   int cudaDevice{-1};
   bool bidirectional{false};
   std::vector<int> numStreams{1, 2, 4, 8};
+  std::string topology{"fanout"};
   std::vector<std::string> rdmaDevices;
 };
 
@@ -90,6 +91,7 @@ void printUsage(const char* prog) {
       << "  --num-nics <n>         Cap number of NICs to use (default: 0 = all)\n"
       << "  --chunk-size <bytes>   RDMA transfer chunk size in bytes (default: 524288)\n"
       << "  --cuda-device <id>     GPU device index for buffer allocation (default: CPU memory)\n"
+      << "  --topology <type>      Send/recv pattern: fanout|fanin (default: fanout)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -124,6 +126,7 @@ CliOptions parseArgs(int argc, char** argv) {
       {"num-nics", required_argument, nullptr, 258},
       {"chunk-size", required_argument, nullptr, 256},
       {"cuda-device", required_argument, nullptr, 'c'},
+      {"topology", required_argument, nullptr, 259},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0},
@@ -255,6 +258,14 @@ CliOptions parseArgs(int argc, char** argv) {
           std::exit(1);
         }
         break;
+      case 259:
+        opts.topology = optarg;
+        if (opts.topology != "fanout" && opts.topology != "fanin") {
+          std::cerr << "Invalid value for --topology: '" << optarg
+                    << "' (expected fanout|fanin)\n";
+          std::exit(1);
+        }
+        break;
       case 'l':
         listMode = true;
         break;
@@ -322,6 +333,7 @@ int main(int argc, char** argv) {
   config.chunkSize = opts.chunkSize;
   config.cudaDevice = opts.cudaDevice;
   config.numStreams = opts.numStreams;
+  config.topology = opts.topology;
 
   UNIFLOW_LOG_INFO(
       "Rank {}/{} starting benchmark (transport={})",

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -15,6 +15,7 @@
 #include "comms/uniflow/benchmarks/bench/ConnectionSetupBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
+#include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
 #include "comms/uniflow/logging/Logger.h"
 
 namespace {
@@ -302,6 +303,9 @@ int main(int argc, char** argv) {
           opts.rdmaDevices));
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::NVLinkBandwidthBenchmark>());
+  runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::SendRecvBandwidthBenchmark>(
+          opts.rdmaDevices));
 
   if (opts.benchmark == "__list__") {
     std::cout << "Available benchmarks:\n";

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -14,6 +14,7 @@
 #include "comms/uniflow/benchmarks/Reporter.h"
 #include "comms/uniflow/benchmarks/bench/ConnectionSetupBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.h"
+#include "comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
 #include "comms/uniflow/logging/Logger.h"
@@ -40,6 +41,8 @@ struct CliOptions {
   std::vector<int> numStreams{1, 2, 4, 8};
   std::string topology{"fanout"};
   int pipelineDepth{2};
+  size_t slabSize{0};
+  int slabNum{0};
   std::vector<std::string> rdmaDevices;
 };
 
@@ -95,6 +98,8 @@ void printUsage(const char* prog) {
       << "  --cuda-device <id>     GPU device index for buffer allocation (default: CPU memory)\n"
       << "  --topology <type>      Send/recv pattern: fanout|fanin (default: fanout)\n"
       << "  --pipeline-depth <n>   Send/recv staging pipeline depth (default: 2)\n"
+      << "  --slab-size <bytes>    Staging slab size in bytes (default: chunk-size)\n"
+      << "  --slab-num <n>         Number of staging slabs (default: pipeline-depth)\n"
       << "  --list                 List available benchmarks\n"
       << "  --help                 Show this help message\n"
       << "\n"
@@ -131,6 +136,8 @@ CliOptions parseArgs(int argc, char** argv) {
       {"cuda-device", required_argument, nullptr, 'c'},
       {"topology", required_argument, nullptr, 259},
       {"pipeline-depth", required_argument, nullptr, 260},
+      {"slab-size", required_argument, nullptr, 261},
+      {"slab-num", required_argument, nullptr, 262},
       {"list", no_argument, nullptr, 'l'},
       {"help", no_argument, nullptr, 'h'},
       {nullptr, 0, nullptr, 0},
@@ -284,6 +291,30 @@ CliOptions parseArgs(int argc, char** argv) {
           std::exit(1);
         }
         break;
+      case 261:
+        try {
+          opts.slabSize = std::stoull(optarg);
+          if (opts.slabSize < 1) {
+            std::cerr << "Invalid value for --slab-size: must be >= 1\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --slab-size: '" << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
+      case 262:
+        try {
+          opts.slabNum = std::stoi(optarg);
+          if (opts.slabNum < 1) {
+            std::cerr << "Invalid value for --slab-num: must be >= 1\n";
+            std::exit(1);
+          }
+        } catch (const std::exception&) {
+          std::cerr << "Invalid value for --slab-num: '" << optarg << "'\n";
+          std::exit(1);
+        }
+        break;
       case 'l':
         listMode = true;
         break;
@@ -323,6 +354,8 @@ int main(int argc, char** argv) {
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::SendRecvBandwidthBenchmark>(
           opts.rdmaDevices));
+  runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::NcclSendRecvBenchmark>());
 
   if (opts.benchmark == "__list__") {
     std::cout << "Available benchmarks:\n";
@@ -356,6 +389,8 @@ int main(int argc, char** argv) {
   config.numStreams = opts.numStreams;
   config.topology = opts.topology;
   config.pipelineDepth = opts.pipelineDepth;
+  config.slabSize = opts.slabSize;
+  config.slabNum = opts.slabNum;
 
   UNIFLOW_LOG_INFO(
       "Rank {}/{} starting benchmark (transport={})",

--- a/comms/uniflow/benchmarks/scripts/run_sendrecv_benchmark.sh
+++ b/comms/uniflow/benchmarks/scripts/run_sendrecv_benchmark.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# Benchmark uniflow copy-based send/recv and compare with NCCL sendrecv.
+# Runs both benchmarks under the same framework and prints a side-by-side
+# comparison table.
+#
+# Usage:
+#   bash run_sendrecv_benchmark.sh [OPTIONS]
+#
+# Options:
+#   --nproc N           Number of ranks (default: 2)
+#   --gpu0 ID           GPU for rank 0 (default: 0)
+#   --gpu1 ID           GPU for rank 1 (default: 1)
+#   --cpu               Use CPU (host) memory instead of GPU memory
+#   --nic0 NAME         RDMA device for rank 0 (default: auto)
+#   --nic1 NAME         RDMA device for rank 1 (default: auto)
+#   --min-size BYTES    Minimum message size (default: 1048576)
+#   --max-size BYTES    Maximum message size (default: 1073741824)
+#   --iterations N      Timed iterations per size (default: 100)
+#   --warmup N          Warmup iterations (default: 20)
+#   --chunk-size BYTES  Slab/RDMA chunk size (default: 2097152)
+#   --pipeline-depth N  Staging pipeline depth (default: 4)
+#   --topology TYPE     fanout|fanin (default: fanout)
+#   --skip-nccl         Skip NCCL baseline
+#   --skip-uniflow      Skip uniflow send/recv
+#   --nccl-net          Force NCCL through network (disable P2P/SHM)
+#   --slab-size BYTES   Staging slab size (default: chunk-size)
+#   --slab-num N        Number of staging slabs (default: pipeline-depth)
+#
+# Examples:
+#   # GPU memory comparison:
+#   bash run_sendrecv_benchmark.sh --nic0 mlx5_0 --nic1 mlx5_3 --nccl-net
+#
+#   # CPU memory comparison:
+#   bash run_sendrecv_benchmark.sh --cpu --nic0 mlx5_0 --nic1 mlx5_3 --nccl-net
+#
+#   # Tune chunk size and pipeline depth:
+#   bash run_sendrecv_benchmark.sh --chunk-size 4194304 --pipeline-depth 8
+
+set -euo pipefail
+
+# Defaults
+NPROC=2
+GPU0=0
+GPU1=1
+USE_CPU=false
+NIC0=""
+NIC1=""
+MIN_SIZE=1048576
+MAX_SIZE=1073741824
+ITERATIONS=100
+WARMUP=20
+CHUNK_SIZE=2097152
+PIPELINE_DEPTH=4
+SLAB_SIZE=""
+SLAB_NUM=""
+TOPOLOGY="fanout"
+SKIP_NCCL=false
+SKIP_UNIFLOW=false
+NCCL_NET=false
+NO_GDR=false
+PORT=29500
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --nproc)        NPROC="$2"; shift 2 ;;
+    --gpu0)         GPU0="$2"; shift 2 ;;
+    --gpu1)         GPU1="$2"; shift 2 ;;
+    --cpu)          USE_CPU=true; shift ;;
+    --nic0)         NIC0="$2"; shift 2 ;;
+    --nic1)         NIC1="$2"; shift 2 ;;
+    --min-size)     MIN_SIZE="$2"; shift 2 ;;
+    --max-size)     MAX_SIZE="$2"; shift 2 ;;
+    --iterations)   ITERATIONS="$2"; shift 2 ;;
+    --warmup)       WARMUP="$2"; shift 2 ;;
+    --chunk-size)   CHUNK_SIZE="$2"; shift 2 ;;
+    --pipeline-depth) PIPELINE_DEPTH="$2"; shift 2 ;;
+    --slab-size)    SLAB_SIZE="$2"; shift 2 ;;
+    --slab-num)     SLAB_NUM="$2"; shift 2 ;;
+    --topology)     TOPOLOGY="$2"; shift 2 ;;
+    --skip-nccl)    SKIP_NCCL=true; shift ;;
+    --skip-uniflow) SKIP_UNIFLOW=true; shift ;;
+    --nccl-net)     NCCL_NET=true; shift ;;
+    --no-gdr)       NO_GDR=true; shift ;;
+    --port)         PORT="$2"; shift 2 ;;
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# Build
+echo "=== Building uniflow_bench (opt mode) ==="
+BENCH_BIN=$(buck build @fbcode//mode/opt fbcode//comms/uniflow/benchmarks:uniflow_bench \
+  --show-full-output 2>/dev/null | awk '{print $2}')
+
+if [[ -z "${BENCH_BIN}" || ! -x "${BENCH_BIN}" ]]; then
+  echo "ERROR: build failed"
+  exit 1
+fi
+echo "Binary: ${BENCH_BIN}"
+echo ""
+
+# Memory mode
+MEM_LABEL="GPU"
+GPU0_ARG="--cuda-device ${GPU0}"
+GPU1_ARG="--cuda-device ${GPU1}"
+if [[ "${USE_CPU}" == "true" ]]; then
+  MEM_LABEL="CPU"
+  GPU0_ARG=""
+  GPU1_ARG=""
+fi
+
+COMMON_ARGS="--min-size ${MIN_SIZE} --max-size ${MAX_SIZE} --iterations ${ITERATIONS} --warmup ${WARMUP}"
+
+# NIC args
+NIC0_ARGS=""
+NIC1_ARGS=""
+if [[ -n "${NIC0}" ]]; then
+  NIC0_ARGS="--rdma-devices ${NIC0} --num-nics 1"
+fi
+if [[ -n "${NIC1}" ]]; then
+  NIC1_ARGS="--rdma-devices ${NIC1} --num-nics 1"
+fi
+
+run_benchmark() {
+  local LABEL="$1"
+  local R0_ARGS="$2"
+  local R1_ARGS="$3"
+  local R0_ENV="${4:-}"
+  local R1_ENV="${5:-}"
+
+  echo "=== ${LABEL} ==="
+  echo ""
+
+  local LPORT=$((PORT + RANDOM % 100))
+
+  env MASTER_ADDR=127.0.0.1 MASTER_PORT=${LPORT} RANK=1 WORLD_SIZE=${NPROC} LOCAL_RANK=1 \
+    SPDLOG_LEVEL=err ${R1_ENV} \
+    "${BENCH_BIN}" ${R1_ARGS} &
+  local PID1=$!
+
+  sleep 0.5
+
+  env MASTER_ADDR=127.0.0.1 MASTER_PORT=${LPORT} RANK=0 WORLD_SIZE=${NPROC} LOCAL_RANK=0 \
+    SPDLOG_LEVEL=warn ${R0_ENV} \
+    "${BENCH_BIN}" ${R0_ARGS}
+
+  wait ${PID1} 2>/dev/null || true
+  echo ""
+}
+
+# --- Uniflow send/recv ---
+if [[ "${SKIP_UNIFLOW}" != "true" ]]; then
+  SLAB_ARGS=""
+  SLAB_LABEL=""
+  if [[ -n "${SLAB_SIZE}" ]]; then
+    SLAB_ARGS="${SLAB_ARGS} --slab-size ${SLAB_SIZE}"
+    SLAB_LABEL=", slabSize=$(( SLAB_SIZE / 1024 ))K"
+  fi
+  if [[ -n "${SLAB_NUM}" ]]; then
+    SLAB_ARGS="${SLAB_ARGS} --slab-num ${SLAB_NUM}"
+    SLAB_LABEL="${SLAB_LABEL}, slabNum=${SLAB_NUM}"
+  fi
+  SENDRECV_ARGS="--benchmark sendrecv_bandwidth --topology ${TOPOLOGY} ${COMMON_ARGS} --chunk-size ${CHUNK_SIZE} --pipeline-depth ${PIPELINE_DEPTH}${SLAB_ARGS}"
+  run_benchmark \
+    "Uniflow send/recv (${TOPOLOGY}, ${MEM_LABEL}, chunk=$(( CHUNK_SIZE / 1024 ))K, depth=${PIPELINE_DEPTH}${SLAB_LABEL})" \
+    "${GPU0_ARG} ${NIC0_ARGS} ${SENDRECV_ARGS}" \
+    "${GPU1_ARG} ${NIC1_ARGS} ${SENDRECV_ARGS}"
+fi
+
+# --- NCCL sendrecv baseline ---
+if [[ "${SKIP_NCCL}" != "true" ]]; then
+  NCCL_ARGS="--benchmark nccl_sendrecv ${COMMON_ARGS} --topology ${TOPOLOGY}"
+  NCCL_ENV=""
+  NCCL_LABEL="NCCL sendrecv (${MEM_LABEL})"
+  if [[ "${NCCL_NET}" == "true" ]]; then
+    NCCL_ENV="NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1"
+    NCCL_LABEL="NCCL sendrecv (${MEM_LABEL}, network only)"
+  fi
+  if [[ "${NO_GDR}" == "true" ]]; then
+    NCCL_ENV="${NCCL_ENV} NCCL_NET_GDR_LEVEL=0"
+    NCCL_LABEL="${NCCL_LABEL}, no-GDR"
+  fi
+  run_benchmark \
+    "${NCCL_LABEL}" \
+    "${GPU0_ARG} ${NCCL_ARGS}" \
+    "${GPU1_ARG} ${NCCL_ARGS}" \
+    "${NCCL_ENV}" \
+    "${NCCL_ENV}"
+fi
+
+echo "=== Done ==="

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1826,6 +1826,11 @@ RdmaTransportFactory::RdmaTransportFactory(
 
     nicsHandle_->emplace_back(targetDevice, ibvApi_, config_.gidIndex, portNum);
   }
+
+  if (config_.slabPoolConfig.slabNum > 0) {
+    slabPool_ = std::make_shared<RdmaSlabPool>(
+        config_.slabPoolConfig, cudaApi_, ibvApi_, nicsHandle_);
+  }
 }
 
 Result<std::unique_ptr<RegistrationHandle>>
@@ -1974,6 +1979,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
   auto peerTopo = RdmaTopologyInfo::deserialize(peerTopology).value();
   auto config = config_;
   config.numQps = std::min(peerTopo.numQps, config.numQps);
+
   return std::make_unique<RdmaTransport>(
       ibvApi_,
       cudaApi_,
@@ -1982,7 +1988,7 @@ Result<std::unique_ptr<Transport>> RdmaTransportFactory::createTransport(
       nicsHandle_,
       domainId_,
       config,
-      nullptr);
+      slabPool_);
 }
 
 // TODO: get ai_zone_name from fbwhoami / serfwhoami or develop a plugin for

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -1355,7 +1355,7 @@ Result<size_t> RdmaTransport::postSlabTransfer(
 
   size_t chunkIdx = 0;
   for (uint32_t q = 0; q < numQps; ++q) {
-    if (qpAssigned[q] == 0) {
+    if (qpAssigned[q] <= 1) {
       continue;
     }
     uint32_t localNicIdx = q % nics_.size();

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 
 #include "comms/uniflow/transport/rdma/CopyEngine.h"
+#include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 
 #include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
@@ -58,6 +59,7 @@ struct RdmaTransportConfig {
   uint32_t maxInlineData{16}; /* Max inline data bytes per WR. */
   size_t chunkSize{512 * 1024}; /* Transfer chunk size in bytes (512KB). */
   uint16_t pipelineDepth{2}; /* Send/recv pipeline depth (D staging slabs). */
+  RdmaSlabPoolConfig slabPoolConfig{.slabNum = 0}; /* Disabled by default. */
 };
 
 /*
@@ -675,6 +677,7 @@ class RdmaTransportFactory : public TransportFactory {
   std::atomic<uint64_t> dmaBufFallbackCount_{0};
   std::shared_ptr<std::vector<NicResources>> nicsHandle_;
   const RdmaTransportConfig config_;
+  std::shared_ptr<RdmaSlabPool> slabPool_;
 };
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -714,6 +714,26 @@ TEST_F(RdmaTransportFactoryTest, GetTopologyReflectsConfiguredQps) {
   EXPECT_EQ(topo1[0], topo4[0]);
 }
 
+// --- Slab pool ownership tests ---
+
+TEST_F(RdmaTransportFactoryTest, DefaultConfigSkipsSlabPool) {
+  setupSingleDevice();
+  RdmaTransportFactory factory(
+      {"mlx5_0"}, evbThread_.getEventBase(), {}, mockApi_);
+}
+
+TEST_F(RdmaTransportFactoryTest, SlabPoolFailurePropagates) {
+  setupSingleDevice();
+  ON_CALL(*mockApi_, regMr(_, _, _, _))
+      .WillByDefault(
+          Return(Err(ErrCode::DriverError, "simulated regMr failure")));
+  RdmaTransportConfig config{.slabPoolConfig = {.slabNum = 4}};
+  EXPECT_THROW(
+      RdmaTransportFactory(
+          {"mlx5_0"}, evbThread_.getEventBase(), config, mockApi_),
+      std::runtime_error);
+}
+
 // --- supported() tests ---
 
 TEST_F(RdmaTransportFactoryTest, SupportedReturnsTrueWithActiveDevice) {


### PR DESCRIPTION
Summary:

Add NcclSendRecvBenchmark, which drives ncclSend/ncclRecv (same pattern as nccl-tests sendrecv) under the existing uniflow benchmark framework, so NCCL can be compared apples-to-apples with the uniflow copy-based send/recv path.

  - The NCCL communicator is bootstrapped without MPI: rank 0 generates a
    ncclUniqueId and broadcasts it to peers over the existing TCP control
    channel (exchangeMetadata), then every rank calls ncclCommInitRank.
  - Supports the fanout, fanin, and ring topologies, GPU (cudaMalloc) and host
    (cudaMallocHost) buffers, and reports aggregate + per-link bandwidth and
    average latency per message size.

Also included in this change:
  - Expose staging slab tuning to the sendrecv benchmark: new --slab-size and
    --slab-num flags (BenchmarkConfig.slabSize / slabNum) that override the
    RDMA slab pool's slabSize (default: chunk-size) and slabNum (default:
    pipeline-depth) in SendRecvBandwidthBenchmark.
  - Add scripts/run_sendrecv_benchmark.sh to run uniflow send/recv and the NCCL
    baseline back-to-back and print a side-by-side comparison, with flags for
    NICs, memory mode, sizes, chunk/pipeline/slab tuning, and forcing NCCL
    through the network (NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1).

Usage:
    uniflow_bench --benchmark nccl_sendrecv --cuda-device 0
    bash run_sendrecv_benchmark.sh --nic0 mlx5_0 --nic1 mlx5_3 --nccl-net

Reviewed By: rmahidhar

Differential Revision: D107258242


