### PR TITLE
Preserve H100 no-flush progress around CTRAN flush

### DIFF
--- a/comms/ctran/algos/AllGather/StreamedRd/Common.h
+++ b/comms/ctran/algos/AllGather/StreamedRd/Common.h
@@ -153,6 +153,11 @@ template <typename AlgoContext>
 inline commResult_t
 postRecvFlush(AlgoContext& ctx, int step, CtranMapperRequest** flushReq) {
   *flushReq = nullptr;
+  // Preserve the pre-flush scheduling path on platforms where local flush is a
+  // no-op; do not add a completed request that gates the put queue.
+  if (!ctx.mapper->isLocalFlushEnabled()) {
+    return commSuccess;
+  }
 
   CtranMapperRequest* req = nullptr;
   FB_COMMCHECK(ctx.mapper->iflush(ctx.recvbuff, ctx.memHdl, &req));

--- a/comms/ctran/algos/AllGather/StreamedRd/tests/PlanTest.cc
+++ b/comms/ctran/algos/AllGather/StreamedRd/tests/PlanTest.cc
@@ -4,9 +4,11 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <set>
 #include <vector>
 
+#include "comms/ctran/algos/AllGather/StreamedRd/Common.h"
 #include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
 
 namespace ctran::allgather::ctsrd {
@@ -47,6 +49,31 @@ void printPlan(
     std::cout << "]\n";
   }
 }
+
+struct FakeFlushMapper {
+  bool localFlushEnabled{false};
+  int iflushCalls{0};
+
+  bool isLocalFlushEnabled() const {
+    return localFlushEnabled;
+  }
+
+  commResult_t iflush(
+      const void* /*buf*/,
+      const void* /*regHdl*/,
+      CtranMapperRequest** req) {
+    iflushCalls++;
+    *req = new CtranMapperRequest();
+    return commSuccess;
+  }
+};
+
+struct FakeFlushContext {
+  FakeFlushMapper* mapper{nullptr};
+  void* recvbuff{nullptr};
+  void* memHdl{nullptr};
+  std::vector<std::vector<std::unique_ptr<CtranMapperRequest>>> recvFlushReqs;
+};
 
 int peerAt(const int rank, const int step, const int nRanks) {
   const auto dist = nRanks / (2 << step);
@@ -359,6 +386,35 @@ TEST(PlanFwdPeersInvariantsTest, BurstStepChunkCountIsPowerOfTwo) {
     EXPECT_EQ(burst.chunks(s).front(), 0)
         << "fp=0 step " << s << ": own chunk must be at front";
   }
+}
+
+TEST(CommonFlushTest, SkipsFlushRequestWhenLocalFlushDisabled) {
+  FakeFlushMapper mapper;
+  mapper.localFlushEnabled = false;
+  FakeFlushContext ctx;
+  ctx.mapper = &mapper;
+  ctx.recvFlushReqs.resize(1);
+  CtranMapperRequest* flushReq = nullptr;
+
+  EXPECT_EQ(common::postRecvFlush(ctx, 0, &flushReq), commSuccess);
+  EXPECT_EQ(flushReq, nullptr);
+  EXPECT_EQ(mapper.iflushCalls, 0);
+  EXPECT_TRUE(ctx.recvFlushReqs.at(0).empty());
+}
+
+TEST(CommonFlushTest, StoresFlushRequestWhenLocalFlushEnabled) {
+  FakeFlushMapper mapper;
+  mapper.localFlushEnabled = true;
+  FakeFlushContext ctx;
+  ctx.mapper = &mapper;
+  ctx.recvFlushReqs.resize(1);
+  CtranMapperRequest* flushReq = nullptr;
+
+  EXPECT_EQ(common::postRecvFlush(ctx, 0, &flushReq), commSuccess);
+  ASSERT_NE(flushReq, nullptr);
+  EXPECT_EQ(mapper.iflushCalls, 1);
+  ASSERT_EQ(ctx.recvFlushReqs.at(0).size(), 1);
+  EXPECT_EQ(ctx.recvFlushReqs.at(0).front().get(), flushReq);
 }
 
 } // namespace

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -120,9 +120,11 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
     // Wait till received data from upstream peer
     FB_COMMCHECK(mapper->waitNotify(notify.get()));
 
