### PR TITLE
Add CUDA graph memcpy microbenchmark (#2845)

### DIFF
--- a/comms/ctran/gpe/benchmarks/CopyGraphMemcpyBench.cc
+++ b/comms/ctran/gpe/benchmarks/CopyGraphMemcpyBench.cc
@@ -1,0 +1,274 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+// Allocate fixed 2 GiB source/destination buffers, then copy the first --bytes
+// bytes using either eager cudaMemcpyAsync submissions or a CUDA graph captured
+// from the same memcpy sequence. With --p2p, allocate the source on GPU 0 and
+// destination on GPU 1. Keeping the allocation fixed makes copy length the main
+// variable.
+#define CHECK_CUDA(expr)               \
+  do {                                 \
+    cudaError_t err__ = (expr);        \
+    if (err__ != cudaSuccess) {        \
+      std::fprintf(                    \
+          stderr,                      \
+          "CUDA error at %s:%d: %s\n", \
+          __FILE__,                    \
+          __LINE__,                    \
+          cudaGetErrorString(err__));  \
+      std::exit(1);                    \
+    }                                  \
+  } while (0)
+
+struct Options {
+  size_t bytes{512ULL * 1024 * 1024};
+  bool graph{false};
+  bool p2p{false};
+};
+
+constexpr size_t kKiB = 1024;
+constexpr size_t kMiB = 1024 * kKiB;
+constexpr size_t kGiB = 1024 * kMiB;
+constexpr size_t kAllocationBytes = 2 * kGiB;
+constexpr int kSrcDevice = 0;
+constexpr int kDstDevice = 1;
+constexpr int kCopiesPerGraph = 100;
+constexpr int kLaunches = 100;
+constexpr int kWarmups = 100;
+
+size_t parseBytes(const char* value) {
+  char* end = nullptr;
+  const unsigned long long base = std::strtoull(value, &end, 0);
+  if (end == value) {
+    std::fprintf(stderr, "invalid byte count: %s\n", value);
+    std::exit(1);
+  }
+  size_t multiplier = 1;
+  if (*end != '\0') {
+    const char suffix = static_cast<char>(std::toupper(*end));
+    if (end[1] != '\0') {
+      std::fprintf(stderr, "invalid byte suffix: %s\n", value);
+      std::exit(1);
+    }
+    if (suffix == 'K') {
+      multiplier = 1024ULL;
+    } else if (suffix == 'M') {
+      multiplier = 1024ULL * 1024;
+    } else if (suffix == 'G') {
+      multiplier = 1024ULL * 1024 * 1024;
+    } else {
+      std::fprintf(stderr, "invalid byte suffix: %s\n", value);
+      std::exit(1);
+    }
+  }
+  return static_cast<size_t>(base) * multiplier;
+}
+
+Options parseOptions(int argc, char** argv) {
+  Options opts;
+  for (int i = 1; i < argc; ++i) {
+    auto requireValue = [&](const char* name) -> const char* {
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "missing value for %s\n", name);
+        std::exit(1);
+      }
+      return argv[++i];
+    };
+
+    if (std::strcmp(argv[i], "--bytes") == 0) {
+      opts.bytes = parseBytes(requireValue(argv[i]));
+    } else if (std::strcmp(argv[i], "--graph") == 0) {
+      opts.graph = true;
+    } else if (std::strcmp(argv[i], "--p2p") == 0) {
+      opts.p2p = true;
+    } else {
+      std::fprintf(stderr, "unknown argument: %s\n", argv[i]);
+      std::exit(1);
+    }
+  }
+  if (opts.bytes > kAllocationBytes) {
+    std::fprintf(
+        stderr,
+        "requested %zu bytes but benchmark allocates only %zu bytes\n",
+        opts.bytes,
+        kAllocationBytes);
+    std::exit(1);
+  }
+  return opts;
+}
+
+void enablePeerAccess(int device, int peer) {
+  int canAccessPeer = 0;
+  CHECK_CUDA(cudaDeviceCanAccessPeer(&canAccessPeer, device, peer));
+  if (!canAccessPeer) {
+    std::fprintf(
+        stderr, "device %d cannot access peer device %d\n", device, peer);
+    std::exit(1);
+  }
+
+  CHECK_CUDA(cudaSetDevice(device));
+  const cudaError_t err = cudaDeviceEnablePeerAccess(peer, 0);
+  if (err != cudaSuccess && err != cudaErrorPeerAccessAlreadyEnabled) {
+    std::fprintf(
+        stderr,
+        "CUDA error at %s:%d: %s\n",
+        __FILE__,
+        __LINE__,
+        cudaGetErrorString(err));
+    std::exit(1);
+  }
+}
+
+float timeEagerUsPerCopy(
+    void* dst,
+    const void* src,
+    size_t bytes,
+    cudaStream_t stream) {
+  cudaEvent_t start = nullptr;
+  cudaEvent_t stop = nullptr;
+  CHECK_CUDA(cudaEventCreate(&start));
+  CHECK_CUDA(cudaEventCreate(&stop));
+
+  CHECK_CUDA(cudaEventRecord(start, stream));
+  for (int launch = 0; launch < kLaunches; ++launch) {
+    for (int copy = 0; copy < kCopiesPerGraph; ++copy) {
+      CHECK_CUDA(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDefault, stream));
+    }
+  }
+  CHECK_CUDA(cudaEventRecord(stop, stream));
+  CHECK_CUDA(cudaEventSynchronize(stop));
+
+  float ms = 0.0f;
+  CHECK_CUDA(cudaEventElapsedTime(&ms, start, stop));
+  CHECK_CUDA(cudaEventDestroy(start));
+  CHECK_CUDA(cudaEventDestroy(stop));
+  return ms * 1000.0f / (kLaunches * kCopiesPerGraph);
+}
+
+void warmupEager(
+    void* dst,
+    const void* src,
+    size_t bytes,
+    cudaStream_t stream) {
+  for (int warmup = 0; warmup < kWarmups; ++warmup) {
+    for (int copy = 0; copy < kCopiesPerGraph; ++copy) {
+      CHECK_CUDA(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDefault, stream));
+    }
+  }
+  CHECK_CUDA(cudaStreamSynchronize(stream));
+}
+
+float timeGraphUsPerCopy(
+    void* dst,
+    const void* src,
+    size_t bytes,
+    cudaStream_t stream) {
+  cudaGraph_t graph = nullptr;
+  cudaGraphExec_t graphExec = nullptr;
+  CHECK_CUDA(cudaStreamBeginCapture(stream, cudaStreamCaptureModeRelaxed));
+  for (int copy = 0; copy < kCopiesPerGraph; ++copy) {
+    CHECK_CUDA(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDefault, stream));
+  }
+  CHECK_CUDA(cudaStreamEndCapture(stream, &graph));
+  CHECK_CUDA(cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+
+  for (int warmup = 0; warmup < kWarmups; ++warmup) {
+    CHECK_CUDA(cudaGraphLaunch(graphExec, stream));
+  }
+  CHECK_CUDA(cudaStreamSynchronize(stream));
+
+  cudaEvent_t start = nullptr;
+  cudaEvent_t stop = nullptr;
+  CHECK_CUDA(cudaEventCreate(&start));
+  CHECK_CUDA(cudaEventCreate(&stop));
+  CHECK_CUDA(cudaEventRecord(start, stream));
+  for (int launch = 0; launch < kLaunches; ++launch) {
+    CHECK_CUDA(cudaGraphLaunch(graphExec, stream));
+  }
+  CHECK_CUDA(cudaEventRecord(stop, stream));
+  CHECK_CUDA(cudaEventSynchronize(stop));
+
+  float ms = 0.0f;
+  CHECK_CUDA(cudaEventElapsedTime(&ms, start, stop));
+  CHECK_CUDA(cudaEventDestroy(start));
+  CHECK_CUDA(cudaEventDestroy(stop));
+  CHECK_CUDA(cudaGraphExecDestroy(graphExec));
+  CHECK_CUDA(cudaGraphDestroy(graph));
+  return ms * 1000.0f / (kLaunches * kCopiesPerGraph);
+}
+
+double gbps(size_t bytes, float us) {
+  return static_cast<double>(bytes) / (static_cast<double>(us) * 1000.0);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const Options opts = parseOptions(argc, argv);
+
+  if (opts.p2p) {
+    int deviceCount = 0;
+    CHECK_CUDA(cudaGetDeviceCount(&deviceCount));
+    if (deviceCount <= kDstDevice) {
+      std::fprintf(
+          stderr,
+          "--p2p requires at least %d CUDA devices but found %d\n",
+          kDstDevice + 1,
+          deviceCount);
+      std::exit(1);
+    }
+    enablePeerAccess(kSrcDevice, kDstDevice);
+    enablePeerAccess(kDstDevice, kSrcDevice);
+  }
+
+  void* src = nullptr;
+  void* dst = nullptr;
+  CHECK_CUDA(cudaSetDevice(kSrcDevice));
+  CHECK_CUDA(cudaMalloc(&src, kAllocationBytes));
+  CHECK_CUDA(cudaMemset(src, 0x5a, kAllocationBytes));
+
+  const int dstDevice = opts.p2p ? kDstDevice : kSrcDevice;
+  CHECK_CUDA(cudaSetDevice(dstDevice));
+  CHECK_CUDA(cudaMalloc(&dst, kAllocationBytes));
+  CHECK_CUDA(cudaMemset(dst, 0, kAllocationBytes));
+
+  cudaStream_t stream = nullptr;
+  CHECK_CUDA(cudaSetDevice(dstDevice));
+  CHECK_CUDA(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  float us = 0.0f;
+  if (opts.graph) {
+    us = timeGraphUsPerCopy(dst, src, opts.bytes, stream);
+  } else {
+    warmupEager(dst, src, opts.bytes, stream);
+    us = timeEagerUsPerCopy(dst, src, opts.bytes, stream);
+  }
+  std::printf(
+      "mode=%s src_device=%d dst_device=%d allocation_bytes=%zu bytes=%zu copies_per_graph=%d launches=%d warmups=%d us_per_copy=%.1f gbps=%.1f\n",
+      opts.graph ? "graph" : "eager",
+      kSrcDevice,
+      dstDevice,
+      kAllocationBytes,
+      opts.bytes,
+      kCopiesPerGraph,
+      kLaunches,
+      kWarmups,
+      us,
+      gbps(opts.bytes, us));
+
+  CHECK_CUDA(cudaSetDevice(dstDevice));
+  CHECK_CUDA(cudaStreamDestroy(stream));
+  CHECK_CUDA(cudaSetDevice(dstDevice));
+  CHECK_CUDA(cudaFree(dst));
+  CHECK_CUDA(cudaSetDevice(kSrcDevice));
+  CHECK_CUDA(cudaFree(src));
+  return 0;
+}

--- a/comms/ctran/gpe/benchmarks/results.md
+++ b/comms/ctran/gpe/benchmarks/results.md
@@ -1,0 +1,71 @@
+# CUDA graph memcpy granularity
+
+The benchmark uses fixed 2 GiB `cudaMalloc` allocations and copies the first `--bytes` bytes. By default, source and destination are on CUDA device 0. With `--p2p`, the source is on device 0 and the destination is on device 1.
+
+Eager command template: `buck run @fbcode//mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=gb200 fbcode//comms/ctran/gpe/benchmarks:copy_graph_memcpy_bench -- --bytes <BYTES>`
+
+Graph command template: `buck run @fbcode//mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=gb200 fbcode//comms/ctran/gpe/benchmarks:copy_graph_memcpy_bench -- --bytes <BYTES> --graph`
+
+P2P command template: add `--p2p` to either command.
+
+Each run uses `copies_per_graph=100`, `launches=100`, and `warmups=100`.
+
+| Size | Bytes | Eager GB/s | Graph GB/s |
+|---|---:|---:|---:|
+| 1 GiB | 1073741824 | 3362.3 | 1563.7 |
+| 1 GiB + 8 KiB | 1073750016 | 3362.3 | 1564.7 |
+| 1 GiB + 64 KiB | 1073807360 | 3405.4 | 3433.9 |
+| 1 GiB + 1 MiB | 1074790400 | 3403.6 | 3433.9 |
+| 1 GiB + 2 MiB | 1075838976 | 3366.1 | 1564.6 |
+| 1 GiB + 4 MiB | 1077936128 | 3367.0 | 1564.5 |
+| 1 GiB + 8 MiB | 1082130432 | 3365.4 | 1564.5 |
+| 1 GiB + 16 MiB | 1090519040 | 3411.4 | 3434.7 |
+| 1 GiB + 32 MiB | 1107296256 | 3362.2 | 1564.5 |
+| 1 GiB + 64 MiB | 1140850688 | 3374.2 | 1564.4 |
+| 1 GiB + 128 MiB | 1207959552 | 3372.0 | 1564.5 |
+| 1 GiB + 256 MiB | 1342177280 | 3377.4 | 1565.0 |
+| 1 GiB + 512 MiB | 1610612736 | 3392.1 | 1565.2 |
+| 1 GiB + 1 GiB | 2147483648 | 3407.3 | 1565.5 |
+
+Eager memcpy stays near peak bandwidth. CUDA graph memcpy flips between a fast path and a ~1.56 TB/s path depending on copy length.
+
+## 256 MiB Base
+
+| Size | Bytes | Eager GB/s | Graph GB/s |
+|---|---:|---:|---:|
+| 256 MiB | 268435456 | 3277.6 | 3389.4 |
+| 256 MiB + 8 KiB | 268443648 | 3277.6 | 3389.5 |
+| 256 MiB + 64 KiB | 268500992 | 3278.3 | 3389.7 |
+| 256 MiB + 1 MiB | 269484032 | 3289.2 | 3390.9 |
+| 256 MiB + 2 MiB | 270532608 | 3300.9 | 3390.9 |
+| 256 MiB + 4 MiB | 272629760 | 3279.2 | 3389.9 |
+| 256 MiB + 8 MiB | 276824064 | 3295.8 | 3391.6 |
+| 256 MiB + 16 MiB | 285212672 | 3312.5 | 3393.3 |
+| 256 MiB + 32 MiB | 301989888 | 3285.2 | 3398.9 |
+| 256 MiB + 64 MiB | 335544320 | 3329.4 | 3401.1 |
+| 256 MiB + 128 MiB | 402653184 | 3331.7 | 3402.5 |
+| 256 MiB + 256 MiB | 536870912 | 3277.7 | 1560.6 |
+| 256 MiB + 512 MiB | 805306368 | 3390.3 | 3427.5 |
+| 256 MiB + 1 GiB | 1342177280 | 3377.6 | 1565.0 |
+
+## P2P Device 0 to Device 1
+
+The devgpu used for these runs has two GB200 GPUs connected by `NV18`. P2P mode enables peer access in both directions, creates the timing stream on device 1, and submits the copy with `cudaMemcpyAsync(..., cudaMemcpyDefault, stream)`.
+
+| Size | Bytes | Eager GB/s | Graph GB/s |
+|---|---:|---:|---:|
+| 1 GiB | 1073741824 | 776.9 | 779.8 |
+| 1 GiB + 64 KiB | 1073807360 | 776.9 | 779.8 |
+| 1 GiB + 1 MiB | 1074790400 | 776.9 | 779.8 |
+| 1 GiB + 2 MiB | 1075838976 | 776.9 | 779.9 |
+| 1 GiB + 16 MiB | 1090519040 | 777.7 | 779.8 |
+| 1 GiB + 32 MiB | 1107296256 | 776.8 | 779.8 |
+| 256 MiB + 256 MiB | 536870912 | 770.7 | 775.6 |
+| 256 MiB + 512 MiB | 805306368 | 776.1 | 778.8 |
+
+P2P copies are NVLink-limited and do not show the local-device graph fast/slow cliff.
+
+NCU graph profiling command template:
+`/usr/local/cuda-12.8/bin/ncu --target-processes all --graph-profiling graph --launch-count 1 --csv --page raw --metrics <METRICS> <BENCHMARK> --bytes <BYTES> --p2p --graph`
+
+For one graph launch, `nvlrx__bytes_data_user.sum` matched `bytes * copies_per_graph`, `nvltx__bytes_data_user.sum` was zero on the destination-device profile, and PCIe traffic was negligible relative to the NVLink payload. The `syslts__*_srcunit_ce_aperture_peer*` read/write counters were zero in these runs, and the generic CE sector counters were small control-path-sized counts rather than payload-sized counts. Unlike local graph memcpy, P2P graph rows did not expose kernel-like block/grid geometry in NCU.


### PR DESCRIPTION
Summary:

Add an isolated CUDA-only benchmark that compares repeated eager `cudaMemcpyAsync` against replaying a CUDA graph containing the same memcpy nodes. This is intended to validate graph memcpy-node overhead outside of ctran.

Reviewed By: minsii

Differential Revision: D107315103


