### PR TITLE
enable fine-grained pipestrace in P2pIbgdaTransportDevice for perf profiling (#2873)

### DIFF
--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -359,12 +359,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
           args.ready_counters,
           static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
           args.ready_sequence);
-      trace_hierarchical_allgather(
-          args.trace,
-          group,
-          PipesTraceEventType::kHierAgIbChunkReady,
-          chunk,
-          args.ib_rank);
 
       int fwd_ready_rank = args.ib_rank;
       for (int step = 0; step < W - 1; step++) {
@@ -374,13 +368,13 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             args.ready_counters,
             static_cast<std::size_t>(fwd_ready_rank) * total_chunks + chunk,
             args.ready_sequence);
-        trace_hierarchical_allgather(
-            args.trace,
-            group,
-            PipesTraceEventType::kHierAgIbChunkReady,
-            chunk,
-            fwd_ready_rank);
       }
+      trace_hierarchical_allgather(
+          args.trace,
+          group,
+          PipesTraceEventType::kHierAgIbChunkReady,
+          chunk,
+          args.ib_rank);
     }
     return;
   }

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -315,13 +315,15 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         const std::size_t window =
             remaining < ib_window ? remaining : ib_window;
 
-        next.template send<MemcpyAndSelfCopy>(
+        next.template sendWithTrace<MemcpyAndSelfCopy>(
             group,
             send_src + chunk_off,
             window,
             args.ib_num_blocks,
             args.ib_signaling_data_size,
             timeout,
+            args.trace,
+            static_cast<uint8_t>(args.ib_rank),
             own_dst + chunk_off);
 
         int fwd_current_rank = args.ib_rank;
@@ -334,22 +336,26 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
               off + chunk_off;
 
           if (step < W - 2) {
-            prev.forward(
+            prev.forwardWithTrace(
                 group,
                 dst,
                 next,
                 window,
                 args.ib_num_blocks,
                 args.ib_signaling_data_size,
-                timeout);
+                timeout,
+                args.trace,
+                static_cast<uint8_t>(args.ib_rank));
           } else {
-            prev.recv(
+            prev.recvWithTrace(
                 group,
                 dst,
                 window,
                 args.ib_num_blocks,
                 args.ib_signaling_data_size,
-                timeout);
+                timeout,
+                args.trace,
+                static_cast<uint8_t>(args.ib_rank));
           }
         }
       }

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -326,6 +326,26 @@ void runTestPutCooperativePartitioningBlock(bool* d_success) {
 }
 
 // =============================================================================
+// trace_ibgda_event test kernel
+// =============================================================================
+
+__global__ void testTraceIbgdaEvent(PipesTraceHandle trace) {
+#if PIPES_IS_DEVICE_COMPILE
+  trace_ibgda_event(
+      trace,
+      /*self_rank=*/7,
+      PipesTraceEventType::kIbSendBegin,
+      /*step=*/0x12345678,
+      /*group_id=*/0x4321);
+#endif
+}
+
+void runTestTraceIbgdaEvent(PipesTraceHandle trace) {
+  testTraceIbgdaEvent<<<1, 1>>>(trace);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
 // wait_signal timeout test kernels
 // =============================================================================
 

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims::tests {
@@ -70,6 +71,9 @@ void runTestBroadcast64DoubleSafety(bool* d_success);
 
 // Test put_cooperative partitioning logic with block-sized groups
 void runTestPutCooperativePartitioningBlock(bool* d_success);
+
+// Test trace_ibgda_event writes the expected trace payload.
+void runTestTraceIbgdaEvent(PipesTraceHandle trace);
 
 // =============================================================================
 // wait_signal timeout tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -21,6 +21,8 @@
 #include "comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/utils/CudaRAII.h"
 #endif
@@ -269,6 +271,42 @@ TEST_F(P2pIbgdaTransportDeviceTestFixture, PutCooperativePartitioningBlock) {
     runTestPutCooperativePartitioningBlock(d_success);
   });
 }
