### PR TITLE
don't disable event tracker when NCCL_COLLTRACE= (#2841)

### DIFF
--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -12,6 +12,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <fmt/core.h>
+#include <folly/String.h>
 #include <nccl.h> // @manual
 #include <torch/csrc/cuda/CUDAPluggableAllocator.h> // @manual=//caffe2:torch-cpp-cuda
 #include "comms/torchcomms/TorchCommFactory.hpp"
@@ -51,13 +52,46 @@ void validateIntDtype(const at::Tensor& tensor, std::string_view name) {
 
 std::atomic<int> g_graphTimeoutMonitoringState{-1};
 
-bool isColltraceGraphTracingEnabled() {
+// Returns true if NCCL_COLLTRACE enables a full-trace mode ("trace" or
+// "verbose"), i.e. the colltrace worker thread and WatchdogPlugin will actually
+// be created by CollTraceWrapper::newCollTraceInit. NCCL_COLLTRACE is a
+// comma-separated stringlist, so we tokenize and trim exactly like the cvar
+// parser (comms/utils/cvars) and newCollTraceInit do — an exact whole-string
+// compare would miss valid multi-token configs such as "trace,algostat".
+bool colltraceTraceModeEnabled() {
+  const char* env = std::getenv("NCCL_COLLTRACE");
+  if (env == nullptr) {
+    return false;
+  }
+  std::vector<std::string> tokens;
+  folly::split(',', env, tokens, true /* ignoreEmpty */);
+  for (const auto& token : tokens) {
+    const std::string trimmed = folly::trimWhitespace(token).str();
+    if (trimmed == "trace" || trimmed == "verbose") {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Returns true if NCCL_COLLTRACE_TRACE_CUDA_GRAPH requests cudagraph-captured
+// collective tracing.
+bool colltraceCudaGraphTracingRequested() {
   const char* env = std::getenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   if (env == nullptr) {
     return false;
   }
-  std::string val(env);
+  const std::string val(env);
   return val == "1" || val == "true";
+}
+
+// The colltrace cudagraph watchdog only fires when BOTH the cudagraph tracing
+// flag is set AND colltrace itself is in trace/verbose mode — otherwise
+// CollTraceWrapper::newCollTraceInit short-circuits before installing the
+// WatchdogPlugin. Both conditions must hold before we hand graph-timeout
+// monitoring over to colltrace and disable GraphEventTracker.
+bool isColltraceGraphTracingEnabled() {
+  return colltraceCudaGraphTracingRequested() && colltraceTraceModeEnabled();
 }
 
 } // namespace
@@ -71,6 +105,25 @@ bool isGraphTimeoutMonitoringEnabled() {
       std::string val(env);
       enabled = (val != "0" && val != "false");
     }
+    // Misconfiguration guard: the operator asked for colltrace cudagraph
+    // tracing, but colltrace is not in trace/verbose mode, so
+    // CollTraceWrapper::newCollTraceInit will never install the timeout
+    // WatchdogPlugin. Warn loudly — otherwise both watchdogs can end up
+    // silently disabled (the failure mode that let a hang go undetected).
+    if (colltraceCudaGraphTracingRequested() && !colltraceTraceModeEnabled()) {
+      const char* colltraceEnv = std::getenv("NCCL_COLLTRACE");
+      LOG(WARNING)
+          << "[TC] NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled but NCCL_COLLTRACE='"
+          << (colltraceEnv != nullptr ? colltraceEnv : "<unset>")
+          << "' does not enable a 'trace'/'verbose' mode — the colltrace timeout "
+          << "watchdog will NOT be installed. "
+          << (enabled
+                  ? "Keeping GraphEventTracker as the graph-collective watchdog."
+                  : "TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING is also disabled, so "
+                    "NO graph-collective watchdog will be active.")
+          << " Set NCCL_COLLTRACE=trace to enable the colltrace watchdog.";
+    }
+
     if (enabled && isColltraceGraphTracingEnabled()) {
       LOG(WARNING)
           << "[TC] NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled — "

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -64,8 +64,12 @@ constexpr size_t kDefaultGraphTimeoutCheckIntervalMs = 1000;
 // Global call-once check for graph timeout monitoring (env var gated).
 // Reads TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING on first call; caches result.
 // Default: enabled. Set to "0" or "false" to disable (for benchmarking).
-// Also returns false when NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled, since
-// the colltrace watchdog plugin handles graph timeout detection instead.
+// Also returns false when the colltrace cudagraph watchdog will actually run —
+// i.e. NCCL_COLLTRACE_TRACE_CUDA_GRAPH is enabled AND NCCL_COLLTRACE selects a
+// "trace"/"verbose" mode — since the colltrace watchdog plugin then handles
+// graph timeout detection instead. If cudagraph tracing is requested but
+// colltrace is not in trace/verbose mode (so no watchdog plugin is installed),
+// GraphEventTracker is kept active and a warning is logged.
 bool isGraphTimeoutMonitoringEnabled();
 
 // Test-only: reset the cached state so next call re-reads the env var.

--- a/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/GraphEventTrackerTest.cpp
@@ -1235,9 +1235,11 @@ TEST_F(
     ColltraceGraphTracing_DisablesGraphTimeoutMonitoring) {
   resetGraphTimeoutMonitoringCacheForTest();
 
+  ::setenv("NCCL_COLLTRACE", "trace", 1);
   ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
   EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
 
+  ::unsetenv("NCCL_COLLTRACE");
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   resetGraphTimeoutMonitoringCacheForTest();
 }
@@ -1247,9 +1249,58 @@ TEST_F(
     ColltraceGraphTracing_MonitoringEnabledWhenNotSet) {
   resetGraphTimeoutMonitoringCacheForTest();
 
+  ::unsetenv("NCCL_COLLTRACE");
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
 
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+// NCCL_COLLTRACE_TRACE_CUDA_GRAPH only disables monitoring when colltrace is
+// actually active (NCCL_COLLTRACE=trace|verbose). With NCCL_COLLTRACE unset the
+// colltrace watchdog plugin is not running, so monitoring must stay enabled.
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_MonitoringEnabledWhenColltraceUnset) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+// NCCL_COLLTRACE set to a value other than trace/verbose does not activate the
+// colltrace watchdog plugin, so monitoring stays enabled.
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_MonitoringEnabledWhenColltraceNotTraceOrVerbose) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::setenv("NCCL_COLLTRACE", "1", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+// NCCL_COLLTRACE=verbose also activates the colltrace watchdog plugin, so
+// monitoring is disabled just like the trace case.
+TEST_F(
+    GraphEventTrackerTest,
+    ColltraceGraphTracing_VerboseDisablesGraphTimeoutMonitoring) {
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  ::setenv("NCCL_COLLTRACE", "verbose", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   resetGraphTimeoutMonitoringCacheForTest();
 }
 
@@ -1277,6 +1328,7 @@ TEST_F(
   nccl_mock_->setupDefaultBehaviors();
 
   auto options = createAbortModeOptions();
+  ::setenv("NCCL_COLLTRACE", "trace", 1);
   ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
   comm->init(*device_, "test_colltrace_graph_no_events", options);
 
@@ -1309,6 +1361,7 @@ TEST_F(
   ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
 
   switchToReplayMode();
+  ::unsetenv("NCCL_COLLTRACE");
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   resetGraphTimeoutMonitoringCacheForTest();
   setupFinalizeExpectations(*comm);
@@ -1322,6 +1375,7 @@ TEST_F(GraphEventTrackerTest, ColltraceGraphTracing_CheckGraphEventsReturnsOK) {
   nccl_mock_->setupDefaultBehaviors();
 
   auto options = createAbortModeOptions();
+  ::setenv("NCCL_COLLTRACE", "trace", 1);
   ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
   comm->init(*device_, "test_colltrace_graph_check_ok", options);
 
@@ -1353,6 +1407,7 @@ TEST_F(GraphEventTrackerTest, ColltraceGraphTracing_CheckGraphEventsReturnsOK) {
 
   ::testing::Mock::VerifyAndClearExpectations(cuda_mock_.get());
 
+  ::unsetenv("NCCL_COLLTRACE");
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   resetGraphTimeoutMonitoringCacheForTest();
   setupFinalizeExpectations(*comm);
@@ -1368,6 +1423,20 @@ TEST_F(
       tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
 }
 
+// Regression: with NCCL_COLLTRACE unset the colltrace watchdog is never created
+// (this path short-circuits), so it must not be relied on to replace the
+// GraphEventTracker timeout monitoring.
+TEST_F(
+    GraphEventTrackerTest,
+    TryEnableColltraceWatchdog_ReturnsFalseWhenColltraceUnset) {
+  ::unsetenv("NCCL_COLLTRACE");
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  EXPECT_FALSE(
+      tryEnableColltraceTimeoutWatchdog(std::chrono::milliseconds{5000}));
+
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+}
+
 TEST_F(
     GraphEventTrackerTest,
     TryEnableColltraceWatchdog_ReturnsFalseWhenMonitoringExplicitlyDisabled) {
@@ -1378,6 +1447,74 @@ TEST_F(
 
   ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
   ::unsetenv("TORCHCOMM_NCCLX_GRAPH_TIMEOUT_MONITORING");
+}
+
+// --- NCCL_COLLTRACE stringlist parsing in isGraphTimeoutMonitoringEnabled ---
+// NCCL_COLLTRACE is a comma-separated stringlist. Graph-timeout monitoring is
+// handed to colltrace (GraphEventTracker disabled) iff a "trace"/"verbose"
+// token is present AND NCCL_COLLTRACE_TRACE_CUDA_GRAPH is set — consistent with
+// CollTraceWrapper::newCollTraceInit. Otherwise GraphEventTracker must remain
+// active so a watchdog always covers graph-captured collectives.
+
+TEST_F(
+    GraphEventTrackerTest,
+    GraphTimeoutMonitoring_DisabledForMultiTokenTrace) {
+  // "trace,algostat" starts the colltrace worker + watchdog, so colltrace owns
+  // graph-timeout detection and GraphEventTracker monitoring is disabled.
+  ::setenv("NCCL_COLLTRACE", "trace,algostat", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  EXPECT_FALSE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_KeptForAlgostatOnly) {
+  // "algostat" alone does NOT start the colltrace worker/watchdog, so
+  // GraphEventTracker must stay active even though cudagraph tracing is asked.
+  ::setenv("NCCL_COLLTRACE", "algostat", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(GraphEventTrackerTest, GraphTimeoutMonitoring_KeptForEmptyColltrace) {
+  // Regression for the observed MAST hang: NCCL_COLLTRACE blanked while
+  // cudagraph tracing is requested. No colltrace watchdog is installed, so
+  // GraphEventTracker must remain the graph-collective watchdog.
+  ::setenv("NCCL_COLLTRACE", "", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
+}
+
+TEST_F(
+    GraphEventTrackerTest,
+    GraphTimeoutMonitoring_KeptForWrongCaseColltrace) {
+  // Token matching is case-sensitive (mirrors CollTraceWrapper); "Trace" does
+  // not enable colltrace, so GraphEventTracker must stay active.
+  ::setenv("NCCL_COLLTRACE", "Trace", 1);
+  ::setenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH", "1", 1);
+  resetGraphTimeoutMonitoringCacheForTest();
+
+  EXPECT_TRUE(isGraphTimeoutMonitoringEnabled());
+
+  ::unsetenv("NCCL_COLLTRACE");
+  ::unsetenv("NCCL_COLLTRACE_TRACE_CUDA_GRAPH");
+  resetGraphTimeoutMonitoringCacheForTest();
 }
 
 } // namespace torch::comms::test


### PR DESCRIPTION
Summary:

this caused problems. NCCL_COLLTRACE_TRACE_CUDA_GRAPH is only relevant when NCCL_COLLTRACE=trace|verbose

Reviewed By: kapilsh

Differential Revision: D107147433


