### PR TITLE
ctran/tcpdm: keep transport singleton alive

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmSingleton.cc
@@ -53,9 +53,10 @@ bool CtranTcpDmSingleton::supportBondTransport() {
   return false;
 }
 
-static folly::Singleton<::comms::tcp_devmem::TransportInterface>
+static const folly::LeakySingleton<::comms::tcp_devmem::TransportInterface>
 tcpTransportPtr([]() -> ::comms::tcp_devmem::TransportInterface* {
-  if (!CtranTcpDmSingleton::supportBondTransport()) {
+  const bool bondSupported = CtranTcpDmSingleton::supportBondTransport();
+  if (!bondSupported) {
     return new ::comms::tcp_devmem::Transport();
   }
 
@@ -63,21 +64,16 @@ tcpTransportPtr([]() -> ::comms::tcp_devmem::TransportInterface* {
       NCCL_IB_HCA, NCCL_CTRAN_IB_DEVICES_PER_RANK);
   if (devs.size() && devs.front().size() == 1) {
     return new ::comms::tcp_devmem::Transport();
-  } else {
-    return new ::comms::tcp_devmem::BondTransport(devs);
   }
+
+  return new ::comms::tcp_devmem::BondTransport(devs);
 });
 
 std::shared_ptr<::comms::tcp_devmem::TransportInterface>
 CtranTcpDmSingleton::getTransport() {
-  auto ptr =
-      folly::Singleton<::comms::tcp_devmem::TransportInterface>::try_get();
-  if (!ptr) {
-    FB_ERRORTHROW_EX_NOCOMM(
-        commInternalError,
-        "TCP-DEVMEM: TransportInterface singleton is not available");
-  }
-  return ptr;
+  auto& transport = tcpTransportPtr.get();
+  return std::shared_ptr<::comms::tcp_devmem::TransportInterface>(
+      &transport, [](::comms::tcp_devmem::TransportInterface*) {});
 }
 
 } // namespace ctran


### PR DESCRIPTION
Summary: Use `folly::LeakySingleton` for the TCPDM transport singleton and return a non-owning `shared_ptr` from `getTransport()`. TCPDM communicators can outlive normal singleton teardown paths during job shutdown/recovery, so the transport should remain available for the process lifetime instead of becoming unavailable through `folly::Singleton::try_get()`.

Reviewed By: erfan111

Differential Revision: D107912803


