### PR TITLE
Use _exit() in forked test children to avoid folly singleton shutdown hang

### DIFF
--- a/comms/rcclx/develop/projects/rccl/test/common/CallCollectiveForked.cpp
+++ b/comms/rcclx/develop/projects/rccl/test/common/CallCollectiveForked.cpp
@@ -8,6 +8,7 @@
 #include "CollectiveArgs.hpp"
 #include <rccl/rccl.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 
 #define HIPCALL(cmd)                                                                          \
     do {                                                                                      \
@@ -68,7 +69,7 @@ void callCollective(ncclUniqueId id, int collID, int rank, int nranks, const std
         sendSize = send.size();
         recvSize = nranks*send.size();
         break;
-      default: exit(0);
+      default: _exit(0);
     }
 
     if(!use_managed_mem){
@@ -93,7 +94,7 @@ void callCollective(ncclUniqueId id, int collID, int rank, int nranks, const std
       case ncclCollAllGather:
         NCCLCHECK(ncclAllGather(sendbuff, recvbuff, sendSize, ncclInt, comm, stream));
         break;
-      default: exit(0);
+      default: _exit(0);
     }
 
     HIPCALL(hipStreamSynchronize(stream));
@@ -145,7 +146,10 @@ void callCollectiveForked(int nranks,  int collID, const std::vector<int>& sendB
         int ngpus = 0;
         HIPCALL(hipGetDeviceCount(&ngpus));
         if(ngpus != nranks){
-          exit(0);
+          // Forked child of a multithreaded folly binary: _exit() skips atexit
+          // handlers / static destructors that would hang on folly singleton
+          // teardown post-fork and abort after a timeout.
+          _exit(0);
         }
         //child processes
         if(r == 0)
@@ -157,7 +161,7 @@ void callCollectiveForked(int nranks,  int collID, const std::vector<int>& sendB
         for(int i = 0; i < recvBuff.size(); ++i){
           ASSERT_EQ(recvBuff[i], expected[i]);
         }
-        exit(0);
+        _exit(0);
       }
     }
 

--- a/comms/rcclx/develop/projects/rccl/test/common/EnvVars.cpp
+++ b/comms/rcclx/develop/projects/rccl/test/common/EnvVars.cpp
@@ -45,10 +45,13 @@ namespace RcclUnitTesting
           break;
         }
       }
-      if (write(pipefd[1], &isGfxTest, sizeof(isGfxTest)) != sizeof(isGfxTest)) return TEST_FAIL;
+      if (write(pipefd[1], &isGfxTest, sizeof(isGfxTest)) != sizeof(isGfxTest)) _exit(TEST_FAIL);
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      // Forked child of a multithreaded folly binary: must _exit() to skip
+      // atexit handlers / static destructors (folly singleton teardown would
+      // hang on threads that don't exist post-fork and abort after a timeout).
+      _exit(EXIT_SUCCESS);
     }
     else {
       int status;
@@ -75,10 +78,13 @@ namespace RcclUnitTesting
     {
       int dev;
       hipGetDeviceCount(&dev);
-      if (write(pipefd[1], &dev, sizeof(dev)) != sizeof(dev)) return TEST_FAIL;
+      if (write(pipefd[1], &dev, sizeof(dev)) != sizeof(dev)) _exit(TEST_FAIL);
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      // Forked child of a multithreaded folly binary: must _exit() to skip
+      // atexit handlers / static destructors (folly singleton teardown would
+      // hang on threads that don't exist post-fork and abort after a timeout).
+      _exit(EXIT_SUCCESS);
     }
     else
     {
@@ -108,10 +114,13 @@ namespace RcclUnitTesting
       int deviceIdx = 0;
       hipDeviceGetAttribute(&numDeviceCUs, hipDeviceAttributeMultiprocessorCount, deviceIdx);
       if(numDeviceCUs == 20 || numDeviceCUs == 38) isCpxMode = true;
-      if (write(pipefd[1], &isCpxMode, sizeof(isCpxMode)) != sizeof(isCpxMode)) return TEST_FAIL;
+      if (write(pipefd[1], &isCpxMode, sizeof(isCpxMode)) != sizeof(isCpxMode)) _exit(TEST_FAIL);
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      // Forked child of a multithreaded folly binary: must _exit() to skip
+      // atexit handlers / static destructors (folly singleton teardown would
+      // hang on threads that don't exist post-fork and abort after a timeout).
+      _exit(EXIT_SUCCESS);
     }
     else {
       int status;
@@ -173,12 +182,15 @@ namespace RcclUnitTesting
           }
       } catch (const std::exception& e) {
           std::cerr << "Error: " << e.what() << std::endl;
-          return 1;
+          _exit(1);
       }
