### PR TITLE
Benchmark IBGDA progress send/recv APIs

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -18,6 +18,12 @@ __device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
   return (nbytes + 15ULL) & ~15ULL;
 }
 
+__device__ __forceinline__ std::size_t section_bytes(
+    P2pIbgdaTransportDevice* transport,
+    std::size_t totalBytes) {
+  return min(transport->send_recv_state().dataBufferSize, totalBytes);
+}
+
 __device__ __forceinline__ std::size_t
 protocol_bytes_for_tiled_group_per_launch(
     std::size_t totalBytes,
@@ -59,8 +65,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
 
   // Section size = transport's staging slot size (dataBufferSize).
   // Clamp to totalBytes for small transfers.
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -93,6 +98,85 @@ void launch_ibgda_send_recv(
   if (err != cudaSuccess) {
     printf("[PIPES] Kernel launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (isSender) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
+      transport->init_send_progress(
+          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      while (transport->progress_send_once(
+                 sub,
+                 tiles.data(),
+                 tiles.bytes(),
+                 numBlocks,
+                 maxSignalBytes,
+                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+      }
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
+      transport->init_recv_progress(
+          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      while (transport->progress_recv_once(
+                 sub,
+                 tiles.data(),
+                 tiles.bytes(),
+                 numBlocks,
+                 maxSignalBytes,
+                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+      }
+    }
+  }
+}
+#endif
+
+void launch_ibgda_progress_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)dst;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress send/recv benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] progress sendrecv kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
@@ -184,8 +268,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
     Timeout timeout) {
   auto group = make_block_group();
 
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -204,8 +287,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
     Timeout timeout) {
   auto group = make_block_group();
 
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -333,6 +415,108 @@ void launch_ibgda_reset_send_recv(
   if (err != cudaSuccess) {
     printf("[PIPES] Reset launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    transport->init_send_progress(
+        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    while (transport->progress_send_once(
+               group,
+               tiles.data(),
+               tiles.bytes(),
+               numBlocks,
+               maxSignalBytes,
+               timeout) != IbgdaSendRecvProgressStatus::Done) {
+    }
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    transport->init_recv_progress(
+        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    while (transport->progress_recv_once(
+               group,
+               tiles.data(),
+               tiles.bytes(),
+               numBlocks,
+               maxSignalBytes,
+               timeout) != IbgdaSendRecvProgressStatus::Done) {
+    }
+  }
+}
+#endif
+
+void launch_ibgda_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress send benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+#endif
+}
+
+void launch_ibgda_progress_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)dst;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress recv benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_recv_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+#endif
 }
 
 __global__ void ibgda_snapshot_step_state_kernel(

--- a/comms/prims/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cuh
@@ -29,6 +29,17 @@ __global__ void ibgda_send_recv_kernel(
     std::size_t maxSignalBytes,
     Timeout timeout);
 
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void ibgda_progress_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+#endif
+
 __global__ void ibgda_send_recv_two_call_kernel(
     P2pIbgdaTransportDevice* transport,
     char* src,
@@ -63,5 +74,31 @@ __global__ void ibgda_recv_kernel(
     int numBlocks,
     std::size_t maxSignalBytes,
     Timeout timeout);
+
+#ifndef __HIP_PLATFORM_AMD__
+/**
+ * Unidirectional progress send kernel. All blocks send.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+
+/**
+ * Unidirectional progress recv kernel. All blocks receive.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_progress_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+#endif
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -40,6 +40,22 @@ void launch_ibgda_send_recv(
     Timeout timeout = Timeout());
 
 /**
+ * Launch bidirectional progress-send/recv kernel for IBGDA transport.
+ *
+ * Uses the resumable init/progress API and loops until each initialized
+ * transfer reaches Done.
+ */
+void launch_ibgda_progress_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
  * Launch bidirectional tile sendrecv kernel that performs two back-to-back
  * send()/recv() calls with independent maxSignalBytes values.
  */
@@ -99,6 +115,30 @@ void launch_ibgda_reset_send_recv(
     P2pIbgdaTransportDevice* transport,
     int maxGroups,
     cudaStream_t stream);
+
+/**
+ * Launch unidirectional progress send kernel. All blocks send.
+ */
+void launch_ibgda_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch unidirectional progress recv kernel. All blocks receive.
+ */
+void launch_ibgda_progress_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
 
 /**
  * Snapshot the transport send/recv byte cursors into device memory.

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -48,6 +48,29 @@ constexpr std::array<SendRecvBenchmarkGeometry, 2> kSendRecvBenchmarkGeometries{
     {{1, 2, "activeBlocks=1/maxGroups=2"},
      {2, 2, "activeBlocks=2/maxGroups=2"}}};
 
+enum class SendRecvApi {
+  Blocking,
+  Progress,
+};
+
+const char* sendRecvApiName(SendRecvApi api) {
+  switch (api) {
+    case SendRecvApi::Blocking:
+      return "send/recv";
+    case SendRecvApi::Progress:
+      return "progress";
+  }
+  return "unknown";
+}
+
+std::vector<SendRecvApi> benchmarkApis() {
+  std::vector<SendRecvApi> apis{SendRecvApi::Blocking};
+#ifndef __HIP_PLATFORM_AMD__
+  apis.push_back(SendRecvApi::Progress);
+#endif
+  return apis;
+}
+
 std::string formatMessageSize(std::size_t nbytes) {
   if (nbytes >= (1ULL << 30)) {
     return fmt::format("{}GB", nbytes >> 30);
@@ -235,7 +258,8 @@ class IbgdaSendRecvTest : public BenchmarkTestFixture {
             "================================================================");
         XLOGF(
             INFO,
-            "{:>10s}  {:>10s}  {:>12s}  {:>12s}",
+            "{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}",
+            "API",
             "MsgSize",
             "Sections",
             "BaseMod",
@@ -245,83 +269,106 @@ class IbgdaSendRecvTest : public BenchmarkTestFixture {
             "------------------------------------------------------------");
       }
 
-      for (auto nBytes : messageSizes) {
-        const std::size_t baseMod = 0;
+      for (auto api : benchmarkApis()) {
+        for (auto nBytes : messageSizes) {
+          const std::size_t baseMod = 0;
 
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        bootstrap->barrierAll();
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          bootstrap->barrierAll();
 
-        // Warmup
-        for (int i = 0; i < kWarmupIters; ++i) {
-          launch_ibgda_send_recv(
+          // Warmup
+          for (int i = 0; i < kWarmupIters; ++i) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+            ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+            bootstrap->barrierAll();
+          }
+          launch_ibgda_drain_send_recv(
               deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
               geometry.activeBlocks,
+              nBytes,
+              kWarmupIters,
               stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+
+          bootstrap->barrierAll();
+
+          // Benchmark
+          ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+          for (int i = 0; i < kBenchIters; ++i) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          }
+          launch_ibgda_drain_send_recv(
+              deviceTransport,
+              geometry.activeBlocks,
+              nBytes,
+              kBenchIters,
+              stream_);
+          ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+          ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
+
+          bootstrap->barrierAll();
+
+          float totalMs = 0;
+          ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+          float avgMs = totalMs / kBenchIters;
+
+          float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
+          std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+          if (globalRank == 0) {
+            std::string sizeStr = formatMessageSize(nBytes);
+            XLOGF(
+                INFO,
+                "{:>10s}  {:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
+                sendRecvApiName(api),
+                sizeStr,
+                numSections,
+                baseMod,
+                bwGBs);
+          }
+
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
           ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
           bootstrap->barrierAll();
         }
-        launch_ibgda_drain_send_recv(
-            deviceTransport,
-            geometry.activeBlocks,
-            nBytes,
-            kWarmupIters,
-            stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-
-        bootstrap->barrierAll();
-
-        // Benchmark
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-        for (int i = 0; i < kBenchIters; ++i) {
-          launch_ibgda_send_recv(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        }
-        launch_ibgda_drain_send_recv(
-            deviceTransport,
-            geometry.activeBlocks,
-            nBytes,
-            kBenchIters,
-            stream_);
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
-
-        bootstrap->barrierAll();
-
-        float totalMs = 0;
-        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-        float avgMs = totalMs / kBenchIters;
-
-        float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
-        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
-
-        if (globalRank == 0) {
-          std::string sizeStr = formatMessageSize(nBytes);
-          XLOGF(
-              INFO,
-              "{:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
-              sizeStr,
-              numSections,
-              baseMod,
-              bwGBs);
-        }
-
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        bootstrap->barrierAll();
       }
 
       if (globalRank == 0) {
@@ -809,74 +856,115 @@ TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
           "================================================================");
       XLOGF(
           INFO,
-          "{:>10s}  {:>10s}  {:>12s}",
+          "{:>10s}  {:>10s}  {:>10s}  {:>12s}",
+          "API",
           "MsgSize",
           "Sections",
           "BW (GB/s)");
       XLOGF(INFO, "----------------------------------------------");
     }
 
-    for (auto nBytes : messageSizes) {
-      bootstrap->barrierAll();
-
-      // Warmup
-      for (int i = 0; i < kWarmupIters; ++i) {
-        if (globalRank == 0) {
-          launch_ibgda_send(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        } else {
-          launch_ibgda_recv(
-              deviceTransport,
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        }
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+    for (auto api : benchmarkApis()) {
+      for (auto nBytes : messageSizes) {
         bootstrap->barrierAll();
-      }
 
-      bootstrap->barrierAll();
-
-      // Benchmark
-      ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-      for (int i = 0; i < kBenchIters; ++i) {
-        if (globalRank == 0) {
-          launch_ibgda_send(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        } else {
-          launch_ibgda_recv(
-              deviceTransport,
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
+        // Warmup
+        for (int i = 0; i < kWarmupIters; ++i) {
+          if (globalRank == 0) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          } else if (api == SendRecvApi::Blocking) {
+            launch_ibgda_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          } else {
+            launch_ibgda_progress_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          }
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          bootstrap->barrierAll();
         }
-      }
-      ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-      ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
 
-      bootstrap->barrierAll();
+        bootstrap->barrierAll();
 
-      float totalMs = 0;
-      ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-      float avgMs = totalMs / kBenchIters;
+        // Benchmark
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+        for (int i = 0; i < kBenchIters; ++i) {
+          if (globalRank == 0) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          } else if (api == SendRecvApi::Blocking) {
+            launch_ibgda_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          } else {
+            launch_ibgda_progress_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          }
+        }
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
 
-      // Unidirectional: only one direction
-      float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
-      std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+        bootstrap->barrierAll();
 
-      if (globalRank == 0) {
-        std::string sizeStr = formatMessageSize(nBytes);
-        XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+        float totalMs = 0;
+        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+        float avgMs = totalMs / kBenchIters;
+
+        // Unidirectional: only one direction.
+        float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
+        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+        if (globalRank == 0) {
+          std::string sizeStr = formatMessageSize(nBytes);
+          XLOGF(
+              INFO,
+              "{:>10s}  {:>10s}  {:>10d}  {:>12.2f}",
+              sendRecvApiName(api),
+              sizeStr,
+              numSections,
+              bwGBs);
+        }
       }
     }
 

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -672,39 +672,22 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     });
   };
 
+  std::vector<std::size_t> benchmarkSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    benchmarkSizes.push_back(sizeBytes);
+  }
+
   // === BLOCK-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024, "8K", SyncScope::BLOCK, "Block");
-  addNcclConfig(16 * 1024, "16K", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024, "64K", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024, "128K", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024, "256K", SyncScope::BLOCK, "Block");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::BLOCK, "Block");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::BLOCK, "Block");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::BLOCK, "Block");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::BLOCK, "Block");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::BLOCK, "Block");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(sizeBytes, formatSize(sizeBytes), SyncScope::BLOCK, "Block");
+  }
 
   // === CLUSTER-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024, "8K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(16 * 1024, "16K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024, "64K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024, "128K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024, "256K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::CLUSTER, "Cluster");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(
+        sizeBytes, formatSize(sizeBytes), SyncScope::CLUSTER, "Cluster");
+  }
 
   std::vector<BenchmarkResult> results;
 
@@ -773,25 +756,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   std::vector<BenchmarkConfig> configs;
 
   // NCCL-like bidirectional configs at all message sizes
-  std::vector<std::pair<std::size_t, std::string>> bidiSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> bidiSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    bidiSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : bidiSizes) {
     configs.push_back({
         .nBytes = sz,
@@ -821,25 +790,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
     });
   };
 
-  std::vector<std::pair<std::size_t, std::string>> tileSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1 * 1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> tileSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    tileSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : tileSizes) {
     addTileConfig(sz, "Tile_" + nm);
   }

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -640,6 +640,19 @@ static unsigned char multiCallPattern(int rank, int call) {
   return static_cast<unsigned char>(0x30 + rank * 0x20 + call);
 }
 
+static size_t alignTileProtocolBytes(size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+static size_t
+validPayloadBytes(size_t byteOffset, size_t chunkBytes, size_t payloadBytes) {
+  if (byteOffset >= payloadBytes) {
+    return 0;
+  }
+  const size_t remaining = payloadBytes - byteOffset;
+  return chunkBytes < remaining ? chunkBytes : remaining;
+}
+
 static std::vector<char> makeTwoCallPatternBuffer(
     size_t firstCallBytes,
     size_t secondCallBytes,
@@ -713,21 +726,24 @@ static void expectPersistentTwoCallStagingPattern(
     uint64_t baseByte = 0;
     for (int call = 0; call < 2; ++call) {
       const unsigned char expected = multiCallPattern(sourceRank, call);
-      for (size_t dataOff = 0; dataOff < callBytes[call];) {
+      const size_t protocolBytes = alignTileProtocolBytes(callBytes[call]);
+      for (size_t dataOff = 0; dataOff < protocolBytes;) {
         const uint64_t streamStart = baseByte + dataOff;
         const size_t pipelineOff =
             static_cast<size_t>(streamStart % pipelineBytes);
         const size_t slot = pipelineOff / perBlockSlotSize;
         const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
         const size_t slotRemaining = perBlockSlotSize - chunkOff;
-        const size_t dataRemaining = callBytes[call] - dataOff;
+        const size_t dataRemaining = protocolBytes - dataOff;
         size_t chunkBytes =
             effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
         chunkBytes = chunkBytes < slotRemaining ? chunkBytes : slotRemaining;
+        const size_t validBytes =
+            validPayloadBytes(dataOff, chunkBytes, callBytes[call]);
         const size_t offset =
             slot * slotSize + block * perBlockSlotSize + chunkOff;
 
-        for (size_t i = 0; i < chunkBytes; ++i) {
+        for (size_t i = 0; i < validBytes; ++i) {
           EXPECT_EQ(static_cast<unsigned char>(data[offset + i]), expected)
               << label << ": block=" << block << " call=" << call
               << " dataOff=" << dataOff << " byte=" << i;
@@ -737,7 +753,7 @@ static void expectPersistentTwoCallStagingPattern(
         }
         dataOff += chunkBytes;
       }
-      baseByte += callBytes[call];
+      baseByte += protocolBytes;
     }
   }
 }
@@ -844,6 +860,10 @@ class LocalTileHarness {
 
   DeviceBuffer& stagingBuffer() {
     return stagingBuf_;
+  }
+
+  DeviceBuffer& stepStateBuffer() {
+    return stepStateBuf_;
   }
 
   size_t stagingBytes() const {
@@ -1195,6 +1215,223 @@ TEST_F(
       numBlocks,
       0,
       "tile recv persistent cursor");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+
+  LocalTileHarness sendHarness(options, numBlocks);
+  const std::vector<char> hostSend =
+      makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
+  DeviceBuffer sendBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+
+  auto sendOnlyP2p = sendHarness.stagingDevice();
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallSendOnly(
+      sendOnlyP2p,
+      sendTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostStaging(sendHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostStaging.data(),
+      sendHarness.stagingBuffer().get(),
+      sendHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile send unaligned protocol staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostStaging[i]), 0)
+        << "padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> sendStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendStepState.data(),
+      sendHarness.stepStateBuffer().get(),
+      sendStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(sendStepState[0], static_cast<int64_t>(expectedStep));
+
+  LocalTileHarness loopbackHarness(options, numBlocks);
+  DeviceBuffer recvBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+  auto loopbackP2p = loopbackHarness.loopbackDevice();
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallVariableSignalSendRecv(
+      loopbackP2p,
+      sendTiles,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      maxSignalBytes,
+      true,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile sendrecv unaligned protocol");
+
+  std::vector<int64_t> loopbackStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      loopbackStepState.data(),
+      loopbackHarness.stepStateBuffer().get(),
+      loopbackStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(loopbackStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(loopbackStepState[numBlocks], static_cast<int64_t>(expectedStep));
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileForwardUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+  LocalTileHarness predHarness(options, numBlocks);
+  LocalTileHarness succHarness(options, numBlocks);
+
+  auto pred = predHarness.device(predHarness.staging(), nullptr);
+  auto succ = succHarness.device(nullptr, succHarness.staging());
+
+  test::testPrepareTileTwoCallStaging(
+      pred,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceBuffer dstBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, totalBytes));
+  TiledBuffer<char> dstTiles(
+      static_cast<char*>(dstBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallForward(
+      pred,
+      succ,
+      dstTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostDst(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(), dstBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostDst,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol dst");
+
+  std::vector<char> hostSuccStaging(succHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostSuccStaging.data(),
+      succHarness.stagingBuffer().get(),
+      succHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostSuccStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol successor staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostSuccStaging[i]), 0)
+        << "forward padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> predStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      predStepState.data(),
+      predHarness.stepStateBuffer().get(),
+      predStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(predStepState[0], 0);
+  EXPECT_EQ(predStepState[numBlocks], static_cast<int64_t>(expectedStep));
+
+  std::vector<int64_t> succStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      succStepState.data(),
+      succHarness.stepStateBuffer().get(),
+      succStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(succStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(succStepState[numBlocks], 0);
 }
 
 TEST_F(

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -183,6 +183,7 @@ __device__ void wait_for_second_call_signal(
   if (!enabled) {
     return;
   }
+  const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
   const size_t perBlockSlotSize =
       (p2p.options().dataBufferSize / activeBlocks) & ~15ULL;
   const size_t chunkSize =
@@ -190,8 +191,8 @@ __device__ void wait_for_second_call_signal(
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
   const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
-  const uint64_t secondCallStarted = bytesPerCall +
-      (bytesPerCall < effectiveChunk ? bytesPerCall : effectiveChunk);
+  const uint64_t secondCallStarted = protocolBytes +
+      (protocolBytes < effectiveChunk ? protocolBytes : effectiveChunk);
   p2p.tile_state().local_signals[blockId].wait_until(
       group, CmpOp::CMP_GE, secondCallStarted, timeout);
 }
@@ -485,25 +486,31 @@ __global__ void testPrepareTileStagingKernel(
   uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < bytesPerCall;) {
+    const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = bytesPerCall - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < bytesPerCall) {
+        const size_t remaining = bytesPerCall - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += bytesPerCall;
+    baseByte += protocolBytes;
   }
 
   group.sync();
@@ -540,25 +547,31 @@ __global__ void testPrepareTileTwoCallStagingKernel(
   for (int call = 0; call < 2; ++call) {
     const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < callBytes;) {
+    const size_t protocolBytes = (callBytes + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = callBytes - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < callBytes) {
+        const size_t remaining = callBytes - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += callBytes;
+    baseByte += protocolBytes;
   }
 
   group.sync();

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -101,8 +101,9 @@ struct NvlinkTransportTileState {
   // Persistent byte cursors:
   //   [0, tile_max_groups) tracks send progress per tile group.
   //   [tile_max_groups, 2 * tile_max_groups) tracks recv progress.
-  // The byte cursor is independent of max_signal_bytes, so callers may change
-  // signal granularity between calls as long as active_blocks is unchanged.
+  // The byte cursor advances in 16-byte protocol quanta and is independent of
+  // max_signal_bytes, so callers may change signal granularity between calls
+  // as long as active_blocks is unchanged.
   DeviceSpan<int64_t> step_state;
   int tile_max_groups{0};
   DeviceSpan<SignalState> local_signals;
@@ -1490,7 +1491,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1498,7 +1500,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1509,11 +1511,13 @@ class P2pNvlTransportDevice {
             group, CmpOp::CMP_GE, streamEnd - pipelineBytes, timeout);
       }
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         memcpy_vectorized(
             stagBuf + slotOff + stagingOff + chunkOff,
             srcPtr + dataOff,
-            copyBytes,
+            validBytes,
             group);
       }
 
@@ -1526,7 +1530,8 @@ class P2pNvlTransportDevice {
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[groupId] = static_cast<int64_t>(baseByte + nbytes);
+      tile_state_.step_state[groupId] =
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1599,7 +1604,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[max_groups + groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1607,7 +1613,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1616,11 +1622,13 @@ class P2pNvlTransportDevice {
       tile_state_.local_signals[tailSignalId].wait_until(
           group, CmpOp::CMP_GE, streamEnd, timeout);
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1629,7 +1637,7 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         if (chunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, streamEnd);
         }
@@ -1639,7 +1647,7 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(baseByte + nbytes);
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1753,7 +1761,8 @@ class P2pNvlTransportDevice {
     const uint64_t sendBaseByte =
         static_cast<uint64_t>(successor.tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t recvStreamStart = recvBaseByte + dataOff;
       const std::size_t recvPipelineOff =
           static_cast<std::size_t>(recvStreamStart % pipelineBytes);
@@ -1770,7 +1779,7 @@ class P2pNvlTransportDevice {
           sendPipelineOff - sendSlot * perBlockSlotSize;
       const std::size_t recvSlotRemaining = perBlockSlotSize - recvChunkOff;
       const std::size_t sendSlotRemaining = perBlockSlotSize - sendChunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < recvSlotRemaining ? copyBytes : recvSlotRemaining;
@@ -1791,12 +1800,14 @@ class P2pNvlTransportDevice {
 
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::forward(
             dstPtr ? dstPtr + dataOff : nullptr,
             sendBuf + sendSlotOff + stagingOff + sendChunkOff,
             recvBuf + recvSlotOff + stagingOff + recvChunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1811,7 +1822,7 @@ class P2pNvlTransportDevice {
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
         if (recvChunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, recvStreamEnd);
         }
@@ -1821,9 +1832,9 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(recvBaseByte + nbytes);
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
       successor.tile_state_.step_state[groupId] =
-          static_cast<int64_t>(sendBaseByte + nbytes);
+          static_cast<int64_t>(sendBaseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -2061,6 +2072,22 @@ class P2pNvlTransportDevice {
   }
 
  private:
+  __device__ __forceinline__ static std::size_t align_tile_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
+
   const int myRank_{-1};
   const int peerRank_{-1};
   const P2pNvlTransportOptions options_{};


### PR DESCRIPTION
Summary: Add IBGDA benchmark launchers that exercise the resumable progress send/recv APIs added in `D107588349`, and extend the existing send/recv benchmark tables to report blocking `send`/`recv` rows next to `init_*_progress` + `progress_*_once` rows under the same message-size sweep and transport configuration.

Reviewed By: goelayu

Differential Revision: D107728822


