### PR TITLE
GFX9 post-peer fence modes, RCCL_GFX9_BARRIER, and init logging

### DIFF
--- a/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
+++ b/comms/rcclx/develop/projects/rccl/ext-src/rocm_netib.patch
@@ -53,7 +53,7 @@ index 9bfd8dcf..4d3f0a08 100644
  NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
  NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
  RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-+NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
++NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 +
 +// AMD AINIC
 +RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
@@ -89,7 +89,7 @@ index 9bfd8dcf..4d3f0a08 100644
 +      // for AINIC IbUseInline is enabled by default always
 +      ncclIbUseInline = true;
 +      // for AINIC GDR flush is disabled by default
-+      ncclIbGdrFlushDisable = 1;
++      // ncclIbGdrFlushDisable = 1;
 +
 +      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
 +           "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",

--- a/comms/rcclx/develop/projects/rccl/src/device/prims_simple.h
+++ b/comms/rcclx/develop/projects/rccl/src/device/prims_simple.h
@@ -13,6 +13,7 @@
 #include "rccl_metadata.h"
 #include "msccl/msccl_struct.h"
 #include "network/unpack/unpack.h"
+#include "device.h"
 #include <cassert>
 
 enum primsMode {
@@ -68,7 +69,11 @@ class Primitives<
   uint64_t* barriers_pat;
   uint64_t barrier_next_pat = 0;
   int repeat;
-  bool skip_fence = 0;
+#if defined(__GFX9__)
+  uint8_t gfx9CheapFenceMode = ncclGfx9PostPeerFenceThread;
+#else
+  uint8_t gfx9CheapFenceMode = ncclGfx9PostPeerFenceSystem;
+#endif
 
 #if defined(ENABLE_NPKIT)
 public:
@@ -83,12 +88,16 @@ private:
   inline __device__ void barrier() {
     if (nthreads == WARP_SIZE)
       __syncwarp();
-    else
-      #if defined(__gfx942__) || defined(__gfx950__)
+    else {
+      unsigned const m = (unsigned)ncclShmem.comm.gfx9BarrierMode;
+      if (m == (unsigned)ncclGfx9BarrierFenceBlock) {
         barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
-      #else
+      } else if (m == (unsigned)ncclGfx9BarrierFenceThread) {
         barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
-      #endif
+      } else {
+        barrier_generic(__threadfence_system(), nworkers, barrier_next, barriers);
+      }
+    }
   }
   inline __device__ void subBarrier() {
     if (nworkers == WARP_SIZE) __syncwarp();
@@ -214,17 +223,16 @@ private:
 
   template<int Recv, int Send>
   inline __device__ void postPeer(bool dataStored) {
-    if (skip_fence){
+    if (gfx9CheapFenceMode == ncclGfx9PostPeerFenceCheap) {
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
       barrier_generic(asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)"), nworkers, barrier_next, barriers);
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
-    }
-    else if((flags & RolePostSend) && dataStored){
-#ifdef __GFX9__
-    __threadfence();
-#else
-    __threadfence_system();
-#endif
+    } else if ((flags & RolePostSend) && dataStored) {
+      if (gfx9CheapFenceMode == ncclGfx9PostPeerFenceThread) {
+        __threadfence();
+      } else {
+        __threadfence_system();
+      }
     }
 
     if ((flags & Send*RolePostSend) && next_hdp_reg)
@@ -902,8 +910,8 @@ public:
       }
       patBarrier();
     }
-    if(collWork){
-      skip_fence = !collWork -> gfx9CheapFenceOff;
+    if (collWork) {
+      gfx9CheapFenceMode = (uint8_t)collWork->gfx9CheapFenceMode;
     }
   }
 

--- a/comms/rcclx/develop/projects/rccl/src/enqueue.cc
+++ b/comms/rcclx/develop/projects/rccl/src/enqueue.cc
@@ -40,6 +40,7 @@
 #include "comms/rcclx/develop/meta/lib/ScubaLogger.h"
 #endif
 #include "latency_profiler/CollTraceFunc.h"
+#include "device.h"
 
 NCCL_PARAM_DECLARE(EnableProxyTrace);
 #ifdef ENABLE_ROCSHMEM
@@ -369,11 +370,16 @@ static bool testBudget(
   return ok;
 }
 
-// Returns whether this should be disabled at the device level.  Should be called after devWork fields have been set for what
-// it depends on.
-bool gfx9CheapFenceOff(const ncclDevWorkColl& devWork, bool disabledByPrecheck){
-    bool fenceOk = devWork.regUsed == 0 && devWork.netRegUsed == 0 && !disabledByPrecheck;
-    return !fenceOk;
+// Resolves ncclGfx9PostPeerFenceMode for device postPeer; call after regUsed/netRegUsed are set.
+static int ncclResolveGfx9CheapFenceMode(struct ncclComm* comm, struct ncclDevWorkColl const& devWork) {
+  int mode = comm->gfx9CheapFenceMode;
+  if (mode < ncclGfx9PostPeerFenceCheap || mode > ncclGfx9PostPeerFenceSystem)
+    mode = ncclGfx9PostPeerFenceCheap;
+  bool const fenceOk = devWork.regUsed == 0 && devWork.netRegUsed == 0;
+  if (!fenceOk && mode == ncclGfx9PostPeerFenceCheap) {
+    return IsArchMatch(comm->archName, "gfx9") ? ncclGfx9PostPeerFenceThread : ncclGfx9PostPeerFenceSystem;
+  }
+  return mode;
 }
 
 ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
@@ -440,12 +446,12 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     
     devWork.isOneRPN = comm->isOneRPN;
     devWork.netRegUsed = devWork.regUsed = 0;
-    devWork.gfx9CheapFenceOff = gfx9CheapFenceOff(devWork, comm->gfx9CheapFenceOff);
     devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
     if (task->regBufType & NCCL_NET_REG_BUFFER)
       devWork.netRegUsed = 1;
     if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
       devWork.regUsed = 1;
+    devWork.gfx9CheapFenceMode = ncclResolveGfx9CheapFenceMode(comm, devWork);
 
     if (task->regBufType & NCCL_NVLS_REG_BUFFER) {
       struct ncclDevWorkCollReg workReg = {};
@@ -630,6 +636,7 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
         devWork.netRegUsed = 1;
       if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
         devWork.regUsed = 1;
+      devWork.gfx9CheapFenceMode = ncclResolveGfx9CheapFenceMode(comm, devWork);
       devWork.pivotA2ANumBiRings = comm->topo->pivotA2ANumBiRings;
       devWork.opCount = task->opCount;
 

--- a/comms/rcclx/develop/projects/rccl/src/include/comm.h
+++ b/comms/rcclx/develop/projects/rccl/src/include/comm.h
@@ -538,7 +538,8 @@ struct ncclComm {
   int node;
   int nNodes;
   int rcclUseOneSlice; // RCCL: true if this comm is using one slice per primitive
-  int gfx9CheapFenceOff; // RCCL: true if gfx9 cheap fence is disabled
+  int gfx9CheapFenceMode; // RCCL: ncclGfx9PostPeerFenceMode (0 cheap, 1 threadfence, 2 threadfence_system)
+  int gfx9BarrierMode; // RCCL: ncclGfx9BarrierFenceMode for ProtoSimple barrier()
   int localRank;
   int localRanks;
   int maxLocalRanks;

--- a/comms/rcclx/develop/projects/rccl/src/include/device.h
+++ b/comms/rcclx/develop/projects/rccl/src/include/device.h
@@ -368,6 +368,20 @@ inline __device__ int ncclP2pChannelToPart(int nP2pChannels, int base, int chann
   }
 }
 
+// RCCL_GFX9_CHEAP_FENCE_OFF (RCCL_*): 0 = cheap post-peer fence, 1 = __threadfence, 2 = __threadfence_system
+enum ncclGfx9PostPeerFenceMode {
+  ncclGfx9PostPeerFenceCheap = 0,
+  ncclGfx9PostPeerFenceThread = 1,
+  ncclGfx9PostPeerFenceSystem = 2
+};
+
+// RCCL_GFX9_BARRIER (RCCL_*): Primitives::barrier() fence — 0 = __threadfence_block, 1 = __threadfence, 2 = __threadfence_system
+enum ncclGfx9BarrierFenceMode {
+  ncclGfx9BarrierFenceBlock = 0,
+  ncclGfx9BarrierFenceThread = 1,
+  ncclGfx9BarrierFenceSystem = 2
+};
+
 struct alignas(16) ncclDevWorkColl {
   // Running on channels [channelLo..channelHi], hi is inclusive.
   //   nChannels == (channelHi - channelLo) + 1
@@ -377,7 +391,7 @@ struct alignas(16) ncclDevWorkColl {
   uint32_t channelLo:8, channelHi:8;
 #endif
   uint32_t nWarps:8;
-  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, gfx9CheapFenceOff:1;
+  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, gfx9CheapFenceMode:2;
   uint32_t root:30, connIndex:2;
   uint16_t pivotA2ANumBiRings:15, profilerEnabled:1;
   void* recvbuff;
@@ -611,6 +625,7 @@ struct ncclKernelComm {
   int p2pChunkSize;
   int isAllNvlink;
   int p2pnChannelsPerPeer;
+  int gfx9BarrierMode; // ncclGfx9BarrierFenceMode
   int warpLevelComm;
   int* collNetDenseToUserRank;
 

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -161,8 +161,10 @@ RCCL_PARAM(MscclppThreshold, "MSCCLPP_THRESHOLD", (size_t)(16*1024*1024));
 static constexpr int64_t defaultEnableMscclpp = 0;
 RCCL_PARAM(MscclppEnabled, "MSCCLPP_ENABLE", defaultEnableMscclpp);
 RCCL_PARAM(MscclppForceEnabled, "MSCCLPP_FORCE_ENABLE", 0);
-// Turn off cheap fence for gfx942/gfx950
-RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 0);
+// RCCL_GFX9_CHEAP_FENCE_OFF: 0 = arch-tuned default, 1 = __threadfence, 2 = __threadfence_system
+RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 2);
+// RCCL_GFX9_BARRIER: ProtoSimple barrier() — 0 = __threadfence_block, 1 = __threadfence, 2 = __threadfence_system
+RCCL_PARAM(Gfx9Barrier, "GFX9_BARRIER", 2);
 
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
@@ -918,6 +920,14 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   tmpCommAndChans.comm.abortFlag = comm->abortFlagDev;
   tmpCommAndChans.comm.isAllNvlink = comm->isAllNvlink;
   tmpCommAndChans.comm.p2pnChannelsPerPeer = comm->p2pnChannelsPerPeer;
+  {
+    int64_t const pBarrier = rcclParamGfx9Barrier();
+    int bm = ncclGfx9BarrierFenceBlock;
+    if (pBarrier == ncclGfx9BarrierFenceThread) bm = ncclGfx9BarrierFenceThread;
+    else if (pBarrier == ncclGfx9BarrierFenceSystem) bm = ncclGfx9BarrierFenceSystem;
+    comm->gfx9BarrierMode = bm;
+    tmpCommAndChans.comm.gfx9BarrierMode = bm;
+  }
   for (int p=0; p < NCCL_NUM_PROTOCOLS; p++) {
     tmpCommAndChans.comm.buffSizes[p] = comm->buffSizes[p];
   }
@@ -950,6 +960,14 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
   if (comm->rank == 0) {
     INFO(NCCL_INIT, "CC %s, workFifoBytes %d", ccEnable ? "On" : "Off", comm->workFifoBytes);
+    static char const* const kGfx9BarrierFenceModeStr[] = {
+      "__threadfence_block",
+      "__threadfence",
+      "__threadfence_system"
+    };
+    int const bfm = comm->gfx9BarrierMode;
+    INFO(NCCL_INIT, "GFX9 BarrierFenceMode: %s (RCCL_GFX9_BARRIER=%d)",
+         (unsigned)bfm <= 2u ? kGfx9BarrierFenceModeStr[bfm] : kGfx9BarrierFenceModeStr[0], bfm);
   }
 
   if (ncclGdrCopy != NULL && ncclParamGdrCopyFifoEnable() == 1) {
@@ -1596,17 +1614,29 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4/ringGraph->nChannels);
   if (ringGraph->nChannels > MAXCHANNELS/2)
     allGather3Data[rank].nc = 1;
-  comm -> gfx9CheapFenceOff = 1;
+  comm->gfx9CheapFenceMode = ncclGfx9PostPeerFenceThread;
   #ifdef HIP_UNCACHED_MEMORY
-  if(!rcclParamGfx9CheapFenceOff()){
-    if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")){
-      comm -> gfx9CheapFenceOff = 0;
+  {
+    int64_t const p = rcclParamGfx9CheapFenceOff();
+    if (p == ncclGfx9PostPeerFenceThread || p == ncclGfx9PostPeerFenceSystem) {
+      comm->gfx9CheapFenceMode = (int)p;
+    } else {
+      comm->gfx9CheapFenceMode = ncclGfx9PostPeerFenceThread;
+      if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")) {
+        comm->gfx9CheapFenceMode = ncclGfx9PostPeerFenceCheap;
+      } else if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
+        comm->gfx9CheapFenceMode = (ROCM_VERSION < 70002 && nNodes > 1) ? ncclGfx9PostPeerFenceThread : ncclGfx9PostPeerFenceCheap;
+      }
     }
-    else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
-      comm -> gfx9CheapFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
-    }
+    static char const* const fenceModeStr[] = {
+      "cheap (signal fence)",
+      "__threadfence",
+      "__threadfence_system"
+    };
+    int const mi = comm->gfx9CheapFenceMode;
+    INFO(NCCL_INIT, "GFX9 post-peer fence mode: %s",
+         (unsigned)mi <= 2u ? fenceModeStr[mi] : fenceModeStr[0]);
   }
-  INFO(NCCL_INIT, "GFX9 cheap fence is %s", comm -> gfx9CheapFenceOff ? "OFF" : "ON");
   #endif
   // RCCL: Only use one slice per primitive on some single node gfx9xx systems, only currently enabled for AllReduce, ReduceScatter, and AllGather
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){

--- a/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
+++ b/comms/rcclx/develop/projects/rccl/src/transport/net_ib_rocm.cc
@@ -164,7 +164,7 @@ NCCL_PARAM(RocmIbEceEnable,"IB_ECE_ENABLE",1);
 NCCL_PARAM(RocmIbDataDirect,"IB_DATA_DIRECT",1);
 NCCL_PARAM(RocmIbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
 RCCL_PARAM(RocmIbQpsPerP2p, "IB_QPS_PER_P2P", 0);
-NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+NCCL_PARAM(RocmIbGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 
 // AMD AINIC
 RCCL_PARAM(CtsInlineData, "CTS_INLINE_DATA", -1);
@@ -989,7 +989,7 @@ ncclResult_t rocmIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config
       // for AINIC IbUseInline is enabled by default always
       ncclIbUseInline = true;
       // for AINIC GDR flush is disabled by default
-      ncclIbGdrFlushDisable = 1;
+      // ncclIbGdrFlushDisable = 1;
 
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled", rcclCtsInlineData ? "Enabled": "Disabled",


### PR DESCRIPTION
Summary:
Port AMD RCCL change to fbcode/comms/rcclx. Introduce
ncclGfx9PostPeerFenceMode and ncclGfx9BarrierFenceMode enums and thread
them through ncclComm, ncclDevComm, and ncclDevWorkColl.

- prims_simple.h: ProtoSimple barrier() selects __threadfence_block /
  __threadfence / __threadfence_system based on gfx9BarrierMode;
  postPeer() uses the resolved per-work gfx9CheapFenceMode (cheap signal
  fence, __threadfence, or __threadfence_system) instead of skip_fence.
- enqueue.cc: replace gfx9CheapFenceOff() with
  ncclResolveGfx9CheapFenceMode(), forcing non-cheap fence when
  IPC/net registration is used, and set devWork.gfx9CheapFenceMode in
  both the task-reg and prepare-tasks paths.
- init.cc: add RCCL_GFX9_BARRIER (RCCL_PARAM Gfx9Barrier); resolve and
  set gfx9BarrierMode/gfx9CheapFenceMode in devCommSetup and
  initTransportsRank, and log the resolved barrier and post-peer fence
  modes during init.

Reviewed By: JinghanHuang

Differential Revision: D108343358


