### PR TITLE
Implement allocator API and caching allocator hook for XCCL backend.

### DIFF
--- a/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
@@ -30,6 +30,7 @@ run_tests () {
         FinalizeWarningTest.py
         FSDPCommTest.py
         GatherTest.py
+        MemPoolTest.py
         MultiCommTest.py
         ObjColTest.py
         OptionsTest.py

--- a/comms/torchcomms/tests/integration/py/MemPoolTest.py
+++ b/comms/torchcomms/tests/integration/py/MemPoolTest.py
@@ -13,7 +13,7 @@ class MemPoolTorchCommTest(unittest.TestCase):
     def setUp(self) -> None:
         if "TEST_BACKEND" not in os.environ:
             raise AssertionError("TEST_BACKEND not set")
-        self.device_ = torch.device("cuda")
+        self.device_ = torch.accelerator.current_accelerator()
         self.backend_ = os.environ["TEST_BACKEND"]
 
         self.num_comms_ = 16
@@ -47,21 +47,22 @@ class MemPoolTorchCommTest(unittest.TestCase):
         torch.testing.assert_close(tensor.cpu(), expected_tensor)
 
     @unittest.skipIf(
-        os.getenv("TEST_BACKEND") not in ["ncclx", "nccl"]
-        or torch.cuda.get_device_capability() < (9, 0),
-        "Skipping NCCLX/NCCL-only mem pool tests",
+        (os.getenv("TEST_BACKEND") not in ["ncclx", "nccl", "xccl"]
+        or (torch.cuda.is_available() and torch.cuda.get_device_capability() < (9, 0))),
+        "Skipping NCCLX/NCCL/XCCL-only mem pool tests",
     )
     def test_mem_pool(self) -> None:
         # Use the global allocator obtained in setUp - shared across all comms
         tensors = []
+        device_module = torch.get_device_module()
         for comm in self.comms_:
-            pool = torch.cuda.MemPool(self.allocator_)
-            with torch.cuda.use_mem_pool(pool):
+            pool = device_module.MemPool(self.allocator_)
+            with device_module.use_mem_pool(pool):
                 tensor = self._create_input_tensor(comm)
             tensors.append(tensor)
             comm.all_reduce(tensor, torchcomms.ReduceOp.SUM, False).wait()
 
-        torch.cuda.current_stream().synchronize()
+        device_module.current_stream().synchronize()
 
         for i, comm in enumerate(self.comms_):
             self._verify_results(tensors[i], comm)

--- a/comms/torchcomms/tests/integration/py/MemPoolTest.py
+++ b/comms/torchcomms/tests/integration/py/MemPoolTest.py
@@ -47,8 +47,13 @@ class MemPoolTorchCommTest(unittest.TestCase):
         torch.testing.assert_close(tensor.cpu(), expected_tensor)
 
     @unittest.skipIf(
-        (os.getenv("TEST_BACKEND") not in ["ncclx", "nccl", "xccl"]
-        or (torch.cuda.is_available() and torch.cuda.get_device_capability() < (9, 0))),
+        (
+            os.getenv("TEST_BACKEND") not in ["ncclx", "nccl", "xccl"]
+            or (
+                torch.cuda.is_available()
+                and torch.cuda.get_device_capability() < (9, 0)
+            )
+        ),
         "Skipping NCCLX/NCCL/XCCL-only mem pool tests",
     )
     def test_mem_pool(self) -> None:

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -411,7 +411,7 @@ void TorchCommXCCL::init(
   } else if (options_.abort_process_on_timeout_or_error) {
     TC_LOG(ERROR) << "Aborting process due to error: " << xcclException.what();
     runAbortHooks();
-    abort();
+    ::abort();
   }
   throw xcclException;
 }
