### PR TITLE
Run ring collectives through common IB device handle (#2893)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -149,6 +149,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/rdma/IbHcaParser.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -157,6 +157,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/rdma/IbHcaParser.cc

--- a/comms/prims/collectives/Ring.cuh
+++ b/comms/prims/collectives/Ring.cuh
@@ -4,15 +4,15 @@
 
 #include <cstddef>
 
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 
 namespace comms::prims {
 
 struct RingTopology {
   int prev_rank{0};
   int next_rank{0};
-  P2pIbgdaTransportDevice* prev{nullptr};
-  P2pIbgdaTransportDevice* next{nullptr};
+  P2pIbTransportDevice prev{};
+  P2pIbTransportDevice next{};
 };
 
 template <int NumRings>

--- a/comms/prims/collectives/RingAllgather.cu
+++ b/comms/prims/collectives/RingAllgather.cu
@@ -18,8 +18,8 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
   auto group = make_block_group();
   auto [ring_id, ring_group] = group.partition(NumRings);
   const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
+  auto prev = topo.prev;
+  auto next = topo.next;
 
   const int W = args.num_ranks;
   const std::size_t chunk_bytes = args.sendcount;

--- a/comms/prims/collectives/RingAllgatherLauncher.h
+++ b/comms/prims/collectives/RingAllgatherLauncher.h
@@ -4,9 +4,9 @@
 
 #include <cstddef>
 
-namespace comms::prims {
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
-class P2pIbgdaTransportDevice;
+namespace comms::prims {
 
 struct RingAllgatherLaunchParams {
   int my_rank{0};
@@ -22,8 +22,8 @@ struct RingAllgatherLaunchParams {
   struct RingParams {
     int prev_rank{0};
     int next_rank{0};
-    P2pIbgdaTransportDevice* prev{nullptr};
-    P2pIbgdaTransportDevice* next{nullptr};
+    P2pIbTransportDevice prev{};
+    P2pIbTransportDevice next{};
   };
   static constexpr int kMaxRings = 4;
   RingParams rings[kMaxRings]{};

--- a/comms/prims/collectives/RingReduceScatter.cu
+++ b/comms/prims/collectives/RingReduceScatter.cu
@@ -23,8 +23,8 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
   auto group = make_block_group();
   auto [ring_id, ring_group] = group.partition(NumRings);
   const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
+  auto prev = topo.prev;
+  auto next = topo.next;
 
   const int W = args.num_ranks;
   const std::size_t chunk_elems = args.chunk_elements;

--- a/comms/prims/collectives/RingReduceScatterLauncher.h
+++ b/comms/prims/collectives/RingReduceScatterLauncher.h
@@ -4,9 +4,9 @@
 
 #include <cstddef>
 
-namespace comms::prims {
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
-class P2pIbgdaTransportDevice;
+namespace comms::prims {
 
 struct RingReduceScatterLaunchParams {
   int my_rank{0};
@@ -22,8 +22,8 @@ struct RingReduceScatterLaunchParams {
   struct RingParams {
     int prev_rank{0};
     int next_rank{0};
-    P2pIbgdaTransportDevice* prev{nullptr};
-    P2pIbgdaTransportDevice* next{nullptr};
+    P2pIbTransportDevice prev{};
+    P2pIbTransportDevice next{};
   };
   static constexpr int kMaxRings = 4;
   RingParams rings[kMaxRings]{};

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -91,8 +91,10 @@ TEST_P(RingAllGatherTest, Correctness) {
   transport->connectPeers();
   for (int r = 0; r < params.num_rings; r++) {
     auto& ringParams = launchParams.rings[r];
-    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+    ringParams.prev = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.prev_rank));
+    ringParams.next = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.next_rank));
   }
 
   bootstrap->barrierAll();

--- a/comms/prims/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/RingReduceScatterTest.cc
@@ -93,8 +93,10 @@ TEST_P(RingReduceScatterTest, Correctness) {
   transport->connectPeers();
   for (int r = 0; r < params.num_rings; r++) {
     auto& ringParams = launchParams.rings[r];
-    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+    ringParams.prev = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.prev_rank));
+    ringParams.next = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.next_rank));
   }
 
   bootstrap->barrierAll();

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -27,11 +27,15 @@
 #include <hip/hip_runtime.h>
 
 #include "comms/prims/transport/amd/DocaCompat.h"
+// meta::comms::DeviceBuffer (HIP shim) for the send/recv staging bulks.
+#include "comms/prims/transport/amd/HipHostCompat.h"
 #else
 #include <cuda_runtime.h>
 
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
+// meta::comms::DeviceBuffer (CUDA RAII) for the send/recv staging bulks.
+#include "comms/utils/CudaRAII.h"
 #endif
 
 namespace comms::prims {
@@ -199,6 +203,375 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
   numNics_ = n;
   VLOG(1) << "MultiPeerIbTransport: numNics_=" << numNics_
           << " (source=" << source << ")";
+}
+
+// Out-of-line so the unique_ptr<DeviceBuffer> send/recv members destruct
+// against a complete type (DeviceBuffer is only forward-declared in the
+// header).
+MultiPeerIbTransportBase::~MultiPeerIbTransportBase() = default;
+
+// ---- shared send/recv staging-ring lifecycle (eager mode) ----
+
+const MultipeerIbTransportConfig::SendRecvConfig&
+MultiPeerIbTransportBase::sendRecvConfig() const {
+  if (!config_.sendRecv.has_value()) {
+    throw std::runtime_error("MultiPeerIbTransport: send/recv not configured");
+  }
+  return *config_.sendRecv;
+}
+
+void MultiPeerIbTransportBase::validateSendRecvConfig() const {
+  const auto& sr = sendRecvConfig();
+  if (sr.pipelineDepth < 1) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: sendRecv.pipelineDepth must be >= 1");
+  }
+  if (sr.maxGroups < 1) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: sendRecv.maxGroups must be >= 1");
+  }
+  if (config_.dataBufferSize == 0) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: dataBufferSize must be > 0 when sendRecv is "
+        "enabled");
+  }
+  if ((config_.dataBufferSize / static_cast<std::size_t>(sr.maxGroups)) < 16) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultiPeerIbTransport: dataBufferSize / maxGroups must be >= 16, "
+            "got {} / {} = {}",
+            config_.dataBufferSize,
+            sr.maxGroups,
+            config_.dataBufferSize / sr.maxGroups));
+  }
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return static_cast<std::size_t>(sr.pipelineDepth) * config_.dataBufferSize;
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return 2 * static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvStateBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return 2 * static_cast<std::size_t>(sr.maxGroups) *
+      sizeof(IbSendRecvState::ProgressSlot);
+}
+
+IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
+    int peerIndex) const {
+  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty() ||
+      peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return {};
+  }
+  const auto& pb = sendRecvPeerBuffers_[peerIndex];
+  return IbSendRecvState{
+      .sendStagingBuf = pb.sendStaging,
+      .recvStagingBuf = pb.remoteRecvStaging,
+      .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
+      .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
+      .localSignalBuf = pb.signal,
+      .remoteSignalBuf = pb.remoteSignal,
+      .localCounterBuf = pb.counter,
+      .localCounterCompletionBuf = pb.counterCompletion,
+      .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
+      .maxGroups = config_.sendRecv->maxGroups,
+      .pipelineDepth = config_.sendRecv->pipelineDepth,
+      .dataBufferSize = config_.dataBufferSize,
+  };
+}
+
+void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
+    IbCounterStorage counterStorage) {
+  if (!config_.sendRecv.has_value()) {
+    return;
+  }
+  validateSendRecvConfig();
+
+  const int numPeers = nRanks_ - 1;
+  if (numPeers <= 0) {
+    return;
+  }
+  sendRecvCounterStorage_ = counterStorage;
+
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+  const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
+  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
+  const auto stateSlotsPerPeer =
+      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
+          2 * config_.sendRecv->maxGroups);
+
+  auto allocateBulk = [&](std::size_t perPeer, const char* label) {
+    auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
+    checkSlotGpu(
+        slotGpuMemset(buf->get(), 0, perPeer * numPeers),
+        fmt::format("MultiPeerIbTransport: zero send/recv {}", label));
+    return buf;
+  };
+
+  sendRecvPeerBuffers_.resize(numPeers);
+
+  sendRecvSendStagingBulk_ = allocateBulk(stagingPerPeer, "send staging bulk");
+  sendRecvRecvStagingBulk_ = allocateBulk(stagingPerPeer, "recv staging bulk");
+  sendRecvSignalBulk_ = allocateBulk(signalPerPeer, "signal bulk");
+  sendRecvStateBulk_ = allocateBulk(statePerPeer, "state bulk");
+
+  auto sendStagingBulkReg = registerBuffer(
+      sendRecvSendStagingBulk_->get(), stagingPerPeer * numPeers);
+  sendRecvRecvStagingBulkReg_ = registerBuffer(
+      sendRecvRecvStagingBulk_->get(), stagingPerPeer * numPeers);
+  sendRecvSignalBulkReg_ =
+      registerBuffer(sendRecvSignalBulk_->get(), signalPerPeer * numPeers);
+
+  IbgdaLocalBuffer counterBulkBuf;
+  IbgdaLocalBuffer counterCompletionBulkBuf;
+  if (counterStorage == IbCounterStorage::Device) {
+    // Device counter: transport-allocated + registered. The NIC bumps it via a
+    // loopback RDMA atomic (IBGDA).
+    sendRecvCounterBulk_ = allocateBulk(counterPerPeer, "counter bulk");
+    sendRecvCounterBulkReg_ =
+        registerBuffer(sendRecvCounterBulk_->get(), counterPerPeer * numPeers);
+    counterBulkBuf = sendRecvCounterBulkReg_;
+    counterCompletionBulkBuf = sendRecvCounterBulkReg_;
+  } else {
+    // Host counter: transport-allocated host-mapped (cudaHostAllocMapped). The
+    // CPU proxy writes the host alias on CQE; the device reads via the mapped
+    // pointer (IBRC). lkeys are unused (no RDMA target), so wrap with empty
+    // keys.
+    sendRecvHostCounterAllocation_ = allocateCounterSlotAllocation(
+        IbCounterStorage::HostPinned,
+        counterPerPeer * numPeers,
+        "send/recv host counter");
+    counterBulkBuf = IbgdaLocalBuffer(
+        sendRecvHostCounterAllocation_.devicePtr, NetworkLKeys{});
+    counterCompletionBulkBuf = IbgdaLocalBuffer(
+        sendRecvHostCounterAllocation_.hostPtr, NetworkLKeys{});
+    sendRecvCounterBulkReg_ = counterBulkBuf;
+  }
+
+  for (int i = 0; i < numPeers; ++i) {
+    auto& pb = sendRecvPeerBuffers_[i];
+    pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
+    pb.recvStaging = sendRecvRecvStagingBulkReg_.subBuffer(i * stagingPerPeer);
+    pb.signal = sendRecvSignalBulkReg_.subBuffer(i * signalPerPeer);
+    pb.counter = counterBulkBuf.subBuffer(i * counterPerPeer);
+    pb.counterCompletion =
+        counterCompletionBulkBuf.subBuffer(i * counterPerPeer);
+    auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(
+        static_cast<char*>(sendRecvStateBulk_->get()) + i * statePerPeer);
+    pb.state.emplace(statePtr, stateSlotsPerPeer);
+  }
+
+  VLOG(1) << "MultiPeerIbTransport: rank " << myRank_
+          << " allocated send/recv staging for " << numPeers
+          << " peers (staging=" << stagingPerPeer << "B per peer, counter="
+          << (counterStorage == IbCounterStorage::Device ? "device" : "host")
+          << ")";
+}
+
+void MultiPeerIbTransportBase::exchangeSendRecvBuffersEager() {
+  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
+    return;
+  }
+
+  const int numPeers = nRanks_ - 1;
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+
+  auto recvStagingRemotes = exchangeBuffer(sendRecvRecvStagingBulkReg_);
+  auto signalRemotes = exchangeBuffer(sendRecvSignalBulkReg_);
+
+  for (int i = 0; i < numPeers; ++i) {
+    const int peerRank = peerIndexToRank(i);
+    const int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+    sendRecvPeerBuffers_[i].remoteRecvStaging =
+        recvStagingRemotes[i].subBuffer(remotePeerIndex * stagingPerPeer);
+    sendRecvPeerBuffers_[i].remoteSignal =
+        signalRemotes[i].subBuffer(remotePeerIndex * signalPerPeer);
+  }
+
+  VLOG(1) << "MultiPeerIbTransport: rank " << myRank_
+          << " exchanged send/recv staging with " << numPeers << " peers";
+}
+
+void MultiPeerIbTransportBase::cleanupSendRecvBuffers() noexcept {
+  auto deregisterNoexcept = [&](void* ptr) noexcept {
+    if (ptr == nullptr) {
+      return;
+    }
+    try {
+      deregisterBuffer(ptr);
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultiPeerIbTransport: failed to deregister send/recv "
+                    "buffer: "
+                 << ex.what();
+    }
+  };
+
+  deregisterNoexcept(
+      sendRecvSendStagingBulk_ ? sendRecvSendStagingBulk_->get() : nullptr);
+  deregisterNoexcept(
+      sendRecvRecvStagingBulk_ ? sendRecvRecvStagingBulk_->get() : nullptr);
+  deregisterNoexcept(
+      sendRecvSignalBulk_ ? sendRecvSignalBulk_->get() : nullptr);
+  // Device counter is transport-owned + registered; host counter is host-mapped
+  // and freed via freeCounterSlotAllocation below (never registered).
+  if (sendRecvCounterStorage_ == IbCounterStorage::Device) {
+    deregisterNoexcept(
+        sendRecvCounterBulk_ ? sendRecvCounterBulk_->get() : nullptr);
+  }
+
+  sendRecvSendStagingBulk_.reset();
+  sendRecvRecvStagingBulk_.reset();
+  sendRecvSignalBulk_.reset();
+  sendRecvStateBulk_.reset();
+  sendRecvCounterBulk_.reset();
+  freeCounterSlotAllocation(sendRecvHostCounterAllocation_);
+  sendRecvRecvStagingBulkReg_ = IbgdaLocalBuffer{};
+  sendRecvSignalBulkReg_ = IbgdaLocalBuffer{};
+  sendRecvCounterBulkReg_ = IbgdaLocalBuffer{};
+  // Lazy per-peer allocations (empty in eager mode).
+  for (auto& buf : lazyPeerBufs_) {
+    deregisterNoexcept(buf ? buf->get() : nullptr);
+    buf.reset();
+  }
+  lazyPeerBufs_.clear();
+  for (auto& counter : lazySendRecvHostCounters_) {
+    freeCounterSlotAllocation(counter);
+  }
+  lazySendRecvHostCounters_.clear();
+  sendRecvCounterStorage_ = IbCounterStorage::Device;
+  sendRecvPeerBuffers_.clear();
+}
+
+void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
+    int peerIndex,
+    PeerBufferPayload& payload,
+    IbCounterStorage counterStorage) {
+  if (!config_.sendRecv.has_value()) {
+    return;
+  }
+  validateSendRecvConfig();
+  const int numPeers = nRanks_ - 1;
+  if (peerIndex < 0 || peerIndex >= numPeers) {
+    throw std::invalid_argument(
+        fmt::format(
+            "allocateSendRecvBufferForPeer: invalid peerIndex={}", peerIndex));
+  }
+  sendRecvPeerBuffers_.resize(numPeers);
+  lazyPeerBufs_.resize(numPeers);
+  lazySendRecvHostCounters_.resize(numPeers);
+  sendRecvCounterStorage_ = counterStorage;
+
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+  const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
+  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
+  const auto stateSlots =
+      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
+          2 * config_.sendRecv->maxGroups);
+  const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
+
+  // One contiguous device buffer: sendStaging | recvStaging | signal | state,
+  // plus the counter when it is device-resident. A HostPinned counter is
+  // allocated separately (host-mapped, never RDMA-registered).
+  std::size_t total = 2 * stagingPerPeer + signalPerPeer + statePerPeer;
+  if (deviceCounter) {
+    total += counterPerPeer;
+  }
+  auto buf = std::make_unique<meta::comms::DeviceBuffer>(total);
+  checkSlotGpu(
+      slotGpuMemset(buf->get(), 0, total),
+      "MultiPeerIbTransport: zero per-peer send/recv buffer");
+  auto reg = registerBuffer(buf->get(), total);
+
+  char* p = static_cast<char*>(buf->get());
+  std::size_t off = 0;
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.sendStaging = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
+  off += stagingPerPeer;
+  void* recvStagingPtr = p + off;
+  pb.recvStaging = IbgdaLocalBuffer(recvStagingPtr, reg.lkey_per_device);
+  off += stagingPerPeer;
+  void* signalPtr = p + off;
+  pb.signal = IbgdaLocalBuffer(signalPtr, reg.lkey_per_device);
+  off += signalPerPeer;
+  auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(p + off);
+  off += statePerPeer;
+  pb.state.emplace(statePtr, stateSlots);
+  if (deviceCounter) {
+    pb.counter = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
+    pb.counterCompletion = pb.counter;
+  } else {
+    auto alloc = allocateCounterSlotAllocation(
+        IbCounterStorage::HostPinned,
+        counterPerPeer,
+        "lazy send/recv host counter");
+    pb.counter = IbgdaLocalBuffer(alloc.devicePtr, NetworkLKeys{});
+    pb.counterCompletion = IbgdaLocalBuffer(alloc.hostPtr, NetworkLKeys{});
+    lazySendRecvHostCounters_[peerIndex] = std::move(alloc);
+  }
+
+  // The peer RDMA-writes into our recvStaging ring and signal inbox; publish
+  // their addr + per-NIC rkeys (whole per-peer regions, no slicing).
+  payload.recvStaging = registeredSlotMemoryExchInfo(recvStagingPtr);
+  payload.srSignal = registeredSlotMemoryExchInfo(signalPtr);
+  lazyPeerBufs_[peerIndex] = std::move(buf);
+}
+
+void MultiPeerIbTransportBase::applyRemoteSendRecvBuffer(
+    int peerIndex,
+    const PeerBufferPayload& remotePayload) {
+  if (!config_.sendRecv.has_value() || peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return;
+  }
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
+  pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
+}
+
+void MultiPeerIbTransportBase::cleanupSendRecvBufferForPeer(
+    int peerIndex) noexcept {
+  if (peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return;
+  }
+  if (peerIndex < static_cast<int>(lazyPeerBufs_.size()) &&
+      lazyPeerBufs_[peerIndex]) {
+    try {
+      deregisterBuffer(lazyPeerBufs_[peerIndex]->get());
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultiPeerIbTransport: failed to deregister per-peer "
+                    "send/recv buffer: "
+                 << ex.what();
+    }
+    lazyPeerBufs_[peerIndex].reset();
+  }
+  if (peerIndex < static_cast<int>(lazySendRecvHostCounters_.size())) {
+    freeCounterSlotAllocation(lazySendRecvHostCounters_[peerIndex]);
+  }
+  // Reset the per-peer views field-wise (IbSendRecvPeerBuffers is not
+  // copy-assignable due to its optional<DeviceSpan> state member).
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.sendStaging = IbgdaLocalBuffer{};
+  pb.recvStaging = IbgdaLocalBuffer{};
+  pb.signal = IbgdaLocalBuffer{};
+  pb.counter = IbgdaLocalBuffer{};
+  pb.remoteRecvStaging = IbgdaRemoteBuffer{};
+  pb.remoteSignal = IbgdaRemoteBuffer{};
+  pb.state.reset();
 }
 
 void MultiPeerIbTransportBase::openNics() {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -16,7 +16,12 @@
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace meta::comms {
+class DeviceBuffer;
+} // namespace meta::comms
 
 namespace comms::prims {
 
@@ -239,9 +244,31 @@ struct PeerBufferPayload {
   IbgdaBufferExchInfo slotDiscard;
 };
 
+// Which memory a NIC completion counter lives in. Shared by the slot counter
+// (#16) and the send/recv NIC_DONE counter:
+//   Device     - GPU device memory, allocated and registered by the transport.
+//                The NIC bumps it via a loopback RDMA atomic (IBGDA).
+//   HostPinned - host-mapped (cudaHostAllocMapped) memory, allocated by the
+//                transport; the CPU progress thread writes it and the device
+//                reads via the mapped pointer (IBRC). Never MR-registered.
 enum class IbCounterStorage {
   Device,
   HostPinned,
+};
+
+// Per-peer send/recv staging-ring views. Eager mode owns the bulk allocations
+// and slices these; the device side reads them via sendRecvStateForPeer().
+struct IbSendRecvPeerBuffers {
+  IbgdaLocalBuffer sendStaging;
+  IbgdaLocalBuffer recvStaging;
+  IbgdaLocalBuffer signal;
+  IbgdaLocalBuffer counter;
+  IbgdaLocalBuffer counterCompletion;
+  // DeviceSpan has a const data_ member (no copy-assign), so wrap in optional
+  // and emplace() the per-peer slice.
+  std::optional<DeviceSpan<IbSendRecvState::ProgressSlot>> state;
+  IbgdaRemoteBuffer remoteRecvStaging;
+  IbgdaRemoteBuffer remoteSignal;
 };
 
 /**
@@ -321,8 +348,10 @@ class MultiPeerIbTransportBase {
       MultipeerIbTransportConfig config);
 
   // Non-virtual protected dtor: the base is never owned/deleted polymorphically
-  // (the dispatcher holds the concrete backend type).
-  ~MultiPeerIbTransportBase() = default;
+  // (the dispatcher holds the concrete backend type). Defined out-of-line in
+  // the .cc so the unique_ptr<DeviceBuffer> members destruct against a complete
+  // type.
+  ~MultiPeerIbTransportBase();
 
   MultiPeerIbTransportBase(const MultiPeerIbTransportBase&) = delete;
   MultiPeerIbTransportBase& operator=(const MultiPeerIbTransportBase&) = delete;
@@ -372,6 +401,52 @@ class MultiPeerIbTransportBase {
       void* remotePayload,
       std::size_t bytes,
       int tag);
+
+  // ---- shared send/recv staging-ring lifecycle (eager mode) ----
+  // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
+  // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
+  // = pipelineDepth * dataBufferSize per direction; signal/state are sized off
+  // maxGroups. Per-peer staging + signal are device-registered; recvStaging +
+  // signal are collectively exchanged so peers can RDMA into our ring.
+  bool sendRecvBuffersEnabled() const {
+    return config_.sendRecv.has_value();
+  }
+  IbSendRecvState sendRecvStateForPeer(int peerIndex) const;
+  // Allocate + register the per-peer staging/signal/state bulks and slice them.
+  // counterStorage selects the NIC_DONE counter: Device (transport-allocated,
+  // registered) or HostPinned (transport-allocated host-mapped, never
+  // registered).
+  void allocateSendRecvBuffersEager(IbCounterStorage counterStorage);
+  // COLLECTIVE. allGather recvStaging + signal so each peer holds our remote
+  // views. Must be called after allocateSendRecvBuffersEager().
+  void exchangeSendRecvBuffersEager();
+  void cleanupSendRecvBuffers() noexcept;
+
+  // ---- per-peer (lazy) send/recv: shared by IBGDA + IBRC ----
+  // Allocate + register ONE peer's send/recv rings on demand (lazy connect) and
+  // fill the outbound payload's recvStaging/srSignal exch info. counterStorage
+  // selects the NIC_DONE counter: Device (a registered slice of the contiguous
+  // per-peer buffer; NIC loopback atomic — IBGDA) or HostPinned (a separate
+  // host-mapped allocation written by the CPU proxy — IBRC). The per-peer
+  // buffer is dedicated to this peer pair, so no numPeers slicing is needed.
+  void allocateSendRecvBufferForPeer(
+      int peerIndex,
+      PeerBufferPayload& payload,
+      IbCounterStorage counterStorage);
+  // Apply a peer's payload: remote recvStaging/signal views are used whole.
+  void applyRemoteSendRecvBuffer(
+      int peerIndex,
+      const PeerBufferPayload& remotePayload);
+  // Per-peer teardown: deregister + free this peer's lazy allocation and reset
+  // its views. Safe on an unmaterialized peer.
+  void cleanupSendRecvBufferForPeer(int peerIndex) noexcept;
+
+  const MultipeerIbTransportConfig::SendRecvConfig& sendRecvConfig() const;
+  void validateSendRecvConfig() const;
+  std::size_t sendRecvStagingBytesPerPeer() const;
+  std::size_t sendRecvSignalBytesPerPeer() const;
+  std::size_t sendRecvCounterBytesPerPeer() const;
+  std::size_t sendRecvStateBytesPerPeer() const;
 
   void allocateSignalCounterResources(
       IbCounterStorage counterStorage,
@@ -432,6 +507,20 @@ class MultiPeerIbTransportBase {
   // Maps allocation base address -> cached MR covering the full allocation.
   // Ordered map enables O(log n) containment lookup via upper_bound.
   std::map<uintptr_t, CachedMr> registeredBuffers_;
+
+  // Shared send/recv staging-ring state (eager mode). Owns the bulk
+  // allocations; sendRecvPeerBuffers_ slices them per peer.
+  std::vector<IbSendRecvPeerBuffers> sendRecvPeerBuffers_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvSendStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvRecvStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvSignalBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvStateBulk_;
+  // Device counter bulk (counterStorage == Device). Null for Host counters.
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvCounterBulk_;
+  IbgdaLocalBuffer sendRecvRecvStagingBulkReg_;
+  IbgdaLocalBuffer sendRecvSignalBulkReg_;
+  IbgdaLocalBuffer sendRecvCounterBulkReg_;
+  IbCounterStorage sendRecvCounterStorage_{IbCounterStorage::Device};
 
   // Lazy materialization state machine.
   std::vector<int> pendingPeers_;
@@ -512,9 +601,19 @@ class MultiPeerIbTransportBase {
   DeviceSlotAllocation slotSignalAllocation_;
   CounterSlotAllocation slotCounterAllocation_;
   DeviceSlotAllocation slotDiscardSignalAllocation_;
+  // Host-mapped send/recv NIC_DONE counter (counterStorage == Host). Owns the
+  // host-pinned allocation; sliced per peer into IbSendRecvPeerBuffers.counter.
+  CounterSlotAllocation sendRecvHostCounterAllocation_;
   std::vector<DeviceSlotAllocation> lazySlotSignalAllocations_;
   std::vector<CounterSlotAllocation> lazySlotCounterAllocations_;
   std::vector<DeviceSlotAllocation> lazySlotDiscardSignalAllocations_;
+  // Lazy per-peer send/recv allocations: one contiguous device buffer per
+  // materialized peer (sendStaging|recvStaging|signal|state, plus the counter
+  // when device-resident). Empty in eager mode. Shared by IBGDA (Device
+  // counter) and IBRC, which additionally allocates a per-peer host-mapped
+  // NIC_DONE counter below.
+  std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
+  std::vector<CounterSlotAllocation> lazySendRecvHostCounters_;
 };
 
 /**

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -487,4 +487,145 @@ __device__ __forceinline__ void P2pIbTransportDevice::fence() {
   flush();
 }
 
+// ===========================================================================
+// Pipelined send/recv — forwarded to the active backend.
+// ===========================================================================
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::send(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->send<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->send<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::recv(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->recv<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->recv<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::forward(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    P2pIbTransportDevice& fwd,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->forward<CopyOp>(
+        group,
+        dst,
+        *fwd.ibrc,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  } else {
+    ibgda->forward<CopyOp>(
+        group,
+        dst,
+        *fwd.ibgda,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+}
+
+__device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window(
+    int active_blocks) const {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->pipeline_window(active_blocks);
+  }
+  return ibgda->pipeline_window(active_blocks);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+  } else {
+    ibgda->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+  }
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+  } else {
+    ibgda->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_send_once(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_send_once<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_send_once<CopyOp>(
+      group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_recv_once(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_recv_once<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_recv_once<CopyOp>(
+      group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+}
+
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -6,11 +6,15 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "comms/prims/core/DeviceMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
+
+struct Memcpy;
 
 class P2pIbgdaTransportDevice;
 class P2pIbrcTransportDevice;
@@ -18,6 +22,1688 @@ class P2pIbrcTransportDevice;
 enum class P2pIbBackendType : uint8_t {
   IBGDA,
   IBRC,
+};
+
+/**
+ * Result of one bounded send/recv progress attempt.
+ *
+ * `progress_send_once()` and `progress_recv_once()` are intended for callers
+ * that multiplex several independent transfers from one kernel. A single call
+ * may complete immediately, advance one protocol step, or find that the next
+ * signal/counter dependency is not ready yet.
+ *
+ * `Waiting` means no user-visible data movement or protocol signal was
+ * issued. The caller may retry the same transport operation later after
+ * making progress on another lane. `Progressed` means the call advanced the
+ * operation but more calls are required. `Done` means the transfer has
+ * completed the byte range reserved by the corresponding init call.
+ */
+enum class IbgdaSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+};
+
+#if PIPES_IS_DEVICE_COMPILE
+__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
+  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
+  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
+}
+
+__device__ __forceinline__ void trace_ibgda_event(
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    PipesTraceEventType type,
+    uint32_t step,
+    uint16_t group_id) {
+  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
+  // unconfigured handle has effectively no cost.
+  write_pipes_trace(trace, type, step, group_id, self_rank);
+}
+#endif
+
+/**
+ * IbSendRecvDevice — transport-agnostic pipelined RDMA send/recv.
+ *
+ * This class owns master's full async send/recv algorithm: the blocking
+ * `send`/`recv`/`forward`, the resumable `init_*_progress` /
+ * `progress_*_once` pair, and all of their private helpers. The send/recv
+ * algorithm is independent of the underlying transport: it only needs the
+ * common explicit-buffer IB device ops `put` (fused signal+counter),
+ * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
+ *
+ * Every public method takes the owning transport as a `Transport& transport`
+ * parameter and routes every transport op through it. `P2pIbgdaTransportDevice`
+ * and `P2pIbrcTransportDevice` hold one `IbSendRecvDevice sendRecv_` member and
+ * delegate their `send`/`recv`/`forward`/progress methods to it, passing
+ * `*this` as the transport. The send/recv protocol state lives in
+ * `sendRecvState_`, populated by the host transport builder.
+ */
+class IbSendRecvDevice {
+ public:
+  IbSendRecvState sendRecvState_{};
+
+  __host__ __device__ IbSendRecvDevice() = default;
+
+  __host__ __device__ explicit IbSendRecvDevice(IbSendRecvState initialState)
+      : sendRecvState_(initialState) {}
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const {
+    return sendRecvState_;
+  }
+
+  /**
+   * Initialize transport-owned state for one pipelined send operation.
+   *
+   * The transport reserves the sender-side byte stream for `group.group_id`
+   * and starts the internal state in the sender state machine unless
+   * `nbytes == 0`. It does not capture the source pointer; callers pass the
+   * pointer to each `progress_send_once()` call.
+   *
+   * The send progress slot for this group must be idle. Re-initializing a
+   * group while a previous send is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * `active_blocks == 0` means all configured groups participate. Non-zero
+   * values must match the peer's recv-side initialization for the same logical
+   * transfer. `max_signal_bytes == 0` sends one signal per per-block staging
+   * partition; smaller non-zero values split that partition into multiple
+   * signaled sub-chunks for finer overlap with the receiver.
+   *
+   * Zero-byte sends mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `send()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to send for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_send_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "send");
+    IbSendRecvState::ProgressSlot state{};
+    state.activeStage = nbytes == 0
+        ? detail::IbSendRecvProgressStage::Done
+        : detail::IbSendRecvProgressStage::WaitNicDone;
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    // Validate the transfer before reserving the transport byte cursor.
+    const ProgressGeometry geometry = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
+    store_progress_state(group, progressIndex, state);
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+#endif
+  }
+
+  /**
+   * Initialize transport-owned state for one pipelined recv operation.
+   *
+   * The transport reserves the receiver-side byte stream for `group.group_id`
+   * and starts the internal state in the receiver state machine unless
+   * `nbytes == 0`. It does not capture the destination pointer; callers pass
+   * the pointer to each `progress_recv_once()` call.
+   *
+   * The recv progress slot for this group must be idle. Re-initializing a
+   * group while a previous recv is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * The sender and receiver must use the same `active_blocks` and compatible
+   * `max_signal_bytes` for a logical transfer. The staging offset and protocol
+   * signal values are derived from those values, so a mismatch can make one
+   * side wait on a different byte range than the other side produced.
+   *
+   * Zero-byte receives mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `recv()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to receive for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_recv_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "recv");
+    IbSendRecvState::ProgressSlot state{};
+    state.activeStage = nbytes == 0
+        ? detail::IbSendRecvProgressStage::Done
+        : detail::IbSendRecvProgressStage::WaitDataReady;
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    // Validate the transfer before reserving the transport byte cursor.
+    const ProgressGeometry geometry = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
+    store_progress_state(group, progressIndex, state);
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized send.
+   *
+   * This method advances at most one staged copy plus one RDMA put for the
+   * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
+   * dependency is not ready, it returns immediately so a higher-level scheduler
+   * can try another independent lane. If a `Timeout` is enabled, it is checked
+   * only at those readiness points and should already have been started by the
+   * caller.
+   *
+   * The send path first waits for NIC_DONE before reusing the local
+   * send-staging range, then copies user data into send-staging through
+   * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
+   * range, and finally issues an RDMA put that piggybacks DATA_READY and
+   * records NIC_DONE in the local counter. Returning `Done` means the reserved
+   * byte range has completed.
+   *
+   * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param transport Owning transport used for every transport op.
+   * @param group Thread group matching the one used during initialization.
+   * @param src Source user buffer. The range `[src, src + nbytes)` must remain
+   *            valid until `Done`.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param active_blocks Number of participating groups from init.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::send`.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      Transport& transport,
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::progress_send_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_send_index(group);
+    IbSendRecvState::ProgressSlot state =
+        progress_state_slot(group, progressIndex);
+    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    const ProgressGeometry progress_params = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
+            static_cast<unsigned long long>(state.activeNextByte),
+            static_cast<unsigned long long>(progress_params.protocolBytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_send_progress_stage(group, state);
+
+    const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+    const std::size_t initialNextByte = state.activeNextByte;
+    const std::size_t pipelineBytes = progress_params.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+
+    if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
+      const ProgressChunk chunk = next_chunk(state, progress_params);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              transport.read_counter(sendRecvState_.localCounterBuf.subBuffer(
+                  progress_params.groupId * sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      const std::size_t validBytes = valid_payload_bytes(
+          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + chunk.stagingOff,
+            static_cast<const char*>(src) + chunk.dataOff,
+            validBytes,
+            group,
+            chunk.dataOff,
+            args...);
+      }
+      group.sync();
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+    }
+
+    if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+      const ProgressChunk chunk = next_chunk(state, progress_params);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                  (sendRecvState_.maxGroups + progress_params.groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          if (state.activeStage != initialStage ||
+              state.activeNextByte != initialNextByte) {
+            store_progress_state(group, progressIndex, state);
+            return IbgdaSendRecvProgressStatus::Progressed;
+          }
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        transport.put(
+            solo,
+            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            chunk.bytes,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                progress_params.groupId * sizeof(uint64_t)),
+            chunk.bytes,
+            sendRecvState_.localCounterCompletionBuf.subBuffer(
+                progress_params.groupId * sizeof(uint64_t)),
+            chunk.bytes);
+      }
+      group.sync();
+
+      state.activeNextByte += chunk.bytes;
+      if (state.activeNextByte >= progress_params.protocolBytes) {
+        transition_progress_stage(
+            group, state, detail::IbSendRecvProgressStage::Done);
+        store_progress_state(group, progressIndex, state);
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
+    }
+
+    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
+    // WaitNicDone in one call, leaving the stage unchanged while nextByte
+    // advances. Check both fields so that case reports Progressed.
+    if (state.activeStage != initialStage ||
+        state.activeNextByte != initialNextByte) {
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Progressed;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
+#else
+    (void)transport;
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized recv.
+   *
+   * This method advances at most one recv-staging copy for the current chunk.
+   * It never spins on DATA_READY: if the sender has not signaled the next
+   * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
+   * checked only while the DATA_READY dependency is not ready and should
+   * already have been started by the caller.
+   *
+   * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
+   * transport-owned recv-staging into the caller's destination through
+   * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
+   * means the reserved byte range has completed.
+   *
+   * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param transport Owning transport used for every transport op.
+   * @param group Thread group matching the one used during initialization.
+   * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
+   *            remain valid until `Done`.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param active_blocks Number of participating groups from init.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::recv`.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::progress_recv_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_recv_index(group);
+    IbSendRecvState::ProgressSlot state =
+        progress_state_slot(group, progressIndex);
+    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    const ProgressGeometry progress_params = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
+            static_cast<unsigned long long>(state.activeNextByte),
+            static_cast<unsigned long long>(progress_params.protocolBytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_recv_progress_stage(group, state);
+
+    const ProgressChunk chunk = next_chunk(state, progress_params);
+    const uint64_t expected = chunk.streamEnd;
+    uint32_t ready = 1;
+    unsigned long long current = 0;
+    if (group.is_leader()) {
+      current = static_cast<unsigned long long>(
+          transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
+              progress_params.groupId * sizeof(uint64_t))));
+      ready = current >= expected ? 1U : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_recv_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            static_cast<unsigned long long>(expected),
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    const std::size_t validBytes = valid_payload_bytes(
+        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+    if (validBytes > 0) {
+      CopyOp::recv(
+          static_cast<char*>(dst) + chunk.dataOff,
+          sendRecvState_.recvStagingPtr + chunk.stagingOff,
+          validBytes,
+          group,
+          chunk.dataOff,
+          args...);
+    }
+    group.sync();
+
+    transport.signal(
+        group,
+        sendRecvState_.remoteSignalBuf.subBuffer(
+            (sendRecvState_.maxGroups + progress_params.groupId) *
+            sizeof(uint64_t)),
+        chunk.bytes);
+
+    state.activeNextByte += chunk.bytes;
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    store_progress_state(group, progressIndex, state);
+    return IbgdaSendRecvProgressStatus::Progressed;
+#else
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * send — send one block's tile via pipelined RDMA.
+   *
+   * Copies src -> sendStaging, then RDMA puts sendStaging -> peer's
+   * recvStaging. For this call, each logical slot contributes one
+   * perBlockSlot-sized region for this group. If nbytes > perBlockSlot, send()
+   * advances through multiple ring positions. max_signal_bytes can further
+   * subdivide each perBlockSlot into multiple signaled sub-chunks, enabling
+   * finer-grained overlap at the receiver.
+   *
+   * Signaling protocol (per group):
+   *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
+   *                send waits on this before overwriting local sendStaging.
+   *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
+   *                range. send waits before overwriting recvStaging.
+   *   DATA_READY — sender increments by bytesThis, piggybacked on put.
+   *                recv waits on this before reading recvStaging.
+   *
+   * state[].nextStep persists across calls, so send() resumes the staging-ring
+   * cursor and protocol sequence numbers on each invocation. This allows
+   * callers to pipeline across repeated send() calls without a separate drain.
+   *
+   * The caller must keep the staging layout stable while a sequence is in
+   * flight. Changing active_blocks changes the per-block staging partition, so
+   * both sides must perform a higher-level barrier/quiescence step first.
+   * max_signal_bytes may vary across calls with the same active_blocks.
+   *
+   * @param transport       Owning transport used for every transport op.
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does RDMA ops).
+   * @param src             Source data for this block's tile.
+   * @param nbytes          Bytes to send for this group. Internally consumed
+   *                        in perBlockSlot-sized pieces, or smaller sub-chunks
+   *                        when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      Transport& transport,
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)transport;
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int stateIndex = progress_send_index(group);
+    auto& state = progress_state_slot(group, stateIndex);
+    assert_progress_slot_idle(group, state, "send");
+    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+    if (group.is_leader()) {
+      state.activeStage = detail::IbSendRecvProgressStage::Busy;
+      state.activeBaseStep = static_cast<int64_t>(baseByte);
+      state.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const uint64_t streamEnd = streamStart + bytesThis;
+
+      // (1) Wait for NIC to finish with this slot's local sendStaging.
+      if (streamEnd > pipelineBytes) {
+        transport.wait_counter(
+            group,
+            sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            streamEnd - pipelineBytes,
+            timeout);
+      }
+
+      // (2) Cooperative copy: src -> local sendStaging via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + stagingOff,
+            static_cast<const char*>(src) + dataOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (3) Backpressure: wait for receiver to free this byte range's
+      //     recvStaging offset. Symmetric with DATA_READY.
+      if (streamEnd > pipelineBytes) {
+        transport.wait_signal(
+            group,
+            sendRecvState_.localSignalBuf.subBuffer(
+                (maxGroups + groupId) * sizeof(uint64_t)),
+            streamEnd - pipelineBytes,
+            timeout);
+      }
+
+      // (4) threadfence_system + leader-only single-WQE RDMA put with
+      //     fused signal+counter. All threads fence to ensure memcpy
+      //     stores are visible to the NIC before the leader posts the WQE.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        transport.put(
+            solo,
+            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
+            bytesThis,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis,
+            sendRecvState_.localCounterCompletionBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis);
+      }
+      group.sync();
+      dataOff += bytesThis;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * recv — receive one block's tile from pipelined RDMA.
+   *
+   * Waits for data to arrive in recvStaging, then copies recvStaging -> dst.
+   * For this call, each logical slot contributes one perBlockSlot-sized region
+   * for this group. If nbytes > perBlockSlot, recv() advances through multiple
+   * ring positions. max_signal_bytes controls sub-chunk granularity and must
+   * match the sender.
+   *
+   * Signaling protocol (per group, symmetric with send):
+   *   DATA_READY — sender increments by bytesThis after RDMA put completes.
+   *                recv waits on this before copying from recvStaging.
+   *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
+   *                to release backpressure on sender.
+   *
+   * @param transport       Owning transport used for every transport op.
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does signal ops).
+   * @param dst             Destination for this block's tile.
+   * @param nbytes          Bytes to receive for this group. Internally
+   *                        consumed in perBlockSlot-sized pieces, or smaller
+   *                        sub-chunks when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   *                        Must match the sender's value.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int stateIndex = progress_recv_index(group);
+    auto& state = progress_state_slot(group, stateIndex);
+    assert_progress_slot_idle(group, state, "recv");
+    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+    if (group.is_leader()) {
+      state.activeStage = detail::IbSendRecvProgressStage::Busy;
+      state.activeBaseStep = static_cast<int64_t>(baseByte);
+      state.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const uint64_t streamEnd = streamStart + bytesThis;
+
+      // (1) Wait for sender's DATA_READY signal.
+      transport.wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          streamEnd,
+          timeout);
+
+      // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::recv(
+            static_cast<char*>(dst) + dataOff,
+            sendRecvState_.recvStagingPtr + stagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
+      //     threshold before reusing remote recvStaging at the same offset.
+      transport.signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (maxGroups + groupId) * sizeof(uint64_t)),
+          bytesThis);
+      dataOff += bytesThis;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * forward — receive data and forward it to the next peer in a ring.
+   *
+   * Combines recv + send in a single method, sharing the staging buffer to
+   * avoid an extra copy. The CopyOp::forward() method receives three
+   * buffers: dst (application output), fwd_staging (next peer's send staging),
+   * and staging (this transport's recv staging). This enables fused
+   * receive-reduce-forward patterns.
+   *
+   * Signal ordering invariant (critical for ring deadlock avoidance):
+   *   1. Wait DATA_READY from sender (this transport)
+   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
+   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
+   *   5. Wait SLOT_FREE from fwd transport's receiver
+   *   6. threadfence_system + RDMA put via fwd transport
+   *
+   * Step 4 before step 5 breaks the circular dependency in rings: each rank
+   * releases its predecessor's staging before waiting on its successor.
+   *
+   * Protocol compatibility with send() and recv():
+   *
+   * forward acts as a recv on "this" transport and a send on "fwd".
+   * The signal protocol is wire-compatible:
+   *
+   *   Recv side (this transport):
+   *     - Reads state[maxGroups + groupId].nextStep (same index as recv)
+   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
+   *       piggybacked signal on remoteSignalBuf[groupId])
+   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
+   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
+   *       groupId])
+   *
+   *   Fwd side (fwd transport):
+   *     - Reads state[groupId].nextStep (same index as send)
+   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
+   *       self-counter)
+   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
+   *       (matches recv's backpressure release)
+   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
+   *       + NIC_DONE on localCounterBuf[groupId]
+   *       (matches recv's DATA_READY wait)
+   *
+   * Any chain of send → forward* → recv is therefore valid: each
+   * forward consumes exactly the signals its predecessor produces
+   * and produces exactly the signals its successor expects.
+   *
+   * @param transport       Recv-side transport (this peer's receiver).
+   * @param group           ThreadGroup (all threads participate).
+   * @param dst             Application destination (may be nullptr if
+   *                        CopyOp handles it, e.g. reduce-scatter).
+   * @param fwdDevice       Forward-side send/recv device (next peer).
+   * @param fwdTransport    Forward transport (sends to next peer in ring).
+   * @param nbytes          Bytes to receive and forward.
+   * @param active_blocks   Number of block-groups sharing the slot. 0 =
+   * maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   * @param args            Extra args forwarded to CopyOp::forward.
+   */
+  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+  __device__ __forceinline__ void forward(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      IbSendRecvDevice& fwdDevice,
+      Transport& fwdTransport,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+
+    // --- recv side (this transport) ---
+    const int recvEffActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward recv active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            recvEffActive,
+            sendRecvState_.maxGroups,
+            groupId);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t recvPerBlockSlot =
+        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
+    if (recvPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    // --- fwd side (fwd transport) ---
+    const int fwdEffActive =
+        active_blocks > 0 ? active_blocks : fwdDevice.sendRecvState_.maxGroups;
+    if (fwdEffActive > fwdDevice.sendRecvState_.maxGroups ||
+        groupId >= fwdEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward fwd active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            fwdEffActive,
+            fwdDevice.sendRecvState_.maxGroups,
+            groupId);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t fwdPerBlockSlot =
+        (fwdDevice.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
+    if (fwdPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    // Chunk sizes for recv and fwd sides
+    std::size_t recvChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : recvPerBlockSlot;
+    if (recvChunkSize == 0) {
+      recvChunkSize = recvPerBlockSlot;
+    }
+    std::size_t fwdChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : fwdPerBlockSlot;
+    if (fwdChunkSize == 0) {
+      fwdChunkSize = fwdPerBlockSlot;
+    }
+
+    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
+    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const int recvStateIndex = progress_recv_index(group);
+    auto& recvSlotState = progress_state_slot(group, recvStateIndex);
+    assert_progress_slot_idle(group, recvSlotState, "forward recv");
+    const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
+    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
+
+    const int fwdPipelineDepth = fwdDevice.sendRecvState_.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwdDevice.sendRecvState_.dataBufferSize;
+    const int fwdMaxGroups = fwdDevice.sendRecvState_.maxGroups;
+    const int fwdStateIndex = fwdDevice.progress_send_index(group);
+    auto& fwdSlotState = fwdDevice.progress_state_slot(group, fwdStateIndex);
+    fwdDevice.assert_progress_slot_idle(group, fwdSlotState, "forward send");
+    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
+    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
+    if (group.is_leader()) {
+      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+      recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
+      recvSlotState.activeNextByte = 0;
+      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+      fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
+      fwdSlotState.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      // --- Recv side offsets ---
+      const uint64_t recvStreamStart = recvBaseByte + dataOff;
+      const std::size_t recvPipelineOff =
+          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
+      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+      const std::size_t recvChunkOff =
+          recvPipelineOff - recvSlot * recvPerBlockSlot;
+      const std::size_t recvStagingOff =
+          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+
+      // --- Fwd side offsets ---
+      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
+      const std::size_t fwdPipelineOff =
+          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
+      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+      const std::size_t fwdChunkOff =
+          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
+      const std::size_t fwdStagingOff =
+          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
+      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
+      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
+      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
+
+      // (1) Wait for sender's DATA_READY.
+      transport.wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          recvStreamEnd,
+          timeout);
+
+      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        fwdTransport.wait_counter(
+            group,
+            fwdDevice.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            fwdStreamEnd - fwdPipelineBytes,
+            timeout);
+      }
+
+      // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::forward(
+            dst ? static_cast<char*>(dst) + dataOff : nullptr,
+            fwdDevice.sendRecvState_.sendStagingPtr + fwdStagingOff,
+            sendRecvState_.recvStagingPtr + recvStagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (4) Signal SLOT_FREE to sender (this transport).
+      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
+      //     to break circular ring dependency.
+      transport.signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (recvMaxGroups + groupId) * sizeof(uint64_t)),
+          bytesThis);
+
+      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+      //     recvStaging).
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        fwdTransport.wait_signal(
+            group,
+            fwdDevice.sendRecvState_.localSignalBuf.subBuffer(
+                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
+            fwdStreamEnd - fwdPipelineBytes,
+            timeout);
+      }
+
+      // (6) threadfence_system + RDMA put via fwd transport.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        fwdTransport.put(
+            solo,
+            fwdDevice.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwdDevice.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            bytesThis,
+            fwdDevice.sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis,
+            fwdDevice.sendRecvState_.localCounterCompletionBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis);
+      }
+      group.sync();
+      dataOff += bytesThis;
+    }
+
+    // Update shared byte cursors for both recv and fwd sides.
+    if (group.is_leader()) {
+      recvSlotState.nextStep =
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
+      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+      recvSlotState.activeBaseStep = 0;
+      recvSlotState.activeNextByte = 0;
+      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
+      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+      fwdSlotState.activeBaseStep = 0;
+      fwdSlotState.activeNextByte = 0;
+    }
+    group.sync();
+#else
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)fwdDevice;
+    (void)fwdTransport;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#endif
+  }
+
+  /**
+   * Maximum bytes a block can send without blocking on pipeline backpressure.
+   *
+   * The staging buffer is split into pipelineDepth slots, each divided evenly
+   * across active_blocks. A block can fill all its slots before the NIC must
+   * drain any of them, so the non-blocking window is:
+   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *
+   * Callers should loop over their data in pipeline_window-sized chunks so
+   * that send()/forward() never stall waiting for a free slot.
+   *
+   * @param active_blocks  Total blocks sharing this transport (typically
+   *                       gridDim.x).
+   */
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    const std::size_t per_block_slot =
+        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
+    return per_block_slot * sendRecvState_.pipelineDepth;
+  }
+
+ private:
+  /**
+   * Physical staging range for the next resumable progress step.
+   *
+   * `stagingOff` is an offset into the transport-owned send/recv staging
+   * buffers. `dataOff` is the matching protocol offset into the caller's user
+   * buffer. `bytes` never crosses a per-block staging partition or the
+   * reserved protocol byte count. `streamEnd` is the absolute protocol byte
+   * value after this chunk and is used as the DATA_READY, SLOT_FREE, and
+   * NIC_DONE readiness threshold. `dataOff` is a protocol offset; callers mask
+   * it against the payload byte count before invoking user-buffer copy
+   * callbacks.
+   */
+  struct ProgressChunk {
+    std::size_t stagingOff;
+    std::size_t dataOff;
+    std::size_t bytes;
+    uint64_t streamEnd;
+  };
+
+  /**
+   * Register-only geometry for one resumable progress call.
+   *
+   * This is intentionally not stored in `IbSendRecvState::ProgressSlot`:
+   * callers pass the same static geometry to init and progress, and each
+   * progress call derives these values in registers instead of reloading
+   * duplicated fields from HBM-backed progress state.
+   */
+  struct ProgressGeometry {
+    int groupId;
+    std::size_t payloadBytes;
+    std::size_t protocolBytes;
+    std::size_t perBlockSlot;
+    std::size_t chunkSize;
+  };
+
+  /**
+   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
+   * the staging stream on the same granularity as the vectorized local staging
+   * copies while preserving caller-facing payload byte counts; padding is
+   * transport-private and is never exposed to CopyOp callbacks.
+   */
+  __device__ __forceinline__ static std::size_t align_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
+
+  /**
+   * Return the internal send progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, 0);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return the internal recv progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, sendRecvState_.maxGroups);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Validate a progress group and map it into the transport-owned slot array.
+   */
+  __device__ __forceinline__ int progress_index_for_group(
+      ThreadGroup& group,
+      int baseIndex) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (sendRecvState_.state.empty() ||
+        sendRecvState_.state.data() == nullptr) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: send/recv state is null\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (sendRecvState_.maxGroups <= 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const auto requiredStateSlots =
+        static_cast<uint32_t>(2 * sendRecvState_.maxGroups);
+    if (sendRecvState_.state.size() < requiredStateSlots ||
+        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
+            "state slots=%u\n",
+            group.group_id,
+            sendRecvState_.maxGroups,
+            static_cast<unsigned>(sendRecvState_.state.size()));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    return baseIndex + static_cast<int>(group.group_id);
+#else
+    (void)group;
+    (void)baseIndex;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return a reference to a transport-owned progress state slot.
+   */
+  __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
+      ThreadGroup& group,
+      int progressIndex) const {
+    (void)group;
+    return sendRecvState_.state[progressIndex];
+  }
+
+  /**
+   * Trap if a caller tries to start a second send/recv before the first ends.
+   *
+   * The broadcast is the ordering point for init callers: if the leader sees a
+   * non-idle slot, every thread traps before any caller can store new state.
+   */
+  __device__ __forceinline__ void assert_progress_slot_idle(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state,
+      const char* direction) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    uint32_t idle = 1;
+    if (group.is_leader()) {
+      const auto activeStage = state.activeStage;
+      idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
+      if (!idle) {
+        printf(
+            "[PIPES] FATAL: %s requested with outstanding %s progress "
+            "for group_id=%u stage=%d nextByte=%llu\n",
+            direction,
+            direction,
+            group.group_id,
+            static_cast<int>(activeStage),
+            static_cast<unsigned long long>(state.activeNextByte));
+      }
+    }
+    idle = group.broadcast<uint32_t>(idle);
+    if (!idle) {
+      PIPES_DEVICE_TRAP();
+    }
+#else
+    (void)group;
+    (void)state;
+    (void)direction;
+#endif
+  }
+
+  /**
+   * Commit an updated local progress state back to its transport-owned slot.
+   * The trailing sync orders the leader's store before later group work.
+   */
+  __device__ __forceinline__ void store_progress_state(
+      ThreadGroup& group,
+      int progressIndex,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (group.is_leader()) {
+      auto& slot = sendRecvState_.state[progressIndex];
+      slot.activeNextByte = state.activeNextByte;
+      slot.activeBaseStep = state.activeBaseStep;
+      slot.activeStage = state.activeStage;
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)progressIndex;
+    (void)state;
+#endif
+  }
+
+  /**
+   * Validate and return the static staging geometry for one progress call.
+   *
+   * This helper is called by the public init APIs and each progress attempt. It
+   * verifies that the group participates in this transfer and that the
+   * requested active block count can fit at least one 16-byte-aligned region in
+   * each staging slot.
+   *
+   * On success, `perBlockSlot` is the caller's partition within each logical
+   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
+   * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
+   * rounded down to the same 16-byte alignment used by the blocking send/recv
+   * path. Invalid geometry traps on device because continuing would corrupt
+   * another block group's staging partition.
+   *
+   * The public init methods handle zero-byte operations before calling this
+   * helper. A progress call should only see zero bytes when its state is
+   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
+   * protocol counts here; copy callbacks still see only valid payload bytes.
+   */
+  __device__ __forceinline__ ProgressGeometry make_progress_geometry(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const char* opName) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (nbytes == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
+            "transfer\n",
+            opName);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const int groupId = static_cast<int>(group.group_id);
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s active_blocks=%d > maxGroups=%d\n",
+            opName,
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId < 0 || groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s group_id=%d >= active_blocks=%d\n",
+            opName,
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            opName,
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+    return ProgressGeometry{
+        .groupId = groupId,
+        .payloadBytes = nbytes,
+        .protocolBytes = protocolBytes,
+        .perBlockSlot = perBlockSlot,
+        .chunkSize = chunkSize,
+    };
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)opName;
+    return {};
+#endif
+  }
+
+  /**
+   * Reserve a non-overlapping protocol byte range for one progress state.
+   *
+   * Blocking send()/recv() read `state[].nextStep` at call entry and commit it
+   * at completion. Progress init cannot wait until completion because progress
+   * operations may complete across many bounded calls. Reserving at init gives
+   * the transport-owned state a stable byte-stream base and makes later
+   * blocking calls start after all in-flight progress ranges.
+   */
+  __device__ __forceinline__ int64_t reserve_progress_step(
+      ThreadGroup& group,
+      int stateIndex,
+      std::size_t nbytes) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    uint64_t baseStep = 0;
+    if (group.is_leader()) {
+      auto& slot = sendRecvState_.state[stateIndex];
+      baseStep = static_cast<uint64_t>(slot.nextStep);
+      slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
+    }
+    baseStep = group.broadcast<uint64_t>(baseStep);
+    return static_cast<int64_t>(baseStep);
+#else
+    (void)group;
+    (void)stateIndex;
+    (void)nbytes;
+    return 0;
+#endif
+  }
+
+  /**
+   * Trap if a send progress state is not in a sender-owned stage.
+   *
+   * Without this check, corrupted or mismatched transport-owned state could
+   * return `Waiting` forever because no send-side transition would match.
+   * Trapping turns that misuse into an immediate device failure with a clear
+   * diagnostic.
+   */
+  __device__ __forceinline__ void validate_send_progress_stage(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
+        state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
+        state.activeStage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
+            static_cast<int>(state.activeStage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Trap if a recv progress state is not in a receiver-owned stage.
+   *
+   * Receiver progress is only valid while waiting for DATA_READY. Sender
+   * stages are protocol misuse and cannot make progress on the recv path.
+   */
+  __device__ __forceinline__ void validate_recv_progress_stage(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
+        state.activeStage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
+            static_cast<int>(state.activeStage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Return whether `current -> next` is a valid progress-state transition.
+   */
+  __device__ __forceinline__ bool is_valid_progress_transition(
+      detail::IbSendRecvProgressStage current,
+      detail::IbSendRecvProgressStage next) const {
+    switch (current) {
+      case detail::IbSendRecvProgressStage::WaitNicDone:
+        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
+      case detail::IbSendRecvProgressStage::WaitSlotFree:
+        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
+            next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::WaitDataReady:
+        return next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::Done:
+        return false;
+      case detail::IbSendRecvProgressStage::Busy:
+        return false;
+    }
+    return false;
+  }
+
+  /**
+   * Apply one legal progress-state transition.
+   *
+   * The explicit transition table keeps the send/recv state machine local and
+   * auditable. If future progress states are added, this switch must opt into
+   * each new legal edge instead of allowing silent fallthrough.
+   */
+  __device__ __forceinline__ void transition_progress_stage(
+      ThreadGroup& group,
+      IbSendRecvState::ProgressSlot& state,
+      detail::IbSendRecvProgressStage next) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const detail::IbSendRecvProgressStage current = state.activeStage;
+    if (!is_valid_progress_transition(current, next)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
+            static_cast<int>(current),
+            static_cast<int>(next));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    state.activeStage = next;
+#endif
+  }
+
+  /**
+   * Map the state's logical protocol byte cursor to the next staging-ring
+   * chunk.
+   *
+   * The transport stores each logical slot as `dataBufferSize` bytes, split
+   * into geometry-specific per-group partitions. The protocol cursor advances
+   * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
+   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
+   *
+   * The returned chunk is clipped by three boundaries: the configured
+   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
+   * current per-block staging partition. This keeps every progress call
+   * bounded and prevents a single RDMA put or recv copy from spanning two
+   * staging slots.
+   */
+  __device__ __forceinline__ ProgressChunk next_chunk(
+      const IbSendRecvState::ProgressSlot& state,
+      const ProgressGeometry& geometry) const {
+    const uint64_t streamStart =
+        static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
+    const std::size_t pipelineBytes = geometry.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
+    const std::size_t slotOff =
+        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+    const std::size_t chunkOff =
+        pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
+    const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
+    const std::size_t dataRemaining =
+        geometry.protocolBytes - state.activeNextByte;
+    std::size_t bytes =
+        geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
+    bytes = bytes < slotRemaining ? bytes : slotRemaining;
+    return ProgressChunk{
+        .stagingOff = slotOff +
+            static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
+            chunkOff,
+        .dataOff = state.activeNextByte,
+        .bytes = bytes,
+        .streamEnd = streamStart + bytes,
+    };
+  }
 };
 
 struct P2pIbTransportDevice {
@@ -199,6 +1885,74 @@ struct P2pIbTransportDevice {
   __device__ void fence(ThreadGroup& group);
 
   __device__ void fence();
+
+  // Pipelined send/recv — forwarded to the active backend's IbSendRecvDevice.
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  // Per-block pipelined staging window — forwarded to the active backend.
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const;
+
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0);
+
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
 };
 
 static_assert(std::is_standard_layout_v<P2pIbTransportDevice>);

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -500,7 +500,8 @@ struct IbSendRecvState {
       nullptr}; ///< Raw local recvStaging pointer (recv memcpy)
   IbgdaLocalBuffer localSignalBuf; ///< Signal inbox (DATA_READY + SLOT_FREE)
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
-  IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
+  IbgdaLocalBuffer localCounterBuf; ///< GPU-readable NIC_DONE counter inbox
+  IbgdaLocalBuffer localCounterCompletionBuf; ///< Transport completion target
   DeviceSpan<ProgressSlot> state; ///< Protocol cursors + async state
   int maxGroups{0}; ///< Layout size for signal/state arrays
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -51,38 +51,6 @@ constexpr int kMaxQpLanesPerBlock = 64;
 
 } // namespace
 
-struct PeerBufferSizes {
-  std::size_t staging{0};
-  std::size_t srSignal{0};
-  std::size_t srCounter{0};
-  std::size_t srState{0};
-
-  // Pointers into a contiguous allocation (set by layout())
-  void* sendStagingPtr{nullptr};
-  void* recvStagingPtr{nullptr};
-  void* srSignalPtr{nullptr};
-  void* srCounterPtr{nullptr};
-  void* srStatePtr{nullptr};
-
-  std::size_t total() const {
-    return staging * 2 + srSignal + srCounter + srState;
-  }
-
-  void layout(void* base) {
-    char* p = static_cast<char*>(base);
-    sendStagingPtr = p;
-    p += staging;
-    recvStagingPtr = p;
-    p += staging;
-    srSignalPtr = p;
-    p += srSignal;
-    srCounterPtr = p;
-    p += srCounter;
-    srStatePtr = p;
-    p += srState;
-  }
-};
-
 namespace {
 
 // Convert ibverbx::ibv_mtu enum to doca_verbs_mtu_size enum.
@@ -596,43 +564,13 @@ void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
   }
 }
 
-PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
-  PeerBufferSizes sizes;
-  if (config_.sendRecv.has_value()) {
-    const auto& sr = *config_.sendRecv;
-    sizes.staging = sr.pipelineDepth * config_.dataBufferSize;
-    sizes.srSignal = 2 * sr.maxGroups * sizeof(uint64_t);
-    sizes.srCounter = sr.maxGroups * sizeof(uint64_t);
-    sizes.srState = 2 * sr.maxGroups * sizeof(IbSendRecvState::ProgressSlot);
-  }
-  return sizes;
-}
-
 P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
     int peerIndex) const {
   const int mainQpsPerPeerPerNic =
       config_.maxGroups * config_.qpsPerBlockPerNic;
-  auto makeSendRecvState = [&]() -> IbSendRecvState {
-    if (sendRecvPeerBuffers_.empty()) {
-      return {};
-    }
-    const auto& pb = sendRecvPeerBuffers_[peerIndex];
-    return IbSendRecvState{
-        .sendStagingBuf = pb.sendStaging,
-        .recvStagingBuf = pb.remoteRecvStaging,
-        .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
-        .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
-        .localSignalBuf = pb.signal,
-        .remoteSignalBuf = pb.remoteSignal,
-        .localCounterBuf = pb.counter,
-        .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
-        .maxGroups = config_.sendRecv->maxGroups,
-        .pipelineDepth = config_.sendRecv->pipelineDepth,
-        .dataBufferSize = config_.dataBufferSize,
-    };
-  };
-
-  P2pIbgdaTransportBuildParams params(makeSendRecvState());
+  // Build the device-side send/recv state from the shared base (delegates to
+  // the inherited sendRecvPeerBuffers_).
+  P2pIbgdaTransportBuildParams params(sendRecvStateForPeer(peerIndex));
   params.maxGroups = config_.maxGroups;
   params.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
   params.h_nicDeviceIbgdaResources.resize(numNics_);
@@ -789,7 +727,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
         nic.loopbackCompanionQps.resize(
             static_cast<size_t>(numPeers) * config.maxGroups);
       }
