### PR TITLE
Support in-place pipes allgather

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -31,6 +31,61 @@ constexpr size_t kHierarchicalAgOverlapChunk2MiB = 2 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk4MiB = 4 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk8MiB = 8 * 1024 * 1024;
 
+bool rangesOverlap(
+    uintptr_t lhs,
+    size_t lhsBytes,
+    uintptr_t rhs,
+    size_t rhsBytes) {
+  if (lhsBytes == 0 || rhsBytes == 0) {
+    return false;
+  }
+  return lhs < rhs + rhsBytes && rhs < lhs + lhsBytes;
+}
+
+bool isAllGatherInPlace(
+    const void* sendbuff,
+    const void* recvbuff,
+    size_t sendBytes,
+    int rank,
+    int nRanks) {
+  const uintptr_t sendPtr = reinterpret_cast<uintptr_t>(sendbuff);
+  const uintptr_t recvPtr = reinterpret_cast<uintptr_t>(recvbuff);
+  const size_t recvBytes = sendBytes * static_cast<size_t>(nRanks);
+  const uintptr_t ownRecvPtr = recvPtr + static_cast<size_t>(rank) * sendBytes;
+  const bool buffersOverlap =
+      rangesOverlap(sendPtr, sendBytes, recvPtr, recvBytes);
+  return buffersOverlap && sendPtr == ownRecvPtr;
+}
+
+commResult_t validateAllGatherBufferLayout(
+    const void* sendbuff,
+    const void* recvbuff,
+    size_t sendBytes,
+    int rank,
+    int nRanks) {
+  const uintptr_t sendPtr = reinterpret_cast<uintptr_t>(sendbuff);
+  const uintptr_t recvPtr = reinterpret_cast<uintptr_t>(recvbuff);
+  const size_t recvBytes = sendBytes * static_cast<size_t>(nRanks);
+  const uintptr_t ownRecvPtr = recvPtr + static_cast<size_t>(rank) * sendBytes;
+
+  if (rangesOverlap(sendPtr, sendBytes, recvPtr, recvBytes) &&
+      sendPtr != ownRecvPtr) {
+    CLOGF_SUBSYS(
+        WARN,
+        COLL,
+        "AllGather {} invalid buffer layout: sendbuff range [0x{:x}, 0x{:x}) overlaps recvbuff range [0x{:x}, 0x{:x}) but does not start at this rank's recv slot 0x{:x}. Use sendbuff=recvbuff+rank*sendcount*sizeof(datatype) for in-place allgather, or use a disjoint send buffer for out-of-place allgather.",
+        allGatherAlgoName(myAlgo),
+        sendPtr,
+        sendPtr + sendBytes,
+        recvPtr,
+        recvPtr + recvBytes,
+        ownRecvPtr);
+    return commInvalidArgument;
+  }
+
+  return commSuccess;
+}
+
 size_t selectHierarchicalAgOverlapChunkBytes(size_t sendBytes) {
   const size_t targetChunkBytes = (sendBytes + 7) / 8;
   if (targetChunkBytes <= kHierarchicalAgOverlapChunk512KiB) {
@@ -263,6 +318,7 @@ commResult_t ctranAllGatherHierarchicalRing(
   const int nRanks = statex->nRanks();
   const int nNodes = statex->nNodes();
   const int nLocalRanks = statex->nLocalRanks();
+  const int rank = statex->rank();
   const int localRank = statex->localRank();
   const int node = statex->node();
   const size_t sendBytes = sendcount * commTypeSize(datatype);
@@ -279,6 +335,11 @@ commResult_t ctranAllGatherHierarchicalRing(
     comm->ctran_->updateOpCount();
     return commSuccess;
   }
+
+  FB_COMMCHECK(validateAllGatherBufferLayout(
+      sendbuff, recvbuff, sendBytes, rank, nRanks));
+  const bool inPlace =
+      isAllGatherInPlace(sendbuff, recvbuff, sendBytes, rank, nRanks);
 
   const bool useOverlap = NCCL_CTRAN_HIER_AG_OVERLAP_ENABLE && nLocalRanks > 1;
   const int numBlocks = static_cast<int>(NCCL_CTRAN_HIER_AG_IB_NUM_BLOCKS);
@@ -316,6 +377,7 @@ commResult_t ctranAllGatherHierarchicalRing(
       static_cast<size_t>(NCCL_CTRAN_HIER_AG_NVL_SIGNAL_BYTES);
   params.sendbuf = static_cast<const char*>(sendbuff);
   params.recvbuf = static_cast<char*>(recvbuff);
+  params.in_place = inPlace;
   params.ib_num_blocks = numBlocks;
   params.timeout_ms = NCCL_CTRAN_HIER_AG_TIMEOUT_MS;
   params.stream = stream;
@@ -379,6 +441,7 @@ commResult_t ctranAllGatherHierarchicalRing(
     overlapParams.ready_sequence = comm->ctran_->getOpCount() + 1;
     overlapParams.sendbuf = params.sendbuf;
     overlapParams.recvbuf = params.recvbuf;
+    overlapParams.in_place = params.in_place;
     overlapParams.ib_num_blocks = params.ib_num_blocks;
     overlapParams.nvl_num_blocks = nvlNumBlocks;
     overlapParams.timeout_ms = params.timeout_ms;

--- a/comms/pipes/CopyUtils.cuh
+++ b/comms/pipes/CopyUtils.cuh
@@ -5,6 +5,8 @@
 #include <cuda_runtime.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <cstdio>
 #include "comms/pipes/amd/HipHostCompat.h"
 
 #include "comms/pipes/ThreadGroup.cuh"
@@ -250,6 +252,46 @@ __device__ __forceinline__ void memcpy_vectorized_aligned_sys(
 }
 #endif
 
+/**
+ * assert_buffer_non_overlap - Assert that source and destination buffers do not
+ * overlap.
+ *
+ * memcpy_vectorized uses memcpy-style, __restrict__ vectorized loads/stores and
+ * a cooperative striding order, so overlapping source/destination ranges are
+ * not safe. Callers that support in-place operation must bypass the copy.
+ */
+__device__ __forceinline__ void assert_buffer_non_overlap(
+    char* dst_d,
+    const char* src_d,
+    std::size_t nbytes,
+    const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  const uintptr_t dst_begin = reinterpret_cast<uintptr_t>(dst_d);
+  const uintptr_t src_begin = reinterpret_cast<uintptr_t>(src_d);
+  const uintptr_t dst_end = dst_begin + nbytes;
+  const uintptr_t src_end = src_begin + nbytes;
+  if (nbytes > 0 && dst_begin != src_begin && dst_begin < src_end &&
+      src_begin < dst_end) {
+    if (group.is_leader()) {
+      printf(
+          "memcpy_vectorized partial overlap: dst=[0x%llx,0x%llx) src=[0x%llx,0x%llx) nbytes=%llu block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          static_cast<unsigned long long>(dst_begin),
+          static_cast<unsigned long long>(dst_end),
+          static_cast<unsigned long long>(src_begin),
+          static_cast<unsigned long long>(src_end),
+          static_cast<unsigned long long>(nbytes),
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          threadIdx.x,
+          threadIdx.y,
+          threadIdx.z);
+    }
+    __trap();
+  }
+#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+}
+
 template <int kUnroll = 8>
 __device__ __forceinline__ void memcpy_vectorized(
     char* dst,
@@ -257,6 +299,11 @@ __device__ __forceinline__ void memcpy_vectorized(
     std::size_t len,
     const ThreadGroup& group) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (len == 0 || dst == src) {
+    return;
+  }
+  assert_buffer_non_overlap(dst, src, len, group);
+
   constexpr std::size_t kAlignment = sizeof(uint4);
   if ((uintptr_t)dst % kAlignment == 0 && (uintptr_t)src % kAlignment == 0) {
     const std::size_t nelems = len / kAlignment;
@@ -290,6 +337,21 @@ __device__ __forceinline__ void memcpy_vectorized(
     std::size_t len,
     const ThreadGroup& group) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  if (len == 0 || (dst1 == src && dst2 == src)) {
+    return;
+  }
+  if (dst1 == src) {
+    memcpy_vectorized<kUnroll>(dst2, src, len, group);
+    return;
+  }
+  if (dst2 == src || dst1 == dst2) {
+    memcpy_vectorized<kUnroll>(dst1, src, len, group);
+    return;
+  }
+  assert_buffer_non_overlap(dst1, src, len, group);
+  assert_buffer_non_overlap(dst2, src, len, group);
+  assert_buffer_non_overlap(dst1, dst2, len, group);
+
   constexpr std::size_t kAlignment = sizeof(uint4);
   if ((uintptr_t)dst1 % kAlignment == 0 && (uintptr_t)dst2 % kAlignment == 0 &&
       (uintptr_t)src % kAlignment == 0) {
@@ -309,34 +371,6 @@ __device__ __forceinline__ void memcpy_vectorized(
   }
 
   memcpy_vectorized_aligned<char, kUnroll>(dst1, dst2, src, len, group);
-#endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-}
-
-/**
- * assert_buffer_non_overlap - Assert that source and destination buffers do not
- * overlap
- *
- * Checks that the memory regions [src_d, src_d + nbytes) and
- * [dst_d, dst_d + nbytes) are disjoint (non-overlapping). If they overlap,
- * the kernel is aborted via __trap().
- *
- * This is a safety check for memory copy operations that assume non-overlapping
- * buffers. Overlapping buffers with memcpy-style operations lead to undefined
- * behavior.
- *
- * @param dst_d Destination buffer pointer
- * @param src_d Source buffer pointer
- * @param nbytes Size of both buffers in bytes
- *
- * Note: Only active on device (__CUDA_ARCH__ / __HIP_DEVICE_COMPILE__). No-op
- * on host.
- */
-__device__ __forceinline__ void
-assert_buffer_non_overlap(char* dst_d, const char* src_d, std::size_t nbytes) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  if (!(src_d + nbytes <= dst_d || dst_d + nbytes <= src_d)) {
-    __trap(); // Abort kernel if buffers overlap
-  }
 #endif // defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 }
 

--- a/comms/pipes/P2pNvlTransportDevice.cuh
+++ b/comms/pipes/P2pNvlTransportDevice.cuh
@@ -1169,16 +1169,13 @@ class P2pNvlTransportDevice {
    * @param src_d Source pointer (device memory)
    * @param nbytes Number of bytes to copy
    */
-  __device__ __forceinline__ void put(
-      ThreadGroup& group,
-      char* __restrict__ dst_d,
-      const char* __restrict__ src_d,
-      std::size_t nbytes) {
+  __device__ __forceinline__ void
+  put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
 #if PIPES_IS_DEVICE_COMPILE
-    if (nbytes == 0) {
+    if (nbytes == 0 || dst_d == src_d) {
       return;
     }
-    assert_buffer_non_overlap(dst_d, src_d, nbytes);
+    assert_buffer_non_overlap(dst_d, src_d, nbytes, group);
     memcpy_vectorized(dst_d, src_d, nbytes, group);
 #endif
   }

--- a/comms/pipes/P2pSelfTransportDevice.cuh
+++ b/comms/pipes/P2pSelfTransportDevice.cuh
@@ -98,7 +98,7 @@ class P2pSelfTransportDevice {
     }
 
     // Check for buffer overlap - only support non-overlapping buffers
-    assert_buffer_non_overlap(dst_d, src_d, nbytes);
+    assert_buffer_non_overlap(dst_d, src_d, nbytes, group);
 
     // Compute chunk size: aim for nbytes / total_groups per chunk,
     // aligned to 16 bytes (uint4 size) for efficient vectorized access
@@ -146,16 +146,13 @@ class P2pSelfTransportDevice {
    * @param src_d Source pointer (device memory)
    * @param nbytes Number of bytes to copy
    */
-  __device__ __forceinline__ void put(
-      ThreadGroup& group,
-      char* __restrict__ dst_d,
-      const char* __restrict__ src_d,
-      std::size_t nbytes) {
+  __device__ __forceinline__ void
+  put(ThreadGroup& group, char* dst_d, const char* src_d, std::size_t nbytes) {
 #if PIPES_IS_DEVICE_COMPILE
     if (nbytes == 0 || dst_d == src_d) {
       return;
     }
-    assert_buffer_non_overlap(dst_d, src_d, nbytes);
+    assert_buffer_non_overlap(dst_d, src_d, nbytes, group);
     memcpy_vectorized(dst_d, src_d, nbytes, group);
 #endif
   }

--- a/comms/pipes/collectives/AllGatherDirect.cu
+++ b/comms/pipes/collectives/AllGatherDirect.cu
@@ -5,6 +5,7 @@
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/pipes/CopyUtils.cuh"
 #include "comms/pipes/DeviceCheck.cuh"
+#include "comms/pipes/MemcpyCopyOp.cuh"
 #include "comms/pipes/P2pIbgdaTransportDevice.cuh"
 #include "comms/pipes/ThreadGroup.cuh"
 #include "comms/pipes/TiledBuffer.cuh"
@@ -12,7 +13,7 @@
 
 namespace comms::pipes {
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
     Timeout timeout) {
@@ -29,10 +30,13 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
   const std::size_t tile_offset = group.group_id * tile.tile_elements;
   const std::size_t tile_bytes = tile.bytes();
 
-  const char* own_src = args.sendbuf + tile_offset;
-  char* own_dst = args.recvbuf + my_rank * sendcount + tile_offset;
-  memcpy_vectorized(own_dst, own_src, tile_bytes, group);
-  group.sync();
+  const char* tile_src = args.sendbuf + tile_offset;
+  if constexpr (!kInPlace) {
+    char* own_dst = args.recvbuf +
+        static_cast<std::size_t>(my_rank) * sendcount + tile_offset;
+    memcpy_vectorized(own_dst, tile_src, tile_bytes, group);
+    group.sync();
+  }
 
   if (W <= 1 || tile_bytes == 0) {
     return;
@@ -48,7 +52,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const std::size_t window =
         remaining < pipeline_window ? remaining : pipeline_window;
 
-    const char* send_src = args.sendbuf + tile_offset + off;
+    const char* send_src = tile_src + off;
     for (int peer_rank = 0; peer_rank < W; ++peer_rank) {
       if (peer_rank == my_rank) {
         continue;
@@ -69,7 +73,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
 #endif
 }
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
     const __grid_constant__ HierarchicalAllgatherFusedArgs args,
@@ -86,18 +90,20 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
   const std::size_t io_tile_offset = group.group_id * ring_tile.tile_elements;
   const std::size_t io_tile_bytes = ring_tile.bytes();
 
-  const char* own_src = args.sendbuf + io_tile_offset;
   char* own_dst = args.recvbuf +
       (static_cast<std::size_t>(args.ib_rank) * args.nvl_size + args.nvl_rank) *
           chunk_bytes +
       io_tile_offset;
+  const char* tile_src = args.sendbuf + io_tile_offset;
 
   // Single IB node (W==1): self-copy then NVL broadcast within the local
   // NVL group. The broadcast is still needed because each NVL peer must
   // receive every other peer's chunk even when there is only one IB node.
   if (W <= 1) {
-    memcpy_vectorized(own_dst, own_src, io_tile_bytes, group);
-    group.sync();
+    if constexpr (!kInPlace) {
+      memcpy_vectorized(own_dst, tile_src, io_tile_bytes, group);
+      group.sync();
+    }
     hierarchical_allgather_nvl_broadcast_from_recvbuf(
         group,
         args.ib_size,
@@ -126,15 +132,20 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
     const std::size_t window =
         (remaining < pipeline_window) ? remaining : pipeline_window;
 
-    const char* send_src = args.sendbuf + io_tile_offset + off;
-    next.template send<MemcpyAndSelfCopy>(
-        group,
-        send_src,
-        window,
-        group.total_groups,
-        max_sig,
-        timeout,
-        own_dst + off);
+    const char* send_src = tile_src + off;
+    if constexpr (kInPlace) {
+      next.template send<Memcpy>(
+          group, send_src, window, group.total_groups, max_sig, timeout);
+    } else {
+      next.template send<MemcpyAndSelfCopy>(
+          group,
+          send_src,
+          window,
+          group.total_groups,
+          max_sig,
+          timeout,
+          own_dst + off);
+    }
 
     int fwd_current_rank = args.ib_rank;
     for (int step = 0; step < W - 1; step++) {
@@ -242,7 +253,7 @@ __device__ __forceinline__ void trace_hierarchical_allgather(
 
 } // namespace
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
@@ -275,15 +286,17 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
       const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
           ? chunk_bytes
           : (args.sendcount - off);
-      const char* send_src = args.sendbuf + off;
       char* own_dst = args.recvbuf +
           (static_cast<std::size_t>(args.ib_rank) * args.nvl_size +
            args.nvl_rank) *
               args.sendcount +
           off;
+      const char* send_src = args.sendbuf + off;
 
       if (W <= 1) {
-        memcpy_vectorized(own_dst, send_src, bytes, group);
+        if constexpr (!kInPlace) {
+          memcpy_vectorized(own_dst, send_src, bytes, group);
+        }
         publish_ready(
             group,
             args.ready_counters,
@@ -313,14 +326,24 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const std::size_t window =
             remaining < ib_window ? remaining : ib_window;
 
-        next.template send<MemcpyAndSelfCopy>(
-            group,
-            send_src + chunk_off,
-            window,
-            args.ib_num_blocks,
-            args.ib_signaling_data_size,
-            timeout,
-            own_dst + chunk_off);
+        if constexpr (kInPlace) {
+          next.template send<Memcpy>(
+              group,
+              send_src + chunk_off,
+              window,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        } else {
+          next.template send<MemcpyAndSelfCopy>(
+              group,
+              send_src + chunk_off,
+              window,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout,
+              own_dst + chunk_off);
+        }
 
         int fwd_current_rank = args.ib_rank;
         for (int step = 0; step < W - 1; step++) {
@@ -479,15 +502,27 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
 #endif
 }
 
-template __global__ void direct_allgather_nvl_kernel<512>(
+template __global__ void direct_allgather_nvl_kernel<false, 512>(
     const __grid_constant__ DirectAllgatherNvlArgs,
     Timeout);
 
-template __global__ void hierarchical_allgather_fused_kernel<512>(
+template __global__ void direct_allgather_nvl_kernel<true, 512>(
+    const __grid_constant__ DirectAllgatherNvlArgs,
+    Timeout);
+
+template __global__ void hierarchical_allgather_fused_kernel<false, 512>(
     const __grid_constant__ HierarchicalAllgatherFusedArgs,
     Timeout);
 
-template __global__ void hierarchical_allgather_overlap_kernel<512>(
+template __global__ void hierarchical_allgather_fused_kernel<true, 512>(
+    const __grid_constant__ HierarchicalAllgatherFusedArgs,
+    Timeout);
+
+template __global__ void hierarchical_allgather_overlap_kernel<false, 512>(
+    const __grid_constant__ HierarchicalAllgatherOverlapArgs,
+    Timeout);
+
+template __global__ void hierarchical_allgather_overlap_kernel<true, 512>(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs,
     Timeout);
 

--- a/comms/pipes/collectives/AllGatherDirect.cuh
+++ b/comms/pipes/collectives/AllGatherDirect.cuh
@@ -9,18 +9,18 @@
 
 namespace comms::pipes {
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
     Timeout timeout);
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
         const __grid_constant__ HierarchicalAllgatherFusedArgs args,
         Timeout timeout);
 
-template <int kBlockSize>
+template <bool kInPlace, int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const __grid_constant__ HierarchicalAllgatherOverlapArgs args,

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -59,9 +59,15 @@ void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params) {
     new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
   }
 
-  direct_allgather_nvl_kernel<512>
-      <<<params.num_blocks, 512, 0, params.stream>>>(
-          args, make_launch_timeout(params.timeout_ms));
+  if (params.in_place) {
+    direct_allgather_nvl_kernel<true, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(
+            args, make_launch_timeout(params.timeout_ms));
+  } else {
+    direct_allgather_nvl_kernel<false, 512>
+        <<<params.num_blocks, 512, 0, params.stream>>>(
+            args, make_launch_timeout(params.timeout_ms));
+  }
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -91,9 +97,15 @@ void launch_hierarchical_allgather_fused(
     new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
   }
 
-  hierarchical_allgather_fused_kernel<512>
-      <<<params.ib_num_blocks, 512, 0, params.stream>>>(
-          args, make_launch_timeout(params.timeout_ms));
+  if (params.in_place) {
+    hierarchical_allgather_fused_kernel<true, 512>
+        <<<params.ib_num_blocks, 512, 0, params.stream>>>(
+            args, make_launch_timeout(params.timeout_ms));
+  } else {
+    hierarchical_allgather_fused_kernel<false, 512>
+        <<<params.ib_num_blocks, 512, 0, params.stream>>>(
+            args, make_launch_timeout(params.timeout_ms));
+  }
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -142,9 +154,19 @@ void launch_hierarchical_allgather_overlap(
     new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
   }
 
-  hierarchical_allgather_overlap_kernel<512>
-      <<<params.ib_num_blocks + params.nvl_num_blocks, 512, 0, params.stream>>>(
-          args, make_launch_timeout(params.timeout_ms));
+  if (params.in_place) {
+    hierarchical_allgather_overlap_kernel<true, 512>
+        <<<params.ib_num_blocks + params.nvl_num_blocks,
+           512,
+           0,
+           params.stream>>>(args, make_launch_timeout(params.timeout_ms));
+  } else {
+    hierarchical_allgather_overlap_kernel<false, 512>
+        <<<params.ib_num_blocks + params.nvl_num_blocks,
+           512,
+           0,
+           params.stream>>>(args, make_launch_timeout(params.timeout_ms));
+  }
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 

--- a/comms/pipes/collectives/AllGatherLauncher.h
+++ b/comms/pipes/collectives/AllGatherLauncher.h
@@ -18,6 +18,7 @@ struct DirectAllgatherNvlLaunchParams {
   std::size_t signaling_data_size{0};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
+  bool in_place{false};
   int num_blocks{16};
   float timeout_ms{0.0f};
   cudaStream_t stream{nullptr};
@@ -37,6 +38,7 @@ struct HierarchicalAllgatherLaunchParams {
   std::size_t nvl_signaling_data_size{0};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
+  bool in_place{false};
   int ib_num_blocks{16};
   float timeout_ms{0.0f};
   cudaStream_t stream{nullptr};
@@ -61,6 +63,7 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   uint64_t* ready_counters{nullptr};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
+  bool in_place{false};
   int ib_num_blocks{16};
   int nvl_num_blocks{16};
   float timeout_ms{0.0f};

--- a/comms/pipes/collectives/tests/DirectNvlTest.cc
+++ b/comms/pipes/collectives/tests/DirectNvlTest.cc
@@ -22,6 +22,7 @@ namespace {
 struct DirectNvlTestParams {
   std::size_t bytes{0};
   int num_blocks{8};
+  bool in_place{false};
   std::string name;
 };
 
@@ -73,19 +74,24 @@ TEST_P(DirectAllGatherNvlTest, Correctness) {
     GTEST_SKIP() << "NVLink transport not available: " << e.what();
   }
 
-  DeviceBuffer sendbuf(params.bytes);
   DeviceBuffer recvbuf(params.bytes * worldSize);
   CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, params.bytes * worldSize));
 
-  fill_sendbuf(static_cast<char*>(sendbuf.get()), params.bytes);
+  DeviceBuffer sendbuf(params.bytes);
+  const auto ownOffset = static_cast<std::size_t>(globalRank) * params.bytes;
+  char* ownRecvSlot = static_cast<char*>(recvbuf.get()) + ownOffset;
+  char* sendbuf_d =
+      params.in_place ? ownRecvSlot : static_cast<char*>(sendbuf.get());
+  fill_sendbuf(sendbuf_d, params.bytes);
 
   DirectAllgatherNvlLaunchParams launchParams{};
   launchParams.my_rank = globalRank;
   launchParams.num_ranks = worldSize;
   launchParams.sendcount = params.bytes;
   launchParams.signaling_data_size = 0;
-  launchParams.sendbuf = static_cast<const char*>(sendbuf.get());
+  launchParams.sendbuf = sendbuf_d;
   launchParams.recvbuf = static_cast<char*>(recvbuf.get());
+  launchParams.in_place = params.in_place;
   launchParams.num_blocks = params.num_blocks;
   launchParams.timeout_ms = 30000.0f;
 
@@ -167,7 +173,12 @@ INSTANTIATE_TEST_SUITE_P(
         DirectNvlTestParams{
             .bytes = 1024 * 1024,
             .num_blocks = 8,
-            .name = "1MB_8B"}),
+            .name = "1MB_8B"},
+        DirectNvlTestParams{
+            .bytes = 64 * 1024,
+            .num_blocks = 4,
+            .in_place = true,
+            .name = "64KB_4B_InPlace"}),
     param_name);
 
 INSTANTIATE_TEST_SUITE_P(

--- a/comms/pipes/collectives/tests/HierarchicalAllGatherTest.cc
+++ b/comms/pipes/collectives/tests/HierarchicalAllGatherTest.cc
@@ -19,107 +19,120 @@ namespace comms::pipes::test {
 
 namespace {
 
-class HierarchicalAllGatherTest : public AllGatherTestBase {};
+class HierarchicalAllGatherTest : public AllGatherTestBase {
+ protected:
+  void runCorrectness(bool inPlace) {
+    constexpr int kNvlSize = 2;
+    constexpr int kIbSize = 2;
+    constexpr std::size_t kSendcount = 64 * 1024;
+    constexpr int kNumBlocks = 4;
+
+    if (worldSize != kNvlSize * kIbSize) {
+      GTEST_SKIP() << "Hierarchical test expects " << kNvlSize * kIbSize
+                   << " ranks";
+    }
+
+    const int ibRank = globalRank / kNvlSize;
+    const int nvlRank = globalRank % kNvlSize;
+
+    std::unique_ptr<MultipeerIbgdaTransport> ibTransport;
+    try {
+      MultipeerIbgdaTransportConfig ibConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = 1024 * 1024,
+          .sendRecv =
+              MultipeerIbgdaTransportConfig::SendRecvConfig{
+                  .maxGroups = kNumBlocks,
+                  .pipelineDepth = 2,
+              },
+      };
+      ibTransport = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, ibConfig);
+      ibTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    }
+
+    std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
+    try {
+      MultiPeerNvlTransportConfig nvlConfig{
+          .dataBufferSize = 1024 * 1024,
+          .chunkSize = 1024 * 1024,
+          .pipelineDepth = 2,
+          .p2pSignalCount = static_cast<std::size_t>(kNumBlocks),
+          .tile_max_groups = kNumBlocks,
+          .memSharingMode = MemSharingMode::kCudaIpc,
+      };
+      std::vector<int> nvlRankToGlobal(kNvlSize);
+      for (int peer = 0; peer < kNvlSize; ++peer) {
+        nvlRankToGlobal[peer] = ibRank * kNvlSize + peer;
+      }
+      auto nvlBootstrap = std::make_shared<NvlBootstrapAdapter>(
+          bootstrap, std::move(nvlRankToGlobal));
+      nvlTransport = std::make_unique<MultiPeerNvlTransport>(
+          nvlRank, kNvlSize, nvlBootstrap, nvlConfig);
+      nvlTransport->exchange();
+    } catch (const std::exception& e) {
+      GTEST_SKIP() << "NVLink transport not available: " << e.what();
+    }
+
+    DeviceBuffer sendbuf(kSendcount);
+    DeviceBuffer recvbuf(kSendcount * worldSize);
+    CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, kSendcount * worldSize));
+
+    const auto ownOffset = static_cast<std::size_t>(globalRank) * kSendcount;
+    char* ownRecvSlot = static_cast<char*>(recvbuf.get()) + ownOffset;
+    char* sendbuf_d = inPlace ? ownRecvSlot : static_cast<char*>(sendbuf.get());
+    fill_sendbuf(sendbuf_d, kSendcount);
+
+    auto ibRingsOpt = make_standard_rings(kIbSize, ibRank, 1);
+    ASSERT_TRUE(ibRingsOpt.has_value());
+    const auto& ibRings = *ibRingsOpt;
+
+    HierarchicalAllgatherLaunchParams launchParams{};
+    launchParams.num_ranks = worldSize;
+    launchParams.ib_rank = ibRank;
+    launchParams.ib_size = kIbSize;
+    launchParams.nvl_rank = nvlRank;
+    launchParams.nvl_size = kNvlSize;
+    launchParams.sendcount = kSendcount;
+    launchParams.sendbuf = sendbuf_d;
+    launchParams.recvbuf = static_cast<char*>(recvbuf.get());
+    launchParams.in_place = inPlace;
+    launchParams.ib_num_blocks = kNumBlocks;
+    launchParams.timeout_ms = 30000.0f;
+
+    const auto& ibRing = ibRings[0];
+    const int prevGlobal = ibRing.prev_rank * kNvlSize + nvlRank;
+    const int nextGlobal = ibRing.next_rank * kNvlSize + nvlRank;
+    launchParams.ib_ring.prev_rank = ibRing.prev_rank;
+    launchParams.ib_ring.next_rank = ibRing.next_rank;
+    launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
+    launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
+
+    for (int peer = 0; peer < kNvlSize; ++peer) {
+      if (peer == nvlRank) {
+        continue;
+      }
+      new (&launchParams.nvl_peers[peer])
+          P2pNvlTransportDevice(nvlTransport->getP2pTransportDevice(peer));
+    }
+
+    bootstrap->barrierAll();
+    launch_hierarchical_allgather_fused(launchParams);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    bootstrap->barrierAll();
+
+    verify_allgather(static_cast<const char*>(recvbuf.get()), kSendcount);
+  }
+};
 
 TEST_F(HierarchicalAllGatherTest, Correctness) {
-  constexpr int kNvlSize = 2;
-  constexpr int kIbSize = 2;
-  constexpr std::size_t kSendcount = 64 * 1024;
-  constexpr int kNumBlocks = 4;
+  runCorrectness(false);
+}
 
-  if (worldSize != kNvlSize * kIbSize) {
-    GTEST_SKIP() << "Hierarchical test expects " << kNvlSize * kIbSize
-                 << " ranks";
-  }
-
-  const int ibRank = globalRank / kNvlSize;
-  const int nvlRank = globalRank % kNvlSize;
-
-  std::unique_ptr<MultipeerIbgdaTransport> ibTransport;
-  try {
-    MultipeerIbgdaTransportConfig ibConfig{
-        .cudaDevice = localRank,
-        .dataBufferSize = 1024 * 1024,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = kNumBlocks,
-                .pipelineDepth = 2,
-            },
-    };
-    ibTransport = std::make_unique<MultipeerIbgdaTransport>(
-        globalRank, worldSize, bootstrap, ibConfig);
-    ibTransport->exchange();
-  } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
-  }
-
-  std::unique_ptr<MultiPeerNvlTransport> nvlTransport;
-  try {
-    MultiPeerNvlTransportConfig nvlConfig{
-        .dataBufferSize = 1024 * 1024,
-        .chunkSize = 1024 * 1024,
-        .pipelineDepth = 2,
-        .p2pSignalCount = static_cast<std::size_t>(kNumBlocks),
-        .tile_max_groups = kNumBlocks,
-        .memSharingMode = MemSharingMode::kCudaIpc,
-    };
-    std::vector<int> nvlRankToGlobal(kNvlSize);
-    for (int peer = 0; peer < kNvlSize; ++peer) {
-      nvlRankToGlobal[peer] = ibRank * kNvlSize + peer;
-    }
-    auto nvlBootstrap = std::make_shared<NvlBootstrapAdapter>(
-        bootstrap, std::move(nvlRankToGlobal));
-    nvlTransport = std::make_unique<MultiPeerNvlTransport>(
-        nvlRank, kNvlSize, nvlBootstrap, nvlConfig);
-    nvlTransport->exchange();
-  } catch (const std::exception& e) {
-    GTEST_SKIP() << "NVLink transport not available: " << e.what();
-  }
-
-  DeviceBuffer sendbuf(kSendcount);
-  DeviceBuffer recvbuf(kSendcount * worldSize);
-  CUDACHECK_TEST(cudaMemset(recvbuf.get(), 0, kSendcount * worldSize));
-
-  fill_sendbuf(static_cast<char*>(sendbuf.get()), kSendcount);
-
-  auto ibRingsOpt = make_standard_rings(kIbSize, ibRank, 1);
-  ASSERT_TRUE(ibRingsOpt.has_value());
-  const auto& ibRings = *ibRingsOpt;
-
-  HierarchicalAllgatherLaunchParams launchParams{};
-  launchParams.num_ranks = worldSize;
-  launchParams.ib_rank = ibRank;
-  launchParams.ib_size = kIbSize;
-  launchParams.nvl_rank = nvlRank;
-  launchParams.nvl_size = kNvlSize;
-  launchParams.sendcount = kSendcount;
-  launchParams.sendbuf = static_cast<const char*>(sendbuf.get());
-  launchParams.recvbuf = static_cast<char*>(recvbuf.get());
-  launchParams.ib_num_blocks = kNumBlocks;
-  launchParams.timeout_ms = 30000.0f;
-
-  const auto& ibRing = ibRings[0];
-  const int prevGlobal = ibRing.prev_rank * kNvlSize + nvlRank;
-  const int nextGlobal = ibRing.next_rank * kNvlSize + nvlRank;
-  launchParams.ib_ring.prev_rank = ibRing.prev_rank;
-  launchParams.ib_ring.next_rank = ibRing.next_rank;
-  launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
-  launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
-
-  for (int peer = 0; peer < kNvlSize; ++peer) {
-    if (peer == nvlRank) {
-      continue;
-    }
-    new (&launchParams.nvl_peers[peer])
-        P2pNvlTransportDevice(nvlTransport->getP2pTransportDevice(peer));
-  }
-
-  bootstrap->barrierAll();
-  launch_hierarchical_allgather_fused(launchParams);
-  CUDACHECK_TEST(cudaDeviceSynchronize());
-  bootstrap->barrierAll();
-
-  verify_allgather(static_cast<const char*>(recvbuf.get()), kSendcount);
+TEST_F(HierarchicalAllGatherTest, InPlaceCorrectness) {
+  runCorrectness(true);
 }
 
 } // namespace

--- a/comms/pipes/tests/CopyUtilsTest.cc
+++ b/comms/pipes/tests/CopyUtilsTest.cc
@@ -94,6 +94,39 @@ TEST_P(CopyUtilsTestParameterized, CopyChunkVectorized) {
       << ", srcOffset=" << params.srcOffset << ")";
 }
 
+TEST_F(CopyUtilsTestFixture, CopyChunkVectorizedExactOverlapIsNoOp) {
+  constexpr std::size_t kBufferSize = 4097;
+  DeviceBuffer buffer(kBufferSize);
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+
+  auto buffer_d = static_cast<char*>(buffer.get());
+  auto errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+
+  std::vector<char> expected(kBufferSize);
+  for (std::size_t i = 0; i < kBufferSize; i++) {
+    expected[i] = static_cast<char>((i * 17) % 256);
+  }
+
+  CUDACHECK_TEST(cudaMemcpy(
+      buffer_d, expected.data(), kBufferSize, cudaMemcpyHostToDevice));
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  testCopyChunkVectorized(
+      buffer_d, buffer_d, kBufferSize, errorCount_d, 1, 256);
+
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0);
+
+  std::vector<char> actual(kBufferSize);
+  CUDACHECK_TEST(
+      cudaMemcpy(actual.data(), buffer_d, kBufferSize, cudaMemcpyDeviceToHost));
+  EXPECT_EQ(actual, expected);
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CopyUtilsTests,
     CopyUtilsTestParameterized,


### PR DESCRIPTION
Summary: Add memcpy_vectorized overlap assertions and exact-alias no-op handling, and teach pipes direct/hierarchical allgather to support NCCL's in-place layout safely. CTRAN cthierarchical_ring now treats exact own recv-slot overlap as in-place via `isAllGatherInPlace`; other overlap patterns are handled as out-of-place and remain guarded by device-side copy overlap assertions. The pipes kernels dispatch compile-time in-place/out-of-place variants, keep in-place detection as launch-time state, and use the user-provided sendbuf consistently; in-place avoids the local self-copy while out-of-place keeps the fused send+self-copy path. Public `put()` helpers no longer mark src/dst as `__restrict__` because exact alias is an allowed no-op.

Differential Revision: D107459667


