### PR TITLE
Fix NCCL 2.29 ncclCommInitRank CPU‑affinity restore (disagg TTFT 10+% regression)

### DIFF
--- a/comms/ncclx/v2_29/src/init.cc
+++ b/comms/ncclx/v2_29/src/init.cc
@@ -1000,7 +1000,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   int rank = comm->rank;
   int nranks = comm->nRanks;
   int nNodes = 1;
-  ncclAffinity affinitySave;
+  ncclAffinity affinitySave = {};
   struct ncclTopoGraph* ringGraph = &comm->graphs[NCCL_ALGO_RING];
   struct ncclTopoGraph* treeGraph = &comm->graphs[NCCL_ALGO_TREE];
   struct ncclTopoGraph* collNetChainGraph = &comm->graphs[NCCL_ALGO_COLLNET_CHAIN];
@@ -1603,7 +1603,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "rank %d nranks %d - DONE", rank, nranks);
 
 exit:
-  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(comm->cpuAffinity);
+  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(affinitySave);
   /* If split resource is shared, we are not able to unlink the proxy ops pool here since the child comm can
    * attach the proxy ops pool of parent at any time; otherwise, unlink it here to make sure the pool will be
    * properly cleaned up. */


### PR DESCRIPTION
Summary:
NCCL 2.29's `ncclCommInitRank` pins the calling thread to the GPU-local NUMA
cores during init, but at the `exit:` label it re-applies `comm->cpuAffinity`
(the GPU-local mask) instead of restoring the caller's saved `affinitySave`
(which is written but never read -- a dead store). As a result the worker
thread, and every thread it spawns afterward (the disagg KV-cache stream
pools, ServiceRouter/folly IO, Thrift deserialize), inherits the GPU-local
mask and is clamped to a single NUMA node (72 of 144 cores on GB200).

On the disaggregated IPNext vLLM predictor this throttles the CPU-bound
prefill->decode KV-cache transfer (FBThrift/TCP stream + deserialize), which
dominates disagg TTFT, adding a fixed ~75 ms / +38% per-request TTFT
regression vs NCCL 2.28. TTIT (decode) is unaffected.

The bug is absent in 2.28 and already fixed in 2.30 (init.cc:1638). This
cherry-picks the 2.30 one-liner into the 2.29 tree: restore `affinitySave`
at exit (and zero-init it, matching 2.30).

Detailed root cause and full investigation (collective analysis, TTFT
breakdown, thread-affinity confirmation, end-to-end fix validation): D108570619.

Reviewed By: pavanbalaji

Differential Revision: D108469172


