### PR TITLE
GPU runtime seam via oss_gpu_cpp_library + OSS allowlist

### DIFF
--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -48,7 +48,10 @@ Status CudaApi::deviceEnablePeerAccess(int peerDevice) {
   auto err = cudaDeviceEnablePeerAccess(peerDevice, 0);
   // cudaErrorPeerAccessAlreadyEnabled is not an error for us.
   if (err == cudaErrorPeerAccessAlreadyEnabled) {
-    cudaGetLastError(); // Clear the error.
+    // Clear the error. Cast to void: cudaGetLastError() is not nodiscard, but
+    // its hipified twin hipGetLastError() is, so discard explicitly to keep
+    // the single source compiling under -Werror on both platforms.
+    (void)cudaGetLastError();
     return Ok();
   }
   CUDA_RETURN_ERR(err, "cudaDeviceEnablePeerAccess", ErrCode::DriverError);
@@ -177,7 +180,8 @@ Result<bool> CudaApi::eventQuery(cudaEvent_t event) {
   }
   if (err == cudaErrorNotReady) {
     // Not an error — clear the sticky error and report not-ready.
-    cudaGetLastError();
+    // Cast to void: hipGetLastError() is nodiscard on AMD (see above).
+    (void)cudaGetLastError();
     return false;
   }
   CUDA_RETURN_ERR(err, "cudaEventQuery", ErrCode::DriverError);

--- a/comms/uniflow/drivers/cuda/CudaDevicePtr.h
+++ b/comms/uniflow/drivers/cuda/CudaDevicePtr.h
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+#include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
+
+namespace uniflow {
+
+// Convert an integer device address to the CUDA driver pointer type. On NVIDIA
+// CUdeviceptr is an integer handle, so the address converts with static_cast.
+// After hipification CUdeviceptr is hipDeviceptr_t (a pointer), which requires
+// reinterpret_cast from the integer address. Shared by the RDMA copy/dma-buf
+// paths so the platform-divergent cast lives in exactly one place.
+inline CUdeviceptr toDevicePtr(uint64_t addr) {
+#if defined(__HIP_PLATFORM_AMD__)
+  return reinterpret_cast<CUdeviceptr>(addr);
+#else
+  return static_cast<CUdeviceptr>(addr);
+#endif
+}
+
+} // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
@@ -3,30 +3,56 @@
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/Constants.h"
 
+// NVIDIA loads the CUDA driver entry points dynamically via PFN typedefs from
+// <cudaTypedefs.h> + cudaGetDriverEntryPoint. HIP has no versioned PFN
+// typedefs and exposes the driver (hip*) functions directly, so the AMD build
+// (hipified: cu* -> hip*) calls them directly. The divergence is confined to
+// the symbol-loading machinery below; the per-method bodies are shared via the
+// CU_PFN()/CU_CALL() indirection.
+#ifndef __HIP_PLATFORM_AMD__
 #include <cudaTypedefs.h>
+#endif
 #include <cuda_runtime.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+// For the AMD GPUDirect-RDMA (ib_peer_mem / amdkfd) sysfs + kallsyms probe.
+#include <unistd.h>
+#include <cstdio>
+#include <cstring>
+#endif
 
 #include <mutex>
 #include <string>
 
 namespace uniflow {
 
+#ifndef __HIP_PLATFORM_AMD__
 constexpr int CUDA_DRIVER_MIN_VERSION = 12040;
 
 static_assert(
     CUDA_VERSION >= CUDA_DRIVER_MIN_VERSION,
     "CudaDriverApi requires CUDA 12.4 or later");
+#endif
 
-// ---------------------------------------------------------------------------
-// Function pointer declarations using PFN types from <cudaTypedefs.h>
-// ---------------------------------------------------------------------------
-
-#define DECLARE_CUDA_PFN(symbol, version) \
-  PFN_##symbol##_v##version pfn_##symbol = nullptr
+// On NVIDIA, CU_PFN(name) resolves to the dynamically loaded pfn_<name>; on AMD
+// (hipified) it resolves to the driver function itself, called directly.
+#if defined(__HIP_PLATFORM_AMD__)
+#define CU_PFN(name) name
+#else
+#define CU_PFN(name) pfn_##name
+#endif
 
 namespace {
 
 // NOLINTBEGIN(facebook-avoid-non-const-global-variables)
+
+#ifndef __HIP_PLATFORM_AMD__
+// ---------------------------------------------------------------------------
+// Function pointer declarations using PFN types from <cudaTypedefs.h> (NVIDIA)
+// ---------------------------------------------------------------------------
+
+#define DECLARE_CUDA_PFN(symbol, version) \
+  PFN_##symbol##_v##version pfn_##symbol = nullptr
 
 // --- Error ---
 DECLARE_CUDA_PFN(cuGetErrorString, 6000);
@@ -55,6 +81,7 @@ DECLARE_CUDA_PFN(cuMemGetAddressRange, 3020);
 DECLARE_CUDA_PFN(cuStreamWriteValue64, 11070);
 
 #undef DECLARE_CUDA_PFN
+#endif // !__HIP_PLATFORM_AMD__
 
 std::once_flag g_initFlag;
 Status g_initStatus{Ok()};
@@ -71,20 +98,26 @@ Status cuRetToStatus(CUresult ret, const char* funcName) {
   }
   std::string msg = funcName;
   msg += "() failed, ret = ";
-  msg += std::to_string(ret);
-  if (pfn_cuGetErrorString != nullptr) {
-    const char* errStr = nullptr;
-    if (pfn_cuGetErrorString(ret, &errStr) == CUDA_SUCCESS &&
-        errStr != nullptr) {
-      msg += ": ";
-      msg += errStr;
-    }
+  msg += std::to_string(static_cast<int>(ret));
+  const char* errStr = nullptr;
+#if defined(__HIP_PLATFORM_AMD__)
+  if (cuGetErrorString(ret, &errStr) == CUDA_SUCCESS && errStr != nullptr) {
+    msg += ": ";
+    msg += errStr;
   }
+#else
+  if (pfn_cuGetErrorString != nullptr &&
+      pfn_cuGetErrorString(ret, &errStr) == CUDA_SUCCESS && errStr != nullptr) {
+    msg += ": ";
+    msg += errStr;
+  }
+#endif
   return Err(ErrCode::DriverError, std::move(msg));
 }
 
+#ifndef __HIP_PLATFORM_AMD__
 // ---------------------------------------------------------------------------
-// Symbol loading via cudaGetDriverEntryPoint
+// Symbol loading via cudaGetDriverEntryPoint (NVIDIA only)
 // ---------------------------------------------------------------------------
 
 #if CUDART_VERSION >= 13000
@@ -140,25 +173,29 @@ Status cuRetToStatus(CUresult ret, const char* funcName) {
   (pfn_##name == nullptr                                      \
        ? Err(ErrCode::DriverError, #name " symbol not found") \
        : cuRetToStatus(pfn_##name(__VA_ARGS__), #name))
+#endif // !__HIP_PLATFORM_AMD__
 
 void checkCuMemSupported(int cudaDev) {
+#ifndef __HIP_PLATFORM_AMD__
   if (pfn_cuMemCreate == nullptr) {
     g_isCuMemSupported = false;
-  } else {
-    CUdevice currentDev;
-    if (pfn_cuDeviceGet(&currentDev, cudaDev) != CUDA_SUCCESS) {
-      g_isCuMemSupported = false;
-    } else {
-      int flag = 0;
-      auto ret = pfn_cuDeviceGetAttribute(
-          &flag,
-          CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
-          currentDev);
-      g_isCuMemSupported = (ret == CUDA_SUCCESS && flag != 0);
-    }
+    return;
   }
+#endif
+  CUdevice currentDev;
+  if (CU_PFN(cuDeviceGet)(&currentDev, cudaDev) != CUDA_SUCCESS) {
+    g_isCuMemSupported = false;
+    return;
+  }
+  int flag = 0;
+  auto ret = CU_PFN(cuDeviceGetAttribute)(
+      &flag,
+      CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
+      currentDev);
+  g_isCuMemSupported = (ret == CUDA_SUCCESS && flag != 0);
 }
 
+#ifndef __HIP_PLATFORM_AMD__
 void probeCuMemHandleType() {
   CUdevice cuDevice;
   const int deviceId = 0;
@@ -357,6 +394,67 @@ void doInit() {
 
 #undef LOAD_SYM
 
+#else // __HIP_PLATFORM_AMD__
+
+// Detect GPUDirect-RDMA (peer-mem) support on AMD. There is no HIP query for
+// this, so we probe the same signals as rccl/ctran (see
+// comms/ctran/utils/HipGdrCheck.h): the amdkfd peer-mem sysfs version node, and
+// the `ib_register_peer_memory_client` symbol in /proc/kallsyms as a fallback
+// for native-OS ib_peer modules. Used to decide whether VRAM can be registered
+// via dma-buf; callers fall back to plain ibv_reg_mr when this returns false.
+bool amdGpuDirectRdmaSupported() {
+  static const char* kMemoryPeersPaths[] = {
+      "/sys/kernel/mm/memory_peers/amdkfd/version",
+      "/sys/kernel/memory_peers/amdkfd/version",
+      "/sys/memory_peers/amdkfd/version",
+  };
+  for (const char* path : kMemoryPeersPaths) {
+    if (access(path, F_OK) == 0) {
+      return true;
+    }
+  }
+
+  // Fallback: look for the native ib_peer_mem registration symbol.
+  FILE* fp = std::fopen("/proc/kallsyms", "r");
+  if (fp == nullptr) {
+    return false;
+  }
+  char buf[256];
+  bool found = false;
+  while (std::fgets(buf, sizeof(buf), fp) != nullptr) {
+    if (std::strstr(buf, "ib_register_peer_memory_client") != nullptr) {
+      found = true;
+      break;
+    }
+  }
+  std::fclose(fp);
+  return found;
+}
+
+// AMD driver entry points (hip*) are linked directly, so there is no PFN
+// loading. Init initializes the driver, probes cuMem (VMM) support, and detects
+// GPUDirect-RDMA via the peer-mem probe above. The NVIDIA-only fabric handle
+// path does not apply — AMD uses POSIX-FD / dma-buf sharing.
+void doInit() {
+  int cudaDev;
+  auto ret = cudaGetDevice(&cudaDev); // Initialize the driver
+  if (ret != cudaSuccess) {
+    g_initStatus = Err(ErrCode::DriverError, "cudaGetDevice failed");
+    return;
+  }
+
+  checkCuMemSupported(cudaDev);
+
+  const bool gdrSupported = amdGpuDirectRdmaSupported();
+  for (int i = 0; i < kMaxDevices; i++) {
+    g_isDmaBufSupported[i] = gdrSupported;
+  }
+
+  g_initStatus = Ok();
+}
+
+#endif // __HIP_PLATFORM_AMD__
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -371,6 +469,13 @@ void doInit() {
     }                               \
   } while (0)
 
+#if defined(__HIP_PLATFORM_AMD__)
+#define CU_CALL(name, ...)                            \
+  do {                                                \
+    CU_ENSURE_INIT();                                 \
+    return cuRetToStatus(::name(__VA_ARGS__), #name); \
+  } while (0)
+#else
 #define CU_CALL(name, ...)                                         \
   do {                                                             \
     CU_ENSURE_INIT();                                              \
@@ -379,6 +484,7 @@ void doInit() {
     }                                                              \
     return cuRetToStatus(pfn_##name(__VA_ARGS__), #name);          \
   } while (0)
+#endif
 
 Status CudaDriverApi::init() {
   std::call_once(g_initFlag, doInit);
@@ -498,7 +604,17 @@ Status CudaDriverApi::cuMemGetHandleForAddressRange(
     size_t size,
     CUmemRangeHandleType handleType,
     unsigned long long flags) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // hipify-perl does not map cuMemGetHandleForAddressRange, so call the HIP
+  // dma-buf fd export directly (GPUDirect RDMA path). CU_ENSURE_INIT() mirrors
+  // the CU_CALL path; the global symbol is qualified to avoid the member name.
+  CU_ENSURE_INIT();
+  return cuRetToStatus(
+      ::hipMemGetHandleForAddressRange(handle, dptr, size, handleType, flags),
+      "hipMemGetHandleForAddressRange");
+#else
   CU_CALL(cuMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);
+#endif
 }
 
 // --- Stream memory ops ---

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.h
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.h
@@ -6,6 +6,22 @@
 
 #include "comms/uniflow/Result.h"
 
+#if defined(__HIP_PLATFORM_AMD__)
+// hipify-perl does not map this newer VMM dma-buf handle type; alias the CUDA
+// spelling (which survives hipification untranslated) to the HIP type so the
+// hipified interface still names a valid type on AMD. The dma-buf export path
+// that uses it is implemented for AMD in a later diff.
+using CUmemRangeHandleType = hipMemRangeHandleType;
+// Same hipify gap for the dma-buf-fd enumerator used by callers of
+// cuMemGetHandleForAddressRange.
+inline constexpr hipMemRangeHandleType CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD =
+    hipMemRangeHandleTypeDmaBufFd;
+// hipify-perl also misses the stream write-value flag enumerator used by
+// streamWriteValue64. HIP has no named constant for it; the CUDA default value
+// is 0x0 (no memory barrier), which is also HIP's default, so alias to 0.
+inline constexpr unsigned int CU_STREAM_WRITE_VALUE_DEFAULT = 0u;
+#endif
+
 namespace uniflow {
 
 /// Thin wrapper around CUDA Driver (cu*) APIs loaded via


### PR DESCRIPTION
Summary:
Phase 2: build the GPU runtime seam for AMD/ROCm by translating the single CUDA
source to HIP at build time; NVIDIA keeps building the original source.

Per review, adopt the standard fbcode GPU macro where it works:
- comms/strict_oss_defs.bzl: add `oss_gpu_cpp_library` = fbcode `gpu_cpp_library`
  + the OSS dependency guard (check_dependencies_test, allowlist). Keeps the OSS
  guard while using standard accelerator selection (CUDA/HIP/MTIA), hipify
  generation (sources + headers), ROCm deps, toolchain, and CI labels. ROCm/HIP
  + lazify allowlist entries added.
- drivers/cuda/BUCK:
  - cuda-api (runtime) and cuda-device-adapter -> oss_gpu_cpp_library
    (rename_cpp_to_hip, cuda_/hip_exported_external_deps,
    hip_preprocessor_flags/hip_propagated_pp_flags for __HIP_PLATFORM_AMD__).
  - cuda-driver-api: kept on the uniflow-local hipify (hipify-perl) +
    hip_toolchain_override. BLOCKER: the fbcode gpu_cpp_library hipify tool
    translates some CUDA Driver-API symbols differently than hipify-perl -- e.g.
    it renames CU_STREAM_WRITE_VALUE_DEFAULT -> hipStreamWriteValueDefault in the
    exported CudaDriverApi.h. transport/rdma consumers (CopyEngine), still
    hipify-perl, reference the CUDA spelling, so the renamed export breaks their
    build. Until those consumers also move to gpu_cpp_library (consistent
    translation on both ends), cuda-driver-api stays on hipify-perl, whose
    CudaDriverApi.h preserves the CUDA spellings. Tracked as a follow-up.
- defs.bzl retains the hipify rule + hip_toolchain_override (used by
  cuda-driver-api and the benchmarks).

Differential Revision: D107220750


