### PR TITLE
Support allGatherCtrl() NVL handle exchange over socket/TcpDM control planes (#2880)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -1040,8 +1040,9 @@ commResult_t CtranMapper::allGatherCtrl(
 
   // When totalSegments > CTRAN_IPC_INLINE_SEGMENTS (2), the extra segment
   // descriptors are sent as raw CtranIpcSegDesc data packed densely into
-  // MAX_PAYLOAD_SIZE (4096 byte) packets. This reduces per-segment
-  // overhead compared to wrapping each batch in a full ControlMsg.
+  // MAX_PAYLOAD_SIZE (4096 byte) packets on IB control planes. Socket/TcpDM
+  // control planes only support ControlMsg-sized messages, so they exchange
+  // overflow descriptors in ControlMsg chunks.
   //
   // segsPerPacket = MAX_PAYLOAD_SIZE / sizeof(CtranIpcSegDesc)
   //
@@ -1052,11 +1053,17 @@ commResult_t CtranMapper::allGatherCtrl(
 
   auto regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
 
-  constexpr int kExtraSegsPerPacket =
+  constexpr int kRawExtraSegsPerPacket =
       MAX_PAYLOAD_SIZE / sizeof(ctran::utils::CtranIpcSegDesc);
   static_assert(
-      kExtraSegsPerPacket >= 1,
+      kRawExtraSegsPerPacket >= 1,
       "MAX_PAYLOAD_SIZE must be large enough to hold at least one CtranIpcSegDesc");
+  constexpr int kCtrlMsgExtraSegsPerPacket = CTRAN_IPC_INLINE_SEGMENTS;
+  const bool useCtrlMsgExtraPackets =
+      getCtrlBackend() != CtranMapperBackend::IB;
+  const int extraSegsPerPacket = useCtrlMsgExtraPackets
+      ? kCtrlMsgExtraSegsPerPacket
+      : kRawExtraSegsPerPacket;
 
   // Build peer list and classify backends
   std::vector<int> peerList;
@@ -1116,6 +1123,7 @@ commResult_t CtranMapper::allGatherCtrl(
   }
   std::vector<std::unique_ptr<CtranMapperRequest>> sendReqs;
   std::vector<ControlMsg> recvMsgs(numPeers);
+  std::vector<std::unique_ptr<ControlMsg>> ctrlMsgExtraSendMsgs;
 
   // Phase 1: Header Send + Overflow Send + Header Recv
 
@@ -1137,22 +1145,34 @@ commResult_t CtranMapper::allGatherCtrl(
       const auto extraInfo = computeExtraPacketInfo(
           static_cast<int>(nvlExtraSegments.size()) + CTRAN_IPC_INLINE_SEGMENTS,
           CTRAN_IPC_INLINE_SEGMENTS,
-          kExtraSegsPerPacket);
+          extraSegsPerPacket);
       for (int pktIdx = 0; pktIdx < extraInfo.numExtraPackets; pktIdx++) {
         int startIdx, count;
         computePacketSlice(
             pktIdx,
-            kExtraSegsPerPacket,
+            extraSegsPerPacket,
             extraInfo.numExtraSegments,
             startIdx,
             count);
-        size_t sendSize = count * sizeof(ctran::utils::CtranIpcSegDesc);
         sendReqs.push_back(std::make_unique<CtranMapperRequest>());
-        FB_COMMCHECK(isendCtrlMsgImpl(
-            &nvlExtraSegments[startIdx],
-            sendSize,
-            peerList[i],
-            sendReqs.back().get()));
+        if (useCtrlMsgExtraPackets) {
+          auto& msg = *ctrlMsgExtraSendMsgs.emplace_back(
+              std::make_unique<ControlMsg>(ControlMsgType::NVL_EXPORT_MEM));
+          msg.ipcDesc.desc.totalSegments = count;
+          for (int segIdx = 0; segIdx < count; segIdx++) {
+            msg.ipcDesc.desc.segments[segIdx] =
+                nvlExtraSegments[startIdx + segIdx];
+          }
+          FB_COMMCHECK(isendCtrlMsgImpl(
+              &msg, sizeof(ControlMsg), peerList[i], sendReqs.back().get()));
+        } else {
+          size_t sendSize = count * sizeof(ctran::utils::CtranIpcSegDesc);
+          FB_COMMCHECK(isendCtrlMsgImpl(
+              &nvlExtraSegments[startIdx],
+              sendSize,
+              peerList[i],
+              sendReqs.back().get()));
+        }
       }
     }
   }
