### PR TITLE
Fix IBGDA put signal and counter fusion

### DIFF
--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -167,7 +168,7 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
 
     // Only rank 0 (sender) runs the batched benchmark
     if (globalRank == 0) {
-      launchIbgdaPutSignalWaitLocalBatch(
+      launchIbgdaPutSignalWaitCounterBatch(
           deviceTransportPtr,
           localBuf,
           remoteBuf,
@@ -337,7 +338,109 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
   }
 };
 
-TEST_F(IbgdaBenchmarkFixture, PutWaitLocal) {
+TEST_F(IbgdaBenchmarkFixture, PutFlush) {
+  // Measures raw RDMA Write latency as put + flush.
+  if (numRanks != 2) {
+    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  auto configs = getFullConfigs();
+
+  std::size_t maxBufferSize = 0;
+  for (const auto& config : configs) {
+    maxBufferSize = std::max(maxBufferSize, config.nBytes);
+  }
+
+  std::vector<IbgdaBenchmarkResult> results;
+
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    MultipeerIbgdaTransport transport(
+        globalRank, numRanks, bootstrap, transportConfig);
+    transport.exchange();
+
+    DeviceBuffer dataBuffer(maxBufferSize);
+    auto localDataBuf =
+        transport.registerBuffer(dataBuffer.get(), maxBufferSize);
+
+    auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
+    int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    P2pIbgdaTransportDevice* deviceTransportPtr =
+        transport.getP2pTransportDevice(peerRank);
+
+    unsigned long long* d_totalCycles;
+    CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
+
+    XLOGF(
+        INFO,
+        "Rank {}: GPU clock rate = {:.2f} GHz",
+        globalRank,
+        clockRateGHz_);
+
+    for (const auto& config : configs) {
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (globalRank == 0) {
+        launchIbgdaPutFlushBatch(
+            deviceTransportPtr,
+            localDataBuf,
+            remoteDataBuf,
+            config.nBytes,
+            kIbgdaBatchIters,
+            d_totalCycles,
+            stream_);
+        CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+
+        unsigned long long totalCycles;
+        CUDA_CHECK_VOID(cudaMemcpy(
+            &totalCycles,
+            d_totalCycles,
+            sizeof(unsigned long long),
+            cudaMemcpyDeviceToHost));
+
+        IbgdaBenchmarkResult result;
+        result.testName = config.name;
+        result.messageSize = config.nBytes;
+        result.latency = cyclesToUs(totalCycles) / kIbgdaBatchIters;
+        result.bandwidth = (config.nBytes / 1e9f) / (result.latency / 1e6f);
+
+        results.push_back(result);
+
+        XLOGF(
+            INFO,
+            "Rank {}: {} - Latency: {:.2f} us, BW: {:.2f} GB/s",
+            globalRank,
+            config.name,
+            result.latency,
+            result.bandwidth);
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    CUDA_CHECK_VOID(cudaFree(d_totalCycles));
+
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  printResultsTable("IBGDA Put+Flush (RDMA Write)", results);
+}
+
+TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
   // Measures raw RDMA Write latency (put + counter wait via companion QP)
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -373,6 +476,11 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitLocal) {
 
     auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
     int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
     // Counter buffer (local only — companion QP atomically increments via
@@ -407,7 +515,7 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitLocal) {
 
       // Only rank 0 sends
       if (globalRank == 0) {
-        launchIbgdaPutWaitLocalBatch(
+        launchIbgdaPutWaitCounterBatch(
             deviceTransportPtr,
             localDataBuf,
             remoteDataBuf,
@@ -452,10 +560,10 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitLocal) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();
   }
 
-  printResultsTable("IBGDA Put+WaitLocal (RDMA Write)", results);
+  printResultsTable("IBGDA Put+WaitCounter (RDMA Write)", results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, PutSignalWaitLocal) {
+TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
   // Measures RDMA Write + atomic signal latency (put + signal + counter wait)
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -492,6 +600,11 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitLocal) {
 
     auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
     int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
     // Allocate and exchange signal buffer (1 signal slot)
@@ -534,7 +647,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitLocal) {
 
       // Only rank 0 sends
       if (globalRank == 0) {
-        launchIbgdaPutSignalWaitLocalBatch(
+        launchIbgdaPutSignalWaitCounterBatch(
             deviceTransportPtr,
             localDataBuf,
             remoteDataBuf,
@@ -582,7 +695,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitLocal) {
   }
 
   printResultsTable(
-      "IBGDA Put+Signal+WaitLocal (RDMA Write + Atomic)", results);
+      "IBGDA Put+Signal+WaitCounter (RDMA Write + Atomic)", results);
 }
 
 TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
@@ -723,6 +836,11 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
         transport.registerBuffer(dataBuffer.get(), maxBufferSize);
     auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
     int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
     // Allocate and exchange signal buffer (1 signal slot)

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -27,7 +27,7 @@ constexpr int kMaxPeers = 128;
 // Each kernel does exactly one put + signal + counter, then waits on the
 // local counter slot. No warmup, no loop.
 
-__global__ void ibgdaPutSignalWaitLocalKernel(
+__global__ void ibgdaPutSignalWaitCounterKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
@@ -58,7 +58,7 @@ __global__ void ibgdaPutSignalWaitLocalKernel(
 // kernel launch to exclude kernel launch overhead and use GPU cycle counters
 // for accurate timing.
 
-__global__ void ibgdaPutWaitLocalBatchKernel(
+__global__ void ibgdaPutWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
@@ -111,7 +111,33 @@ __global__ void ibgdaPutWaitLocalBatchKernel(
   }
 }
 
-__global__ void ibgdaPutSignalWaitLocalBatchKernel(
+__global__ void ibgdaPutFlushBatchKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles) {
+  auto group = make_block_group();
+  if (group.is_global_leader()) {
+    for (int i = 0; i < 10; i++) {
+      transport->put(localBuf, remoteBuf, nbytes);
+      transport->flush();
+    }
+
+    unsigned long long startCycle = BENCHMARK_CLOCK64();
+
+    for (int i = 0; i < numIters; i++) {
+      transport->put(localBuf, remoteBuf, nbytes);
+      transport->flush();
+    }
+
+    unsigned long long endCycle = BENCHMARK_CLOCK64();
+    *totalCycles = endCycle - startCycle;
+  }
+}
+
+__global__ void ibgdaPutSignalWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
@@ -352,7 +378,7 @@ void launchIbgdaPutSignalSingle(
     const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     cudaStream_t stream) {
-  ibgdaPutSignalWaitLocalKernel<<<1, 32, 0, stream>>>(
+  ibgdaPutSignalWaitCounterKernel<<<1, 32, 0, stream>>>(
       transport,
       localBuf,
       remoteBuf,
@@ -370,7 +396,7 @@ void launchIbgdaPutSignalSingle(
 
 // Batched launchers for performance measurement
 
-void launchIbgdaPutWaitLocalBatch(
+void launchIbgdaPutWaitCounterBatch(
     P2pIbgdaTransportDevice* transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
@@ -380,7 +406,7 @@ void launchIbgdaPutWaitLocalBatch(
     int numIters,
     unsigned long long* totalCycles,
     cudaStream_t stream) {
-  ibgdaPutWaitLocalBatchKernel<<<1, 32, 0, stream>>>(
+  ibgdaPutWaitCounterBatchKernel<<<1, 32, 0, stream>>>(
       transport,
       localBuf,
       remoteBuf,
@@ -391,7 +417,24 @@ void launchIbgdaPutWaitLocalBatch(
       totalCycles);
 }
 
-void launchIbgdaPutSignalWaitLocalBatch(
+void launchIbgdaPutFlushBatch(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream) {
+  ibgdaPutFlushBatchKernel<<<1, 32, 0, stream>>>(
+      transport, localBuf, remoteBuf, nbytes, numIters, totalCycles);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void launchIbgdaPutSignalWaitCounterBatch(
     P2pIbgdaTransportDevice* transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
@@ -403,7 +446,7 @@ void launchIbgdaPutSignalWaitLocalBatch(
     int numIters,
     unsigned long long* totalCycles,
     cudaStream_t stream) {
-  ibgdaPutSignalWaitLocalBatchKernel<<<1, 32, 0, stream>>>(
+  ibgdaPutSignalWaitCounterBatchKernel<<<1, 32, 0, stream>>>(
       transport,
       localBuf,
       remoteBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.cuh
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cuh
@@ -15,7 +15,7 @@ namespace comms::prims::benchmark {
 
 // Internal kernel declarations - only visible to CUDA compilation units
 
-__global__ void ibgdaPutSignalWaitLocalKernel(
+__global__ void ibgdaPutSignalWaitCounterKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
@@ -25,13 +25,13 @@ __global__ void ibgdaPutSignalWaitLocalKernel(
     IbgdaLocalBuffer localCounterBuf,
     int counterId);
 
-__global__ void ibgdaPutWaitLocalKernel(
+__global__ void ibgdaPutWaitCounterKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes);
 
-__global__ void ibgdaPutWaitLocalBatchKernel(
+__global__ void ibgdaPutWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
@@ -41,7 +41,15 @@ __global__ void ibgdaPutWaitLocalBatchKernel(
     int numIters,
     unsigned long long* totalCycles);
 
-__global__ void ibgdaPutSignalWaitLocalBatchKernel(
+__global__ void ibgdaPutFlushBatchKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytes,
+    int numIters,
+    unsigned long long* totalCycles);
+
+__global__ void ibgdaPutSignalWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -42,13 +42,30 @@ void launchIbgdaPutSignalSingle(
  *
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
-void launchIbgdaPutWaitLocalBatch(
+void launchIbgdaPutWaitCounterBatch(
     P2pIbgdaTransportDevice* transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
     const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
+    int numIters,
+    unsigned long long* totalCycles,
+    cudaStream_t stream);
+
+/**
+ * Launch batched kernel: Multiple put + flush iterations
+ *
+ * Measures raw RDMA write completion through flush(), matching the NCCL GIN
+ * put latency benchmark shape.
+ *
+ * @param totalCycles Output: total GPU cycles for numIters operations
+ */
+void launchIbgdaPutFlushBatch(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
     int numIters,
     unsigned long long* totalCycles,
     cudaStream_t stream);
@@ -61,7 +78,7 @@ void launchIbgdaPutWaitLocalBatch(
  *
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
-void launchIbgdaPutSignalWaitLocalBatch(
+void launchIbgdaPutSignalWaitCounterBatch(
     P2pIbgdaTransportDevice* transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -76,7 +76,6 @@ struct PeerBufferPayload {
   IbgdaBufferExchInfo recvStaging;
   IbgdaBufferExchInfo srSignal;
   IbgdaBufferExchInfo slotSignal;
-  IbgdaBufferExchInfo slotDiscard;
 };
 
 struct PeerBufferSizes {
@@ -86,7 +85,6 @@ struct PeerBufferSizes {
   std::size_t srState{0};
   std::size_t slotSignal{0};
   std::size_t slotCounter{0};
-  std::size_t slotDiscard{0};
 
   // Pointers into a contiguous allocation (set by layout())
   void* sendStagingPtr{nullptr};
@@ -96,11 +94,10 @@ struct PeerBufferSizes {
   void* srStatePtr{nullptr};
   void* slotSignalPtr{nullptr};
   void* slotCounterPtr{nullptr};
-  void* slotDiscardPtr{nullptr};
 
   std::size_t total() const {
     return staging * 2 + srSignal + srCounter + srState + slotSignal +
-        slotCounter + slotDiscard;
+        slotCounter;
   }
 
   void layout(void* base) {
@@ -118,8 +115,6 @@ struct PeerBufferSizes {
     slotSignalPtr = p;
     p += slotSignal;
     slotCounterPtr = p;
-    p += slotCounter;
-    slotDiscardPtr = p;
   }
 };
 
@@ -804,7 +799,6 @@ PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
       static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
   sizes.slotCounter =
       static_cast<std::size_t>(config_.numCounterSlots) * sizeof(uint64_t);
-  sizes.slotDiscard = (config_.numCounterSlots > 0) ? sizeof(uint64_t) : 0;
   return sizes;
 }
 
@@ -863,7 +857,6 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   }
   if (config_.numCounterSlots > 0) {
     params.counterBuf = counterViews_[peerIndex];
-    params.discardSignalSlot = discardSignalRemoteViews_[peerIndex];
     params.numCounterSlots = config_.numCounterSlots;
   }
   return params;
@@ -984,7 +977,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
       signalRemoteViews_.resize(numPeers);
       signalLocalViews_.resize(numPeers);
       counterViews_.resize(numPeers);
-      discardSignalRemoteViews_.resize(numPeers);
       lazyPeerBufs_.resize(numPeers);
       peerMaterialized_.resize(numPeers, false);
     }
@@ -1045,8 +1037,8 @@ void MultipeerIbgdaTransport::cleanup() {
 
   // Deregister and free transport-owned signal/counter buffers.
   // MRs must be deregistered BEFORE freeing (correct RDMA teardown order).
-  // On AMD: signal/discard inboxes are host-pinned (NIC-accessible);
-  // counter is GPU device memory (sender-local, no NIC access).
+  // On AMD: signal inboxes are host-pinned (NIC-accessible); counter is GPU
+  // device memory (sender-local, no NIC access).
   if (signalInboxGpu_ != nullptr) {
     deregisterBuffer(signalInboxGpu_);
 #ifdef __HIP_PLATFORM_AMD__
@@ -1069,17 +1061,6 @@ void MultipeerIbgdaTransport::cleanup() {
     counterGpu_ = nullptr;
   }
   counterViews_.clear();
-
-  if (discardSignalGpu_ != nullptr) {
-    deregisterBuffer(discardSignalGpu_);
-#ifdef __HIP_PLATFORM_AMD__
-    hipHostFree(discardSignalGpu_);
-#else
-    cudaFree(discardSignalGpu_);
-#endif
-    discardSignalGpu_ = nullptr;
-  }
-  discardSignalRemoteViews_.clear();
 
   // Destroy user buffer MRs
   for (auto& [_, cached] : registeredBuffers_) {
@@ -1420,63 +1401,6 @@ void MultipeerIbgdaTransport::exchange() {
     VLOG(1) << "MultipeerIbgdaTransport: allocated counter buffer "
             << totalCounterBytes << " bytes (" << config_.numCounterSlots
             << " slots/peer, " << numPeers << " peers)";
-  }
-
-  // ---- Allocate transport-owned discard-signal buffer (if counter used) ----
-  //
-  // The discard-signal buffer exists solely so that counter-only puts can be
-  // routed through the async signal_counter compound (see
-  // P2pIbgdaTransportDevice::put_impl). DOCA verbs has no "counter-only"
-  // primitive: signal_counter posts the counter atomic on the companion QP
-  // ordered against a FENCEd signal on the primary QP. To use it without a
-  // real signal recipient, we need a remote-addressable uint64_t to act as
-  // the signal target — peers never read these slots, so the value is
-  // garbage by design.
-  //
-  // Layout: numPeers slots, one per peer that may write to us. Each rank
-  // exchanges the buffer addr/rkey; per-peer remote view points to *our*
-  // slot in the peer's discard buffer (offset = myPeerIndexOnPeer).
-  if (config_.numCounterSlots > 0) {
-    const std::size_t totalDiscardBytes =
-        static_cast<std::size_t>(numPeers) * sizeof(uint64_t);
-
-#ifdef __HIP_PLATFORM_AMD__
-    // See signal-inbox AMD branch above — same host-pinned rationale.
-    hipError_t hipErr = hipHostMalloc(
-        &discardSignalGpu_, totalDiscardBytes, hipHostMallocDefault);
-    if (hipErr != hipSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate discard-signal buffer (host-pinned): " +
-          std::string(hipGetErrorString(hipErr)));
-    }
-    std::memset(discardSignalGpu_, 0, totalDiscardBytes);
-#else
-    cudaError_t cudaErr = cudaMalloc(&discardSignalGpu_, totalDiscardBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate discard-signal buffer: " +
-          std::string(cudaGetErrorString(cudaErr)));
-    }
-    cudaErr = cudaMemset(discardSignalGpu_, 0, totalDiscardBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error("Failed to zero discard-signal buffer");
-    }
-#endif
-
-    auto localDiscardBuf = registerBuffer(discardSignalGpu_, totalDiscardBytes);
-    auto remoteDiscardBufs = exchangeBuffer(localDiscardBuf);
-
-    discardSignalRemoteViews_.resize(numPeers);
-    for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-      int peerRank = peerIndexToRank(peerIndex);
-      int myPeerIndexOnPeer = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
-      discardSignalRemoteViews_[peerIndex] =
-          remoteDiscardBufs[peerIndex].subBuffer(
-              static_cast<std::size_t>(myPeerIndexOnPeer) * sizeof(uint64_t));
-    }
-
-    VLOG(1) << "MultipeerIbgdaTransport: allocated discard-signal buffer "
-            << totalDiscardBytes << " bytes (" << numPeers << " peers)";
   }
 
   exchange_send_recv_buffers();
@@ -2055,11 +1979,6 @@ void MultipeerIbgdaTransport::allocatePeerBuffers(
   if (config_.numCounterSlots > 0) {
     counterViews_[peerIndex] =
         IbgdaLocalBuffer(sizes.slotCounterPtr, reg.lkey_per_device);
-    payload.slotDiscard.addr = reinterpret_cast<uint64_t>(sizes.slotDiscardPtr);
-    payload.slotDiscard.numNics = numNics_;
-    for (int n = 0; n < numNics_; ++n) {
-      payload.slotDiscard.rkey_per_device[n] = HostRKey(mr.mrs[n]->rkey);
-    }
   }
 }
 
@@ -2169,10 +2088,6 @@ void MultipeerIbgdaTransport::applyRemoteViews(
   }
   if (config_.numSignalSlots > 0) {
     signalRemoteViews_[peerIndex] = remotePayload.slotSignal.toRemoteBuffer();
-  }
-  if (config_.numCounterSlots > 0) {
-    discardSignalRemoteViews_[peerIndex] =
-        remotePayload.slotDiscard.toRemoteBuffer();
   }
 }
 

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -630,16 +630,14 @@ class MultipeerIbgdaTransport {
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Slot-index signal/counter/discard buffers.
+  // Slot-index signal/counter buffers.
   // Eager mode: bulk-allocated in exchange(). Null in lazy mode.
   void* signalInboxGpu_{nullptr};
   void* counterGpu_{nullptr};
-  void* discardSignalGpu_{nullptr};
-  // Per-peer views into signal/counter/discard (populated by both modes).
+  // Per-peer views into signal/counter (populated by both modes).
   std::vector<IbgdaRemoteBuffer> signalRemoteViews_;
   std::vector<IbgdaLocalBuffer> signalLocalViews_;
   std::vector<IbgdaLocalBuffer> counterViews_;
-  std::vector<IbgdaRemoteBuffer> discardSignalRemoteViews_;
 
   // Per-peer send/recv buffer views (populated by both modes).
   struct SendRecvPeerBuffers {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -125,7 +125,6 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         params[i].counterBuf,
         params[i].numSignalSlots,
         params[i].numCounterSlots,
-        params[i].discardSignalSlot,
         params[i].sendRecvState);
   }
 
@@ -211,7 +210,6 @@ void writeDeviceTransportSlot(
       params.counterBuf,
       params.numSignalSlots,
       params.numCounterSlots,
-      params.discardSignalSlot,
       params.sendRecvState);
 
   err = cudaMemcpy(

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -64,7 +64,6 @@ struct P2pIbgdaTransportBuildParams {
   IbgdaRemoteBuffer remoteSignalBuf{};
   IbgdaLocalBuffer localSignalBuf{};
   IbgdaLocalBuffer counterBuf{};
-  IbgdaRemoteBuffer discardSignalSlot{};
   int numSignalSlots{0};
   int numCounterSlots{0};
   IbSendRecvState sendRecvState{};

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -176,11 +176,6 @@ class P2pIbgdaTransportDevice {
    * @param numCounterSlots       Number of uint64_t slots in the owned
    *                              counter buffer. Zero disables the
    *                              slot-index counter API.
-   * @param discardSignalSlot     Remote uint64_t slot used as a "throwaway"
-   *                              signal target for counter-only puts (see
-   *                              put_impl for rationale). The peer never
-   *                              reads this slot. Required when counter is
-   *                              used; ignored otherwise.
    * @param sendRecvState         Optional pipelined send/recv protocol state.
    *                              When empty, send()/recv() are unavailable.
    */
@@ -191,13 +186,11 @@ class P2pIbgdaTransportDevice {
       IbgdaLocalBuffer ownedCounterBuf = {},
       int numSignalSlots = 0,
       int numCounterSlots = 0,
-      IbgdaRemoteBuffer discardSignalSlot = {},
       IbSendRecvState sendRecvState = {})
       : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
         ownedCounterBuf_(ownedCounterBuf),
-        discardSignalSlot_(discardSignalSlot),
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
         sendRecvState_(sendRecvState) {}
@@ -468,9 +461,8 @@ class P2pIbgdaTransportDevice {
    *                   the signal arrives after the put completes at the NIC.
    * @param signalVal  Value added to *signalBuf (atomic FA).
    * @param counterBuf Pre-resolved local counter slot. ptr==nullptr disables
-   *                   the counter. With signalBuf set: companion-QP loopback
-   *                   atomic. Counter-only uses a discard signal target plus
-   *                   the same companion-QP loopback counter.
+   *                   the counter. With a put, the counter waits for the put
+   *                   WQE through the companion QP.
    * @param counterVal Value added to *counterBuf.
    */
   __device__ void put(
@@ -756,43 +748,6 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
-  __device__ void finish_put_impl(
-      ThreadGroup& group,
-      const IbgdaRemoteBuffer& signalBuf,
-      uint64_t signalVal,
-      const IbgdaLocalBuffer& counterBuf,
-      uint64_t counterVal) {
-    const bool hasSignal = signalBuf.ptr != nullptr;
-    const bool hasCounter = counterBuf.ptr != nullptr;
-
-    // The DOCA verbs API exposes:
-    //   - signal_fenced (atomic FA, FENCEd against prior put)
-    //   - signal_counter (signal_fenced on primary QP + companion-QP loopback
-    //     atomic for the local counter, both ordered against prior put)
-    //
-    // It does NOT expose a "counter-only" primitive. To keep put() async and
-    // ordered for the counter-only case, we route through signal_counter with
-    // a transport-owned discard slot as the signal target — the peer never
-    // reads it, so the signal value is garbage by design.
-    //
-    // The discard-slot trick lets every put_impl branch be a single async
-    // WQE post; the alternative (flush_impl + GPU atomicAdd) would silently
-    // make counter-only puts synchronous and add a CQ-poll round-trip on
-    // the hot path.
-    if (group.is_leader()) {
-      if (hasSignal && hasCounter) {
-        signal_counter(
-            group.group_id, signalBuf, signalVal, counterBuf, counterVal);
-      } else if (hasSignal) {
-        signal_fenced(group.group_id, signalBuf, signalVal);
-      } else if (hasCounter) {
-        signal_counter(
-            group.group_id, discardSignalSlot_, 0, counterBuf, counterVal);
-      }
-    }
-    group.sync();
-  }
-
   __device__ void put_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
@@ -802,11 +757,46 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
-    if (group.is_leader() && nbytes > 0) {
-      put_single_impl(group.group_id, localBuf, remoteBuf, nbytes);
+    const bool hasSignal = signalBuf.ptr != nullptr;
+    if (nbytes == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: zero-byte IBGDA put is unsupported. "
+            "Use signal() for no-data signaling.\n");
+        PIPES_DEVICE_TRAP();
+      }
+      group.sync();
+      return;
+    }
+
+    if (group.is_leader()) {
+      const bool hasCounter = counterBuf.ptr != nullptr;
+      if (hasSignal && hasCounter) {
+        put_signal_counter_single_impl(
+            group.group_id,
+            localBuf,
+            remoteBuf,
+            nbytes,
+            signalBuf,
+            signalVal,
+            counterBuf,
+            counterVal);
+      } else if (hasSignal) {
+        put_signal_single_impl(
+            group.group_id, localBuf, remoteBuf, nbytes, signalBuf, signalVal);
+      } else if (hasCounter) {
+        put_counter_single_impl(
+            group.group_id,
+            localBuf,
+            remoteBuf,
+            nbytes,
+            counterBuf,
+            counterVal);
+      } else {
+        put_single_impl(group.group_id, localBuf, remoteBuf, nbytes);
+      }
     }
     group.sync();
-    finish_put_impl(group, signalBuf, signalVal, counterBuf, counterVal);
   }
 
   __device__ void put_cooperative_impl(
@@ -818,8 +808,31 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
-    put_cooperative_data_impl(group, localBuf, remoteBuf, nbytes);
-    finish_put_impl(group, signalBuf, signalVal, counterBuf, counterVal);
+    const bool hasSignal = signalBuf.ptr != nullptr;
+    if (nbytes == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: zero-byte IBGDA put_cooperative is unsupported. "
+            "Use signal() for no-data signaling.\n");
+        PIPES_DEVICE_TRAP();
+      }
+      group.sync();
+      return;
+    }
+
+    const uint64_t lastPutWqeIdx =
+        put_cooperative_data_impl(group, localBuf, remoteBuf, nbytes);
+    if (group.is_leader()) {
+      const bool hasCounter = counterBuf.ptr != nullptr;
+      if (hasSignal) {
+        signal_fenced(group.group_id, signalBuf, signalVal);
+      }
+      if (hasCounter) {
+        counter_after_wqe_impl(
+            group.group_id, lastPutWqeIdx, counterBuf, counterVal);
+      }
+    }
+    group.sync();
   }
 
   // --- wait_signal_impl ---
@@ -893,16 +906,11 @@ class P2pIbgdaTransportDevice {
 
   // --- put_cooperative_data_impl: group-collaborative WQE construction ---
 
-  __device__ void put_cooperative_data_impl(
+  __device__ uint64_t put_cooperative_data_impl(
       ThreadGroup& group,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes) {
-    if (nbytes == 0) {
-      group.sync();
-      return;
-    }
-
     std::size_t chunkSize = nbytes / group.group_size;
     std::size_t offset = group.thread_id_in_group * chunkSize;
     std::size_t laneBytes = (group.thread_id_in_group == group.group_size - 1)
@@ -911,11 +919,6 @@ class P2pIbgdaTransportDevice {
 
     IbgdaLocalBuffer laneBuf = localBuf.subBuffer(offset);
     IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
-
-    if (group.group_size == 1) {
-      put_single_impl(group.group_id, laneBuf, laneRemoteBuf, laneBytes);
-      return;
-    }
 
     auto idx = nic_qp_for_group(group.group_id);
     const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
@@ -976,6 +979,8 @@ class P2pIbgdaTransportDevice {
     }
 
     group.sync();
+
+    return base_wqe_idx + group.group_size - 1;
   }
 
   // --- put_single_impl: one thread, one WQE ---
@@ -1000,6 +1005,353 @@ class P2pIbgdaTransportDevice {
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
         nic.qps[idx.qp_id], remoteAddr, localAddr, nbytes, &ticket);
+  }
+
+  __device__ void put_signal_single_impl(
+      uint32_t group_id,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal) {
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
+        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+
+#ifdef __HIP_PLATFORM_AMD__
+    pipes_gda::ActiveNicBackend amdNic{};
+    uint64_t ticket = 0;
+    pipes_gda::pipes_gda_gpu_dev_verbs_put_signal(
+        amdNic,
+        nic.qps[idx.qp_id],
+        remoteAddr,
+        localAddr,
+        nbytes,
+        sigRemoteAddr,
+        sigSinkAddr,
+        signalVal,
+        &ticket);
+#else
+    doca_gpu_dev_verbs_put_signal<
+        DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
+        nic.qps[idx.qp_id],
+        remoteAddr,
+        localAddr,
+        nbytes,
+        sigRemoteAddr,
+        sigSinkAddr,
+        signalVal);
+#endif
+  }
+
+  __device__ void put_counter_single_impl(
+      uint32_t group_id,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t counterVal) {
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
+        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+
+#ifdef __HIP_PLATFORM_AMD__
+    // AMD: route data + local counter through put_signal_counter with the
+    // signal disabled (sigRemoteAddr.addr == 0 short-circuits the atomic-FA
+    // WQE in pipes_gda_gpu_dev_verbs_put_signal_counter).
+    doca_gpu_dev_verbs_addr noSigRemoteAddr = {.addr = 0, .key = 0};
+    doca_gpu_dev_verbs_addr noSigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+    pipes_gda::ActiveNicBackend amdNic{};
+    pipes_gda::pipes_gda_gpu_dev_verbs_put_signal_counter(
+        amdNic,
+        nic.qps[idx.qp_id],
+        remoteAddr,
+        localAddr,
+        nbytes,
+        noSigRemoteAddr,
+        noSigSinkAddr,
+        0,
+        nic.companion_qps[idx.qp_id],
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+#else
+    doca_gpu_dev_verbs_put_counter<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
+        nic.qps[idx.qp_id],
+        remoteAddr,
+        localAddr,
+        nbytes,
+        nic.companion_qps[idx.qp_id],
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+#endif
+  }
+
+  __device__ void put_signal_counter_single_impl(
+      uint32_t group_id,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal,
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t counterVal) {
+#ifdef __HIP_PLATFORM_AMD__
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
+        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+    doca_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
+        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+    pipes_gda::ActiveNicBackend amdNic{};
+    pipes_gda::pipes_gda_gpu_dev_verbs_put_signal_counter(
+        amdNic,
+        nic.qps[idx.qp_id],
+        remoteAddr,
+        localAddr,
+        nbytes,
+        sigRemoteAddr,
+        sigSinkAddr,
+        signalVal,
+        nic.companion_qps[idx.qp_id],
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+#else
+    constexpr unsigned int kNumQps = 2;
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
+    doca_gpu_dev_verbs_qp* companionQp = nic.companion_qps[idx.qp_id];
+
+    doca_gpu_dev_verbs_addr localAddr = {
+        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
+        .key = localBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr remoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
+        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
+        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr sigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+    doca_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
+        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+
+    uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
+        nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+    numChunks = numChunks > 1 ? numChunks : 1;
+    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks + 1);
+    uint64_t wqeIdx = baseWqeIdx;
+    std::size_t remainingSize = nbytes;
+
+#pragma unroll 1
+    for (uint64_t i = 0; i < numChunks; ++i) {
+      wqeIdx = baseWqeIdx + i;
+      const std::size_t chunkSize =
+          remainingSize > DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          ? DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          : remainingSize;
+      doca_gpu_dev_verbs_wqe* wqePtr =
+          doca_gpu_dev_verbs_get_wqe_ptr(qp, wqeIdx);
+      [[likely]] if (chunkSize > 0) {
+        doca_gpu_dev_verbs_wqe_prepare_write(
+            qp,
+            wqePtr,
+            wqeIdx,
+            DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+            DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+            0,
+            remoteAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+            remoteAddr.key,
+            localAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+            localAddr.key,
+            chunkSize);
+      } else {
+        doca_gpu_dev_verbs_wqe_prepare_nop(
+            qp, wqePtr, wqeIdx, DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE);
+      }
+      remainingSize -= chunkSize;
+    }
+    const uint64_t lastPutWqeIdx = wqeIdx;
+
+    ++wqeIdx;
+    doca_gpu_dev_verbs_wqe* wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(qp, wqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_atomic(
+        qp,
+        wqePtr,
+        wqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_OPCODE_ATOMIC_FA,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        sigRemoteAddr.addr,
+        sigRemoteAddr.key,
+        sigSinkAddr.addr,
+        sigSinkAddr.key,
+        sizeof(uint64_t),
+        signalVal,
+        0);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, baseWqeIdx, wqeIdx);
+
+    uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t companionWqeIdx = companionBaseWqeIdx;
+    wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_wait(
+        companionQp,
+        wqePtr,
+        companionWqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        lastPutWqeIdx,
+        qp->cq_sq.cq_num);
+
+    ++companionWqeIdx;
+    wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_atomic(
+        companionQp,
+        wqePtr,
+        companionWqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_OPCODE_ATOMIC_FA,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        counterRemoteAddr.addr,
+        counterRemoteAddr.key,
+        counterSinkAddr.addr,
+        counterSinkAddr.key,
+        sizeof(uint64_t),
+        counterVal,
+        0);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        companionQp, companionBaseWqeIdx, companionWqeIdx);
+
+    doca_gpu_dev_verbs_qp* qps[kNumQps] = {qp, companionQp};
+    uint64_t prodIndices[kNumQps] = {wqeIdx + 1, companionWqeIdx + 1};
+    doca_gpu_dev_verbs_submit_multi_qps<
+        kNumQps,
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
+#endif
+  }
+
+  __device__ void counter_after_wqe_impl(
+      uint32_t group_id,
+      uint64_t waitWqeIdx,
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t counterVal) {
+    auto idx = nic_qp_for_group(group_id);
+    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
+    doca_gpu_dev_verbs_qp* companionQp = nic.companion_qps[idx.qp_id];
+
+    doca_gpu_dev_verbs_addr counterRemoteAddr = {
+        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
+        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+    doca_gpu_dev_verbs_addr counterSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+
+#ifdef __HIP_PLATFORM_AMD__
+    // AMD: pipes_gda doesn't expose inter-QP wait WQEs at the public API,
+    // and signal_counter waits on mainQp's last reserved WQE — which is
+    // exactly the most recent put issued before this call. Routing through
+    // signal_counter with sig disabled (sigRemoteAddr.addr == 0) gives us
+    // the same "wait on previous put + atomic counter" semantics.
+    (void)waitWqeIdx;
+    (void)qp;
+    doca_gpu_dev_verbs_addr noSigRemoteAddr = {.addr = 0, .key = 0};
+    doca_gpu_dev_verbs_addr noSigSinkAddr = {
+        .addr = 0, .key = nic.sink_lkey.value};
+    pipes_gda::ActiveNicBackend amdNic{};
+    pipes_gda::pipes_gda_gpu_dev_verbs_signal_counter(
+        amdNic,
+        nic.qps[idx.qp_id],
+        noSigRemoteAddr,
+        noSigSinkAddr,
+        0,
+        companionQp,
+        counterRemoteAddr,
+        counterSinkAddr,
+        counterVal);
+#else
+    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t wqeIdx = baseWqeIdx;
+    doca_gpu_dev_verbs_wqe* wqePtr =
+        doca_gpu_dev_verbs_get_wqe_ptr(companionQp, wqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_wait(
+        companionQp,
+        wqePtr,
+        wqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        waitWqeIdx,
+        qp->cq_sq.cq_num);
+
+    ++wqeIdx;
+    wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, wqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_atomic(
+        companionQp,
+        wqePtr,
+        wqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_OPCODE_ATOMIC_FA,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        counterRemoteAddr.addr,
+        counterRemoteAddr.key,
+        counterSinkAddr.addr,
+        counterSinkAddr.key,
+        sizeof(uint64_t),
+        counterVal,
+        0);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        companionQp, baseWqeIdx, wqeIdx);
+    doca_gpu_dev_verbs_submit<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(companionQp, wqeIdx + 1);
+#endif
   }
 
   // --- signal_fenced: atomic fetch-add with NIC FENCE (always fenced) ---
@@ -2847,8 +3199,6 @@ class P2pIbgdaTransportDevice {
   IbgdaRemoteBuffer ownedRemoteSignalBuf_{}; // outbox: signal peer's inbox
   IbgdaLocalBuffer ownedLocalSignalBuf_{}; // inbox: receive signals from peers
   IbgdaLocalBuffer ownedCounterBuf_{}; // local counter for companion QP
-
-  IbgdaRemoteBuffer discardSignalSlot_{};
 
   int numSignalSlots_{0};
   int numCounterSlots_{0};


### PR DESCRIPTION
Summary:
- Route `put` + `signal` through the fused DOCA verb path so the write and remote atomic are posted together instead of as separate operations.
- Add an IBGDA `put_signal_counter_single_impl` helper that keeps the signal fused with the write while making the local counter wait on the RDMA write WQE, matching the `put_counter` ordering semantics.
- Use `put_counter` for `put` + `counter`, reject zero-byte IBGDA puts, and direct no-data signaling callers to `signal()`.
- Remove `finish_put_impl`; cooperative puts now return the last posted data WQE and use a companion-QP counter helper so cooperative `put` + `counter` waits on the put.
- Remove the unused scratch discard signal slot that was only needed when `put` + `counter` was implemented through `signal_counter`.
- Rename IBGDA benchmark `WaitLocal` labels/functions/tests to `WaitCounter`, matching the `wait_counter` path they measure.
- Add an IBGDA `Put+Flush` benchmark so counter completion can be compared against the existing flush-based completion path.

Reviewed By: siyengar, saifhhasan

Differential Revision: D107699848


