### PR TITLE
Add generic comm tuner for A2A non-contig configs

### DIFF
--- a/comms/tuning/comm_tuning/__init__.py
+++ b/comms/tuning/comm_tuning/__init__.py
@@ -1,0 +1,2 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+

--- a/comms/tuning/comm_tuning/adapter.py
+++ b/comms/tuning/comm_tuning/adapter.py
@@ -1,0 +1,146 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Adapter interface for Triton communication kernel tuning."""
+
+from __future__ import annotations
+
+import argparse
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+import torch
+
+KeyT = TypeVar("KeyT")
+ConfigT = TypeVar("ConfigT")
+InputSpecT = TypeVar("InputSpecT")
+InputsT = TypeVar("InputsT")
+OutputT = TypeVar("OutputT")
+
+
+class CommKernelTuningAdapter(
+    ABC,
+    Generic[KeyT, ConfigT, InputSpecT, InputsT, OutputT],
+):
+    """Base interface for one Triton communication kernel tuner."""
+
+    name: str
+
+    def add_cli_args(self, parser: argparse.ArgumentParser) -> None:
+        pass
+
+    def configure(self, args: argparse.Namespace) -> None:
+        pass
+
+    @abstractmethod
+    def enumerate_input_specs(self, world_size: int) -> list[InputSpecT]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def make_key(self, spec: InputSpecT, world_size: int) -> KeyT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def enumerate_candidate_configs(
+        self,
+        spec: InputSpecT,
+        key: KeyT,
+    ) -> list[ConfigT]:
+        raise NotImplementedError
+
+    def enumerate_baselines(self, spec: InputSpecT, key: KeyT) -> list[str]:
+        return []
+
+    @abstractmethod
+    def make_inputs(
+        self,
+        spec: InputSpecT,
+        *,
+        rank: int,
+        world_size: int,
+        device: torch.device,
+    ) -> InputsT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_candidate(
+        self,
+        inputs: InputsT,
+        config: ConfigT,
+        group: Any,
+    ) -> OutputT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_baseline(
+        self,
+        inputs: InputsT,
+        baseline: str,
+        group: Any,
+    ) -> OutputT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_reference(self, inputs: InputsT, group: Any) -> OutputT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def check_correctness(
+        self,
+        candidate_output: OutputT,
+        reference_output: OutputT,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def spec_to_json(self, spec: InputSpecT) -> tuple[str, dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def spec_from_json(self, spec_type: str, data: dict[str, Any]) -> InputSpecT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def key_to_json(self, key: KeyT) -> tuple[str, dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def key_from_json(self, key_type: str, data: dict[str, Any]) -> KeyT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def config_to_json(self, config: ConfigT) -> tuple[str, dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def config_from_json(
+        self,
+        config_type: str,
+        data: dict[str, Any],
+    ) -> ConfigT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def generated_table_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def generated_filename(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def generated_imports(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def render_key(self, key_type: str, key: dict[str, Any]) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def render_config(self, config_type: str, config: dict[str, Any]) -> str:
+        raise NotImplementedError
+
+    def render_result_comment(self, result: dict[str, Any]) -> str | None:
+        return None
+
+    def result_is_artifact_eligible(self, result: dict[str, Any]) -> bool:
+        return True

--- a/comms/tuning/comm_tuning/artifacts.py
+++ b/comms/tuning/comm_tuning/artifacts.py
@@ -1,0 +1,62 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Artifact writers for Triton comm tuning results."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from comm_tuning.adapter import CommKernelTuningAdapter
+
+
+def write_best_configs_json(output_dir: Path, best_configs: dict) -> Path:
+    path = output_dir / "best_configs.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(best_configs, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return path
+
+
+def write_generated_python(
+    *,
+    adapter: CommKernelTuningAdapter,
+    output_dir: Path,
+    best_configs: dict,
+) -> Path:
+    generated_dir = output_dir / "generated"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+    path = generated_dir / adapter.generated_filename()
+
+    lines = [
+        "# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.",
+        "",
+        '"""Generated tuned configs for Triton communication kernels.',
+        "",
+        "Generated from `best_configs.json` by the comm tuning framework.",
+        "Do not edit entries manually; regenerate from autotune results instead.",
+        '"""',
+        "",
+        adapter.generated_imports().rstrip(),
+        "",
+        "",
+        f"{adapter.generated_table_name()} = {{",
+    ]
+    for result in best_configs["results"]:
+        if not adapter.result_is_artifact_eligible(result):
+            continue
+        comment = adapter.render_result_comment(result)
+        if comment:
+            lines.append(f"    # {comment}")
+        key_expr = adapter.render_key(result["key_type"], result["key"])
+        config_expr = adapter.render_config(
+            result["best_config_type"],
+            result["best_config"],
+        )
+        lines.append(f"    {key_expr}: {config_expr},")
+    lines.extend(["}", ""])
+
+    with path.open("w") as f:
+        f.write("\n".join(lines))
+    return path

--- a/comms/tuning/comm_tuning/cli.py
+++ b/comms/tuning/comm_tuning/cli.py
@@ -1,0 +1,76 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""CLI helpers for Triton comm tuning entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from comm_tuning import artifacts, engine, selection
+from comm_tuning.adapter import CommKernelTuningAdapter
+
+
+def run_tuning_cli(adapter: CommKernelTuningAdapter) -> None:
+    parser = argparse.ArgumentParser(description=f"Tune {adapter.name}.")
+    parser.add_argument("--mode", choices=("parent", "child", "select"), required=True)
+    parser.add_argument("--work-item-json", default=None)
+    parser.add_argument("--rank-output-path", default=None)
+    parser.add_argument("--run-name", default="local")
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--input-dir", default=None)
+    parser.add_argument("--base-master-port", type=int, default=31000)
+    parser.add_argument("--master-port-stride", type=int, default=100)
+    parser.add_argument(
+        "--candidate-port-mode",
+        choices=("dynamic", "deterministic"),
+        default="dynamic",
+    )
+    parser.add_argument("--candidate-timeout-sec", type=int, default=180)
+    parser.add_argument("--work-item-timeout-sec", type=int, default=None)
+    parser.add_argument("--num-warmup", type=int, default=20)
+    parser.add_argument("--num-iters", type=int, default=100)
+    parser.add_argument("--pg-timeout-sec", type=int, default=120)
+    parser.add_argument(
+        "--cuda-graph", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--torchx",
+        action="store_true",
+        help="Accepted for compatibility with ops/mast.py.",
+    )
+    adapter.add_cli_args(parser)
+    args = parser.parse_args()
+    adapter.configure(args)
+
+    if args.mode == "child":
+        if args.work_item_json is None:
+            raise ValueError("--work-item-json is required in child mode")
+        if args.rank_output_path is None:
+            raise ValueError("--rank-output-path is required in child mode")
+        engine.run_child(args, adapter)
+        return
+
+    if args.mode == "parent":
+        engine.run_parent(args, adapter, entrypoint_path=sys.argv[0])
+        return
+
+    if args.input_dir is None:
+        raise ValueError("--input-dir is required in select mode")
+    if args.output_dir is None:
+        raise ValueError("--output-dir is required in select mode")
+    output_dir = Path(args.output_dir)
+    records = selection.load_result_records(args.input_dir)
+    best_configs = selection.select_best_configs(
+        adapter=adapter,
+        records=records,
+    )
+    best_path = artifacts.write_best_configs_json(output_dir, best_configs)
+    generated_path = artifacts.write_generated_python(
+        adapter=adapter,
+        output_dir=output_dir,
+        best_configs=best_configs,
+    )
+    print(f"wrote {best_path}")
+    print(f"wrote {generated_path}")

