### PR TITLE
GpuMemHandler kCudaIpcUncached IPC alloc mode

### DIFF
--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -6,9 +6,11 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <cstdlib>
 #include <iomanip>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #ifdef __HIP_PLATFORM_AMD__
@@ -38,6 +40,19 @@ constexpr int kIbgdaBatchIters = 450;
 #else
 constexpr int kIbgdaBatchIters = 1000;
 #endif
+
+// NIC selection for the benchmark transport. Returns an NCCL_IB_HCA-style
+// filter string (e.g. "mlx5_0") read from the NCCL_IB_HCA env var, or ""
+// for PCIe-topology auto-discovery. Hosts with multiple NIC vendors (e.g.
+// a host exposing both bnxt and mlx5) need this to pin the
+// benchmark to the NIC matching the compiled backend; single-vendor hosts
+// leave it unset and keep the auto-discovery default. When the env var is
+// unset the behavior is identical to before (so the NVIDIA path, which
+// never sets it here, is unchanged).
+inline std::string benchIbHca() {
+  const char* hca = std::getenv("NCCL_IB_HCA");
+  return hca ? std::string(hca) : std::string();
+}
 
 // CUDA error checking macro for void functions
 #define CUDA_CHECK_VOID(call)        \
@@ -345,6 +360,7 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitLocal) {
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(
@@ -463,6 +479,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitLocal) {
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(
@@ -583,6 +600,7 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(
@@ -693,6 +711,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(
@@ -836,6 +855,7 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
     MultipeerIbgdaTransport transport(

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -278,6 +278,14 @@ void GpuMemHandler::exchangeMemPtrs() {
   exchanged_ = true;
 }
 
+const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
+  if (mode_ == MemSharingMode::kFabric) {
+    throw std::runtime_error(
+        "GpuMemHandler::getLocalIpcHandle: not available in kFabric mode");
+  }
+  return cudaIpcLocalHandle_;
+}
+
 // ============================================================================
 // Fabric Mode Implementation
 // ============================================================================
@@ -508,7 +516,18 @@ void GpuMemHandler::cleanupFabric() {
 // ============================================================================
 
 void GpuMemHandler::allocateCudaIpcMemory(size_t size) {
-  checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
+  if (mode_ == MemSharingMode::kCudaIpcUncached) {
+    // GPU-uncached alloc on AMD; see MemSharingMode::kCudaIpcUncached.
+#ifdef __HIP_PLATFORM_AMD__
+    checkCudaError(
+        hipExtMallocWithFlags(&cudaIpcLocalPtr_, size, hipDeviceMallocUncached),
+        "hipExtMallocWithFlags(hipDeviceMallocUncached) failed");
+#else
+    checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
+#endif
+  } else {
+    checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
+  }
   allocatedSize_ = size;
 
   // Get IPC handle for local memory

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -45,6 +45,12 @@ enum class MemSharingMode {
   // Works on: All CUDA GPUs
   // Limitation: Intra-node only
   kCudaIpc,
+
+  // Like kCudaIpc, but on AMD the buffer is allocated GPU-uncached / HSA
+  // fine-grained (hipExtMallocWithFlags + hipDeviceMallocUncached) so BNXT NICs
+  // can DMA into it via dma-buf (see transport/amd/docs/design.md). On NVIDIA
+  // it falls back to cudaMalloc; the IPC contract is identical.
+  kCudaIpcUncached,
 };
 
 /**
@@ -160,6 +166,14 @@ class GpuMemHandler {
    * @throws std::runtime_error if exchange hasn't happened yet
    */
   void* getPeerDeviceMemPtr(int32_t rank) const;
+
+  /**
+   * Get the local IPC handle (cudaIpc / hipIpc). Only valid in `kCudaIpc` /
+   * `kCudaIpcUncached` mode.
+   *
+   * @throws std::runtime_error when mode is `kFabric`.
+   */
+  const cudaIpcMemHandle_t& getLocalIpcHandle() const;
 
   /**
    * Get the actual allocated size (may be larger than requested due to

--- a/comms/prims/platform/IbverbsLazy.cc
+++ b/comms/prims/platform/IbverbsLazy.cc
@@ -35,8 +35,15 @@ void do_load_ibverbs() {
     return;
   }
 
+  // Try the versioned symbol first (preferred — pins to the ABI we built
+  // against), fall back to the unversioned symbol (older system
+  // libibverbs.so.1 on production hosts may not export the versioned tag).
   gIbvRegMrIova2 = reinterpret_cast<IbvRegMrIova2Fn>(
       dlvsym(handle, "ibv_reg_mr_iova2", "IBVERBS_1.8"));
+  if (!gIbvRegMrIova2) {
+    gIbvRegMrIova2 =
+        reinterpret_cast<IbvRegMrIova2Fn>(dlsym(handle, "ibv_reg_mr_iova2"));
+  }
   if (!gIbvRegMrIova2) {
     LOG(WARNING) << "IbverbsLazy: ibv_reg_mr_iova2 not available: "
                  << dlerror();
@@ -44,6 +51,10 @@ void do_load_ibverbs() {
 
   gIbvRegDmabufMr = reinterpret_cast<IbvRegDmabufMrFn>(
       dlvsym(handle, "ibv_reg_dmabuf_mr", "IBVERBS_1.12"));
+  if (!gIbvRegDmabufMr) {
+    gIbvRegDmabufMr =
+        reinterpret_cast<IbvRegDmabufMrFn>(dlsym(handle, "ibv_reg_dmabuf_mr"));
+  }
   if (!gIbvRegDmabufMr) {
     LOG(WARNING) << "IbverbsLazy: ibv_reg_dmabuf_mr not available: "
                  << dlerror();

--- a/comms/prims/transport/amd/nic/Mlx5NicBackend.h
+++ b/comms/prims/transport/amd/nic/Mlx5NicBackend.h
@@ -96,20 +96,26 @@ struct Mlx5NicBackend {
     amd_atomic_max_device(&qp->sq_ready_index, lastIdx + 1);
   }
 
+  // Ring the doorbell: publish the producer index to the DBR, then copy the
+  // last WQE's ctrl segment to the BlueFlame register. The DBR store uses
+  // RELEASE + system scope so the NIC observes the new producer index before
+  // the BlueFlame write (a plain volatile store was observed to stall the NIC
+  // for hundreds of us at small message sizes).
   __device__ void ringDoorbell(
       pipes_gda_gpu_dev_verbs_qp* qp,
       uint64_t nextWqeIdx) {
     uint32_t pi =
         static_cast<uint32_t>(nextWqeIdx) & PIPES_GDA_VERBS_WQE_PI_MASK;
 
-    *reinterpret_cast<volatile uint32_t*>(
-        qp->sq_dbrec + PIPES_GDA_IB_MLX5_SND_DBR) = amd_bswap32(pi);
-    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+    __hip_atomic_store(
+        reinterpret_cast<uint32_t*>(qp->sq_dbrec + PIPES_GDA_IB_MLX5_SND_DBR),
+        amd_bswap32(pi),
+        __ATOMIC_RELEASE,
+        __HIP_MEMORY_SCOPE_SYSTEM);
 
     uint64_t lastWqeIdx = nextWqeIdx - 1;
     pipes_gda_gpu_dev_verbs_wqe* lastWqe = getWqePtr(qp, lastWqeIdx);
     uint64_t dbVal = *reinterpret_cast<volatile uint64_t*>(lastWqe);
-
     amd_store_doorbell_sys_u64(qp->sq_db, dbVal);
 
     uint64_t dbAddr = __hip_atomic_load(

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
@@ -7,7 +7,7 @@
 // AMD-native host APIs that mirror the DOCA host surface
 // (`doca_gpu_*`, `doca_verbs_*`, `doca_gpu_verbs_*`) used by
 // `comms/prims/MultipeerIbgdaTransport.{h,cc}`. Implementations call
-// HSA + raw `mlx5dv_devx_*` + libibverbs directly.
+// HSA + libibverbs directly.
 //
 // Call-site translation `doca_* -> pipes_gda::pipes_gda_*` lives in
 // `comms/prims/transport/amd/DocaCompat.h` so cross-platform call sites stay
@@ -137,7 +137,8 @@ enum pipes_gda_verbs_qp_attr_mask {
 // pipes_gda_gpu_verbs_* - GPU-side QP / CQ creation
 // ===========================================================================
 //
-// Manual orchestration via raw `mlx5dv_devx_*` + `hsa_amd_memory_lock`.
+// Manual orchestration via `ibv_create_qp` + `mlx5dv_init_obj` +
+// `hsa_amd_memory_lock`.
 
 struct pipes_gda_gpu_verbs_qp_init_attr_hl {
   pipes_gda_gpu* gpu_dev{nullptr};

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
@@ -88,7 +88,7 @@
 
 namespace pipes_gda {
 
-#ifdef NIC_BNXT
+#if defined(__HIP_PLATFORM_AMD__)
 namespace {
 // File-local helper: spin on the non-blocking `pollOneCqAt` until the
 // CQE arrives, then trap on NIC error. Intentionally does NOT advance
@@ -96,9 +96,15 @@ namespace {
 // locally because ringing the CQ doorbell on the BNXT counter-only
 // paths flushes the QP into LOC_QP_OP error state (see callers).
 //
-// Not exposed in the `pipes_gda_*` API surface: this is a BNXT
-// CQE-drain idiom with no DOCA equivalent, kept internal to preserve
-// the 1:1 mirror with NVIDIA's `doca_gpu_dev_verbs_*` names.
+// Used by both the BNXT chunked-put paths (`#ifdef NIC_BNXT`) and the
+// AMD counter/signal fast paths (`#if defined(__HIP_PLATFORM_AMD__)`),
+// so it must be visible for every AMD build (bnxt AND mlx5), not just
+// NIC_BNXT. NVIDIA never compiles this file (it uses the real DOCA
+// `doca_gpu_dev_verbs_*` headers), so this is AMD-only.
+//
+// Not exposed in the `pipes_gda_*` API surface: this is a CQE-drain
+// idiom with no DOCA equivalent, kept internal to preserve the 1:1
+// mirror with NVIDIA's `doca_gpu_dev_verbs_*` names.
 template <typename NicBackend>
 __device__ __forceinline__ void spin_poll_or_trap(
     NicBackend& nic,
@@ -294,6 +300,8 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put(
   uint64_t lastIdx = baseIdx + numChunks - 1;
 #ifdef NIC_MLX5
   // Mlx5: batched doorbell — single ring after all chunks prepared.
+  // Uses fast submit with ctrl segment captured on GPU stack (avoids
+  // PCIe round-trip re-read from SQ buffer).
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, qp, baseIdx, lastIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, qp, lastIdx + 1);
 #endif
@@ -627,14 +635,17 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_put_signal_counter(
   pipes_gda_gpu_dev_verbs_submit(nic, mainQp, lastIdx + 1);
 #endif
 
-#ifdef NIC_BNXT
-  // BNXT has no inter-QP wait WQE primitive, so we can't gate a companion
-  // QP's atomic on the main QP's CQ. Use a single QP for everything:
-  // spin-poll the main QP's CQ on the monotonic con_indx, then
-  // GPU-atomic-increment the local counter directly. ncqe=1 + phase
-  // compression means the NIC overwrites the single CQE slot per WQE
-  // completion; ringing the CQ doorbell here causes the NIC to flush the
-  // QP into error state (status=LOC_QP_OP), so just track cqe_ci locally.
+#if defined(__HIP_PLATFORM_AMD__)
+  // AMD: spin-poll main QP CQ + GPU atomic instead of companion-QP/WAIT.
+  // BNXT: no inter-QP wait WQE primitive (must use this path).
+  // mlx5+AMD: WAIT WQE / companion-QP loopback observed not to advance
+  // cross-host on the available MI300X test hardware — matches the legacy
+  // AMD `wait_local(work)` direct main-QP CQ-poll pattern, which was the
+  // validated cross-host surface.
+  // (BNXT-specific note: ncqe=1 + phase compression means the NIC
+  // overwrites the single CQE slot per WQE completion; ringing the CQ
+  // doorbell here would cause the NIC to flush the QP into LOC_QP_OP,
+  // so just track cqe_ci locally.)
   spin_poll_or_trap(nic, &mainQp->cq_sq, lastIdx);
   mainQp->cq_sq.cqe_ci = lastIdx + 1;
   __atomic_fetch_add(
@@ -697,17 +708,20 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
     pipes_gda_gpu_dev_verbs_addr counterRemoteAddr,
     pipes_gda_gpu_dev_verbs_addr counterSinkAddr,
     uint64_t counterVal) {
-#ifdef NIC_BNXT
-  // BNXT counter-only fast path: when sigVal == 0 (P2pIbgdaTransportDevice
+#if defined(__HIP_PLATFORM_AMD__)
+  // AMD counter-only fast path: when sigVal == 0 (P2pIbgdaTransportDevice
   // routes counter-only puts through signal_counter with sigVal=0 against
   // a discardSignalSlot — atomic FA on the slot is purely there to give
-  // mlx5's companion-QP something to wait on; on BNXT we don't need it),
-  // skip posting the slow atomic-FA WQE entirely. The prior put_cooperative
-  // WRITE was posted with CQ_UPDATE, so a CQE is on its way for that
-  // completion. Spin-poll until we observe the new CQE (con_indx >
-  // current cqe_ci) and bump the local counter via GPU atomic. Drops
-  // per-iter latency from ~700us (BNXT atomic-FA RTT) to ~10us (RDMA-WRITE
-  // RTT).
+  // NVIDIA mlx5's companion-QP something to wait on; on AMD we don't need
+  // it), skip posting the slow atomic-FA WQE entirely. The prior put's
+  // WRITE was posted with CQ_UPDATE, so a CQE is on its way. Spin-poll
+  // until we observe the new CQE and bump the local counter via GPU atomic.
+  //
+  // Required on AMD across both BNXT (no inter-QP wait WQE primitive) and
+  // mlx5 (WAIT WQE / companion-QP loopback path observed to never advance
+  // cross-host on the available MI300X test hardware) — matches the legacy
+  // `wait_local(work)` direct main-QP CQ-poll pattern, which was the
+  // validated cross-host surface.
   if (sigVal == 0) {
     // Wait for the last reserved WQE (the prior put() may have chunked
     // into multiple WRITE WQEs when size > PIPES_GDA_VERBS_MAX_TRANSFER_SIZE).
@@ -746,11 +760,13 @@ __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_signal_counter(
   pipes_gda_gpu_dev_verbs_mark_wqes_ready(nic, mainQp, sigIdx, sigIdx);
   pipes_gda_gpu_dev_verbs_submit(nic, mainQp, sigIdx + 1);
 
-#ifdef NIC_BNXT
-  // BNXT: signal-with-real-target path. Spin-poll on mainQp's CQ
-  // con_indx, advance cqe_ci locally, then GPU-atomic-increment the local
-  // counter. Don't ring the CQ doorbell — for ncqe=1 it triggers a NIC
-  // flush into LOC_QP_OP.
+#if defined(__HIP_PLATFORM_AMD__)
+  // AMD: signal-with-real-target path. Spin-poll on mainQp's CQ con_indx,
+  // advance cqe_ci locally, then GPU-atomic-increment the local counter.
+  // Same rationale as the sigVal==0 fast path above — companion-QP/WAIT
+  // path is broken on AMD across BNXT and mlx5 cross-host. (BNXT-specific
+  // note: don't ring the CQ doorbell — for ncqe=1 it triggers a NIC flush
+  // into LOC_QP_OP.)
   spin_poll_or_trap(nic, &mainQp->cq_sq, sigIdx);
   mainQp->cq_sq.cqe_ci = sigIdx + 1;
   __atomic_fetch_add(

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -539,26 +539,24 @@ void MultipeerIbgdaTransport::registerMemory() {
   int accessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
       IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
 
-  // Register sink buffer as a zero-based MR (iova=0) on each NIC's PD.
-  //
-  // The sink buffer receives the discarded return value from RDMA atomic
-  // fetch-add operations. Device code uses sinkAddr.addr=0 with the sink
-  // lkey, so the MR must be zero-based: addr=0 maps to offset 0 within the
-  // MR (i.e., the actual sinkBuffer_ GPU address).
-  //
-  // With a standard ibv_reg_mr(), the IOVA equals the virtual address, so
-  // addr=0 would be outside the MR's valid range → NIC local protection
-  // error → QP error state → hang.
-  //
-  // ibv_reg_mr_iova2(pd, addr, length, iova=0, access) creates a zero-based
-  // MR where IOVA range [0, length) maps to [addr, addr+length). Matches
-  // GIN's gdakiRegMr() pattern (gin_host_gdaki.cc).
-  //
-  // Multi-NIC: the same physical sink buffer is registered once per PD
-  // (one MR per NIC). DMABUF export is shared across NICs (same fd
-  // re-imported per PD); on first dmabuf failure we fall back to plain
-  // ibv_reg_mr_iova2 across the remaining NICs to keep behavior consistent.
+  // Register the sink buffer (which receives discarded RDMA atomic fetch-add
+  // return values) as a zero-based MR (iova=0) on each NIC's PD. Device code
+  // addresses it as sinkAddr.addr=0, so the MR must be zero-based: a standard
+  // ibv_reg_mr() has IOVA==virtual address, so addr=0 would be out of range →
+  // NIC local protection error → QP error → hang. ibv_reg_mr_iova2(pd, addr,
+  // length, iova=0, access) maps IOVA [0, length) onto [addr, addr+length).
+  // One MR per NIC.
   for (int n = 0; n < numNics_; ++n) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(NIC_MLX5)
+    // AMD+mlx5: register directly against the PD's libibverbs, the same policy
+    // registerBuffer() uses to avoid the lazy/dlopen'd libibverbs on AMD+mlx5
+    // (a separate instance from the PD's). The sink is host-pinned, so unlike
+    // the data path there is no GPU dmabuf to export — hence direct
+    // ibv_reg_mr_iova2 here vs direct ibv_reg_dmabuf_mr in registerBuffer.
+    nicDevices_[n].sinkMr = ibv_reg_mr_iova2(
+        nicDevices_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
+#else
+    // NVIDIA / AMD+BNXT: DMABUF export (zero-based) with a lazy iova2 fallback.
     auto sinkDmabuf =
         export_gpu_dmabuf_aligned(docaGpu_, sinkBuffer_, sinkBufferSize_);
     if (sinkDmabuf) {
@@ -574,11 +572,11 @@ void MultipeerIbgdaTransport::registerMemory() {
     if (!nicDevices_[n].sinkMr) {
       nicDevices_[n].sinkMr = lazy_ibv_reg_mr_iova2(
           nicDevices_[n].ibvPd, sinkBuffer_, sinkBufferSize_, 0, accessFlags);
-      if (!nicDevices_[n].sinkMr) {
-        throw std::runtime_error(
-            "Failed to register sink memory region on NIC " +
-            std::to_string(n));
-      }
+    }
+#endif
+    if (!nicDevices_[n].sinkMr) {
+      throw std::runtime_error(
+          "Failed to register sink memory region on NIC " + std::to_string(n));
     }
 
     VLOG(1) << "MultipeerIbgdaTransport: NIC " << n
@@ -1614,11 +1612,32 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
   // Try DMABUF first per NIC, fall back to plain reg_mr per NIC. If any
   // NIC's registration fails, deregister everything we already registered
   // and propagate the error.
+  //
+  // On AMD+mlx5, call `ibv_reg_dmabuf_mr` DIRECTLY (not via the lazy/
+  // dlopen'd system libibverbs path). The PD on AMD+mlx5 is owned by
+  // `pipes_gda` which uses a statically-linked libibverbs; the lazy
+  // path's dlopen'd system libibverbs is a separate instance with
+  // independent state — registering across instances SIGSEGVs inside the
+  // userspace mlx5 provider. Direct call uses the same static libibverbs
+  // as the PD. On NVIDIA the lazy and direct paths refer to the same
+  // libibverbs (DOCA's internal one), so we keep the lazy form. On
+  // AMD+BNXT (`NIC_BNXT`) the lazy path goes through SysIbv (the same
+  // libibverbs that pipes_gda's BNXT path uses) — keep it. Future ionic
+  // support (`NIC_IONIC`) defaults to the lazy path until proven otherwise.
   for (int n = 0; n < numNics_; ++n) {
     ibv_mr* mr = nullptr;
     auto dmabuf = export_gpu_dmabuf_aligned(
         docaGpu_, reinterpret_cast<void*>(allocBase), allocSize);
     if (dmabuf) {
+#if defined(__HIP_PLATFORM_AMD__) && defined(NIC_MLX5)
+      mr = ibv_reg_dmabuf_mr(
+          nicDevices_[n].ibvPd,
+          dmabuf->alignment.dmabufOffset,
+          allocSize,
+          static_cast<uint64_t>(allocBase),
+          dmabuf->fd,
+          accessFlags);
+#else
       mr = lazy_ibv_reg_dmabuf_mr(
           nicDevices_[n].ibvPd,
           dmabuf->alignment.dmabufOffset,
@@ -1626,6 +1645,7 @@ IbgdaLocalBuffer MultipeerIbgdaTransport::registerBuffer(
           static_cast<uint64_t>(allocBase),
           dmabuf->fd,
           accessFlags);
+#endif
       close(dmabuf->fd);
     }
     if (!mr) {


### PR DESCRIPTION
Summary: Adds `GpuMemHandler::kCudaIpcUncached`: the same IPC mechanism as `kCudaIpc`, but on AMD allocates the buffer with `hipExtMallocWithFlags(..., hipDeviceMallocUncached)` so it is GPU-uncached / HSA fine-grained — required for BNXT NICs to DMA into it via dma-buf. On NVIDIA the flag has no equivalent and it falls back to plain `cudaMalloc`, so callers can request the mode unconditionally. Also adds a `getLocalIpcHandle()` accessor that returns the local IPC handle while `GpuMemHandler` keeps ownership of the exchange/open lifecycle.

Reviewed By: srinathb-meta

Differential Revision: D104958304


