### PR TITLE
Extract MultiPeerIbTransport CRTP base from IBGDA (#2846)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -211,6 +211,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           config.ibgdaConfig.dataBufferSize);
     }
 
+    if (NCCL_CTRAN_PIPES_IB_MODE == NCCL_CTRAN_PIPES_IB_MODE::ibrc) {
+      config.ibMode = comms::prims::IbBackendMode::kIbrc;
+    }
     config.disableIb = NCCL_CTRAN_PIPES_DISABLE_IB;
     config.topoConfig.p2pDisable = NCCL_P2P_DISABLE ||
         NCCL_COMM_STATE_DEBUG_TOPO == NCCL_COMM_STATE_DEBUG_TOPO::nolocal;

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -145,6 +145,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -153,6 +153,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc

--- a/comms/prims/platform/CudaDriverLazy.cc
+++ b/comms/prims/platform/CudaDriverLazy.cc
@@ -30,6 +30,8 @@ PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle =
     nullptr;
 PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange = nullptr;
+PFN_cuMemGetHandleForAddressRange_v11070 pfn_cuMemGetHandleForAddressRange =
+    nullptr;
 
 namespace {
 
@@ -76,6 +78,7 @@ void do_init() {
   LOAD(cuMemGetAllocationPropertiesFromHandle);
   LOAD(cuMemRetainAllocationHandle);
   LOAD(cuMemGetAddressRange);
+  LOAD(cuMemGetHandleForAddressRange);
 
 #undef LOAD
 

--- a/comms/prims/platform/CudaDriverLazy.h
+++ b/comms/prims/platform/CudaDriverLazy.h
@@ -62,4 +62,9 @@ extern PFN_cuMemGetAllocationPropertiesFromHandle_v10020
 extern PFN_cuMemRetainAllocationHandle_v11000 pfn_cuMemRetainAllocationHandle;
 extern PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange;
 
+// DMA-BUF export. doca_gpu_dmabuf_fd() is a thin wrapper over this driver call,
+// so the generic GPU dmabuf helper uses it directly (no DOCA context needed).
+extern PFN_cuMemGetHandleForAddressRange_v11070
+    pfn_cuMemGetHandleForAddressRange;
+
 } // namespace comms::prims

--- a/comms/prims/platform/DocaHostUtils.h
+++ b/comms/prims/platform/DocaHostUtils.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <doca_gpunetio_host.h>
 #include <glog/logging.h>
 #include <unistd.h>
 #include <cstddef>
@@ -57,13 +56,23 @@ struct DmaBufExport {
 // Handles the full flow for cudaMalloc buffers on Grace/aarch64:
 //   1. cuMemGetAddressRange → find CUDA allocation base
 //   2. compute_dmabuf_alignment → align base/size to host page size
-//   3. doca_gpu_dmabuf_fd → export as DMA-BUF
+//   3. cuMemGetHandleForAddressRange → export as DMA-BUF fd
 //
-// Returns std::nullopt on failure (caller can fall back to ibv_reg_mr).
-// The returned DmaBufExport contains the fd and alignment info needed
-// for ibv_reg_dmabuf_mr (dmabufOffset as offset, ptr as iova).
-inline std::optional<DmaBufExport>
-export_gpu_dmabuf_aligned(doca_gpu* gpu, void* ptr, size_t size) {
+// This is the plain CUDA-driver DMA-BUF export — doca_gpu_dmabuf_fd is a thin
+// wrapper over the same cuMemGetHandleForAddressRange call — so no DOCA context
+// is needed. Returns std::nullopt on failure (caller can fall back to
+// ibv_reg_mr). The returned DmaBufExport contains the fd and alignment info
+// needed for ibv_reg_dmabuf_mr (dmabufOffset as offset, ptr as iova).
+inline std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
+    void* ptr,
+    size_t size) {
+  if (cuda_driver_lazy_init() != 0 || pfn_cuMemGetAddressRange == nullptr ||
+      pfn_cuMemGetHandleForAddressRange == nullptr) {
+    LOG(WARNING)
+        << "export_gpu_dmabuf_aligned: CUDA driver API is not available";
+    return std::nullopt;
+  }
+
   CUdeviceptr allocBase = 0;
   size_t allocSize = 0;
   CUresult cuRes =
@@ -79,11 +88,15 @@ export_gpu_dmabuf_aligned(doca_gpu* gpu, void* ptr, size_t size) {
       compute_dmabuf_alignment(allocBase, allocSize, ptr, pageSize);
 
   int fd = -1;
-  doca_error_t err = doca_gpu_dmabuf_fd(
-      gpu, alignment.alignedBase, alignment.alignedSize, &fd);
-  if (err != DOCA_SUCCESS || fd < 0) {
-    LOG(WARNING) << "export_gpu_dmabuf_aligned: doca_gpu_dmabuf_fd failed"
-                 << " err=" << err << " ptr=" << ptr
+  CUresult fdRes = pfn_cuMemGetHandleForAddressRange(
+      &fd,
+      reinterpret_cast<CUdeviceptr>(alignment.alignedBase),
+      alignment.alignedSize,
+      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+      0);
+  if (fdRes != CUDA_SUCCESS || fd < 0) {
+    LOG(WARNING) << "export_gpu_dmabuf_aligned: cuMemGetHandleForAddressRange"
+                 << " failed err=" << fdRes << " ptr=" << ptr
                  << " alignedBase=" << alignment.alignedBase
                  << " alignedSize=" << alignment.alignedSize;
     return std::nullopt;

--- a/comms/prims/transport/IbTransportConfig.h
+++ b/comms/prims/transport/IbTransportConfig.h
@@ -1,0 +1,12 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::prims {
+
+enum class IbBackendMode {
+  kIbgda,
+  kIbrc,
+};
+
+} // namespace comms::prims

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -1,0 +1,226 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/MultiPeerIbTransport.h"
+
+#include <cerrno>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+#include <fmt/core.h>
+#include <glog/logging.h>
+
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
+// GPU DMA-BUF export for MR registration. Generic (no DOCA context): on NVIDIA
+// it is cuMemGetHandleForAddressRange via DocaHostUtils (with the CUDA driver
+// address-range lookup from CudaDriverLazy); on AMD it is the HSA path provided
+// through DocaCompat.
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/DocaCompat.h"
+#else
+#include "comms/prims/platform/CudaDriverLazy.h"
+#include "comms/prims/platform/DocaHostUtils.h"
+#endif
+
+namespace comms::prims {
+
+MultiPeerIbTransportBase::MultiPeerIbTransportBase(
+    int myRank,
+    int nRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap)
+    : myRank_(myRank), nRanks_(nRanks), bootstrap_(std::move(bootstrap)) {
+  if (myRank_ < 0 || myRank_ >= nRanks_) {
+    throw std::invalid_argument("Invalid rank");
+  }
+  if (nRanks_ < 2) {
+    throw std::invalid_argument("Need at least 2 ranks");
+  }
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
+    void* ptr,
+    std::size_t size) {
+  if (ptr == nullptr || size == 0) {
+    throw std::invalid_argument("Invalid buffer pointer or size");
+  }
+
+  // Fast path: containment lookup — if [ptr, ptr+size) falls entirely within an
+  // existing registration, return the cached per-NIC lkeys with no driver call.
+  const auto addr = reinterpret_cast<uintptr_t>(ptr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  if (it != registeredBuffers_.begin()) {
+    --it;
+    if (addr + size <= it->first + it->second.allocSize) {
+      it->second.refs++;
+      VLOG(1) << "MultiPeerIbTransport: cache hit for ptr=" << ptr
+              << " allocBase=0x" << std::hex << it->first << std::dec
+              << " refs=" << it->second.refs;
+      NetworkLKeys keys(numNics_);
+      for (int n = 0; n < numNics_; ++n) {
+        keys[n] = NetworkLKey(HostLKey(it->second.mrs[n]->lkey));
+      }
+      return IbgdaLocalBuffer(ptr, keys);
+    }
+  }
+
+  // Cache miss: resolve the GPU allocation base and register one MR per NIC
+  // (DMABUF-first, ibv_reg_mr fallback). Generic — no DOCA, no backend hook.
+#ifdef __HIP_PLATFORM_AMD__
+  // HIP doesn't expose an exact cuMemGetAddressRange equivalent; for the common
+  // case where the caller passes the allocation base, register the requested
+  // range.
+  uintptr_t allocBase = reinterpret_cast<uintptr_t>(ptr);
+  std::size_t allocSize = size;
+#else
+  if (cuda_driver_lazy_init() != 0 || pfn_cuMemGetAddressRange == nullptr) {
+    throw std::runtime_error(
+        "registerBuffer: failed to initialize CUDA driver API");
+  }
+  CUdeviceptr allocBase = 0;
+  std::size_t allocSize = 0;
+  CUresult cuRes =
+      pfn_cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)ptr);
+  if (cuRes != CUDA_SUCCESS || allocBase == 0) {
+    throw std::runtime_error(
+        "registerBuffer: cuMemGetAddressRange failed for ptr");
+  }
+#endif
+  auto& symbols = ibverbx::ibvSymbols;
+  int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
+      ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
+
+  CachedMr cached;
+  cached.allocSize = allocSize;
+  cached.refs = 1;
+
+  // Try DMABUF first per NIC, fall back to plain reg_mr per NIC. If any NIC's
+  // registration fails, deregister everything already registered and propagate.
+  for (int n = 0; n < numNics_; ++n) {
+    ibverbx::ibv_mr* mr = nullptr;
+    auto dmabuf = export_gpu_dmabuf_aligned(
+        reinterpret_cast<void*>(allocBase), allocSize);
+    if (dmabuf) {
+      if (symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
+        mr = symbols.ibv_internal_reg_dmabuf_mr(
+            nics_[n].ibvPd,
+            dmabuf->alignment.dmabufOffset,
+            allocSize,
+            static_cast<uint64_t>(allocBase),
+            dmabuf->fd,
+            accessFlags);
+      }
+      close(dmabuf->fd);
+    }
+    if (!mr) {
+      errno = 0;
+      mr = symbols.ibv_internal_reg_mr(
+          nics_[n].ibvPd,
+          reinterpret_cast<void*>(allocBase),
+          allocSize,
+          accessFlags);
+      if (!mr) {
+        const int savedErrno = errno;
+        for (int j = 0; j < n; ++j) {
+          symbols.ibv_internal_dereg_mr(cached.mrs[j]);
+        }
+        throw std::runtime_error(
+            fmt::format(
+                "Failed to register buffer with RDMA on NIC {} "
+                "(allocBase=0x{:x} allocSize={} errno={} ({}))",
+                n,
+                allocBase,
+                allocSize,
+                savedErrno,
+                std::strerror(savedErrno)));
+      }
+    }
+    cached.mrs[n] = mr;
+  }
+
+  registeredBuffers_.emplace(static_cast<uintptr_t>(allocBase), cached);
+
+  NetworkLKeys keys(numNics_);
+  for (int n = 0; n < numNics_; ++n) {
+    keys[n] = NetworkLKey(HostLKey(cached.mrs[n]->lkey));
+  }
+  return IbgdaLocalBuffer(ptr, keys);
+}
+
+void MultiPeerIbTransportBase::deregisterBuffer(void* ptr) {
+  // Containment lookup on the ordered map avoids resolving the allocation range
+  // again (which fails once the underlying memory is freed).
+  const auto addr = reinterpret_cast<uintptr_t>(ptr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  if (it != registeredBuffers_.begin()) {
+    --it;
+    if (addr < it->first + it->second.allocSize) {
+      it->second.refs--;
+      VLOG(1) << "MultiPeerIbTransport: deregister ptr=" << ptr
+              << " allocBase=0x" << std::hex << it->first << std::dec
+              << " refs=" << it->second.refs;
+      if (it->second.refs <= 0) {
+        // Deregistration is backend-agnostic (no PD/DOCA needed).
+        for (int n = 0; n < numNics_; ++n) {
+          ibverbx::ibvSymbols.ibv_internal_dereg_mr(it->second.mrs[n]);
+        }
+        registeredBuffers_.erase(it);
+      }
+      return;
+    }
+  }
+  LOG(WARNING) << "MultiPeerIbTransport: buffer not registered: " << ptr;
+}
+
+std::vector<IbgdaRemoteBuffer> MultiPeerIbTransportBase::exchangeBuffer(
+    const IbgdaLocalBuffer& localBuf) {
+  const int numPeers = nRanks_ - 1;
+
+  // Containment lookup (same as deregisterBuffer): find the registered
+  // allocation covering localBuf.ptr. Avoids re-resolving the allocation base;
+  // sub-buffers resolve correctly via the ordered map.
+  const auto addr = reinterpret_cast<uintptr_t>(localBuf.ptr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  if (it == registeredBuffers_.begin()) {
+    throw std::runtime_error(
+        "Buffer not registered - call registerBuffer() first");
+  }
+  --it;
+  if (addr >= it->first + it->second.allocSize) {
+    throw std::runtime_error(
+        "Buffer not registered - call registerBuffer() first");
+  }
+
+  // allGather addr + per-NIC rkeys; one entry per rank.
+  std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
+  allInfo[myRank_].addr = reinterpret_cast<uint64_t>(localBuf.ptr);
+  allInfo[myRank_].numNics = numNics_;
+  for (int n = 0; n < numNics_; ++n) {
+    allInfo[myRank_].rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
+  }
+
+  auto result =
+      bootstrap_
+          ->allGather(
+              allInfo.data(), sizeof(IbgdaBufferExchInfo), myRank_, nRanks_)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "MultiPeerIbTransport::exchangeBuffer allGather failed");
+  }
+
+  std::vector<IbgdaRemoteBuffer> peerBuffers(numPeers);
+  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
+    const int peerRank = peerIndexToRank(peerIndex);
+    peerBuffers[peerIndex] = allInfo[peerRank].toRemoteBuffer();
+  }
+
+  VLOG(1) << "MultiPeerIbTransport: exchanged buffer info with " << numPeers
+          << " peers";
+  return peerBuffers;
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -1,0 +1,235 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace comms::prims {
+
+/**
+ * Transport connection information for RDMA QP setup.
+ *
+ * This struct is exchanged ONCE during the bootstrap phase to establish
+ * RDMA connectivity between peers. Contains immutable connection parameters
+ * that define how to reach a peer's QP.
+ */
+struct IbTransportExchInfo {
+  // Queue Pair Number for RDMA connection
+  uint32_t qpn{0};
+
+  // Global Identifier for RoCE routing (16 bytes)
+  uint8_t gid[16]{};
+
+  // GID index used
+  int gidIndex{0};
+
+  // Local Identifier (for IB, not used in RoCE)
+  uint16_t lid{0};
+
+  // Port active MTU. Used to negotiate path MTU: min(local, remote).
+  ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
+};
+
+/**
+ * Maximum number of ranks supported for allGather-based exchange.
+ * This limit exists because we use fixed-size arrays for QPN exchange.
+ */
+constexpr int kMaxRanksForAllGather = 128;
+
+/**
+ * Maximum number of QP sets per (peer, NIC) for multi-QP support.
+ */
+constexpr int kMaxQpsPerPeerPerNic = 128;
+
+/**
+ * Transport exchange info for allGather-based exchange.
+ *
+ * Each rank contributes this structure containing per-NIC GID/LID and the
+ * per-(target_rank, q) QPN this rank uses on that NIC.
+ */
+struct IbTransportExchInfoAll {
+  // Per-NIC public info shared with peers (wire format). nicInfo[n] holds
+  // this rank's NIC n's GID, LID, and the QPNs it uses to connect to each
+  // (target_rank, q). Indices [numNics .. kMaxNicsPerGpu) are zero-init and
+  // never read by peers (both ranks must agree on numNics — validated at
+  // exchange time).
+  struct NicWireInfo {
+    uint8_t gid[16]{};
+    uint16_t lid{0};
+    // QPN this rank uses on this NIC to connect to (target_rank, q).
+    // qpnForRank[myRank][*] is unused (set to 0).
+    uint32_t qpnForRank[kMaxRanksForAllGather][kMaxQpsPerPeerPerNic]{};
+  };
+  NicWireInfo nicInfo[kMaxNicsPerGpu]{};
+
+  // Common (shared across NICs on this rank).
+  int gidIndex{0};
+  ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
+
+  // Number of NICs (rails) used by this rank.
+  // Must match across all ranks (validated at exchange time).
+  int numNics{1};
+
+  // Number of QPs per (peer, NIC) used by this rank.
+  int numQpsPerPeerPerNic{1};
+};
+
+/**
+ * MultiPeerIbTransportBase - backend-agnostic host control plane shared by the
+ * multi-peer IB transports (IBGDA today, IBRC next).
+ *
+ * This is a NON-template base so its (heavy) method bodies live in
+ * MultiPeerIbTransport.cc and are compiled exactly once, reused by every
+ * backend with no per-backend wiring. It owns rank state + rank<->peerIndex
+ * mapping and the full refcounted MR registry
+ * (registerBuffer/deregisterBuffer/exchangeBuffer), plus the generic per-NIC IB
+ * resources (NicResources). It NEVER calls into a backend.
+ *
+ * MR registration is generic — it resolves the allocation, exports a DMA-BUF
+ * via the platform helper, and registers one MR per NIC on the base-owned PDs
+ * (nics_[n].ibvPd), which the backend fills during NIC bring-up. No backend
+ * hook is involved.
+ */
+class MultiPeerIbTransportBase {
+ public:
+  /** @return Number of peers (nRanks - 1). */
+  int numPeers() const {
+    return nRanks_ - 1;
+  }
+
+  /** @return This rank's id. */
+  int myRank() const {
+    return myRank_;
+  }
+
+  /** @return Total number of ranks. */
+  int nRanks() const {
+    return nRanks_;
+  }
+
+  /**
+   * @return Number of NICs (rails) in use. Resolved by the backend at
+   * construction time (see backend ctor for the resolution rules).
+   */
+  int numNics() const {
+    return numNics_;
+  }
+
+  /**
+   * registerBuffer - Register a user GPU buffer for RDMA, refcounted per
+   * allocation. Containment fast-path returns cached per-NIC lkeys without any
+   * driver call; on a miss it resolves the allocation, exports a DMA-BUF, and
+   * registers one MR per NIC on the base-owned PDs.
+   *
+   * @return IbgdaLocalBuffer carrying one lkey per NIC.
+   */
+  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size);
+
+  /** deregisterBuffer - Decrement refcount; deregister all per-NIC MRs at 0. */
+  void deregisterBuffer(void* ptr);
+
+  /**
+   * exchangeBuffer - COLLECTIVE. allGather a registered buffer's addr + per-NIC
+   * rkeys; return one IbgdaRemoteBuffer per peer (indexed by peerIndexToRank).
+   */
+  std::vector<IbgdaRemoteBuffer> exchangeBuffer(
+      const IbgdaLocalBuffer& localBuf);
+
+ protected:
+  MultiPeerIbTransportBase(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap);
+
+  // Non-virtual protected dtor: the base is never owned/deleted polymorphically
+  // (the dispatcher holds the concrete backend type).
+  ~MultiPeerIbTransportBase() = default;
+
+  MultiPeerIbTransportBase(const MultiPeerIbTransportBase&) = delete;
+  MultiPeerIbTransportBase& operator=(const MultiPeerIbTransportBase&) = delete;
+
+  int rankToPeerIndex(int rank) const {
+    return (rank < myRank_) ? rank : (rank - 1);
+  }
+  int peerIndexToRank(int peerIndex) const {
+    return (peerIndex < myRank_) ? peerIndex : (peerIndex + 1);
+  }
+
+  // Cached MR entry: one MR per (CUDA allocation, NIC), refcounted. Multiple
+  // user buffers within the same allocation share one MR set.
+  struct CachedMr {
+    std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs{};
+    std::size_t allocSize{0};
+    int refs{0};
+  };
+
+  const int myRank_{-1};
+  const int nRanks_{0};
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+
+  // Number of NICs (rails) in use; set by the backend at construction.
+  int numNics_{1};
+
+  // Per-NIC generic IB resources (device name, context, PD, GID). The backend
+  // fills these during NIC bring-up; the base registers MRs on the PDs. The
+  // backend keeps only its backend-specific per-NIC state (e.g. DOCA AH attrs
+  // and QP groups), index-aligned with this vector.
+  struct NicResources {
+    std::string deviceName;
+    ibverbx::ibv_context* ibvCtx{nullptr};
+    ibverbx::ibv_pd* ibvPd{nullptr};
+    ibverbx::ibv_gid localGid{};
+  };
+  std::vector<NicResources> nics_;
+
+  // Maps allocation base address -> cached MR covering the full allocation.
+  // Ordered map enables O(log n) containment lookup via upper_bound.
+  std::map<uintptr_t, CachedMr> registeredBuffers_;
+};
+
+/**
+ * MultiPeerIbTransport<Backend> - CRTP layer over MultiPeerIbTransportBase.
+ *
+ * Each backend derives as
+ *   `class MultipeerIbgdaTransport : public
+ * MultiPeerIbTransport<MultipeerIbgdaTransport>`.
+ * The base can statically call backend-specific hooks via `backend()` with no
+ * vtable. All backend-agnostic state and methods are inherited from the
+ * non-template base, so they are compiled once (in MultiPeerIbTransport.cc) and
+ * shared. Backend-coupled control flow (the exchange/lazy skeleton) moves up in
+ * later slices and will use `backend()` hooks.
+ */
+template <typename Backend>
+class MultiPeerIbTransport : public MultiPeerIbTransportBase {
+ protected:
+  MultiPeerIbTransport(
+      int myRank,
+      int nRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap)
+      : MultiPeerIbTransportBase(myRank, nRanks, std::move(bootstrap)) {}
+
+  ~MultiPeerIbTransport() = default;
+
+  // CRTP downcast for static dispatch into backend hooks (used by later
+  // slices).
+  Backend& backend() {
+    return static_cast<Backend&>(*this);
+  }
+  const Backend& backend() const {
+    return static_cast<const Backend&>(*this);
+  }
+};
+
+} // namespace comms::prims

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -109,6 +109,12 @@ void MultiPeerTransport::initFromTopology(
     }
     // ibgdaPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
   } else {
+    if (config.ibMode == IbBackendMode::kIbrc) {
+      throw std::runtime_error(
+          "MultiPeerTransport: IBRC mode selected, but the IBRC "
+          "backend is not implemented yet.");
+    }
+
     for (int r = 0; r < nRanks_; ++r) {
       if (r == myRank_) {
         typePerRank_.at(r) = TransportType::SELF;

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -22,6 +22,7 @@
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
+#include "comms/prims/transport/IbTransportConfig.h"
 #include "comms/prims/transport/Transport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
@@ -36,6 +37,9 @@ struct MultiPeerDeviceHandle;
 struct MultiPeerTransportConfig {
   MultiPeerNvlTransportConfig nvlConfig;
   MultipeerIbgdaTransportConfig ibgdaConfig;
+
+  // Selects the IB backend for non-NVL peers. Default remains IBGDA.
+  IbBackendMode ibMode{IbBackendMode::kIbgda};
 
   // MNNVL topology overrides for UUID and clique ID.
   // See TopologyConfig for field-level documentation.

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
@@ -1956,8 +1956,9 @@ pipes_gda_error_t pipes_gda_gpu_verbs_destroy_qp_group_hl(
 
 namespace comms::prims {
 
-std::optional<DmaBufExport>
-export_gpu_dmabuf_aligned(pipes_gda_gpu* /*gpu*/, void* ptr, std::size_t size) {
+std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
+    void* ptr,
+    std::size_t size) {
   // Skip dmabuf for non-GPU pointers. HSA's
   // `hsa_amd_portable_export_dmabuf` will export host-pinned
   // (`hipHostMalloc`) memory as a dmabuf, but the resulting fd

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
@@ -393,8 +393,9 @@ struct DmaBufExport {
   DmaBufAlignment alignment;
 };
 
-std::optional<DmaBufExport>
-export_gpu_dmabuf_aligned(pipes_gda_gpu* gpu, void* ptr, std::size_t size);
+std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
+    void* ptr,
+    std::size_t size);
 
 } // namespace comms::prims
 

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -219,7 +219,8 @@ void MultipeerIbgdaTransport::initDocaGpu() {
 }
 
 void MultipeerIbgdaTransport::openIbDevice() {
-  nicDevices_.resize(numNics_);
+  nicDoca_.resize(numNics_);
+  nics_.resize(numNics_); // base-owned generic per-NIC resources, filled below
   auto initResult = ibverbx::ibvInit();
   if (!initResult) {
     throw std::runtime_error(
@@ -235,7 +236,7 @@ void MultipeerIbgdaTransport::openIbDevice() {
     throw std::runtime_error("No IB devices found");
   }
 
-  // Resolve nicDevices_[0..numNics_).deviceName — config override first,
+  // Resolve nicDoca_[0..numNics_).deviceName — config override first,
   // then topology-aware auto-discovery.
   //
   // Priority 1: Explicit GPU-to-NIC mapping from config (vector per GPU,
@@ -253,17 +254,17 @@ void MultipeerIbgdaTransport::openIbDevice() {
               numNics_));
     }
     for (int n = 0; n < numNics_; ++n) {
-      nicDevices_[n].deviceName = names[n];
+      nics_[n].deviceName = names[n];
     }
     VLOG(1) << "MultipeerIbgdaTransport: using config.gpuNicMap for GPU "
-            << config_.cudaDevice << " -> " << nicDevices_[0].deviceName
+            << config_.cudaDevice << " -> " << nics_[0].deviceName
             << (numNics_ > 1 ? " (+ " + std::to_string(numNics_ - 1) +
                         " more for multi-NIC)"
                              : "");
   }
 
   // Priority 2: Auto-discovery (top-numNics_ candidates by NUMA affinity).
-  if (nicDevices_[0].deviceName.empty()) {
+  if (nics_[0].deviceName.empty()) {
     // On AMD, the `DataDirectMode::Only` default triggers
     // `ibv_reg_dmabuf_mr` inside `augmentWithDataDirect()`, which is not
     // exercised on AMD's libibverbs path here. Force `Disabled` to skip the
@@ -287,11 +288,10 @@ void MultipeerIbgdaTransport::openIbDevice() {
               numNics_));
     }
     for (int n = 0; n < numNics_; ++n) {
-      nicDevices_[n].deviceName = candidates[n].name;
+      nics_[n].deviceName = candidates[n].name;
     }
     VLOG(1) << "MultipeerIbgdaTransport: auto-discovered NIC "
-            << nicDevices_[0].deviceName << " for GPU device "
-            << config_.cudaDevice;
+            << nics_[0].deviceName << " for GPU device " << config_.cudaDevice;
   }
 
   // Open + setup each NIC: find by name, open ctx, alloc PD, query GID +
@@ -301,7 +301,7 @@ void MultipeerIbgdaTransport::openIbDevice() {
     int nicIdx = -1;
     for (int i = 0; i < numDevices; i++) {
       const char* devName = symbols.ibv_internal_get_device_name(deviceList[i]);
-      if (devName && nicDevices_[n].deviceName == devName) {
+      if (devName && nics_[n].deviceName == devName) {
         nicIdx = i;
         break;
       }
@@ -309,65 +309,60 @@ void MultipeerIbgdaTransport::openIbDevice() {
     if (nicIdx < 0) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
-          "Specified NIC not found: " + nicDevices_[n].deviceName);
+          "Specified NIC not found: " + nics_[n].deviceName);
     }
     VLOG(1) << "MultipeerIbgdaTransport: NIC " << n << " = "
-            << nicDevices_[n].deviceName << " at device-list index " << nicIdx;
+            << nics_[n].deviceName << " at device-list index " << nicIdx;
 
-    nicDevices_[n].ibvCtx =
-        symbols.ibv_internal_open_device(deviceList[nicIdx]);
-    if (!nicDevices_[n].ibvCtx) {
+    nics_[n].ibvCtx = symbols.ibv_internal_open_device(deviceList[nicIdx]);
+    if (!nics_[n].ibvCtx) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
-          "Failed to open IB device: " + nicDevices_[n].deviceName);
+          "Failed to open IB device: " + nics_[n].deviceName);
     }
 
-    nicDevices_[n].ibvPd = symbols.ibv_internal_alloc_pd(nicDevices_[n].ibvCtx);
-    if (!nicDevices_[n].ibvPd) {
+    nics_[n].ibvPd = symbols.ibv_internal_alloc_pd(nics_[n].ibvCtx);
+    if (!nics_[n].ibvPd) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
-          "Failed to allocate protection domain on NIC " +
-          nicDevices_[n].deviceName);
+          "Failed to allocate protection domain on NIC " + nics_[n].deviceName);
     }
 
     if (symbols.ibv_internal_query_gid(
-            nicDevices_[n].ibvCtx, 1, gidIndex_, &nicDevices_[n].localGid) !=
-        0) {
+            nics_[n].ibvCtx, 1, gidIndex_, &nics_[n].localGid) != 0) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
           "Failed to query GID at index " + std::to_string(gidIndex_) +
-          " on NIC " + nicDevices_[n].deviceName);
+          " on NIC " + nics_[n].deviceName);
     }
 
     auto gidStr = fmt::format(
         "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:"
         "{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}:{:02x}{:02x}",
-        nicDevices_[n].localGid.raw[0],
-        nicDevices_[n].localGid.raw[1],
-        nicDevices_[n].localGid.raw[2],
-        nicDevices_[n].localGid.raw[3],
-        nicDevices_[n].localGid.raw[4],
-        nicDevices_[n].localGid.raw[5],
-        nicDevices_[n].localGid.raw[6],
-        nicDevices_[n].localGid.raw[7],
-        nicDevices_[n].localGid.raw[8],
-        nicDevices_[n].localGid.raw[9],
-        nicDevices_[n].localGid.raw[10],
-        nicDevices_[n].localGid.raw[11],
-        nicDevices_[n].localGid.raw[12],
-        nicDevices_[n].localGid.raw[13],
-        nicDevices_[n].localGid.raw[14],
-        nicDevices_[n].localGid.raw[15]);
+        nics_[n].localGid.raw[0],
+        nics_[n].localGid.raw[1],
+        nics_[n].localGid.raw[2],
+        nics_[n].localGid.raw[3],
+        nics_[n].localGid.raw[4],
+        nics_[n].localGid.raw[5],
+        nics_[n].localGid.raw[6],
+        nics_[n].localGid.raw[7],
+        nics_[n].localGid.raw[8],
+        nics_[n].localGid.raw[9],
+        nics_[n].localGid.raw[10],
+        nics_[n].localGid.raw[11],
+        nics_[n].localGid.raw[12],
+        nics_[n].localGid.raw[13],
+        nics_[n].localGid.raw[14],
+        nics_[n].localGid.raw[15]);
     VLOG(1) << "MultipeerIbgdaTransport: NIC " << n << " GID[" << gidIndex_
             << "] = " << gidStr;
 
     ibverbx::ibv_port_attr portAttr{};
