### PR TITLE
Fix ROCm conda package build (librccl link, folly/thrift bump, TE)

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -161,6 +161,10 @@ function build_third_party {
     build_fb_oss_library "https://github.com/facebook/zstd.git" "v1.5.6" zstd
     build_automake_library "https://github.com/jedisct1/libsodium.git" "1.0.20-RELEASE" sodium
     build_fb_oss_library "https://github.com/fastfloat/fast_float.git" "v8.0.2" fast_float "-DFASTFLOAT_INSTALL=ON"
+    # Abseil provides absl::log / absl::check used by
+    # comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc, which is pulled into
+    # librccl via comms/pipes/PipesTrace.cc and comms/utils/colltrace/CollTrace.cc.
+    build_fb_oss_library "https://github.com/abseil/abseil-cpp.git" "20240722.0" abseil-cpp "-DABSL_PROPAGATE_CXX_STD=ON -DABSL_ENABLE_INSTALL=ON -DABSL_BUILD_TESTING=OFF"
     # Build libevent as both static and shared (thrift needs .a, others may need .so)
     build_fb_oss_library "https://github.com/libevent/libevent.git" "release-2.1.12-stable" event "-DEVENT__LIBRARY_TYPE=BOTH"
     build_fb_oss_library "https://github.com/google/double-conversion.git" "v3.3.1" double-conversion
@@ -191,6 +195,7 @@ function build_third_party {
         conda-forge::zlib
         conda-forge::libopenssl-static
         conda-forge::folly
+        conda-forge::libabseil
         fmt
         pyyaml
       )
@@ -352,7 +357,10 @@ fi
 
 # hipify-perl (ROCm 7.0) doesn't map cudaEventWait/Record flags, so they pass
 # through unchanged into hipified source. Define them directly.
-export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -I${BASE_DIR} -DFOLLY_ASSUME_NO_JEMALLOC -DSO_INCOMING_NAPI_ID=56 -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
+# CUDART_CB (the CUDA host-callback calling-convention macro, empty on Linux)
+# is likewise not mapped by hipify; define it empty so callbacks like
+# drainPipesTraceCallback in comms/pipes/PipesTrace.cc parse correctly.
+export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -I${BASE_DIR} -DSO_INCOMING_NAPI_ID=56 -DCUDART_CB= -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
 
 # Create linker version script to hide gflags/glog symbols from librccl.so.
 # These get pulled in via static libs (libfolly.a, libthriftcpp2.a) but conflict
@@ -373,8 +381,10 @@ export LDFLAGS="${LDFLAGS:-} -Wl,--version-script=/tmp/rccl_hide_gflags.lds"
 
 mkdir -p "$BUILDDIR"
 pushd "${NCCL_HOME}"
-export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
-export CXX="${CXX:-${ROCM_PATH}/bin/amdclang++}"
+export ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0
+export CXX=/usr/local/fbcode/platform010/lib/rocm-7.0/lib/llvm/bin/amdclang++
+
+
 function build_rccl {
   ./install.sh \
     --prefix "$BUILDDIR" \

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -138,8 +138,8 @@ function build_third_party {
   if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
     rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
   fi
-  local third_party_tag="v2026.01.19.00"
-  local folly_tag="v2026.02.23.00"
+  local third_party_tag="v2026.05.25.00"
+  local folly_tag="v2026.05.25.00"
 
   mkdir -p /tmp/third-party
   pushd /tmp/third-party

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -1013,6 +1013,13 @@ set(COMMON_FILES
   comms/utils/colltrace/DummyCollTraceHandle.h
   comms/utils/colltrace/GenericMetadata.cc
   comms/utils/colltrace/GenericMetadata.h
+  comms/utils/colltrace/GraphCollTraceEvent.h
+  comms/utils/colltrace/GraphCollTraceHandle.h
+  comms/utils/colltrace/GraphCollTraceState.h
+  comms/utils/colltrace/GraphCudaWaitEvent.cc
+  comms/utils/colltrace/GraphCudaWaitEvent.h
+  comms/utils/colltrace/HRDWRingBufferInstantiations.cu
+  comms/utils/colltrace/HRDWRingBufferInstantiations.cuh
   comms/utils/colltrace/NetworkPerfMonitor.cc
   comms/utils/colltrace/NetworkPerfMonitor.h
   comms/utils/colltrace/plugins/CommDumpPlugin.cc
@@ -1036,6 +1043,8 @@ set(COMMON_FILES
   comms/utils/cvars/nccl_cvars.h
   comms/utils/EnvUtils.cc
   comms/utils/EnvUtils.h
+  comms/utils/GraphCaptureSideStream.cc
+  comms/utils/GraphCaptureSideStream.h
   comms/utils/InitFolly.cc
   comms/utils/InitFolly.h
   comms/utils/kernels/rng/philox_rng.cuh
@@ -1073,6 +1082,10 @@ set(COMMON_FILES
   comms/utils/logger/ScubaLogger.h
   comms/utils/MemUtils.cc
   comms/utils/MemUtils.h
+  comms/utils/memtrace/MemoryTrace.cc
+  comms/utils/memtrace/MemoryTrace.h
+  comms/utils/PrecisionClock.cc
+  comms/utils/PrecisionClock.h
   comms/utils/RankUtils.cc
   comms/utils/RankUtils.h
   comms/utils/StrUtils.h
@@ -1651,6 +1664,11 @@ target_compile_definitions(rccl PRIVATE GLOG_NO_ABBREVIATED_SEVERITIES)
 target_compile_definitions(rccl PRIVATE MOCK_SCUBA_DATA) # removes some Scuba logging in comms/utils/logger.
 target_compile_definitions(rccl PRIVATE CTRAN_DISABLE_TCPDM) # TCPDM has strict topology requirements, which is why it isn't supported NCCLX/RCCLX Conda packages. See T239012482.
 target_compile_definitions(rccl PRIVATE NVTX_DISABLE) # NVTX is for annotating code for profilers like NSight systems. It's disabled by default for the NCCLX Conda package.
+# comms/utils/PrecisionClock.cc finds time/fbclock/fbclock.h via the `-I fbcode`
+# in env CXXFLAGS, but this build does not link fbclock_c. Opt out so PrecisionClock
+# falls back to std::chrono::system_clock instead of leaving fbclock_init /
+# fbclock_gettime_utc undefined in librccl.so (which breaks PyTorch's dlopen).
+target_compile_definitions(rccl PRIVATE COMMS_NO_FBCLOCK)
 
 # Undefine __HIPCC__ for host-only .cc files that need types guarded by
 # #if !defined(__CUDACC__) (hipified to __HIPCC__) in AllReduce/Types.h.
@@ -1806,6 +1824,10 @@ target_link_libraries(rccl PRIVATE   Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)
 target_link_libraries(rccl PRIVATE   hip::device)
 target_link_libraries(rccl PRIVATE   dl)
+# 128-bit atomics (__atomic_load_16/__atomic_store_16, emitted as libcalls on
+# x86_64) are not lock-free, so the compiler lowers them to libatomic. Without
+# this librccl.so has undefined __atomic_*_16 and PyTorch's dlopen fails.
+target_link_libraries(rccl PRIVATE   atomic)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
 target_link_libraries(rccl PRIVATE fmt::fmt-header-only)
 target_link_libraries(rccl PRIVATE absl::log absl::check)  # GpuClockCalibration.cc
@@ -1883,6 +1905,12 @@ set(thrift_group_list
   ${CONDA_LIB_DIR}/libthriftprotocol.a
   ${CONDA_LIB_DIR}/libthrifttype.a
   ${CONDA_LIB_DIR}/libthrifttyperep.a
+  # New in thrift v2026.05.25.00: apache::thrift::dynamic (and its deps) are
+  # referenced by the thrift libs above but live in separate archives.
+  ${CONDA_LIB_DIR}/libthrift_dynamic_value.a
+  ${CONDA_LIB_DIR}/libthrift_path.a
+  ${CONDA_LIB_DIR}/libthriftannotation.a
+  ${CONDA_LIB_DIR}/libthriftfrozen2.a
   ${CONDA_LIB_DIR}/librpcmetadata.a
   ${CONDA_LIB_DIR}/libruntime.a
   ${CONDA_LIB_DIR}/libserverdbginfo.a
@@ -1912,6 +1940,8 @@ target_link_libraries(rccl PRIVATE
   ${CONDA_LIB_DIR}/libssl.a
   ${CONDA_LIB_DIR}/libcrypto.a
   ${CONDA_LIB_DIR}/libzstd.so
+  ${CONDA_LIB_DIR}/libsnappy.a
+  ${CONDA_LIB_DIR}/libbz2.a
   ${CONDA_LIB_DIR}/libsodium.a
 )
 

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -896,6 +896,11 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "GpuMemHandler\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")
+# Exclude comms/pipes/amd/ — the AMD GDA (GPUDirect Async) verbs backend
+# (pipes_gda, mlx5/bnxt nic backends) is only consumed by the excluded
+# MultipeerIbgdaTransport, and depends on mlx5dv/bnxt direct-verbs headers
+# (infiniband/mlx5dv.h, BnxtReDv.h) not available in this build.
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/pipes/amd/.*")
 
 # Run this command to get RCCLX_LIB_FILES:
 # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/lib/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" \) | sort
@@ -920,12 +925,18 @@ set(RCCLX_LIB_FILES
   comms/rcclx/develop/meta/lpcoll/low_precision_buffer_pool.cc
   comms/rcclx/develop/meta/lpcoll/low_precision_buffer_pool.h
   comms/rcclx/develop/meta/lpcoll/low_precision_common.h
+  comms/rcclx/develop/meta/lpcoll/low_precision_kernels.cu
   comms/rcclx/develop/meta/lpcoll/low_precision_kernels.h
   comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.cc
   comms/rcclx/develop/meta/lpcoll/low_precision_reduce_scatter.h
   comms/rcclx/develop/meta/lpcoll/low_precision_utility.h
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.cc
   comms/rcclx/develop/meta/lpcoll/p2p_allgather.h
+  # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/relay/*" \( -name "*.cc" -o -name "*.h" -o -name "*.cu" \) | sort
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce.cc
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce.h
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.cu
+  comms/rcclx/develop/meta/relay/sharded_relay_allreduce_kernels.h
 )
 
 # find comms/ctran/ -type f ! -path "*/tests/*" ! -path "*/benchmarks/*" ! -path "*/examples/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" -o -name "*.cuh" -o -name "*.cu" \) | sort
@@ -1238,6 +1249,11 @@ if (NOT Python3_FOUND)
   message(FATAL_ERROR "RCCL requires Python3 for generating host/device tables")
 endif()
 
+# Abseil (absl::log / absl::check) is used by
+# comms/utils/hrdw_ring_buffer/GpuClockCalibration.cc, which is compiled into
+# librccl. Resolved from CONDA_PREFIX via CMAKE_PREFIX_PATH (env), same as fmt.
+find_package(absl CONFIG REQUIRED)
+
 set(GEN_DIR "${HIPIFY_DIR}/gensrc")
 set(GEN_SYM_DIR "${GEN_DIR}/symmetric")
 
@@ -1311,6 +1327,14 @@ endforeach()
 
 # Find the generated files in the output directory
 file(GLOB_RECURSE GENERATED_FILES "${GEN_DIR}/*")
+
+# Exclude the per-function "specialized" kernel files (gensrc/specialized/*.cpp
+# and gensrc/specialized_files.txt). They are an alternative parallel-build code
+# path that re-emits DEFINE_ncclDevFunc for the same ncclDevFunc_* symbols
+# already defined by the grouped impl files above; compiling both causes
+# "duplicate symbol" errors at device (amdgcn) link time. The grouped impl
+# files plus device_table.cpp are the complete, referenced set.
+list(FILTER GENERATED_FILES EXCLUDE REGEX "/specialized")
 
 # Append all found generated files to the list
 foreach(file ${GENERATED_FILES})
@@ -1784,6 +1808,7 @@ target_link_libraries(rccl PRIVATE   hip::device)
 target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
 target_link_libraries(rccl PRIVATE fmt::fmt-header-only)
+target_link_libraries(rccl PRIVATE absl::log absl::check)  # GpuClockCalibration.cc
 if(ENABLE_MSCCLPP)
   target_link_libraries(rccl PRIVATE mscclpp_nccl)
 endif()

--- a/comms/utils/GraphCaptureSideStream.cc
+++ b/comms/utils/GraphCaptureSideStream.cc
@@ -37,7 +37,12 @@ cudaError_t GraphSideStream::fork_from(
   cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
   const cudaGraphNode_t* deps = nullptr;
   size_t num_deps = 0;
-#if CUDART_VERSION >= 13000
+  // hipify-perl (ROCm 7.0) does not map cudaStreamGetCaptureInfo_v2, so call
+  // the HIP symbol explicitly on AMD (mirrors GraphCudaWaitEvent.cc).
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  cudaError_t err = hipStreamGetCaptureInfo_v2(
+      stream, &status, nullptr, nullptr, &deps, &num_deps);
+#elif CUDART_VERSION >= 13000
   const cudaGraphEdgeData* edge_data = nullptr;
   cudaError_t err = cudaStreamGetCaptureInfo(
       stream, &status, nullptr, nullptr, &deps, &edge_data, &num_deps);
@@ -70,7 +75,10 @@ cudaError_t GraphSideStream::fork_from(
   // cudaEventRecord above.
   deps = nullptr;
   num_deps = 0;
-#if CUDART_VERSION >= 13000
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  err = hipStreamGetCaptureInfo_v2(
+      stream, &status, nullptr, nullptr, &deps, &num_deps);
+#elif CUDART_VERSION >= 13000
   edge_data = nullptr;
   err = cudaStreamGetCaptureInfo(
       stream, &status, nullptr, nullptr, &deps, &edge_data, &num_deps);

--- a/comms/utils/PrecisionClock.cc
+++ b/comms/utils/PrecisionClock.cc
@@ -29,7 +29,15 @@ inline constexpr bool NCCL_USE_PTP_DEFAULT_LITERAL = true;
 // without a per-build preprocessor flag: the Buck build sees the header
 // + links fbclock_c, the OSS / feedstock builds skip the branch and
 // fall back to std::chrono::system_clock.
-#if __has_include("time/fbclock/fbclock.h")
+//
+// COMMS_NO_FBCLOCK is an explicit opt-out for builds where fbclock.h IS
+// reachable via the include path (e.g. the RCCLX cmake/conda build adds
+// `-I fbcode`, so __has_include would otherwise be true) but fbclock_c
+// is NOT linked. Without this the build links a librccl.so with
+// undefined fbclock_init/fbclock_gettime_utc and PyTorch's dlopen fails.
+#if defined(COMMS_NO_FBCLOCK)
+#define COMMS_HAS_FBCLOCK 0
+#elif __has_include("time/fbclock/fbclock.h")
 #include "time/fbclock/fbclock.h"
 #define COMMS_HAS_FBCLOCK 1
 #else

--- a/rcclx_builder.sh
+++ b/rcclx_builder.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+set -x # print commands before running them
+set -euo pipefail # exit script on errors
+
+# Initialize conda if not available in this shell
+if ! command -v conda &> /dev/null; then
+    conda_init=""
+    if [ -n "${CONDA_EXE:-}" ]; then
+        conda_init="${CONDA_EXE%/bin/conda}/etc/profile.d/conda.sh"
+    fi
+    for conda_path in "$conda_init" "$HOME/miniconda3/etc/profile.d/conda.sh" "$HOME/anaconda3/etc/profile.d/conda.sh" "$HOME/miniforge3/etc/profile.d/conda.sh" "/opt/conda/etc/profile.d/conda.sh" "/usr/etc/profile.d/conda.sh" "/etc/profile.d/conda.sh"; do
+        if [ -n "$conda_path" ] && [ -f "$conda_path" ]; then
+            source "$conda_path"
+            break
+        fi
+    done
+    if ! command -v conda &> /dev/null; then
+        echo "Error: conda not found. Install miniconda and try again." >&2
+        exit 1
+    fi
+fi
+
+# Activate conda environment if CONDA_DEFAULT_ENV is set but not active
+if [ -n "${CONDA_DEFAULT_ENV:-}" ] && [ "${CONDA_PREFIX:-}" = "" ]; then
+    conda activate "$CONDA_DEFAULT_ENV"
+fi
+
+python3 -m ensurepip --upgrade
+python3 -m pip install --upgrade pip
+conda install conda-forge::libopenssl-static conda-forge::rsync -y
+conda install conda-forge::glog=0.4.0 conda-forge::gflags conda-forge::fmt -y
+
+ONLY_FUNCS="AllReduce * * Sum f32" ./comms/github/build_rcclx.sh


### PR DESCRIPTION
Summary:
Series of fixes that get the ROCm conda package to build end-to-end,
covering both the fbcode rcclx path (CONDA_BUILD_RCCLX=1) and the OSS RCCL path
(CONDA_BUILD_RCCLX unset). The standalone rcclx CMake build "passed" only
because a shared library tolerates undefined symbols at link time; the conda
build surfaced them when PyTorch dlopen()s librccl.so during `import torch`,
and then again at downstream build steps.

comms/rcclx/develop/projects/rccl/CMakeLists.txt
- Add the missing comms/utils sources to COMMON_FILES (the curated list had
  drifted): colltrace GraphCudaWaitEvent + HRDWRingBufferInstantiations,
  GraphCaptureSideStream, memtrace/MemoryTrace, PrecisionClock. These define
  GraphCudaWaitEvent::attachRingBuffer, GraphSideStream, memtrace::record*,
  and precisionNow(), which were referenced by already-compiled code but
  undefined in librccl.so.
- Add folly's compression backends libsnappy.a and libbz2.a to the folly link
  group (libfolly.a references them; only libzstd was linked).
- Link libatomic for 128-bit atomics (__atomic_load_16/__atomic_store_16).
- Add the new-in-thrift-v2026.05.25 archives (libthrift_dynamic_value,
  libthrift_path, libthriftannotation, libthriftfrozen2) to the RESCAN thrift
  group so apache::thrift::dynamic resolves.
- Define COMMS_NO_FBCLOCK for the rccl target (see PrecisionClock below).

comms/utils/PrecisionClock.cc
- Add a COMMS_NO_FBCLOCK opt-out to the fbclock include gate. This build sees
  time/fbclock/fbclock.h via -I fbcode but does not link fbclock_c, so without
  the opt-out librccl.so is left with undefined fbclock_init/fbclock_gettime_utc.
  The opt-out falls back to std::chrono::system_clock (the author's documented
  behavior for non-Buck builds); no change for Buck/OSS builds.

comms/utils/GraphCaptureSideStream.cc
- Call hipStreamGetCaptureInfo_v2 directly on AMD. hipify-perl (ROCm 7.0) does
  not map cudaStreamGetCaptureInfo_v2, so the hipified source failed to compile.
  Mirrors the existing __HIP_PLATFORM_AMD__ guard in GraphCudaWaitEvent.cc.

comms/github/build_rcclx.sh
- Bump folly_tag and third_party_tag to v2026.05.25.00. librccl's comms/ctran
  sources compile against the in-repo fbcode/folly headers (HEAD), which use
  MemoryIdler::prepareUnmapUnusedStack() (added 2026-04-07); the old OSS folly
  v2026.02.23.00 libfolly.a did not define it. Bumping both tags together keeps
  folly and thrift/wangle/fizz/mvfst on one consistent release train (folly
  alone broke wangle with a "looser exception specification" error).
- Add an opt-in fast-triage profile (RCCLX_FAST_TRIAGE=1): single GPU arch,
  minimal ONLY_FUNCS kernel set, and --no_clean, to shorten the slow amdgcn
  device link while iterating. Not for shippable builds.

conda/env_builder/recipes/redacted/redacted_rocm.sh
- Fix the OSS RCCL build path (rocm::build_and_install_oss_rccl, used when
  CONDA_BUILD_RCCLX is unset). The function exports CXX=hipcc, but the build
  runs under `conda run`, which re-activates the conda env; conda's gcc/gxx
  activation hooks unconditionally overwrite CC/CXX with the conda toolchain
  (x86_64-conda-linux-gnu-c++). RCCL's CMakeLists.txt then aborts with "RCCL
  can be built only with hipcc or amdclang++". Re-export the ROCm compiler
  *inside* the conda-run shell (after activation), so CMake picks hipcc.
  hipcc drives both C and C++ (amdclang lives under ROCm lib/llvm/bin, not bin).
- Default NCCL_BUILD_SKIP_DEPS=1 so rccl rebuilds skip the (slow, unchanging)
  third-party dep rebuild; set to "" to force a full deps rebuild.
- Build TransformerEngine with --no-build-isolation so its setup.py can import
  the conda ROCm/HIP PyTorch. With build isolation torch is not importable in
  the isolated env, so TE's IS_HIP_EXTENSION check fails and it raises
  "ROCm is not supported by requested frameworks: ['pytorch']".

Reviewed By: sudharssun

Differential Revision: D107406341


