### PR TITLE
Extend VerifyAlgoStatsHelper with verifyExact and verifyEqual

### DIFF
--- a/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.cc
+++ b/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.cc
@@ -41,16 +41,40 @@ std::string formatAlgoStats(const AlgoStatsMap& algoStats) {
   return result;
 }
 
-// Check if any algorithm matching the substring was used (callCount > 0).
+// Check algorithm usage (callCount > 0) against a substring.
+// When matchAll is false (default), returns true if ANY used algorithm name
+// contains algoSubstr. When matchAll is true, returns true IFF there is at
+// least one used algorithm AND every used algorithm name contains algoSubstr.
 bool findAlgoWithCalls(
     const AlgoStatsMap& stats,
-    const std::string& algoSubstr) {
+    const std::string& algoSubstr,
+    const bool matchAll = false) {
+  int numValid = 0;
   for (const auto& [algoName, callCount] : stats) {
-    if (algoName.find(algoSubstr) != std::string::npos && callCount > 0) {
-      return true;
+    if (callCount <= 0) {
+      continue;
+    }
+    numValid++;
+    const bool matches = algoName.find(algoSubstr) != std::string::npos;
+    if (matches) {
+      // early return if match any
+      if (!matchAll) {
+        return true;
+      }
+    } else if (matchAll) {
+      // early return if any mismatch found but match all is required
+      return false;
     }
   }
-  return false;
+
+  if (matchAll) {
+    // any mismatch should have returned false above, so true if valid records
+    // exists
+    return numValid > 0;
+  } else {
+    // match any, any match should have returned true above.
+    return false;
+  }
 }
 
 } // namespace
@@ -86,6 +110,28 @@ void VerifyAlgoStatsHelper::verifyNot(
       << "Unexpected algorithm containing '" << unexpectedAlgoSubstr
       << "' was used in " << collective << ". Found algorithms: ["
       << formatAlgoStats(stats) << "]";
+}
+
+void VerifyAlgoStatsHelper::verifyExact(
+    ncclComm_t comm,
+    const std::string& collective,
+    const std::string& expectedSubstr) const {
+  const auto stats = getAlgoStats(comm, collective);
+  EXPECT_TRUE(findAlgoWithCalls(stats, expectedSubstr, /*matchAll=*/true))
+      << "Not all " << collective << " algorithms contain '" << expectedSubstr
+      << "'. Recorded: [" << formatAlgoStats(stats) << "]";
+}
+
+void VerifyAlgoStatsHelper::verifyEqual(
+    ncclComm_t expected,
+    ncclComm_t actual,
+    const std::string& collective) const {
+  const auto expectedStats = getAlgoStats(expected, collective);
+  const auto actualStats = getAlgoStats(actual, collective);
+  EXPECT_EQ(expectedStats, actualStats)
+      << "Algo stats for " << collective << " differ: expected ["
+      << formatAlgoStats(expectedStats) << "], actual ["
+      << formatAlgoStats(actualStats) << "]";
 }
 
 } // namespace ncclx::test

--- a/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h
+++ b/comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h
@@ -61,6 +61,26 @@ class VerifyAlgoStatsHelper {
       const std::string& collective,
       const std::string& unexpectedAlgoSubstr) const;
 
+  // Verify that EVERY recorded algorithm (callCount > 0) for the collective
+  // contains `expectedSubstr`, and that there is at least one such record.
+  // @param comm The NCCL communicator to query stats from
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  // @param expectedSubstr Substring every recorded algorithm name must contain
+  void verifyExact(
+      ncclComm_t comm,
+      const std::string& collective,
+      const std::string& expectedSubstr) const;
+
+  // Compares the full algo-stats maps (algorithm names AND call counts) between
+  // two comms for complete equality.
+  // @param expected The reference comm (e.g. the no-tuner default)
+  // @param actual The comm under test (e.g. with a non-matching rule)
+  // @param collective The collective name (e.g., "ReduceScatter", "AllReduce")
+  void verifyEqual(
+      ncclComm_t expected,
+      ncclComm_t actual,
+      const std::string& collective) const;
+
  private:
   std::optional<EnvRAII<std::vector<std::string>>> colltraceGuard_;
 };


### PR DESCRIPTION
Summary:
Extends the `VerifyAlgoStatsHelper` test utility (`comms/ncclx/meta/tests/VerifyAlgoStatsUtil`) with two new assertions plus a reusable matcher, for tests that need to check exactly which algorithm NCCL selected for a collective:
- `verifyExact(comm, collective, substr)`: asserts the collective recorded at least one algorithm AND that EVERY recorded algorithm (callCount > 0) contains `substr` — i.e. all invocations used the expected algorithm. This is stronger than `verify`, which passes if ANY record matches.
- `verifyEqual(expected, actual, collective)`: asserts two communicators recorded identical algorithm stats (names and call counts) for the collective — used to confirm one comm's selection is unchanged versus another (e.g. a comm with an ignored/non-matching tuner rule selects identically to the no-tuner default).
- `findAlgoWithCalls` gains an optional `matchAll` parameter (ANY by default; ALL when set), reused by both `verify` and `verifyExact`.
Existing `verify` / `verifyNot` behavior is unchanged. Test-utility-only change; no production code is touched.

Differential Revision: D108656825


