### PR TITLE
Build static snappy in build_rcclx.sh for RCCL link

### DIFF
--- a/build_rccl.sh
+++ b/build_rccl.sh
@@ -35,6 +35,11 @@ done
 
 BRANCH_TO_USE="${CUSTOM_BRANCH:-$DEFAULT_BRANCH}"
 
+# Install into a writable prefix. /lib64 requires root, which is why the install
+# step failed; build_rcclx.sh installs into $PWD/build/rcclx instead. Default to
+# the active conda env (overridable via RCCL_INSTALL_PREFIX).
+RCCL_INSTALL_PREFIX="${RCCL_INSTALL_PREFIX:-${CONDA_PREFIX:-$PWD/build/rccl-install}}"
+
 function build_rccl_oss_library() {
   local repo_url="$1"
   local repo_tag="$2"
@@ -47,15 +52,33 @@ function build_rccl_oss_library() {
   mkdir -p build-output
   cd "$library_name" || exit 1
 
+  # Point the ROCm toolchain at the fbcode platform010 install (mirrors
+  # build_rcclx.sh). The default /opt/rocm does not ship amdclang++ here, so
+  # CMake fails with "is not a full path to an existing compiler tool".
+  export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
+  export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"
+  export CC="${CC:-$ROCM_PATH/lib/llvm/bin/amdclang}"
+
+  # Build flags mirror build_rcclx.sh: build for the production GPU archs
+  # (NOT --fast, which builds local-gpu-only), disable colltrace + msccl
+  # kernels, and --install into a known prefix so RCCL_HOME points at a real
+  # library. AMDGPU_TARGETS is overridable from the environment.
+  local amdgpu_targets="${AMDGPU_TARGETS:-gfx942,gfx950}"
+  local install_prefix="$RCCL_INSTALL_PREFIX"
+
   # We want to disable mscclpp as it is not needed for torchcomms_rccl
   # rocm-7.0.0 branch has an option to disable mscclpp (--disable-mscclpp)
   # develop branch does not have this option, since mscclpp is disabled by default
   if ./install.sh --help 2>&1 | grep -q "\-\-disable-mscclpp"; then
     echo "Using --disable-mscclpp option (found in install.sh)"
-    ./install.sh --disable-mscclpp --fast --disable-msccl-kernel
+    ./install.sh --install --prefix "$install_prefix" \
+      --amdgpu_targets "$amdgpu_targets" \
+      --disable-mscclpp --disable-colltrace --disable-msccl-kernel
   else
-    echo "Using --fast --disable-msccl-kernel options (--disable-mscclpp not found in install.sh)"
-    ./install.sh --install --prefix /lib64/rccl  --fast --disable-msccl-kernel
+    echo "Using --disable-colltrace --disable-msccl-kernel options (--disable-mscclpp not found in install.sh)"
+    ./install.sh --install --prefix "$install_prefix" \
+      --amdgpu_targets "$amdgpu_targets" \
+      --disable-colltrace --disable-msccl-kernel
   fi
 
   cd .. || exit 1
@@ -69,11 +92,10 @@ if [ "$FORCE_BUILD" = true ] || [ ! -f "$ROCM_HOME/lib/librccl.so" ]; then
     echo "librccl.so not found in $ROCM_HOME/lib, building OSS library with branch: $BRANCH_TO_USE"
   fi
   build_rccl_oss_library "https://github.com/ROCm/rccl.git" "$BRANCH_TO_USE" "rccl"
-  export RCCL_HOME=/lib64/rccl/lib
+  export RCCL_HOME="$RCCL_INSTALL_PREFIX/lib"
 else
   echo "librccl.so found in $ROCM_HOME/lib, skipping OSS library build (use --custom-branch to override)"
   export RCCL_HOME=$ROCM_HOME/lib
 fi
 
-popd || true
 pip install numpy

--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -159,6 +159,9 @@ function build_third_party {
     build_fb_oss_library "https://github.com/google/glog.git" "v0.4.0" glog
     build_fb_oss_library "https://github.com/google/glog.git" "v0.4.0" glog "-DBUILD_SHARED_LIBS=ON"
     build_fb_oss_library "https://github.com/facebook/zstd.git" "v1.5.6" zstd
+    # RCCL (projects/rccl/CMakeLists.txt) links the static libsnappy.a from
+    # folly's transitive deps; build it static+PIC so the link step resolves.
+    build_fb_oss_library "https://github.com/google/snappy.git" "1.2.1" snappy "-DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF"
     build_automake_library "https://github.com/jedisct1/libsodium.git" "1.0.20-RELEASE" sodium
     build_fb_oss_library "https://github.com/fastfloat/fast_float.git" "v8.0.2" fast_float "-DFASTFLOAT_INSTALL=ON"
     # Abseil provides absl::log / absl::check used by

--- a/rccl_builder.sh
+++ b/rccl_builder.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+set -x # print commands before running them
+set -euo pipefail # exit script on errors
+
+# Initialize conda if not available in this shell
+if ! command -v conda &> /dev/null; then
+    conda_init=""
+    if [ -n "${CONDA_EXE:-}" ]; then
+        conda_init="${CONDA_EXE%/bin/conda}/etc/profile.d/conda.sh"
+    fi
+    for conda_path in "$conda_init" "$HOME/miniconda3/etc/profile.d/conda.sh" "$HOME/anaconda3/etc/profile.d/conda.sh" "$HOME/miniforge3/etc/profile.d/conda.sh" "/opt/conda/etc/profile.d/conda.sh" "/usr/etc/profile.d/conda.sh" "/etc/profile.d/conda.sh"; do
+        if [ -n "$conda_path" ] && [ -f "$conda_path" ]; then
+            source "$conda_path"
+            break
+        fi
+    done
+    if ! command -v conda &> /dev/null; then
+        echo "Error: conda not found. Install miniconda and try again." >&2
+        exit 1
+    fi
+fi
+
+# Activate conda environment if CONDA_DEFAULT_ENV is set but not active
+if [ -n "${CONDA_DEFAULT_ENV:-}" ] && [ "${CONDA_PREFIX:-}" = "" ]; then
+    conda activate "$CONDA_DEFAULT_ENV"
+fi
+
+python3 -m ensurepip --upgrade
+python3 -m pip install --upgrade pip
+conda install conda-forge::rsync -y
+
+# Build the third-party/rccl bits. build_rccl.sh clones ROCm rccl and runs
+# ./install.sh in the rccl directory.
+# Any arguments (e.g. --custom-branch <branch>) are forwarded to build_rccl.sh.
+# Pass --custom-branch to force a build even when a system librccl.so exists.
+ONLY_FUNCS="AllReduce * * Sum f32" ./comms/github/build_rccl.sh "$@"


### PR DESCRIPTION
Summary:
The rcclx build (projects/rccl/CMakeLists.txt) links the static libsnappy.a
that is pulled in via folly's transitive dependencies. When snappy is not built
as part of the third-party deps, the rcclx link step fails to resolve those
symbols.

Add a build_fb_oss_library step for google/snappy (v1.2.1) built static + PIC
(tests and benchmarks disabled) so the static libsnappy.a is available for the
rcclx link.

Differential Revision: D107944160


