### PR TITLE
Standalone ANS CopyOp compress/decompress microbenchmark (#2900)

### DIFF
--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cc
@@ -1,0 +1,528 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Standalone single-GPU microbenchmark for the raw ANS CopyOp APIs
+// (`AnsCompress::send()` / `AnsCompress::recv()` in
+// `comms/prims/core/CopyOp.cuh`) — no transport, no inter-rank
+// communication. Extracted from AllToAllvTileBenchmark.cc so the ANS
+// CopyOp primitive can be enabled and benchmarked independently of the
+// AllToAllv-tile collective.
+
+#include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <cuda.h> // driver API: green contexts for SM partitioning
+
+#include "comms/common/CudaWrap.h"
+#include "comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh"
+#include "comms/prims/core/Checks.h"
+#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/mpi/MpiTestUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::CudaEvent;
+using meta::comms::DeviceBuffer;
+
+namespace comms::prims::benchmark {
+namespace {
+
+// Local placeholder for the ANS stats struct. The standalone microbench
+// measures the produced compressed size directly per iteration rather than
+// via the device-global stat counters, so this stays {0, 0} (the ratio
+// branch guarded by `compressed_bytes > 0` is intentionally inert here).
+struct LocalCompStats {
+  uint64_t uncompressed_bytes = 0;
+  uint64_t compressed_bytes = 0;
+};
+
+// Driver-API error check (runtime calls use PIPES_CUDA_CHECK).
+#define PIPES_CU_CHECK(expr)                                           \
+  do {                                                                 \
+    CUresult _res = (expr);                                            \
+    if (_res != CUDA_SUCCESS) {                                        \
+      const char* _msg = nullptr;                                      \
+      cuGetErrorString(_res, &_msg);                                   \
+      XLOG(FATAL) << "[AnsCopyOpStandalone] CUDA driver error: " #expr \
+                  << " -> " << (_msg ? _msg : "unknown");              \
+    }                                                                  \
+  } while (0)
+
+// A stream confined to a green context spanning >= `numSms` SMs of the
+// current device. Launching the bench kernels on this stream restricts
+// them to that SM partition, so a fixed grid runs at a controlled
+// blocks/SM ratio (e.g. 512 blocks on 32 SMs => 16 blocks/SM). `numSms
+// <= 0` returns an empty handle (stream == nullptr) = the default stream
+// over the whole GPU. The realized SM count may round up to the hardware
+// split granularity.
+struct GreenCtxStream {
+  CUgreenCtx ctx = nullptr;
+  cudaStream_t stream = nullptr;
+};
+
+GreenCtxStream makeGreenCtxStream(int numSms) {
+  GreenCtxStream out;
+  if (numSms <= 0) {
+    return out;
+  }
+  int ordinal = 0;
+  PIPES_CUDA_CHECK(cudaGetDevice(&ordinal));
+  CUdevice dev = 0;
+  PIPES_CU_CHECK(cuDeviceGet(&dev, ordinal));
+
+  CUdevResource sm{};
+  const CUresult smRes =
+      cuDeviceGetDevResource(dev, &sm, CU_DEV_RESOURCE_TYPE_SM);
+  if (smRes != CUDA_SUCCESS) {
+    const char* nm = nullptr;
+    cuGetErrorName(smRes, &nm);
+    XLOG(FATAL)
+        << "[AnsCopyOpStandalone] green-context SM partitioning unavailable "
+        << "(cuDeviceGetDevResource -> " << (nm ? nm : "?") << "). "
+        << "PIPES_COPYOP_BENCH_NUM_SMS requires CUDA driver >= 12.4 (R550); "
+        << "this host's driver is older. Re-run without "
+        << "PIPES_COPYOP_BENCH_NUM_SMS (whole GPU) or use a newer-driver host.";
+  }
+  CUdevResource group{};
+  CUdevResource remaining{};
+  unsigned int nGroups = 1;
+  PIPES_CU_CHECK(cuDevSmResourceSplitByCount(
+      &group,
+      &nGroups,
+      &sm,
+      &remaining,
+      /*useFlags=*/0,
+      /*minCount=*/static_cast<unsigned int>(numSms)));
+
+  CUdevResourceDesc desc{};
+  PIPES_CU_CHECK(cuDevResourceGenerateDesc(&desc, &group, 1));
+  PIPES_CU_CHECK(
+      cuGreenCtxCreate(&out.ctx, desc, dev, CU_GREEN_CTX_DEFAULT_STREAM));
+
+  CUstream cuStream = nullptr;
+  PIPES_CU_CHECK(cuGreenCtxStreamCreate(
+      &cuStream, out.ctx, CU_STREAM_NON_BLOCKING, /*priority=*/0));
+  out.stream = reinterpret_cast<cudaStream_t>(cuStream);
+  return out;
+}
+
+std::string format_bytes(std::size_t bytes) {
+  if (bytes >= 1024UL * 1024 * 1024) {
+    return std::to_string(bytes / (1024UL * 1024 * 1024)) + "GB";
+  }
+  if (bytes >= 1024 * 1024) {
+    return std::to_string(bytes / (1024 * 1024)) + "MB";
+  }
+  if (bytes >= 1024) {
+    return std::to_string(bytes / 1024) + "KB";
+  }
+  return std::to_string(bytes) + "B";
+}
+
+class AnsCopyOpBenchFixture : public meta::comms::BenchmarkTestFixture {
+ protected:
+  void SetUp() override {
+    BenchmarkTestFixture::SetUp();
+    const char* localRankEnv = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    if (localRankEnv) {
+      localRank = std::atoi(localRankEnv);
+    }
+    PIPES_CUDA_CHECK(cudaSetDevice(localRank));
+  }
+};
+
+TEST_F(AnsCopyOpBenchFixture, AnsCopyOpStandalone) {
+  // Single-GPU microbenchmark for the raw `AnsCompress::send()` /
+  // `AnsCompress::recv()` APIs in `CopyOp.cuh` — no transport, no
+  // inter-rank communication. Only rank 0 drives the launches; the
+  // other ranks return immediately so the run wall-time isn't
+  // dominated by per-rank serialisation. There are no in-test
+  // `bootstrap->barrierAll()` calls because each rank's behaviour is
+  // independent.
+  if (globalRank != 0) {
+    return;
+  }
+
+  // Defaults requested by the bench owner: 20 warmup + 200 timed
+  // iterations per (sparsity, size) cell, driven from inside the
+  // kernel so we measure pure ANS (de)compression time and amortise
+  // the per-launch overhead.
+  constexpr int kCopyOpWarmupIter = 20;
+  constexpr int kCopyOpMeasureIter = 200;
+  // Launch geometry. Both overridable at runtime via env vars (no
+  // rebuild) for quick sweeps:
+  //
+  //   PIPES_COPYOP_BENCH_BLOCKS=128 PIPES_COPYOP_BENCH_THREADS=512 \
+  //       buck2 run ... -- --gtest_filter='*AnsCopyOpStandalone*'
+  //
+  // `threads` must be one of {32, 64, 128, 256, 512} (the NumWarps
+  // ∈ {1, 2, 4, 8, 16} values explicitly instantiated in
+  // `AnsCopyOpBench.cu`); `min_blocks_per_sm` must be one of {1, 2,
+  // 3, 4}, plus the two 100%-occupancy points {256 threads → 8,
+  // 128 threads → 16} (the second `__launch_bounds__` argument).
+  // Other values are rejected at launch.
+  //
+  // Defaults target 100% occupancy on H100-class SMs: 512 blocks ×
+  // 256 threads confined to 64 SMs = 8 blocks/SM = 64 warps/SM, with
+  // `min_blocks_per_sm=8` capping registers at 65536/(256*8)=32/thread
+  // so all 8 blocks stay resident.
+  auto env_int = [](const char* name, int fallback) {
+    const char* v = std::getenv(name);
+    return (v != nullptr && *v != '\0') ? std::atoi(v) : fallback;
+  };
+  const int kCopyOpBlocks = env_int("PIPES_COPYOP_BENCH_BLOCKS", 512);
+  const int kCopyOpThreads = env_int("PIPES_COPYOP_BENCH_THREADS", 256);
+  const int kCopyOpMinBlocksPerSM =
+      env_int("PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM", 8);
+  // >0 = confine the kernel to a green context of this many SMs (rounds
+  // up to the hw split granularity); 0 = whole GPU. Default 64 pairs
+  // with 512 blocks to give 8 blocks/SM.
+  const int kCopyOpNumSms = env_int("PIPES_COPYOP_BENCH_NUM_SMS", 64);
+  const AnsCopyOpBenchKernels bench_kernels =
+      pick_ans_copy_op_bench_kernels(kCopyOpThreads, kCopyOpMinBlocksPerSM);
+  if (kCopyOpBlocks <= 0 || bench_kernels.compress_kernel == nullptr) {
+    GTEST_FAIL() << "Invalid PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+                 << " / PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+                 << " / PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
+                 << kCopyOpMinBlocksPerSM
+                 << " (threads must be one of 32, 64, 128, 256, 512; "
+                 << "min_blocks_per_sm must be one of 1, 2, 3, 4, or the "
+                 << "100%-occupancy points 8 (256 threads) / 16 (128 "
+                 << "threads); blocks must be positive)";
+  }
+
+  const std::vector<std::size_t> sizes = {
+      256ULL * 1024,
+      512ULL * 1024,
+      1024ULL * 1024,
+      2ULL * 1024 * 1024,
+      4ULL * 1024 * 1024,
+  };
+
+  // Allocate buffers once at the largest size and reuse them across
+  // the sparsity × size sweep. Layout: [block 0 region | block 1
+  // region | ...]. The compress kernel writes into `d_staging` and
+  // the decompress kernel reads from the same buffer, so the
+  // decompress measurement always sees a freshly-produced layout
+  // from the immediately preceding compress measurement (matches
+  // the ratio reported below).
+  const std::size_t maxInputBytes = sizes.back();
+  const std::size_t maxStagingStride =
+      ans_copy_op_bench_staging_stride(maxInputBytes);
+
+  DeviceBuffer d_input(static_cast<std::size_t>(kCopyOpBlocks) * maxInputBytes);
+  DeviceBuffer d_staging(
+      static_cast<std::size_t>(kCopyOpBlocks) * maxStagingStride);
+  DeviceBuffer d_output(
+      static_cast<std::size_t>(kCopyOpBlocks) * maxInputBytes);
+
+  // Host-side incompressible (under ANS) pattern — same SplitMix64
+  // hash used by `IbSweepCompressed` so the two benches see
+  // identical ANS ratios at matched sparsity. Each byte is a hash
+  // of its position so the value distribution within any
+  // `kAnsMaxUncompBytes` (256 KiB) window is uniform over [0..255].
+  // The pattern is tiled into every block's input region; the
+  // leading `sparsityPct%` of each block's region is then
+  // `cudaMemset`-zeroed to produce the requested sparsity.
+  constexpr std::size_t kPatternBytes = 1ULL * 1024 * 1024;
+  std::vector<uint8_t> host_pattern(kPatternBytes);
+  for (std::size_t i = 0; i < kPatternBytes; ++i) {
+    uint64_t x = static_cast<uint64_t>(i) * 0x9E3779B97F4A7C15ULL +
+        0xDEADBEEFCAFEBABEULL;
+    x = (x ^ (x >> 33)) * 0xff51afd7ed558ccdULL;
+    x = (x ^ (x >> 33)) * 0xc4ceb9fe1a85ec53ULL;
+    x = x ^ (x >> 33);
+    host_pattern[i] = static_cast<uint8_t>(x & 0xff);
+  }
+
+  const GreenCtxStream gctx = makeGreenCtxStream(kCopyOpNumSms);
+  const cudaStream_t benchStream =
+      gctx.stream; // nullptr => default stream (whole GPU)
+
+  XLOG(INFO) << "\n=== ANS CopyOp Standalone Microbenchmark "
+             << "(single GPU) ===\n"
+             << "PIPES_COPYOP_BENCH_BLOCKS=" << kCopyOpBlocks
+             << " PIPES_COPYOP_BENCH_THREADS=" << kCopyOpThreads
+             << " PIPES_COPYOP_BENCH_MIN_BLOCKS_PER_SM="
+             << kCopyOpMinBlocksPerSM
+             << " PIPES_COPYOP_BENCH_NUM_SMS=" << kCopyOpNumSms
+             << (kCopyOpNumSms > 0 ? " (green-ctx SM-limited)" : " (full GPU)")
+             << "\n"
+             << kCopyOpBlocks << " threadblocks × " << kCopyOpThreads
+             << " threads/block, " << kCopyOpWarmupIter << " warmup + "
+             << kCopyOpMeasureIter << " timed iterations per cell\n"
+             << "Sweep: sizes {256KB, 512KB, 1MB, 2MB, 4MB} × "
+             << "sparsity 0%→100% step 10%\n"
+             << "BW = aggregate uncompressed bytes / measured kernel "
+             << "time (sum over all " << kCopyOpBlocks << " blocks)\n";
+
+  for (int sparsityPct = 0; sparsityPct <= 100; sparsityPct += 10) {
+    XLOG(INFO) << "\n--- Sparsity " << sparsityPct
+               << "% (zero-byte prefix of each block's input region) ---";
+    printf(
+        "%-10s  %14s  %16s  %10s  %11s\n",
+        "Size",
+        "CompBW(GB/s)",
+        "DecompBW(GB/s)",
+        "compRatio",
+        "Correctness");
+    printf(
+        "%-10s  %14s  %16s  %10s  %11s\n",
+        "--------",
+        "--------------",
+        "----------------",
+        "----------",
+        "-----------");
+
+    for (std::size_t inputBytes : sizes) {
+      // Local non-const copies so we can take addresses for the
+      // `void* ka[]` kernel argument array (cudaLaunchKernel needs
+      // non-const argument pointers). The range-for variable
+      // `inputBytes` and the `const std::size_t stagingStride` below
+      // would otherwise be const-qualified, making `&...` a
+      // `const std::size_t*` that doesn't implicitly convert to
+      // `void*`.
+      std::size_t inputBytesArg = inputBytes;
+      std::size_t stagingStride = ans_copy_op_bench_staging_stride(inputBytes);
+      std::size_t stagingStrideArg = stagingStride;
+
+      // Re-initialise every block's input region for this
+      // (sparsity, inputBytes) cell. We do this per-cell rather than
+      // once because the sparsity overlay differs between rows.
+      for (int b = 0; b < kCopyOpBlocks; ++b) {
+        const std::size_t blockStart = static_cast<std::size_t>(b) * inputBytes;
+        std::size_t off = 0;
+        while (off < inputBytes) {
+          const std::size_t copy = std::min(kPatternBytes, inputBytes - off);
+          PIPES_CUDA_CHECK(cudaMemcpy(
+              static_cast<char*>(d_input.get()) + blockStart + off,
+              host_pattern.data(),
+              copy,
+              cudaMemcpyHostToDevice));
+          off += copy;
+        }
+        const std::size_t zeroBytes =
+            (inputBytes * static_cast<std::size_t>(sparsityPct)) / 100;
+        if (zeroBytes > 0) {
+          PIPES_CUDA_CHECK(cudaMemset(
+              static_cast<char*>(d_input.get()) + blockStart, 0, zeroBytes));
+        }
+      }
+
+      // ---------------------------------------------------------------
+      // Compression bandwidth measurement.
+      // The kernel itself loops `iters` times so the kernel-event
+      // window captures only ANS work plus one launch's worth of
+      // setup overhead, amortised across `kCopyOpMeasureIter`
+      // iterations.
+      //
+      // Per-launch synchronous error checks (cudaGetLastError +
+      // cudaDeviceSynchronize) sit on EACH launch so a kernel-side
+      // illegal memory access surfaces immediately at the failing
+      // (sparsity, size, phase) cell instead of getting deferred to
+      // scope-exit's `cudaFree`.
+      // ---------------------------------------------------------------
+      auto sync_check = [&](const char* phase) {
+        const cudaError_t launchErr = cudaGetLastError();
+        if (launchErr != cudaSuccess) {
+          XLOG(FATAL) << "[AnsCopyOpStandalone] launch error in " << phase
+                      << " sparsity=" << sparsityPct
+                      << "% size=" << format_bytes(inputBytes)
+                      << " blocks=" << kCopyOpBlocks
+                      << " threads=" << kCopyOpThreads
+                      << " stagingStride=" << stagingStride
+                      << " err=" << cudaGetErrorString(launchErr);
+        }
+        const cudaError_t syncErr = cudaDeviceSynchronize();
+        if (syncErr != cudaSuccess) {
+          XLOG(FATAL) << "[AnsCopyOpStandalone] async error in " << phase
+                      << " sparsity=" << sparsityPct
+                      << "% size=" << format_bytes(inputBytes)
+                      << " blocks=" << kCopyOpBlocks
+                      << " threads=" << kCopyOpThreads
+                      << " stagingStride=" << stagingStride
+                      << " err=" << cudaGetErrorString(syncErr);
+        }
+      };
+
+      char* in_ptr = static_cast<char*>(d_input.get());
+      char* st_ptr = static_cast<char*>(d_staging.get());
+      auto launch_compress = [&](int& iters_ref) {
+        void* ka[] = {
+            &in_ptr,
+            &st_ptr,
+            &inputBytesArg,
+            &stagingStrideArg,
+            &iters_ref,
+        };
+        return comms::common::launchKernel(
+            reinterpret_cast<void*>(bench_kernels.compress_kernel),
+            dim3(kCopyOpBlocks),
+            dim3(kCopyOpThreads),
+            ka,
+            /*stream=*/benchStream,
+            /*clusterDim=*/std::nullopt);
+      };
+
+      int warmupIters = kCopyOpWarmupIter;
+      PIPES_CUDA_CHECK(launch_compress(warmupIters));
+      sync_check("compress-warmup");
+
+      // NOTE: Intentionally NOT calling
+      // `fetch_and_reset_ans_compress_stats()` here. That function
+      // lives in the production `:alltoallv_tile_compressed_obj` TU
+      // and references `g_pipes_ans_total_*_bytes` `__device__`
+      // globals defined in `CopyOp.cuh`. Because the bench's
+      // `:ans_copy_op_bench_obj` is its OWN device-link unit (with
+      // its own nvcompdx dlink), it ALSO emits its own copies of
+      // those globals — the runtime then has two duplicate symbols,
+      // `cudaMemcpyFromSymbol(g_pipes_ans_total_uncomp_bytes)` fails
+      // with "invalid device symbol", and CUDA's "first error
+      // sticks" semantics make every subsequent `cudaLaunchKernel`
+      // fail with the same error. We always report `n/a` for the
+      // bench's compRatio column instead — the bench TU has
+      // `PIPES_ANS_COLLECT_STATS` off by default anyway so the
+      // counters wouldn't be populated even if the symbol lookup
+      // worked.
+      const LocalCompStats compStats{0, 0};
+
+      int measureIters = kCopyOpMeasureIter;
+      CudaEvent c_start, c_stop;
+      PIPES_CUDA_CHECK(cudaEventRecord(c_start.get(), benchStream));
+      PIPES_CUDA_CHECK(launch_compress(measureIters));
+      PIPES_CUDA_CHECK(cudaEventRecord(c_stop.get(), benchStream));
+      sync_check("compress-timed");
+
+      float compMs = 0;
+      PIPES_CUDA_CHECK(
+          cudaEventElapsedTime(&compMs, c_start.get(), c_stop.get()));
+      const float compAvgMs = compMs / static_cast<float>(kCopyOpMeasureIter);
+      // Aggregate uncompressed bytes processed per iteration across
+      // all blocks (each block compresses its own `inputBytes`).
+      const std::size_t bytesPerIter =
+          static_cast<std::size_t>(kCopyOpBlocks) * inputBytes;
+      const float compBwGbps = (bytesPerIter / 1e9f) / (compAvgMs / 1000.0f);
+
+      // ---------------------------------------------------------------
+      // Decompression bandwidth measurement.
+      // d_staging is already populated by the timed compress run
+      // above. The recv kernel just walks the existing per-block
+      // layout `iters` times.
+      // ---------------------------------------------------------------
+      char* out_ptr = static_cast<char*>(d_output.get());
+      const char* cst_ptr = static_cast<const char*>(d_staging.get());
+      auto launch_decompress = [&](int& iters_ref) {
+        void* ka[] = {
+            &out_ptr,
+            const_cast<char**>(&cst_ptr),
+            &inputBytesArg,
+            &stagingStrideArg,
+            &iters_ref,
+        };
+        return comms::common::launchKernel(
+            reinterpret_cast<void*>(bench_kernels.decompress_kernel),
+            dim3(kCopyOpBlocks),
+            dim3(kCopyOpThreads),
+            ka,
+            /*stream=*/benchStream,
+            /*clusterDim=*/std::nullopt);
+      };
+
+      warmupIters = kCopyOpWarmupIter;
+      PIPES_CUDA_CHECK(launch_decompress(warmupIters));
+      sync_check("decompress-warmup");
+
+      measureIters = kCopyOpMeasureIter;
+      CudaEvent d_start, d_stop;
+      PIPES_CUDA_CHECK(cudaEventRecord(d_start.get(), benchStream));
+      PIPES_CUDA_CHECK(launch_decompress(measureIters));
+      PIPES_CUDA_CHECK(cudaEventRecord(d_stop.get(), benchStream));
+      sync_check("decompress-timed");
+
+      float decompMs = 0;
+      PIPES_CUDA_CHECK(
+          cudaEventElapsedTime(&decompMs, d_start.get(), d_stop.get()));
+      const float decompAvgMs =
+          decompMs / static_cast<float>(kCopyOpMeasureIter);
+      const float decompBwGbps =
+          (bytesPerIter / 1e9f) / (decompAvgMs / 1000.0f);
+
+      char ratioBuf[32];
+      if (compStats.compressed_bytes > 0) {
+        const double ratio = static_cast<double>(compStats.uncompressed_bytes) /
+            static_cast<double>(compStats.compressed_bytes);
+        snprintf(ratioBuf, sizeof(ratioBuf), "%.2fx", ratio);
+      } else {
+        // PIPES_ANS_COLLECT_STATS was compiled out — the kernels
+        // still run, the ratio just isn't observable from the host.
+        snprintf(ratioBuf, sizeof(ratioBuf), "n/a");
+      }
+
+      printf(
+          "%-10s  %14.2f  %16.2f  %10s  ",
+          format_bytes(inputBytes).c_str(),
+          compBwGbps,
+          decompBwGbps,
+          ratioBuf);
+      fflush(stdout);
+
+      // ---------------------------------------------------------------
+      // Round-trip correctness check.
+      // After the timed decompress, `d_output` holds the decompressed
+      // bytes that the ans_copy_op_decompress_bench_kernel just
+      // produced from `d_staging` (which was populated by the timed
+      // compress run from `d_input`). Compare per-block.
+      // ---------------------------------------------------------------
+      std::vector<uint8_t> host_input(inputBytes);
+      std::vector<uint8_t> host_output(inputBytes);
+      for (int b = 0; b < kCopyOpBlocks; ++b) {
+        const std::size_t blockStart = static_cast<std::size_t>(b) * inputBytes;
+        PIPES_CUDA_CHECK(cudaMemcpy(
+            host_input.data(),
+            static_cast<const char*>(d_input.get()) + blockStart,
+            inputBytes,
+            cudaMemcpyDeviceToHost));
+        PIPES_CUDA_CHECK(cudaMemcpy(
+            host_output.data(),
+            static_cast<const char*>(d_output.get()) + blockStart,
+            inputBytes,
+            cudaMemcpyDeviceToHost));
+        if (host_input != host_output) {
+          std::size_t firstMismatch = 0;
+          while (firstMismatch < inputBytes &&
+                 host_input[firstMismatch] == host_output[firstMismatch]) {
+            ++firstMismatch;
+          }
+          // Close the row with FAIL before fataling so the partial
+          // row in the table makes clear which cell crashed.
+          printf("%11s\n", "FAIL");
+          fflush(stdout);
+          XLOG(FATAL) << "[AnsCopyOpStandalone] round-trip mismatch sparsity="
+                      << sparsityPct << "% size=" << format_bytes(inputBytes)
+                      << " block=" << b << " firstMismatch=" << firstMismatch
+                      << " in=" << static_cast<int>(host_input[firstMismatch])
+                      << " out="
+                      << static_cast<int>(host_output[firstMismatch]);
+        }
+      }
+      printf("%11s\n", "OK");
+    }
+  }
+
+  if (gctx.ctx != nullptr) {
+    PIPES_CU_CHECK(cuStreamDestroy(reinterpret_cast<CUstream>(benchStream)));
+    PIPES_CU_CHECK(cuGreenCtxDestroy(gctx.ctx));
+  }
+}
+
+} // namespace
+} // namespace comms::prims::benchmark
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::BenchmarkEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cu
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cu
@@ -1,0 +1,235 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Standalone microbenchmark kernels for `AnsCompress::send()` /
+// `::recv()`. See the matching header (`AnsCopyOpBench.cuh`) for the
+// "why this lives in its own TU + dlink target" rationale.
+//
+// Built with `--device-c` + `PIPES_ENABLE_ANS_COMPRESSION` so that
+// `AnsCompress<...>` instantiates against nvcompdx, and device-linked
+// against `:nvcompdx_fatbin` via `gen_alltoallv_tile_dlink_cmd` in
+// the sibling `:ans_copy_op_bench` BUCK target.
+
+#include <cstddef>
+
+#include "comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims {
+
+namespace {
+
+// Pin the per-piece chunking constant to the same value the
+// production IBGDA dispatcher uses. Sourced from CopyOp.cuh's
+// `PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES` macro (256 KiB) so the two
+// stay in lockstep without re-declaring the literal.
+constexpr std::size_t kBenchAnsMaxUncompBytes =
+    PIPES_ANS_DEFAULT_MAX_UNCOMP_BYTES;
+
+} // namespace
+
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+__launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_compress_bench_kernel(
+    char* d_input,
+    char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters) {
+  auto group = make_block_group();
+  char* my_input = d_input + static_cast<std::size_t>(blockIdx.x) * input_bytes;
+  char* my_staging =
+      d_staging + static_cast<std::size_t>(blockIdx.x) * staging_stride;
+
+  // `kSrcAligned=false` (template default) so this matches the
+  // production IBGDA `ibgda_send_compressed` instantiation for the
+  // same NumWarps; sharing the instantiation across TUs keeps
+  // `s_compress_shmem` from doubling when LTO link-time pools static
+  // `__shared__`. The runtime realign branch inside `send()` is dead
+  // here because `my_input = base + blockIdx.x * input_bytes` is
+  // always 16-byte aligned, so `nullptr` for `alignedAuxBuf` is safe.
+  using Comp = AnsCompress<NumWarps, kBenchAnsMaxUncompBytes>;
+
+  for (int i = 0; i < iters; ++i) {
+    (void)Comp::send(
+        my_staging,
+        my_input,
+        input_bytes,
+        group,
+        /*byte_offset=*/0,
+        /*alignedAuxBuf=*/static_cast<char*>(nullptr));
+    group.sync();
+  }
+}
+
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+__launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_decompress_bench_kernel(
+    char* d_output,
+    const char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters) {
+  auto group = make_block_group();
+  char* my_output =
+      d_output + static_cast<std::size_t>(blockIdx.x) * input_bytes;
+  const char* my_staging =
+      d_staging + static_cast<std::size_t>(blockIdx.x) * staging_stride;
+
+  using Comp = AnsCompress<NumWarps, kBenchAnsMaxUncompBytes>;
+
+  for (int i = 0; i < iters; ++i) {
+    (void)Comp::recv(
+        my_output,
+        my_staging,
+        input_bytes,
+        group,
+        /*byte_offset=*/0);
+    group.sync();
+  }
+}
+
+// Explicit instantiations for every (NumWarps, MinBlocksPerSM) pair
+// accepted by `pick_ans_copy_op_bench_kernels`. NumWarps controls
+// blockDim.x (= NumWarps * 32); MinBlocksPerSM is the second
+// `__launch_bounds__` argument, which tells ptxas the minimum blocks
+// it must keep resident per SM and therefore caps per-thread register
+// usage at ~`65536 / (NumWarps * 32 * MinBlocksPerSM)`. Extend this
+// macro block (and the switch below) if a wider range is needed.
+#define PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, MIN_BLOCKS)           \
+  template __global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS) void \
+  ans_copy_op_compress_bench_kernel<NUM_WARPS, MIN_BLOCKS>(              \
+      char* d_input,                                                     \
+      char* d_staging,                                                   \
+      std::size_t input_bytes,                                           \
+      std::size_t staging_stride,                                        \
+      int iters);                                                        \
+  template __global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS) void \
+  ans_copy_op_decompress_bench_kernel<NUM_WARPS, MIN_BLOCKS>(            \
+      char* d_output,                                                    \
+      const char* d_staging,                                             \
+      std::size_t input_bytes,                                           \
+      std::size_t staging_stride,                                        \
+      int iters);
+
+// NumWarps ∈ {1, 2, 4, 8, 16} (blockDim.x ∈ {32, 64, 128, 256, 512})
+// × MinBlocksPerSM ∈ {1, 2, 3, 4}.
+#define PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(NUM_WARPS) \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 1)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 2)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 3)              \
+  PIPES_INSTANTIATE_BENCH_KERNELS(NUM_WARPS, 4)
+
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(1)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(2)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(4)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(8)
+PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS(16)
+
+// Extra point: 128 threads (NumWarps=4) with MinBlocksPerSM=16 caps registers
+// at 65536/(128*16)=32/thread, the value needed to fit 16 blocks/SM
+// (= 64 warps = 100% occupancy) at 128 threads/block. Used to measure whether
+// forcing 100% occupancy (at the cost of heavy spill) helps the 128-thread
+// kernel.
+PIPES_INSTANTIATE_BENCH_KERNELS(4, 16)
+
+// 256 threads (NumWarps=8) with MinBlocksPerSM=8 caps registers at
+// 65536/(256*8)=32/thread, fitting 8 blocks/SM (= 64 warps = 100% occupancy).
+PIPES_INSTANTIATE_BENCH_KERNELS(8, 8)
+
+#undef PIPES_INSTANTIATE_BENCH_KERNELS_FOR_WARPS
+#undef PIPES_INSTANTIATE_BENCH_KERNELS
+
+namespace {
+// {compress, decompress} kernel-address pair for one explicit
+// (NumWarps, MinBlocksPerSM) instantiation.
+#define PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, MIN_BLOCKS)                   \
+  AnsCopyOpBenchKernels {                                                \
+    reinterpret_cast<void*>(                                             \
+        &ans_copy_op_compress_bench_kernel<NUM_WARPS, MIN_BLOCKS>),      \
+        reinterpret_cast<void*>(                                         \
+            &ans_copy_op_decompress_bench_kernel<NUM_WARPS, MIN_BLOCKS>) \
+  }
+
+// Inner dispatch on MinBlocksPerSM for a fixed NumWarps. Every arm
+// (including `default`) returns, so it is safe to drop into from the
+// outer threads_per_block switch.
+#define PIPES_BENCH_PICK_MIN_BLOCKS(NUM_WARPS)      \
+  switch (min_blocks_per_sm) {                      \
+    case 1:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 1); \
+    case 2:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 2); \
+    case 3:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 3); \
+    case 4:                                         \
+      return PIPES_BENCH_KERNEL_PAIR(NUM_WARPS, 4); \
+    default:                                        \
+      return {nullptr, nullptr};                    \
+  }
+} // namespace
+
+AnsCopyOpBenchKernels pick_ans_copy_op_bench_kernels(
+    int threads_per_block,
+    int min_blocks_per_sm) {
+  switch (threads_per_block) {
+    case 32:
+      PIPES_BENCH_PICK_MIN_BLOCKS(1);
+    case 64:
+      PIPES_BENCH_PICK_MIN_BLOCKS(2);
+    case 128:
+      // m=16 (100% occupancy, 32-reg cap) is instantiated only for
+      // NumWarps=4; handle it before the generic 1..4 dispatch.
+      if (min_blocks_per_sm == 16) {
+        return PIPES_BENCH_KERNEL_PAIR(4, 16);
+      }
+      PIPES_BENCH_PICK_MIN_BLOCKS(4);
+    case 256:
+      // m=8 (100% occupancy, 32-reg cap) is instantiated only for
+      // NumWarps=8; handle it before the generic 1..4 dispatch.
+      if (min_blocks_per_sm == 8) {
+        return PIPES_BENCH_KERNEL_PAIR(8, 8);
+      }
+      PIPES_BENCH_PICK_MIN_BLOCKS(8);
+    case 512:
+      PIPES_BENCH_PICK_MIN_BLOCKS(16);
+    default:
+      return {nullptr, nullptr};
+  }
+}
+
+#undef PIPES_BENCH_PICK_MIN_BLOCKS
+#undef PIPES_BENCH_KERNEL_PAIR
+
+std::size_t ans_copy_op_bench_staging_stride(std::size_t input_bytes) {
+  // Closed-form upper bound on
+  //   AnsCompress<N, kBenchAnsMaxUncompBytes>::worst_case_chunk_stride(
+  //       input_bytes)
+  // for any supported NumWarps N. Doesn't require nvcompdx's
+  // `max_comp_chunk_size()` to be host-callable. nvcompdx's
+  // documented ANS worst-case output is approximately
+  // `1.3 * MaxUncompChunkSize + 1576` bytes per piece; we use
+  // `1.4 * MaxUncompChunkSize + 4096` for headroom, then pad per
+  // piece to 256 bytes (nvCOMPDx decompress input alignment) and
+  // pad the total to the 512-byte NIC-burst boundary.
+  if (input_bytes == 0) {
+    return 0;
+  }
+  constexpr std::size_t kMaxUncomp = kBenchAnsMaxUncompBytes;
+  constexpr std::size_t kInputAlign = 256ULL;
+  constexpr std::size_t kBurstAlign = 512ULL;
+  const std::size_t numChunks = (input_bytes + kMaxUncomp - 1ULL) / kMaxUncomp;
+  constexpr std::size_t kPerPieceUnaligned =
+      (kMaxUncomp * 14ULL) / 10ULL + 4096ULL;
+  constexpr std::size_t kPerPiecePadded =
+      (kPerPieceUnaligned + (kInputAlign - 1ULL)) & ~(kInputAlign - 1ULL);
+  const std::size_t headerBytes = numChunks * sizeof(std::size_t);
+  const std::size_t headerPadded =
+      (headerBytes + (kInputAlign - 1ULL)) & ~(kInputAlign - 1ULL);
+  const std::size_t total = headerPadded + numChunks * kPerPiecePadded;
+  const std::size_t aligned =
+      (total + (kBurstAlign - 1ULL)) & ~(kBurstAlign - 1ULL);
+  return input_bytes > aligned ? input_bytes : aligned;
+}
+
+} // namespace comms::prims