-    if (symbols.ibv_internal_query_port(nicDevices_[n].ibvCtx, 1, &portAttr) !=
-        0) {
+    if (symbols.ibv_internal_query_port(nics_[n].ibvCtx, 1, &portAttr) != 0) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
-          "Failed to query port attributes on NIC " +
-          nicDevices_[n].deviceName);
+          "Failed to query port attributes on NIC " + nics_[n].deviceName);
     }
 
     VLOG(1) << "MultipeerIbgdaTransport: NIC " << n
@@ -378,7 +373,7 @@ void MultipeerIbgdaTransport::openIbDevice() {
     if (portAttr.state != ibverbx::IBV_PORT_ACTIVE) {
       symbols.ibv_internal_free_device_list(deviceList);
       throw std::runtime_error(
-          "NIC " + nicDevices_[n].deviceName + " port 1 is not active (state=" +
+          "NIC " + nics_[n].deviceName + " port 1 is not active (state=" +
           std::to_string(portAttr.state) + ")");
     }
 
@@ -395,27 +390,25 @@ void MultipeerIbgdaTransport::openIbDevice() {
       }
     } else if (portAttr.active_mtu != localMtu_) {
       LOG(WARNING) << "MultipeerIbgdaTransport: NIC " << n << " ("
-                   << nicDevices_[n].deviceName
+                   << nics_[n].deviceName
                    << ") active_mtu=" << portAttr.active_mtu
                    << " differs from NIC 0 active_mtu=" << localMtu_
                    << "; using NIC 0's MTU for negotiation";
     }
 
     doca_error_t err = doca_verbs_ah_attr_create(
-        reinterpret_cast<::ibv_context*>(nicDevices_[n].ibvCtx),
-        &nicDevices_[n].ahAttr);
+        reinterpret_cast<::ibv_context*>(nics_[n].ibvCtx), &nicDoca_[n].ahAttr);
     checkDocaError(err, "Failed to create AH attributes");
