### PR TITLE
Move signal-counter resources into common IB transport (#2890)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceTree.cu
@@ -461,10 +461,10 @@ __device__ __forceinline__ TreeLaneProgressState<T> makeTreeLaneState(
   // per-peer. If per-peer buffer sizes diverge, active edges must agree.
   state.pipelineWindow = state.dataBytes;
   if (!tree.isLeaf && tree.numChildren > 0) {
-    auto* t = args.transports[tree.childRanks[0]].p2p_ibgda;
+    auto* t = args.transports[tree.childRanks[0]].p2p_ib.ibgda;
     state.pipelineWindow = t->pipeline_window(activeBlocks);
   } else if (!tree.isRoot && tree.parentRank >= 0) {
-    auto* t = args.transports[tree.parentRank].p2p_ibgda;
+    auto* t = args.transports[tree.parentRank].p2p_ib.ibgda;
     state.pipelineWindow = t->pipeline_window(activeBlocks);
   }
   PIPES_DEVICE_CHECK_MSG(
@@ -527,7 +527,8 @@ progressTreeLane(
 
   switch (state.phase) {
     case TreeLanePhase::ReduceLeafSend: {
-      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      auto* parentTransport =
+          args.transports[state.tree.parentRank].p2p_ib.ibgda;
       const auto status = progressLaneSend(
           state, parentTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {
@@ -546,7 +547,7 @@ progressTreeLane(
         return IbgdaSendRecvProgressStatus::Progressed;
       }
       auto* childTransport =
-          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ib.ibgda;
       const auto status = progressLaneRecv<T, TreeIbReduceCopy<T>>(
           state, childTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {
@@ -564,7 +565,8 @@ progressTreeLane(
       return status;
     }
     case TreeLanePhase::ReduceInternalSend: {
-      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      auto* parentTransport =
+          args.transports[state.tree.parentRank].p2p_ib.ibgda;
       const auto status = progressLaneSend(
           state, parentTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {
@@ -580,7 +582,7 @@ progressTreeLane(
         return IbgdaSendRecvProgressStatus::Progressed;
       }
       auto* childTransport =
-          args.transports[state.tree.childRanks[state.childIdx]].p2p_ibgda;
+          args.transports[state.tree.childRanks[state.childIdx]].p2p_ib.ibgda;
       const auto status =
           progressLaneSend(state, childTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {
@@ -594,7 +596,8 @@ progressTreeLane(
       return status;
     }
     case TreeLanePhase::BcastInternalRecv: {
-      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      auto* parentTransport =
+          args.transports[state.tree.parentRank].p2p_ib.ibgda;
       const auto status = progressLaneRecv(
           state, parentTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {
@@ -606,7 +609,8 @@ progressTreeLane(
       return status;
     }
     case TreeLanePhase::BcastLeafRecv: {
-      auto* parentTransport = args.transports[state.tree.parentRank].p2p_ibgda;
+      auto* parentTransport =
+          args.transports[state.tree.parentRank].p2p_ib.ibgda;
       const auto status = progressLaneRecv(
           state, parentTransport, data, window, group, timeout);
       if (status == IbgdaSendRecvProgressStatus::Done) {

--- a/comms/prims/transport/MultiPeerDeviceHandle.cuh
+++ b/comms/prims/transport/MultiPeerDeviceHandle.cuh
@@ -42,6 +42,7 @@ namespace comms::prims {
  *           handle.get_nvl(rank).send_group(...);
  *           break;
  *         case TransportType::P2P_IBGDA:
+ *         case TransportType::P2P_IBRC:
  *           handle.get_ib(rank).put(...);
  *           break;
  *       }
@@ -88,6 +89,17 @@ struct MultiPeerDeviceHandle {
   __device__ __forceinline__ const P2pIbgdaTransportDevice& get_ibgda(
       int rank) const {
     return *transports[rank].p2p_ib.ibgda;
+  }
+
+  /** @return Mutable reference to the IBRC transport for the given rank. */
+  __device__ __forceinline__ P2pIbrcTransportDevice& get_ibrc(int rank) {
+    return *transports[rank].p2p_ib.ibrc;
+  }
+
+  /** @return Const reference to the IBRC transport for the given rank. */
+  __device__ __forceinline__ const P2pIbrcTransportDevice& get_ibrc(
+      int rank) const {
+    return *transports[rank].p2p_ib.ibrc;
   }
 
   /** @return Backend-dispatching IB transport for the given rank. */

--- a/comms/prims/transport/MultiPeerDeviceHandle.cuh
+++ b/comms/prims/transport/MultiPeerDeviceHandle.cuh
@@ -2,13 +2,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/Transport.cuh"
 
-// In CUDA compilation, include full Transport definition for device accessors.
-// In host-only compilation, a forward declaration suffices because DeviceSpan
-// only stores a pointer (T*) — it doesn't need sizeof(T).
 #ifdef __CUDACC__
 #include "comms/prims/transport/Transport.cuh"
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
@@ -32,15 +31,19 @@ namespace comms::prims {
  * already carries the type discriminant, so no separate type array is needed.
  *
  * Layout: transports[0..nRanks-1] where transports[myRank].type == SELF,
- *         NVL peers sorted first, followed by IBGDA-only peers.
+ *         NVL peers sorted first, followed by IB-only peers.
  *
  * USAGE:
  *   __global__ void kernel(MultiPeerDeviceHandle handle, ...) {
  *     for (int rank = 0; rank < handle.nRanks; ++rank) {
  *       switch (handle.get_type(rank)) {
- *         case TransportType::SELF: ... break;
- *         case TransportType::P2P_NVL: handle.get_nvl(rank).send_group(...);
- * break; case TransportType::P2P_IBGDA: handle.get_ibgda(rank).put(...); break;
+ *         case TransportType::SELF: ...; break;
+ *         case TransportType::P2P_NVL:
+ *           handle.get_nvl(rank).send_group(...);
+ *           break;
+ *         case TransportType::P2P_IBGDA:
+ *           handle.get_ib(rank).put(...);
+ *           break;
  *       }
  *     }
  *   }
@@ -56,7 +59,7 @@ struct MultiPeerDeviceHandle {
   // Number of NVL peers (excluding self)
   int numNvlPeers{0};
 
-  // Number of IBGDA peers (= nRanks - 1, all non-self)
+  // Number of IB peers (= nRanks - 1, all non-self)
   int numIbPeers{0};
 
 #ifdef __CUDACC__
@@ -78,13 +81,23 @@ struct MultiPeerDeviceHandle {
 
   /** @return Mutable reference to the IBGDA transport for the given rank. */
   __device__ __forceinline__ P2pIbgdaTransportDevice& get_ibgda(int rank) {
-    return *transports[rank].p2p_ibgda;
+    return *transports[rank].p2p_ib.ibgda;
   }
 
   /** @return Const reference to the IBGDA transport for the given rank. */
   __device__ __forceinline__ const P2pIbgdaTransportDevice& get_ibgda(
       int rank) const {
-    return *transports[rank].p2p_ibgda;
+    return *transports[rank].p2p_ib.ibgda;
+  }
+
+  /** @return Backend-dispatching IB transport for the given rank. */
+  __device__ __forceinline__ P2pIbTransportDevice get_ib(int rank) {
+    return transports[rank].p2p_ib;
+  }
+
+  /** @return Backend-dispatching IB transport for the given rank. */
+  __device__ __forceinline__ P2pIbTransportDevice get_ib(int rank) const {
+    return transports[rank].p2p_ib;
   }
 
 #endif

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <unistd.h>
@@ -23,8 +24,12 @@
 // address-range lookup from CudaDriverLazy); on AMD it is the HSA path provided
 // through DocaCompat.
 #ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+
 #include "comms/prims/transport/amd/DocaCompat.h"
 #else
+#include <cuda_runtime.h>
+
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
 #endif
@@ -33,6 +38,77 @@ namespace comms::prims {
 
 namespace {
 constexpr int kDefaultGidIndex = 3; // Default RoCE GID index
+
+#ifdef __HIP_PLATFORM_AMD__
+using SlotGpuError = hipError_t;
+constexpr SlotGpuError kSlotGpuSuccess = hipSuccess;
+
+const char* slotGpuGetErrorString(SlotGpuError err) {
+  return hipGetErrorString(err);
+}
+
+SlotGpuError slotGpuMalloc(void** ptr, std::size_t bytes) {
+  return hipMalloc(ptr, bytes);
+}
+
+SlotGpuError slotGpuFree(void* ptr) {
+  return hipFree(ptr);
+}
+
+SlotGpuError slotGpuMemset(void* ptr, int value, std::size_t bytes) {
+  return hipMemset(ptr, value, bytes);
+}
+
+SlotGpuError slotHostPinnedAlloc(void** ptr, std::size_t bytes) {
+  return hipHostMalloc(ptr, bytes, hipHostMallocMapped);
+}
+
+SlotGpuError slotHostGetDevicePointer(void** devicePtr, void* hostPtr) {
+  return hipHostGetDevicePointer(devicePtr, hostPtr, 0);
+}
+
+SlotGpuError slotHostFree(void* ptr) {
+  return hipHostFree(ptr);
+}
+#else
+using SlotGpuError = cudaError_t;
+constexpr SlotGpuError kSlotGpuSuccess = cudaSuccess;
+
+const char* slotGpuGetErrorString(SlotGpuError err) {
+  return cudaGetErrorString(err);
+}
+
+SlotGpuError slotGpuMalloc(void** ptr, std::size_t bytes) {
+  return cudaMalloc(ptr, bytes);
+}
+
+SlotGpuError slotGpuFree(void* ptr) {
+  return cudaFree(ptr);
+}
+
+SlotGpuError slotGpuMemset(void* ptr, int value, std::size_t bytes) {
+  return cudaMemset(ptr, value, bytes);
+}
+
+SlotGpuError slotHostPinnedAlloc(void** ptr, std::size_t bytes) {
+  return cudaHostAlloc(ptr, bytes, cudaHostAllocMapped);
+}
+
+SlotGpuError slotHostGetDevicePointer(void** devicePtr, void* hostPtr) {
+  return cudaHostGetDevicePointer(devicePtr, hostPtr, 0);
+}
+
+SlotGpuError slotHostFree(void* ptr) {
+  return cudaFreeHost(ptr);
+}
+#endif
+
+void checkSlotGpu(SlotGpuError err, const std::string& what) {
+  if (err != kSlotGpuSuccess) {
+    throw std::runtime_error(
+        fmt::format("{}: {}", what, slotGpuGetErrorString(err)));
+  }
+}
 } // namespace
 
 MultiPeerIbTransportBase::MultiPeerIbTransportBase(
@@ -473,6 +549,451 @@ std::vector<IbgdaRemoteBuffer> MultiPeerIbTransportBase::exchangeBuffer(
   VLOG(1) << "MultiPeerIbTransport: exchanged buffer info with " << numPeers
           << " peers";
   return peerBuffers;
+}
+
+MultiPeerIbTransportBase::DeviceSlotAllocation
+MultiPeerIbTransportBase::allocateDeviceSlotAllocation(
+    std::size_t bytes,
+    const char* label) {
+  if (bytes == 0) {
+    throw std::invalid_argument(
+        fmt::format("MultiPeerIbTransport: {} size must be non-zero", label));
+  }
+  DeviceSlotAllocation allocation;
+  allocation.bytes = bytes;
+#ifdef __HIP_PLATFORM_AMD__
+  // On AMD, GPU-memory MR registration relies on amdgpu's peer-mem
+  // integration which is unreliable on test hosts; host-pinned memory
+  // registers with ibv_reg_mr (no peer_mem) and is GPU-accessible.
+  checkSlotGpu(
+      slotHostPinnedAlloc(&allocation.ptr, bytes),
+      fmt::format(
+          "MultiPeerIbTransport: host-pinned allocation for {}", label));
+  allocation.isHostPinned = true;
+  std::memset(allocation.ptr, 0, bytes);
+#else
+  checkSlotGpu(
+      slotGpuMalloc(&allocation.ptr, bytes),
+      fmt::format("MultiPeerIbTransport: device allocation for {}", label));
+  checkSlotGpu(
+      slotGpuMemset(allocation.ptr, 0, bytes),
+      fmt::format(
+          "MultiPeerIbTransport: zero device allocation for {}", label));
+#endif
+  return allocation;
+}
+
+MultiPeerIbTransportBase::CounterSlotAllocation
+MultiPeerIbTransportBase::allocateCounterSlotAllocation(
+    IbCounterStorage storage,
+    std::size_t bytes,
+    const char* label) {
+  if (bytes == 0) {
+    throw std::invalid_argument(
+        fmt::format("MultiPeerIbTransport: {} size must be non-zero", label));
+  }
+  CounterSlotAllocation allocation;
+  allocation.bytes = bytes;
+  switch (storage) {
+    case IbCounterStorage::Device:
+      checkSlotGpu(
+          slotGpuMalloc(&allocation.devicePtr, bytes),
+          fmt::format("MultiPeerIbTransport: device allocation for {}", label));
+      checkSlotGpu(
+          slotGpuMemset(allocation.devicePtr, 0, bytes),
+          fmt::format(
+              "MultiPeerIbTransport: zero device allocation for {}", label));
+      break;
+    case IbCounterStorage::HostPinned:
+      checkSlotGpu(
+          slotHostPinnedAlloc(&allocation.hostPtr, bytes),
+          fmt::format(
+              "MultiPeerIbTransport: host-pinned allocation for {}", label));
+      std::memset(allocation.hostPtr, 0, bytes);
+      checkSlotGpu(
+          slotHostGetDevicePointer(&allocation.devicePtr, allocation.hostPtr),
+          fmt::format(
+              "MultiPeerIbTransport: host-pinned device pointer lookup for {}",
+              label));
+      break;
+  }
+  return allocation;
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::registerSlotMemory(
+    void* registrationPtr,
+    void* devicePtr,
+    std::size_t bytes,
+    bool& registered) {
+  if (registrationPtr == nullptr || devicePtr == nullptr || bytes == 0) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: invalid slot memory registration");
+  }
+  if (!registered) {
+    (void)registerBuffer(registrationPtr, bytes);
+    registered = true;
+  }
+
+  NetworkLKeys keys(numNics_);
+  const auto addr = reinterpret_cast<uintptr_t>(registrationPtr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  CHECK(it != registeredBuffers_.begin())
+      << "slot allocation MR not found after registration";
+  --it;
+  CHECK(addr < it->first + it->second.allocSize)
+      << "slot allocation MR does not cover registration pointer";
+  for (int n = 0; n < numNics_; ++n) {
+    keys[n] = NetworkLKey(HostLKey(it->second.mrs[n]->lkey));
+  }
+  return IbgdaLocalBuffer(devicePtr, keys);
+}
+
+IbgdaBufferExchInfo MultiPeerIbTransportBase::registeredSlotMemoryExchInfo(
+    void* registrationPtr) const {
+  if (registrationPtr == nullptr) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: invalid slot memory exchange info");
+  }
+  const auto addr = reinterpret_cast<uintptr_t>(registrationPtr);
+  auto it = registeredBuffers_.upper_bound(addr);
+  CHECK(it != registeredBuffers_.begin())
+      << "slot allocation MR not found after registration";
+  --it;
+  CHECK(addr < it->first + it->second.allocSize)
+      << "slot allocation MR does not cover registration pointer";
+
+  IbgdaBufferExchInfo info;
+  info.addr = reinterpret_cast<uint64_t>(registrationPtr);
+  info.numNics = numNics_;
+  for (int n = 0; n < numNics_; ++n) {
+    info.rkey_per_device[n] = HostRKey(it->second.mrs[n]->rkey);
+  }
+  return info;
+}
+
+void MultiPeerIbTransportBase::freeDeviceSlotAllocation(
+    DeviceSlotAllocation& allocation) noexcept {
+  if (allocation.ptr == nullptr) {
+    return;
+  }
+
+  if (allocation.registered) {
+    try {
+      deregisterBuffer(allocation.ptr);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "MultiPeerIbTransport: failed to deregister device slot "
+                   << "allocation: " << ex.what();
+    }
+    allocation.registered = false;
+  }
+
+  SlotGpuError err = allocation.isHostPinned ? slotHostFree(allocation.ptr)
+                                             : slotGpuFree(allocation.ptr);
+  if (err != kSlotGpuSuccess) {
+    LOG(WARNING) << "MultiPeerIbTransport: failed to free device slot "
+                 << "allocation: " << slotGpuGetErrorString(err);
+  }
+  allocation = DeviceSlotAllocation{};
+}
+
+void MultiPeerIbTransportBase::freeCounterSlotAllocation(
+    CounterSlotAllocation& allocation) noexcept {
+  if (allocation.devicePtr == nullptr && allocation.hostPtr == nullptr) {
+    return;
+  }
+
+  if (allocation.registered && allocation.devicePtr != nullptr) {
+    try {
+      void* registerPtr = allocation.hostPtr != nullptr ? allocation.hostPtr
+                                                        : allocation.devicePtr;
+      deregisterBuffer(registerPtr);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "MultiPeerIbTransport: failed to deregister slot "
+                   << "allocation: " << ex.what();
+    }
+    allocation.registered = false;
+  }
+
+  SlotGpuError err = kSlotGpuSuccess;
+  if (allocation.hostPtr != nullptr) {
+    err = slotHostFree(allocation.hostPtr);
+  } else if (allocation.devicePtr != nullptr) {
+    err = slotGpuFree(allocation.devicePtr);
+  }
+  if (err != kSlotGpuSuccess) {
+    LOG(WARNING) << "MultiPeerIbTransport: failed to free counter slot "
+                 << "allocation: " << slotGpuGetErrorString(err);
+  }
+  allocation = CounterSlotAllocation{};
+}
+
+void MultiPeerIbTransportBase::allocateSignalCounterResources(
+    IbCounterStorage counterStorage,
+    bool allocateDiscardSignal) {
+  cleanupSignalCounterResources();
+
+  const int numPeers = nRanks_ - 1;
+  slotRemoteSignalViews_.assign(numPeers, IbgdaRemoteBuffer{});
+  slotLocalSignalViews_.assign(numPeers, IbgdaLocalBuffer{});
+  slotCounterDeviceViews_.assign(numPeers, IbgdaLocalBuffer{});
+  slotCounterHostViews_.assign(numPeers, IbgdaLocalBuffer{});
+  slotDiscardSignalRemoteViews_.assign(numPeers, IbgdaRemoteBuffer{});
+
+  if (config_.numSignalSlots > 0) {
+    const auto slotsPerPeer = static_cast<std::size_t>(config_.numSignalSlots);
+    const std::size_t totalSignalBytes =
+        static_cast<std::size_t>(numPeers) * slotsPerPeer * sizeof(uint64_t);
+    slotSignalAllocation_ =
+        allocateDeviceSlotAllocation(totalSignalBytes, "slot signal buffer");
+    auto localSignalBuf = registerSlotMemory(
+        slotSignalAllocation_.ptr,
+        slotSignalAllocation_.ptr,
+        slotSignalAllocation_.bytes,
+        slotSignalAllocation_.registered);
+    auto remoteSignalBufs = exchangeBuffer(localSignalBuf);
+    for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+      const int peerRank = peerIndexToRank(peerIndex);
+      const int myPeerIndexOnPeer =
+          (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+      slotRemoteSignalViews_[peerIndex] = remoteSignalBufs[peerIndex].subBuffer(
+          static_cast<std::size_t>(myPeerIndexOnPeer) * slotsPerPeer *
+          sizeof(uint64_t));
+      slotLocalSignalViews_[peerIndex] = localSignalBuf.subBuffer(
+          static_cast<std::size_t>(peerIndex) * slotsPerPeer *
+          sizeof(uint64_t));
+    }
+  }
+
+  if (config_.numCounterSlots > 0) {
+    const auto slotsPerPeer = static_cast<std::size_t>(config_.numCounterSlots);
+    const std::size_t totalCounterBytes =
+        static_cast<std::size_t>(numPeers) * slotsPerPeer * sizeof(uint64_t);
+    slotCounterAllocation_ = allocateCounterSlotAllocation(
+        counterStorage, totalCounterBytes, "slot counter buffer");
+    if (counterStorage == IbCounterStorage::HostPinned) {
+      IbgdaLocalBuffer deviceCounterBuf(
+          slotCounterAllocation_.devicePtr, NetworkLKeys{});
+      IbgdaLocalBuffer hostCounterBuf(
+          slotCounterAllocation_.hostPtr, NetworkLKeys{});
+      for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+        const auto offset = static_cast<std::size_t>(peerIndex) * slotsPerPeer *
+            sizeof(uint64_t);
+        slotCounterDeviceViews_[peerIndex] = deviceCounterBuf.subBuffer(offset);
+        slotCounterHostViews_[peerIndex] = hostCounterBuf.subBuffer(offset);
+      }
+    } else {
+      auto localCounterBuf = registerSlotMemory(
+          slotCounterAllocation_.devicePtr,
+          slotCounterAllocation_.devicePtr,
+          slotCounterAllocation_.bytes,
+          slotCounterAllocation_.registered);
+      for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+        const auto offset = static_cast<std::size_t>(peerIndex) * slotsPerPeer *
+            sizeof(uint64_t);
+        slotCounterDeviceViews_[peerIndex] = localCounterBuf.subBuffer(offset);
+        slotCounterHostViews_[peerIndex] = localCounterBuf.subBuffer(offset);
+      }
+    }
+  }
+
+  if (allocateDiscardSignal && config_.numCounterSlots > 0) {
+    const std::size_t totalDiscardBytes =
+        static_cast<std::size_t>(numPeers) * sizeof(uint64_t);
+    slotDiscardSignalAllocation_ = allocateDeviceSlotAllocation(
+        totalDiscardBytes, "slot discard-signal buffer");
+    auto localDiscardBuf = registerSlotMemory(
+        slotDiscardSignalAllocation_.ptr,
+        slotDiscardSignalAllocation_.ptr,
+        slotDiscardSignalAllocation_.bytes,
+        slotDiscardSignalAllocation_.registered);
+    auto remoteDiscardBufs = exchangeBuffer(localDiscardBuf);
+    for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+      const int peerRank = peerIndexToRank(peerIndex);
+      const int myPeerIndexOnPeer =
+          (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+      slotDiscardSignalRemoteViews_[peerIndex] =
+          remoteDiscardBufs[peerIndex].subBuffer(
+              static_cast<std::size_t>(myPeerIndexOnPeer) * sizeof(uint64_t));
+    }
+  }
+}
+
+void MultiPeerIbTransportBase::cleanupSignalCounterResources() noexcept {
+  freeDeviceSlotAllocation(slotSignalAllocation_);
+  freeCounterSlotAllocation(slotCounterAllocation_);
+  freeDeviceSlotAllocation(slotDiscardSignalAllocation_);
+  for (auto& allocation : lazySlotSignalAllocations_) {
+    freeDeviceSlotAllocation(allocation);
+  }
+  for (auto& allocation : lazySlotCounterAllocations_) {
+    freeCounterSlotAllocation(allocation);
+  }
+  for (auto& allocation : lazySlotDiscardSignalAllocations_) {
+    freeDeviceSlotAllocation(allocation);
+  }
+  lazySlotSignalAllocations_.clear();
+  lazySlotCounterAllocations_.clear();
+  lazySlotDiscardSignalAllocations_.clear();
+  slotRemoteSignalViews_.clear();
+  slotLocalSignalViews_.clear();
+  slotCounterDeviceViews_.clear();
+  slotCounterHostViews_.clear();
+  slotDiscardSignalRemoteViews_.clear();
+}
+
+void MultiPeerIbTransportBase::cleanupPeerSignalCounterResources(
+    int peerIndex) noexcept {
+  if (peerIndex < 0 || peerIndex >= nRanks_ - 1) {
+    return;
+  }
+  if (peerIndex < static_cast<int>(lazySlotSignalAllocations_.size())) {
+    freeDeviceSlotAllocation(lazySlotSignalAllocations_[peerIndex]);
+  }
+  if (peerIndex < static_cast<int>(lazySlotCounterAllocations_.size())) {
+    freeCounterSlotAllocation(lazySlotCounterAllocations_[peerIndex]);
+  }
+  if (peerIndex < static_cast<int>(lazySlotDiscardSignalAllocations_.size())) {
+    freeDeviceSlotAllocation(lazySlotDiscardSignalAllocations_[peerIndex]);
+  }
+  if (peerIndex < static_cast<int>(slotRemoteSignalViews_.size())) {
+    slotRemoteSignalViews_[peerIndex] = IbgdaRemoteBuffer{};
+  }
+  if (peerIndex < static_cast<int>(slotLocalSignalViews_.size())) {
+    slotLocalSignalViews_[peerIndex] = IbgdaLocalBuffer{};
+  }
+  if (peerIndex < static_cast<int>(slotCounterDeviceViews_.size())) {
+    slotCounterDeviceViews_[peerIndex] = IbgdaLocalBuffer{};
+  }
+  if (peerIndex < static_cast<int>(slotCounterHostViews_.size())) {
+    slotCounterHostViews_[peerIndex] = IbgdaLocalBuffer{};
+  }
+  if (peerIndex < static_cast<int>(slotDiscardSignalRemoteViews_.size())) {
+    slotDiscardSignalRemoteViews_[peerIndex] = IbgdaRemoteBuffer{};
+  }
+}
+
+void MultiPeerIbTransportBase::allocatePeerSignalCounterResources(
+    int peerIndex,
+    PeerBufferPayload& payload,
+    IbCounterStorage counterStorage,
+    bool allocateDiscardSignal) {
+  const int numPeers = nRanks_ - 1;
+  if (peerIndex < 0 || peerIndex >= numPeers) {
+    throw std::invalid_argument(
+        fmt::format(
+            "allocatePeerSignalCounterResources: invalid peerIndex={}",
+            peerIndex));
+  }
+
+  slotRemoteSignalViews_.resize(numPeers);
+  slotLocalSignalViews_.resize(numPeers);
+  slotCounterDeviceViews_.resize(numPeers);
+  slotCounterHostViews_.resize(numPeers);
+  slotDiscardSignalRemoteViews_.resize(numPeers);
+  lazySlotSignalAllocations_.resize(numPeers);
+  lazySlotCounterAllocations_.resize(numPeers);
+  lazySlotDiscardSignalAllocations_.resize(numPeers);
+
+  if (config_.numSignalSlots > 0) {
+    const std::size_t signalBytes =
+        static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
+    freeDeviceSlotAllocation(lazySlotSignalAllocations_[peerIndex]);
+    auto allocation =
+        allocateDeviceSlotAllocation(signalBytes, "lazy slot signal buffer");
+    auto localSignalBuf = registerSlotMemory(
+        allocation.ptr,
+        allocation.ptr,
+        allocation.bytes,
+        allocation.registered);
+    payload.slotSignal = registeredSlotMemoryExchInfo(allocation.ptr);
+    slotLocalSignalViews_[peerIndex] = localSignalBuf;
+    lazySlotSignalAllocations_[peerIndex] = std::move(allocation);
+  }
+
+  if (config_.numCounterSlots > 0) {
+    const std::size_t counterBytes =
+        static_cast<std::size_t>(config_.numCounterSlots) * sizeof(uint64_t);
+    freeCounterSlotAllocation(lazySlotCounterAllocations_[peerIndex]);
+    auto allocation = allocateCounterSlotAllocation(
+        counterStorage, counterBytes, "lazy slot counter buffer");
+    if (counterStorage == IbCounterStorage::HostPinned) {
+      slotCounterDeviceViews_[peerIndex] =
+          IbgdaLocalBuffer(allocation.devicePtr, NetworkLKeys{});
+      slotCounterHostViews_[peerIndex] =
+          IbgdaLocalBuffer(allocation.hostPtr, NetworkLKeys{});
+      lazySlotCounterAllocations_[peerIndex] = std::move(allocation);
+    } else {
+      auto localCounterBuf = registerSlotMemory(
+          allocation.devicePtr,
+          allocation.devicePtr,
+          allocation.bytes,
+          allocation.registered);
+      slotCounterDeviceViews_[peerIndex] = localCounterBuf;
+      slotCounterHostViews_[peerIndex] = localCounterBuf;
+      lazySlotCounterAllocations_[peerIndex] = std::move(allocation);
+    }
+  }
+
+  if (allocateDiscardSignal && config_.numCounterSlots > 0) {
+    freeDeviceSlotAllocation(lazySlotDiscardSignalAllocations_[peerIndex]);
+    auto allocation = allocateDeviceSlotAllocation(
+        sizeof(uint64_t), "lazy slot discard-signal buffer");
+    (void)registerSlotMemory(
+        allocation.ptr,
+        allocation.ptr,
+        allocation.bytes,
+        allocation.registered);
+    payload.slotDiscard = registeredSlotMemoryExchInfo(allocation.ptr);
+    lazySlotDiscardSignalAllocations_[peerIndex] = std::move(allocation);
+  }
+}
+
+void MultiPeerIbTransportBase::applyRemoteSignalCounterResources(
+    int peerIndex,
+    const PeerBufferPayload& remotePayload,
+    bool hasDiscardSignal) {
+  const int numPeers = nRanks_ - 1;
+  if (peerIndex < 0 || peerIndex >= numPeers) {
+    throw std::invalid_argument(
+        fmt::format(
+            "applyRemoteSignalCounterResources: invalid peerIndex={}",
+            peerIndex));
+  }
+  slotRemoteSignalViews_.resize(numPeers);
+  slotDiscardSignalRemoteViews_.resize(numPeers);
+  if (config_.numSignalSlots > 0) {
+    slotRemoteSignalViews_[peerIndex] =
+        remotePayload.slotSignal.toRemoteBuffer();
+  }
+  if (hasDiscardSignal && config_.numCounterSlots > 0) {
+    slotDiscardSignalRemoteViews_[peerIndex] =
+        remotePayload.slotDiscard.toRemoteBuffer();
+  }
+}
+
+IbgdaRemoteBuffer MultiPeerIbTransportBase::slotRemoteSignalView(
+    int peerIndex) const {
+  return slotRemoteSignalViews_.at(peerIndex);
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::slotLocalSignalView(
+    int peerIndex) const {
+  return slotLocalSignalViews_.at(peerIndex);
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::slotCounterDeviceView(
+    int peerIndex) const {
+  return slotCounterDeviceViews_.at(peerIndex);
+}
+
+IbgdaLocalBuffer MultiPeerIbTransportBase::slotCounterHostView(
+    int peerIndex) const {
+  return slotCounterHostViews_.at(peerIndex);
+}
+
+IbgdaRemoteBuffer MultiPeerIbTransportBase::slotDiscardSignalRemoteView(
+    int peerIndex) const {
+  return slotDiscardSignalRemoteViews_.at(peerIndex);
 }
 
 bool MultiPeerIbTransportBase::isPeerMaterialized(int peerRank) const {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -194,6 +194,32 @@ struct IbTransportExchInfoAll {
   int numQpsPerPeerPerNic{1};
 };
 
+// Bootstrap tags for the two-phase bilateral exchange in lazy materialization.
+constexpr int kIbPeerQpExchangeTag = 0;
+constexpr int kIbPeerBufferExchangeTag = 1;
+
+// Wire formats for bilateral peer materialization. Split into two phases: QP
+// info first (to connect), then buffer info (acts as QP-ready barrier).
+struct PeerQpPayload {
+  struct NicQpInfo {
+    uint8_t gid[16]{};
+    uint16_t lid{0};
+    uint32_t qpns[kMaxQpsPerPeerPerNic]{};
+  };
+  NicQpInfo nicInfo[kMaxNicsPerGpu]{};
+  int gidIndex{0};
+  int mtu{0};
+  int numNics{0};
+  int numQpsPerPeerPerNic{0};
+};
+
+struct PeerBufferPayload {
+  IbgdaBufferExchInfo recvStaging;
+  IbgdaBufferExchInfo srSignal;
+  IbgdaBufferExchInfo slotSignal;
+  IbgdaBufferExchInfo slotDiscard;
+};
+
 /**
  * MultiPeerIbTransportBase - backend-agnostic host control plane shared by the
  * multi-peer IB transports (IBGDA today, IBRC next).

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -220,6 +220,11 @@ struct PeerBufferPayload {
   IbgdaBufferExchInfo slotDiscard;
 };
 
+enum class IbCounterStorage {
+  Device,
+  HostPinned,
+};
+
 /**
  * MultiPeerIbTransportBase - backend-agnostic host control plane shared by the
  * multi-peer IB transports (IBGDA today, IBRC next).
@@ -349,6 +354,27 @@ class MultiPeerIbTransportBase {
       std::size_t bytes,
       int tag);
 
+  void allocateSignalCounterResources(
+      IbCounterStorage counterStorage,
+      bool allocateDiscardSignal);
+  void cleanupSignalCounterResources() noexcept;
+  void cleanupPeerSignalCounterResources(int peerIndex) noexcept;
+  void allocatePeerSignalCounterResources(
+      int peerIndex,
+      PeerBufferPayload& payload,
+      IbCounterStorage counterStorage,
+      bool allocateDiscardSignal);
+  void applyRemoteSignalCounterResources(
+      int peerIndex,
+      const PeerBufferPayload& remotePayload,
+      bool hasDiscardSignal);
+
+  IbgdaRemoteBuffer slotRemoteSignalView(int peerIndex) const;
+  IbgdaLocalBuffer slotLocalSignalView(int peerIndex) const;
+  IbgdaLocalBuffer slotCounterDeviceView(int peerIndex) const;
+  IbgdaLocalBuffer slotCounterHostView(int peerIndex) const;
+  IbgdaRemoteBuffer slotDiscardSignalRemoteView(int peerIndex) const;
+
   // Cached MR entry: one MR per (CUDA allocation, NIC), refcounted. Multiple
   // user buffers within the same allocation share one MR set.
   struct CachedMr {
@@ -392,6 +418,84 @@ class MultiPeerIbTransportBase {
   std::vector<int> pendingPeers_;
   std::vector<bool> peerMaterialized_;
   bool materializationFailed_{false};
+
+ private:
+  struct DeviceSlotAllocation {
+    void* ptr{nullptr};
+    std::size_t bytes{0};
+    bool registered{false};
+    // On AMD the signal-inbox/discard buffers are host-pinned (device-memory
+    // MR registration via peer-mem is unreliable); free accordingly.
+    bool isHostPinned{false};
+
+    DeviceSlotAllocation() = default;
+    DeviceSlotAllocation(const DeviceSlotAllocation&) = delete;
+    DeviceSlotAllocation& operator=(const DeviceSlotAllocation&) = delete;
+    DeviceSlotAllocation(DeviceSlotAllocation&& other) noexcept
+        : ptr(std::exchange(other.ptr, nullptr)),
+          bytes(std::exchange(other.bytes, 0)),
+          registered(std::exchange(other.registered, false)),
+          isHostPinned(std::exchange(other.isHostPinned, false)) {}
+    DeviceSlotAllocation& operator=(DeviceSlotAllocation&& other) noexcept {
+      ptr = std::exchange(other.ptr, nullptr);
+      bytes = std::exchange(other.bytes, 0);
+      registered = std::exchange(other.registered, false);
+      isHostPinned = std::exchange(other.isHostPinned, false);
+      return *this;
+    }
+  };
+
+  struct CounterSlotAllocation {
+    void* hostPtr{nullptr};
+    void* devicePtr{nullptr};
+    std::size_t bytes{0};
+    bool registered{false};
+
+    CounterSlotAllocation() = default;
+    CounterSlotAllocation(const CounterSlotAllocation&) = delete;
+    CounterSlotAllocation& operator=(const CounterSlotAllocation&) = delete;
+    CounterSlotAllocation(CounterSlotAllocation&& other) noexcept
+        : hostPtr(std::exchange(other.hostPtr, nullptr)),
+          devicePtr(std::exchange(other.devicePtr, nullptr)),
+          bytes(std::exchange(other.bytes, 0)),
+          registered(std::exchange(other.registered, false)) {}
+    CounterSlotAllocation& operator=(CounterSlotAllocation&& other) noexcept {
+      hostPtr = std::exchange(other.hostPtr, nullptr);
+      devicePtr = std::exchange(other.devicePtr, nullptr);
+      bytes = std::exchange(other.bytes, 0);
+      registered = std::exchange(other.registered, false);
+      return *this;
+    }
+  };
+
+  void freeDeviceSlotAllocation(DeviceSlotAllocation& allocation) noexcept;
+  DeviceSlotAllocation allocateDeviceSlotAllocation(
+      std::size_t bytes,
+      const char* label);
+  void freeCounterSlotAllocation(CounterSlotAllocation& allocation) noexcept;
+  CounterSlotAllocation allocateCounterSlotAllocation(
+      IbCounterStorage storage,
+      std::size_t bytes,
+      const char* label);
+  IbgdaLocalBuffer registerSlotMemory(
+      void* registrationPtr,
+      void* devicePtr,
+      std::size_t bytes,
+      bool& registered);
+  IbgdaBufferExchInfo registeredSlotMemoryExchInfo(void* registrationPtr) const;
+
+  std::vector<IbgdaRemoteBuffer> slotRemoteSignalViews_;
+  std::vector<IbgdaLocalBuffer> slotLocalSignalViews_;
+  std::vector<IbgdaLocalBuffer> slotCounterDeviceViews_;
+  std::vector<IbgdaLocalBuffer> slotCounterHostViews_;
+  std::vector<IbgdaRemoteBuffer> slotDiscardSignalRemoteViews_;
+
+  DeviceSlotAllocation slotSignalAllocation_;
+  CounterSlotAllocation slotCounterAllocation_;
+  DeviceSlotAllocation slotDiscardSignalAllocation_;
+  std::vector<DeviceSlotAllocation> lazySlotSignalAllocations_;
+  std::vector<CounterSlotAllocation> lazySlotCounterAllocations_;
+  std::vector<DeviceSlotAllocation> lazySlotDiscardSignalAllocations_;
 };
 
 /**

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -821,6 +821,17 @@ void MultiPeerTransport::build_device_handle() {
         new (&transportsHost[r]) Transport(devPtr);
         break;
       }
+
+      case TransportType::P2P_IBRC: {
+        // The IBRC device-slot accessor (getP2pTransportDeviceSlot) and the
+        // P2P_IBRC peer tagging land with the device-slot wiring in the next
+        // diff, so no peer is tagged P2P_IBRC at this commit and this case is
+        // not yet reached. Construct a null IBRC handle to keep the switch
+        // exhaustive under -Werror,-Wswitch.
+        new (&transportsHost[r])
+            Transport(static_cast<P2pIbrcTransportDevice*>(nullptr));
+        break;
+      }
     }
   }
 

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -109,17 +109,16 @@ void MultiPeerTransport::initFromTopology(
     }
     // ibgdaPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
   } else {
-    // NOTE: non-NVL peers are tagged P2P_IBGDA regardless of ibMode; the IBRC
-    // device-side type tag + tagged-union handoff land with the IBRC device
-    // transport. IBRC's exchange() currently throws before the device handle is
-    // built, so this tag is not yet observed for IBRC.
+    const auto ibTransportType = config.ibMode == IbBackendMode::kIbrc
+        ? TransportType::P2P_IBRC
+        : TransportType::P2P_IBGDA;
     for (int r = 0; r < nRanks_; ++r) {
       if (r == myRank_) {
         typePerRank_.at(r) = TransportType::SELF;
       } else if (globalToNvlLocal_.count(r)) {
         typePerRank_.at(r) = TransportType::P2P_NVL;
       } else {
-        typePerRank_.at(r) = TransportType::P2P_IBGDA;
+        typePerRank_.at(r) = ibTransportType;
       }
     }
 
@@ -134,16 +133,19 @@ void MultiPeerTransport::initFromTopology(
   {
     int nvlCount = 0;
     int ibgdaCount = 0;
+    int ibrcCount = 0;
     for (int r = 0; r < nRanks_; ++r) {
       if (typePerRank_[r] == TransportType::P2P_NVL) {
         ++nvlCount;
       } else if (typePerRank_[r] == TransportType::P2P_IBGDA) {
         ++ibgdaCount;
+      } else if (typePerRank_[r] == TransportType::P2P_IBRC) {
+        ++ibrcCount;
       }
     }
     LOG(INFO) << "MultiPeerTransport: rank " << myRank_ << "/" << nRanks_
               << " topology: " << nvlCount << " NVL peers, " << ibgdaCount
-              << " IBGDA peers";
+              << " IBGDA peers, " << ibrcCount << " IBRC peers";
   }
   for (int r = 0; r < nRanks_; ++r) {
     VLOG(1) << "MultiPeerTransport: rank " << myRank_ << " -> rank " << r
@@ -169,8 +171,7 @@ void MultiPeerTransport::initFromTopology(
 
   // Create the IB sub-transport — the universal fallback for all non-NVL peers.
   // Exactly one backend is built, selected by config.ibMode (kIbgda default;
-  // kIbrc selects the CPU-proxy skeleton backend, whose functional entry points
-  // still fail fast until the backend is implemented).
+  // kIbrc selects the CPU-proxy backend).
   if (!config.disableIb && nRanks_ > 1) {
     auto ibConfig = config.ibgdaConfig;
     ibConfig.cudaDevice = deviceId_;
@@ -214,7 +215,8 @@ void MultiPeerTransport::exchange() {
 
   VLOG(1) << "MultiPeerTransport: rank " << myRank_ << " exchange()"
           << " nvl=" << (nvlTransport_ ? "yes" : "no")
-          << " ibgda=" << (ibgdaTransport_ ? "yes" : "no");
+          << " ibgda=" << (ibgdaTransport_ ? "yes" : "no")
+          << " ibrc=" << (ibrcTransport_ ? "yes" : "no");
 
   if (nvlTransport_) {
     nvlTransport_->exchange();
@@ -313,15 +315,11 @@ bool MultiPeerTransport::is_lazy_mode() const {
 }
 
 void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
-  if (ibrcTransport_) {
-    throw std::runtime_error(
-        "MultiPeerTransport::materializePeers: IBRC lazy materialization is not implemented yet");
-  }
-
   auto materializeOn = [&](auto& ibTransport) {
     for (int peer : peers) {
       if (peer >= 0 && peer < nRanks_ && peer != myRank_ &&
-          typePerRank_[peer] == TransportType::P2P_IBGDA) {
+          (typePerRank_[peer] == TransportType::P2P_IBGDA ||
+           typePerRank_[peer] == TransportType::P2P_IBRC)) {
         ibTransport->queuePeerForMaterialization(peer);
       }
     }
@@ -329,6 +327,8 @@ void MultiPeerTransport::materializePeers(const std::vector<int>& peers) {
   };
   if (ibgdaTransport_) {
     materializeOn(ibgdaTransport_);
+  } else if (ibrcTransport_) {
+    materializeOn(ibrcTransport_);
   }
 }
 
@@ -336,8 +336,7 @@ void MultiPeerTransport::connectPeers() {
   if (ibgdaTransport_) {
     ibgdaTransport_->connectPeers();
   } else if (ibrcTransport_) {
-    throw std::runtime_error(
-        "MultiPeerTransport::connectPeers: IBRC lazy materialization is not implemented yet");
+    ibrcTransport_->connectPeers();
   }
 }
 
@@ -797,9 +796,6 @@ void MultiPeerTransport::build_device_handle() {
     throw std::runtime_error("Failed to allocate host Transport array");
   }
 
-  // Get IBGDA GPU pointers per-peer via getP2pTransportDevice()
-  // which returns device-memory addresses suitable for Transport.p2p_ibgda
-
   for (int r = 0; r < nRanks_; ++r) {
     switch (typePerRank_[r]) {
       case TransportType::SELF:
@@ -823,13 +819,10 @@ void MultiPeerTransport::build_device_handle() {
       }
 
       case TransportType::P2P_IBRC: {
-        // The IBRC device-slot accessor (getP2pTransportDeviceSlot) and the
-        // P2P_IBRC peer tagging land with the device-slot wiring in the next
-        // diff, so no peer is tagged P2P_IBRC at this commit and this case is
-        // not yet reached. Construct a null IBRC handle to keep the switch
-        // exhaustive under -Werror,-Wswitch.
-        new (&transportsHost[r])
-            Transport(static_cast<P2pIbrcTransportDevice*>(nullptr));
+        P2pIbrcTransportDevice* devPtr = ibrcTransport_
+            ? ibrcTransport_->getP2pTransportDeviceSlot(r)
+            : nullptr;
+        new (&transportsHost[r]) Transport(devPtr);
         break;
       }
     }

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -1,0 +1,263 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
+
+#include <cstdio>
+
+#include "comms/prims/core/DeviceMacros.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+namespace comms::prims {
+
+namespace detail {
+
+__device__ __forceinline__ void unsupportedIbrcDeviceCall(const char* method) {
+  printf(
+      "P2pIbTransportDevice: IBRC backend does not implement %s yet\n", method);
+  PIPES_DEVICE_TRAP();
+}
+
+} // namespace detail
+
+__device__ __forceinline__ void P2pIbTransportDevice::signal(
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("signal");
+    return;
+  }
+  ibgda->signal(signalBuf, signalVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::signal(
+    ThreadGroup& group,
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("signal");
+    return;
+  }
+  ibgda->signal(group, signalBuf, signalVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::put(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal,
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t counterVal) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("put");
+    return;
+  }
+  ibgda->put(
+      group,
+      localBuf,
+      remoteBuf,
+      nbytes,
+      signalBuf,
+      signalVal,
+      counterBuf,
+      counterVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::put(
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal,
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t counterVal) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("put");
+    return;
+  }
+  ibgda->put(
+      localBuf,
+      remoteBuf,
+      nbytes,
+      signalBuf,
+      signalVal,
+      counterBuf,
+      counterVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal,
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t counterVal) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("put_cooperative");
+    return;
+  }
+  ibgda->put_cooperative(
+      group,
+      localBuf,
+      remoteBuf,
+      nbytes,
+      signalBuf,
+      signalVal,
+      counterBuf,
+      counterVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytes,
+    const IbgdaRemoteBuffer& signalBuf,
+    uint64_t signalVal,
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t counterVal) {
+  ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+  put_cooperative(
+      solo,
+      localBuf,
+      remoteBuf,
+      nbytes,
+      signalBuf,
+      signalVal,
+      counterBuf,
+      counterVal);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& signalBuf,
+    uint64_t expected,
+    const Timeout& timeout) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("wait_signal");
+    return;
+  }
+  ibgda->wait_signal(group, signalBuf, expected, timeout);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
+    const IbgdaLocalBuffer& signalBuf,
+    uint64_t expected,
+    const Timeout& timeout) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("wait_signal");
+    return;
+  }
+  ibgda->wait_signal(signalBuf, expected, timeout);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t expected,
+    const Timeout& timeout) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("wait_counter");
+    return;
+  }
+  ibgda->wait_counter(group, counterBuf, expected, timeout);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
+    const IbgdaLocalBuffer& counterBuf,
+    uint64_t expected,
+    const Timeout& timeout) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("wait_counter");
+    return;
+  }
+  ibgda->wait_counter(counterBuf, expected, timeout);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::reset_signal(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& signalBuf) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("reset_signal");
+    return;
+  }
+  ibgda->reset_signal(group, signalBuf);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::reset_signal(
+    const IbgdaLocalBuffer& signalBuf) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("reset_signal");
+    return;
+  }
+  ibgda->reset_signal(signalBuf);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::reset_counter(
+    ThreadGroup& group,
+    const IbgdaLocalBuffer& counterBuf) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("reset_counter");
+    return;
+  }
+  ibgda->reset_counter(group, counterBuf);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::reset_counter(
+    const IbgdaLocalBuffer& counterBuf) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("reset_counter");
+    return;
+  }
+  ibgda->reset_counter(counterBuf);
+}
+
+__device__ __forceinline__ uint64_t
+P2pIbTransportDevice::read_signal(const IbgdaLocalBuffer& signalBuf) const {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("read_signal");
+    return 0;
+  }
+  return ibgda->read_signal(signalBuf);
+}
+
+__device__ __forceinline__ uint64_t
+P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("read_counter");
+    return 0;
+  }
+  return ibgda->read_counter(counterBuf);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::flush(
+    ThreadGroup& group) {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("flush");
+    return;
+  }
+  ibgda->flush(group);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::flush() {
+  if (type == P2pIbBackendType::IBRC) {
+    detail::unsupportedIbrcDeviceCall("flush");
+    return;
+  }
+  ibgda->flush();
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::fence(
+    ThreadGroup& group) {
+  flush(group);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::fence() {
+  flush();
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -4,31 +4,19 @@
 
 #include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
-#include <cstdio>
-
-#include "comms/prims/core/DeviceMacros.cuh"
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
 
 namespace comms::prims {
 
-namespace detail {
-
-__device__ __forceinline__ void unsupportedIbrcDeviceCall(const char* method) {
-  printf(
-      "P2pIbTransportDevice: IBRC backend does not implement %s yet\n", method);
-  PIPES_DEVICE_TRAP();
-}
-
-} // namespace detail
-
 __device__ __forceinline__ void P2pIbTransportDevice::signal(
     const IbgdaRemoteBuffer& signalBuf,
     uint64_t signalVal) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("signal");
-    return;
+    ibrc->signal(signalBuf, signalVal);
+  } else {
+    ibgda->signal(signalBuf, signalVal);
   }
-  ibgda->signal(signalBuf, signalVal);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::signal(
@@ -36,10 +24,10 @@ __device__ __forceinline__ void P2pIbTransportDevice::signal(
     const IbgdaRemoteBuffer& signalBuf,
     uint64_t signalVal) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("signal");
-    return;
+    ibrc->signal(group, signalBuf, signalVal);
+  } else {
+    ibgda->signal(group, signalBuf, signalVal);
   }
-  ibgda->signal(group, signalBuf, signalVal);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::put(
@@ -52,18 +40,26 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("put");
-    return;
+    ibrc->put(
+        group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  } else {
+    ibgda->put(
+        group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
   }
-  ibgda->put(
-      group,
-      localBuf,
-      remoteBuf,
-      nbytes,
-      signalBuf,
-      signalVal,
-      counterBuf,
-      counterVal);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::put(
@@ -75,17 +71,24 @@ __device__ __forceinline__ void P2pIbTransportDevice::put(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("put");
-    return;
+    ibrc->put(
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  } else {
+    ibgda->put(
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
   }
-  ibgda->put(
-      localBuf,
-      remoteBuf,
-      nbytes,
-      signalBuf,
-      signalVal,
-      counterBuf,
-      counterVal);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
@@ -98,18 +101,26 @@ __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
     const IbgdaLocalBuffer& counterBuf,
     uint64_t counterVal) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("put_cooperative");
-    return;
+    ibrc->put_cooperative(
+        group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  } else {
+    ibgda->put_cooperative(
+        group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
   }
-  ibgda->put_cooperative(
-      group,
-      localBuf,
-      remoteBuf,
-      nbytes,
-      signalBuf,
-      signalVal,
-      counterBuf,
-      counterVal);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
@@ -138,10 +149,10 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     uint64_t expected,
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("wait_signal");
-    return;
+    ibrc->wait_signal(group, signalBuf, expected, timeout);
+  } else {
+    ibgda->wait_signal(group, signalBuf, expected, timeout);
   }
-  ibgda->wait_signal(group, signalBuf, expected, timeout);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
@@ -149,10 +160,10 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_signal(
     uint64_t expected,
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("wait_signal");
-    return;
+    ibrc->wait_signal(signalBuf, expected, timeout);
+  } else {
+    ibgda->wait_signal(signalBuf, expected, timeout);
   }
-  ibgda->wait_signal(signalBuf, expected, timeout);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
@@ -161,10 +172,10 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     uint64_t expected,
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("wait_counter");
-    return;
+    ibrc->wait_counter(group, counterBuf, expected, timeout);
+  } else {
+    ibgda->wait_counter(group, counterBuf, expected, timeout);
   }
-  ibgda->wait_counter(group, counterBuf, expected, timeout);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
@@ -172,55 +183,54 @@ __device__ __forceinline__ void P2pIbTransportDevice::wait_counter(
     uint64_t expected,
     const Timeout& timeout) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("wait_counter");
-    return;
+    ibrc->wait_counter(counterBuf, expected, timeout);
+  } else {
+    ibgda->wait_counter(counterBuf, expected, timeout);
   }
-  ibgda->wait_counter(counterBuf, expected, timeout);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::reset_signal(
     ThreadGroup& group,
     const IbgdaLocalBuffer& signalBuf) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("reset_signal");
-    return;
+    ibrc->reset_signal(group, signalBuf);
+  } else {
+    ibgda->reset_signal(group, signalBuf);
   }
-  ibgda->reset_signal(group, signalBuf);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::reset_signal(
     const IbgdaLocalBuffer& signalBuf) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("reset_signal");
-    return;
+    ibrc->reset_signal(signalBuf);
+  } else {
+    ibgda->reset_signal(signalBuf);
   }
-  ibgda->reset_signal(signalBuf);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::reset_counter(
     ThreadGroup& group,
     const IbgdaLocalBuffer& counterBuf) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("reset_counter");
-    return;
+    ibrc->reset_counter(group, counterBuf);
+  } else {
+    ibgda->reset_counter(group, counterBuf);
   }
-  ibgda->reset_counter(group, counterBuf);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::reset_counter(
     const IbgdaLocalBuffer& counterBuf) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("reset_counter");
-    return;
+    ibrc->reset_counter(counterBuf);
+  } else {
+    ibgda->reset_counter(counterBuf);
   }
-  ibgda->reset_counter(counterBuf);
 }
 
 __device__ __forceinline__ uint64_t
 P2pIbTransportDevice::read_signal(const IbgdaLocalBuffer& signalBuf) const {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("read_signal");
-    return 0;
+    return ibrc->read_signal(signalBuf);
   }
   return ibgda->read_signal(signalBuf);
 }
@@ -228,8 +238,7 @@ P2pIbTransportDevice::read_signal(const IbgdaLocalBuffer& signalBuf) const {
 __device__ __forceinline__ uint64_t
 P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("read_counter");
-    return 0;
+    return ibrc->read_counter(counterBuf);
   }
   return ibgda->read_counter(counterBuf);
 }
@@ -237,18 +246,18 @@ P2pIbTransportDevice::read_counter(const IbgdaLocalBuffer& counterBuf) const {
 __device__ __forceinline__ void P2pIbTransportDevice::flush(
     ThreadGroup& group) {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("flush");
-    return;
+    ibrc->flush(group);
+  } else {
+    ibgda->flush(group);
   }
-  ibgda->flush(group);
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::flush() {
   if (type == P2pIbBackendType::IBRC) {
-    detail::unsupportedIbrcDeviceCall("flush");
-    return;
+    ibrc->flush();
+  } else {
+    ibgda->flush();
   }
-  ibgda->flush();
 }
 
 __device__ __forceinline__ void P2pIbTransportDevice::fence(

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -1,0 +1,139 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace comms::prims {
+
+class P2pIbgdaTransportDevice;
+class P2pIbrcTransportDevice;
+
+enum class P2pIbBackendType : uint8_t {
+  IBGDA,
+  IBRC,
+};
+
+struct P2pIbTransportDevice {
+  P2pIbBackendType type{P2pIbBackendType::IBGDA};
+  union {
+    P2pIbgdaTransportDevice* ibgda;
+    P2pIbrcTransportDevice* ibrc;
+  };
+
+  IBGDA_HOST_DEVICE P2pIbTransportDevice() : ibgda(nullptr) {}
+  IBGDA_HOST_DEVICE explicit P2pIbTransportDevice(P2pIbgdaTransportDevice* p)
+      : type(P2pIbBackendType::IBGDA), ibgda(p) {}
+  IBGDA_HOST_DEVICE explicit P2pIbTransportDevice(P2pIbrcTransportDevice* p)
+      : type(P2pIbBackendType::IBRC), ibrc(p) {}
+
+  IBGDA_HOST_DEVICE P2pIbTransportDevice(const P2pIbTransportDevice&) = default;
+  IBGDA_HOST_DEVICE P2pIbTransportDevice& operator=(
+      const P2pIbTransportDevice&) = default;
+
+  // Common explicit-buffer IB device API. Backend-owned slot-index helpers and
+  // send/recv staging stay backend-specific until IBRC owns matching state.
+  __device__ void signal(
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1);
+
+  __device__ void signal(
+      ThreadGroup& group,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1);
+
+  __device__ void put(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf = {},
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1);
+
+  __device__ void put(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf = {},
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1);
+
+  __device__ void put_cooperative(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf = {},
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1);
+
+  __device__ void put_cooperative(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf = {},
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1);
+
+  __device__ void wait_signal(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& signalBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout());
+
+  __device__ void wait_signal(
+      const IbgdaLocalBuffer& signalBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout());
+
+  __device__ void wait_counter(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout());
+
+  __device__ void wait_counter(
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout());
+
+  __device__ void reset_signal(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& signalBuf);
+
+  __device__ void reset_signal(const IbgdaLocalBuffer& signalBuf);
+
+  __device__ void reset_counter(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& counterBuf);
+
+  __device__ void reset_counter(const IbgdaLocalBuffer& counterBuf);
+
+  __device__ uint64_t read_signal(const IbgdaLocalBuffer& signalBuf) const;
+
+  __device__ uint64_t read_counter(const IbgdaLocalBuffer& counterBuf) const;
+
+  __device__ void flush(ThreadGroup& group);
+
+  __device__ void flush();
+
+  __device__ void fence(ThreadGroup& group);
+
+  __device__ void fence();
+};
+
+static_assert(std::is_standard_layout_v<P2pIbTransportDevice>);
+static_assert(std::is_trivially_copyable_v<P2pIbTransportDevice>);
+
+} // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -38,7 +38,7 @@ struct P2pIbTransportDevice {
       const P2pIbTransportDevice&) = default;
 
   // Common explicit-buffer IB device API. Backend-owned slot-index helpers and
-  // send/recv staging stay backend-specific until IBRC owns matching state.
+  // send/recv staging remain backend-specific until IBRC owns matching state.
   __device__ void signal(
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1);

--- a/comms/prims/transport/Transport.cuh
+++ b/comms/prims/transport/Transport.cuh
@@ -38,6 +38,7 @@ enum class TransportType : uint8_t {
   SELF,
   P2P_NVL,
   P2P_IBGDA,
+  P2P_IBRC,
 };
 
 /// Human-readable name for TransportType (host-only).
@@ -49,6 +50,8 @@ inline const char* transport_type_name(TransportType t) {
       return "P2P_NVL";
     case TransportType::P2P_IBGDA:
       return "P2P_IBGDA";
+    case TransportType::P2P_IBRC:
+      return "P2P_IBRC";
   }
   return "UNKNOWN";
 }
@@ -91,6 +94,10 @@ struct Transport {
   __host__ __device__ explicit Transport(P2pIbgdaTransportDevice* p)
       : type(TransportType::P2P_IBGDA), p2p_ib(p) {}
 
+  /** Constructor for IBRC device transport (non-owning pointer). */
+  __host__ __device__ explicit Transport(P2pIbrcTransportDevice* p)
+      : type(TransportType::P2P_IBRC), p2p_ib(p) {}
+
   /**
    * Delete copy constructor and copy assignment.
    * Transport objects contain device pointers and IPC handles that should not
@@ -108,7 +115,8 @@ struct Transport {
       new (&self) P2pSelfTransportDevice(std::move(other.self));
     } else if (type == TransportType::P2P_NVL) {
       new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-    } else if (type == TransportType::P2P_IBGDA) {
+    } else if (
+        type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC) {
       new (&p2p_ib) P2pIbTransportDevice(other.p2p_ib);
     }
   }
@@ -133,7 +141,8 @@ struct Transport {
         new (&self) P2pSelfTransportDevice(std::move(other.self));
       } else if (type == TransportType::P2P_NVL) {
         new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
-      } else if (type == TransportType::P2P_IBGDA) {
+      } else if (
+          type == TransportType::P2P_IBGDA || type == TransportType::P2P_IBRC) {
         new (&p2p_ib) P2pIbTransportDevice(other.p2p_ib);
       }
     }

--- a/comms/prims/transport/Transport.cuh
+++ b/comms/prims/transport/Transport.cuh
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <new>
 #include <type_traits>
+#include <utility>
 
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 #include "comms/prims/transport/self/P2pSelfTransportDevice.cuh"
 
@@ -23,9 +25,10 @@ static_assert(
     std::is_standard_layout_v<P2pNvlTransportDevice> &&
         std::is_trivially_destructible_v<P2pNvlTransportDevice>,
     "P2pNvlTransportDevice must be standard layout with trivial destructor");
-
-// Forward declaration for IBGDA transport (full definition in .cuh, needs CUDA)
-class P2pIbgdaTransportDevice;
+static_assert(
+    std::is_standard_layout_v<P2pIbTransportDevice> &&
+        std::is_trivially_destructible_v<P2pIbTransportDevice>,
+    "P2pIbTransportDevice must be standard layout with trivial destructor");
 
 /**
  * Transport type tag for discriminated union.
@@ -53,13 +56,12 @@ inline const char* transport_type_name(TransportType t) {
 /**
  * Polymorphic transport wrapper using tagged union.
  * Allows storing either self-transport (intra-GPU) or P2P NVL transport
- * (inter-GPU) in a single type for heterogeneous communication patterns.
+ * (inter-GPU) or an IB transport pointer in a single type for heterogeneous
+ * communication patterns.
  *
- * NOTE: All three transport types are lightweight handle structs containing
- * pointers to externally-managed GPU resources. Transport owns a copy of the
- * handle, NOT the underlying GPU memory — the parent transport object
- * (MultiPeerNvlTransport, MultipeerIbgdaTransport) must outlive any Transport
- * instance.
+ * NOTE: Transport handle structs contain pointers to externally-managed GPU
+ * resources. Transport owns a copy of the handle, NOT the underlying GPU
+ * memory. The parent transport object must outlive any Transport instance.
  *
  * Memory layout: [type tag (1 byte)] + [union of transport objects]
  *
@@ -74,11 +76,7 @@ struct Transport {
   union {
     P2pSelfTransportDevice self;
     P2pNvlTransportDevice p2p_nvl;
-    // Stored as pointer (not by value) because P2pIbgdaTransportDevice.cuh
-    // includes DOCA device headers with CUDA-only intrinsics (atomicCAS, __ldg,
-    // etc.) that cannot compile in .cc translation units. A forward declaration
-    // + non-owning pointer avoids pulling those headers into Transport.cuh.
-    P2pIbgdaTransportDevice* p2p_ibgda;
+    P2pIbTransportDevice p2p_ib;
   };
 
   /** Constructor for SelfTransportDevice */
@@ -89,9 +87,9 @@ struct Transport {
   __host__ __device__ explicit Transport(const P2pNvlTransportDevice& p)
       : type(TransportType::P2P_NVL), p2p_nvl(p) {}
 
-  /** Constructor for P2pIbgdaTransportDevice (non-owning pointer) */
+  /** Constructor for IBGDA device transport (non-owning pointer). */
   __host__ __device__ explicit Transport(P2pIbgdaTransportDevice* p)
-      : type(TransportType::P2P_IBGDA), p2p_ibgda(p) {}
+      : type(TransportType::P2P_IBGDA), p2p_ib(p) {}
 
   /**
    * Delete copy constructor and copy assignment.
@@ -111,7 +109,7 @@ struct Transport {
     } else if (type == TransportType::P2P_NVL) {
       new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
     } else if (type == TransportType::P2P_IBGDA) {
-      p2p_ibgda = other.p2p_ibgda;
+      new (&p2p_ib) P2pIbTransportDevice(other.p2p_ib);
     }
   }
 
@@ -122,7 +120,7 @@ struct Transport {
   __host__ __device__ Transport& operator=(Transport&& other) noexcept {
     if (this != &other) {
       // Destroy current union member.
-      // P2P_IBGDA is a non-owning pointer, no cleanup needed.
+      // IB transports are non-owning pointers, no cleanup needed.
       if (type == TransportType::SELF) {
         self.~P2pSelfTransportDevice();
       } else if (type == TransportType::P2P_NVL) {
@@ -136,7 +134,7 @@ struct Transport {
       } else if (type == TransportType::P2P_NVL) {
         new (&p2p_nvl) P2pNvlTransportDevice(std::move(other.p2p_nvl));
       } else if (type == TransportType::P2P_IBGDA) {
-        p2p_ibgda = other.p2p_ibgda;
+        new (&p2p_ib) P2pIbTransportDevice(other.p2p_ib);
       }
     }
     return *this;
@@ -148,7 +146,7 @@ struct Transport {
    */
   __host__ __device__ ~Transport() {
     // Union members with non-trivial destructors need explicit cleanup.
-    // P2P_IBGDA is a non-owning pointer, no cleanup needed.
+    // IB transports are non-owning pointers, no cleanup needed.
     if (type == TransportType::SELF) {
       self.~P2pSelfTransportDevice();
     } else if (type == TransportType::P2P_NVL) {

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -47,33 +47,7 @@ constexpr int kHopLimit = 255;
 // depth since they only carry WAIT + atomic operations (2 WQEs per round).
 constexpr uint32_t kCompanionQpDepth = 32;
 
-// Bootstrap tags for the two-phase bilateral exchange in materializePeer.
-constexpr int kTagQpExchange = 0;
-constexpr int kTagBufferExchange = 1;
-
 } // namespace
-
-// Wire formats for bilateral exchange in materializePeer.
-// Split into two phases: QP info first (to connect), then buffer info
-// (acts as QP-ready barrier — mirrors the eager path's two-allGather pattern).
-struct PeerQpPayload {
-  struct NicQpInfo {
-    uint8_t gid[16]{};
-    uint16_t lid{0};
-    uint32_t qpns[kMaxQpsPerPeerPerNic]{};
-  };
-  NicQpInfo nicInfo[kMaxNicsPerGpu]{};
-  int gidIndex{0};
-  int mtu{0};
-  int numNics{0};
-  int numQpsPerPeerPerNic{0};
-};
-
-struct PeerBufferPayload {
-  IbgdaBufferExchInfo recvStaging;
-  IbgdaBufferExchInfo srSignal;
-  IbgdaBufferExchInfo slotSignal;
-};
 
 struct PeerBufferSizes {
   std::size_t staging{0};
@@ -1528,9 +1502,9 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
 
   createPeerQps(peerIndex);
 
-  // Phase 1: exchange QP info, connect QPs
+  // Phase 1: exchange QP info, connect QPs.
   auto localQp = buildLocalQpPayload(peerIndex);
-  auto remoteQp = exchangeWithPeer(peerRank, localQp, kTagQpExchange);
+  auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
 
   if (remoteQp.numNics != numNics_) {
     throw std::runtime_error(
@@ -1552,10 +1526,11 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
   connectPeerMainQps(peerIndex, remoteQp);
   connectPeerLoopback(peerIndex);
 
-  // Phase 2: exchange buffer info (acts as QP-ready barrier)
+  // Phase 2: exchange buffer info (acts as QP-ready barrier).
   PeerBufferPayload localBuf{};
   allocatePeerBuffers(peerIndex, localBuf);
-  auto remoteBuf = exchangeWithPeer(peerRank, localBuf, kTagBufferExchange);
+  auto remoteBuf =
+      exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
   applyRemoteViews(peerIndex, remoteBuf);
 
   auto params = buildPeerTransportParams(peerIndex);

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -54,8 +54,6 @@ struct PeerBufferSizes {
   std::size_t srSignal{0};
   std::size_t srCounter{0};
   std::size_t srState{0};
-  std::size_t slotSignal{0};
-  std::size_t slotCounter{0};
 
   // Pointers into a contiguous allocation (set by layout())
   void* sendStagingPtr{nullptr};
@@ -63,12 +61,9 @@ struct PeerBufferSizes {
   void* srSignalPtr{nullptr};
   void* srCounterPtr{nullptr};
   void* srStatePtr{nullptr};
-  void* slotSignalPtr{nullptr};
-  void* slotCounterPtr{nullptr};
 
   std::size_t total() const {
-    return staging * 2 + srSignal + srCounter + srState + slotSignal +
-        slotCounter;
+    return staging * 2 + srSignal + srCounter + srState;
   }
 
   void layout(void* base) {
@@ -83,9 +78,6 @@ struct PeerBufferSizes {
     p += srCounter;
     srStatePtr = p;
     p += srState;
-    slotSignalPtr = p;
-    p += slotSignal;
-    slotCounterPtr = p;
   }
 };
 
@@ -597,10 +589,6 @@ PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
     sizes.srCounter = sr.maxGroups * sizeof(uint64_t);
     sizes.srState = 2 * sr.maxGroups * sizeof(IbSendRecvState::ProgressSlot);
   }
-  sizes.slotSignal =
-      static_cast<std::size_t>(config_.numSignalSlots) * sizeof(uint64_t);
-  sizes.slotCounter =
-      static_cast<std::size_t>(config_.numCounterSlots) * sizeof(uint64_t);
   return sizes;
 }
 
@@ -653,12 +641,13 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   }
 
   if (config_.numSignalSlots > 0) {
-    params.remoteSignalBuf = signalRemoteViews_[peerIndex];
-    params.localSignalBuf = signalLocalViews_[peerIndex];
+    params.remoteSignalBuf = slotRemoteSignalView(peerIndex);
+    params.localSignalBuf = slotLocalSignalView(peerIndex);
     params.numSignalSlots = config_.numSignalSlots;
   }
   if (config_.numCounterSlots > 0) {
-    params.counterBuf = counterViews_[peerIndex];
+    params.counterBuf = slotCounterDeviceView(peerIndex);
+    params.discardSignalSlot = slotDiscardSignalRemoteView(peerIndex);
     params.numCounterSlots = config_.numCounterSlots;
   }
   return params;
@@ -718,9 +707,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
         nic.loopbackCompanionQps.resize(
             static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
       }
-      signalRemoteViews_.resize(numPeers);
-      signalLocalViews_.resize(numPeers);
-      counterViews_.resize(numPeers);
       lazyPeerBufs_.resize(numPeers);
       peerMaterialized_.resize(numPeers, false);
     }
@@ -781,32 +767,7 @@ void MultipeerIbgdaTransport::cleanup() {
     nic.loopbackCompanionQps.clear();
   }
 
-  // Deregister and free transport-owned signal/counter buffers.
-  // MRs must be deregistered BEFORE freeing (correct RDMA teardown order).
-  // On AMD: signal inboxes are host-pinned (NIC-accessible); counter is GPU
-  // device memory (sender-local, no NIC access).
-  if (signalInboxGpu_ != nullptr) {
-    deregisterBuffer(signalInboxGpu_);
-#ifdef __HIP_PLATFORM_AMD__
-    hipHostFree(signalInboxGpu_);
-#else
-    cudaFree(signalInboxGpu_);
-#endif
-    signalInboxGpu_ = nullptr;
-  }
-  signalRemoteViews_.clear();
-  signalLocalViews_.clear();
-
-  if (counterGpu_ != nullptr) {
-    deregisterBuffer(counterGpu_);
-#ifdef __HIP_PLATFORM_AMD__
-    hipFree(counterGpu_);
-#else
-    cudaFree(counterGpu_);
-#endif
-    counterGpu_ = nullptr;
-  }
-  counterViews_.clear();
+  cleanupSignalCounterResources();
 
   // Destroy user buffer MRs
   for (auto& [_, cached] : registeredBuffers_) {
@@ -1001,121 +962,8 @@ void MultipeerIbgdaTransport::exchange() {
     }
     connectPeerLoopback(peerIndex);
   }
-  // ---- Allocate transport-owned signal buffers (if configured) ----
-  if (config_.numSignalSlots > 0) {
-    // Signal inbox: one contiguous buffer with numSignalSlots per peer.
-    // Total size = numPeers * numSignalSlots * sizeof(uint64_t).
-    // Each peer writes to its own region via RDMA atomic fetch-add.
-    const std::size_t slotsPerPeer =
-        static_cast<std::size_t>(config_.numSignalSlots);
-    const std::size_t totalSignalBytes =
-        static_cast<std::size_t>(numPeers) * slotsPerPeer * sizeof(uint64_t);
-
-#ifdef __HIP_PLATFORM_AMD__
-    // Host-pinned: on AMD, GPU-memory MR registration relies on amdgpu's
-    // peer-mem integration which is unreliable on test hosts. Host-pinned
-    // memory works with `ibv_reg_mr` (no peer_mem needed) and is GPU-
-    // accessible via mapped memory — same approach as the deleted
-    // `MultipeerIbgdaTransportAmd::sinkBuffer_`.
-    hipError_t hipErr =
-        hipHostMalloc(&signalInboxGpu_, totalSignalBytes, hipHostMallocDefault);
-    if (hipErr != hipSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate signal inbox (host-pinned): " +
-          std::string(hipGetErrorString(hipErr)));
-    }
-    std::memset(signalInboxGpu_, 0, totalSignalBytes);
-#else
-    cudaError_t cudaErr = cudaMalloc(&signalInboxGpu_, totalSignalBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate signal inbox: " +
-          std::string(cudaGetErrorString(cudaErr)));
-    }
-    cudaErr = cudaMemset(signalInboxGpu_, 0, totalSignalBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error("Failed to zero signal inbox");
-    }
-#endif
-
-    // Register and exchange signal inbox
-    auto localSignalBuf = registerBuffer(signalInboxGpu_, totalSignalBytes);
-    auto remoteSignalBufs = exchangeBuffer(localSignalBuf);
-
-    // Build per-peer views:
-    // - remoteSignalViews_[peerIndex] = remote view into peer's inbox at the
-    //   region reserved for us (offset = myPeerIndexOnPeer * slotsPerPeer)
-    // - signalLocalViews_[peerIndex] = local view into our inbox at the
-    //   region where this peer writes (offset = peerIndex * slotsPerPeer)
-    signalRemoteViews_.resize(numPeers);
-    signalLocalViews_.resize(numPeers);
-    for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-      int peerRank = peerIndexToRank(peerIndex);
-      int myPeerIndexOnPeer = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
-      signalRemoteViews_[peerIndex] = remoteSignalBufs[peerIndex].subBuffer(
-          static_cast<std::size_t>(myPeerIndexOnPeer) * slotsPerPeer *
-          sizeof(uint64_t));
-      signalLocalViews_[peerIndex] = localSignalBuf.subBuffer(
-          static_cast<std::size_t>(peerIndex) * slotsPerPeer *
-          sizeof(uint64_t));
-    }
-
-    VLOG(1) << "MultipeerIbgdaTransport: allocated signal inbox "
-            << totalSignalBytes << " bytes (" << config_.numSignalSlots
-            << " slots/peer, " << numPeers << " peers)";
-  }
-
-  // ---- Allocate transport-owned counter buffers (if configured) ----
-  if (config_.numCounterSlots > 0) {
-    // Counter buffer: local only, no exchange needed.
-    // Each peer's companion QP writes to its own counter region.
-    const std::size_t slotsPerPeer =
-        static_cast<std::size_t>(config_.numCounterSlots);
-    const std::size_t totalCounterBytes =
-        static_cast<std::size_t>(numPeers) * slotsPerPeer * sizeof(uint64_t);
-
-#ifdef __HIP_PLATFORM_AMD__
-    // Counter is GPU-only: GPU writes via atomic_fetch_add and reads in
-    // wait_counter spin loop, no NIC-side access. Device memory (HBM,
-    // ~100ns/access) outperforms host-pinned (PCIe, ~1us/access) and
-    // dma-buf isn't needed.
-    hipError_t hipErr = hipMalloc(&counterGpu_, totalCounterBytes);
-    if (hipErr != hipSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate counter buffer: " +
-          std::string(hipGetErrorString(hipErr)));
-    }
-    hipErr = hipMemset(counterGpu_, 0, totalCounterBytes);
-    if (hipErr != hipSuccess) {
-      throw std::runtime_error("Failed to zero counter buffer");
-    }
-#else
-    cudaError_t cudaErr = cudaMalloc(&counterGpu_, totalCounterBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error(
-          "Failed to allocate counter buffer: " +
-          std::string(cudaGetErrorString(cudaErr)));
-    }
-    cudaErr = cudaMemset(counterGpu_, 0, totalCounterBytes);
-    if (cudaErr != cudaSuccess) {
-      throw std::runtime_error("Failed to zero counter buffer");
-    }
-#endif
-
-    auto localCounterBuf = registerBuffer(counterGpu_, totalCounterBytes);
-
-    // Build per-peer views (local only)
-    counterViews_.resize(numPeers);
-    for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
-      counterViews_[peerIndex] = localCounterBuf.subBuffer(
-          static_cast<std::size_t>(peerIndex) * slotsPerPeer *
-          sizeof(uint64_t));
-    }
-
-    VLOG(1) << "MultipeerIbgdaTransport: allocated counter buffer "
-            << totalCounterBytes << " bytes (" << config_.numCounterSlots
-            << " slots/peer, " << numPeers << " peers)";
-  }
+  allocateSignalCounterResources(
+      IbCounterStorage::Device, /*allocateDiscardSignal=*/true);
 
   exchange_send_recv_buffers();
 
@@ -1412,20 +1260,6 @@ void MultipeerIbgdaTransport::allocatePeerBuffers(
       payload.srSignal.rkey_per_device[n] = rkey;
     }
   }
-
-  if (config_.numSignalSlots > 0) {
-    signalLocalViews_[peerIndex] =
-        IbgdaLocalBuffer(sizes.slotSignalPtr, reg.lkey_per_device);
-    payload.slotSignal.addr = reinterpret_cast<uint64_t>(sizes.slotSignalPtr);
-    payload.slotSignal.numNics = numNics_;
-    for (int n = 0; n < numNics_; ++n) {
-      payload.slotSignal.rkey_per_device[n] = HostRKey(mr.mrs[n]->rkey);
-    }
-  }
-  if (config_.numCounterSlots > 0) {
-    counterViews_[peerIndex] =
-        IbgdaLocalBuffer(sizes.slotCounterPtr, reg.lkey_per_device);
-  }
 }
 
 void MultipeerIbgdaTransport::connectPeerMainQps(
@@ -1456,9 +1290,6 @@ void MultipeerIbgdaTransport::applyRemoteViews(
     pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
     pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
   }
-  if (config_.numSignalSlots > 0) {
-    signalRemoteViews_[peerIndex] = remotePayload.slotSignal.toRemoteBuffer();
-  }
 }
 
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
@@ -1483,6 +1314,7 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
     deregisterBuffer(buf->get());
     buf.reset();
   }
+  cleanupPeerSignalCounterResources(peerIndex);
   peerMaterialized_[peerIndex] = false;
   if (peerTransportsGpu_ != nullptr && peerTransportSize_ != 0) {
     cudaError_t err = cudaMemset(
@@ -1529,9 +1361,16 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
   // Phase 2: exchange buffer info (acts as QP-ready barrier).
   PeerBufferPayload localBuf{};
   allocatePeerBuffers(peerIndex, localBuf);
+  allocatePeerSignalCounterResources(
+      peerIndex,
+      localBuf,
+      IbCounterStorage::Device,
+      /*allocateDiscardSignal=*/true);
   auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
   applyRemoteViews(peerIndex, remoteBuf);
+  applyRemoteSignalCounterResources(
+      peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
 
   auto params = buildPeerTransportParams(peerIndex);
   writeDeviceTransportSlot(

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -311,15 +311,6 @@ class MultipeerIbgdaTransport
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Slot-index signal/counter buffers.
-  // Eager mode: bulk-allocated in exchange(). Null in lazy mode.
-  void* signalInboxGpu_{nullptr};
-  void* counterGpu_{nullptr};
-  // Per-peer views into signal/counter (populated by both modes).
-  std::vector<IbgdaRemoteBuffer> signalRemoteViews_;
-  std::vector<IbgdaLocalBuffer> signalLocalViews_;
-  std::vector<IbgdaLocalBuffer> counterViews_;
-
   // Per-peer send/recv buffer views (populated by both modes).
   struct SendRecvPeerBuffers {
     IbgdaLocalBuffer sendStaging;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -64,6 +64,7 @@ struct P2pIbgdaTransportBuildParams {
   IbgdaRemoteBuffer remoteSignalBuf{};
   IbgdaLocalBuffer localSignalBuf{};
   IbgdaLocalBuffer counterBuf{};
+  IbgdaRemoteBuffer discardSignalSlot{};
   int numSignalSlots{0};
   int numCounterSlots{0};
   IbSendRecvState sendRecvState{};

--- a/comms/prims/transport/ibrc/IbrcTypes.h
+++ b/comms/prims/transport/ibrc/IbrcTypes.h
@@ -16,6 +16,10 @@ inline constexpr uint64_t kIbrcInvalidReadySeq = ~uint64_t{0};
 // data payload plus an ATOMIC_FETCH_AND_ADD for the signal.
 inline constexpr uint32_t kIbrcMaxWrsPerDescriptor = 2;
 
+// Sentinel error_queue value for transport-level errors that are not
+// attributable to a specific command queue.
+inline constexpr uint32_t kIbrcUnknownQueue = ~uint32_t{0};
+
 // Cache-line size: aligns the IBRC POD types and separates the host-mapped
 // command-queue producer/consumer indices to avoid false-sharing across the
 // GPU<->CPU boundary.

--- a/comms/prims/transport/ibrc/IbrcTypes.h
+++ b/comms/prims/transport/ibrc/IbrcTypes.h
@@ -44,17 +44,17 @@ struct alignas(kIbrcCacheLineBytes) IbrcDesc {
   uint64_t signal_addr;
   uint64_t signal_value;
 
+  uint64_t counter_addr;
   uint64_t counter_value;
 
   uint32_t lkey_device_order;
   uint32_t rkey_device_order;
   uint32_t signal_rkey_device_order;
-  uint32_t counter_id;
 
   uint16_t op;
   uint16_t flags;
 
-  uint8_t padding[52];
+  uint8_t padding[48];
 
   uint64_t ready_seq;
 };

--- a/comms/prims/transport/ibrc/IbrcTypes.h
+++ b/comms/prims/transport/ibrc/IbrcTypes.h
@@ -1,0 +1,87 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace comms::prims {
+
+inline constexpr std::size_t kIbrcCqPollBatch = 32;
+inline constexpr uint32_t kIbrcDefaultCmdQueueDepth = 128;
+inline constexpr uint64_t kIbrcInvalidReadySeq = ~uint64_t{0};
+
+// Max work requests a single descriptor posts to its QP: an RDMA_WRITE for the
+// data payload plus an ATOMIC_FETCH_AND_ADD for the signal.
+inline constexpr uint32_t kIbrcMaxWrsPerDescriptor = 2;
+
+// Cache-line size: aligns the IBRC POD types and separates the host-mapped
+// command-queue producer/consumer indices to avoid false-sharing across the
+// GPU<->CPU boundary.
+inline constexpr std::size_t kIbrcCacheLineBytes = 64;
+
+enum class IbrcOp : uint16_t {
+  PUT = 0,
+  SIGNAL = 1,
+};
+
+enum IbrcFlags : uint16_t {
+  IBRC_HAS_SIGNAL = 1 << 0,
+  IBRC_SIGNAL_ADD = 1 << 1,
+  IBRC_HAS_COUNTER = 1 << 2,
+};
+
+struct alignas(kIbrcCacheLineBytes) IbrcDesc {
+  uint64_t local_addr;
+  uint64_t remote_addr;
+  uint64_t bytes;
+
+  uint64_t signal_addr;
+  uint64_t signal_value;
+
+  uint64_t counter_value;
+
+  uint32_t lkey_device_order;
+  uint32_t rkey_device_order;
+  uint32_t signal_rkey_device_order;
+  uint32_t counter_id;
+
+  uint16_t op;
+  uint16_t flags;
+
+  uint8_t padding[52];
+
+  uint64_t ready_seq;
+};
+
+static_assert(sizeof(IbrcDesc) == 128);
+static_assert(alignof(IbrcDesc) == 64);
+static_assert(offsetof(IbrcDesc, ready_seq) == 120);
+static_assert(std::is_standard_layout_v<IbrcDesc>);
+static_assert(std::is_trivially_copyable_v<IbrcDesc>);
+
+struct alignas(kIbrcCacheLineBytes) IbrcNicStatus {
+  uint32_t error;
+  uint32_t error_queue;
+  uint32_t error_code;
+};
+
+static_assert(sizeof(IbrcNicStatus) == 64);
+static_assert(alignof(IbrcNicStatus) == 64);
+static_assert(std::is_standard_layout_v<IbrcNicStatus>);
+static_assert(std::is_trivially_copyable_v<IbrcNicStatus>);
+
+struct IbrcCmdQueueDevice {
+  IbrcDesc* descs;
+  uint64_t* pi;
+  uint64_t* ci;
+  IbrcNicStatus* status;
+  uint32_t depth;
+  uint32_t mask;
+};
+
+static_assert(std::is_standard_layout_v<IbrcCmdQueueDevice>);
+static_assert(std::is_trivially_copyable_v<IbrcCmdQueueDevice>);
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -2,12 +2,15 @@
 
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 
+#include <endian.h>
+
 #include <cerrno>
 #include <cstddef>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -126,6 +129,14 @@ std::size_t alignUp(std::size_t value, std::size_t alignment) {
   return checkedAdd(value, alignment - remainder, "aligned control block");
 }
 
+uint32_t keyForIbvPostSend(uint32_t deviceOrderKey) {
+#if defined(NIC_BNXT) || defined(NIC_IONIC)
+  return deviceOrderKey;
+#else
+  return be32toh(deviceOrderKey);
+#endif
+}
+
 } // namespace
 
 MultipeerIbrcTransport::MappedAllocation::~MappedAllocation() {
@@ -222,6 +233,8 @@ void MultipeerIbrcTransport::exchange() {
 }
 
 void MultipeerIbrcTransport::cleanup() {
+  stopProgressThread();
+
   for (int peerIndex = 0; peerIndex < static_cast<int>(peerResources_.size());
        ++peerIndex) {
     cleanupPeerCmdQueues(peerIndex);
@@ -250,6 +263,301 @@ void MultipeerIbrcTransport::cleanup() {
   statusControl_.reset();
 
   closeNics();
+}
+
+void MultipeerIbrcTransport::startProgressThread() {
+  if (progressThread_.joinable()) {
+    return;
+  }
+  stopProgress_.store(false, std::memory_order_release);
+  progressThread_ = std::thread([this] { progressLoop(); });
+}
+
+void MultipeerIbrcTransport::stopProgressThread() noexcept {
+  stopProgress_.store(true, std::memory_order_release);
+  if (!progressThread_.joinable()) {
+    return;
+  }
+  try {
+    progressThread_.join();
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "MultipeerIbrcTransport: failed to join progress thread: "
+               << ex.what();
+  }
+}
+
+void MultipeerIbrcTransport::progressLoop() noexcept {
+  while (!stopProgress_.load(std::memory_order_acquire)) {
+    bool progressed = false;
+    try {
+      progressed = progressOnce();
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultipeerIbrcTransport: progress thread failed: "
+                 << ex.what();
+      publishTransportError(EIO, "progress error");
+      return;
+    } catch (...) {
+      LOG(ERROR) << "MultipeerIbrcTransport: progress thread failed";
+      publishTransportError(EIO, "progress error");
+      return;
+    }
+
+    if (!progressed) {
+      std::this_thread::yield();
+    }
+  }
+}
+
+bool MultipeerIbrcTransport::progressOnce() {
+  bool progressed = false;
+  for (int peerIndex = 0; peerIndex < static_cast<int>(peerResources_.size());
+       ++peerIndex) {
+    auto& peer = peerResources_[peerIndex];
+    for (auto& cmdQueue : peer.cmdQueues) {
+      progressed |= pollCmdQueueCompletions(peerIndex, cmdQueue);
+      progressed |= pollOneCmdQueueDescriptor(peerIndex, cmdQueue);
+    }
+  }
+  return progressed;
+}
+
+bool MultipeerIbrcTransport::pollOneCmdQueueDescriptor(
+    int peerIndex,
+    IbrcCmdQueueHost& cmdQueue) {
+  const uint64_t seq = cmdQueue.nextToPoll;
+  if (__atomic_load_n(cmdQueue.piHost, __ATOMIC_ACQUIRE) <= seq) {
+    return false;
+  }
+
+  const uint32_t slot = static_cast<uint32_t>(seq & cmdQueue.device.mask);
+  IbrcDesc& descSlot = cmdQueue.descsHost[slot];
+  if (__atomic_load_n(&descSlot.ready_seq, __ATOMIC_ACQUIRE) != seq) {
+    return false;
+  }
+
+  IbrcDesc desc = descSlot;
+  auto& state = cmdQueue.cmdStates.at(slot);
+  state.seq = seq;
+  state.flags = desc.flags;
+  state.counterId = desc.counter_id;
+  state.counterValue = desc.counter_value;
+  state.peerCompleted = false;
+
+  __atomic_store_n(&descSlot.ready_seq, kIbrcInvalidReadySeq, __ATOMIC_RELEASE);
+  postDescriptor(peerIndex, cmdQueue, desc, seq);
+  cmdQueue.nextToPoll = seq + 1;
+  return true;
+}
+
+bool MultipeerIbrcTransport::pollCmdQueueCompletions(
+    int peerIndex,
+    IbrcCmdQueueHost& cmdQueue) {
+  auto& qpResource = qpResourceAt(
+      peerIndex,
+      static_cast<int>(cmdQueue.nic),
+      static_cast<int>(cmdQueue.qpSlot));
+  bool progressed = false;
+
+  ibverbx::ibv_wc completions[kIbrcCqPollBatch]{};
+  const int n = qpResource.cq->context->ops.poll_cq(
+      qpResource.cq, static_cast<int>(kIbrcCqPollBatch), completions);
+  if (n < 0) {
+    publishQueueError(
+        peerIndex, cmdQueue, errno == 0 ? EIO : errno, "ibv_poll_cq failed");
+    return false;
+  }
+
+  for (int i = 0; i < n; ++i) {
+    const auto& wc = completions[i];
+    if (wc.status != ibverbx::IBV_WC_SUCCESS) {
+      publishQueueError(
+          peerIndex, cmdQueue, static_cast<uint32_t>(wc.status), "CQE error");
+      continue;
+    }
+
+    // Mark the descriptor's peer-facing WR complete; retirement (advancing
+    // nextToComplete / publishing ci) happens strictly in seq order in
+    // drainCompletedCommands(), so a no-WR descriptor can never retire ahead
+    // of an in-flight peer WR at a lower seq.
+    auto& state = cmdQueue.cmdStates.at(wc.wr_id & cmdQueue.device.mask);
+    if (state.seq != wc.wr_id) {
+      publishQueueError(peerIndex, cmdQueue, EPROTO, "stale CQE state");
+      continue;
+    }
+    state.peerCompleted = true;
+    progressed = true;
+  }
+
+  return drainCompletedCommands(peerIndex, cmdQueue) || progressed;
+}
+
+bool MultipeerIbrcTransport::drainCompletedCommands(
+    int peerIndex,
+    IbrcCmdQueueHost& cmdQueue) {
+  bool progressed = false;
+  while (true) {
+    auto& state =
+        cmdQueue.cmdStates.at(cmdQueue.nextToComplete & cmdQueue.device.mask);
+    if (state.seq != cmdQueue.nextToComplete || !state.peerCompleted) {
+      return progressed;
+    }
+
+    state = IbrcCmdState{};
+    ++cmdQueue.nextToComplete;
+    __atomic_store_n(
+        cmdQueue.ciHost, cmdQueue.nextToComplete, __ATOMIC_RELEASE);
+    progressed = true;
+  }
+}
+
+void MultipeerIbrcTransport::postDescriptor(
+    int peerIndex,
+    IbrcCmdQueueHost& cmdQueue,
+    const IbrcDesc& desc,
+    uint64_t seq) {
+  const auto op = static_cast<IbrcOp>(desc.op);
+  const bool hasSignal = (desc.flags & IBRC_HAS_SIGNAL) != 0;
+  const bool hasCounter = (desc.flags & IBRC_HAS_COUNTER) != 0;
+  const bool hasData = op == IbrcOp::PUT && desc.bytes > 0;
+
+  if (op != IbrcOp::PUT && op != IbrcOp::SIGNAL) {
+    publishQueueError(peerIndex, cmdQueue, EINVAL, "unsupported descriptor op");
+    return;
+  }
+  if (op == IbrcOp::SIGNAL && desc.bytes != 0) {
+    publishQueueError(
+        peerIndex, cmdQueue, EINVAL, "SIGNAL descriptor cannot carry data");
+    return;
+  }
+  if (hasCounter) {
+    publishQueueError(
+        peerIndex, cmdQueue, ENOTSUP, "counter completion is not implemented");
+    return;
+  }
+  if (hasSignal && (desc.flags & IBRC_SIGNAL_ADD) == 0) {
+    publishQueueError(
+        peerIndex, cmdQueue, ENOTSUP, "only signal add is supported");
+    return;
+  }
+  if (desc.bytes > std::numeric_limits<uint32_t>::max()) {
+    publishQueueError(
+        peerIndex,
+        cmdQueue,
+        EMSGSIZE,
+        "descriptor bytes exceed verbs SGE size");
+    return;
+  }
+
+  auto& qpResource = qpResourceAt(
+      peerIndex,
+      static_cast<int>(cmdQueue.nic),
+      static_cast<int>(cmdQueue.qpSlot));
+  if (!hasData && !hasSignal) {
+    publishQueueError(peerIndex, cmdQueue, EINVAL, "empty descriptor");
+    return;
+  }
+  if (hasSignal && qpResource.signalAtomicSinkMr == nullptr) {
+    publishQueueError(peerIndex, cmdQueue, EINVAL, "missing signal sink MR");
+    return;
+  }
+
+  ibverbx::ibv_sge dataSge{};
+  ibverbx::ibv_send_wr dataWr{};
+  ibverbx::ibv_sge signalSge{};
+  ibverbx::ibv_send_wr signalWr{};
+  ibverbx::ibv_send_wr* firstWr = nullptr;
+  ibverbx::ibv_send_wr* finalWr = nullptr;
+
+  if (hasData) {
+    dataSge.addr = desc.local_addr;
+    dataSge.length = static_cast<uint32_t>(desc.bytes);
+    dataSge.lkey = keyForIbvPostSend(desc.lkey_device_order);
+
+    dataWr.wr_id = seq;
+    dataWr.sg_list = &dataSge;
+    dataWr.num_sge = 1;
+    dataWr.opcode = ibverbx::IBV_WR_RDMA_WRITE;
+    dataWr.send_flags = hasSignal ? 0 : ibverbx::IBV_SEND_SIGNALED;
+    dataWr.wr.rdma.remote_addr = desc.remote_addr;
+    dataWr.wr.rdma.rkey = keyForIbvPostSend(desc.rkey_device_order);
+    firstWr = &dataWr;
+    finalWr = &dataWr;
+  }
+
+  if (hasSignal) {
+    signalSge.addr =
+        reinterpret_cast<uint64_t>(qpResource.signalAtomicSink.get());
+    signalSge.length = sizeof(uint64_t);
+    signalSge.lkey = qpResource.signalAtomicSinkMr->lkey;
+
+    signalWr.wr_id = seq;
+    signalWr.sg_list = &signalSge;
+    signalWr.num_sge = 1;
+    signalWr.opcode = ibverbx::IBV_WR_ATOMIC_FETCH_AND_ADD;
+    signalWr.send_flags = ibverbx::IBV_SEND_SIGNALED | ibverbx::IBV_SEND_FENCE;
+    signalWr.wr.atomic.remote_addr = desc.signal_addr;
+    signalWr.wr.atomic.compare_add = desc.signal_value;
+    signalWr.wr.atomic.rkey = keyForIbvPostSend(desc.signal_rkey_device_order);
+
+    if (firstWr == nullptr) {
+      firstWr = &signalWr;
+    } else {
+      finalWr->next = &signalWr;
+    }
+  }
+
+  ibverbx::ibv_send_wr* badWr = nullptr;
+  const int rc =
+      qpResource.qp->context->ops.post_send(qpResource.qp, firstWr, &badWr);
+  if (rc != 0) {
+    publishQueueError(
+        peerIndex,
+        cmdQueue,
+        rc > 0 ? rc : (errno == 0 ? EIO : errno),
+        "ibv_post_send failed");
+  }
+}
+
+void MultipeerIbrcTransport::publishQueueError(
+    int peerIndex,
+    const IbrcCmdQueueHost& cmdQueue,
+    uint32_t errorCode,
+    const char* reason) noexcept {
+  const int peerRank = peerIndex < myRank_ ? peerIndex : peerIndex + 1;
+  const auto queueIndex = static_cast<uint32_t>(
+      ((static_cast<uint64_t>(peerIndex) *
+            static_cast<uint64_t>(config_.numQpsPerPeerPerNic) +
+        static_cast<uint64_t>(cmdQueue.qpSlot)) *
+       static_cast<uint64_t>(numNics_)) +
+      static_cast<uint64_t>(cmdQueue.nic));
+
+  LOG(ERROR) << "MultipeerIbrcTransport: " << reason << " peerRank=" << peerRank
+             << " queue=" << queueIndex << " nic=" << cmdQueue.nic
+             << " qpSlot=" << cmdQueue.qpSlot << " code=" << errorCode;
+  for (auto* status : statusHostByNic_) {
+    if (status == nullptr) {
+      continue;
+    }
+    __atomic_store_n(&status->error_queue, queueIndex, __ATOMIC_RELAXED);
+    __atomic_store_n(&status->error_code, errorCode, __ATOMIC_RELAXED);
+    __atomic_store_n(&status->error, 1, __ATOMIC_RELEASE);
+  }
+  stopProgress_.store(true, std::memory_order_release);
+}
+
+void MultipeerIbrcTransport::publishTransportError(
+    uint32_t errorCode,
+    const char* reason) noexcept {
+  LOG(ERROR) << "MultipeerIbrcTransport: " << reason << " code=" << errorCode;
+  for (auto* status : statusHostByNic_) {
+    if (status == nullptr) {
+      continue;
+    }
+    __atomic_store_n(&status->error_queue, kIbrcUnknownQueue, __ATOMIC_RELAXED);
+    __atomic_store_n(&status->error_code, errorCode, __ATOMIC_RELAXED);
+    __atomic_store_n(&status->error, 1, __ATOMIC_RELEASE);
+  }
+  stopProgress_.store(true, std::memory_order_release);
 }
 
 void MultipeerIbrcTransport::initializeControlResources() {
@@ -441,6 +749,19 @@ void MultipeerIbrcTransport::destroyPeerQps(
     }
   }
   for (auto& qpResource : qpResources) {
+    if (qpResource.signalAtomicSinkMr != nullptr &&
+        symbols.ibv_internal_dereg_mr != nullptr) {
+      int rc = symbols.ibv_internal_dereg_mr(qpResource.signalAtomicSinkMr);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to deregister IBRC signal sink MR nic="
+                     << qpResource.nic << " qpSlot=" << qpResource.qpSlot
+                     << ": rc=" << rc;
+      }
+      qpResource.signalAtomicSinkMr = nullptr;
+    }
+    qpResource.signalAtomicSink.reset();
+  }
+  for (auto& qpResource : qpResources) {
     if (qpResource.cq != nullptr &&
         symbols.ibv_internal_destroy_cq != nullptr) {
       int rc = symbols.ibv_internal_destroy_cq(qpResource.cq);
@@ -529,7 +850,7 @@ void MultipeerIbrcTransport::createPeerQps(int peerIndex) {
         qpResource.cq = cq;
         qpResource.nic = nic;
         qpResource.qpSlot = q;
-        qpResources.push_back(qpResource);
+        qpResources.push_back(std::move(qpResource));
         auto& createdQpResource = qpResources.back();
 
         ibverbx::ibv_qp_init_attr initAttr{};
@@ -558,6 +879,30 @@ void MultipeerIbrcTransport::createPeerQps(int peerIndex) {
                   savedErrno,
                   errnoString(savedErrno)));
         }
+
+        auto signalAtomicSink = std::make_unique<uint64_t>(0);
+        if (symbols.ibv_internal_reg_mr == nullptr) {
+          throw std::runtime_error("ibv_reg_mr is unavailable");
+        }
+        errno = 0;
+        createdQpResource.signalAtomicSinkMr = symbols.ibv_internal_reg_mr(
+            nics_[nic].ibvPd,
+            signalAtomicSink.get(),
+            sizeof(uint64_t),
+            ibverbx::IBV_ACCESS_LOCAL_WRITE);
+        if (createdQpResource.signalAtomicSinkMr == nullptr) {
+          const int savedErrno = errno;
+          throw std::runtime_error(
+              fmt::format(
+                  "Failed to register IBRC signal sink MR for peerIndex={} "
+                  "nic={} qpSlot={}: errno={} ({})",
+                  peerIndex,
+                  nic,
+                  q,
+                  savedErrno,
+                  errnoString(savedErrno)));
+        }
+        createdQpResource.signalAtomicSink = std::move(signalAtomicSink);
       }
     }
   } catch (const std::exception&) {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -2,18 +2,35 @@
 
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 
+#include <cerrno>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+#include <glog/logging.h>
+
+#include "comms/ctran/ibverbx/IbverbxSymbols.h"
 
 namespace comms::prims {
 
 namespace {
-[[noreturn]] void ibrcUnimplemented(const char* what) {
+
+constexpr uint8_t kDefaultIbPort = 1;
+constexpr uint8_t kDefaultIbHopLimit = 255;
+
+std::string errnoString(int err) {
+  return std::strerror(err);
+}
+
+[[noreturn]] void throwIbrcUnimplemented(const char* what) {
   throw std::runtime_error(
       std::string("MultipeerIbrcTransport: ") + what +
       " is not implemented yet");
 }
+
 } // namespace
 
 MultipeerIbrcTransport::MultipeerIbrcTransport(
@@ -25,23 +42,483 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
           myRank,
           nRanks,
           std::move(bootstrap),
-          config) {}
+          config) {
+  if (config.numQpsPerPeerPerNic < 1 ||
+      config.numQpsPerPeerPerNic > kMaxQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "numQpsPerPeerPerNic must be in [1, {}], got {}",
+            kMaxQpsPerPeerPerNic,
+            config.numQpsPerPeerPerNic));
+  }
+
+  peerResources_.resize(nRanks_ - 1);
+
+  try {
+    openNics();
+    if (config_.ibLazyConnect) {
+      peerMaterialized_.resize(nRanks_ - 1, false);
+    }
+  } catch (const std::exception&) {
+    cleanup();
+    throw;
+  }
+}
+
+MultipeerIbrcTransport::~MultipeerIbrcTransport() {
+  cleanup();
+}
 
 void MultipeerIbrcTransport::exchange() {
-  ibrcUnimplemented("exchange()");
+  if (!config_.ibLazyConnect) {
+    exchangeAndConnectQps();
+  } else {
+    VLOG(1)
+        << "MultipeerIbrcTransport: rank " << myRank_
+        << " lazy exchange complete (per-peer QPs deferred to materializePeer)";
+  }
+
+  throwIbrcUnimplemented("command-ring/device transport path");
 }
 
-void MultipeerIbrcTransport::doMaterializePeer(int /*peerRank*/) {
-  // Lazy per-peer materialization: create this peer's lane resources, do the
-  // bilateral QP + buffer exchange, and build its device-transport slot. Not
-  // yet implemented.
-  ibrcUnimplemented("doMaterializePeer()");
+void MultipeerIbrcTransport::cleanup() {
+  for (auto& peer : peerResources_) {
+    destroyPeerQps(peer.qpResources);
+    peer.qpsConnected = false;
+  }
+
+  auto& symbols = ibverbx::ibvSymbols;
+  if (symbols.ibv_internal_dereg_mr != nullptr) {
+    for (auto& [_, cached] : registeredBuffers_) {
+      for (int n = 0; n < numNics_; ++n) {
+        if (cached.mrs[n] != nullptr) {
+          int rc = symbols.ibv_internal_dereg_mr(cached.mrs[n]);
+          if (rc != 0) {
+            LOG(WARNING) << "Failed to deregister IBRC MR on NIC " << n
+                         << ": rc=" << rc;
+          }
+          cached.mrs[n] = nullptr;
+        }
+      }
+    }
+  }
+  registeredBuffers_.clear();
+
+  closeNics();
 }
 
-void MultipeerIbrcTransport::cleanupPeerOnFailure(int /*peerIndex*/) {
-  // Per-peer rollback hook. The base invokes this from a catch(...) block
-  // during failure rollback, where throwing would call std::terminate — so it
-  // must stay no-throw. No-op until lazy materialization is implemented.
+void MultipeerIbrcTransport::destroyPeerQps(
+    std::vector<PeerQpResource>& qpResources) noexcept {
+  auto& symbols = ibverbx::ibvSymbols;
+  for (auto& qpResource : qpResources) {
+    if (qpResource.qp != nullptr &&
+        symbols.ibv_internal_destroy_qp != nullptr) {
+      int rc = symbols.ibv_internal_destroy_qp(qpResource.qp);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to destroy IBRC QP nic=" << qpResource.nic
+                     << " qpSlot=" << qpResource.qpSlot << ": rc=" << rc;
+      }
+      qpResource.qp = nullptr;
+    }
+  }
+  for (auto& qpResource : qpResources) {
+    if (qpResource.cq != nullptr &&
+        symbols.ibv_internal_destroy_cq != nullptr) {
+      int rc = symbols.ibv_internal_destroy_cq(qpResource.cq);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to destroy IBRC CQ nic=" << qpResource.nic
+                     << " qpSlot=" << qpResource.qpSlot << ": rc=" << rc;
+      }
+      qpResource.cq = nullptr;
+    }
+  }
+  qpResources.clear();
+}
+
+void MultipeerIbrcTransport::closeNics() noexcept {
+  auto& symbols = ibverbx::ibvSymbols;
+  for (auto& nic : nics_) {
+    if (nic.ibvPd != nullptr && symbols.ibv_internal_dealloc_pd != nullptr) {
+      int rc = symbols.ibv_internal_dealloc_pd(nic.ibvPd);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to dealloc IBRC PD on NIC " << nic.deviceName
+                     << ": rc=" << rc;
+      }
+      nic.ibvPd = nullptr;
+    }
+  }
+  for (auto& nic : nics_) {
+    if (nic.ibvCtx != nullptr && symbols.ibv_internal_close_device != nullptr) {
+      int rc = symbols.ibv_internal_close_device(nic.ibvCtx);
+      if (rc != 0) {
+        LOG(WARNING) << "Failed to close IBRC device " << nic.deviceName
+                     << ": rc=" << rc;
+      }
+      nic.ibvCtx = nullptr;
+    }
+  }
+  nics_.clear();
+}
+
+void MultipeerIbrcTransport::cleanupPeerQps(int peerIndex) noexcept {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size())) {
+    return;
+  }
+  destroyPeerQps(peerResources_[peerIndex].qpResources);
+  peerResources_[peerIndex].qpsConnected = false;
+}
+
+void MultipeerIbrcTransport::createPeerQps(int peerIndex) {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size())) {
+    throw std::invalid_argument(
+        fmt::format("createPeerQps: invalid peerIndex={}", peerIndex));
+  }
+  auto& peer = peerResources_[peerIndex];
+  if (!peer.qpResources.empty()) {
+    return;
+  }
+
+  const int numQps = config_.numQpsPerPeerPerNic;
+  std::vector<PeerQpResource> qpResources;
+  qpResources.reserve(static_cast<std::size_t>(numNics_) * numQps);
+  auto& symbols = ibverbx::ibvSymbols;
+
+  try {
+    for (int q = 0; q < numQps; ++q) {
+      for (int nic = 0; nic < numNics_; ++nic) {
+        errno = 0;
+        ibverbx::ibv_cq* cq = symbols.ibv_internal_create_cq(
+            nics_[nic].ibvCtx,
+            static_cast<int>(config_.qpDepth),
+            nullptr,
+            nullptr,
+            0);
+        if (cq == nullptr) {
+          const int savedErrno = errno;
+          throw std::runtime_error(
+              fmt::format(
+                  "Failed to create IBRC CQ for peerIndex={} nic={} qpSlot={}: "
+                  "errno={} ({})",
+                  peerIndex,
+                  nic,
+                  q,
+                  savedErrno,
+                  errnoString(savedErrno)));
+        }
+
+        PeerQpResource qpResource;
+        qpResource.cq = cq;
+        qpResource.nic = nic;
+        qpResource.qpSlot = q;
+        qpResources.push_back(qpResource);
+        auto& createdQpResource = qpResources.back();
+
+        ibverbx::ibv_qp_init_attr initAttr{};
+        initAttr.send_cq = cq;
+        initAttr.recv_cq = cq;
+        initAttr.cap.max_send_wr = config_.qpDepth;
+        initAttr.cap.max_recv_wr = 1;
+        initAttr.cap.max_send_sge = 1;
+        initAttr.cap.max_recv_sge = 1;
+        initAttr.cap.max_inline_data = 0;
+        initAttr.qp_type = ibverbx::IBV_QPT_RC;
+        initAttr.sq_sig_all = 0;
+
+        errno = 0;
+        createdQpResource.qp =
+            symbols.ibv_internal_create_qp(nics_[nic].ibvPd, &initAttr);
+        if (createdQpResource.qp == nullptr) {
+          const int savedErrno = errno;
+          throw std::runtime_error(
+              fmt::format(
+                  "Failed to create IBRC QP for peerIndex={} nic={} qpSlot={}: "
+                  "errno={} ({})",
+                  peerIndex,
+                  nic,
+                  q,
+                  savedErrno,
+                  errnoString(savedErrno)));
+        }
+      }
+    }
+  } catch (const std::exception&) {
+    destroyPeerQps(qpResources);
+    throw;
+  }
+
+  peer.qpResources = std::move(qpResources);
+}
+
+MultipeerIbrcTransport::PeerQpResource&
+MultipeerIbrcTransport::qpResourceAt(int peerIndex, int nic, int qpSlot) {
+  return const_cast<PeerQpResource&>(
+      static_cast<const MultipeerIbrcTransport&>(*this).qpResourceAt(
+          peerIndex, nic, qpSlot));
+}
+
+const MultipeerIbrcTransport::PeerQpResource&
+MultipeerIbrcTransport::qpResourceAt(int peerIndex, int nic, int qpSlot) const {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size()) ||
+      nic < 0 || nic >= numNics_ || qpSlot < 0 ||
+      qpSlot >= config_.numQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "qpResourceAt: invalid peerIndex={} nic={} qpSlot={}",
+            peerIndex,
+            nic,
+            qpSlot));
+  }
+  const auto& qpResources = peerResources_[peerIndex].qpResources;
+  const int slot = qpSlot * numNics_ + nic;
+  if (slot >= static_cast<int>(qpResources.size())) {
+    throw std::runtime_error(
+        fmt::format(
+            "qpResourceAt: peerIndex={} has {} QP resource(s), missing slot {}",
+            peerIndex,
+            qpResources.size(),
+            slot));
+  }
+  return qpResources[slot];
+}
+
+PeerQpPayload MultipeerIbrcTransport::buildLocalQpPayload(int peerIndex) const {
+  const int numQps = config_.numQpsPerPeerPerNic;
+  PeerQpPayload payload{};
+  payload.gidIndex = gidIndex_;
+  payload.mtu = static_cast<int>(localMtu_);
+  payload.numNics = numNics_;
+  payload.numQpsPerPeerPerNic = numQps;
+
+  auto& symbols = ibverbx::ibvSymbols;
+  for (int n = 0; n < numNics_; ++n) {
+    std::memcpy(
+        payload.nicInfo[n].gid,
+        nics_[n].localGid.raw,
+        sizeof(payload.nicInfo[n].gid));
+    ibverbx::ibv_port_attr portAttr{};
+    if (symbols.ibv_internal_query_port(
+            nics_[n].ibvCtx, kDefaultIbPort, &portAttr) == 0) {
+      payload.nicInfo[n].lid = portAttr.lid;
+    } else {
+      LOG(WARNING) << "Failed to query port for IBRC LID on NIC " << n;
+    }
+    for (int q = 0; q < numQps; ++q) {
+      payload.nicInfo[n].qpns[q] = qpResourceAt(peerIndex, n, q).qp->qp_num;
+    }
+  }
+  return payload;
+}
+
+void MultipeerIbrcTransport::connectPeerQp(
+    PeerQpResource& qpResource,
+    uint32_t remoteQpn,
+    const uint8_t* remoteGid,
+    uint16_t remoteLid,
+    int remoteMtu) {
+  if (qpResource.qp == nullptr) {
+    throw std::runtime_error("connectPeerQp: QP resource is null");
+  }
+
+  auto& symbols = ibverbx::ibvSymbols;
+  auto modifyQp = [&](const char* state, ibverbx::ibv_qp_attr& attr, int mask) {
+    errno = 0;
+    int rc = symbols.ibv_internal_modify_qp(qpResource.qp, &attr, mask);
+    if (rc != 0) {
+      const int savedErrno = errno;
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to modify IBRC QP {} to {} (nic={} qpSlot={} "
+              "remoteQpn={}): rc={} errno={} ({})",
+              qpResource.qp->qp_num,
+              state,
+              qpResource.nic,
+              qpResource.qpSlot,
+              remoteQpn,
+              rc,
+              savedErrno,
+              errnoString(savedErrno)));
+    }
+  };
+
+  ibverbx::ibv_qp_attr initAttr{};
+  initAttr.qp_state = ibverbx::IBV_QPS_INIT;
+  initAttr.pkey_index = 0;
+  initAttr.port_num = kDefaultIbPort;
+  initAttr.qp_access_flags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
+      ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
+      ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
+  modifyQp(
+      "INIT",
+      initAttr,
+      ibverbx::IBV_QP_STATE | ibverbx::IBV_QP_PKEY_INDEX |
+          ibverbx::IBV_QP_PORT | ibverbx::IBV_QP_ACCESS_FLAGS);
+
+  ibverbx::ibv_qp_attr rtrAttr{};
+  rtrAttr.qp_state = ibverbx::IBV_QPS_RTR;
+  // path_mtu = min(local, remote), guarding an unset (0) or invalid remote MTU
+  // that would otherwise select an invalid ibv_mtu(0) and fail modify_qp.
+  rtrAttr.path_mtu = (remoteMtu >= 1 && remoteMtu < static_cast<int>(localMtu_))
+      ? static_cast<ibverbx::ibv_mtu>(remoteMtu)
+      : localMtu_;
+  rtrAttr.dest_qp_num = remoteQpn;
+  rtrAttr.rq_psn = 0;
+  rtrAttr.max_dest_rd_atomic = 1;
+  rtrAttr.min_rnr_timer = config_.minRnrTimer;
+  rtrAttr.ah_attr.dlid = remoteLid;
+  rtrAttr.ah_attr.sl = config_.serviceLevel;
+  rtrAttr.ah_attr.src_path_bits = 0;
+  rtrAttr.ah_attr.port_num = kDefaultIbPort;
+  rtrAttr.ah_attr.static_rate = 0;
+  if (nics_[qpResource.nic].linkLayer == ibverbx::IBV_LINK_LAYER_ETHERNET) {
+    rtrAttr.ah_attr.is_global = 1;
+    std::memcpy(
+        rtrAttr.ah_attr.grh.dgid.raw,
+        remoteGid,
+        sizeof(rtrAttr.ah_attr.grh.dgid.raw));
+    rtrAttr.ah_attr.grh.flow_label = 0;
+    rtrAttr.ah_attr.grh.sgid_index = static_cast<uint8_t>(gidIndex_);
+    rtrAttr.ah_attr.grh.hop_limit = kDefaultIbHopLimit;
+    rtrAttr.ah_attr.grh.traffic_class = config_.trafficClass;
+  } else {
+    rtrAttr.ah_attr.is_global = 0;
+  }
+  modifyQp(
+      "RTR",
+      rtrAttr,
+      ibverbx::IBV_QP_STATE | ibverbx::IBV_QP_AV | ibverbx::IBV_QP_PATH_MTU |
+          ibverbx::IBV_QP_DEST_QPN | ibverbx::IBV_QP_RQ_PSN |
+          ibverbx::IBV_QP_MAX_DEST_RD_ATOMIC | ibverbx::IBV_QP_MIN_RNR_TIMER);
+
+  ibverbx::ibv_qp_attr rtsAttr{};
+  rtsAttr.qp_state = ibverbx::IBV_QPS_RTS;
+  rtsAttr.sq_psn = 0;
+  rtsAttr.timeout = config_.timeout;
+  rtsAttr.retry_cnt = config_.retryCount;
+  rtsAttr.rnr_retry = config_.rnrRetry;
+  rtsAttr.max_rd_atomic = 1;
+  modifyQp(
+      "RTS",
+      rtsAttr,
+      ibverbx::IBV_QP_STATE | ibverbx::IBV_QP_SQ_PSN | ibverbx::IBV_QP_TIMEOUT |
+          ibverbx::IBV_QP_RETRY_CNT | ibverbx::IBV_QP_RNR_RETRY |
+          ibverbx::IBV_QP_MAX_QP_RD_ATOMIC);
+}
+
+void MultipeerIbrcTransport::connectPeerQps(
+    int peerIndex,
+    const PeerQpPayload& remotePayload) {
+  if (remotePayload.numNics != numNics_) {
+    throw std::runtime_error(
+        fmt::format(
+            "IBRC peerIndex={} numNics={} vs local {}",
+            peerIndex,
+            remotePayload.numNics,
+            numNics_));
+  }
+  if (remotePayload.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
+    throw std::runtime_error(
+        fmt::format(
+            "IBRC peerIndex={} numQps={} vs local {}",
+            peerIndex,
+            remotePayload.numQpsPerPeerPerNic,
+            config_.numQpsPerPeerPerNic));
+  }
+
+  const int numQps = config_.numQpsPerPeerPerNic;
+  for (int nic = 0; nic < numNics_; ++nic) {
+    for (int q = 0; q < numQps; ++q) {
+      connectPeerQp(
+          qpResourceAt(peerIndex, nic, q),
+          remotePayload.nicInfo[nic].qpns[q],
+          remotePayload.nicInfo[nic].gid,
+          remotePayload.nicInfo[nic].lid,
+          remotePayload.mtu);
+    }
+  }
+  peerResources_[peerIndex].qpsConnected = true;
+}
+
+void MultipeerIbrcTransport::exchangeAndConnectQps() {
+  const int numPeers = nRanks_ - 1;
+  const int numQps = config_.numQpsPerPeerPerNic;
+
+  for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+    createPeerQps(peerIndex);
+  }
+
+  IbTransportExchInfoAll myInfo{};
+  myInfo.gidIndex = gidIndex_;
+  myInfo.mtu = localMtu_;
+  myInfo.numNics = numNics_;
+  myInfo.numQpsPerPeerPerNic = numQps;
+
+  auto& symbols = ibverbx::ibvSymbols;
+  for (int n = 0; n < numNics_; ++n) {
+    std::memcpy(
+        myInfo.nicInfo[n].gid,
+        nics_[n].localGid.raw,
+        sizeof(myInfo.nicInfo[n].gid));
+    ibverbx::ibv_port_attr portAttr{};
+    if (symbols.ibv_internal_query_port(
+            nics_[n].ibvCtx, kDefaultIbPort, &portAttr) == 0) {
+      myInfo.nicInfo[n].lid = portAttr.lid;
+    } else {
+      LOG(WARNING) << "Failed to query port for IBRC LID on NIC " << n;
+    }
+  }
+
+  const int totalQpsPerPeer = numNics_ * numQps;
+  for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+    const int peerRank = peerIndexToRank(peerIndex);
+    for (int nic = 0; nic < numNics_; ++nic) {
+      for (int q = 0; q < numQps; ++q) {
+        myInfo.nicInfo[nic].qpnForRank[peerRank][q] =
+            qpResourceAt(peerIndex, nic, q).qp->qp_num;
+      }
+    }
+  }
+
+  VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_
+          << " performing allGather QP exchange (" << totalQpsPerPeer
+          << " slots/peer = " << numNics_ << " NICs x " << numQps << " QPs)";
+
+  std::vector<IbTransportExchInfoAll> allInfo = allGatherExchInfo(myInfo);
+  validatePeerTopology(allInfo);
+
+  for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+    const auto& peerInfo = allInfo[peerIndexToRank(peerIndex)];
+    for (int nic = 0; nic < numNics_; ++nic) {
+      for (int q = 0; q < numQps; ++q) {
+        connectPeerQp(
+            qpResourceAt(peerIndex, nic, q),
+            peerInfo.nicInfo[nic].qpnForRank[myRank_][q],
+            peerInfo.nicInfo[nic].gid,
+            peerInfo.nicInfo[nic].lid,
+            static_cast<int>(peerInfo.mtu));
+      }
+    }
+    peerResources_[peerIndex].qpsConnected = true;
+  }
+}
+
+void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
+  const int peerIndex = rankToPeerIndex(peerRank);
+
+  createPeerQps(peerIndex);
+
+  auto localQp = buildLocalQpPayload(peerIndex);
+  auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
+  connectPeerQps(peerIndex, remoteQp);
+
+  throwIbrcUnimplemented("lazy command-ring/device transport path");
+}
+
+void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
+  cleanupPeerQps(peerIndex);
+  if (peerIndex >= 0 &&
+      peerIndex < static_cast<int>(peerMaterialized_.size())) {
+    peerMaterialized_[peerIndex] = false;
+  }
 }
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstring>
 #include <limits>
+#include <new>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -24,6 +25,7 @@
 #include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
 
 namespace comms::prims {
 
@@ -34,12 +36,6 @@ constexpr uint8_t kDefaultIbHopLimit = 255;
 
 std::string errnoString(int err) {
   return std::strerror(err);
-}
-
-[[noreturn]] void throwIbrcUnimplemented(const char* what) {
-  throw std::runtime_error(
-      std::string("MultipeerIbrcTransport: ") + what +
-      " is not implemented yet");
 }
 
 bool isPowerOfTwo(uint32_t value) {
@@ -195,6 +191,7 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
   }
 
   peerResources_.resize(nRanks_ - 1);
+  peerQueuesPublished_ = std::make_unique<std::atomic<bool>[]>(nRanks_ - 1);
 
   try {
     // Pin GPU work to config_.cudaDevice.
@@ -203,6 +200,7 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
         "MultipeerIbrcTransport: set CUDA device");
     openNics();
     initializeControlResources();
+    initializeDeviceTransportSlots();
     if (config_.ibLazyConnect) {
       peerMaterialized_.resize(nRanks_ - 1, false);
     }
@@ -222,14 +220,13 @@ void MultipeerIbrcTransport::exchange() {
     allocateCmdQueuesForAllPeers();
     VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_ << " allocated "
             << allocatedCmdQueueCount() << " command queues";
+    startProgressThread();
   } else {
     VLOG(1)
         << "MultipeerIbrcTransport: rank " << myRank_
         << " lazy exchange complete (per-peer QPs and command queues deferred "
            "to materializePeer)";
   }
-
-  throwIbrcUnimplemented("command-ring/device transport path");
 }
 
 void MultipeerIbrcTransport::cleanup() {
@@ -261,6 +258,7 @@ void MultipeerIbrcTransport::cleanup() {
   statusHostByNic_.clear();
   statusDeviceByNic_.clear();
   statusControl_.reset();
+  p2pTransportDevices_.reset();
 
   closeNics();
 }
@@ -312,6 +310,11 @@ bool MultipeerIbrcTransport::progressOnce() {
   bool progressed = false;
   for (int peerIndex = 0; peerIndex < static_cast<int>(peerResources_.size());
        ++peerIndex) {
+    // Acquire pairs with the release in allocatePeerCmdQueues: skip peers whose
+    // cmdQueues is not fully built (avoids racing a lazy move-assignment).
+    if (!peerQueuesPublished_[peerIndex].load(std::memory_order_acquire)) {
+      continue;
+    }
     auto& peer = peerResources_[peerIndex];
     for (auto& cmdQueue : peer.cmdQueues) {
       progressed |= pollCmdQueueCompletions(peerIndex, cmdQueue);
@@ -617,9 +620,15 @@ void MultipeerIbrcTransport::cleanupPeerCmdQueues(int peerIndex) noexcept {
   if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size())) {
     return;
   }
+  // Unpublish before clearing so progressOnce can't walk a half-cleared vector.
+  peerQueuesPublished_[peerIndex].store(false, std::memory_order_release);
   auto& peer = peerResources_[peerIndex];
   peer.cmdQueues.clear();
+  peer.cmdQueueDevices.reset();
   peer.cmdQueuesAllocated = false;
+  if (p2pTransportDevices_.host != nullptr) {
+    updatePeerDeviceTransport(peerIndex);
+  }
 }
 
 void MultipeerIbrcTransport::allocateCmdQueuesForAllPeers() {
@@ -652,6 +661,8 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
 
   std::vector<IbrcCmdQueueHost> cmdQueues;
   cmdQueues.reserve(cmdQueuesPerPeer);
+  std::vector<IbrcCmdQueueDevice> deviceCmdQueues;
+  deviceCmdQueues.reserve(cmdQueuesPerPeer);
 
   for (int q = 0; q < numQps; ++q) {
     for (int nic = 0; nic < numNics_; ++nic) {
@@ -682,12 +693,55 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
       for (uint32_t slot = 0; slot < cmdQueueDepth_; ++slot) {
         cmdQueue.descsHost[slot].ready_seq = kIbrcInvalidReadySeq;
       }
+      deviceCmdQueues.push_back(cmdQueue.device);
       cmdQueues.push_back(std::move(cmdQueue));
     }
   }
 
+  peer.cmdQueueDevices = allocateMapped(
+      deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice),
+      "per-peer command queue device descriptors");
+  std::memcpy(
+      peer.cmdQueueDevices.host,
+      deviceCmdQueues.data(),
+      deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice));
   peer.cmdQueues = std::move(cmdQueues);
   peer.cmdQueuesAllocated = true;
+  updatePeerDeviceTransport(peerIndex);
+  // Publish last (release): progressOnce may now iterate this peer's cmdQueues.
+  peerQueuesPublished_[peerIndex].store(true, std::memory_order_release);
+}
+
+void MultipeerIbrcTransport::initializeDeviceTransportSlots() {
+  const std::size_t numPeers = static_cast<std::size_t>(nRanks_ - 1);
+  p2pTransportDevices_ = allocateMapped(
+      numPeers * sizeof(P2pIbrcTransportDevice),
+      "P2pIbrcTransportDevice slots");
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
+  for (std::size_t peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
+    new (&slots[peerIndex]) P2pIbrcTransportDevice();
+  }
+}
+
+void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
+  if (p2pTransportDevices_.host == nullptr || peerIndex < 0 ||
+      peerIndex >= static_cast<int>(peerResources_.size())) {
+    return;
+  }
+
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
+  auto& peer = peerResources_[peerIndex];
+  if (!peer.cmdQueuesAllocated || peer.cmdQueueDevices.device == nullptr) {
+    new (&slots[peerIndex]) P2pIbrcTransportDevice();
+    return;
+  }
+
+  new (&slots[peerIndex]) P2pIbrcTransportDevice(
+      DeviceSpan<IbrcCmdQueueDevice>(
+          static_cast<IbrcCmdQueueDevice*>(peer.cmdQueueDevices.device),
+          static_cast<uint32_t>(peer.cmdQueues.size())),
+      static_cast<uint32_t>(numNics_),
+      static_cast<uint32_t>(config_.numQpsPerPeerPerNic));
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {
@@ -1165,6 +1219,37 @@ void MultipeerIbrcTransport::exchangeAndConnectQps() {
   }
 }
 
+P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
+    int peerRank) const {
+  if (config_.ibLazyConnect) {
+    LOG_FIRST_N(WARNING, 1)
+        << "MultipeerIbrcTransport: lazy mode is enabled but Transport[] "
+        << "array is being built with possibly unmaterialized IBRC slots. "
+        << "Call get_device_handle(peers) before kernels access lazy peers.";
+  }
+  if (p2pTransportDevices_.device == nullptr) {
+    throw std::runtime_error(
+        "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
+  }
+  const int peerIndex = rankToPeerIndex(peerRank);
+  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
+      peerIndex;
+}
+
+P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
+    int peerRank) const {
+  // IBRC builds every peer slot eagerly in initializeDeviceTransportSlots(), so
+  // the per-peer accessor is just slot pointer arithmetic (no materialization,
+  // hence no lazy warning unlike getP2pTransportDeviceSlot()).
+  if (p2pTransportDevices_.device == nullptr) {
+    throw std::runtime_error(
+        "getP2pTransportDevice: IBRC device transport slots are not initialized");
+  }
+  const int peerIndex = rankToPeerIndex(peerRank);
+  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
+      peerIndex;
+}
+
 void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
   const int peerIndex = rankToPeerIndex(peerRank);
 
@@ -1174,11 +1259,13 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
   auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
   connectPeerQps(peerIndex, remoteQp);
   allocatePeerCmdQueues(peerIndex);
-
-  throwIbrcUnimplemented("lazy command-ring/device transport path");
+  startProgressThread();
+  peerMaterialized_[peerIndex] = true;
 }
 
 void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
+  // Quiesce progress before teardown; next doMaterializePeer restarts it.
+  stopProgressThread();
   cleanupPeerCmdQueues(peerIndex);
   cleanupPeerQps(peerIndex);
   if (peerIndex >= 0 &&

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -3,11 +3,19 @@
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
 
 #include <fmt/core.h>
 #include <glog/logging.h>
@@ -31,7 +39,130 @@ std::string errnoString(int err) {
       " is not implemented yet");
 }
 
+bool isPowerOfTwo(uint32_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+#ifdef __HIP_PLATFORM_AMD__
+using GpuError = hipError_t;
+constexpr GpuError kGpuSuccess = hipSuccess;
+
+const char* gpuGetErrorString(GpuError err) {
+  return hipGetErrorString(err);
+}
+
+GpuError gpuHostAlloc(void** ptr, std::size_t bytes) {
+  return hipHostMalloc(ptr, bytes, hipHostMallocMapped);
+}
+
+GpuError gpuHostGetDevicePointer(void** devicePtr, void* hostPtr) {
+  return hipHostGetDevicePointer(devicePtr, hostPtr, 0);
+}
+
+GpuError gpuFreeHost(void* ptr) {
+  return hipHostFree(ptr);
+}
+
+GpuError gpuSetDevice(int device) {
+  return hipSetDevice(device);
+}
+#else
+using GpuError = cudaError_t;
+constexpr GpuError kGpuSuccess = cudaSuccess;
+
+const char* gpuGetErrorString(GpuError err) {
+  return cudaGetErrorString(err);
+}
+
+GpuError gpuHostAlloc(void** ptr, std::size_t bytes) {
+  return cudaHostAlloc(ptr, bytes, cudaHostAllocMapped);
+}
+
+GpuError gpuHostGetDevicePointer(void** devicePtr, void* hostPtr) {
+  return cudaHostGetDevicePointer(devicePtr, hostPtr, 0);
+}
+
+GpuError gpuFreeHost(void* ptr) {
+  return cudaFreeHost(ptr);
+}
+
+GpuError gpuSetDevice(int device) {
+  return cudaSetDevice(device);
+}
+#endif
+
+void checkGpu(GpuError err, const std::string& what) {
+  if (err != kGpuSuccess) {
+    throw std::runtime_error(
+        fmt::format("{}: {}", what, gpuGetErrorString(err)));
+  }
+}
+
+std::size_t checkedMul(std::size_t a, std::size_t b, const char* label) {
+  if (a != 0 && b > std::numeric_limits<std::size_t>::max() / a) {
+    throw std::overflow_error(
+        fmt::format("MultipeerIbrcTransport: {} size overflow", label));
+  }
+  return a * b;
+}
+
+std::size_t checkedAdd(std::size_t a, std::size_t b, const char* label) {
+  if (b > std::numeric_limits<std::size_t>::max() - a) {
+    throw std::overflow_error(
+        fmt::format("MultipeerIbrcTransport: {} size overflow", label));
+  }
+  return a + b;
+}
+
+std::size_t alignUp(std::size_t value, std::size_t alignment) {
+  if (alignment == 0) {
+    throw std::invalid_argument(
+        "MultipeerIbrcTransport: alignment must be non-zero");
+  }
+  const std::size_t remainder = value % alignment;
+  if (remainder == 0) {
+    return value;
+  }
+  return checkedAdd(value, alignment - remainder, "aligned control block");
+}
+
 } // namespace
+
+MultipeerIbrcTransport::MappedAllocation::~MappedAllocation() {
+  reset();
+}
+
+MultipeerIbrcTransport::MappedAllocation::MappedAllocation(
+    MappedAllocation&& other) noexcept
+    : host(std::exchange(other.host, nullptr)),
+      device(std::exchange(other.device, nullptr)),
+      bytes(std::exchange(other.bytes, 0)) {}
+
+MultipeerIbrcTransport::MappedAllocation&
+MultipeerIbrcTransport::MappedAllocation::operator=(
+    MappedAllocation&& other) noexcept {
+  if (this != &other) {
+    reset();
+    host = std::exchange(other.host, nullptr);
+    device = std::exchange(other.device, nullptr);
+    bytes = std::exchange(other.bytes, 0);
+  }
+  return *this;
+}
+
+void MultipeerIbrcTransport::MappedAllocation::reset() noexcept {
+  if (host == nullptr) {
+    return;
+  }
+  const GpuError err = gpuFreeHost(host);
+  if (err != kGpuSuccess) {
+    LOG(ERROR) << "MultipeerIbrcTransport: gpuFreeHost failed for " << bytes
+               << " bytes at " << host << ": " << gpuGetErrorString(err);
+  }
+  host = nullptr;
+  device = nullptr;
+  bytes = 0;
+}
 
 MultipeerIbrcTransport::MultipeerIbrcTransport(
     int myRank,
@@ -55,7 +186,12 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
   peerResources_.resize(nRanks_ - 1);
 
   try {
+    // Pin GPU work to config_.cudaDevice.
+    checkGpu(
+        gpuSetDevice(config_.cudaDevice),
+        "MultipeerIbrcTransport: set CUDA device");
     openNics();
+    initializeControlResources();
     if (config_.ibLazyConnect) {
       peerMaterialized_.resize(nRanks_ - 1, false);
     }
@@ -72,19 +208,24 @@ MultipeerIbrcTransport::~MultipeerIbrcTransport() {
 void MultipeerIbrcTransport::exchange() {
   if (!config_.ibLazyConnect) {
     exchangeAndConnectQps();
+    allocateCmdQueuesForAllPeers();
+    VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_ << " allocated "
+            << allocatedCmdQueueCount() << " command queues";
   } else {
     VLOG(1)
         << "MultipeerIbrcTransport: rank " << myRank_
-        << " lazy exchange complete (per-peer QPs deferred to materializePeer)";
+        << " lazy exchange complete (per-peer QPs and command queues deferred "
+           "to materializePeer)";
   }
 
   throwIbrcUnimplemented("command-ring/device transport path");
 }
 
 void MultipeerIbrcTransport::cleanup() {
-  for (auto& peer : peerResources_) {
-    destroyPeerQps(peer.qpResources);
-    peer.qpsConnected = false;
+  for (int peerIndex = 0; peerIndex < static_cast<int>(peerResources_.size());
+       ++peerIndex) {
+    cleanupPeerCmdQueues(peerIndex);
+    cleanupPeerQps(peerIndex);
   }
 
   auto& symbols = ibverbx::ibvSymbols;
@@ -104,7 +245,185 @@ void MultipeerIbrcTransport::cleanup() {
   }
   registeredBuffers_.clear();
 
+  statusHostByNic_.clear();
+  statusDeviceByNic_.clear();
+  statusControl_.reset();
+
   closeNics();
+}
+
+void MultipeerIbrcTransport::initializeControlResources() {
+  if (!isPowerOfTwo(cmdQueueDepth_)) {
+    throw std::invalid_argument(
+        "MultipeerIbrcTransport: command queue depth must be a power of two");
+  }
+  if (numNics_ <= 0) {
+    throw std::invalid_argument(
+        "MultipeerIbrcTransport: numNics must be positive");
+  }
+  // The progress loop self-limits inflight work to one command-queue ring
+  // (cmdQueueDepth_ descriptors), and each descriptor posts at most
+  // kIbrcMaxWrsPerDescriptor WRs (RDMA_WRITE + ATOMIC) to its own QP. Requiring
+  // the SQ/CQ (sized to qpDepth) to cover a full ring makes overrun
+  // structurally impossible without per-post accounting.
+  const std::size_t wrsPerRing =
+      checkedMul(cmdQueueDepth_, kIbrcMaxWrsPerDescriptor, "qp depth");
+  if (config_.qpDepth < wrsPerRing) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultipeerIbrcTransport: qpDepth ({}) must be >= cmdQueueDepth ({}) "
+            "* {}",
+            config_.qpDepth,
+            cmdQueueDepth_,
+            kIbrcMaxWrsPerDescriptor));
+  }
+
+  const std::size_t statusBytes = checkedMul(
+      static_cast<std::size_t>(numNics_), sizeof(IbrcNicStatus), "NIC status");
+  statusControl_ = allocateMapped(statusBytes, "NIC status block");
+  auto* const statusHostBase = static_cast<IbrcNicStatus*>(statusControl_.host);
+  auto* const statusDeviceBase =
+      static_cast<IbrcNicStatus*>(statusControl_.device);
+  statusHostByNic_.resize(numNics_);
+  statusDeviceByNic_.resize(numNics_);
+  for (int nic = 0; nic < numNics_; ++nic) {
+    statusHostByNic_.at(nic) = statusHostBase + nic;
+    statusDeviceByNic_.at(nic) = statusDeviceBase + nic;
+  }
+
+  const std::size_t descBytes = checkedMul(
+      static_cast<std::size_t>(cmdQueueDepth_),
+      sizeof(IbrcDesc),
+      "command queue descriptor");
+  // Place pi and ci on separate cache lines (kIbrcCacheLineBytes) to avoid
+  // false-sharing across the host-mapped GPU<->CPU boundary: the GPU fetch_adds
+  // pi while the CPU writes ci on every reservation/completion.
+  cmdQueuePiOffset_ = alignUp(descBytes, kIbrcCacheLineBytes);
+  cmdQueueCiOffset_ =
+      checkedAdd(cmdQueuePiOffset_, kIbrcCacheLineBytes, "command queue pi");
+  cmdQueueControlBytes_ =
+      checkedAdd(cmdQueueCiOffset_, kIbrcCacheLineBytes, "command queue ci");
+}
+
+void MultipeerIbrcTransport::cleanupPeerCmdQueues(int peerIndex) noexcept {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size())) {
+    return;
+  }
+  auto& peer = peerResources_[peerIndex];
+  peer.cmdQueues.clear();
+  peer.cmdQueuesAllocated = false;
+}
+
+void MultipeerIbrcTransport::allocateCmdQueuesForAllPeers() {
+  for (int peerIndex = 0; peerIndex < static_cast<int>(peerResources_.size());
+       ++peerIndex) {
+    allocatePeerCmdQueues(peerIndex);
+  }
+}
+
+void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
+  if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size())) {
+    throw std::invalid_argument(
+        fmt::format("allocatePeerCmdQueues: invalid peerIndex={}", peerIndex));
+  }
+
+  auto& peer = peerResources_[peerIndex];
+  if (peer.cmdQueuesAllocated) {
+    return;
+  }
+
+  const int numQps = config_.numQpsPerPeerPerNic;
+  const std::size_t cmdQueuesPerPeer = checkedMul(
+      static_cast<std::size_t>(numNics_),
+      static_cast<std::size_t>(numQps),
+      "command queues per peer");
+  if (cmdQueuesPerPeer == 0) {
+    throw std::overflow_error(
+        "MultipeerIbrcTransport: command queues per peer must be non-zero");
+  }
+
+  std::vector<IbrcCmdQueueHost> cmdQueues;
+  cmdQueues.reserve(cmdQueuesPerPeer);
+
+  for (int q = 0; q < numQps; ++q) {
+    for (int nic = 0; nic < numNics_; ++nic) {
+      IbrcCmdQueueHost cmdQueue;
+      cmdQueue.control =
+          allocateMapped(cmdQueueControlBytes_, "command queue control block");
+      cmdQueue.cmdStates.resize(cmdQueueDepth_);
+
+      auto* const hostBase = static_cast<std::byte*>(cmdQueue.control.host);
+      auto* const deviceBase = static_cast<std::byte*>(cmdQueue.control.device);
+      cmdQueue.descsHost = reinterpret_cast<IbrcDesc*>(hostBase);
+      cmdQueue.piHost =
+          reinterpret_cast<uint64_t*>(hostBase + cmdQueuePiOffset_);
+      cmdQueue.ciHost =
+          reinterpret_cast<uint64_t*>(hostBase + cmdQueueCiOffset_);
+      cmdQueue.device.descs = reinterpret_cast<IbrcDesc*>(deviceBase);
+      cmdQueue.device.pi =
+          reinterpret_cast<uint64_t*>(deviceBase + cmdQueuePiOffset_);
+      cmdQueue.device.ci =
+          reinterpret_cast<uint64_t*>(deviceBase + cmdQueueCiOffset_);
+      cmdQueue.device.status = statusDeviceByNic_.at(nic);
+      cmdQueue.device.depth = cmdQueueDepth_;
+      cmdQueue.device.mask = cmdQueueDepth_ - 1;
+
+      cmdQueue.nic = static_cast<uint32_t>(nic);
+      cmdQueue.qpSlot = static_cast<uint32_t>(q);
+
+      for (uint32_t slot = 0; slot < cmdQueueDepth_; ++slot) {
+        cmdQueue.descsHost[slot].ready_seq = kIbrcInvalidReadySeq;
+      }
+      cmdQueues.push_back(std::move(cmdQueue));
+    }
+  }
+
+  peer.cmdQueues = std::move(cmdQueues);
+  peer.cmdQueuesAllocated = true;
+}
+
+std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {
+  std::size_t count = 0;
+  for (const auto& peer : peerResources_) {
+    count = checkedAdd(count, peer.cmdQueues.size(), "allocated command queue");
+  }
+  return count;
+}
+
+MultipeerIbrcTransport::MappedAllocation MultipeerIbrcTransport::allocateMapped(
+    std::size_t bytes,
+    const char* label) {
+  if (bytes == 0) {
+    throw std::invalid_argument(
+        fmt::format("MultipeerIbrcTransport: {} size must be non-zero", label));
+  }
+
+  MappedAllocation allocation;
+  allocation.bytes = bytes;
+  checkGpu(
+      gpuHostAlloc(&allocation.host, bytes),
+      fmt::format(
+          "MultipeerIbrcTransport: mapped host allocation for {}", label));
+  if (allocation.host == nullptr) {
+    throw std::runtime_error(
+        fmt::format(
+            "MultipeerIbrcTransport: mapped host allocation returned null for {}",
+            label));
+  }
+  std::memset(allocation.host, 0, bytes);
+  checkGpu(
+      gpuHostGetDevicePointer(&allocation.device, allocation.host),
+      fmt::format(
+          "MultipeerIbrcTransport: mapped device pointer lookup for {}",
+          label));
+  if (allocation.device == nullptr) {
+    throw std::runtime_error(
+        fmt::format(
+            "MultipeerIbrcTransport: mapped device pointer returned null for {}",
+            label));
+  }
+
+  return allocation;
 }
 
 void MultipeerIbrcTransport::destroyPeerQps(
@@ -509,11 +828,13 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
   auto localQp = buildLocalQpPayload(peerIndex);
   auto remoteQp = exchangeWithPeer(peerRank, localQp, kIbPeerQpExchangeTag);
   connectPeerQps(peerIndex, remoteQp);
+  allocatePeerCmdQueues(peerIndex);
 
   throwIbrcUnimplemented("lazy command-ring/device transport path");
 }
 
 void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
+  cleanupPeerCmdQueues(peerIndex);
   cleanupPeerQps(peerIndex);
   if (peerIndex >= 0 &&
       peerIndex < static_cast<int>(peerMaterialized_.size())) {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -133,6 +133,9 @@ uint32_t keyForIbvPostSend(uint32_t deviceOrderKey) {
 #endif
 }
 
+constexpr uint16_t kSupportedIbrcFlags =
+    IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD | IBRC_HAS_COUNTER;
+
 } // namespace
 
 MultipeerIbrcTransport::MappedAllocation::~MappedAllocation() {
@@ -342,7 +345,7 @@ bool MultipeerIbrcTransport::pollOneCmdQueueDescriptor(
   auto& state = cmdQueue.cmdStates.at(slot);
   state.seq = seq;
   state.flags = desc.flags;
-  state.counterId = desc.counter_id;
+  state.counterAddr = desc.counter_addr;
   state.counterValue = desc.counter_value;
   state.peerCompleted = false;
 
@@ -405,6 +408,13 @@ bool MultipeerIbrcTransport::drainCompletedCommands(
       return progressed;
     }
 
+    if ((state.flags & IBRC_HAS_COUNTER) != 0) {
+      __atomic_fetch_add(
+          reinterpret_cast<uint64_t*>(state.counterAddr),
+          state.counterValue,
+          __ATOMIC_RELEASE);
+    }
+
     state = IbrcCmdState{};
     ++cmdQueue.nextToComplete;
     __atomic_store_n(
@@ -422,19 +432,20 @@ void MultipeerIbrcTransport::postDescriptor(
   const bool hasSignal = (desc.flags & IBRC_HAS_SIGNAL) != 0;
   const bool hasCounter = (desc.flags & IBRC_HAS_COUNTER) != 0;
   const bool hasData = op == IbrcOp::PUT && desc.bytes > 0;
+  const uint16_t unsupportedFlags = desc.flags & ~kSupportedIbrcFlags;
 
   if (op != IbrcOp::PUT && op != IbrcOp::SIGNAL) {
     publishQueueError(peerIndex, cmdQueue, EINVAL, "unsupported descriptor op");
     return;
   }
+  if (unsupportedFlags != 0) {
+    publishQueueError(
+        peerIndex, cmdQueue, ENOTSUP, "unsupported descriptor flags");
+    return;
+  }
   if (op == IbrcOp::SIGNAL && desc.bytes != 0) {
     publishQueueError(
         peerIndex, cmdQueue, EINVAL, "SIGNAL descriptor cannot carry data");
-    return;
-  }
-  if (hasCounter) {
-    publishQueueError(
-        peerIndex, cmdQueue, ENOTSUP, "counter completion is not implemented");
     return;
   }
   if (hasSignal && (desc.flags & IBRC_SIGNAL_ADD) == 0) {
@@ -455,11 +466,31 @@ void MultipeerIbrcTransport::postDescriptor(
       peerIndex,
       static_cast<int>(cmdQueue.nic),
       static_cast<int>(cmdQueue.qpSlot));
-  if (!hasData && !hasSignal) {
+  auto& state = cmdQueue.cmdStates.at(seq & cmdQueue.device.mask);
+  if (hasCounter) {
+    if (desc.counter_addr == 0) {
+      publishQueueError(peerIndex, cmdQueue, EINVAL, "counter address is null");
+      return;
+    }
+    const auto counterAddr = static_cast<uintptr_t>(desc.counter_addr);
+    if (counterAddr % alignof(uint64_t) != 0) {
+      publishQueueError(
+          peerIndex, cmdQueue, EINVAL, "counter address is unaligned");
+      return;
+    }
+  }
+  if (!hasData && !hasSignal && !hasCounter) {
     publishQueueError(peerIndex, cmdQueue, EINVAL, "empty descriptor");
     return;
   }
-  if (hasSignal && qpResource.signalAtomicSinkMr == nullptr) {
+  if (!hasData && !hasSignal) {
+    state.peerCompleted = true;
+    drainCompletedCommands(peerIndex, cmdQueue);
+    return;
+  }
+  if (hasSignal &&
+      (qpResource.signalAtomicSinkMr == nullptr ||
+       qpResource.signalAtomicSink == nullptr)) {
     publishQueueError(peerIndex, cmdQueue, EINVAL, "missing signal sink MR");
     return;
   }

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
@@ -10,19 +12,23 @@
 namespace comms::prims {
 
 /**
- * MultipeerIbrcTransport - CPU-proxy IBRC backend (skeleton).
+ * MultipeerIbrcTransport - CPU-proxy IBRC backend.
  *
  * The IBRC backend posts RDMA work from a CPU progress thread that drains
  * GPU-written command-queue rings, updating host-mapped completion counters.
  * It derives from the shared CRTP base MultiPeerIbTransport<Backend> so the
  * host control plane can be wired in as the backend-specific pieces land.
  *
- * This is currently a SKELETON: the IBRC-specific machinery (per-lane RC QPs +
- * atomic sink, GPU<->CPU command-queue rings, the CPU progress thread,
- * host-mapped completion counters, and the device transport) is not yet ported.
- * The backend is selectable (NCCL_CTRAN_PIPES_IB_MODE=ibrc) and constructs on
- * the shared base, but exchange(), buffer registration/exchange, lazy
- * materialization, and device-handle use are not yet functional.
+ * This is still incomplete: per-lane RC QP exchange/connect is implemented, but
+ * GPU<->CPU command-queue rings, the CPU progress thread, host-mapped
+ * completion counters, and the device transport are not yet ported. The common
+ * (inherited) API works; the backend is selectable
+ * (NCCL_CTRAN_PIPES_IB_MODE=ibrc), but exchange() still throws after QPs are
+ * connected until the remaining data path lands.
+ *
+ * IBRC supports both eager exchange() and lazy per-peer materialization from
+ * day one: the base's lazy connect loop drives the doMaterializePeer() hook
+ * below, so there is no design-level eager-only restriction.
  */
 class MultipeerIbrcTransport
     : public MultiPeerIbTransport<MultipeerIbrcTransport> {
@@ -33,7 +39,7 @@ class MultipeerIbrcTransport
       std::shared_ptr<meta::comms::IBootstrap> bootstrap,
       const MultipeerIbTransportConfig& config);
 
-  ~MultipeerIbrcTransport() = default;
+  ~MultipeerIbrcTransport();
 
   // Non-copyable, non-movable
   MultipeerIbrcTransport(const MultipeerIbrcTransport&) = delete;
@@ -42,8 +48,8 @@ class MultipeerIbrcTransport
   MultipeerIbrcTransport& operator=(MultipeerIbrcTransport&&) = delete;
 
   /**
-   * exchange - COLLECTIVE. Allocate command queues, connect QPs, build device
-   * transports, and start the CPU progress thread. NOT YET IMPLEMENTED.
+   * exchange - COLLECTIVE. Connect QPs eagerly, then build command queues,
+   * device transports, and the CPU progress thread once those slices land.
    */
   void exchange();
 
@@ -53,14 +59,47 @@ class MultipeerIbrcTransport
   // IBRC backend initializes the required resources.
 
  private:
-  // Lazy per-peer materialization hook. Not yet implemented
-  // (doMaterializePeer throws).
+  // Lazy per-peer materialization hook. The shared base owns queueing,
+  // ordering, and failure rollback; IBRC fills in per-peer QPs here and will
+  // add ring/device setup in the next implementation slice.
   void doMaterializePeer(int peerRank);
   void cleanupPeerOnFailure(int peerIndex);
+
+  struct PeerQpResource {
+    ibverbx::ibv_cq* cq{nullptr};
+    ibverbx::ibv_qp* qp{nullptr};
+    int nic{0};
+    int qpSlot{0};
+  };
+
+  struct PeerResources {
+    std::vector<PeerQpResource> qpResources;
+    bool qpsConnected{false};
+  };
+
+  void cleanup();
+  void cleanupPeerQps(int peerIndex) noexcept;
+  void destroyPeerQps(std::vector<PeerQpResource>& qpResources) noexcept;
+  void closeNics() noexcept;
+
+  void createPeerQps(int peerIndex);
+  PeerQpPayload buildLocalQpPayload(int peerIndex) const;
+  void connectPeerQps(int peerIndex, const PeerQpPayload& remotePayload);
+  void connectPeerQp(
+      PeerQpResource& qpResource,
+      uint32_t remoteQpn,
+      const uint8_t* remoteGid,
+      uint16_t remoteLid,
+      int remoteMtu);
+  void exchangeAndConnectQps();
+  PeerQpResource& qpResourceAt(int peerIndex, int nic, int qpSlot);
+  const PeerQpResource& qpResourceAt(int peerIndex, int nic, int qpSlot) const;
 
   // MultiPeerIbTransport drives the shared control plane and calls the private
   // hooks above.
   friend class MultiPeerIbTransport<MultipeerIbrcTransport>;
+
+  std::vector<PeerResources> peerResources_;
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -25,9 +25,11 @@ class P2pIbrcTransportDevice;
  * It derives from the shared CRTP base MultiPeerIbTransport<Backend> so the
  * host control plane can be wired in as the backend-specific pieces land.
  *
- * This is still incomplete: per-peer RC QP exchange/connect, GPU-visible
- * command-queue resources, the host progress loop, and the device enqueue
- * transport are implemented, but HostWindow counters are not yet ported.
+ * Per-peer RC QP exchange/connect, GPU-visible command-queue resources, the
+ * host progress loop, device enqueue transport, and proxy-completion local
+ * counters are implemented. The counter path follows NCCL GIN proxy style by
+ * polling the normal CQ and then updating host-mapped counter memory directly,
+ * instead of adding IBGDA-style companion counter QPs.
  *
  * IBRC supports both eager exchange() and lazy per-peer materialization from
  * day one: the base's lazy connect loop drives the doMaterializePeer() hook
@@ -103,8 +105,8 @@ class MultipeerIbrcTransport
 
   struct IbrcCmdState {
     uint64_t seq{kIbrcInvalidReadySeq};
+    uint64_t counterAddr{0};
     uint64_t counterValue{0};
-    uint32_t counterId{0};
     uint16_t flags{0};
     // Set when the peer-facing WR for this descriptor has completed (CQE
     // reaped), or for descriptors that post no WR. Retirement (nextToComplete/

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -2,12 +2,14 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
+#include "comms/prims/transport/ibrc/IbrcTypes.h"
 
 namespace comms::prims {
 
@@ -19,12 +21,12 @@ namespace comms::prims {
  * It derives from the shared CRTP base MultiPeerIbTransport<Backend> so the
  * host control plane can be wired in as the backend-specific pieces land.
  *
- * This is still incomplete: per-lane RC QP exchange/connect is implemented, but
- * GPU<->CPU command-queue rings, the CPU progress thread, host-mapped
- * completion counters, and the device transport are not yet ported. The common
- * (inherited) API works; the backend is selectable
- * (NCCL_CTRAN_PIPES_IB_MODE=ibrc), but exchange() still throws after QPs are
- * connected until the remaining data path lands.
+ * This is still incomplete: per-peer RC QP exchange/connect and GPU-visible
+ * command-queue resources are implemented, but the CPU progress thread,
+ * device transport, and HostWindow counter plumbing are not yet ported. The
+ * common (inherited) API works; the backend is selectable
+ * (NCCL_CTRAN_PIPES_IB_MODE=ibrc), but exchange() still throws after QPs and
+ * command queues are ready until the remaining data path lands.
  *
  * IBRC supports both eager exchange() and lazy per-peer materialization from
  * day one: the base's lazy connect loop drives the doMaterializePeer() hook
@@ -60,8 +62,8 @@ class MultipeerIbrcTransport
 
  private:
   // Lazy per-peer materialization hook. The shared base owns queueing,
-  // ordering, and failure rollback; IBRC fills in per-peer QPs here and will
-  // add ring/device setup in the next implementation slice.
+  // ordering, and failure rollback; IBRC fills in per-peer QPs and command
+  // queues here, then later slices will attach the device transport.
   void doMaterializePeer(int peerRank);
   void cleanupPeerOnFailure(int peerIndex);
 
@@ -72,15 +74,61 @@ class MultipeerIbrcTransport
     int qpSlot{0};
   };
 
+  struct MappedAllocation {
+    void* host{nullptr};
+    void* device{nullptr};
+    std::size_t bytes{0};
+
+    MappedAllocation() = default;
+    ~MappedAllocation();
+
+    MappedAllocation(const MappedAllocation&) = delete;
+    MappedAllocation& operator=(const MappedAllocation&) = delete;
+
+    MappedAllocation(MappedAllocation&& other) noexcept;
+    MappedAllocation& operator=(MappedAllocation&& other) noexcept;
+
+    void reset() noexcept;
+  };
+
+  struct IbrcCmdState {
+    uint64_t seq{kIbrcInvalidReadySeq};
+    uint64_t counterValue{0};
+    uint32_t counterId{0};
+    uint16_t flags{0};
+  };
+
+  struct IbrcCmdQueueHost {
+    MappedAllocation control;
+    std::vector<IbrcCmdState> cmdStates;
+    IbrcDesc* descsHost{nullptr};
+    uint64_t* piHost{nullptr};
+    uint64_t* ciHost{nullptr};
+    IbrcCmdQueueDevice device{};
+    uint32_t nic{0};
+    uint32_t qpSlot{0};
+    uint64_t nextToPoll{0};
+    uint64_t nextToComplete{0};
+  };
+
   struct PeerResources {
     std::vector<PeerQpResource> qpResources;
+    std::vector<IbrcCmdQueueHost> cmdQueues;
     bool qpsConnected{false};
+    bool cmdQueuesAllocated{false};
   };
 
   void cleanup();
+  void initializeControlResources();
+  void cleanupPeerCmdQueues(int peerIndex) noexcept;
   void cleanupPeerQps(int peerIndex) noexcept;
   void destroyPeerQps(std::vector<PeerQpResource>& qpResources) noexcept;
   void closeNics() noexcept;
+
+  void allocateCmdQueuesForAllPeers();
+  void allocatePeerCmdQueues(int peerIndex);
+  std::size_t allocatedCmdQueueCount() const;
+  MappedAllocation allocateMapped(std::size_t bytes, const char* label);
 
   void createPeerQps(int peerIndex);
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
@@ -100,6 +148,13 @@ class MultipeerIbrcTransport
   friend class MultiPeerIbTransport<MultipeerIbrcTransport>;
 
   std::vector<PeerResources> peerResources_;
+  MappedAllocation statusControl_;
+  std::vector<IbrcNicStatus*> statusHostByNic_;
+  std::vector<IbrcNicStatus*> statusDeviceByNic_;
+  uint32_t cmdQueueDepth_{kIbrcDefaultCmdQueueDepth};
+  std::size_t cmdQueuePiOffset_{0};
+  std::size_t cmdQueueCiOffset_{0};
+  std::size_t cmdQueueControlBytes_{0};
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -15,6 +15,8 @@
 
 namespace comms::prims {
 
+class P2pIbrcTransportDevice;
+
 /**
  * MultipeerIbrcTransport - CPU-proxy IBRC backend.
  *
@@ -24,11 +26,8 @@ namespace comms::prims {
  * host control plane can be wired in as the backend-specific pieces land.
  *
  * This is still incomplete: per-peer RC QP exchange/connect, GPU-visible
- * command-queue resources, and the host progress loop are implemented, but the
- * device transport and HostWindow counter plumbing are not yet ported. The
- * common (inherited) API works; the backend is selectable
- * (NCCL_CTRAN_PIPES_IB_MODE=ibrc), but exchange() still throws after QPs and
- * command queues are ready until the remaining data path lands.
+ * command-queue resources, the host progress loop, and the device enqueue
+ * transport are implemented, but HostWindow counters are not yet ported.
  *
  * IBRC supports both eager exchange() and lazy per-peer materialization from
  * day one: the base's lazy connect loop drives the doMaterializePeer() hook
@@ -61,6 +60,13 @@ class MultipeerIbrcTransport
   // MultiPeerIbTransport(Base). Buffer registration/exchange and lazy
   // materialization are intentionally blocked by MultiPeerTransport until the
   // IBRC backend initializes the required resources.
+
+  P2pIbrcTransportDevice* getP2pTransportDeviceSlot(int peerRank) const;
+
+  // Per-peer device handle accessor used by Ring/SendRecv algorithms (the
+  // counterpart of IBGDA's getP2pTransportDevice). IBRC builds all slots
+  // eagerly, so this returns the slot pointer directly.
+  P2pIbrcTransportDevice* getP2pTransportDevice(int peerRank) const;
 
  private:
   // Lazy per-peer materialization hook. The shared base owns queueing,
@@ -122,6 +128,7 @@ class MultipeerIbrcTransport
   struct PeerResources {
     std::vector<PeerQpResource> qpResources;
     std::vector<IbrcCmdQueueHost> cmdQueues;
+    MappedAllocation cmdQueueDevices;
     bool qpsConnected{false};
     bool cmdQueuesAllocated{false};
   };
@@ -156,6 +163,8 @@ class MultipeerIbrcTransport
 
   void allocateCmdQueuesForAllPeers();
   void allocatePeerCmdQueues(int peerIndex);
+  void initializeDeviceTransportSlots();
+  void updatePeerDeviceTransport(int peerIndex) noexcept;
   std::size_t allocatedCmdQueueCount() const;
   MappedAllocation allocateMapped(std::size_t bytes, const char* label);
 
@@ -177,7 +186,12 @@ class MultipeerIbrcTransport
   friend class MultiPeerIbTransport<MultipeerIbrcTransport>;
 
   std::vector<PeerResources> peerResources_;
+  // Per-peer publish flag (release in allocatePeerCmdQueues, acquire in
+  // progressOnce) so the progress thread never reads a half-moved cmdQueues.
+  // Separate array: std::atomic can't live in the movable PeerResources vector.
+  std::unique_ptr<std::atomic<bool>[]> peerQueuesPublished_;
   MappedAllocation statusControl_;
+  MappedAllocation p2pTransportDevices_;
   std::vector<IbrcNicStatus*> statusHostByNic_;
   std::vector<IbrcNicStatus*> statusDeviceByNic_;
   uint32_t cmdQueueDepth_{kIbrcDefaultCmdQueueDepth};

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -2,9 +2,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
@@ -21,9 +23,9 @@ namespace comms::prims {
  * It derives from the shared CRTP base MultiPeerIbTransport<Backend> so the
  * host control plane can be wired in as the backend-specific pieces land.
  *
- * This is still incomplete: per-peer RC QP exchange/connect and GPU-visible
- * command-queue resources are implemented, but the CPU progress thread,
- * device transport, and HostWindow counter plumbing are not yet ported. The
+ * This is still incomplete: per-peer RC QP exchange/connect, GPU-visible
+ * command-queue resources, and the host progress loop are implemented, but the
+ * device transport and HostWindow counter plumbing are not yet ported. The
  * common (inherited) API works; the backend is selectable
  * (NCCL_CTRAN_PIPES_IB_MODE=ibrc), but exchange() still throws after QPs and
  * command queues are ready until the remaining data path lands.
@@ -70,6 +72,8 @@ class MultipeerIbrcTransport
   struct PeerQpResource {
     ibverbx::ibv_cq* cq{nullptr};
     ibverbx::ibv_qp* qp{nullptr};
+    ibverbx::ibv_mr* signalAtomicSinkMr{nullptr};
+    std::unique_ptr<uint64_t> signalAtomicSink;
     int nic{0};
     int qpSlot{0};
   };
@@ -96,6 +100,10 @@ class MultipeerIbrcTransport
     uint64_t counterValue{0};
     uint32_t counterId{0};
     uint16_t flags{0};
+    // Set when the peer-facing WR for this descriptor has completed (CQE
+    // reaped), or for descriptors that post no WR. Retirement (nextToComplete/
+    // ci advance) happens strictly in seq order in drainCompletedCommands().
+    bool peerCompleted{false};
   };
 
   struct IbrcCmdQueueHost {
@@ -124,6 +132,27 @@ class MultipeerIbrcTransport
   void cleanupPeerQps(int peerIndex) noexcept;
   void destroyPeerQps(std::vector<PeerQpResource>& qpResources) noexcept;
   void closeNics() noexcept;
+
+  void startProgressThread();
+  void stopProgressThread() noexcept;
+  void progressLoop() noexcept;
+  bool progressOnce();
+  bool pollOneCmdQueueDescriptor(int peerIndex, IbrcCmdQueueHost& cmdQueue);
+  bool pollCmdQueueCompletions(int peerIndex, IbrcCmdQueueHost& cmdQueue);
+  bool drainCompletedCommands(int peerIndex, IbrcCmdQueueHost& cmdQueue);
+  void postDescriptor(
+      int peerIndex,
+      IbrcCmdQueueHost& cmdQueue,
+      const IbrcDesc& desc,
+      uint64_t seq);
+  void publishQueueError(
+      int peerIndex,
+      const IbrcCmdQueueHost& cmdQueue,
+      uint32_t errorCode,
+      const char* reason) noexcept;
+  // Publish a transport-level error to every NIC status block, independent of
+  // any specific command queue, so all device wait paths observe the failure.
+  void publishTransportError(uint32_t errorCode, const char* reason) noexcept;
 
   void allocateCmdQueuesForAllPeers();
   void allocatePeerCmdQueues(int peerIndex);
@@ -155,6 +184,8 @@ class MultipeerIbrcTransport
   std::size_t cmdQueuePiOffset_{0};
   std::size_t cmdQueueCiOffset_{0};
   std::size_t cmdQueueControlBytes_{0};
+  std::atomic<bool> stopProgress_{false};
+  std::thread progressThread_;
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -1,0 +1,484 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#ifdef __HIP_PLATFORM_AMD__
+#include "HipDeviceCompat.h"
+#else
+#include <cuda/atomic>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+#include "comms/prims/core/DeviceMacros.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibrc/IbrcTypes.h"
+
+namespace comms::prims {
+
+// Default bound for device-side waits on the CPU progress thread (flush /
+// reserve). Mirrors IBGDA's kDefaultDeviceTimeoutCycles: converts an indefinite
+// hang (a stalled progress thread that never publishes an error) into a bounded
+// trap.
+inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
+
+/**
+ * Device-side IBRC peer handle.
+ *
+ * IBRC uses a GPU-visible command queue per peer/QP/NIC. Device code reserves a
+ * queue slot, writes an IbrcDesc, then publishes ready_seq with release
+ * ordering. The CPU progress thread consumes descriptors and posts the verbs
+ * work requests on the matching QP.
+ */
+class P2pIbrcTransportDevice {
+ public:
+  DeviceSpan<IbrcCmdQueueDevice> cmdQueues{};
+  uint32_t numNics{0};
+  uint32_t numQpsPerPeerPerNic{0};
+
+  P2pIbrcTransportDevice() = default;
+
+  __host__ __device__ P2pIbrcTransportDevice(
+      DeviceSpan<IbrcCmdQueueDevice> queues,
+      uint32_t nics,
+      uint32_t qpsPerPeerPerNic)
+      : cmdQueues(queues),
+        numNics(nics),
+        numQpsPerPeerPerNic(qpsPerPeerPerNic) {}
+
+  __device__ void signal(
+      ThreadGroup& group,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1) {
+    if (group.is_leader()) {
+      if (signalBuf.ptr == nullptr) {
+        trap("P2pIbrcTransportDevice: signal buffer is null");
+      }
+      const uint32_t queueId = queue_for_group(group.group_id);
+      const uint32_t nicId = nic_for_queue(queueId);
+      IbrcDesc desc{};
+      desc.signal_addr = reinterpret_cast<uint64_t>(signalBuf.ptr);
+      desc.signal_value = signalVal;
+      desc.signal_rkey_device_order = signalBuf.rkey_per_device[nicId].value;
+      desc.op = static_cast<uint16_t>(IbrcOp::SIGNAL);
+      desc.flags = IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD;
+      desc.ready_seq = kIbrcInvalidReadySeq;
+      enqueue(queueId, desc);
+    }
+    group.sync();
+  }
+
+  __device__ void signal(
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    signal(solo, signalBuf, signalVal);
+  }
+
+  __device__ void put(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    (void)counterVal;
+    if (counterBuf.ptr != nullptr) {
+      trap("P2pIbrcTransportDevice: counters are not implemented");
+    }
+
+    const bool hasData = nbytes > 0;
+    const bool hasSignal = signalBuf.ptr != nullptr;
+    if (hasData) {
+      if (localBuf.ptr == nullptr || remoteBuf.ptr == nullptr) {
+        trap("P2pIbrcTransportDevice: put data buffer is null");
+      }
+      threadfence_system();
+    }
+    group.sync();
+
+    if (group.is_leader()) {
+      const uint32_t queueId = queue_for_group(group.group_id);
+      const uint32_t nicId = nic_for_queue(queueId);
+      IbrcDesc desc{};
+      desc.op = static_cast<uint16_t>(hasData ? IbrcOp::PUT : IbrcOp::SIGNAL);
+      desc.ready_seq = kIbrcInvalidReadySeq;
+
+      if (hasData) {
+        desc.local_addr = reinterpret_cast<uint64_t>(localBuf.ptr);
+        desc.remote_addr = reinterpret_cast<uint64_t>(remoteBuf.ptr);
+        desc.bytes = nbytes;
+        desc.lkey_device_order = localBuf.lkey_per_device[nicId].value;
+        desc.rkey_device_order = remoteBuf.rkey_per_device[nicId].value;
+      }
+
+      if (hasSignal) {
+        desc.signal_addr = reinterpret_cast<uint64_t>(signalBuf.ptr);
+        desc.signal_value = signalVal;
+        desc.signal_rkey_device_order = signalBuf.rkey_per_device[nicId].value;
+        desc.flags |= IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD;
+      }
+
+      enqueue(queueId, desc);
+    }
+    group.sync();
+  }
+
+  __device__ void put(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    put(solo,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  }
+
+  __device__ void put_cooperative(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    put(group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  }
+
+  __device__ void put_cooperative(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    put_cooperative(
+        solo,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  }
+
+  __device__ void put_after_system_fence(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    put(group,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  }
+
+  __device__ void put_after_system_fence(
+      const IbgdaLocalBuffer& localBuf,
+      const IbgdaRemoteBuffer& remoteBuf,
+      std::size_t nbytes,
+      const IbgdaRemoteBuffer& signalBuf,
+      uint64_t signalVal = 1,
+      const IbgdaLocalBuffer& counterBuf = {},
+      uint64_t counterVal = 1) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    put_after_system_fence(
+        solo,
+        localBuf,
+        remoteBuf,
+        nbytes,
+        signalBuf,
+        signalVal,
+        counterBuf,
+        counterVal);
+  }
+
+  __device__ void wait_signal(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& signalBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    wait_local(group, signalBuf.ptr, expected, timeout, "signal");
+  }
+
+  __device__ void wait_signal(
+      const IbgdaLocalBuffer& signalBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    wait_signal(solo, signalBuf, expected, timeout);
+  }
+
+  __device__ void reset_signal(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& signalBuf) {
+    reset_local(group, signalBuf.ptr, "signal");
+  }
+
+  __device__ void reset_signal(const IbgdaLocalBuffer& signalBuf) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    reset_signal(solo, signalBuf);
+  }
+
+  __device__ void reset_counter(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& counterBuf) {
+    reset_local(group, counterBuf.ptr, "counter");
+  }
+
+  __device__ void reset_counter(const IbgdaLocalBuffer& counterBuf) {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    reset_counter(solo, counterBuf);
+  }
+
+  __device__ void wait_counter(
+      ThreadGroup& group,
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    wait_local(group, counterBuf.ptr, expected, timeout, "counter");
+  }
+
+  __device__ void wait_counter(
+      const IbgdaLocalBuffer& counterBuf,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    wait_counter(solo, counterBuf, expected, timeout);
+  }
+
+  __device__ uint64_t read_signal(const IbgdaLocalBuffer& signalBuf) const {
+    return load_acquire_system_u64(signalBuf.ptr);
+  }
+
+  __device__ uint64_t read_counter(const IbgdaLocalBuffer& counterBuf) const {
+    return load_acquire_system_u64(counterBuf.ptr);
+  }
+
+  __device__ void flush(ThreadGroup& group) {
+    if (group.is_leader()) {
+      const uint32_t queueId = queue_for_group(group.group_id);
+      const IbrcCmdQueueDevice& queue = cmdQueues[queueId];
+      const uint64_t target = load_acquire_system_u64(queue.pi);
+      Timeout timeout{kIbrcDefaultDeviceTimeoutCycles};
+      timeout.start();
+      while (load_acquire_system_u64(queue.ci) < target) {
+        check_status(queue);
+        if (timeout.checkExpired()) {
+          printf("P2pIbrcTransportDevice: flush timed out\n");
+          PIPES_DEVICE_TRAP();
+        }
+      }
+    }
+    group.sync();
+  }
+
+  __device__ void flush() {
+    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    flush(solo);
+  }
+
+  __device__ void fence(ThreadGroup& group) {
+    flush(group);
+  }
+
+  __device__ void fence() {
+    flush();
+  }
+
+ private:
+  __device__ __forceinline__ uint32_t queue_for_group(uint32_t groupId) const {
+    if (cmdQueues.empty()) {
+      trap("P2pIbrcTransportDevice: no command queues");
+    }
+    return groupId % cmdQueues.size();
+  }
+
+  __device__ __forceinline__ uint32_t nic_for_queue(uint32_t queueId) const {
+    if (numNics == 0) {
+      trap("P2pIbrcTransportDevice: no NICs");
+    }
+    return queueId % numNics;
+  }
+
+  __device__ __forceinline__ uint64_t reserve(IbrcCmdQueueDevice& queue) const {
+    const uint64_t seq = fetch_add_system_u64(queue.pi, 1);
+    Timeout timeout{kIbrcDefaultDeviceTimeoutCycles};
+    timeout.start();
+    while (seq - load_acquire_system_u64(queue.ci) >= queue.depth) {
+      check_status(queue);
+      if (timeout.checkExpired()) {
+        printf("P2pIbrcTransportDevice: reserve timed out\n");
+        PIPES_DEVICE_TRAP();
+      }
+    }
+    return seq;
+  }
+
+  __device__ __forceinline__ void enqueue(
+      uint32_t queueId,
+      const IbrcDesc& desc) const {
+    IbrcCmdQueueDevice& queue = cmdQueues[queueId];
+    check_status(queue);
+    const uint64_t seq = reserve(queue);
+    IbrcDesc& slot = queue.descs[seq & queue.mask];
+    slot = desc;
+    store_release_system_u64(&slot.ready_seq, seq);
+  }
+
+  __device__ __forceinline__ void check_status(
+      const IbrcCmdQueueDevice& queue) const {
+    if (queue.status == nullptr) {
+      return;
+    }
+    if (load_acquire_system_u32(&queue.status->error) != 0) {
+      printf(
+          "P2pIbrcTransportDevice: queue error queue=%u code=%u\n",
+          load_acquire_system_u32(&queue.status->error_queue),
+          load_acquire_system_u32(&queue.status->error_code));
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  __device__ void wait_local(
+      ThreadGroup& group,
+      const void* ptr,
+      uint64_t expected,
+      const Timeout& timeout,
+      const char* kind) const {
+    if (ptr == nullptr) {
+      trap("P2pIbrcTransportDevice: wait buffer is null");
+    }
+    if (group.is_leader()) {
+      const uint32_t queueId = queue_for_group(group.group_id);
+      const IbrcCmdQueueDevice& queue = cmdQueues[queueId];
+      while (load_acquire_system_u64(ptr) < expected) {
+        check_status(queue);
+        if (timeout.checkExpired()) {
+          printf(
+              "P2pIbrcTransportDevice: wait_%s timed out expected=%llu\n",
+              kind,
+              static_cast<unsigned long long>(expected));
+          PIPES_DEVICE_TRAP();
+        }
+      }
+    }
+    group.sync();
+  }
+
+  __device__ void reset_local(ThreadGroup& group, void* ptr, const char* kind)
+      const {
+    (void)kind;
+    if (ptr == nullptr) {
+      trap("P2pIbrcTransportDevice: reset buffer is null");
+    }
+    if (group.is_leader()) {
+      store_release_system_u64(static_cast<uint64_t*>(ptr), 0);
+    }
+    group.sync();
+  }
+
+  // System-scope release fence, portable across NVIDIA/AMD and host/device
+  // passes. The PIPES_IS_DEVICE_COMPILE gate makes it a no-op in the host pass
+  // so this header is parseable when included from a host .cc TU.
+  __device__ __forceinline__ static void threadfence_system() {
+#if PIPES_IS_DEVICE_COMPILE
+#ifdef __HIP_PLATFORM_AMD__
+    amd_fence_system();
+#else
+    __threadfence_system();
+#endif
+#endif
+  }
+
+  __device__ __forceinline__ static uint64_t load_acquire_system_u64(
+      const void* ptr) {
+    auto* slot = static_cast<uint64_t*>(const_cast<void*>(ptr));
+#ifdef __HIP_PLATFORM_AMD__
+    return __hip_atomic_load(slot, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    return cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{*slot}.load(
+        cuda::memory_order_acquire);
+#endif
+  }
+
+  __device__ __forceinline__ static uint32_t load_acquire_system_u32(
+      const uint32_t* ptr) {
+    auto* slot = const_cast<uint32_t*>(ptr);
+#ifdef __HIP_PLATFORM_AMD__
+    return __hip_atomic_load(slot, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    return cuda::atomic_ref<uint32_t, cuda::thread_scope_system>{*slot}.load(
+        cuda::memory_order_acquire);
+#endif
+  }
+
+  __device__ __forceinline__ static uint64_t fetch_add_system_u64(
+      uint64_t* ptr,
+      uint64_t value) {
+#ifdef __HIP_PLATFORM_AMD__
+    return __hip_atomic_fetch_add(
+        ptr, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    return cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{*ptr}
+        .fetch_add(value, cuda::memory_order_relaxed);
+#endif
+  }
+
+  __device__ __forceinline__ static void store_release_system_u64(
+      uint64_t* ptr,
+      uint64_t value) {
+#ifdef __HIP_PLATFORM_AMD__
+    __hip_atomic_store(ptr, value, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{*ptr}.store(
+        value, cuda::memory_order_release);
+#endif
+  }
+
+  __device__ __forceinline__ static void trap(const char* msg) {
+    printf("%s\n", msg);
+    PIPES_DEVICE_TRAP();
+  }
+};
+
+static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);
+static_assert(std::is_trivially_copyable_v<P2pIbrcTransportDevice>);
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -90,13 +90,9 @@ class P2pIbrcTransportDevice {
       uint64_t signalVal = 1,
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
-    (void)counterVal;
-    if (counterBuf.ptr != nullptr) {
-      trap("P2pIbrcTransportDevice: counters are not implemented");
-    }
-
     const bool hasData = nbytes > 0;
     const bool hasSignal = signalBuf.ptr != nullptr;
+    const bool hasCounter = counterBuf.ptr != nullptr;
     if (hasData) {
       if (localBuf.ptr == nullptr || remoteBuf.ptr == nullptr) {
         trap("P2pIbrcTransportDevice: put data buffer is null");
@@ -125,6 +121,12 @@ class P2pIbrcTransportDevice {
         desc.signal_value = signalVal;
         desc.signal_rkey_device_order = signalBuf.rkey_per_device[nicId].value;
         desc.flags |= IBRC_HAS_SIGNAL | IBRC_SIGNAL_ADD;
+      }
+
+      if (hasCounter) {
+        desc.counter_addr = reinterpret_cast<uint64_t>(counterBuf.ptr);
+        desc.counter_value = counterVal;
+        desc.flags |= IBRC_HAS_COUNTER;
       }
 
       enqueue(queueId, desc);

--- a/comms/prims/window/DeviceWindow.cuh
+++ b/comms/prims/window/DeviceWindow.cuh
@@ -13,10 +13,11 @@
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 #ifdef __CUDACC__
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 #else
 namespace comms::prims {
 class P2pIbgdaTransportDevice;
+struct P2pIbTransportDevice;
 } // namespace comms::prims
 #endif
 
@@ -443,11 +444,9 @@ class DeviceWindow {
       // Remote buffer is pre-offset to "my row" in the peer's inbox
       // (computed once at exchange time in HostWindow), so signal_id
       // is the only offset needed here.
-      handle_.get_ibgda(target_rank)
-          .signal(
-              ibgdaPeerSignalRemoteBufs_[ibgdaIdx].subBuffer(
-                  signal_id * sizeof(uint64_t)),
-              value);
+      auto signalBuf = ibgdaPeerSignalRemoteBufs_[ibgdaIdx].subBuffer(
+          signal_id * sizeof(uint64_t));
+      handle_.get_ib(target_rank).signal(signalBuf, value);
     }
   }
 
@@ -511,10 +510,9 @@ class DeviceWindow {
         nvlPeerSignalSpans_[nvlIdx][signal_id].signal(op, value);
       } else {
         DEVICE_WINDOW_CHECK_IBGDA_SIGNAL_ADD(op);
-        handle_.get_ibgda(r).signal(
-            ibgdaPeerSignalRemoteBufs_[peer_index].subBuffer(
-                signal_id * sizeof(uint64_t)),
-            value);
+        auto signalBuf = ibgdaPeerSignalRemoteBufs_[peer_index].subBuffer(
+            signal_id * sizeof(uint64_t));
+        handle_.get_ib(r).signal(signalBuf, value);
       }
     }
     group.sync();
@@ -919,10 +917,9 @@ class DeviceWindow {
         int nvlIdx = rankToNvlPeerIndex_[r];
         nvlBarrierPeerPtrs_[nvlIdx][barrier_id].signal(SignalOp::SIGNAL_ADD, 1);
       } else {
-        handle_.get_ibgda(r).signal(
-            ibgdaBarrierRemoteBufs_[peer_index].subBuffer(
-                barrier_id * sizeof(uint64_t)),
-            1);
+        auto signalBuf = ibgdaBarrierRemoteBufs_[peer_index].subBuffer(
+            barrier_id * sizeof(uint64_t));
+        handle_.get_ib(r).signal(signalBuf, 1);
       }
     }
     group.sync();
@@ -949,11 +946,9 @@ class DeviceWindow {
         nvlBarrierPeerPtrs_[nvlIdx][barrier_id].signal(SignalOp::SIGNAL_ADD, 1);
       } else {
         int ibgdaIdx = rank_to_peer_index(target_rank);
-        handle_.get_ibgda(target_rank)
-            .signal(
-                ibgdaBarrierRemoteBufs_[ibgdaIdx].subBuffer(
-                    barrier_id * sizeof(uint64_t)),
-                1);
+        auto signalBuf = ibgdaBarrierRemoteBufs_[ibgdaIdx].subBuffer(
+            barrier_id * sizeof(uint64_t));
+        handle_.get_ib(target_rank).signal(signalBuf, 1);
       }
     }
     group.sync();
@@ -1047,7 +1042,7 @@ class DeviceWindow {
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
           remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
-      handle_.get_ibgda(target_rank)
+      handle_.get_ib(target_rank)
           .put(group, localBuf, remoteBuf.subBuffer(dst_offset), nbytes);
     }
   }
@@ -1101,17 +1096,16 @@ class DeviceWindow {
       IbgdaRemoteBuffer remoteBuf(
           const_cast<void*>(remoteBufferRegistry_[ibgdaPeerIdx].base),
           remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
-      handle_.get_ibgda(target_rank)
+      auto signalBuf = ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx].subBuffer(
+          signalId * sizeof(uint64_t));
+      handle_.get_ib(target_rank)
           .put(
               group,
               localBuf,
               remoteBuf.subBuffer(dst_offset),
               nbytes,
-              ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx].subBuffer(
-                  signalId * sizeof(uint64_t)),
-              signalVal,
-              {},
-              1);
+              signalBuf,
+              signalVal);
     }
   }
   // ===========================================================================
@@ -1170,16 +1164,19 @@ class DeviceWindow {
           remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
       IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkeys_);
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
-      handle_.get_ibgda(target_rank)
+      auto signalBuf = ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx].subBuffer(
+          signalId * sizeof(uint64_t));
+      auto counterSlotBuf =
+          counterBuf.subBuffer(counterSlot * sizeof(uint64_t));
+      handle_.get_ib(target_rank)
           .put(
               group,
               localBuf,
               remoteBuf.subBuffer(dst_offset),
               nbytes,
-              ibgdaPeerSignalRemoteBufs_[ibgdaPeerIdx].subBuffer(
-                  signalId * sizeof(uint64_t)),
+              signalBuf,
               signalVal,
-              counterBuf.subBuffer(counterSlot * sizeof(uint64_t)),
+              counterSlotBuf,
               counterVal);
     }
   }
@@ -1233,7 +1230,9 @@ class DeviceWindow {
           remoteBufferRegistry_[ibgdaPeerIdx].rkey_per_device);
       IbgdaLocalBuffer counterBuf(ibgdaPeerCounterBuf_, ibgdaPeerCounterLkeys_);
       int counterSlot = ibgdaPeerIdx * peerCounterCount_ + counterId;
-      handle_.get_ibgda(target_rank)
+      auto counterSlotBuf =
+          counterBuf.subBuffer(counterSlot * sizeof(uint64_t));
+      handle_.get_ib(target_rank)
           .put(
               group,
               localBuf,
@@ -1241,7 +1240,7 @@ class DeviceWindow {
               nbytes,
               {},
               1,
-              counterBuf.subBuffer(counterSlot * sizeof(uint64_t)),
+              counterSlotBuf,
               counterVal);
     }
   }


### PR DESCRIPTION
Summary:

Move transport-owned signal/counter resource allocation and exchange from `MultipeerIbgdaTransport` into `MultiPeerIbTransportBase`. Keep IBGDA behavior by using registered device counter storage and the existing discard-signal path, while centralizing eager and lazy per-peer signal-counter cleanup and remote view setup.

Reviewed By: snarayankh

Differential Revision: D107738444