--- a/comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh
+++ b/comms/prims/collectives/benchmarks/AnsCopyOpBench.cuh
@@ -1,0 +1,140 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+//
+// Single-GPU standalone microbenchmark for the raw ANS `CopyOp` APIs
+// in `comms/prims/core/CopyOp.cuh` (`AnsCompress<NumWarps, ...>::send()` /
+// `::recv()`). Lives in its own translation unit / device-link target
+// (`:ans_copy_op_bench` in `comms/prims/collectives/benchmarks/BUCK`)
+// instead of being bolted onto `:alltoallv_tile_compressed` so that:
+//
+//   1. The existing `alltoallv_tile_{1d,2d}_compressed_kernel` symbols
+//      stay in a `--device-c` TU that does NOT carry any additional
+//      static `__shared__` allocations from these bench kernels.
+//   2. Host-only callers that don't want the bench symbols (and the
+//      extra nvcompdx fatbin device-link they imply) keep a clean
+//      `:alltoallv_tile_compressed` dependency.
+//
+// The bench kernels are templated on `NumWarps = blockDim.x / 32`
+// so the bench .cc can pick the matching kernel symbol at runtime
+// (via `pick_ans_copy_op_bench_kernels()`) without dragging every
+// NumWarps' static `__shared__` scratch into a single kernel's
+// footprint.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+namespace comms::prims {
+
+#ifdef __CUDACC__
+/**
+ * Single-GPU microbenchmark kernel for measuring the raw
+ * `AnsCompress::send()` (compression) throughput in isolation — no
+ * transport, no inter-block communication, no NVL/IB path. Each
+ * threadblock owns its own per-block input region (`input_bytes`
+ * bytes at offset `blockIdx.x * input_bytes`) and per-block staging
+ * region (`staging_stride` bytes at offset
+ * `blockIdx.x * staging_stride`) and loops `iters` times calling
+ * `AnsCompress<NumWarps, kAnsMaxUncompBytes>::send()` over those
+ * regions.
+ *
+ * Templated on `NumWarps = blockDim.x / 32` and `MinBlocksPerSM`
+ * (the second `__launch_bounds__` argument — the minimum blocks ptxas
+ * must keep resident per SM, which caps per-thread register usage).
+ * Explicit instantiations are emitted in `AnsCopyOpBench.cu` for
+ * `NumWarps ∈ {1, 2, 4, 8, 16}` (blockDim.x ∈ {32, 64, 128, 256, 512})
+ * × `MinBlocksPerSM ∈ {1, 2, 3, 4}`; extend the macro block there if a
+ * wider range is needed.
+ *
+ * Launch requirements:
+ *   - blockDim.x == NumWarps * 32
+ *   - d_input / d_staging must be 16-byte aligned (cudaMalloc gives
+ *     >=256 so this is satisfied for any base pointer)
+ *   - `staging_stride` must be >=
+ *     `ans_copy_op_bench_staging_stride(input_bytes)`
+ */
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+    __launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_compress_bench_kernel(
+        char* d_input,
+        char* d_staging,
+        std::size_t input_bytes,
+        std::size_t staging_stride,
+        int iters);
+
+/**
+ * Single-GPU microbenchmark companion to
+ * `ans_copy_op_compress_bench_kernel` — measures raw
+ * `AnsCompress::recv()` (decompression) throughput in isolation.
+ * The per-block staging region must already be populated with the
+ * ANS-compressed payload produced by the matching compress kernel
+ * over the same (input_bytes, staging_stride, NumWarps) parameters.
+ */
+template <int NumWarps, int MinBlocksPerSM>
+__global__
+    __launch_bounds__(NumWarps * 32, MinBlocksPerSM) void ans_copy_op_decompress_bench_kernel(
+        char* d_output,
+        const char* d_staging,
+        std::size_t input_bytes,
+        std::size_t staging_stride,
+        int iters);
+#else
+template <int NumWarps, int MinBlocksPerSM>
+void ans_copy_op_compress_bench_kernel(
+    char* d_input,
+    char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters);
+template <int NumWarps, int MinBlocksPerSM>
+void ans_copy_op_decompress_bench_kernel(
+    char* d_output,
+    const char* d_staging,
+    std::size_t input_bytes,
+    std::size_t staging_stride,
+    int iters);
+#endif
+
+/**
+ * Addresses of the compress + decompress bench kernels matching the
+ * caller's runtime-chosen `threads_per_block`. Both `nullptr` when
+ * the caller picks a value that no explicit instantiation in
+ * `AnsCopyOpBench.cu` covers — the bench should fail loudly
+ * host-side rather than launching an uninstantiated symbol.
+ */
+struct AnsCopyOpBenchKernels {
+  void* compress_kernel;
+  void* decompress_kernel;
+};
+
+/**
+ * Map a runtime-chosen `threads_per_block` (= `NumWarps * 32`) and
+ * `min_blocks_per_sm` (the `__launch_bounds__` minBlocksPerSM) to the
+ * matching explicit instantiation of the bench kernels in
+ * `AnsCopyOpBench.cu`. Supported `threads_per_block`: 32, 64, 128,
+ * 256, 512 (NumWarps ∈ {1, 2, 4, 8, 16}); supported
+ * `min_blocks_per_sm`: 1, 2, 3, 4. Returns `{nullptr, nullptr}` for
+ * any unsupported combination.
+ */
+AnsCopyOpBenchKernels pick_ans_copy_op_bench_kernels(
+    int threads_per_block,
+    int min_blocks_per_sm);
+
+/**
+ * Host-side helper that returns the per-block staging stride (in
+ * bytes) the `ans_copy_op_{compress,decompress}_bench_kernel` pair
+ * requires to safely hold the worst-case ANS-compressed output of an
+ * `input_bytes`-byte uncompressed input. Closed-form upper bound on
+ * `AnsCompress<...>::worst_case_chunk_stride(input_bytes)` —
+ * conservative enough to avoid requiring nvcompdx's
+ * `max_comp_chunk_size()` to be host-callable, while staying within
+ * ~1.5x of the uncompressed input size for the bench's range
+ * (256KiB..4MiB). NumWarps does not affect this size at the bench's
+ * MaxUncomp=256KiB, so the same value works for every supported
+ * NumWarps.
+ */
+std::size_t ans_copy_op_bench_staging_stride(std::size_t input_bytes);
+
+} // namespace comms::prims


