### PR TITLE
Use versioned CUDA driver entrypoint on CUDA 13 (#2879)

### DIFF
--- a/comms/prims/platform/CudaDriverLazy.cc
+++ b/comms/prims/platform/CudaDriverLazy.cc
@@ -38,15 +38,21 @@ namespace {
 std::once_flag init_flag;
 int init_result = -1;
 
-int load_sym(const char* name, void** ptr) {
-  cudaDriverEntryPointQueryResult status;
+int load_sym(const char* name, void** ptr, int version) {
+  cudaDriverEntryPointQueryResult status = cudaDriverEntryPointSymbolNotFound;
+#if CUDART_VERSION >= 13000
+  auto res = cudaGetDriverEntryPointByVersion(
+      name, ptr, version, cudaEnableDefault, &status);
+#else
   auto res = cudaGetDriverEntryPoint(name, ptr, cudaEnableDefault, &status);
+#endif
   if (res != cudaSuccess || status != cudaDriverEntryPointSuccess) {
     fprintf(
         stderr,
-        "prims: failed to resolve CUDA driver symbol %s "
+        "prims: failed to resolve CUDA driver symbol %s version %d "
         "(cudaError=%d, status=%d)\n",
         name,
+        version,
         static_cast<int>(res),
         static_cast<int>(status));
     return -1;
@@ -55,30 +61,31 @@ int load_sym(const char* name, void** ptr) {
 }
 
 void do_init() {
-#define LOAD(symbol)                                                     \
-  if (load_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol)) != 0) { \
-    init_result = -1;                                                    \
-    return;                                                              \
+#define LOAD(symbol, version)                                                \
+  if (load_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol), version) != \
+      0) {                                                                   \
+    init_result = -1;                                                        \
+    return;                                                                  \
   }
 
-  LOAD(cuDeviceGet);
-  LOAD(cuDeviceGetAttribute);
-  LOAD(cuCtxGetCurrent);
-  LOAD(cuGetErrorString);
-  LOAD(cuMemCreate);
-  LOAD(cuMemRelease);
-  LOAD(cuMemAddressReserve);
-  LOAD(cuMemAddressFree);
-  LOAD(cuMemMap);
-  LOAD(cuMemUnmap);
-  LOAD(cuMemSetAccess);
-  LOAD(cuMemGetAllocationGranularity);
-  LOAD(cuMemExportToShareableHandle);
-  LOAD(cuMemImportFromShareableHandle);
-  LOAD(cuMemGetAllocationPropertiesFromHandle);
-  LOAD(cuMemRetainAllocationHandle);
-  LOAD(cuMemGetAddressRange);
-  LOAD(cuMemGetHandleForAddressRange);
+  LOAD(cuDeviceGet, 2000);
+  LOAD(cuDeviceGetAttribute, 2000);
+  LOAD(cuCtxGetCurrent, 4000);
+  LOAD(cuGetErrorString, 6000);
+  LOAD(cuMemCreate, 10020);
+  LOAD(cuMemRelease, 10020);
+  LOAD(cuMemAddressReserve, 10020);
+  LOAD(cuMemAddressFree, 10020);
+  LOAD(cuMemMap, 10020);
+  LOAD(cuMemUnmap, 10020);
+  LOAD(cuMemSetAccess, 10020);
+  LOAD(cuMemGetAllocationGranularity, 10020);
+  LOAD(cuMemExportToShareableHandle, 10020);
+  LOAD(cuMemImportFromShareableHandle, 10020);
+  LOAD(cuMemGetAllocationPropertiesFromHandle, 10020);
+  LOAD(cuMemRetainAllocationHandle, 11000);
+  LOAD(cuMemGetAddressRange, 3020);
+  LOAD(cuMemGetHandleForAddressRange, 11070);
 
 #undef LOAD
 

--- a/comms/utils/CudaChecks.h
+++ b/comms/utils/CudaChecks.h
@@ -24,19 +24,57 @@ namespace comms::utils::cuda {
  * available).
  */
 template <typename FuncPtr>
-inline FuncPtr loadDriverFunction(const char* funcName) {
+inline FuncPtr loadDriverFunction(const char* funcName, int version) {
   FuncPtr func = nullptr;
-#if CUDART_VERSION >= 12000
+#if CUDART_VERSION >= 13000
   cudaDriverEntryPointQueryResult driverStatus =
       cudaDriverEntryPointSymbolNotFound;
-  cudaGetDriverEntryPoint(
+  cudaError_t res = cudaGetDriverEntryPointByVersion(
+      funcName,
+      reinterpret_cast<void**>(&func),
+      version,
+      cudaEnableDefault,
+      &driverStatus);
+  if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
+    CLOGF(
+        WARN,
+        "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
+        funcName,
+        version,
+        static_cast<int>(res),
+        static_cast<int>(driverStatus));
+    return nullptr;
+  }
+#elif CUDART_VERSION >= 12000
+  cudaDriverEntryPointQueryResult driverStatus =
+      cudaDriverEntryPointSymbolNotFound;
+  cudaError_t res = cudaGetDriverEntryPoint(
       funcName,
       reinterpret_cast<void**>(&func),
       cudaEnableDefault,
       &driverStatus);
+  if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) {
+    CLOGF(
+        WARN,
+        "Failed to load CUDA driver symbol {} version {} (cudaError={}, status={})",
+        funcName,
+        version,
+        static_cast<int>(res),
+        static_cast<int>(driverStatus));
+    return nullptr;
+  }
 #elif CUDART_VERSION >= 11030
-  cudaGetDriverEntryPoint(
+  cudaError_t res = cudaGetDriverEntryPoint(
       funcName, reinterpret_cast<void**>(&func), cudaEnableDefault);
+  if (res != cudaSuccess) {
+    CLOGF(
+        WARN,
+        "Failed to load CUDA driver symbol {} version {} (cudaError={})",
+        funcName,
+        version,
+        static_cast<int>(res));
+    return nullptr;
+  }
 #endif
   return func;
 }
@@ -50,7 +88,7 @@ inline FuncPtr loadDriverFunction(const char* funcName) {
 inline const char* getCuErrorString(CUresult err) {
 #if CUDART_VERSION >= 11030
   static auto pfn_cuGetErrorString =
-      loadDriverFunction<PFN_cuGetErrorString_v6000>("cuGetErrorString");
+      loadDriverFunction<PFN_cuGetErrorString_v6000>("cuGetErrorString", 6000);
   if (pfn_cuGetErrorString != nullptr) {
     const char* errStr = nullptr;
     pfn_cuGetErrorString(err, &errStr);
@@ -75,7 +113,7 @@ inline CUresult cuMemGetAddressRangeDynamic(
 #if CUDART_VERSION >= 11030
   static auto pfn_cuMemGetAddressRange =
       loadDriverFunction<PFN_cuMemGetAddressRange_v3020>(
-          "cuMemGetAddressRange");
+          "cuMemGetAddressRange", 3020);
   if (pfn_cuMemGetAddressRange != nullptr) {
     return pfn_cuMemGetAddressRange(pbase, psize, dptr);
   }


### PR DESCRIPTION
Summary:

CUDA 13.1 returns `cudaErrorInvalidValue` from the unversioned `cudaGetDriverEntryPoint` path even for baseline symbols like `cuDeviceGet`, while `cudaGetDriverEntryPointByVersion` succeeds. Update the prims CUDA driver lazy loader to match the existing NCCLX  CUDA 13 loading pattern by using `cudaGetDriverEntryPointByVersion` with each symbol typedef version when `CUDART_VERSION >= 13000`, while preserving the existing CUDA 12 path.

Reviewed By: cenzhaometa, snarayankh

Differential Revision: D108432780