-    err = doca_verbs_ah_attr_set_addr_type(nicDevices_[n].ahAttr, addrType);
+    err = doca_verbs_ah_attr_set_addr_type(nicDoca_[n].ahAttr, addrType);
     checkDocaError(err, "Failed to set address type");
-    err = doca_verbs_ah_attr_set_sgid_index(nicDevices_[n].ahAttr, gidIndex_);
+    err = doca_verbs_ah_attr_set_sgid_index(nicDoca_[n].ahAttr, gidIndex_);
     checkDocaError(err, "Failed to set SGID index");
-    err = doca_verbs_ah_attr_set_hop_limit(nicDevices_[n].ahAttr, kHopLimit);
+    err = doca_verbs_ah_attr_set_hop_limit(nicDoca_[n].ahAttr, kHopLimit);
     checkDocaError(err, "Failed to set hop limit");
     err = doca_verbs_ah_attr_set_traffic_class(
-        nicDevices_[n].ahAttr, config_.trafficClass);
+        nicDoca_[n].ahAttr, config_.trafficClass);
     checkDocaError(err, "Failed to set traffic class");
-    err =
-        doca_verbs_ah_attr_set_sl(nicDevices_[n].ahAttr, config_.serviceLevel);
+    err = doca_verbs_ah_attr_set_sl(nicDoca_[n].ahAttr, config_.serviceLevel);
     checkDocaError(err, "Failed to set service level");
   }
   symbols.ibv_internal_free_device_list(deviceList);
