### PR TITLE
Validate cthierarchical_ring block-count tiers; wire the ring into benchmark_allreduce.sh (#2908)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -115,8 +115,19 @@ comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
   }
   return multiPeerTransport_->get_device_handle().transports.data();
 }
+comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr(
+    const std::vector<int>& peers) {
+  if (!multiPeerTransport_) {
+    return nullptr;
+  }
+  return multiPeerTransport_->get_device_handle(peers).transports.data();
+}
 #else
 comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr() const {
+  return nullptr;
+}
+comms::prims::Transport* CtranComm::getMultiPeerTransportsPtr(
+    const std::vector<int>& /*peers*/) {
   return nullptr;
 }
 #endif // defined(ENABLE_PRIMS)

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -172,6 +172,14 @@ class CtranComm {
   // initialized.
   comms::prims::Transport* getMultiPeerTransportsPtr() const;
 
+  // Lazy-safe overload: materializes `peers` (via get_device_handle(peers))
+  // and returns the Transport array pointer. Required in lazy-connect mode,
+  // where the no-arg overload throws. Non-const because materialization
+  // mutates transport state. An empty `peers` list materializes nothing and
+  // still returns a valid pointer (for ranks that use no IB slots).
+  comms::prims::Transport* getMultiPeerTransportsPtr(
+      const std::vector<int>& peers);
+
   // Returns a snapshot of the algo stats, or std::nullopt if stats are
   // disabled.
   std::optional<meta::comms::colltrace::AlgoStatDump> dumpAlgoStats() const;

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -43,14 +43,25 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
       }
       return true;
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
-      // The real support predicate and implementation land in the next stacked
-      // diff. Return false for now so explicit selection falls back at the
-      // McclComm layer (non-silent WARN) rather than reaching the
-      // not-yet-implemented stub.
-      CLOGF(
-          WARN,
-          "cthierarchical_ring algo is not yet implemented; falling back to baseline");
-      return false;
+      // Coarse runtime knobs only: this gates on Pipes/IBGDA being enabled but
+      // does NOT prove the selected peer transport is actually P2P_IBGDA, nor
+      // that the (datatype, redOp) are supported. Exact dtype/op/transport
+      // compatibility is validated inside ctranAllReduceHierarchicalRing, which
+      // surfaces unsupported cases as a hard commInvalidArgument (no silent
+      // fallback).
+      if (!NCCL_CTRAN_USE_PIPES) {
+        CLOGF(
+            WARN,
+            "cthierarchical_ring algo requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+        return false;
+      }
+      if (comm->statex_->nNodes() > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF(
+            WARN,
+            "cthierarchical_ring algo requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+        return false;
+      }
+      return true;
     default: // invalid query
       return false;
   }

--- a/comms/ctran/algos/AllReduce/AllReduceFused.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.cc
@@ -4,11 +4,16 @@
 
 #include <algorithm>
 #include <climits>
+#include <exception>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
+
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/transport/MultiPeerTransport.h"
+#endif
 
 namespace ctran::allreduce::fused {
 
@@ -42,6 +47,29 @@ int compute_num_blocks(size_t totalBytes, int cap) {
   return numBlocks;
 }
 
+int compute_num_blocks_ring(size_t segmentBytes, int cap) {
+  // Size-aware launch-geometry cap on the Phase-2 owner-segment size. The
+  // hierarchical ring does 2(W-1) serialized IB steps per pipeline window, so
+  // per-WQE/group overhead dominates at small/medium sizes and fewer blocks win
+  // there; large segments use the full cap. This is a launch-geometry ceiling
+  // on TOP of compute_num_blocks -- NOT a re-implementation of per-block
+  // sizing: the per-block byte threshold and the reduce-to-fit loop live in
+  // compute_num_blocks (single source of truth); this only lowers the ceiling
+  // before delegating. Keyed on segmentBytes (not totalBytes) because Phase 2
+  // operates per owner segment (segmentBytes ~= totalBytes/pMin in HYBRID). The
+  // 4/8/16 tiers are a starting point at this stack position; they are
+  // validated by the block-count sweep in the descendant diff D108428650.
+  int tier;
+  if (segmentBytes <= (1ull << 20)) { // <= 1 MB
+    tier = 4;
+  } else if (segmentBytes <= (32ull << 20)) { // <= 32 MB
+    tier = 8;
+  } else {
+    tier = 16;
+  }
+  return compute_num_blocks(segmentBytes, std::min(cap, tier));
+}
+
 void* compute_phase2_buf(
     void* recvbuff,
     int localRank,
@@ -70,7 +98,8 @@ commResult_t fill_common_kern_args(
     int numBlocks,
     commDataType_t datatype,
     commRedOp_t redOp,
-    CtranComm* comm) {
+    CtranComm* comm,
+    std::optional<std::vector<int>> ibPeers) {
   args.sendbuff = sendbuff;
   args.recvbuff = recvbuff;
   args.phase2Buf = phase2Buf;
@@ -83,7 +112,38 @@ commResult_t fill_common_kern_args(
   args.numBlocks = numBlocks;
   args.datatype = datatype;
   args.redOp = redOp;
-  args.transports = comm->getMultiPeerTransportsPtr();
+  // Transport array for the kernel. Eager mode: the no-peer getter is valid.
+  // Lazy mode: the no-peer getter throws, so the caller MUST hand us an
+  // explicit peer list to materialize -- an empty list is fine (ranks that use
+  // no IB slots still get a valid pointer), but a missing (nullopt) list is a
+  // caller that has not audited its lazy peers, so fail rather than hand the
+  // kernel unmaterialized slots.
+  const bool lazy =
+      comm->multiPeerTransport_ && comm->multiPeerTransport_->is_lazy_mode();
+  if (!lazy) {
+    args.transports = comm->getMultiPeerTransportsPtr();
+  } else if (!ibPeers.has_value()) {
+    CLOGF(
+        ERR,
+        "AllReduce fused: lazy IB connect requires an explicit peer list, "
+        "but the caller provided none");
+    return commInvalidArgument;
+  } else {
+    try {
+      args.transports = comm->getMultiPeerTransportsPtr(*ibPeers);
+    } catch (const std::exception& e) {
+      CLOGF(
+          ERR,
+          "AllReduce fused: lazy peer materialization failed: {}",
+          e.what());
+      return commInternalError;
+    } catch (...) {
+      CLOGF(
+          ERR,
+          "AllReduce fused: lazy peer materialization failed (non-standard exception)");
+      return commInternalError;
+    }
+  }
   if (args.transports == nullptr) {
     CLOGF(
         ERR,

--- a/comms/ctran/algos/AllReduce/AllReduceFused.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.cuh
@@ -41,18 +41,18 @@ __device__ __forceinline__ void runAllReduceFused(
     const common::CommonKernArgs& args,
     comms::prims::ThreadGroup& group,
     IbAllReduce&& ibAllReduce) {
-  NvlOps::template nvlReduceScatter<T>(args, group);
+  NvlOps::template nvlReduceScatter<T>(args, group); // Phase 1
   if (args.nLocalRanks > 1) {
     group.sync();
   }
   if (args.nNodes > 1) {
-    ibAllReduce(group);
+    ibAllReduce(group); // Phase 2
     if (args.nLocalRanks > 1) {
       group.sync();
     }
   }
   if (args.nLocalRanks > 1) {
-    NvlOps::template nvlAllGather<T>(args, group);
+    NvlOps::template nvlAllGather<T>(args, group); // Phase 3
   }
 }
 

--- a/comms/ctran/algos/AllReduce/AllReduceFused.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.h
@@ -4,6 +4,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <vector>
 
 #include <cuda_runtime.h>
 
@@ -18,6 +20,7 @@ bool is_supported_fused_type(commDataType_t datatype);
 int compute_p_min(CtranComm* comm);
 int get_num_block_cap();
 int compute_num_blocks(size_t totalBytes, int cap);
+int compute_num_blocks_ring(size_t segmentBytes, int cap);
 
 void* compute_phase2_buf(
     void* recvbuff,
@@ -41,7 +44,8 @@ commResult_t fill_common_kern_args(
     int numBlocks,
     commDataType_t datatype,
     commRedOp_t redOp,
-    CtranComm* comm);
+    CtranComm* comm,
+    std::optional<std::vector<int>> ibPeers = std::nullopt);
 
 commResult_t submit_fused_kernel(
     CtranComm* comm,

--- a/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
@@ -51,7 +51,7 @@ __device__ __forceinline__ void scalarReduce(
 /**
  * Accumulate `staging` into `accum` using Prims tiles when alignment allows.
  */
-template <typename T, int kTileElems, int kGroupSize>
+template <typename T, int kTileElems, int kBlockSize>
 __device__ __forceinline__ void tileReduce(
     T* accum,
     const T* staging,
@@ -67,20 +67,76 @@ __device__ __forceinline__ void tileReduce(
 
   for (size_t t = 0; t < nFullTiles; t++) {
     auto acc =
-        comms::prims::tile_load<T, kTileElems, kGroupSize>(accum, t, group);
+        comms::prims::tile_load<T, kTileElems, kBlockSize>(accum, t, group);
     comms::prims::
-        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kGroupSize>(
+        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kBlockSize>(
             acc, staging, t, group);
-    comms::prims::tile_store<T, kTileElems, kGroupSize>(accum, t, acc, group);
+    comms::prims::tile_store<T, kTileElems, kBlockSize>(accum, t, acc, group);
   }
   if (rem > 0) {
-    auto acc = comms::prims::tile_load<T, kTileElems, kGroupSize>(
+    auto acc = comms::prims::tile_load<T, kTileElems, kBlockSize>(
         accum, nFullTiles, group, rem);
     comms::prims::
-        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kGroupSize>(
+        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kBlockSize>(
             acc, staging, nFullTiles, group, rem);
-    comms::prims::tile_store<T, kTileElems, kGroupSize>(
+    comms::prims::tile_store<T, kTileElems, kBlockSize>(
         accum, nFullTiles, acc, group, rem);
+  }
+}
+
+/**
+ * Write `a + b` into a distinct `out` buffer without assuming tile alignment.
+ * Scalar fallback for tileReduceCopy (small buffers / unaligned pointers).
+ */
+template <typename T>
+__device__ __forceinline__ void scalarReduceCopy(
+    T* out,
+    const T* a,
+    const T* b,
+    size_t nelems,
+    comms::prims::ThreadGroup& group) {
+  for (size_t i = group.thread_id_in_group; i < nelems; i += group.group_size) {
+    out[i] = a[i] + b[i];
+  }
+}
+
+/**
+ * Write `a + b` into a distinct `out` buffer using Prims tiles when alignment
+ * allows, falling back to a scalar loop otherwise. Distinct-buffer analogue of
+ * tileReduce (which accumulates in place). Used by the ring reduce-scatter
+ * forward step (fwd_staging = staging + local_input).
+ */
+template <typename T, int kTileElems, int kBlockSize>
+__device__ __forceinline__ void tileReduceCopy(
+    T* out,
+    const T* a,
+    const T* b,
+    size_t nelems,
+    comms::prims::ThreadGroup& group) {
+  if (!isAligned16(out) || !isAligned16(a) || !isAligned16(b) ||
+      nelems < kTileElems) {
+    scalarReduceCopy(out, a, b, nelems, group);
+    return;
+  }
+
+  const size_t nFullTiles = nelems / kTileElems;
+  const size_t rem = nelems % kTileElems;
+
+  for (size_t t = 0; t < nFullTiles; t++) {
+    auto acc = comms::prims::tile_load<T, kTileElems, kBlockSize>(a, t, group);
+    comms::prims::
+        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kBlockSize>(
+            acc, b, t, group);
+    comms::prims::tile_store<T, kTileElems, kBlockSize>(out, t, acc, group);
+  }
+  if (rem > 0) {
+    auto acc = comms::prims::tile_load<T, kTileElems, kBlockSize>(
+        a, nFullTiles, group, rem);
+    comms::prims::
+        tile_load_accumulate<T, comms::prims::SumOp, kTileElems, kBlockSize>(
+            acc, b, nFullTiles, group, rem);
+    comms::prims::tile_store<T, kTileElems, kBlockSize>(
+        out, nFullTiles, acc, group, rem);
   }
 }
 
@@ -180,6 +236,35 @@ struct IbReduceCopy {
 
     tileReduce<T, common::TileElems<T>::k, common::kBlockSize>(
         accum, staged, nelems, group);
+#endif
+  }
+
+  /**
+   * Reduce-forward for the ring reduce-scatter: writes `fwd_staging = staging +
+   * local_input`, alignment-safe (tile fast path when 16B-aligned, scalar
+   * fallback otherwise). `dst` is unused -- the reduce-scatter forwards without
+   * a local store. `local_input` is the transfer base and MUST be indexed by
+   * `byteOffset`: the transport advances `staging`/`fwd_staging` per sub-chunk
+   * but passes `local_input` un-advanced (see P2pIbTransportDeviceDecl.cuh).
+   */
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* /* dst */,
+      char* fwd_staging,
+      const char* staging,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byteOffset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    T* fwd = reinterpret_cast<T*>(fwd_staging);
+    const T* staged = reinterpret_cast<const T*>(staging);
+    const T* local = reinterpret_cast<const T*>(local_input + byteOffset);
+    const size_t nelems = nbytes / sizeof(T);
+
+    tileReduceCopy<T, common::TileElems<T>::k, common::kBlockSize>(
+        fwd, staged, local, nelems, group);
 #endif
   }
 };

--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -99,7 +99,12 @@ struct CommonKernArgs {
 
   /** Total number of elements in the user tensor. */
   size_t count;
-  /** Elements per owner segment, equal to `ceil(count / pMin)`. */
+  /**
+   * Elements per owner segment. The base value is `ceil(count / pMin)`, but
+   * some algorithms round it up for alignment (e.g. hierring rounds up to a
+   * 16-byte multiple so sub-shard offsets are 16-aligned); over-padding past
+   * `count` is handled by `actualSegElems`.
+   */
   size_t segmentElems;
 
   /** Number of nodes in the communicator. */

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
@@ -92,10 +92,10 @@ commResult_t ctranAllReduceHierarchicalRing(
     return commInvalidArgument;
   }
 
-  if (datatype != commFloat32) {
+  if (datatype != commFloat32 && datatype != commFloat16) {
     CLOGF(
         ERR,
-        "AllReduce cthierarchical_ring currently supports commFloat32 only, got {}",
+        "AllReduce cthierarchical_ring currently supports commFloat32/commFloat16 only, got {}",
         commDataTypeToString(datatype));
     return commInvalidArgument;
   }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
@@ -1,26 +1,271 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <optional>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceFused.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-// Stub for the Pipes-backed hierarchical ring AllReduce (NVL ReduceScatter +
-// inter-node IBGDA ring + NVL AllGather). The wiring (enum, AlgoStrConv,
-// dispatch) lands in this diff; the real implementation lands in the next
-// stacked diff. Until then `ctranAllReduceSupport` returns false for
-// `cthierarchical_ring`, so this path is not reached in practice.
-commResult_t ctranAllReduceHierarchicalRing(
-    const void* /* sendbuff */,
-    void* /* recvbuff */,
-    size_t /* count */,
-    commDataType_t /* datatype */,
-    commRedOp_t /* redOp */,
-    CtranComm* /* comm */,
-    cudaStream_t /* stream */,
-    std::optional<std::chrono::milliseconds> /* timeout */) {
-  CLOGF(ERR, "AllReduce cthierarchical_ring is not yet implemented");
+// AllReduceIbRing.cuh exposes the host-safe `hierring::RingTopology` (used
+// below regardless of ENABLE_PRIMS) outside its ENABLE_PRIMS guard; the device
+// `KernArgs` / kernel entry inside the guard are used only on the PIPES path.
+#include "comms/ctran/algos/AllReduce/AllReduceIbRing.cuh"
+
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/transport/MultiPeerTransport.h"
+#endif
+
+namespace fused = ctran::allreduce::fused;
+
+#if defined(ENABLE_PRIMS)
+namespace {
+// Validates that an IB ring neighbor (`peerRank`) resolves to a P2P_IBGDA
+// transport. The kernel dereferences `transports[peerRank].p2p_ib.ibgda`
+// (AllReduceIbRing.cu), so a non-IBGDA peer — e.g. a comm using the IBRC
+// backend, where the same union holds `.ibrc` — would reinterpret the wrong
+// union member and trap/hang at kernel time. The coarse
+// NCCL_CTRAN_IBGDA_SENDRECV_ENABLE knob does not catch this. Mirrors
+// AllReduceIbTree.cc's validateAllReduceTreeIbPeer (file-local, not reusable).
+commResult_t validateHierRingIbPeer(
+    const comms::prims::MultiPeerTransport& transport,
+    int rank,
+    int peerRank,
+    const char* edgeName) {
+  const auto type = transport.get_transport_type(peerRank);
+  if (type == comms::prims::TransportType::P2P_IBGDA) {
+    return commSuccess;
+  }
+  CLOGF(
+      ERR,
+      "AllReduce cthierarchical_ring requires P2P_IBGDA transport for {} edge "
+      "rank {} -> peer {}; got {}",
+      edgeName,
+      rank,
+      peerRank,
+      comms::prims::transport_type_name(type));
   return commInvalidArgument;
+}
+} // namespace
+#endif
+
+commResult_t ctranAllReduceHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int localRank = statex->localRank();
+  const int nodeId = statex->node();
+
+  if (nRanks == 1) {
+    // Degenerate case: device-to-device memcpy short-circuit
+    if (sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * commTypeSize(datatype),
+          cudaMemcpyDeviceToDevice,
+          stream));
+    }
+    return commSuccess;
+  }
+
+  if (redOp != commSum) {
+    CLOGF(ERR, "AllReduce cthierarchical_ring currently supports commSum only");
+    return commInvalidArgument;
+  }
+
+  if (datatype != commFloat32) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring currently supports commFloat32 only, got {}",
+        commDataTypeToString(datatype));
+    return commInvalidArgument;
+  }
+
+  if (nNodes > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+    return commInvalidArgument;
+  }
+  if (!NCCL_CTRAN_USE_PIPES) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+    return commInvalidArgument;
+  }
+
+  const int pMin = fused::compute_p_min(comm);
+
+  const size_t rawSegmentElems = (count + pMin - 1) / pMin; // ceil(count/pMin)
+  const size_t elemSz = commTypeSize(datatype);
+  // The 16B round-up below uses alignElems = 16 / elemSz with a power-of-two
+  // mask, which requires elemSz to divide 16 (true for all supported/plausible
+  // dtypes: 1/2/4/8B). Developer invariant only (assert compiles out in opt);
+  // the runtime guard is the commFloat32-only datatype check above. If a dtype
+  // with elemSz not dividing 16 is ever added, switch to
+  // alignElems = 16 / std::gcd(16, elemSz).
+  assert(elemSz != 0 && elemSz <= 16 && 16 % elemSz == 0);
+  const size_t alignElems = 16 / elemSz;
+  const size_t segmentElems =
+      (rawSegmentElems + alignElems - 1) & ~(alignElems - 1); // round up to 16B
+  const bool participatesInIB = (localRank < pMin);
+
+  ctran::allreduce::hierring::RingTopology ring{};
+  if (participatesInIB && nNodes > 1) {
+    int prevNode = (nodeId - 1 + nNodes) % nNodes;
+    int nextNode = (nodeId + 1) % nNodes;
+    ring.prevRank = statex->localRankToRank(localRank, prevNode);
+    ring.nextRank = statex->localRankToRank(localRank, nextNode);
+    ring.nNodes = nNodes;
+    ring.myNodeIdx = nodeId;
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce cthierarchical_ring: rank {} localRank {} nNodes {} pMin {} "
+      "segmentElems {} participatesInIB {} ring[prev={} next={} myNode={}]",
+      rank,
+      localRank,
+      nNodes,
+      pMin,
+      segmentElems,
+      participatesInIB,
+      ring.prevRank,
+      ring.nextRank,
+      ring.myNodeIdx);
+
+#if defined(ENABLE_PRIMS)
+  const int nLocalRanks = statex->nLocalRanks();
+  const size_t totalBytes = count * elemSz;
+  const size_t segmentBytes = segmentElems * elemSz;
+  const bool hasIbPhase = participatesInIB && nNodes > 1;
+
+  // Size-tiered count that drives block tiling (i.e., bucket the
+  // owner-segment size into the 4/8/16 tiers, then cap it and reduce).
+  // Larger segments get more blocks (more tile parallelism).
+  // Small segments get fewer (avoids too much per-block/WQE overhead).
+  const int numBlocks =
+      fused::compute_num_blocks_ring(segmentBytes, fused::get_num_block_cap());
+
+  // Fixed IB staging/signaling reservation (the transport `active_blocks`) for
+  // Phase 2. Derived from the SAME clamped cap (std::max(1,
+  // NCCL_CTRAN_MAX_NBLOCKS)) that bounds numBlocks, so the two never diverge on
+  // a bad CVAR and (numBlocks <= ibSendRecvGroups) holds by construction. Kept
+  // fixed (not numBlocks) so the transport staging layout is stable across
+  // launches. The ring runs one lane per block, so this is MAX_NBLOCKS (default
+  // 16) -- intentionally different from the tree's NCCL_CTRAN_IB_MAX_GROUPS.
+  const int ibSendRecvGroups = fused::get_num_block_cap();
+
+  if (hasIbPhase) {
+    // Validate the IB transport before launching: the kernel blindly
+    // dereferences `transports[prev/next].p2p_ib.ibgda`, so a missing
+    // MultiPeerTransport, lazy (unmaterialized) connect, or a non-IBGDA peer
+    // would trap/hang on device. Fail fast on the host instead.
+    if (!comm->multiPeerTransport_) {
+      CLOGF(
+          ERR,
+          "AllReduce cthierarchical_ring requires MultiPeerTransport for inter-node IB transfers");
+      return commInvalidArgument;
+    }
+    commResult_t prevValid = validateHierRingIbPeer(
+        *comm->multiPeerTransport_, rank, ring.prevRank, "prev");
+    if (prevValid != commSuccess) {
+      return prevValid;
+    }
+    commResult_t nextValid = validateHierRingIbPeer(
+        *comm->multiPeerTransport_, rank, ring.nextRank, "next");
+    if (nextValid != commSuccess) {
+      return nextValid;
+    }
+
+    // Device IB QP selection uses block_id and requires
+    // block_id < NCCL_CTRAN_IB_MAX_GROUPS. The ring's transport reservation is
+    // the fixed ibSendRecvGroups; numBlocks <= ibSendRecvGroups holds by
+    // construction (shared clamped cap), so only the upper bound needs
+    // checking.
+    if (ibSendRecvGroups > NCCL_CTRAN_IB_MAX_GROUPS) {
+      CLOGF(
+          ERR,
+          "AllReduce cthierarchical_ring requires {} IBGDA send/recv groups, "
+          "exceeding NCCL_CTRAN_IB_MAX_GROUPS={}",
+          ibSendRecvGroups,
+          NCCL_CTRAN_IB_MAX_GROUPS);
+      return commInvalidArgument;
+    }
+  }
+
+  void* phase2Buf = fused::compute_phase2_buf(
+      recvbuff, localRank, segmentBytes, participatesInIB);
+
+  CLOGF(
+      DBG,
+      "AllReduce cthierarchical_ring launch: totalBytes {} segmentBytes {} "
+      "numBlocks {} threadsPerBlock {} hasIbPhase {}",
+      totalBytes,
+      segmentBytes,
+      numBlocks,
+      ctran::allreduce::hierring::kBlockSize,
+      hasIbPhase);
+
+  auto opCount = comm->ctran_->getOpCount();
+
+  ctran::allreduce::hierring::KernArgs kernArgs{};
+  FB_COMMCHECK(
+      fused::fill_common_kern_args(
+          kernArgs.common,
+          sendbuff,
+          recvbuff,
+          phase2Buf,
+          count,
+          segmentElems,
+          nNodes,
+          pMin,
+          nLocalRanks,
+          localRank,
+          numBlocks,
+          datatype,
+          redOp,
+          comm,
+          // Lazy connect: materialize exactly the IB ring neighbors. Non-IB
+          // ranks pass an explicit empty list (materializes nothing, still
+          // returns a valid transports pointer); passing nullopt would be
+          // rejected in lazy mode.
+          std::optional<std::vector<int>>(
+              hasIbPhase ? std::vector<int>{ring.prevRank, ring.nextRank}
+                         : std::vector<int>{})));
+  kernArgs.ring = ring;
+  kernArgs.ibSendRecvGroups = ibSendRecvGroups;
+
+  return fused::submit_fused_kernel(
+      comm,
+      stream,
+      "AllReduceHierarchicalRing",
+      opCount,
+      numBlocks,
+      ctran::allreduce::hierring::kBlockSize,
+      &kernArgs,
+      reinterpret_cast<const void*>(ctranKernelAllReduceHierarchicalRing));
+#else
+  CLOGF(ERR, "AllReduce cthierarchical_ring requires ENABLE_PRIMS");
+  return commInternalError;
+#endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
@@ -2,6 +2,8 @@
 
 #if defined(ENABLE_PRIMS)
 
+#include <cuda_fp16.h>
+
 #include <cstdint>
 
 #include "comms/ctran/algos/AllReduce/AllReduceFused.cuh"
@@ -272,6 +274,12 @@ __launch_bounds__(ctran::allreduce::hierring::kBlockSize, 1) void ctranKernelAll
         runAllReduceFused<float, ctran::allreduce::nvl::direct::Ops>(
             args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
               phase2IbRing<float>(args, phaseGroup);
+            });
+  } else if (args.common.datatype == commFloat16) {
+    ctran::allreduce::fused::
+        runAllReduceFused<__half, ctran::allreduce::nvl::direct::Ops>(
+            args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
+              phase2IbRing<__half>(args, phaseGroup);
             });
   }
 }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
@@ -1,0 +1,279 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstdint>
+
+#include "comms/ctran/algos/AllReduce/AllReduceFused.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceIbRing.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/Transport.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+using namespace ctran::allreduce::common;
+
+namespace {
+
+// Non-negative (base - s) mod W.
+__device__ __forceinline__ int ringRotate(int base, int s, int W) {
+  return ((base - s) % W + W) % W;
+}
+
+// Largest of the W node sub-shards -- the pipeline-loop upper bound. Sub-shards
+// are a TiledBuffer over the block tile, so every offset is 16B-spaced and each
+// non-empty interior sub-shard is exactly tile_elements; at most one non-empty
+// sub-shard (the last) may carry a short/non-16B tail.
+__device__ __forceinline__ size_t
+maxShardTileBytes(const comms::prims::TiledBuffer<char>& shardTiles, int W) {
+  size_t m = 0;
+  for (int k = 0; k < W; k++) {
+    const size_t b = shardTiles.tile_bytes(k);
+    m = b > m ? b : m;
+  }
+  return m;
+}
+
+// Valid bytes of sub-shard `k` at pipeline offset `off` (0 if past the end).
+__device__ __forceinline__ size_t shardWindow(
+    const comms::prims::TiledBuffer<char>& shardTiles,
+    int k,
+    size_t off,
+    size_t pipelineWindow) {
+  const size_t b = shardTiles.tile_bytes(k);
+  if (off >= b) {
+    return 0;
+  }
+  const size_t rem = b - off;
+  return pipelineWindow < rem ? pipelineWindow : rem;
+}
+
+// Phase-2 ring reduce-scatter over the W node sub-shards of this block's tile.
+// Per pipeline window: send(shard me) + forward(shard me-1 .. me-(W-2)) +
+// recv(shard me+1). Each forward reduces this node's local sub-shard into the
+// running partial via IbReduceCopy<T> and passes it on; the final recv lands
+// the fully reduced sub-shard (me+1). Other sub-shards keep this node's local
+// data until all-gather fills them in. `ringGroup` carries the per-block
+// group_id with total_groups relabeled to the fixed IB reservation, and
+// `ibSendRecvGroups` is that same reservation passed as the transport
+// `active_blocks`.
+template <typename T>
+__device__ __forceinline__ void reduceScatterRing(
+    comms::prims::P2pIbgdaTransportDevice& prev,
+    comms::prims::P2pIbgdaTransportDevice& next,
+    comms::prims::ThreadGroup& ringGroup,
+    const comms::prims::TiledBuffer<char>& shardTiles,
+    size_t maxShardBytes,
+    int W,
+    int me,
+    int ibSendRecvGroups,
+    size_t pipelineWindow,
+    const comms::prims::Timeout& timeout) {
+  for (size_t off = 0; off < maxShardBytes; off += pipelineWindow) {
+    // step 0: initiate own owner sub-shard (raw local data).
+    {
+      const int k = me;
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = shardTiles.tile_data(k) + off;
+        next.send(ringGroup, buf, v, ibSendRecvGroups, 0, timeout);
+      }
+    }
+    // steps 1..W-2: receive partial for shard (me-s), reduce local, forward.
+    for (int s = 1; s <= W - 2; ++s) {
+      const int k = ringRotate(me, s, W);
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* lin = shardTiles.tile_data(k) + off;
+        prev.template forward<IbReduceCopy<T>>(
+            ringGroup, nullptr, next, v, ibSendRecvGroups, 0, timeout, lin);
+      }
+    }
+    // step W-1: final receive-reduce of shard (me+1) into the tile.
+    {
+      const int k =
+          ringRotate(me, W - 1, W); // (me - (W-1)) mod W = (me+1) mod W
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = shardTiles.tile_data(k) + off;
+        prev.template recv<IbReduceCopy<T>>(
+            ringGroup, buf, v, ibSendRecvGroups, 0, timeout);
+      }
+    }
+  }
+}
+
+// Phase-2 ring all-gather over the W node sub-shards. Per window: send(shard
+// me+1) + forward(shard me .. me+1-(W-2), storing each) + recv(shard me+2).
+// All-gather never reduces (uses the transport's default Memcpy CopyOp). Args
+// mirror reduceScatterRing.
+template <typename T>
+__device__ __forceinline__ void allGatherRing(
+    comms::prims::P2pIbgdaTransportDevice& prev,
+    comms::prims::P2pIbgdaTransportDevice& next,
+    comms::prims::ThreadGroup& ringGroup,
+    const comms::prims::TiledBuffer<char>& shardTiles,
+    size_t maxShardBytes,
+    int W,
+    int me,
+    int ibSendRecvGroups,
+    size_t pipelineWindow,
+    const comms::prims::Timeout& timeout) {
+  for (size_t off = 0; off < maxShardBytes; off += pipelineWindow) {
+    // step 0: broadcast own reduced sub-shard (me+1).
+    {
+      const int k = ringRotate(me + 1, 0, W);
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = shardTiles.tile_data(k) + off;
+        next.send(ringGroup, buf, v, ibSendRecvGroups, 0, timeout);
+      }
+    }
+    // steps 1..W-2: receive shard (me+1-s), store into the tile, forward.
+    for (int s = 1; s <= W - 2; ++s) {
+      const int k = ringRotate(me + 1, s, W);
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = shardTiles.tile_data(k) + off;
+        prev.forward(ringGroup, buf, next, v, ibSendRecvGroups, 0, timeout);
+      }
+    }
+    // step W-1: final receive of shard (me+2) into the tile.
+    {
+      const int k = ringRotate(me + 1, W - 1, W); // (me+2) mod W
+      const size_t v = shardWindow(shardTiles, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = shardTiles.tile_data(k) + off;
+        prev.recv(ringGroup, buf, v, ibSendRecvGroups, 0, timeout);
+      }
+    }
+  }
+}
+
+// Phase-2 inter-node ring (reduce-scatter then all-gather) over this block's
+// owner-segment tile.
+//
+// Group invariant (data vs staging): `blockGroup` (total_groups = numBlocks)
+// governs data ownership -- both the block tile and its sub-shard TiledBuffer
+// are derived from it. `ringGroup` reuses the per-block group_id but relabels
+// total_groups to the FIXED `args.ibSendRecvGroups` reservation, used ONLY for
+// transport staging/signaling identity. Never tile data with `ringGroup`:
+// TiledBuffer tiles by group.total_groups, so tiling with the (larger, fixed)
+// reservation would leave data uncovered by the launched blocks.
+template <typename T>
+__device__ __noinline__ void phase2IbRing(
+    const ctran::allreduce::hierring::KernArgs& args,
+    comms::prims::ThreadGroup& blockGroup) {
+  if (args.common.localRank >= args.common.pMin) {
+    return;
+  }
+  if (args.common.nNodes <= 1) {
+    return;
+  }
+
+  const int W = args.ring.nNodes;
+  const int me = args.ring.myNodeIdx;
+  const size_t actualElems = actualSegElems(
+      args.common.count, args.common.segmentElems, args.common.localRank);
+
+  // Data ownership: this block's tile of phase2Buf (from blockGroup), then
+  // split into W node sub-shards with 16B-aligned offsets. blockTile is
+  // group-bound so blockTile.data()/bytes() are valid; shardTiles is a plain
+  // W-way split so use only tile_data(k)/tile_bytes(k).
+  comms::prims::TiledBuffer<char> blockTile(
+      static_cast<char*>(args.common.phase2Buf),
+      actualElems * sizeof(T),
+      blockGroup);
+
+  if (blockTile.bytes() == 0) {
+    // Blocks whose tile is empty (tiny counts, trailing blocks) do no work.
+    return;
+  }
+
+  comms::prims::TiledBuffer<char> shardTiles(
+      blockTile.data(), blockTile.bytes(), W);
+
+  auto& prev = *args.common.transports[args.ring.prevRank].p2p_ib.ibgda;
+  auto& next = *args.common.transports[args.ring.nextRank].p2p_ib.ibgda;
+
+  // Fixed IB staging/signaling reservation, independent of numBlocks so the
+  // transport staging layout is stable across launches (see
+  // AllReduceIbRing.cc).
+  const int ibSendRecvGroups = args.ibSendRecvGroups;
+  auto ringGroup = blockGroup;
+  ringGroup.total_groups = static_cast<uint32_t>(ibSendRecvGroups);
+
+  const size_t pipelineWindow = next.pipeline_window(ibSendRecvGroups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0, "phase2IbRing: pipeline window is zero");
+
+  // The block tile is a view into recvbuff; the AllReduce API guarantees only
+  // element alignment (alignof(T)), which is all we require. The CopyOps
+  // (IbReduceCopy's tileReduce and the transport's default Memcpy) take the 16B
+  // vectorized path when aligned and a scalar path otherwise, and the transport
+  // rounds the wire byte count to 16B internally (D108444748), so no manual
+  // rounding/valid-masking is needed. Sub-shard offsets inherit this alignment
+  // (tile_elements is 16B-rounded).
+  PIPES_DEVICE_CHECK_MSG(
+      reinterpret_cast<uintptr_t>(blockTile.data()) % alignof(T) == 0,
+      "phase2IbRing: tile must be element-aligned");
+
+  const size_t maxShardBytes = maxShardTileBytes(shardTiles, W);
+  comms::prims::Timeout timeout{};
+
+  reduceScatterRing<T>(
+      prev,
+      next,
+      ringGroup,
+      shardTiles,
+      maxShardBytes,
+      W,
+      me,
+      ibSendRecvGroups,
+      pipelineWindow,
+      timeout);
+
+  // Block-local phase transition: shard (me+1) is now reduced in the tile and
+  // is read by all-gather step 0.
+  blockGroup.sync();
+
+  allGatherRing<T>(
+      prev,
+      next,
+      ringGroup,
+      shardTiles,
+      maxShardBytes,
+      W,
+      me,
+      ibSendRecvGroups,
+      pipelineWindow,
+      timeout);
+}
+
+} // namespace
+
+__global__
+__launch_bounds__(ctran::allreduce::hierring::kBlockSize, 1) void ctranKernelAllReduceHierarchicalRing(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::hierring::KernArgs args) {
+  // Maps the physical block to a logical data group.
+  auto blockGroup = comms::prims::make_block_group();
+  const int blockId = static_cast<int>(blockIdx.x);
+  if (blockId >= args.common.numBlocks) {
+    return;
+  }
+  auto group = logicalDataGroup(blockGroup, blockId, args.common.numBlocks);
+
+  if (args.common.datatype == commFloat32) {
+    ctran::allreduce::fused::
+        runAllReduceFused<float, ctran::allreduce::nvl::direct::Ops>(
+            args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
+              phase2IbRing<float>(args, phaseGroup);
+            });
+  }
+}
+
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cuh
@@ -1,0 +1,59 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace ctran::allreduce::hierring {
+
+// Host-safe ring topology POD shared by the host launcher (AllReduceIbRing.cc)
+// and the device KernArgs below. Kept outside the ENABLE_PRIMS guard so it is
+// visible on host-only builds where ENABLE_PRIMS is undefined (e.g. AMD/HIP),
+// mirroring how ctran::allreduce::TreeTopology lives in Types.h.
+struct RingTopology {
+  int prevRank{-1};
+  int nextRank{-1};
+  int nNodes{0};
+  int myNodeIdx{0};
+};
+
+} // namespace ctran::allreduce::hierring
+
+#if defined(ENABLE_PRIMS)
+
+#include "comms/ctran/algos/AllReduce/AllReduceFusedTypes.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::allreduce::hierring {
+
+static constexpr int kBlockSize = ctran::allreduce::common::kBlockSize;
+
+struct KernArgs {
+  ctran::allreduce::common::CommonKernArgs common;
+
+  /**
+   * Per-NVL-variant device-state slot. Empty for NvlDirect; the orchestrator
+   * dispatches the NVL phases through `nvl::direct::Ops`.
+   * `[[no_unique_address]]` keeps `sizeof(KernArgs)` unchanged while empty.
+   */
+  [[no_unique_address]] ctran::allreduce::nvl::direct::ExtraArgs nvl;
+
+  RingTopology ring;
+
+  /**
+   * Fixed IB send/recv group reservation (the transport `active_blocks`), kept
+   * independent of `common.numBlocks` so the staging-buffer layout is stable
+   * across launches. Set on the host from `fused::get_num_block_cap()` (the
+   * same clamped `NCCL_CTRAN_MAX_NBLOCKS` source that caps `numBlocks`); see
+   * AllReduceIbRing.cc.
+   */
+  int ibSendRecvGroups{0};
+};
+
+} // namespace ctran::allreduce::hierring
+
+__global__ void ctranKernelAllReduceHierarchicalRing(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::hierring::KernArgs args);
+
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -42,7 +42,7 @@ static inline const std::string allReduceAlgoName(
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "CtranAllReduceTreeDirect";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
-      return "CtranAllReduceRingDirect";
+      return "CtranAllReduceHierarchicalRingDirect";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/benchmarks/benchmark_allreduce.sh
+++ b/comms/ctran/algos/AllReduce/benchmarks/benchmark_allreduce.sh
@@ -258,6 +258,12 @@ build_perf_binary() {
       -m "$cuda_mode"
     )
   fi
+  if [[ -n "${USE_MCCL_ADAPTER:-}" ]]; then
+    # Link the MCCL adapter so the binary exercises the LOCAL comms/ctran
+    # AllReduce code (e.g. cthierarchical_ring) instead of the pinned
+    # use_ncclx=stable build. Required when sweeping uncommitted kernel changes.
+    build_flags+=(-c hpc_comms.nccl_testonly_override=nccl_adapter -c nccl.enable_profapi=True)
+  fi
   if ! buck2 build "${build_flags[@]}" \
     "$BUCK_TARGET" --show-full-json-output >"$json_file"; then
     rm -f "$json_file"
@@ -534,7 +540,7 @@ print_command() {
 
 variant_uses_ctran() {
   case "$1" in
-    ctree|ctring) return 0 ;;
+    ctree|ctring|cthierarchical_ring) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -561,13 +567,20 @@ variant_envs() {
         "NCCL_PROTO=Simple" \
         "TORCH_NCCL_BCAST_UNIQUEID=1"
       ;;
+    nccl_ring_ll128)
+      printf '%s\n' \
+        "NCCL_ALLREDUCE_ALGO=orig" \
+        "NCCL_ALGO=allreduce:ring" \
+        "NCCL_PROTO=LL128" \
+        "TORCH_NCCL_BCAST_UNIQUEID=1"
+      ;;
     ctree)
       printf '%s\n' \
         "NCCL_CTRAN_USE_PIPES=1" \
         "NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE=${NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE:-33554432}" \
         "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1"
       ;;
