### PR TITLE
Counter-based checkRecvNotify for TCPDM irecv completion (#2860)

### DIFF
--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -74,9 +74,19 @@ class CtranTcpDm {
     return commInvalidUsage;
   }
 
-  // irecv operations can not proceed unless the peer has been connected.
-  // When there is no peer, irecv operations are queued and progress()
-  // has to be called to make progress on them.
+  commResult_t irecvCounted(
+      int peerRank,
+      void* handle,
+      void* data,
+      size_t size,
+      void* unpackPool) {
+    return commInvalidUsage;
+  }
+
+  commResult_t checkNotify(int peerRank, bool* done) {
+    return commInvalidUsage;
+  }
+
   commResult_t progress() {
     return commInvalidUsage;
   }

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -426,6 +426,7 @@ commResult_t CtranTcpDm::progress() {
   std::unique_lock lock(mutex_);
 
   ctrlSyncProgress();
+  recvNotifyProgress();
 
   for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
     auto& recvReq = *it;
@@ -503,6 +504,55 @@ commResult_t CtranTcpDm::irecvConnected(
 
   req.track(transport.get(), request);
 
+  return commSuccess;
+}
+
+commResult_t CtranTcpDm::irecvCounted(
+    int peerRank,
+    void* handle,
+    void* data,
+    size_t size,
+    void* unpackPool) {
+  auto req = std::make_unique<CtranTcpDmRequest>();
+  auto* rawReq = req.get();
+  pendingRecvNotifies_[peerRank].push_back(std::move(req));
+
+  {
+    std::unique_lock lock(mutex_);
+    if (recvComms_.find(peerRank) == recvComms_.end()) {
+      auto recvReq = std::make_unique<RecvRequest>();
+      recvReq->peerRank = peerRank;
+      recvReq->handle = handle;
+      recvReq->data = data;
+      recvReq->size = size;
+      recvReq->req = rawReq;
+      recvReq->unpackPool = unpackPool;
+      queuedRecv_.push_back(std::move(recvReq));
+      return commSuccess;
+    }
+  }
+
+  return irecvConnected(peerRank, handle, data, size, *rawReq, unpackPool);
+}
+
+void CtranTcpDm::recvNotifyProgress() {
+  for (auto& [peerRank, pending] : pendingRecvNotifies_) {
+    while (!pending.empty() && pending.front()->isComplete()) {
+      pending.pop_front();
+      recvNotifyCount_[peerRank]++;
+    }
+  }
+}
+
+commResult_t CtranTcpDm::checkNotify(int peerRank, bool* done) {
+  recvNotifyProgress();
+  auto it = recvNotifyCount_.find(peerRank);
+  if (it != recvNotifyCount_.end() && it->second > 0) {
+    it->second--;
+    *done = true;
+  } else {
+    *done = false;
+  }
   return commSuccess;
 }
 

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -47,6 +47,19 @@ class CtranTcpDm {
       CtranTcpDmRequest& req,
       void* unpackPool);
 
+  // Counter-based irecv: request is managed internally, completion
+  // increments a per-peer counter checked by checkNotify.
+  commResult_t irecvCounted(
+      int peerRank,
+      void* handle,
+      void* data,
+      size_t size,
+      void* unpackPool);
+
+  // Check if a data recv has completed for peerRank (counter-based,
+  // analogous to IB's notifyCount_ approach).
+  commResult_t checkNotify(int peerRank, bool* done);
+
   commResult_t iput(
       const void* sbuf,
       void* dbuf,
@@ -137,6 +150,14 @@ class CtranTcpDm {
   // Per-peer count of received sync bytes (for debugging).
   std::unordered_map<int, int> syncRecvCount_;
 
+  // Counter-based recv notification (analogous to IB's notifyCount_).
+  // Internally-owned requests for irecvCounted; completed in FIFO order.
+  std::unordered_map<int, std::deque<std::unique_ptr<CtranTcpDmRequest>>>
+      pendingRecvNotifies_;
+  // Per-peer count of completed data recvs, decremented by checkNotify.
+  std::unordered_map<int, int> recvNotifyCount_;
+
+  void recvNotifyProgress();
   void ctrlSyncProgress();
 
   commResult_t connectPeer(int peerRank);

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1105,9 +1105,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       FB_COMMCHECK(this->ctranIb->waitNotify<PerfConfig>(
           notify->peer, notify->notifyCnt));
     } else if (notify->backend == CtranMapperBackend::TCPDM) {
-      // TODO(T239012482): enable and test TCPDM FT
-      while (!notify->tcpDmReq.isComplete()) {
+      bool done = false;
+      while (!done && !comm->testAbort()) {
         FB_COMMCHECK(this->ctranTcpDm->progress());
+        FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, &done));
       }
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
@@ -1942,14 +1943,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       kernElem->revoke();
       kernElem = nullptr;
     } else if (backend == CtranMapperBackend::TCPDM) {
-      // We are mapping two-sided communications (i.e., send/receive) to
-      // one-sided communications (i.e., iPUT/waitNotify). Due to this, we
-      // handle TCP differently. Specifically, for iPUT, TCP performs the send
-      // operation, and for waitNotify, TCP performs the receive operation.
-      // Consequently, we need to progress TCP to ensure it completes the
-      // receive operation. Once it does, it will mark tcpDmReq as complete,
-      // allowing us to exit the loop.
-
       const void* rbuff = nullptr;
       size_t len = 0;
       if (kernElem != nullptr) {
@@ -1973,12 +1966,14 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         len = regElem->len;
       }
 
-      FB_COMMCHECK(this->ctranTcpDm->irecv(
+      // Counter-based: request managed internally by CtranTcpDm.
+      // Completions are tracked via a per-peer counter, checked by
+      // checkNotify (analogous to IB's notifyCount_).
+      FB_COMMCHECK(this->ctranTcpDm->irecvCounted(
           peerRank,
           regElem->tcpRegElem,
           (void*)rbuff,
           len,
-          notify->tcpDmReq,
           this->context.unpackPool));
     }
 
@@ -2005,9 +2000,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (notify->backend == CtranMapperBackend::IB) {
       FB_COMMCHECK(this->ctranIb->checkNotify<PerfConfig>(notify->peer, done));
     } else if (notify->backend == CtranMapperBackend::TCPDM) {
-      // Progress TCPDM transport to post any queued irecv requests
       FB_COMMCHECK(this->ctranTcpDm->progress());
-      *done = notify->tcpDmReq.isComplete();
+      FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, done));
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
       return commInternalError;


### PR DESCRIPTION
Summary:

Add `irecvCounted` and `checkNotify` to `CtranTcpDm`, providing a counter-based irecv completion mechanism analogous to IB's `notifyCount_`. Each `irecvCounted` call creates an internally-managed `CtranTcpDmRequest` in a per-peer FIFO; `recvNotifyProgress` drains completed requests and increments a per-peer counter; `checkNotify` checks/decrements the counter. The mapper's `initNotifyImpl` now calls `irecvCounted` (request managed internally, not by the notify's embedded `tcpDmReq`), and `checkNotifyImpl` calls `checkNotify`. This enables the AllReduceRing to use a single `CtranMapperNotify` for TCPDM, matching the IB pattern.

Reviewed By: fomichev

Differential Revision: D106677739


