### PR TITLE
Add numaNode to NicResources from Topology (#2802)

### DIFF
--- a/comms/uniflow/transport/Topology.cpp
+++ b/comms/uniflow/transport/Topology.cpp
@@ -61,6 +61,7 @@ void Topology::clear() {
   pxnPaths_.clear();
   gpuNodeIds_.clear();
   nicNodeIds_.clear();
+  nicNameToNuma_.clear();
   cpuNodeIds_.clear();
   p2pMatrix_.clear();
 }
@@ -96,6 +97,9 @@ void Topology::registerNicNode(int nicIndex, int nodeId) {
     nicNodeIds_.resize(nicIndex + 1, -1);
   }
   nicNodeIds_[nicIndex] = nodeId;
+  const auto& node = nodes_[nodeId];
+  const auto& nicData = std::get<TopoNode::NicData>(node.data);
+  nicNameToNuma_[node.name] = nicData.numaNode;
 }
 
 void Topology::setP2pMatrix(std::vector<std::vector<bool>> matrix) {
@@ -320,6 +324,14 @@ int Topology::getCurrentCpuNumaNode() const {
     return static_cast<int>(node);
   }
   return -1;
+}
+
+int Topology::nicNumaNode(const std::string& nicName) const {
+  if (nicName.empty()) {
+    return -1;
+  }
+  auto it = nicNameToNuma_.find(nicName);
+  return it != nicNameToNuma_.end() ? it->second : -1;
 }
 
 bool Topology::filterNic(int nicIndex, const NicFilter& filter) const {

--- a/comms/uniflow/transport/Topology.h
+++ b/comms/uniflow/transport/Topology.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -191,6 +192,10 @@ class Topology {
   /// Returns the NUMA node of the calling thread's CPU.
   int getCurrentCpuNumaNode() const;
 
+  /// Returns the NUMA node id of the NIC with the given device name (e.g.
+  /// "mlx5_0"), or -1 if unknown. O(1) lookup into a map built at discovery.
+  int nicNumaNode(const std::string& nicName) const;
+
   /// Check if a NIC passes the given filter.
   bool filterNic(int nicIndex, const NicFilter& filter) const;
 
@@ -259,6 +264,7 @@ class Topology {
   // Index maps for quick lookup
   std::vector<int> gpuNodeIds_; // gpuNodeIds_[cudaDeviceId] = nodeId
   std::vector<int> nicNodeIds_; // nicNodeIds_[nicIndex] = nodeId
+  std::unordered_map<std::string, int> nicNameToNuma_; // nic name -> NUMA id
   std::vector<int> cpuNodeIds_; // cpuNodeIds_[numaId] = nodeId
   std::vector<std::vector<bool>> p2pMatrix_;
 };

--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -11,9 +11,10 @@ namespace uniflow {
 NicResources::NicResources(
     ibv_device* device,
     std::shared_ptr<IbvApi> api,
+    int numaNode,
     uint8_t gidIndex,
     std::optional<uint8_t> port)
-    : ibvApi(std::move(api)) {
+    : numaNode(numaNode), ibvApi(std::move(api)) {
   try {
     if (!ibvApi) {
       ibvApi = std::make_shared<IbvApi>();
@@ -21,7 +22,8 @@ NicResources::NicResources(
 
     auto ctxResult = ibvApi->openDevice(device);
     if (ctxResult.hasError()) {
-      throw std::runtime_error("NicResources: failed to open device");
+      throw std::runtime_error(
+          "NicResources: failed to open device" + ctxResult.error().message());
     }
     ctx = ctxResult.value();
 
@@ -73,6 +75,7 @@ NicResources::NicResources(NicResources&& other) noexcept
       linkLayer(other.linkLayer),
       portNum(other.portNum),
       dmaBufSupported(other.dmaBufSupported),
+      numaNode(other.numaNode),
       ibvApi(std::move(other.ibvApi)) {
   other.ctx = nullptr;
   other.pd = nullptr;

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -24,10 +24,12 @@ struct NicResources {
   int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
   uint8_t portNum{1}; /* Physical port number on the HCA. */
   bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
+  int numaNode{-1}; /* NUMA node of the NIC, from Topology (-1 = unknown). */
 
   NicResources(
       ibv_device* device,
       std::shared_ptr<IbvApi> api,
+      int numaNode = -1,
       uint8_t gidIndex = 3,
       std::optional<uint8_t> port = std::nullopt);
 

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 #include "comms/uniflow/drivers/DeviceAdapter.h"
+#include "comms/uniflow/drivers/TopologyDiscovery.h"
 #include "comms/uniflow/drivers/cuda/CudaDriverApi.h"
 #include "comms/uniflow/logging/Logger.h"
 #include "comms/uniflow/transport/rdma/RdmaRegistrationHandle.h"
@@ -1824,7 +1825,9 @@ RdmaTransportFactory::RdmaTransportFactory(
       throw std::runtime_error("RDMA device not found: " + deviceName);
     }
 
-    nicsHandle_->emplace_back(targetDevice, ibvApi_, config_.gidIndex, portNum);
+    int numaNode = sharedTopology().nicNumaNode(deviceName);
+    nicsHandle_->emplace_back(
+        targetDevice, ibvApi_, numaNode, config_.gidIndex, portNum);
   }
 
   if (config_.slabPoolConfig.slabNum > 0) {

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
@@ -84,10 +84,10 @@ class RdmaSlabPoolTest : public ::testing::Test {
 
     nics->reserve(count);
     setupNic(&fakeDev0_, &fakeCtx0_, &fakePd0_);
-    nics->emplace_back(&fakeDev0_, mockIbvApi_, 3, uint8_t{1});
+    nics->emplace_back(&fakeDev0_, mockIbvApi_, -1, 3, uint8_t{1});
     if (count > 1) {
       setupNic(&fakeDev1_, &fakeCtx1_, &fakePd1_);
-      nics->emplace_back(&fakeDev1_, mockIbvApi_, 3, uint8_t{1});
+      nics->emplace_back(&fakeDev1_, mockIbvApi_, -1, 3, uint8_t{1});
     }
     return nics;
   }

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -206,7 +206,7 @@ NicResources makeNic(
   ON_CALL(*mockApi, deallocPd(pd)).WillByDefault(Return(Ok()));
   ON_CALL(*mockApi, closeDevice(ctx)).WillByDefault(Return(Ok()));
 
-  return NicResources(dev, mockApi, 3, port);
+  return NicResources(dev, mockApi, -1, 3, port);
 }
 
 // --- Mock-based transport tests ---

--- a/comms/uniflow/transport/tests/unit/TopologyTest.cpp
+++ b/comms/uniflow/transport/tests/unit/TopologyTest.cpp
@@ -1057,6 +1057,19 @@ TEST_F(TopologyNicTest, NodeNamesAreSet) {
   EXPECT_EQ(topo->getNicNode(0).name, "mlx5_0");
 }
 
+TEST_F(TopologyNicTest, NicNumaNodeLookup) {
+  // Override nic2_ to NUMA node 1 so we can verify per-NIC differentiation.
+  ON_CALL(*sysfs_, readFile(nic2_ + "/numa_node")).WillByDefault(Return("1"));
+
+  setupNics({{"mlx5_0", nic0_}, {"mlx5_2", nic2_}});
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  EXPECT_EQ(topo->nicNumaNode("mlx5_0"), 0);
+  EXPECT_EQ(topo->nicNumaNode("mlx5_2"), 1);
+  EXPECT_EQ(topo->nicNumaNode("missing_nic"), -1);
+}
+
 TEST_F(TopologyNicTest, PortSpeedIsCapturedFromIbverbs) {
   setupNics({{"mlx5_0", nic0_}, {"mlx5_1", nic1_}});
 


### PR DESCRIPTION
Summary:

Add a `numaNode` field to `NicResources`, resolved in the `NicResources` constructor from the uniflow `Topology` module via a new `Topology::nicNumaNode(nicName)` helper. The device name is passed explicitly into the constructor (rather than read from `ibv_device->name`). Topology builds a NIC-name -> NUMA-node `unordered_map` during discovery, so the lookup is O(1). This surfaces the NUMA node of each NIC to the RDMA transport layer as a foundation for future NUMA-aware scheduling. No behavior change: the field defaults to -1 and is informational for now (the lookup is skipped for an empty device name, which keeps the unit tests hermetic).

Reviewed By: rmahidhar

Differential Revision: D107671370


