### PR TITLE
Port parallel device linker to stable snapshot

### DIFF
--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/common.cu
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/common.cu
@@ -8,12 +8,14 @@
 #include "collectives.h"
 #include "common.h"
 
+#ifndef RCCL_DEVICE_LINKER
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
+#endif
 
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
 __device__ void ncclDevFunc_Nop();
 #else
 __device__ __attribute__((noinline)) void ncclDevFunc_Nop();

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/common.h
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/common.h
@@ -166,11 +166,16 @@ struct ncclShmemData {
 #endif
 };
 
+#ifdef RCCL_DEVICE_LINKER
+__shared__ ncclShmemData ncclShmem;
+__shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#else
 extern __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ >= 700
   extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
 #else
   extern __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
@@ -574,7 +579,9 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
       SpecializedRunWorkBatch().run();
     } else {
+#ifndef RCCL_DEVICE_TABLE_OMIT
       NCCL_CALL_FUNCTIONS<COLL_UNROLL>(ncclShmem.funcId);
+#endif
     }
 
     if (ncclShmem.nextBatchIx == -1) break;
@@ -619,7 +626,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgs4K NCCL_GRID_CONSTANT const args4K) {}
 
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, unroll) \
   __device__ void ncclDevFunc_##suffix() { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, unroll>().run(); \

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/generate.py
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/generate.py
@@ -285,6 +285,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out("%s %s();\n" % (func_declaration, sym))
   out("\n")
 
+  out("#ifndef RCCL_DEVICE_TABLE_OMIT\n")
   out("typedef void(*ncclDevFuncPtr_t)();\n\n")
 
   # Generate function tables per unroll factor
@@ -366,6 +367,8 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     out("  {(void*)&(rcclGenericKernel<%s, true>), %s},\n" % (unroll, unroll))
   out("#endif\n");
   out("};\n\n");
+
+  out("#endif // RCCL_DEVICE_TABLE_OMIT\n")
 
 # Generate <gensrc>/device_table.cpp
 if is_colltrace:
@@ -498,3 +501,85 @@ if is_msccl_kernels:
             "MSCCL_IMPL_KERNEL_ENTRY_FUNC_DEVREDOP_TYPE({redop}, {ty_cxx}, false);\n"
             .format(redop=redop, ty_cxx=ty_to_cxx[ty])
           )
+
+################################################################################
+# Generate per-function specialized kernel .cpp files for the parallel build.
+# Each file contains one device function + a kernel wrapper that calls it,
+# enabling the compiler to optimize the device function in kernel context
+# while keeping it as a separate linkable symbol.
+
+# Snapshot guard convention: only LL128 functions are arch-guarded (matching the
+# device_table.h / impl .cpp generation above). gfx942/gfx950 both satisfy the
+# guard, so the specialized kernels are emitted for the built arches.
+def get_arch_guard(fn):
+  proto = fn[2]
+  if proto == "LL128":
+    return "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)"
+  return None
+
+specialized_dir = os.path.join(gensrc, "specialized")
+if not os.path.exists(specialized_dir):
+  os.makedirs(specialized_dir)
+else:
+  for name in os.listdir(specialized_dir):
+    os.remove(os.path.join(specialized_dir, name))
+
+specialized_filelist = []
+for fn in primary_funcs:
+  (coll, algo, proto, redop, ty, unroll) = fn
+  if coll == "Nop":
+    continue
+  sym = paste("_", coll, algo, proto, redop, ty, unroll)
+  func_name = "ncclDevFunc_" + sym
+  lower_coll = coll_camel_to_lower[coll]
+  guard = get_arch_guard(fn)
+
+  filename = "specialized_%s.cpp" % sym.lower()
+  filepath = os.path.join(specialized_dir, filename)
+  specialized_filelist.append((filename, func_name, guard, fn))
+
+  with open(filepath, "w") as f:
+    out = f.write
+    out('#define RCCL_DEVICE_TABLE_OMIT\n')
+    out('#include "common.h"\n')
+    out('#include "%s.h"\n\n' % lower_coll)
+    if guard:
+      out("#if %s\n" % guard)
+    out(
+      "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, "
+      "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {unroll})\n\n"
+      "__launch_bounds__(NCCL_MAX_NTHREADS, 1)\n"
+      "__global__ void ncclDevKernel_{sym}_Specialized(\n"
+      "    ncclDevKernelArgs4K NCCL_GRID_CONSTANT const args4K) {{\n"
+      "  ncclShmemPerWarp[0].x = 0;\n"
+      "  {func_name}();\n"
+      "}}\n"
+      .format(sym=sym, coll=coll, redop_cxx=redop_to_cxx[redop],
+              ty_cxx=ty_to_cxx[ty], algo=(algo or "RING"),
+              proto=(proto or "SIMPLE"), unroll=unroll, func_name=func_name)
+    )
+    if guard:
+      out("#endif\n")
+
+# Sort specialized files so the heaviest kernels appear first in build.ninja.
+_ty_cost = {t: (0 if t in ("f8e4m3", "f8e5m2") else 1) for t in all_tys}
+_proto_cost = {"SIMPLE": 0, "LL": 1, "LL128": 2}
+_algo_cost = {"TREE": 0, "RING": 1}
+
+def _compile_cost_key(entry):
+  fn = entry[3]  # func tuple stashed as 4th element
+  return (
+    _ty_cost.get(fn[4], 1),
+    _proto_cost.get(fn[2], 1),
+    _algo_cost.get(fn[1], 1),
+    -int(fn[5]),
+  )
+
+specialized_filelist.sort(key=_compile_cost_key)
+
+# Write the list of specialized files for CMake consumption
+with open(os.path.join(gensrc, "specialized_files.txt"), "w") as f:
+  for filename, func_name, guard, _ in specialized_filelist:
+    f.write("%s %s %s\n" % (filename, func_name, guard or ""))
+
+print("-- Generated %d specialized kernel files in %s" % (len(specialized_filelist), specialized_dir))

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/onerank.cu
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/src/device/onerank.cu
@@ -8,7 +8,6 @@
 #include "alloc.h"
 #include "collectives.h"
 #include "common_kernel.h"