-      if (write(pipefd[1], result.data(), gpuPriorityOrder->size() * sizeof(int)) != gpuPriorityOrder->size() * sizeof(int)) return TEST_FAIL;
+      if (write(pipefd[1], result.data(), gpuPriorityOrder->size() * sizeof(int)) != gpuPriorityOrder->size() * sizeof(int)) _exit(TEST_FAIL);
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      // Forked child of a multithreaded folly binary: must _exit() to skip
+      // atexit handlers / static destructors (folly singleton teardown would
+      // hang on threads that don't exist post-fork and abort after a timeout).
+      _exit(EXIT_SUCCESS);
     }
     else {
       int status;

--- a/comms/rcclx/develop/projects/rccl/test/common/TestBedChild.cpp
+++ b/comms/rcclx/develop/projects/rccl/test/common/TestBedChild.cpp
@@ -8,6 +8,7 @@
 
 #include <thread>
 #include <execinfo.h>
+#include <unistd.h>
 #ifdef ENABLE_OPENMP
 #include <omp.h>
 #endif
@@ -129,7 +130,7 @@ namespace RcclUnitTesting
       case CHILD_DESTROY_COMMS   : status = DestroyComms();         break;
       case CHILD_DESTROY_GRAPHS  : status = DestroyGraphs();        break;
       case CHILD_STOP            : goto stop;
-      default: exit(0);
+      default: _exit(0);
       }
 
       // Send back acknowledgement to parent
@@ -152,7 +153,10 @@ namespace RcclUnitTesting
     close(this->childReadFd);
     close(this->childWriteFd);
 
-    exit(0);
+    // Forked child of a multithreaded folly binary: _exit() skips atexit
+    // handlers / static destructors that would hang on folly singleton
+    // teardown post-fork and abort after a timeout.
+    _exit(0);
   }
 
   ErrCode TestBedChild::GetUniqueId(std::vector<char>& retValBuf)


### PR DESCRIPTION
Summary:
RCCL unit tests fork child processes to probe HIP device info and to run
multi-process collectives. These children called exit(), which runs the
parent binary's atexit handlers and static destructors. In a forked child
of a multithreaded folly binary only the calling thread survives fork(), so
folly's SingletonVault shutdown waits forever on background threads that no
longer exist. After the 300s watchdog, SingletonVault::fireShutdownTimer()
throws "Failed to complete shutdown within 300000ms" and the child aborts
(SIGABRT). The parent then sees a non-zero waitpid status and trips
assert(!status) in EnvVars.cpp, aborting the whole test.

Fix: forked children now terminate with _exit() (immediate, no atexit
handlers / static destructors) instead of exit(), matching the existing
precedent in common/ProcessIsolatedTestRunner.cpp.

- EnvVars.cpp: device-probe children (getArchInfo, getDeviceCount,
  getDeviceMode, getDevicePriority); also converted in-child error-path
  return statements to _exit() (returning fell through into parent logic).
- TestBedChild.cpp: per-rank child execution loop (multi-process tests).
- CallCollectiveForked.cpp: forked-collective child processes.

Differential Revision: D107716825