@@ -558,12 +551,11 @@ void MultipeerIbgdaTransport::registerMemory() {
         nicDevices_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
 #else
     // NVIDIA / AMD+BNXT: DMABUF export (zero-based) with a lazy iova2 fallback.
-    auto sinkDmabuf =
-        export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
+    auto sinkDmabuf = export_gpu_dmabuf_aligned(sinkBuffer_, sinkBufferSize_);
     if (sinkDmabuf) {
       if (symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
-        nicDevices_[n].sinkMr = symbols.ibv_internal_reg_dmabuf_mr(
-            nicDevices_[n].ibvPd,
+        nicDoca_[n].sinkMr = symbols.ibv_internal_reg_dmabuf_mr(
+            nics_[n].ibvPd,
             sinkDmabuf->alignment.dmabufOffset,
             sinkBufferSize_,
             0, // iova=0: zero-based MR
@@ -572,21 +564,21 @@ void MultipeerIbgdaTransport::registerMemory() {
       }
       close(sinkDmabuf->fd);
     }
-    if (!nicDevices_[n].sinkMr) {
+    if (!nicDoca_[n].sinkMr) {
       if (symbols.ibv_internal_reg_mr_iova2 == nullptr) {
         throw std::runtime_error("ibv_reg_mr_iova2 is unavailable");
       }
-      nicDevices_[n].sinkMr = symbols.ibv_internal_reg_mr_iova2(
-          nicDevices_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
+      nicDoca_[n].sinkMr = symbols.ibv_internal_reg_mr_iova2(
+          nics_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
     }
 #endif
-    if (!nicDevices_[n].sinkMr) {
+    if (!nicDoca_[n].sinkMr) {
       throw std::runtime_error(
           "Failed to register sink memory region on NIC " + std::to_string(n));
     }
 
     VLOG(1) << "MultipeerIbgdaTransport: NIC " << n
-            << " sink lkey=" << nicDevices_[n].sinkMr->lkey
+            << " sink lkey=" << nicDoca_[n].sinkMr->lkey
             << " (zero-based MR, iova=0)";
   }
 }
@@ -595,7 +587,7 @@ void MultipeerIbgdaTransport::createQpGroups() {
   const int numQps = config_.numQpsPerPeerPerNic;
   const int totalQpsPerPeer = numNics_ * numQps;
   const int totalQpGroups = numPeers * totalQpsPerPeer;
-  for (auto& nic : nicDevices_) {
+  for (auto& nic : nicDoca_) {
     nic.qpGroups.resize(static_cast<size_t>(numPeers) * numQps);
     nic.loopbackCompanionQps.resize(static_cast<size_t>(numPeers) * numQps);
   }
@@ -614,7 +606,7 @@ void MultipeerIbgdaTransport::createQpGroups() {
   // Query IB device capabilities for debugging (NIC 0 is representative).
   ibverbx::ibv_device_attr devAttr{};
   auto& symbols = ibverbx::ibvSymbols;
-  if (symbols.ibv_internal_query_device(nicDevices_[0].ibvCtx, &devAttr) == 0) {
+  if (symbols.ibv_internal_query_device(nics_[0].ibvCtx, &devAttr) == 0) {
     VLOG(1) << "MultipeerIbgdaTransport: IB device - max_qp=" << devAttr.max_qp
             << " max_cq=" << devAttr.max_cq << " max_mr=" << devAttr.max_mr
             << " max_qp_wr=" << devAttr.max_qp_wr;
@@ -641,17 +633,16 @@ void MultipeerIbgdaTransport::connectQp(
   doca_verbs_gid remoteGid{};
   memcpy(remoteGid.raw, peerInfo.gid, sizeof(remoteGid.raw));
   doca_error_t err =
-      doca_verbs_ah_attr_set_gid(nicDevices_[nic].ahAttr, remoteGid);
+      doca_verbs_ah_attr_set_gid(nicDoca_[nic].ahAttr, remoteGid);
   checkDocaError(err, "Failed to set remote GID");
 
   // Query port for IB-specific parameters
   ibverbx::ibv_port_attr portAttr{};
   auto& symbols = ibverbx::ibvSymbols;
-  if (symbols.ibv_internal_query_port(nicDevices_[nic].ibvCtx, 1, &portAttr) !=
-      0) {
+  if (symbols.ibv_internal_query_port(nics_[nic].ibvCtx, 1, &portAttr) != 0) {
     LOG(WARNING) << "Failed to query port for IB-specific parameters";
   } else if (portAttr.link_layer == ibverbx::IBV_LINK_LAYER_INFINIBAND) {
-    err = doca_verbs_ah_attr_set_dlid(nicDevices_[nic].ahAttr, peerInfo.lid);
+    err = doca_verbs_ah_attr_set_dlid(nicDoca_[nic].ahAttr, peerInfo.lid);
     checkDocaError(err, "Failed to set DLID");
   }
 
@@ -696,7 +687,7 @@ void MultipeerIbgdaTransport::connectQp(
     checkDocaError(err, "Failed to set RQ PSN");
     err = doca_verbs_qp_attr_set_dest_qp_num(qpAttr, peerInfo.qpn);
     checkDocaError(err, "Failed to set dest QP number");
-    err = doca_verbs_qp_attr_set_ah_attr(qpAttr, nicDevices_[nic].ahAttr);
+    err = doca_verbs_qp_attr_set_ah_attr(qpAttr, nicDoca_[nic].ahAttr);
     checkDocaError(err, "Failed to set AH attributes");
     err = doca_verbs_qp_attr_set_min_rnr_timer(qpAttr, config_.minRnrTimer);
     checkDocaError(err, "Failed to set min RNR timer");
@@ -738,20 +729,12 @@ void MultipeerIbgdaTransport::connectQp(
           << peerInfo.qpn;
 }
 
-int MultipeerIbgdaTransport::rankToPeerIndex(int rank) const {
-  return (rank < myRank_) ? rank : (rank - 1);
-}
-
-int MultipeerIbgdaTransport::peerIndexToRank(int peerIndex) const {
-  return (peerIndex < myRank_) ? peerIndex : (peerIndex + 1);
-}
-
 void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
   const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
     doca_gpu_verbs_qp_init_attr_hl mainAttr{};
     mainAttr.gpu_dev = docaGpu_;
-    mainAttr.ibpd = reinterpret_cast<::ibv_pd*>(nicDevices_[nic].ibvPd);
+    mainAttr.ibpd = reinterpret_cast<::ibv_pd*>(nics_[nic].ibvPd);
     mainAttr.sq_nwqe = config_.qpDepth;
     mainAttr.nic_handler = DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO;
     mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
@@ -759,8 +742,8 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
     loopbackAttr.sq_nwqe = kCompanionQpDepth;
 
-    auto& nicQps = nicDevices_[nic].qpGroups;
-    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
     for (int q = 0; q < numQps; q++) {
       const int qpIdx = peerIndex * numQps + q;
       doca_error_t err =
@@ -775,17 +758,16 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
 void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
   const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDevices_[nic].qpGroups;
-    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
 
     IbgdaTransportExchInfo selfInfo;
-    memcpy(selfInfo.gid, nicDevices_[nic].localGid.raw, sizeof(selfInfo.gid));
+    memcpy(selfInfo.gid, nics_[nic].localGid.raw, sizeof(selfInfo.gid));
     selfInfo.gidIndex = gidIndex_;
     selfInfo.mtu = localMtu_;
     ibverbx::ibv_port_attr portAttr{};
     auto& symbols = ibverbx::ibvSymbols;
-    if (symbols.ibv_internal_query_port(
-            nicDevices_[nic].ibvCtx, 1, &portAttr) == 0) {
+    if (symbols.ibv_internal_query_port(nics_[nic].ibvCtx, 1, &portAttr) == 0) {
       selfInfo.lid = portAttr.lid;
     }
 
@@ -844,12 +826,12 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
     auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
     nicSpec.qps.resize(numQps);
     nicSpec.companionQps.resize(numQps);
-    nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDevices_[n].sinkMr->lkey));
+    nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDoca_[n].sinkMr->lkey));
     nicSpec.deviceId = n;
   }
 
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].qpGroups;
     auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
     for (int q = 0; q < numQps; q++) {
       const int qpIdx = peerIndex * numQps + q;
@@ -882,16 +864,11 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     int nRanks,
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     const MultipeerIbgdaTransportConfig& config)
-    : myRank_(myRank),
-      nRanks_(nRanks),
-      bootstrap_(std::move(bootstrap)),
+    : MultiPeerIbTransport<MultipeerIbgdaTransport>(
+          myRank,
+          nRanks,
+          std::move(bootstrap)),
       config_(config) {
-  if (myRank < 0 || myRank >= nRanks) {
-    throw std::invalid_argument("Invalid rank");
-  }
-  if (nRanks < 2) {
-    throw std::invalid_argument("Need at least 2 ranks");
-  }
   if (config.numQpsPerPeerPerNic < 1 ||
       config.numQpsPerPeerPerNic > kMaxQpsPerPeerPerNic) {
     throw std::invalid_argument(
@@ -981,7 +958,7 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
       createQpGroups();
     } else {
       const int numPeers = nRanks - 1;
-      for (auto& nic : nicDevices_) {
+      for (auto& nic : nicDoca_) {
         nic.qpGroups.resize(
             static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
         nic.loopbackCompanionQps.resize(
@@ -1035,7 +1012,7 @@ void MultipeerIbgdaTransport::cleanup() {
   cleanup_send_recv_buffers();
 
   // Destroy per-NIC QP groups (main + companion) and loopback responders.
-  for (auto& nic : nicDevices_) {
+  for (auto& nic : nicDoca_) {
     for (auto* qpGroup : nic.qpGroups) {
       if (qpGroup != nullptr) {
         doca_gpu_verbs_destroy_qp_group_hl(qpGroup);
@@ -1090,15 +1067,15 @@ void MultipeerIbgdaTransport::cleanup() {
   }
   registeredBuffers_.clear();
 
-  // Destroy per-NIC sink MRs. Iterate over actual nicDevices_ entries
+  // Destroy per-NIC sink MRs. Iterate over actual nicDoca_ entries
   // (vector is empty if cleanup runs before openIbDevice; partial init leaves
   // unset fields as nullptr).
-  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
-    if (nicDevices_[n].sinkMr != nullptr) {
+  for (int n = 0; n < static_cast<int>(nicDoca_.size()); ++n) {
+    if (nicDoca_[n].sinkMr != nullptr) {
       if (symbols.ibv_internal_dereg_mr != nullptr) {
-        symbols.ibv_internal_dereg_mr(nicDevices_[n].sinkMr);
+        symbols.ibv_internal_dereg_mr(nicDoca_[n].sinkMr);
       }
-      nicDevices_[n].sinkMr = nullptr;
+      nicDoca_[n].sinkMr = nullptr;
     }
   }
 
@@ -1119,30 +1096,30 @@ void MultipeerIbgdaTransport::cleanup() {
   }
 
   // Destroy per-NIC AH attributes
-  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
-    if (nicDevices_[n].ahAttr != nullptr) {
-      doca_verbs_ah_attr_destroy(nicDevices_[n].ahAttr);
-      nicDevices_[n].ahAttr = nullptr;
+  for (int n = 0; n < static_cast<int>(nicDoca_.size()); ++n) {
+    if (nicDoca_[n].ahAttr != nullptr) {
+      doca_verbs_ah_attr_destroy(nicDoca_[n].ahAttr);
+      nicDoca_[n].ahAttr = nullptr;
     }
   }
 
-  // Destroy per-NIC PDs
-  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
-    if (nicDevices_[n].ibvPd != nullptr) {
+  // Destroy per-NIC PDs (bound on nics_, the vector indexed here)
+  for (int n = 0; n < static_cast<int>(nics_.size()); ++n) {
+    if (nics_[n].ibvPd != nullptr) {
       if (symbols.ibv_internal_dealloc_pd != nullptr) {
-        symbols.ibv_internal_dealloc_pd(nicDevices_[n].ibvPd);
+        symbols.ibv_internal_dealloc_pd(nics_[n].ibvPd);
       }
-      nicDevices_[n].ibvPd = nullptr;
+      nics_[n].ibvPd = nullptr;
     }
   }
 
-  // Close per-NIC devices
-  for (int n = 0; n < static_cast<int>(nicDevices_.size()); ++n) {
-    if (nicDevices_[n].ibvCtx != nullptr) {
+  // Close per-NIC devices (bound on nics_, the vector indexed here)
+  for (int n = 0; n < static_cast<int>(nics_.size()); ++n) {
+    if (nics_[n].ibvCtx != nullptr) {
       if (symbols.ibv_internal_close_device != nullptr) {
-        symbols.ibv_internal_close_device(nicDevices_[n].ibvCtx);
+        symbols.ibv_internal_close_device(nics_[n].ibvCtx);
       }
-      nicDevices_[n].ibvCtx = nullptr;
+      nics_[n].ibvCtx = nullptr;
     }
   }
 
@@ -1201,12 +1178,12 @@ void MultipeerIbgdaTransport::exchange() {
   for (int n = 0; n < numNics_; ++n) {
     memcpy(
         myInfo.nicInfo[n].gid,
-        nicDevices_[n].localGid.raw,
+        nics_[n].localGid.raw,
         sizeof(myInfo.nicInfo[n].gid));
     // Query NIC n's port for LID (IB only — RoCE leaves LID as 0).
     ibverbx::ibv_port_attr exchPortAttr{};
-    if (symbols.ibv_internal_query_port(
-            nicDevices_[n].ibvCtx, 1, &exchPortAttr) != 0) {
+    if (symbols.ibv_internal_query_port(nics_[n].ibvCtx, 1, &exchPortAttr) !=
+        0) {
       LOG(WARNING) << "Failed to query port for LID on NIC " << n;
     } else {
       myInfo.nicInfo[n].lid = exchPortAttr.lid;
@@ -1219,7 +1196,7 @@ void MultipeerIbgdaTransport::exchange() {
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
     const int peerRank = peerIndexToRank(peerIndex);
     for (int nic = 0; nic < numNics_; nic++) {
-      const auto& nicQps = nicDevices_[nic].qpGroups;
+      const auto& nicQps = nicDoca_[nic].qpGroups;
       for (int q = 0; q < numQps; q++) {
         const int qpIdx = peerIndex * numQps + q;
         myInfo.nicInfo[nic].qpnForRank[peerRank][q] =
@@ -1297,7 +1274,7 @@ void MultipeerIbgdaTransport::exchange() {
         allInfo[peerIndexToRank(peerIndex)];
 
     for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDevices_[nic].qpGroups;
+      auto& nicQps = nicDoca_[nic].qpGroups;
       for (int q = 0; q < numQps; q++) {
         const int qpIdx = peerIndex * numQps + q;
         IbgdaTransportExchInfo qpPeerInfo;
@@ -1487,246 +1464,12 @@ P2pIbgdaTransportDevice* MultipeerIbgdaTransport::getP2pTransportDeviceSlot(
       peerIndex * peerTransportSize_);
 }
 
-int MultipeerIbgdaTransport::numPeers() const {
-  return nRanks_ - 1;
-}
-
-int MultipeerIbgdaTransport::myRank() const {
-  return myRank_;
-}
-
 int MultipeerIbgdaTransport::getGidIndex() const {
   return gidIndex_;
 }
 
 int MultipeerIbgdaTransport::numQpsPerPeerPerNic() const {
   return config_.numQpsPerPeerPerNic;
-}
-
-IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
-    void* ptr,
-    std::size_t size) {
-  if (ptr == nullptr || size == 0) {
-    throw std::invalid_argument("Invalid buffer pointer or size");
-  }
-
-  // Fast path: containment lookup — if [ptr, ptr+size) falls entirely
-  // within an existing registration, return the cached per-NIC lkeys
-  // without any CUDA driver call.
-  auto addr = reinterpret_cast<uintptr_t>(ptr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  if (it != registeredBuffers_.begin()) {
-    --it;
-    if (addr + size <= it->first + it->second.allocSize) {
-      it->second.refs++;
-      VLOG(1) << "MultipeerIbgdaTransport: cache hit for ptr=" << ptr
-              << " allocBase=0x" << std::hex << it->first << std::dec
-              << " refs=" << it->second.refs;
-      NetworkLKeys keys(numNics_);
-      for (int n = 0; n < numNics_; ++n) {
-        keys[n] = NetworkLKey(HostLKey(it->second.mrs[n]->lkey));
-      }
-      return IbgdaLocalBuffer(ptr, keys);
-    }
-  }
-
-  // Cache miss — find the GPU allocation base and register it on every
-  // NIC's PD. Each NIC gets an independent MR over the same physical
-  // memory; lkey/rkey differ per NIC.
-#ifdef __HIP_PLATFORM_AMD__
-  // On AMD: HIP doesn't expose an exact equivalent of
-  // `cuMemGetAddressRange` (which returns the original allocation
-  // base/size for a pointer in the middle of an allocation). For the
-  // common case where the caller passes the base pointer of an
-  // allocation, register exactly the requested range.
-  uintptr_t allocBase = reinterpret_cast<uintptr_t>(ptr);
-  size_t allocSize = size;
-#else
-  CUdeviceptr allocBase = 0;
-  size_t allocSize = 0;
-  CUresult cuRes =
-      pfn_cuMemGetAddressRange(&allocBase, &allocSize, (CUdeviceptr)ptr);
-  if (cuRes != CUDA_SUCCESS || allocBase == 0) {
-    throw std::runtime_error(
-        "registerBuffer: cuMemGetAddressRange failed for ptr");
-  }
-#endif
-  auto& symbols = ibverbx::ibvSymbols;
-  int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
-      ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
-      ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
-
-  CachedMr cached;
-  cached.allocSize = allocSize;
-  cached.refs = 1;
-
-  // Try DMABUF first per NIC, fall back to plain reg_mr per NIC. If any
-  // NIC's registration fails, deregister everything we already registered
-  // and propagate the error. Registration goes through the ibverbx symbol
-  // table so it shares the same libibverbs instance that owns the PD.
-  for (int n = 0; n < numNics_; ++n) {
-    ibverbx::ibv_mr* mr = nullptr;
-    auto dmabuf = export_gpu_dmabuf_aligned(
-        docaGpu_, reinterpret_cast<void*>(allocBase), allocSize);
-    if (dmabuf) {
-      if (symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
-        mr = symbols.ibv_internal_reg_dmabuf_mr(
-            nicDevices_[n].ibvPd,
-            dmabuf->alignment.dmabufOffset,
-            allocSize,
-            static_cast<uint64_t>(allocBase),
-            dmabuf->fd,
-            accessFlags);
-      }
-      close(dmabuf->fd);
-    }
-    if (!mr) {
-      errno = 0;
-      mr = symbols.ibv_internal_reg_mr(
-          nicDevices_[n].ibvPd,
-          reinterpret_cast<void*>(allocBase),
-          allocSize,
-          accessFlags);
-      if (!mr) {
-        const int savedErrno = errno;
-        // Roll back partial registration before throwing.
-        for (int j = 0; j < n; ++j) {
-          symbols.ibv_internal_dereg_mr(cached.mrs[j]);
-        }
-        throw std::runtime_error(
-            fmt::format(
-                "Failed to register buffer with RDMA on NIC {} "
-                "(allocBase=0x{:x} allocSize={} errno={} ({}))",
-                n,
-                allocBase,
-                allocSize,
-                savedErrno,
-                std::strerror(savedErrno)));
-      }
-    }
-    cached.mrs[n] = mr;
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: registered allocation allocBase=0x"
-          << std::hex << allocBase << std::dec << " allocSize=" << allocSize
-          << " across " << numNics_
-          << " NIC(s) (NIC0 lkey=" << cached.mrs[0]->lkey
-          << " rkey=" << cached.mrs[0]->rkey << ", requested ptr=" << ptr
-          << " size=" << size << ")";
-
-  registeredBuffers_.emplace(static_cast<uintptr_t>(allocBase), cached);
-
-  NetworkLKeys keys(numNics_);
-  for (int n = 0; n < numNics_; ++n) {
-    keys[n] = NetworkLKey(HostLKey(cached.mrs[n]->lkey));
-  }
-  return IbgdaLocalBuffer(ptr, keys);
-}
-
-void MultipeerIbgdaTransport::deregisterBuffer(void* ptr) {
-  // Containment lookup on the ordered map: find the allocation whose base
-  // address is <= ptr and whose range covers ptr.  This avoids calling
-  // cuMemGetAddressRange, which fails when CUDA has already freed the
-  // underlying memory (e.g. PyTorch caching allocator teardown).
-  auto addr = reinterpret_cast<uintptr_t>(ptr);
-  auto it = registeredBuffers_.upper_bound(addr);
-  if (it != registeredBuffers_.begin()) {
-    --it;
-    if (addr < it->first + it->second.allocSize) {
-      it->second.refs--;
-      VLOG(1) << "MultipeerIbgdaTransport: deregister ptr=" << ptr
-              << " allocBase=0x" << std::hex << it->first << std::dec
-              << " refs=" << it->second.refs;
-      if (it->second.refs <= 0) {
-        auto& symbols = ibverbx::ibvSymbols;
-        for (int n = 0; n < numNics_; ++n) {
-          symbols.ibv_internal_dereg_mr(it->second.mrs[n]);
-        }
-        registeredBuffers_.erase(it);
-      }
-      return;
-    }
-  }
-  LOG(WARNING) << "MultipeerIbgdaTransport: buffer not registered: " << ptr;
-}
-
-std::vector<IbgdaRemoteBuffer> MultipeerIbgdaTransport::exchangeBuffer(
-    const IbgdaLocalBuffer& localBuf) {
-  const int numPeers = nRanks_ - 1;
-
-  // Find the MR for this buffer via its GPU allocation base.
-#ifdef __HIP_PLATFORM_AMD__
-  // Use `hipMemGetAddressRange` (direct analog of NVIDIA's
-  // `cuMemGetAddressRange`) so a sub-buffer (`localBuf.ptr` pointing into
-  // the middle of an allocation) resolves to the same key the MR was
-  // registered under. NOTE: an earlier attempt used
-  // `hipPointerGetAttributes().devicePointer`, but that returns the queried
-  // pointer (or its host-mapped equivalent) — NOT the allocation base —
-  // so it didn't actually fix the sub-buffer bug.
-  hipDeviceptr_t basePtr = 0;
-  size_t allocRange = 0;
-  if (hipMemGetAddressRange(&basePtr, &allocRange, localBuf.ptr) !=
-          hipSuccess ||
-      basePtr == 0) {
-    throw std::runtime_error(
-        "exchangeBuffer: hipMemGetAddressRange failed for ptr");
-  }
-  uintptr_t allocBase = reinterpret_cast<uintptr_t>(basePtr);
-#else
-  CUdeviceptr allocBase = 0;
-  size_t allocSize = 0;
-  CUresult cuRes = pfn_cuMemGetAddressRange(
-      &allocBase, &allocSize, (CUdeviceptr)localBuf.ptr);
-  if (cuRes != CUDA_SUCCESS || allocBase == 0) {
-    throw std::runtime_error(
-        "exchangeBuffer: cuMemGetAddressRange failed for ptr");
-  }
-#endif
-  auto it = registeredBuffers_.find(static_cast<uintptr_t>(allocBase));
-  if (it == registeredBuffers_.end()) {
-    throw std::runtime_error(
-        "Buffer not registered - call registerBuffer() first");
-  }
-
-  // Allocate buffer for allGather: one entry per rank.
-  std::vector<IbgdaBufferExchInfo> allInfo(nRanks_);
-
-  // Write my info at my rank's slot — populate per-NIC rkeys (each PD
-  // gave us its own MR for the same physical buffer).
-  allInfo[myRank_].addr = reinterpret_cast<uint64_t>(localBuf.ptr);
-  allInfo[myRank_].numNics = numNics_;
-  for (int n = 0; n < numNics_; ++n) {
-    allInfo[myRank_].rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
-  }
-
-  // Use allGather to exchange buffer info with all ranks
-  auto result =
-      bootstrap_
-          ->allGather(
-              allInfo.data(), sizeof(IbgdaBufferExchInfo), myRank_, nRanks_)
-          .get();
-  if (result != 0) {
-    throw std::runtime_error(
-        "MultipeerIbgdaTransport::exchangeBuffer allGather failed");
-  }
-
-  // Convert to IbgdaRemoteBuffer vector, extracting peer entries
-  // peerIndex maps to ranks: 0..myRank_-1 -> ranks 0..myRank_-1
-  //                          myRank_..numPeers-1 -> ranks
-  //                          myRank_+1..nRanks_-1
-  std::vector<IbgdaRemoteBuffer> peerBuffers(numPeers);
-  for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-    int peerRank = peerIndexToRank(peerIndex);
-    peerBuffers[peerIndex] = allInfo[peerRank].toRemoteBuffer();
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: exchanged buffer info with " << numPeers
-          << " peers";
-
-  return peerBuffers;
-}
-int MultipeerIbgdaTransport::nRanks() const {
-  return nRanks_;
 }
 
 // =============================================================================
@@ -1903,14 +1646,13 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
   for (int n = 0; n < numNics_; ++n) {
     memcpy(
         payload.nicInfo[n].gid,
-        nicDevices_[n].localGid.raw,
+        nics_[n].localGid.raw,
         sizeof(payload.nicInfo[n].gid));
     ibverbx::ibv_port_attr portAttr{};
-    if (symbols.ibv_internal_query_port(nicDevices_[n].ibvCtx, 1, &portAttr) ==
-        0) {
+    if (symbols.ibv_internal_query_port(nics_[n].ibvCtx, 1, &portAttr) == 0) {
       payload.nicInfo[n].lid = portAttr.lid;
     }
-    auto& nicQps = nicDevices_[n].qpGroups;
+    auto& nicQps = nicDoca_[n].qpGroups;
     for (int q = 0; q < numQps; q++) {
       const int qpIdx = peerIndex * numQps + q;
       payload.nicInfo[n].qpns[q] =
@@ -2071,7 +1813,7 @@ void MultipeerIbgdaTransport::connectPeerMainQps(
     const PeerQpPayload& remotePayload) {
   const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDevices_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].qpGroups;
     for (int q = 0; q < numQps; q++) {
       const int qpIdx = peerIndex * numQps + q;
       IbgdaTransportExchInfo peerInfo;
@@ -2102,8 +1844,8 @@ void MultipeerIbgdaTransport::applyRemoteViews(
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
   const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDevices_[nic].qpGroups;
-    auto& nicLoopback = nicDevices_[nic].loopbackCompanionQps;
+    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
     for (int q = 0; q < numQps; q++) {
       const int qpIdx = peerIndex * numQps + q;
       if (nicQps[qpIdx] != nullptr) {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -24,6 +24,7 @@
 #endif
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/transport/MultiPeerIbTransport.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/utils/CudaRAII.h"
@@ -189,73 +190,12 @@ struct MultipeerIbgdaTransportConfig {
   uint32_t materializePeerTimeoutMs{30000};
 };
 
-/**
- * Transport connection information for RDMA QP setup.
- *
- * This struct is exchanged ONCE during the bootstrap phase to establish
- * RDMA connectivity between peers. Contains immutable connection parameters
- * that define how to reach a peer's QP.
- */
-struct IbgdaTransportExchInfo {
-  // Queue Pair Number for RDMA connection
-  uint32_t qpn{0};
-
-  // Global Identifier for RoCE routing (16 bytes)
-  uint8_t gid[16]{};
-
-  // GID index used
-  int gidIndex{0};
-
-  // Local Identifier (for IB, not used in RoCE)
-  uint16_t lid{0};
-
-  // Port active MTU. Used to negotiate path MTU: min(local, remote).
-  ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
-};
-
-/**
- * Maximum number of ranks supported for allGather-based exchange.
- * This limit exists because we use fixed-size arrays for QPN exchange.
- */
-constexpr int kMaxRanksForAllGather = 128;
-
-/**
- * Maximum number of QP sets per (peer, NIC) for multi-QP support.
- */
-constexpr int kMaxQpsPerPeerPerNic = 128;
-
-/**
- * Transport exchange info for allGather-based exchange.
- *
- * Each rank contributes this structure containing per-NIC GID/LID and the
- * per-(target_rank, q) QPN this rank uses on that NIC.
- */
-struct IbgdaTransportExchInfoAll {
-  // Per-NIC public info shared with peers (wire format). nicInfo[n] holds
-  // this rank's NIC n's GID, LID, and the QPNs it uses to connect to each
-  // (target_rank, q). Indices [numNics .. kMaxNicsPerGpu) are zero-init and
-  // never read by peers (both ranks must agree on numNics — validated at
-  // exchange time).
-  struct NicWireInfo {
-    uint8_t gid[16]{};
-    uint16_t lid{0};
-    // QPN this rank uses on this NIC to connect to (target_rank, q).
-    // qpnForRank[myRank][*] is unused (set to 0).
-    uint32_t qpnForRank[kMaxRanksForAllGather][kMaxQpsPerPeerPerNic]{};
-  };
-  NicWireInfo nicInfo[kMaxNicsPerGpu]{};
-
-  // Common (shared across NICs on this rank).
-  int gidIndex{0};
-  ibverbx::ibv_mtu mtu{ibverbx::IBV_MTU_4096};
-
-  // Number of NICs (rails) used by this rank.
-  // Must match across all ranks (validated at exchange time).
-  int numNics{1};
-
-  // Number of QPs per (peer, NIC) used by this rank.
-  int numQpsPerPeerPerNic{1};
-};
+// The exchange wire structs and allGather caps (kMaxRanksForAllGather,
+// kMaxQpsPerPeerPerNic) now live in MultiPeerIbTransport.h so they are shared
+// across IB backends. Keep the historical IBGDA names as aliases so callers and
+// the .cc are unchanged.
+using IbgdaTransportExchInfo = IbTransportExchInfo;
+using IbgdaTransportExchInfoAll = IbTransportExchInfoAll;
 
 /**
  * MultipeerIbgdaTransport - Host-side multi-peer RDMA transport manager
@@ -316,7 +256,8 @@ struct IbgdaTransportExchInfoAll {
  * - exchange(): COLLECTIVE operation (all ranks must call)
  * - getDeviceTransportPtr(): Local operation (after exchange completes)
  */
-class MultipeerIbgdaTransport {
+class MultipeerIbgdaTransport
+    : public MultiPeerIbTransport<MultipeerIbgdaTransport> {
  public:
   /**
    * Constructor - Initialize multi-peer IBGDA transport
@@ -445,57 +386,12 @@ class MultipeerIbgdaTransport {
    */
   P2pIbgdaTransportDevice* getP2pTransportDeviceSlot(int peerRank) const;
 
-  /**
-   * Get number of peers (nRanks - 1)
-   */
-  int numPeers() const;
+  // numPeers()/myRank()/nRanks() are inherited from MultiPeerIbTransport.
 
-  /**
-   * Get this rank's ID
-   */
-  int myRank() const;
-
-  /**
-   * Get total number of ranks
-   */
-  int nRanks() const;
-
-  /**
-   * registerBuffer - Register a user-provided buffer for RDMA access
-   *
-   * Registers the specified GPU memory buffer with the RDMA device, making it
-   * accessible for RDMA operations. The buffer must remain valid until
-   * deregisterBuffer() is called or the transport is destroyed.
-   *
-   * @param ptr Pointer to GPU memory (must be cudaMalloc'd or similar)
-   * @param size Size of the buffer in bytes
-   * @return IbgdaLocalBuffer with valid lkey for local RDMA operations
-   * @throws std::runtime_error if registration fails
-   */
-  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size);
-
-  /**
-   * deregisterBuffer - Deregister a previously registered buffer
-   *
-   * Releases the RDMA memory registration for the specified buffer.
-   * The buffer pointer must match a previously registered buffer.
-   *
-   * @param ptr Pointer to the buffer to deregister
-   */
-  void deregisterBuffer(void* ptr);
-
-  /**
-   * exchangeBuffer - Collectively exchange buffer info with all peers
-   *
-   * COLLECTIVE OPERATION: All ranks MUST call this with their local buffer.
-   * Returns remote buffer info for all peers, indexed by peer rank.
-   *
-   * @param localBuf Local buffer that was registered with registerBuffer()
-   * @return Vector of remote buffers, one per peer (size = nRanks - 1)
-   *         Index i corresponds to peerIndexToRank(i)
-   */
-  std::vector<IbgdaRemoteBuffer> exchangeBuffer(
-      const IbgdaLocalBuffer& localBuf);
+  // registerBuffer()/deregisterBuffer()/exchangeBuffer() are inherited from
+  // MultiPeerIbTransport (the refcounted MR registry lives in the base; the
+  // backend supplies the register_mr_on_nics()/lookup_alloc_base()/
+  // deregister_mr() hooks below).
 
   /**
    * Get the number of QP sets per (peer, NIC).
@@ -503,14 +399,7 @@ class MultipeerIbgdaTransport {
    */
   int numQpsPerPeerPerNic() const;
 
-  /**
-   * Get the number of NICs (rails) actually in use after auto-detection.
-   * Resolved at construction time from `gpuNicMap` or topology discovery;
-   * see ctor doc for the resolution rules.
-   */
-  int numNics() const {
-    return numNics_;
-  }
+  // numNics() is inherited from MultiPeerIbTransport.
 
   /**
    * Get the GID index being used
@@ -535,8 +424,8 @@ class MultipeerIbgdaTransport {
       doca_gpu_verbs_qp_hl* qpHl,
       const IbgdaTransportExchInfo& peerInfo,
       int nic);
-  int rankToPeerIndex(int rank) const;
-  int peerIndexToRank(int peerIndex) const;
+  // rankToPeerIndex()/peerIndexToRank() are inherited from
+  // MultiPeerIbTransport.
 
   // Per-peer helpers shared by eager exchange() and lazy materializePeer()
   void createPeerQps(int peerIndex);
@@ -555,12 +444,12 @@ class MultipeerIbgdaTransport {
   void applyRemoteViews(int peerIndex, const PeerBufferPayload& remotePayload);
   void cleanupPeerOnFailure(int peerIndex);
 
-  // Rank information
-  const int myRank_{-1};
-  const int nRanks_{0};
+  // The MR registry (register/deregister/exchangeBuffer + the cache) lives
+  // entirely in MultiPeerIbTransport; it registers on the base-owned
+  // nics_[*].ibvPd, which openIbDevice() fills.
 
-  // Bootstrap for collective operations
-  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  // myRank_/nRanks_/bootstrap_ are inherited (protected) from
+  // MultiPeerIbTransport.
 
   // Configuration
   MultipeerIbgdaTransportConfig config_;
@@ -568,23 +457,21 @@ class MultipeerIbgdaTransport {
   // DOCA GPU context (shared across NICs).
   doca_gpu* docaGpu_{nullptr};
 
-  // Number of NICs (rails) actually in use. <= kMaxNicsPerGpu.
+  // numNics_ is inherited (protected) from MultiPeerIbTransport;
   // nicDevices_.size() == numNics_ after openIbDevice().
-  int numNics_{1};
 
   // Per-NIC host-side IB verbs resources. qpGroups and loopbackCompanionQps
   // are indexed [peer * numQpsPerPeerPerNic + q].
-  struct NicHostIbgdaResources {
-    std::string deviceName;
-    ibverbx::ibv_context* ibvCtx{nullptr};
-    ibverbx::ibv_pd* ibvPd{nullptr};
+  // Backend-specific (DOCA) per-NIC state. The generic per-NIC resources
+  // (device name, context, PD, GID) live in MultiPeerIbTransport::nics_,
+  // index-aligned with this vector; openIbDevice() fills both.
+  struct NicDocaResources {
     doca_verbs_ah_attr* ahAttr{nullptr};
-    ibverbx::ibv_gid localGid{};
     ibverbx::ibv_mr* sinkMr{nullptr};
     std::vector<doca_gpu_verbs_qp_group_hl*> qpGroups;
     std::vector<doca_gpu_verbs_qp_hl*> loopbackCompanionQps;
   };
-  std::vector<NicHostIbgdaResources> nicDevices_;
+  std::vector<NicDocaResources> nicDoca_;
 
   // Sink buffer for RDMA atomic return values (discarded).
   // DOCA's OPCODE_ATOMIC_FA requires a local address for the fetch-add
@@ -596,22 +483,8 @@ class MultipeerIbgdaTransport {
   std::size_t sinkBufferAllocSize_{0};
   std::uint64_t sinkBufferHandle_{0};
 
-  // Cached MR entry: one MR per (CUDA allocation, NIC), refcounted.
-  // Multiple user buffers within the same cudaMalloc allocation share one
-  // MR per NIC; the MR set covers all NICs for the same physical buffer.
-  struct CachedMr {
-    std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs{};
-    size_t allocSize{0};
-    int refs{0};
-  };
-
-  // Maps CUDA allocation base address -> cached MR covering the full
-  // allocation. Keyed by allocBase from cuMemGetAddressRange, not by user
-  // pointer. Ordered map enables O(log n) containment lookup via
-  // upper_bound — used by deregisterBuffer to find the owning allocation
-  // without calling cuMemGetAddressRange (which fails if CUDA already freed
-  // the memory).
-  std::map<uintptr_t, CachedMr> registeredBuffers_;
+  // The refcounted MR cache (CachedMr + registeredBuffers_) lives in
+  // MultiPeerIbTransport.
 
   // GPU PCIe bus ID.
   std::string gpuPciBusId_;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1888,6 +1888,15 @@ cvars:
      to be NVL-connected. All data movement and sync operations go over
      NVLink. Requires that all ranks are in the same NVL domain.
 
+ - name        : NCCL_CTRAN_PIPES_IB_MODE
+   type        : enum
+   default     : ibgda
+   choices     : ibgda, ibrc
+   description : |-
+     Select the IB backend used by Pipes MultiPeerTransport for non-NVL peers.
+     ibgda - use GPU-posted IBGDA.
+     ibrc - use CPU-posted IBRC.
+
  - name        : NCCL_CTRAN_IBGDA_QP_DEPTH
    type        : uint64_t
    default     : 1024


### PR DESCRIPTION
Summary:

Add `MultiPeerIbTransport<Backend>`, a CRTP base that owns the backend-agnostic host control plane so a future IBRC backend can reuse it: rank state, rank<->peerIndex mapping, the generic per-NIC resources (`NicResources`: device name, context, PD, GID), and the full refcounted MR registry (`registerBuffer`/`deregisterBuffer`/`exchangeBuffer`). `MultipeerIbgdaTransport` now derives from the base and keeps only its DOCA-specific per-NIC state (`NicDocaResources`: AH attrs, sink MR, QP groups, loopback companion QPs), the DOCA context, QP setup, and the device-transport/exchange logic.

MR registration is fully generic with no backend hook: the base owns the per-NIC PDs (filled by `MultipeerIbgdaTransport::openIbDevice`) and registers MRs on them. To drop the last DOCA dependency from registration, the GPU DMABUF export (`export_gpu_dmabuf_aligned`) is now DOCA-free -- it calls `cuMemGetHandleForAddressRange` (newly wired into `CudaDriverLazy`) directly instead of `doca_gpu_dmabuf_fd`, which is a thin wrapper over the same driver call; the `doca_gpu*`/`pipes_gda_gpu*` parameter is dropped on both NVIDIA and AMD.

Behavior change: on NVIDIA, MR registration exports the DMABUF fd via `cuMemGetHandleForAddressRange` rather than `doca_gpu_dmabuf_fd`. These are equivalent (DOCA wraps the same call) but it is on the RDMA registration path, so it must pass the MAST device-API matrix before land.

Reviewed By: snarayankh

Differential Revision: D107447516


