### PR TITLE
Add rccl_builder.sh for OSS RCCL builds and fix build_rccl.sh

### DIFF
--- a/build_rccl.sh
+++ b/build_rccl.sh
@@ -35,6 +35,11 @@ done
 
 BRANCH_TO_USE="${CUSTOM_BRANCH:-$DEFAULT_BRANCH}"
 
+# Install into a writable prefix. /lib64 requires root, which is why the install
+# step failed; build_rcclx.sh installs into $PWD/build/rcclx instead. Default to
+# the active conda env (overridable via RCCL_INSTALL_PREFIX).
+RCCL_INSTALL_PREFIX="${RCCL_INSTALL_PREFIX:-${CONDA_PREFIX:-$PWD/build/rccl-install}}"
+
 function build_rccl_oss_library() {
   local repo_url="$1"
   local repo_tag="$2"
@@ -47,15 +52,33 @@ function build_rccl_oss_library() {
   mkdir -p build-output
   cd "$library_name" || exit 1
 
+  # Point the ROCm toolchain at the fbcode platform010 install (mirrors
+  # build_rcclx.sh). The default /opt/rocm does not ship amdclang++ here, so
+  # CMake fails with "is not a full path to an existing compiler tool".
+  export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
+  export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"
+  export CC="${CC:-$ROCM_PATH/lib/llvm/bin/amdclang}"
+
+  # Build flags mirror build_rcclx.sh: build for the production GPU archs
+  # (NOT --fast, which builds local-gpu-only), disable colltrace + msccl
+  # kernels, and --install into a known prefix so RCCL_HOME points at a real
+  # library. AMDGPU_TARGETS is overridable from the environment.
+  local amdgpu_targets="${AMDGPU_TARGETS:-gfx942,gfx950}"
+  local install_prefix="$RCCL_INSTALL_PREFIX"
+
   # We want to disable mscclpp as it is not needed for torchcomms_rccl
   # rocm-7.0.0 branch has an option to disable mscclpp (--disable-mscclpp)
   # develop branch does not have this option, since mscclpp is disabled by default
   if ./install.sh --help 2>&1 | grep -q "\-\-disable-mscclpp"; then
     echo "Using --disable-mscclpp option (found in install.sh)"
-    ./install.sh --disable-mscclpp --fast --disable-msccl-kernel
+    ./install.sh --install --prefix "$install_prefix" \
+      --amdgpu_targets "$amdgpu_targets" \
+      --disable-mscclpp --disable-colltrace --disable-msccl-kernel
   else
-    echo "Using --fast --disable-msccl-kernel options (--disable-mscclpp not found in install.sh)"
-    ./install.sh --install --prefix /lib64/rccl  --fast --disable-msccl-kernel
+    echo "Using --disable-colltrace --disable-msccl-kernel options (--disable-mscclpp not found in install.sh)"
+    ./install.sh --install --prefix "$install_prefix" \
+      --amdgpu_targets "$amdgpu_targets" \
+      --disable-colltrace --disable-msccl-kernel
   fi
 
   cd .. || exit 1
@@ -69,11 +92,10 @@ if [ "$FORCE_BUILD" = true ] || [ ! -f "$ROCM_HOME/lib/librccl.so" ]; then
     echo "librccl.so not found in $ROCM_HOME/lib, building OSS library with branch: $BRANCH_TO_USE"
   fi
   build_rccl_oss_library "https://github.com/ROCm/rccl.git" "$BRANCH_TO_USE" "rccl"
-  export RCCL_HOME=/lib64/rccl/lib
+  export RCCL_HOME="$RCCL_INSTALL_PREFIX/lib"
 else
   echo "librccl.so found in $ROCM_HOME/lib, skipping OSS library build (use --custom-branch to override)"
   export RCCL_HOME=$ROCM_HOME/lib
 fi
 
-popd || true
 pip install numpy

--- a/rccl_builder.sh
+++ b/rccl_builder.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+set -x # print commands before running them
+set -euo pipefail # exit script on errors
+
+# Initialize conda if not available in this shell
+if ! command -v conda &> /dev/null; then
+    conda_init=""
+    if [ -n "${CONDA_EXE:-}" ]; then
+        conda_init="${CONDA_EXE%/bin/conda}/etc/profile.d/conda.sh"
+    fi
+    for conda_path in "$conda_init" "$HOME/miniconda3/etc/profile.d/conda.sh" "$HOME/anaconda3/etc/profile.d/conda.sh" "$HOME/miniforge3/etc/profile.d/conda.sh" "/opt/conda/etc/profile.d/conda.sh" "/usr/etc/profile.d/conda.sh" "/etc/profile.d/conda.sh"; do
+        if [ -n "$conda_path" ] && [ -f "$conda_path" ]; then
+            source "$conda_path"
+            break
+        fi
+    done
+    if ! command -v conda &> /dev/null; then
+        echo "Error: conda not found. Install miniconda and try again." >&2
+        exit 1
+    fi
+fi
+
+# Activate conda environment if CONDA_DEFAULT_ENV is set but not active
+if [ -n "${CONDA_DEFAULT_ENV:-}" ] && [ "${CONDA_PREFIX:-}" = "" ]; then
+    conda activate "$CONDA_DEFAULT_ENV"
+fi
+
+python3 -m ensurepip --upgrade
+python3 -m pip install --upgrade pip
+conda install conda-forge::rsync -y
+
+# Build the third-party/rccl bits. build_rccl.sh clones ROCm rccl and runs
+# ./install.sh in the rccl directory.
+# Any arguments (e.g. --custom-branch <branch>) are forwarded to build_rccl.sh.
+# Pass --custom-branch to force a build even when a system librccl.so exists.
+ONLY_FUNCS="AllReduce * * Sum f32" ./comms/github/build_rccl.sh "$@"


### PR DESCRIPTION
Summary:
Adds comms/github/rccl_builder.sh, a wrapper that mirrors rcclx_builder.sh but
builds the third-party OSS RCCL library (cloned from ROCm/rccl) via
build_rccl.sh + the upstream install.sh, restricted to AllReduce/Sum/f32 via
ONLY_FUNCS (matching rcclx_builder.sh).

While bringing the OSS RCCL build up, fixed several issues in build_rccl.sh:

- Forward args from rccl_builder.sh so --custom-branch can force a build even
  when a system librccl.so is present.
- Point the ROCm toolchain at the fbcode platform010 install (ROCM_PATH/CXX/CC)
  instead of /opt/rocm, which does not ship amdclang++ and made CMake fail with
  "is not a full path to an existing compiler tool" (ported from build_rcclx.sh).
- Replace install.sh --fast (local-GPU-only) with --amdgpu_targets gfx942,gfx950
  + --disable-colltrace + --disable-msccl-kernel so the production archs are
  actually compiled, matching build_rcclx.sh.
- Install into a writable prefix (defaults to $CONDA_PREFIX, overridable via
  RCCL_INSTALL_PREFIX) instead of root-owned /lib64/rccl, which caused the
  install step to fail with a permission error. RCCL_HOME is set accordingly.
- Remove a stray "popd" that ran with an empty directory stack.

Differential Revision: D107944158


