### PR TITLE
Enable FlightRecorderAbort test for XPU

### DIFF
--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderAbortTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderAbortTest.py
@@ -145,3 +145,6 @@ class TestFlightRecorderAbort(unittest.TestCase):
                     os.remove(trace_file)
                 except OSError:
                     pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/hooks/fr/tests/py/FlightRecorderAbortTest.py
+++ b/comms/torchcomms/hooks/fr/tests/py/FlightRecorderAbortTest.py
@@ -146,5 +146,6 @@ class TestFlightRecorderAbort(unittest.TestCase):
                 except OSError:
                     pass
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
@@ -49,6 +49,7 @@ run_tests () {
 
     cd -
     cd "$(dirname "$0")/../hooks/fr/tests/py"
+    torchrun --nnodes 1 --nproc_per_node "${NPROC_PER_NODE}" -m pytest -v -s FlightRecorderAbortTest.py
     torchrun --nnodes 1 --nproc_per_node "${NPROC_PER_NODE}" -m pytest -v -s FlightRecorderTest.py
 }
 


### PR DESCRIPTION
This PR enables the `FlightRecorderAbort` test for XPU device