### PR TITLE
Rename pipes build flag to prims (#2832)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -459,7 +459,7 @@ function build_nccl {
     CONDA_LIB_DIR="$CONDA_LIB_DIR" \
     THIRD_PARTY_LDFLAGS="$THIRD_PARTY_LDFLAGS" \
     CUDARTLIB="$CUDARTLIB" \
-    ENABLE_PIPES="${ENABLE_PIPES:-0}"
+    ENABLE_PRIMS="${ENABLE_PRIMS:-0}"
 }
 
 function build_and_install_nccl {
@@ -476,7 +476,7 @@ make VERBOSE=1 -j$(nproc) \
     CONDA_LIB_DIR="$CONDA_LIB_DIR" \
     THIRD_PARTY_LDFLAGS="$THIRD_PARTY_LDFLAGS" \
     CUDARTLIB="$CUDARTLIB" \
-    ENABLE_PIPES="${ENABLE_PIPES:-0}"
+    ENABLE_PRIMS="${ENABLE_PRIMS:-0}"
 }
 
 if [[ -z "${NCCL_BUILD_AND_INSTALL}" ]]; then

--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -19,11 +19,11 @@
 // Import "commGroupDepth" from CommGroupUtils.h
 #include "comms/ctran/utils/CommGroupUtils.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/trace/PipesTrace.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 #include "comms/prims/transport/MultiPeerTransport.h"
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)
 
 Ctran::Ctran(
     CtranComm* comm,
@@ -108,7 +108,7 @@ uint64_t Ctran::getCtranOpCount() const {
   return comm_->getCtranOpCount();
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
   if (!multiPeerTransport_) {
     return nullptr;
@@ -119,7 +119,7 @@ comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
 comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
   return nullptr;
 }
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)
 
 std::optional<meta::comms::colltrace::AlgoStatDump> CtranComm::dumpAlgoStats()
     const {
@@ -197,7 +197,7 @@ void CtranComm::destroy() {
   // All smart pointers are automatically de-initialized, but we want to
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   pipesTrace_.reset();
   if (hierarchicalAgReadyCounters_ != nullptr) {
     cudaFree(hierarchicalAgReadyCounters_);
@@ -208,7 +208,7 @@ void CtranComm::destroy() {
   // buffers used as external data buffers) and before bootstrap_ (since
   // multiPeerTransport_ holds a non-owning reference to it).
   multiPeerTransport_.reset();
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)
   ctran_.reset();
   bootstrap_.reset();
   colltraceNew_.reset();

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -198,12 +198,12 @@ class CtranComm {
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;
   std::unique_ptr<ncclx::CommStateX> statex_;
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   std::unique_ptr<comms::prims::MultiPeerTransport> multiPeerTransport_;
   uint64_t* hierarchicalAgReadyCounters_{nullptr};
   size_t hierarchicalAgReadyCounterCount_{0};
   std::unique_ptr<comms::prims::PipesTrace> pipesTrace_;
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)
 
   // Deferred cleanup for CUDA graph resources. CUDA user-object destructor
   // callbacks cannot call CUDA APIs, so cleanup is enqueued here and

--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -14,7 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/prims/trace/PipesTrace.h"
 #include "comms/prims/transport/MultiPeerTransport.h"
@@ -512,4 +512,4 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   return commSuccess;
 }
 
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)

--- a/comms/ctran/CtranPipes.h
+++ b/comms/ctran/CtranPipes.h
@@ -6,9 +6,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/trace/PipesTraceTypes.h"
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -33,7 +33,7 @@ commResult_t ctranInitializePipes(CtranComm* comm);
 // CtranAlgo (SharedResource) and MultiPeerTransport have been created.
 commResult_t ctranInitPipesResources(CtranAlgo* algo);
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 namespace ctran {
 
 commResult_t ctranPreparePipesTrace(
@@ -41,4 +41,4 @@ commResult_t ctranPreparePipesTrace(
     comms::prims::PipesTraceHandle& trace);
 
 } // namespace ctran
-#endif // defined(ENABLE_PIPES)
+#endif // defined(ENABLE_PRIMS)

--- a/comms/ctran/algos/AllGather/AllGather.cc
+++ b/comms/ctran/algos/AllGather/AllGather.cc
@@ -58,7 +58,7 @@ bool ctranAllGatherSupport(
       }
       break;
     case NCCL_ALLGATHER_ALGO::cthierarchical_ring:
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
       if (statex->nRanks() <= 1 || statex->nNodes() <= 1) {
         CLOGF_SUBSYS(
             WARN,

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include <cuda_runtime.h>
 
@@ -476,7 +476,7 @@ commResult_t ctranAllGatherHierarchicalRing(
   return commSuccess;
 }
 
-#else // !ENABLE_PIPES
+#else // !ENABLE_PRIMS
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
@@ -491,4 +491,4 @@ commResult_t ctranAllGatherHierarchicalRing(
   return commInternalError;
 }
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cc
@@ -14,7 +14,7 @@
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/ctran/algos/AllReduce/AllReduceTree.cuh"
 #include "comms/prims/transport/MultiPeerTransport.h"
 #endif
@@ -56,7 +56,7 @@ int getAllReduceTreeFanOut() {
   return kDefaultFanOut;
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 /** Return the topology-wide cap for CTREE logical CUDA blocks. */
 int getAllReduceTreeNumBlockCap() {
   return std::max(1, NCCL_CTRAN_MAX_NBLOCKS);
@@ -260,7 +260,7 @@ commResult_t ctranAllReduceTree(
       tree1.isRoot,
       tree1.isLeaf);
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   const int nLocalRanks = statex->nLocalRanks();
   const size_t elementSize = commTypeSize(datatype);
   const size_t totalBytes = count * elementSize;
@@ -340,7 +340,7 @@ commResult_t ctranAllReduceTree(
     CLOGF(
         ERR,
         "AllReduce ctree: getMultiPeerTransportsPtr() returned null - "
-        "Prims transport not initialized. Ensure ENABLE_PIPES is defined "
+        "Prims transport not initialized. Ensure ENABLE_PRIMS is defined "
         "and multiPeerTransport is set up.");
     return commInternalError;
   }
@@ -380,7 +380,7 @@ commResult_t ctranAllReduceTree(
 
   return commSuccess;
 #else
-  CLOGF(ERR, "AllReduce ctree requires ENABLE_PIPES");
+  CLOGF(ERR, "AllReduce ctree requires ENABLE_PRIMS");
   return commInternalError;
 #endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cu
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include <cuda_fp16.h>
 
@@ -841,4 +841,4 @@ __launch_bounds__(ctran::allreduce::tree::kBlockSize, 1) void ctranKernelAllRedu
   }
 }
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceTree.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cuh
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -90,4 +90,4 @@ __global__ void ctranKernelAllReduceTree(
     CtranAlgoDeviceState* devState,
     ctran::allreduce::tree::KernArgs args);
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllToAll/AllToAll.cc
+++ b/comms/ctran/algos/AllToAll/AllToAll.cc
@@ -8,7 +8,7 @@
 #include "comms/ctran/algos/AllToAll/AllToAllImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllPImpl.h"
 #include "comms/ctran/algos/AllToAll/AllToAllvImpl.h"
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/transport/Transport.cuh"
@@ -18,7 +18,7 @@
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 template <PipeProtocol Proto>
 extern __global__ void ncclKernelDeviceAllToAllvPipes(
     int* flag,
@@ -187,7 +187,7 @@ bool ctranAllToAllSupport(
   return commTypeSize(datatype) * count >= NCCL_CTRAN_ALLTOALL_THRESHOLD;
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 // ============================================================================
 // Device AllToAllv (split sizes on device)
 // NVLink domain only — all peers must be reachable via NVLink.
@@ -284,11 +284,11 @@ bool ctranDeviceAllToAllvSupport(CtranComm* comm) {
 
   return true;
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
-// Stubs when ENABLE_PIPES is not defined — prevents linker errors from
+// Stubs when ENABLE_PRIMS is not defined — prevents linker errors from
 // unconditional declarations in Ctran.h.
-#if !defined(ENABLE_PIPES)
+#if !defined(ENABLE_PRIMS)
 commResult_t ctranDeviceAllToAllv(
     const void* /*sendbuff*/,
     void* /*recvbuff*/,
@@ -306,4 +306,4 @@ commResult_t ctranDeviceAllToAllv(
 bool ctranDeviceAllToAllvSupport(CtranComm* /*comm*/) {
   return false;
 }
-#endif // !ENABLE_PIPES
+#endif // !ENABLE_PRIMS

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipes.cu
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include <cstddef>
 #include "comms/ctran/algos/AllToAll/Types.h"
@@ -171,4 +171,4 @@ template __global__ void ncclKernelDeviceAllToAllvPipes<PipeProtocol::LL128>(
     CtranAlgoDeviceState* devState,
     ctran::device_alltoallv_pipes::KernArgs args);
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
+++ b/comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.cc
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/ctran/algos/AllToAll/DeviceAllToAllvPipesImpl.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -170,4 +170,4 @@ commResult_t setupKernelConfig(
 
 } // namespace ctran::device_alltoallv_pipes
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ctran/window/CtranWin.h
+++ b/comms/ctran/window/CtranWin.h
@@ -14,11 +14,11 @@
 #include "comms/ctran/utils/CtranIpc.h"
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/Types.h"
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 namespace comms::prims {
 class DeviceWindow;
 class HostWindow;
@@ -108,7 +108,7 @@ struct CtranWin {
   commResult_t allocate(void* userBufPtr = nullptr);
   commResult_t exchange();
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // COLLECTIVE on first call: all ranks must call this together.
   // Prerequisite: allocate() and exchange() must have been called first.
   // Registers the window data buffer with pipes' MultiPeerTransport for
@@ -176,7 +176,7 @@ struct CtranWin {
   // Actual size allocated for the total buffer per rank in this window
   size_t range_{0};
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   std::unique_ptr<comms::prims::HostWindow> hostWindow_;
 #endif
 };

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -11,7 +11,7 @@
 #include "comms/ctran/utils/DevMemType.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/ctran/window/Types.h"
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/MultiPeerTransport.h"
 #include "comms/prims/window/DeviceWindow.cuh"
 #include "comms/prims/window/HostWindow.h"
@@ -309,7 +309,7 @@ commResult_t CtranWin::free(bool skipBarrier) {
     }
   }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // HostWindow handles cleanup via RAII
   hostWindow_.reset();
 #endif
@@ -324,7 +324,7 @@ bool CtranWin::nvlEnabled(int rank) const {
       comm->ctran_->mapper->hasBackend(rank, CtranMapperBackend::NVL);
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 commResult_t CtranWin::getDeviceWin(
     comms::prims::DeviceWindow* devWin,
     const comms::prims::WindowConfig& config) {
@@ -361,7 +361,7 @@ commResult_t CtranWin::getDeviceWin(
   new (devWin) comms::prims::DeviceWindow(hostWindow_->getDeviceWindow());
   return commSuccess;
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 commResult_t ctranWinAllocate(
     size_t size,

--- a/comms/ncclx/meta/rma/transport.cc
+++ b/comms/ncclx/meta/rma/transport.cc
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // Pipes transport API implementations (non-window transport operations).
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "checks.h"
 #include "comm.h"
@@ -55,4 +55,4 @@ ncclResult_t ncclGetMultiPeerDeviceHandle(
   return ncclSuccess;
 }
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ncclx/meta/rma/window.cc
+++ b/comms/ncclx/meta/rma/window.cc
@@ -205,7 +205,7 @@ ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr) {
   return ncclSuccess;
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include <cuda_runtime_api.h>
 
 #include "comms/prims/transport/MultiPeerTransport.h"
@@ -392,4 +392,4 @@ ncclResult_t ncclWinLocalDeregisterBuffer(ncclComm_t comm, void* ptr) {
     return ncclInternalError;
   }
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -6,14 +6,14 @@
 #
 
 ENABLE_TCPDM ?= 0
-ENABLE_PIPES ?= 1
+ENABLE_PRIMS ?= 1
 
 # Assuming calling from src directory
 SRCDIR = $(abspath ./)
 NCCLDIR = $(abspath ../)
 SHAREDDIR = $(abspath ${NCCLDIR}/..)
 
-# fbcode/Pipes CUDA sources include Folly headers that require C++20.
+# fbcode/prims CUDA sources include Folly headers that require C++20.
 CXXSTD ?= -std=c++20
 
 include ../makefiles/common.mk
@@ -28,9 +28,9 @@ ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM
 endif
 
-ifeq ($(ENABLE_PIPES),1)
-CXXFLAGS += -DENABLE_PIPES
-NVCUFLAGS += -DENABLE_PIPES
+ifeq ($(ENABLE_PRIMS),1)
+CXXFLAGS += -DENABLE_PRIMS
+NVCUFLAGS += -DENABLE_PRIMS
 endif
 
 ##### src files
@@ -96,7 +96,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
 LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
-ifeq ($(ENABLE_PIPES),1)
+ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceTree.cu
 endif
@@ -276,7 +276,7 @@ DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d)
 LDFLAGS    += -Wl,--no-undefined
 LDFLAGS    += -L${CUDA_LIB} -L${BUILDDIR} -L${CONDA_LIB_DIR} -l$(CUDARTLIB) -lpthread -lm -lrt -ldl
 LDFLAGS    += ${THIRD_PARTY_LDFLAGS}
-ifeq ($(ENABLE_PIPES),1)
+ifeq ($(ENABLE_PRIMS),1)
 LDFLAGS    += -lpipes
 endif
 LDFLAGS    += -Wl,--version-script=version.script

--- a/comms/ncclx/v2_29/src/collectives.cc
+++ b/comms/ncclx/v2_29/src/collectives.cc
@@ -482,7 +482,7 @@ ncclResult_t ncclAllToAllv(
   return ncclSuccess;
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 __attribute__((visibility("default")))
 ncclResult_t ncclx::deviceAllToAllv(
     const void* sendbuff,
@@ -527,7 +527,7 @@ ncclResult_t ncclx::deviceAllToAllv(
     const std::unordered_map<std::string, std::string>& /*hints*/) {
   return ncclInvalidUsage;
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 __attribute__((visibility("default")))
 ncclResult_t ncclx::alltoallvDynamic(

--- a/comms/ncclx/v2_29/src/device/Makefile
+++ b/comms/ncclx/v2_29/src/device/Makefile
@@ -39,9 +39,9 @@ NVCUFLAGS += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 NVCUFLAGS_SYM += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 endif
 
-ifeq ($(ENABLE_PIPES),1)
-NVCUFLAGS += --compiler-options "-DENABLE_PIPES"
-NVCUFLAGS_SYM += --compiler-options "-DENABLE_PIPES"
+ifeq ($(ENABLE_PRIMS),1)
+NVCUFLAGS += --compiler-options "-DENABLE_PRIMS"
+NVCUFLAGS_SYM += --compiler-options "-DENABLE_PRIMS"
 endif
 
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY

--- a/comms/ncclx/v2_29/src/nccl.h.in
+++ b/comms/ncclx/v2_29/src/nccl.h.in
@@ -995,7 +995,7 @@ ncclResult_t pncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, vo
  */
 ncclResult_t ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr);
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 /*
  * Create a DeviceWindow in device memory from a ctran-registered ncclWindow_t.
  * COLLECTIVE on first call — all ranks must call together.
@@ -1087,7 +1087,7 @@ ncclResult_t ncclWinLocalRegisterBuffer(
 ncclResult_t ncclWinLocalDeregisterBuffer(
     ncclComm_t comm,
     void* ptr);
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 /*
  * Free the window object and free the allocated memory

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -6,14 +6,14 @@
 #
 
 ENABLE_TCPDM ?= 0
-ENABLE_PIPES ?= 1
+ENABLE_PRIMS ?= 1
 
 # Assuming calling from src directory
 SRCDIR = $(abspath ./)
 NCCLDIR = $(abspath ../)
 SHAREDDIR = $(abspath ${NCCLDIR}/..)
 
-# fbcode/Pipes CUDA sources include Folly headers that require C++20.
+# fbcode/prims CUDA sources include Folly headers that require C++20.
 CXXSTD ?= -std=c++20
 
 include ../makefiles/common.mk
@@ -28,9 +28,9 @@ ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM
 endif
 
-ifeq ($(ENABLE_PIPES),1)
-CXXFLAGS += -DENABLE_PIPES
-NVCUFLAGS += -DENABLE_PIPES
+ifeq ($(ENABLE_PRIMS),1)
+CXXFLAGS += -DENABLE_PRIMS
+NVCUFLAGS += -DENABLE_PRIMS
 endif
 
 ##### src files
@@ -104,7 +104,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/utils/hrdw_ring_buffer/*.cc)
 ## CollTrace CUDA source files (host-side kernel launchers)
 LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
-ifeq ($(ENABLE_PIPES),1)
+ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceTree.cu
 endif
@@ -287,7 +287,7 @@ DEPFILES   := $(LIBOBJ:%.o=%.d) $(BINOBJ:%.o=%.d) $(PARAMBINOBJ:%.o=%.d)
 LDFLAGS    += -Wl,--no-undefined
 LDFLAGS    += -L${CUDA_LIB} -L${BUILDDIR} -L${CONDA_LIB_DIR} -l$(CUDARTLIB) -lpthread -lm -lrt -ldl
 LDFLAGS    += ${THIRD_PARTY_LDFLAGS}
-ifeq ($(ENABLE_PIPES),1)
+ifeq ($(ENABLE_PRIMS),1)
 LDFLAGS    += -lpipes
 endif
 LDFLAGS    += -Wl,--version-script=version.script

--- a/comms/ncclx/v2_30/src/collectives.cc
+++ b/comms/ncclx/v2_30/src/collectives.cc
@@ -482,7 +482,7 @@ ncclResult_t ncclAllToAllv(
   return ncclSuccess;
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 __attribute__((visibility("default")))
 ncclResult_t ncclx::deviceAllToAllv(
     const void* sendbuff,
@@ -527,7 +527,7 @@ ncclResult_t ncclx::deviceAllToAllv(
     const std::unordered_map<std::string, std::string>& /*hints*/) {
   return ncclInvalidUsage;
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 __attribute__((visibility("default")))
 ncclResult_t ncclx::alltoallvDynamic(

--- a/comms/ncclx/v2_30/src/device/Makefile
+++ b/comms/ncclx/v2_30/src/device/Makefile
@@ -44,9 +44,9 @@ NVCUFLAGS += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 NVCUFLAGS_SYM += --compiler-options "-DCTRAN_DISABLE_TCPDM"
 endif
 
-ifeq ($(ENABLE_PIPES),1)
-NVCUFLAGS += --compiler-options "-DENABLE_PIPES"
-NVCUFLAGS_SYM += --compiler-options "-DENABLE_PIPES"
+ifeq ($(ENABLE_PRIMS),1)
+NVCUFLAGS += --compiler-options "-DENABLE_PRIMS"
+NVCUFLAGS_SYM += --compiler-options "-DENABLE_PRIMS"
 endif
 
 SAY = @bash -c 'path="$$2"; [[ "$$(realpath "$$2")" =~ ^$(subst .,\.,$(abspath $(NCCLDIR)))/(.*)$$ ]] && path="$${BASH_REMATCH[1]}"; printf "%-15s %s\n" "$$1" "$$path"' SAY

--- a/comms/ncclx/v2_30/src/nccl.h.in
+++ b/comms/ncclx/v2_30/src/nccl.h.in
@@ -1003,7 +1003,7 @@ ncclResult_t pncclWinSharedQuery(int rank, ncclComm_t comm, ncclWindow_t win, vo
  */
 ncclResult_t ncclWinGetAttributes(int rank, ncclWindow_t win, ncclWinAttr_t* attr);
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 /*
  * Create a DeviceWindow in device memory from a ctran-registered ncclWindow_t.
  * COLLECTIVE on first call — all ranks must call together.
@@ -1095,7 +1095,7 @@ ncclResult_t ncclWinLocalRegisterBuffer(
 ncclResult_t ncclWinLocalDeregisterBuffer(
     ncclComm_t comm,
     void* ptr);
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 /*
  * Free the window object and free the allocated memory

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // PipesDeviceBackend - Static method implementations
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
@@ -308,4 +308,4 @@ PipesDeviceBackend::get_device_transport(
 
 } // namespace torchcomms::device
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
+++ b/comms/torchcomms/device/pipes/PipesDeviceBackend.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include <memory>
 
@@ -206,4 +206,4 @@ struct PipesDeviceBackend {
 
 } // namespace torchcomms::device
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipes.cuh
@@ -17,7 +17,7 @@
 // NOLINTNEXTLINE(clang-diagnostic-pragma-once-outside-header)
 #pragma once
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #ifndef __CUDACC__
 #error "TorchCommDevicePipes.cuh must be compiled with nvcc."
@@ -391,4 +391,4 @@ TorchCommDeviceWindow<PipesDeviceBackend>::get_multimem_address(
 
 } // namespace torchcomms::device
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp
+++ b/comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
@@ -26,4 +26,4 @@ using RegisteredBufferPipes = torch::comms::RegisteredBuffer;
 
 } // namespace torchcomms::device
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -83,12 +83,12 @@ else()
     set(TORCHCOMMS_DEVICE_NCCLX_SOURCE "")
 endif()
 
-# Check if ENABLE_PIPES is requested via environment variable.
-# When enabled, compiles pipes device backend support into _comms_ncclx.
-# Requires NCCL built with ENABLE_PIPES=1 (pipes transport in libnccl.so).
-if("$ENV{ENABLE_PIPES}" STREQUAL "1")
-    set(TORCHCOMMS_ENABLE_PIPES ON)
-    message(STATUS "ENABLE_PIPES=1 set, building with pipes support")
+# Check if ENABLE_PRIMS is requested via environment variable.
+# When enabled, compiles prims device backend support into _comms_ncclx.
+# Requires NCCL built with ENABLE_PRIMS=1 (prims transport in libnccl.so).
+if("$ENV{ENABLE_PRIMS}" STREQUAL "1")
+    set(TORCHCOMMS_ENABLE_PRIMS ON)
+    message(STATUS "ENABLE_PRIMS=1 set, building with prims support")
     if(TORCHCOMMS_HAS_NCCL_DEVICE_API)
         file(GLOB TORCHCOMMS_DEVICE_PIPES_SOURCE
             "comms/torchcomms/device/pipes/*.cpp")
@@ -96,9 +96,9 @@ if("$ENV{ENABLE_PIPES}" STREQUAL "1")
         set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
     endif()
 else()
-    set(TORCHCOMMS_ENABLE_PIPES OFF)
+    set(TORCHCOMMS_ENABLE_PRIMS OFF)
     set(TORCHCOMMS_DEVICE_PIPES_SOURCE "")
-    message(STATUS "ENABLE_PIPES not set, building without pipes support")
+    message(STATUS "ENABLE_PRIMS not set, building without prims support")
 endif()
 
 add_library(torchcomms_comms_ncclx MODULE
@@ -129,10 +129,10 @@ if(TORCHCOMMS_HAS_NCCL_DEVICE_API)
         PRIVATE TORCHCOMMS_HAS_NCCL_DEVICE_API=1)
 endif()
 
-# Add ENABLE_PIPES compile definition for pipes device backend
-if(TORCHCOMMS_ENABLE_PIPES)
+# Add ENABLE_PRIMS compile definition for prims device backend
+if(TORCHCOMMS_ENABLE_PRIMS)
     target_compile_definitions(torchcomms_comms_ncclx
-        PRIVATE ENABLE_PIPES=1)
+        PRIVATE ENABLE_PRIMS=1)
 endif()
 
 target_link_directories(torchcomms_comms_ncclx PRIVATE ${CONDA_LIB})

--- a/comms/torchcomms/ncclx/NcclxApi.cpp
+++ b/comms/torchcomms/ncclx/NcclxApi.cpp
@@ -498,7 +498,7 @@ ncclResult_t DefaultNcclxApi::commDump(
   return ::ncclCommDump(comm, map);
 }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 ncclResult_t DefaultNcclxApi::winCreateDeviceWin(
     NcclxWindow win,
     int signal_count,
@@ -542,7 +542,7 @@ ncclResult_t DefaultNcclxApi::winLocalDeregisterBuffer(
     void* ptr) {
   return ncclWinLocalDeregisterBuffer(comm, ptr);
 }
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
 ncclResult_t DefaultNcclxApi::devCommCreate(

--- a/comms/torchcomms/ncclx/NcclxApi.hpp
+++ b/comms/torchcomms/ncclx/NcclxApi.hpp
@@ -360,7 +360,7 @@ class NcclxApi {
       ncclComm_t comm) = 0;
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // Create a DeviceWindow in device memory from a ctran-registered NcclxWindow.
   // COLLECTIVE on first call — all ranks must call together.
   // Returns opaque device pointer via outDevicePtr; free with
@@ -702,7 +702,7 @@ class DefaultNcclxApi : public NcclxApi {
       ncclComm_t comm) override;
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   ncclResult_t winCreateDeviceWin(
       NcclxWindow win,
       int signal_count,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -20,7 +20,7 @@
 #include "comms/torchcomms/utils/TracingGuard.hpp"
 #include "comms/utils/CudaRAII.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #endif
 
@@ -2112,7 +2112,7 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCLX::gather(
 std::shared_ptr<TorchCommWindow> TorchCommNCCLX::new_window(
     const std::optional<at::Tensor>& tensor) {
   std::shared_ptr<TorchCommWindow> win;
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // Select Pipes backend when NCCL_CTRAN_USE_PIPES is enabled.
   // Pipes uses ctran IBGDA/NVLink instead of GIN for device-side P2P.
   const char* pipes_env = std::getenv("NCCL_CTRAN_USE_PIPES");
@@ -2338,7 +2338,7 @@ class NCCLXRegistration {
 static const NCCLXRegistration registration{};
 } // namespace
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 int64_t TorchCommNCCLX::get_device_transport() {
   if (!device_transport_handle_) {
     device_transport_handle_ =

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -25,7 +25,7 @@
 #include "comms/torchcomms/ncclx/TorchWorkNCCLX.hpp"
 #include "comms/utils/GraphCaptureSideStream.h"
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #endif
 
@@ -297,7 +297,7 @@ class TorchCommNCCLX : public TorchCommBackend,
     return device_;
   }
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // Get device-allocated transport handle for Triton/CUDA kernels.
   // Returns device pointer as int64 (same pointer on subsequent calls).
   // The handle is freed when TorchCommNCCLX is destroyed.
@@ -487,7 +487,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   // Initialize the NcclxCachingAllocatorHook singleton
   void attachMemoryHook();
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   torchcomms::device::PipesDeviceBackend::TransportHandleDevPtr
       device_transport_handle_;
 #endif

--- a/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXPy.cpp
@@ -269,7 +269,7 @@ Returns:
       py::call_guard<py::gil_scoped_release>());
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   // --- Pipes backend window class ---
   auto pipes_cls = py::class_<
       TorchCommWindowNCCLXPipes,

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp
@@ -18,7 +18,7 @@
 #include "comms/torchcomms/device/DeviceBackendTraits.hpp"
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #endif
 
@@ -680,12 +680,12 @@ template class TorchCommWindowNCCLX<HostOnlyBackend>;
 #endif
 
 // Pipes instantiation is independent of the device API flag.
-// ENABLE_PIPES can be set without TORCHCOMMS_HAS_NCCL_DEVICE_API (e.g.,
-// NCCLX 2.27 CMake builds with ENABLE_PIPES=1). In that case, host-side
+// ENABLE_PRIMS can be set without TORCHCOMMS_HAS_NCCL_DEVICE_API (e.g.,
+// NCCLX 2.27 CMake builds with ENABLE_PRIMS=1). In that case, host-side
 // window operations (put, signal, wait_signal) work; device API methods
 // (get_device_window, register_local_buffer) fall back to the base class
 // default that throws "not yet supported".
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 template class TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
 #endif
 

--- a/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp
@@ -19,7 +19,7 @@
 #include "comms/torchcomms/device/TorchCommDeviceWindow.hpp"
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 #include "comms/torchcomms/device/pipes/PipesDeviceBackend.hpp"
 #include "comms/torchcomms/device/pipes/TorchCommDevicePipesTypes.hpp"
 #endif
@@ -239,8 +239,8 @@ using TorchCommWindowNCCLXGin = TorchCommWindowNCCLX<HostOnlyBackend>;
 #endif
 
 // Type alias for the Pipes backend (IBGDA + NVLink device-side P2P).
-// Only available when ENABLE_PIPES is defined (propagated from ctran_lib).
-#if defined(ENABLE_PIPES)
+// Only available when ENABLE_PRIMS is defined (propagated from ctran_lib).
+#if defined(ENABLE_PRIMS)
 using TorchCommWindowNCCLXPipes =
     TorchCommWindowNCCLX<torchcomms::device::PipesDeviceBackend>;
 #endif

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommWindowNCCLXPipesTest.cpp
@@ -15,7 +15,7 @@
 #include "comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp"
 
 #ifdef TORCHCOMMS_HAS_NCCL_DEVICE_API
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
 
 #include "comms/torchcomms/ncclx/TorchCommWindowNCCLX.hpp"
 
@@ -213,5 +213,5 @@ TEST_F(TorchCommWindowNCCLXPipesTest, RegisterLocalBufferSuccess) {
 
 } // namespace torch::comms::test
 
-#endif // ENABLE_PIPES
+#endif // ENABLE_PRIMS
 #endif // TORCHCOMMS_HAS_NCCL_DEVICE_API

--- a/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/mocks/NcclxMock.hpp
@@ -376,7 +376,7 @@ class NcclxMock : public NcclxApi {
 #endif
 #endif
 
-#if defined(ENABLE_PIPES)
+#if defined(ENABLE_PRIMS)
   MOCK_METHOD(
       ncclResult_t,
       winCreateDeviceWin,


### PR DESCRIPTION
Summary:

Rename the internal build and preprocessor switch from `ENABLE_PIPES`/`enable_pipes` to `ENABLE_PRIMS`/`enable_prims` across CTRAN, NCCLX, AFD, TorchComms, and conda feedstock build scripts. This keeps behavior unchanged while removing the old pipes name from the build flag surface.

Reviewed By: siyengar

Differential Revision: D107951971