-#include "common.h"
 #include <cuda_runtime.h>
 
 #if defined(__gfx950__)

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/aggregate_resources.py
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/aggregate_resources.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Aggregate resource usage from individual JSON files into a single max JSON.
+
+Reads all .json files in a directory (produced by extract_device_function.py)
+and writes a single JSON with the maximum of each resource field, plus
+derived values needed for kernel descriptor patching.
+
+Usage:
+    python3 aggregate_resources.py <resources_dir> <output.json> <gpu_target>
+"""
+
+import sys
+import os
+import re
+import json
+
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+]
+
+
+def align_up(val, alignment):
+    return ((val + alignment - 1) // alignment) * alignment
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    """gfx90a+ (CDNA2+) have a unified VGPR/AGPR register file where
+    next_free_vgpr = accum_offset + agpr_count (up to 512).
+    gfx908 (CDNA1) and RDNA (gfx10xx+) do not."""
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <resources_dir> <output.json> <gpu_target>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    resources_dir = sys.argv[1]
+    output_path = sys.argv[2]
+    gpu_target = sys.argv[3]
+
+    max_vals = {k: 0 for k in RESOURCE_KEYS}
+    max_regular_vgpr = 0
+    count = 0
+
+    for fname in sorted(os.listdir(resources_dir)):
+        if not fname.endswith('.json'):
+            continue
+        with open(os.path.join(resources_dir, fname)) as f:
+            res = json.load(f)
+        for key in RESOURCE_KEYS:
+            max_vals[key] = max(max_vals[key], res.get(key, 0))
+        regular = res.get('vgpr_count', 0) - res.get('agpr_count', 0)
+        max_regular_vgpr = max(max_regular_vgpr, regular)
+        count += 1
+
+    if count == 0:
+        print(f"ERROR: No .json files found in {resources_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    accum_offset = align_up(max_regular_vgpr, 4)
+
+    if _has_unified_vgpr_agpr(gpu_target):
+        next_free_vgpr = max(max_vals['vgpr_count'],
+                             accum_offset + max_vals['agpr_count'])
+    else:
+        next_free_vgpr = max_vals['vgpr_count']
+
+    max_vals['accum_offset'] = accum_offset
+    max_vals['next_free_vgpr'] = next_free_vgpr
+
+    print(f"Aggregated {count} resource files ({gpu_target}): "
+          f"VGPR={max_vals['vgpr_count']}, AGPR={max_vals['agpr_count']}, "
+          f"SGPR={max_vals['sgpr_count']}, "
+          f"scratch={max_vals['private_segment_fixed_size']}, "
+          f"LDS={max_vals['group_segment_fixed_size']}, "
+          f"accum_offset={accum_offset}, next_free_vgpr={next_free_vgpr}")
+
+    with open(output_path, 'w') as f:
+        json.dump(max_vals, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/extract_device_function.py
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/extract_device_function.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Extract ncclDevFunc_* device functions from specialized kernel assembly.
+
+Given a .s file from compiling a specialized kernel, this script:
+1. Keeps all code, debug sections, .rodata, CFI, etc. intact
+2. Removes .globl for the kernel wrapper so it becomes a local symbol
+3. Strips the .amdhsa_kernel block (no .kd generated for the wrapper)
+4. Strips the .amdgpu_metadata block (runtime won't see this kernel)
+5. Adds .globl for the ncclDevFunc_* so the linker can resolve it
+6. Parses .amdgpu_metadata YAML for resource usage (before stripping)
+
+Usage:
+    python3 extract_device_function.py <input.s> <output.s> [output.json]
+"""
+
+import sys
+import re
+import json
+
+
+def parse_metadata_resources(lines):
+    """Parse .amdgpu_metadata YAML to extract resource usage."""
+    metadata_start = None
+    metadata_end = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            metadata_start = i + 1
+        elif line.strip() == '.end_amdgpu_metadata':
+            metadata_end = i
+
+    if metadata_start is None or metadata_end is None:
+        return {}
+
+    yaml_text = ''.join(lines[metadata_start:metadata_end])
+    resources = {}
+    for key, pattern in [
+        ('vgpr_count', r'\.vgpr_count:\s+(\d+)'),
+        ('agpr_count', r'\.agpr_count:\s+(\d+)'),
+        ('sgpr_count', r'\.sgpr_count:\s+(\d+)'),
+        ('group_segment_fixed_size', r'\.group_segment_fixed_size:\s+(\d+)'),
+        ('private_segment_fixed_size', r'\.private_segment_fixed_size:\s+(\d+)'),
+        ('sgpr_spill_count', r'\.sgpr_spill_count:\s+(\d+)'),
+        ('vgpr_spill_count', r'\.vgpr_spill_count:\s+(\d+)'),
+    ]:
+        m = re.search(pattern, yaml_text)
+        if m:
+            resources[key] = int(m.group(1))
+
+    return resources
+
+
+def find_devfunc_symbol(lines):
+    """Find the mangled ncclDevFunc_* symbol name."""
+    for line in lines:
+        m = re.match(r'\s+\.type\s+(.*ncclDevFunc[^,]+),\s*@function', line)
+        if m:
+            mangled = m.group(1)
+            dm = re.search(r'ncclDevFunc_\w+', mangled)
+            unmangled = dm.group(0) if dm else mangled
+            return mangled, unmangled
+    return None, None
+
+
+def find_kernel_symbol(lines):
+    """Find the mangled ncclDevKernel_* symbol name."""
+    for line in lines:
+        m = re.match(r'\s+\.globl\s+(.*ncclDevKernel\S+)', line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def find_amdhsa_kernel_range(lines):
+    """Find the .section .rodata block containing .amdhsa_kernel through
+    the .text directive that follows .end_amdhsa_kernel.
+    Returns (start, end+1) line indices to skip, or None."""
+    amdhsa_start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('.amdhsa_kernel'):
+            # Walk back to find the .section .rodata and .p2align before it
+            start = i
+            for j in range(i - 1, max(i - 5, -1), -1):
+                s = lines[j].strip()
+                if s.startswith('.section') and '.rodata' in s:
+                    start = j
+                    break
+                if s.startswith('.p2align') or s == '':
+                    start = j
+                else:
+                    break
+            amdhsa_start = start
+        if line.strip() == '.end_amdhsa_kernel':
+            # Include the .text directive that typically follows
+            end = i + 1
+            if end < len(lines) and lines[end].strip() == '.text':
+                end += 1
+            return (amdhsa_start, end)
+    return None
+
+
+def find_metadata_range(lines):
+    """Find .amdgpu_metadata ... .end_amdgpu_metadata block.
+    Returns (start, end+1) line indices to skip, or None."""
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            start = i
+        elif line.strip() == '.end_amdgpu_metadata':
+            if start is not None:
+                return (start, i + 1)
+    return None
+
+
+def extract(input_path, output_asm_path, output_json_path=None):
+    with open(input_path) as f:
+        lines = f.readlines()
+
+    mangled, unmangled = find_devfunc_symbol(lines)
+    if not mangled:
+        print(f"ERROR: No ncclDevFunc found in {input_path}", file=sys.stderr)
+        return 1
+
+    kernel_sym = find_kernel_symbol(lines)
+
+    # Parse resources BEFORE stripping metadata
+    resources = parse_metadata_resources(lines)
+    resources['function_name'] = unmangled
+    resources['mangled_name'] = mangled
+
+    # Identify ranges to skip
+    skip_ranges = []
+    amdhsa_range = find_amdhsa_kernel_range(lines)
+    if amdhsa_range:
+        skip_ranges.append(amdhsa_range)
+    metadata_range = find_metadata_range(lines)
+    if metadata_range:
+        skip_ranges.append(metadata_range)
+
+    def in_skip_range(idx):
+        return any(s <= idx < e for s, e in skip_ranges)
+
+    out_lines = []
+    globl_inserted = False
+    for i, line in enumerate(lines):
+        if in_skip_range(i):
+            continue
+
+        stripped = line.strip()
+
+        if '__hip_cuid' in stripped:
+            continue
+
+        # Remove .globl for the kernel wrapper
+        if kernel_sym and re.match(r'\s*\.globl\s+' + re.escape(kernel_sym), stripped):
+            continue
+
+        # Add .globl before the .type directive for the device function
+        if not globl_inserted and mangled in line and '.type' in line and '@function' in line:
+            out_lines.append(f'\t.globl\t{mangled}\n')
+            globl_inserted = True
+
+        out_lines.append(line)
+
+    with open(output_asm_path, 'w') as f:
+        f.writelines(out_lines)
+
+    if output_json_path:
+        with open(output_json_path, 'w') as f:
+            json.dump(resources, f, indent=2)
+
+    print(f"Extracted: {unmangled} -> {output_asm_path}")
+    print(f"  Resources: VGPR={resources.get('vgpr_count', '?')}, "
+          f"SGPR={resources.get('sgpr_count', '?')}, "
+          f"scratch={resources.get('private_segment_fixed_size', '?')}, "
+          f"LDS={resources.get('group_segment_fixed_size', '?')}")
+
+    return 0
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <input.s> <output.s> [output.json]")
+        sys.exit(1)
+
+    rc = extract(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else None)
+    sys.exit(rc)

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/patch_dispatcher.py
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/patch_dispatcher.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Patch common_device.s with aggregated resource usage from extracted device functions.
+
+Patches all dispatcher kernel descriptors, ABS symbols, and metadata to reflect
+the maximum resource requirements of the device functions they dispatch to.
+
+Patched sections:
+1. .set ABS symbols per kernel (num_vgpr, num_agpr, numbered_sgpr, etc.)
+2. .amdhsa_kernel directives (accum_offset, next_free_vgpr, next_free_sgpr, etc.)
+3. .AMDGPU.gpr_maximums (amdgpu.max_num_vgpr/agpr/sgpr)
+4. .amdgpu_metadata YAML (vgpr_count, agpr_count, sgpr_count, etc.)
+
+Usage:
+    python3 patch_dispatcher.py <common_device.s> <output.s> <max_resources.json> <gpu_target>
+"""
+
+import sys
+import re
+import json
+
+
+# Maximum addressable (numbered) SGPRs per architecture generation.
+# GFX9 has 104 physical SGPRs with s[102:103] reserved for VCC -> 102 addressable.
+# GFX10+ has 108 physical SGPRs with s[106:107] reserved for VCC -> 106 addressable.
+_MAX_NUMBERED_SGPR = {
+    9:  102,
+    10: 106,
+    11: 106,
+    12: 106,
+}
+
+
+def _gfx_generation(gpu_target):
+    """Extract the major generation number from a target like 'gfx942' -> 9, 'gfx1200' -> 12."""
+    m = re.match(r'gfx(\d+)', gpu_target)
+    if not m:
+        sys.exit(f"ERROR: cannot parse GPU target '{gpu_target}'")
+    gen = int(m.group(1))
+    if gen >= 100:
+        gen //= 100
+    elif gen >= 10:
+        gen //= 10
+    return gen
+
+
+def max_numbered_sgpr(gpu_target):
+    gen = _gfx_generation(gpu_target)
+    if gen not in _MAX_NUMBERED_SGPR:
+        sys.exit(f"ERROR: unknown SGPR limit for generation gfx{gen}xx "
+                 f"(target '{gpu_target}')")
+    return _MAX_NUMBERED_SGPR[gen]
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    """gfx90a+ (CDNA2+) have a unified VGPR/AGPR register file."""
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def load_max_resources(json_path, gpu_target):
+    with open(json_path) as f:
+        res = json.load(f)
+    # amdhsa_next_free_sgpr is numbered SGPRs only (excludes VCC, flat_scratch, xnack).
+    # .sgpr_count in metadata includes system SGPRs. Cap for the .amdhsa_kernel directive.
+    res['next_free_sgpr'] = min(res['sgpr_count'], max_numbered_sgpr(gpu_target))
+
+    # On gfx908 (CDNA1) and RDNA, VGPRs and AGPRs are separate banks;
+    # .amdhsa_next_free_vgpr counts only VGPRs (max 256 on gfx908).
+    if not _has_unified_vgpr_agpr(gpu_target):
+        res['next_free_vgpr'] = res['vgpr_count']
+
+    return res
+
+
+def patch_abs_symbols(lines, max_res):
+    """Patch .set ABS symbols for each dispatcher kernel."""
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_vgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_vgpr, {max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_agpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_agpr, {max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(numbered_sgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.numbered_sgpr, {max_res["next_free_sgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_named_barrier),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_named_barrier, 0\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(private_seg_size),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.private_seg_size, {max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(uses_flat_scratch),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.uses_flat_scratch, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_dyn_sized_stack),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_dyn_sized_stack, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_recursion),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_recursion, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_indirect_call),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_indirect_call, 1\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_amdhsa_kernel_directives(lines, max_res):
+    """Patch .amdhsa_kernel block directives with literal values."""
+    result = []
+    in_kernel = False
+    for line in lines:
+        if re.match(r'\s*\.amdhsa_kernel\s+', line):
+            in_kernel = True
+            result.append(line)
+            continue
+        if in_kernel and re.match(r'\s*\.end_amdhsa_kernel', line):
+            in_kernel = False
+            result.append(line)
+            continue
+
+        if not in_kernel:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_accum_offset)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_accum_offset {max_res["accum_offset"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_next_free_vgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_vgpr {max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_next_free_sgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_sgpr {max_res["next_free_sgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_private_segment_fixed_size)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_private_segment_fixed_size {max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_uses_dynamic_stack)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_uses_dynamic_stack 1\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_enable_private_segment)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_enable_private_segment 1\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_gpr_maximums(lines, max_res):
+    """Patch .set amdgpu.max_num_* in .AMDGPU.gpr_maximums section."""
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_vgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_agpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_sgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_sgpr"]}\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_amdgpu_metadata(lines, max_res):
+    """Patch .amdgpu_metadata YAML values for each kernel."""
+    result = []
+    in_metadata = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            result.append(line)
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            in_metadata = False
+            result.append(line)
+            continue
+
+        if not in_metadata:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s+\.vgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s+(?:-\s+)?\.agpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.sgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["sgpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.private_segment_fixed_size:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.uses_dynamic_stack:\s+)(true|false)', line)
+        if m:
+            result.append(f'{m.group(1)}true\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def normalize_file_directives(lines):
+    """Strip MD5 checksums from .file directives to avoid
+    'inconsistent use of MD5 checksums' assembler warnings."""
+    return [re.sub(r'(\s+\.file\s+\d+\s+"[^"]*"\s+"[^"]*")\s+md5\s+0x[0-9a-fA-F]+', r'\1', line)
+            for line in lines]
+
+
+def patch(asm_path, output_path, max_resources_path, gpu_target):
+    max_res = load_max_resources(max_resources_path, gpu_target)
+
+    print(f"Max resources: VGPR={max_res['vgpr_count']}, AGPR={max_res['agpr_count']}, "
+          f"SGPR={max_res['sgpr_count']}, scratch={max_res['private_segment_fixed_size']}, "
+          f"accum_offset={max_res['accum_offset']}, next_free_vgpr={max_res['next_free_vgpr']}")
+
+    with open(asm_path) as f:
+        lines = f.readlines()
+
+    lines = patch_abs_symbols(lines, max_res)
+    lines = patch_amdhsa_kernel_directives(lines, max_res)
+    lines = patch_gpr_maximums(lines, max_res)
+    lines = patch_amdgpu_metadata(lines, max_res)
+    lines = normalize_file_directives(lines)
+
+    with open(output_path, 'w') as f:
+        f.writelines(lines)
+
+    print(f"Patched: {output_path}")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        print(f"Usage: {sys.argv[0]} <common_device.s> <output.s> <max_resources.json> <gpu_target>")
+        sys.exit(1)
+
+    patch(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/resource_summary.py
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/asm_extract/resource_summary.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Summarize resource usage across all extracted device functions.
+
+Reads resource JSON files produced by extract_device_function.py and
+(optionally) the dispatcher assembly to compare current vs required values.
+
+Usage:
+    python3 resource_summary.py <resources_dir> [dispatcher.s]
+"""
+
+import sys
+import os
+import re
+import json
+import collections
+
+
+def load_resources(resources_dir):
+    """Load all resource JSON files."""
+    results = []
+    for f in sorted(os.listdir(resources_dir)):
+        if not f.endswith('.json'):
+            continue
+        with open(os.path.join(resources_dir, f)) as fh:
+            results.append(json.load(fh))
+    return results
+
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+    'vgpr_spill_count', 'sgpr_spill_count',
+]
+
+SHORT_NAMES = {
+    'vgpr_count': 'VGPR',
+    'agpr_count': 'AGPR',
+    'sgpr_count': 'SGPR',
+    'private_segment_fixed_size': 'Scratch',
+    'group_segment_fixed_size': 'LDS',
+    'vgpr_spill_count': 'VSpill',
+    'sgpr_spill_count': 'SSpill',
+}
+
+
+def compute_maximums(resources):
+    maxes = {}
+    for key in RESOURCE_KEYS:
+        maxes[key] = max((r.get(key, 0) for r in resources), default=0)
+    return maxes
+
+
+def parse_dispatcher_kernels(asm_path):
+    """Parse .kd and .amdgpu_metadata from the dispatcher assembly."""
+    with open(asm_path) as f:
+        lines = f.readlines()
+
+    kernels_kd = {}
+    kernels_meta = {}
+
+    # Parse .amdhsa_kernel blocks
+    cur_kernel = None
+    cur_fields = {}
+    for line in lines:
+        m = re.match(r'\s*\.amdhsa_kernel\s+(\S+)', line)
+        if m:
+            cur_kernel = m.group(1)
+            cur_fields = {}
+            continue
+        if cur_kernel and '.end_amdhsa_kernel' in line:
+            kernels_kd[cur_kernel] = cur_fields
+            cur_kernel = None
+            continue
+        if cur_kernel:
+            for field in ['amdhsa_next_free_vgpr', 'amdhsa_next_free_sgpr',
+                          'amdhsa_accum_offset',
+                          'amdhsa_private_segment_fixed_size',
+                          'amdhsa_group_segment_fixed_size']:
+                m = re.match(rf'\s*\.{field}\s+(.*)', line)
+                if m:
+                    val = m.group(1).strip()
+                    try:
+                        cur_fields[field] = int(val)
+                    except ValueError:
+                        cur_fields[field] = val
+
+    # Parse .amdgpu_metadata YAML
+    in_metadata = False
+    cur_name = None
+    cur_meta = {}
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            if cur_name:
+                kernels_meta[cur_name] = cur_meta
+            in_metadata = False
+            continue
+        if not in_metadata:
+            continue
+
+        m = re.match(r'\s+\.name:\s+(\S+)', line)
+        if m:
+            if cur_name:
+                kernels_meta[cur_name] = cur_meta
+            cur_name = m.group(1)
+            cur_meta = {}
+            continue
+
+        for field, key in [('.vgpr_count', 'vgpr_count'),
+                           ('.agpr_count', 'agpr_count'),
+                           ('.sgpr_count', 'sgpr_count'),
+                           ('.private_segment_fixed_size', 'private_segment_fixed_size'),
+                           ('.group_segment_fixed_size', 'group_segment_fixed_size')]:
+            m = re.match(rf'\s+{re.escape(field)}:\s+(\d+)', line)
+            if m:
+                cur_meta[key] = int(m.group(1))
+
+    if cur_name:
+        kernels_meta[cur_name] = cur_meta
+
+    return kernels_kd, kernels_meta
+
+
+def parse_gpr_maximums(asm_path):
+    """Parse .set amdgpu.max_num_* from the assembly."""
+    maxes = {}
+    with open(asm_path) as f:
+        for line in f:
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_vgpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_vgpr'] = int(m.group(1))
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_agpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_agpr'] = int(m.group(1))
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_sgpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_sgpr'] = int(m.group(1))
+    return maxes
+
+
+def demangle_short(name):
+    """Extract a short name from the mangled function name."""
+    m = re.search(r'ncclDevFunc_(\w+)', name)
+    return m.group(0) if m else name
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <resources_dir> [dispatcher.s]")
+        sys.exit(1)
+
+    resources_dir = sys.argv[1]
+    dispatcher_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    resources = load_resources(resources_dir)
+    if not resources:
+        print("No resource files found.")
+        sys.exit(1)
+
+    maxes = compute_maximums(resources)
+
+    # --- Per-function detail, grouped by unique profile ---
+    profiles = collections.defaultdict(list)
+    for r in resources:
+        key = tuple(r.get(k, 0) for k in RESOURCE_KEYS)
+        profiles[key].append(demangle_short(r.get('function_name', '?')))
+
+    print(f"{'='*78}")
+    print(f"  Resource Summary: {len(resources)} device functions, "
+          f"{len(profiles)} unique profiles")
+    print(f"{'='*78}")
+    print()
+
+    hdr = (f"  {'VGPR':>5} {'AGPR':>5} {'SGPR':>5} "
+           f"{'Scratch':>8} {'LDS':>8} {'VSpill':>6} {'SSpill':>6}  "
+           f"{'#':>4}  Functions")
+    print(hdr)
+    print(f"  {'-'*74}")
+
+    for key in sorted(profiles.keys(), key=lambda k: (-k[0], -k[3])):
+        funcs = profiles[key]
+        v, a, s, scratch, lds, vs, ss = key
+        if len(funcs) <= 3:
+            func_str = ', '.join(funcs)
+        else:
+            func_str = f"{funcs[0]}, {funcs[1]}, ... +{len(funcs)-2} more"
+        print(f"  {v:5d} {a:5d} {s:5d} {scratch:8d} {lds:8d} {vs:6d} {ss:6d}  "
+              f"{len(funcs):4d}  {func_str}")
+
+    # --- Maximums ---
+    print()
+    print(f"  {'='*74}")
+    print(f"  Required maximums (across all {len(resources)} functions):")
+    print(f"  {'='*74}")
+    for key in RESOURCE_KEYS:
+        print(f"    {SHORT_NAMES[key]:>8}: {maxes[key]}")
+
+    # --- Dispatcher comparison ---
+    if dispatcher_path and os.path.exists(dispatcher_path):
+        print()
+        print(f"  {'='*74}")
+        print(f"  Dispatcher kernel descriptors ({os.path.basename(dispatcher_path)}):")
+        print(f"  {'='*74}")
+
+        kd, meta = parse_dispatcher_kernels(dispatcher_path)
+        gpr_max = parse_gpr_maximums(dispatcher_path)
+
+        if gpr_max:
+            print()
+            print("  .AMDGPU.gpr_maximums:")
+            for k, v in sorted(gpr_max.items()):
+                required = {'max_num_vgpr': maxes['vgpr_count'],
+                            'max_num_agpr': maxes['agpr_count'],
+                            'max_num_sgpr': maxes['sgpr_count']}.get(k, '?')
+                status = "OK" if v >= required else f"NEEDS UPDATE (have {v}, need {required})"
+                print(f"    {k}: {v}  [{status}]")
+
+        for name in sorted(kd.keys()):
+            fields = kd[name]
+            m = meta.get(name, {})
+            short = name.split('ncclDevKernel')[-1].split('24nccl')[0] if 'ncclDevKernel' in name else name
+
+            print()
+            print(f"  Kernel: ncclDevKernel{short}")
+            print(f"    .kd fields:")
+            for field, val in sorted(fields.items()):
+                print(f"      {field}: {val}")
+
+            if m:
+                print(f"    .amdgpu_metadata:")
+                for field in ['vgpr_count', 'agpr_count', 'sgpr_count',
+                              'private_segment_fixed_size', 'group_segment_fixed_size']:
+                    if field in m:
+                        required = maxes.get(field, 0)
+                        current = m[field]
+                        if field in ('private_segment_fixed_size',):
+                            status = "OK" if current >= required else f"NEEDS UPDATE ({current} -> {required})"
+                        else:
+                            status = ""
+                        print(f"        {field}: {current}  {status}")
+
+    # --- Warnings ---
+    print()
+    print(f"  {'='*74}")
+    print("  Consistency checks:")
+    print(f"  {'='*74}")
+
+    spill_funcs = [(r['function_name'], r.get('vgpr_spill_count', 0), r.get('sgpr_spill_count', 0))
+                   for r in resources
+                   if r.get('vgpr_spill_count', 0) > 0 or r.get('sgpr_spill_count', 0) > 0]
+    if spill_funcs:
+        print(f"  WARNING: {len(spill_funcs)} functions have register spills:")
+        for name, vs, ss in spill_funcs[:10]:
+            print(f"    {demangle_short(name)}: VGPR_spill={vs}, SGPR_spill={ss}")
+        if len(spill_funcs) > 10:
+            print(f"    ... and {len(spill_funcs) - 10} more")
+    else:
+        print("  OK: No register spills detected")
+
+    lds_values = set(r.get('group_segment_fixed_size', 0) for r in resources)
+    if dispatcher_path and os.path.exists(dispatcher_path):
+        _, meta = parse_dispatcher_kernels(dispatcher_path)
+        for name, m in meta.items():
+            kd_lds = m.get('group_segment_fixed_size', 0)
+            if kd_lds < maxes['group_segment_fixed_size']:
+                print(f"  WARNING: Kernel {name} LDS={kd_lds} < max={maxes['group_segment_fixed_size']}")
+    if len(lds_values) > 1:
+        print(f"  NOTE: Multiple LDS sizes in use: {sorted(lds_values)}")
+    else:
+        print(f"  OK: All functions use LDS={lds_values.pop()}")
+
+    print()
+
+
+if __name__ == '__main__':
+    main()