--- a/comms/tuning/comm_tuning/engine.py
+++ b/comms/tuning/comm_tuning/engine.py
@@ -1,0 +1,557 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Generic parent/child runner for Triton comm tuning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import traceback
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from comm_tuning.adapter import CommKernelTuningAdapter
+from comm_tuning.schemas import TuningWorkItem
+
+
+def benchmark_callable(
+    fn,
+    *,
+    num_warmup: int,
+    num_iters: int,
+    use_cuda_graph: bool,
+) -> float:
+    """Return average latency in microseconds."""
+    if use_cuda_graph:
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            for _ in range(num_warmup):
+                fn()
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream):
+            with torch.cuda.graph(graph, stream=stream):
+                for _ in range(num_iters):
+                    fn()
+        torch.cuda.synchronize()
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(stream):
+            start.record()
+            graph.replay()
+            end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) * 1000 / num_iters
+
+    for _ in range(num_warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(num_iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) * 1000 / num_iters
+
+
+def build_worklist(
+    adapter: CommKernelTuningAdapter,
+    *,
+    world_size: int,
+) -> list[TuningWorkItem]:
+    worklist: list[TuningWorkItem] = []
+    for spec in adapter.enumerate_input_specs(world_size):
+        key = adapter.make_key(spec, world_size)
+        spec_type, spec_json = adapter.spec_to_json(spec)
+        key_type, key_json = adapter.key_to_json(key)
+
+        for config in adapter.enumerate_candidate_configs(spec, key):
+            config_type, config_json = adapter.config_to_json(config)
+            worklist.append(
+                TuningWorkItem(
+                    work_item_id=len(worklist),
+                    kind="candidate",
+                    spec_type=spec_type,
+                    spec=spec_json,
+                    key_type=key_type,
+                    key=key_json,
+                    config_type=config_type,
+                    config=config_json,
+                )
+            )
+
+        for baseline in adapter.enumerate_baselines(spec, key):
+            worklist.append(
+                TuningWorkItem(
+                    work_item_id=len(worklist),
+                    kind="baseline",
+                    spec_type=spec_type,
+                    spec=spec_json,
+                    key_type=key_type,
+                    key=key_json,
+                    baseline=baseline,
+                )
+            )
+    return worklist
+
+
+def default_run_name(args: argparse.Namespace, adapter_name: str) -> str:
+    if args.run_name != "local":
+        return args.run_name
+    env_run_name = os.environ.get("COMM_TUNER_RUN_NAME")
+    if env_run_name:
+        return env_run_name
+    mast_job = os.environ.get("MAST_JOB_NAME") or os.environ.get("MAST_HPC_JOB_NAME")
+    if mast_job:
+        return f"{mast_job}_{os.environ.get('MASTER_PORT', 'unknown')}"
+    return f"{adapter_name}_local_" + datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def run_dir(args: argparse.Namespace, adapter_name: str, run_name: str) -> Path:
+    if args.output_dir is not None:
+        return Path(args.output_dir)
+    dump_dir = os.environ.get("DUMP_DIR")
+    if dump_dir:
+        return Path(dump_dir) / "comm_tuning" / adapter_name / run_name
+    return Path("/tmp") / "comm_tuning" / adapter_name / run_name
+
+
+def append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _get_free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return int(sock.getsockname()[1])
+
+
+def _validate_work_item_port_range(
+    args: argparse.Namespace,
+    worklist: list[TuningWorkItem],
+) -> None:
+    if args.candidate_port_mode != "deterministic" or not worklist:
+        return
+    max_port = args.base_master_port + (len(worklist) - 1) * args.master_port_stride
+    if max_port > 65535:
+        raise ValueError(f"work item port range exceeds 65535: {max_port=}")
+
+
+def _work_item_port(
+    *,
+    args: argparse.Namespace,
+    rank: int,
+    work_item: TuningWorkItem,
+) -> int:
+    if args.candidate_port_mode == "dynamic":
+        port_obj: list[int | None] = [_get_free_tcp_port() if rank == 0 else None]
+        dist.broadcast_object_list(port_obj, src=0)
+        return int(port_obj[0])
+    return args.base_master_port + work_item.work_item_id * args.master_port_stride
+
+
+def _has_work_item_result(path: Path, work_item_id: int) -> bool:
+    if not path.exists():
+        return False
+    with path.open() as f:
+        for line in f:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                record.get("record_type") == "work_item_result"
+                and record.get("work_item_id") == work_item_id
+            ):
+                return True
+    return False
+
+
+def _child_args(
+    *,
+    args: argparse.Namespace,
+    entrypoint_path: str,
+    work_item: TuningWorkItem,
+    rank_output_path: Path,
+    run_name: str,
+) -> list[str]:
+    child_args = [
+        sys.executable,
+        entrypoint_path,
+        "--mode",
+        "child",
+        "--work-item-json",
+        json.dumps(work_item.to_json_dict(), separators=(",", ":")),
+        "--rank-output-path",
+        str(rank_output_path),
+        "--run-name",
+        run_name,
+        "--num-warmup",
+        str(args.num_warmup),
+        "--num-iters",
+        str(args.num_iters),
+        "--pg-timeout-sec",
+        str(args.pg_timeout_sec),
+    ]
+    child_args.append("--cuda-graph" if args.cuda_graph else "--no-cuda-graph")
+    return child_args
+
+
+def _run_parent_work_item(
+    *,
+    args: argparse.Namespace,
+    entrypoint_path: str,
+    work_item: TuningWorkItem,
+    rank_output_path: Path,
+    run_name: str,
+    child_log_path: Path,
+    work_item_port: int,
+) -> tuple[int, bool, float]:
+    child_env = os.environ.copy()
+    child_env["MASTER_PORT"] = str(work_item_port)
+    child_env["PYTHONUNBUFFERED"] = "1"
+    child_env.pop("TORCHELASTIC_USE_AGENT_STORE", None)
+
+    timeout_sec = args.work_item_timeout_sec
+    if timeout_sec is None:
+        timeout_sec = args.candidate_timeout_sec
+
+    started = time.time()
+    timed_out = False
+    returncode = 0
+    with child_log_path.open("w") as child_log:
+        try:
+            completed = subprocess.run(
+                _child_args(
+                    args=args,
+                    entrypoint_path=entrypoint_path,
+                    work_item=work_item,
+                    rank_output_path=rank_output_path,
+                    run_name=run_name,
+                ),
+                env=child_env,
+                stdout=child_log,
+                stderr=subprocess.STDOUT,
+                timeout=timeout_sec,
+                check=False,
+            )
+            returncode = completed.returncode
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            returncode = -1
+    return returncode, timed_out, time.time() - started
+
+
+def _record_parent_child_failure(
+    *,
+    rank_output_path: Path,
+    adapter_name: str,
+    run_name: str,
+    rank: int,
+    world_size: int,
+    work_item: TuningWorkItem,
+    returncode: int,
+    timed_out: bool,
+    child_log_path: Path,
+    elapsed_sec: float,
+) -> None:
+    if _has_work_item_result(rank_output_path, work_item.work_item_id):
+        return
+    ended = time.time()
+    append_jsonl(
+        rank_output_path,
+        {
+            "schema_version": 1,
+            "record_type": "parent_child_failure",
+            "adapter": adapter_name,
+            "run_name": run_name,
+            "rank": rank,
+            "world_size": world_size,
+            "work_item_id": work_item.work_item_id,
+            "kind": work_item.kind,
+            "spec_type": work_item.spec_type,
+            "spec": work_item.spec,
+            "key_type": work_item.key_type,
+            "key": work_item.key,
+            "config_type": work_item.config_type,
+            "config": work_item.config,
+            "baseline": work_item.baseline,
+            "status": "error",
+            "returncode": returncode,
+            "timeout": timed_out,
+            "child_log_path": str(child_log_path),
+            "timing": {
+                "start_time_unix": ended - elapsed_sec,
+                "end_time_unix": ended,
+                "elapsed_sec": elapsed_sec,
+            },
+        },
+    )
+
+
+def run_parent(
+    args: argparse.Namespace,
+    adapter: CommKernelTuningAdapter,
+    *,
+    entrypoint_path: str,
+) -> None:
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    run_name = default_run_name(args, adapter.name)
+    output_dir = run_dir(args, adapter.name, run_name)
+    results_dir = output_dir / "results"
+    child_logs_dir = output_dir / "child_logs"
+    worklist = build_worklist(adapter, world_size=world_size)
+    _validate_work_item_port_range(args, worklist)
+
+    parent_pg_initialized = False
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="gloo",
+            timeout=timedelta(seconds=args.pg_timeout_sec),
+        )
+        parent_pg_initialized = True
+
+    if rank == 0:
+        write_json(
+            output_dir / "metadata.json",
+            {
+                "schema_version": 1,
+                "adapter": adapter.name,
+                "run_name": run_name,
+                "world_size": world_size,
+                "num_warmup": args.num_warmup,
+                "num_iters": args.num_iters,
+                "cuda_graph": args.cuda_graph,
+                "work_item_count": len(worklist),
+                "base_master_port": args.base_master_port,
+                "master_port_stride": args.master_port_stride,
+                "candidate_port_mode": args.candidate_port_mode,
+            },
+        )
+        write_json(
+            output_dir / "worklist.json",
+            [work_item.to_json_dict() for work_item in worklist],
+        )
+        print(
+            "[comm-tuner] parent_start "
+            f"adapter={adapter.name} run_name={run_name} world_size={world_size} "
+            f"work_item_count={len(worklist)} output_dir={output_dir} "
+            f"cuda_graph={args.cuda_graph} num_warmup={args.num_warmup} "
+            f"num_iters={args.num_iters}",
+            flush=True,
+        )
+
+    rank_output_path = results_dir / f"rank_{rank:03d}.jsonl"
+    local_ok_count = 0
+    local_error_count = 0
+    try:
+        for work_item in worklist:
+            port = _work_item_port(args=args, rank=rank, work_item=work_item)
+            child_log_path = (
+                child_logs_dir
+                / f"rank_{rank:03d}_work_item_{work_item.work_item_id:06d}.log"
+            )
+            child_log_path.parent.mkdir(parents=True, exist_ok=True)
+            if rank == 0:
+                print(
+                    "[comm-tuner] work_item_start "
+                    f"index={work_item.work_item_id + 1}/{len(worklist)} "
+                    f"kind={work_item.kind} port={port} child_log={child_log_path} "
+                    f"payload={json.dumps(work_item.to_json_dict(), sort_keys=True)}",
+                    flush=True,
+                )
+
+            returncode, timed_out, elapsed_sec = _run_parent_work_item(
+                args=args,
+                entrypoint_path=entrypoint_path,
+                work_item=work_item,
+                rank_output_path=rank_output_path,
+                run_name=run_name,
+                child_log_path=child_log_path,
+                work_item_port=port,
+            )
+            status = "timeout" if timed_out else ("ok" if returncode == 0 else "error")
+            if returncode == 0:
+                local_ok_count += 1
+            else:
+                local_error_count += 1
+            if rank == 0:
+                print(
+                    "[comm-tuner] work_item_done "
+                    f"index={work_item.work_item_id + 1}/{len(worklist)} "
+                    f"work_item_id={work_item.work_item_id} kind={work_item.kind} "
+                    f"status={status} returncode={returncode} "
+                    f"elapsed_sec={elapsed_sec:.3f} child_log={child_log_path}",
+                    flush=True,
+                )
+            if returncode != 0:
+                _record_parent_child_failure(
+                    rank_output_path=rank_output_path,
+                    adapter_name=adapter.name,
+                    run_name=run_name,
+                    rank=rank,
+                    world_size=world_size,
+                    work_item=work_item,
+                    returncode=returncode,
+                    timed_out=timed_out,
+                    child_log_path=child_log_path,
+                    elapsed_sec=elapsed_sec,
+                )
+    finally:
+        if rank == 0:
+            print(
+                "[comm-tuner] parent_done "
+                f"adapter={adapter.name} run_name={run_name} "
+                f"local_ok_count={local_ok_count} "
+                f"local_error_count={local_error_count} results={results_dir}",
+                flush=True,
+            )
+        if parent_pg_initialized:
+            dist.destroy_process_group()
+
+
+def run_child(args: argparse.Namespace, adapter: CommKernelTuningAdapter) -> None:
+    work_item = TuningWorkItem.from_json_dict(json.loads(args.work_item_json))
+    spec = adapter.spec_from_json(work_item.spec_type, work_item.spec)
+    config = (
+        None
+        if work_item.config_type is None or work_item.config is None
+        else adapter.config_from_json(work_item.config_type, work_item.config)
+    )
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    started = time.time()
+    status = "ok"
+    error = None
+    correctness: dict[str, Any] = {"status": "not_applicable"}
+    perf = None
+
+    try:
+        store = dist.TCPStore(
+            host_name=os.environ["MASTER_ADDR"],
+            port=int(os.environ["MASTER_PORT"]),
+            world_size=world_size,
+            is_master=rank == 0,
+            timeout=timedelta(seconds=args.pg_timeout_sec),
+        )
+        dist.init_process_group(
+            backend="nccl",
+            store=store,
+            world_size=world_size,
+            rank=rank,
+            timeout=timedelta(seconds=args.pg_timeout_sec),
+        )
+
+        inputs = adapter.make_inputs(
+            spec,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+        )
+        if work_item.kind == "candidate":
+            assert config is not None
+            reference_output = adapter.run_reference(inputs, dist.group.WORLD)
+            candidate_output = adapter.run_candidate(inputs, config, dist.group.WORLD)
+            torch.cuda.synchronize()
+            dist.barrier()
+            correctness = adapter.check_correctness(candidate_output, reference_output)
+
+            dist.barrier()
+            torch.cuda.synchronize()
+            latency_us = benchmark_callable(
+                lambda: adapter.run_candidate(inputs, config, dist.group.WORLD),
+                num_warmup=args.num_warmup,
+                num_iters=args.num_iters,
+                use_cuda_graph=args.cuda_graph,
+            )
+        elif work_item.kind == "baseline":
+            assert work_item.baseline is not None
+            dist.barrier()
+            torch.cuda.synchronize()
+            latency_us = benchmark_callable(
+                lambda: adapter.run_baseline(
+                    inputs,
+                    work_item.baseline,
+                    dist.group.WORLD,
+                ),
+                num_warmup=args.num_warmup,
+                num_iters=args.num_iters,
+                use_cuda_graph=args.cuda_graph,
+            )
+        else:
+            raise ValueError(f"unsupported work item kind: {work_item.kind}")
+
+        dist.barrier()
+        torch.cuda.synchronize()
+        if rank == 0:
+            perf = {
+                "latency_us": latency_us,
+                "num_warmup": args.num_warmup,
+                "num_iters": args.num_iters,
+                "cuda_graph": args.cuda_graph,
+            }
+    except Exception as exc:
+        status = "error"
+        error = f"{exc!r}\n{traceback.format_exc()}"
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    ended = time.time()
+    record = {
+        "schema_version": 1,
+        "record_type": "work_item_result",
+        "adapter": adapter.name,
+        "run_name": args.run_name,
+        "rank": rank,
+        "world_size": world_size,
+        "work_item_id": work_item.work_item_id,
+        "kind": work_item.kind,
+        "spec_type": work_item.spec_type,
+        "spec": work_item.spec,
+        "key_type": work_item.key_type,
+        "key": work_item.key,
+        "config_type": work_item.config_type,
+        "config": work_item.config,
+        "baseline": work_item.baseline,
+        "status": status,
+        "correctness": correctness,
+        "perf": perf,
+        "timing": {
+            "start_time_unix": started,
+            "end_time_unix": ended,
+            "elapsed_sec": ended - started,
+        },
+        "error": error,
+    }
+    append_jsonl(Path(args.rank_output_path), record)
+    if status != "ok":
+        raise RuntimeError(error)