### PR DESCRIPTION
Summary:

Final diff of the 5-way decomposition of D108485978 (this diff keeps the D108485978 number; the four diffs below it — BUCK/mathdx plumbing, CopyOp API normalization, the `AnsCompress` policy, and IBGDA variable-size transport — are new). It adds a self-contained single-GPU microbenchmark that exercises the raw ANS `CopyOp` primitive directly, with no transport and no AllToAllv dependency, so the compress/decompress compute can be enabled and measured on its own before any collective consumes it.

What this adds:
- `collectives/benchmarks/AnsCopyOpBench.{cu,cuh}` (new): single-GPU microbench kernels calling `AnsCompress::send()` / `AnsCompress::recv()` directly for NumWarps in {1,2,4,8,16}, plus the `pick_ans_copy_op_bench_kernels` / `ans_copy_op_bench_staging_stride` helpers. Uses CUDA green contexts to confine a run to a fixed SM partition so a fixed grid runs at a controlled blocks/SM ratio.
- `collectives/benchmarks/AnsCopyOpBench.cc` (new): the standalone `AnsCopyOpStandalone` runner — a per-block compress/decompress sweep over sizes {256KB..4MB} x sparsity 0->100%, reporting compress/decompress GB/s and verifying a byte-exact round-trip on every cell.
- `collectives/benchmarks/BUCK`: new `:ans_copy_op_benchmark` target. It turns on relocatable device code and device-links the nvcompdx LTO fatbin via `gen_alltoallv_tile_dlink_cmd` (from `collectives/defs.bzl`) and depends on `:copy_op_compress` — i.e. it is the first real consumer that both instantiates `AnsCompress` and device-links nvcompdx, exercising the plumbing added at the bottom of this stack.

Invariants:
- Standalone by construction: no transport, no inter-rank communication, no AllToAllv target dependency. The single-GPU sweep is driven by rank 0 only.
- Correctness is asserted, not just timed: every (size x sparsity) cell verifies a byte-exact compress->decompress round-trip and fails the test on mismatch, so a compression regression can't hide behind a passing bandwidth number.

Depends on the AnsCompress-impl diff (compiles `AnsCompress::send/recv`) and the plumbing diff (`:copy_op_compress` + `gen_alltoallv_tile_dlink_cmd` + the `collectives/PACKAGE` CUDA 12.8 CI pin). Does not depend on the IBGDA variable-size transport diff (this bench never touches the transport).

Reviewed By: dboyda

Differential Revision: D108485978