--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/rccl-device-compile
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/tools/rccl-device-compile
@@ -1,0 +1,782 @@
+#!/usr/bin/env python3
+"""RCCL device compilation driver.
+
+A compiler/linker driver for the RCCL assembly-extract device pipeline.
+Presents a standard compiler CLI to CMake's custom language machinery.
+
+Compile mode (--compile):
+    rccl-device-compile --compile --arch=gfx942 -DFOO -Ipath -o out.o in.cpp
+    1. Compiles .cpp to assembly via amdclang++
+    2. Extracts device function + resource JSON (inline)
+    3. Assembles extracted .s to .o via amdclang++
+    Side effect: writes out.resources.json alongside out.o
+
+Link mode (--link):
+    rccl-device-compile --link --arch=gfx942 --dispatcher=common.cu.cpp -o device.elf obj1.o obj2.o
+    1. Aggregates resource JSON files from all input objects
+    2. Compiles dispatcher source to assembly
+    3. Patches dispatcher with aggregated resources
+    4. Assembles patched dispatcher
+    5. Links all objects + dispatcher into device.elf via ld.lld
+
+Tool discovery:
+    amdclang++, ld.lld are found relative to --clang=<path> or by searching
+    PATH and the directory containing the system C++ compiler.
+    Uses --offload-device-only for device compilation.  HIP path flags
+    (--hip-path, --hip-device-lib-path) are forwarded from CMake when present.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+# ---------------------------------------------------------------------------
+# Assembly extraction (from extract_device_function.py)
+# ---------------------------------------------------------------------------
+
+def _parse_metadata_resources(lines):
+    """Parse .amdgpu_metadata YAML to extract resource usage."""
+    metadata_start = None
+    metadata_end = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            metadata_start = i + 1
+        elif line.strip() == '.end_amdgpu_metadata':
+            metadata_end = i
+
+    if metadata_start is None or metadata_end is None:
+        return {}
+
+    yaml_text = ''.join(lines[metadata_start:metadata_end])
+    resources = {}
+    for key, pattern in [
+        ('vgpr_count', r'\.vgpr_count:\s+(\d+)'),
+        ('agpr_count', r'\.agpr_count:\s+(\d+)'),
+        ('sgpr_count', r'\.sgpr_count:\s+(\d+)'),
+        ('group_segment_fixed_size', r'\.group_segment_fixed_size:\s+(\d+)'),
+        ('private_segment_fixed_size', r'\.private_segment_fixed_size:\s+(\d+)'),
+        ('sgpr_spill_count', r'\.sgpr_spill_count:\s+(\d+)'),
+        ('vgpr_spill_count', r'\.vgpr_spill_count:\s+(\d+)'),
+    ]:
+        m = re.search(pattern, yaml_text)
+        if m:
+            resources[key] = int(m.group(1))
+    return resources
+
+
+def _find_devfunc_symbol(lines):
+    for line in lines:
+        m = re.match(r'\s+\.type\s+(.*ncclDevFunc[^,]+),\s*@function', line)
+        if m:
+            mangled = m.group(1)
+            dm = re.search(r'ncclDevFunc_\w+', mangled)
+            unmangled = dm.group(0) if dm else mangled
+            return mangled, unmangled
+    return None, None
+
+
+def _find_kernel_symbol(lines):
+    for line in lines:
+        m = re.match(r'\s+\.globl\s+(.*ncclDevKernel\S+)', line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def _find_amdhsa_kernel_range(lines):
+    amdhsa_start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('.amdhsa_kernel'):
+            start = i
+            for j in range(i - 1, max(i - 5, -1), -1):
+                s = lines[j].strip()
+                if s.startswith('.section') and '.rodata' in s:
+                    start = j
+                    break
+                if s.startswith('.p2align') or s == '':
+                    start = j
+                else:
+                    break
+            amdhsa_start = start
+        if line.strip() == '.end_amdhsa_kernel':
+            end = i + 1
+            if end < len(lines) and lines[end].strip() == '.text':
+                end += 1
+            return (amdhsa_start, end)
+    return None
+
+
+def _find_metadata_range(lines):
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            start = i
+        elif line.strip() == '.end_amdgpu_metadata':
+            if start is not None:
+                return (start, i + 1)
+    return None
+
+
+def extract_device_function(asm_lines):
+    """Extract device function from assembly lines.
+    Returns (extracted_asm_lines, resources_dict) or raises on error."""
+    mangled, unmangled = _find_devfunc_symbol(asm_lines)
+    if not mangled:
+        raise RuntimeError("No ncclDevFunc found in assembly")
+
+    kernel_sym = _find_kernel_symbol(asm_lines)
+    resources = _parse_metadata_resources(asm_lines)
+    resources['function_name'] = unmangled
+    resources['mangled_name'] = mangled
+
+    skip_ranges = []
+    amdhsa_range = _find_amdhsa_kernel_range(asm_lines)
+    if amdhsa_range:
+        skip_ranges.append(amdhsa_range)
+    metadata_range = _find_metadata_range(asm_lines)
+    if metadata_range:
+        skip_ranges.append(metadata_range)
+
+    def in_skip_range(idx):
+        return any(s <= idx < e for s, e in skip_ranges)
+
+    out_lines = []
+    globl_inserted = False
+    for i, line in enumerate(asm_lines):
+        if in_skip_range(i):
+            continue
+        stripped = line.strip()
+        if '__hip_cuid' in stripped:
+            continue
+        if kernel_sym and re.match(r'\s*\.globl\s+' + re.escape(kernel_sym), stripped):
+            continue
+        if not globl_inserted and mangled in line and '.type' in line and '@function' in line:
+            out_lines.append(f'\t.globl\t{mangled}\n')
+            out_lines.append(f'\t.hidden\t{mangled}\n')
+            globl_inserted = True
+        out_lines.append(line)
+
+    return out_lines, resources
+
+
+# ---------------------------------------------------------------------------
+# Resource aggregation (from aggregate_resources.py)
+# ---------------------------------------------------------------------------
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+]
+
+
+def _align_up(val, alignment):
+    return ((val + alignment - 1) // alignment) * alignment
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def aggregate_resources(resource_list, gpu_target):
+    """Aggregate a list of resource dicts into max values.
+    Returns the aggregated dict with derived fields."""
+    max_vals = {k: 0 for k in RESOURCE_KEYS}
+    max_regular_vgpr = 0
+
+    for res in resource_list:
+        for key in RESOURCE_KEYS:
+            max_vals[key] = max(max_vals[key], res.get(key, 0))
+        regular = res.get('vgpr_count', 0) - res.get('agpr_count', 0)
+        max_regular_vgpr = max(max_regular_vgpr, regular)
+
+    accum_offset = _align_up(max_regular_vgpr, 4)
+
+    if _has_unified_vgpr_agpr(gpu_target):
+        next_free_vgpr = max(max_vals['vgpr_count'],
+                             accum_offset + max_vals['agpr_count'])
+    else:
+        next_free_vgpr = max_vals['vgpr_count']
+
+    max_vals['accum_offset'] = accum_offset
+    max_vals['next_free_vgpr'] = next_free_vgpr
+
+    _MAX_NUMBERED_SGPR = {9: 102, 10: 106, 11: 106, 12: 106}
+    gen = _gfx_generation(gpu_target)
+    if gen not in _MAX_NUMBERED_SGPR:
+        raise RuntimeError(f"Unknown SGPR limit for generation gfx{gen}xx (target '{gpu_target}')")
+    max_vals['next_free_sgpr'] = min(max_vals['sgpr_count'], _MAX_NUMBERED_SGPR[gen])
+
+    return max_vals
+
+
+def _gfx_generation(gpu_target):
+    m = re.match(r'gfx(\d+)', gpu_target)
+    if not m:
+        raise RuntimeError(f"Cannot parse GPU target '{gpu_target}'")
+    gen = int(m.group(1))
+    if gen >= 100:
+        gen //= 100
+    elif gen >= 10:
+        gen //= 10
+    return gen
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher patching (from patch_dispatcher.py)
+# ---------------------------------------------------------------------------
+
+def _patch_abs_symbols(lines, max_res):
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_vgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_vgpr, {max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_agpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_agpr, {max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(numbered_sgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.numbered_sgpr, {max_res["next_free_sgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_named_barrier),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_named_barrier, 0\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(private_seg_size),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.private_seg_size, {max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(uses_flat_scratch),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.uses_flat_scratch, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_dyn_sized_stack),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_dyn_sized_stack, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_recursion),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_recursion, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_indirect_call),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_indirect_call, 1\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_amdhsa_kernel_directives(lines, max_res):
+    result = []
+    in_kernel = False
+    for line in lines:
+        if re.match(r'\s*\.amdhsa_kernel\s+', line):
+            in_kernel = True
+            result.append(line)
+            continue
+        if in_kernel and re.match(r'\s*\.end_amdhsa_kernel', line):
+            in_kernel = False
+            result.append(line)
+            continue
+        if not in_kernel:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_accum_offset)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_accum_offset {max_res["accum_offset"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_next_free_vgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_vgpr {max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_next_free_sgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_sgpr {max_res["next_free_sgpr"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_private_segment_fixed_size)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_private_segment_fixed_size {max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_uses_dynamic_stack)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_uses_dynamic_stack 1\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_enable_private_segment)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_enable_private_segment 1\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_gpr_maximums(lines, max_res):
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_vgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_agpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_sgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_sgpr"]}\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_amdgpu_metadata(lines, max_res):
+    result = []
+    in_metadata = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            result.append(line)
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            in_metadata = False
+            result.append(line)
+            continue
+        if not in_metadata:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s+\.vgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s+(?:-\s+)?\.agpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s+\.sgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["sgpr_count"]}\n')
+            continue
+        m = re.match(r'(\s+\.private_segment_fixed_size:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s+\.uses_dynamic_stack:\s+)(true|false)', line)
+        if m:
+            result.append(f'{m.group(1)}true\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _normalize_file_directives(lines):
+    return [re.sub(r'(\s+\.file\s+\d+\s+"[^"]*"\s+"[^"]*")\s+md5\s+0x[0-9a-fA-F]+', r'\1', line)
+            for line in lines]
+
+
+def patch_dispatcher(asm_lines, max_res):
+    """Patch dispatcher assembly with aggregated resource values.
+    Returns patched lines."""
+    lines = _patch_abs_symbols(asm_lines, max_res)
+    lines = _patch_amdhsa_kernel_directives(lines, max_res)
+    lines = _patch_gpr_maximums(lines, max_res)
+    lines = _patch_amdgpu_metadata(lines, max_res)
+    lines = _normalize_file_directives(lines)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery
+# ---------------------------------------------------------------------------
+
+def find_tool(name, hints, required=True):
+    """Find an executable by name, searching hints first, then PATH."""
+    for d in hints:
+        if not d:
+            continue
+        path = os.path.join(d, name)
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    # Fall back to PATH
+    import shutil
+    path = shutil.which(name)
+    if path:
+        return path
+    if required:
+        raise FileNotFoundError(
+            f"Required tool '{name}' not found. Searched: {hints} and PATH")
+    return None
+
+
+
+def discover_tools(clang_path, ld_lld_path=None):
+    """Discover amdclang++ and ld.lld from the given compiler path or explicit overrides."""
+    if clang_path:
+        clang = clang_path
+    else:
+        import shutil
+        clang = shutil.which('amdclang++') or shutil.which('clang++')
+        if not clang:
+            raise FileNotFoundError("Cannot find amdclang++ or clang++ on PATH")
+
+    if ld_lld_path:
+        lld = ld_lld_path
+    else:
+        compiler_dir = os.path.dirname(os.path.realpath(clang))
+        llvm_bin = os.path.join(compiler_dir, '..', 'lib', 'llvm', 'bin')
+        hints = [compiler_dir, llvm_bin]
+        lld = find_tool('ld.lld', hints)
+        
+    return clang, lld
+
+
+# ---------------------------------------------------------------------------
+# Run subprocess with error handling
+# ---------------------------------------------------------------------------
+
+def run(cmd, description=""):
+    """Run a command, raising on failure with the full command for diagnosis."""
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        label = f" ({description})" if description else ""
+        print(f"ERROR{label}: command failed with exit code {e.returncode}:",
+              file=sys.stderr)
+        print(f"  {' '.join(cmd)}", file=sys.stderr)
+        sys.exit(e.returncode)
+    except FileNotFoundError:
+        print(f"ERROR: executable not found: {cmd[0]}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Compile mode: .cpp -> .o + .resources.json
+# ---------------------------------------------------------------------------
+
+
+def do_compile(args, forwarded_flags):
+    clang, _ = discover_tools(args.clang)
+    arch = args.arch
+    source = args.source
+    output = args.output
+    keep_temps = args.keep_temps
+
+    base = os.path.splitext(output)[0]
+    json_out = base + '.resources.json'
+
+    # Determine temp directory: alongside output if --keep-temps, else truly temp
+    if keep_temps:
+        asm_file = base + '.full.s'
+        ext_file = base + '.extracted.s'
+        cleanup = []
+    else:
+        tmpdir = tempfile.mkdtemp(prefix='rccl-dc-')
+        asm_file = os.path.join(tmpdir, 'full.s')
+        ext_file = os.path.join(tmpdir, 'extracted.s')
+        cleanup = [asm_file, ext_file, tmpdir]
+
+    try:
+        # Step 1: Compile to assembly
+        compile_cmd = [
+            clang,
+            '-x', 'hip',
+            '--offload-device-only',
+            f'--{args.arch_flag_spelling}={arch}',
+            '-gline-tables-only',
+            '-w',
+        ] + forwarded_flags + [
+            '-S', '-o', asm_file, source,
+        ]
+        run(compile_cmd, f"compile {os.path.basename(source)}")
+
+        # Step 2: Extract device function (inline)
+        with open(asm_file) as f:
+            asm_lines = f.readlines()
+
+        try:
+            extracted_lines, resources = extract_device_function(asm_lines)
+        except RuntimeError as e:
+            print(f"ERROR: extraction failed for {source}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        extracted_lines = _normalize_file_directives(extracted_lines)
+
+        with open(ext_file, 'w') as f:
+            f.writelines(extracted_lines)
+
+        with open(json_out, 'w') as f:
+            json.dump(resources, f, indent=2)
+
+        # Step 3: Assemble to object
+        assemble_cmd = [
+            clang,
+            '-x', 'assembler',
+            '-target', 'amdgcn-amd-amdhsa',
+            f'-mcpu={arch}',
+            '-c', '-o', output, ext_file,
+        ] + [f for f in forwarded_flags if f == '-fPIC']
+        run(assemble_cmd, f"assemble {os.path.basename(source)}")
+
+    finally:
+        if not keep_temps:
+            for f in cleanup:
+                try:
+                    if os.path.isfile(f):
+                        os.unlink(f)
+                    elif os.path.isdir(f):
+                        os.rmdir(f)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Link mode: objects -> device.elf
+# ---------------------------------------------------------------------------
+
+def do_link(args, forwarded_flags):
+    clang, lld = discover_tools(args.clang, args.ld_lld)
+    arch = args.arch
+    objects = args.objects
+    output = args.output
+    dispatcher = args.dispatcher
+    keep_temps = args.keep_temps
+
+    if not dispatcher:
+        raise SystemExit("ERROR: --link requires --dispatcher=<source>")
+
+    # Collect resource JSONs from alongside each .o
+    resource_list = []
+    for obj in objects:
+        if args.resources_dir:
+            json_path = os.path.join(args.resources_dir, os.path.basename(os.path.splitext(obj)[0]) + '.resources.json')
+        else:
+            json_path = os.path.splitext(obj)[0] + '.resources.json'
+        if os.path.exists(json_path):
+            with open(json_path) as f:
+                resource_list.append(json.load(f))
+
+    if not resource_list:
+        raise SystemExit(f"ERROR: no .resources.json files found alongside input objects")
+
+    # Step 1: Aggregate resources
+    max_res = aggregate_resources(resource_list, arch)
+    print(f"[{arch}] Aggregated {len(resource_list)} resources: "
+          f"VGPR={max_res['vgpr_count']}, AGPR={max_res['agpr_count']}, "
+          f"SGPR={max_res['sgpr_count']}, "
+          f"scratch={max_res['private_segment_fixed_size']}")
+
+    output_dir = os.path.dirname(output) or '.'
+    if keep_temps:
+        disp_asm = os.path.join(output_dir, f'dispatcher_{arch}.s')
+        disp_patched = os.path.join(output_dir, f'dispatcher_{arch}_patched.s')
+        disp_obj = os.path.join(output_dir, f'dispatcher_{arch}.o')
+        cleanup = []
+    else:
+        tmpdir = tempfile.mkdtemp(prefix='rccl-dl-')
+        disp_asm = os.path.join(tmpdir, 'dispatcher.s')
+        disp_patched = os.path.join(tmpdir, 'dispatcher_patched.s')
+        disp_obj = os.path.join(tmpdir, 'dispatcher.o')
+        cleanup = [disp_asm, disp_patched, disp_obj, tmpdir]
+
+    try:
+        # Step 2: Compile dispatcher to assembly
+        disp_compile_cmd = [
+            clang,
+            '-x', 'hip',
+            '--offload-device-only',
+            f'--{args.arch_flag_spelling}={arch}',
+            '-g', '-w',
+        ] + forwarded_flags + [
+            '-S', '-o', disp_asm, dispatcher,
+        ]
+        run(disp_compile_cmd, f"compile dispatcher for {arch}")
+
+        # Step 3: Patch dispatcher with aggregated resources
+        with open(disp_asm) as f:
+            disp_lines = f.readlines()
+        patched_lines = patch_dispatcher(disp_lines, max_res)
+        with open(disp_patched, 'w') as f:
+            f.writelines(patched_lines)
+
+        # Step 4: Assemble patched dispatcher
+        disp_assemble_cmd = [
+            clang,
+            '-x', 'assembler',
+            '-target', 'amdgcn-amd-amdhsa',
+            f'-mcpu={arch}',
+            '-c', '-o', disp_obj, disp_patched,
+        ] + [f for f in forwarded_flags if f == '-fPIC']
+        run(disp_assemble_cmd, f"assemble dispatcher for {arch}")
+
+        # Step 5: Link all objects + dispatcher into device.elf
+        # Use a response file for potentially long object lists
+        rsp_path = os.path.join(output_dir, f'link_{arch}.rsp')
+        with open(rsp_path, 'w') as f:
+            f.write(disp_obj + '\n')
+            for obj in objects:
+                f.write(obj + '\n')
+
+        link_cmd = [
+            lld, '-shared',
+            '-o', output,
+            f'@{rsp_path}',
+        ]
+        run(link_cmd, f"link device.elf for {arch}")
+
+        if not keep_temps:
+            try:
+                os.unlink(rsp_path)
+            except OSError:
+                pass
+
+    finally:
+        if not keep_temps:
+            for f in cleanup:
+                try:
+                    if os.path.isfile(f):
+                        os.unlink(f)
+                    elif os.path.isdir(f):
+                        os.rmdir(f)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_compiler_flags(argv):
+    """Separate our flags from forwarded compiler flags (-D, -I, -isystem, -std, -O, etc.)"""
+    our_args = []
+    forwarded = []
+    sources = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        # Our flags
+        if arg in ('--compile', '--link', '--keep-temps', '--version'):
+            our_args.append(arg)
+        elif arg.startswith('--arch='):
+            our_args.append(arg)
+        elif arg == '--arch' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--clang='):
+            our_args.append(arg)
+        elif arg == '--clang' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--resources-dir='):
+            our_args.append(arg)
+        elif arg == '--resources-dir' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--ld-lld='):
+            our_args.append(arg)
+        elif arg == '--ld-lld' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--arch-flag-spelling='):
+            our_args.append(arg)
+        elif arg == '--arch-flag-spelling' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--dispatcher='):
+            our_args.append(arg)
+        elif arg == '--dispatcher' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg == '-o' and i + 1 < len(argv):
+            our_args.extend(['-o', argv[i + 1]])
+            i += 1
+        # Forwarded compiler flags
+        elif arg.startswith('-D') or arg.startswith('-I') or arg.startswith('-isystem'):
+            forwarded.append(arg)
+        elif arg.startswith('-std=') or arg.startswith('-O') or arg == '-g':
+            forwarded.append(arg)
+        elif arg == '-D' and i + 1 < len(argv):
+            forwarded.extend(['-D', argv[i + 1]])
+            i += 1
+        elif arg == '-I' and i + 1 < len(argv):
+            forwarded.extend(['-I', argv[i + 1]])
+            i += 1
+        elif arg.startswith('-'):
+            forwarded.append(arg)
+        else:
+            # Positional: source file or object file
+            sources.append(arg)
+        i += 1
+    return our_args, forwarded, sources
+
+
+def expand_response_files(argv):
+    """Expand @file arguments: replace with one-per-line entries from file."""
+    expanded = []
+    for arg in argv:
+        if arg.startswith('@') and os.path.isfile(arg[1:]):
+            with open(arg[1:]) as f:
+                expanded.extend(line.strip() for line in f if line.strip())
+        else:
+            expanded.append(arg)
+    return expanded
+
+
+def main():
+    raw_args, forwarded_flags, positional = parse_compiler_flags(
+        expand_response_files(sys.argv[1:]))
+
+    parser = argparse.ArgumentParser(prog='rccl-device-compile', add_help=False)
+    parser.add_argument('--compile', action='store_true')
+    parser.add_argument('--link', action='store_true')
+    parser.add_argument('--arch', required=False)
+    parser.add_argument('--clang', default=None)
+    parser.add_argument('--dispatcher', default=None)
+    parser.add_argument('-o', '--output', required=False)
+    parser.add_argument('--keep-temps', action='store_true')
+    parser.add_argument('--version', action='store_true')
+    parser.add_argument('--resources-dir', default=None)
+    parser.add_argument('--ld-lld', default=None)
+    parser.add_argument('--bundler', default=None)
+    parser.add_argument('--arch-flag-spelling', default='offload-arch')
+
+
+    args = parser.parse_args(raw_args)
+
+    if args.version:
+        print("rccl-device-compile 1.0")
+        sys.exit(0)
+
+    if args.compile:
+        if not positional:
+            raise SystemExit("ERROR: --compile requires a source file")
+        if not args.arch:
+            raise SystemExit("ERROR: --compile requires --arch=<target>")
+        if not args.output:
+            raise SystemExit("ERROR: --compile requires -o <output>")
+        args.source = positional[0]
+        do_compile(args, forwarded_flags)
+
+    elif args.link:
+        if not positional:
+            raise SystemExit("ERROR: --link requires object files")
+        if not args.arch:
+            raise SystemExit("ERROR: --link requires --arch=<target>")
+        if not args.output:
+            raise SystemExit("ERROR: --link requires -o <output>")
+        args.objects = positional
+        do_link(args, forwarded_flags)
+
+    else:
+        raise SystemExit("ERROR: specify --compile or --link mode")
+
+
+if __name__ == '__main__':
+    main()

--- a/comms/rcclx/snapshots/scripts/create_snapshot.py
+++ b/comms/rcclx/snapshots/scripts/create_snapshot.py
@@ -89,7 +89,8 @@ def extract_rcclx_from_commit(
     Only extracts the essential AMD drop bits:
     - BUCK
     - defs.bzl
-    - develop/
+    - develop/ (includes the device-compile driver + asm_extract tools)
+    - device_linker.bzl
     - rccl_build_config.bzl
     - utils.bzl
 
@@ -105,7 +106,9 @@ def extract_rcclx_from_commit(
         archive_path = Path(tmpdir) / "rcclx.tar"
 
         # Use sl archive to extract only the core rcclx files from specific commit
-        # Only include: BUCK, defs.bzl, develop/, rccl_build_config.bzl, utils.bzl
+        # Only include: BUCK, defs.bzl, develop/ (with the parallel device-linker
+        # driver under develop/projects/rccl/tools), device_linker.bzl,
+        # rccl_build_config.bzl, utils.bzl
         cmd = [
             "sl",
             "archive",
@@ -117,6 +120,8 @@ def extract_rcclx_from_commit(
             "fbcode/comms/rcclx/defs.bzl",
             "--include",
             "fbcode/comms/rcclx/develop/**",
+            "--include",
+            "fbcode/comms/rcclx/device_linker.bzl",
             "--include",
             "fbcode/comms/rcclx/rccl_build_config.bzl",
             "--include",
@@ -277,6 +282,25 @@ def _fix_load_paths(file_path: Path, snapshot_pkg: str) -> None:
         (
             '"//comms/rcclx:utils.bzl"',
             f'"{snapshot_pkg}:utils.bzl"',
+        ),
+        # @fbcode//comms/rcclx:device_linker.bzl -> snapshot:device_linker.bzl
+        (
+            '"@fbcode//comms/rcclx:device_linker.bzl"',
+            f'"{snapshot_pkg}:device_linker.bzl"',
+        ),
+        # //comms/rcclx:device_linker.bzl -> snapshot:device_linker.bzl
+        (
+            '"//comms/rcclx:device_linker.bzl"',
+            f'"{snapshot_pkg}:device_linker.bzl"',
+        ),
+        # rccl-device-compile driver target -> snapshot package
+        (
+            '"fbcode//comms/rcclx/develop/projects/rccl/tools:rccl-device-compile"',
+            f'"{snapshot_pkg}/develop/projects/rccl/tools:rccl-device-compile"',
+        ),
+        (
+            '"//comms/rcclx/develop/projects/rccl/tools:rccl-device-compile"',
+            f'"{snapshot_pkg}/develop/projects/rccl/tools:rccl-device-compile"',
         ),
     ]
 

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/common.cu
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/common.cu
@@ -8,9 +8,11 @@
 #include "collectives.h"
 #include "common.h"
 
+#ifndef RCCL_DEVICE_LINKER
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
 #endif
 
 struct RunWorkNop {
@@ -38,7 +40,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Gener
 }
 #endif
 
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
 __device__ void ncclDevFunc_Nop();
 #else
 __device__ __attribute__((noinline)) void ncclDevFunc_Nop();

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/common.h
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/common.h
@@ -168,11 +168,16 @@ struct ncclShmemData {
   uint64_t barrier_pat;
 };
 
+#ifdef RCCL_DEVICE_LINKER
+__shared__ ncclShmemData ncclShmem;
+__shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#else
 extern __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ >= 700
   extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
 #else
   extern __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
@@ -601,7 +606,8 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
       SpecializedRunWorkBatch().run();
     } else {
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#ifndef RCCL_DEVICE_TABLE_OMIT
+#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
       if (COLL_UNROLL == 1)
         ncclDevFuncTable_1[ncclShmem.funcId]();
       else if (COLL_UNROLL == 2)
@@ -615,6 +621,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
         NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
       else
         NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
+#endif
 #endif
     }
 
@@ -660,7 +667,7 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgs4K NCCL_GRID_CONST
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgs4K NCCL_GRID_CONSTANT const args4K) {}
 
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
   __device__ void ncclDevFunc_##suffix() { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/generate.py
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/generate.py
@@ -359,6 +359,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out("%s %s();\n" % (func_declaration, sym))
   out("\n")
 
+  out("#ifndef RCCL_DEVICE_TABLE_OMIT\n")
   out("typedef void(*ncclDevFuncPtr_t)();\n\n")
   out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_1[] = {\n")
   index1 = 0
@@ -467,6 +468,8 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     out("__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_4(unsigned short funcIndex) noexcept {\n")
     out(f"  Caller4<0, {index4}>::call4(funcIndex);\n")
     out("}\n\n")
+
+  out("#endif // RCCL_DEVICE_TABLE_OMIT\n")
 
 # Generate <gensrc>/device_table.cpp
 if is_colltrace:
@@ -638,3 +641,88 @@ if is_msccl_kernels:
             "MSCCL_IMPL_KERNEL_ENTRY_FUNC_DEVREDOP_TYPE({redop}, {ty_cxx}, false);\n"
             .format(redop=redop, ty_cxx=ty_to_cxx[ty])
           )
+
+################################################################################
+# Generate per-function specialized kernel .cpp files for the parallel build.
+# Each file contains one device function + a kernel wrapper that calls it,
+# enabling the compiler to optimize the device function in kernel context
+# (LDS allocation, barriers, etc.) while keeping it as a separate linkable symbol.
+
+# Snapshot guard convention: only LL128 functions are arch-guarded (matching the
+# device_table.h / impl .cpp generation above). gfx942/gfx950 both satisfy the
+# guard, so the specialized kernels are emitted for the built arches.
+def get_arch_guard(fn):
+  proto = fn[2]
+  if proto == "LL128":
+    return "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)"
+  return None
+
+specialized_dir = os.path.join(gensrc, "specialized")
+if not os.path.exists(specialized_dir):
+  os.makedirs(specialized_dir)
+else:
+  for name in os.listdir(specialized_dir):
+    os.remove(os.path.join(specialized_dir, name))
+
+specialized_filelist = []
+for fn in primary_funcs:
+  (coll, algo, proto, redop, ty, acc, pipeline, unroll) = fn
+  if coll == "Nop":
+    continue
+  sym = paste("_", coll, algo, proto, redop, ty, acc, pipeline, unroll)
+  func_name = "ncclDevFunc_" + sym
+  lower_coll = coll_camel_to_lower[coll]
+  guard = get_arch_guard(fn)
+
+  filename = "specialized_%s.cpp" % sym.lower()
+  filepath = os.path.join(specialized_dir, filename)
+  specialized_filelist.append((filename, func_name, guard, fn))
+
+  with open(filepath, "w") as f:
+    out = f.write
+    out('#define RCCL_DEVICE_TABLE_OMIT\n')
+    out('#include "common.h"\n')
+    out('#include "%s.h"\n\n' % lower_coll)
+    if guard:
+      out("#if %s\n" % guard)
+    out(
+      "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, "
+      "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll})\n\n"
+      "__launch_bounds__(NCCL_MAX_NTHREADS, 1)\n"
+      "__global__ void ncclDevKernel_{sym}_Specialized(\n"
+      "    ncclDevKernelArgs4K NCCL_GRID_CONSTANT const args4K) {{\n"
+      "  ncclShmemPerWarp[0].x = 0;\n"
+      "  {func_name}();\n"
+      "}}\n"
+      .format(sym=sym, coll=coll, redop_cxx=redop_to_cxx[redop],
+              ty_cxx=ty_to_cxx[ty], algo=(algo or "RING"),
+              proto=(proto or "SIMPLE"), acc=acc, pipeline=pipeline,
+              unroll=unroll, func_name=func_name)
+    )
+    if guard:
+      out("#endif\n")
+
+# Sort specialized files so the heaviest kernels appear first in build.ninja.
+# Ninja breaks scheduling ties by edge ID (= rule order in the manifest), so
+# putting slow kernels first ensures they start early and don't form a long tail.
+_ty_cost = {t: (0 if t in ("f8e4m3", "f8e5m2") else 1) for t in all_tys}
+_proto_cost = {"SIMPLE": 0, "LL": 1, "LL128": 2}
+_algo_cost = {"TREE": 0, "RING": 1, "PAT": 2}
+
+def _compile_cost_key(entry):
+  fn = entry[3]  # func tuple stashed as 4th element
+  return (
+    _ty_cost.get(fn[4], 1),
+    _proto_cost.get(fn[2], 1),
+    _algo_cost.get(fn[1], 1),
+    -int(fn[7]),
+  )
+
+specialized_filelist.sort(key=_compile_cost_key)
+
+# Write the list of specialized files for CMake consumption
+with open(os.path.join(gensrc, "specialized_files.txt"), "w") as f:
+  for filename, func_name, guard, _ in specialized_filelist:
+    f.write("%s %s %s\n" % (filename, func_name, guard or ""))
+
+print("-- Generated %d specialized kernel files in %s" % (len(specialized_filelist), specialized_dir))

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/onerank.cu
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/src/device/onerank.cu
@@ -8,7 +8,6 @@
 #include "alloc.h"
 #include "collectives.h"
 #include "common_kernel.h"
-#include "common.h"
 #include <cuda_runtime.h>
 
 #if defined(__gfx950__)

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/aggregate_resources.py
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/aggregate_resources.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Aggregate resource usage from individual JSON files into a single max JSON.
+
+Reads all .json files in a directory (produced by extract_device_function.py)
+and writes a single JSON with the maximum of each resource field, plus
+derived values needed for kernel descriptor patching.
+
+Usage:
+    python3 aggregate_resources.py <resources_dir> <output.json> <gpu_target>
+"""
+
+import sys
+import os
+import re
+import json
+
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+]
+
+
+def align_up(val, alignment):
+    return ((val + alignment - 1) // alignment) * alignment
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    """gfx90a+ (CDNA2+) have a unified VGPR/AGPR register file where
+    next_free_vgpr = accum_offset + agpr_count (up to 512).
+    gfx908 (CDNA1) and RDNA (gfx10xx+) do not."""
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <resources_dir> <output.json> <gpu_target>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    resources_dir = sys.argv[1]
+    output_path = sys.argv[2]
+    gpu_target = sys.argv[3]
+
+    max_vals = {k: 0 for k in RESOURCE_KEYS}
+    max_regular_vgpr = 0
+    count = 0
+
+    for fname in sorted(os.listdir(resources_dir)):
+        if not fname.endswith('.json'):
+            continue
+        with open(os.path.join(resources_dir, fname)) as f:
+            res = json.load(f)
+        for key in RESOURCE_KEYS:
+            max_vals[key] = max(max_vals[key], res.get(key, 0))
+        regular = res.get('vgpr_count', 0) - res.get('agpr_count', 0)
+        max_regular_vgpr = max(max_regular_vgpr, regular)
+        count += 1
+
+    if count == 0:
+        print(f"ERROR: No .json files found in {resources_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    accum_offset = align_up(max_regular_vgpr, 4)
+
+    if _has_unified_vgpr_agpr(gpu_target):
+        next_free_vgpr = max(max_vals['vgpr_count'],
+                             accum_offset + max_vals['agpr_count'])
+    else:
+        next_free_vgpr = max_vals['vgpr_count']
+
+    max_vals['accum_offset'] = accum_offset
+    max_vals['next_free_vgpr'] = next_free_vgpr
+
+    print(f"Aggregated {count} resource files ({gpu_target}): "
+          f"VGPR={max_vals['vgpr_count']}, AGPR={max_vals['agpr_count']}, "
+          f"SGPR={max_vals['sgpr_count']}, "
+          f"scratch={max_vals['private_segment_fixed_size']}, "
+          f"LDS={max_vals['group_segment_fixed_size']}, "
+          f"accum_offset={accum_offset}, next_free_vgpr={next_free_vgpr}")
+
+    with open(output_path, 'w') as f:
+        json.dump(max_vals, f, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/extract_device_function.py
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/extract_device_function.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Extract ncclDevFunc_* device functions from specialized kernel assembly.
+
+Given a .s file from compiling a specialized kernel, this script:
+1. Keeps all code, debug sections, .rodata, CFI, etc. intact
+2. Removes .globl for the kernel wrapper so it becomes a local symbol
+3. Strips the .amdhsa_kernel block (no .kd generated for the wrapper)
+4. Strips the .amdgpu_metadata block (runtime won't see this kernel)
+5. Adds .globl for the ncclDevFunc_* so the linker can resolve it
+6. Parses .amdgpu_metadata YAML for resource usage (before stripping)
+
+Usage:
+    python3 extract_device_function.py <input.s> <output.s> [output.json]
+"""
+
+import sys
+import re
+import json
+
+
+def parse_metadata_resources(lines):
+    """Parse .amdgpu_metadata YAML to extract resource usage."""
+    metadata_start = None
+    metadata_end = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            metadata_start = i + 1
+        elif line.strip() == '.end_amdgpu_metadata':
+            metadata_end = i
+
+    if metadata_start is None or metadata_end is None:
+        return {}
+
+    yaml_text = ''.join(lines[metadata_start:metadata_end])
+    resources = {}
+    for key, pattern in [
+        ('vgpr_count', r'\.vgpr_count:\s+(\d+)'),
+        ('agpr_count', r'\.agpr_count:\s+(\d+)'),
+        ('sgpr_count', r'\.sgpr_count:\s+(\d+)'),
+        ('group_segment_fixed_size', r'\.group_segment_fixed_size:\s+(\d+)'),
+        ('private_segment_fixed_size', r'\.private_segment_fixed_size:\s+(\d+)'),
+        ('sgpr_spill_count', r'\.sgpr_spill_count:\s+(\d+)'),
+        ('vgpr_spill_count', r'\.vgpr_spill_count:\s+(\d+)'),
+    ]:
+        m = re.search(pattern, yaml_text)
+        if m:
+            resources[key] = int(m.group(1))
+
+    return resources
+
+
+def find_devfunc_symbol(lines):
+    """Find the mangled ncclDevFunc_* symbol name."""
+    for line in lines:
+        m = re.match(r'\s+\.type\s+(.*ncclDevFunc[^,]+),\s*@function', line)
+        if m:
+            mangled = m.group(1)
+            dm = re.search(r'ncclDevFunc_\w+', mangled)
+            unmangled = dm.group(0) if dm else mangled
+            return mangled, unmangled
+    return None, None
+
+
+def find_kernel_symbol(lines):
+    """Find the mangled ncclDevKernel_* symbol name."""
+    for line in lines:
+        m = re.match(r'\s+\.globl\s+(.*ncclDevKernel\S+)', line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def find_amdhsa_kernel_range(lines):
+    """Find the .section .rodata block containing .amdhsa_kernel through
+    the .text directive that follows .end_amdhsa_kernel.
+    Returns (start, end+1) line indices to skip, or None."""
+    amdhsa_start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('.amdhsa_kernel'):
+            # Walk back to find the .section .rodata and .p2align before it
+            start = i
+            for j in range(i - 1, max(i - 5, -1), -1):
+                s = lines[j].strip()
+                if s.startswith('.section') and '.rodata' in s:
+                    start = j
+                    break
+                if s.startswith('.p2align') or s == '':
+                    start = j
+                else:
+                    break
+            amdhsa_start = start
+        if line.strip() == '.end_amdhsa_kernel':
+            # Include the .text directive that typically follows
+            end = i + 1
+            if end < len(lines) and lines[end].strip() == '.text':
+                end += 1
+            return (amdhsa_start, end)
+    return None
+
+
+def find_metadata_range(lines):
+    """Find .amdgpu_metadata ... .end_amdgpu_metadata block.
+    Returns (start, end+1) line indices to skip, or None."""
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            start = i
+        elif line.strip() == '.end_amdgpu_metadata':
+            if start is not None:
+                return (start, i + 1)
+    return None
+
+
+def extract(input_path, output_asm_path, output_json_path=None):
+    with open(input_path) as f:
+        lines = f.readlines()
+
+    mangled, unmangled = find_devfunc_symbol(lines)
+    if not mangled:
+        print(f"ERROR: No ncclDevFunc found in {input_path}", file=sys.stderr)
+        return 1
+
+    kernel_sym = find_kernel_symbol(lines)
+
+    # Parse resources BEFORE stripping metadata
+    resources = parse_metadata_resources(lines)
+    resources['function_name'] = unmangled
+    resources['mangled_name'] = mangled
+
+    # Identify ranges to skip
+    skip_ranges = []
+    amdhsa_range = find_amdhsa_kernel_range(lines)
+    if amdhsa_range:
+        skip_ranges.append(amdhsa_range)
+    metadata_range = find_metadata_range(lines)
+    if metadata_range:
+        skip_ranges.append(metadata_range)
+
+    def in_skip_range(idx):
+        return any(s <= idx < e for s, e in skip_ranges)
+
+    out_lines = []
+    globl_inserted = False
+    for i, line in enumerate(lines):
+        if in_skip_range(i):
+            continue
+
+        stripped = line.strip()
+
+        if '__hip_cuid' in stripped:
+            continue
+
+        # Remove .globl for the kernel wrapper
+        if kernel_sym and re.match(r'\s*\.globl\s+' + re.escape(kernel_sym), stripped):
+            continue
+
+        # Add .globl before the .type directive for the device function
+        if not globl_inserted and mangled in line and '.type' in line and '@function' in line:
+            out_lines.append(f'\t.globl\t{mangled}\n')
+            globl_inserted = True
+
+        out_lines.append(line)
+
+    with open(output_asm_path, 'w') as f:
+        f.writelines(out_lines)
+
+    if output_json_path:
+        with open(output_json_path, 'w') as f:
+            json.dump(resources, f, indent=2)
+
+    print(f"Extracted: {unmangled} -> {output_asm_path}")
+    print(f"  Resources: VGPR={resources.get('vgpr_count', '?')}, "
+          f"SGPR={resources.get('sgpr_count', '?')}, "
+          f"scratch={resources.get('private_segment_fixed_size', '?')}, "
+          f"LDS={resources.get('group_segment_fixed_size', '?')}")
+
+    return 0
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <input.s> <output.s> [output.json]")
+        sys.exit(1)
+
+    rc = extract(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else None)
+    sys.exit(rc)

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/patch_dispatcher.py
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/patch_dispatcher.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Patch common_device.s with aggregated resource usage from extracted device functions.
+
+Patches all dispatcher kernel descriptors, ABS symbols, and metadata to reflect
+the maximum resource requirements of the device functions they dispatch to.
+
+Patched sections:
+1. .set ABS symbols per kernel (num_vgpr, num_agpr, numbered_sgpr, etc.)
+2. .amdhsa_kernel directives (accum_offset, next_free_vgpr, next_free_sgpr, etc.)
+3. .AMDGPU.gpr_maximums (amdgpu.max_num_vgpr/agpr/sgpr)
+4. .amdgpu_metadata YAML (vgpr_count, agpr_count, sgpr_count, etc.)
+
+Usage:
+    python3 patch_dispatcher.py <common_device.s> <output.s> <max_resources.json> <gpu_target>
+"""
+
+import sys
+import re
+import json
+
+
+# Maximum addressable (numbered) SGPRs per architecture generation.
+# GFX9 has 104 physical SGPRs with s[102:103] reserved for VCC -> 102 addressable.
+# GFX10+ has 108 physical SGPRs with s[106:107] reserved for VCC -> 106 addressable.
+_MAX_NUMBERED_SGPR = {
+    9:  102,
+    10: 106,
+    11: 106,
+    12: 106,
+}
+
+
+def _gfx_generation(gpu_target):
+    """Extract the major generation number from a target like 'gfx942' -> 9, 'gfx1200' -> 12."""
+    m = re.match(r'gfx(\d+)', gpu_target)
+    if not m:
+        sys.exit(f"ERROR: cannot parse GPU target '{gpu_target}'")
+    gen = int(m.group(1))
+    if gen >= 100:
+        gen //= 100
+    elif gen >= 10:
+        gen //= 10
+    return gen
+
+
+def max_numbered_sgpr(gpu_target):
+    gen = _gfx_generation(gpu_target)
+    if gen not in _MAX_NUMBERED_SGPR:
+        sys.exit(f"ERROR: unknown SGPR limit for generation gfx{gen}xx "
+                 f"(target '{gpu_target}')")
+    return _MAX_NUMBERED_SGPR[gen]
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    """gfx90a+ (CDNA2+) have a unified VGPR/AGPR register file."""
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def load_max_resources(json_path, gpu_target):
+    with open(json_path) as f:
+        res = json.load(f)
+    # amdhsa_next_free_sgpr is numbered SGPRs only (excludes VCC, flat_scratch, xnack).
+    # .sgpr_count in metadata includes system SGPRs. Cap for the .amdhsa_kernel directive.
+    res['next_free_sgpr'] = min(res['sgpr_count'], max_numbered_sgpr(gpu_target))
+
+    # On gfx908 (CDNA1) and RDNA, VGPRs and AGPRs are separate banks;
+    # .amdhsa_next_free_vgpr counts only VGPRs (max 256 on gfx908).
+    if not _has_unified_vgpr_agpr(gpu_target):
+        res['next_free_vgpr'] = res['vgpr_count']
+
+    return res
+
+
+def patch_abs_symbols(lines, max_res):
+    """Patch .set ABS symbols for each dispatcher kernel."""
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_vgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_vgpr, {max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_agpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_agpr, {max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(numbered_sgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.numbered_sgpr, {max_res["next_free_sgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_named_barrier),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_named_barrier, 0\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(private_seg_size),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.private_seg_size, {max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(uses_flat_scratch),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.uses_flat_scratch, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_dyn_sized_stack),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_dyn_sized_stack, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_recursion),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_recursion, 1\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_indirect_call),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_indirect_call, 1\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_amdhsa_kernel_directives(lines, max_res):
+    """Patch .amdhsa_kernel block directives with literal values."""
+    result = []
+    in_kernel = False
+    for line in lines:
+        if re.match(r'\s*\.amdhsa_kernel\s+', line):
+            in_kernel = True
+            result.append(line)
+            continue
+        if in_kernel and re.match(r'\s*\.end_amdhsa_kernel', line):
+            in_kernel = False
+            result.append(line)
+            continue
+
+        if not in_kernel:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_accum_offset)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_accum_offset {max_res["accum_offset"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_next_free_vgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_vgpr {max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_next_free_sgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_sgpr {max_res["next_free_sgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_private_segment_fixed_size)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_private_segment_fixed_size {max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_uses_dynamic_stack)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_uses_dynamic_stack 1\n')
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_enable_private_segment)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_enable_private_segment 1\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_gpr_maximums(lines, max_res):
+    """Patch .set amdgpu.max_num_* in .AMDGPU.gpr_maximums section."""
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_vgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_agpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_sgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_sgpr"]}\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def patch_amdgpu_metadata(lines, max_res):
+    """Patch .amdgpu_metadata YAML values for each kernel."""
+    result = []
+    in_metadata = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            result.append(line)
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            in_metadata = False
+            result.append(line)
+            continue
+
+        if not in_metadata:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s+\.vgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+
+        m = re.match(r'(\s+(?:-\s+)?\.agpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.sgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["sgpr_count"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.private_segment_fixed_size:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["private_segment_fixed_size"]}\n')
+            continue
+
+        m = re.match(r'(\s+\.uses_dynamic_stack:\s+)(true|false)', line)
+        if m:
+            result.append(f'{m.group(1)}true\n')
+            continue
+
+        result.append(line)
+    return result
+
+
+def normalize_file_directives(lines):
+    """Strip MD5 checksums from .file directives to avoid
+    'inconsistent use of MD5 checksums' assembler warnings."""
+    return [re.sub(r'(\s+\.file\s+\d+\s+"[^"]*"\s+"[^"]*")\s+md5\s+0x[0-9a-fA-F]+', r'\1', line)
+            for line in lines]
+
+
+def patch(asm_path, output_path, max_resources_path, gpu_target):
+    max_res = load_max_resources(max_resources_path, gpu_target)
+
+    print(f"Max resources: VGPR={max_res['vgpr_count']}, AGPR={max_res['agpr_count']}, "
+          f"SGPR={max_res['sgpr_count']}, scratch={max_res['private_segment_fixed_size']}, "
+          f"accum_offset={max_res['accum_offset']}, next_free_vgpr={max_res['next_free_vgpr']}")
+
+    with open(asm_path) as f:
+        lines = f.readlines()
+
+    lines = patch_abs_symbols(lines, max_res)
+    lines = patch_amdhsa_kernel_directives(lines, max_res)
+    lines = patch_gpr_maximums(lines, max_res)
+    lines = patch_amdgpu_metadata(lines, max_res)
+    lines = normalize_file_directives(lines)
+
+    with open(output_path, 'w') as f:
+        f.writelines(lines)
+
+    print(f"Patched: {output_path}")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        print(f"Usage: {sys.argv[0]} <common_device.s> <output.s> <max_resources.json> <gpu_target>")
+        sys.exit(1)
+
+    patch(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/resource_summary.py
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/asm_extract/resource_summary.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Summarize resource usage across all extracted device functions.
+
+Reads resource JSON files produced by extract_device_function.py and
+(optionally) the dispatcher assembly to compare current vs required values.
+
+Usage:
+    python3 resource_summary.py <resources_dir> [dispatcher.s]
+"""
+
+import sys
+import os
+import re
+import json
+import collections
+
+
+def load_resources(resources_dir):
+    """Load all resource JSON files."""
+    results = []
+    for f in sorted(os.listdir(resources_dir)):
+        if not f.endswith('.json'):
+            continue
+        with open(os.path.join(resources_dir, f)) as fh:
+            results.append(json.load(fh))
+    return results
+
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+    'vgpr_spill_count', 'sgpr_spill_count',
+]
+
+SHORT_NAMES = {
+    'vgpr_count': 'VGPR',
+    'agpr_count': 'AGPR',
+    'sgpr_count': 'SGPR',
+    'private_segment_fixed_size': 'Scratch',
+    'group_segment_fixed_size': 'LDS',
+    'vgpr_spill_count': 'VSpill',
+    'sgpr_spill_count': 'SSpill',
+}
+
+
+def compute_maximums(resources):
+    maxes = {}
+    for key in RESOURCE_KEYS:
+        maxes[key] = max((r.get(key, 0) for r in resources), default=0)
+    return maxes
+
+
+def parse_dispatcher_kernels(asm_path):
+    """Parse .kd and .amdgpu_metadata from the dispatcher assembly."""
+    with open(asm_path) as f:
+        lines = f.readlines()
+
+    kernels_kd = {}
+    kernels_meta = {}
+
+    # Parse .amdhsa_kernel blocks
+    cur_kernel = None
+    cur_fields = {}
+    for line in lines:
+        m = re.match(r'\s*\.amdhsa_kernel\s+(\S+)', line)
+        if m:
+            cur_kernel = m.group(1)
+            cur_fields = {}
+            continue
+        if cur_kernel and '.end_amdhsa_kernel' in line:
+            kernels_kd[cur_kernel] = cur_fields
+            cur_kernel = None
+            continue
+        if cur_kernel:
+            for field in ['amdhsa_next_free_vgpr', 'amdhsa_next_free_sgpr',
+                          'amdhsa_accum_offset',
+                          'amdhsa_private_segment_fixed_size',
+                          'amdhsa_group_segment_fixed_size']:
+                m = re.match(rf'\s*\.{field}\s+(.*)', line)
+                if m:
+                    val = m.group(1).strip()
+                    try:
+                        cur_fields[field] = int(val)
+                    except ValueError:
+                        cur_fields[field] = val
+
+    # Parse .amdgpu_metadata YAML
+    in_metadata = False
+    cur_name = None
+    cur_meta = {}
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            if cur_name:
+                kernels_meta[cur_name] = cur_meta
+            in_metadata = False
+            continue
+        if not in_metadata:
+            continue
+
+        m = re.match(r'\s+\.name:\s+(\S+)', line)
+        if m:
+            if cur_name:
+                kernels_meta[cur_name] = cur_meta
+            cur_name = m.group(1)
+            cur_meta = {}
+            continue
+
+        for field, key in [('.vgpr_count', 'vgpr_count'),
+                           ('.agpr_count', 'agpr_count'),
+                           ('.sgpr_count', 'sgpr_count'),
+                           ('.private_segment_fixed_size', 'private_segment_fixed_size'),
+                           ('.group_segment_fixed_size', 'group_segment_fixed_size')]:
+            m = re.match(rf'\s+{re.escape(field)}:\s+(\d+)', line)
+            if m:
+                cur_meta[key] = int(m.group(1))
+
+    if cur_name:
+        kernels_meta[cur_name] = cur_meta
+
+    return kernels_kd, kernels_meta
+
+
+def parse_gpr_maximums(asm_path):
+    """Parse .set amdgpu.max_num_* from the assembly."""
+    maxes = {}
+    with open(asm_path) as f:
+        for line in f:
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_vgpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_vgpr'] = int(m.group(1))
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_agpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_agpr'] = int(m.group(1))
+            m = re.match(r'\s*\.set\s+amdgpu\.max_num_sgpr,\s*(\d+)', line)
+            if m:
+                maxes['max_num_sgpr'] = int(m.group(1))
+    return maxes
+
+
+def demangle_short(name):
+    """Extract a short name from the mangled function name."""
+    m = re.search(r'ncclDevFunc_(\w+)', name)
+    return m.group(0) if m else name
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <resources_dir> [dispatcher.s]")
+        sys.exit(1)
+
+    resources_dir = sys.argv[1]
+    dispatcher_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    resources = load_resources(resources_dir)
+    if not resources:
+        print("No resource files found.")
+        sys.exit(1)
+
+    maxes = compute_maximums(resources)
+
+    # --- Per-function detail, grouped by unique profile ---
+    profiles = collections.defaultdict(list)
+    for r in resources:
+        key = tuple(r.get(k, 0) for k in RESOURCE_KEYS)
+        profiles[key].append(demangle_short(r.get('function_name', '?')))
+
+    print(f"{'='*78}")
+    print(f"  Resource Summary: {len(resources)} device functions, "
+          f"{len(profiles)} unique profiles")
+    print(f"{'='*78}")
+    print()
+
+    hdr = (f"  {'VGPR':>5} {'AGPR':>5} {'SGPR':>5} "
+           f"{'Scratch':>8} {'LDS':>8} {'VSpill':>6} {'SSpill':>6}  "
+           f"{'#':>4}  Functions")
+    print(hdr)
+    print(f"  {'-'*74}")
+
+    for key in sorted(profiles.keys(), key=lambda k: (-k[0], -k[3])):
+        funcs = profiles[key]
+        v, a, s, scratch, lds, vs, ss = key
+        if len(funcs) <= 3:
+            func_str = ', '.join(funcs)
+        else:
+            func_str = f"{funcs[0]}, {funcs[1]}, ... +{len(funcs)-2} more"
+        print(f"  {v:5d} {a:5d} {s:5d} {scratch:8d} {lds:8d} {vs:6d} {ss:6d}  "
+              f"{len(funcs):4d}  {func_str}")
+
+    # --- Maximums ---
+    print()
+    print(f"  {'='*74}")
+    print(f"  Required maximums (across all {len(resources)} functions):")
+    print(f"  {'='*74}")
+    for key in RESOURCE_KEYS:
+        print(f"    {SHORT_NAMES[key]:>8}: {maxes[key]}")
+
+    # --- Dispatcher comparison ---
+    if dispatcher_path and os.path.exists(dispatcher_path):
+        print()
+        print(f"  {'='*74}")
+        print(f"  Dispatcher kernel descriptors ({os.path.basename(dispatcher_path)}):")
+        print(f"  {'='*74}")
+
+        kd, meta = parse_dispatcher_kernels(dispatcher_path)
+        gpr_max = parse_gpr_maximums(dispatcher_path)
+
+        if gpr_max:
+            print()
+            print("  .AMDGPU.gpr_maximums:")
+            for k, v in sorted(gpr_max.items()):
+                required = {'max_num_vgpr': maxes['vgpr_count'],
+                            'max_num_agpr': maxes['agpr_count'],
+                            'max_num_sgpr': maxes['sgpr_count']}.get(k, '?')
+                status = "OK" if v >= required else f"NEEDS UPDATE (have {v}, need {required})"
+                print(f"    {k}: {v}  [{status}]")
+
+        for name in sorted(kd.keys()):
+            fields = kd[name]
+            m = meta.get(name, {})
+            short = name.split('ncclDevKernel')[-1].split('24nccl')[0] if 'ncclDevKernel' in name else name
+
+            print()
+            print(f"  Kernel: ncclDevKernel{short}")
+            print(f"    .kd fields:")
+            for field, val in sorted(fields.items()):
+                print(f"      {field}: {val}")
+
+            if m:
+                print(f"    .amdgpu_metadata:")
+                for field in ['vgpr_count', 'agpr_count', 'sgpr_count',
+                              'private_segment_fixed_size', 'group_segment_fixed_size']:
+                    if field in m:
+                        required = maxes.get(field, 0)
+                        current = m[field]
+                        if field in ('private_segment_fixed_size',):
+                            status = "OK" if current >= required else f"NEEDS UPDATE ({current} -> {required})"
+                        else:
+                            status = ""
+                        print(f"        {field}: {current}  {status}")
+
+    # --- Warnings ---
+    print()
+    print(f"  {'='*74}")
+    print("  Consistency checks:")
+    print(f"  {'='*74}")
+
+    spill_funcs = [(r['function_name'], r.get('vgpr_spill_count', 0), r.get('sgpr_spill_count', 0))
+                   for r in resources
+                   if r.get('vgpr_spill_count', 0) > 0 or r.get('sgpr_spill_count', 0) > 0]
+    if spill_funcs:
+        print(f"  WARNING: {len(spill_funcs)} functions have register spills:")
+        for name, vs, ss in spill_funcs[:10]:
+            print(f"    {demangle_short(name)}: VGPR_spill={vs}, SGPR_spill={ss}")
+        if len(spill_funcs) > 10:
+            print(f"    ... and {len(spill_funcs) - 10} more")
+    else:
+        print("  OK: No register spills detected")
+
+    lds_values = set(r.get('group_segment_fixed_size', 0) for r in resources)
+    if dispatcher_path and os.path.exists(dispatcher_path):
+        _, meta = parse_dispatcher_kernels(dispatcher_path)
+        for name, m in meta.items():
+            kd_lds = m.get('group_segment_fixed_size', 0)
+            if kd_lds < maxes['group_segment_fixed_size']:
+                print(f"  WARNING: Kernel {name} LDS={kd_lds} < max={maxes['group_segment_fixed_size']}")
+    if len(lds_values) > 1:
+        print(f"  NOTE: Multiple LDS sizes in use: {sorted(lds_values)}")
+    else:
+        print(f"  OK: All functions use LDS={lds_values.pop()}")
+
+    print()
+
+
+if __name__ == '__main__':
+    main()

--- a/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/rccl-device-compile
+++ b/comms/rcclx/snapshots/stable/comms/rcclx/develop/tools/rccl-device-compile
@@ -1,0 +1,782 @@
+#!/usr/bin/env python3
+"""RCCL device compilation driver.
+
+A compiler/linker driver for the RCCL assembly-extract device pipeline.
+Presents a standard compiler CLI to CMake's custom language machinery.
+
+Compile mode (--compile):
+    rccl-device-compile --compile --arch=gfx942 -DFOO -Ipath -o out.o in.cpp
+    1. Compiles .cpp to assembly via amdclang++
+    2. Extracts device function + resource JSON (inline)
+    3. Assembles extracted .s to .o via amdclang++
+    Side effect: writes out.resources.json alongside out.o
+
+Link mode (--link):
+    rccl-device-compile --link --arch=gfx942 --dispatcher=common.cu.cpp -o device.elf obj1.o obj2.o
+    1. Aggregates resource JSON files from all input objects
+    2. Compiles dispatcher source to assembly
+    3. Patches dispatcher with aggregated resources
+    4. Assembles patched dispatcher
+    5. Links all objects + dispatcher into device.elf via ld.lld
+
+Tool discovery:
+    amdclang++, ld.lld are found relative to --clang=<path> or by searching
+    PATH and the directory containing the system C++ compiler.
+    Uses --offload-device-only for device compilation.  HIP path flags
+    (--hip-path, --hip-device-lib-path) are forwarded from CMake when present.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+# ---------------------------------------------------------------------------
+# Assembly extraction (from extract_device_function.py)
+# ---------------------------------------------------------------------------
+
+def _parse_metadata_resources(lines):
+    """Parse .amdgpu_metadata YAML to extract resource usage."""
+    metadata_start = None
+    metadata_end = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            metadata_start = i + 1
+        elif line.strip() == '.end_amdgpu_metadata':
+            metadata_end = i
+
+    if metadata_start is None or metadata_end is None:
+        return {}
+
+    yaml_text = ''.join(lines[metadata_start:metadata_end])
+    resources = {}
+    for key, pattern in [
+        ('vgpr_count', r'\.vgpr_count:\s+(\d+)'),
+        ('agpr_count', r'\.agpr_count:\s+(\d+)'),
+        ('sgpr_count', r'\.sgpr_count:\s+(\d+)'),
+        ('group_segment_fixed_size', r'\.group_segment_fixed_size:\s+(\d+)'),
+        ('private_segment_fixed_size', r'\.private_segment_fixed_size:\s+(\d+)'),
+        ('sgpr_spill_count', r'\.sgpr_spill_count:\s+(\d+)'),
+        ('vgpr_spill_count', r'\.vgpr_spill_count:\s+(\d+)'),
+    ]:
+        m = re.search(pattern, yaml_text)
+        if m:
+            resources[key] = int(m.group(1))
+    return resources
+
+
+def _find_devfunc_symbol(lines):
+    for line in lines:
+        m = re.match(r'\s+\.type\s+(.*ncclDevFunc[^,]+),\s*@function', line)
+        if m:
+            mangled = m.group(1)
+            dm = re.search(r'ncclDevFunc_\w+', mangled)
+            unmangled = dm.group(0) if dm else mangled
+            return mangled, unmangled
+    return None, None
+
+
+def _find_kernel_symbol(lines):
+    for line in lines:
+        m = re.match(r'\s+\.globl\s+(.*ncclDevKernel\S+)', line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def _find_amdhsa_kernel_range(lines):
+    amdhsa_start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('.amdhsa_kernel'):
+            start = i
+            for j in range(i - 1, max(i - 5, -1), -1):
+                s = lines[j].strip()
+                if s.startswith('.section') and '.rodata' in s:
+                    start = j
+                    break
+                if s.startswith('.p2align') or s == '':
+                    start = j
+                else:
+                    break
+            amdhsa_start = start
+        if line.strip() == '.end_amdhsa_kernel':
+            end = i + 1
+            if end < len(lines) and lines[end].strip() == '.text':
+                end += 1
+            return (amdhsa_start, end)
+    return None
+
+
+def _find_metadata_range(lines):
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == '.amdgpu_metadata':
+            start = i
+        elif line.strip() == '.end_amdgpu_metadata':
+            if start is not None:
+                return (start, i + 1)
+    return None
+
+
+def extract_device_function(asm_lines):
+    """Extract device function from assembly lines.
+    Returns (extracted_asm_lines, resources_dict) or raises on error."""
+    mangled, unmangled = _find_devfunc_symbol(asm_lines)
+    if not mangled:
+        raise RuntimeError("No ncclDevFunc found in assembly")
+
+    kernel_sym = _find_kernel_symbol(asm_lines)
+    resources = _parse_metadata_resources(asm_lines)
+    resources['function_name'] = unmangled
+    resources['mangled_name'] = mangled
+
+    skip_ranges = []
+    amdhsa_range = _find_amdhsa_kernel_range(asm_lines)
+    if amdhsa_range:
+        skip_ranges.append(amdhsa_range)
+    metadata_range = _find_metadata_range(asm_lines)
+    if metadata_range:
+        skip_ranges.append(metadata_range)
+
+    def in_skip_range(idx):
+        return any(s <= idx < e for s, e in skip_ranges)
+
+    out_lines = []
+    globl_inserted = False
+    for i, line in enumerate(asm_lines):
+        if in_skip_range(i):
+            continue
+        stripped = line.strip()
+        if '__hip_cuid' in stripped:
+            continue
+        if kernel_sym and re.match(r'\s*\.globl\s+' + re.escape(kernel_sym), stripped):
+            continue
+        if not globl_inserted and mangled in line and '.type' in line and '@function' in line:
+            out_lines.append(f'\t.globl\t{mangled}\n')
+            out_lines.append(f'\t.hidden\t{mangled}\n')
+            globl_inserted = True
+        out_lines.append(line)
+
+    return out_lines, resources
+
+
+# ---------------------------------------------------------------------------
+# Resource aggregation (from aggregate_resources.py)
+# ---------------------------------------------------------------------------
+
+RESOURCE_KEYS = [
+    'vgpr_count', 'agpr_count', 'sgpr_count',
+    'private_segment_fixed_size', 'group_segment_fixed_size',
+]
+
+
+def _align_up(val, alignment):
+    return ((val + alignment - 1) // alignment) * alignment
+
+
+def _has_unified_vgpr_agpr(gpu_target):
+    return gpu_target in ('gfx90a', 'gfx942', 'gfx950')
+
+
+def aggregate_resources(resource_list, gpu_target):
+    """Aggregate a list of resource dicts into max values.
+    Returns the aggregated dict with derived fields."""
+    max_vals = {k: 0 for k in RESOURCE_KEYS}
+    max_regular_vgpr = 0
+
+    for res in resource_list:
+        for key in RESOURCE_KEYS:
+            max_vals[key] = max(max_vals[key], res.get(key, 0))
+        regular = res.get('vgpr_count', 0) - res.get('agpr_count', 0)
+        max_regular_vgpr = max(max_regular_vgpr, regular)
+
+    accum_offset = _align_up(max_regular_vgpr, 4)
+
+    if _has_unified_vgpr_agpr(gpu_target):
+        next_free_vgpr = max(max_vals['vgpr_count'],
+                             accum_offset + max_vals['agpr_count'])
+    else:
+        next_free_vgpr = max_vals['vgpr_count']
+
+    max_vals['accum_offset'] = accum_offset
+    max_vals['next_free_vgpr'] = next_free_vgpr
+
+    _MAX_NUMBERED_SGPR = {9: 102, 10: 106, 11: 106, 12: 106}
+    gen = _gfx_generation(gpu_target)
+    if gen not in _MAX_NUMBERED_SGPR:
+        raise RuntimeError(f"Unknown SGPR limit for generation gfx{gen}xx (target '{gpu_target}')")
+    max_vals['next_free_sgpr'] = min(max_vals['sgpr_count'], _MAX_NUMBERED_SGPR[gen])
+
+    return max_vals
+
+
+def _gfx_generation(gpu_target):
+    m = re.match(r'gfx(\d+)', gpu_target)
+    if not m:
+        raise RuntimeError(f"Cannot parse GPU target '{gpu_target}'")
+    gen = int(m.group(1))
+    if gen >= 100:
+        gen //= 100
+    elif gen >= 10:
+        gen //= 10
+    return gen
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher patching (from patch_dispatcher.py)
+# ---------------------------------------------------------------------------
+
+def _patch_abs_symbols(lines, max_res):
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_vgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_vgpr, {max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_agpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_agpr, {max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(numbered_sgpr),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.numbered_sgpr, {max_res["next_free_sgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(num_named_barrier),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.num_named_barrier, 0\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(private_seg_size),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.private_seg_size, {max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(uses_flat_scratch),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.uses_flat_scratch, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_dyn_sized_stack),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_dyn_sized_stack, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_recursion),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_recursion, 1\n')
+            continue
+        m = re.match(r'(\s*\.set\s+\S+)\.(has_indirect_call),\s*(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.has_indirect_call, 1\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_amdhsa_kernel_directives(lines, max_res):
+    result = []
+    in_kernel = False
+    for line in lines:
+        if re.match(r'\s*\.amdhsa_kernel\s+', line):
+            in_kernel = True
+            result.append(line)
+            continue
+        if in_kernel and re.match(r'\s*\.end_amdhsa_kernel', line):
+            in_kernel = False
+            result.append(line)
+            continue
+        if not in_kernel:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s*)(\.amdhsa_accum_offset)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_accum_offset {max_res["accum_offset"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_next_free_vgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_vgpr {max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_next_free_sgpr)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_next_free_sgpr {max_res["next_free_sgpr"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_private_segment_fixed_size)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_private_segment_fixed_size {max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_uses_dynamic_stack)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_uses_dynamic_stack 1\n')
+            continue
+        m = re.match(r'(\s*)(\.amdhsa_enable_private_segment)\s+(.*)', line)
+        if m:
+            result.append(f'{m.group(1)}.amdhsa_enable_private_segment 1\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_gpr_maximums(lines, max_res):
+    result = []
+    for line in lines:
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_vgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_agpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s*\.set\s+amdgpu\.max_num_sgpr,\s*)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_sgpr"]}\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _patch_amdgpu_metadata(lines, max_res):
+    result = []
+    in_metadata = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == '.amdgpu_metadata':
+            in_metadata = True
+            result.append(line)
+            continue
+        if stripped == '.end_amdgpu_metadata':
+            in_metadata = False
+            result.append(line)
+            continue
+        if not in_metadata:
+            result.append(line)
+            continue
+
+        m = re.match(r'(\s+\.vgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["next_free_vgpr"]}\n')
+            continue
+        m = re.match(r'(\s+(?:-\s+)?\.agpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["agpr_count"]}\n')
+            continue
+        m = re.match(r'(\s+\.sgpr_count:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["sgpr_count"]}\n')
+            continue
+        m = re.match(r'(\s+\.private_segment_fixed_size:\s+)\d+', line)
+        if m:
+            result.append(f'{m.group(1)}{max_res["private_segment_fixed_size"]}\n')
+            continue
+        m = re.match(r'(\s+\.uses_dynamic_stack:\s+)(true|false)', line)
+        if m:
+            result.append(f'{m.group(1)}true\n')
+            continue
+        result.append(line)
+    return result
+
+
+def _normalize_file_directives(lines):
+    return [re.sub(r'(\s+\.file\s+\d+\s+"[^"]*"\s+"[^"]*")\s+md5\s+0x[0-9a-fA-F]+', r'\1', line)
+            for line in lines]
+
+
+def patch_dispatcher(asm_lines, max_res):
+    """Patch dispatcher assembly with aggregated resource values.
+    Returns patched lines."""
+    lines = _patch_abs_symbols(asm_lines, max_res)
+    lines = _patch_amdhsa_kernel_directives(lines, max_res)
+    lines = _patch_gpr_maximums(lines, max_res)
+    lines = _patch_amdgpu_metadata(lines, max_res)
+    lines = _normalize_file_directives(lines)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery
+# ---------------------------------------------------------------------------
+
+def find_tool(name, hints, required=True):
+    """Find an executable by name, searching hints first, then PATH."""
+    for d in hints:
+        if not d:
+            continue
+        path = os.path.join(d, name)
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    # Fall back to PATH
+    import shutil
+    path = shutil.which(name)
+    if path:
+        return path
+    if required:
+        raise FileNotFoundError(
+            f"Required tool '{name}' not found. Searched: {hints} and PATH")
+    return None
+
+
+
+def discover_tools(clang_path, ld_lld_path=None):
+    """Discover amdclang++ and ld.lld from the given compiler path or explicit overrides."""
+    if clang_path:
+        clang = clang_path
+    else:
+        import shutil
+        clang = shutil.which('amdclang++') or shutil.which('clang++')
+        if not clang:
+            raise FileNotFoundError("Cannot find amdclang++ or clang++ on PATH")
+
+    if ld_lld_path:
+        lld = ld_lld_path
+    else:
+        compiler_dir = os.path.dirname(os.path.realpath(clang))
+        llvm_bin = os.path.join(compiler_dir, '..', 'lib', 'llvm', 'bin')
+        hints = [compiler_dir, llvm_bin]
+        lld = find_tool('ld.lld', hints)
+        
+    return clang, lld
+
+
+# ---------------------------------------------------------------------------
+# Run subprocess with error handling
+# ---------------------------------------------------------------------------
+
+def run(cmd, description=""):
+    """Run a command, raising on failure with the full command for diagnosis."""
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        label = f" ({description})" if description else ""
+        print(f"ERROR{label}: command failed with exit code {e.returncode}:",
+              file=sys.stderr)
+        print(f"  {' '.join(cmd)}", file=sys.stderr)
+        sys.exit(e.returncode)
+    except FileNotFoundError:
+        print(f"ERROR: executable not found: {cmd[0]}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Compile mode: .cpp -> .o + .resources.json
+# ---------------------------------------------------------------------------
+
+
+def do_compile(args, forwarded_flags):
+    clang, _ = discover_tools(args.clang)
+    arch = args.arch
+    source = args.source
+    output = args.output
+    keep_temps = args.keep_temps
+
+    base = os.path.splitext(output)[0]
+    json_out = base + '.resources.json'
+
+    # Determine temp directory: alongside output if --keep-temps, else truly temp
+    if keep_temps:
+        asm_file = base + '.full.s'
+        ext_file = base + '.extracted.s'
+        cleanup = []
+    else:
+        tmpdir = tempfile.mkdtemp(prefix='rccl-dc-')
+        asm_file = os.path.join(tmpdir, 'full.s')
+        ext_file = os.path.join(tmpdir, 'extracted.s')
+        cleanup = [asm_file, ext_file, tmpdir]
+
+    try:
+        # Step 1: Compile to assembly
+        compile_cmd = [
+            clang,
+            '-x', 'hip',
+            '--offload-device-only',
+            f'--{args.arch_flag_spelling}={arch}',
+            '-gline-tables-only',
+            '-w',
+        ] + forwarded_flags + [
+            '-S', '-o', asm_file, source,
+        ]
+        run(compile_cmd, f"compile {os.path.basename(source)}")
+
+        # Step 2: Extract device function (inline)
+        with open(asm_file) as f:
+            asm_lines = f.readlines()
+
+        try:
+            extracted_lines, resources = extract_device_function(asm_lines)
+        except RuntimeError as e:
+            print(f"ERROR: extraction failed for {source}: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        extracted_lines = _normalize_file_directives(extracted_lines)
+
+        with open(ext_file, 'w') as f:
+            f.writelines(extracted_lines)
+
+        with open(json_out, 'w') as f:
+            json.dump(resources, f, indent=2)
+
+        # Step 3: Assemble to object
+        assemble_cmd = [
+            clang,
+            '-x', 'assembler',
+            '-target', 'amdgcn-amd-amdhsa',
+            f'-mcpu={arch}',
+            '-c', '-o', output, ext_file,
+        ] + [f for f in forwarded_flags if f == '-fPIC']
+        run(assemble_cmd, f"assemble {os.path.basename(source)}")
+
+    finally:
+        if not keep_temps:
+            for f in cleanup:
+                try:
+                    if os.path.isfile(f):
+                        os.unlink(f)
+                    elif os.path.isdir(f):
+                        os.rmdir(f)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Link mode: objects -> device.elf
+# ---------------------------------------------------------------------------
+
+def do_link(args, forwarded_flags):
+    clang, lld = discover_tools(args.clang, args.ld_lld)
+    arch = args.arch
+    objects = args.objects
+    output = args.output
+    dispatcher = args.dispatcher
+    keep_temps = args.keep_temps
+
+    if not dispatcher:
+        raise SystemExit("ERROR: --link requires --dispatcher=<source>")
+
+    # Collect resource JSONs from alongside each .o
+    resource_list = []
+    for obj in objects:
+        if args.resources_dir:
+            json_path = os.path.join(args.resources_dir, os.path.basename(os.path.splitext(obj)[0]) + '.resources.json')
+        else:
+            json_path = os.path.splitext(obj)[0] + '.resources.json'
+        if os.path.exists(json_path):
+            with open(json_path) as f:
+                resource_list.append(json.load(f))
+
+    if not resource_list:
+        raise SystemExit(f"ERROR: no .resources.json files found alongside input objects")
+
+    # Step 1: Aggregate resources
+    max_res = aggregate_resources(resource_list, arch)
+    print(f"[{arch}] Aggregated {len(resource_list)} resources: "
+          f"VGPR={max_res['vgpr_count']}, AGPR={max_res['agpr_count']}, "
+          f"SGPR={max_res['sgpr_count']}, "
+          f"scratch={max_res['private_segment_fixed_size']}")
+
+    output_dir = os.path.dirname(output) or '.'
+    if keep_temps:
+        disp_asm = os.path.join(output_dir, f'dispatcher_{arch}.s')
+        disp_patched = os.path.join(output_dir, f'dispatcher_{arch}_patched.s')
+        disp_obj = os.path.join(output_dir, f'dispatcher_{arch}.o')
+        cleanup = []
+    else:
+        tmpdir = tempfile.mkdtemp(prefix='rccl-dl-')
+        disp_asm = os.path.join(tmpdir, 'dispatcher.s')
+        disp_patched = os.path.join(tmpdir, 'dispatcher_patched.s')
+        disp_obj = os.path.join(tmpdir, 'dispatcher.o')
+        cleanup = [disp_asm, disp_patched, disp_obj, tmpdir]
+
+    try:
+        # Step 2: Compile dispatcher to assembly
+        disp_compile_cmd = [
+            clang,
+            '-x', 'hip',
+            '--offload-device-only',
+            f'--{args.arch_flag_spelling}={arch}',
+            '-g', '-w',
+        ] + forwarded_flags + [
+            '-S', '-o', disp_asm, dispatcher,
+        ]
+        run(disp_compile_cmd, f"compile dispatcher for {arch}")
+
+        # Step 3: Patch dispatcher with aggregated resources
+        with open(disp_asm) as f:
+            disp_lines = f.readlines()
+        patched_lines = patch_dispatcher(disp_lines, max_res)
+        with open(disp_patched, 'w') as f:
+            f.writelines(patched_lines)
+
+        # Step 4: Assemble patched dispatcher
+        disp_assemble_cmd = [
+            clang,
+            '-x', 'assembler',
+            '-target', 'amdgcn-amd-amdhsa',
+            f'-mcpu={arch}',
+            '-c', '-o', disp_obj, disp_patched,
+        ] + [f for f in forwarded_flags if f == '-fPIC']
+        run(disp_assemble_cmd, f"assemble dispatcher for {arch}")
+
+        # Step 5: Link all objects + dispatcher into device.elf
+        # Use a response file for potentially long object lists
+        rsp_path = os.path.join(output_dir, f'link_{arch}.rsp')
+        with open(rsp_path, 'w') as f:
+            f.write(disp_obj + '\n')
+            for obj in objects:
+                f.write(obj + '\n')
+
+        link_cmd = [
+            lld, '-shared',
+            '-o', output,
+            f'@{rsp_path}',
+        ]
+        run(link_cmd, f"link device.elf for {arch}")
+
+        if not keep_temps:
+            try:
+                os.unlink(rsp_path)
+            except OSError:
+                pass
+
+    finally:
+        if not keep_temps:
+            for f in cleanup:
+                try:
+                    if os.path.isfile(f):
+                        os.unlink(f)
+                    elif os.path.isdir(f):
+                        os.rmdir(f)
+                except OSError:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_compiler_flags(argv):
+    """Separate our flags from forwarded compiler flags (-D, -I, -isystem, -std, -O, etc.)"""
+    our_args = []
+    forwarded = []
+    sources = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        # Our flags
+        if arg in ('--compile', '--link', '--keep-temps', '--version'):
+            our_args.append(arg)
+        elif arg.startswith('--arch='):
+            our_args.append(arg)
+        elif arg == '--arch' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--clang='):
+            our_args.append(arg)
+        elif arg == '--clang' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--resources-dir='):
+            our_args.append(arg)
+        elif arg == '--resources-dir' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--ld-lld='):
+            our_args.append(arg)
+        elif arg == '--ld-lld' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--arch-flag-spelling='):
+            our_args.append(arg)
+        elif arg == '--arch-flag-spelling' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg.startswith('--dispatcher='):
+            our_args.append(arg)
+        elif arg == '--dispatcher' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
+        elif arg == '-o' and i + 1 < len(argv):
+            our_args.extend(['-o', argv[i + 1]])
+            i += 1
+        # Forwarded compiler flags
+        elif arg.startswith('-D') or arg.startswith('-I') or arg.startswith('-isystem'):
+            forwarded.append(arg)
+        elif arg.startswith('-std=') or arg.startswith('-O') or arg == '-g':
+            forwarded.append(arg)
+        elif arg == '-D' and i + 1 < len(argv):
+            forwarded.extend(['-D', argv[i + 1]])
+            i += 1
+        elif arg == '-I' and i + 1 < len(argv):
+            forwarded.extend(['-I', argv[i + 1]])
+            i += 1
+        elif arg.startswith('-'):
+            forwarded.append(arg)
+        else:
+            # Positional: source file or object file
+            sources.append(arg)
+        i += 1
+    return our_args, forwarded, sources
+
+
+def expand_response_files(argv):
+    """Expand @file arguments: replace with one-per-line entries from file."""
+    expanded = []
+    for arg in argv:
+        if arg.startswith('@') and os.path.isfile(arg[1:]):
+            with open(arg[1:]) as f:
+                expanded.extend(line.strip() for line in f if line.strip())
+        else:
+            expanded.append(arg)
+    return expanded
+
+
+def main():
+    raw_args, forwarded_flags, positional = parse_compiler_flags(
+        expand_response_files(sys.argv[1:]))
+
+    parser = argparse.ArgumentParser(prog='rccl-device-compile', add_help=False)
+    parser.add_argument('--compile', action='store_true')
+    parser.add_argument('--link', action='store_true')
+    parser.add_argument('--arch', required=False)
+    parser.add_argument('--clang', default=None)
+    parser.add_argument('--dispatcher', default=None)
+    parser.add_argument('-o', '--output', required=False)
+    parser.add_argument('--keep-temps', action='store_true')
+    parser.add_argument('--version', action='store_true')
+    parser.add_argument('--resources-dir', default=None)
+    parser.add_argument('--ld-lld', default=None)
+    parser.add_argument('--bundler', default=None)
+    parser.add_argument('--arch-flag-spelling', default='offload-arch')
+
+
+    args = parser.parse_args(raw_args)
+
+    if args.version:
+        print("rccl-device-compile 1.0")
+        sys.exit(0)
+
+    if args.compile:
+        if not positional:
+            raise SystemExit("ERROR: --compile requires a source file")
+        if not args.arch:
+            raise SystemExit("ERROR: --compile requires --arch=<target>")
+        if not args.output:
+            raise SystemExit("ERROR: --compile requires -o <output>")
+        args.source = positional[0]
+        do_compile(args, forwarded_flags)
+
+    elif args.link:
+        if not positional:
+            raise SystemExit("ERROR: --link requires object files")
+        if not args.arch:
+            raise SystemExit("ERROR: --link requires --arch=<target>")
+        if not args.output:
+            raise SystemExit("ERROR: --link requires -o <output>")
+        args.objects = positional
+        do_link(args, forwarded_flags)
+
+    else:
+        raise SystemExit("ERROR: specify --compile or --link mode")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Summary:
Ports the parallel device-linker build mechanism (already in rcclx-dev) into
the stable snapshot targets so the pinned stable snapshot benefits from the same
per-arch parallel compile/link speedups, and teaches the snapshot generator to
carry the new files forward.

- Add device_linker.bzl with per-arch parallel device compile/link, bundle, and
  host-object genrule helpers
- Add the develop/tools device-compile driver (rccl-device-compile) and the
  asm_extract tooling (extract_device_function, patch_dispatcher,
  aggregate_resources, resource_summary)
- Wire the new device-linker path through BUCK, def_build.bzl and
  rccl_build_config.bzl, with matching device source/generator updates
  (generate.py, common.cu/.h, onerank.cu) and a utils.bzl tweak
- Update create_snapshot.py to include device_linker.bzl and the device-compile
  driver/tools when generating snapshots, and to rewrite their load/target paths
  to the snapshot package

Differential Revision: D108204435


