### PR TITLE
Add self-contained Int64Range interval matcher (#2910)

### DIFF
--- a/comms/ncclx/meta/tuner/Int64Range.cc
+++ b/comms/ncclx/meta/tuner/Int64Range.cc
@@ -1,0 +1,158 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/tuner/Int64Range.h"
+
+#include <cstdlib>
+#include <exception>
+
+namespace ncclx::tuner {
+
+namespace {
+
+// Strips leading/trailing ASCII whitespace from value.
+std::string_view trim(std::string_view value) {
+  const auto isSpace = [](const char character) {
+    return character == ' ' || character == '\t' || character == '\r' ||
+        character == '\n';
+  };
+  while (!value.empty() && isSpace(value.front())) {
+    value.remove_prefix(1);
+  }
+  while (!value.empty() && isSpace(value.back())) {
+    value.remove_suffix(1);
+  }
+  return value;
+}
+
+// Parses a decimal int64 from a (trimmed) string. Returns nullopt if value is
+// empty or not a fully-consumed integer.
+std::optional<int64_t> parseInt64(std::string_view value) {
+  const std::string_view trimmed = trim(value);
+  if (trimmed.empty()) {
+    return std::nullopt;
+  }
+  try {
+    size_t consumed = 0;
+    const int64_t parsed = std::stoll(std::string(trimmed), &consumed);
+    if (consumed != trimmed.size()) {
+      return std::nullopt;
+    }
+    return parsed;
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+} // namespace
+
+bool Int64Range::matches(int64_t n) const {
+  if (loBounded) {
+    if (loInclusive ? (n < lo) : (n <= lo)) {
+      return false;
+    }
+  }
+  if (hiBounded) {
+    if (hiInclusive ? (n > hi) : (n >= hi)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string Int64Range::toString() const {
+  if (!loBounded && !hiBounded) {
+    return "*";
+  }
+  if (loBounded && hiBounded && loInclusive && hiInclusive && lo == hi) {
+    return std::to_string(lo);
+  }
+  std::string result;
+  result += loInclusive ? '[' : '(';
+  if (loBounded) {
+    result += std::to_string(lo);
+  }
+  result += ',';
+  if (hiBounded) {
+    result += std::to_string(hi);
+  }
+  result += hiInclusive ? ']' : ')';
+  return result;
+}
+
+std::optional<Int64Range> parseInt64Range(std::string_view value) {
+  const std::string_view trimmed = trim(value);
+  if (trimmed.empty()) {
+    return std::nullopt;
+  }
+
+  const char front = trimmed.front();
+  const bool isInterval = front == '(' || front == '[';
+  if (!isInterval) {
+    // Bare value: "*" is the wildcard; any integer N is exact [N, N].
+    if (trimmed == "*") {
+      return Int64Range{};
+    }
+    const std::optional<int64_t> parsed = parseInt64(trimmed);
+    if (!parsed.has_value()) {
+      return std::nullopt;
+    }
+    return Int64Range{/* lo */ *parsed,
+                      /* hi */ *parsed,
+                      /* loInclusive */ true,
+                      /* hiInclusive */ true,
+                      /* loBounded */ true,
+                      /* hiBounded */ true};
+  }
+
+  const char back = trimmed.back();
+  const bool hiInclusive = back == ']';
+  const bool hiBracketValid = back == ']' || back == ')';
+  if (!hiBracketValid) {
+    return std::nullopt;
+  }
+  const bool loInclusive = front == '[';
+
+  // Strip the surrounding brackets and split on the single comma.
+  const std::string_view body = trim(trimmed.substr(1, trimmed.size() - 2));
+  const size_t comma = body.find(',');
+  if (comma == std::string_view::npos) {
+    return std::nullopt;
+  }
+  const std::string_view loStr = trim(body.substr(0, comma));
+  const std::string_view hiStr = trim(body.substr(comma + 1));
+  // A second comma is malformed.
+  if (hiStr.find(',') != std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  Int64Range range{};
+  range.loInclusive = loInclusive;
+  range.hiInclusive = hiInclusive;
+
+  if (!loStr.empty()) {
+    const std::optional<int64_t> lo = parseInt64(loStr);
+    if (!lo.has_value()) {
+      return std::nullopt;
+    }
+    range.lo = *lo;
+    range.loBounded = true;
+  }
+  if (!hiStr.empty()) {
+    const std::optional<int64_t> hi = parseInt64(hiStr);
+    if (!hi.has_value()) {
+      return std::nullopt;
+    }
+    range.hi = *hi;
+    range.hiBounded = true;
+  }
+
+  // An empty interval body on a side means unbounded; lo > hi (when both
+  // bounded) is an empty set, treated as a parse error.
+  if (range.loBounded && range.hiBounded && range.lo > range.hi) {
+    return std::nullopt;
+  }
+
+  return range;
+}
+
+} // namespace ncclx::tuner

--- a/comms/ncclx/meta/tuner/Int64Range.h
+++ b/comms/ncclx/meta/tuner/Int64Range.h
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef NCCLX_META_TUNER_INT64_RANGE_H_
+#define NCCLX_META_TUNER_INT64_RANGE_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace ncclx::tuner {
+
+// A self-contained integer interval matcher used by the meta tuner to match the
+// byte size and topology (nNodes / nLocalRanks) of a collective against a rule.
+// It deliberately has NO NCCL/folly dependency so it can be unit-tested with a
+// plain cpp_unittest while also being compiled into libnccl via the
+// meta/tuner/*.cc glob.
+//
+// An Int64Range is the half-open/closed interval [lo, hi] where each bound may
+// be inclusive, exclusive, or unbounded. A fully unbounded range (both bounds
+// unbounded) matches any value (the "*" wildcard). int64_t is used so the
+// range covers GB-scale byte values.
+struct Int64Range {
+  int64_t lo{0};
+  int64_t hi{0};
+  bool loInclusive{true};
+  bool hiInclusive{true};
+  bool loBounded{false};
+  bool hiBounded{false};
+
+  // Returns true when n lies within the interval, honoring bound inclusivity
+  // and unboundedness on each side.
+  bool matches(int64_t n) const;
+
+  // Renders the interval back to its grammar form (e.g. "[0,1048576]", "(1,)",
+  // "*") for logging.
+  std::string toString() const;
+};
+
+// Parses a single interval expression into an Int64Range, returning
+// std::nullopt on any parse error. Grammar (leading/trailing whitespace
+// tolerated):
+//   *             -> wildcard, fully unbounded (matches any)
+//   N             -> exact [N, N]
+//   [a,b]         -> a <= n <= b
+//   (a,b)         -> a <  n <  b
+//   (a,b] / [a,b) -> half-open
+//   (a,)  / [a,)  -> lower-bounded only (n > a / n >= a)
+//   (,b)  / (,b]  -> upper-bounded only (n < b / n <= b)
+// Parse errors (-> nullopt): empty string, unbalanced/missing brackets,
+// non-numeric bound, missing comma in an interval, and lo > hi (e.g. "(2,1]").
+std::optional<Int64Range> parseInt64Range(std::string_view value);
+
+} // namespace ncclx::tuner
+
+#endif // NCCLX_META_TUNER_INT64_RANGE_H_

--- a/comms/ncclx/meta/tuner/tests/Int64RangeTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/Int64RangeTest.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "meta/tuner/Int64Range.h"
+
+namespace {
+
+using ncclx::tuner::Int64Range;
+using ncclx::tuner::parseInt64Range;
+
+// Convenience: parse and assert success, returning the Int64Range.
+Int64Range parseOk(const std::string& value) {
+  const std::optional<Int64Range> range = parseInt64Range(value);
+  EXPECT_TRUE(range.has_value()) << "expected '" << value << "' to parse";
+  return range.value_or(Int64Range{});
+}
+
+// "*" is the wildcard: fully unbounded, matches every value.
+TEST(Int64RangeTest, WildcardMatchesEverything) {
+  const Int64Range range = parseOk("*");
+  EXPECT_FALSE(range.loBounded);
+  EXPECT_FALSE(range.hiBounded);
+  EXPECT_TRUE(range.matches(INT64_MIN));
+  EXPECT_TRUE(range.matches(0));
+  EXPECT_TRUE(range.matches(INT64_MAX));
+}
+
+// "-1" is no longer special: it parses as the ordinary exact value [-1, -1].
+TEST(Int64RangeTest, NegativeOneIsExactNotWildcard) {
+  const Int64Range range = parseOk("-1");
+  EXPECT_TRUE(range.loBounded);
+  EXPECT_TRUE(range.hiBounded);
+  EXPECT_TRUE(range.matches(-1));
+  EXPECT_FALSE(range.matches(0));
+  EXPECT_FALSE(range.matches(5));
+}
+
+// A bare integer N parses to the exact closed interval [N, N].
+TEST(Int64RangeTest, ExactValue) {
+  const Int64Range zero = parseOk("0");
+  EXPECT_TRUE(zero.matches(0));
+  EXPECT_FALSE(zero.matches(1));
+  EXPECT_FALSE(zero.matches(-1));
+
+  const Int64Range five = parseOk("5");
+  EXPECT_TRUE(five.loBounded);
+  EXPECT_TRUE(five.hiBounded);
+  EXPECT_TRUE(five.matches(5));
+  EXPECT_FALSE(five.matches(4));
+  EXPECT_FALSE(five.matches(6));
+}
+
+// Closed interval [0,2]: both endpoints included.
+TEST(Int64RangeTest, ClosedInterval) {
+  const Int64Range range = parseOk("[0,2]");
+  EXPECT_FALSE(range.matches(-1));
+  EXPECT_TRUE(range.matches(0));
+  EXPECT_TRUE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_FALSE(range.matches(3));
+}
+
+// Open interval (0,2): both endpoints excluded.
+TEST(Int64RangeTest, OpenInterval) {
+  const Int64Range range = parseOk("(0,2)");
+  EXPECT_FALSE(range.matches(0));
+  EXPECT_TRUE(range.matches(1));
+  EXPECT_FALSE(range.matches(2));
+}
+
+// Half-open (0,2]: lower excluded, upper included.
+TEST(Int64RangeTest, HalfOpenLowerExclusive) {
+  const Int64Range range = parseOk("(0,2]");
+  EXPECT_FALSE(range.matches(0));
+  EXPECT_TRUE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_FALSE(range.matches(3));
+}
+
+// Half-open [1,3): lower included, upper excluded.
+TEST(Int64RangeTest, HalfOpenUpperExclusive) {
+  const Int64Range range = parseOk("[1,3)");
+  EXPECT_FALSE(range.matches(0));
+  EXPECT_TRUE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_FALSE(range.matches(3));
+}
+
+// (1,): lower-bounded exclusive, upper unbounded -> n > 1.
+TEST(Int64RangeTest, OpenEndedLowerExclusive) {
+  const Int64Range range = parseOk("(1,)");
+  EXPECT_TRUE(range.loBounded);
+  EXPECT_FALSE(range.hiBounded);
+  EXPECT_FALSE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_TRUE(range.matches(INT64_MAX));
+}
+
+// [2,): lower-bounded inclusive, upper unbounded -> n >= 2.
+TEST(Int64RangeTest, OpenEndedLowerInclusive) {
+  const Int64Range range = parseOk("[2,)");
+  EXPECT_FALSE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_TRUE(range.matches(3));
+}
+
+// (,4]: lower unbounded, upper-bounded inclusive -> n <= 4.
+TEST(Int64RangeTest, OpenEndedUpperInclusive) {
+  const Int64Range range = parseOk("(,4]");
+  EXPECT_FALSE(range.loBounded);
+  EXPECT_TRUE(range.hiBounded);
+  EXPECT_TRUE(range.matches(INT64_MIN));
+  EXPECT_TRUE(range.matches(4));
+  EXPECT_FALSE(range.matches(5));
+}
+
+// (,4): lower unbounded, upper-bounded exclusive -> n < 4.
+TEST(Int64RangeTest, OpenEndedUpperExclusive) {
+  const Int64Range range = parseOk("(,4)");
+  EXPECT_TRUE(range.matches(3));
+  EXPECT_FALSE(range.matches(4));
+  EXPECT_FALSE(range.matches(5));
+}
+
+// 64-bit GB-scale values match (1 GiB .. 16 GiB inclusive).
+TEST(Int64RangeTest, SixtyFourBitValues) {
+  constexpr int64_t kOneGiB = 1073741824;
+  constexpr int64_t kSixteenGiB = 17179869184;
+  const Int64Range range = parseOk("[1073741824,17179869184]");
+  EXPECT_EQ(range.lo, kOneGiB);
+  EXPECT_EQ(range.hi, kSixteenGiB);
+  EXPECT_FALSE(range.matches(kOneGiB - 1));
+  EXPECT_TRUE(range.matches(kOneGiB));
+  EXPECT_TRUE(range.matches(4294967296)); // 4 GiB, inside
+  EXPECT_TRUE(range.matches(kSixteenGiB));
+  EXPECT_FALSE(range.matches(kSixteenGiB + 1));
+}
+
+// Surrounding and internal whitespace is tolerated.
+TEST(Int64RangeTest, Whitespace) {
+  const Int64Range range = parseOk("  (1, 4]  ");
+  EXPECT_FALSE(range.matches(1));
+  EXPECT_TRUE(range.matches(2));
+  EXPECT_TRUE(range.matches(4));
+  EXPECT_FALSE(range.matches(5));
+}
+
+// Invalid inputs all return nullopt.
+TEST(Int64RangeTest, InvalidInputsReturnNullopt) {
+  EXPECT_FALSE(parseInt64Range("").has_value());
+  EXPECT_FALSE(parseInt64Range("   ").has_value());
+  EXPECT_FALSE(parseInt64Range("garbage").has_value());
+  EXPECT_FALSE(parseInt64Range("[a,b]").has_value());
+  EXPECT_FALSE(parseInt64Range("[1,x]").has_value());
+  EXPECT_FALSE(parseInt64Range("[1,2").has_value()); // missing closing bracket
+  EXPECT_FALSE(parseInt64Range("1,2]").has_value()); // missing opening bracket
+  EXPECT_FALSE(parseInt64Range("[12]").has_value()); // no comma in interval
+  EXPECT_FALSE(parseInt64Range("[1,2,3]").has_value()); // extra comma
+  EXPECT_FALSE(parseInt64Range("(2,1]").has_value()); // lo > hi
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -79,6 +79,7 @@ LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/ctran-integration/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/hints/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/algoconf/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/wrapper/*.cc)
+LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/tuner/*.cc)
 
 #### Start of fbcode source files
 ## Trainer Context for getting/setting trainer steps.

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -87,6 +87,7 @@ LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/ctran-integration/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/hints/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/algoconf/*.cc)
 LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/wrapper/*.cc)
+LIBSRCFILES += $(wildcard ${SHAREDDIR}/meta/tuner/*.cc)
 
 #### Start of fbcode source files
 ## Trainer Context for getting/setting trainer steps.


### PR DESCRIPTION
Summary:

Introduce `Int64Range`, a small dependency-free `int64_t` interval matcher that the upcoming NCCLX built-in tuner uses to match a collective's `bytes`, `nNodes`, and `nLocalRanks` against config rules. Splitting it into its own diff keeps the matcher self-contained and independently testable before the tuner lands on top.
- `parseInt64Range` accepts a compact grammar (whitespace tolerated): `-1` is a fully-unbounded wildcard that matches any value; `N` is the exact range `[N, N]`; `[a,b]`, `(a,b)`, `(a,b]`, `[a,b)` are the closed/open/half-open intervals; and `(a,)` / `[a,)` / `(,b)` / `(,b]` are the one-sided bounded forms.
- `matches(int64_t)` tests membership honoring per-bound inclusivity and unboundedness; `toString()` renders an interval back to its grammar form for logging.
- Invalid input (empty string, unbalanced brackets, non-numeric bound, missing comma, or `lo > hi` such as `(2,1]`) parses to `std::nullopt`, letting the tuner reject a malformed rule with an error log.
- Compiled into `libnccl` via a `meta/tuner/*.cc` source glob and `meta/tuner/*.h` private-header glob added to both the v2.29 and v2.30 `def_build.bzl` and `src/Makefile`, so the next diff's tuner sources build into the same lib with no additional target.
- Because it has no NCCL or folly dependency, its unit test links the version-suffixed nccl-internal lib directly (`ncclx_meta_unittest`, `num_gpus = 0`) and needs no separate library target.

Reviewed By: dsjohns2

Differential Revision: D108656824


