### PR TITLE
xccl: fix batch_isend_irecv deadlock and enable BackendWrapper tests on XPU

### DIFF
--- a/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
+++ b/comms/torchcomms/scripts/run_tests_integration_xccl_py.sh
@@ -20,9 +20,13 @@ run_tests () {
         AllToAllSingleTest.py
         AllToAllTest.py
         AllToAllvSingleTest.py
+        BackendWrapperAllGatherAliasedTest.py
+        BackendWrapperCoalescingTest.py
+        BackendWrapperShutdownTest.py
         BarrierTest.py
         BatchSendRecvTest.py
         BroadcastTest.py
+        C10dBatchIsendIrecvTest.py
         C10dTorchCommTest.py
         DDPCommTest.py
         DeviceMeshTest.py
@@ -44,6 +48,7 @@ run_tests () {
         ScatterTest.py
         SplitTest.py
         TPCommTest.py
+        WaitBlockingTest.py
     )
 
     for test_file in "${tests[@]}"; do
@@ -52,10 +57,11 @@ run_tests () {
 
     cd -
     cd "$(dirname "$0")/../hooks/fr/tests/py"
+    torchrun --nnodes 1 --nproc_per_node "${NPROC_PER_NODE}" -m pytest -v -s FlightRecorderFinalizeOpIdTest.py
     torchrun --nnodes 1 --nproc_per_node "${NPROC_PER_NODE}" -m pytest -v -s FlightRecorderTest.py
 }
 
 # XCCL
-export TEST_BACKEND=xccl
+export TEST_BACKEND="xccl"
 export TEST_DEVICE="xpu"
 run_tests

--- a/comms/torchcomms/tests/integration/py/BackendWrapperCoalescingTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperCoalescingTest.py
@@ -70,8 +70,8 @@ class TestBackendWrapperCoalescing(unittest.TestCase):
         ]
         for req in dist.batch_isend_irecv(ops):
             req.wait()
-        if self.device.type == "cuda":
-            torch.cuda.synchronize()
+        if torch.accelerator.is_available():
+            torch.accelerator.synchronize()
 
         expected = torch.full((4,), float(recv_peer), dtype=torch.float32)
         self.assertTrue(
@@ -104,8 +104,8 @@ class TestBackendWrapperCoalescing(unittest.TestCase):
 
         for req in dist.batch_isend_irecv(ops):
             req.wait()
-        if self.device.type == "cuda":
-            torch.cuda.synchronize()
+        if torch.accelerator.is_available():
+            torch.accelerator.synchronize()
 
         for i in range(2):
             expected_value = float(recv_peers[i] * 10 + i)

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -128,5 +128,6 @@ class TestBackendWrapperShutdown(unittest.TestCase):
             # Must not raise even though both sub-backends share the comm.
             dist.destroy_process_group()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -72,10 +72,8 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         # ``torch.device("cuda")`` with no index when ``TEST_DEVICE=cuda``
         # is set, so resolve the index explicitly from LOCAL_RANK / rank.
         device = get_device(os.environ["TEST_BACKEND"], rank)
-        if device.type == "cuda":
-            if device.index is None:
-                device = torch.device(f"cuda:{_local_rank()}")
-            torch.cuda.set_device(device)
+        if torch.accelerator.is_available():
+            torch.accelerator.set_device_index(_local_rank())
         dist.config.use_torchcomms = True
         dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
         torch.set_default_device(device)

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -127,3 +127,6 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         finally:
             # Must not raise even though both sub-backends share the comm.
             dist.destroy_process_group()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -729,42 +729,61 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
       xccl_api_->groupStart(),
       "XCCL groupStart failed in batch_op_issue");
 
