### PR TITLE
make all_gather_p setups fail first and make the lifecycle derterministic

### DIFF
--- a/comms/ctran/algos/AllGatherP/AllGatherP.cc
+++ b/comms/ctran/algos/AllGatherP/AllGatherP.cc
@@ -229,8 +229,12 @@ bool allGatherPSupport(CtranComm* comm) {
   const auto myRank = statex->rank();
   // Check if all remote peers are supported by ctran
   for (auto rank = 0; rank < statex->nRanks(); rank++) {
-    if (mapper->getBackend(rank) == CtranMapperBackend::UNSET &&
-        rank != myRank) {
+    if (rank == myRank) {
+      continue;
+    }
+    auto backend = mapper->getBackend(rank);
+    if (backend == CtranMapperBackend::UNSET ||
+        backend == CtranMapperBackend::TCPDM) {
       return false;
     }
   }
@@ -263,6 +267,14 @@ commResult_t allGatherPInit(
     return commInternalError;
   }
 
+  std::string supportReason;
+  auto supportRc = mapper->validateAllGatherPHandle(recvHdl, &supportReason);
+  if (supportRc != commSuccess) {
+    FB_ERRORRETURN(
+        supportRc,
+        "Persistent AllGather is not supported on this communicator: {}",
+        supportReason);
+  }
   FB_COMMCHECK(createPersistentRequest(comm, stream, &request));
   auto requestGuard = folly::makeGuard([&request, comm] {
     comm->unregisterPersistentCleanup(request->cleanup_);

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <string>
 
+#include <fmt/core.h>
+
 #include "comms/ctran/colltrace/MapperTrace.h"
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/mapper/CtranMapperTypes.h"
@@ -955,6 +957,46 @@ std::vector<bool> CtranMapper::getBackends() {
     }
   }
   return backends;
+}
+
+commResult_t CtranMapper::validateAllGatherPHandle(
+    void* hdl,
+    std::string* reason) {
+  auto setReason = [&](std::string message) {
+    if (reason != nullptr) {
+      *reason = std::move(message);
+    }
+  };
+
+  if (hdl == nullptr) {
+    setReason("recv buffer registration handle is null");
+    return commInvalidArgument;
+  }
+
+  auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
+  const auto& statex = comm->statex_;
+  const int myRank = statex->rank();
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer == myRank) {
+      continue;
+    }
+
+    auto peerBackend = queryPeerBackend(regElem, peer);
+    if (peerBackend == CtranMapperBackend::UNSET) {
+      setReason(fmt::format(
+          "recv buffer is not exportable to rank {} via NVL or IB",
+          peer));
+      return commInvalidUsage;
+    }
+    if (peerBackend == CtranMapperBackend::TCPDM) {
+      setReason(fmt::format(
+          "rank {} requires TCPDM, which Persistent AllGather does not support",
+          peer));
+      return commInvalidUsage;
+    }
+  }
+
+  return commSuccess;
 }
 
 CtranIb* CtranMapper::ctranIbPtr() {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -997,6 +997,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   bool hasBackend();
 
+  /* Validate whether a registered recv buffer can participate in
+   * Persistent AllGather on this mapper. This is stricter than hasBackend():
+   * it checks the actual per-peer export path for the registered buffer and
+   * rejects control-transport combinations that allGatherCtrl cannot serve.
+   */
+  commResult_t validateAllGatherPHandle(
+      void* hdl,
+      std::string* reason = nullptr);
+
   /* Check whether the local rank has the specified backend to communicate with
    * the given peer ranks.
    * Input arguments:
@@ -1525,16 +1534,20 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CLOGF_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} SEND ctrlmsg to rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        req->backend == CtranMapperBackend::IB ? "ibReq "
+        : req->backend == CtranMapperBackend::SOCKET ? "sockReq "
+                                                    : "tcpDmReq ",
+        req->backend == CtranMapperBackend::IB ? (void*)&req->ibReq
+        : req->backend == CtranMapperBackend::SOCKET ? (void*)&req->sockReq
+                                                     : (void*)&req->tcpDmReq,
         msg.toString());
-    if (ctranIb) {
+    if (req->backend == CtranMapperBackend::IB) {
       return ctranIb->isendCtrlMsg<PerfConfig>(
           msg.type, &msg, sizeof(ControlMsg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET) {
       return ctranSock->isendCtrlMsg(msg, peerRank, req->sockReq);
     } else {
       return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -1565,16 +1578,20 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     CLOGF_TRACE(
         COLL,
         "CTRAN-MAPPER: Post {} RECV ctrlmsg from rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        backendToStr(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        req->backend == CtranMapperBackend::IB ? "ibReq "
+        : req->backend == CtranMapperBackend::SOCKET ? "sockReq "
+                                                    : "tcpDmReq ",
+        req->backend == CtranMapperBackend::IB ? (void*)&req->ibReq
+        : req->backend == CtranMapperBackend::SOCKET ? (void*)&req->sockReq
+                                                     : (void*)&req->tcpDmReq,
         msg.toString());
-    if (ctranIb) {
+    if (req->backend == CtranMapperBackend::IB) {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           &msg, sizeof(msg), peerRank, req->ibReq);
-    } else if (ctranSock) {
+    } else if (req->backend == CtranMapperBackend::SOCKET) {
       return ctranSock->irecvCtrlMsg(msg, peerRank, req->sockReq);
     } else {
       return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
@@ -1590,8 +1607,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::SEND_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = ctranIb ? CtranMapperBackend::IB
+        : ctranSock        ? CtranMapperBackend::SOCKET
+                           : CtranMapperBackend::UNSET;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::SendCtrlStart{
@@ -1612,7 +1630,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       return ctranIb->isendCtrlMsg(
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
-    // only support ib for now
+    if (ctranSock && size == sizeof(ControlMsg)) {
+      return ctranSock->isendCtrlMsg(
+          *reinterpret_cast<const ControlMsg*>(payload), peerRank, req->sockReq);
+    }
     return commInvalidArgument;
   }
 
@@ -1625,8 +1646,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::RECV_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = ctranIb ? CtranMapperBackend::IB
+        : ctranSock        ? CtranMapperBackend::SOCKET
+                           : CtranMapperBackend::UNSET;
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::RecvCtrlStart{
@@ -1646,6 +1668,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     if (ctranIb) {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
+    }
+    if (ctranSock && size == sizeof(ControlMsg)) {
+      return ctranSock->irecvCtrlMsg(
+          *reinterpret_cast<ControlMsg*>(payload), peerRank, req->sockReq);
     }
     return commInvalidArgument;
   }

--- a/comms/ctran/tests/CtranDistAllgatherPTests.cc
+++ b/comms/ctran/tests/CtranDistAllgatherPTests.cc
@@ -66,8 +66,9 @@ class CtranAllgatherPTest : public ctran::CtranDistTestFixture {
 
     CUDACHECK_TEST(cudaStreamCreate(&stream));
     ctranComm = makeCtranComm();
-    EXPECT_TRUE(ctran::allGatherPSupport(ctranComm.get()))
-        << "allGatherP algo is not supported!";
+    if (!ctran::allGatherPSupport(ctranComm.get())) {
+      GTEST_SKIP() << "allGatherP algo is not supported!";
+    }
   }
 
   void TearDown() override {

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -164,14 +164,6 @@ struct CtranWin {
     atomicCapable_ = val;
   }
 
-  // Check whether persistent allgather (allgatherP) is supported.
-  // Returns true if ctran is initialized and all peers have configured
-  // backends. Static variant allows checking before a window is created.
-  static bool allGatherPSupported(CtranComm* comm);
-  bool allGatherPSupported() const {
-    return allGatherPSupported(comm);
-  }
-
  private:
   DevMemType bufType_{DevMemType::kCumem};
   // whether allocate window data buffer or provided by users

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -301,22 +301,6 @@ commResult_t CtranWin::exchange() {
   return commSuccess;
 }
 
-bool CtranWin::allGatherPSupported(CtranComm* comm) {
-  if (comm == nullptr || comm->isSplitShare() || !ctranInitialized(comm)) {
-    return false;
-  }
-  auto statex = comm->statex_.get();
-  auto mapper = comm->ctran_->mapper.get();
-  const auto myRank = statex->rank();
-  for (int rank = 0; rank < statex->nRanks(); rank++) {
-    if (rank != myRank &&
-        mapper->getBackend(rank) == CtranMapperBackend::UNSET) {
-      return false;
-    }
-  }
-  return true;
-}
-
 commResult_t CtranWin::allocate(void* userBufPtr) {
   auto statex = comm->statex_.get();
   const auto myRank = statex->rank();

--- a/comms/ncclx/meta/collectives/pCollectives.cc
+++ b/comms/ncclx/meta/collectives/pCollectives.cc
@@ -20,7 +20,8 @@ __attribute__((visibility("default"))) ncclResult_t allGatherInit(
   if (!ctran::allGatherPSupport(comm->ctranComm_.get())) {
     FB_ERRORTHROW(
         commInvalidUsage,
-        "Persistent AllGather is not supported. Check whether CTRAN is enabled.");
+        "Persistent AllGather is not supported. "
+        "Requires CTRAN Persistent AllGather transport support.");
   }
 
   SetCudaDevRAII setCudaDev(comm->cudaDev);

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -443,11 +443,13 @@ void TorchCommNCCLX::finalize() {
 
   // Update comm_state_ based on the work status
   if (work_status == TorchWorkNCCLX::WorkStatus::TIMEDOUT) {
+    cleanupAllGatherPHandles();
     TC_LOG(INFO, this) << "Aborting NCCL comm due to timeout";
     comm_state_ = CommState::TIMEOUT;
     abortNcclComm();
     throw std::runtime_error("Work timed out during finalize");
   } else if (work_status == TorchWorkNCCLX::WorkStatus::ERROR) {
+    cleanupAllGatherPHandles();
     TC_LOG(INFO, this) << "Aborting NCCL comm due to error";
     comm_state_ = CommState::ERROR;
     ncclResult_t asyncErr;
@@ -456,11 +458,15 @@ void TorchCommNCCLX::finalize() {
         nccl_comm_,
         nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
         "failed to get async error");
+    TC_LOG(ERROR, this) << "AllGatherP/NCCLX finalize observed async error: "
+                        << nccl_api_->getErrorString(asyncErr);
     NCCLXException ncclException(
         *nccl_api_, "NCCLX Async Error", asyncErr, nccl_comm_);
     abortNcclComm();
     throw ncclException;
   }
+
+  cleanupAllGatherPHandles();
 
   // Clean up event pool
   {
@@ -1200,36 +1206,79 @@ TorchCommBackend::AllGatherPHandle TorchCommNCCLX::all_gather_p_init(
   checkInitialized();
   checkAndAbortIfTimedOutOrError();
   ensureTensorContiguous(output);
+  checkTensorDevice(output);
 
   size_t maxRecvCount = output.numel();
   size_t bufferSize = maxRecvCount * output.element_size();
 
-  // Register the output buffer if not already registered
   void* dataPtr = output.data_ptr();
+  bool releaseManagedRegistrationOnError = false;
   auto it = memoryRegistrationHandles_.find(dataPtr);
   if (it == memoryRegistrationHandles_.end()) {
-    void* regHandle = nullptr;
-    NCCLX_CHECK(
-        nccl_api_,
-        nccl_comm_,
-        nccl_api_->commRegister(nccl_comm_, dataPtr, bufferSize, &regHandle),
-        "NCCLX commRegister failed for AllGatherP output buffer");
-    memoryRegistrationHandles_.emplace(dataPtr, RegistrationHandle(regHandle));
+    register_address(AddressWithLen{dataPtr, bufferSize});
+    it = memoryRegistrationHandles_.find(dataPtr);
+    it->second.allGatherPRefCount = 1;
+    releaseManagedRegistrationOnError = true;
+  } else if (it->second.allGatherPRefCount > 0) {
+    it->second.allGatherPRefCount++;
+    releaseManagedRegistrationOnError = true;
   }
 
   void* request = nullptr;
-  NCCLX_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->allGatherInit(
-          dataPtr,
-          maxRecvCount,
-          options.hints,
-          getNcclDataType(output),
-          nccl_comm_,
-          getInternalStream(),
-          &request),
-      "NCCLX allGatherInit failed");
+  try {
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->allGatherInit(
+            dataPtr,
+            maxRecvCount,
+            options.hints,
+            getNcclDataType(output),
+            nccl_comm_,
+            getInternalStream(),
+            &request),
+        "NCCLX allGatherInit failed");
+
+    // allGatherInit queues async control-path work on the internal stream.
+    // Return the handle only once that init work is ready.
+    CUDA_CHECK(
+        cuda_api_,
+        cuda_api_->streamSynchronize(getInternalStream()),
+        "NCCLX allGatherInit stream synchronize failed");
+
+    ncclResult_t asyncErr;
+    NCCLX_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error after NCCLX allGatherInit");
+    if (asyncErr != ncclSuccess) {
+      TC_LOG(ERROR, this) << "AllGatherP/NCCLX init observed async error: "
+                          << nccl_api_->getErrorString(asyncErr);
+      comm_state_ = CommState::ERROR;
+      checkAndAbortIfTimedOutOrError();
+    }
+  } catch (...) {
+    if (request != nullptr) {
+      NCCLX_CHECK_IGNORE(
+          nccl_api_,
+          nccl_api_->pFree(request),
+          "NCCLX pFree failed during init rollback");
+    }
+    if (releaseManagedRegistrationOnError) {
+      auto regIt = memoryRegistrationHandles_.find(dataPtr);
+      if (regIt != memoryRegistrationHandles_.end() &&
+          regIt->second.allGatherPRefCount > 0) {
+        if (--regIt->second.allGatherPRefCount == 0) {
+          (void)nccl_api_->commDeregister(nccl_comm_, regIt->second.regHandle);
+          memoryRegistrationHandles_.erase(regIt);
+        }
+      }
+    }
+    throw;
+  }
+
+  allGatherPHandleStates_.emplace(request, AllGatherPHandleState{dataPtr});
 
   return request;
 }
@@ -1267,11 +1316,52 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::all_gather_p_exec(
   return work;
 }
 
+void TorchCommNCCLX::cleanupAllGatherPHandle(AllGatherPHandle handle) {
+  if (handle == nullptr) {
+    return;
+  }
+
+  auto stateIt = allGatherPHandleStates_.find(handle);
+  if (stateIt == allGatherPHandleStates_.end()) {
+    return;
+  }
+
+  NCCLX_CHECK_IGNORE(nccl_api_, nccl_api_->pFree(handle), "NCCLX pFree failed");
+
+  const auto outputAddr = stateIt->second.outputAddr;
+  auto regIt = memoryRegistrationHandles_.find(outputAddr);
+  if (regIt != memoryRegistrationHandles_.end() &&
+      regIt->second.allGatherPRefCount > 0) {
+    if (--regIt->second.allGatherPRefCount == 0) {
+      if (nccl_comm_ != nullptr) {
+        NCCLX_CHECK_IGNORE(
+            nccl_api_,
+            nccl_api_->commDeregister(nccl_comm_, regIt->second.regHandle),
+            "Failed to deregister NCCLX AllGatherP output buffer");
+      }
+      memoryRegistrationHandles_.erase(regIt);
+    }
+  }
+  allGatherPHandleStates_.erase(stateIt);
+}
+
+void TorchCommNCCLX::cleanupAllGatherPHandles() {
+  std::vector<AllGatherPHandle> handles;
+  handles.reserve(allGatherPHandleStates_.size());
+  for (const auto& [handle, _] : allGatherPHandleStates_) {
+    handles.push_back(handle);
+  }
+  for (auto handle : handles) {
+    cleanupAllGatherPHandle(handle);
+  }
+}
+
 void TorchCommNCCLX::all_gather_p_free(AllGatherPHandle handle) {
   if (handle == nullptr) {
     return;
   }
-  NCCLX_CHECK_IGNORE(nccl_api_, nccl_api_->pFree(handle), "NCCLX pFree failed");
+  checkInitialized();
+  cleanupAllGatherPHandle(handle);
 }
 
 c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reduce_scatter(
@@ -2317,6 +2407,45 @@ std::shared_ptr<TorchCommBackend> TorchCommNCCLX::split(
   new_torchcomm->init(device_, commDesc, options);
 
   return new_torchcomm;
+}
+
+void TorchCommNCCLX::register_address(
+    const TorchCommNCCLX::AddressWithLen& addr) {
+  if (nccl_comm_ == nullptr) {
+    return;
+  }
+
+  if (memoryRegistrationHandles_.find(addr.addr) !=
+      memoryRegistrationHandles_.end()) {
+    throw std::runtime_error("Memory already registered with NCCLX");
+  }
+
+  void* handle = nullptr;
+  NCCLX_CHECK(
+      nccl_api_,
+      nccl_comm_,
+      nccl_api_->commRegister(nccl_comm_, addr.addr, addr.len, &handle),
+      "Failed to register memory with NCCLX");
+  memoryRegistrationHandles_.emplace(addr.addr, RegistrationHandle(handle));
+}
+
+void TorchCommNCCLX::deregister_address(const TorchCommNCCLX::Address& addr) {
+  if (nccl_comm_ == nullptr) {
+    return;
+  }
+
+  auto it = memoryRegistrationHandles_.find(addr.addr);
+  if (it == memoryRegistrationHandles_.end()) {
+    return;
+  }
+
+  void* handle = it->second.regHandle;
+  NCCLX_CHECK(
+      nccl_api_,
+      nccl_comm_,
+      nccl_api_->commDeregister(nccl_comm_, handle),
+      "Failed to deregister memory with NCCLX");
+  memoryRegistrationHandles_.erase(it);
 }
 
 void TorchCommNCCLX::global_register_address(

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -357,6 +357,9 @@ class TorchCommNCCLX : public TorchCommBackend,
     size_t len;
   };
 
+  void register_address(const AddressWithLen& addr);
+  void deregister_address(const Address& addr);
+
   // Global pointer-based registration that doesn't require a comm instance.
   // Used by NcclxCachingAllocatorHook for pre-comm memory registration.
   // The caller provides the NcclxApi to use for the registration.
@@ -457,12 +460,15 @@ class TorchCommNCCLX : public TorchCommBackend,
   // Struct to hold the registration handle for a buffer
   struct RegistrationHandle {
     void* regHandle;
+    size_t allGatherPRefCount{0};
 
     explicit RegistrationHandle(void* regHandle) : regHandle{regHandle} {}
 
     RegistrationHandle(RegistrationHandle&& other) noexcept
-        : regHandle{other.regHandle} {
+        : regHandle{other.regHandle},
+          allGatherPRefCount{other.allGatherPRefCount} {
       other.regHandle = nullptr;
+      other.allGatherPRefCount = 0;
     }
 
     RegistrationHandle(const RegistrationHandle&) = delete;
@@ -471,7 +477,9 @@ class TorchCommNCCLX : public TorchCommBackend,
     RegistrationHandle& operator=(RegistrationHandle&& other) noexcept {
       if (this != &other) {
         regHandle = other.regHandle;
+        allGatherPRefCount = other.allGatherPRefCount;
         other.regHandle = nullptr;
+        other.allGatherPRefCount = 0;
       }
       return *this;
     }
@@ -492,6 +500,8 @@ class TorchCommNCCLX : public TorchCommBackend,
   void initNcclxResources();
   void checkAndAbortIfTimedOutOrError();
   void checkWorkQueue();
+  void cleanupAllGatherPHandle(AllGatherPHandle handle);
+  void cleanupAllGatherPHandles();
   bool getGraphCaptureMode();
   void ensureTensorContiguous(const at::Tensor& tensor);
   void checkTensorDevice(const at::Tensor& tensor) const;
@@ -528,6 +538,11 @@ class TorchCommNCCLX : public TorchCommBackend,
   // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
   // buffer address to the registeration handle
   std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
+
+  struct AllGatherPHandleState {
+    void* outputAddr{nullptr};
+  };
+  std::unordered_map<void*, AllGatherPHandleState> allGatherPHandleStates_;
 
   // NCCL API abstraction
   std::shared_ptr<NcclxApi> nccl_api_;

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -305,22 +305,28 @@ void TorchCommRCCLX::finalize() {
   stream_work_queues_.clear();
 
   if (comm_state_ == CommState::TIMEOUT) {
+    cleanupAllGatherPHandles();
     abortRcclxComm();
     throw std::runtime_error("Work timed out during finalize");
   } else if (
       comm_state_ == CommState::ERROR &&
       comm_state_on_entry != CommState::ERROR) {
+    cleanupAllGatherPHandles();
     ncclResult_t asyncErr;
     RCCLX_CHECK(
         rcclx_api_,
         nccl_comm_,
         rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr),
         "failed to get async error");
+    TC_LOG(ERROR, this) << "AllGatherP/RCCLX finalize observed async error: "
+                        << rcclx_api_->getErrorString(asyncErr);
     RCCLXException RCCLXException(
         *rcclx_api_, "RCCLX Async Error", asyncErr, nccl_comm_);
     abortRcclxComm();
     throw RCCLXException;
   }
+
+  cleanupAllGatherPHandles();
 
   // Clear the completed works queue
   std::queue<c10::intrusive_ptr<TorchWorkRCCLX>> empty;
@@ -1910,20 +1916,18 @@ TorchCommBackend::AllGatherPHandle TorchCommRCCLX::all_gather_p_init(
   size_t maxRecvCount = output.numel();
   size_t bufferSize = maxRecvCount * output.element_size();
 
-  // Register the output buffer with NCCL before calling allGatherInit
-  // AllGatherP requires pre-registered memory
   void* dataPtr = output.data_ptr();
-  void* regHandle = nullptr;
+  bool releaseManagedRegistrationOnError = false;
 
-  // Check if already registered, if not register it
   auto it = memoryRegistrationHandles_.find(dataPtr);
   if (it == memoryRegistrationHandles_.end()) {
-    RCCLX_CHECK(
-        rcclx_api_,
-        nccl_comm_,
-        rcclx_api_->commRegister(nccl_comm_, dataPtr, bufferSize, &regHandle),
-        "RCCLX commRegister failed for AllGatherP output buffer");
-    memoryRegistrationHandles_.emplace(dataPtr, RegistrationHandle(regHandle));
+    register_address(AddressWithLen{dataPtr, bufferSize});
+    it = memoryRegistrationHandles_.find(dataPtr);
+    it->second.allGatherPRefCount = 1;
+    releaseManagedRegistrationOnError = true;
+  } else if (it->second.allGatherPRefCount > 0) {
+    it->second.allGatherPRefCount++;
+    releaseManagedRegistrationOnError = true;
   }
 
   // Convert hints from options
@@ -1934,18 +1938,58 @@ TorchCommBackend::AllGatherPHandle TorchCommRCCLX::all_gather_p_init(
 
   void* request = nullptr;
 
-  RCCLX_CHECK(
-      rcclx_api_,
-      nccl_comm_,
-      rcclx_api_->allGatherInit(
-          dataPtr,
-          maxRecvCount,
-          rcclxHints,
-          getNcclDataType(output),
-          nccl_comm_,
-          internal_stream_,
-          &request),
-      "RCCLX allGatherInit failed");
+  try {
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->allGatherInit(
+            dataPtr,
+            maxRecvCount,
+            rcclxHints,
+            getNcclDataType(output),
+            nccl_comm_,
+            internal_stream_,
+            &request),
+        "RCCLX allGatherInit failed");
+
+    HIP_CHECK(
+        hip_api_,
+        hip_api_->streamSynchronize(internal_stream_),
+        "RCCLX allGatherInit stream synchronize failed");
+
+    ncclResult_t asyncErr;
+    RCCLX_CHECK(
+        rcclx_api_,
+        nccl_comm_,
+        rcclx_api_->commGetAsyncError(nccl_comm_, &asyncErr),
+        "failed to get async error after RCCLX allGatherInit");
+    if (asyncErr != ncclSuccess) {
+      TC_LOG(ERROR, this) << "AllGatherP/RCCLX init observed async error: "
+                          << rcclx_api_->getErrorString(asyncErr);
+      comm_state_ = CommState::ERROR;
+      checkAndAbortIfTimedOutOrError();
+    }
+  } catch (...) {
+    if (request != nullptr) {
+      RCCLX_CHECK_IGNORE(
+          rcclx_api_,
+          rcclx_api_->pFree(request),
+          "RCCLX pFree failed during init rollback");
+    }
+    if (releaseManagedRegistrationOnError) {
+      auto regIt = memoryRegistrationHandles_.find(dataPtr);
+      if (regIt != memoryRegistrationHandles_.end() &&
+          regIt->second.allGatherPRefCount > 0) {
+        if (--regIt->second.allGatherPRefCount == 0) {
+          (void)rcclx_api_->commDeregister(nccl_comm_, regIt->second.regHandle);
+          memoryRegistrationHandles_.erase(regIt);
+        }
+      }
+    }
+    throw;
+  }
+
+  allGatherPHandleStates_.emplace(request, AllGatherPHandleState{dataPtr});
 
   return request;
 }
@@ -1983,13 +2027,53 @@ c10::intrusive_ptr<TorchWork> TorchCommRCCLX::all_gather_p_exec(
   return work;
 }
 
-void TorchCommRCCLX::all_gather_p_free(AllGatherPHandle handle) {
+void TorchCommRCCLX::cleanupAllGatherPHandle(AllGatherPHandle handle) {
   if (handle == nullptr) {
+    return;
+  }
+
+  auto stateIt = allGatherPHandleStates_.find(handle);
+  if (stateIt == allGatherPHandleStates_.end()) {
     return;
   }
 
   RCCLX_CHECK_IGNORE(
       rcclx_api_, rcclx_api_->pFree(handle), "RCCLX pFree failed");
+
+  const auto outputAddr = stateIt->second.outputAddr;
+  auto regIt = memoryRegistrationHandles_.find(outputAddr);
+  if (regIt != memoryRegistrationHandles_.end() &&
+      regIt->second.allGatherPRefCount > 0) {
+    if (--regIt->second.allGatherPRefCount == 0) {
+      if (nccl_comm_ != nullptr) {
+        RCCLX_CHECK_IGNORE(
+            rcclx_api_,
+            rcclx_api_->commDeregister(nccl_comm_, regIt->second.regHandle),
+            "Failed to deregister RCCLX AllGatherP output buffer");
+      }
+      memoryRegistrationHandles_.erase(regIt);
+    }
+  }
+  allGatherPHandleStates_.erase(stateIt);
+}
+
+void TorchCommRCCLX::cleanupAllGatherPHandles() {
+  std::vector<AllGatherPHandle> handles;
+  handles.reserve(allGatherPHandleStates_.size());
+  for (const auto& [handle, _] : allGatherPHandleStates_) {
+    handles.push_back(handle);
+  }
+  for (auto handle : handles) {
+    cleanupAllGatherPHandle(handle);
+  }
+}
+
+void TorchCommRCCLX::all_gather_p_free(AllGatherPHandle handle) {
+  if (handle == nullptr) {
+    return;
+  }
+  checkInitialized();
+  cleanupAllGatherPHandle(handle);
 }
 
 std::shared_ptr<TorchCommBackend> TorchCommRCCLX::split(

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -353,12 +353,15 @@ class TorchCommRCCLX : public TorchCommBackend,
 
   struct RegistrationHandle {
     void* regHandle;
+    size_t allGatherPRefCount{0};
 
     explicit RegistrationHandle(void* regHandle) : regHandle{regHandle} {}
 
     RegistrationHandle(RegistrationHandle&& other) noexcept
-        : regHandle{other.regHandle} {
+        : regHandle{other.regHandle},
+          allGatherPRefCount{other.allGatherPRefCount} {
       other.regHandle = nullptr;
+      other.allGatherPRefCount = 0;
     }
 
     RegistrationHandle(const RegistrationHandle&) = delete;
@@ -367,7 +370,9 @@ class TorchCommRCCLX : public TorchCommBackend,
     RegistrationHandle& operator=(RegistrationHandle&& other) noexcept {
       if (this != &other) {
         regHandle = other.regHandle;
+        allGatherPRefCount = other.allGatherPRefCount;
         other.regHandle = nullptr;
+        other.allGatherPRefCount = 0;
       }
       return *this;
     }
@@ -391,6 +396,8 @@ class TorchCommRCCLX : public TorchCommBackend,
   void checkInitialized() const;
   void checkAndAbortIfTimedOutOrError();
   void garbageCollectWorkQueues();
+  void cleanupAllGatherPHandle(AllGatherPHandle handle);
+  void cleanupAllGatherPHandles();
 
   void enqueueWork(
       const c10::intrusive_ptr<TorchWorkRCCLX>& work,
@@ -423,6 +430,11 @@ class TorchCommRCCLX : public TorchCommBackend,
   // List of [comm, regHandlesMap] pairs.  Each regHandlesMap is a map from the
   // buffer address to the registeration handle
   std::map<void*, RegistrationHandle> memoryRegistrationHandles_;
+
+  struct AllGatherPHandleState {
+    void* outputAddr{nullptr};
+  };
+  std::unordered_map<void*, AllGatherPHandleState> allGatherPHandleStates_;
 
   // Store held for reconfigure bootstrap (kept alive across reconfigure calls)
   c10::intrusive_ptr<c10d::Store> reconfigure_store_;

--- a/comms/torchcomms/tests/integration/py/AllGatherPTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherPTest.py
@@ -26,20 +26,39 @@ class AllGatherPTest(unittest.TestCase):
     ELEM_COUNT = 1024
 
     def setUp(self) -> None:
-        self.wrapper = TorchCommTestWrapper()
+        if os.getenv("NCCL_CTRAN_ENABLE") != "true":
+            self.skipTest("Requires ctran Persistent AllGather transport support")
+        try:
+            self.wrapper = TorchCommTestWrapper()
+        except RuntimeError as e:
+            message = str(e)
+            if (
+                "Persistent AllGather is not supported" in message
+                or "Failed to initialize NCCL communicator" in message
+            ):
+                self.skipTest(
+                    f"Requires ctran Persistent AllGather transport support: {e}"
+                )
+            raise
         self.comm = self.wrapper.get_torchcomm()
         self.rank = self.comm.get_rank()
         self.size = self.comm.get_size()
         self.device = self.comm.get_device()
 
+    def _init_or_skip(self, output_tensor: torch.Tensor):
+        try:
+            return self.comm.all_gather_p_init(output_tensor)
+        except RuntimeError as e:
+            if "Persistent AllGather is not supported" in str(e):
+                self.skipTest(
+                    f"Requires ctran Persistent AllGather transport support: {e}"
+                )
+            raise
+
     def tearDown(self) -> None:
         del self.comm
         del self.wrapper
 
-    @unittest.skipIf(
-        os.getenv("NCCL_CTRAN_ENABLE") != "true",
-        "Requires ctran transport (NCCL_CTRAN_ENABLE=true)",
-    )
     def test_allgatherp(self) -> None:
         """Eager allgatherp followed by compute on the output buffer."""
         count = self.ELEM_COUNT
@@ -55,8 +74,7 @@ class AllGatherPTest(unittest.TestCase):
                 count * self.size, dtype=torch.float32, device=self.device
             )
 
-        handle = self.comm.all_gather_p_init(output_tensor)
-        self.comm.barrier(False)
+        handle = self._init_or_skip(output_tensor)
 
         for _ in range(self.NUM_REPLAYS):
             work = self.comm.all_gather_p_exec(handle, input_tensor, async_op=True)
@@ -87,6 +105,20 @@ class AllGatherPTest(unittest.TestCase):
                 msg=f"Rank {self.rank}: compute on allgatherp output mismatch",
             )
 
+        self.comm.all_gather_p_free(handle)
+
+    def test_allgatherp_init_free_without_exec(self) -> None:
+        """Init returns a ready handle and free succeeds without an exec."""
+        allocator = torchcomms.get_mem_allocator(self.comm.get_backend())
+        pool = torch.cuda.MemPool(allocator)
+        with torch.cuda.use_mem_pool(pool):
+            output_tensor = torch.zeros(
+                self.ELEM_COUNT * self.size,
+                dtype=torch.float32,
+                device=self.device,
+            )
+
+        handle = self._init_or_skip(output_tensor)
         self.comm.all_gather_p_free(handle)
 
 


### PR DESCRIPTION
for `all_gather_p_init()` on no-IB hosts the feature failed later with confusing runtime errors instead of rejecting the configuration up front

```
handle = comm.all_gather_p_init(output_tensor)
work = comm.all_gather_p_exec(handle, input_tensor, async_op=True)
# RuntimeError: NCCLX allGatherExec failed: invalid argument
```

made some changes so it fails immediately and cleanly, added test and cleaned up some code