-    ctring)
+    ctring|cthierarchical_ring)
       ;;
     *)
       echo "Unsupported variant: ${variant}" >&2
@@ -641,6 +654,22 @@ run_one() {
   if variant_uses_ctran "$variant"; then
     envs+=("NCCL_CTRAN_ENABLE=1")
     envs+=("NCCL_ALLREDUCE_ALGO=${variant}")
+    envs+=("NCCL_CTRAN_USE_PIPES=1")
+    envs+=("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE=${NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE:-33554432}")
+    envs+=("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1")
+  fi
+
+  # Forward optional ring-tuning knobs (only when set in the caller's env) so a
+  # parameter sweep can vary block count / pipeline / QP depth without further
+  # script edits. Applies to cthierarchical_ring only.
+  if [[ "$variant" == "cthierarchical_ring" ]]; then
+    local knob
+    for knob in NCCL_CTRAN_MAX_NBLOCKS \
+      NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH NCCL_CTRAN_IBGDA_QP_DEPTH; do
+      if [[ -n "${!knob:-}" ]]; then
+        envs+=("${knob}=${!knob}")
+      fi
+    done
   fi
 
   envs+=("${extra_envs[@]}")
@@ -666,12 +695,21 @@ run_one() {
     echo "== ${variant} ${topology} np=${np} arch=${arch}${block_desc} size=${min_bytes}..${max_bytes} =="
   fi
 
+  # cthierarchical_ring is fp32/sum-only; its support gate does NOT check
+  # dtype/op, so a non-fp32/non-sum run passes the gate then hard-fails inside
+  # ctranAllReduceHierarchicalRing. Pin -d float -o sum (-c 1 = explicit check)
+  # for it; other variants keep the script's -d "$DTYPE" (unchanged behavior).
+  local -a dtype_args=(-d "$DTYPE")
+  if [[ "$variant" == "cthierarchical_ring" ]]; then
+    dtype_args=(-d float -o sum -c 1)
+  fi
+
   local -a cmd=(
     env "${envs[@]}" "$MPI_BIN" --allow-run-as-root --bind-to none
     --mca btl "^openib" -np "$np" -host "localhost:${np}"
     "${mpi_envs[@]}"
     "$perf_bin" -b "$min_bytes" -e "$max_bytes" -f "$FACTOR" -g 1
-    -n "$ITERS" -w "$WARMUP" -d "$DTYPE"
+    -n "$ITERS" -w "$WARMUP" "${dtype_args[@]}"
   )
   if [[ -n "$RUN_TIMEOUT_SECONDS" ]]; then
     cmd=(timeout --foreground "$RUN_TIMEOUT_SECONDS" "${cmd[@]}")
@@ -788,7 +826,7 @@ run_local() {
 
   local -a variant_values
   read_csv_values "$VARIANTS" variant_values
-  validate_csv_values "variant" variant_values nccl nccl_tree nccl_tree_simple nccl_ring_simple ctree ctring
+  validate_csv_values "variant" variant_values nccl nccl_tree nccl_tree_simple nccl_ring_simple nccl_ring_ll128 ctree ctring cthierarchical_ring
 
   local -a block_cap_values=()
   if [[ -n "$BLOCK_CAPS" ]]; then

--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -132,6 +132,7 @@ The primary benchmark comparison is forced NCCL Tree against CTREE using the thi
 - **Performance tuning**: continue tuning launch shape, tile sizing, transport progress, and tiny-message overhead.
 - **LL protocol for IB**: add a lower-latency IB protocol for small payloads.
 - **NVLS-based ReduceScatter**: replace the current Phase 1 implementation with an NVLS-based local ReduceScatter path.
-- **Ring-based IB implementation**: add a ring implementation for the IB phase so the cross-node phase can choose between Ring and Tree implementations.
+- **Ring-based IB implementation**: *delivered* — the cross-node IB phase can now select a ring (`cthierarchical_ring`) as well as the tree. See [RingAllReduce.md](RingAllReduce.md).
+- **Share ReduceScatter/AllGather with standalone collectives**: the ring's Phase 2 is factored into `reduceScatterRing` / `allGatherRing` halves (see [RingAllReduce.md](RingAllReduce.md)) that are structurally reusable for the standalone ReduceScatter / AllGather collectives; the tree's phases are analogous. Unifying the fused halves with the standalone collectives is possible future work — not yet pursued.
 - **Wider reduction ops and datatypes**: add support beyond the current `commSum` scope, with correctness tests and benchmark coverage across all topologies.
 - **Uneven `pMin` topology coverage**: add targeted validation for mixed local-rank-count topologies where extra local ranks contribute to NVL phases but do not participate in IB.

--- a/comms/ctran/tests/AllReduceTestSuite.cc
+++ b/comms/ctran/tests/AllReduceTestSuite.cc
@@ -763,12 +763,13 @@ INSTANTIATE_TEST_SUITE_P(
 #if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY) || \
     defined(CTRAN_ALLREDUCE_TEST_HYBRID)
 // Ring Phase 2 requires nNodes > 1.
+// cthierarchical_ring supports fp32 and fp16, so sweep the full datatype axis.
 INSTANTIATE_TEST_SUITE_P(
     CtranAllReduceRing,
     CtranAllReduceCorrectnessTest,
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
-        ::testing::Values(commFloat32),
+        ::testing::ValuesIn(allReduceDataTypes()),
         ::testing::Bool()),
     correctnessTestName);
 

--- a/comms/ctran/tests/AllReduceTestSuite.cc
+++ b/comms/ctran/tests/AllReduceTestSuite.cc
@@ -246,7 +246,7 @@ class AllReduceTestSuite : public ctran::CtranDistTestFixture,
    */
   void SetUp() override {
     ctran::CtranDistTestFixture::SetUp(envOverrides());
-    ctranComm = makeCtranComm();
+    ctranComm = makeCtranComm(ibLazyConnect());
   }
 
   void TearDown() override {
@@ -287,8 +287,11 @@ class AllReduceTestSuite : public ctran::CtranDistTestFixture,
     }
 
     constexpr uint8_t kGuardPattern = 0xA5;
+    // Trailing guard sized to catch a worst-case 16B-rounded tail overwrite
+    // (e.g. transport-delegated padding leaking past the payload end).
+    constexpr size_t kSuffixGuardBytes = 16;
     const size_t bytes = count * commTypeSize(datatype);
-    const size_t allocBytes = bytes + bufferOffsetBytes;
+    const size_t allocBytes = bufferOffsetBytes + bytes + kSuffixGuardBytes;
     DeviceBuffer sendbuf = makeDeviceBuffer(allocBytes);
     DeviceBuffer recvbuf = inPlace ? nullptr : makeDeviceBuffer(allocBytes);
     DeviceBuffer expectedBuf = makeDeviceBuffer(bytes);
@@ -358,9 +361,19 @@ class AllReduceTestSuite : public ctran::CtranDistTestFixture,
     }
 
     CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+    // Prefix guard: bytes before the (optionally offset) payload.
     expectDeviceBytePattern(sendbuf.get(), bufferOffsetBytes, kGuardPattern);
+    // Suffix guard: bytes after the payload end -- catches tail overwrites.
+    expectDeviceBytePattern(
+        static_cast<char*>(sendbuf.get()) + bufferOffsetBytes + bytes,
+        kSuffixGuardBytes,
+        kGuardPattern);
     if (!inPlace) {
       expectDeviceBytePattern(recvbuf.get(), bufferOffsetBytes, kGuardPattern);
+      expectDeviceBytePattern(
+          static_cast<char*>(recvbuf.get()) + bufferOffsetBytes + bytes,
+          kSuffixGuardBytes,
+          kGuardPattern);
     }
 
     for (int repeat = 1; repeat < kDeterminismRepeats; ++repeat) {
@@ -401,6 +414,9 @@ class AllReduceTestSuite : public ctran::CtranDistTestFixture,
       case NCCL_ALLREDUCE_ALGO::ctree:
         return ctranAllReduceTree(
             sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
+        return ctranAllReduceHierarchicalRing(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
       default:
         return commInvalidArgument;
     }
@@ -429,6 +445,12 @@ class AllReduceTestSuite : public ctran::CtranDistTestFixture,
     envs.emplace_back("NCCL_CTRAN_BACKENDS", "socket, nvl");
 #endif
     return envs;
+  }
+
+  // Whether to construct the communicator with lazy IB connect enabled.
+  // Overridden by the lazy fixture; base tests use eager connect.
+  virtual bool ibLazyConnect() const {
+    return false;
   }
 };
 
@@ -727,7 +749,7 @@ TEST_P(CtranAllReduceBlockCapCorrectnessTest, Correctness) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    CtranAllReduce,
+    CtranAllReduceTree,
     CtranAllReduceCorrectnessTest,
     ::testing::ValuesIn(allReduceParams()),
     correctnessTestName);
@@ -737,6 +759,68 @@ INSTANTIATE_TEST_SUITE_P(
     CtranAllReduceBlockCapCorrectnessTest,
     ::testing::ValuesIn(allReduceBlockCapParams()),
     blockCapCorrectnessTestName);
+
+#if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY) || \
+    defined(CTRAN_ALLREDUCE_TEST_HYBRID)
+// Ring Phase 2 requires nNodes > 1.
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduceRing,
+    CtranAllReduceCorrectnessTest,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
+        ::testing::Values(commFloat32),
+        ::testing::Bool()),
+    correctnessTestName);
+
+// NOTE: unsupported (datatype, redOp) for cthierarchical_ring are rejected on
+// the host with commInvalidArgument (no silent fallback; see
+// AllReduceIbRing.cc), as are the defensive IB-transport guards (null
+// multiPeerTransport_, non-P2P_IBGDA neighbor). These are intentionally not
+// unit-tested per-variant here: the dtype/op-rejection contract moves to the
+// unified dtype/op matrix shared across tree and ring, and the transport guards
+// are impractical to trigger from this distributed fixture. Lazy IB connect IS
+// supported for the ring: the ring neighbors are materialized on-demand via
+// get_device_handle(peers) (see AllReduceIbRing.cc / AllReduceFused.cc),
+// covered by the CtranAllReduceRingLazy instantiation below. Tree lazy support
+// is a follow-up.
+
+// Lazy-connect coverage: exercise the ring with lazy IB connect enabled so the
+// ring-neighbor IBGDA peers are materialized on-demand inside
+// fill_common_kern_args (get_device_handle(peers)). A dedicated fixture
+// subclass is required because a TEST_P body is bound to its fixture class; it
+// enables lazy via the ibLazyConnect() hook, which reaches
+// pipesConfig.ibLazyConnect -- unlike the NCCL_CTRAN_IBGDA_LAZY_CONNECT env,
+// which this test's default ctranConfig bypasses.
+class CtranAllReduceLazyCorrectnessTest : public CtranAllReduceCorrectnessTest {
+ public:
+  bool ibLazyConnect() const override {
+    return true;
+  }
+};
+
+TEST_P(CtranAllReduceLazyCorrectnessTest, Correctness) {
+  auto [algo, datatype, inPlace] = GetParam();
+  // Lazy connect validates on-demand peer materialization + clean teardown, not
+  // exhaustive size coverage: sweep the bounded (no huge-payload) count list at
+  // a representative non-16B buffer offset, which also covers lazy + unaligned.
+  const size_t offsetBytes = commTypeSize(datatype); // fp32: 4B, non-16B
+  runCorrectnessSweep(
+      algo,
+      datatype,
+      allReduceElementCounts(datatype, offsetBytes),
+      inPlace,
+      offsetBytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CtranAllReduceRingLazy,
+    CtranAllReduceLazyCorrectnessTest,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
+        ::testing::Values(commFloat32),
+        ::testing::Bool()),
+    correctnessTestName);
+#endif
 #else
 #error "Define one CTRAN AllReduce topology: NVL_ONLY, IB_ONLY, or HYBRID"
 #endif

