### PR TITLE
Restore CTRAN flush (#2839)

### DIFF
--- a/comms/ctran/algos/AllGather/StreamedRd/Common.h
+++ b/comms/ctran/algos/AllGather/StreamedRd/Common.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <deque>
+#include <memory>
 #include <vector>
 
 #include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
@@ -30,6 +31,7 @@ inline int resolveFwdPeers(int nSteps) {
 struct PutQElem {
   int step;
   int chunk;
+  CtranMapperRequest* flushReq;
 };
 
 } // namespace ctran::allgather::ctsrd::common
@@ -57,9 +59,11 @@ struct AlgoContext {
   // Only the last iput to each peer uses a tracked request; earlier iputs
   // pass nullptr (fire-and-forget, safe due to in-order completion guarantee).
   std::vector<CtranMapperRequest> iputReqs;
-
   // Per-step deferred puts flushed at step start.
   std::vector<std::vector<common::PutQElem>> deferredPuts;
+  // Per-step iflush requests referenced by putQ/deferredPuts. progressPuts()
+  // waits for the relevant flush before issuing a dependent iput.
+  std::vector<std::vector<std::unique_ptr<CtranMapperRequest>>> recvFlushReqs;
   // Per-step count of received notifications.
   std::vector<int> numReceived;
 
@@ -87,6 +91,7 @@ struct AlgoContext {
         notifyVec(notifyVecSize),
         iputReqs(recvPlan.nSteps()),
         deferredPuts(recvPlan.nSteps()),
+        recvFlushReqs(recvPlan.nSteps()),
         numReceived(recvPlan.nSteps(), 0),
         putCount(recvPlan.nSteps(), 0) {}
 
@@ -144,11 +149,29 @@ inline commResult_t waitCtrl(AlgoContext& ctx) {
   return commSuccess;
 }
 
-// Receive chunks for the current step and post forward puts for future steps.
+template <typename AlgoContext>
+inline commResult_t
+postRecvFlush(AlgoContext& ctx, int step, CtranMapperRequest** flushReq) {
+  *flushReq = nullptr;
+
+  CtranMapperRequest* req = nullptr;
+  FB_COMMCHECK(ctx.mapper->iflush(ctx.recvbuff, ctx.memHdl, &req));
+  if (req != nullptr) {
+    auto reqOwner = std::unique_ptr<CtranMapperRequest>(req);
+    *flushReq = reqOwner.get();
+    ctx.recvFlushReqs.at(step).push_back(std::move(reqOwner));
+  }
+  return commSuccess;
+}
+
+// Receive chunks for the current step, post one iflush for the ready batch, and
+// queue future-step forwards that will poll that flush before issuing iput.
 template <typename AlgoContext>
 inline commResult_t progressRecvFwd(AlgoContext& ctx, int step) {
   const auto nSteps = ctx.recvPlan.nSteps();
   const auto expNumRecv = static_cast<int>(ctx.recvPlan.chunks(step).size());
+  std::vector<int> readyChunks;
+  readyChunks.reserve(static_cast<std::size_t>(expNumRecv));
   while (ctx.numReceived.at(step) < expNumRecv) {
     const auto recvIdx = ctx.numReceived.at(step);
     const auto chunk = ctx.recvPlan.chunk(step, recvIdx);
@@ -158,13 +181,23 @@ inline commResult_t progressRecvFwd(AlgoContext& ctx, int step) {
       break;
     }
     ctx.numReceived.at(step)++;
+    readyChunks.push_back(chunk);
+  }
 
+  if (readyChunks.empty()) {
+    return commSuccess;
+  }
+
+  CtranMapperRequest* flushReq = nullptr;
+  FB_COMMCHECK(postRecvFlush(ctx, step, &flushReq));
+
+  for (const auto chunk : readyChunks) {
     const int immEnd = std::min(step + 1 + ctx.recvPlan.fwdPeers(), nSteps);
     for (int fwd = step + 1; fwd < immEnd; fwd++) {
-      ctx.enqueuePut(fwd, chunk);
+      ctx.enqueuePut(fwd, chunk, flushReq);
     }
     for (int fwd = immEnd; fwd < nSteps; fwd++) {
-      ctx.deferredPuts.at(fwd).push_back({fwd, chunk});
+      ctx.deferredPuts.at(fwd).push_back({fwd, chunk, flushReq});
     }
   }
   return commSuccess;
@@ -193,6 +226,14 @@ template <typename AlgoContext>
 inline commResult_t progressPuts(AlgoContext& ctx) {
   while (!ctx.putQ.empty()) {
     const auto elem = ctx.putQ.front();
+    if (elem.flushReq != nullptr) {
+      bool flushComplete = false;
+      FB_COMMCHECK(ctx.mapper->testRequest(elem.flushReq, &flushComplete));
+      if (!flushComplete) {
+        return commSuccess;
+      }
+    }
+
     CtranMapperRequest* req = nullptr;
     if (ctx.sendPlan.isLastChunk(elem.step, elem.chunk)) {
       req = &ctx.iputReqs.at(elem.step);
@@ -207,8 +248,25 @@ inline commResult_t progressPuts(AlgoContext& ctx) {
 template <typename AlgoContext>
 inline void postDeferredPuts(AlgoContext& ctx, int step) {
   for (const auto& fwd : ctx.deferredPuts.at(step)) {
-    ctx.enqueuePut(fwd.step, fwd.chunk);
+    ctx.enqueuePut(fwd.step, fwd.chunk, fwd.flushReq);
   }
+}
+
+template <typename AlgoContext>
+inline commResult_t waitStepFlushes(AlgoContext& ctx, int step) {
+  for (const auto& req : ctx.recvFlushReqs.at(step)) {
+    FB_COMMCHECK(ctx.mapper->waitRequest(req.get()));
+  }
+  return commSuccess;
+}
+
+template <typename AlgoContext>
+inline commResult_t waitAllFlushes(AlgoContext& ctx) {
+  const auto nSteps = ctx.recvPlan.nSteps();
+  for (int step = 0; step < nSteps; step++) {
+    FB_COMMCHECK(waitStepFlushes(ctx, step));
+  }
+  return commSuccess;
 }
 
 // Wait for all tracked iput requests (one per peer/step).
@@ -238,6 +296,12 @@ inline commResult_t progressSteps(AlgoContext& ctx, int localChunk) {
     FB_COMMCHECK(ctx.onStepComplete(step));
   }
 
+  // Flush-gated puts may still be queued after all recv steps are done.
+  while (!ctx.putQ.empty()) {
+    FB_COMMCHECK(progressPuts(ctx));
+  }
+  // Make all received NIC writes GPU-visible before subsequent GPU work.
+  FB_COMMCHECK(waitAllFlushes(ctx));
   FB_COMMCHECK(waitAllPuts(ctx));
   return commSuccess;
 }

--- a/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/Impl.cc
@@ -42,7 +42,10 @@ struct AlgoContext : CtsrdAlgoContext {
     return static_cast<size_t>(chunk) * sendSize;
   }
 
-  inline void enqueuePut(int step, int chunkOffset) {
+  inline void enqueuePut(
+      int step,
+      int chunkOffset,
+      CtranMapperRequest* flushReq = nullptr) {
     const auto nth = putCount.at(step)++;
     const auto expChunkOffset = sendPlan.chunk(step, nth);
     FB_CHECKABORT(
@@ -52,7 +55,7 @@ struct AlgoContext : CtsrdAlgoContext {
         nth,
         expChunkOffset,
         chunkOffset);
-    putQ.push_back({step, chunkOffset});
+    putQ.push_back({step, chunkOffset, flushReq});
   }
 };
 

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -120,7 +120,11 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
     // Wait till received data from upstream peer
     FB_COMMCHECK(mapper->waitNotify(notify.get()));
 
-    // Kick off local broadcast of the received data
+    // Drain received RDMA writes before the stream-side CE/cudaMemcpyAsync
+    // broadcast reads the chunk.
+    FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+
+    // Kick off local broadcast of the received data.
     resource->pipeSync->post(step);
   }
 

--- a/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
@@ -196,6 +196,10 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
 
+    // Drain received RDMA writes before the next step forwards them or the
+    // stream-side CE/cudaMemcpyAsync broadcast reads them.
+    FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+
     // Notify the stream that step `i` IB exchange is done. The stream can
     // now issue the intra-node CE broadcast for the 2^i chunks just
     // received at column `localRank`.

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -68,6 +68,9 @@ struct AlgoContext : CtsrdAlgoContext {
 
   inline commResult_t onStepComplete(int step) {
     if (nLocalRanks > 1) {
+      // pipeSync releases NVL readers for this step's received chunks.
+      FB_COMMCHECK(
+          ctran::allgather::ctsrd::common::waitStepFlushes(*this, step));
       resource->pipeSync->post(step);
     }
     return commSuccess;
@@ -77,7 +80,8 @@ struct AlgoContext : CtsrdAlgoContext {
     return (static_cast<size_t>(node) * nLocalRanks + localRank) * sendSize;
   }
 
-  inline void enqueuePut(int step, int node) {
+  inline void
+  enqueuePut(int step, int node, CtranMapperRequest* flushReq = nullptr) {
     const auto nth = putCount.at(step)++;
     const auto expectedNode = sendPlan.chunk(step, nth);
     FB_CHECKABORT(
@@ -87,7 +91,7 @@ struct AlgoContext : CtsrdAlgoContext {
         nth,
         expectedNode,
         node);
-    putQ.push_back({step, node});
+    putQ.push_back({step, node, flushReq});
   }
 };
 

--- a/comms/ctran/algos/AllReduce/AllReduceDirect.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceDirect.cc
@@ -69,23 +69,6 @@ static const auto myAlgo = NCCL_ALLREDUCE_ALGO::ctdirect;
     }                                                                          \
   } while (0)
 
-// Drain pending NIC PCIe writes into GPU HBM after RDMA receives complete and
-// before launching the GPU kernel that reads the just-received buffer. On
-// GB200 (split-path topology: NIC<->SoC over PCIe, CPU<->GPU over NVLink-C2C),
-// PCIe write ordering does not extend across the SoC<->C2C boundary, so the
-// CPU may observe waitNotify completion before the RDMA payload has committed
-// to HBM. Issuing an RDMA READ per device drains the PCIe write pipeline.
-// Companion to D103775295 (proxy receive path) and D103503273 (ctrd AG).
-static commResult_t flushAfterRecv(CtranComm* comm, void* buf, void* hdl) {
-  CtranMapperRequest* rawReq = nullptr;
-  FB_COMMCHECK(comm->ctran_->mapper->iflush(buf, hdl, &rawReq));
-  std::unique_ptr<CtranMapperRequest> req(rawReq);
-  if (req) {
-    FB_COMMCHECK(comm->ctran_->mapper->waitRequest(req.get()));
-  }
-  return commSuccess;
-}
-
 static commResult_t impl(
     const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   struct OpElem* op = opGroup.front().get();
@@ -334,9 +317,9 @@ static commResult_t impl(
         }
       }
 
-      // See flushAfterRecv: drain peers' RDMA WRITEs into tmpBuf before the
+      // Drain peers' RDMA WRITEs into tmpBuf before the
       // kInterReduceScatter kernel reads it.
-      FB_COMMCHECK(flushAfterRecv(comm, tmpBuf, tmpbufRegHdl));
+      FB_COMMCHECK(comm->ctran_->mapper->flush(tmpBuf, tmpbufRegHdl));
     }
 
     /* local reduction from tmpbuf */
@@ -390,10 +373,10 @@ static commResult_t impl(
         }
       }
 
-      // See flushAfterRecv: drain peers' RDMA WRITEs into recvbuff before the
+      // Drain peers' RDMA WRITEs into recvbuff before the
       // kIntraAllGather kernel (Step 4) reads it for NVLink bcast.
-      FB_COMMCHECK(
-          flushAfterRecv(comm, BUFOFFSET(recvbuff, localOffset), recvHdl));
+      FB_COMMCHECK(comm->ctran_->mapper->flush(
+          BUFOFFSET(recvbuff, localOffset), recvHdl));
     }
     THROW_IF_ABORTED(, "ctdirect step 3: inter-node allgather");
 
@@ -517,9 +500,9 @@ static commResult_t impl(
       }
     }
 
-    // See flushAfterRecv: drain peers' RDMA WRITEs into tmpBuf before the
+    // Drain peers' RDMA WRITEs into tmpBuf before the
     // kRemInterReduce kernel reads it.
-    FB_COMMCHECK(flushAfterRecv(comm, tmpBuf, tmpbufRegHdl));
+    FB_COMMCHECK(comm->ctran_->mapper->flush(tmpBuf, tmpbufRegHdl));
 
     /* local reduction from tmpbuf */
     elem = op->allreduce.kElemStepMap.at(

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -47,7 +47,8 @@ constexpr int kGb300CudaArch = 1030;
 thread_local std::unordered_map<void*, std::atomic_bool> epochLockedFlags;
 
 bool CtranIb::shouldEnableLocalFlushByDefault(int cudaArch) {
-  return cudaArch < kH100CudaArch || cudaArch == kGb300CudaArch;
+  return cudaArch < kH100CudaArch || cudaArch == kGb300CudaArch ||
+      NCCL_CTRAN_NET_FORCE_FLUSH;
 }
 
 commResult_t checkEpochLock(CtranIb* ctranIb) {
@@ -332,7 +333,9 @@ CtranIb::CtranIb(
     // https://ontrack.amd.com/browse/FBA-633
     enableLocalFlush_ = true;
 #else
-    // Turn on flush for NVidia GPUs older than H100 and GB300.
+    // Turn on flush by default for NVidia GPUs older than H100 and for GB300.
+    // Multi-NIC topologies with cross-NIC DMA ordering hazards must opt in via
+    // NCCL_CTRAN_NET_FORCE_FLUSH=1.
     // TODO: Replace the GB300 CUDA-arch proxy with a topology query similar to
     // baseline ncclTopoNeedFlush(); CUDA arch is not precise topology
     // detection.

--- a/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbDqplbRelayDistUT.cc
@@ -81,8 +81,8 @@ class CtranIbDqplbRelayTest : public ctran::CtranDistTestFixture {
 
   struct DqplbEnvRAII {
     // The relay case depends on multi-NIC DQPLB over multiple QPs. It does not
-    // issue iflush, so only the NIC and QP selection cvars are part of the
-    // local test setup.
+    // issue iflush, so NCCL_CTRAN_NET_FORCE_FLUSH is not part of the local test
+    // setup.
     std::vector<std::string> qpConfig{"524288", "2", "dqplb", "128"};
     EnvRAII<decltype(NCCL_CTRAN_IB_DEVICES_PER_RANK)> devices{
         NCCL_CTRAN_IB_DEVICES_PER_RANK,

--- a/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
@@ -83,9 +83,30 @@ TEST(CtranIbQpConfigRegressionTest, MaxQps1DevPerRank2) {
   EXPECT_EQ(vc.getMaxNumQp(), 2);
 }
 
-TEST(CtranIbDefaultFlushTest, EnablesFlushForOldNvidiaAndGb300) {
-  EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(800));
-  EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(900));
-  EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(1000));
-  EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(1030));
+TEST(CtranIbDefaultFlushTest, EnablesFlushForOldNvidiaGb300AndForceFlush) {
+  ncclCvarInit();
+
+  {
+    EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+    EnvRAII envNetForceFlush(NCCL_CTRAN_NET_FORCE_FLUSH, 1);
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(800));
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(900));
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(1000));
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(1030));
+  }
+
+  {
+    EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 1);
+    EnvRAII envNetForceFlush(NCCL_CTRAN_NET_FORCE_FLUSH, 0);
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(800));
+    EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(900));
+    EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(1000));
+    EXPECT_TRUE(CtranIb::shouldEnableLocalFlushByDefault(1030));
+  }
+
+  {
+    EnvRAII envDevPerRank(NCCL_CTRAN_IB_DEVICES_PER_RANK, 2);
+    EnvRAII envNetForceFlush(NCCL_CTRAN_NET_FORCE_FLUSH, 0);
+    EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(900));
+  }
 }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -641,6 +641,38 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return commSuccess;
   }
 
