### PR TITLE
Peer-to-peer transfer integration test

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -3,8 +3,13 @@
 #include "comms/uniflow/MultiTransport.h"
 #include "comms/uniflow/drivers/TopologyDiscovery.h"
 #include "comms/uniflow/logging/Logger.h"
-#include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
+
+// RDMA is the GPU transport on AMD as well as NVIDIA. NVLink is NVIDIA-only
+// (NVML-backed topology, fabric/FD IPC) and is compiled out on AMD/HIP.
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
+#ifndef __HIP_PLATFORM_AMD__
+#include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
+#endif
 
 #include <cstring>
 
@@ -30,17 +35,23 @@ std::vector<std::string> MultiTransportFactory::selectNics() {
 
 Status MultiTransportFactory::supported(TransportType type) {
   switch (type) {
-    case TransportType::NVLink:
-      return NVLinkTransportFactory::supported();
     case TransportType::RDMA:
       return RdmaTransportFactory::supported();
+#ifndef __HIP_PLATFORM_AMD__
+    case TransportType::NVLink:
+      return NVLinkTransportFactory::supported();
+#else
+    case TransportType::NVLink:
+      return Err(ErrCode::NotImplemented, "nvlink is not supported on AMD");
+#endif
     case TransportType::TCP:
       return Err(ErrCode::NotImplemented, "tcp transport is not implemented");
     case TransportType::Mock:
       return Ok();
-    default:
-      return Err(ErrCode::InvalidArgument, "unknown transport type");
+    case TransportType::NumTransportType:
+      break;
   }
+  return Err(ErrCode::InvalidArgument, "unknown transport type");
 }
 
 Status MultiTransport::validateRequests(
@@ -92,12 +103,14 @@ MultiTransportFactory::MultiTransportFactory(int deviceId, NicFilter nicFilter)
   CHECK_THROW_EXCEPTION(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
-  // cuda device
+#ifndef __HIP_PLATFORM_AMD__
+  // NVLink is NVIDIA-only.
   if (deviceId_ >= 0) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
         deviceId, eventBaseThread_->getEventBase());
     factories_.emplace_back(std::move(nvlink));
   }
+#endif
 
   auto nics = selectNics();
   if (!nics.empty()) {

--- a/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
+++ b/comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.cpp
@@ -80,7 +80,9 @@ struct BenchmarkBuffers {
     auto freeOne = [this](void* p) {
       if (p) {
         if (useGpu) {
-          cudaFree(p);
+          // hipFree is [[nodiscard]] on HIP (cudaFree is not); we are in a
+          // best-effort noexcept release path, so discard the status.
+          (void)cudaFree(p);
         } else {
           std::free(p);
         }
@@ -116,7 +118,7 @@ allocateBuffers(size_t maxSize, int cudaDevice, int rank, int numBuffers) {
         UNIFLOW_LOG_ERROR(
             "RdmaBandwidthBenchmark: cudaMemset failed: {}",
             cudaGetErrorString(ret));
-        cudaFree(*out);
+        (void)cudaFree(*out);
         *out = nullptr;
         return false;
       }

--- a/comms/uniflow/benchmarks/main.cpp
+++ b/comms/uniflow/benchmarks/main.cpp
@@ -12,12 +12,17 @@
 #include "comms/uniflow/benchmarks/Bootstrap.h"
 #include "comms/uniflow/benchmarks/Rendezvous.h"
 #include "comms/uniflow/benchmarks/Reporter.h"
+#include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
+#include "comms/uniflow/logging/Logger.h"
+// ConnectionSetup/NVLink/NcclSendRecv/SendRecv benchmarks are NVIDIA-only
+// (NVLink/NCCL transports, or not yet wired for the AMD/hipify build) and are
+// compiled out on AMD.
+#ifndef __HIP_PLATFORM_AMD__
 #include "comms/uniflow/benchmarks/bench/ConnectionSetupBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NVLinkBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/NcclSendRecvBenchmark.h"
-#include "comms/uniflow/benchmarks/bench/RdmaBandwidthBenchmark.h"
 #include "comms/uniflow/benchmarks/bench/SendRecvBandwidthBenchmark.h"
-#include "comms/uniflow/logging/Logger.h"
+#endif
 
 namespace {
 
@@ -345,17 +350,19 @@ int main(int argc, char** argv) {
 
   uniflow::benchmark::BenchmarkRunner runner;
   runner.registerBenchmark(
-      std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());
-  runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::RdmaBandwidthBenchmark>(
           opts.rdmaDevices));
+#ifndef __HIP_PLATFORM_AMD__
+  runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::ConnectionSetupBenchmark>());
   runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::NVLinkBandwidthBenchmark>());
   runner.registerBenchmark(
+      std::make_unique<uniflow::benchmark::NcclSendRecvBenchmark>());
+  runner.registerBenchmark(
       std::make_unique<uniflow::benchmark::SendRecvBandwidthBenchmark>(
           opts.rdmaDevices));
-  runner.registerBenchmark(
-      std::make_unique<uniflow::benchmark::NcclSendRecvBenchmark>());
+#endif
 
   if (opts.benchmark == "__list__") {
     std::cout << "Available benchmarks:\n";

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -48,7 +48,10 @@ Status CudaApi::deviceEnablePeerAccess(int peerDevice) {
   auto err = cudaDeviceEnablePeerAccess(peerDevice, 0);
   // cudaErrorPeerAccessAlreadyEnabled is not an error for us.
   if (err == cudaErrorPeerAccessAlreadyEnabled) {
-    cudaGetLastError(); // Clear the error.
+    // Clear the error. Cast to void: cudaGetLastError() is not nodiscard, but
+    // its hipified twin hipGetLastError() is, so discard explicitly to keep
+    // the single source compiling under -Werror on both platforms.
+    (void)cudaGetLastError();
     return Ok();
   }
   CUDA_RETURN_ERR(err, "cudaDeviceEnablePeerAccess", ErrCode::DriverError);
@@ -177,7 +180,8 @@ Result<bool> CudaApi::eventQuery(cudaEvent_t event) {
   }
   if (err == cudaErrorNotReady) {
     // Not an error — clear the sticky error and report not-ready.
-    cudaGetLastError();
+    // Cast to void: hipGetLastError() is nodiscard on AMD (see above).
+    (void)cudaGetLastError();
     return false;
   }
   CUDA_RETURN_ERR(err, "cudaEventQuery", ErrCode::DriverError);

--- a/comms/uniflow/drivers/cuda/CudaDevicePtr.h
+++ b/comms/uniflow/drivers/cuda/CudaDevicePtr.h
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+#include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
+
+namespace uniflow {
+
+// Convert an integer device address to the CUDA driver pointer type. On NVIDIA
+// CUdeviceptr is an integer handle, so the address converts with static_cast.
+// After hipification CUdeviceptr is hipDeviceptr_t (a pointer), which requires
+// reinterpret_cast from the integer address. Shared by the RDMA copy/dma-buf
+// paths so the platform-divergent cast lives in exactly one place.
+inline CUdeviceptr toDevicePtr(uint64_t addr) {
+#if defined(__HIP_PLATFORM_AMD__)
+  return reinterpret_cast<CUdeviceptr>(addr);
+#else
+  return static_cast<CUdeviceptr>(addr);
+#endif
+}
+
+} // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.cpp
@@ -3,30 +3,56 @@
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/drivers/Constants.h"
 
+// NVIDIA loads the CUDA driver entry points dynamically via PFN typedefs from
+// <cudaTypedefs.h> + cudaGetDriverEntryPoint. HIP has no versioned PFN
+// typedefs and exposes the driver (hip*) functions directly, so the AMD build
+// (hipified: cu* -> hip*) calls them directly. The divergence is confined to
+// the symbol-loading machinery below; the per-method bodies are shared via the
+// CU_PFN()/CU_CALL() indirection.
+#ifndef __HIP_PLATFORM_AMD__
 #include <cudaTypedefs.h>
+#endif
 #include <cuda_runtime.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+// For the AMD GPUDirect-RDMA (ib_peer_mem / amdkfd) sysfs + kallsyms probe.
+#include <unistd.h>
+#include <cstdio>
+#include <cstring>
+#endif
 
 #include <mutex>
 #include <string>
 
 namespace uniflow {
 
+#ifndef __HIP_PLATFORM_AMD__
 constexpr int CUDA_DRIVER_MIN_VERSION = 12040;
 
 static_assert(
     CUDA_VERSION >= CUDA_DRIVER_MIN_VERSION,
     "CudaDriverApi requires CUDA 12.4 or later");
+#endif
 
-// ---------------------------------------------------------------------------
-// Function pointer declarations using PFN types from <cudaTypedefs.h>
-// ---------------------------------------------------------------------------
-
-#define DECLARE_CUDA_PFN(symbol, version) \
-  PFN_##symbol##_v##version pfn_##symbol = nullptr
+// On NVIDIA, CU_PFN(name) resolves to the dynamically loaded pfn_<name>; on AMD
+// (hipified) it resolves to the driver function itself, called directly.
+#if defined(__HIP_PLATFORM_AMD__)
+#define CU_PFN(name) name
+#else
+#define CU_PFN(name) pfn_##name
+#endif
 
 namespace {
 
 // NOLINTBEGIN(facebook-avoid-non-const-global-variables)
+
+#ifndef __HIP_PLATFORM_AMD__
+// ---------------------------------------------------------------------------
+// Function pointer declarations using PFN types from <cudaTypedefs.h> (NVIDIA)
+// ---------------------------------------------------------------------------
+
+#define DECLARE_CUDA_PFN(symbol, version) \
+  PFN_##symbol##_v##version pfn_##symbol = nullptr
 
 // --- Error ---
 DECLARE_CUDA_PFN(cuGetErrorString, 6000);
@@ -55,6 +81,7 @@ DECLARE_CUDA_PFN(cuMemGetAddressRange, 3020);
 DECLARE_CUDA_PFN(cuStreamWriteValue64, 11070);
 
 #undef DECLARE_CUDA_PFN
+#endif // !__HIP_PLATFORM_AMD__
 
 std::once_flag g_initFlag;
 Status g_initStatus{Ok()};
@@ -71,20 +98,26 @@ Status cuRetToStatus(CUresult ret, const char* funcName) {
   }
   std::string msg = funcName;
   msg += "() failed, ret = ";
-  msg += std::to_string(ret);
-  if (pfn_cuGetErrorString != nullptr) {
-    const char* errStr = nullptr;
-    if (pfn_cuGetErrorString(ret, &errStr) == CUDA_SUCCESS &&
-        errStr != nullptr) {
-      msg += ": ";
-      msg += errStr;
-    }
+  msg += std::to_string(static_cast<int>(ret));
+  const char* errStr = nullptr;
+#if defined(__HIP_PLATFORM_AMD__)
+  if (cuGetErrorString(ret, &errStr) == CUDA_SUCCESS && errStr != nullptr) {
+    msg += ": ";
+    msg += errStr;
   }
+#else
+  if (pfn_cuGetErrorString != nullptr &&
+      pfn_cuGetErrorString(ret, &errStr) == CUDA_SUCCESS && errStr != nullptr) {
+    msg += ": ";
+    msg += errStr;
+  }
+#endif
   return Err(ErrCode::DriverError, std::move(msg));
 }
 
+#ifndef __HIP_PLATFORM_AMD__
 // ---------------------------------------------------------------------------
-// Symbol loading via cudaGetDriverEntryPoint
+// Symbol loading via cudaGetDriverEntryPoint (NVIDIA only)
 // ---------------------------------------------------------------------------
 
 #if CUDART_VERSION >= 13000
@@ -140,25 +173,29 @@ Status cuRetToStatus(CUresult ret, const char* funcName) {
   (pfn_##name == nullptr                                      \
        ? Err(ErrCode::DriverError, #name " symbol not found") \
        : cuRetToStatus(pfn_##name(__VA_ARGS__), #name))
+#endif // !__HIP_PLATFORM_AMD__
 
 void checkCuMemSupported(int cudaDev) {
+#ifndef __HIP_PLATFORM_AMD__
   if (pfn_cuMemCreate == nullptr) {
     g_isCuMemSupported = false;
-  } else {
-    CUdevice currentDev;
-    if (pfn_cuDeviceGet(&currentDev, cudaDev) != CUDA_SUCCESS) {
-      g_isCuMemSupported = false;
-    } else {
-      int flag = 0;
-      auto ret = pfn_cuDeviceGetAttribute(
-          &flag,
-          CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
-          currentDev);
-      g_isCuMemSupported = (ret == CUDA_SUCCESS && flag != 0);
-    }
+    return;
   }
+#endif
+  CUdevice currentDev;
+  if (CU_PFN(cuDeviceGet)(&currentDev, cudaDev) != CUDA_SUCCESS) {
+    g_isCuMemSupported = false;
+    return;
+  }
+  int flag = 0;
+  auto ret = CU_PFN(cuDeviceGetAttribute)(
+      &flag,
+      CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED,
+      currentDev);
+  g_isCuMemSupported = (ret == CUDA_SUCCESS && flag != 0);
 }
 
+#ifndef __HIP_PLATFORM_AMD__
 void probeCuMemHandleType() {
   CUdevice cuDevice;
   const int deviceId = 0;
@@ -357,6 +394,67 @@ void doInit() {
 
 #undef LOAD_SYM
 
+#else // __HIP_PLATFORM_AMD__
+
+// Detect GPUDirect-RDMA (peer-mem) support on AMD. There is no HIP query for
+// this, so we probe the same signals as rccl/ctran (see
+// comms/ctran/utils/HipGdrCheck.h): the amdkfd peer-mem sysfs version node, and
+// the `ib_register_peer_memory_client` symbol in /proc/kallsyms as a fallback
+// for native-OS ib_peer modules. Used to decide whether VRAM can be registered
+// via dma-buf; callers fall back to plain ibv_reg_mr when this returns false.
+bool amdGpuDirectRdmaSupported() {
+  static const char* kMemoryPeersPaths[] = {
+      "/sys/kernel/mm/memory_peers/amdkfd/version",
+      "/sys/kernel/memory_peers/amdkfd/version",
+      "/sys/memory_peers/amdkfd/version",
+  };
+  for (const char* path : kMemoryPeersPaths) {
+    if (access(path, F_OK) == 0) {
+      return true;
+    }
+  }
+
+  // Fallback: look for the native ib_peer_mem registration symbol.
+  FILE* fp = std::fopen("/proc/kallsyms", "r");
+  if (fp == nullptr) {
+    return false;
+  }
+  char buf[256];
+  bool found = false;
+  while (std::fgets(buf, sizeof(buf), fp) != nullptr) {
+    if (std::strstr(buf, "ib_register_peer_memory_client") != nullptr) {
+      found = true;
+      break;
+    }
+  }
+  std::fclose(fp);
+  return found;
+}
+
+// AMD driver entry points (hip*) are linked directly, so there is no PFN
+// loading. Init initializes the driver, probes cuMem (VMM) support, and detects
+// GPUDirect-RDMA via the peer-mem probe above. The NVIDIA-only fabric handle
+// path does not apply — AMD uses POSIX-FD / dma-buf sharing.
+void doInit() {
+  int cudaDev;
+  auto ret = cudaGetDevice(&cudaDev); // Initialize the driver
+  if (ret != cudaSuccess) {
+    g_initStatus = Err(ErrCode::DriverError, "cudaGetDevice failed");
+    return;
+  }
+
+  checkCuMemSupported(cudaDev);
+
+  const bool gdrSupported = amdGpuDirectRdmaSupported();
+  for (int i = 0; i < kMaxDevices; i++) {
+    g_isDmaBufSupported[i] = gdrSupported;
+  }
+
+  g_initStatus = Ok();
+}
+
+#endif // __HIP_PLATFORM_AMD__
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -371,6 +469,13 @@ void doInit() {
     }                               \
   } while (0)
 
+#if defined(__HIP_PLATFORM_AMD__)
+#define CU_CALL(name, ...)                            \
+  do {                                                \
+    CU_ENSURE_INIT();                                 \
+    return cuRetToStatus(::name(__VA_ARGS__), #name); \
+  } while (0)
+#else
 #define CU_CALL(name, ...)                                         \
   do {                                                             \
     CU_ENSURE_INIT();                                              \
@@ -379,6 +484,7 @@ void doInit() {
     }                                                              \
     return cuRetToStatus(pfn_##name(__VA_ARGS__), #name);          \
   } while (0)
+#endif
 
 Status CudaDriverApi::init() {
   std::call_once(g_initFlag, doInit);
@@ -498,7 +604,17 @@ Status CudaDriverApi::cuMemGetHandleForAddressRange(
     size_t size,
     CUmemRangeHandleType handleType,
     unsigned long long flags) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // hipify-perl does not map cuMemGetHandleForAddressRange, so call the HIP
+  // dma-buf fd export directly (GPUDirect RDMA path). CU_ENSURE_INIT() mirrors
+  // the CU_CALL path; the global symbol is qualified to avoid the member name.
+  CU_ENSURE_INIT();
+  return cuRetToStatus(
+      ::hipMemGetHandleForAddressRange(handle, dptr, size, handleType, flags),
+      "hipMemGetHandleForAddressRange");
+#else
   CU_CALL(cuMemGetHandleForAddressRange, handle, dptr, size, handleType, flags);
+#endif
 }
 
 // --- Stream memory ops ---

--- a/comms/uniflow/drivers/cuda/CudaDriverApi.h
+++ b/comms/uniflow/drivers/cuda/CudaDriverApi.h
@@ -6,6 +6,22 @@
 
 #include "comms/uniflow/Result.h"
 
+#if defined(__HIP_PLATFORM_AMD__)
+// hipify-perl does not map this newer VMM dma-buf handle type; alias the CUDA
+// spelling (which survives hipification untranslated) to the HIP type so the
+// hipified interface still names a valid type on AMD. The dma-buf export path
+// that uses it is implemented for AMD in a later diff.
+using CUmemRangeHandleType = hipMemRangeHandleType;
+// Same hipify gap for the dma-buf-fd enumerator used by callers of
+// cuMemGetHandleForAddressRange.
+inline constexpr hipMemRangeHandleType CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD =
+    hipMemRangeHandleTypeDmaBufFd;
+// hipify-perl also misses the stream write-value flag enumerator used by
+// streamWriteValue64. HIP has no named constant for it; the CUDA default value
+// is 0x0 (no memory barrier), which is also HIP's default, so alias to 0.
+inline constexpr unsigned int CU_STREAM_WRITE_VALUE_DEFAULT = 0u;
+#endif
+
 namespace uniflow {
 
 /// Thin wrapper around CUDA Driver (cu*) APIs loaded via

--- a/comms/uniflow/drivers/cuda/CudaTopologyDiscovery.cpp
+++ b/comms/uniflow/drivers/cuda/CudaTopologyDiscovery.cpp
@@ -1016,7 +1016,7 @@ CudaTopologyDiscovery::CudaTopologyDiscovery(
     std::shared_ptr<IbvApi> ibvApi,
     std::shared_ptr<SysfsApi> sysfsApi)
     : cudaApi_(cudaApi ? std::move(cudaApi) : std::make_shared<CudaApi>()),
-      nvmlApi_(nvmlApi ? std::move(nvmlApi) : std::make_shared<NvmlApi>()),
+      nvmlApi_(nvmlApi ? std::move(nvmlApi) : createNvmlApi()),
       ibvApi_(ibvApi ? std::move(ibvApi) : std::make_shared<IbvApi>()),
       sysfsApi_(sysfsApi ? std::move(sysfsApi) : std::make_shared<SysfsApi>()) {
 }

--- a/comms/uniflow/drivers/nvml/NvmlApi.cpp
+++ b/comms/uniflow/drivers/nvml/NvmlApi.cpp
@@ -516,4 +516,8 @@ Status NvmlApi::nvmlSystemGetConfComputeStatus(NvmlCCStatus* status) {
   return Ok();
 }
 
+std::shared_ptr<NvmlApi> createNvmlApi() {
+  return std::make_shared<NvmlApi>();
+}
+
 } // namespace uniflow

--- a/comms/uniflow/drivers/nvml/NvmlApi.h
+++ b/comms/uniflow/drivers/nvml/NvmlApi.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "comms/uniflow/Result.h"
 #include "comms/uniflow/drivers/nvml/NvmlCore.h"
 
@@ -95,5 +97,12 @@ class NvmlApi {
   /// Get the confidential compute status of the system
   virtual Status nvmlSystemGetConfComputeStatus(NvmlCCStatus* state);
 };
+
+/// Create the NVML wrapper for the platform this binary was built for. NVIDIA
+/// builds return the real (dlopen-backed) NvmlApi; AMD builds return a no-op
+/// stub that reports every query as unsupported (NVML has no HIP analog). The
+/// definition lives in the build-selected translation unit (NvmlApi.cpp /
+/// NvmlApiStub.cpp), mirroring createCudaApi().
+std::shared_ptr<NvmlApi> createNvmlApi();
 
 } // namespace uniflow

--- a/comms/uniflow/drivers/nvml/NvmlApiStub.cpp
+++ b/comms/uniflow/drivers/nvml/NvmlApiStub.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// AMD/ROCm no-op implementation of NvmlApi. NVML is NVIDIA-only and has no HIP
+// analog, so this stub reports every query as unsupported and never dlopen's
+// libnvidia-ml. The build selects this translation unit instead of NvmlApi.cpp
+// on AMD (see drivers/nvml/BUCK), mirroring createCudaApi()'s per-platform TU
+// split. Topology discovery degrades gracefully: callers skip NVLink/C2C edges
+// when these calls fail, leaving NIC/PCIe + GPU P2P edges (correct for AMD).
+//
+// A real amdsmi-backed implementation can replace this stub later.
+
+#include "comms/uniflow/drivers/nvml/NvmlApi.h"
+
+namespace uniflow {
+namespace {
+
+Err unsupported() {
+  return Err(
+      ErrCode::NotImplemented, "NVML is not supported on AMD/ROCm builds");
+}
+
+} // namespace
+
+Result<int> NvmlApi::deviceCount() {
+  return unsupported();
+}
+
+Result<NvmlApi::DeviceInfo> NvmlApi::deviceInfo(int) {
+  return unsupported();
+}
+
+Result<NvmlApi::DevicePairInfo> NvmlApi::devicePairInfo(int, int) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlInit() {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetHandleByPciBusId(const char*, nvmlDevice_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetHandleByIndex(unsigned int, nvmlDevice_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetIndex(nvmlDevice_t, unsigned int*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetNvLinkState(
+    nvmlDevice_t,
+    unsigned int,
+    nvmlEnableState_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetNvLinkRemotePciInfo(
+    nvmlDevice_t,
+    unsigned int,
+    nvmlPciInfo_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetNvLinkCapability(
+    nvmlDevice_t,
+    unsigned int,
+    nvmlNvLinkCapability_t,
+    unsigned int*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetCudaComputeCapability(nvmlDevice_t, int*, int*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetP2PStatus(
+    nvmlDevice_t,
+    nvmlDevice_t,
+    nvmlGpuP2PCapsIndex_t,
+    nvmlGpuP2PStatus_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetFieldValues(nvmlDevice_t, int, nvmlFieldValue_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetGpuFabricInfoV(
+    nvmlDevice_t,
+    nvmlGpuFabricInfoV_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlDeviceGetPlatformInfo(nvmlDevice_t, nvmlPlatformInfo_t*) {
+  return unsupported();
+}
+
+Status NvmlApi::nvmlSystemGetConfComputeStatus(NvmlCCStatus*) {
+  return unsupported();
+}
+
+std::shared_ptr<NvmlApi> createNvmlApi() {
+  return std::make_shared<NvmlApi>();
+}
+
+} // namespace uniflow

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -162,13 +162,18 @@ TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndRdma) {
   }
 
   MultiTransportFactory factory(0);
-  // GPU mode: NVLink factory first, then RDMA if PIX NICs exist.
   ASSERT_GE(factoryCount(factory), 1u);
+#if defined(__HIP_PLATFORM_AMD__)
+  // NVLink is NVIDIA-only and is compiled out on AMD, so the GPU factory
+  // provides RDMA as the GPU transport (see MultiTransport.cpp).
+  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+#else
+  // GPU mode: NVLink factory first, then RDMA if PIX NICs exist.
   EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
-
   if (factoryCount(factory) > 1) {
     EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
   }
+#endif
 }
 
 TEST_F(MultiTransportFactoryTest, ConstructorRejectsInvalidDeviceId) {

--- a/comms/uniflow/transport/nvlink/tests/integration/PeerToPeerTransferTest.cpp
+++ b/comms/uniflow/transport/nvlink/tests/integration/PeerToPeerTransferTest.cpp
@@ -1,0 +1,227 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// Confidential and proprietary.
+// Peer-to-Peer GPU transfer integration test for intra-node device-to-device
+// transfers.
+//
+// This test verifies device-to-device P2P transfers over the GPU interconnect
+// (XGMI on AMD, NVLink on NVIDIA) using the platform-agnostic CudaApi
+// abstraction. Buffers are allocated in device memory (cudaMalloc / hipMalloc)
+// and peer access is enabled in both directions, so memcpyPeerAsync actually
+// traverses the GPU-to-GPU interconnect rather than staging through host
+// memory; a host staging buffer is used only to seed device A and to read back
+// device B for verification.
+
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace uniflow {
+
+namespace {
+
+// Peer-to-peer GPU transfer test fixture.
+// Tests intra-node GPU-to-GPU transfers over the GPU interconnect (XGMI on AMD,
+// NVLink on NVIDIA) using the platform-agnostic CudaApi abstraction.
+class PeerToPeerTransferTest : public ::testing::Test {
+ protected:
+  static constexpr int kDeviceA = 0;
+  static constexpr int kDeviceB = 1;
+  static constexpr size_t kTransferSize = 1 << 20; // 1MB
+
+  void SetUp() override {
+    // Check if we have at least 2 GPUs.
+    auto deviceCount = cudaApi_->getDeviceCount();
+    if (!deviceCount.hasValue() || deviceCount.value() < 2) {
+      GTEST_SKIP() << "P2P transfer test requires at least 2 GPUs";
+    }
+
+    // Check if P2P is supported between devices.
+    auto canAccess = cudaApi_->deviceCanAccessPeer(kDeviceA, kDeviceB);
+    if (!canAccess.hasValue() || !canAccess.value()) {
+      GTEST_SKIP() << "P2P not supported between GPU " << kDeviceA
+                   << " and GPU " << kDeviceB;
+    }
+
+    // deviceCanAccessPeer only reports capability; peer access must actually be
+    // enabled or memcpyPeerAsync may stage through host memory instead of going
+    // over the GPU interconnect (XGMI/NVLink) -- which would make this test
+    // pass without exercising the interconnect it is meant to validate. Enable
+    // in both directions, each from its own device context
+    // (deviceEnablePeerAccess acts on the current device). The seam treats
+    // "already enabled" as success, so this is safe across both test cases.
+    ASSERT_TRUE(cudaApi_->setDevice(kDeviceA).hasValue());
+    ASSERT_TRUE(cudaApi_->deviceEnablePeerAccess(kDeviceB).hasValue())
+        << "Failed to enable peer access " << kDeviceA << " -> " << kDeviceB;
+    ASSERT_TRUE(cudaApi_->setDevice(kDeviceB).hasValue());
+    ASSERT_TRUE(cudaApi_->deviceEnablePeerAccess(kDeviceA).hasValue())
+        << "Failed to enable peer access " << kDeviceB << " -> " << kDeviceA;
+  }
+
+  // Release device buffers unconditionally, so a failing ASSERT_* in a test
+  // body does not leak GPU memory.
+  void TearDown() override {
+    freeDeviceMemory(kDeviceA, devA_);
+    freeDeviceMemory(kDeviceB, devB_);
+    devA_ = nullptr;
+    devB_ = nullptr;
+  }
+
+  // Build a host buffer of `size` bytes with a deterministic pattern.
+  static std::vector<uint8_t> makePattern(size_t size) {
+    std::vector<uint8_t> buf(size);
+    for (size_t i = 0; i < size; ++i) {
+      buf[i] = static_cast<uint8_t>((i * 37) & 0xFF);
+    }
+    return buf;
+  }
+
+  // Allocate device memory on `deviceId` via cudaMalloc (hipMalloc on AMD), so
+  // P2P transfers traverse the GPU-to-GPU interconnect rather than host memory.
+  void* allocateDeviceMemory(int deviceId, size_t size) {
+    if (!cudaApi_->setDevice(deviceId).hasValue()) {
+      return nullptr;
+    }
+    void* ptr = nullptr;
+    if (cudaMalloc(&ptr, size) != cudaSuccess) {
+      return nullptr;
+    }
+    return ptr;
+  }
+
+  void freeDeviceMemory(int deviceId, void* ptr) {
+    if (ptr) {
+      cudaApi_->setDevice(deviceId);
+      // hipFree is [[nodiscard]] on HIP (cudaFree is not on CUDA); discard
+      // explicitly so the single source compiles under -Werror on both.
+      (void)cudaFree(ptr);
+    }
+  }
+
+  void* devA_ = nullptr;
+  void* devB_ = nullptr;
+  std::shared_ptr<CudaApi> cudaApi_{std::make_shared<CudaApi>()};
+};
+
+// Test basic P2P transfer from Device A to Device B.
+// Seeds device A from a host buffer, copies A->B over the interconnect, reads
+// device B back, and verifies the round trip preserved the data.
+TEST_F(PeerToPeerTransferTest, BasicP2PTransfer) {
+  devA_ = allocateDeviceMemory(kDeviceA, kTransferSize);
+  devB_ = allocateDeviceMemory(kDeviceB, kTransferSize);
+  ASSERT_NE(devA_, nullptr) << "Failed to allocate device memory on device A";
+  ASSERT_NE(devB_, nullptr) << "Failed to allocate device memory on device B";
+
+  // Seed device A with a known pattern from host.
+  const std::vector<uint8_t> srcHost = makePattern(kTransferSize);
+  ASSERT_TRUE(cudaApi_->setDevice(kDeviceA).hasValue());
+  ASSERT_TRUE(cudaApi_
+                  ->memcpyAsync(
+                      devA_,
+                      srcHost.data(),
+                      kTransferSize,
+                      cudaMemcpyHostToDevice,
+                      nullptr)
+                  .hasValue())
+      << "Failed to copy to device A";
+  ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+
+  // Device-to-device P2P transfer: Device A -> Device B over the interconnect:
+  // - On AMD: XGMI via hipMemcpyPeerAsync
+  // - On NVIDIA: NVLink via cudaMemcpyPeerAsync
+  auto status = cudaApi_->memcpyPeerAsync(
+      devB_, kDeviceB, devA_, kDeviceA, kTransferSize, nullptr);
+  ASSERT_TRUE(status.hasValue())
+      << "P2P transfer failed: " << status.error().message();
+  ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+
+  // Read device B back to host and verify against the original pattern.
+  std::vector<uint8_t> dstHost(kTransferSize, 0);
+  ASSERT_TRUE(cudaApi_->setDevice(kDeviceB).hasValue());
+  ASSERT_TRUE(cudaApi_
+                  ->memcpyAsync(
+                      dstHost.data(),
+                      devB_,
+                      kTransferSize,
+                      cudaMemcpyDeviceToHost,
+                      nullptr)
+                  .hasValue())
+      << "Failed to copy from device B";
+  ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+
+  EXPECT_EQ(srcHost, dstHost) << "P2P transfer data mismatch";
+}
+
+// Test multiple small P2P transfers (simulates real-world usage). Each chunk is
+// staged into device A then copied A->B device-to-device; the whole device B
+// buffer is read back once and compared against the constructed expected
+// buffer.
+TEST_F(PeerToPeerTransferTest, MultipleSmallP2PTransfers) {
+  constexpr size_t kNumTransfers = 10;
+  constexpr size_t kSmallSize = 4096; // 4KB each
+  constexpr size_t kTotalSize = kNumTransfers * kSmallSize;
+  static_assert(kTotalSize <= kTransferSize, "transfers exceed buffer size");
+
+  devA_ = allocateDeviceMemory(kDeviceA, kTransferSize);
+  devB_ = allocateDeviceMemory(kDeviceB, kTransferSize);
+  ASSERT_NE(devA_, nullptr);
+  ASSERT_NE(devB_, nullptr);
+
+  // Construct the expected buffer host-side: chunk i carries the byte value i.
+  std::vector<uint8_t> expected(kTotalSize);
+  for (size_t i = 0; i < kNumTransfers; ++i) {
+    std::fill_n(
+        expected.begin() + i * kSmallSize,
+        kSmallSize,
+        static_cast<uint8_t>(i & 0xFF));
+  }
+
+  for (size_t i = 0; i < kNumTransfers; ++i) {
+    const size_t offset = i * kSmallSize;
+
+    // Stage chunk i into device A from host.
+    ASSERT_TRUE(cudaApi_->setDevice(kDeviceA).hasValue());
+    ASSERT_TRUE(cudaApi_
+                    ->memcpyAsync(
+                        static_cast<uint8_t*>(devA_) + offset,
+                        expected.data() + offset,
+                        kSmallSize,
+                        cudaMemcpyHostToDevice,
+                        nullptr)
+                    .hasValue())
+        << "H2D staging for transfer " << i << " failed";
+    ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+
+    // Device-to-device P2P transfer for chunk i.
+    auto status = cudaApi_->memcpyPeerAsync(
+        static_cast<uint8_t*>(devB_) + offset,
+        kDeviceB,
+        static_cast<uint8_t*>(devA_) + offset,
+        kDeviceA,
+        kSmallSize,
+        nullptr);
+    ASSERT_TRUE(status.hasValue())
+        << "P2P transfer " << i << " failed: " << status.error().message();
+    ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+  }
+
+  // Read the whole device B buffer back and compare in one shot.
+  std::vector<uint8_t> actual(kTotalSize, 0);
+  ASSERT_TRUE(cudaApi_->setDevice(kDeviceB).hasValue());
+  ASSERT_TRUE(
+      cudaApi_
+          ->memcpyAsync(
+              actual.data(), devB_, kTotalSize, cudaMemcpyDeviceToHost, nullptr)
+          .hasValue())
+      << "Failed to copy from device B";
+  ASSERT_TRUE(cudaApi_->streamSynchronize(nullptr).hasValue());
+
+  EXPECT_EQ(actual, expected) << "P2P transfer data mismatch";
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/transport/rdma/CopyEngine.cpp
+++ b/comms/uniflow/transport/rdma/CopyEngine.cpp
@@ -1,6 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "comms/uniflow/transport/rdma/CopyEngine.h"
+
+#include "comms/uniflow/drivers/cuda/CudaDevicePtr.h"
 #include "comms/uniflow/transport/rdma/RdmaSlabPool.h"
 
 #include <cstring>
@@ -26,7 +28,7 @@ void CopyEngine::copyToSlab(RdmaSlab& slab, const void* src, size_t len) {
         slab.ptr(), src, len, cudaMemcpyDeviceToHost, *stream_);
     cudaDriverApi_->streamWriteValue64(
         *stream_,
-        static_cast<CUdeviceptr>(slab.stateDeviceAddr()),
+        toDevicePtr(slab.stateDeviceAddr()),
         1,
         CU_STREAM_WRITE_VALUE_DEFAULT);
   } else {
@@ -41,7 +43,7 @@ void CopyEngine::copyFromSlab(void* dst, RdmaSlab& slab, size_t len) {
         dst, slab.ptr(), len, cudaMemcpyHostToDevice, *stream_);
     cudaDriverApi_->streamWriteValue64(
         *stream_,
-        static_cast<CUdeviceptr>(slab.stateDeviceAddr()),
+        toDevicePtr(slab.stateDeviceAddr()),
         1,
         CU_STREAM_WRITE_VALUE_DEFAULT);
   } else {

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -4,6 +4,7 @@
 #include "comms/uniflow/core/NumaUtils.h"
 #include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/TopologyDiscovery.h"
+#include "comms/uniflow/drivers/cuda/CudaDevicePtr.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
@@ -1922,7 +1923,7 @@ RdmaTransportFactory::registerSegment(Segment& segment) {
       // link is available.
       auto dmaBufStatus = cudaDriverApi_->cuMemGetHandleForAddressRange(
           &fdGuard.fd,
-          static_cast<CUdeviceptr>(alignedAddr),
+          toDevicePtr(alignedAddr),
           dmaBufLen,
           CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
           flags);


### PR DESCRIPTION
Summary:
Phase 2: platform-agnostic intra-node GPU-to-GPU peer-to-peer test over the GPU
interconnect (XGMI on AMD, NVLink on NVIDIA) via the neutral CudaApi. Allocates
device memory (cudaMalloc/hipMalloc) so memcpyPeerAsync exercises real
device-to-device traffic; hip_ci=True for real AMD GPU CI.

- transport/nvlink/tests/integration/PeerToPeerTransferTest.cpp + BUCK.

Differential Revision: D107346920