-  // Issue each operation individually
+  // Issue all sends before any recvs within the group. WORKAROUND for a oneCCL
+  // grouped-P2P deadlock: group ops are replayed in enqueue order and a recv
+  // blocks in a host-side IPC handle exchange until its peer's matching send is
+  // reached, so recv-before-send on both peers (e.g. batch_isend_irecv with
+  // irecv first) deadlocks. Sends first avoids this; relative order within
+  // sends and within recvs is preserved.
   for (const auto& op : ops) {
-    if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
-      onecclResult_t result = xccl_api_->send(
-          op.tensor.data_ptr(),
-          op.tensor.numel(),
-          getXcclDataType(op.tensor),
-          op.peer,
-          xccl_comm_,
-          stream);
+    if (op.type != BatchSendRecv::P2POp::OpType::SEND) {
+      continue;
+    }
 
-      if (result != onecclSuccess) [[unlikely]] {
-        XCCL_CHECK_IGNORE(
-            xccl_api_,
-            xccl_api_->groupEnd(),
-            "XCCL groupEnd failed during error cleanup after send failure in batch_op_issue");
-        throw XCCLException(
-            *xccl_api_, "XCCL send failed in batch_op_issue", result);
-      }
-    } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
-      onecclResult_t result = xccl_api_->recv(
-          op.tensor.data_ptr(),
-          op.tensor.numel(),
-          getXcclDataType(op.tensor),
-          op.peer,
-          xccl_comm_,
-          stream);
+    result = xccl_api_->send(
+        op.tensor.data_ptr(),
+        op.tensor.numel(),
+        getXcclDataType(op.tensor),
+        op.peer,
+        xccl_comm_,
+        stream);
 
-      if (result != onecclSuccess) [[unlikely]] {
-        XCCL_CHECK_IGNORE(
-            xccl_api_,
-            xccl_api_->groupEnd(),
-            "XCCL groupEnd failed during error cleanup after recv failure in batch_op_issue");
-        throw XCCLException(
-            *xccl_api_, "XCCL recv failed in batch_op_issue", result);
+    if (result != onecclSuccess) [[unlikely]] {
+      onecclResult_t result_cleanup =
+          xccl_api_->groupEnd(); // Clean up group on error
+      if (result_cleanup != onecclSuccess) {
+        TC_LOG(ERROR, this)
+            << "XCCL groupEnd failed during error cleanup after send failure in batch_op_issue: "
+            << xccl_api_->getErrorString(result_cleanup);
       }
+      throw XCCLException(
+          *xccl_api_, "XCCL send failed in batch_op_issue", result);
+    }
+  }
+
+  for (const auto& op : ops) {
+    if (op.type != BatchSendRecv::P2POp::OpType::RECV) {
+      continue;
+    }
+
+    result = xccl_api_->recv(
+        op.tensor.data_ptr(),
+        op.tensor.numel(),
+        getXcclDataType(op.tensor),
+        op.peer,
+        xccl_comm_,
+        stream);
+
+    if (result != onecclSuccess) [[unlikely]] {
+      onecclResult_t result_cleanup =
+          xccl_api_->groupEnd(); // Clean up group on error
+      if (result_cleanup != onecclSuccess) {
+        TC_LOG(ERROR, this)
+            << "XCCL groupEnd failed during error cleanup after recv failure in batch_op_issue: "
+            << xccl_api_->getErrorString(result_cleanup);
+      }
+      throw XCCLException(
+          *xccl_api_, "XCCL recv failed in batch_op_issue", result);
     }
   }
 

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -693,14 +693,11 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
   std::vector<at::Tensor> output_tensors;
 
   for (const auto& op : ops) {
+    ensureTensorContiguous(op.tensor);
     if (op.type == BatchSendRecv::P2POp::OpType::SEND) {
-      at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
-      input_tensors.push_back(tensor);
+      input_tensors.push_back(op.tensor);
     } else if (op.type == BatchSendRecv::P2POp::OpType::RECV) {
-      at::Tensor tensor = op.tensor;
-      ensureTensorContiguous(tensor);
-      output_tensors.push_back(tensor);
+      output_tensors.push_back(op.tensor);
     } else {
       throw std::runtime_error("Unknown op type in batch_op_issue");
     }
@@ -740,7 +737,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
       continue;
     }
 