+  /* Drain pending NIC PCIe writes into GPU HBM after RDMA receives complete
+   * and before host or stream-side work reads the just-received buffer. On
+   * split-path topologies, PCIe write ordering does not necessarily extend to
+   * GPU memory visibility, so callers that need immediate GPU-side visibility
+   * should issue a flush and wait for it to complete.
+   */
+  template <typename PerfConfig = DefaultPerfCollConfig>
+  inline commResult_t flush(const void* buf, const void* regHdl) {
+    if (this->ctranIb) {
+      auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
+          const_cast<void*>(regHdl));
+      if (!regElem) {
+        CLOGF(WARN, "CTRAN-MAPPER: No IB registration for flush, skip");
+        return commSuccess;
+      }
+
+      CtranIbRequest ibReq;
+      {
+        auto regLk = regElem->stateMnger.rlock();
+        FB_COMMCHECK(this->ctranIb->iflush(buf, regElem->ibRegElem, &ibReq));
+      }
+      while (!ibReq.isComplete() && !comm->testAbort()) {
+        FB_COMMCHECK(this->ctranIb->progress<PerfConfig>());
+      }
+
+      if (comm->testAbort()) {
+        throwCommAbortException("flush");
+      }
+    }
+    return commSuccess;
+  }
+
   /* Initialize the notify instance for receiving remote notification from a
    * peer rank. The backend of flag is determined based on the peer's backend
    * and the local receive buffer. NVL-based notify instance will be initialized
@@ -969,6 +1001,19 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
  private:
+  [[noreturn]] inline void throwCommAbortException(
+      const std::string& abortContext) {
+    auto commAbort = comm->getAbort();
+    std::string message =
+        commAbort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
+    throw ctran::utils::Exception(
+        message,
+        commRemoteError,
+        comm->logMetaData_.rank,
+        comm->logMetaData_.commHash,
+        abortContext);
+  }
+
   inline commResult_t checkComplete(CtranMapperRequest* req, bool* isComplete) {
     if (req->isComplete()) {
       *isComplete = true;
@@ -1104,6 +1149,11 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   inline commResult_t testRequestImpl(
       CtranMapperRequest* req,
       bool* isComplete) {
+    FB_COMMCHECK(this->checkComplete(req, isComplete));
+    if (*isComplete) {
+      return commSuccess;
+    }
+
     FB_COMMCHECK(this->progress<PerfConfig>());
     FB_COMMCHECK(this->checkComplete(req, isComplete));
 
@@ -1119,14 +1169,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (comm->testAbort()) {
-      auto _abort = comm->getAbort();
-      std::string _ctx =
-          _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
-      throw ctran::utils::Exception(
-          _ctx,
-          commRemoteError,
-          comm->logMetaData_.rank,
-          comm->logMetaData_.commHash,
+      throwCommAbortException(
           fmt::format("waitRequest for peer {}", req->peer));
     }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1642,6 +1642,15 @@ cvars:
      per CQ. For example, setting to 32768 keeps per-CQ memory at ~2MB.
      Default -1 to use the device-reported maximum.
 
+ - name        : NCCL_CTRAN_NET_FORCE_FLUSH
+   type        : int
+   default     : 0
+   description : |-
+     Enable PCIe flush support (RDMA READ) for CTRAN network receives. On
+     platforms where the NIC-PCIe-GPU topology does not guarantee immediate
+     GPU visibility for DMA writes, the flush drains pending writes before
+     received data is forwarded or read by GPU copy engines/kernels.
+
  - name        : NCCL_CTRAN_IB_DEVICES_PER_RANK
    type        : int
    default     : 1


### PR DESCRIPTION
Summary:

Restore flush gated by NCCL_CTRAN_NET_FORCE_FLUSH. It was removed by D105361164. Reintroduce receive-side flushes before AllGatherP pipeline/recursive-doubling stream-side reads, and add the same receive boundary flush in shared CTSRD progress so streamed forwarding and CUDA-side copies cannot read just-notified RDMA data before it is visible in GPU memory.

Reviewed By: minsii

Differential Revision: D107941271


