### PR TITLE
Fix pyyaml dependency for release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 torch
-pyyaml
 packaging

--- a/scripts/_build_wheel.sh
+++ b/scripts/_build_wheel.sh
@@ -23,6 +23,10 @@ python --version
 which python
 
 pip install -r requirements.txt
+# pyyaml is a build-time-only dep (used by extractcvars.py codegen, run from
+# CMake); it is intentionally not in requirements.txt/install_requires so the
+# runtime wheel resolves from the PyTorch index alone.
+pip install pyyaml
 
 export NCCL_SKIP_CONDA_INSTALL=1
 export CLEAN_BUILD=1


### PR DESCRIPTION
`extractcvars.py` that uses pyyaml is a codegen step. It's invoked by the build tooling — not by pip's dependency resolver — and that tooling installs yaml itself, right before calling it:

```sh
# comms/ncclx/v2_29/maint/oss_build.sh:327
# Install pyyaml if not already installed (required by extractcvars.py)
conda install pyyaml --yes
```

```python
python3 "$CVARS_DIR/extractcvars.py"     # reads nccl_cvars.yaml → writes nccl_cvars.cc
```