### PR TITLE
AllReduceRing: single notify with numChunks pipeline depth for TCPDM (#2861)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -259,7 +259,6 @@ inline void progressSendCheckTrans(
           resource.comm->ctran_->mapper->testRequest(resp.get(), &isComplete),
           resource.comm->logMetaData_);
       if (isComplete) {
-        // FIXME: step might be incorrect
         CLOGF_TRACE(
             COLL,
             "progressSendCheckTrans {} done",
@@ -527,8 +526,8 @@ inline void progressRecvPostRecvBuf(
   bufSyncSResps.at(round).reset(req);
 }
 
-// Post irecv for the current round (TCPDM requires 1:1 irecv per iput).
-// Round 0, partition 0 is posted in completeHostResourceSetup.
+// Post irecv for the current round using the single leftNotify.
+// The backend tracks requests internally via counter-based notification.
 inline void progressRecvPostTcpDmIrecv(
     const ctran::allreduce::ring::HostArgs& args,
     ctran::allreduce::ring::HostResource& resource,
@@ -542,19 +541,13 @@ inline void progressRecvPostTcpDmIrecv(
   size_t chunkBytes = chunkArg.numel * algoCtx.typeSize;
   resource.recvKernElem->waitNotify.recvbuff = chunkRecvBuf;
   resource.recvKernElem->waitNotify.nbytes = chunkBytes;
-  if (round > 0 || algoCtx.partition > 0) {
-    // The TCPDM needs to call initNotify, i.e. tcpdm->irecv() in every single
-    // recv round. Reuse the initNotify mechnaisim here to post irecv().
-    // Reuse leftNotify — the ready counter guarantees the previous round's
-    // checkNotify completed before we post the next irecv.
-    FB_COMMCHECKTHROW_EX(
-        resource.comm->ctran_->mapper->initNotify(
-            args.leftRank,
-            resource.tmpRecvBufHdl,
-            resource.recvKernElem,
-            args.leftNotify.get()),
-        resource.comm->logMetaData_);
-  }
+  FB_COMMCHECKTHROW_EX(
+      resource.comm->ctran_->mapper->initNotify(
+          args.leftRank,
+          resource.tmpRecvBufHdl,
+          resource.recvKernElem,
+          args.leftNotify.get()),
+      resource.comm->logMetaData_);
 }
 
 inline void progressSend(
@@ -596,20 +589,10 @@ inline void progressRecv(
     std::vector<std::unique_ptr<CtranMapperRequest>>& bufSyncSResps,
     std::vector<std::unique_ptr<CtranMapperRequest>>& flushResps) {
   // Post step: TCPDM posts irecv, IB is a no-op (data arrives via RDMA put).
-  // Serialized via ready counter (TCPDM: ready=1, IB: ready=-1 unlimited).
   if (opReadyToPost<Op::kRecvTrans>(algoCtx)) {
     if (hasTcpDmRecv(args, resource)) {
-      // TCPDM: don't post irecv if the target tmpRecvBuf slot is still being
-      // read by a previous round's recvRedCopy. IB doesn't need this because
-      // the sender-side bufSync gates writes until recvRedCopy completes.
-      int round = algoCtx.opRounds[Op::kRecvTrans].post;
-      bool slotFree = round < static_cast<int>(algoCtx.numChunks) ||
-          algoCtx.opRounds[Op::kRecvRedCopy].done >
-              round - static_cast<int>(algoCtx.numChunks);
-      if (slotFree) {
-        progressRecvPostTcpDmIrecv(args, resource, algoCtx);
-        opUpdatePost<Op::kRecvTrans>(algoCtx);
-      }
+      progressRecvPostTcpDmIrecv(args, resource, algoCtx);
+      opUpdatePost<Op::kRecvTrans>(algoCtx);
     } else {
       opUpdatePost<Op::kRecvTrans>(algoCtx);
     }
@@ -619,11 +602,6 @@ inline void progressRecv(
   if (opHasPosted<Op::kRecvTrans>(algoCtx) &&
       progressRecvCheckTrans(args, resource, algoCtx)) {
     opUpdateDone<Op::kRecvTrans>(algoCtx);
-    if (hasTcpDmRecv(args, resource)) {
-      // Allow next round's irecv to post (one in flight at a time —
-      // initNotify reuses leftNotify after checkNotify completes).
-      algoCtx.opRounds[Op::kRecvTrans].ready++;
-    }
   }
 
   // Check if any received chunk is ready to flush
@@ -641,12 +619,6 @@ inline void progressRecv(
   // Check if any received chunk is ready to reduce with local data
   if (opReadyToPost<Op::kRecvRedCopy>(algoCtx)) {
     int step = algoCtx.opRounds[Op::kRecvRedCopy].postStep.step;
-    // Combine reduce and sendCopy.
-    // ## When it is not a isRecvFwd round:
-    // - For last step, we don't need sendCopy.
-    // ## When it is a isRecvFwd round:
-    // - Combine reduce and next step's sendCopy. Consequently, need check
-    // sendBuf availability before reduce.
     if (!isRecvFwd(algoCtx, step) || progressRecvCheckSendBuf(algoCtx)) {
       progressRecvPostRedCopyKern(args, resource, algoCtx);
       opUpdatePost<Op::kRecvRedCopy>(algoCtx);
@@ -656,8 +628,10 @@ inline void progressRecv(
   // Check if any outstanding reduceCopy is done
   if (opHasPosted<Op::kRecvRedCopy>(algoCtx)) {
     if (progressRecvCheckRedCopyKern(args, resource, algoCtx)) {
-      // Post buffer-ready sync after local reduce used the data.
       progressRecvPostRecvBuf(args, resource, algoCtx, bufSyncSResps);
+      if (hasTcpDmRecv(args, resource)) {
+        algoCtx.opRounds[Op::kRecvTrans].ready++;
+      }
       opUpdateDone<Op::kRecvRedCopy>(algoCtx);
     }
   }
@@ -985,9 +959,8 @@ inline void updatePartitionCtxHost(
     updatePartitionCtx<false>(algoCtx);
   }
   if (hasTcpDmRecv(args, resource)) {
-    // TCPDM: serialize irecv posts (one at a time) since initNotify reuses
-    // leftNotify. IB uses ready=-1 to pre-post all rounds.
-    algoCtx.opRounds[Op::kRecvTrans].ready = 1;
+    // TCPDM: post numChunks irecvs upfront; back-pressure via isendCtrl.
+    algoCtx.opRounds[Op::kRecvTrans].ready = algoCtx.numChunks;
   }
 
   if (algoCtx.partition > 0) {
@@ -1020,13 +993,19 @@ inline commResult_t completeHostResourceSetup(
     ctran::allreduce::ring::HostResource& resource) {
   exchangePeerTmpBufs(comm, args);
 
-  // Forward: notifications from left on tmpRecvBuf
+  // Forward: notifications from left on tmpRecvBuf.
   args.leftNotify.reset(new CtranMapperNotify());
-  FB_COMMCHECK(comm->ctran_->mapper->initNotify(
-      args.leftRank,
-      resource.tmpRecvBufHdl,
-      resource.recvKernElem,
-      args.leftNotify.get()));
+  if (hasTcpDmRecv(args, resource)) {
+    // TCPDM: irecvs are posted from the progress loop, not here.
+    // The backend tracks completions via counter (checkRecvNotify).
+  } else {
+    // IB: single initNotify, data arrives via RDMA put.
+    FB_COMMCHECK(comm->ctran_->mapper->initNotify(
+        args.leftRank,
+        resource.tmpRecvBufHdl,
+        resource.recvKernElem,
+        args.leftNotify.get()));
+  }
 
   size_t offsetRingTmpRecv = comm->ctran_->algo->getTmpBufOffset(
       CtranAlgo::TmpbufType::RING_TMP_RECV_BUF);
@@ -1130,6 +1109,8 @@ static commResult_t impl(
   std::vector<std::unique_ptr<CtranMapperRequest>> revBufSyncRResps;
   std::vector<std::unique_ptr<CtranMapperRequest>> revFlushResps;
 
+  // Perftrace: create tracer on first use, create record per allreduce
+
   CTRAN_PROFILER_IF(
       profiler, profiler->startEvent(ctran::ProfilerEvent::ALGO_DATA));
   while (algoCtx.partitionOffset < algoCtx.numElements) {
@@ -1224,6 +1205,8 @@ static commResult_t impl(
       profiler, profiler->endEvent(ctran::ProfilerEvent::ALGO_DATA));
 
   CTRAN_PROFILER_IF(profiler, { profiler->reportToScuba(); });
+
+  // No notify cleanup needed — backend tracks requests internally.
 
   // Reset flags for next allreduce to reuse. Only clear sync status (post/
   // complete flags); do not release to pool (inuse stays true). Pool release
@@ -1478,6 +1461,9 @@ commResult_t ctranAllReduceRing(
     op->allreduce.kElemStepMap[static_cast<int>(
         ctran::allreduce::KernElemRole::kTcpDmRecv)] =
         hostResource.recvKernElem;
+
+    // leftNotify allocated in completeHostResourceSetup (GPE thread).
+    // Backend manages irecv requests internally via counter-based notification.
   }
   // rightRemBuf, rightRemKey, leftNotify init from gpe thread for EpochLock
 

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -85,7 +85,9 @@ struct HostArgs {
   void* rightRemBuf{nullptr};
   CtranMapperRemoteAccessKey rightRemKey;
 
-  // Forward: receive notifications from left
+  // Forward: receive notifications from left.
+  // Single notify for both IB and TCPDM. IB uses IMM sequence numbers;
+  // TCPDM uses counter-based checkRecvNotify in the backend.
   std::unique_ptr<CtranMapperNotify> leftNotify{nullptr};
 
   // Reverse: remote receive buffer on left (left neighbor's tmpRecvBufRev)

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -74,9 +74,19 @@ class CtranTcpDm {
     return commInvalidUsage;
   }
 
-  // irecv operations can not proceed unless the peer has been connected.
-  // When there is no peer, irecv operations are queued and progress()
-  // has to be called to make progress on them.
+  commResult_t irecvCounted(
+      int peerRank,
+      void* handle,
+      void* data,
+      size_t size,
+      void* unpackPool) {
+    return commInvalidUsage;
+  }
+
+  commResult_t checkNotify(int peerRank, bool* done) {
+    return commInvalidUsage;
+  }
+
   commResult_t progress() {
     return commInvalidUsage;
   }

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -1,4 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+#include <sys/socket.h>
+#include <thread>
+
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/profiler/Profiler.h"
@@ -109,6 +112,21 @@ void CtranTcpDm::bootstrapAccept() {
 
     auto transport = CtranTcpDmSingleton::getTransport();
 
+    // Negative rank = ctrl socket connection (bufSync)
+    if (peerRank < 0) {
+      int actualPeer = -(peerRank + 1);
+      int ctrlFd = socket.getFd();
+      std::lock_guard lock(mutex_);
+      ctrlSocks_.emplace(actualPeer, std::move(socket));
+      CLOGF_SUBSYS(
+          INFO,
+          INIT,
+          "CTRAN-TCPDM: ctrl socket accepted from peer {} fd={}",
+          actualPeer,
+          ctrlFd);
+      continue;
+    }
+
     ::comms::tcp_devmem::Handle handle{};
     ::comms::tcp_devmem::ListenerInterface* listenComm{};
     COMMCHECKTHROW(transport->listen(netdev_, &handle, &listenComm));
@@ -126,8 +144,8 @@ void CtranTcpDm::bootstrapAccept() {
     CLOGF_SUBSYS(
         INFO,
         INIT,
-        "CTRAN-TC: Established connection: commHash {:x}, commDesc {}, "
-        "rank {}, peer {}",
+        "CTRAN-TCPDM: Established data connection: commHash {:x}, "
+        "commDesc {}, rank {}, peer {}",
         commHash_,
         commDesc_,
         rank_,
@@ -178,8 +196,8 @@ commResult_t CtranTcpDm::bootstrapConnect(
   CLOGF_SUBSYS(
       INFO,
       INIT,
-      "CTRAN-TCPDM: Established connection: commHash {:x}, commDesc {}, pimpl {}, "
-      "rank {}, peer {}",
+      "CTRAN-TCPDM: Established data connection: commHash {:x}, "
+      "commDesc {}, pimpl {}, rank {}, peer {}",
       commHash_,
       commDesc_,
       (void*)this,
@@ -187,6 +205,34 @@ commResult_t CtranTcpDm::bootstrapConnect(
       peerRank);
 
   return res;
+}
+
+void CtranTcpDm::ensureCtrlSocket(int peerRank) {
+  {
+    std::lock_guard lock(mutex_);
+    if (ctrlSocks_.count(peerRank)) {
+      return;
+    }
+  }
+
+  folly::SocketAddress peerAddr;
+  peerAddr.setFromSockaddr(
+      reinterpret_cast<sockaddr_in6*>(&allListenSocketAddrs_[peerRank]));
+  ctran::bootstrap::Socket sock;
+  FB_SYSCHECKTHROW_EX(
+      sock.connect(
+          peerAddr,
+          NCCL_CLIENT_SOCKET_IFNAME,
+          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
+          NCCL_SOCKET_RETRY_CNT),
+      rank_,
+      commHash_,
+      commDesc_);
+  int marker = -(rank_ + 1);
+  FB_SYSCHECKTHROW_EX(
+      sock.send(&marker, sizeof(int)), rank_, commHash_, commDesc_);
+  std::lock_guard lock(mutex_);
+  ctrlSocks_.emplace(peerRank, std::move(sock));
 }
 
 CtranTcpDm::CtranTcpDm(
@@ -320,8 +366,66 @@ commResult_t CtranTcpDm::connectPeer(int peerRank) {
   return bootstrapConnect(peerRank, peerAddr);
 }
 
+void CtranTcpDm::ctrlSyncProgress() {
+  for (auto& [peerRank, sock] : ctrlSocks_) {
+    auto& pending = pendingSyncRecvs_[peerRank];
+    while (!pending.empty()) {
+      uint8_t sync;
+      int ret = ::recv(sock.getFd(), &sync, sizeof(sync), MSG_DONTWAIT);
+      if (ret <= 0) {
+        break;
+      }
+      syncRecvCount_[peerRank]++;
+      pending.front()->complete();
+      pending.pop_front();
+      CLOGF_SUBSYS(
+          INFO,
+          COLL,
+          "CTRAN-TCPDM: ctrlSyncProgress completed sync from peer {}, total={}, remaining={}, fd={}",
+          peerRank,
+          syncRecvCount_[peerRank],
+          pending.size(),
+          sock.getFd());
+    }
+  }
+}
+
+commResult_t CtranTcpDm::isendCtrlMsg(
+    const ControlMsg& msg,
+    int peerRank,
+    CtranTcpDmRequest& req) {
+  // only allow sync messages to be sent on the ctrl socket
+  if (msg.type != ControlMsgType::SYNC) {
+    req.complete();
+    return commSuccess;
+  }
+  // only sendeer can do lazy connect to avoid deadlock.
+  ensureCtrlSocket(peerRank);
+  std::lock_guard lock(mutex_);
+  auto& sock = ctrlSocks_.at(peerRank);
+  uint8_t sync = 1;
+  sock.send(&sync, sizeof(sync));
+  req.complete();
+  return commSuccess;
+}
+
+commResult_t CtranTcpDm::irecvCtrlMsg(
+    ControlMsg& msg,
+    int peerRank,
+    CtranTcpDmRequest& req) {
+  if (msg.type != ControlMsgType::SYNC) {
+    req.complete();
+    return commSuccess;
+  }
+  std::lock_guard lock(mutex_);
+  pendingSyncRecvs_[peerRank].push_back(&req);
+  return commSuccess;
+}
+
 commResult_t CtranTcpDm::progress() {
   std::unique_lock lock(mutex_);
+
+  ctrlSyncProgress();
 
   for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
     auto& recvReq = *it;

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -426,6 +426,7 @@ commResult_t CtranTcpDm::progress() {
   std::unique_lock lock(mutex_);
 
   ctrlSyncProgress();
+  recvNotifyProgress();
 
   for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
     auto& recvReq = *it;
@@ -503,6 +504,55 @@ commResult_t CtranTcpDm::irecvConnected(
 
   req.track(transport.get(), request);
 
+  return commSuccess;
+}
+
+commResult_t CtranTcpDm::irecvCounted(
+    int peerRank,
+    void* handle,
+    void* data,
+    size_t size,
+    void* unpackPool) {
+  auto req = std::make_unique<CtranTcpDmRequest>();
+  auto* rawReq = req.get();
+  pendingRecvNotifies_[peerRank].push_back(std::move(req));
+
+  {
+    std::unique_lock lock(mutex_);
+    if (recvComms_.find(peerRank) == recvComms_.end()) {
+      auto recvReq = std::make_unique<RecvRequest>();
+      recvReq->peerRank = peerRank;
+      recvReq->handle = handle;
+      recvReq->data = data;
+      recvReq->size = size;
+      recvReq->req = rawReq;
+      recvReq->unpackPool = unpackPool;
+      queuedRecv_.push_back(std::move(recvReq));
+      return commSuccess;
+    }
+  }
+
+  return irecvConnected(peerRank, handle, data, size, *rawReq, unpackPool);
+}
+
+void CtranTcpDm::recvNotifyProgress() {
+  for (auto& [peerRank, pending] : pendingRecvNotifies_) {
+    while (!pending.empty() && pending.front()->isComplete()) {
+      pending.pop_front();
+      recvNotifyCount_[peerRank]++;
+    }
+  }
+}
+
+commResult_t CtranTcpDm::checkNotify(int peerRank, bool* done) {
+  recvNotifyProgress();
+  auto it = recvNotifyCount_.find(peerRank);
+  if (it != recvNotifyCount_.end() && it->second > 0) {
+    it->second--;
+    *done = true;
+  } else {
+    *done = false;
+  }
   return commSuccess;
 }
 

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -47,6 +47,19 @@ class CtranTcpDm {
       CtranTcpDmRequest& req,
       void* unpackPool);
 
+  // Counter-based irecv: request is managed internally, completion
+  // increments a per-peer counter checked by checkNotify.
+  commResult_t irecvCounted(
+      int peerRank,
+      void* handle,
+      void* data,
+      size_t size,
+      void* unpackPool);
+
+  // Check if a data recv has completed for peerRank (counter-based,
+  // analogous to IB's notifyCount_ approach).
+  commResult_t checkNotify(int peerRank, bool* done);
+
   commResult_t iput(
       const void* sbuf,
       void* dbuf,
@@ -137,6 +150,14 @@ class CtranTcpDm {
   // Per-peer count of received sync bytes (for debugging).
   std::unordered_map<int, int> syncRecvCount_;
 
+  // Counter-based recv notification (analogous to IB's notifyCount_).
+  // Internally-owned requests for irecvCounted; completed in FIFO order.
+  std::unordered_map<int, std::deque<std::unique_ptr<CtranTcpDmRequest>>>
+      pendingRecvNotifies_;
+  // Per-peer count of completed data recvs, decremented by checkNotify.
+  std::unordered_map<int, int> recvNotifyCount_;
+
+  void recvNotifyProgress();
   void ctrlSyncProgress();
 
   commResult_t connectPeer(int peerRank);

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <deque>
 #include <unordered_map>
 
 #include "comms/ctran/CtranComm.h"
@@ -58,27 +59,11 @@ class CtranTcpDm {
     return isend(peerRank, tcpdmRegElem, (void*)sbuf, len, *req);
   }
 
-  commResult_t irecvCtrlMsg(
-      [[maybe_unused]] ControlMsg& msg,
-      [[maybe_unused]] int peerRank,
-      CtranTcpDmRequest& req) {
-    // Don't share receiver's control information with the sender. Rely
-    // on the receiver buffering (TCP window) instead of explicit
-    // synchronization.
-    req.complete();
-    return commSuccess;
-  }
+  commResult_t
+  irecvCtrlMsg(ControlMsg& msg, int peerRank, CtranTcpDmRequest& req);
 
-  commResult_t isendCtrlMsg(
-      [[maybe_unused]] const ControlMsg& msg,
-      [[maybe_unused]] int peerRank,
-      CtranTcpDmRequest& req) {
-    // Don't share receiver's control information with the sender. Rely
-    // on the receiver buffering (TCP window) instead of explicit
-    // synchronization.
-    req.complete();
-    return commSuccess;
-  }
+  commResult_t
+  isendCtrlMsg(const ControlMsg& msg, int peerRank, CtranTcpDmRequest& req);
 
   void profilerStart();
   void profilerEnd();
@@ -138,6 +123,21 @@ class CtranTcpDm {
     void* unpackPool{nullptr};
   };
   std::list<std::unique_ptr<RecvRequest>> queuedRecv_;
+
+  // Lazy per-peer TCP connections for sync-only control messages.
+  // Created on-demand by ensureCtrlSocket() on first isendCtrlMsg/irecvCtrlMsg.
+  // Smaller rank initiates; larger rank's bootstrapAccept thread accepts.
+  std::unordered_map<int, ctran::bootstrap::Socket> ctrlSocks_;
+  void ensureCtrlSocket(int peerRank);
+
+  // Per-peer queue of pending sync recv requests (from irecvCtrlMsg).
+  // Completed in FIFO order as sync bytes arrive on ctrlSocks_.
+  std::unordered_map<int, std::deque<CtranTcpDmRequest*>> pendingSyncRecvs_;
+
+  // Per-peer count of received sync bytes (for debugging).
+  std::unordered_map<int, int> syncRecvCount_;
+
+  void ctrlSyncProgress();
 
   commResult_t connectPeer(int peerRank);
 

--- a/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
+++ b/comms/ctran/backends/tcpdevmem/tests/CtranTcpDmDistUT.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -12,6 +13,7 @@
 #include <folly/logging/xlog.h>
 
 #include "comms/ctran/Ctran.h"
+#include "comms/ctran/backends/CtranCtrl.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDm.h"
 #include "comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.h"
 #include "comms/ctran/tests/CtranDistTestUtils.h"
@@ -155,7 +157,89 @@ TEST_F(CtranTcpTest, SendRecv) {
         ctranTcpDm->isend(recvRank, memHandle, &send, sizeof(send), req));
     COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
   }
-  COMMCHECK_TEST(CtranTcpDm::deregMem(memHandle));
+  // Ranks outside the sender/receiver pair never registered memory.
+  if (memHandle != nullptr) {
+    COMMCHECK_TEST(CtranTcpDm::deregMem(memHandle));
+  }
+}
+
+TEST_F(CtranTcpTest, SyncCtrlMsg) {
+  this->printTestDesc(
+      "SyncCtrlMsg",
+      "Expect CtranTcpDm to deliver a SYNC control message over a "
+      "lazily-established ctrl socket.");
+
+  if (this->numRanks < 2) {
+    GTEST_SKIP() << "Test requires at least 2 ranks. Skip test.";
+  }
+
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::SYNC);
+  CtranTcpDmRequest req{};
+
+  if (this->globalRank == sendRank) {
+    // Sender lazily connects the ctrl socket and pushes the sync byte; the
+    // send request completes synchronously.
+    COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, req));
+    EXPECT_TRUE(req.isComplete());
+  } else if (this->globalRank == recvRank) {
+    // Receiver queues the sync recv and drains it via progress().
+    COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, req));
+    COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
+  }
+}
+
+TEST_F(CtranTcpTest, SyncCtrlMsgBackPressure) {
+  this->printTestDesc(
+      "SyncCtrlMsgBackPressure",
+      "Expect CtranTcpDm to deliver multiple SYNC control messages in FIFO "
+      "order over a single ctrl socket.");
+
+  if (this->numRanks < 2) {
+    GTEST_SKIP() << "Test requires at least 2 ranks. Skip test.";
+  }
+
+  constexpr int kNumSyncs = 8;
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::SYNC);
+
+  if (this->globalRank == sendRank) {
+    for (int i = 0; i < kNumSyncs; i++) {
+      CtranTcpDmRequest req{};
+      COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, req));
+      EXPECT_TRUE(req.isComplete());
+    }
+  } else if (this->globalRank == recvRank) {
+    // Post all sync recvs up-front so they are completed from the pending
+    // queue in FIFO order as bytes arrive.
+    std::vector<CtranTcpDmRequest> reqs(kNumSyncs);
+    for (auto& req : reqs) {
+      COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, req));
+    }
+    for (auto& req : reqs) {
+      COMMCHECK_TEST(waitTcpReq(req, ctranTcpDm));
+    }
+  }
+}
+
+TEST_F(CtranTcpTest, NonSyncCtrlMsgIsNoop) {
+  this->printTestDesc(
+      "NonSyncCtrlMsgIsNoop",
+      "Expect non-SYNC control messages to complete immediately without "
+      "establishing a ctrl socket.");
+
+  // Non-SYNC ctrl messages are a local no-op on the TCPDM backend, so every
+  // rank can exercise this independently without peer interaction.
+  ControlMsg msg{};
+  msg.setType(ControlMsgType::UNSPECIFIED);
+
+  CtranTcpDmRequest sendReq{};
+  COMMCHECK_TEST(ctranTcpDm->isendCtrlMsg(msg, recvRank, sendReq));
+  EXPECT_TRUE(sendReq.isComplete());
+
+  CtranTcpDmRequest recvReq{};
+  COMMCHECK_TEST(ctranTcpDm->irecvCtrlMsg(msg, sendRank, recvReq));
+  EXPECT_TRUE(recvReq.isComplete());
 }
 
 TEST_F(CtranTcpTest, getIfNames) {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1105,9 +1105,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       FB_COMMCHECK(this->ctranIb->waitNotify<PerfConfig>(
           notify->peer, notify->notifyCnt));
     } else if (notify->backend == CtranMapperBackend::TCPDM) {
-      // TODO(T239012482): enable and test TCPDM FT
-      while (!notify->tcpDmReq.isComplete()) {
+      bool done = false;
+      while (!done && !comm->testAbort()) {
         FB_COMMCHECK(this->ctranTcpDm->progress());
+        FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, &done));
       }
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
@@ -1942,14 +1943,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       kernElem->revoke();
       kernElem = nullptr;
     } else if (backend == CtranMapperBackend::TCPDM) {
-      // We are mapping two-sided communications (i.e., send/receive) to
-      // one-sided communications (i.e., iPUT/waitNotify). Due to this, we
-      // handle TCP differently. Specifically, for iPUT, TCP performs the send
-      // operation, and for waitNotify, TCP performs the receive operation.
-      // Consequently, we need to progress TCP to ensure it completes the
-      // receive operation. Once it does, it will mark tcpDmReq as complete,
-      // allowing us to exit the loop.
-
       const void* rbuff = nullptr;
       size_t len = 0;
       if (kernElem != nullptr) {
@@ -1973,12 +1966,14 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         len = regElem->len;
       }
 
-      FB_COMMCHECK(this->ctranTcpDm->irecv(
+      // Counter-based: request managed internally by CtranTcpDm.
+      // Completions are tracked via a per-peer counter, checked by
+      // checkNotify (analogous to IB's notifyCount_).
+      FB_COMMCHECK(this->ctranTcpDm->irecvCounted(
           peerRank,
           regElem->tcpRegElem,
           (void*)rbuff,
           len,
-          notify->tcpDmReq,
           this->context.unpackPool));
     }
 
@@ -2005,9 +2000,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else if (notify->backend == CtranMapperBackend::IB) {
       FB_COMMCHECK(this->ctranIb->checkNotify<PerfConfig>(notify->peer, done));
     } else if (notify->backend == CtranMapperBackend::TCPDM) {
-      // Progress TCPDM transport to post any queued irecv requests
       FB_COMMCHECK(this->ctranTcpDm->progress());
-      *done = notify->tcpDmReq.isComplete();
+      FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, done));
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
       return commInternalError;


### PR DESCRIPTION
Summary:

Replace the FIFO-based notify pool (`pendingNotifies`/`freeNotifies` deques, `kTcpDmPipelineDepth=2`) with a single `leftNotify` and `numChunks` pipeline depth for TCPDM, matching the IB path. The backend's counter-based `checkRecvNotify` (from the previous diff) enables this: multiple `initNotify` calls with the same notify are safe because the backend manages requests internally. `kRecvTrans.ready` starts at `numChunks` (was 2) and increments at `kRecvRedCopy` done (was `kRecvTrans` done), tying the irecv pipeline to staging buffer slot availability. All irecvs are posted from the progress loop — no pre-posting in setup.

Reviewed By: fomichev

Differential Revision: D107115151


