### PR TITLE
DeviceWindow: use system-scope acquire loads (not volatile) for IBGDA signal/counter/barrier inbox polling

### DIFF
--- a/comms/pipes/window/DeviceWindow.cuh
+++ b/comms/pipes/window/DeviceWindow.cuh
@@ -559,9 +559,8 @@ class DeviceWindow {
     } else {
       int ibgdaIdx = rank_to_peer_index(source_rank);
       int slot = ibgdaIdx * peerSignalCount_ + signal_id;
-      // volatile: bypass L1 to read from L2 where RDMA atomics land
-      volatile uint64_t* sig = &ibgdaPeerSignalInbox_[slot];
-      while (!compare(*sig, cmp, value)) {
+      const uint64_t* sig = &ibgdaPeerSignalInbox_[slot];
+      while (!compare(load_ibgda_slot_acquire(sig), cmp, value)) {
         TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
             timeout,
             "DeviceWindow::wait_signal_from(source_rank=%d,"
@@ -635,11 +634,9 @@ class DeviceWindow {
             total += nvlPeerSignalInbox_[nvlIdx * peerSignalCount_ + signal_id]
                          .load();
           } else {
-            // volatile: bypass L1 to read from L2 where RDMA atomics land
-            volatile uint64_t* p =
+            total += load_ibgda_slot_acquire(
                 &ibgdaPeerSignalInbox_
-                    [peer_index * peerSignalCount_ + signal_id];
-            total += *p;
+                    [peer_index * peerSignalCount_ + signal_id]);
           }
         }
         if (compare(total, cmp, value)) {
@@ -678,10 +675,8 @@ class DeviceWindow {
         total +=
             nvlPeerSignalInbox_[nvlIdx * peerSignalCount_ + signal_id].load();
       } else {
-        // volatile: bypass L1 to read from L2 where RDMA atomics land
-        volatile uint64_t* p =
-            &ibgdaPeerSignalInbox_[peer_index * peerSignalCount_ + signal_id];
-        total += *p;
+        total += load_ibgda_slot_acquire(
+            &ibgdaPeerSignalInbox_[peer_index * peerSignalCount_ + signal_id]);
       }
     }
     return total;
@@ -706,10 +701,8 @@ class DeviceWindow {
       return nvlPeerSignalInbox_[nvlIdx * peerSignalCount_ + signal_id].load();
     }
     int ibgdaIdx = rank_to_peer_index(source_rank);
-    // volatile: bypass L1 to read from L2 where RDMA atomics land
-    volatile uint64_t* p =
-        &ibgdaPeerSignalInbox_[ibgdaIdx * peerSignalCount_ + signal_id];
-    return *p;
+    return load_ibgda_slot_acquire(
+        &ibgdaPeerSignalInbox_[ibgdaIdx * peerSignalCount_ + signal_id]);
   }
 
   // ===========================================================================
@@ -744,9 +737,8 @@ class DeviceWindow {
     }
     int ibgdaIdx = rank_to_peer_index(peer_rank);
     int slot = ibgdaIdx * peerCounterCount_ + counter_id;
-    // volatile: bypass L1 to read from L2 where RDMA atomics land
-    volatile uint64_t* ctr = &ibgdaPeerCounterBuf_[slot];
-    while (!compare(*ctr, cmp, value)) {
+    const uint64_t* ctr = &ibgdaPeerCounterBuf_[slot];
+    while (!compare(load_ibgda_slot_acquire(ctr), cmp, value)) {
       TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
           timeout,
           "DeviceWindow::wait_counter(peer_rank=%d,"
@@ -806,10 +798,8 @@ class DeviceWindow {
       return 0;
     }
     int ibgdaIdx = rank_to_peer_index(peer_rank);
-    // volatile: bypass L1 to read from L2 where RDMA atomics land
-    volatile uint64_t* ctr =
-        &ibgdaPeerCounterBuf_[ibgdaIdx * peerCounterCount_ + counter_id];
-    return *ctr;
+    return load_ibgda_slot_acquire(
+        &ibgdaPeerCounterBuf_[ibgdaIdx * peerCounterCount_ + counter_id]);
   }
 
   /**
@@ -986,9 +976,7 @@ class DeviceWindow {
           total += nvlBarrierInbox_[barrier_id].load();
         }
         if (nIbgdaPeers_ > 0) {
-          // volatile: bypass L1 to read from L2 where RDMA atomics land
-          volatile uint64_t* p = &ibgdaBarrierInbox_[barrier_id];
-          total += *p;
+          total += load_ibgda_slot_acquire(&ibgdaBarrierInbox_[barrier_id]);
         }
         if (compare(total, cmp, value)) {
           break;
@@ -1262,6 +1250,17 @@ class DeviceWindow {
 
  private:
 #ifdef __CUDACC__
+  __device__ __forceinline__ static uint64_t load_ibgda_slot_acquire(
+      const uint64_t* ptr) {
+    auto* slot = const_cast<uint64_t*>(ptr);
+#ifdef __HIP_PLATFORM_AMD__
+    return __hip_atomic_load(slot, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    return cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{*slot}.load(
+        cuda::memory_order_acquire);
+#endif
+  }
+
   __device__ __forceinline__ static bool
   compare(uint64_t actual, CmpOp cmp, uint64_t expected) {
     switch (cmp) {


### PR DESCRIPTION
Summary:
## Problem

`DeviceWindow` provides the device-side wait/read primitives for the pipes window abstraction. For IBGDA (RDMA) peers, three classes of inbox slots — the signal inbox (`ibgdaPeerSignalInbox_`), the NIC completion counter buffer (`ibgdaPeerCounterBuf_`), and the barrier inbox (`ibgdaBarrierInbox_`) — are written by the NIC via RDMA / companion-QP loopback atomics, landing in GPU L2. Device threads poll these slots to learn that a peer's payload has arrived and is safe to consume.

These slots were polled with plain `volatile` loads, for example:

```
volatile uint64_t* sig = &ibgdaPeerSignalInbox_[slot];
while (!compare(*sig, cmp, value)) { ... }
```

`volatile` only forces the compiler to re-issue the load on each iteration (it cannot hoist the read into a register or out of the spin loop). It provides **no memory-ordering guarantee**. The polled flag and the payload bytes it guards live at different addresses, so nothing establishes a happens-before edge between observing the flag and reading the payload. Once the spin sees the flag satisfied, the subsequent payload reads can still return stale data — the classic flag→data visibility hazard across a producer/consumer boundary.

Because the producer here is the NIC — a separate system agent from the polling SM — the ordering must be enforced at **system scope**, not merely device/GPU scope.

The sibling lower-level transport `P2pIbgdaTransportDevice` already does this correctly: it polls the same kind of IBGDA signal/counter slots through a system-scope acquire load (`load_acquire_system_u64`). `DeviceWindow` was inconsistent with it, which is the gap this diff closes.

## The hazard, and how the acquire load fixes it

```
 Producer (remote rank / NIC)              Consumer (this rank, polling SM)
 ----------------------------              --------------------------------

   write payload  ──── RDMA ───►   payload buffer (L2 / HBM)
   write flag     ──── RDMA ───►   inbox slot (L2)
                                          │
   BEFORE (volatile):                     │
        volatile load  ───────────────────┘   re-reads the slot, but with
            observes flag set                  NO acquire fence
            read payload  ────────────────►    may return STALE bytes
                                               (load reordering / cached data)

   AFTER (acquire):
        acquire load  (ld.acquire.sys) ────┐   system-scope acquire
            observes flag set              │   establishes happens-before:
            read payload  ─────────────────┘   guaranteed to observe every
                                               producer write ordered before
                                               the flag
```

## Fix

Add a private device helper `load_ibgda_slot_acquire()` that mirrors `P2pIbgdaTransportDevice::load_acquire_system_u64`:

- NVIDIA: `cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{slot}.load(cuda::memory_order_acquire)`
- AMD / HIP: `__hip_atomic_load(slot, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM)`

and route every IBGDA inbox poll/read through it: `wait_signal_from`, `wait_signal`, `read_signal`, `read_signal_from`, `wait_counter`, `read_counter`, and `barrier_wait`.

The system-scope acquire load also subsumes the previous "bypass L1 to read from L2" intent of the `volatile` reads — an acquire load from the coherent point covers that and more — so the now-redundant `volatile`-explaining comments are removed.

## Scope / what is unchanged

- NVL (`P2P_NVL`) paths are untouched. Those slots are `SignalState` / atomic-wrapped and already read via `.load()`; their semantics are unchanged.
- No public API, signature, or memory-layout changes. This is purely the memory-ordering of the IBGDA poll loads.
- Host compilation is unaffected — the helper is guarded under `#ifdef __CUDACC__`.

## Risk / rollback

Low risk: this applies a strictly stronger ordering on read-only poll paths and leaves NVL behavior identical. Rollback is reverting this single-file change.

Differential Revision: D107692995


