### PR TITLE
Remove testRequestImpl fast path

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1150,11 +1150,6 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   inline commResult_t testRequestImpl(
       CtranMapperRequest* req,
       bool* isComplete) {
-    FB_COMMCHECK(this->checkComplete(req, isComplete));
-    if (*isComplete) {
-      return commSuccess;
-    }
-
     FB_COMMCHECK(this->progress<PerfConfig>());
     FB_COMMCHECK(this->checkComplete(req, isComplete));
 


### PR DESCRIPTION
Summary:
**Context:** D107941271 restored CTRAN receive flushes, but it also added a `testRequestImpl` fast path that returns before calling mapper transport progress when the request is already complete.

**Motivation:** Keep the flush restore from D107941271 while removing that mapper polling behavior change.

**This diff:**
- Removes the pre-progress `checkComplete()` fast path from `testRequestImpl`.
- Leaves the blocking `flush()` helper and `waitRequestImpl` abort handling unchanged.

Differential Revision: D108534381


