### PR TITLE
Do not enforce flushing in data direct NICs

### DIFF
--- a/comms/ncclx/v2_30/src/transport/net_ib/init.cc
+++ b/comms/ncclx/v2_30/src/transport/net_ib/init.cc
@@ -490,9 +490,6 @@ ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
     props->ptrSupport |= NCCL_PTR_DMABUF; // GDR support via DMA-BUF
   }
   props->forceFlush = 0;
-  if (ibDev->capsProvider.mlx5.dataDirect) {
-    props->forceFlush = 1;
-  }
   props->latency = 0; // Not set
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;


### PR DESCRIPTION
Summary:
Cherry-pick of NVIDIA NCCL upstream commit `46872c4cba5860a90ad9e879eb201461f0223ce4` ("Do not enforce flushing in data direct NICs", Theofilos Manitaras 2026-05-27), `Mirrored-from: 75196b02e970251c4ce0237dde8f2134f5e811f9`.

Removes the `forceFlush = 1` override that `ncclIbGetPhysProperties` was applying when the mlx5 device exposes `capsProvider.mlx5.dataDirect`. After this change, `forceFlush` keeps its default value (`0`) and `NCCL_NET_FORCE_FLUSH` (consumed by `src/graph/paths.cc:599`) remains the only operator override — matching upstream behavior so data-direct NICs follow the same flush policy as other NICs.

Localized to `v2_30/src/transport/net_ib/init.cc`. No `[NCCLX-PerCommConfig]` or other Meta-specific block is touched. `grep "forceFlush" v2_30/src/` confirms no other call site replicates the `dataDirect` override — the plugin shims in `src/plugin/net/net_v{6,7,8,9,10,11,12}.cc` and `src/plugin/gin/*.cc` either pass through or zero-initialize the field.

Differential Revision: D108062319