+
+#ifndef __HIP_PLATFORM_AMD__
+TEST_F(P2pIbgdaTransportDeviceTestFixture, TraceIbgdaEventWritesEvent) {
+  cudaDeviceProp props{};
+  CUDACHECK_TEST(cudaGetDeviceProperties(&props, 0));
+  if (props.major < 9) {
+    GTEST_SKIP() << "HRDWRingBuffer trace writes require sm_90+";
+  }
+
+  ::hrdw_ring_buffer::HRDWRingBuffer<PipesTraceEvent> traceBuffer(8);
+  ASSERT_TRUE(traceBuffer.valid());
+
+  auto deviceHandle = traceBuffer.deviceHandle();
+  runTestTraceIbgdaEvent(
+      PipesTraceHandle{
+          .ring = reinterpret_cast<PipesTraceEntry*>(deviceHandle.ring),
+          .writeIndex = deviceHandle.writeIndex,
+          .mask = deviceHandle.mask,
+          .shift = deviceHandle.shift});
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<PipesTraceEvent> events;
+  ::hrdw_ring_buffer::HRDWRingBufferReader<PipesTraceEvent> reader(traceBuffer);
+  const auto result = reader.poll(
+      [&](const auto& entry, uint64_t) { events.push_back(entry.data); });
+
+  EXPECT_EQ(result.entriesLost, 0u);
+  ASSERT_EQ(result.entriesRead, 1u);
+  ASSERT_EQ(events.size(), 1u);
+  EXPECT_EQ(events[0].step, 0x12345678u);
+  EXPECT_EQ(events[0].detail, 0x4321u);
+  EXPECT_EQ(
+      events[0].type, static_cast<uint8_t>(PipesTraceEventType::kIbSendBegin));
+  EXPECT_EQ(events[0].rank, 7u);
+}
+#endif // !__HIP_PLATFORM_AMD__
 
 // =============================================================================
 // wait_signal Timeout Tests

--- a/comms/prims/tests/PipesTraceTest.cc
+++ b/comms/prims/tests/PipesTraceTest.cc
@@ -19,12 +19,23 @@
 #include "comms/utils/hrdw_ring_buffer/HRDWRingBufferReader.h"
 
 using comms::prims::PipesTrace;
+using comms::prims::PipesTraceEntry;
 using comms::prims::PipesTraceEvent;