--- a/comms/ctran/tests/CtranDistTestUtils.cc
+++ b/comms/ctran/tests/CtranDistTestUtils.cc
@@ -105,7 +105,8 @@ void CtranDistTestFixture::TearDown() {
   distTearDown();
 }
 
-std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
+std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm(
+    bool ibLazyConnect) {
   const std::string uuid{"0"};
   uint64_t commHash =
       ctran::utils::getHash(uuid.data(), static_cast<int>(uuid.size()));
@@ -149,6 +150,11 @@ std::unique_ptr<CtranComm> CtranDistTestFixture::makeCtranComm() {
       std::move(commBootstrap));
 
   comm->config_.commDesc = comm->statex_->commDesc().c_str();
+  // Set lazy IB connect on the per-comm config BEFORE ctranInit, which builds
+  // the Pipes transport from pipesConfig. The NCCL_CTRAN_IBGDA_LAZY_CONNECT env
+  // only feeds lazy via NcclxConfig, which this default-ctranConfig path does
+  // not go through, so tests must set it here explicitly.
+  comm->config_.pipesConfig.ibLazyConnect = ibLazyConnect;
 
   COMMCHECK_TEST(ctranInit(comm.get()));
   CHECK(ctranInitialized(comm.get())) << "Ctran not initialized";

--- a/comms/ctran/tests/CtranDistTestUtils.h
+++ b/comms/ctran/tests/CtranDistTestUtils.h
@@ -68,7 +68,11 @@ class CtranDistTestFixture : public CtranTestFixtureBase,
 
   void TearDown() override;
 
-  std::unique_ptr<CtranComm> makeCtranComm();
+  // When ibLazyConnect is true, the communicator is built with
+  // pipesConfig.ibLazyConnect set so IBGDA peers are materialized on-demand
+  // (the NCCL_CTRAN_IBGDA_LAZY_CONNECT env does NOT reach this default-config
+  // path -- see comment in makeCtranComm).
+  std::unique_ptr<CtranComm> makeCtranComm(bool ibLazyConnect = false);
 
   // Intra-node (NVL domain) barrier using CtranComm's bootstrap
   void barrierNvlDomain(CtranComm* comm);

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -107,6 +107,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
 endif
 ## CollTrace plugin source files

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -115,6 +115,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
 endif
 ## CollTrace plugin source files


### PR DESCRIPTION
Summary:

B1 found the `cthierarchical_ring` small/medium AllReduce regime (<=16M, 20-65% of NCCL) is latency-bound. B2 sweeps the Phase-2 block count and IBGDA transport knobs to confirm or retune `compute_num_blocks_ring`'s tiers, whose sub-4M values were previously extrapolated rather than measured.

**Result:** the existing tiers are empirically optimal at every boundary — a validate-not-change outcome. **No production code change:** per review, the temporary block-forcing override used to drive the sweep is NOT landed; this diff only touches the benchmark script. Ongoing block-count experimentation uses the existing `NCCL_CTRAN_MAX_NBLOCKS` → `get_num_block_cap()` path.

**Changes:**
- `benchmark_allreduce.sh`: add `cthierarchical_ring` to the algorithm allow-list; share the CTran selection env with `ctree` (the algorithm name is the `NCCL_ALLREDUCE_ALGO` token for both); pin `-d float -o sum -c 1` for the ring only (it is fp32/sum-only and its support gate does not check dtype/op; other variants keep the script's `-d "$DTYPE"`); add an opt-in `USE_MCCL_ADAPTER` build mode (links the local `comms/ctran` code via the MCCL adapter instead of the pinned `use_ncclx=stable` build, required to sweep uncommitted kernel changes); and forward the existing ring-tuning knobs (`NCCL_CTRAN_MAX_NBLOCKS`, `NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH`, `NCCL_CTRAN_IBGDA_QP_DEPTH`) when set in the caller's env.
- `AllReduceFused.cc`: **no change.** The block-count sweep below was driven by a temporary, local-only forcing patch during measurement, intentionally not committed (per review — no collective-specific production knob; `compute_num_blocks_ring`'s tiers are unchanged).

**Block-count sweep (busbw GB/s; 8x H100, nolocal/IB_ONLY, W=8, fp32, OOP; block count forced via a temporary local patch during measurement):**
  size    nb=1   nb=2   nb=4   nb=8  nb=16   best
   64K    0.20   0.20   0.21   0.19   0.14   nb=4
  256K    0.72   0.75   0.76   0.74   0.52   nb=4
    1M    2.45   2.65   2.80   2.67   1.91   nb=4
    4M    6.31   8.01   8.91   9.23   6.32   nb=8
   16M   10.89  16.04  21.07  25.06  18.90   nb=8
   64M     -      -      -    40.6   43.0    nb=16   (3-rep median)
  256M     -      -      -    42.5   44.5    nb=16   (3-rep median)
  512M+    -      -      -      -    ~45     nb=16 (nb=32 no further gain)

This confirms the current tiers: <=1MB -> 4, <=32MB -> 8, else -> 16. Over-blocking regresses (16M: nb=8=25 vs nb=16=19); exceeding the cap (nb=32) gives no gain.

**Pipeline depth {2,4,8}:** no measurable effect at any size (e.g. 16M = 25.3 for all). Data-buffer size {8M,16M,32M,64M}: below 32M hurts (16M: 8M=22.8 vs 32M=25.3), above gains marginally (64M: 16M=25.9, +2%); `NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE` is a global transport CVAR so its default is left unchanged (optional per-call tuning only).

**Net:** host-side block/pipeline/buffer tuning is marginal, confirming B1. The structural lever for the latency-bound small/medium regime remains B3 (multi-lane Phase-2 overlap).

**Coverage caveats (NOT swept by this validation):**
- HYBRID (pMin>1) not covered: all runs nolocal/IB_ONLY (segmentBytes == totalBytes, 1 rank/node). Tiers are keyed on segmentBytes so they transfer in principle, but real multi-node + NVL HYBRID perf is unverified (MAST track).
- fp16 not swept: block sweep was fp32 only. Block count is dtype-agnostic (keyed on segmentBytes) so tiers should hold for fp16, but this is not empirically confirmed.
- Block count swept only at W=8: B1 separately swept W={2,3,4,7,8} at fixed sizes; block-count x W was not crossed. Tiers assumed W-independent.
- QP depth not swept (no WQE pressure indicated since pipeline depth had no effect); tile width (`kIbTileElems`) not swept (needs a rebuild per value, and no gap required it).
- In-place not perf-compared (OOP busbw used throughout; IP `#wrong=0` confirmed).
- Data-buffer x block-count not crossed (data-buffer swept at natural tiers only).
- H100 only (no GB200/GB300); IBGDA is single-host loopback (simulated IB, not real inter-node NIC latency/BW).

NOTE: For full, detailed results and analysis of this parameter sweep, please see [P2376297857](https://www.internalfb.com/phabricator/paste/view/P2376297857).

Reviewed By: saifhhasan

Differential Revision: D108428650