-      lazyPeerBufs_.resize(numPeers);
       peerMaterialized_.resize(numPeers, false);
     }
 
@@ -797,8 +734,17 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     allocateResources();
     registerMemory();
 
-    // Allocate tile sendrecv buffers (if configured)
-    allocate_send_recv_buffers();
+    // Allocate send/recv staging buffers (if configured). Eager mode delegates
+    // to the shared base (Device counter: NIC loopback atomic); lazy mode only
+    // sizes the inherited per-peer view vector — the shared base
+    // allocateSendRecvBufferForPeer() fills it per peer at materialization.
+    if (config_.sendRecv.has_value()) {
+      if (!config_.ibLazyConnect) {
+        allocateSendRecvBuffersEager(IbCounterStorage::Device);
+      } else {
+        sendRecvPeerBuffers_.resize(nRanks_ - 1);
+      }
+    }
   } catch (const std::exception&) {
     // Destructor won't run for a partially-constructed object, so clean up
     // all resources allocated by the init methods above.
@@ -830,8 +776,9 @@ void MultipeerIbgdaTransport::cleanup() {
   gpuAllocations_.clear();
   peerTransportsGpu_ = nullptr;
 
-  // Free tile sendrecv buffers
-  cleanup_send_recv_buffers();
+  // Free send/recv staging buffers (eager bulks + any lazy per-peer
+  // allocations) via the shared base cleanup.
+  cleanupSendRecvBuffers();
 
   // Destroy per-NIC QPs and loopback responders.
   for (auto& nic : nicDoca_) {
@@ -1087,7 +1034,7 @@ void MultipeerIbgdaTransport::exchange() {
   allocateSignalCounterResources(
       IbCounterStorage::Device, /*allocateDiscardSignal=*/true);
 
-  exchange_send_recv_buffers();
+  exchangeSendRecvBuffersEager();
 
   // Build device transports on GPU
   std::vector<P2pIbgdaTransportBuildParams> buildParams;
@@ -1163,146 +1110,10 @@ int MultipeerIbgdaTransport::qpsPerBlockPerNic() const {
 // Send/recv buffer lifecycle
 // =============================================================================
 
-void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
-  if (!config_.sendRecv.has_value()) {
-    return;
-  }
-  const auto& sr = *config_.sendRecv;
-  if (sr.pipelineDepth < 1) {
-    throw std::invalid_argument("sendRecv.pipelineDepth must be >= 1");
-  }
-  if (sr.maxGroups < 1) {
-    throw std::invalid_argument("sendRecv.maxGroups must be >= 1");
-  }
-  if (config_.dataBufferSize == 0) {
-    throw std::invalid_argument(
-        "dataBufferSize must be > 0 when sendRecv is enabled");
-  }
-  if ((config_.dataBufferSize / sr.maxGroups) < 16) {
-    throw std::invalid_argument(
-        fmt::format(
-            "dataBufferSize / maxGroups must be >= 16, got {} / {} = {}",
-            config_.dataBufferSize,
-            sr.maxGroups,
-            config_.dataBufferSize / sr.maxGroups));
-  }
-
-  const int numPeers = nRanks_ - 1;
-  auto sizes = computePeerBufferSizes();
-  const auto stagingPerPeer = sizes.staging;
-  const auto signalPerPeer = sizes.srSignal;
-  const auto counterPerPeer = sizes.srCounter;
-  const auto statePerPeer = sizes.srState;
-  const auto stateSlotsPerPeer =
-      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * sr.maxGroups);
-
-  auto allocateBulk = [&](std::size_t perPeer) {
-    auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
-    auto err = cudaMemset(buf->get(), 0, perPeer * numPeers);
-    if (err != cudaSuccess) {
-      throw std::runtime_error(
-          fmt::format(
-              "Failed to zero send/recv buffer: {}", cudaGetErrorString(err)));
-    }
-    return buf;
-  };
-
-  sendRecvPeerBuffers_.resize(numPeers);
-
-  if (!config_.ibLazyConnect) {
-    sendStagingBulk_ = allocateBulk(stagingPerPeer);
-    recvStagingBulk_ = allocateBulk(stagingPerPeer);
-    signalBulk_ = allocateBulk(signalPerPeer);
-    counterBulk_ = allocateBulk(counterPerPeer);
-    stateBulk_ = allocateBulk(statePerPeer);
-
-    auto sendStagingBulkReg =
-        registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
-    recvStagingBulkReg_ =
-        registerBuffer(recvStagingBulk_->get(), stagingPerPeer * numPeers);
-    signalBulkReg_ =
-        registerBuffer(signalBulk_->get(), signalPerPeer * numPeers);
-    counterBulkReg_ =
-        registerBuffer(counterBulk_->get(), counterPerPeer * numPeers);
-
-    for (int i = 0; i < numPeers; ++i) {
-      auto& pb = sendRecvPeerBuffers_[i];
-      pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
-      pb.recvStaging = recvStagingBulkReg_.subBuffer(i * stagingPerPeer);
-      pb.signal = signalBulkReg_.subBuffer(i * signalPerPeer);
-      pb.counter = counterBulkReg_.subBuffer(i * counterPerPeer);
-      auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(
-          static_cast<char*>(stateBulk_->get()) + i * statePerPeer);
-      pb.state.emplace(statePtr, stateSlotsPerPeer);
-    }
-
-    VLOG(1) << "MultipeerIbgdaTransport: eager mode — allocated tile buffers "
-            << "for " << numPeers << " peers (staging=" << stagingPerPeer
-            << "B per peer, 5 bulks)";
-  } else {
-    VLOG(1) << "MultipeerIbgdaTransport: lazy mode — per-peer allocation "
-            << "deferred to materializePeer";
-  }
-}
-
-void MultipeerIbgdaTransport::exchange_send_recv_buffers() {
-  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
-    return;
-  }
-
-  const int numPeers = nRanks_ - 1;
-  const std::size_t stagingPerPeer =
-      config_.sendRecv->pipelineDepth * config_.dataBufferSize;
-
-  const std::size_t signalPerPeer =
-      2 * config_.sendRecv->maxGroups * sizeof(uint64_t);
-
-  auto recvStagingRemotes = exchangeBuffer(recvStagingBulkReg_);
-  auto signalRemotes = exchangeBuffer(signalBulkReg_);
-
-  for (int i = 0; i < numPeers; ++i) {
-    int peerRank = peerIndexToRank(i);
-    int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
-
-    sendRecvPeerBuffers_[i].remoteRecvStaging =
-        recvStagingRemotes[i].subBuffer(remotePeerIndex * stagingPerPeer);
-    sendRecvPeerBuffers_[i].remoteSignal =
-        signalRemotes[i].subBuffer(remotePeerIndex * signalPerPeer);
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: exchanged tile buffers with " << numPeers
-          << " peers";
-}
-
-void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
-  for (auto& buf : lazyPeerBufs_) {
-    if (buf) {
-      deregisterBuffer(buf->get());
-      buf.reset();
-    }
-  }
-  sendRecvPeerBuffers_.clear();
-
-  if (sendStagingBulk_) {
-    deregisterBuffer(sendStagingBulk_->get());
-  }
-  if (recvStagingBulk_) {
-    deregisterBuffer(recvStagingBulk_->get());
-  }
-  if (signalBulk_) {
-    deregisterBuffer(signalBulk_->get());
-  }
-  if (counterBulk_) {
-    deregisterBuffer(counterBulk_->get());
-  }
-
-  sendStagingBulk_.reset();
-  recvStagingBulk_.reset();
-  signalBulk_.reset();
-  counterBulk_.reset();
-  stateBulk_.reset();
-}
+// Eager send/recv staging allocation, exchange, and cleanup are now provided by
+// MultiPeerIbTransportBase (allocateSendRecvBuffersEager(Device) /
+// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers()). The lazy per-peer
+// path below fills the inherited sendRecvPeerBuffers_ directly.
 
 PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
     int peerIndex) const {
@@ -1345,62 +1156,6 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
   return payload;
 }
 
-void MultipeerIbgdaTransport::allocatePeerBuffers(
-    int peerIndex,
-    PeerBufferPayload& payload) {
-  auto sizes = computePeerBufferSizes();
-  const std::size_t totalPerPeer = sizes.total();
-  if (totalPerPeer == 0) {
-    return;
-  }
-
-  lazyPeerBufs_[peerIndex] =
-      std::make_unique<meta::comms::DeviceBuffer>(totalPerPeer);
-  cudaError_t cudaErr =
-      cudaMemset(lazyPeerBufs_[peerIndex]->get(), 0, totalPerPeer);
-  if (cudaErr != cudaSuccess) {
-    throw std::runtime_error("Failed to zero per-peer buffer");
-  }
-
-  auto& peerBuf = lazyPeerBufs_[peerIndex];
-  sizes.layout(peerBuf->get());
-
-  auto reg = registerBuffer(peerBuf->get(), totalPerPeer);
-
-  auto addr = reinterpret_cast<uintptr_t>(peerBuf->get());
-  auto mrIt = registeredBuffers_.upper_bound(addr);
-  CHECK(mrIt != registeredBuffers_.begin())
-      << "materializePeer: peerBuf MR not found after registerBuffer";
-  --mrIt;
-  auto& mr = mrIt->second;
-
-  if (config_.sendRecv.has_value()) {
-    auto& pb = sendRecvPeerBuffers_[peerIndex];
-    pb.sendStaging =
-        IbgdaLocalBuffer(sizes.sendStagingPtr, reg.lkey_per_device);
-    pb.recvStaging =
-        IbgdaLocalBuffer(sizes.recvStagingPtr, reg.lkey_per_device);
-    pb.signal = IbgdaLocalBuffer(sizes.srSignalPtr, reg.lkey_per_device);
-    pb.counter = IbgdaLocalBuffer(sizes.srCounterPtr, reg.lkey_per_device);
-    auto* statePtr =
-        reinterpret_cast<IbSendRecvState::ProgressSlot*>(sizes.srStatePtr);
-    const auto stateSlots =
-        static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-            2 * config_.sendRecv->maxGroups);
-    pb.state.emplace(statePtr, stateSlots);
-
-    payload.recvStaging.addr = reinterpret_cast<uint64_t>(sizes.recvStagingPtr);
-    payload.recvStaging.numNics = numNics_;
-    payload.srSignal.addr = reinterpret_cast<uint64_t>(sizes.srSignalPtr);
-    payload.srSignal.numNics = numNics_;
-    for (int n = 0; n < numNics_; ++n) {
-      auto rkey = HostRKey(mr.mrs[n]->rkey);
-      payload.recvStaging.rkey_per_device[n] = rkey;
-      payload.srSignal.rkey_per_device[n] = rkey;
-    }
-  }
-}
-
 void MultipeerIbgdaTransport::connectPeerMainQps(
     int peerIndex,
     const PeerQpPayload& remotePayload) {
@@ -1430,16 +1185,6 @@ void MultipeerIbgdaTransport::connectPeerMainQps(
   }
 }
 