@@ -1160,6 +1180,7 @@ commResult_t CtranMapper::allGatherCtrl(
   // Phase 2: Overflow Recv + Import
   std::vector<std::vector<ctran::utils::CtranIpcSegDesc>> allRecvExtraSegments(
       numPeers);
+  std::vector<std::vector<ControlMsg>> ctrlMsgExtraRecvMsgs(numPeers);
   // Flat vector of all extra recv requests for testSomeRequests
   std::vector<std::unique_ptr<CtranMapperRequest>> extraRecvReqPtrs;
 
@@ -1173,28 +1194,39 @@ commResult_t CtranMapper::allGatherCtrl(
 
       if (peerTotalSegments > CTRAN_IPC_INLINE_SEGMENTS) {
         const auto extraInfo = computeExtraPacketInfo(
-            peerTotalSegments, CTRAN_IPC_INLINE_SEGMENTS, kExtraSegsPerPacket);
+            peerTotalSegments, CTRAN_IPC_INLINE_SEGMENTS, extraSegsPerPacket);
 
         allRecvExtraSegments[i].resize(extraInfo.numExtraSegments);
+        if (useCtrlMsgExtraPackets) {
+          ctrlMsgExtraRecvMsgs[i].resize(extraInfo.numExtraPackets);
+        }
 
         // Issue all irecvs for this peer
         for (int pktIdx = 0; pktIdx < extraInfo.numExtraPackets; pktIdx++) {
           int startIdx, count;
           computePacketSlice(
               pktIdx,
-              kExtraSegsPerPacket,
+              extraSegsPerPacket,
               extraInfo.numExtraSegments,
               startIdx,
               count);
-          size_t recvSize = count * sizeof(ctran::utils::CtranIpcSegDesc);
 
           auto req = std::make_unique<CtranMapperRequest>();
           req->peer = peerList[i];
-          FB_COMMCHECK(irecvCtrlMsgImp(
-              &allRecvExtraSegments[i][startIdx],
-              recvSize,
-              peerList[i],
-              req.get()));
+          if (useCtrlMsgExtraPackets) {
+            FB_COMMCHECK(irecvCtrlMsgImp(
+                &ctrlMsgExtraRecvMsgs[i][pktIdx],
+                sizeof(ControlMsg),
+                peerList[i],
+                req.get()));
+          } else {
+            size_t recvSize = count * sizeof(ctran::utils::CtranIpcSegDesc);
+            FB_COMMCHECK(irecvCtrlMsgImp(
+                &allRecvExtraSegments[i][startIdx],
+                recvSize,
+                peerList[i],
+                req.get()));
+          }
           extraRecvReqPtrs.push_back(std::move(req));
         }
       }
@@ -1220,6 +1252,17 @@ commResult_t CtranMapper::allGatherCtrl(
         }
       }
       if (!hasPending) {
+        if (useCtrlMsgExtraPackets && !ctrlMsgExtraRecvMsgs[i].empty()) {
+          int segIdx = 0;
+          for (const auto& msg : ctrlMsgExtraRecvMsgs[i]) {
+            const int count = std::min(
+                kCtrlMsgExtraSegsPerPacket,
+                static_cast<int>(allRecvExtraSegments[i].size()) - segIdx);
+            for (int j = 0; j < count; j++) {
+              allRecvExtraSegments[i][segIdx++] = msg.ipcDesc.desc.segments[j];
+            }
+          }
+        }
         FB_COMMCHECK(this->importMem(
             peerList[i],
             recvMsgs[i],

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1443,8 +1443,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::SEND_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = getCtrlBackend(backend);
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::SendCtrlStart{
@@ -1454,18 +1453,34 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
     CLOGF_TRACE(
         COLL,
-        "CTRAN-MAPPER: Post {} SEND msg to rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        "CTRAN-MAPPER: Post backend {} SEND msg to rank {} with req {} {} {}: {}",
+        static_cast<int>(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        req->backend == CtranMapperBackend::IB ? "ibReq " : "ctrlReq ",
+        req->backend == CtranMapperBackend::IB ? (void*)&req->ibReq
+                                               : (void*)&req->sockReq,
         payload);
-    if (ctranIb) {
+    if (req->backend == CtranMapperBackend::IB) {
       return ctranIb->isendCtrlMsg(
           ControlMsgType::SYNC, payload, size, peerRank, req->ibReq);
     }
-    // only support ib for now
+
+    if (size != sizeof(ControlMsg)) {
+      CLOGF(
+          ERR,
+          "CTRAN-MAPPER: raw SEND control payload size {} is only supported by IB",
+          size);
+      return commInvalidArgument;
+    }
+
+    const auto& msg = *reinterpret_cast<const ControlMsg*>(payload);
+    if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
+      return ctranSock->isendCtrlMsg(msg, peerRank, req->sockReq);
+    } else if (req->backend == CtranMapperBackend::TCPDM && ctranTcpDm) {
+      return ctranTcpDm->isendCtrlMsg(msg, peerRank, req->tcpDmReq);
+    }
+
     return commInvalidArgument;
   }
 
@@ -1478,8 +1493,7 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       CtranMapperBackend backend = CtranMapperBackend::UNSET) {
     req->type = CtranMapperRequest::ReqType::RECV_CTRL_MSG;
     req->peer = peerRank;
-    req->backend =
-        ctranIb ? CtranMapperBackend::IB : CtranMapperBackend::SOCKET;
+    req->backend = getCtrlBackend(backend);
     if (this->mapperTrace) {
       this->mapperTrace->recordMapperEvent(
           ncclx::colltrace::RecvCtrlStart{
@@ -1489,17 +1503,34 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
     CLOGF_TRACE(
         COLL,
-        "CTRAN-MAPPER: Post {} RECV msg from rank {} with req {} {} {}: {}",
-        ctranIb ? "IB" : "SOCKET",
+        "CTRAN-MAPPER: Post backend {} RECV msg from rank {} with req {} {} {}: {}",
+        static_cast<int>(req->backend),
         peerRank,
         (void*)req,
-        ctranIb ? "ibReq " : "sockReq ",
-        ctranIb ? (void*)&req->ibReq : (void*)&req->sockReq,
+        req->backend == CtranMapperBackend::IB ? "ibReq " : "ctrlReq ",
+        req->backend == CtranMapperBackend::IB ? (void*)&req->ibReq
+                                               : (void*)&req->sockReq,
         payload);
-    if (ctranIb) {
+    if (req->backend == CtranMapperBackend::IB) {
       return ctranIb->irecvCtrlMsg<PerfConfig>(
           payload, size, peerRank, req->ibReq);
     }
+
+    if (size != sizeof(ControlMsg)) {
+      CLOGF(
+          ERR,
+          "CTRAN-MAPPER: raw RECV control payload size {} is only supported by IB",
+          size);
+      return commInvalidArgument;
+    }
+
+    auto& msg = *reinterpret_cast<ControlMsg*>(payload);
+    if (req->backend == CtranMapperBackend::SOCKET && ctranSock) {
+      return ctranSock->irecvCtrlMsg(msg, peerRank, req->sockReq);
+    } else if (req->backend == CtranMapperBackend::TCPDM && ctranTcpDm) {
+      return ctranTcpDm->irecvCtrlMsg(msg, peerRank, req->tcpDmReq);
+    }
+
     return commInvalidArgument;
   }
 


### PR DESCRIPTION
Summary:

## Problem

`CtranMapper::allGatherCtrl()` is the control-plane handshake that exchanges IPC memory descriptors so peers can initialize persistent AllGatherP NVL handles. The overflow segment exchange (Phase 2, used when a registered buffer is backed by more than `CTRAN_IPC_INLINE_SEGMENTS` (2) disjoint physical segments) was hard-wired to the IB control plane:

- The raw helpers `isendCtrlMsgImpl()` / `irecvCtrlMsgImp()` only had an IB branch — every non-IB path fell through to `return commInvalidArgument;` (literally commented `// only support ib for now`).
- The overflow descriptors were sent as raw `CtranIpcSegDesc` bytes densely packed into `MAX_PAYLOAD_SIZE` (4096-byte) packets, a framing that only the IB backend accepts.

As a result, launching with `NCCL_CTRAN_BACKENDS=nvl,socket` (or `nvl,tcpdm`) could not initialize the persistent AllGatherP NVL handles: `allGatherCtrl()` returned `commInvalidArgument` as soon as it tried to exchange a `ControlMsg` header over a socket/TcpDM control plane. The socket/TcpDM control transports only support fixed `sizeof(ControlMsg)` messages, not arbitrarily-sized raw packets.

## What this diff does

It teaches `allGatherCtrl()` and its control-message helpers to run the descriptor exchange over socket/TcpDM control planes, while leaving the IB raw-packed fast path untouched.

### `CtranMapper.h` — generalize the raw control-message helpers

`isendCtrlMsgImpl()` / `irecvCtrlMsgImp()`:
- Resolve the request backend through `getCtrlBackend(backend)` instead of the binary `ctranIb ? IB : SOCKET`, so SOCKET and TCPDM are now first-class.
- Keep the IB branch unchanged (IB still accepts raw, arbitrarily-sized payloads).
- For non-IB backends, require `size == sizeof(ControlMsg)` (raw, variable-size payloads remain IB-only) and dispatch to `ctranSock->isendCtrlMsg()` / `ctranTcpDm->isendCtrlMsg()` (and the `irecv` equivalents) based on the resolved backend, returning `commInvalidArgument` with an explanatory log otherwise.

This is a strict capability expansion: before, every non-IB call returned `commInvalidArgument`; now `ControlMsg`-sized non-IB calls succeed and only oversized non-IB raw payloads error out (same return code as before, plus a diagnostic).

### `CtranMapper.cc` — two overflow encodings in `allGatherCtrl()`

A single switch, `useCtrlMsgExtraPackets = (getCtrlBackend() != IB)`, selects the overflow framing and the segments-per-packet count:

- IB control plane (unchanged): `kRawExtraSegsPerPacket = MAX_PAYLOAD_SIZE / sizeof(CtranIpcSegDesc)` raw descriptors per 4096-byte packet.
- socket / TcpDM control plane (new): `kCtrlMsgExtraSegsPerPacket = CTRAN_IPC_INLINE_SEGMENTS` (2) descriptors carried inside each `ControlMsg` (`NVL_EXPORT_MEM`), exchanged as fixed `sizeof(ControlMsg)` messages.

Send side packs each chunk of up to 2 overflow descriptors into a `ControlMsg.ipcDesc.desc.segments[]` and sends it; the `ControlMsg` buffers are held in a `std::vector<std::unique_ptr<ControlMsg>>` so their addresses stay stable until the trailing `waitRequest()` loop (the backends retain a pointer to the payload until completion). Receive side posts one `ControlMsg` `irecv` per chunk, then — once all chunks for a peer have arrived — reassembles them back into the flat `allRecvExtraSegments[i]` vector before calling `importMem()`. Both sides use the same `extraSegsPerPacket` with `computeExtraPacketInfo()` / `computePacketSlice()`, so the packetization is symmetric.

## Wire format

```
Buffer with N disjoint physical segments (N > 2):

  [ seg0 | seg1 | seg2 | seg3 | ... | seg(N-1) ]
    \_________/   \________________________/
     INLINE (2)        OVERFLOW (N-2)
     in header          Phase 2 exchange
     ControlMsg

IB control plane (unchanged):
  ControlMsg header  ->  raw packets, ~ (4096/sizeof(CtranIpcSegDesc)) segs each
  [seg2 seg3 seg4 ... ] densely packed into MAX_PAYLOAD_SIZE buffers

socket / TcpDM control plane (new):
  ControlMsg header  ->  ControlMsg chunks, 2 segs each (NVL_EXPORT_MEM)
  [seg2 seg3] [seg4 seg5] ... each in its own sizeof(ControlMsg) message
```

## allGatherCtrl() flow

```
                       allGatherCtrl(buf, hdl, ranks, ...)
                                     |
              export local IPC desc per backend (NVL / IB)
              -> header ControlMsg + nvlExtraSegments (overflow)
                                     |
   useCtrlMsgExtraPackets = getCtrlBackend() != IB ?  (socket/tcpdm => true)
                                     |
        +----------------- Phase 1 -----------------+
        | irecv header ControlMsg from every peer   |
        | isend header ControlMsg to   every peer   |
        | NVL peers w/ overflow: isend extra chunks |
        |   true  -> ControlMsg chunks (2 segs ea.) |
        |   false -> raw packed CtranIpcSegDesc      |
        +-------------------------------------------+
                                     |
        +----------------- Phase 2 -----------------+
        | wait header recv; size overflow buffers   |
        | irecv overflow (ControlMsg chunks | raw)  |
        | poll; when a peer's recvs are all done:   |
        |   ControlMsg path -> reassemble chunks     |
        |     into allRecvExtraSegments[peer]        |
        |   importMem(peer, header, extraSegments)   |
        +-------------------------------------------+
                                     |
                 wait all sends complete -> return
```

## Compatibility / risk

- IB control plane behavior is byte-for-byte unchanged (guarded by `useCtrlMsgExtraPackets`).
- No new wire format on IB; the new `ControlMsg`-chunk format is only used when both peers run a socket/TcpDM control plane, which is uniform across a job (job-wide `NCCL_CTRAN_BACKENDS`), so send/recv always agree on the encoding.
- `kCtrlMsgExtraSegsPerPacket == CTRAN_IPC_INLINE_SEGMENTS == sizeof(ControlMsg.ipcDesc.desc.segments)/...`, so packing at most 2 descriptors per chunk can never overrun the inline array (asserted indirectly by `AllGatherCtrlUT`).

## Known follow-ups (non-blocking, trace/clarity only)

- The `CLOGF_TRACE` lines in `isendCtrlMsgImpl()` / `irecvCtrlMsgImp()` print `&req->sockReq` for every non-IB backend, but TCPDM actually uses `req->tcpDmReq` (distinct members; `CtranMapperRequest` has a `// FIXME: use union`), and the `"ctrlReq"` label does not distinguish SOCKET from TCPDM. Trace-only; flagged by the AI reviewer.
- Overflow `ControlMsg` chunks reuse `ipcDesc.desc.totalSegments` to carry the per-chunk count; the receiver recomputes the count instead of reading it, so that field is effectively redundant on the wire. The inner `auto& msg` overflow packet also shadows the outer header `msg`.
- TCPDM control-plane path is symmetric to socket but is not yet exercised by a dedicated E2E test in this diff.

Differential Revision: D108337827