-    result = xccl_api_->send(
+    auto result = xccl_api_->send(
         op.tensor.data_ptr(),
         op.tensor.numel(),
         getXcclDataType(op.tensor),
@@ -749,13 +746,10 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
         stream);
 
     if (result != onecclSuccess) [[unlikely]] {
-      onecclResult_t result_cleanup =
-          xccl_api_->groupEnd(); // Clean up group on error
-      if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR, this)
-            << "XCCL groupEnd failed during error cleanup after send failure in batch_op_issue: "
-            << xccl_api_->getErrorString(result_cleanup);
-      }
+      XCCL_CHECK_IGNORE(
+          xccl_api_,
+          xccl_api_->groupEnd(), // Clean up group on error
+          "XCCL groupEnd failed during error cleanup after send failure in batch_op_issue");
       throw XCCLException(
           *xccl_api_, "XCCL send failed in batch_op_issue", result);
     }
@@ -766,7 +760,7 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
       continue;
     }
 
-    result = xccl_api_->recv(
+    auto result = xccl_api_->recv(
         op.tensor.data_ptr(),
         op.tensor.numel(),
         getXcclDataType(op.tensor),
@@ -775,13 +769,10 @@ c10::intrusive_ptr<TorchWork> TorchCommXCCL::batch_op_issue(
         stream);
 
     if (result != onecclSuccess) [[unlikely]] {
-      onecclResult_t result_cleanup =
-          xccl_api_->groupEnd(); // Clean up group on error
-      if (result_cleanup != onecclSuccess) {
-        TC_LOG(ERROR, this)
-            << "XCCL groupEnd failed during error cleanup after recv failure in batch_op_issue: "
-            << xccl_api_->getErrorString(result_cleanup);
-      }
+      XCCL_CHECK_IGNORE(
+          xccl_api_,
+          xccl_api_->groupEnd(), // Clean up group on error
+          "XCCL groupEnd failed during error cleanup after recv failure in batch_op_issue");
       throw XCCLException(
           *xccl_api_, "XCCL recv failed in batch_op_issue", result);
     }

--- a/comms/torchcomms/xccl/TorchWorkXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchWorkXCCL.cpp
@@ -186,6 +186,12 @@ void TorchWorkXCCL::wait() {
       comm_->getXpuApi()->streamWaitEvent(current_stream, end_event_, 0),
       "Failed to make stream wait for event");
 
+  // Release tensor references. The XPU caching allocator manages stream
+  // semantics and will not reclaim memory until the stream operations
+  // complete.
+  inputTensors_.clear();
+  inputTensor_.reset();
+
   runWaitPostHooks();
 }
 } // namespace torch::comms


### PR DESCRIPTION
`batch_isend_irecv` with an `irecv` listed before its `isend` deadlocked on `XPU`. Both ranks hung in oneCCL's `onecclGroupEnd`, blocked in the recv-side Level-Zero IPC handle exchange (`pt2pt_fd_mode_exchange` -> `ccl::utils::recv`).

oneCCL's `group_impl::end()` replays grouped ops in enqueue order via a synchronous loop, and a recv op blocks in a host-side handle exchange until its peer's matching send op is reached. The recv pre-pass that would avoid this is gated on multi-thread instances, so with one process per rank only the in-order blocking loop runs. When both peers enqueue recv before send, each blocks on its first recv before reaching its send -> symmetric deadlock.

Issue all sends before any recvs within the group so the sender-side handles are posted before any blocking recv exchange. Relative order within sends and within recvs is preserved, so peer matching is unchanged.

Also release tensor references in `TorchWorkXCCL::wait()` once the stream wait is recorded; the `XPU` caching allocator preserves stream ordering, so this is safe and avoids holding tensors alive past completion.

Make `BackendWrapperCoalescingTest` and `BackendWrapperShutdownTest` device-agnostic (`torch.accelerator` instead of `torch.cuda`) so they run on` XPU`, and enable the `BackendWrapper`, `C10dBatchIsendIrecv`, `WaitBlocking`, and `FlightRecorderFinalizeOpId` tests in the `XCCL` integration suite.