@@ -536,7 +536,7 @@ void TorchCommXCCL::abortXcclComm() {
   if (options_.abort_process_on_timeout_or_error) {
     TC_LOG(ERROR, this) << "Aborting process due to error or timeout";
     runAbortHooks();
-    abort();
+    ::abort();
   }
 }
 

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -1,7 +1,10 @@
 #include "comms/torchcomms/xccl/TorchCommXCCL.hpp"
 
 #include <ATen/xpu/XPUContext.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/xpu/XPUCachingAllocator.h>
 #include <c10/xpu/XPUStream.h>
+#include <torch/csrc/xpu/XPUPluggableAllocator.h>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
@@ -251,6 +254,8 @@ TorchCommXCCL::~TorchCommXCCL() {
   if (options_.store) {
     options_.store.reset();
   }
+
+  detachMemoryHook();
 }
 
 void TorchCommXCCL::init(
@@ -385,6 +390,9 @@ void TorchCommXCCL::init(
 
   // Start timeout watchdog thread
   timeout_thread_ = std::thread(&TorchCommXCCL::timeoutWatchdog, this);
+
+  // Register comm with CachingAllocator
+  attachMemoryHook();
 }
 
 [[noreturn]] void TorchCommXCCL::throwAsyncError(bool abort_comm) {
@@ -499,6 +507,7 @@ void TorchCommXCCL::finalize() {
   // Destroy XCCL communicator
   // TODO: should probably not call this after calling abort.
   if (xccl_comm_) {
+    detachMemoryHook();
     onecclResult_t result = xccl_api_->commDestroy(xccl_comm_);
     if (result != onecclSuccess) [[unlikely]] {
       TC_LOG(ERROR, this) << "XCCL commDestroy failed: "
@@ -516,6 +525,7 @@ void TorchCommXCCL::finalize() {
 }
 
 void TorchCommXCCL::abortXcclComm() {
+  detachMemoryHook();
   if (xccl_comm_) {
     onecclResult_t res = xccl_api_->commAbort(xccl_comm_);
     if (res != onecclSuccess) {
@@ -2313,6 +2323,51 @@ std::shared_ptr<TorchCommBackend> TorchCommXCCL::split(
   return new_torchcomm;
 }
 
+void TorchCommXCCL::register_address(
+    const TorchCommXCCL::AddressWithLen& addr) {
+  // We got a register after we got rid of the comm. Is this a fatal error?
+  if (xccl_comm_ == nullptr) {
+    return;
+  }
+
+  if (memoryRegistrationHandles_.contains(addr.addr)) {
+    throw std::runtime_error("Memory already registered with XCCL");
+  }
+  void* handle = nullptr;
+  onecclResult_t result =
+      xccl_api_->commRegister(xccl_comm_, addr.addr, addr.len, &handle);
+
+  if (result != onecclSuccess) [[unlikely]] {
+    throw XCCLException(
+        *xccl_api_, "Failed to register memory with XCCL", result);
+  }
+  memoryRegistrationHandles_.emplace(addr.addr, RegistrationHandle(handle));
+}
+
+void TorchCommXCCL::deregister_address(const TorchCommXCCL::Address& addr) {
+  // We got a deregister after we got rid of the comm. Is this a fatal error?
+  if (xccl_comm_ == nullptr) {
+    return;
+  }
+
+  auto it = memoryRegistrationHandles_.find(addr.addr);
+  if (it == memoryRegistrationHandles_.end()) {
+    // it's possible that the memory was registered for a different comm,
+    // however failed registration for this comm.
+    return;
+  }
+
+  void* handle = it->second.regHandle;
+  onecclResult_t result = xccl_api_->commDeregister(xccl_comm_, handle);
+
+  if (result != onecclSuccess) [[unlikely]] {
+    throw XCCLException(
+        *xccl_api_, "Failed to deregister memory with XCCL", result);
+  }
+
+  memoryRegistrationHandles_.erase(it);
+}
+
 XCCLException::XCCLException(
     XcclApi& xccl_api,
     const std::string& message,
@@ -2333,6 +2388,54 @@ class XCCLRegistration {
     torch::comms::TorchCommFactory::get().register_backend("xccl", []() {
       return std::make_shared<torch::comms::TorchCommXCCL>();
     });
+
+    // Register allocator factory with its own xccl_api instance
+    torch::comms::TorchCommFactory::get().register_allocator_factory(
+        "xccl", []() {
+          // Create xccl_api for this allocator (captured in lambdas below)
+          auto xccl_api = std::make_shared<torch::comms::DefaultXcclApi>();
+          using xpuStream_t = ::c10::xpu::XPUStream;
+          static std::shared_ptr<c10::xpu::XPUCachingAllocator::XPUAllocator>
+              xccl_allocator =
+                  torch::xpu::XPUPluggableAllocator::createCustomAllocator(
+                      // alloc_fn
+                      [xccl_api](size_t size, int device, sycl::queue* queue) {
+                        c10::OptionalDeviceGuard gpuGuard(
+                            c10::Device(c10::kXPU, device));
+                        void* ptr = nullptr;
+                        onecclResult_t result = xccl_api->memAlloc(&ptr, size);
+                        TORCH_CHECK(
+                            result == onecclSuccess,
+                            "onecclMemAlloc failed: ",
+                            xccl_api->getErrorString(result));
+                        xpuStream_t stream =
+                            at::xpu::getStreamFromExternal(queue, device);
+                        LOG(INFO) << "XCCL mem allocator: allocated " << ptr
+                                  << " with " << size << " bytes in stream "
+                                  << stream;
+                        return ptr;
+                      },
+                      // free_fn
+                      [xccl_api](
+                          void* ptr,
+                          size_t size,
+                          int device,
+                          sycl::queue* queue) {
+                        xpuStream_t stream =
+                            at::xpu::getStreamFromExternal(queue, device);
+                        LOG(INFO)
+                            << "XCCL mem allocator: freeing " << ptr << " with "
+                            << size << " bytes in stream " << stream;
+                        c10::OptionalDeviceGuard gpuGuard(
+                            c10::Device(c10::kXPU, device));
+                        onecclResult_t result = xccl_api->memFree(ptr);
+                        TORCH_CHECK(
+                            result == onecclSuccess,
+                            "onecclMemFree failed: ",
+                            xccl_api->getErrorString(result));
+                      });
+          return xccl_allocator;
+        });
   }
 };
 

--- a/comms/torchcomms/xccl/TorchCommXCCL.hpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.hpp
@@ -183,6 +183,7 @@ class TorchCommXCCL : public TorchCommBackend,
 
   // Friend access for TorchCommXCCL
   friend class TorchWorkXCCL;
+  friend class XcclCachingAllocatorHookImpl;
 
   // Getter for XPU API (for friend classes)
   XpuApi* getXpuApi() const {
@@ -218,6 +219,15 @@ class TorchCommXCCL : public TorchCommBackend,
   void returnEvent(xpuEvent_t&& event);
   void abortXcclComm();
 
+  struct Address {
+    void* addr;
+  };
+
+  struct AddressWithLen {
+    void* addr;
+    size_t len;
+  };
+
   enum class CommState {
     NORMAL,
     ERROR,
@@ -226,6 +236,9 @@ class TorchCommXCCL : public TorchCommBackend,
 
   std::atomic<CommState> comm_state_{
       CommState::NORMAL}; // State of the communicator
+
+  void register_address(const AddressWithLen& addr);
+  void deregister_address(const Address& addr);
 
   onecclDataType_t getXcclDataType(const at::Tensor& tensor);
   c10::intrusive_ptr<TorchWorkXCCL> createWork(
@@ -274,6 +287,31 @@ class TorchCommXCCL : public TorchCommBackend,
     std::shared_ptr<XcclApi> xccl_api_;
   };
 
+  // Struct to hold the registration handle for a buffer
+  struct RegistrationHandle {
+    void* regHandle;
+
+    explicit RegistrationHandle(void* regHandle) : regHandle{regHandle} {}
+
+    RegistrationHandle(RegistrationHandle&& other) noexcept
+        : regHandle{other.regHandle} {
+      other.regHandle = nullptr;
+    }
+
+    RegistrationHandle(const RegistrationHandle&) = delete;
+    RegistrationHandle& operator=(const RegistrationHandle&) = delete;
+
+    RegistrationHandle& operator=(RegistrationHandle&& other) noexcept {
+      if (this != &other) {
+        regHandle = other.regHandle;
+        other.regHandle = nullptr;
+      }
+      return *this;
+    }
+
+    ~RegistrationHandle() = default;
+  };
+
   // Constructor for split communicators
   explicit TorchCommXCCL(const onecclComm_t xccl_comm);
 
@@ -292,6 +330,9 @@ class TorchCommXCCL : public TorchCommBackend,
   xpuStream_t getOperationStream(bool async_op);
   void ensureTensorContiguous(const at::Tensor& tensor);
 
+  void attachMemoryHook();
+  void detachMemoryHook();
+
   // Member variables
   onecclComm_t xccl_comm_{};
   at::Device device_;
@@ -305,6 +346,10 @@ class TorchCommXCCL : public TorchCommBackend,
     INITIALIZED,
     FINALIZED,
   } init_state_;
+
+  // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
+  // buffer address to the registeration handle
+  std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
 
   // XCCL API abstraction
   std::shared_ptr<XcclApi> xccl_api_;

--- a/comms/torchcomms/xccl/TorchCommXCCLCCA.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLCCA.cpp
@@ -1,0 +1,143 @@
+#include "comms/torchcomms/xccl/TorchCommXCCLCCA.hpp"
+
+namespace torch::comms {
+
+// Global function to be registered as a hook
+void xcclCachingAllocatorHookFn(
+    const c10::CachingDeviceAllocator::TraceEntry& te) {
+  // Forward to the singleton instance
+  XcclCachingAllocatorHook::getInstance().regDeregMem(te);
+}
+
+XcclCachingAllocatorHookImpl& XcclCachingAllocatorHook::getInstance() {
+  // Use std::call_once for thread-safe singleton initialization
+  // NOLINTNEXTLINE(facebook-hte-std::call_once)
+  std::call_once(init_flag_, createInstance);
+  return *instance_;
+}
+
+DefaultXcclCachingAllocatorHookImpl::DefaultXcclCachingAllocatorHookImpl() {
+  // Setup memory registration hooks
+  at::globalContext().lazyInitDevice(c10::DeviceType::XPU);
+  registerMemPreHook();
+  c10::xpu::XPUCachingAllocator::attachAllocatorTraceTracker(
+      &xcclCachingAllocatorHookFn);
+}
+
+void XcclCachingAllocatorHookImpl::registerMemPreHook() {
+  // We assume no mem pool and no comm has been created yet, we just loop up the
+  // snapshot of the default pool for all devices.
+  auto snapshot = c10::xpu::XPUCachingAllocator::snapshot();
+  for (const auto& segmentInfo : snapshot.segments) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(segmentInfo.address);
+    size_t len = segmentInfo.total_size;
+
+    if (registeredMemMap_.contains(addr)) {
+      throw std::runtime_error("Memory already registered with XCCL");
+    } else {
+      registeredMemMap_.emplace(addr, MemInfo{len, segmentInfo.device});
+    }
+  }
+}
+
+void XcclCachingAllocatorHookImpl::regDeregMem(
+    const c10::CachingDeviceAllocator::TraceEntry& te) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  bool register_mem = te.action_ ==
+      c10::CachingDeviceAllocator::TraceEntry::Action::SEGMENT_ALLOC;
+  bool unregister_mem = te.action_ ==
+      c10::CachingDeviceAllocator::TraceEntry::Action::SEGMENT_FREE;
+
+  if (register_mem) {
+    // Memory got allocated, register it with XCCL
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
+    size_t len = te.size_;
+
+    if (registeredMemMap_.contains(addr)) {
+      throw std::runtime_error("Memory already registered with XCCL");
+    } else {
+      registeredMemMap_.emplace(addr, MemInfo{len, te.device_});
+    }
+
+    // Register the memory through xcclCommRegister and add to commRegHandles_
+    for (auto& comm : registeredComms_) {
+      if (te.device_ == comm->getDevice().index()) {
+        comm->register_address(TorchCommXCCL::AddressWithLen(addr, len));
+      }
+    }
+  } else if (unregister_mem) {
+    // Memory got freed, deregister it with XCCL
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
+
+    if (!registeredMemMap_.contains(addr)) {
+      throw std::runtime_error("Memory not registered with XCCL");
+    } else {
+      registeredMemMap_.erase(addr);
+    }
+
+    for (auto& comm : registeredComms_) {
+      if (te.device_ == comm->getDevice().index()) {
+        comm->deregister_address(TorchCommXCCL::Address(addr));
+      }
+    }
+  }
+}
+
+void XcclCachingAllocatorHookImpl::registerComm(TorchCommXCCL* comm) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Check if the communicator is already registered
+  if (registeredComms_.contains(comm)) {
+    throw std::runtime_error("Communicator already registered");
+  }
+
+  // Register all memory that has already been allocated
+  for (const auto& [addr, mem_info] : registeredMemMap_) {
+    if (mem_info.device == comm->getDevice().index()) {
+      comm->register_address(TorchCommXCCL::AddressWithLen(addr, mem_info.len));
+    }
+  }
+
+  registeredComms_.insert(comm);
+}
+
+void XcclCachingAllocatorHookImpl::deregisterComm(TorchCommXCCL* comm) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (!registeredComms_.contains(comm)) {
+    // Should this be fatal?
+    return;
+  }
+
+  // De-register all memory that has already been allocated
+  for (const auto& [addr, mem_info] : registeredMemMap_) {
+    if (mem_info.device == comm->getDevice().index()) {
+      comm->deregister_address(TorchCommXCCL::Address(addr));
+    }
+  }
+
+  registeredComms_.erase(comm);
+}
+
+void XcclCachingAllocatorHookImpl::clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto& comm : registeredComms_) {
+    for (const auto& [addr, mem_info] : registeredMemMap_) {
+      if (mem_info.device == comm->getDevice().index()) {
+        comm->deregister_address(TorchCommXCCL::Address(addr));
+      }
+    }
+  }
+  registeredMemMap_.clear();
+  registeredComms_.clear();
+}
+
+bool XcclCachingAllocatorHookImpl::isCommRegistered(TorchCommXCCL* comm) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return registeredComms_.contains(comm);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/xccl/TorchCommXCCLCCA.hpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLCCA.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <ATen/xpu/XPUContext.h>
+#include <c10/xpu/XPUCachingAllocator.h>
+#include <memory>
+#include <mutex>
+#include "comms/torchcomms/xccl/TorchCommXCCL.hpp"
+
+namespace torch::comms {
+
+class XcclCachingAllocatorHookImpl {
+ public:
+  virtual ~XcclCachingAllocatorHookImpl() = default;
+  virtual void regDeregMem(const c10::CachingDeviceAllocator::TraceEntry& te);
+  virtual void registerComm(TorchCommXCCL* comm);
+  virtual void deregisterComm(TorchCommXCCL* comm);
+  virtual void registerMemPreHook();
+  virtual void clear();
+
+  virtual bool isCommRegistered(TorchCommXCCL* comm);
+
+ private:
+  std::mutex mutex_;
+
+  struct MemInfo {
+    size_t len;
+    int32_t device;
+
+    MemInfo(size_t l, int32_t d) : len(l), device(d) {}
+  };
+
+  // Map of registered memory addresses to their sizes and device
+  std::unordered_map<void*, MemInfo> registeredMemMap_;
+  // Set of registered communicators. TorchComms, manages it's membership inside
+  // this set.
+  std::set<TorchCommXCCL*> registeredComms_;
+};
+
+class DefaultXcclCachingAllocatorHookImpl
+    : public XcclCachingAllocatorHookImpl {
+ public:
+  DefaultXcclCachingAllocatorHookImpl();
+  virtual ~DefaultXcclCachingAllocatorHookImpl() = default;
+
+  // Delete copy constructor and assignment operator
+  DefaultXcclCachingAllocatorHookImpl(
+      const DefaultXcclCachingAllocatorHookImpl&) = delete;
+  DefaultXcclCachingAllocatorHookImpl& operator=(
+      const DefaultXcclCachingAllocatorHookImpl&) = delete;
+  // Delete move constructor and assignment operator
+  DefaultXcclCachingAllocatorHookImpl(DefaultXcclCachingAllocatorHookImpl&&) =
+      delete;
+  DefaultXcclCachingAllocatorHookImpl& operator=(
+      DefaultXcclCachingAllocatorHookImpl&&) = delete;
+};
+
+class XcclCachingAllocatorHook {
+ public:
+  // Get the singleton instance
+  static XcclCachingAllocatorHookImpl& getInstance();
+
+  // only for use by tests
+  static void setInstance(
+      std::unique_ptr<XcclCachingAllocatorHookImpl> instance) {
+    instance_ = std::move(instance);
+  }
+
+ protected:
+  static void createInstance() {
+    if (!instance_) {
+      instance_ = std::make_unique<DefaultXcclCachingAllocatorHookImpl>();
+    }
+  }
+
+  inline static std::unique_ptr<XcclCachingAllocatorHookImpl> instance_ =
+      nullptr;
+  // NOLINTNEXTLINE(facebook-hte-std::once_flag)
+  inline static std::once_flag init_flag_;
+};
+
+// Global function to be registered as a hook
+void xcclCachingAllocatorHookFn(
+    const c10::CachingDeviceAllocator::TraceEntry& te);
+
+} // namespace torch::comms

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -1,5 +1,6 @@
 #include <oneapi/ccl.h>
 #include <oneapi/ccl.hpp>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include "comms/torchcomms/utils/Logging.hpp"
@@ -215,7 +216,7 @@ void TorchCommXCCL::timeoutWatchdog() noexcept {
 
       runAbortHooks();
 
-      abort();
+      ::abort();
     }
   }
 
@@ -237,7 +238,7 @@ void TorchCommXCCL::checkAndAbortIfTimedOutOrError() {
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR) << "Aborting process due to timeout";
       runAbortHooks();
-      abort();
+      ::abort();
     } else {
       throw std::runtime_error("XCCL operation timed out");
     }

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include "comms/torchcomms/utils/Logging.hpp"
 #include "comms/torchcomms/xccl/TorchCommXCCL.hpp"
+#include "comms/torchcomms/xccl/TorchCommXCCLCCA.hpp"
 
 namespace torch::comms {
 
@@ -332,4 +333,13 @@ void TorchCommXCCL::returnEvent(xpuEvent_t&& event) {
         xpu_api_, xpu_api_->eventDestroy(event), "Failed to destroy event");
   }
 }
+
+void TorchCommXCCL::attachMemoryHook() {
+  XcclCachingAllocatorHook::getInstance().registerComm(this);
+}
+
+void TorchCommXCCL::detachMemoryHook() {
+  XcclCachingAllocatorHook::getInstance().deregisterComm(this);
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/xccl/XcclApi.cpp
+++ b/comms/torchcomms/xccl/XcclApi.cpp
@@ -59,24 +59,18 @@ onecclResult_t DefaultXcclApi::commSplit(
   return onecclCommSplit(comm, color, key, newcomm, config);
 }
 
-// Remove [[maybe_unused]] when implementing this function once
-// onecclCommRegister is available.
 onecclResult_t DefaultXcclApi::commRegister(
-    [[maybe_unused]] onecclComm_t comm,
-    [[maybe_unused]] void* buffer,
-    [[maybe_unused]] size_t size,
-    [[maybe_unused]] void** handle) {
-  // return onecclCommRegister(comm, buffer, size, handle);
-  return onecclNotImplemented;
+    onecclComm_t comm,
+    void* buffer,
+    size_t size,
+    void** handle) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return onecclCommRegister(comm, buffer, size, handle);
 }
 
-// Remove [[maybe_unused]] when implementing this function once
-// onecclCommDeregister is available.
-onecclResult_t DefaultXcclApi::commDeregister(
-    [[maybe_unused]] onecclComm_t comm,
-    [[maybe_unused]] void* handle) {
-  // return onecclCommDeregister(comm, handle);
-  return onecclNotImplemented;
+onecclResult_t DefaultXcclApi::commDeregister(onecclComm_t comm, void* handle) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return onecclCommDeregister(comm, handle);
 }
 
 onecclResult_t DefaultXcclApi::send(
@@ -246,6 +240,16 @@ onecclResult_t DefaultXcclApi::redOpDestroy(
     onecclComm_t comm) {
   std::lock_guard<std::mutex> lock(api_mutex_);
   return onecclRedOpDestroy(op, comm);
+}
+
+onecclResult_t DefaultXcclApi::memAlloc(void** buff, size_t size) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return onecclMemAlloc(buff, size);
+}
+
+onecclResult_t DefaultXcclApi::memFree(void* buff) {
+  std::lock_guard<std::mutex> lock(api_mutex_);
+  return onecclMemFree(buff);
 }
 
 void DefaultXcclApi::setVersionInfo() {

--- a/comms/torchcomms/xccl/XcclApi.hpp
+++ b/comms/torchcomms/xccl/XcclApi.hpp
@@ -159,6 +159,12 @@ class XcclApi {
       onecclRedOp_t op,
       onecclComm_t comm) = 0;
 
+  [[nodiscard]] virtual onecclResult_t memAlloc(
+      void** buff,
+      size_t size) = 0;
+  [[nodiscard]] virtual onecclResult_t memFree(
+      void* buff) = 0;
+
   virtual void setVersionInfo() = 0;
 
   [[nodiscard]] int getVersion() const {
@@ -323,6 +329,9 @@ class DefaultXcclApi : public XcclApi {
       onecclComm_t comm) override;
   [[nodiscard]] onecclResult_t redOpDestroy(onecclRedOp_t op, onecclComm_t comm)
       override;
+
+  [[nodiscard]] onecclResult_t memAlloc(void** buff, size_t size) override;
+  [[nodiscard]] onecclResult_t memFree(void* buff) override;
 
   void setVersionInfo() override;
 

--- a/comms/torchcomms/xccl/XcclApi.hpp
+++ b/comms/torchcomms/xccl/XcclApi.hpp
@@ -159,11 +159,8 @@ class XcclApi {
       onecclRedOp_t op,
       onecclComm_t comm) = 0;
 
-  [[nodiscard]] virtual onecclResult_t memAlloc(
-      void** buff,
-      size_t size) = 0;
-  [[nodiscard]] virtual onecclResult_t memFree(
-      void* buff) = 0;
+  [[nodiscard]] virtual onecclResult_t memAlloc(void** buff, size_t size) = 0;
+  [[nodiscard]] virtual onecclResult_t memFree(void* buff) = 0;
 
   virtual void setVersionInfo() = 0;
 

--- a/comms/torchcomms/xccl/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/xccl/tests/unit/cpp/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(TorchCommXCCLTestBase STATIC
     ${ROOT}/comms/torchcomms/xccl/TorchWorkXCCLQueue.cpp
     ${ROOT}/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
     ${ROOT}/comms/torchcomms/xccl/TorchCommXCCLBootstrap.cpp
+    ${ROOT}/comms/torchcomms/xccl/TorchCommXCCLCCA.cpp
     ${ROOT}/comms/torchcomms/xccl/XcclApi.cpp
     ${ROOT}/comms/torchcomms/xccl/../device/xpu/XpuApi.cpp
 )
@@ -17,11 +18,27 @@ target_include_directories(TorchCommXCCLTestBase PRIVATE
 )
 target_compile_features(TorchCommXCCLTestBase PRIVATE cxx_std_20)
 target_link_directories(TorchCommXCCLTestBase PUBLIC ${CONDA_LIB})
+
+# libtorch_python.so references torch::xpu::XPUPluggableAllocator (link-time)
+# and the CPython API (runtime). It has no DT_NEEDED on libpython since it
+# expects the embedding interpreter to supply those symbols, so for standalone
+# test executables we also link libpython directly.
+find_library(PYTHON_EMBED_LIB
+    NAMES python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}
+          python${Python3_VERSION_MAJOR}
+          python
+    HINTS ${Python3_LIBRARY_DIRS} ${Python3_RUNTIME_LIBRARY_DIRS}
+          ${CONDA_LIB} "${TORCH_INSTALL_PREFIX}/../../.."
+    REQUIRED)
+
 target_link_libraries(TorchCommXCCLTestBase PUBLIC
     torchcomms
     ${TORCH_LIBRARIES}
+    ${TORCH_PYTHON_LIB}
+    ${PYTHON_EMBED_LIB}
     GTest::gmock
 )
+
 if(USE_SYSTEM_LIBS)
     target_link_libraries(TorchCommXCCLTestBase PUBLIC
         "-lglog"

--- a/comms/torchcomms/xccl/tests/unit/cpp/TorchCommXCCLTestBase.cpp
+++ b/comms/torchcomms/xccl/tests/unit/cpp/TorchCommXCCLTestBase.cpp
@@ -1,8 +1,16 @@
 #include "TorchCommXCCLTestBase.hpp"
 
+#include "comms/torchcomms/xccl/TorchCommXCCLCCA.hpp"
+
 namespace torch::comms::test {
 
 void TorchCommXCCLTest::SetUp() {
+  // Install a no-op caching-allocator hook so TorchCommXCCL::detachMemoryHook
+  // does not lazy-init the default impl, whose constructor calls into the XPU
+  // runtime and hangs on hosts with no XPU device.
+  XcclCachingAllocatorHook::setInstance(
+      std::make_unique<XcclCachingAllocatorHookImpl>());
+
   xpu_mock_ = std::make_shared<NiceMock<XpuMock>>();
   xccl_mock_ = std::make_shared<NiceMock<XcclMock>>();
 

--- a/comms/torchcomms/xccl/tests/unit/cpp/mocks/XcclMock.hpp
+++ b/comms/torchcomms/xccl/tests/unit/cpp/mocks/XcclMock.hpp
@@ -180,6 +180,8 @@ class XcclMock : public XcclApi {
       redOpDestroy,
       (onecclRedOp_t op, onecclComm_t comm),
       (override));
+  MOCK_METHOD(onecclResult_t, memAlloc, (void** buff, size_t size), (override));
+  MOCK_METHOD(onecclResult_t, memFree, (void* buff), (override));
   MOCK_METHOD(void, setVersionInfo, (), (override));
 
   void setupDefaultBehaviors() {
@@ -234,6 +236,9 @@ class XcclMock : public XcclApi {
     ON_CALL(*this, redOpCreatePreMulSum(_, _, _, _, _))
         .WillByDefault(Return(onecclSuccess));
     ON_CALL(*this, redOpDestroy(_, _)).WillByDefault(Return(onecclSuccess));
+
+    ON_CALL(*this, memAlloc(_, _)).WillByDefault(Return(onecclSuccess));
+    ON_CALL(*this, memFree(_)).WillByDefault(Return(onecclSuccess));
 
     ON_CALL(*this, getErrorString(_)).WillByDefault(Return("Mock XCCL Error"));
   }


### PR DESCRIPTION
The PR implements two memory management functions that are missing in XCCL backend. One is caching allocator hook for memory registration (and deregistration). The other is to register its own get allocator instance and generalize MemPoolTest.

Co-authored-by: Tanima Dey tanima.dey@intel.com
Co-authored-by: jemitche1 jerome.mitchell@intel.com
Co-authored-by: Panagiotis Kourdis panagiotis.kourdis@intel.com