-void MultipeerIbgdaTransport::applyRemoteViews(
-    int peerIndex,
-    const PeerBufferPayload& remotePayload) {
-  if (config_.sendRecv.has_value()) {
-    auto& pb = sendRecvPeerBuffers_[peerIndex];
-    pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
-    pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
-  }
-}
-
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
@@ -1466,11 +1211,7 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
       }
     }
   }
-  auto& buf = lazyPeerBufs_[peerIndex];
-  if (buf) {
-    deregisterBuffer(buf->get());
-    buf.reset();
-  }
+  cleanupSendRecvBufferForPeer(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
   peerMaterialized_[peerIndex] = false;
   if (peerTransportsGpu_ != nullptr && peerTransportSize_ != 0) {
@@ -1521,7 +1262,7 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
 
   // Phase 2: exchange buffer info (acts as QP-ready barrier).
   PeerBufferPayload localBuf{};
-  allocatePeerBuffers(peerIndex, localBuf);
+  allocateSendRecvBufferForPeer(peerIndex, localBuf, IbCounterStorage::Device);
   allocatePeerSignalCounterResources(
       peerIndex,
       localBuf,
@@ -1529,7 +1270,7 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
       /*allocateDiscardSignal=*/true);
   auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
-  applyRemoteViews(peerIndex, remoteBuf);
+  applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   applyRemoteSignalCounterResources(
       peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
 

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -37,7 +37,6 @@ struct MultipeerIbgdaDeviceTransport;
 struct P2pIbgdaTransportBuildParams;
 struct PeerQpPayload;
 struct PeerBufferPayload;
-struct PeerBufferSizes;
 } // namespace comms::prims
 
 namespace comms::prims {
@@ -222,9 +221,6 @@ class MultipeerIbgdaTransport
   void allocateResources();
   void registerMemory();
   void createQpGroups();
-  void allocate_send_recv_buffers();
-  void exchange_send_recv_buffers();
-  void cleanup_send_recv_buffers();
   void cleanup();
   // Connect a QP to a peer (or self for loopback). The nic argument selects
   // which local NIC's AH attrs / port to use; the peerInfo carries the
@@ -241,14 +237,10 @@ class MultipeerIbgdaTransport
   void connectPeerLoopback(int peerIndex);
   P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
 
-  PeerBufferSizes computePeerBufferSizes() const;
-
   void doMaterializePeer(int peerRank);
 
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
-  void allocatePeerBuffers(int peerIndex, PeerBufferPayload& payload);
   void connectPeerMainQps(int peerIndex, const PeerQpPayload& remotePayload);
-  void applyRemoteViews(int peerIndex, const PeerBufferPayload& remotePayload);
   void cleanupPeerOnFailure(int peerIndex);
 
   // MultiPeerIbTransport drives the shared control plane (config, MR registry,
@@ -310,32 +302,12 @@ class MultipeerIbgdaTransport
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Per-peer send/recv buffer views (populated by both modes).
-  struct SendRecvPeerBuffers {
-    IbgdaLocalBuffer sendStaging;
-    IbgdaLocalBuffer recvStaging;
-    IbgdaLocalBuffer signal;
-    IbgdaLocalBuffer counter;
-    std::optional<DeviceSpan<IbSendRecvState::ProgressSlot>> state;
-    IbgdaRemoteBuffer remoteRecvStaging;
-    IbgdaRemoteBuffer remoteSignal;
-  };
-  std::vector<SendRecvPeerBuffers> sendRecvPeerBuffers_;
-
-  // Eager mode: bulk allocations for all peers. Null in lazy mode.
-  std::unique_ptr<meta::comms::DeviceBuffer> sendStagingBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> recvStagingBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> signalBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> counterBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> stateBulk_;
-  IbgdaLocalBuffer recvStagingBulkReg_;
-  IbgdaLocalBuffer signalBulkReg_;
-  IbgdaLocalBuffer counterBulkReg_;
-
-  // Lazy mode: per-peer contiguous allocation (staging + signal + counter +
-  // state + slot-index). Null for unmaterialized peers.
-  // Empty in eager mode.
-  std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
+  // Per-peer send/recv buffer views (IbSendRecvPeerBuffers) and the eager-mode
+  // bulk allocations now live in MultiPeerIbTransportBase
+  // (sendRecvPeerBuffers_). Eager allocation/exchange/cleanup delegate to the
+  // base's allocateSendRecvBuffersEager(Device)/exchangeSendRecvBuffersEager()/
+  // cleanupSendRecvBuffers(); the lazy path below fills the inherited
+  // sendRecvPeerBuffers_ directly.
 
   // Lazy state (pendingPeers_/peerMaterialized_/materializationFailed_) is
   // inherited (protected) from MultiPeerIbTransport.

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -30,7 +30,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
-#include "comms/prims/trace/PipesTraceTypes.h"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
@@ -39,46 +39,13 @@ struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
-#if PIPES_IS_DEVICE_COMPILE
-__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
-  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
-  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
-}
-
-__device__ __forceinline__ void trace_ibgda_event(
-    PipesTraceHandle trace,
-    uint8_t self_rank,
-    PipesTraceEventType type,
-    uint32_t step,
-    uint16_t group_id) {
-  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
-  // unconfigured handle has effectively no cost.
-  write_pipes_trace(trace, type, step, group_id, self_rank);
-}
-#endif
-
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
-
-/**
- * Result of one bounded send/recv progress attempt.
- *
- * `progress_send_once()` and `progress_recv_once()` are intended for callers
- * that multiplex several independent transfers from one kernel. A single call
- * may complete immediately, advance one protocol step, or find that the next
- * signal/counter dependency is not ready yet.
- *
- * `Waiting` means no user-visible data movement or protocol signal was
- * issued. The caller may retry the same transport operation later after
- * making progress on another lane. `Progressed` means the call advanced the
- * operation but more calls are required. `Done` means the transfer has
- * completed the byte range reserved by the corresponding init call.
- */
-enum class IbgdaSendRecvProgressStatus : uint8_t {
-  Waiting,
-  Progressed,
-  Done,
-};
+//
+// `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm now live
+// in the shared `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh); this class
+// delegates its send/recv/forward/init/progress methods to a `sendRecv_`
+// member.
 
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
@@ -251,7 +218,7 @@ class P2pIbgdaTransportDevice {
         maxGroups_(maxGroups),
         qpsPerBlockPerNic_(qpsPerBlockPerNic),
         blockQpState_(blockQpState),
-        sendRecvState_(sendRecvState) {}
+        sendRecv_(sendRecvState) {}
 
   // =========================================================================
   // Slot-Index API (resolves owned buffers, forwards to explicit-buffer API)
@@ -1979,25 +1946,8 @@ class P2pIbgdaTransportDevice {
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_send_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
-    assert_progress_slot_idle(group, slot, "send");
-    IbSendRecvState::ProgressSlot state{};
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitNicDone;
-    if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
-#endif
+    sendRecv_.init_send_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
   }
 
   /**
@@ -2034,25 +1984,8 @@ class P2pIbgdaTransportDevice {
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_recv_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
-    assert_progress_slot_idle(group, slot, "recv");
-    IbSendRecvState::ProgressSlot state{};
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitDataReady;
-    if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
-#endif
+    sendRecv_.init_recv_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
   }
 
   /**
@@ -2097,152 +2030,15 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "P2pIbgdaTransportDevice::progress_send_once() requires NVIDIA GPU");
-#endif
-    const int progressIndex = progress_send_index(group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_send_progress_stage(group, state);
-
-    const detail::IbSendRecvProgressStage initialStage = state.activeStage;
-    const std::size_t initialNextByte = state.activeNextByte;
-    const std::size_t pipelineBytes = progress_params.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              read_counter(sendRecvState_.localCounterBuf.subBuffer(
-                  progress_params.groupId * sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for NIC_DONE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      const std::size_t validBytes = valid_payload_bytes(
-          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState_.sendStagingPtr + chunk.stagingOff,
-            static_cast<const char*>(src) + chunk.dataOff,
-            validBytes,
-            group,
-            chunk.dataOff,
-            args...);
-      }
-      group.sync();
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
-    }
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              read_signal(sendRecvState_.localSignalBuf.subBuffer(
-                  (sendRecvState_.maxGroups + progress_params.groupId) *
-                  sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          if (state.activeStage != initialStage ||
-              state.activeNextByte != initialNextByte) {
-            store_progress_state(group, progressIndex, state);
-            return IbgdaSendRecvProgressStatus::Progressed;
-          }
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        put(solo,
-            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
-            chunk.bytes,
-            sendRecvState_.remoteSignalBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes,
-            sendRecvState_.localCounterBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes);
-      }
-      group.sync();
-
-      state.activeNextByte += chunk.bytes;
-      if (state.activeNextByte >= progress_params.protocolBytes) {
-        transition_progress_stage(
-            group, state, detail::IbSendRecvProgressStage::Done);
-        store_progress_state(group, progressIndex, state);
-        return IbgdaSendRecvProgressStatus::Done;
-      }
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
-    }
-
-    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
-    // WaitNicDone in one call, leaving the stage unchanged while nextByte
-    // advances. Check both fields so that case reports Progressed.
-    if (state.activeStage != initialStage ||
-        state.activeNextByte != initialNextByte) {
-      store_progress_state(group, progressIndex, state);
-      return IbgdaSendRecvProgressStatus::Progressed;
-    }
-    return IbgdaSendRecvProgressStatus::Waiting;
-#else
-    return IbgdaSendRecvProgressStatus::Done;
-#endif
+    return sendRecv_.progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2284,88 +2080,15 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "P2pIbgdaTransportDevice::progress_recv_once() requires NVIDIA GPU");
-#endif
-    const int progressIndex = progress_recv_index(group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_recv_progress_stage(group, state);
-
-    const ProgressChunk chunk = next_chunk(state, progress_params);
-    const uint64_t expected = chunk.streamEnd;
-    uint32_t ready = 1;
-    unsigned long long current = 0;
-    if (group.is_leader()) {
-      current = static_cast<unsigned long long>(
-          read_signal(sendRecvState_.localSignalBuf.subBuffer(
-              progress_params.groupId * sizeof(uint64_t))));
-      ready = current >= expected ? 1U : 0U;
-      if (!ready) {
-        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-            timeout,
-            "progress_recv_once waiting for DATA_READY expected>=%llu, "
-            "current=%llu",
-            static_cast<unsigned long long>(expected),
-            current);
-      }
-    }
-    ready = group.broadcast<uint32_t>(ready);
-    if (!ready) {
-      return IbgdaSendRecvProgressStatus::Waiting;
-    }
-
-    const std::size_t validBytes = valid_payload_bytes(
-        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-    if (validBytes > 0) {
-      CopyOp::recv(
-          static_cast<char*>(dst) + chunk.dataOff,
-          sendRecvState_.recvStagingPtr + chunk.stagingOff,
-          validBytes,
-          group,
-          chunk.dataOff,
-          args...);
-    }
-    group.sync();
-
-    signal(
+    return sendRecv_.progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
         group,
-        sendRecvState_.remoteSignalBuf.subBuffer(
-            (sendRecvState_.maxGroups + progress_params.groupId) *
-            sizeof(uint64_t)),
-        chunk.bytes);
-
-    state.activeNextByte += chunk.bytes;
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::Done);
-      store_progress_state(group, progressIndex, state);
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-
-    store_progress_state(group, progressIndex, state);
-    return IbgdaSendRecvProgressStatus::Progressed;
-#else
-    return IbgdaSendRecvProgressStatus::Done;
-#endif
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2417,14 +2140,6 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)group;
-    (void)src;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
     sendWithTrace<CopyOp>(
         group,
         src,
@@ -2435,7 +2150,6 @@ class P2pIbgdaTransportDevice {
         {},
         0,
         args...);
-#endif
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2462,162 +2176,31 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send active_blocks=%d > maxGroups=%d\n",
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send group_id=%u >= active_blocks=%d\n",
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int maxGroups = sendRecvState_.maxGroups;
-    const int stateIndex = progress_send_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
-    assert_progress_slot_idle(group, state, "send");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbSendBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for NIC to finish with this slot's local sendStaging.
-      if (streamEnd > pipelineBytes) {
-        wait_counter(
-            group,
-            sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (2) Cooperative copy: src → local sendStaging via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState_.sendStagingPtr + stagingOff,
-            static_cast<const char*>(src) + dataOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Backpressure: wait for receiver to free this byte range's
-      //     recvStaging offset. Symmetric with DATA_READY.
-      if (streamEnd > pipelineBytes) {
-        wait_signal(
-            group,
-            sendRecvState_.localSignalBuf.subBuffer(
-                (maxGroups + groupId) * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (4) threadfence_system + leader-only single-WQE RDMA put with
-      //     fused signal+counter. All threads fence to ensure memcpy
-      //     stores are visible to the NIC before the leader posts the WQE.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        put(solo,
-            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
-            bytesThis,
-            sendRecvState_.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis,
-            sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
-      }
-      group.sync();
-      dataOff += bytesThis;
-    }
-
+    sendRecv_.send<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbSendEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
@@ -2659,14 +2242,6 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)group;
-    (void)dst;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
     recvWithTrace<CopyOp>(
         group,
         dst,
@@ -2677,7 +2252,6 @@ class P2pIbgdaTransportDevice {
         {},
         0,
         args...);
-#endif
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2704,135 +2278,31 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv active_blocks=%d > maxGroups=%d\n",
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv group_id=%u >= active_blocks=%d\n",
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int maxGroups = sendRecvState_.maxGroups;
-    const int stateIndex = progress_recv_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
-    assert_progress_slot_idle(group, state, "recv");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbRecvBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY signal.
-      wait_signal(
-          group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          streamEnd,
-          timeout);
-
-      // (2) Cooperative copy: local recvStaging → dst via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::recv(
-            static_cast<char*>(dst) + dataOff,
-            sendRecvState_.recvStagingPtr + stagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
-      //     threshold before reusing remote recvStaging at the same offset.
-      signal(
-          group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (maxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis);
-      dataOff += bytesThis;
-    }
-
+    sendRecv_.recv<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbRecvEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
@@ -2931,251 +2401,43 @@ class P2pIbgdaTransportDevice {
       uint8_t self_rank,
       Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        false,
-        "P2pIbgdaTransportDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
-#endif
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-
-    // --- recv side (this transport) ---
-    const int recvEffActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward recv active_blocks=%d "
-            "maxGroups=%d groupId=%u\n",
-            recvEffActive,
-            sendRecvState_.maxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t recvPerBlockSlot =
-        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
-    if (recvPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // --- fwd side (fwd transport) ---
-    const int fwdEffActive =
-        active_blocks > 0 ? active_blocks : fwd.sendRecvState_.maxGroups;
-    if (fwdEffActive > fwd.sendRecvState_.maxGroups ||
-        groupId >= fwdEffActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward fwd active_blocks=%d "
-            "maxGroups=%d groupId=%u\n",
-            fwdEffActive,
-            fwd.sendRecvState_.maxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t fwdPerBlockSlot =
-        (fwd.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
-    if (fwdPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // Chunk sizes for recv and fwd sides
-    std::size_t recvChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : recvPerBlockSlot;
-    if (recvChunkSize == 0) {
-      recvChunkSize = recvPerBlockSlot;
-    }
-    std::size_t fwdChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : fwdPerBlockSlot;
-    if (fwdChunkSize == 0) {
-      fwdChunkSize = fwdPerBlockSlot;
-    }
-
-    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
-    const int recvMaxGroups = sendRecvState_.maxGroups;
-    const int recvStateIndex = progress_recv_index(group);
-    auto& recvSlotState = progress_state_slot(group, recvStateIndex);
-    assert_progress_slot_idle(group, recvSlotState, "forward recv");
-    const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
-    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
-
-    const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
-    const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
-    const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
-    const int fwdStateIndex = fwd.progress_send_index(group);
-    auto& fwdSlotState = fwd.progress_state_slot(group, fwdStateIndex);
-    fwd.assert_progress_slot_idle(group, fwdSlotState, "forward send");
-    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
-    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
-    if (group.is_leader()) {
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
-      fwdSlotState.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbForwardBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      // --- Recv side offsets ---
-      const uint64_t recvStreamStart = recvBaseByte + dataOff;
-      const std::size_t recvPipelineOff =
-          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
-      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
-      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
-      const std::size_t recvChunkOff =
-          recvPipelineOff - recvSlot * recvPerBlockSlot;
-      const std::size_t recvStagingOff =
-          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
-
-      // --- Fwd side offsets ---
-      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
-      const std::size_t fwdPipelineOff =
-          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
-      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
-      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
-      const std::size_t fwdChunkOff =
-          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
-      const std::size_t fwdStagingOff =
-          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
-      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
-      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
-      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
-      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
-      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
-      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
-      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY.
-      wait_signal(
-          group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          recvStreamEnd,
-          timeout);
-
-      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwd.wait_counter(
-            group,
-            fwd.sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (3) CopyOp::forward — transform recv staging → dst + fwd staging.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::forward(
-            dst ? static_cast<char*>(dst) + dataOff : nullptr,
-            fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
-            sendRecvState_.recvStagingPtr + recvStagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (4) Signal SLOT_FREE to sender (this transport).
-      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
-      //     to break circular ring dependency.
-      signal(
-          group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (recvMaxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis);
-
-      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
-      //     recvStaging).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwd.wait_signal(
-            group,
-            fwd.sendRecvState_.localSignalBuf.subBuffer(
-                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (6) threadfence_system + RDMA put via fwd transport.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        fwd.put(
-            solo,
-            fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
-            fwd.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
-            bytesThis,
-            fwd.sendRecvState_.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis,
-            fwd.sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
-      }
-      group.sync();
-      dataOff += bytesThis;
-    }
-
-    // Update shared byte cursors for both recv and fwd sides.
+    sendRecv_.forward<CopyOp>(
+        *this,
+        group,
+        dst,
+        fwd.sendRecv_,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      recvSlotState.nextStep =
-          static_cast<int64_t>(recvBaseByte + protocolBytes);
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      recvSlotState.activeBaseStep = 0;
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      fwdSlotState.activeBaseStep = 0;
-      fwdSlotState.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbForwardEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecvState_;
+    return sendRecv_.send_recv_state();
   }
 
   /**
@@ -3194,476 +2456,10 @@ class P2pIbgdaTransportDevice {
    */
   __device__ __forceinline__ std::size_t pipeline_window(
       int active_blocks) const {
-    const std::size_t per_block_slot =
-        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
-    return per_block_slot * sendRecvState_.pipelineDepth;
+    return sendRecv_.pipeline_window(active_blocks);
   }
 
  private:
-  /**
-   * Physical staging range for the next resumable progress step.
-   *
-   * `stagingOff` is an offset into the transport-owned send/recv staging
-   * buffers. `dataOff` is the matching protocol offset into the caller's user
-   * buffer.
-   * `bytes` never crosses a per-block staging partition or the reserved
-   * protocol byte count. `streamEnd` is the absolute protocol byte value after
-   * this chunk and is used as the DATA_READY, SLOT_FREE, and NIC_DONE
-   * readiness threshold. `dataOff` is a protocol offset; callers mask it
-   * against the payload byte count before invoking user-buffer copy callbacks.
-   */
-  struct ProgressChunk {
-    std::size_t stagingOff;
-    std::size_t dataOff;
-    std::size_t bytes;
-    uint64_t streamEnd;
-  };
-
-  /**
-   * Register-only geometry for one resumable progress call.
-   *
-   * This is intentionally not stored in `IbSendRecvState::ProgressSlot`:
-   * callers pass the same static geometry to init and progress, and each
-   * progress call derives these values in registers instead of reloading
-   * duplicated fields from HBM-backed progress state.
-   */
-  struct ProgressGeometry {
-    int groupId;
-    std::size_t payloadBytes;
-    std::size_t protocolBytes;
-    std::size_t perBlockSlot;
-    std::size_t chunkSize;
-  };
-
-  /**
-   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
-   * the staging stream on the same granularity as the vectorized local staging
-   * copies while preserving caller-facing payload byte counts; padding is
-   * transport-private and is never exposed to CopyOp callbacks.
-   */
-  __device__ __forceinline__ static std::size_t align_protocol_bytes(
-      std::size_t nbytes) {
-    return (nbytes + 15ULL) & ~15ULL;
-  }
-
-  __device__ __forceinline__ static std::size_t valid_payload_bytes(
-      std::size_t byteOffset,
-      std::size_t chunkBytes,
-      std::size_t payloadBytes) {
-    if (byteOffset >= payloadBytes) {
-      return 0;
-    }
-    const std::size_t remaining = payloadBytes - byteOffset;
-    return chunkBytes < remaining ? chunkBytes : remaining;
-  }
-
-  /**
-   * Return the internal send progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, 0);
-#else
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return the internal recv progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, sendRecvState_.maxGroups);
-#else
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Validate a progress group and map it into the transport-owned slot array.
-   */
-  __device__ __forceinline__ int progress_index_for_group(
-      ThreadGroup& group,
-      int baseIndex) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (sendRecvState_.state.empty() ||
-        sendRecvState_.state.data() == nullptr) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: send/recv state is null\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (sendRecvState_.maxGroups <= 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const auto requiredStateSlots =
-        static_cast<uint32_t>(2 * sendRecvState_.maxGroups);
-    if (sendRecvState_.state.size() < requiredStateSlots ||
-        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
-            "state slots=%u\n",
-            group.group_id,
-            sendRecvState_.maxGroups,
-            static_cast<unsigned>(sendRecvState_.state.size()));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    return baseIndex + static_cast<int>(group.group_id);
-#else
-    (void)group;
-    (void)baseIndex;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return a reference to a transport-owned progress state slot.
-   */
-  __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
-      ThreadGroup& group,
-      int progressIndex) const {
-    (void)group;
-    return sendRecvState_.state[progressIndex];
-  }
-
-  /**
-   * Trap if a caller tries to start a second send/recv before the first ends.
-   *
-   * The broadcast is the ordering point for init callers: if the leader sees a
-   * non-idle slot, every thread traps before any caller can store new state.
-   */
-  __device__ __forceinline__ void assert_progress_slot_idle(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state,
-      const char* direction) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint32_t idle = 1;
-    if (group.is_leader()) {
-      const auto activeStage = state.activeStage;
-      idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
-      if (!idle) {
-        printf(
-            "[PIPES] FATAL: %s requested with outstanding %s progress "
-            "for group_id=%u stage=%d nextByte=%llu\n",
-            direction,
-            direction,
-            group.group_id,
-            static_cast<int>(activeStage),
-            static_cast<unsigned long long>(state.activeNextByte));
-      }
-    }
-    idle = group.broadcast<uint32_t>(idle);
-    if (!idle) {
-      PIPES_DEVICE_TRAP();
-    }
-#else
-    (void)group;
-    (void)state;
-    (void)direction;
-#endif
-  }
-
-  /**
-   * Commit an updated local progress state back to its transport-owned slot.
-   * The trailing sync orders the leader's store before later group work.
-   */
-  __device__ __forceinline__ void store_progress_state(
-      ThreadGroup& group,
-      int progressIndex,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[progressIndex];
-      slot.activeNextByte = state.activeNextByte;
-      slot.activeBaseStep = state.activeBaseStep;
-      slot.activeStage = state.activeStage;
-    }
-    group.sync();
-#else
-    (void)group;
-    (void)progressIndex;
-    (void)state;
-#endif
-  }
-
-  /**
-   * Validate and return the static staging geometry for one progress call.
-   *
-   * This helper is called by the public init APIs and each progress attempt. It
-   * verifies that the group participates in this transfer and that the
-   * requested active block count can fit at least one 16-byte-aligned region in
-   * each staging slot.
-   *
-   * On success, `perBlockSlot` is the caller's partition within each logical
-   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
-   * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
-   * rounded down to the same 16-byte alignment used by the blocking send/recv
-   * path. Invalid geometry traps on device because continuing would corrupt
-   * another block group's staging partition.
-   *
-   * The public init methods handle zero-byte operations before calling this
-   * helper. A progress call should only see zero bytes when its state is
-   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
-   * protocol counts here; copy callbacks still see only valid payload bytes.
-   */
-  __device__ __forceinline__ ProgressGeometry make_progress_geometry(
-      ThreadGroup& group,
-      std::size_t nbytes,
-      int active_blocks,
-      std::size_t max_signal_bytes,
-      const char* opName) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (nbytes == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
-            "transfer\n",
-            opName);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const int groupId = static_cast<int>(group.group_id);
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s active_blocks=%d > maxGroups=%d\n",
-            opName,
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId < 0 || groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s group_id=%d >= active_blocks=%d\n",
-            opName,
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            opName,
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-    return ProgressGeometry{
-        .groupId = groupId,
-        .payloadBytes = nbytes,
-        .protocolBytes = protocolBytes,
-        .perBlockSlot = perBlockSlot,
-        .chunkSize = chunkSize,
-    };
-#else
-    (void)group;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)opName;
-    return {};
-#endif
-  }
-
-  /**
-   * Reserve a non-overlapping protocol byte range for one progress state.
-   *
-   * Blocking send()/recv() read `state[].nextStep` at call entry and commit it
-   * at completion. Progress init cannot wait until completion because progress
-   * operations may complete across many bounded calls. Reserving at init gives
-   * the transport-owned state a stable byte-stream base and makes later
-   * blocking calls start after all in-flight progress ranges.
-   */
-  __device__ __forceinline__ int64_t reserve_progress_step(
-      ThreadGroup& group,
-      int stateIndex,
-      std::size_t nbytes) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint64_t baseStep = 0;
-    if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[stateIndex];
-      baseStep = static_cast<uint64_t>(slot.nextStep);
-      slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
-    }
-    baseStep = group.broadcast<uint64_t>(baseStep);
-    return static_cast<int64_t>(baseStep);
-#else
-    (void)group;
-    (void)stateIndex;
-    (void)nbytes;
-    return 0;
-#endif
-  }
-
-  /**
-   * Trap if a send progress state is not in a sender-owned stage.
-   *
-   * Without this check, corrupted or mismatched transport-owned state could
-   * return `Waiting` forever because no send-side transition would match.
-   * Trapping turns that misuse into an immediate device failure with a clear
-   * diagnostic.
-   */
-  __device__ __forceinline__ void validate_send_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
-        state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Trap if a recv progress state is not in a receiver-owned stage.
-   *
-   * Receiver progress is only valid while waiting for DATA_READY. Sender
-   * stages are protocol misuse and cannot make progress on the recv path.
-   */
-  __device__ __forceinline__ void validate_recv_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Return whether `current -> next` is a valid progress-state transition.
-   */
-  __device__ __forceinline__ bool is_valid_progress_transition(
-      detail::IbSendRecvProgressStage current,
-      detail::IbSendRecvProgressStage next) const {
-    switch (current) {
-      case detail::IbSendRecvProgressStage::WaitNicDone:
-        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
-      case detail::IbSendRecvProgressStage::WaitSlotFree:
-        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
-            next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::WaitDataReady:
-        return next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::Done:
-        return false;
-      case detail::IbSendRecvProgressStage::Busy:
-        return false;
-    }
-    return false;
-  }
-
-  /**
-   * Apply one legal progress-state transition.
-   *
-   * The explicit transition table keeps the send/recv state machine local and
-   * auditable. If future progress states are added, this switch must opt into
-   * each new legal edge instead of allowing silent fallthrough.
-   */
-  __device__ __forceinline__ void transition_progress_stage(
-      ThreadGroup& group,
-      IbSendRecvState::ProgressSlot& state,
-      detail::IbSendRecvProgressStage next) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const detail::IbSendRecvProgressStage current = state.activeStage;
-    if (!is_valid_progress_transition(current, next)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
-            static_cast<int>(current),
-            static_cast<int>(next));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    state.activeStage = next;
-#endif
-  }
-
-  /**
-   * Map the state's logical protocol byte cursor to the next staging-ring
-   * chunk.
-   *
-   * The transport stores each logical slot as `dataBufferSize` bytes, split
-   * into geometry-specific per-group partitions. The protocol cursor advances
-   * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
-   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
-   *
-   * The returned chunk is clipped by three boundaries: the configured
-   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
-   * current per-block staging partition. This keeps every progress call
-   * bounded and prevents a single RDMA put or recv copy from spanning two
-   * staging slots.
-   */
-  __device__ __forceinline__ ProgressChunk next_chunk(
-      const IbSendRecvState::ProgressSlot& state,
-      const ProgressGeometry& geometry) const {
-    const uint64_t streamStart =
-        static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
-    const std::size_t pipelineBytes = geometry.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
-    const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamStart % pipelineBytes);
-    const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
-    const std::size_t slotOff =
-        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
-    const std::size_t chunkOff =
-        pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-    const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
-    const std::size_t dataRemaining =
-        geometry.protocolBytes - state.activeNextByte;
-    std::size_t bytes =
-        geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
-    bytes = bytes < slotRemaining ? bytes : slotRemaining;
-    return ProgressChunk{
-        .stagingOff = slotOff +
-            static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
-            chunkOff,
-        .dataOff = state.activeNextByte,
-        .bytes = bytes,
-        .streamEnd = streamStart + bytes,
-    };
-  }
-
   // --- Members ---
   // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id).
   DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