-    // Drain received RDMA writes before the stream-side CE/cudaMemcpyAsync
-    // broadcast reads the chunk.
-    FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+    if (mapper->isLocalFlushEnabled()) {
+      // Drain received RDMA writes before the stream-side CE/cudaMemcpyAsync
+      // broadcast reads the chunk.
+      FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+    }
 
     // Kick off local broadcast of the received data.
     resource->pipeSync->post(step);

--- a/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/RecursiveDoublingImpl.cc
@@ -196,9 +196,11 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
 
     FB_COMMCHECK(mapper->waitNotify(notifyVec[i].get()));
 
-    // Drain received RDMA writes before the next step forwards them or the
-    // stream-side CE/cudaMemcpyAsync broadcast reads them.
-    FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+    if (mapper->isLocalFlushEnabled()) {
+      // Drain received RDMA writes before the next step forwards them or the
+      // stream-side CE/cudaMemcpyAsync broadcast reads them.
+      FB_COMMCHECK(mapper->flush(pArgs->recvbuff, pArgs->recvHdl));
+    }
 
     // Notify the stream that step `i` IB exchange is done. The stream can
     // now issue the intra-node CE broadcast for the 2^i chunks just

--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -913,7 +913,9 @@ commResult_t CtranIb::iflush(
       return vc->iflush(dbuf, localRegHdl, req);
     });
   } else {
-    req->complete();
+    if (req != nullptr) {
+      req->complete();
+    }
     return commSuccess;
   }
 }

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -61,6 +61,10 @@ class CtranIb {
 
   static bool shouldEnableLocalFlushByDefault(int cudaArch);
 
+  bool isLocalFlushEnabled() const {
+    return enableLocalFlush;
+  }
+
   // Creates local IB resources without pre-existing communicator.
   // Supports three types of bootstrap mode as defined below.
   // Input arguments:

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -641,6 +641,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
     return commSuccess;
   }
 
+  bool isLocalFlushEnabled() const {
+    return this->ctranIb != nullptr && this->ctranIb->isLocalFlushEnabled();
+  }
+
   /* Drain pending NIC PCIe writes into GPU HBM after RDMA receives complete
    * and before host or stream-side work reads the just-received buffer. On
    * split-path topologies, PCIe write ordering does not necessarily extend to
@@ -650,6 +654,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline commResult_t flush(const void* buf, const void* regHdl) {
     if (this->ctranIb) {
+      if (!this->ctranIb->isLocalFlushEnabled()) {
+        return commSuccess;
+      }
+
       auto* regElem = reinterpret_cast<ctran::regcache::RegElem*>(
           const_cast<void*>(regHdl));
       if (!regElem) {
@@ -1150,11 +1158,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   inline commResult_t testRequestImpl(
       CtranMapperRequest* req,
       bool* isComplete) {
-    FB_COMMCHECK(this->checkComplete(req, isComplete));
-    if (*isComplete) {
-      return commSuccess;
-    }
-
+    // Keep request polling progress-first so completed/no-op backend requests
+    // do not silently change collective progress cadence.
     FB_COMMCHECK(this->progress<PerfConfig>());
     FB_COMMCHECK(this->checkComplete(req, isComplete));
 


### PR DESCRIPTION
Summary:
`D107941271` restored CTRAN receive-side flushes so platforms that require local IB flush do not let stream-side reads or forwarded puts observe just-notified RDMA data before it is GPU-visible.

The H100 conda numerics regression was isolated to the CTRAN flush restore. On H100, local flush is disabled by default, so the correctness flush is effectively a no-op, but the added completed flush requests and completion-first mapper polling still changed CTRAN collective progress cadence enough to perturb training.

This diff exposes `isLocalFlushEnabled()` on `CtranIb` and `CtranMapper` so receive-side flush call sites can distinguish real flush-required paths from disabled no-op paths. It makes `CtranMapper::flush()` return immediately when local flush is disabled, while preserving the existing blocking IB flush behavior when local flush is enabled. It skips CTSRD receive-flush request creation and AllGatherP blocking flush calls when local flush is disabled, preserving the pre-flush scheduling path on H100. It also restores `CtranMapper::testRequestImpl()` to progress-first polling so completed backend requests do not silently alter collective progress cadence, and adds focused CTSRD unit coverage for disabled vs enabled local flush request handling.

Differential Revision: D108527036


