### PR TITLE
Remove forced GDR flush disable, honor NCCL_GDR_FLUSH_DISABLE

### DIFF
--- a/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
+++ b/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
@@ -53,7 +53,7 @@ index 9bfd8dcf..4d3f0a08 100644
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-+NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
++NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 +
 +// AMD AINIC
 +RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
@@ -89,7 +89,7 @@ index 9bfd8dcf..4d3f0a08 100644
 +      // for AINIC IbUseInline is enabled by default always
 +      ncclIbUseInline = true;
 +      // for AINIC GDR flush is disabled by default
-+      ncclIbGdrFlushDisable = 1;
++      // ncclIbGdrFlushDisable = 1;
 +
 +      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
 +           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",

--- a/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
+++ b/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
@@ -164,7 +164,7 @@ NCCL_PARAM(RocmIbEceEnable,"IB_ECE_ENABLE",1);
 NCCL_PARAM(RocmIbDataDirect,"IB_DATA_DIRECT",1);
 NCCL_PARAM(RocmIbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
 RCCL_PARAM(RocmIbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 
 // AMD AINIC
 RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
@@ -989,7 +989,7 @@ ncclResult_t rocmIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
       // for AINIC IbUseInline is enabled by default always
       ncclIbUseInline = true;
       // for AINIC GDR flush is disabled by default
-      ncclIbGdrFlushDisable = 1;
+      // ncclIbGdrFlushDisable = 1;
 
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",


### PR DESCRIPTION
Summary:
Port AMD RCCL fix to fbcode/comms/rcclx. Default the GDR_FLUSH_DISABLE
NCCL param (NCCL_GDR_FLUSH_DISABLE) to 1 so GDR flush is disabled by
default, and stop unconditionally forcing ncclIbGdrFlushDisable = 1 in
the AINIC RoCEv2 path so the param can actually control GDR flush
behavior.

Applied in both the ext-src/rocm_netib.patch overlay and the
materialized src/transport/net_ib_rocm.cc (RocmIbGdrFlushDisable default
0 -> 1; comment out the forced ncclIbGdrFlushDisable = 1 in the AINIC
path).

Reviewed By: JinghanHuang

Differential Revision: D108343346