@@ -3679,7 +2475,7 @@ class P2pIbgdaTransportDevice {
   int qpsPerBlockPerNic_{1};
   DeviceSpan<IbgdaBlockQpState> blockQpState_{};
 
-  IbSendRecvState sendRecvState_{};
+  IbSendRecvDevice sendRecv_{};
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/IbrcTypes.h
+++ b/comms/prims/transport/ibrc/IbrcTypes.h
@@ -88,4 +88,11 @@ struct IbrcCmdQueueDevice {
 static_assert(std::is_standard_layout_v<IbrcCmdQueueDevice>);
 static_assert(std::is_trivially_copyable_v<IbrcCmdQueueDevice>);
 
+struct IbrcBlockQpState {
+  uint32_t put_rr{0};
+};
+
+static_assert(std::is_standard_layout_v<IbrcBlockQpState>);
+static_assert(std::is_trivially_copyable_v<IbrcBlockQpState>);
+
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -25,7 +25,12 @@
 #include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
-#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
+// Device-handle construction lives in MultipeerIbrcTransportCuda.cu: the full
+// P2pIbrcTransportDevice pulls hip_bf16 (via the send/recv CopyOp) which a host
+// .cc can't compile on AMD, so it's built in device context there (mirrors
+// IBGDA's MultipeerIbgdaTransportCuda). This .cc only needs the host-callable
+// builder declarations.
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh"
 
 namespace comms::prims {
 
@@ -65,6 +70,10 @@ GpuError gpuFreeHost(void* ptr) {
 GpuError gpuSetDevice(int device) {
   return hipSetDevice(device);
 }
+
+GpuError gpuMemset(void* ptr, int value, std::size_t bytes) {
+  return hipMemset(ptr, value, bytes);
+}
 #else
 using GpuError = cudaError_t;
 constexpr GpuError kGpuSuccess = cudaSuccess;
@@ -87,6 +96,10 @@ GpuError gpuFreeHost(void* ptr) {
 
 GpuError gpuSetDevice(int device) {
   return cudaSetDevice(device);
+}
+
+GpuError gpuMemset(void* ptr, int value, std::size_t bytes) {
+  return cudaMemset(ptr, value, bytes);
 }
 #endif
 
@@ -252,6 +265,13 @@ void MultipeerIbrcTransport::exchange() {
     exchangeAndConnectQps();
     allocateSignalCounterResources(
         IbCounterStorage::HostPinned, /*allocateDiscardSignal=*/false);
+    // Allocate + collectively exchange send/recv staging before building the
+    // device transports, so updatePeerDeviceTransport can embed the resulting
+    // IbSendRecvState. Delegated to the shared base; IBRC uses a host-mapped
+    // NIC_DONE counter (CPU proxy writes it) via the HostPinned counter
+    // storage.
+    allocateSendRecvBuffersEager(IbCounterStorage::HostPinned);
+    exchangeSendRecvBuffersEager();
     allocateCmdQueuesForAllPeers();
     VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_ << " allocated "
             << allocatedCmdQueueCount() << " command queues";
@@ -272,6 +292,7 @@ void MultipeerIbrcTransport::cleanup() {
     cleanupPeerCmdQueues(peerIndex);
     cleanupPeerQps(peerIndex);
   }
+  cleanupSendRecvBuffers();
   cleanupSignalCounterResources();
 
   auto& symbols = ibverbx::ibvSymbols;
@@ -783,12 +804,9 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
 void MultipeerIbrcTransport::initializeDeviceTransportSlots() {
   const std::size_t numPeers = static_cast<std::size_t>(nRanks_ - 1);
   p2pTransportDevices_ = allocateMapped(
-      numPeers * sizeof(P2pIbrcTransportDevice),
-      "P2pIbrcTransportDevice slots");
-  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
-  for (std::size_t peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
-    new (&slots[peerIndex]) P2pIbrcTransportDevice();
-  }
+      numPeers * ibrcDeviceSlotSize(), "P2pIbrcTransportDevice slots");
+  constructIbrcDeviceSlots(
+      p2pTransportDevices_.host, static_cast<int>(numPeers));
 }
 
 void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
@@ -797,10 +815,12 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
     return;
   }
 
-  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
   auto& peer = peerResources_[peerIndex];
   if (!peer.cmdQueuesAllocated || peer.cmdQueueDevices.device == nullptr) {
-    new (&slots[peerIndex]) P2pIbrcTransportDevice();
+    constructIbrcDeviceSlots(
+        static_cast<char*>(p2pTransportDevices_.host) +
+            peerIndex * ibrcDeviceSlotSize(),
+        1);
     return;
   }
 
@@ -817,7 +837,9 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
     counterHostBuf = slotCounterHostView(peerIndex);
   }
 
-  new (&slots[peerIndex]) P2pIbrcTransportDevice(
+  writeIbrcDeviceSlot(
+      p2pTransportDevices_.host,
+      peerIndex,
       DeviceSpan<IbrcCmdQueueDevice>(
           static_cast<IbrcCmdQueueDevice*>(peer.cmdQueueDevices.device),
           static_cast<uint32_t>(peer.cmdQueues.size())),
@@ -832,7 +854,8 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
       counterDeviceBuf,
       counterHostBuf,
       config_.numSignalSlots,
-      config_.numCounterSlots);
+      config_.numCounterSlots,
+      sendRecvStateForPeer(peerIndex));
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {
@@ -878,6 +901,12 @@ MultipeerIbrcTransport::MappedAllocation MultipeerIbrcTransport::allocateMapped(
 
   return allocation;
 }
+
+// Send/recv staging allocation, exchange, cleanup, and IbSendRecvState
+// construction are provided by MultiPeerIbTransportBase. IBRC delegates via
+// allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) /
+// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers() /
+// sendRecvStateForPeer().
 
 void MultipeerIbrcTransport::destroyPeerQps(
     std::vector<PeerQpResource>& qpResources) noexcept {
@@ -1339,8 +1368,9 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
         "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
   }
   const int peerIndex = rankToPeerIndex(peerRank);
-  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
-      peerIndex;
+  return reinterpret_cast<P2pIbrcTransportDevice*>(
+      static_cast<char*>(p2pTransportDevices_.device) +
+      peerIndex * ibrcDeviceSlotSize());
 }
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
@@ -1353,8 +1383,9 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
         "getP2pTransportDevice: IBRC device transport slots are not initialized");
   }
   const int peerIndex = rankToPeerIndex(peerRank);
-  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
-      peerIndex;
+  return reinterpret_cast<P2pIbrcTransportDevice*>(
+      static_cast<char*>(p2pTransportDevices_.device) +
+      peerIndex * ibrcDeviceSlotSize());
 }
 
 void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
