### PR TITLE
Add isAborted and revoke-on-timeout in reconfigurable mode to nccl/ncclx

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -342,7 +342,10 @@ void TorchCommNCCL::abortNcclComm() {
         "NCCL Abort failed");
     nccl_comm_ = nullptr;
   }
-  if (options_.abort_process_on_timeout_or_error) {
+  // Never abort the process in reconfigurable mode: callers fall back to
+  // revoke + throw so the failure can be handled by reconfiguring.
+  if (options_.abort_process_on_timeout_or_error &&
+      !options_.enable_reconfigure) {
     TC_LOG(ERROR, this) << "Aborting process due to timeout";
     runAbortHooks();
     ::abort();
@@ -350,16 +353,34 @@ void TorchCommNCCL::abortNcclComm() {
 }
 
 void TorchCommNCCL::revokeNcclComm() {
+  // Idempotent: the timeout watchdog and a synchronous collective may both
+  // observe the same timeout and attempt a revoke. Run the teardown (abort
+  // hooks, memory hook detach, commRevoke) at most once per communicator
+  // generation. revoked_ is reset on reconfigure.
+  if (revoked_.exchange(true)) {
+    return;
+  }
   TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
   runAbortHooks();
   detachMemoryHook();
   if (nccl_comm_) {
-    NCCL_CHECK(
-        nccl_api_,
-        nccl_comm_,
-        nccl_api_->commRevoke(nccl_comm_),
-        "NCCL Revoke failed");
+    // Best-effort: this may run on the timeout watchdog thread, so log instead
+    // of throwing on failure (the communicator is already being torn down).
+    NCCL_CHECK_IGNORE(
+        nccl_api_, nccl_api_->commRevoke(nccl_comm_), "NCCL Revoke failed");
   }
+}
+
+bool TorchCommNCCL::isAbortSupported() const {
+  return true;
+}
+
+bool TorchCommNCCL::isAborted() const {
+  // A non-NORMAL state means the communicator hit a timeout or error (set by
+  // the timeout watchdog, a synchronous collective, or abort()). Reading the
+  // atomic issues no CUDA/NCCL calls, so this is safe to poll during CUDA graph
+  // replay, where per-operation work handles are unavailable.
+  return comm_state_.load() != CommState::NORMAL;
 }
 
 int TorchCommNCCL::getRank() const {

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -214,6 +214,8 @@ class TorchCommNCCL : public TorchCommBackend,
   c10::intrusive_ptr<TorchWork> reconfigure(
       const ReconfigureOptions& opts) override;
   void abort() override;
+  bool isAbortSupported() const override;
+  bool isAborted() const override;
 
   // Friend access for TorchCommNCCL
   friend class TorchWorkNCCL;
@@ -289,6 +291,12 @@ class TorchCommNCCL : public TorchCommBackend,
 
   std::atomic<CommState> comm_state_{
       CommState::NORMAL}; // State of the communicator
+
+  // Set once the communicator has been revoked (the graceful abort path used in
+  // reconfigurable mode). Guards revokeNcclComm() so its teardown runs at most
+  // once per communicator generation, even when both the timeout watchdog and a
+  // synchronous collective observe the same failure. Reset on reconfigure.
+  std::atomic<bool> revoked_{false};
 
   void register_address(const AddressWithLen& addr);
   void deregister_address(const Address& addr);

--- a/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLReconfigure.cpp
@@ -266,6 +266,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
   if (quorum.ranks.empty()) {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
 
     CUDA_CHECK(
         cuda_api_,
@@ -385,10 +386,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::reconfigure(
     nccl_comm_ = current;
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
     initNcclResources();
   } else {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
 
     int quorumSize = static_cast<int>(quorum.ranks.size());
     auto store = connectStore(

--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -252,7 +252,7 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
       ::abort();
     }
 
-    // Check communicator for async error
+    // Detect a communicator-level async error while the comm is still healthy.
     if (comm_state_ == CommState::NORMAL) {
       ncclResult_t asyncErr;
       NCCL_CHECK(
@@ -262,14 +262,39 @@ void TorchCommNCCL::timeoutWatchdog() noexcept {
           "failed to get async error");
       if (asyncErr != ncclSuccess) {
         comm_state_ = CommState::ERROR;
-        TC_LOG(ERROR, this)
-            << "Aborting process due to error on rank " << rank_
-            << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
+        if (!options_.enable_reconfigure) {
+          TC_LOG(ERROR, this)
+              << "Aborting process due to error on rank " << rank_
+              << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
 
-        runAbortHooks();
+          runAbortHooks();
 
-        abort();
+          abort();
+        } else {
+          // Revoked below by the reconfigurable-mode handler.
+          TC_LOG(ERROR, this)
+              << "Async error on rank " << rank_ << ": "
+              << ncclGetErrorString(asyncErr) << " (reconfigurable mode)";
+        }
       }
+    }
+
+    // In reconfigurable mode, gracefully revoke the communicator on any failure
+    // -- timeout or error, whether surfaced by the work queue or an async comm
+    // error -- so in-flight operations are stopped and the comm can later be
+    // reconfigured. This is the only revoke path under CUDA graph replay, where
+    // no synchronous collective reaches checkAndAbortIfTimedOutOrError();
+    // isAborted() then reports the revoked state to the caller.
+    // revokeNcclComm() is idempotent and the revoked_ check keeps the watchdog
+    // from logging every iteration.
+    if (comm_state_ != CommState::NORMAL && options_.enable_reconfigure &&
+        !revoked_.load()) {
+      TC_LOG(ERROR, this) << "Revoking communicator on rank " << rank_
+                          << " - watchdog detected "
+                          << (comm_state_ == CommState::TIMEOUT ? "timeout"
+                                                                : "error")
+                          << " (reconfigurable mode)";
+      revokeNcclComm();
     }
   }
 
@@ -314,6 +339,12 @@ void TorchCommNCCL::checkAndAbortIfTimedOutOrError() {
         "failed to get async error");
     NCCLException ncclException(
         *nccl_api_, "NCCL Async Error", asyncErr, nccl_comm_);
+    if (options_.enable_reconfigure) {
+      // In reconfigurable mode we never abort the process: revoke the comm so
+      // it can be reconfigured and surface the error to the caller.
+      revokeNcclComm();
+      throw ncclException;
+    }
     abortNcclComm();
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -484,15 +484,33 @@ void TorchCommNCCLX::abortNcclComm() {
 }
 
 void TorchCommNCCLX::revokeNcclComm() {
+  // Idempotent: the timeout watchdog and a synchronous collective may both
+  // observe the same timeout and attempt a revoke. Run the teardown (abort
+  // hooks, commRevoke) at most once per communicator generation. revoked_ is
+  // reset on reconfigure.
+  if (revoked_.exchange(true)) {
+    return;
+  }
   TC_LOG(INFO, this) << "Calling abort hooks before commRevoke.";
   runAbortHooks();
   if (nccl_comm_) {
-    NCCLX_CHECK(
-        nccl_api_,
-        nccl_comm_,
-        nccl_api_->commRevoke(nccl_comm_),
-        "NCCLX Revoke failed");
+    // Best-effort: this may run on the timeout watchdog thread, so log instead
+    // of throwing on failure (the communicator is already being torn down).
+    NCCLX_CHECK_IGNORE(
+        nccl_api_, nccl_api_->commRevoke(nccl_comm_), "NCCLX Revoke failed");
   }
+}
+
+bool TorchCommNCCLX::isAbortSupported() const {
+  return true;
+}
+
+bool TorchCommNCCLX::isAborted() const {
+  // A non-NORMAL state means the communicator hit a timeout or error (set by
+  // the timeout watchdog, a synchronous collective, or abort()). Reading the
+  // atomic issues no CUDA/NCCL calls, so this is safe to poll during CUDA graph
+  // replay, where per-operation work handles are unavailable.
+  return comm_state_.load() != CommState::NORMAL;
 }
 
 int TorchCommNCCLX::getRank() const {

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -255,6 +255,8 @@ class TorchCommNCCLX : public TorchCommBackend,
   c10::intrusive_ptr<TorchWork> reconfigure(
       const ReconfigureOptions& opts) override;
   void abort() override;
+  bool isAbortSupported() const override;
+  bool isAborted() const override;
 
   std::unordered_map<std::string, std::string> comm_dump();
   // Friend access for TorchCommNCCLX
@@ -319,6 +321,12 @@ class TorchCommNCCLX : public TorchCommBackend,
 
   std::atomic<CommState> comm_state_{
       CommState::NORMAL}; // State of the communicator
+
+  // Set once the communicator has been revoked (the graceful abort path used in
+  // reconfigurable mode). Guards revokeNcclComm() so its teardown runs at most
+  // once per communicator generation, even when both the timeout watchdog and a
+  // synchronous collective observe the same failure. Reset on reconfigure.
+  std::atomic<bool> revoked_{false};
 
   cudaEvent_t
       dependency_event_{}; // Pre-allocated event for stream dependencies

--- a/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXReconfigure.cpp
@@ -263,6 +263,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
   if (quorum.ranks.empty()) {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
 
     CUDA_CHECK(
         cuda_api_,
@@ -379,10 +380,12 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::reconfigure(
     nccl_comm_ = current;
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
     initNcclxResources();
   } else {
     comm_state_ = CommState::NORMAL;
     shutdown_ = false;
+    revoked_ = false;
 
     int quorumSize = static_cast<int>(quorum.ranks.size());
     auto store = connectStore(

--- a/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXUtils.cpp
@@ -293,7 +293,7 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
       std::abort();
     }
 
-    // Check communicator for async error
+    // Detect a communicator-level async error while the comm is still healthy.
     if (comm_state_ == CommState::NORMAL) {
       ncclResult_t asyncErr;
       NCCLX_CHECK(
@@ -303,14 +303,39 @@ void TorchCommNCCLX::timeoutWatchdog() noexcept {
           "failed to get async error");
       if (asyncErr != ncclSuccess) {
         comm_state_ = CommState::ERROR;
-        TC_LOG(ERROR, this)
-            << "Aborting process due to error on rank " << rank_
-            << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
+        if (!options_.enable_reconfigure) {
+          TC_LOG(ERROR, this)
+              << "Aborting process due to error on rank " << rank_
+              << " - nccl hit async error: " << ncclGetErrorString(asyncErr);
 
-        runAbortHooks();
+          runAbortHooks();
 
-        std::abort();
+          std::abort();
+        } else {
+          // Revoked below by the reconfigurable-mode handler.
+          TC_LOG(ERROR, this)
+              << "Async error on rank " << rank_ << ": "
+              << ncclGetErrorString(asyncErr) << " (reconfigurable mode)";
+        }
       }
+    }
+
+    // In reconfigurable mode, gracefully revoke the communicator on any failure
+    // -- timeout or error, whether surfaced by the work queue, the graph-event
+    // tracker, or an async comm error -- so in-flight operations are stopped
+    // and the comm can later be reconfigured. This is the only revoke path
+    // under CUDA graph replay, where no synchronous collective reaches
+    // checkAndAbortIfTimedOutOrError(); isAborted() then reports the revoked
+    // state to the caller. revokeNcclComm() is idempotent and the revoked_
+    // check keeps the watchdog from logging every iteration.
+    if (comm_state_ != CommState::NORMAL && options_.enable_reconfigure &&
+        !revoked_.load()) {
+      TC_LOG(ERROR, this) << "Revoking communicator on rank " << rank_
+                          << " - watchdog detected "
+                          << (comm_state_ == CommState::TIMEOUT ? "timeout"
+                                                                : "error")
+                          << " (reconfigurable mode)";
+      revokeNcclComm();
     }
   }
 
@@ -358,6 +383,12 @@ void TorchCommNCCLX::checkAndAbortIfTimedOutOrError() {
         "failed to get async error");
     NCCLXException ncclException(
         *nccl_api_, "NCCLX Async Error", asyncErr, nccl_comm_);
+    if (options_.enable_reconfigure) {
+      // In reconfigurable mode we never abort the process: revoke the comm so
+      // it can be reconfigured and surface the error to the caller.
+      revokeNcclComm();
+      throw ncclException;
+    }
     abortNcclComm();
     if (options_.abort_process_on_timeout_or_error) {
       TC_LOG(ERROR, this) << "Aborting process due to error: "

--- a/comms/torchcomms/tests/integration/py/AbortTest.py
+++ b/comms/torchcomms/tests/integration/py/AbortTest.py
@@ -77,6 +77,18 @@ class AbortTest(unittest.TestCase):
         comm.abort()
         comm.finalize()
 
+    def test_is_aborted(self):
+        """is_aborted() reflects the communicator state across abort()."""
+        comm = self._create_reconfigurable_comm("abort_is_aborted_state", 1)
+
+        self.assertTrue(comm.is_abort_supported())
+        self.assertFalse(comm.is_aborted())
+
+        comm.abort()
+        self.assertTrue(comm.is_aborted())
+
+        comm.finalize()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implement isAborted()/isAbortSupported() on the NCCL and NCCLX backends and make reconfigurable mode fully graceful: on any timeout or error the communicator is revoked (not destroyed) and the failure is surfaced via throw or isAborted(), never by aborting the process.

- isAborted() returns comm_state_ != NORMAL; isAbortSupported() returns true. isAborted() only reads an atomic, so it is safe to poll during CUDA graph replay where per-operation work handles are unavailable.
- The timeout watchdog now revokes the communicator on any failure -- timeout or error, whether surfaced by the work queue, the graph-event tracker, or an async comm error -- in reconfigurable mode. This is the only revoke path under CUDA graph replay, where no synchronous collective reaches checkAndAbortIfTimedOutOrError(). revokeNcclComm() (ncclCommRevoke) stops in-flight operations while keeping the comm valid for reconfigure.
- revokeNcclComm() is now idempotent (guarded by an atomic revoked_ flag, reset on reconfigure) and best-effort (NCCL*_CHECK_IGNORE), so the watchdog and a synchronous collective can both observe the same failure without double-firing abort hooks or terminating from the noexcept watchdog.
- Removed every remaining std::abort()/::abort() path reachable in reconfigurable mode: watchdog async-error handling, the ERROR branch of checkAndAbortIfTimedOutOrError, and abortNcclComm()'s process-abort.

Adds an is_aborted integration test to AbortTest.

Test plan:
- lintrunner clean on all changed files.
- Built + linked the NCCL backend (torchcomms_comms_nccl); compile-checked the changed NCCLX translation units (0 errors beyond a pre-existing, unrelated commSetConfig mismatch from a stale vendored fork header).
- torchrun --nproc_per_node=2 comms/torchcomms/tests/integration/py/AbortTest.py with TEST_BACKEND in {nccl, ncclx} (exercises abort() and the new is_aborted()).