### PR TITLE
Guard ncclCommShrink with RCCL version check

### DIFF
--- a/comms/torchcomms/rcclx/RcclxApi.cpp
+++ b/comms/torchcomms/rcclx/RcclxApi.cpp
@@ -87,8 +87,20 @@ ncclResult_t DefaultRcclxApi::commShrink(
     ncclConfig_t* config,
     int shrinkFlags) {
   std::lock_guard<std::mutex> lock(api_mutex_);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
   return ncclCommShrink(
       comm, excludeRanksList, excludeRanksCount, newcomm, config, shrinkFlags);
+#else
+  (void)comm;
+  (void)excludeRanksList;
+  (void)excludeRanksCount;
+  (void)newcomm;
+  (void)config;
+  (void)shrinkFlags;
+  TC_LOG(ERROR) << "RCCL version " << NCCL_VERSION_CODE
+                << " does not support ncclCommShrink API";
+  return ncclInvalidUsage;
+#endif
 }
 
 ncclResult_t DefaultRcclxApi::commGetUniqueId(


### PR DESCRIPTION
Summary:
D103994885 added commShrink, commRevoke, commGrow, and abort() to the rccl/rcclx backends. While every other new fault-tolerance function in the rcclx backend (commRevoke, commGrow, commGetUniqueId) was wrapped in an NCCL_VERSION_CODE guard, commShrink was not. RCCL versions that don't declare ncclCommShrink therefore fail to compile with:

  RcclxApi.cpp:90:10: error: use of undeclared identifier 'ncclCommShrink'; did you mean 'commShrink'?

Wrap the ncclCommShrink call in the same version guard with a graceful fallback (logs an error and returns ncclInvalidUsage), matching the pattern used by the sibling functions.

The guard uses NCCL_VERSION(2, 27, 0) to match the non-AMD rccl backend (RcclApi.cpp), which already gates this same API at 2.27 (ncclCommShrink is a 2.27 API, distinct from the 2.29 revoke/grow APIs).

Reviewed By: liukeOoO

Differential Revision: D107696072