@@ -1371,10 +1402,17 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
       localBuf,
       IbCounterStorage::HostPinned,
       /*allocateDiscardSignal=*/false);
+  // Allocate this peer's send/recv rings on demand (HostPinned NIC_DONE
+  // counter, CPU-proxy written) and publish them on the same bilateral round,
+  // so sendRecvStateForPeer(peerIndex) is populated when allocatePeerCmdQueues
+  // -> updatePeerDeviceTransport bakes it into the device slot.
+  allocateSendRecvBufferForPeer(
+      peerIndex, localBuf, IbCounterStorage::HostPinned);
   auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
   applyRemoteSignalCounterResources(
       peerIndex, remoteBuf, /*hasDiscardSignal=*/false);
+  applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   allocatePeerCmdQueues(peerIndex);
   startProgressThread();
   peerMaterialized_[peerIndex] = true;
@@ -1386,6 +1424,7 @@ void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
   cleanupPeerCmdQueues(peerIndex);
   cleanupPeerQps(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
+  cleanupSendRecvBufferForPeer(peerIndex);
   if (peerIndex >= 0 &&
       peerIndex < static_cast<int>(peerMaterialized_.size())) {
     peerMaterialized_[peerIndex] = false;

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -6,11 +6,22 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <vector>
 
+// `meta::comms::DeviceBuffer`: HIP shim on AMD, CUDA RAII on NVIDIA (mirrors
+// MultipeerIbgdaTransport.h).
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
+
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
 
 namespace comms::prims {
@@ -172,6 +183,16 @@ class MultipeerIbrcTransport
   std::size_t allocatedCmdQueueCount() const;
   MappedAllocation allocateMapped(std::size_t bytes, const char* label);
 
+  // ---- Pipelined send/recv staging (eager mode only) ----
+  //
+  // Host send/recv buffer management is shared with IBGDA in
+  // MultiPeerIbTransportBase. IBRC delegates to
+  // allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) — the NIC_DONE
+  // counter is host-mapped and updated by the CPU proxy (NCCL GIN style)
+  // instead of an IBGDA companion-QP loopback counter — plus
+  // exchangeSendRecvBuffersEager(), sendRecvStateForPeer(), and
+  // cleanupSendRecvBuffers().
+
   void createPeerQps(int peerIndex);
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
   void connectPeerQps(int peerIndex, const PeerQpPayload& remotePayload);
@@ -204,6 +225,9 @@ class MultipeerIbrcTransport
   std::size_t cmdQueueControlBytes_{0};
   std::atomic<bool> stopProgress_{false};
   std::thread progressThread_;
+
+  // Send/recv staging state (eager mode) lives in MultiPeerIbTransportBase
+  // (sendRecvPeerBuffers_ + bulks); IBRC delegates allocation/exchange/cleanup.
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh"
+
+#include <new>
+
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
+
+namespace comms::prims {
+
+std::size_t ibrcDeviceSlotSize() {
+  return sizeof(P2pIbrcTransportDevice);
+}
+
+void constructIbrcDeviceSlots(void* slotsHost, int numSlots) {
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
+  for (int i = 0; i < numSlots; ++i) {
+    new (&slots[i]) P2pIbrcTransportDevice();
+  }
+}
+
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxGroups,
+    uint32_t numQpsPerPeerPerNic,
+    DeviceSpan<IbrcBlockQpState> blockQpState,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbSendRecvState sendRecvState) {
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
+  new (&slots[peerIndex]) P2pIbrcTransportDevice(
+      queues,
+      numNics,
+      maxGroups,
+      numQpsPerPeerPerNic,
+      blockQpState,
+      remoteSignalBuf,
+      localSignalBuf,
+      counterDeviceBuf,
+      counterHostBuf,
+      numSignalSlots,
+      numCounterSlots,
+      sendRecvState);
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibrc/IbrcTypes.h"
+
+namespace comms::prims {
+
+// Forward declaration: the full definition lives in P2pIbrcTransportDevice.cuh,
+// which transitively pulls device-only headers (CopyOp.cuh -> Tile.cuh ->
+// hip/hip_bf16.h) that a host `.cc` cannot compile on AMD. Host callers only
+// ever name `P2pIbrcTransportDevice*` (a pointer) and use these builders to
+// construct/size the slots inside the `.cu` (mirrors IBGDA's
+// MultipeerIbgdaTransportCuda).
+class P2pIbrcTransportDevice;
+
+// Size of one P2pIbrcTransportDevice slot (for host-side pointer arithmetic
+// into the host-pinned mapped array of device handles).
+std::size_t ibrcDeviceSlotSize();
+
+// Default-construct (placement-new) each P2pIbrcTransportDevice slot in a
+// host-pinned mapped array.
+void constructIbrcDeviceSlots(void* slotsHost, int numSlots);
+
+// Placement-new a single populated P2pIbrcTransportDevice into the host-pinned
+// mapped array. Args mirror the device-handle constructor; all are plain-data
+// host-safe types.
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxGroups,
+    uint32_t numQpsPerPeerPerNic,
+    DeviceSpan<IbrcBlockQpState> blockQpState,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbSendRecvState sendRecvState);
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -18,6 +18,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
 
@@ -54,10 +55,6 @@ inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 #define IBRC_CHECK_SLOT_ID(id, count, kind) assert((id) >= 0 && (id) < (count))
 #endif
 
-struct IbrcBlockQpState {
-  uint32_t put_rr{0};
-};
-
 /**
  * Device-side IBRC peer handle.
  *
@@ -82,7 +79,8 @@ class P2pIbrcTransportDevice {
       IbgdaLocalBuffer ownedCounterDeviceBuf = {},
       IbgdaLocalBuffer ownedCounterHostBuf = {},
       int numSignalSlots = 0,
-      int numCounterSlots = 0)
+      int numCounterSlots = 0,
+      IbSendRecvState sendRecvState = {})
       : cmdQueues(queues),
         numNics(nics),
         maxGroups_(maxGroups),
@@ -93,7 +91,8 @@ class P2pIbrcTransportDevice {
         ownedCounterDeviceBuf_(ownedCounterDeviceBuf),
         ownedCounterHostBuf_(ownedCounterHostBuf),
         numSignalSlots_(numSignalSlots),
-        numCounterSlots_(numCounterSlots) {}
+        numCounterSlots_(numCounterSlots),
+        sendRecv_(sendRecvState) {}
 
   __device__ void put(
       ThreadGroup& group,
@@ -449,6 +448,144 @@ class P2pIbrcTransportDevice {
     flush();
   }
 
+  // ===========================================================================
+  // Pipelined send/recv — delegated to the shared IbSendRecvDevice.
+  // ===========================================================================
+  //
+  // The send/recv algorithm is transport-agnostic and lives in
+  // `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh). Each method routes every
+  // transport op through `*this`, so IBRC reuses IBGDA's send/recv unchanged.
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const {
+    return sendRecv_.send_recv_state();
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    return sendRecv_.pipeline_window(active_blocks);
+  }
+
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+    sendRecv_.init_send_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
+  }
+
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+    sendRecv_.init_recv_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    return sendRecv_.progress_send_once<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    return sendRecv_.progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.send<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.recv<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbrcTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.forward<CopyOp>(
+        *this,
+        group,
+        dst,
+        fwd.sendRecv_,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
  private:
   __device__ __forceinline__ uint32_t num_qp_lanes() const {
     return numNics * qpsPerBlockPerNic_;
@@ -761,6 +898,7 @@ class P2pIbrcTransportDevice {
   IbgdaLocalBuffer ownedCounterHostBuf_{};
   int numSignalSlots_{0};
   int numCounterSlots_{0};
+  IbSendRecvDevice sendRecv_{};
 };
 
 static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);


### PR DESCRIPTION
Summary:

Change ring all-gather and reduce-scatter launch params to carry `P2pIbTransportDevice` so the same kernels can call `send`, `recv`, `forward`, and `pipeline_window` through either IBGDA or IBRC.

Reviewed By: snarayankh

Differential Revision: D107777293


