### PR TITLE
Collapse in-place allgather kernel variants

### DIFF
--- a/comms/pipes/collectives/AllGatherDirect.cu
+++ b/comms/pipes/collectives/AllGatherDirect.cu
@@ -13,7 +13,7 @@
 
 namespace comms::pipes {
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
     Timeout timeout) {
@@ -31,12 +31,10 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
   const std::size_t tile_bytes = tile.bytes();
 
   const char* tile_src = args.sendbuf + tile_offset;
-  if constexpr (!kInPlace) {
-    char* own_dst = args.recvbuf +
-        static_cast<std::size_t>(my_rank) * sendcount + tile_offset;
-    memcpy_vectorized(own_dst, tile_src, tile_bytes, group);
-    group.sync();
-  }
+  char* own_dst = args.recvbuf + static_cast<std::size_t>(my_rank) * sendcount +
+      tile_offset;
+  memcpy_vectorized(own_dst, tile_src, tile_bytes, group);
+  group.sync();
 
   if (W <= 1 || tile_bytes == 0) {
     return;
@@ -73,7 +71,7 @@ __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
 #endif
 }
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
     const __grid_constant__ HierarchicalAllgatherFusedArgs args,
@@ -100,10 +98,8 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
   // NVL group. The broadcast is still needed because each NVL peer must
   // receive every other peer's chunk even when there is only one IB node.
   if (W <= 1) {
-    if constexpr (!kInPlace) {
-      memcpy_vectorized(own_dst, tile_src, io_tile_bytes, group);
-      group.sync();
-    }
+    memcpy_vectorized(own_dst, tile_src, io_tile_bytes, group);
+    group.sync();
     hierarchical_allgather_nvl_broadcast_from_recvbuf(
         group,
         args.ib_size,
@@ -133,19 +129,14 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
         (remaining < pipeline_window) ? remaining : pipeline_window;
 
     const char* send_src = tile_src + off;
-    if constexpr (kInPlace) {
-      next.template send<Memcpy>(
-          group, send_src, window, group.total_groups, max_sig, timeout);
-    } else {
-      next.template send<MemcpyAndSelfCopy>(
-          group,
-          send_src,
-          window,
-          group.total_groups,
-          max_sig,
-          timeout,
-          own_dst + off);
-    }
+    next.template send<MemcpyAndSelfCopy>(
+        group,
+        send_src,
+        window,
+        group.total_groups,
+        max_sig,
+        timeout,
+        own_dst + off);
 
     int fwd_current_rank = args.ib_rank;
     for (int step = 0; step < W - 1; step++) {
@@ -253,7 +244,7 @@ __device__ __forceinline__ void trace_hierarchical_allgather(
 
 } // namespace
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__
 __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs args,
@@ -294,9 +285,7 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
       const char* send_src = args.sendbuf + off;
 
       if (W <= 1) {
-        if constexpr (!kInPlace) {
-          memcpy_vectorized(own_dst, send_src, bytes, group);
-        }
+        memcpy_vectorized(own_dst, send_src, bytes, group);
         publish_ready(
             group,
             args.ready_counters,
@@ -326,24 +315,14 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const std::size_t window =
             remaining < ib_window ? remaining : ib_window;
 
-        if constexpr (kInPlace) {
-          next.template send<Memcpy>(
-              group,
-              send_src + chunk_off,
-              window,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout);
-        } else {
-          next.template send<MemcpyAndSelfCopy>(
-              group,
-              send_src + chunk_off,
-              window,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout,
-              own_dst + chunk_off);
-        }
+        next.template send<MemcpyAndSelfCopy>(
+            group,
+            send_src + chunk_off,
+            window,
+            args.ib_num_blocks,
+            args.ib_signaling_data_size,
+            timeout,
+            own_dst + chunk_off);
 
         int fwd_current_rank = args.ib_rank;
         for (int step = 0; step < W - 1; step++) {
@@ -502,27 +481,15 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
 #endif
 }
 
-template __global__ void direct_allgather_nvl_kernel<false, 512>(
+template __global__ void direct_allgather_nvl_kernel<512>(
     const __grid_constant__ DirectAllgatherNvlArgs,
     Timeout);
 
-template __global__ void direct_allgather_nvl_kernel<true, 512>(
-    const __grid_constant__ DirectAllgatherNvlArgs,
-    Timeout);
-
-template __global__ void hierarchical_allgather_fused_kernel<false, 512>(
+template __global__ void hierarchical_allgather_fused_kernel<512>(
     const __grid_constant__ HierarchicalAllgatherFusedArgs,
     Timeout);
 
-template __global__ void hierarchical_allgather_fused_kernel<true, 512>(
-    const __grid_constant__ HierarchicalAllgatherFusedArgs,
-    Timeout);
-
-template __global__ void hierarchical_allgather_overlap_kernel<false, 512>(
-    const __grid_constant__ HierarchicalAllgatherOverlapArgs,
-    Timeout);
-
-template __global__ void hierarchical_allgather_overlap_kernel<true, 512>(
+template __global__ void hierarchical_allgather_overlap_kernel<512>(
     const __grid_constant__ HierarchicalAllgatherOverlapArgs,
     Timeout);
 

--- a/comms/pipes/collectives/AllGatherDirect.cuh
+++ b/comms/pipes/collectives/AllGatherDirect.cuh
@@ -9,18 +9,18 @@
 
 namespace comms::pipes {
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__ __launch_bounds__(kBlockSize, 1) void direct_allgather_nvl_kernel(
     const __grid_constant__ DirectAllgatherNvlArgs args,
     Timeout timeout);
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
         const __grid_constant__ HierarchicalAllgatherFusedArgs args,
         Timeout timeout);
 
-template <bool kInPlace, int kBlockSize>
+template <int kBlockSize>
 __global__
     __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const __grid_constant__ HierarchicalAllgatherOverlapArgs args,

--- a/comms/pipes/collectives/AllGatherLauncher.cu
+++ b/comms/pipes/collectives/AllGatherLauncher.cu
@@ -59,15 +59,9 @@ void launch_direct_allgather_nvl(const DirectAllgatherNvlLaunchParams& params) {
     new (&args.peers[peer]) P2pNvlTransportDevice(params.peers[peer]);
   }
 
-  if (params.in_place) {
-    direct_allgather_nvl_kernel<true, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(
-            args, make_launch_timeout(params.timeout_ms));
-  } else {
-    direct_allgather_nvl_kernel<false, 512>
-        <<<params.num_blocks, 512, 0, params.stream>>>(
-            args, make_launch_timeout(params.timeout_ms));
-  }
+  direct_allgather_nvl_kernel<512>
+      <<<params.num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -97,15 +91,9 @@ void launch_hierarchical_allgather_fused(
     new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
   }
 
-  if (params.in_place) {
-    hierarchical_allgather_fused_kernel<true, 512>
-        <<<params.ib_num_blocks, 512, 0, params.stream>>>(
-            args, make_launch_timeout(params.timeout_ms));
-  } else {
-    hierarchical_allgather_fused_kernel<false, 512>
-        <<<params.ib_num_blocks, 512, 0, params.stream>>>(
-            args, make_launch_timeout(params.timeout_ms));
-  }
+  hierarchical_allgather_fused_kernel<512>
+      <<<params.ib_num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 
@@ -154,19 +142,9 @@ void launch_hierarchical_allgather_overlap(
     new (&args.nvl_peers[peer]) P2pNvlTransportDevice(params.nvl_peers[peer]);
   }
 
-  if (params.in_place) {
-    hierarchical_allgather_overlap_kernel<true, 512>
-        <<<params.ib_num_blocks + params.nvl_num_blocks,
-           512,
-           0,
-           params.stream>>>(args, make_launch_timeout(params.timeout_ms));
-  } else {
-    hierarchical_allgather_overlap_kernel<false, 512>
-        <<<params.ib_num_blocks + params.nvl_num_blocks,
-           512,
-           0,
-           params.stream>>>(args, make_launch_timeout(params.timeout_ms));
-  }
+  hierarchical_allgather_overlap_kernel<512>
+      <<<params.ib_num_blocks + params.nvl_num_blocks, 512, 0, params.stream>>>(
+          args, make_launch_timeout(params.timeout_ms));
   PIPES_CUDA_CHECK(cudaGetLastError());
 }
 


### PR DESCRIPTION
Summary: Remove the compile-time in-place/out-of-place specialization from the pipes allgather kernels. The kernels now always issue the self-copy-capable path and rely on memcpy_vectorized exact-alias no-op handling for NCCL in-place layouts, while still synchronizing after real self-copies before recvbuf-backed broadcasts.

Differential Revision: D107571733


