### PR TITLE
ctran/tcp_dm: treat TCPDM bootstrap disconnects as remote errors (#2882)

### DIFF
--- a/comms/ctran/backends/mock/CtranTcpDmBaseMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmBaseMock.h
@@ -17,6 +17,8 @@ class CtranTcpDmRequest {
   }
 
   void complete() {}
+
+  void markQueuedRecv() {}
 };
 
 } // namespace ctran

--- a/comms/ctran/backends/mock/CtranTcpDmMock.h
+++ b/comms/ctran/backends/mock/CtranTcpDmMock.h
@@ -91,6 +91,10 @@ class CtranTcpDm {
     return commInvalidUsage;
   }
 
+  void abortOutstanding(const char* /*reason*/) {}
+
+  void cancelQueuedRecv(CtranTcpDmRequest* /*req*/) {}
+
   // Export the location of GPU kernel consumer queues.
   commResult_t
   prepareUnpackConsumer(SQueues* sqs, size_t blocks, void** pool = nullptr) {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -164,6 +164,7 @@ void CtranTcpDm::bootstrapAccept() {
 void CtranTcpDm::bootstrapAddSendPeer(
     int peerRank,
     ::comms::tcp_devmem::CommunicatorInterface* comm) {
+  std::lock_guard lock(mutex_);
   sendComms_[peerRank] = comm;
 }
 
@@ -235,9 +236,8 @@ void CtranTcpDm::ensureCtrlSocket(int peerRank) {
   ctrlSocks_.emplace(peerRank, std::move(sock));
 }
 
-CtranTcpDm::CtranTcpDm(
-    [[maybe_unused]] CtranComm* comm,
-    ctran::Profiler* profiler) {
+CtranTcpDm::CtranTcpDm(CtranComm* comm, ctran::Profiler* profiler) {
+  comm_ = comm;
   cudaDev_ = comm->statex_->cudaDev();
   rank_ = comm->statex_->rank();
   nRanks_ = comm->statex_->nRanks();
@@ -270,17 +270,123 @@ CtranTcpDm::~CtranTcpDm() {
   listenSocket_.shutdown();
   listenThread_.join();
 
-  auto transport = CtranTcpDmSingleton::getTransport();
-  for (auto comm : sendComms_) {
-    transport->closeSend(comm.second);
-  }
-  for (auto comm : recvComms_) {
-    transport->closeRecv(comm.second);
+  const uint32_t closeFlags = comm_ != nullptr && comm_->testAbort()
+      ? ::comms::tcp_devmem::kCloseFlagForce
+      : 0;
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "CTRAN-TCPDM: destroying backend {} commHash {:x} commDesc {} aborted {} closeFlags {:#x}",
+      (void*)this,
+      commHash_,
+      commDesc_,
+      aborted_.load(),
+      closeFlags);
+  closeComms("backend destruction", closeFlags);
+  CtranTcpDmSingleton::getTransport()->shutdown(false);
+}
+
+void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
+  std::unordered_map<int, ::comms::tcp_devmem::CommunicatorInterface*>
+      sendComms;
+  std::unordered_map<int, ::comms::tcp_devmem::CommunicatorInterface*>
+      recvComms;
+  size_t queuedRecvCount = 0;
+  size_t cancelledQueuedRecvCount = 0;
+  {
+    std::lock_guard lock(mutex_);
+    queuedRecvCount = queuedRecv_.size();
+    for (auto& recvReq : queuedRecv_) {
+      if (recvReq->req != nullptr) {
+        recvReq->req->complete(::comms::tcp_devmem::Status::RemoteError);
+        ++cancelledQueuedRecvCount;
+      }
+    }
+    queuedRecv_.clear();
+    sendComms.swap(sendComms_);
+    recvComms.swap(recvComms_);
   }
 
-  // Always request shutdown; Transport self-gates on `comms_ > 0` so only
-  // the last CtranTcpDm actually tears down, while CUDA is still alive.
-  transport->shutdown(false);
+  const bool forceClose = closeFlags & ::comms::tcp_devmem::kCloseFlagForce;
+  if (forceClose) {
+    CLOGF(
+        WARN,
+        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {}",
+        (void*)this,
+        rank_,
+        commHash_,
+        commDesc_,
+        reason == nullptr ? "unknown" : reason,
+        closeFlags,
+        sendComms.size(),
+        recvComms.size(),
+        queuedRecvCount,
+        cancelledQueuedRecvCount);
+  } else {
+    CLOGF(
+        INFO,
+        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {}",
+        (void*)this,
+        rank_,
+        commHash_,
+        commDesc_,
+        reason == nullptr ? "unknown" : reason,
+        closeFlags,
+        sendComms.size(),
+        recvComms.size(),
+        queuedRecvCount,
+        cancelledQueuedRecvCount);
+  }
+
+  auto transport = CtranTcpDmSingleton::getTransport();
+  for (auto& [peerRank, comm] : sendComms) {
+    auto status = transport->closeSend(comm, closeFlags);
+    if (status != ::comms::tcp_devmem::Status::Ok) {
+      CLOGF(
+          WARN,
+          "CTRAN-TCPDM: closeSend failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
+          peerRank,
+          rank_,
+          commHash_,
+          commDesc_,
+          reason == nullptr ? "unknown" : reason,
+          closeFlags,
+          static_cast<int>(status));
+    }
+  }
+
+  for (auto& [peerRank, comm] : recvComms) {
+    auto status = transport->closeRecv(comm, closeFlags);
+    if (status != ::comms::tcp_devmem::Status::Ok) {
+      CLOGF(
+          WARN,
+          "CTRAN-TCPDM: closeRecv failed for peer {} on rank {} commHash {:x} commDesc {} reason {} flags {:#x} status {}",
+          peerRank,
+          rank_,
+          commHash_,
+          commDesc_,
+          reason == nullptr ? "unknown" : reason,
+          closeFlags,
+          static_cast<int>(status));
+    }
+  }
+}
+
+void CtranTcpDm::abortOutstanding(const char* reason) {
+  if (aborted_.exchange(true)) {
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "CTRAN-TCPDM: backend {} already aborted for rank {} commHash {:x} commDesc {} reason {}",
+        (void*)this,
+        rank_,
+        commHash_,
+        commDesc_,
+        reason == nullptr ? "unknown" : reason);
+    return;
+  }
+
+  closeComms(reason, ::comms::tcp_devmem::kCloseFlagForce);
 }
 
 void CtranTcpDm::profilerStart() {
@@ -292,6 +398,9 @@ void CtranTcpDm::profilerEnd() {
 }
 
 commResult_t CtranTcpDm::preConnect(const std::unordered_set<int>& peerRanks) {
+  if (aborted_.load()) {
+    return commRemoteError;
+  }
   for (int peerRank : peerRanks) {
     FB_COMMCHECK(connectPeer(peerRank));
   }
@@ -337,9 +446,27 @@ commResult_t CtranTcpDm::isend(
     void* data,
     size_t size,
     CtranTcpDmRequest& req) {
-  FB_COMMCHECK(connectPeer(peerRank));
+  const auto connectResult = connectPeer(peerRank);
+  if (connectResult != commSuccess) {
+    if (connectResult == commRemoteError) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+    }
+    return connectResult;
+  }
 
-  ::comms::tcp_devmem::CommunicatorInterface* comm = sendComms_.at(peerRank);
+  ::comms::tcp_devmem::CommunicatorInterface* comm = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
+    auto it = sendComms_.find(peerRank);
+    if (it == sendComms_.end()) {
+      return commInternalError;
+    }
+    comm = it->second;
+  }
 
   auto transport = CtranTcpDmSingleton::getTransport();
   ::comms::tcp_devmem::RequestInterface* request{nullptr};
@@ -356,8 +483,14 @@ commResult_t CtranTcpDm::isend(
 }
 
 commResult_t CtranTcpDm::connectPeer(int peerRank) {
-  if (sendComms_.find(peerRank) != sendComms_.end()) {
-    return commSuccess;
+  {
+    std::lock_guard lock(mutex_);
+    if (aborted_.load()) {
+      return commRemoteError;
+    }
+    if (sendComms_.find(peerRank) != sendComms_.end()) {
+      return commSuccess;
+    }
   }
 
   folly::SocketAddress peerAddr;
@@ -423,31 +556,58 @@ commResult_t CtranTcpDm::irecvCtrlMsg(
 }
 
 commResult_t CtranTcpDm::progress() {
-  std::unique_lock lock(mutex_);
-
   ctrlSyncProgress();
   recvNotifyProgress();
 
-  for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
-    auto& recvReq = *it;
+  while (true) {
+    std::unique_ptr<RecvRequest> recvReq;
+    {
+      std::unique_lock lock(mutex_);
+      if (aborted_.load()) {
+        return commRemoteError;
+      }
 
-    if (recvComms_.find(recvReq->peerRank) == recvComms_.end()) {
-      ++it;
-      continue;
+      for (auto it = queuedRecv_.begin(); it != queuedRecv_.end(); ++it) {
+        if (recvComms_.find((*it)->peerRank) == recvComms_.end()) {
+          continue;
+        }
+        recvReq = std::move(*it);
+        queuedRecv_.erase(it);
+        break;
+      }
     }
 
-    FB_COMMCHECK(irecvConnected(
+    if (recvReq == nullptr) {
+      return commSuccess;
+    }
+
+    auto result = irecvConnected(
         recvReq->peerRank,
         recvReq->handle,
         recvReq->data,
         recvReq->size,
         *recvReq->req,
-        recvReq->unpackPool));
-
-    it = queuedRecv_.erase(it);
+        recvReq->unpackPool);
+    if (result != commSuccess) {
+      recvReq->req->complete(::comms::tcp_devmem::Status::RemoteError);
+      return result;
+    }
   }
+}
 
-  return commSuccess;
+void CtranTcpDm::cancelQueuedRecv(CtranTcpDmRequest* req) {
+  std::unique_lock lock(mutex_);
+
+  for (auto it = queuedRecv_.begin(); it != queuedRecv_.end();) {
+    if ((*it)->req == req) {
+      if (req != nullptr) {
+        req->complete(::comms::tcp_devmem::Status::RemoteError);
+      }
+      it = queuedRecv_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 commResult_t CtranTcpDm::irecv(
@@ -459,6 +619,10 @@ commResult_t CtranTcpDm::irecv(
     void* unpackPool) {
   {
     std::unique_lock lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
 
     // Peer is not connected, queue this operation. We can't block
     // the irecv callers. progress() should be called periodically to
@@ -471,6 +635,7 @@ commResult_t CtranTcpDm::irecv(
       recvReq->size = size;
       recvReq->req = &req;
       recvReq->unpackPool = unpackPool;
+      req.markQueuedRecv();
       queuedRecv_.push_back(std::move(recvReq));
       return commSuccess;
     }
@@ -486,7 +651,19 @@ commResult_t CtranTcpDm::irecvConnected(
     size_t size,
     CtranTcpDmRequest& req,
     void* unpackPool) {
-  ::comms::tcp_devmem::CommunicatorInterface* comm = recvComms_.at(peerRank);
+  ::comms::tcp_devmem::CommunicatorInterface* comm = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
+    auto it = recvComms_.find(peerRank);
+    if (it == recvComms_.end()) {
+      return commInternalError;
+    }
+    comm = it->second;
+  }
   if (!comm) {
     return commInternalError;
   }
@@ -527,6 +704,7 @@ commResult_t CtranTcpDm::irecvCounted(
       recvReq->size = size;
       recvReq->req = rawReq;
       recvReq->unpackPool = unpackPool;
+      rawReq->markQueuedRecv();
       queuedRecv_.push_back(std::move(recvReq));
       return commSuccess;
     }

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -13,6 +13,8 @@
 #include "folly/SocketAddress.h"
 #include "folly/synchronization/CallOnce.h"
 
+#include <cerrno>
+
 namespace ctran {
 
 #define COMMCHECK_TCP(cmd)                                            \
@@ -26,6 +28,56 @@ namespace ctran {
       return commInvalidArgument;                                     \
     }                                                                 \
   } while (0)
+
+namespace {
+
+bool isPeerDisconnectErrno(int err) {
+  switch (err) {
+    case ECONNABORTED:
+    case ECONNREFUSED:
+    case ECONNRESET:
+    case ENOTCONN:
+    case EPIPE:
+    case ETIMEDOUT:
+      return true;
+    default:
+      return false;
+  }
+}
+
+commResult_t mapBootstrapSocketError(
+    int err,
+    const char* op,
+    int rank,
+    int peerRank,
+    uint64_t commHash,
+    const std::string& commDesc) {
+  if (isPeerDisconnectErrno(err)) {
+    CLOGF(
+        WARN,
+        "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={} (treating as remote error)",
+        op,
+        peerRank,
+        rank,
+        commHash,
+        commDesc,
+        err);
+    return commRemoteError;
+  }
+
+  CLOGF(
+      ERR,
+      "CTRAN-TCPDM: bootstrap {} failed with peer {} on rank {} commHash {:x} commDesc {} errno={}",
+      op,
+      peerRank,
+      rank,
+      commHash,
+      commDesc,
+      err);
+  return commInternalError;
+}
+
+} // namespace
 
 void CtranTcpDm::bootstrapPrepare(meta::comms::IBootstrap* bootstrap) {
   folly::SocketAddress ifAddrSockAddr;
@@ -174,17 +226,28 @@ commResult_t CtranTcpDm::bootstrapConnect(
   commResult_t res = commSuccess;
 
   ctran::bootstrap::Socket sock;
-  FB_SYSCHECKRETURN(
-      sock.connect(
-          peerSockAddr,
-          NCCL_CLIENT_SOCKET_IFNAME,
-          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
-          NCCL_SOCKET_RETRY_CNT),
-      commInternalError);
-  FB_SYSCHECKRETURN(sock.send(&rank_, sizeof(int)), commInternalError);
+  int err = sock.connect(
+      peerSockAddr,
+      NCCL_CLIENT_SOCKET_IFNAME,
+      std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
+      NCCL_SOCKET_RETRY_CNT);
+  if (err != 0) {
+    return mapBootstrapSocketError(
+        err, "connect", rank_, peerRank, commHash_, commDesc_);
+  }
+
+  err = sock.send(&rank_, sizeof(int));
+  if (err != 0) {
+    return mapBootstrapSocketError(
+        err, "send", rank_, peerRank, commHash_, commDesc_);
+  }
 
   ::comms::tcp_devmem::Handle handle{};
-  FB_SYSCHECKRETURN(sock.recv(&handle, sizeof(handle)), commInternalError);
+  err = sock.recv(&handle, sizeof(handle));
+  if (err != 0) {
+    return mapBootstrapSocketError(
+        err, "recv", rank_, peerRank, commHash_, commDesc_);
+  }
 
   ::comms::tcp_devmem::CommunicatorInterface* sendComm{};
   COMMCHECKTHROW(

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <deque>
 #include <unordered_map>
 
@@ -86,6 +87,10 @@ class CtranTcpDm {
   // has to be called to make progress on them.
   commResult_t progress();
 
+  void cancelQueuedRecv(CtranTcpDmRequest* req);
+
+  void abortOutstanding(const char* reason);
+
   // Export the location of GPU kernel consumer queues.
   // Returns the allocated pool via the out parameter pool.
   commResult_t
@@ -114,12 +119,14 @@ class CtranTcpDm {
   std::vector<sockaddr_storage> allListenSocketAddrs_{};
   std::thread listenThread_;
 
+  CtranComm* comm_{nullptr};
   int cudaDev_{-1};
   int rank_{-1};
   int nRanks_{-1};
   uint64_t commHash_{0};
   std::string commDesc_;
   ::comms::tcp_devmem::NetDevInterface* netdev_{nullptr};
+  std::atomic<bool> aborted_{false};
 
   std::mutex mutex_;
   std::unordered_map<int, ::comms::tcp_devmem::CommunicatorInterface*>
@@ -161,6 +168,7 @@ class CtranTcpDm {
   void ctrlSyncProgress();
 
   commResult_t connectPeer(int peerRank);
+  void closeComms(const char* reason, uint32_t closeFlags);
 
   void bootstrapPrepare(meta::comms::IBootstrap* bootstrap);
   void bootstrapAddRecvPeer(

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmBase.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmBase.h
@@ -18,6 +18,9 @@ class CtranTcpDmRequest {
     if (request_ == nullptr) {
       // Pending irecv where sender has not been connected yet or send/recv
       // control.
+      if (done_ && status_ != ::comms::tcp_devmem::Status::Ok) {
+        COMMCHECKTHROW(status_);
+      }
       return done_;
     }
 
@@ -44,14 +47,23 @@ class CtranTcpDmRequest {
     return done_;
   }
 
-  void complete() {
+  void complete(
+      ::comms::tcp_devmem::Status status = ::comms::tcp_devmem::Status::Ok) {
+    status_ = status;
     done_ = true;
+  }
+
+  void markQueuedRecv() {
+    done_ = false;
+    status_ = ::comms::tcp_devmem::Status::Ok;
+    request_ = nullptr;
   }
 
   void track(
       ::comms::tcp_devmem::TransportInterface* transport,
       ::comms::tcp_devmem::RequestInterface* request) {
     done_ = false;
+    status_ = ::comms::tcp_devmem::Status::Ok;
     transport_ = transport;
     request_ = request;
   }
@@ -59,6 +71,7 @@ class CtranTcpDmRequest {
  private:
   ::comms::tcp_devmem::RequestInterface* request_{nullptr};
   ::comms::tcp_devmem::TransportInterface* transport_{nullptr};
+  ::comms::tcp_devmem::Status status_{::comms::tcp_devmem::Status::Ok};
   bool done_{false};
 };
 

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -858,15 +858,28 @@ void CtranGpe::Impl::gpeThreadFn() {
                     "collective skipped: communicator aborted",
                     commRemoteError));
           }
+          if (mapper != nullptr && mapper->hasTcpDmBackend()) {
+            mapper->abortTcpDm("collective skipped: communicator aborted");
+          }
         } else if (!cmd->coll.opGroup.empty() /* skip when opGroup is empty, i.e,. we are only here for post-kernel cmd destruction/cleanup */) {
-          CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
-              comm,
-              {
-                FB_COMMCHECKTHROW_EX(
-                    cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
-              },
-              static_cast<int>(cmd->coll.opGroup.front()->type),
-              cmd->coll.opGroup.front()->opCount);
+          if (mapper != nullptr && mapper->hasTcpDmBackend()) {
+            mapper->runTcpDmCollectiveAbortGuard(
+                [&] {
+                  FB_COMMCHECKTHROW_EX(
+                      cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
+                },
+                static_cast<int>(cmd->coll.opGroup.front()->type),
+                cmd->coll.opGroup.front()->opCount);
+          } else {
+            CTRAN_ASYNC_ERR_GUARD_FAULT_TOLERANCE(
+                comm,
+                {
+                  FB_COMMCHECKTHROW_EX(
+                      cmd->coll.func(cmd->coll.opGroup), comm->logMetaData_);
+                },
+                static_cast<int>(cmd->coll.opGroup.front()->type),
+                cmd->coll.opGroup.front()->opCount);
+          }
         }
 
         if (cmd->persistent) {

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -25,6 +25,7 @@
 #include "comms/ctran/regcache/IpcRegCache.h"
 #include "comms/ctran/regcache/RegCache.h"
 #include "comms/ctran/transport/IP2pHostTransport.h"
+#include "comms/ctran/utils/AsyncError.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/CtranPerf.h"
 #include "comms/ctran/utils/Exception.h"
@@ -178,6 +179,66 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *   - peerRanks: the ranks of the peers to be connected
    */
   commResult_t preConnect(const std::unordered_set<int>& peerRanks);
+
+  bool hasTcpDmBackend() const {
+    return ctranTcpDm != nullptr;
+  }
+
+  void abortTcpDm(const char* reason) {
+    if (ctranTcpDm != nullptr) {
+      ctranTcpDm->abortOutstanding(reason);
+    }
+  }
+
+  template <typename Func>
+  void runTcpDmCollectiveAbortGuard(Func&& func, int opType, uint64_t opCount) {
+    try {
+      func();
+    } catch (const ctran::utils::Exception& e) {
+      CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, e, opType, opCount);
+      if (comm->testAbort()) {
+        abortTcpDm(e.what());
+      }
+    } catch (const std::runtime_error& e) {
+      ctran::utils::Exception ex(e.what(), commRemoteError);
+      CTRAN_ASYNC_ERR_HANDLE_IMPL_FAULT_TOLERANCE(comm, ex, opType, opCount);
+      if (comm->testAbort()) {
+        abortTcpDm(e.what());
+      }
+    }
+  }
+
+  [[noreturn]] void throwTcpDmNotifyAbort(CtranMapperNotify* notify) {
+    CLOGF(
+        WARN,
+        "CTRAN-MAPPER: TCPDM notify abort notify={} rank {} commHash {:x}",
+        notify->toString(),
+        comm->logMetaData_.rank,
+        comm->logMetaData_.commHash);
+    this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
+
+    auto _abort = comm->getAbort();
+    std::string _ctx =
+        _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
+    throw ctran::utils::Exception(
+        _ctx,
+        commRemoteError,
+        comm->logMetaData_.rank,
+        comm->logMetaData_.commHash,
+        fmt::format("checkNotify for peer {}", notify->peer));
+  }
+
+  [[noreturn]] void throwTcpDmRequestsAbort(size_t numRequests) {
+    auto _abort = comm->getAbort();
+    std::string _ctx =
+        _abort->TimedOut() ? "comm aborted due to timeout" : "comm aborted";
+    throw ctran::utils::Exception(
+        _ctx,
+        commRemoteError,
+        comm->logMetaData_.rank,
+        comm->logMetaData_.commHash,
+        fmt::format("testSomeRequests with {} requests", numRequests));
+  }
 
   /* Post a send control op to associated backend.
    * Input arguments:
@@ -1110,6 +1171,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         FB_COMMCHECK(this->ctranTcpDm->progress());
         FB_COMMCHECK(this->ctranTcpDm->checkNotify(notify->peer, &done));
       }
+      if (comm->testAbort()) {
+        this->ctranTcpDm->cancelQueuedRecv(&notify->tcpDmReq);
+      }
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
       return commInternalError;
@@ -1170,6 +1234,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     }
 
     if (comm->testAbort()) {
+      if (req->backend == CtranMapperBackend::TCPDM) {
+        this->ctranTcpDm->cancelQueuedRecv(&req->tcpDmReq);
+      }
       throwCommAbortException(
           fmt::format("waitRequest for peer {}", req->peer));
     }
@@ -1995,6 +2062,11 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
 
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t checkNotifyImpl(CtranMapperNotify* notify, bool* done) {
+    const bool isTcpDmNotify = notify->backend == CtranMapperBackend::TCPDM;
+    if (isTcpDmNotify && comm->testAbort()) {
+      throwTcpDmNotifyAbort(notify);
+    }
+
     if (notify->backend == CtranMapperBackend::NVL) {
       *done = notify->kernElem->isComplete();
     } else if (notify->backend == CtranMapperBackend::IB) {
@@ -2005,6 +2077,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     } else {
       CLOGF(ERR, "CTRAN-MAPPER: unexpected backend {}", notify->backend);
       return commInternalError;
+    }
+
+    if (isTcpDmNotify && comm->testAbort()) {
+      throwTcpDmNotifyAbort(notify);
     }
 
     if (*done) {
@@ -2022,9 +2098,23 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       std::vector<std::unique_ptr<CtranMapperRequest>>& reqs,
       std::vector<CtranMapperTimestampPoint>& tps,
       bool recordTime) {
+    const bool aborted = comm->testAbort();
+    bool cancelledTcpDmReq = false;
+
     for (auto it = reqs.begin(); it != reqs.end();) {
       auto& req = *it;
       if (req) {
+        if (cancelledTcpDmReq) {
+          it++;
+          continue;
+        }
+        if (aborted && req->backend == CtranMapperBackend::TCPDM) {
+          this->ctranTcpDm->cancelQueuedRecv(&req->tcpDmReq);
+          cancelledTcpDmReq = true;
+          it++;
+          continue;
+        }
+
         // Only icopy request doesn't have peer; expect it is not used in
         // testSomeRequests with timepoints.
         if (req->peer == -1) {
@@ -2046,6 +2136,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         // Remove completed requests
         it = reqs.erase(it);
       }
+    }
+    if (cancelledTcpDmReq) {
+      throwTcpDmRequestsAbort(reqs.size());
     }
     return commSuccess;
   }

--- a/comms/ctran/mapper/tests/CtranMapperTcpdmUT.cc
+++ b/comms/ctran/mapper/tests/CtranMapperTcpdmUT.cc
@@ -1,10 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <folly/init/Init.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <thread>
 
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/regcache/RegCache.h"
@@ -35,13 +38,24 @@ class CtranMapperTcpdmTest : public ::testing::Test {
   }
   void TearDown() override {
     unsetenv("NCCL_CTRAN_BACKENDS");
+    if (timer_.joinable()) {
+      timer_.join();
+    }
     commRAII_.reset();
   }
-  void createComm() {
+  void createComm(bool abortEnabled = false) {
     ncclCvarInit();
-    commRAII_ = ctran::createDummyCtranComm();
+    commRAII_ = ctran::createDummyCtranComm(0, abortEnabled);
     dummyComm_ = commRAII_->ctranComm.get();
   }
+  void setAbortAfter(std::chrono::milliseconds delay) {
+    timer_ = std::thread([this, delay]() {
+      std::this_thread::sleep_for(delay);
+      dummyComm_->setAbort();
+    });
+  }
+
+  std::thread timer_;
 };
 
 TEST_F(CtranMapperTcpdmTest, EnableTCPDMBackendThroughCVARs) {
@@ -54,6 +68,51 @@ TEST_F(CtranMapperTcpdmTest, EnableTCPDMBackendThroughCVARs) {
   EXPECT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::NVL));
   EXPECT_FALSE(mapper->hasBackend(rank, CtranMapperBackend::SOCKET));
   EXPECT_TRUE(mapper->hasBackend(rank, CtranMapperBackend::TCPDM));
+}
+
+TEST_F(CtranMapperTcpdmTest, WaitNotifyReturnsWhenCommAborts) {
+  setenv("NCCL_CTRAN_BACKENDS", "tcpdm", 1);
+  this->createComm(/*abortEnabled=*/true);
+
+  auto mapper = std::make_unique<CtranMapper>(this->dummyComm_);
+  CtranMapperNotify notify;
+  notify.peer = 0;
+  notify.backend = CtranMapperBackend::TCPDM;
+
+  this->setAbortAfter(std::chrono::milliseconds(100));
+
+  EXPECT_THROW(mapper->waitNotify(&notify), ::ctran::utils::Exception);
+}
+
+TEST_F(CtranMapperTcpdmTest, CheckNotifyReturnsWhenCommAborts) {
+  setenv("NCCL_CTRAN_BACKENDS", "tcpdm", 1);
+  this->createComm(/*abortEnabled=*/true);
+
+  auto mapper = std::make_unique<CtranMapper>(this->dummyComm_);
+  CtranMapperNotify notify;
+  notify.peer = 0;
+  notify.backend = CtranMapperBackend::TCPDM;
+  bool done = false;
+
+  this->dummyComm_->setAbort();
+
+  EXPECT_THROW(mapper->checkNotify(&notify, &done), ::ctran::utils::Exception);
+}
+
+TEST_F(CtranMapperTcpdmTest, TestSomeRequestsReturnsWhenCommAborts) {
+  setenv("NCCL_CTRAN_BACKENDS", "tcpdm", 1);
+  this->createComm(/*abortEnabled=*/true);
+
+  auto mapper = std::make_unique<CtranMapper>(this->dummyComm_);
+  auto req = std::make_unique<CtranMapperRequest>();
+  req->peer = 0;
+  req->backend = CtranMapperBackend::TCPDM;
+  std::vector<std::unique_ptr<CtranMapperRequest>> reqs;
+  reqs.push_back(std::move(req));
+
+  this->dummyComm_->setAbort();
+
+  EXPECT_THROW(mapper->testSomeRequests(reqs), ::ctran::utils::Exception);
 }
 TEST_F(CtranMapperTcpdmTest, OverrideBackendThroughHints) {
   // Test that config_.backends overrides NCCL_CTRAN_BACKENDS CVAR.
@@ -72,5 +131,6 @@ TEST_F(CtranMapperTcpdmTest, OverrideBackendThroughHints) {
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
   return RUN_ALL_TESTS();
 }

--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -23,7 +23,9 @@
 
 namespace ctran {
 
-std::unique_ptr<TestCtranCommRAII> createDummyCtranComm(int devId) {
+std::unique_ptr<TestCtranCommRAII> createDummyCtranComm(
+    int devId,
+    bool abortEnabled) {
   CUDACHECK_TEST(cudaSetDevice(devId));
 
   CHECK_EQ(ctran::utils::commCudaLibraryInit(), commSuccess);
@@ -33,7 +35,8 @@ std::unique_ptr<TestCtranCommRAII> createDummyCtranComm(int devId) {
       ctran::utils::getHash(uuid.data(), static_cast<int>(uuid.size()));
   std::string commDesc = fmt::format("DummyCtranTestComm-{}", 0);
 
-  auto result = createCtranCommWithBootstrap(0, 1, 0, commHash, commDesc);
+  auto result =
+      createCtranCommWithBootstrap(0, 1, 0, commHash, commDesc, abortEnabled);
 
   // Create a TestCtranCommRAII that also holds the bootstrap
   auto raii = std::make_unique<TestCtranCommRAII>(std::move(result.ctranComm));

--- a/comms/ctran/tests/CtranTestUtils.h
+++ b/comms/ctran/tests/CtranTestUtils.h
@@ -47,7 +47,9 @@ class TestCtranCommRAII {
   }
 };
 
-std::unique_ptr<TestCtranCommRAII> createDummyCtranComm(int devId = 0);
+std::unique_ptr<TestCtranCommRAII> createDummyCtranComm(
+    int devId = 0,
+    bool abortEnabled = false);
 
 // Helper struct to hold bootstrap that needs to stay alive with the CtranComm
 struct CtranCommWithBootstrap {
@@ -60,14 +62,15 @@ inline CtranCommWithBootstrap createCtranCommWithBootstrap(
     int nRanks,
     uint64_t commId = 22,
     int commHash = -1,
-    std::string_view commDesc = "ctran_comm_raii_comm_desc") {
+    std::string_view commDesc = "ctran_comm_raii_comm_desc",
+    bool abortEnabled = false) {
   int cudaDev;
   CUDACHECK_TEST(cudaGetDevice(&cudaDev));
 
   COMMCHECK_TEST(ctran::utils::commCudaLibraryInit());
 
-  std::unique_ptr<CtranComm> ctranComm = std::make_unique<CtranComm>(
-      ::ctran::utils::createAbort(/*enabled=*/false));
+  std::unique_ptr<CtranComm> ctranComm =
+      std::make_unique<CtranComm>(::ctran::utils::createAbort(abortEnabled));
 
   // Create and initialize bootstrap; needed for CTRAN backend initialization
   auto bootstrap = std::make_shared<mccl::bootstrap::Bootstrap>(


### PR DESCRIPTION
Summary:

Map peer-disconnect errno values from the TCPDM bootstrap socket path to `commRemoteError` instead of `commInternalError`. During PAFT recovery a peer can legitimately close or rebuild while the connector is in `connect`, `send`, or `recv`; reporting those as remote errors lets the communicator recovery path handle them consistently with transport-level peer failures.

Reviewed By: function47

Differential Revision: D107912798