+using comms::prims::PipesTraceHandle;
 
 namespace {
 
 constexpr auto kPollInterval = std::chrono::milliseconds{1};
 constexpr auto kWaitTimeout = std::chrono::seconds{10};
+
+template <typename DeviceHandle>
+PipesTraceHandle toPipesTraceHandle(const DeviceHandle& handle) {
+  return PipesTraceHandle{
+      .ring = reinterpret_cast<PipesTraceEntry*>(handle.ring),
+      .writeIndex = handle.writeIndex,
+      .mask = handle.mask,
+      .shift = handle.shift};
+}
 
 class MappedSpinFlag {
  public:
@@ -194,7 +205,7 @@ TEST_F(PipesTraceCudaTest, WriteAndReadEvents) {
   constexpr int kNumEvents = 10;
   Buffer buf(64);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   comms::prims::test::launchWriteEvents(handle, kNumEvents, stream_);
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
@@ -222,7 +233,7 @@ TEST_F(PipesTraceCudaTest, EventsVisibleBeforeKernelCompletes) {
   constexpr int kNumEvents = 10;
   Buffer buf(64);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   MappedSpinFlag releaseFlag(stream_);
   ASSERT_EQ(releaseFlag.init(), cudaSuccess);
@@ -337,7 +348,7 @@ TEST_F(PipesTraceCudaTest, MultipleKernelLaunches) {
 
   Buffer buf(256);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   constexpr int kLaunches = 5;
   constexpr int kEventsPerLaunch = 10;
@@ -365,7 +376,7 @@ TEST_F(PipesTraceCudaTest, GraphCaptureAndReplay) {
   constexpr int kNumEvents = 10;
   Buffer buf(256);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   cudaGraph_t graph = nullptr;
   cudaGraphExec_t instance = nullptr;
@@ -413,7 +424,7 @@ TEST_F(PipesTraceCudaTest, GraphMultipleReplays) {
   constexpr int kReplays = 10;
   Buffer buf(256);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   cudaGraph_t graph = nullptr;
   cudaGraphExec_t instance = nullptr;
@@ -521,7 +532,7 @@ TEST_F(PipesTraceCudaTest, MultiBlockWriteAndRead) {
 
   Buffer buf(256);
   ASSERT_TRUE(buf.valid());
-  auto handle = buf.deviceHandle();
+  auto handle = toPipesTraceHandle(buf.deviceHandle());
 
   comms::prims::test::launchWriteEventsMultiBlock(
       handle, kNumBlocks, kEventsPerBlock, stream_);

--- a/comms/prims/trace/PipesTrace.cc
+++ b/comms/prims/trace/PipesTrace.cc
@@ -31,6 +31,18 @@ const char* pipesTraceEventTypeName(uint8_t type) {
       return "hier_ag_nvl_chunk_ready";
     case Type::kHierAgNvlTaskDone:
       return "hier_ag_nvl_task_done";
+    case Type::kIbSendBegin:
+      return "ib_send_begin";
+    case Type::kIbSendEnd:
+      return "ib_send_end";
+    case Type::kIbRecvBegin:
+      return "ib_recv_begin";
+    case Type::kIbRecvEnd:
+      return "ib_recv_end";
+    case Type::kIbForwardBegin:
+      return "ib_forward_begin";
+    case Type::kIbForwardEnd:
+      return "ib_forward_end";
   }
   return "unknown";
 }
@@ -119,7 +131,12 @@ PipesTraceHandle PipesTrace::deviceHandle() const {
   if (buffer_ == nullptr) {
     return {};
   }
-  return buffer_->deviceHandle();
+  auto handle = buffer_->deviceHandle();
+  return PipesTraceHandle{
+      .ring = reinterpret_cast<PipesTraceEntry*>(handle.ring),
+      .writeIndex = handle.writeIndex,
+      .mask = handle.mask,
+      .shift = handle.shift};
 }
 
 void PipesTrace::drain() {

--- a/comms/prims/trace/PipesTraceTypes.h
+++ b/comms/prims/trace/PipesTraceTypes.h
@@ -4,7 +4,9 @@
 
 #include <cstdint>
 
-#include "comms/utils/hrdw_ring_buffer/HRDWRingBuffer.h"
+#if defined(__CUDACC__) && !defined(__HIPCC__)
+#include <cuda/atomic>
+#endif
 
 namespace comms::prims {
 
@@ -15,6 +17,13 @@ enum class PipesTraceEventType : uint8_t {
   kHierAgNvlWaitBegin = 3,
   kHierAgNvlChunkReady = 4,
   kHierAgNvlTaskDone = 5,
+
+  kIbSendBegin = 6,
+  kIbSendEnd = 7,
+  kIbRecvBegin = 8,
+  kIbRecvEnd = 9,
+  kIbForwardBegin = 10,
+  kIbForwardEnd = 11,
 };
 
 struct PipesTraceEvent {
@@ -26,20 +35,86 @@ struct PipesTraceEvent {
 
 static_assert(sizeof(PipesTraceEvent) == 8);
 
-using PipesTraceHandle =
-    ::hrdw_ring_buffer::HRDWRingBufferDeviceHandle<PipesTraceEvent>;
+struct alignas(16) PipesTraceEntry {
+  uint32_t timestamp;
+  uint32_t epoch;
+  PipesTraceEvent data;
+};
+
+static_assert(sizeof(PipesTraceEntry) == 16);
+static_assert(alignof(PipesTraceEntry) == 16);
+
+struct PipesTraceHandle {
+  PipesTraceEntry* ring{nullptr};
+  uint64_t* writeIndex{nullptr};
+  uint32_t mask{0};
+  uint32_t shift{0};
+};
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
+__device__ __forceinline__ uint64_t read_pipes_trace_globaltimer() {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__CUDA_ARCH__)
+  return wall_clock64();
+#elif defined(__CUDA_ARCH__)
+  uint64_t timer;
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(timer));
+  return timer;
+#else
+  return 0;
+#endif
+}
+
 __device__ __forceinline__ void write_pipes_trace(
     PipesTraceHandle trace,
     PipesTraceEventType type,
     uint32_t step,
     uint16_t detail,
     uint8_t rank) {
-  if (trace.ring == nullptr) {
+  if (trace.ring == nullptr || trace.writeIndex == nullptr) {
     return;
   }
-  trace.write(PipesTraceEvent{step, detail, static_cast<uint8_t>(type), rank});
+
+#if defined(__HIPCC__) || (defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 900)
+  // The backing ring uses 128-bit atomics, which are only available on
+  // Hopper+. Keep traced kernels buildable for other device targets.
+  (void)type;
+  (void)step;
+  (void)detail;
+  (void)rank;
+  return;
+#else
+  uint64_t slot =
+      cuda::atomic_ref<uint64_t, cuda::thread_scope_system>(*trace.writeIndex)
+          .fetch_add(1ULL, cuda::memory_order_relaxed);
+  uint64_t idx = slot & trace.mask;
+
+  PipesTraceEntry packed{};
+  packed.timestamp =
+      static_cast<uint32_t>(read_pipes_trace_globaltimer() >> 10);
+  packed.epoch = static_cast<uint32_t>(slot >> trace.shift) + 1u;
+  packed.data = PipesTraceEvent{
+      .step = step,
+      .detail = detail,
+      .type = static_cast<uint8_t>(type),
+      .rank = rank};
+
+  uint64_t packed_lo, packed_hi;
+  __builtin_memcpy(&packed_lo, &packed, sizeof(packed_lo));
+  __builtin_memcpy(
+      &packed_hi,
+      reinterpret_cast<const char*>(&packed) + sizeof(packed_lo),
+      sizeof(packed_hi));
+
+  [[maybe_unused]] uint64_t prev_lo, prev_hi;
+  asm volatile(
+      "{ .reg .b128 _src, _dst;\n\t"
+      "  mov.b128 _src, {%2, %3};\n\t"
+      "  atom.exch.relaxed.sys.b128 _dst, [%4], _src;\n\t"
+      "  mov.b128 {%0, %1}, _dst; }"
+      : "=l"(prev_lo), "=l"(prev_hi)
+      : "l"(packed_lo), "l"(packed_hi), "l"(&trace.ring[idx])
+      : "memory");
+#endif
 }
 #endif
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -30,6 +30,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
@@ -37,6 +38,24 @@ namespace comms::prims {
 struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
+
+#if PIPES_IS_DEVICE_COMPILE
+__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
+  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
+  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
+}
+
+__device__ __forceinline__ void trace_ibgda_event(
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    PipesTraceEventType type,
+    uint32_t step,
+    uint16_t group_id) {
+  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
+  // unconfigured handle has effectively no cost.
+  write_pipes_trace(trace, type, step, group_id, self_rank);
+}
+#endif
 
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
@@ -2083,6 +2102,40 @@ class P2pIbgdaTransportDevice {
     (void)max_signal_bytes;
     (void)timeout;
 #else
+    sendWithTrace<CopyOp>(
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+#endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void sendWithTrace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    (void)trace;
+    (void)self_rank;
+#else
     if (nbytes == 0) {
       return;
     }
@@ -2143,6 +2196,15 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Busy;
       state.activeBaseStep = static_cast<int64_t>(baseByte);
       state.activeNextByte = 0;
+    }
+
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbSendBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
     }
 
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
@@ -2219,6 +2281,12 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbSendEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif
@@ -2268,6 +2336,40 @@ class P2pIbgdaTransportDevice {
     (void)active_blocks;
     (void)max_signal_bytes;
     (void)timeout;
+#else
+    recvWithTrace<CopyOp>(
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+#endif
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recvWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    (void)trace;
+    (void)self_rank;
 #else
     if (nbytes == 0) {
       return;
@@ -2331,6 +2433,15 @@ class P2pIbgdaTransportDevice {
       state.activeNextByte = 0;
     }
 
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbRecvBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
+    }
+
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
@@ -2379,6 +2490,12 @@ class P2pIbgdaTransportDevice {
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbRecvEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif
@@ -2451,6 +2568,31 @@ class P2pIbgdaTransportDevice {
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
+      Args... args) {
+    forwardWithTrace<CopyOp>(
+        group,
+        dst,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        {},
+        0,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forwardWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
       Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
 #ifdef __HIP_PLATFORM_AMD__
@@ -2553,6 +2695,15 @@ class P2pIbgdaTransportDevice {
       fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
       fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
       fwdSlotState.activeNextByte = 0;
+    }
+
+    if (group.is_leader()) {
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbForwardBegin,
+          /*step=*/0,
+          static_cast<uint16_t>(groupId));
     }
 
     for (std::size_t dataOff = 0; dataOff < nbytes;) {
@@ -2667,6 +2818,12 @@ class P2pIbgdaTransportDevice {
       fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
       fwdSlotState.activeBaseStep = 0;
       fwdSlotState.activeNextByte = 0;
+      trace_ibgda_event(
+          trace,
+          self_rank,
+          PipesTraceEventType::kIbForwardEnd,
+          trace_ibgda_step(nbytes),
+          static_cast<uint16_t>(groupId));
     }
     group.sync();
 #endif


### PR DESCRIPTION
Summary:

This adds fine-grained `PipesTrace` instrumentation to the IBGDA transport path so perf traces can show when each IBGDA `send()`, `recv()`, and `forward()` begins and ends. The transport API now accepts optional `PipesTraceHandle` and `self_rank` parameters and emits `kIbSend*`, `kIbRecv*`, and `kIbForward*` events through `trace_ibgda_event()`; unconfigured trace handles remain no-op via `write_pipes_trace()`.

The hierarchical allgather overlap path plumbs the trace handle and IB rank into IBGDA send/forward/recv calls, while existing callers continue using default empty tracing arguments. The diff also splits `PipesTraceTypes.h` into a lightweight build target for device-side use, adds log names for the new event types, and covers `trace_ibgda_event()` with a focused unit test that verifies the emitted `step`, `detail`, `type`, and `rank` payload.

Reviewed By: dsjohns2

Differential Revision: D107440246


