### PR TITLE
Compute hooks for both DSLs + validate end-to-end (#2831)

### DIFF
--- a/comms/dsl/README.md
+++ b/comms/dsl/README.md
@@ -1,0 +1,112 @@
+# comms/dsl: customized collectives without the plumbing - a hook in, an autotuned kernel out
+
+`comms/dsl` framework lets a kernel developer (user) build a customized, autotunable collective in DSLs (Triton or CuTe) by writing only the small part that differentiates their kernel: per-tile hooks and optionally transports, while the framework owns the generic ~95% (schedule, multi-peer addressing, signal/wait protocol) and automates the performance tuning.
+
+## Why
+
+Researchers prototype new ideas as kernels in DSLs like Triton/CuTe instead of CUDA/C++ for the fast iteration loop. Scaling the idea needs communication, and that usually leads to repetitive work: days-to-weeks of race-prone stage/signal/wait/fence logic, re-derived per kernel, with bugs that could pass tests and fail at scale. Notably, the part that differentiates the kernel is typically small: a transpose, a quantize, or an accumulate, while a lot around it is plumbing.
+
+For instance, the `all_to_all_single_non_contig` kernel is ~800 lines, of which roughly 95% is generic machinery, including the signaling protocol, the pipeline, symmetric-memory staging, multi-peer addressing, and tile-size math. The remaining ~5% is layout transform, which is what really makes this kernel unique.
+
+Furthermore, reaching correctness is only half the journey. Each kernel is then tuned against production shapes maintained per hardware tier, because the launch parameters that win on one shape/hardware may lose on the others.
+
+comms/dsl breaks both loops. It provides the customizable boilerplate, and it turns performance into an autotuner run.
+
+## The pieces
+
+| Piece | What it is |
+|---|---|
+| **Transport** | A fabric binding (NVLink today, IB later): cross-GPU memory + signaling state, created once via a `rendezvous` over PyTorch symmetric memory. The framework ships defaults and the user either sets one up or could provide their own. |
+| **Endpoint (`PeerEndpoint`)** | How the transport hands a schedule per-peer addresses - `send_dst` (where to write into a peer), `recv_src` (where to read its data), and the signal slots - so no schedule touches raw pointers. Two forms: a host-resolved `PeerEndpoint` for a single peer (used by `send_tile`/`recv_tile`), and a device-side table of all peers that a fused collective indexes by peer in-kernel (e.g. `all_to_all`). |
+| **Ops** | The transport's four device functions that act on those addresses: `put` (remote write), `get` (local read), `signal`/`wait` (the data-ready handshake). The only fabric-specific (NVLink vs IB) device code; hooks and schedules call them and stay transport-agnostic. |
+| **Hook + `Ctx`** | The 5% the user writes: `produce(ctx) -> tile` and `consume(ctx, tile)`. `Ctx` is the per-tile view the framework hands the hook - input/output pointer, flat index, mask, and within-chunk position. This is where a transpose / gather / quantize / accumulate goes. |
+| **Collective** | The shipped schedule (e.g. `all_to_all`) that runs the hook over the fused `peer x block` transfer, owning all addressing and signal/wait. |
+| **`Config` + `Key`** | `Config` = the launch tunables the autotuner sweeps; `Key` = how a tuned config is looked up at runtime. Both are defined by the user (see principles). |
+| **Adapter** | A thin class that plugs a collective into the comms-owned tuner engine (`comm_tuning`). |
+
+Flow: a `Transport` gives the kernel per-peer addresses; the `Collective` loops tiles, calling the user's `Hook` (compute) and the `ops` (move + signal); a `Config`, looked up by `Key`, sets the launch parameters.
+
+## Design principles
+
+- Own the 95%, expose the 5%. The framework owns the schedule and the race-prone protocol; the user writes a per-tile `produce`/`consume` hook (transpose, gather, quantize, accumulate) and supplies a transport. No fences, no wait loops, no deadlock reasoning in user code.
+- Performance is autotuned, and the tuner is generic. The user declares two things: a `Key` (which input properties should map to one tuned config - size, dtype, world size, layout, whatever matters for that kernel) and a `Config` (the launch knobs to sweep). A shared engine sweeps configs offline and emits a `{Key: Config}` map; at runtime the collective rebuilds the same key and looks it up (safe default if absent). Changing shapes means re-running the tuner, not rewriting the kernel.
+- Spectrum of control. Plug-and-play collective (write a hook) -> `send_tile`/`recv_tile` (keep your own schedule) -> raw `put`/`get`/`signal`/`wait` ops (full control). Climb only as high as you need.
+- Contracts shared, code per-DSL. Triton and CuTe share the same op names, hook roles, and Config/Key shapes; the device kernels are written per DSL (flat pointers vs partitions), since device code is not portable across DSLs.
+
+## Example: a custom collective (a2a non-contig), end to end
+
+The whole workflow for a non-contiguous all-to-all - write it, then autotune it.
+
+### 1. Write it (the ~5%)
+
+A transport, one hook, one call:
+
+```python
+from comms.dsl import nvl_rendezvous
+from comms.dsl.triton import all_to_all
+from comms.dsl.triton.hooks import transpose_produce   # the 5%: the layout transform
+
+t = nvl_rendezvous(group, dev, per_peer_bytes=chunk_bytes)   # transport (staging + signaling)
+all_to_all(t, out, inp, produce=transpose_produce, rows=R)   # config=None -> tuned lookup
+```
+
+`nvl_rendezvous` allocates the per-peer staging buffer + signal pad once; `rows` describes the 2D tile layout the hook reads; with no `produce` hook this is a plain all-to-all.
+
+The hook is the 5%. `ctx` is the per-tile view (input pointer, flat index, mask, within-chunk position `pos` with `rows`/`cols`); it returns the tile to send - here, the transposed source position, fused into the transfer leg with no extra HBM pass:
+
+```python
+@triton.jit
+def transpose_produce(ctx):
+    r = ctx.pos % ctx.rows           # position in the transposed [cols, rows] layout
+    c = ctx.pos // ctx.rows
+    src = r * ctx.cols + c           # source position in the [rows, cols] layout
+    base = ctx.idx - ctx.pos         # chunk base in the input
+    return tl.load(ctx.ptr + base + src, mask=ctx.mask)
+```
+
+The framework runs the fused `peer x block` schedule (multi-peer addressing, signal/wait) in one launch, validated bit-exact against `dist.all_to_all_single` on 4 ranks.
+
+### 2. Autotune it
+
+Write one thin adapter - the engine is generic, so you only declare your `Key` and the `Config`s to sweep:
+
+```python
+class A2ATuningAdapter(CommKernelTuningAdapter):
+    def enumerate_input_specs(self, world_size): ...      # the shapes to tune
+    def make_key(self, spec, world_size): ...             # YOUR key (must match runtime)
+    def enumerate_candidate_configs(self, spec, key): ... # YOUR configs to sweep
+    def make_inputs(self, spec, *, rank, world_size, device): ...   # tensors + nvl_rendezvous
+    def run_candidate(self, inputs, config, group):       # the collective with the tuned config
+        all_to_all(inputs.transport, inputs.output, inputs.input, rows=inputs.rows, config=config)
+        return inputs.output
+    def run_baseline(self, inputs, baseline, group): ...  # e.g. NCCL, the speed baseline
+    def check_correctness(self, candidate, reference): ...
+```
+
+Parent mode sweeps every candidate, benchmarks it against your baseline, and checks correctness; select mode picks the winner per key and writes a generated table:
+
+```python
+# comms/dsl/triton/generated/a2a_tuned_configs.py  (generated; do not hand-edit)
+from comms.dsl.triton.collectives_tuning import A2AConfig, A2AKey
+
+TUNED_A2A_CONFIGS = {
+    A2AKey(world_size=8, dtype="bfloat16", numel=8192, rows=0, transport_kind="NvlTransport"):
+        A2AConfig(num_blocks=16, block=2048, num_warps=8),
+    # ... one row per tuned key ...
+}
+```
+
+Then nothing else changes: the Step 1 call `all_to_all(..., config=None)` rebuilds the key and looks it up, so it now runs the tuned config automatically. When shapes change, re-run the tuner and regenerate the table - no kernel edits.
+
+## What the same pattern enables next
+
+Concrete doables on the shipped transport + ops + Config/Key + tuner:
+
+- reduce-scatter: an accumulate-on-`consume` hook (sum the received tile into the output) over the same schedule family.
+- all-gather: the gather schedule with the default copy hook.
+- quantized all-to-all: a `produce` hook that casts/scales to fp8 and a `consume` that dequantizes, fusing the conversion into the transfer leg (no extra HBM pass).
+- variable-split a2a (MoE dispatch / combine): the same collective with per-rank split sizes added to the `Key` and layout.
+
+Each is a new hook and/or a sibling schedule on the same substrate - not a new comm stack.
+
+Further out, and a bigger milestone than the items above: comm-compute overlap - hiding a compute kernel (e.g. a GEMM or MoE expert) under the collective via pipelining to cover its latency.

--- a/comms/dsl/__init__.py
+++ b/comms/dsl/__init__.py
@@ -1,0 +1,46 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Composable send/recv framework — DSL-agnostic contract.
+
+This package exposes the stable, backend-independent contract:
+
+* the hook contract :class:`Ctx` (+ ``ProduceFn`` / ``ConsumeFn`` aliases),
+* the user-owned p2p transport objects (:class:`NvlTransport` now,
+  :class:`IbTransport` / :class:`MeshTransport` reserved) and
+  :func:`nvl_rendezvous`.
+
+Device ``send``/``recv`` live in the per-DSL subpackages
+(``comms.dsl.triton``, ``comms.dsl.cute``).
+"""
+
+from __future__ import annotations
+
+from .ctx import ConsumeFn, Ctx, ProduceFn
+from .transport import (
+    check_transfer,
+    ib_rendezvous,
+    IbTransport,
+    LinkKind,
+    MeshTransport,
+    nvl_rendezvous,
+    NvlTransport,
+    P2pTransport,
+    PeerEndpoint,
+)
+
+__all__ = [
+    "Ctx",
+    "ProduceFn",
+    "ConsumeFn",
+    "LinkKind",
+    "P2pTransport",
+    "PeerEndpoint",
+    "NvlTransport",
+    "nvl_rendezvous",
+    "check_transfer",
+    "IbTransport",
+    "ib_rendezvous",
+    "MeshTransport",
+]

--- a/comms/dsl/ctx.py
+++ b/comms/dsl/ctx.py
@@ -1,0 +1,62 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""DSL-agnostic hook contract for the composable send/recv framework.
+
+``Ctx`` describes the *fields* a per-tile compute hook may read. It is the stable
+contract shared by every backend, realized on-device per DSL: the Triton backend
+as a ``@_aggregate`` struct (``triton/ctx.py``) and the CuTe backend as a
+``@dataclass`` (``cute/send_recv.py``). The field set stays identical so the same
+hook is portable across backends and across schedules (a user-written schedule
+today, a library schedule skeleton later).
+
+This dataclass is the DSL-agnostic *spec* of that field set (and is used by the
+GPU-free tests). The device hooks read the per-backend realization; adding a
+field here (and to each realization) never changes a hook signature.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Ctx:
+    """The full-leg hook contract (field set a ``produce``/``consume`` may read)."""
+
+    # --- pointers ---
+    in_ptr: int = 0
+    out_ptr: int = 0
+    # Base pointer for the current tile's transport-addressable data region.
+    # On send paths derived from PeerEndpoint.send_dst; on recv from .recv_src.
+    region_ptr: int = 0
+    slot_base: int = 0
+    # --- pipeline position ---
+    tile_idx: int = 0
+    slot: int = 0
+    step: int = 0
+    tile_rows: int = 0
+    tile_cols: int = 0
+    # --- intra-block work split ---
+    block_id: int = 0
+    flat_tid: int = 0
+    num_blocks: int = 0
+    # --- schedule state (lets one hook serve multiple schedules) ---
+    peer: int = 0
+    recv_peer: int = 0
+    shard_idx: int = 0
+    # --- layout ---
+    in_strides: tuple[int, ...] = ()
+    out_strides: tuple[int, ...] = ()
+    # --- op-specific extension point (e.g. expert_counts, scales) ---
+    extra: dict[str, object] = field(default_factory=dict)
+
+
+# The two hooks. ``produce(ctx) -> regs``: HBM -> staging (reads the input leg).
+# ``consume(ctx, regs)``: staging -> HBM (writes the output leg with the loaded
+# tile payload ``regs``). These aliases document the contract; concrete device
+# hooks are DSL kernels reading the per-backend ``Ctx`` realization.
+ProduceFn = Callable[[Ctx], object]
+ConsumeFn = Callable[[Ctx, object], None]

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -1,0 +1,9 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe backend: send/recv interface stubs (reserved for the CuTe stack)."""
+
+from .send_recv import recv, send
+
+__all__ = ["send", "recv"]

--- a/comms/dsl/cute/__init__.py
+++ b/comms/dsl/cute/__init__.py
@@ -2,8 +2,53 @@
 
 # pyre-strict
 
-"""CuTe backend: send/recv interface stubs (reserved for the CuTe stack)."""
+"""CuTe backend: minimal real send/recv over the shared transport contract.
 
-from .send_recv import recv, send
+Symbols are exposed lazily (PEP 562 ``__getattr__``) so that merely importing
+this package does not eagerly pull the cutlass DSL. The cutlass-backed
+launchers/kernels (``send``/``recv``/``sendrecv``/``send_tiles``/``recv_tiles``/
+``nvl_ops``/``copy_*``) load only on first access, while the pure-Python
+submodules (``ctx``, ``ib_ops``) stay importable in a GPU-less sandbox.
+"""
 
-__all__ = ["send", "recv"]
+from importlib import import_module
+from typing import Any
+
+__all__ = [
+    "send",
+    "recv",
+    "sendrecv",
+    "send_tiles",
+    "recv_tiles",
+    "nvl_ops",
+    "ib_ops",
+    "copy_produce",
+    "copy_consume",
+]
+
+# Exported name -> (submodule, attribute). ``attr is None`` exports the submodule
+# itself (e.g. ``nvl_ops`` / ``ib_ops``).
+_LAZY: dict[str, tuple[str, str | None]] = {
+    "send": ("launch", "send"),
+    "recv": ("launch", "recv"),
+    "sendrecv": ("launch", "sendrecv"),
+    "send_tiles": ("send_recv", "send_tiles"),
+    "recv_tiles": ("send_recv", "recv_tiles"),
+    "copy_produce": ("hooks", "copy_produce"),
+    "copy_consume": ("hooks", "copy_consume"),
+    "nvl_ops": ("nvl_ops", None),
+    "ib_ops": ("ib_ops", None),
+}
+
+
+def __getattr__(name: str) -> Any:
+    entry = _LAZY.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    mod_name, attr = entry
+    mod = import_module(f".{mod_name}", __name__)
+    return mod if attr is None else getattr(mod, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/comms/dsl/cute/ctx.py
+++ b/comms/dsl/cute/ctx.py
@@ -1,0 +1,27 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CuTe realization of the hook-contract ``Ctx`` (the per-tile view a hook reads).
+
+The CuTe twin of ``triton/ctx.py``. Adding a field here never changes a hook
+signature — same intent as the Triton ``@_aggregate`` Ctx.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Ctx:
+    """One tile's view for a hook.
+
+    ``part`` is this tile's partitioned tensor (input partition for ``produce``,
+    output partition for ``consume``); ``atom`` is the gmem<->rmem copy atom.
+    """
+
+    __slots__ = ("part", "atom")
+
+    def __init__(self, part: Any, atom: Any) -> None:
+        self.part = part
+        self.atom = atom

--- a/comms/dsl/cute/device_utils.py
+++ b/comms/dsl/cute/device_utils.py
@@ -1,0 +1,62 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Inline-PTX signaling primitives for the CuTe backend.
+
+The CuTe twin of ``triton/device_utils.py``: the cross-rank acquire/release
+signaling, emitting the **same on-wire protocol** so the two DSLs interoperate.
+Each op is a single PTX snippet via ``@dsl_user_op`` + ``llvm.inline_asm``.
+
+Minimal scope: only the two ops the no-pipeline send/recv needs —
+``wait_ge`` (receiver acquire-poll) and ``fence_and_remote_store_i64`` (sender
+release + remote store).
+"""
+
+from __future__ import annotations
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.typing import Int64
+from cutlass.cutlass_dsl import dsl_user_op
+
+
+@dsl_user_op
+def wait_ge(addr: Int64, target: Int64, *, loc=None, ip=None) -> None:
+    """Acquire-poll int64 until ``*addr >= target`` (local read)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(target).ir_value(loc=loc, ip=ip)],
+        """{
+            .reg .u64   %tmp64;
+            .reg .pred  %p;
+            _fw_wait_ge:
+                ld.global.acquire.sys.b64 %tmp64, [$0];
+                setp.lt.u64 %p, %tmp64, $1;
+                @%p bra _fw_wait_ge;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def fence_and_remote_store_i64(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """System release fence + remote relaxed int64 store (publish data)."""
+    llvm.inline_asm(
+        None,
+        [Int64(addr).ir_value(loc=loc, ip=ip), Int64(val).ir_value(loc=loc, ip=ip)],
+        """{
+            fence.acq_rel.sys;
+            st.global.relaxed.sys.b64 [$0], $1;
+        }""",
+        "l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )

--- a/comms/dsl/cute/hooks.py
+++ b/comms/dsl/cute/hooks.py
@@ -1,0 +1,27 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""CuTe hooks in the unified ``produce(ctx)`` / ``consume(ctx, frag)`` form.
+
+The CuTe twin of ``triton/hooks.py``: the default identity ``copy_*`` hooks plus
+example transforms. Each hook owns its leg — ``produce`` loads the input tile
+into a register fragment and returns it; ``consume`` writes a fragment to the
+output tile. The elementwise transform is register-only CuTe math.
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+
+def copy_produce(ctx):
+    """produce: load the input tile into a register fragment (no transform)."""
+    frag = cute.make_fragment_like(ctx.part)
+    cute.copy(ctx.atom, ctx.part, frag)
+    return frag
+
+
+def copy_consume(ctx, frag):
+    """consume: store a received fragment to the output tile (overwrite)."""
+    cute.copy(ctx.atom, frag, ctx.part)

--- a/comms/dsl/cute/hooks.py
+++ b/comms/dsl/cute/hooks.py
@@ -5,9 +5,9 @@
 """CuTe hooks in the unified ``produce(ctx)`` / ``consume(ctx, frag)`` form.
 
 The CuTe twin of ``triton/hooks.py``: the default identity ``copy_*`` hooks plus
-example transforms. Each hook owns its leg — ``produce`` loads the input tile
-into a register fragment and returns it; ``consume`` writes a fragment to the
-output tile. The elementwise transform is register-only CuTe math.
+example transforms (``scale2``/``addone``). Each hook owns its leg — ``produce``
+loads the input tile into a register fragment and returns it; ``consume`` writes a
+fragment to the output tile. Transforms are register-only CuTe math.
 """
 
 from __future__ import annotations
@@ -24,4 +24,18 @@ def copy_produce(ctx):
 
 def copy_consume(ctx, frag):
     """consume: store a received fragment to the output tile (overwrite)."""
+    cute.copy(ctx.atom, frag, ctx.part)
+
+
+def scale2_produce(ctx):
+    """Send-side: load the input tile, multiply by 2, return the fragment."""
+    frag = cute.make_fragment_like(ctx.part)
+    cute.copy(ctx.atom, ctx.part, frag)
+    frag.store(frag.load() * 2.0)
+    return frag
+
+
+def addone_consume(ctx, frag):
+    """Recv-side: add 1 to the received fragment, store to the output tile."""
+    frag.store(frag.load() + 1.0)
     cute.copy(ctx.atom, frag, ctx.part)

--- a/comms/dsl/cute/ib_ops.py
+++ b/comms/dsl/cute/ib_ops.py
@@ -1,0 +1,31 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Reserved IB device transport-ops (CuTe).
+
+CuTe twin of ``triton/ib_ops.py``: documents the same four-op seam
+(``framework/ops.py``) the IB (RDMA) backend must implement. Bodies raise so any
+attempt to trace/compile a kernel with them fails loudly until the IB stack wires
+them; they remain importable so the interface is visible now.
+"""
+
+from __future__ import annotations
+
+_RESERVED = "framework IB ops (CuTe) are reserved; implemented in the IB stack"
+
+
+def put(atom, frag, dst_part):
+    raise NotImplementedError(_RESERVED)
+
+
+def get(atom, src_part):
+    raise NotImplementedError(_RESERVED)
+
+
+def signal(addr, seq):
+    raise NotImplementedError(_RESERVED)
+
+
+def wait(addr, seq):
+    raise NotImplementedError(_RESERVED)

--- a/comms/dsl/cute/launch.py
+++ b/comms/dsl/cute/launch.py
@@ -1,0 +1,99 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Host launchers for the minimal CuTe backend.
+
+Same shape as ``framework/triton/launch.py`` (``send`` / ``recv`` /
+``sendrecv`` taking a user-owned ``P2pTransport``), proving the host contract
+is DSL-agnostic — only the device kernel differs.
+
+.. warning::
+    Same cross-rank contract as the Triton backend: both peers must use the same
+    ``num_blocks``. Not validated here.
+"""
+
+from __future__ import annotations
+
+import torch
+from comms.dsl.transport import check_transfer, P2pTransport
+
+from . import nvl_ops
+from .hooks import copy_consume, copy_produce
+from .send_recv import _NUM_THREADS, recv_tiles, send_tiles
+
+_DEFAULT_NUM_BLOCKS: int = 8
+
+
+def _check_tileable(numel: int) -> None:
+    assert numel % _NUM_THREADS == 0, (
+        f"cute minimal backend requires numel % {_NUM_THREADS} == 0 "
+        f"(no tail handling); got numel={numel}"
+    )
+
+
+def send(
+    transport: P2pTransport,
+    send_buf: torch.Tensor,
+    peer: int,
+    *,
+    produce=copy_produce,
+    num_blocks: int = _DEFAULT_NUM_BLOCKS,
+) -> None:
+    assert send_buf.is_cuda and send_buf.is_contiguous()
+    check_transfer(transport, send_buf.numel(), send_buf.dtype, num_blocks)
+    _check_tileable(send_buf.numel())
+    ep = transport.endpoint(peer, dtype=send_buf.dtype)
+    staging = ep.send_dst[: send_buf.numel()]
+    send_tiles(
+        send_buf,
+        staging,
+        ep.signal_dst,
+        num_blocks=num_blocks,
+        hook=produce,
+        put=nvl_ops.put,
+        signal=nvl_ops.signal,
+    )
+
+
+def recv(
+    transport: P2pTransport,
+    recv_buf: torch.Tensor,
+    peer: int,
+    *,
+    consume=copy_consume,
+    num_blocks: int = _DEFAULT_NUM_BLOCKS,
+) -> None:
+    assert recv_buf.is_cuda and recv_buf.is_contiguous()
+    check_transfer(transport, recv_buf.numel(), recv_buf.dtype, num_blocks)
+    _check_tileable(recv_buf.numel())
+    ep = transport.endpoint(peer, dtype=recv_buf.dtype)
+    staging = ep.recv_src[: recv_buf.numel()]
+    recv_tiles(
+        recv_buf,
+        staging,
+        ep.signal_src,
+        num_blocks=num_blocks,
+        hook=consume,
+        get=nvl_ops.get,
+        wait=nvl_ops.wait,
+    )
+
+
+def sendrecv(
+    transport: P2pTransport,
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    send_peer: int,
+    recv_peer: int | None = None,
+    *,
+    produce=copy_produce,
+    consume=copy_consume,
+    num_blocks: int = _DEFAULT_NUM_BLOCKS,
+) -> None:
+    # Route the disjoint hooks explicitly: ``produce`` only to ``send`` and
+    # ``consume`` only to ``recv`` (forwarding a shared **kwargs to both would
+    # raise TypeError since each accepts only its own hook).
+    recv_peer = send_peer if recv_peer is None else recv_peer
+    send(transport, send_buf, send_peer, produce=produce, num_blocks=num_blocks)
+    recv(transport, recv_buf, recv_peer, consume=consume, num_blocks=num_blocks)

--- a/comms/dsl/cute/nvl_ops.py
+++ b/comms/dsl/cute/nvl_ops.py
@@ -1,0 +1,41 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops (real, minimal) for the CuTe send/recv seam.
+
+CuTe twin of ``triton/nvl_ops.py``: the concrete four-op seam
+(``framework/ops.py``) for the symmetric-memory transport, in **cute-native**
+signatures. ``put``/``get`` are ``cute.copy`` over the tile's copy atom;
+``signal``/``wait`` wrap the ``device_utils`` PTX. Passed as ``constexpr`` to
+``send_tiles``/``recv_tiles`` so the kernel is transport-agnostic and the
+transport binds per call-site (same intent as the Triton seam).
+"""
+
+from __future__ import annotations
+
+import cutlass.cute as cute
+
+from .device_utils import fence_and_remote_store_i64, wait_ge
+
+
+def put(atom, frag, dst_part):
+    """Write a produced fragment into the peer's staging partition (remote store)."""
+    cute.copy(atom, frag, dst_part)
+
+
+def get(atom, src_part):
+    """Read a received tile from the local staging partition into a fragment."""
+    frag = cute.make_fragment_like(src_part)
+    cute.copy(atom, src_part, frag)
+    return frag
+
+
+def signal(addr, seq):
+    """Publish "data ready" to the peer (fence + remote int64 store)."""
+    fence_and_remote_store_i64(addr, seq)
+
+
+def wait(addr, seq):
+    """Wait until the peer published ``seq`` (acquire-poll local int64)."""
+    wait_ge(addr, seq)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,0 +1,25 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""CuTe send/recv — minimal interface stubs.
+
+Reserves the CuTe backend's device API so the contract is visible now; the real
+CuTe kernels (mirroring the Triton ``send``/``recv`` against the same transport +
+ops seam) land in the CuTe stack. Kept as plain stubs to avoid pulling the CuTe
+DSL dependency into this interface diff.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_RESERVED = "framework CuTe send/recv is reserved; implemented in the CuTe stack"
+
+
+def send(transport: Any, send_buf: Any, peer: int, **kwargs: Any) -> None:
+    raise NotImplementedError(_RESERVED)
+
+
+def recv(transport: Any, recv_buf: Any, peer: int, **kwargs: Any) -> None:
+    raise NotImplementedError(_RESERVED)

--- a/comms/dsl/cute/send_recv.py
+++ b/comms/dsl/cute/send_recv.py
@@ -1,25 +1,277 @@
 # (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-# pyre-strict
+# pyre-unsafe
 
-"""CuTe send/recv — minimal interface stubs.
+"""Minimal CuTe DSL send/recv kernel for the composable framework.
 
-Reserves the CuTe backend's device API so the contract is visible now; the real
-CuTe kernels (mirroring the Triton ``send``/``recv`` against the same transport +
-ops seam) land in the CuTe stack. Kept as plain stubs to avoid pulling the CuTe
-DSL dependency into this interface diff.
+The CuTe realization of the device send/recv primitive. It is the DSL twin of
+``framework/triton/send_recv.py``: same contract (consumes a `PeerEndpoint` from
+the shared `NvlTransport`), same minimal semantics (no pipeline, single-shot,
+per-block chunk + one data-ready signal), just written in CuTe instead of Triton.
+Its existence validates that the host layer (transport, ctx, signal protocol) is
+genuinely DSL-agnostic.
+
+Minimal scope (correctness only; performance is not a goal): no slots /
+double-buffer / credit; ``seq = 1`` single-shot; requires ``numel`` divisible by
+the CTA thread count (no tail handling); fixed 1-element-per-thread copy.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+from importlib import import_module
 from typing import Any
 
-_RESERVED = "framework CuTe send/recv is reserved; implemented in the CuTe stack"
+logger: logging.Logger = logging.getLogger(__name__)
 
 
-def send(transport: Any, send_buf: Any, peer: int, **kwargs: Any) -> None:
-    raise NotImplementedError(_RESERVED)
+def _resolve_cute_dsl_arch() -> str:
+    """``sm_<major><minor>[a]`` for the local device; honors CUTE_DSL_ARCH."""
+    explicit = os.environ.get("CUTE_DSL_ARCH")
+    if explicit:
+        return explicit
+    try:
+        import torch as _torch
+
+        major, minor = _torch.cuda.get_device_capability(0)
+    except (ImportError, RuntimeError, AssertionError) as e:
+        logger.warning(
+            "could not detect CUDA device capability (%s); "
+            "defaulting CUTE_DSL_ARCH to sm_90a",
+            e,
+        )
+        return "sm_90a"
+    if (major, minor) == (9, 0):
+        return "sm_90a"
+    if (major, minor) in {(10, 0), (10, 1)}:
+        return "sm_100a"
+    if (major, minor) == (8, 0):
+        return "sm_80"
+    return f"sm_{major}{minor}"
 
 
-def recv(transport: Any, recv_buf: Any, peer: int, **kwargs: Any) -> None:
-    raise NotImplementedError(_RESERVED)
+# Must be set before importing cutlass.cute.
+os.environ.setdefault("CUTE_DSL_ARCH", _resolve_cute_dsl_arch())
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+from .ctx import Ctx
+
+_cuda_driver: Any = import_module("cuda.bindings.driver")
+_cuda_rt: Any = import_module("cuda.bindings.runtime")
+
+# Some cuda-bindings versions lack symbols the cutlass DSL JIT executor expects
+# (cudaLibrary_t / cudaLibraryUnload). Patch them in, mirroring the existing CuTe
+# sendrecv runtime, so kernel compilation can load the cuda library.
+if not hasattr(_cuda_rt, "cudaLibrary_t"):
+
+    class _cudaLibrary_t:
+        __slots__ = ("value",)
+
+        def __init__(self, value: int = 0) -> None:
+            self.value = value
+
+    _cuda_rt.cudaLibrary_t = _cudaLibrary_t
+    _cuda_rt.cudaLibraryUnload = lambda lib: (_cuda_rt.cudaError_t(0),)
+
+_NUM_THREADS: int = 128
+
+# Minimal dtype support: (cutlass dtype, bits-per-element).
+_CUTLASS_DTYPE: dict[torch.dtype, tuple[Any, int]] = {
+    torch.float32: (cutlass.Float32, 32),
+    torch.bfloat16: (cutlass.BFloat16, 16),
+}
+
+_COMPILED: dict[tuple[Any, ...], object] = {}
+
+
+class _SendTilesKernel:
+    """Send direction: produce hook (HBM -> frag), write frag to staging, signal."""
+
+    def __init__(
+        self, *, num_blocks, num_threads, dtype, dbits, hook, put, signal
+    ) -> None:
+        self.num_blocks = num_blocks
+        self.num_threads = num_threads
+        self.dtype = dtype
+        self.dbits = dbits
+        self.hook = hook  # produce hook; called per tile with a Ctx
+        self.put = put  # transport op: write produced frag to staging
+        self.signal = signal  # transport op: publish data-ready
+
+    @cute.jit
+    def __call__(self, data, staging, sig_addr, stream) -> None:
+        tiler = cute.make_layout(self.num_threads)
+        g_data = cute.zipped_divide(data, tiler)
+        g_staging = cute.zipped_divide(staging, tiler)
+        num_tiles = cute.size(g_data, mode=[1])
+        self.kernel(g_data, g_staging, sig_addr, num_tiles).launch(
+            grid=(self.num_blocks, 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, g_data, g_staging, sig_addr, num_tiles: cutlass.Int32) -> None:
+        tidx = cute.arch.thread_idx()[0]
+        bid = cute.arch.block_idx()[0]
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=self.dbits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(
+            copy_atom, cute.make_layout(self.num_threads), cute.make_layout(1)
+        )
+        thr_copy = tiled_copy.get_slice(tidx)
+        addr = sig_addr[0] + bid * 8  # per-block signal slot (slot == block id)
+
+        tile_idx = bid
+        while tile_idx < num_tiles:
+            # produce hook owns the input leg (HBM -> frag); the primitive writes
+            # the returned fragment to staging.
+            in_part = thr_copy.partition_S(g_data[(None, tile_idx)])
+            stg_part = thr_copy.partition_D(g_staging[(None, tile_idx)])
+            frag = self.hook(Ctx(part=in_part, atom=copy_atom))
+            self.put(copy_atom, frag, stg_part)
+            tile_idx += self.num_blocks
+
+        cute.arch.barrier()  # all staging writes visible before the data-ready signal
+        if tidx == 0:
+            self.signal(addr, 1)
+
+
+class _RecvTilesKernel:
+    """Recv direction: wait, load staging -> frag, consume hook (frag -> HBM)."""
+
+    def __init__(
+        self, *, num_blocks, num_threads, dtype, dbits, hook, get, wait
+    ) -> None:
+        self.num_blocks = num_blocks
+        self.num_threads = num_threads
+        self.dtype = dtype
+        self.dbits = dbits
+        self.hook = hook  # consume hook; called per tile with (Ctx, frag)
+        self.get = get  # transport op: read staging into frag
+        self.wait = wait  # transport op: wait for data-ready
+
+    @cute.jit
+    def __call__(self, data, staging, sig_addr, stream) -> None:
+        tiler = cute.make_layout(self.num_threads)
+        g_data = cute.zipped_divide(data, tiler)
+        g_staging = cute.zipped_divide(staging, tiler)
+        num_tiles = cute.size(g_data, mode=[1])
+        self.kernel(g_data, g_staging, sig_addr, num_tiles).launch(
+            grid=(self.num_blocks, 1, 1),
+            block=(self.num_threads, 1, 1),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(self, g_data, g_staging, sig_addr, num_tiles: cutlass.Int32) -> None:
+        tidx = cute.arch.thread_idx()[0]
+        bid = cute.arch.block_idx()[0]
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.dtype, num_bits_per_copy=self.dbits
+        )
+        tiled_copy = cute.make_tiled_copy_tv(
+            copy_atom, cute.make_layout(self.num_threads), cute.make_layout(1)
+        )
+        thr_copy = tiled_copy.get_slice(tidx)
+        addr = sig_addr[0] + bid * 8  # per-block signal slot (slot == block id)
+
+        if tidx == 0:
+            self.wait(addr, 1)
+        cute.arch.barrier()  # data-ready before any thread reads staging
+
+        tile_idx = bid
+        while tile_idx < num_tiles:
+            # primitive loads staging -> frag; consume hook owns the output leg
+            # (frag -> HBM).
+            stg_part = thr_copy.partition_S(g_staging[(None, tile_idx)])
+            out_part = thr_copy.partition_D(g_data[(None, tile_idx)])
+            frag = self.get(copy_atom, stg_part)
+            self.hook(Ctx(part=out_part, atom=copy_atom), frag)
+            tile_idx += self.num_blocks
+
+
+def _launch(data_buf, staging, sig_slice, *, kernel_cls, num_blocks, hook, ops) -> None:
+    dtype = data_buf.dtype
+    if dtype not in _CUTLASS_DTYPE:
+        raise ValueError(
+            f"cute minimal backend supports {list(_CUTLASS_DTYPE)}, got {dtype}"
+        )
+    cdtype, dbits = _CUTLASS_DTYPE[dtype]
+
+    # Signal-slot base address passed as data (read on device); sig_slice is the
+    # (remote for send, local for recv) address of this peer's slot region.
+    #
+    # NOTE (CUDA graph): this per-call allocation is NOT graph-capture-safe — the
+    # tensor's lifetime ends with this call, so a captured graph would reference
+    # freed memory on replay. A persistent, transport-owned sig-addr buffer is the
+    # follow-up fix (lands with the pipelined/graph work).
+    sig_addr = torch.tensor(
+        [sig_slice.data_ptr()], dtype=torch.int64, device=data_buf.device
+    )
+    data_c = from_dlpack(data_buf, assumed_align=16)
+    staging_c = from_dlpack(staging, assumed_align=16)
+    sig_c = from_dlpack(sig_addr, assumed_align=8)
+    stream = _cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    key = (
+        kernel_cls.__name__,
+        num_blocks,
+        _NUM_THREADS,
+        dtype,
+        data_buf.numel(),
+        hook,
+        *(ops[k] for k in sorted(ops)),
+    )
+    compiled = _COMPILED.get(key)
+    if compiled is None:
+        logger.info(
+            "compiling cute %s: blocks=%s numel=%s hook=%s",
+            kernel_cls.__name__,
+            num_blocks,
+            data_buf.numel(),
+            getattr(hook, "__name__", None),
+        )
+        kernel = kernel_cls(
+            num_blocks=num_blocks,
+            num_threads=_NUM_THREADS,
+            dtype=cdtype,
+            dbits=dbits,
+            hook=hook,
+            **ops,
+        )
+        compiled = cute.compile(kernel, data_c, staging_c, sig_c, stream)
+        _COMPILED[key] = compiled
+    compiled(data_c, staging_c, sig_c, stream)
+
+
+def send_tiles(data_buf, staging, sig_slice, *, num_blocks, hook, put, signal) -> None:
+    """Send-direction device transfer (impl behind the ``send`` launcher)."""
+    _launch(
+        data_buf,
+        staging,
+        sig_slice,
+        kernel_cls=_SendTilesKernel,
+        num_blocks=num_blocks,
+        hook=hook,
+        ops={"put": put, "signal": signal},
+    )
+
+
+def recv_tiles(data_buf, staging, sig_slice, *, num_blocks, hook, get, wait) -> None:
+    """Recv-direction device transfer (impl behind the ``recv`` launcher)."""
+    _launch(
+        data_buf,
+        staging,
+        sig_slice,
+        kernel_cls=_RecvTilesKernel,
+        num_blocks=num_blocks,
+        hook=hook,
+        ops={"get": get, "wait": wait},
+    )

--- a/comms/dsl/ops.py
+++ b/comms/dsl/ops.py
@@ -1,0 +1,45 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""Device transport-ops seam.
+
+These four device primitives are the *only* transport-specific operations.
+``send``/``recv`` are written once against this seam and treat the per-peer
+buffers as opaque, so a single ``send``/``recv``:
+
+  * serves NVLink today and IB later, and
+  * serves **mixed-transport kernels** — a schedule may use NVLink for an
+    intra-domain peer and IB for an inter-domain peer by passing different ops
+    at each call site (the binding is per-call-site, not per-kernel).
+
+There is no runtime dispatch: in Triton the concrete ops are passed as
+``tl.constexpr`` and selected at compile time. Concrete implementations live per
+transport + DSL (e.g. ``framework/triton/nvl_ops.py``). This module documents
+the contract.
+
+Conceptual signatures (the concrete versions are ``@triton.jit`` / cute kernels):
+
+    put(region, idx, regs, mask) -> None   # produced tile -> peer region
+    get(region, idx, mask)        -> regs   # received tile  <- region
+    signal(sig_ptr, sig_idx, seq)          -> None   # publish "data ready"
+    wait(sig_ptr, sig_idx, seq)            -> None   # wait for peer's data
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class TransportOps(Protocol):
+    """Structural description of the four device ops a transport must provide.
+
+    Used for documentation/typing only; the attributes are DSL kernels
+    (``@triton.jit`` functions for the Triton backend), not plain callables, so
+    the parameter types are intentionally left loose.
+    """
+
+    put: object
+    get: object
+    signal: object
+    wait: object

--- a/comms/dsl/tests/__init__.py
+++ b/comms/dsl/tests/__init__.py
@@ -1,0 +1,1 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.

--- a/comms/dsl/tests/test_interface.py
+++ b/comms/dsl/tests/test_interface.py
@@ -1,0 +1,190 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""GPU-free interface tests for the composable send/recv framework.
+
+Asserts the *contract* (types, signatures, transport abstraction, reserved
+stubs) without compiling or launching any kernel, so this runs in CI with no
+GPU. The real end-to-end path is exercised by ``test_minimal_sendrecv``.
+"""
+
+import dataclasses
+import inspect
+import unittest
+from typing import Any, cast
+
+from torch.utils._triton import has_triton
+
+
+class ContractTest(unittest.TestCase):
+    def test_ctx_fields(self) -> None:
+        from comms.dsl import Ctx
+
+        names = {f.name for f in dataclasses.fields(Ctx)}
+        for expected in (
+            "in_ptr",
+            "out_ptr",
+            "region_ptr",
+            "tile_idx",
+            "block_id",
+            "flat_tid",
+            "num_blocks",
+            "peer",
+            "recv_peer",
+            "shard_idx",
+            "in_strides",
+            "out_strides",
+            "extra",
+        ):
+            self.assertIn(expected, names)
+        # Construct + extension point works.
+        ctx = Ctx(in_ptr=1, extra={"scales": 7})
+        self.assertEqual(ctx.in_ptr, 1)
+        self.assertEqual(ctx.extra["scales"], 7)
+
+    def test_hook_aliases_importable(self) -> None:
+        from comms.dsl import ConsumeFn, ProduceFn
+
+        self.assertIsNotNone(ProduceFn)
+        self.assertIsNotNone(ConsumeFn)
+
+    def test_exports(self) -> None:
+        import comms.dsl as fw
+
+        for name in (
+            "Ctx",
+            "NvlTransport",
+            "nvl_rendezvous",
+            "MeshTransport",
+            "LinkKind",
+        ):
+            self.assertIn(name, fw.__all__)
+
+
+class TransportTest(unittest.TestCase):
+    def test_rendezvous_signature(self) -> None:
+        from comms.dsl import nvl_rendezvous
+
+        params = list(inspect.signature(nvl_rendezvous).parameters)
+        for expected in ("group", "device", "per_peer_bytes"):
+            self.assertIn(expected, params)
+
+    def test_nvl_link_kind(self) -> None:
+        from comms.dsl import LinkKind, NvlTransport
+
+        # handle is not touched by link_kind, so we can build this GPU-free.
+        t = NvlTransport(
+            handle=cast(Any, None), world_size=4, local_rank=0, per_peer_bytes=1024
+        )
+        self.assertIs(t.link_kind(1), LinkKind.NVLINK)
+
+    def test_check_transfer_guards(self) -> None:
+        import torch
+        from comms.dsl import check_transfer, NvlTransport
+
+        # per_peer_bytes=4096, fp32 -> 1024 elems per peer; 4 signal slots.
+        t = NvlTransport(
+            handle=cast(Any, None),
+            world_size=2,
+            local_rank=0,
+            per_peer_bytes=4096,
+            max_blocks_per_peer=4,
+        )
+        # Valid transfer: no raise.
+        check_transfer(t, numel=512, dtype=torch.float32, num_blocks=2)
+        # numel exceeds per-peer capacity -> raise (would corrupt the next peer).
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=2000, dtype=torch.float32, num_blocks=2)
+        # num_blocks exceeds signal slots -> raise (would OOB-write the pad).
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=512, dtype=torch.float32, num_blocks=8)
+        # num_blocks must be >= 1.
+        with self.assertRaises(ValueError):
+            check_transfer(t, numel=512, dtype=torch.float32, num_blocks=0)
+        # MeshTransport delegates max_blocks_per_peer to intra, so the
+        # num_blocks guard still fires through a mesh.
+        from comms.dsl import MeshTransport
+
+        mesh = MeshTransport(intra=t)
+        check_transfer(mesh, numel=512, dtype=torch.float32, num_blocks=2)
+        with self.assertRaises(ValueError):
+            check_transfer(mesh, numel=512, dtype=torch.float32, num_blocks=8)
+
+    def test_ib_reserved(self) -> None:
+        from comms.dsl import ib_rendezvous, IbTransport
+
+        ib = IbTransport(world_size=8, per_peer_bytes=1024)
+        with self.assertRaises(NotImplementedError):
+            ib.endpoint(1, dtype=cast(Any, None))
+        with self.assertRaises(NotImplementedError):
+            ib_rendezvous(cast(Any, None), cast(Any, None), 1024)
+
+    def test_mesh_routes_by_domain(self) -> None:
+        from comms.dsl import IbTransport, LinkKind, MeshTransport, NvlTransport
+
+        intra = NvlTransport(
+            handle=cast(Any, None), world_size=8, local_rank=0, per_peer_bytes=1024
+        )
+        # No inter transport yet -> everything is NVLINK.
+        mesh = MeshTransport(intra=intra)
+        self.assertIs(mesh.link_kind(3), LinkKind.NVLINK)
+
+        # With an inter transport + domain size 4: peers 0-3 NVLINK, 4-7 IB.
+        mesh2 = MeshTransport(
+            intra=intra,
+            inter=IbTransport(world_size=8, per_peer_bytes=1024),
+            local_domain_size=4,
+        )
+        self.assertIs(mesh2.link_kind(2), LinkKind.NVLINK)
+        self.assertIs(mesh2.link_kind(5), LinkKind.IB)
+
+
+@unittest.skipUnless(has_triton(), "Triton not available")
+class TritonInterfaceTest(unittest.TestCase):
+    def _arg_names(self, jit_fn: object) -> list[str]:
+        names = getattr(jit_fn, "arg_names", None)
+        if names is not None:
+            return list(names)
+        return list(inspect.signature(getattr(jit_fn, "fn", jit_fn)).parameters)
+
+    def test_send_recv_are_jit(self) -> None:
+        from comms.dsl.triton import recv_tiles as recv, send_tiles as send
+        from triton.runtime.jit import JITFunction
+
+        self.assertIsInstance(send, JITFunction)
+        self.assertIsInstance(recv, JITFunction)
+        for p in ("in_ptr", "produce", "put", "signal"):
+            self.assertIn(p, self._arg_names(send))
+        for p in ("out_ptr", "consume", "get", "wait"):
+            self.assertIn(p, self._arg_names(recv))
+
+    def test_nvl_and_ib_ops_present(self) -> None:
+        from comms.dsl.triton import ib_ops, nvl_ops
+        from triton.runtime.jit import JITFunction
+
+        for ops in (nvl_ops, ib_ops):
+            for name in ("put", "get", "signal", "wait"):
+                self.assertIsInstance(getattr(ops, name), JITFunction)
+
+    def test_hook_ctx_contract(self) -> None:
+        # Hooks take a single Ctx aggregate; consume also gets the tile payload.
+        from comms.dsl.triton import hooks
+        from comms.dsl.triton.ctx import Ctx
+        from triton.runtime.jit import JITFunction
+
+        self.assertIsInstance(hooks.copy_produce, JITFunction)
+        self.assertIsInstance(hooks.copy_consume, JITFunction)
+        self.assertEqual(self._arg_names(hooks.copy_produce), ["ctx"])
+        self.assertEqual(self._arg_names(hooks.copy_consume), ["ctx", "regs"])
+        self.assertIsNotNone(Ctx)
+
+
+class CuteInterfaceTest(unittest.TestCase):
+    def test_cute_stubs_reserved(self) -> None:
+        from comms.dsl.cute import recv, send
+
+        with self.assertRaises(NotImplementedError):
+            send(None, None, 1)
+        with self.assertRaises(NotImplementedError):
+            recv(None, None, 1)

--- a/comms/dsl/tests/test_interface.py
+++ b/comms/dsl/tests/test_interface.py
@@ -184,6 +184,64 @@ class TritonInterfaceTest(unittest.TestCase):
         self.assertEqual(self._arg_names(hooks.copy_consume), ["ctx", "regs"])
         self.assertIsNotNone(Ctx)
 
+    def test_hooks_present(self) -> None:
+        from comms.dsl.triton import hooks
+        from triton.runtime.jit import JITFunction
+
+        for name in (
+            "copy_produce",
+            "copy_consume",
+            "scale2_produce",
+            "addone_consume",
+        ):
+            self.assertIsInstance(getattr(hooks, name), JITFunction)
+
+    def test_launch_send_recv_hook_defaults(self) -> None:
+        # The host launchers expose the hook seam as keyword-only params that
+        # default to the identity copy hooks.
+        from comms.dsl.triton import launch
+        from comms.dsl.triton.hooks import copy_consume, copy_produce
+
+        send_params = inspect.signature(launch.send).parameters
+        recv_params = inspect.signature(launch.recv).parameters
+        self.assertIs(send_params["produce"].default, copy_produce)
+        self.assertIs(recv_params["consume"].default, copy_consume)
+
+    def test_sendrecv_routes_hooks(self) -> None:
+        # sendrecv routes produce -> send leg, consume -> recv leg, defaults
+        # recv_peer to send_peer, and forwards the remaining launch kwargs to
+        # both legs. Patch the leg launchers so this runs GPU-free.
+        from unittest import mock
+
+        from comms.dsl.triton import launch
+
+        produce = object()
+        consume = object()
+        transport = cast(Any, object())
+        send_buf = cast(Any, object())
+        recv_buf = cast(Any, object())
+
+        with (
+            mock.patch.object(launch, "send") as send_mock,
+            mock.patch.object(launch, "recv") as recv_mock,
+        ):
+            launch.sendrecv(
+                transport,
+                send_buf,
+                recv_buf,
+                send_peer=3,
+                produce=produce,
+                consume=consume,
+                num_blocks=2,
+            )
+
+        send_mock.assert_called_once_with(
+            transport, send_buf, 3, produce=produce, num_blocks=2
+        )
+        recv_mock.assert_called_once_with(
+            transport, recv_buf, 3, consume=consume, num_blocks=2
+        )
+
 
 class CuteInterfaceTest(unittest.TestCase):
     def test_cute_ctx_fields(self) -> None:
@@ -217,8 +275,20 @@ class CuteInterfaceTest(unittest.TestCase):
             params = list(inspect.signature(fn).parameters)
             self.assertIn("transport", params)
             self.assertIn("peer", params)
+        for fn in (send, recv):
+            params = list(inspect.signature(fn).parameters)
+            self.assertIn("transport", params)
+            self.assertIn("peer", params)
+        self.assertIn("produce", inspect.signature(send).parameters)
+        self.assertIn("consume", inspect.signature(recv).parameters)
         # sendrecv routes the disjoint hooks explicitly (produce->send,
         # consume->recv), so both are accepted keyword-only params.
         sr_params = list(inspect.signature(sendrecv).parameters)
         self.assertIn("produce", sr_params)
         self.assertIn("consume", sr_params)
+
+        # Example CuTe hooks exist in the unified produce(ctx)/consume(ctx) form.
+        from comms.dsl.cute import hooks as cute_hooks
+
+        self.assertTrue(callable(cute_hooks.scale2_produce))
+        self.assertTrue(callable(cute_hooks.addone_consume))

--- a/comms/dsl/tests/test_interface.py
+++ b/comms/dsl/tests/test_interface.py
@@ -14,6 +14,11 @@ import inspect
 import unittest
 from typing import Any, cast
 
+from comms.dsl.cute import ib_ops as cute_ib_ops
+
+# Pure-Python cute submodules (no cutlass); importable GPU-free thanks to the
+# lazy cute/__init__.py, so they are safe to import at module scope.
+from comms.dsl.cute.ctx import Ctx as CuteCtx
 from torch.utils._triton import has_triton
 
 
@@ -181,10 +186,39 @@ class TritonInterfaceTest(unittest.TestCase):
 
 
 class CuteInterfaceTest(unittest.TestCase):
-    def test_cute_stubs_reserved(self) -> None:
-        from comms.dsl.cute import recv, send
+    def test_cute_ctx_fields(self) -> None:
+        ctx = CuteCtx(part=1, atom=2)
+        self.assertEqual(ctx.part, 1)
+        self.assertEqual(ctx.atom, 2)
 
+    def test_cute_ib_ops_reserved(self) -> None:
+        # The four reserved IB transport ops must raise NotImplementedError until
+        # the IB stack wires them.
         with self.assertRaises(NotImplementedError):
-            send(None, None, 1)
+            cute_ib_ops.put(None, None, None)
         with self.assertRaises(NotImplementedError):
-            recv(None, None, 1)
+            cute_ib_ops.get(None, None)
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.signal(None, None)
+        with self.assertRaises(NotImplementedError):
+            cute_ib_ops.wait(None, None)
+
+    def test_cute_backend_host_api(self) -> None:
+        # The CuTe backend consumes the SAME host contract (transport + peer) as
+        # Triton — only the device kernel differs. Importing it requires the
+        # cutlass DSL, which may be unavailable in a GPU-less sandbox, so skip
+        # rather than fail there.
+        try:
+            from comms.dsl.cute import recv, send, sendrecv
+        except Exception as e:  # cutlass import / CUDA init may fail GPU-free
+            self.skipTest(f"cutlass DSL not importable: {e}")
+
+        for fn in (send, recv):
+            params = list(inspect.signature(fn).parameters)
+            self.assertIn("transport", params)
+            self.assertIn("peer", params)
+        # sendrecv routes the disjoint hooks explicitly (produce->send,
+        # consume->recv), so both are accepted keyword-only params.
+        sr_params = list(inspect.signature(sendrecv).parameters)
+        self.assertIn("produce", sr_params)
+        self.assertIn("consume", sr_params)

--- a/comms/dsl/tests/test_minimal_cute_sendrecv.py
+++ b/comms/dsl/tests/test_minimal_cute_sendrecv.py
@@ -1,0 +1,88 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""2-rank smoke test for the CuTe backend.
+
+Validates the DSL-agnostic design: the CuTe ``send``/``recv`` runs over the
+*same* ``nvl_rendezvous`` transport + signal protocol as the Triton backend.
+Skipped unless >=2 GPUs are present (no-op in GPU-less CI). Sizes are multiples
+of the CTA thread count (the minimal CuTe path has no tail handling).
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+_FP32_BYTES = 4
+
+
+def _directional(rank: int, device: torch.device, numel: int, num_blocks: int) -> None:
+    """rank 0 sends ``arange`` to rank 1 via the CuTe backend; rank 1 verifies."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.cute import recv, send
+
+    pg = dist.group.WORLD
+    assert pg is not None
+    t = nvl_rendezvous(pg, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send_buf = torch.arange(numel, dtype=torch.float32, device=device)
+        send(t, send_buf, peer=1, num_blocks=num_blocks)
+    else:
+        recv_buf = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t, recv_buf, peer=0, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        expected = torch.arange(numel, dtype=torch.float32, device=device)
+        assert torch.equal(recv_buf, expected), (
+            f"cute directional mismatch numel={numel} num_blocks={num_blocks}"
+        )
+    dist.barrier()
+
+
+def _bidirectional(
+    rank: int, device: torch.device, numel: int, num_blocks: int
+) -> None:
+    """Both ranks exchange distinct data simultaneously via the CuTe backend."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.cute import sendrecv
+
+    pg = dist.group.WORLD
+    assert pg is not None
+    t = nvl_rendezvous(pg, device, per_peer_bytes=numel * _FP32_BYTES)
+    peer = 1 - rank
+
+    def pattern(r: int) -> torch.Tensor:
+        return (r + 1) * 1000 + torch.arange(numel, dtype=torch.float32, device=device)
+
+    send_buf = pattern(rank)
+    recv_buf = torch.empty(numel, dtype=torch.float32, device=device)
+    sendrecv(t, send_buf, recv_buf, send_peer=peer, num_blocks=num_blocks)
+    torch.cuda.synchronize()
+    assert torch.equal(recv_buf, pattern(peer)), (
+        f"cute bidirectional mismatch on rank {rank}"
+    )
+    dist.barrier()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+
+    # CuTe minimal path requires numel divisible by the CTA thread count (128).
+    _directional(rank, device, numel=8192, num_blocks=8)
+    _bidirectional(rank, device, numel=4096, num_blocks=8)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+class MinimalCuteSendRecvTest(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "needs >=2 GPUs")
+    def test_2rank_paths(self) -> None:
+        mp.spawn(_worker, args=(2, 12356), nprocs=2, join=True)

--- a/comms/dsl/tests/test_minimal_cute_sendrecv.py
+++ b/comms/dsl/tests/test_minimal_cute_sendrecv.py
@@ -67,6 +67,44 @@ def _bidirectional(
     dist.barrier()
 
 
+def _hooks(rank: int, device: torch.device, numel: int, num_blocks: int) -> None:
+    """Prove the CuTe elementwise transform hook runs during the transfer."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.cute import recv, send
+    from comms.dsl.cute.hooks import addone_consume, scale2_produce
+
+    src = torch.arange(numel, dtype=torch.float32, device=device)
+
+    pg = dist.group.WORLD
+    assert pg is not None
+
+    # transform on send (scale by 2): recv == 2 * src
+    t = nvl_rendezvous(pg, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send(t, src.clone(), peer=1, produce=scale2_produce, num_blocks=num_blocks)
+    else:
+        out = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t, out, peer=0, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        assert torch.equal(out, src * 2), (
+            "cute send-side transform (scale2) not applied"
+        )
+    dist.barrier()
+
+    # transform on recv (add 1): recv == src + 1
+    t2 = nvl_rendezvous(pg, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send(t2, src.clone(), peer=1, num_blocks=num_blocks)
+    else:
+        out = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t2, out, peer=0, consume=addone_consume, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        assert torch.equal(out, src + 1), (
+            "cute recv-side transform (addone) not applied"
+        )
+    dist.barrier()
+
+
 def _worker(rank: int, world_size: int, port: int) -> None:
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
@@ -77,6 +115,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
     # CuTe minimal path requires numel divisible by the CTA thread count (128).
     _directional(rank, device, numel=8192, num_blocks=8)
     _bidirectional(rank, device, numel=4096, num_blocks=8)
+    _hooks(rank, device, numel=8192, num_blocks=8)
 
     dist.barrier()
     dist.destroy_process_group()

--- a/comms/dsl/tests/test_minimal_sendrecv.py
+++ b/comms/dsl/tests/test_minimal_sendrecv.py
@@ -1,0 +1,97 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""2-rank smoke tests: the whole interface composes end-to-end on the minimal path.
+
+Skipped unless >=2 GPUs are present, so it is a no-op in GPU-less CI. On a 2-GPU
+host each case does a real NVLink transfer through the framework (transport + ops
++ hook + send/recv) and checks correctness. Each case re-rendezvous because the
+minimal path is single-shot (seq=1).
+"""
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+_FP32_BYTES = 4
+
+
+def _directional(
+    group: dist.ProcessGroup,
+    rank: int,
+    device: torch.device,
+    numel: int,
+    num_blocks: int,
+) -> None:
+    """rank 0 sends ``arange`` to rank 1; rank 1 verifies."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.triton import recv, send
+
+    t = nvl_rendezvous(group, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send_buf = torch.arange(numel, dtype=torch.float32, device=device)
+        send(t, send_buf, peer=1, num_blocks=num_blocks)
+    else:
+        recv_buf = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t, recv_buf, peer=0, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        expected = torch.arange(numel, dtype=torch.float32, device=device)
+        assert torch.equal(recv_buf, expected), (
+            f"directional mismatch numel={numel} num_blocks={num_blocks}"
+        )
+    dist.barrier()
+
+
+def _bidirectional(
+    group: dist.ProcessGroup,
+    rank: int,
+    device: torch.device,
+    numel: int,
+    num_blocks: int,
+) -> None:
+    """Both ranks exchange distinct data with each other simultaneously."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.triton import sendrecv
+
+    t = nvl_rendezvous(group, device, per_peer_bytes=numel * _FP32_BYTES)
+    peer = 1 - rank
+    base = (rank + 1) * 1000
+
+    def pattern(r: int) -> torch.Tensor:
+        return (r + 1) * 1000 + torch.arange(numel, dtype=torch.float32, device=device)
+
+    send_buf = pattern(rank)
+    recv_buf = torch.empty(numel, dtype=torch.float32, device=device)
+    sendrecv(t, send_buf, recv_buf, send_peer=peer, num_blocks=num_blocks)
+    torch.cuda.synchronize()
+    assert torch.equal(recv_buf, pattern(peer)), (
+        f"bidirectional mismatch on rank {rank} (base={base})"
+    )
+    dist.barrier()
+
+
+def _worker(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.cuda.set_device(rank)
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    device = torch.device(f"cuda:{rank}")
+    group = dist.group.WORLD
+    assert group is not None
+
+    _directional(group, rank, device, numel=8192, num_blocks=8)  # divisible
+    _directional(group, rank, device, numel=8191, num_blocks=1)  # tail mask + boundary
+    _bidirectional(group, rank, device, numel=4096, num_blocks=8)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+class MinimalSendRecvTest(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.device_count() >= 2, "needs >=2 GPUs")
+    def test_2rank_paths(self) -> None:
+        mp.spawn(_worker, args=(2, 12355), nprocs=2, join=True)

--- a/comms/dsl/tests/test_minimal_sendrecv.py
+++ b/comms/dsl/tests/test_minimal_sendrecv.py
@@ -74,6 +74,43 @@ def _bidirectional(
     dist.barrier()
 
 
+def _hooks(
+    group: dist.ProcessGroup,
+    rank: int,
+    device: torch.device,
+    numel: int,
+    num_blocks: int,
+) -> None:
+    """Prove the produce/consume compute hooks actually run during the transfer."""
+    from comms.dsl import nvl_rendezvous
+    from comms.dsl.triton import recv, send
+    from comms.dsl.triton.hooks import addone_consume, scale2_produce
+
+    src = torch.arange(numel, dtype=torch.float32, device=device)
+
+    # produce hook (send-side scale by 2): recv == 2 * src
+    t = nvl_rendezvous(group, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send(t, src.clone(), peer=1, produce=scale2_produce, num_blocks=num_blocks)
+    else:
+        out = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t, out, peer=0, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        assert torch.equal(out, src * 2), "triton produce hook (scale2) not applied"
+    dist.barrier()
+
+    # consume hook (recv-side add 1): recv == src + 1
+    t2 = nvl_rendezvous(group, device, per_peer_bytes=numel * _FP32_BYTES)
+    if rank == 0:
+        send(t2, src.clone(), peer=1, num_blocks=num_blocks)
+    else:
+        out = torch.empty(numel, dtype=torch.float32, device=device)
+        recv(t2, out, peer=0, consume=addone_consume, num_blocks=num_blocks)
+        torch.cuda.synchronize()
+        assert torch.equal(out, src + 1), "triton consume hook (addone) not applied"
+    dist.barrier()
+
+
 def _worker(rank: int, world_size: int, port: int) -> None:
     os.environ["MASTER_ADDR"] = "127.0.0.1"
     os.environ["MASTER_PORT"] = str(port)
@@ -86,6 +123,7 @@ def _worker(rank: int, world_size: int, port: int) -> None:
     _directional(group, rank, device, numel=8192, num_blocks=8)  # divisible
     _directional(group, rank, device, numel=8191, num_blocks=1)  # tail mask + boundary
     _bidirectional(group, rank, device, numel=4096, num_blocks=8)
+    _hooks(group, rank, device, numel=8192, num_blocks=8)
 
     dist.barrier()
     dist.destroy_process_group()

--- a/comms/dsl/transport.py
+++ b/comms/dsl/transport.py
@@ -1,0 +1,271 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""User-owned p2p transport objects for the composable send/recv framework.
+
+A transport owns all transport state (staging buffer + signal pads for the
+symmetric-memory case) behind an abstraction. The device ``send``/``recv``
+primitives consume a per-peer :class:`PeerEndpoint` resolved from a transport and
+never see whether it is NVLink or IB.
+
+Design points realized here:
+
+* **User-owned, one rendezvous.** :func:`nvl_rendezvous` does a single collective
+  rendezvous for the whole group and returns an object the user holds (reused
+  across CUDA-graph replays). There is no hidden module-level cache.
+* **Mixed transport.** :class:`MeshTransport` composes an intra-domain NVLink
+  transport with a (future) inter-domain IB transport and routes per peer via
+  :meth:`P2pTransport.link_kind`, so a single collective can mix transports.
+
+This interface diff implements NVLink for real (minimal) and reserves IB.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch._C._distributed_c10d import _SymmetricMemory
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Shape-independent default; the staging region per peer must hold the message.
+_DEFAULT_MAX_BLOCKS_PER_PEER: int = 32
+
+
+class LinkKind(Enum):
+    """How a given peer is reached."""
+
+    NVLINK = "nvlink"
+    IB = "ib"
+
+
+@dataclass(frozen=True)
+class PeerEndpoint:
+    """Host-resolved per-peer device state, consumed by ``send``/``recv``.
+
+    The four handles are passed directly to the kernel (typed tensors, not
+    pointer-of-pointer indirection). Today each is a ``torch.Tensor`` (NVLink:
+    symm-mem-mapped); an IB transport will carry a ``(remote_addr, rkey)``
+    descriptor instead — a field-type change behind this same struct. ``send_dst``/``signal_dst`` are used by ``send`` (this rank ->
+    ``peer``); ``recv_src``/``signal_src`` by ``recv`` (``peer`` -> this rank).
+    """
+
+    send_dst: torch.Tensor  # WHERE this rank writes for the peer (remote)
+    recv_src: torch.Tensor  # WHERE this rank reads what the peer wrote (local)
+    signal_dst: torch.Tensor  # signal this rank raises at the peer
+    signal_src: torch.Tensor  # signal this rank waits on (the peer raises it)
+
+
+@runtime_checkable
+class P2pTransport(Protocol):
+    """The abstraction ``send``/``recv`` depend on (NVLink now, IB later)."""
+
+    world_size: int
+    per_peer_bytes: int
+
+    def link_kind(self, peer: int) -> LinkKind: ...
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint: ...
+
+
+@dataclass
+class NvlTransport:
+    """Symmetric-memory NVLink transport (real, minimal).
+
+    Owns the ``_SymmetricMemory`` handle. The buffer is ``per_peer_bytes`` per
+    peer (``per_peer_bytes * world_size`` total); the signal pad holds
+    ``world_size * max_blocks_per_peer`` int64 entries laid out by
+    ``[sender_rank * max_blocks_per_peer + block]``.
+    """
+
+    handle: _SymmetricMemory
+    world_size: int
+    local_rank: int
+    per_peer_bytes: int
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER
+
+    def link_kind(self, peer: int) -> LinkKind:
+        return LinkKind.NVLINK
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint:
+        assert 0 <= peer < self.world_size and peer != self.local_rank
+        elem = torch.tensor([], dtype=dtype).element_size()
+        assert self.per_peer_bytes % elem == 0, (
+            f"per_peer_bytes={self.per_peer_bytes} not a multiple of {elem}"
+        )
+        cap_elems = self.per_peer_bytes // elem
+        mbp = self.max_blocks_per_peer
+
+        # Staging regions are indexed by SENDER rank within each rank's buffer.
+        send_dst = self.handle.get_buffer(
+            peer,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=self.local_rank * cap_elems,
+        )
+        recv_src = self.handle.get_buffer(
+            self.local_rank,
+            sizes=[cap_elems],
+            dtype=dtype,
+            storage_offset=peer * cap_elems,
+        )
+        peer_sig = self.handle.get_signal_pad(peer).view(torch.int64)
+        local_sig = self.handle.get_signal_pad(self.local_rank).view(torch.int64)
+        signal_dst = peer_sig[self.local_rank * mbp : self.local_rank * mbp + mbp]
+        signal_src = local_sig[peer * mbp : peer * mbp + mbp]
+        return PeerEndpoint(send_dst, recv_src, signal_dst, signal_src)
+
+
+def nvl_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+    max_blocks_per_peer: int = _DEFAULT_MAX_BLOCKS_PER_PEER,
+) -> NvlTransport:
+    """One collective rendezvous; returns a user-owned :class:`NvlTransport`.
+
+    Allocates ``per_peer_bytes * world_size`` of symmetric memory (one per-peer
+    staging region per peer) and zeroes the signal pad so the first
+    ``wait(_, 1)`` is race-free after the barrier.
+    """
+    world_size = dist.get_world_size(group)
+    local_rank = dist.get_rank(group)
+    total = per_peer_bytes * world_size
+    logger.info(
+        "nvl_rendezvous on PG %s: allocating %d bytes (%d peers x %d)",
+        group.group_desc,
+        total,
+        world_size,
+        per_peer_bytes,
+    )
+    raw = symm_mem.empty(total, dtype=torch.uint8, device=device)
+    handle = symm_mem.rendezvous(raw, group=group)
+
+    need = world_size * max_blocks_per_peer
+    sig = handle.get_signal_pad(handle.rank).view(torch.int64)
+    assert sig.numel() >= need, (
+        f"signal pad too small: {sig.numel()} int64 < required {need} "
+        f"(world_size={world_size} x max_blocks_per_peer={max_blocks_per_peer})"
+    )
+    sig.zero_()
+    dist.barrier(group)
+    return NvlTransport(
+        handle=handle,
+        world_size=world_size,
+        local_rank=local_rank,
+        per_peer_bytes=per_peer_bytes,
+        max_blocks_per_peer=max_blocks_per_peer,
+    )
+
+
+def check_transfer(
+    transport: P2pTransport,
+    numel: int,
+    dtype: torch.dtype,
+    num_blocks: int,
+) -> None:
+    """Validate a transfer against the transport before launch (fail loud).
+
+    Two invariants whose violation would otherwise cause **silent remote
+    corruption** (a kernel writing past a per-peer region overruns the next
+    peer's staging or signal-pad region on the remote rank):
+
+    * ``numel`` must fit the per-peer staging region (``per_peer_bytes``).
+    * ``num_blocks`` must fit the per-peer signal-pad slots
+      (``max_blocks_per_peer``), since each block signals slot ``block_id``.
+    """
+    elem = torch.tensor([], dtype=dtype).element_size()
+    cap_elems = transport.per_peer_bytes // elem
+    if numel > cap_elems:
+        raise ValueError(
+            f"transfer numel={numel} exceeds per-peer capacity={cap_elems} elems "
+            f"(per_peer_bytes={transport.per_peer_bytes}, dtype={dtype}); "
+            f"increase per_peer_bytes at rendezvous"
+        )
+    mbp = getattr(transport, "max_blocks_per_peer", None)
+    if mbp is not None and not (1 <= num_blocks <= mbp):
+        raise ValueError(
+            f"num_blocks={num_blocks} must be in [1, {mbp}] "
+            f"(one signal-pad slot per block per peer)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reserved: IB transport + mixed-transport mesh (interface only this diff)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IbTransport:
+    """Reserved IB (torchcomms window) transport. Implemented in the IB stack."""
+
+    world_size: int
+    per_peer_bytes: int
+
+    def link_kind(self, peer: int) -> LinkKind:
+        return LinkKind.IB
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint:
+        raise NotImplementedError(
+            "IbTransport.endpoint is reserved; implemented in the IB stack"
+        )
+
+
+def ib_rendezvous(
+    group: dist.ProcessGroup,
+    device: torch.device,
+    per_peer_bytes: int,
+) -> IbTransport:
+    raise NotImplementedError("ib_rendezvous is reserved; implemented in the IB stack")
+
+
+@dataclass
+class MeshTransport:
+    """Composes per-link transports and routes each peer to the right one.
+
+    Enables a single collective to mix NVLink (intra-domain) and IB
+    (inter-domain). Constructible today from a single :class:`NvlTransport`
+    (all peers intra); the ``inter`` IB slot and inter-domain routing are filled
+    in by the IB stack.
+    """
+
+    intra: NvlTransport
+    inter: IbTransport | None = None
+    local_domain_size: int | None = None
+
+    @property
+    def world_size(self) -> int:
+        return self.intra.world_size
+
+    @property
+    def per_peer_bytes(self) -> int:
+        return self.intra.per_peer_bytes
+
+    @property
+    def max_blocks_per_peer(self) -> int:
+        # Delegate so check_transfer's num_blocks guard applies to mesh routing
+        # too (a mesh routes NVLINK peers through ``intra``).
+        return self.intra.max_blocks_per_peer
+
+    def _domain_size(self) -> int:
+        return self.local_domain_size or self.intra.world_size
+
+    def link_kind(self, peer: int) -> LinkKind:
+        if self.inter is None:
+            return LinkKind.NVLINK
+        lds = self._domain_size()
+        same_domain = (peer // lds) == (self.intra.local_rank // lds)
+        return LinkKind.NVLINK if same_domain else LinkKind.IB
+
+    def endpoint(self, peer: int, *, dtype: torch.dtype) -> PeerEndpoint:
+        if self.link_kind(peer) is LinkKind.NVLINK:
+            return self.intra.endpoint(peer, dtype=dtype)
+        assert self.inter is not None
+        return self.inter.endpoint(peer, dtype=dtype)

--- a/comms/dsl/triton/__init__.py
+++ b/comms/dsl/triton/__init__.py
@@ -1,0 +1,25 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton backend: device send/recv kernels + NVLink ops + demo hooks + launchers."""
+
+from . import ib_ops, nvl_ops
+from .hooks import copy_consume, copy_produce
+from .launch import recv, send, sendrecv  # transport-agnostic host launchers
+from .send_recv import recv_tiles, send_tiles  # device primitives (power users)
+
+__all__ = [
+    # host launchers (what most users call)
+    "send",
+    "recv",
+    "sendrecv",
+    # device primitives (custom schedules)
+    "send_tiles",
+    "recv_tiles",
+    # ops + demo hooks
+    "nvl_ops",
+    "ib_ops",
+    "copy_produce",
+    "copy_consume",
+]

--- a/comms/dsl/triton/ctx.py
+++ b/comms/dsl/triton/ctx.py
@@ -1,0 +1,39 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Triton on-device realization of the framework hook contract (``Ctx``).
+
+The DSL-agnostic field set (see ``comms.dsl.ctx.Ctx``) realized as a
+Triton ``@_aggregate`` struct, so a hook takes a single ``ctx`` instead of a flat
+positional arg list. Adding a field here never changes a hook signature — that is
+the whole point (stable interface as the framework grows: pipeline ``slot``/
+``step``, MoE ``expert_counts``, FP8 ``scales``, warp-spec role, ...).
+
+NOTE: this Triton build requires the aggregate ``__init__`` to be a plain Python
+function — ``@triton.jit`` and ``@constexpr_function`` are both rejected by
+``_aggregate`` (they are ``JITCallable``).
+"""
+
+import triton.language as tl
+from triton.language.core import _aggregate as aggregate
+
+
+@aggregate
+class Ctx:
+    """Metadata a ``produce``/``consume`` hook reads for the current tile.
+
+    The tile payload (loaded register values) is passed to ``consume`` as an
+    explicit ``regs`` arg, not carried here.
+    """
+
+    ptr: tl.tensor  # in_ptr for produce, out_ptr for consume
+    idx: tl.tensor  # element offsets of the current tile
+    mask: tl.tensor  # bounds mask
+    # Future fields (peer, shard_idx, slot, step, scales, ...) are added here
+    # WITHOUT changing any hook signature.
+
+    def __init__(self, ptr, idx, mask):
+        self.ptr = ptr
+        self.idx = idx
+        self.mask = mask

--- a/comms/dsl/triton/device_utils.py
+++ b/comms/dsl/triton/device_utils.py
@@ -1,0 +1,122 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Self-contained Triton device helpers for the framework's NVLink send/recv.
+
+Thread-id / block-barrier helpers + the cross-rank **acquire/release** signaling
+PTX. This is the Triton twin of ``cute/cute_sync.py`` and emits the **same
+on-wire protocol** (``ld.acquire.sys`` poll + ``fence.acq_rel.sys`` release
+store), so the two DSLs interoperate.
+
+``comms/dsl`` owns these so it does not depend on the ``comms/pipes`` prototype
+(only the minimal single-shot ops are here; credit/volatile variants live with
+the pipelined follow-up).
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def get_tid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %tid.x;
+        mov.u32 $1, %tid.y;
+        mov.u32 $2, %tid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_ntid():
+    return tl.inline_asm_elementwise(
+        """
+        mov.u32 $0, %ntid.x;
+        mov.u32 $1, %ntid.y;
+        mov.u32 $2, %ntid.z;
+        """,
+        "=r,=r,=r",
+        [],
+        dtype=(tl.uint32, tl.uint32, tl.uint32),
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def get_flat_tid():
+    tid_x, tid_y, tid_z = get_tid()
+    ntid_x, ntid_y, _ = get_ntid()
+    return tid_z * ntid_y * ntid_x + tid_y * ntid_x + tid_x
+
+
+@triton.jit
+def sync_threads():
+    """Block-scope barrier (``bar.sync 0``).
+
+    Triton's implicit ``__syncthreads`` is not always emitted around inline-asm
+    sections, so we emit one explicitly when the protocol requires cross-warp
+    ordering inside a block.
+    """
+    tl.inline_asm_elementwise(
+        "bar.sync 0;", "=r", [], dtype=tl.int32, is_pure=False, pack=1
+    )
+
+
+@triton.jit
+def wait_ge(addr, target):
+    """Acquire-poll int64 until ``*addr >= target`` (local read).
+
+    The acquire memory order pairs with the sender's
+    ``fence_and_remote_store_i64`` (release) so the receiver's subsequent
+    staging reads observe the sender's writes.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u64   %tmp64_<1>;
+            .reg .pred  %p<1>;
+
+            wait_ge:
+                ld.global.acquire.sys.b64 %tmp64_0, [$1];
+                setp.lt.u64 %p0, %tmp64_0, $2;
+                @%p0 bra wait_ge;
+        }
+        """,
+        "=r, l, l",
+        [addr, target],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def fence_and_remote_store_i64(addr, val):
+    """System release fence + REMOTE relaxed int64 store (publish data).
+
+    Drains all prior writes (staging data) so the remote rank's acquire-load of
+    the counter sees the data; the store is relaxed because the fence already
+    provided release ordering.
+    """
+    tl.inline_asm_elementwise(
+        """
+        {
+            fence.acq_rel.sys;
+            st.global.relaxed.sys.b64 [$1], $2;
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r, l, l",
+        [addr, val],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )

--- a/comms/dsl/triton/hooks.py
+++ b/comms/dsl/triton/hooks.py
@@ -1,0 +1,26 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Minimal demo hooks: a plain identity copy through staging.
+
+The trivial ``produce``/``consume`` used by the minimal launcher and smoke test.
+Hooks take a single ``Ctx`` (see ``triton/ctx.py``); ``consume`` also receives the
+loaded tile payload ``regs``. Real Ops (transpose, gather, quantize, accumulate,
+…) supply their own hooks against this same ``ctx`` form.
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def copy_produce(ctx):
+    """Load a tile from the input (no transform)."""
+    return tl.load(ctx.ptr + ctx.idx, mask=ctx.mask)
+
+
+@triton.jit
+def copy_consume(ctx, regs):
+    """Write a received tile to the output (overwrite)."""
+    tl.store(ctx.ptr + ctx.idx, regs, mask=ctx.mask)

--- a/comms/dsl/triton/hooks.py
+++ b/comms/dsl/triton/hooks.py
@@ -2,12 +2,13 @@
 
 # pyre-unsafe
 
-"""Minimal demo hooks: a plain identity copy through staging.
+"""Minimal demo + example hooks (Triton), all in the ``Ctx`` form.
 
-The trivial ``produce``/``consume`` used by the minimal launcher and smoke test.
 Hooks take a single ``Ctx`` (see ``triton/ctx.py``); ``consume`` also receives the
-loaded tile payload ``regs``. Real Ops (transpose, gather, quantize, accumulate,
-…) supply their own hooks against this same ``ctx`` form.
+loaded tile payload ``regs``. ``copy_*`` are the trivial identity hooks; the
+``scale2``/``addone`` pair are non-trivial examples that prove the seam composes.
+Real Ops (transpose, gather, quantize, accumulate, …) supply their own hooks
+against this same ``ctx`` form — adding a ``Ctx`` field never changes a signature.
 """
 
 import triton
@@ -24,3 +25,15 @@ def copy_produce(ctx):
 def copy_consume(ctx, regs):
     """Write a received tile to the output (overwrite)."""
     tl.store(ctx.ptr + ctx.idx, regs, mask=ctx.mask)
+
+
+@triton.jit
+def scale2_produce(ctx):
+    """Send-side hook: load a tile and multiply by 2 (a real value transform)."""
+    return tl.load(ctx.ptr + ctx.idx, mask=ctx.mask) * 2.0
+
+
+@triton.jit
+def addone_consume(ctx, regs):
+    """Recv-side hook: add 1 to the received tile before storing."""
+    tl.store(ctx.ptr + ctx.idx, regs + 1.0, mask=ctx.mask)

--- a/comms/dsl/triton/ib_ops.py
+++ b/comms/dsl/triton/ib_ops.py
@@ -1,0 +1,38 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Reserved IB device transport-ops.
+
+These document the same four-op seam (``framework/ops.py``) that the IB
+(torchcomms window / RDMA) backend must implement. Bodies are reserved: a
+``tl.static_assert`` fails at *compile* time if any of these is ever launched,
+which only happens once the IB stack wires them. They remain importable and
+inspectable (JITFunctions) so the interface is visible now.
+"""
+
+import triton
+import triton.language as tl
+
+_RESERVED = "framework IB ops are reserved; implemented in the IB stack"
+
+
+@triton.jit
+def put(region, idx, regs, mask):
+    tl.static_assert(False, _RESERVED)
+
+
+@triton.jit
+def get(region, idx, mask):
+    tl.static_assert(False, _RESERVED)
+    return tl.load(region + idx, mask=mask)
+
+
+@triton.jit
+def signal(sig_ptr, sig_idx, seq):
+    tl.static_assert(False, _RESERVED)
+
+
+@triton.jit
+def wait(sig_ptr, sig_idx, seq):
+    tl.static_assert(False, _RESERVED)

--- a/comms/dsl/triton/launch.py
+++ b/comms/dsl/triton/launch.py
@@ -1,0 +1,118 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Host launchers wiring the NVLink ops + demo hooks into the minimal kernels.
+
+These exist to make the minimal path runnable (and to drive the 2-rank smoke
+test). The user owns the transport (one rendezvous) and passes it in.
+
+A commented mixed-transport sketch at the bottom shows the interface guarantee:
+the *same* ``send``/``recv`` serve different transports per peer by passing the
+matching ops at each call site.
+
+.. warning::
+    ``num_blocks`` is a cross-rank contract: both peers of an exchange MUST use
+    the same ``num_blocks`` (it determines the chunk partition and the per-block
+    signal slot). A mismatch silently misaligns chunks or hangs a receiver block
+    waiting on a slot the sender never signals. There is no cross-rank
+    validation. (Whether to bind ``num_blocks`` into the transport rendezvous is
+    an open question for the pipelined follow-up.)
+"""
+
+import torch
+from comms.dsl.transport import check_transfer, P2pTransport
+
+from . import nvl_ops
+from .hooks import copy_consume, copy_produce
+from .send_recv import recv_tiles as _recv, send_tiles as _send
+
+_DEFAULT_NUM_BLOCKS: int = 8
+_DEFAULT_NUM_WARPS: int = 4
+_DEFAULT_BLOCK: int = 2048
+
+
+def send(
+    transport: P2pTransport,
+    send_buf: torch.Tensor,
+    peer: int,
+    *,
+    num_blocks: int = _DEFAULT_NUM_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+    block: int = _DEFAULT_BLOCK,
+) -> None:
+    assert send_buf.is_cuda and send_buf.is_contiguous()
+    check_transfer(transport, send_buf.numel(), send_buf.dtype, num_blocks)
+    ep = transport.endpoint(peer, dtype=send_buf.dtype)
+    # pyre-ignore[28]: triton launcher accepts JIT-special kwargs (num_warps).
+    _send[(num_blocks,)](
+        send_buf,
+        ep.send_dst,
+        ep.signal_dst,
+        send_buf.numel(),
+        copy_produce,
+        nvl_ops.put,
+        nvl_ops.signal,
+        BLOCK=block,
+        num_warps=num_warps,
+    )
+
+
+def recv(
+    transport: P2pTransport,
+    recv_buf: torch.Tensor,
+    peer: int,
+    *,
+    num_blocks: int = _DEFAULT_NUM_BLOCKS,
+    num_warps: int = _DEFAULT_NUM_WARPS,
+    block: int = _DEFAULT_BLOCK,
+) -> None:
+    assert recv_buf.is_cuda and recv_buf.is_contiguous()
+    check_transfer(transport, recv_buf.numel(), recv_buf.dtype, num_blocks)
+    ep = transport.endpoint(peer, dtype=recv_buf.dtype)
+    # pyre-ignore[28]: triton launcher accepts JIT-special kwargs (num_warps).
+    _recv[(num_blocks,)](
+        recv_buf,
+        ep.recv_src,
+        ep.signal_src,
+        recv_buf.numel(),
+        copy_consume,
+        nvl_ops.get,
+        nvl_ops.wait,
+        BLOCK=block,
+        num_warps=num_warps,
+    )
+
+
+def sendrecv(
+    transport: P2pTransport,
+    send_buf: torch.Tensor,
+    recv_buf: torch.Tensor,
+    send_peer: int,
+    recv_peer: int | None = None,
+    **kwargs: int,
+) -> None:
+    """Bidirectional minimal exchange. ``send`` is non-blocking, so issuing it
+    before ``recv`` does not deadlock."""
+    recv_peer = send_peer if recv_peer is None else recv_peer
+    send(transport, send_buf, send_peer, **kwargs)
+    recv(transport, recv_buf, recv_peer, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Mixed-transport sketch (interface guarantee; IB impl is a follow-up).
+#
+# The same `send`/`recv` serve different transports per peer — the user's
+# schedule branches on `link_kind` and passes the matching ops + buffers:
+#
+#   from comms.dsl.transport import LinkKind
+#   from . import ib_ops
+#   for peer in peers:
+#       ep = mesh.endpoint(peer, dtype=buf.dtype)
+#       if mesh.link_kind(peer) is LinkKind.NVLINK:
+#           _send[grid](buf, ep.send_dst, ep.signal_dst, buf.numel(),
+#                       copy_produce, nvl_ops.put, nvl_ops.signal, BLOCK=...)
+#       else:  # LinkKind.IB
+#           _send[grid](buf, ep.send_dst, ep.signal_dst, buf.numel(),
+#                       copy_produce, ib_ops.put, ib_ops.signal, BLOCK=...)
+# ---------------------------------------------------------------------------

--- a/comms/dsl/triton/launch.py
+++ b/comms/dsl/triton/launch.py
@@ -37,6 +37,7 @@ def send(
     send_buf: torch.Tensor,
     peer: int,
     *,
+    produce=copy_produce,
     num_blocks: int = _DEFAULT_NUM_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
     block: int = _DEFAULT_BLOCK,
@@ -50,7 +51,7 @@ def send(
         ep.send_dst,
         ep.signal_dst,
         send_buf.numel(),
-        copy_produce,
+        produce,
         nvl_ops.put,
         nvl_ops.signal,
         BLOCK=block,
@@ -63,6 +64,7 @@ def recv(
     recv_buf: torch.Tensor,
     peer: int,
     *,
+    consume=copy_consume,
     num_blocks: int = _DEFAULT_NUM_BLOCKS,
     num_warps: int = _DEFAULT_NUM_WARPS,
     block: int = _DEFAULT_BLOCK,
@@ -76,7 +78,7 @@ def recv(
         ep.recv_src,
         ep.signal_src,
         recv_buf.numel(),
-        copy_consume,
+        consume,
         nvl_ops.get,
         nvl_ops.wait,
         BLOCK=block,
@@ -90,13 +92,20 @@ def sendrecv(
     recv_buf: torch.Tensor,
     send_peer: int,
     recv_peer: int | None = None,
+    *,
+    produce=copy_produce,
+    consume=copy_consume,
     **kwargs: int,
 ) -> None:
     """Bidirectional minimal exchange. ``send`` is non-blocking, so issuing it
-    before ``recv`` does not deadlock."""
+    before ``recv`` does not deadlock.
+
+    ``produce`` routes to the send leg and ``consume`` to the recv leg; the
+    remaining launch kwargs (``num_blocks``/``num_warps``/``block``) go to both.
+    """
     recv_peer = send_peer if recv_peer is None else recv_peer
-    send(transport, send_buf, send_peer, **kwargs)
-    recv(transport, recv_buf, recv_peer, **kwargs)
+    send(transport, send_buf, send_peer, produce=produce, **kwargs)
+    recv(transport, recv_buf, recv_peer, consume=consume, **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/comms/dsl/triton/nvl_ops.py
+++ b/comms/dsl/triton/nvl_ops.py
@@ -1,0 +1,41 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""NVLink device transport-ops (real, minimal) for the framework send/recv seam.
+
+Thin ``@triton.jit`` wrappers over the framework's own NVLink PTX helpers in
+``device_utils.py`` (self-contained; no ``comms/pipes`` dependency). These are the concrete
+implementation of the four-op seam documented in ``framework/ops.py`` for the
+symmetric-memory transport. No slots / credit here — that is the pipelined
+version (follow-up Triton stack).
+"""
+
+import triton
+import triton.language as tl
+
+from .device_utils import fence_and_remote_store_i64, wait_ge
+
+
+@triton.jit
+def put(region, idx, regs, mask):
+    """Write a produced tile into the peer's staging region (remote NVLink store)."""
+    tl.store(region + idx, regs, mask=mask)
+
+
+@triton.jit
+def get(region, idx, mask):
+    """Read a received tile from the local staging region."""
+    return tl.load(region + idx, mask=mask)
+
+
+@triton.jit
+def signal(sig_ptr, sig_idx, seq):
+    """Publish "data ready" to the peer (fence + remote int64 store)."""
+    fence_and_remote_store_i64(sig_ptr + sig_idx, seq)
+
+
+@triton.jit
+def wait(sig_ptr, sig_idx, seq):
+    """Wait until the peer published ``seq`` (acquire-poll local int64)."""
+    wait_ge(sig_ptr + sig_idx, seq)

--- a/comms/dsl/triton/send_recv.py
+++ b/comms/dsl/triton/send_recv.py
@@ -1,0 +1,105 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-unsafe
+
+"""Minimal device send_tiles/recv_tiles primitives (Triton).
+
+The composable unit: each call moves one whole peer transfer. The primitive owns
+the per-tile loop and the signaling boundary and calls the user's full-leg hook
+(``produce`` / ``consume``) per tile. The transport ops (``put`` /
+``get`` / ``signal`` / ``wait``) and the hook are passed as
+``tl.constexpr`` so the *same* ``send_tiles``/``recv_tiles`` serve NVLink today, IB later,
+and mixed-transport kernels (different ops per call site).
+
+Minimal scope (correctness only; no performance):
+
+* **No pipeline** — no slots, no double-buffering, no credit/backpressure. Each
+  block copies a contiguous chunk and raises a single data-ready signal.
+* **Single-shot** — uses ``seq = 1``; not safe to reuse the same buffers
+  back-to-back without re-rendezvous. The pipelined, monotonic-counter version
+  is the follow-up Triton stack.
+* **Cross-rank contract** — both peers of an exchange must use the same
+  ``num_blocks``; it sets the chunk partition and the per-block signal slot, so a
+  mismatch silently misaligns chunks or hangs a receiver block. Not validated
+  here (see the launcher warning).
+
+The hook takes a single ``Ctx`` aggregate (see ``triton/ctx.py``):
+``produce(ctx) -> regs`` and ``consume(ctx, regs)``. Adding a field to ``Ctx``
+never changes a hook signature.
+"""
+
+import triton
+import triton.language as tl
+
+from .ctx import Ctx
+from .device_utils import get_flat_tid, sync_threads
+
+
+@triton.jit
+def send_tiles(
+    in_ptr,
+    send_dst,
+    signal_dst,
+    numel,
+    produce: tl.constexpr,
+    put: tl.constexpr,
+    signal: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Send this rank's buffer to a peer through ``send_dst`` + ``signal_dst``."""
+    bid = tl.program_id(0)
+    nblocks = tl.num_programs(0)
+    chunk = tl.cdiv(numel, nblocks)
+    start = bid * chunk
+    end = min(start + chunk, numel)
+
+    off = start
+    while off < end:
+        idx = off + tl.arange(0, BLOCK)
+        mask = idx < end
+        regs = produce(Ctx(in_ptr, idx, mask))
+        put(send_dst, idx, regs, mask)
+        off += BLOCK
+
+    # Ordering: sync_threads() is a block-scope barrier, so every thread's
+    # staging stores above complete before tid 0 proceeds. signal() then
+    # issues a system-scope release (fence.acq_rel.sys) + remote store from
+    # tid 0, so the peer's acquire-poll of the signal observes this block's
+    # staging data.
+    sync_threads()
+    if get_flat_tid() == 0:
+        signal(signal_dst, bid, 1)
+
+
+@triton.jit
+def recv_tiles(
+    out_ptr,
+    recv_src,
+    signal_src,
+    numel,
+    consume: tl.constexpr,
+    get: tl.constexpr,
+    wait: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Receive a peer's buffer from ``recv_src`` after ``signal_src`` fires."""
+    bid = tl.program_id(0)
+    nblocks = tl.num_programs(0)
+    chunk = tl.cdiv(numel, nblocks)
+    start = bid * chunk
+    end = min(start + chunk, numel)
+
+    # Ordering: tid 0 acquire-polls the data-ready signal (pairs with the
+    # sender's release in signal); sync_threads() then publishes that
+    # acquire to the whole block before any thread reads staging.
+    if get_flat_tid() == 0:
+        wait(signal_src, bid, 1)
+    sync_threads()
+
+    off = start
+    while off < end:
+        idx = off + tl.arange(0, BLOCK)
+        mask = idx < end
+        regs = get(recv_src, idx, mask)
+        consume(Ctx(out_ptr, idx, mask), regs)
+        off += BLOCK


### PR DESCRIPTION
Summary:

Proves the framework's hook seam composes for BOTH backends with a single,
unified contract: a user compute transform applied during the transfer, over the
shared transport, for Triton AND CuTe — same `produce(ctx)` / `consume(ctx, ...)`
hook shape on both. Stacked on the CuTe backend commit.

* `triton/hooks.py`: add `scale2_produce(ctx)` (load * 2) + `addone_consume(ctx,
  regs)` (regs + 1) alongside the copy hooks — same `Ctx` form as the defaults.
* `cute/hooks.py` (new): `scale2_produce(ctx) -> frag` + `addone_consume(ctx,
  frag)` — leg-owning CuTe hooks (load/store via `ctx.atom`/`ctx.part`, with the
  arithmetic as register-only `frag.load() * 2` / `+ 1`).
* `triton/launch.py` / `cute/launch.py`: `send(produce=...)` /
  `recv(consume=...)` (default copy), so a hook is supplied without
  hand-writing a kernel.

Both DSLs now share the SAME device hook signature — `produce(ctx)` /
`consume(ctx, payload)` — so a hook is portable in shape across backends and the
contract is churn-proof (new metadata is a `Ctx` field, never a signature change).
A pure-arithmetic convenience wrapper (`from_transform`) that regenerates the
one-liner on top of the leg-owning seam is a deferred follow-up.

Differential Revision: D107296813
