### PR TITLE
ctran/tcpdm: keep TCPDM unpack pools alive for CUDA graphs (#2884)

### DIFF
--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -76,7 +76,8 @@ struct OpElem {
   bool isDevice{true};
 
   // TCP Device Memory unpack pool for this operation.
-  // Allocated by prepareUnpackConsumer() and freed during GPE kernel teardown.
+  // Allocated by prepareUnpackConsumer(). Eager operations return it during
+  // GPE kernel teardown; CUDA graph captures keep it until graph destruction.
   // Used by algorithm implementations to populate CtranMapperContext and
   // pass it down to CtranTcpDm::irecvConnected().
   void* unpackPool{nullptr};

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -297,8 +297,9 @@ commResult_t CtranGpe::Impl::submit(
   // can synchronize with the kernel before running cleanup. During graph
   // capture the cleanup is retained directly on the graph via
   // retainUserObject, avoiding host-node overhead.
-  bool needsKernelFlag =
-      !opGroup.empty() || (kernelConfig.postKernelCleanup && !isCapturing);
+  bool needsKernelFlag = !opGroup.empty() ||
+      kernelConfig.unpackPool != nullptr ||
+      (kernelConfig.postKernelCleanup && !isCapturing);
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   volatile int* flag = nullptr;
@@ -388,6 +389,31 @@ commResult_t CtranGpe::Impl::submit(
     if (isCapturing) {
       FB_COMMCHECK(preLaunchGraphPrepare(cmd, graphPrepareFn));
       cmd->persistent = true;
+      if (cmd->unpackPool != nullptr) {
+        auto existingCleanup = std::move(cmd->postKernelCleanup);
+        auto* unpackPool = cmd->unpackPool;
+        cmd->postKernelCleanup = [comm = comm,
+                                  unpackPool,
+                                  existingCleanup =
+                                      std::move(existingCleanup)]() mutable {
+          if (existingCleanup) {
+            existingCleanup();
+          }
+          if (!ctranInitialized(comm) || comm->ctran_->mapper == nullptr) {
+            return;
+          }
+          auto result =
+              comm->ctran_->mapper->teardownUnpackConsumer(unpackPool);
+          if (result != commSuccess) {
+            CLOGF_SUBSYS(
+                WARN,
+                COLL,
+                "CTRAN-GPE: failed to teardown graph unpack pool {}: result {}",
+                unpackPool,
+                static_cast<int>(result));
+          }
+        };
+      }
       // Mark the flag as persistent so reclaim() won't steal it between
       // graph replays (the kernel writes KERNEL_UNSET after each replay).
       if (kernelFlag) {
@@ -916,11 +942,10 @@ void CtranGpe::Impl::gpeThreadFn() {
               comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
           gpeProfiler_->mark(ctran::GpeTracePoint::TERMINATE_KERNEL);
         }
-        // Teardown unpack queue if it was allocated for this operation (TcpDM
-        // backend). Don't wait for kernel to finish, the pool manages
-        // the allocations in the round robin fashion to avoid immediate
-        // reuse.
-        if (cmd->unpackPool != nullptr) {
+        // Teardown eager unpack queues after this kernel. Persistent graph
+        // commands keep the pool alive across replays and release it from
+        // cmdDestroy when the graph is destroyed.
+        if (cmd->unpackPool != nullptr && !cmd->persistent) {
           FB_COMMCHECKTHROW_EX(
               comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
               comm->logMetaData_);

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -158,7 +158,8 @@ class CtranGpeCmd {
 
   std::optional<std::chrono::milliseconds> timeout{std::nullopt};
 
-  // Unpack queue to teardown after kernel completes (for TcpDM backend)
+  // Unpack queue to teardown after the eager kernel completes, or when
+  // a persistent CUDA graph command is destroyed (for TcpDM backend).
   void* unpackPool{nullptr};
 
   // Post-kernel cleanup callback. Called by GPE thread after kernel finishes.

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2246,6 +2246,7 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
   ctranKernelSetAllGatherArgs(
       a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
   config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+  config.unpackPool = reinterpret_cast<void*>(0x1234);
 
   std::vector<std::unique_ptr<OpElem>> ops;
   auto* op = new OpElem(OpElem::opType::RECV, dummyComm, dummyOpCount);


### PR DESCRIPTION
Summary:

TCP-DM receive/unpack operations allocate an unpack pool that is passed through GPE kernel config into the transport. The eager path can return that pool after the kernel launch path has handed off the work, but CUDA graph replay keeps reusing the captured kernel arguments and host-node state across graph replays. Returning the pool during the first replay lets it be reused or reset while the captured graph still references it.

Keep unpack pools owned by persistent CUDA graph commands and release them from the existing graph-destruction cleanup path instead. Eager commands continue to teardown the pool from the GPE thread. Also make the presence of an unpack pool force the GPE command path during capture so graph-destruction cleanup is available, and stop disabling CUDA graph scopes for TCP-DM PAFT health runs in llama-train.sh.

Reviewed By: function47

Differential Revision: D108339330