--- a/comms/tuning/comm_tuning/schemas.py
+++ b/comms/tuning/comm_tuning/schemas.py
@@ -1,0 +1,42 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""JSON-serializable schemas for Triton comm tuning."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+WorkItemKind = Literal["candidate", "baseline"]
+
+
+@dataclass(frozen=True)
+class TuningWorkItem:
+    work_item_id: int
+    kind: WorkItemKind
+    spec_type: str
+    spec: dict[str, Any]
+    key_type: str
+    key: dict[str, Any]
+    config_type: str | None = None
+    config: dict[str, Any] | None = None
+    baseline: str | None = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json_dict(cls, data: dict[str, Any]) -> "TuningWorkItem":
+        return cls(
+            work_item_id=int(data["work_item_id"]),
+            kind=data["kind"],
+            spec_type=str(data["spec_type"]),
+            spec=dict(data["spec"]),
+            key_type=str(data["key_type"]),
+            key=dict(data["key"]),
+            config_type=(
+                None if data.get("config_type") is None else str(data["config_type"])
+            ),
+            config=(None if data.get("config") is None else dict(data["config"])),
+            baseline=(None if data.get("baseline") is None else str(data["baseline"])),
+        )

--- a/comms/tuning/comm_tuning/selection.py
+++ b/comms/tuning/comm_tuning/selection.py
@@ -1,0 +1,176 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Select best Triton comm tuning configs from raw JSONL results."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+from comm_tuning.adapter import CommKernelTuningAdapter
+
+
+def _ws_cat(path: str) -> str:
+    return subprocess.check_output(["ws", "cat", path], text=True)
+
+
+def _ws_ls(path: str) -> list[str]:
+    output = subprocess.check_output(["ws", "ls", path], text=True)
+    entries = []
+    for line in output.splitlines():
+        fields = line.strip().split()
+        if not fields:
+            continue
+        entries.extend(field for field in fields if field.startswith("ws://"))
+    return entries
+
+
+def _join_uri(base: str, child: str) -> str:
+    return base.rstrip("/") + "/" + child.lstrip("/")
+
+
+def _iter_result_lines(input_dir: str) -> Iterable[str]:
+    if input_dir.startswith("ws://"):
+        results_dir = _join_uri(input_dir, "results")
+        for entry in _ws_ls(results_dir):
+            name = entry.rstrip("/").split("/")[-1]
+            if name.startswith("rank_") and name.endswith(".jsonl"):
+                yield from _ws_cat(_join_uri(results_dir, name)).splitlines()
+        return
+
+    results_dir = Path(input_dir) / "results"
+    for path in sorted(results_dir.glob("rank_*.jsonl")):
+        with path.open() as f:
+            yield from f
+
+
+def load_result_records(input_dir: str) -> list[dict[str, Any]]:
+    records = []
+    for line in _iter_result_lines(input_dir):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def _key_group(record: dict[str, Any]) -> tuple[str, str]:
+    return record["key_type"], json.dumps(record["key"], sort_keys=True)
+
+
+def _is_valid_candidate(record: dict[str, Any]) -> bool:
+    correctness = record.get("correctness") or {}
+    perf = record.get("perf") or {}
+    return (
+        record.get("kind") == "candidate"
+        and record.get("status") == "ok"
+        and correctness.get("status") == "pass"
+        and perf.get("latency_us") is not None
+    )
+
+
+def _candidate_sort_key(record: dict[str, Any]) -> tuple[float, str, int]:
+    config_json = json.dumps(record.get("config"), sort_keys=True)
+    return (
+        float(record["perf"]["latency_us"]),
+        config_json,
+        int(record["work_item_id"]),
+    )
+
+
+def select_best_configs(
+    *,
+    adapter: CommKernelTuningAdapter,
+    records: list[dict[str, Any]],
+    source_rank: int = 0,
+) -> dict[str, Any]:
+    rank_records = [
+        record
+        for record in records
+        if record.get("rank") == source_rank
+        and record.get("record_type") == "work_item_result"
+    ]
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for record in rank_records:
+        groups[_key_group(record)].append(record)
+
+    results = []
+    for _group_key, group_records in sorted(groups.items()):
+        candidate_records = [
+            record for record in group_records if record.get("kind") == "candidate"
+        ]
+        valid_candidates = [
+            record for record in candidate_records if _is_valid_candidate(record)
+        ]
+        if not valid_candidates:
+            continue
+
+        best_overall = min(valid_candidates, key=_candidate_sort_key)
+        artifact_candidates = [
+            record
+            for record in valid_candidates
+            if adapter.result_is_artifact_eligible(record)
+        ]
+        if not artifact_candidates:
+            continue
+
+        best = min(artifact_candidates, key=_candidate_sort_key)
+        baselines = {}
+        for record in group_records:
+            if record.get("kind") != "baseline":
+                continue
+            perf = record.get("perf") or {}
+            baselines[str(record.get("baseline"))] = {
+                "work_item_id": record.get("work_item_id"),
+                "latency_us": perf.get("latency_us"),
+                "status": record.get("status"),
+            }
+
+        failed_count = sum(
+            1
+            for record in candidate_records
+            if record.get("status") != "ok"
+            or (record.get("correctness") or {}).get("status") != "pass"
+        )
+        results.append(
+            {
+                "spec_type": best["spec_type"],
+                "spec": best["spec"],
+                "key_type": best["key_type"],
+                "key": best["key"],
+                "best_work_item_id": best["work_item_id"],
+                "best_config_type": best["config_type"],
+                "best_config": best["config"],
+                "best_latency_us": best["perf"]["latency_us"],
+                "best_overall_work_item_id": best_overall["work_item_id"],
+                "best_overall_config_type": best_overall["config_type"],
+                "best_overall_config": best_overall["config"],
+                "best_overall_latency_us": best_overall["perf"]["latency_us"],
+                "best_overall_artifact_eligible": adapter.result_is_artifact_eligible(
+                    best_overall
+                ),
+                "baselines": baselines,
+                "candidate_count": len(candidate_records),
+                "valid_candidate_count": len(valid_candidates),
+                "artifact_eligible_candidate_count": len(artifact_candidates),
+                "failed_candidate_count": failed_count,
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "adapter": adapter.name,
+        "selection_policy": {
+            "name": "lowest_latency_us_artifact_eligible",
+            "source_rank": source_rank,
+            "requires_correctness": True,
+            "records_best_overall_candidate": True,
+        },
+        "results": results,
+    }

--- a/comms/tuning/mast_launcher.py
+++ b/comms/tuning/mast_launcher.py
@@ -1,0 +1,601 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""MAST launcher for source-based Triton comm tuning jobs."""
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torchx.specs import AppDef
+
+_BLACKWELL_AARCH64_INSTANCE_TYPES = {
+    "gb200",
+    "gb300",
+    "gcp_gb300",
+}
+
+_H100_INSTANCE_ALIASES = {
+    "h100": "grandteton_80g_roce",
+}
+_H100_INSTANCE_TYPES = {
+    "grandteton_80g_roce",
+    "grandteton_80g_ib",
+    "oci_h100",
+    "oci_h100_8",
+}
+
+_NCU_BASE_IMAGE_FBPKG = "tupperware.image.sendstream.mast_environments:stable"
+_MOUNT_SCRIPT = "/packages/conda_mast_core/mount/mount.sh"
+
+
+def _normalize_instance_type(instance_type: str) -> str:
+    return _H100_INSTANCE_ALIASES.get(instance_type, instance_type)
+
+
+def _default_region(instance_type: str) -> str:
+    return {
+        "grandteton_80g_roce": "eag",
+        "grandteton_80g_ib": "pci",
+        "t1": "eag",
+        "gb200": "nao",
+        "gb300": "lco",
+        "gcp_gb300": "oce",
+        "oci_h100": "oas",
+        "oci_h100_8": "oas",
+    }.get(instance_type, "pci")
+
+
+def _driver_paths(
+    instance_type: str,
+    conda_package: str,
+    *,
+    preload_gb200_glog: bool,
+) -> tuple[str, str, str, str | None, str, str]:
+    if instance_type in _BLACKWELL_AARCH64_INSTANCE_TYPES:
+        platform_driver_lib_dir = "/usr/local/fbcode/platform010-aarch64/lib"
+        compiler_triple = "aarch64-conda-linux-gnu"
+        triton_ptxas_path = f"/packages/{conda_package}/conda/bin/ptxas"
+    else:
+        platform_driver_lib_dir = "/usr/local/fbcode/platform010/lib"
+        compiler_triple = "x86_64-conda-linux-gnu"
+        triton_ptxas_path = None
+
+    ld_preload = (
+        f"{platform_driver_lib_dir}/libcuda.so:"
+        f"{platform_driver_lib_dir}/libnvidia-ml.so"
+    )
+    if instance_type == "gb200" and preload_gb200_glog:
+        ld_preload += f":/packages/{conda_package}/conda/lib/libglog.so"
+
+    triton_libcuda_path = f"{platform_driver_lib_dir}/libcuda.so"
+    cc_path = f"/packages/{conda_package}/conda/bin/{compiler_triple}-gcc"
+    cxx_path = f"/packages/{conda_package}/conda/bin/{compiler_triple}-g++"
+    return (
+        platform_driver_lib_dir,
+        ld_preload,
+        triton_libcuda_path,
+        triton_ptxas_path,
+        cc_path,
+        cxx_path,
+    )
+
+
+def _parse_env_vars(env: str) -> dict[str, str]:
+    env_vars: dict[str, str] = {}
+    if not env:
+        return env_vars
+    for entry in env.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise ValueError(f"Expected KEY=VALUE in --env entry, got {entry!r}")
+        key, value = entry.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(
+                f"Expected non-empty env var name in --env entry {entry!r}"
+            )
+        env_vars[key] = value
+    return env_vars
+
+
+def _cuda_env_setup(
+    platform_driver_lib_dir: str,
+    cuda_lib_path: str,
+    ld_preload: str,
+    triton_libcuda_path: str,
+) -> str:
+    return (
+        f"export LD_LIBRARY_PATH={shlex.quote(cuda_lib_path)}:${{LD_LIBRARY_PATH:-}} && "
+        f"export LD_PRELOAD={shlex.quote(ld_preload)} && "
+        f"export TRITON_LIBCUDA_PATH={shlex.quote(triton_libcuda_path)}"
+    )
+
+
+def _build_ncu_workload_cmd(
+    ncu_path: str,
+    ncu_metrics: str,
+    ncu_kernel_regex: str,
+    ncu_launch_count: int,
+    python_workload_cmd: str,
+    workspace_package_name: str,
+) -> str:
+    if ncu_path:
+        ncu_bin_setup = [f"NCU_BIN={shlex.quote(ncu_path)}"]
+    else:
+        ncu_bin_setup = [
+            'NCU_BIN="$(command -v ncu || true)"',
+            (
+                'if [ -z "$NCU_BIN" ]; then for candidate in '
+                "/usr/local/cuda-13.0/bin/ncu "
+                "/usr/local/cuda-12.8/bin/ncu "
+                "/opt/nvidia/nsight-compute/2025.3.1/ncu "
+                "/opt/nvidia/nsight-compute/2025.1.1/ncu "
+                "/usr/local/cuda*/bin/ncu "
+                "/opt/nvidia/nsight-compute/*/ncu "
+                "/usr/local/NVIDIA-Nsight-Compute*/ncu; do "
+                'if [ -x "$candidate" ]; then NCU_BIN="$candidate"; break; fi; '
+                "done; fi"
+            ),
+            'if [ -z "$NCU_BIN" ]; then echo "ncu not found" >&2; exit 1; fi',
+        ]
+
+    ncu_setup_parts = [
+        "mkdir -p $DUMP_DIR/ncu",
+        *ncu_bin_setup,
+        'echo "NCU_BIN=$NCU_BIN"',
+        '"$NCU_BIN" --version',
+    ]
+    ncu_cmd_parts = [
+        "env TORCH_SYMM_MEM_DISABLE_MULTICAST=1",
+        '"$NCU_BIN"',
+        "--replay-mode kernel",
+        "--target-processes all",
+        "-f",
+        "-o",
+        "$DUMP_DIR/ncu/ncu_%p",
+        "--metrics",
+        shlex.quote(ncu_metrics),
+        "--launch-count",
+        str(ncu_launch_count),
+    ]
+    if ncu_kernel_regex:
+        ncu_cmd_parts.extend(
+            ["-k", shlex.quote(ncu_kernel_regex), "--kernel-name-base", "function"]
+        )
+    ncu_cmd_parts.append(
+        f"env PYTHONPATH=/packages/{shlex.quote(workspace_package_name)} "
+        f"{python_workload_cmd}"
+    )
+    return " && ".join(ncu_setup_parts + [" ".join(ncu_cmd_parts)])
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    def ignore(_dir: str, names: list[str]) -> set[str]:
+        return {
+            name for name in names if name == "__pycache__" or name.endswith(".pyc")
+        }
+
+    shutil.copytree(src, dst, ignore=ignore)
+
+
+@contextmanager
+def _packaging_workspace(
+    *,
+    workspace_root: Path,
+    workspace_toplevels: tuple[str, ...],
+) -> Iterator[Path]:
+    """Build a minimal source workspace containing caller code and comm_tuning."""
+    with tempfile.TemporaryDirectory(prefix="comm_tuning_workspace_") as tmp:
+        workspace = Path(tmp)
+        for name in workspace_toplevels:
+            src = workspace_root / name
+            if not src.exists():
+                raise FileNotFoundError(
+                    f"workspace top-level path does not exist: {src}"
+                )
+            dst = workspace / name
+            if src.is_dir():
+                _copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+
+        comm_tuning_dst = workspace / "comm_tuning"
+        _copytree(Path(__file__).resolve().parent / "comm_tuning", comm_tuning_dst)
+        yield workspace
+
+
+def _scheduler_args(
+    *,
+    conda_fbpkg_id: str,
+    hpc_cluster_uuid: str,
+    hpc_identity: str,
+    region: str,
+    tenant: str,
+    workspace_package_name: str,
+    workspace_fbpkg_id: Optional[str],
+    priority: Optional[str],
+) -> dict[str, bool | str]:
+    scheduler_args: dict[str, bool | str] = {
+        "activate_conda": False,
+        "conda_fbpkg_id": conda_fbpkg_id,
+        "conda_pack_ignore_missing_files": True,
+        "conda_path_in_fbpkg": "conda",
+        "git": False,
+        "hpcClusterUuid": hpc_cluster_uuid,
+        "hpcIdentity": hpc_identity,
+        "hpcJobOncall": "ncclx",
+        "localityConstraints": f"region;{region};rmAttribution={tenant}",
+        "use_caf": False,
+        "workspace_fbpkg_name": workspace_package_name,
+        "fbpkg_ids": "cif:stable,clicat:stable,torchx_cli:stable,dsi.logger.cat:prod,oil.oilfs:prod,conda_mast_core:stable",
+    }
+    if workspace_fbpkg_id is not None:
+        scheduler_args["workspace_fbpkg_id"] = workspace_fbpkg_id
+    if priority is not None:
+        scheduler_args["jobPriority"] = priority
+    return scheduler_args
+
+
+def _target_kwargs(args: argparse.Namespace, conda_package_name: str) -> dict[str, str]:
+    target_kwargs = {
+        "--script": args.script,
+        "--instance_type": _normalize_instance_type(args.instance_type),
+        "--region": args.region,
+        "--nnodes": str(args.nnodes),
+        "--nproc_per_node": str(args.nproc_per_node),
+        "--max_domain_multiple": str(args.max_domain_multiple),
+        "--conda_package": conda_package_name,
+        "--workspace_package_name": args.workspace_package_name,
+    }
+    if args.oilfs_profile:
+        target_kwargs["--oilfs_profile"] = args.oilfs_profile
+    if args.preload_gb200_glog:
+        target_kwargs["--preload_gb200_glog"] = "true"
+    if args.script_args:
+        target_kwargs["--script_args"] = args.script_args
+    if args.env:
+        target_kwargs["--env"] = args.env
+    if args.ncu:
+        target_kwargs.update(
+            {
+                "--ncu": "true",
+                "--ncu_path": args.ncu_path,
+                "--ncu_metrics": args.ncu_metrics,
+                "--ncu_kernel_regex": args.ncu_kernel_regex,
+                "--ncu_launch_count": str(args.ncu_launch_count),
+            }
+        )
+    if args.hpc_base_image_fbpkg_id:
+        target_kwargs["--hpc_base_image_fbpkg_id"] = args.hpc_base_image_fbpkg_id
+    return target_kwargs
+
+
+def _torchx_cmd(
+    *,
+    scheduler: str,
+    scheduler_args: dict[str, bool | str],
+    target_kwargs: dict[str, str],
+    workspace: Path,
+    dry_run: bool,
+) -> list[str]:
+    scheduler_args_str = ",".join(f"{k}={v}" for k, v in scheduler_args.items())
+    target = f"{Path(__file__).resolve()}:submit_job"
+    cmd = [
+        "torchx",
+        "run",
+        f"--scheduler={scheduler}",
+        f"--scheduler_args={scheduler_args_str}",
+        "--workspace",
+        str(workspace),
+    ]
+    if dry_run:
+        cmd.append("--dryrun")
+    cmd.append(target)
+    for k, v in target_kwargs.items():
+        cmd.append(f"{k}={v}")
+    return cmd
+
+
+def _run_torchx_cmd(cmd: list[str], interactive: bool) -> tuple[str, str]:
+    env = os.environ.copy()
+    with tempfile.NamedTemporaryFile() as torchx_config:
+        env["TORCHXCONFIG"] = torchx_config.name
+        env.pop("LD_PRELOAD", None)
+        env.pop("LD_LIBRARY_PATH", None)
+        if interactive:
+            env["TORCHX_INTERACTIVE"] = "1"
+
+        result = subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    return result.stdout, result.stderr
+
+
+def submit_job(
+    script: str,
+    instance_type: str = "gb200",
+    region: str = "nao",
+    nnodes: int = 1,
+    nproc_per_node: int = 2,
+    max_domain_multiple: int = 16,
+    script_args: str = "",
+    conda_package: str = "",
+    workspace_package_name: str = "",
+    oilfs_profile: str = "",
+    preload_gb200_glog: bool = False,
+    ncu: bool = False,
+    ncu_path: str = "",
+    ncu_metrics: str = "sm__cycles_elapsed.avg,dram__bytes_read.sum,dram__bytes_write.sum,launch__registers_per_thread",
+    ncu_kernel_regex: str = "",
+    ncu_launch_count: int = 1,
+    hpc_base_image_fbpkg_id: str = "",
+    env: str = "",
+) -> "AppDef":
+    import torchx.components.fb.conda as conda
+    from torchx.specs.fb.named_resources import MAST_WHOLE_HOST_FEATURE
+
+    instance_type = _normalize_instance_type(instance_type)
+    if not conda_package:
+        raise ValueError("conda_package is required")
+    if not workspace_package_name:
+        raise ValueError("workspace_package_name is required")
+
+    script_name = os.path.splitext(os.path.basename(script))[0]
+    script_args_list = script_args.split() if script_args else []
+    script_args_list.append("--torchx")
+    script_args_str = " ".join(script_args_list)
+
+    python_path = f"/packages/{conda_package}/conda/bin/python"
+    cuda_lib_path = f"/packages/{conda_package}/conda/lib"
+
+    (
+        platform_driver_lib_dir,
+        ld_preload,
+        triton_libcuda_path,
+        triton_ptxas_path,
+        cc_path,
+        cxx_path,
+    ) = _driver_paths(
+        instance_type,
+        conda_package,
+        preload_gb200_glog=preload_gb200_glog,
+    )
+
+    python_workload_cmd = (
+        f"{shlex.quote(python_path)} -u ops/{shlex.quote(script)} {script_args_str}"
+    )
+    if ncu:
+        workload_cmd = _build_ncu_workload_cmd(
+            ncu_path,
+            ncu_metrics,
+            ncu_kernel_regex,
+            ncu_launch_count,
+            python_workload_cmd,
+            workspace_package_name,
+        )
+    else:
+        workload_cmd = (
+            f"PYTHONPATH=/packages/{shlex.quote(workspace_package_name)} "
+            f"{python_workload_cmd}"
+        )
+
+    cuda_env_setup = _cuda_env_setup(
+        platform_driver_lib_dir,
+        cuda_lib_path,
+        ld_preload,
+        triton_libcuda_path,
+    )
+    bash_cmd = (
+        f"{cuda_env_setup} && "
+        "mkdir -p $DUMP_DIR && "
+        f"cd /packages/{shlex.quote(workspace_package_name)} && "
+        f"{workload_cmd}"
+    )
+
+    job_env = {
+        "DUMP_DIR": "/mnt/wsfuse/outputs/${app_id}",
+        "TRITON_CACHE_DIR": "/tmp/triton_cache",
+        "CC": cc_path,
+        "CXX": cxx_path,
+        "NCCL_DEBUG": "WARN",
+        "TORCH_CPP_LOG_LEVEL": "WARNING",
+    }
+    if oilfs_profile:
+        job_env["OILFS_PROFILE"] = oilfs_profile
+    job_env.update(_parse_env_vars(env))
+
+    job_spec = conda.torchrun(
+        "--tee",
+        "3",
+        "--role",
+        "trainer",
+        "--nnodes",
+        f"{nnodes}",
+        "--nproc-per-node",
+        f"{nproc_per_node}",
+        "--no-python",
+        "bash",
+        "-c",
+        bash_cmd,
+        h=instance_type,
+        run_as_root=True,
+        env=job_env,
+    )
+    if triton_ptxas_path is not None:
+        job_spec.roles[0].env["TRITON_PTXAS_PATH"] = triton_ptxas_path
+
+    job_spec.name = script_name
+    if not hpc_base_image_fbpkg_id and ncu:
+        hpc_base_image_fbpkg_id = _NCU_BASE_IMAGE_FBPKG
+
+    if instance_type in _BLACKWELL_AARCH64_INSTANCE_TYPES and (
+        nnodes * nproc_per_node >= 2
+    ):
+        job_spec.roles[0].resource.capabilities[MAST_WHOLE_HOST_FEATURE] = True
+
+    hpc_task_group_spec = (
+        job_spec.roles[0]
+        .metadata.setdefault("mast", {})
+        .setdefault("HpcTaskGroupSpec", {})
+    )
+    if hpc_base_image_fbpkg_id:
+        hpc_task_group_spec["baseImage"] = {
+            "baseImagePackage": {"fbpkgIdentifier": hpc_base_image_fbpkg_id}
+        }
+    if instance_type in _BLACKWELL_AARCH64_INSTANCE_TYPES:
+        hpc_task_group_spec["topologyConstraints"] = [
+            {
+                "domain": {
+                    "multiple": min(nnodes, max_domain_multiple),
+                    "quorumBuffer": 0,
+                }
+            }
+        ]
+
+    job_spec.roles[0].env["TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE"] = "[${rank}]:"
+    mount_wsfuse = (
+        f"({_MOUNT_SCRIPT} || "
+        'echo "WARNING: failed to run /mnt/wsfuse mount helper; outputs may not persist." >&2) && '
+        "if ! mountpoint -q /mnt/wsfuse 2>/dev/null && ! grep -q ' /mnt/wsfuse ' /proc/mounts; then "
+        'echo "WARNING: /mnt/wsfuse is not mounted. Outputs under $DUMP_DIR may not persist." >&2; '
+        'echo "WARNING: check warm-storage ACLs for FUSE_SRC=${FUSE_SRC:-unset} and hpcIdentity if outputs are missing." >&2; '
+        "fi"
+    )
+    job_spec.roles[0].entrypoint = f"{mount_wsfuse} && {job_spec.roles[0].entrypoint}"
+    job_spec.metadata["tags"] = ",".join(["comm_tuning", script])
+    return job_spec
+
+
+def launch_mast(args: argparse.Namespace) -> tuple[str, str]:
+    instance_type = _normalize_instance_type(args.instance_type)
+    if args.region is None:
+        args.region = _default_region(instance_type)
+
+    workspace_root = Path(args.workspace_root).expanduser().resolve()
+    workspace_toplevels = tuple(
+        part.strip() for part in args.workspace_toplevels.split(",") if part.strip()
+    )
+    conda_package_name = args.conda_fbpkg_id.split(":")[0]
+    scheduler_args = _scheduler_args(
+        conda_fbpkg_id=args.conda_fbpkg_id,
+        hpc_cluster_uuid=args.hpc_cluster_uuid,
+        hpc_identity=args.hpcIdentity,
+        region=args.region,
+        tenant=args.tenant,
+        workspace_package_name=args.workspace_package_name,
+        workspace_fbpkg_id=args.workspace_fbpkg_id,
+        priority=args.priority,
+    )
+    target_kwargs = _target_kwargs(args, conda_package_name)
+
+    with _packaging_workspace(
+        workspace_root=workspace_root,
+        workspace_toplevels=workspace_toplevels,
+    ) as workspace:
+        cmd = _torchx_cmd(
+            scheduler=args.scheduler,
+            scheduler_args=scheduler_args,
+            target_kwargs=target_kwargs,
+            workspace=workspace,
+            dry_run=args.dry_run,
+        )
+        print(f"\nFull torchx run command:\n{' '.join(cmd)}\n")
+        stdout_content, stderr_content = _run_torchx_cmd(cmd, args.interactive)
+
+    if stdout_content:
+        print(stdout_content, end="")
+    if stderr_content:
+        print(stderr_content, end="", file=sys.stderr)
+
+    if args.dry_run:
+        return "<dry_run>", "<dry_run>"
+
+    pat = rf"{re.escape(args.scheduler)}://torchx/([^\s]+)"
+    for line in stdout_content.splitlines():
+        if match := re.search(pat, line):
+            job_id = match.group(1)
+            return job_id, f"/mnt/wsfuse/outputs/{job_id}"
+    raise ValueError("Unable to extract job name from torchx run output.")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Launch Triton comm tuning jobs on MAST.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--instance_type", type=str, required=True)
+    parser.add_argument("--nnodes", type=int, required=True)
+    parser.add_argument("--nproc_per_node", type=int, required=True)
+    parser.add_argument("--script", type=str, required=True)
+    parser.add_argument("--script_args", type=str, default="")
+    parser.add_argument("--region", type=str, default=None)
+    parser.add_argument("--scheduler", type=str, required=True)
+    parser.add_argument("--tenant", type=str, required=True)
+    parser.add_argument("--hpcIdentity", type=str, required=True)
+    parser.add_argument("--hpc_cluster_uuid", type=str, required=True)
+    parser.add_argument("--conda_fbpkg_id", type=str, required=True)
+    parser.add_argument("--workspace_package_name", type=str, required=True)
+    parser.add_argument("--workspace_fbpkg_id", type=str, default=None)
+    parser.add_argument(
+        "--workspace_root",
+        type=str,
+        required=True,
+        help="Caller source workspace to package.",
+    )
+    parser.add_argument(
+        "--workspace_toplevels",
+        type=str,
+        required=True,
+        help="Comma-separated top-level workspace paths copied into the MAST package.",
+    )
+    parser.add_argument("--oilfs_profile", type=str, default="")
+    parser.add_argument("--max_domain_multiple", type=int, default=32)
+    parser.add_argument("--priority", type=str, default=None)
+    parser.add_argument("--interactive", action="store_true")
+    parser.add_argument("--dry_run", action="store_true")
+    parser.add_argument(
+        "--preload_gb200_glog",
+        action="store_true",
+        help="Preload conda libglog on GB200. Disabled by default due duplicate flag registration failures.",
+    )
+    parser.add_argument("--ncu", action="store_true")
+    parser.add_argument("--ncu_path", type=str, default="")
+    parser.add_argument(
+        "--ncu_metrics",
+        type=str,
+        default="sm__cycles_elapsed.avg,dram__bytes_read.sum,dram__bytes_write.sum,launch__registers_per_thread",
+    )
+    parser.add_argument("--ncu_kernel_regex", type=str, default="")
+    parser.add_argument("--ncu_launch_count", type=int, default=1)
+    parser.add_argument("--hpc_base_image_fbpkg_id", type=str, default=None)
+    parser.add_argument("--env", type=str, default="")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    job_id, dump_dir = launch_mast(args)
+    print("\n" + "=" * 80)
+    print("MAST job submitted successfully!")
+    print(f"Job ID: {job_id}")
+    print(f"\nOutputs written to: {dump_dir}")
+    print("=" * 80 + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary: Add a reusable Triton communication-kernel autotuning framework and wire it to a product-specific A2A non-contig benchmark adapter. The reusable package provides the adapter interface, parent/child execution engine, JSONL schemas, result selection, generated-artifact writers, and a source-based MAST launcher. The kernel-specific adapter remains with the benchmark code so the shared comms package stays independent of product-specific dependencies.

Reviewed By: jspark1105, cenzhaometa

Differential Revision: D106546459


