### PR TITLE
Built-in CSV/JSON-driven tuner for NCCL algo selection (#2911)

### DIFF
--- a/comms/ncclx/meta/baseline_modification_docs/builtin_tuner.md
+++ b/comms/ncclx/meta/baseline_modification_docs/builtin_tuner.md
@@ -1,0 +1,87 @@
+# Built-in Meta Tuner: Baseline Modifications
+
+## Background
+
+The built-in Meta tuner is a CSV/JSON-driven NCCL tuner compiled directly into
+`libnccl.so` (not a separate `dlopen` plugin `.so`). It overrides NCCL core
+`algorithm × protocol` selection, `nChannels`, and (on tuner API v6) `chunkSize`
+from a runtime config file pointed to by the `NCCLX_TUNER_CONFIG_FILE` cvar. Its
+implementation lives entirely in `meta/tuner/` (see
+`meta/design_docs/builtin_csv_json_tuner.md`). It needs exactly one baseline hook
+because NCCL discovers tuners only via `dlopen` + `ncclDlsym` on an external
+`.so` — a tuner compiled into `libnccl.so` is never auto-discovered, so it must
+be explicitly wired into `comm->tuner` from the tuner-load path.
+
+## Versions Affected
+
+v2.29, v2.30
+
+## Baseline Files Modified
+
+Exactly ONE baseline file per version: `src/plugin/tuner.cc`. The change is two
+parts in `ncclTunerPluginLoad`: an `#include` and a `[META]`-tagged early
+fallback that wires the built-in tuner when the cvar is set.
+
+```cpp
+#include "meta/tuner/MetaTuner.h"
+```
+
+```cpp
+ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
+  const char* tunerName;
+  // Initialize to nullptr by default if plugin tuner cannot be loaded.
+  comm->tuner = nullptr;
+  // [META] built-in CSV/JSON tuner takes precedence when set; see meta/tuner/MetaTuner.h
+  if (ncclx::tuner::tryLoadMetaTuner(comm)) {
+    return ncclSuccess;
+  }
+  // ... unchanged external NCCL_TUNER_PLUGIN dlopen path ...
+}
+```
+
+Net footprint is tiny: ~5 lines (1 include + 1 `[META]` comment + a 3-line
+`if`-block). When the cvar is empty, `tryLoadMetaTuner` returns `false` and the
+function proceeds exactly as upstream (zero regression).
+
+All OTHER tuner call sites are UNCHANGED, because they already guard on
+`comm->tuner != NULL`:
+
+| Call site | File | Status |
+|-----------|------|--------|
+| `init` | `src/init.cc` | unchanged (guarded) |
+| `getCollInfo` | `src/enqueue.cc` | unchanged (guarded) |
+| `getChunkSize` | `src/enqueue.cc` (v2.30 only) | unchanged (guarded) |
+| `finalize` | `src/init.cc` | unchanged (guarded) |
+| `ncclTunerPluginUnload` | `src/plugin/tuner.cc` | unchanged (gated on `tunerPluginLoaded`) |
+
+## Why in baseline
+
+NCCL's tuner discovery is `dlopen`-only: `ncclTunerPluginLoad` opens an external
+`.so` and resolves the tuner symbol via `ncclDlsym`. A tuner compiled into
+`libnccl.so` has no `.so` to open and no symbol to discover, so the address of
+the statically linked `kMetaTuner` struct must be assigned to `comm->tuner`
+explicitly from this function — there is no other entry point. The hook runs
+before the external-plugin path so the built-in tuner takes precedence when the
+cvar is set.
+
+The fallback intentionally leaves `comm->tunerPluginLoaded == 0`. Because
+`ncclTunerPluginUnload` gates its `dlclose` on that flag, Unload naturally skips
+`dlclose` on the static struct — no Unload change is needed. `finalize` still
+runs (it only checks `comm->tuner != NULL`) and frees the per-comm heap context.
+
+## Not baseline files
+
+The build glob (`def_build.bzl` / `src/Makefile`) and all `meta/tuner/` sources
+are Meta-only additions, not baseline NCCL files. `getChunkSize` support is
+v2.30-only (tuner API v6); v2.29 uses tuner API v5 and has no `getChunkSize`
+hook, gated in the shared sources by `NCCLX_TUNER_HAS_GETCHUNKSIZE`.
+
+# Design details
+
+The detailed design document for the NCCLX built-in tuner lives next to the tuner
+sources. See it for the motivation, architecture and data flow, key design
+decisions, version handling, config-format reference, and testing strategy.
+[`comms/ncclx/meta/tuner/docs/design.md`](../tuner/docs/design.md)
+
+The user-facing quick reference is
+[`comms/ncclx/meta/tuner/README.md`](../tuner/README.md).

--- a/comms/ncclx/meta/tuner/ConfigParse.h
+++ b/comms/ncclx/meta/tuner/ConfigParse.h
@@ -1,0 +1,207 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// Generic, dependency-light parsers shared by the CSV and JSON config loaders
+// of the meta tuner: whitespace trimming, collective/algorithm/protocol enum
+// parsing, strict integer parsing, and the TuningConfig column builder. These
+// helpers have NO folly dependency, so they can be reused from any config
+// front-end. The CSV line splitter lives in CsvConfigParse.h and the
+// folly::dynamic adapter in JsonConfigParse.h.
+
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "comm.h"
+#include "meta/tuner/Int64Range.h"
+#include "meta/tuner/MetaTuner.h"
+
+namespace ncclx::tuner {
+
+inline std::string_view trim(std::string_view value) {
+  const auto isSpace = [](const char character) {
+    return character == ' ' || character == '\t' || character == '\r' ||
+        character == '\n';
+  };
+  while (!value.empty() && isSpace(value.front())) {
+    value.remove_prefix(1);
+  }
+  while (!value.empty() && isSpace(value.back())) {
+    value.remove_suffix(1);
+  }
+  return value;
+}
+
+// Returns nullopt for an unknown OR empty token so the caller treats an
+// unrecognized collective (e.g. a typo) as a parse failure rather than
+// silently defaulting.
+inline std::optional<ncclFunc_t> parseCollType(const std::string_view value) {
+  if (value == "broadcast") {
+    return ncclFuncBroadcast;
+  } else if (value == "reduce") {
+    return ncclFuncReduce;
+  } else if (value == "allgather") {
+    return ncclFuncAllGather;
+  } else if (value == "reducescatter") {
+    return ncclFuncReduceScatter;
+  } else if (value == "allreduce") {
+    return ncclFuncAllReduce;
+  } else {
+    return std::nullopt;
+  }
+}
+
+// Returns nullopt for an unknown OR empty token (see parseCollType).
+inline std::optional<int> parseAlgorithm(const std::string_view value) {
+  if (value == "tree") {
+    return NCCL_ALGO_TREE;
+  } else if (value == "ring") {
+    return NCCL_ALGO_RING;
+  } else if (value == "collnet_direct") {
+    return NCCL_ALGO_COLLNET_DIRECT;
+  } else if (value == "collnet_chain") {
+    return NCCL_ALGO_COLLNET_CHAIN;
+  } else if (value == "nvls") {
+    return NCCL_ALGO_NVLS;
+  } else if (value == "nvls_tree") {
+    return NCCL_ALGO_NVLS_TREE;
+  } else if (value == "pat") {
+    return NCCL_ALGO_PAT;
+  } else {
+    return std::nullopt;
+  }
+}
+
+// Returns nullopt for an unknown OR empty token (see parseCollType).
+inline std::optional<int> parseProtocol(const std::string_view value) {
+  if (value == "ll") {
+    return NCCL_PROTO_LL;
+  } else if (value == "ll128") {
+    return NCCL_PROTO_LL128;
+  } else if (value == "simple") {
+    return NCCL_PROTO_SIMPLE;
+  } else {
+    return std::nullopt;
+  }
+}
+
+// Strictly parses a whole integer column as long long. Returns nullopt only
+// when the field is non-empty AND does not fully parse as an integer; an empty
+// field returns nullopt too, so the caller must check emptiness first (empty =
+// default). The full-consumption check rejects trailing garbage like "12x".
+inline std::optional<long long> parseIntStrict(const std::string_view value) {
+  if (value.empty()) {
+    return std::nullopt;
+  }
+  try {
+    size_t consumed = 0;
+    const std::string text(value);
+    const long long parsed = std::stoll(text, &consumed);
+    if (consumed != text.size()) {
+      return std::nullopt;
+    }
+    return parsed;
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+// Strictly parses a whole integer column as int. Like parseIntStrict, but
+// std::stoi throws std::out_of_range for a value outside int range, so an
+// out-of-int-range value (e.g. "99999999999") becomes a parse error (nullopt)
+// rather than being silently truncated.
+inline std::optional<int> parseIntStrictAsInt(const std::string_view value) {
+  if (value.empty()) {
+    return std::nullopt;
+  }
+  try {
+    size_t consumed = 0;
+    const std::string text(value);
+    const int parsed = std::stoi(text, &consumed);
+    if (consumed != text.size()) {
+      return std::nullopt;
+    }
+    return parsed;
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+inline bool isFieldSet(
+    const std::vector<std::string_view>& fields,
+    size_t pos) {
+  return fields.size() > pos && !fields[pos].empty();
+}
+
+// Builds a TuningConfig from the already-trimmed CSV/JSON column strings. Order
+// of fields:
+//   collType,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,
+//   numPipeOps,regBuff,chunkSize
+// bytes / nNodes / nLocalRanks are Int64Range expressions (interval, exact, or
+// "*" wildcard). numPipeOps, regBuff and chunkSize are optional; absent fields
+// are passed as empty strings and fall back to their wildcard / no-override
+// defaults. Returns nullopt when any column fails to parse (an Int64Range that
+// does not parse, an unknown collective/algorithm/protocol token, or a numeric
+// column that is present but not a valid integer), so the caller can log an
+// ERROR and reject the rule.
+inline std::optional<TuningConfig> buildConfig(
+    const std::vector<std::string_view>& fields) {
+  // An empty Int64Range column defaults to the wildcard (matches any).
+  const auto parseRangeField =
+      [](const std::string_view field) -> std::optional<Int64Range> {
+    return field.empty() ? Int64Range{} : parseInt64Range(field);
+  };
+
+  const std::optional<Int64Range> bytes = parseRangeField(fields[1]);
+  const std::optional<Int64Range> nNodes = parseRangeField(fields[5]);
+  const std::optional<Int64Range> nLocalRanks = parseRangeField(fields[6]);
+  if (!bytes.has_value() || !nNodes.has_value() || !nLocalRanks.has_value()) {
+    return std::nullopt;
+  }
+
+  const std::optional<ncclFunc_t> collType = parseCollType(fields[0]);
+  const std::optional<int> algorithm = parseAlgorithm(fields[2]);
+  const std::optional<int> protocol = parseProtocol(fields[3]);
+  if (!collType.has_value() || !algorithm.has_value() ||
+      !protocol.has_value()) {
+    return std::nullopt;
+  }
+
+  const std::optional<int> channels =
+      isFieldSet(fields, 4) ? parseIntStrictAsInt(fields[4]) : -1;
+  const std::optional<int> numPipeOps =
+      isFieldSet(fields, 7) ? parseIntStrictAsInt(fields[7]) : -1;
+  const std::optional<int> regBuff =
+      isFieldSet(fields, 8) ? parseIntStrictAsInt(fields[8]) : -1;
+  const std::optional<long long> chunkSize =
+      isFieldSet(fields, 9) ? parseIntStrict(fields[9]) : 0;
+  if (!channels.has_value() || !numPipeOps.has_value() ||
+      !regBuff.has_value() || !chunkSize.has_value()) {
+    return std::nullopt;
+  }
+  // chunkSize is a byte size cast to size_t; a negative value would wrap to a
+  // huge size_t, so reject it like any other present-but-invalid numeric.
+  if (*chunkSize < 0) {
+    return std::nullopt;
+  }
+
+  TuningConfig config{};
+  config.collType = *collType;
+  config.bytes = *bytes;
+  config.algorithm = *algorithm;
+  config.protocol = *protocol;
+  config.nChannels = *channels;
+  config.nNodes = *nNodes;
+  config.nLocalRanks = *nLocalRanks;
+  config.numPipeOps = *numPipeOps;
+  config.regBuff = *regBuff;
+  config.chunkSize = static_cast<size_t>(*chunkSize);
+  return config;
+}
+
+} // namespace ncclx::tuner

--- a/comms/ncclx/meta/tuner/CsvConfigParse.h
+++ b/comms/ncclx/meta/tuner/CsvConfigParse.h
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// CSV-format front-end for the meta tuner config: bracket-aware line splitter +
+// CSV column-count constants; builds on the shared ConfigParse.h parsers.
+
+#include "meta/tuner/ConfigParse.h"
+
+namespace ncclx::tuner {
+
+// Minimum number of CSV columns required to form a valid rule (up to
+// nLocalRanks).
+inline constexpr size_t kMinCsvFields = 7;
+// Maximum number of CSV columns honored (numPipeOps, regBuff, chunkSize add 3).
+inline constexpr size_t kMaxCsvFields = 10;
+
+// Splits a CSV line into trimmed fields, honoring interval brackets: a comma
+// inside () or [] (e.g. "[0,1048576]" or "(1,)") is part of an interval and
+// does NOT separate columns. Only commas at bracket depth 0 split. Stops after
+// kMaxCsvFields fields. The returned views point into `line`.
+inline std::vector<std::string_view> splitCsvLine(std::string_view line) {
+  std::vector<std::string_view> fields;
+  fields.reserve(kMaxCsvFields);
+  size_t start = 0;
+  int depth = 0;
+  for (size_t index = 0; index <= line.size(); index++) {
+    const bool atEnd = index == line.size();
+    const char character = atEnd ? '\0' : line[index];
+    if (!atEnd && (character == '(' || character == '[')) {
+      depth++;
+    } else if (!atEnd && (character == ')' || character == ']')) {
+      if (depth > 0) {
+        depth--;
+      }
+    }
+    const bool isSplit = atEnd || (character == ',' && depth == 0);
+    if (isSplit) {
+      fields.push_back(trim(line.substr(start, index - start)));
+      start = index + 1;
+      if (fields.size() == kMaxCsvFields) {
+        break;
+      }
+    }
+  }
+  return fields;
+}
+
+} // namespace ncclx::tuner

--- a/comms/ncclx/meta/tuner/JsonConfigParse.h
+++ b/comms/ncclx/meta/tuner/JsonConfigParse.h
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+// JSON-format front-end for the meta tuner config: bridges folly::dynamic rule
+// objects to the shared ConfigParse.h column parsers. Compiled only when folly
+// is available (NCCLX_TUNER_WITH_FOLLY_JSON); included by MetaTuner.cc under
+// that gate.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+
+#include "meta/tuner/ConfigParse.h"
+
+namespace ncclx::tuner {
+
+inline std::string jsonStringOr(
+    const folly::dynamic& object,
+    const char* key,
+    const std::string& fallback) {
+  const auto* value = object.get_ptr(key);
+  if (value == nullptr) {
+    return fallback;
+  }
+  if (value->isString()) {
+    return value->asString();
+  }
+  return folly::toJson(*value);
+}
+
+inline std::string jsonIntStr(const folly::dynamic& object, const char* key) {
+  const auto* value = object.get_ptr(key);
+  if (value == nullptr) {
+    return std::string();
+  }
+  return std::to_string(value->asInt());
+}
+
+// bytes / nNodes / nLocalRanks may be a JSON integer (exact), the string "*"
+// (wildcard), OR an interval string (e.g. "[0,1048576]", "(1,)"). Render
+// either form to the string the Int64Range parser consumes. An omitted key
+// maps to an empty string, which buildConfig treats as the wildcard (matches
+// any) -- identical to an omitted CSV column.
+inline std::string jsonRangeStr(const folly::dynamic& object, const char* key) {
+  const auto* value = object.get_ptr(key);
+  if (value == nullptr) {
+    return std::string();
+  }
+  if (value->isString()) {
+    return value->asString();
+  }
+  return std::to_string(value->asInt());
+}
+
+// Parses one rule object into a TuningConfig. Returns nullopt for any
+// per-rule problem (missing filter/config, an unknown enum, an invalid
+// interval/numeric, or a bad value type whose asInt() throws). The whole body
+// is wrapped so a folly::TypeError (e.g. "channels": [4] or "abc") never
+// escapes this function.
+inline std::optional<TuningConfig> parseJsonRule(const folly::dynamic& rule) {
+  try {
+    // Each rule must carry a "filter" object (match conditions) and a
+    // "config" object (overrides). Reject any rule missing either.
+    const auto* filterObj = rule.get_ptr("filter");
+    const auto* configObj = rule.get_ptr("config");
+    if (filterObj == nullptr || !filterObj->isObject() ||
+        configObj == nullptr || !configObj->isObject()) {
+      return std::nullopt;
+    }
+
+    // Reuse the CSV column builder so JSON and CSV always parse to identical
+    // TuningConfig values for an equivalent table.
+    const std::string collType = jsonStringOr(*filterObj, "collective", "");
+    const std::string bytes = jsonRangeStr(*filterObj, "bytes");
+    const std::string algorithm = jsonStringOr(*configObj, "algorithm", "");
+    const std::string protocol = jsonStringOr(*configObj, "protocol", "");
+    const std::string channels = jsonIntStr(*configObj, "channels");
+    const std::string nNodes = jsonRangeStr(*filterObj, "nNodes");
+    const std::string nLocalRanks = jsonRangeStr(*filterObj, "nLocalRanks");
+    const std::string numPipeOps = jsonIntStr(*filterObj, "numPipeOps");
+    const std::string regBuff = jsonIntStr(*filterObj, "regBuff");
+    const std::string chunkSize = jsonIntStr(*configObj, "chunkSize");
+
+    const std::vector<std::string_view> fields{
+        collType,
+        bytes,
+        algorithm,
+        protocol,
+        channels,
+        nNodes,
+        nLocalRanks,
+        numPipeOps,
+        regBuff,
+        chunkSize};
+    return buildConfig(fields);
+  } catch (const std::exception&) {
+    // A non-numeric / non-string value (object/array/null) reaching asInt()
+    // throws folly::TypeError; treat it as a per-rule parse failure.
+    return std::nullopt;
+  }
+}
+
+} // namespace ncclx::tuner

--- a/comms/ncclx/meta/tuner/MetaTuner.cc
+++ b/comms/ncclx/meta/tuner/MetaTuner.cc
@@ -1,0 +1,515 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "meta/tuner/MetaTuner.h"
+
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "comm.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "debug.h"
+#include "meta/tuner/CsvConfigParse.h"
+#include "meta/tuner/Int64Range.h"
+
+#ifdef NCCLX_TUNER_WITH_FOLLY_JSON
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+
+#include "meta/tuner/JsonConfigParse.h"
+#endif
+
+namespace ncclx::tuner {
+
+std::string TuningConfig::toString() const {
+  return fmt::format(
+      "collType={}, bytes={}, algorithm={}, protocol={}, nChannels={}, "
+      "nNodes={}, nLocalRanks={}, numPipeOps={}, regBuff={}, chunkSize={}",
+      static_cast<int>(collType),
+      bytes.toString(),
+      algorithm,
+      protocol,
+      nChannels,
+      nNodes.toString(),
+      nLocalRanks.toString(),
+      numPipeOps,
+      regBuff,
+      chunkSize);
+}
+
+namespace {
+
+// Version-portable aliases for the init callback's versioned parameter types.
+// The init function-pointer field is declared with _v6_t params in NCCLX v2.30
+// (tuner API v6) and _v5_t params in v2.29 (tuner API v5); a free function
+// assigned to it must match the version's struct exactly. v2.29 does not even
+// define the _v6_t names, so they must never appear unguarded.
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+using MetaNvlDomainInfo = ncclNvlDomainInfo_v6_t;
+using MetaTunerConstants = ncclTunerConstants_v6_t;
+#else
+using MetaNvlDomainInfo = ncclNvlDomainInfo_v5_t;
+using MetaTunerConstants = ncclTunerConstants_v5_t;
+#endif
+
+// Heap context allocated per comm in metaTunerInit and freed in
+// metaTunerFinalize. Holds the parsed rule table and the NCCL logger callback.
+struct MetaTunerContext {
+  std::vector<TuningConfig> configs;
+  ncclDebugLogger_t logFunction{nullptr};
+  int nNodes{-1};
+  int nLocalRanks{-1};
+};
+
+// Emits a single line through the NCCL logger callback (if provided). The
+// message is formatted with fmt and passed via a "%s" format to keep the
+// variadic C callback type-safe. The file/line identify the call site (see the
+// NCCLX_TUNER_LOG macro), not this function.
+void logLine(
+    const ncclDebugLogger_t logFunction,
+    const ncclDebugLogLevel level,
+    const char* const file,
+    const int line,
+    const std::string& message) {
+  if (logFunction != nullptr) {
+    logFunction(level, NCCL_TUNING, file, line, "%s", message.c_str());
+  }
+}
+
+// Logs through the NCCL logger, capturing the CALL SITE's file/line (like NCCL
+// core's WARN/INFO macros) so messages point at the real source, not this file.
+#define NCCLX_TUNER_LOG(logFunction, level, message) \
+  logLine((logFunction), (level), __FILE__, __LINE__, (message))
+
+// Hand-written, zero-dependency CSV parser. ALWAYS compiled (fbcode and OSS).
+// Skips blank lines and lines beginning with '#'. When ignoreErrors is false
+// (strict, the default), any file-level or per-rule problem is logged at ERROR
+// and returns ncclInvalidUsage so comm init fails. When ignoreErrors is true,
+// a missing file logs a WARN and returns ncclSuccess (no override), and a bad
+// rule logs an ERROR and is skipped while the remaining valid rules still load.
+ncclResult_t loadConfigCsv(
+    MetaTunerContext& context,
+    const std::string& path,
+    const bool ignoreErrors) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    NCCLX_TUNER_LOG(
+        context.logFunction,
+        ignoreErrors ? NCCL_LOG_WARN : NCCL_LOG_ERROR,
+        fmt::format("NCCLX TUNER: config file '{}' could not be opened", path));
+    return ignoreErrors ? ncclSuccess : ncclInvalidUsage;
+  }
+
+  std::string line;
+  while (std::getline(file, line)) {
+    const std::string_view trimmedLine = trim(line);
+    if (trimmedLine.empty() || trimmedLine.front() == '#') {
+      continue;
+    }
+
+    const std::vector<std::string_view> fields = splitCsvLine(trimmedLine);
+    if (fields.size() < kMinCsvFields) {
+      NCCLX_TUNER_LOG(
+          context.logFunction,
+          NCCL_LOG_ERROR,
+          fmt::format(
+              "NCCLX TUNER: {} malformed CSV line (too few columns) '{}'",
+              ignoreErrors ? "skipping" : "rejecting",
+              trimmedLine));
+      if (!ignoreErrors) {
+        return ncclInvalidUsage;
+      }
+      continue;
+    }
+
+    const std::optional<TuningConfig> config = buildConfig(fields);
+    if (!config.has_value()) {
+      NCCLX_TUNER_LOG(
+          context.logFunction,
+          NCCL_LOG_ERROR,
+          fmt::format(
+              "NCCLX TUNER: {} CSV rule with an invalid collective/algorithm/protocol, interval, or numeric value '{}'",
+              ignoreErrors ? "skipping" : "rejecting",
+              trimmedLine));
+      if (!ignoreErrors) {
+        return ncclInvalidUsage;
+      }
+      continue;
+    }
+    context.configs.push_back(*config);
+  }
+
+  NCCLX_TUNER_LOG(
+      context.logFunction,
+      NCCL_LOG_INFO,
+      fmt::format(
+          "NCCLX TUNER: loaded {} tuning rule(s) from '{}'",
+          context.configs.size(),
+          path));
+  return ncclSuccess;
+}
+
+#ifdef NCCLX_TUNER_WITH_FOLLY_JSON
+// JSON parser, only compiled when folly is available. Parses a top-level
+// object with a "rules" array. Each rule is split into two nested objects:
+//   "filter" -- match conditions: collective, bytes, nNodes, nLocalRanks,
+//               numPipeOps, regBuff. Only "collective" is required; an omitted
+//               filter field means wildcard/any (bytes/nNodes/nLocalRanks -> *,
+//               numPipeOps/regBuff -> -1).
+//   "config" -- overrides applied on match: algorithm, protocol, channels,
+//               chunkSize. "algorithm"/"protocol" are required; "channels" and
+//               "chunkSize" are optional and omitting them means "no override"
+//               (channels defaults to -1 = keep NCCL default, chunkSize to 0).
+// The flat (un-nested) form is no longer accepted. The two objects are
+// flattened back into the CSV column order so JSON and an equivalent CSV always
+// parse to identical TuningConfig values.
+ncclResult_t loadConfigJson(
+    MetaTunerContext& context,
+    const std::string& path,
+    const bool ignoreErrors) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    NCCLX_TUNER_LOG(
+        context.logFunction,
+        ignoreErrors ? NCCL_LOG_WARN : NCCL_LOG_ERROR,
+        fmt::format("NCCLX TUNER: config file '{}' could not be opened", path));
+    return ignoreErrors ? ncclSuccess : ncclInvalidUsage;
+  }
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+
+  // Parse in one shot and copy-initialize `parsed` from the IIFE rather than
+  // default-constructing then move-assigning: this keeps the dynamic's lifetime
+  // unambiguous for static analysis (avoids a USE_AFTER_LIFETIME false positive
+  // on the get_ptr below) and still distinguishes a parse error from a missing
+  // "rules" array.
+  const std::optional<folly::dynamic> parsed =
+      [&]() -> std::optional<folly::dynamic> {
+    try {
+      return folly::parseJson(buffer.str());
+    } catch (const std::exception& exception) {
+      NCCLX_TUNER_LOG(
+          context.logFunction,
+          ignoreErrors ? NCCL_LOG_WARN : NCCL_LOG_ERROR,
+          fmt::format(
+              "NCCLX TUNER: failed to parse JSON '{}': {}",
+              path,
+              exception.what()));
+      return std::nullopt;
+    }
+  }();
+  if (!parsed.has_value()) {
+    return ignoreErrors ? ncclSuccess : ncclInvalidUsage;
+  }
+
+  const auto* rules = parsed->get_ptr("rules");
+  if (rules == nullptr || !rules->isArray()) {
+    NCCLX_TUNER_LOG(
+        context.logFunction,
+        ignoreErrors ? NCCL_LOG_WARN : NCCL_LOG_ERROR,
+        fmt::format("NCCLX TUNER: JSON '{}' has no 'rules' array", path));
+    return ignoreErrors ? ncclSuccess : ncclInvalidUsage;
+  }
+
+  context.configs.reserve(context.configs.size() + rules->size());
+  for (const auto& rule : *rules) {
+    const std::optional<TuningConfig> config = parseJsonRule(rule);
+    if (!config.has_value()) {
+      NCCLX_TUNER_LOG(
+          context.logFunction,
+          NCCL_LOG_ERROR,
+          fmt::format(
+              "NCCLX TUNER: {} JSON rule (missing filter/config, unknown collective/algorithm/protocol, invalid interval/numeric, or bad value type): {}",
+              ignoreErrors ? "skipping" : "rejecting",
+              folly::toJson(rule)));
+      if (!ignoreErrors) {
+        return ncclInvalidUsage;
+      }
+      continue;
+    }
+    context.configs.push_back(*config);
+  }
+
+  NCCLX_TUNER_LOG(
+      context.logFunction,
+      NCCL_LOG_INFO,
+      fmt::format(
+          "NCCLX TUNER: loaded {} tuning rule(s) from JSON '{}'",
+          context.configs.size(),
+          path));
+  return ncclSuccess;
+}
+#else
+ncclResult_t loadConfigJson(
+    MetaTunerContext& context,
+    const std::string& path,
+    const bool ignoreErrors) {
+  NCCLX_TUNER_LOG(
+      context.logFunction,
+      ignoreErrors ? NCCL_LOG_WARN : NCCL_LOG_ERROR,
+      fmt::format(
+          "NCCLX TUNER: JSON config '{}' is unsupported in this build; use CSV",
+          path));
+  return ignoreErrors ? ncclSuccess : ncclInvalidUsage;
+}
+#endif
+
+bool hasJsonExtension(const std::string& path) {
+  constexpr std::string_view kJsonExt = ".json";
+  if (path.size() < kJsonExt.size()) {
+    return false;
+  }
+  return path.compare(
+             path.size() - kJsonExt.size(), kJsonExt.size(), kJsonExt) == 0;
+}
+
+ncclResult_t loadConfig(
+    MetaTunerContext& context,
+    const std::string& path,
+    const bool ignoreErrors) {
+  if (hasJsonExtension(path)) {
+    return loadConfigJson(context, path, ignoreErrors);
+  }
+  return loadConfigCsv(context, path, ignoreErrors);
+}
+
+// Returns true when every populated attribute of config matches the incoming
+// collective. Fields set to -1 act as wildcards. The algorithm/protocol of the
+// rule are NOT part of this match (they are the override target for
+// getCollInfo); they ARE matched separately in getChunkSize.
+inline bool matchesCollective(
+    const TuningConfig& config,
+    const ncclFunc_t collType,
+    const size_t nBytes,
+    const int numPipeOps,
+    const int nNodes,
+    const int nLocalRanks,
+    const int regBuff,
+    const ncclDebugLogger_t logFunction) {
+  auto matched = config.collType == collType &&
+      config.bytes.matches(static_cast<int64_t>(nBytes)) &&
+      config.nNodes.matches(nNodes) &&
+      config.nLocalRanks.matches(nLocalRanks) &&
+      (config.numPipeOps == -1 || config.numPipeOps == numPipeOps) &&
+      (config.regBuff == -1 || config.regBuff == regBuff);
+  if (!matched && NCCLX_META_TUNER_LOG_MISMATCH) {
+    NCCLX_TUNER_LOG(
+        logFunction,
+        NCCL_LOG_INFO,
+        fmt::format(
+            "NCCLX TUNER: rule did not match collective. rule: [{}]. actual: "
+            "collType={}, nBytes={}, nNodes={}, nLocalRanks={}, numPipeOps={}, "
+            "regBuff={}",
+            config.toString(),
+            static_cast<int>(collType),
+            nBytes,
+            nNodes,
+            nLocalRanks,
+            numPipeOps,
+            regBuff));
+  }
+  return matched;
+}
+
+ncclResult_t metaTunerInit(
+    void** ctx,
+    uint64_t /* commId */,
+    size_t nRanks,
+    size_t nNodes,
+    ncclDebugLogger_t logFunction,
+    MetaNvlDomainInfo* /* nvlDomainInfo */,
+    MetaTunerConstants* /* constants */) {
+  auto context = std::make_unique<MetaTunerContext>();
+  context->logFunction = logFunction;
+  // nNodes / nLocalRanks are physical node and per-node rank counts, always
+  // well within int range, so the size_t -> int conversion at this boundary is
+  // safe.
+  context->nNodes = static_cast<int>(nNodes);
+  context->nLocalRanks =
+      nNodes > 0 ? static_cast<int>(nRanks / nNodes) : static_cast<int>(nRanks);
+
+  // An empty/unset config path simply disables the tuner (zero regression);
+  // that is never an error. A SET-but-broken config fails comm init unless
+  // NCCLX_TUNER_IGNORE_CONFIG_ERRORS is true (strict = ignore inverted).
+  const std::string& path = NCCLX_TUNER_CONFIG_FILE;
+  if (!path.empty()) {
+    const bool ignoreErrors = NCCLX_TUNER_IGNORE_CONFIG_ERRORS;
+    const ncclResult_t result = loadConfig(*context, path, ignoreErrors);
+    if (result != ncclSuccess) {
+      // Return before *ctx is set: the unique_ptr frees the context and the
+      // NCCLCHECK on tuner->init in core init.cc fails communicator init.
+      return result;
+    }
+  }
+
+  NCCLX_TUNER_LOG(
+      logFunction,
+      NCCL_LOG_INFO,
+      fmt::format(
+          "NCCLX TUNER: initialized for {} node(s), {} rank(s), {} rule(s)",
+          nNodes,
+          nRanks,
+          context->configs.size()));
+
+  *ctx = context.release();
+  return ncclSuccess;
+}
+
+ncclResult_t metaTunerGetCollInfo(
+    void* ctx,
+    ncclFunc_t collType,
+    size_t nBytes,
+    int numPipeOps,
+    float** collCostTable,
+    int numAlgo,
+    int numProto,
+    int regBuff,
+    int* nChannels) {
+  auto* context = static_cast<MetaTunerContext*>(ctx);
+  if (context == nullptr) {
+    return ncclInternalError;
+  }
+
+  auto* table = reinterpret_cast<float (*)[NCCL_NUM_PROTOCOLS]>(collCostTable);
+  for (const auto& config : context->configs) {
+    if (!matchesCollective(
+            config,
+            collType,
+            nBytes,
+            numPipeOps,
+            context->nNodes,
+            context->nLocalRanks,
+            regBuff,
+            context->logFunction)) {
+      continue;
+    }
+
+    if (config.algorithm >= numAlgo || config.protocol >= numProto) {
+      continue;
+    }
+
+    // Never force an algo/proto combo that core marked unsupported.
+    if (table[config.algorithm][config.protocol] == NCCL_ALGO_PROTO_IGNORE) {
+      continue;
+    }
+
+    table[config.algorithm][config.protocol] = 0.0F;
+    if (config.nChannels != -1) {
+      *nChannels = config.nChannels;
+    }
+
+    NCCLX_TUNER_LOG(
+        context->logFunction,
+        NCCL_LOG_INFO,
+        fmt::format(
+            "NCCLX TUNER: matched rule for collType={} nBytes={} (bytes={} nNodes={} nLocalRanks={}) -> algo={} proto={} channels={}",
+            static_cast<int>(collType),
+            nBytes,
+            config.bytes.toString(),
+            config.nNodes.toString(),
+            config.nLocalRanks.toString(),
+            config.algorithm,
+            config.protocol,
+            config.nChannels));
+    // First matching rule wins (row order = priority).
+    return ncclSuccess;
+  }
+
+  return ncclSuccess;
+}
+
+ncclResult_t metaTunerFinalize(void* ctx) {
+  delete static_cast<MetaTunerContext*>(ctx);
+  return ncclSuccess;
+}
+
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+ncclResult_t metaTunerGetChunkSize(
+    void* ctx,
+    ncclFunc_t collType,
+    size_t nBytes,
+    int algo,
+    int proto,
+    int /* nChannels */,
+    size_t* chunkSize) {
+  auto* context = static_cast<MetaTunerContext*>(ctx);
+  if (context == nullptr) {
+    return ncclInternalError;
+  }
+
+  for (const auto& config : context->configs) {
+    if (config.chunkSize == 0) {
+      continue;
+    }
+    if (config.algorithm != algo || config.protocol != proto) {
+      continue;
+    }
+    if (!matchesCollective(
+            config,
+            collType,
+            nBytes,
+            /* numPipeOps */ -1,
+            context->nNodes,
+            context->nLocalRanks,
+            /* regBuff */ -1,
+            context->logFunction)) {
+      continue;
+    }
+
+    // Core clamps the result to bufferMaxChunkSize; we do not clamp here.
+    *chunkSize = config.chunkSize;
+    NCCLX_TUNER_LOG(
+        context->logFunction,
+        NCCL_LOG_INFO,
+        fmt::format(
+            "NCCLX TUNER: chunkSize override collType={} nBytes={} algo={} proto={} -> {} (clamped by core to bufferMaxChunkSize)",
+            static_cast<int>(collType),
+            nBytes,
+            algo,
+            proto,
+            config.chunkSize));
+    // First matching rule wins (row order = priority).
+    return ncclSuccess;
+  }
+
+  return ncclSuccess;
+}
+#endif
+
+} // namespace
+
+bool metaTunerEnabled() {
+  return !NCCLX_TUNER_CONFIG_FILE.empty();
+}
+
+const ncclTuner_t kMetaTuner = {
+    /* .name = */ "NCCLXBuiltinTuner",
+    /* .init = */ metaTunerInit,
+    /* .getCollInfo = */ metaTunerGetCollInfo,
+    /* .finalize = */ metaTunerFinalize,
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+    /* .getChunkSize = */ metaTunerGetChunkSize,
+#endif
+};
+
+bool tryLoadMetaTuner(struct ncclComm* comm) {
+  if (!metaTunerEnabled()) {
+    return false;
+  }
+  comm->tuner = const_cast<ncclTuner_t*>(&kMetaTuner);
+  INFO(
+      NCCL_INIT | NCCL_TUNING,
+      "NCCLX TUNER: using built-in tuner (NCCLX_TUNER_CONFIG_FILE set)");
+  return true;
+}
+
+} // namespace ncclx::tuner

--- a/comms/ncclx/meta/tuner/MetaTuner.h
+++ b/comms/ncclx/meta/tuner/MetaTuner.h
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef NCCLX_META_TUNER_META_TUNER_H_
+#define NCCLX_META_TUNER_META_TUNER_H_
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "meta/tuner/Int64Range.h"
+#include "nccl_tuner.h"
+
+struct ncclComm;
+
+namespace ncclx::tuner {
+
+// One tuning rule parsed from a CSV row or JSON object. A rule overrides NCCL
+// core algorithm/protocol selection (and optionally nChannels / chunkSize) for
+// collectives whose attributes AND-match every populated field. The bytes,
+// nNodes and nLocalRanks fields are Int64Range matchers (an interval, an exact
+// value, or the "-1" wildcard that matches any value); numPipeOps / regBuff are
+// exact-or-(-1) int matches; chunkSize == 0 means "no override".
+struct TuningConfig {
+  ncclFunc_t collType;
+  Int64Range bytes;
+  int algorithm;
+  int protocol;
+  int nChannels;
+  Int64Range nNodes;
+  Int64Range nLocalRanks;
+  int numPipeOps;
+  int regBuff;
+  size_t chunkSize;
+
+  std::string toString() const;
+};
+
+// Returns true when NCCLX_TUNER_CONFIG_FILE is set to a non-empty value, i.e.
+// the built-in tuner should be wired into comm->tuner as a fallback when no
+// external NCCL_TUNER_PLUGIN is present.
+bool metaTunerEnabled();
+
+// Statically-linked tuner function table. Core takes the address of this
+// (it is NOT dlopen-discovered) and assigns it to comm->tuner. Field order
+// matches this version's ncclTuner_t: name, init, getCollInfo, finalize, and
+// (on tuner API v6 only) getChunkSize.
+extern const ncclTuner_t kMetaTuner;
+
+// Built-in CSV/JSON tuner entry point for NCCL's tuner-load path.
+//
+// When NCCLX_TUNER_CONFIG_FILE is set, this assigns comm->tuner to the
+// statically linked built-in tuner (kMetaTuner), logs, and returns true so
+// the caller skips the external NCCL_TUNER_PLUGIN dlopen path entirely (the
+// built-in tuner takes precedence). The cvar is process-global and read
+// identically by every comm, so no plugin-load status machinery is needed.
+// comm->tunerPluginLoaded is intentionally left 0 so ncclTunerPluginUnload
+// skips dlclose on the static struct. Returns false (no-op) when the cvar is
+// empty, leaving comm->tuner untouched (zero regression).
+bool tryLoadMetaTuner(struct ncclComm* comm);
+
+} // namespace ncclx::tuner
+
+#endif // NCCLX_META_TUNER_META_TUNER_H_

--- a/comms/ncclx/meta/tuner/README.md
+++ b/comms/ncclx/meta/tuner/README.md
@@ -1,0 +1,144 @@
+# NCCLX Built-in CSV/JSON Tuner
+
+`meta/tuner` is a tuner that is compiled directly into `libnccl.so` (no separate
+plugin `.so`). It overrides NCCL core algorithm/protocol selection, the number
+of channels, and the per-collective chunk size based on a runtime config file.
+
+## Enabling
+
+Set the cvar/env var `NCCLX_TUNER_CONFIG_FILE` to the absolute path of a CSV or
+JSON file:
+
+```bash
+export NCCLX_TUNER_CONFIG_FILE=/path/to/algo_override.csv
+```
+
+Precedence rules:
+
+- When `NCCLX_TUNER_CONFIG_FILE` is set, the built-in CSV/JSON tuner takes
+  precedence and the external `NCCL_TUNER_PLUGIN` dlopen path is skipped.
+- If `NCCLX_TUNER_CONFIG_FILE` is empty/unset, no tuner is wired in and NCCL's
+  default cost-model selection is used (zero regression).
+- The config file is read once per communicator at init; one table is shared by
+  all comms in the process.
+
+## Config-error policy
+
+By default, a **set-but-malformed** config **fails communicator init**. Any of
+the following is fatal: the file cannot be opened; malformed JSON; a missing or
+non-array `rules`; a `.json` path in a no-folly build; a rule missing its
+`filter`/`config` object; an unknown collective/algorithm/protocol token; an
+invalid interval; a present-but-invalid numeric value; or a bad JSON value type
+(e.g. `"channels": [4]` or `"channels": "abc"`). The offending file/rule is
+logged at ERROR (saying why), and init returns `ncclInvalidUsage`.
+
+An empty/unset `NCCLX_TUNER_CONFIG_FILE` is **not** an error — it simply
+disables the tuner (zero regression).
+
+Set `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` to downgrade errors: file-level
+problems log a WARN and yield an empty (no-override) table; a bad rule logs an
+ERROR and is skipped while the remaining valid rules still load. Init then
+returns success.
+
+## Config formats
+
+A rule matches a collective when every populated field AND-matches. The first
+matching rule wins, so rule order encodes priority.
+
+### Interval grammar (`bytes`, `nNodes`, `nLocalRanks`)
+
+These three fields are `Int64Range` matchers and share a single value grammar
+(leading/trailing whitespace tolerated; `[` `]` inclusive, `(` `)` exclusive; an
+empty bound means unbounded on that side):
+
+| Form | Meaning |
+|---|---|
+| `*` | wildcard — matches any |
+| `N` (e.g. `5`, `1048576`) | exact, `== N` |
+| `[a,b]` | `a <= n <= b` |
+| `(a,b)` | `a < n < b` |
+| `(a,b]` / `[a,b)` | half-open |
+| `(1,)` | `n > 1` (upper unbounded) |
+| `[2,)` | `n >= 2` |
+| `(,4]` | `n <= 4` (lower unbounded) |
+| `(,4)` | `n < 4` |
+
+An invalid interval (empty, non-numeric bound, unbalanced bracket, missing comma,
+or `lo > hi` such as `(2,1]`) is a config error: by default it fails comm init
+(see "Config-error policy"). With `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` the
+single rule is logged at ERROR and skipped while remaining valid rules load.
+
+### CSV (zero-dependency, always available)
+
+```
+collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
+```
+
+- `collective`: `allreduce` / `broadcast` / `reduce` / `allgather` /
+  `reducescatter`
+- `bytes`: message-size Int64Range (interval / exact / `*` wildcard)
+- `algorithm`: `tree` / `ring` / `collnet_direct` / `collnet_chain` / `nvls` /
+  `nvls_tree` / `pat`
+- `protocol`: `ll` / `ll128` / `simple`
+- `channels`: `-1` keeps the NCCL default; any other value overrides it
+- `nNodes`: number of nodes (Int64Range)
+- `nLocalRanks`: ranks per node (`nRanks / nNodes`) (Int64Range)
+- `numPipeOps` / `regBuff`: exact int, `-1` is a wildcard
+- `numPipeOps`, `regBuff`, `chunkSize` columns are optional (in that order)
+- The CSV split is bracket-aware: commas inside `()` or `[]` are part of an
+  interval and do NOT separate columns (so `[0,1048576]` is one field)
+- Lines beginning with `#` and blank lines are ignored
+
+Example (2 nodes, 8 ranks/node, 1MB-256MB allreduce forced to ring + ll128):
+
+```
+allreduce,[1048576,268435456],ring,ll128,-1,2,8,-1,-1,0
+```
+
+### JSON (folly-enabled build only)
+
+Each rule is split into two nested objects: `filter` holds the match conditions
+and `config` holds the overrides applied on a match.
+
+```json
+{
+  "rules": [
+    {
+      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
+    }
+  ]
+}
+```
+
+- `filter` — match conditions: `collective`, `bytes`, `nNodes`, `nLocalRanks`,
+  `numPipeOps`, `regBuff`. Only `collective` is required; omitting any other
+  filter field means wildcard / any.
+- `config` — overrides: `algorithm`, `protocol`, `channels`, `chunkSize`.
+  `algorithm` and `protocol` are required; `channels` and `chunkSize` are
+  optional and omitting them means "no override".
+- `bytes` / `nNodes` / `nLocalRanks` may be a JSON integer (`N` exact), the
+  string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`, `"(1,)"`).
+- JSON and an equivalent CSV still parse to identical `TuningConfig` values;
+  `rules` array order = priority. The flat (un-nested) form is no longer
+  accepted.
+- In a build without folly (`NCCLX_TUNER_WITH_FOLLY_JSON` undefined, e.g. the
+  OSS Makefile), a `.json` path is rejected with a clear warning and no
+  overrides are applied. Author the config as CSV instead.
+
+## chunkSize and the buffer ceiling
+
+`chunkSize` (bytes) overrides the chunk size NCCL computes for the selected
+`algorithm`/`protocol`. `0` (or an omitted column) means no override.
+
+NCCL core clamps the tuner's chunk size to `bufferMaxChunkSize`. Lowering the
+chunk size always works; raising it above the buffer ceiling is silently
+clamped. To make a larger chunk size effective, also enlarge the buffer via
+`NCCL_BUFFSIZE` (or the per-comm `ncclxConfig.ncclBuffSize`).
+
+## Observability
+
+Run with `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING` to see:
+
+- `NCCLX TUNER: using built-in tuner` (tuner wired in)
+- per-rule match logs and the selected algo/proto/channels/chunkSize

--- a/comms/ncclx/meta/tuner/docs/design.md
+++ b/comms/ncclx/meta/tuner/docs/design.md
@@ -1,0 +1,338 @@
+# NCCLX Built-in CSV/JSON Tuner
+
+## Motivation
+
+NCCL's algorithm/protocol selection comes from a built-in cost model. Overriding
+it normally requires an external `NCCL_TUNER_PLUGIN` `.so` that NCCL discovers
+via `dlopen`. Shipping and packaging a separate plugin `.so` is awkward for L4x
+tuning workflows: every tuning iteration that only edits a cost table should not
+force a binary/conda rebuild, and a `dlopen` plugin adds packaging surface.
+
+The built-in tuner solves this by compiling a CSV/JSON-driven tuner directly into
+`libnccl.so`. It overrides core `algorithm × protocol` selection, `nChannels`,
+and (on tuner API v6 only) `chunkSize`, keyed by `(collective, message-size
+range, topology, numPipeOps, regBuff)`. The topology key is `(nNodes,
+nLocalRanks)` where `nLocalRanks = nRanks / nNodes` is ranks per node. The override table lives in a runtime
+config file (kept in the L4x job's fbpkg, decoupled from the binary), so a tuning
+loop is just "edit the file, repackage the fbpkg, restart" — `libnccl.so` is
+never recompiled.
+
+## User-Facing API
+
+Set the cvar/env var `NCCLX_TUNER_CONFIG_FILE` to the absolute path of a CSV or
+JSON config file. The format is auto-detected by extension (`.json` → JSON,
+otherwise CSV):
+
+```bash
+export NCCLX_TUNER_CONFIG_FILE=/packaged/path/algo_override.csv
+# Do NOT set NCCL_TUNER_PLUGIN.
+```
+
+Precedence and lifecycle:
+
+- When `NCCLX_TUNER_CONFIG_FILE` is set, the built-in tuner takes **precedence**:
+  it is wired into `comm->tuner` and the external `NCCL_TUNER_PLUGIN` `dlopen`
+  path is skipped entirely.
+- When the cvar is empty/unset, no tuner is wired in and NCCL's default
+  cost-model selection is used (zero regression). An external
+  `NCCL_TUNER_PLUGIN`, if present, still loads as usual.
+- The config file is read once per communicator at init; the cvar is
+  process-global, so every comm reads the same table.
+- A **set-but-malformed** config fails comm init by default. Set
+  `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` to instead log and skip the bad
+  rule(s) / ignore the bad file and continue. See "Per-comm-init parsing,
+  process-global table" for the full policy.
+
+Observability — run with `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING` to see the
+`NCCLX TUNER:` log lines: the wiring message, the per-rule match (selected
+algo/proto/channels), and any chunkSize override.
+
+## Architecture
+
+### Data Flow
+
+```
+ncclTunerPluginLoad(comm)                          // src/plugin/tuner.cc [META]
+  comm->tuner = nullptr
+  ncclx::tuner::tryLoadMetaTuner(comm)
+    metaTunerEnabled()  ->  NCCLX_TUNER_CONFIG_FILE non-empty?
+      yes -> comm->tuner = &ncclx::tuner::kMetaTuner   (static struct, NOT dlopen)
+              leave comm->tunerPluginLoaded == 0       (Unload skips dlclose)
+              return true  -> caller skips external NCCL_TUNER_PLUGIN path
+      no  -> return false  -> fall through to external plugin dlopen
+
+comm init (src/init.cc, guarded by comm->tuner != NULL)
+  -> kMetaTuner.init(&ctx, ...)                    // metaTunerInit
+       allocate MetaTunerContext (heap)
+       loadConfig(NCCLX_TUNER_CONFIG_FILE)
+         .json -> loadConfigJson (folly)  else -> loadConfigCsv (zero-dep)
+       *ctx = context
+
+per collective (src/enqueue.cc, guarded by comm->tuner != NULL)
+  -> kMetaTuner.getCollInfo(ctx, collType, nBytes, ...) // metaTunerGetCollInfo
+       AND-match each rule on collType/bytes/nNodes/nLocalRanks/
+                                numPipeOps/regBuff
+       (bytes/nNodes/nLocalRanks are Int64Range matchers with `*` = wildcard;
+        numPipeOps/regBuff are exact-or-(-1))
+       first match: costTable[algo][proto] = 0.0 (skip if NCCL_ALGO_PROTO_IGNORE)
+                    if nChannels != -1, override *nChannels
+
+  -> kMetaTuner.getChunkSize(ctx, collType, nBytes, algo, proto, ...) // v6 only
+       AND-match rule with chunkSize != 0 AND algorithm==algo AND protocol==proto
+       first match: *chunkSize = rule.chunkSize  (core clamps to bufferMaxChunkSize)
+
+comm finalize (src/init.cc, guarded by comm->tuner != NULL)
+  -> kMetaTuner.finalize(ctx)                      // metaTunerFinalize: delete ctx
+```
+
+### File Organization
+
+All tuner logic lives in `meta/tuner/`, shared across NCCLX versions:
+
+| File | Role |
+|------|------|
+| `meta/tuner/MetaTuner.h` | `TuningConfig` rule struct; `metaTunerEnabled()`, `tryLoadMetaTuner(comm)`, `extern const ncclTuner_t kMetaTuner` |
+| `meta/tuner/MetaTuner.cc` | CSV + JSON parsers, the tuner callbacks (`init`/`getCollInfo`/`finalize`/`getChunkSize`), and `kMetaTuner` definition |
+| `meta/tuner/Int64Range.{h,cc}` | Self-contained `Int64Range` interval matcher (`bytes`/`nNodes`/`nLocalRanks`) and `parseInt64Range`; no NCCL/folly dependency |
+| `meta/tuner/tests/MetaTunerTest.cpp` | Unit tests (CSV/JSON parsing, match semantics, version gating) |
+| `meta/tuner/tests/Int64RangeTest.cpp` | `int64_range_ut` (an `ncclx_meta_unittest` that links the nccl-internal lib) for `Int64Range` parse/match edge cases; no GPU |
+| `meta/tuner/tests/example_tuner_config.{csv,json}` | Example configs |
+
+The only baseline change is a single `[META]`-tagged hook in
+`src/plugin/tuner.cc`. Details are in
+`meta/baseline_modification_docs/builtin_tuner.md`.
+
+### Key Design Decisions
+
+**1. Compiled-in, not a dlopen plugin (explicit wiring required)**
+
+NCCL discovers tuners only via `dlopen` + `ncclDlsym` on an external `.so`. A
+tuner compiled into `libnccl.so` is therefore not auto-discovered. We explicitly
+take the address of the static `kMetaTuner` struct and assign it to
+`comm->tuner` from `ncclTunerPluginLoad`. We do NOT set `NCCL_TUNER_PLUGIN`. The
+fallback leaves `comm->tunerPluginLoaded == 0` so `ncclTunerPluginUnload` skips
+`dlclose` on the static struct; `finalize` still runs (it only guards on
+`comm->tuner != NULL`) and frees the per-comm heap context.
+
+**2. Built-in takes precedence over external plugin**
+
+`tryLoadMetaTuner` runs first in `ncclTunerPluginLoad`. If the cvar is set it
+wires the built-in tuner and returns early, so the external-plugin `dlopen` path
+is never reached. This keeps semantics simple: one knob (`NCCLX_TUNER_CONFIG_FILE`)
+fully determines whether the built-in tuner is active.
+
+**3. Per-comm-init parsing, process-global table**
+
+`metaTunerInit` allocates a heap `MetaTunerContext` per comm and parses the file
+into a `std::vector<TuningConfig>`. The cvar is process-global so every comm
+parses the same content.
+
+An **empty/unset** `NCCLX_TUNER_CONFIG_FILE` means the tuner is disabled — no
+parse happens, the context stays empty, and init succeeds (zero regression).
+This is never an error.
+
+A **set-but-malformed** config, by default, **fails communicator init**:
+`loadConfig` returns `ncclInvalidUsage` and `metaTunerInit` propagates it
+*before* publishing `*ctx`, so the `unique_ptr` frees the context and the
+existing `NCCLCHECK(comm->tuner->init(...))` in core `init.cc` fails comm init.
+Fatal conditions: the file cannot be opened; `folly::parseJson` failure;
+missing/non-array `rules`; a `.json` path in a no-folly build; a rule missing
+its `filter`/`config`; an unknown collective/algorithm/protocol; an invalid
+interval; a present-but-invalid numeric; or a bad JSON value type (whose
+`asInt()` would otherwise throw — caught per-rule so it can never escape).
+
+Setting `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` downgrades this to the legacy
+"log-and-continue" behavior: file-level problems log a WARN and yield an empty
+(no-override) table; a bad rule logs an ERROR and is skipped while the valid
+rules still load; init returns success. `strict = !NCCLX_TUNER_IGNORE_CONFIG_ERRORS`
+is threaded from `metaTunerInit` through `loadConfig` into both `loadConfigCsv`
+and `loadConfigJson` (the folly path and the no-folly stub).
+
+**4. First match wins (row order = priority)**
+
+Both `getCollInfo` and `getChunkSize` iterate rules in file order and return on
+the first AND-match. A wildcard field matches any value: `*` for the
+`bytes`/`nNodes`/`nLocalRanks` (`Int64Range`) fields, `-1` for `numPipeOps`/`regBuff`.
+`getCollInfo` never forces an `algo×proto` combo that core marked
+`NCCL_ALGO_PROTO_IGNORE`.
+
+**5. chunkSize via the v6 `getChunkSize` hook (v2.30 only)**
+
+`getChunkSize` receives the already-selected `algo`/`proto`, so it is the only
+knob that can set chunk size per `algo×proto` and per-comm. A rule contributes a
+chunkSize override only when its `chunkSize != 0` AND its `algorithm`/`protocol`
+equal the hook's arguments. Core clamps the result to `bufferMaxChunkSize`, so
+lowering always works but raising above the buffer ceiling is silently clamped —
+enlarge `NCCL_BUFFSIZE` (or per-comm `ncclxConfig.ncclBuffSize`) to make a larger
+chunk effective.
+
+**6. Folly-JSON isolation**
+
+CSV is the always-available, zero-dependency baseline parser (compiled in fbcode
+and OSS). JSON parsing uses `folly::parseJson` and is gated behind the compile
+macro `NCCLX_TUNER_WITH_FOLLY_JSON`. In a build without folly (e.g. the OSS
+Makefile, or a future no-folly conda), `loadConfigJson` compiles to a stub that
+rejects `.json`: by default this fails comm init (with
+`NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` it logs a warning and applies no overrides).
+The CSV path and the public tuner API are unchanged. Dropping folly later does
+not force an API/ABI churn.
+
+## Config Formats
+
+A rule matches a collective when every populated field AND-matches. The first
+matching rule wins, so rule order encodes priority.
+
+### Interval grammar (`bytes`, `nNodes`, `nLocalRanks`)
+
+`bytes`, `nNodes`, and `nLocalRanks` are `Int64Range` matchers backed by
+`meta/tuner/Int64Range.{h,cc}` (a self-contained `int64_t` interval type with no
+NCCL/folly dependency, so it covers GB-scale byte values and is unit-tested by
+the `int64_range_ut` `ncclx_meta_unittest` target). They share one value grammar
+(leading/trailing whitespace tolerated; `[` `]` inclusive, `(` `)` exclusive; an
+empty bound = unbounded on that side):
+
+| Form | Meaning |
+|---|---|
+| `*` | wildcard — matches any |
+| `N` (e.g. `5`, `1048576`) | exact, `== N` |
+| `[a,b]` | `a <= n <= b` |
+| `(a,b)` | `a < n < b` |
+| `(a,b]` / `[a,b)` | half-open |
+| `(1,)` | `n > 1` (upper unbounded) |
+| `[2,)` | `n >= 2` |
+| `(,4]` | `n <= 4` (lower unbounded) |
+| `(,4)` | `n < 4` |
+
+`parseInt64Range` returns `nullopt` on any parse error (empty, non-numeric bound,
+unbalanced bracket, missing comma, or `lo > hi` such as `(2,1]`). A rule with a
+bad interval is a config error: by default it is logged at **ERROR** (naming the
+offending value / line) and **fails comm init**. With
+`NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` it is logged and skipped while the remaining
+valid rules still load (see "Per-comm-init parsing").
+
+### CSV (zero-dependency, always available)
+
+```
+collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
+```
+
+- `collective`: `allreduce` / `broadcast` / `reduce` / `allgather` / `reducescatter`
+- `bytes`: message-size Int64Range (interval / exact / `*` wildcard)
+- `algorithm`: `tree` / `ring` / `collnet_direct` / `collnet_chain` / `nvls` / `nvls_tree` / `pat`
+- `protocol`: `ll` / `ll128` / `simple`
+- `channels`: `-1` keeps the NCCL default; any other value overrides `*nChannels`
+- `nNodes`: number of nodes (Int64Range)
+- `nLocalRanks`: ranks per node (`nRanks / nNodes`) (Int64Range)
+- `numPipeOps` / `regBuff`: exact int, `-1` is a wildcard
+- `chunkSize` (bytes): `0` means no override
+- `numPipeOps`, `regBuff`, `chunkSize` columns are optional (in that order); at
+  least the first 7 columns (through `nLocalRanks`) are required
+- The CSV split is **bracket-aware**: it tracks `()`/`[]` nesting and only splits
+  on commas at depth 0, so an interval like `[0,1048576]` or `(1,)` stays a
+  single column
+- Lines beginning with `#` and blank lines are ignored
+
+Example (small allreduce forced to ring + ll128):
+
+```
+allreduce,[0,1048576],ring,ll128,-1,*,*,-1,-1,0
+```
+
+### JSON (folly-enabled build only)
+
+Each rule is split into two nested objects: `filter` holds the match conditions
+and `config` holds the overrides applied on a match.
+
+```json
+{
+  "rules": [
+    {
+      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
+    }
+  ]
+}
+```
+
+This rule is topology-specific: it only matches an allgather on a 2-node
+communicator with 8 ranks per node (`nNodes` / `nLocalRanks` filters), and also
+overrides `channels`. Rules that should apply regardless of topology simply omit
+`nNodes` / `nLocalRanks` from `filter` (an omitted filter field is the `*`
+wildcard).
+
+- `filter` holds the match conditions: `collective`, `bytes`, `nNodes`,
+  `nLocalRanks`, `numPipeOps`, `regBuff`. Only `collective` is required; omitting
+  any other filter field means wildcard / any.
+- `config` holds the overrides: `algorithm`, `protocol`, `channels`,
+  `chunkSize`. `algorithm` and `protocol` are required; `channels` and
+  `chunkSize` are optional and omitting them means "no override".
+- `bytes` / `nNodes` / `nLocalRanks` may be a JSON integer (`N` exact), the
+  string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`, `"(1,)"`); a
+  bad interval string, an unknown enum, or a bad value type (`"channels": [4]`
+  / `"abc"`) is a config error, handled per the policy in "Per-comm-init
+  parsing" (default: fail comm init; with the ignore cvar: log + skip the rule),
+  mirroring CSV. Bad value types are caught per-rule so a `folly::TypeError`
+  never escapes `loadConfigJson`.
+- JSON and an equivalent CSV parse to identical `TuningConfig` values; the
+  `rules` array order = priority. The flat (un-nested) form is no longer
+  accepted.
+- In a build without folly, a `.json` path is a config error: by default it
+  fails comm init; with `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` it is rejected with
+  a warning and no overrides are applied — convert to CSV first.
+
+See `meta/tuner/tests/example_tuner_config.csv` and `.json` for fuller examples,
+and `meta/tuner/README.md` for the user-facing reference.
+
+## Versions
+
+The tuner is wired into both NCCLX versions; the shared `meta/tuner/` sources are
+identical, with version differences handled by compile macros:
+
+| Version | Tuner API | `getChunkSize` | Macro |
+|---------|-----------|----------------|-------|
+| v2.29 | v5 | not available | — |
+| v2.30 | v6 | available | `NCCLX_TUNER_HAS_GETCHUNKSIZE` |
+
+- The `init` callback's versioned parameter types (`ncclNvlDomainInfo_*`,
+  `ncclTunerConstants_*`) differ between v5 and v6; `MetaTuner.cc` selects the
+  right aliases under `NCCLX_TUNER_HAS_GETCHUNKSIZE`, since v2.29 does not even
+  define the `_v6_t` names.
+- The `kMetaTuner` struct omits the `getChunkSize` field on v2.29 (it is the last
+  member, present only on v6).
+- `NCCLX_TUNER_WITH_FOLLY_JSON` is defined in the buck build (folly present) and
+  undefined in the OSS Makefile.
+
+## Testing
+
+**Unit tests** (`meta/tuner/tests/MetaTunerTest.cpp`, no GPU, OSS-safe). Set
+`NCCLX_TUNER_CONFIG_FILE` via `setenv` then re-read with `ncclCvarInit()`:
+
+- CSV parsing: multiple rows incl. comments / blank lines / omitted columns →
+  verify rule count and fields (`*` / `-1` wildcard placement).
+- JSON parsing & equivalence (folly build only): a `rules` array parses to the
+  same `TuningConfig` vector as the equivalent CSV; JSON in a no-folly build
+  yields a clear error and empty table.
+- `getCollInfo` semantics: size-range match zeroes `table[algo][proto]`; topology
+  filter (`nNodes`/`nLocalRanks`); interval matching (open-ended / endpoint
+  inclusivity / wildcard) on `bytes`/`nNodes`/`nLocalRanks`; bracket-aware CSV
+  split; bad-interval rule skipped; row-order priority; `nChannels` override;
+  `NCCL_ALGO_PROTO_IGNORE` protection; missing/empty file leaves outputs
+  untouched.
+- `Int64Range` parse/match edge cases are covered standalone in
+  `meta/tuner/tests/Int64RangeTest.cpp` (`int64_range_ut`, an `ncclx_meta_unittest` linking the nccl-internal lib; no GPU): wildcard / exact / closed / open / half-open / open-ended
+  intervals, endpoint inclusivity, 64-bit GB-scale values, whitespace tolerance,
+  and invalid inputs (incl. `lo > hi`) returning `nullopt`.
+- `getChunkSize` (v6 only): a matching row with `chunkSize != 0` sets
+  `*chunkSize`; rows differing only in `(algo, proto)` override only when those
+  equal the hook's arguments.
+- Gate: empty cvar → `metaTunerEnabled() == false`.
+
+**Integration / E2E** (GPU):
+
+- Zero-regression gate: without the cvar, existing collective dist tests match
+  baseline and `comm->tuner == NULL`.
+- Effect verification: a config forcing a collective/size range to a specific
+  algo/proto; `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING` logs confirm the
+  `NCCLX TUNER:` wiring + match lines and the actually-selected algo/proto.
+- Precedence: with both `NCCL_TUNER_PLUGIN` and the cvar set, the built-in tuner
+  wins.

--- a/comms/ncclx/meta/tuner/tests/MetaTunerSelectDistTest.cc
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerSelectDistTest.cc
@@ -1,0 +1,581 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+#include <folly/init/Init.h>
+
+#include <comm.h>
+#include <nccl.h>
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h" // @manual
+
+/**
+ * Comprehensive distributed test proving the NCCLX built-in meta tuner controls
+ * the algorithm, protocol, and channel count NCCL actually selects for real
+ * AllReduce, AllGather, and ReduceScatter collectives, across three virtual
+ * topologies and with topology- and size-keyed config matching.
+ *
+ * The tuner is engaged purely by the NCCLX_TUNER_CONFIG_FILE cvar, read during
+ * comm init (metaTunerInit). Each case writes a temp CSV forcing a collective
+ * to a specific algo/proto (and optionally nChannels and a topology/size key),
+ * points the cvar at it BEFORE comm creation, runs a real collective, and uses
+ * VerifyAlgoStatsHelper to confirm the algorithm NCCL actually used matches
+ * (or, for negative cases, does NOT change) the forced config. AlgoStats
+ * reports the algo as "Baseline_{PROTO}_{ALGO}_{nChannels}" (e.g.
+ * "Baseline_SIMPLE_RING_8"); verifyExact() asserts every recorded algorithm
+ * contains the expected substring (e.g. "SIMPLE_RING" or "SIMPLE_RING_2").
+ * Negative cases compare a comm carrying a non-matching rule against a no-tuner
+ * comm via verifyEqual() to prove the rule changed nothing.
+ *
+ * Topology: launched on a single physical 8-GPU host. The EFFECTIVE
+ * comm->nNodes is driven by the NCCL_HOSTID env var, which overrides each
+ * rank's hostHash that NCCL core counts to compute nNodes. Each rank is its own
+ * process and sets its own NCCL_HOSTID in SetUp() BEFORE any comm init (i.e.
+ * before getHostHash()'s std::call_once locks the value). The compile macro
+ * TUNER_TOPO_NNODES selects the topology: default 1 => (nNodes,nRanks)=(1,8);
+ * 8 => (8,8) (nolocal, PAT-eligible since nNodes==nRanks); 2 => (2,8) (vnode2).
+ * The BUCK suite generates one target per topology config. kExpectedNodes/
+ * kExpectedRanks below are derived from the macro so topology-keyed CSV rows
+ * can match the comm, and each comm asserts its realized (nNodes, nRanks).
+ *
+ * All assertions are hard (EXPECT/ASSERT, no GTEST_SKIP): unsupported combos
+ * (e.g. LL128 on a GPU that lacks it) are expected to surface as real failures
+ * so we observe ground truth rather than silently skipping.
+ */
+
+// Effective topology of the comm under the active compile macro. Each rank
+// drives comm->nNodes by setting NCCL_HOSTID before comm creation (see
+// SetUp()). TUNER_TOPO_NNODES is set per BUCK config; default 1 (all ranks
+// share the real host).
+#ifndef TUNER_TOPO_NNODES
+#define TUNER_TOPO_NNODES 1
+#endif
+constexpr int kExpectedNodes = TUNER_TOPO_NNODES;
+constexpr int kExpectedRanks = 8;
+// Ranks per node derived from the topology (1x8 -> 8, nolocal -> 1, vnode2 ->
+// 4). This is the value the tuner context computes as nLocalRanks.
+constexpr int kExpectedLocalRanks = kExpectedRanks / kExpectedNodes;
+
+namespace {
+
+// Collective under test. Drives both the AlgoStats lookup name and which NCCL
+// API the helper invokes.
+enum class Collective { kAllReduce, kAllGather, kReduceScatter };
+
+// AlgoStats collective-name string (from ncclFuncToString in collectives.cc).
+const char* algoStatsName(Collective coll) {
+  switch (coll) {
+    case Collective::kAllReduce:
+      return "AllReduce";
+    case Collective::kAllGather:
+      return "AllGather";
+    case Collective::kReduceScatter:
+      return "ReduceScatter";
+  }
+  return "AllReduce";
+}
+
+// Tuner CSV collective token (from MetaTuner.cc nameToColl).
+const char* tunerName(Collective coll) {
+  switch (coll) {
+    case Collective::kAllReduce:
+      return "allreduce";
+    case Collective::kAllGather:
+      return "allgather";
+    case Collective::kReduceScatter:
+      return "reducescatter";
+  }
+  return "allreduce";
+}
+
+// RAII helper that writes a temp config file and points NCCLX_TUNER_CONFIG_FILE
+// at it via EnvRAII, restoring the cvar and removing the file on teardown.
+// Mirrors the TunerConfigFile helper in MetaTunerTest.cpp. In a multi-process
+// dist test each rank runs this independently and writes its own unique temp
+// file via std::tmpnam.
+class TunerConfigFile {
+ public:
+  explicit TunerConfigFile(const std::string& contents)
+      : path_(writeTempFile(contents)),
+        envGuard_(NCCLX_TUNER_CONFIG_FILE, path_) {}
+
+  ~TunerConfigFile() {
+    std::remove(path_.c_str());
+  }
+
+ private:
+  static std::string writeTempFile(const std::string& contents) {
+    std::string path = std::string(std::tmpnam(nullptr)) + ".csv";
+    std::ofstream out(path);
+    out << contents;
+    return path;
+  }
+
+  std::string path_;
+  EnvRAII<std::string> envGuard_;
+};
+
+class MetaTunerSelectDistTest : public NcclxBaseTestFixture {
+ protected:
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+
+    // Drive the comm's effective nNodes by overriding each rank's hostHash via
+    // NCCL_HOSTID. This must happen after the base SetUp (so
+    // globalRank/numRanks are populated by distSetUp) but before any comm is
+    // created -- getHostHash caches the value via std::call_once on the first
+    // comm init, so setting it here guarantees it takes effect.
+    if (kExpectedNodes > 1) {
+      const int ranksPerNode = numRanks / kExpectedNodes;
+      const int nodeId = globalRank / ranksPerNode;
+      // Overwrite=1 so the value applies even if NCCL_HOSTID was already set.
+      setenv("NCCL_HOSTID", fmt::format("tunertest-node{}", nodeId).c_str(), 1);
+    }
+
+    // AlgoStats tracing must be enabled before comm creation.
+    algoStats_.enable();
+  }
+
+  // Build a tuner CSV rule for one collective covering a broad size range.
+  // Format (MetaTuner CSV): collective,bytes,algo,proto,nChannels,nNodes,
+  // nLocalRanks. The size range is emitted as the closed bytes interval
+  // [minBytes,maxBytes]. A channels of -1 means "keep the NCCL default";
+  // nNodes/nLocalRanks default to -1, emitted as the "*" wildcard (match any).
+  // nNodes/nLocalRanks accept any Int64Range expression string via the
+  // makeRangeRule overload below.
+  static std::string makeRule(
+      Collective coll,
+      const std::string& algo,
+      const std::string& proto,
+      int channels = -1,
+      int64_t minBytes = 0,
+      int64_t maxBytes = 1073741824,
+      int nNodes = -1,
+      int nLocalRanks = -1) {
+    return makeRangeRule(
+        coll,
+        algo,
+        proto,
+        channels,
+        fmt::format("[{},{}]", minBytes, maxBytes),
+        nNodes == -1 ? std::string("*") : std::to_string(nNodes),
+        nLocalRanks == -1 ? std::string("*") : std::to_string(nLocalRanks));
+  }
+
+  // Like makeRule, but bytes / nNodes / nLocalRanks are arbitrary Int64Range
+  // expression strings (e.g. "(1,)", "[0,1048576]"), exercising interval
+  // matching end-to-end.
+  static std::string makeRangeRule(
+      Collective coll,
+      const std::string& algo,
+      const std::string& proto,
+      int channels,
+      const std::string& bytes,
+      const std::string& nNodes,
+      const std::string& nLocalRanks) {
+    return fmt::format(
+        "{},{},{},{},{},{},{}\n",
+        tunerName(coll),
+        bytes,
+        algo,
+        proto,
+        channels,
+        nNodes,
+        nLocalRanks);
+  }
+
+  // Assert a freshly created comm realized the topology this config targets.
+  // If NCCL_HOSTID failed to take effect (e.g. set too late), comm->nNodes
+  // would silently fall back to 1; this hard assert makes that fail loudly.
+  // Called once per comm creation, immediately after the comm is created.
+  static void assertTopology(ncclComm_t comm) {
+    ASSERT_EQ(comm->nNodes, kExpectedNodes);
+    ASSERT_EQ(comm->nRanks, kExpectedRanks);
+    // The tuner derives nLocalRanks = nRanks / nNodes; assert the comm realizes
+    // the ranks-per-node count the topology-keyed rules below target.
+    ASSERT_EQ(comm->nRanks / comm->nNodes, kExpectedLocalRanks);
+  }
+
+  // Create a comm (loading the tuner from the cvar set by the active
+  // TunerConfigFile), run the given collective once at the given element count,
+  // and synchronize. Returns the comm via the RAII guard's lifetime, so the
+  // caller verifies AlgoStats before the guard goes out of scope.
+  void runCollective(ncclComm_t comm, Collective coll, size_t count) {
+    cudaStream_t stream = nullptr;
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+    // ReduceScatter sends count*nRanks and receives count; AllGather sends
+    // count and receives count*nRanks; AllReduce is count in/out. Allocate the
+    // larger count*nRanks for both buffers to cover all three.
+    const size_t maxElems = count * numRanks;
+    float* sendBuf = nullptr;
+    float* recvBuf = nullptr;
+    CUDACHECK_TEST(cudaMalloc(&sendBuf, maxElems * sizeof(float)));
+    CUDACHECK_TEST(cudaMalloc(&recvBuf, maxElems * sizeof(float)));
+
+    ncclResult_t res = ncclSuccess;
+    switch (coll) {
+      case Collective::kAllReduce:
+        res = ncclAllReduce(
+            sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream);
+        break;
+      case Collective::kAllGather:
+        res = ncclAllGather(sendBuf, recvBuf, count, ncclFloat, comm, stream);
+        break;
+      case Collective::kReduceScatter:
+        res = ncclReduceScatter(
+            sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream);
+        break;
+    }
+    ASSERT_EQ(res, ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+    CUDACHECK_TEST(cudaFree(sendBuf));
+    CUDACHECK_TEST(cudaFree(recvBuf));
+    CUDACHECK_TEST(cudaStreamDestroy(stream));
+  }
+
+  // Force a collective to (algo, proto) over a broad size range, create a fresh
+  // comm (the tuner parses the config at comm init, so every forced combo needs
+  // its own comm), run the collective at a mid-range size, and verify AlgoStats
+  // reports exactly expectProtoAlgo (proto+algo, e.g. "LL_RING").
+  void forceAndVerify(
+      Collective coll,
+      const std::string& algo,
+      const std::string& proto,
+      const std::string& expectProtoAlgo) {
+    TunerConfigFile config(makeRule(coll, algo, proto));
+    ncclx::test::NcclCommRAII commGuard(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    ncclComm_t comm = commGuard.get();
+    assertTopology(comm);
+
+    // 4096 floats = 16 KiB, well inside the configured [0, 1 GiB) range.
+    runCollective(comm, coll, 4096);
+    algoStats_.verifyExact(comm, algoStatsName(coll), expectProtoAlgo);
+  }
+};
+
+// One algo x proto sweep case: force a collective to (algo, proto) and verify
+// AlgoStats reports the expected proto+algo token. The name field becomes the
+// gtest instance name (e.g. "AllReduce_ring_LL").
+struct SweepCase {
+  Collective collective;
+  const char* algo; // "ring"/"tree"/"pat"
+  const char* proto; // "ll"/"ll128"/"simple"
+  std::string expectProtoAlgo; // e.g. "LL_RING", "SIMPLE_PAT"
+  std::string name; // test instance name, e.g. "AllReduce_ring_LL"
+};
+
+// Build the algo x proto sweep cases:
+//   AllReduce:     {ring, tree} x {LL, LL128, Simple}
+//   AllGather:     ring x {LL, LL128, Simple}
+//   ReduceScatter: ring x {LL, LL128, Simple}
+// Forcing each distinct combo and verifying its proto+algo token proves the
+// tuner controls both dimensions independently of NCCL's default selection.
+//
+// PAT x Simple is appended for AllGather and ReduceScatter only under the
+// nolocal topology. ncclPatEnable (tuning.cc) returns 0 unless comm->nNodes ==
+// comm->nRanks, which holds only for the nolocal topology (8 nodes / 8 ranks);
+// PAT also supports only the Simple protocol (tuning.cc). Elsewhere PAT is
+// physically disabled, so these cases are gated to nolocal.
+std::vector<SweepCase> makeSweepCases() {
+  std::vector<SweepCase> cases = {
+      {Collective::kAllReduce, "ring", "ll", "LL_RING", "AllReduce_ring_LL"},
+      {Collective::kAllReduce,
+       "ring",
+       "ll128",
+       "LL128_RING",
+       "AllReduce_ring_LL128"},
+      {Collective::kAllReduce,
+       "ring",
+       "simple",
+       "SIMPLE_RING",
+       "AllReduce_ring_Simple"},
+      {Collective::kAllReduce, "tree", "ll", "LL_TREE", "AllReduce_tree_LL"},
+      {Collective::kAllReduce,
+       "tree",
+       "ll128",
+       "LL128_TREE",
+       "AllReduce_tree_LL128"},
+      {Collective::kAllReduce,
+       "tree",
+       "simple",
+       "SIMPLE_TREE",
+       "AllReduce_tree_Simple"},
+      {Collective::kAllGather, "ring", "ll", "LL_RING", "AllGather_ring_LL"},
+      {Collective::kAllGather,
+       "ring",
+       "ll128",
+       "LL128_RING",
+       "AllGather_ring_LL128"},
+      {Collective::kAllGather,
+       "ring",
+       "simple",
+       "SIMPLE_RING",
+       "AllGather_ring_Simple"},
+      {Collective::kReduceScatter,
+       "ring",
+       "ll",
+       "LL_RING",
+       "ReduceScatter_ring_LL"},
+      {Collective::kReduceScatter,
+       "ring",
+       "ll128",
+       "LL128_RING",
+       "ReduceScatter_ring_LL128"},
+      {Collective::kReduceScatter,
+       "ring",
+       "simple",
+       "SIMPLE_RING",
+       "ReduceScatter_ring_Simple"},
+  };
+
+#if TUNER_TOPO_NNODES == 8
+  cases.push_back(
+      {Collective::kAllGather,
+       "pat",
+       "simple",
+       "SIMPLE_PAT",
+       "AllGather_pat_Simple"});
+  cases.push_back(
+      {Collective::kReduceScatter,
+       "pat",
+       "simple",
+       "SIMPLE_PAT",
+       "ReduceScatter_pat_Simple"});
+#endif
+
+  return cases;
+}
+
+// Parameterized fixture over the algo x proto sweep. Inherits SetUp/TearDown
+// and all helpers from MetaTunerSelectDistTest.
+class MetaTunerSweepTest : public MetaTunerSelectDistTest,
+                           public ::testing::WithParamInterface<SweepCase> {};
+
+TEST_P(MetaTunerSweepTest, ForcesAlgoProto) {
+  const auto& sweepCase = GetParam();
+  forceAndVerify(
+      sweepCase.collective,
+      sweepCase.algo,
+      sweepCase.proto,
+      sweepCase.expectProtoAlgo);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Sweep,
+    MetaTunerSweepTest,
+    ::testing::ValuesIn(makeSweepCases()),
+    [](const ::testing::TestParamInfo<SweepCase>& info) {
+      return info.param.name;
+    });
+
+// Force AllReduce to ring+simple with an explicit 2-channel (SM) count and
+// confirm NCCL used exactly 2 channels. Verifying the full "SIMPLE_RING_2"
+// token confirms algo, proto, AND channel count simultaneously.
+TEST_F(MetaTunerSelectDistTest, ForcesTwoChannels) {
+  TunerConfigFile config(
+      makeRule(Collective::kAllReduce, "ring", "simple", /*channels=*/2));
+  ncclx::test::NcclCommRAII commGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t comm = commGuard.get();
+  assertTopology(comm);
+  runCollective(comm, Collective::kAllReduce, 4096);
+  algoStats_.verifyExact(comm, "AllReduce", "SIMPLE_RING_2");
+}
+
+// Topology-keyed matching, positive case: a rule keyed to the comm's ACTUAL
+// (nNodes, nLocalRanks) forces tree+LL, so AllReduce uses LL_TREE.
+TEST_F(MetaTunerSelectDistTest, TopologyKeyMatches) {
+  TunerConfigFile config(makeRule(
+      Collective::kAllReduce,
+      "tree",
+      "ll",
+      /*channels=*/-1,
+      /*minBytes=*/0,
+      /*maxBytes=*/1073741824,
+      /*nNodes=*/kExpectedNodes,
+      /*nLocalRanks=*/kExpectedLocalRanks));
+  ncclx::test::NcclCommRAII commGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t comm = commGuard.get();
+  assertTopology(comm);
+  runCollective(comm, Collective::kAllReduce, 4096);
+  algoStats_.verifyExact(comm, "AllReduce", "LL_TREE");
+}
+
+// Topology-keyed matching, negative case: a rule keyed to a DIFFERENT
+// ranks-per-node count (nLocalRanks = kExpectedLocalRanks+1) does NOT match
+// this comm, so the tuner does not apply it and NCCL falls back to its default
+// selection.
+//
+// "Unchanged vs default" model: create a no-tuner comm (NCCLX_TUNER_CONFIG_FILE
+// unset, tuner disabled) and run AllReduce on it, then create a second comm
+// carrying a topo-MISMATCHED rule (nLocalRanks+1) forcing tree+LL and run the
+// SAME collective at the SAME size on it. verifyEqual asserts both comms
+// selected the same set of algorithms, proving the non-matching rule changed
+// nothing.
+TEST_F(MetaTunerSelectDistTest, TopologyKeyMismatchIgnored) {
+  // No-tuner comm: no TunerConfigFile in scope, so the tuner is disabled and
+  // NCCL uses its default selection.
+  ncclx::test::NcclCommRAII noTunerGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t noTunerComm = noTunerGuard.get();
+  assertTopology(noTunerComm);
+  runCollective(noTunerComm, Collective::kAllReduce, 4096);
+
+  // Rule comm: a topo-MISMATCHED rule (nLocalRanks+1) forcing tree+LL does not
+  // match this comm, so the tuner ignores it. Keep both comms alive until
+  // verifyEqual reads their AlgoStats.
+  TunerConfigFile config(makeRule(
+      Collective::kAllReduce,
+      "tree",
+      "ll",
+      /*channels=*/-1,
+      /*minBytes=*/0,
+      /*maxBytes=*/1073741824,
+      /*nNodes=*/kExpectedNodes,
+      /*nLocalRanks=*/kExpectedLocalRanks + 1));
+  ncclx::test::NcclCommRAII ruleGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t ruleComm = ruleGuard.get();
+  assertTopology(ruleComm);
+  runCollective(ruleComm, Collective::kAllReduce, 4096);
+
+  algoStats_.verifyEqual(noTunerComm, ruleComm, "AllReduce");
+}
+
+// Range-keyed topology matching via an open-ended nNodes interval. A rule keyed
+// nNodes=(1,) (strictly more than one node) forces tree+LL. It MATCHES the
+// multi-node topologies (nolocal: 8 nodes; vnode2: 2 nodes), so AllReduce uses
+// LL_TREE there. On the single-node 1x8 topology (nNodes==1) the interval does
+// NOT match, so the tuner is ignored and NCCL falls back to its default
+// selection -- verified against a no-tuner comm via verifyEqual.
+TEST_F(MetaTunerSelectDistTest, NodesRangeKeyMatchesMultiNode) {
+  if (kExpectedNodes > 1) {
+    // Multi-node topology: nNodes=(1,) matches, so the rule forces LL_TREE.
+    TunerConfigFile config(makeRangeRule(
+        Collective::kAllReduce,
+        "tree",
+        "ll",
+        /*channels=*/-1,
+        /*bytes=*/"*",
+        /*nNodes=*/"(1,)",
+        /*nLocalRanks=*/"*"));
+    ncclx::test::NcclCommRAII commGuard(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    ncclComm_t comm = commGuard.get();
+    assertTopology(comm);
+    runCollective(comm, Collective::kAllReduce, 4096);
+    algoStats_.verifyExact(comm, "AllReduce", "LL_TREE");
+  } else {
+    // Single-node 1x8 topology: nNodes=(1,) does NOT match (nNodes==1), so the
+    // rule is ignored. Compare a comm carrying the rule against a no-tuner
+    // comm.
+    ncclx::test::NcclCommRAII noTunerGuard(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    ncclComm_t noTunerComm = noTunerGuard.get();
+    assertTopology(noTunerComm);
+    runCollective(noTunerComm, Collective::kAllReduce, 4096);
+
+    TunerConfigFile config(makeRangeRule(
+        Collective::kAllReduce,
+        "tree",
+        "ll",
+        /*channels=*/-1,
+        /*bytes=*/"*",
+        /*nNodes=*/"(1,)",
+        /*nLocalRanks=*/"*"));
+    ncclx::test::NcclCommRAII ruleGuard(
+        globalRank, numRanks, localRank, bootstrap_.get());
+    ncclComm_t ruleComm = ruleGuard.get();
+    assertTopology(ruleComm);
+    runCollective(ruleComm, Collective::kAllReduce, 4096);
+
+    algoStats_.verifyEqual(noTunerComm, ruleComm, "AllReduce");
+  }
+}
+
+// Size+topology-keyed matching: a rule keyed by BOTH a [0, 1 MiB] size range
+// AND the actual topology forces tree+LL. An in-range AllReduce (16 KiB) uses
+// LL_TREE; an out-of-range AllReduce (8 MiB > 1 MiB max) does not match the
+// rule, so the forced LL_TREE is absent (NCCL default applies).
+TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyInRange) {
+  TunerConfigFile config(makeRule(
+      Collective::kAllReduce,
+      "tree",
+      "ll",
+      /*channels=*/-1,
+      /*minBytes=*/0,
+      /*maxBytes=*/1048576,
+      /*nNodes=*/kExpectedNodes,
+      /*nLocalRanks=*/kExpectedLocalRanks));
+  ncclx::test::NcclCommRAII commGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t comm = commGuard.get();
+  assertTopology(comm);
+  // 4096 floats = 16 KiB, inside [0, 1 MiB].
+  runCollective(comm, Collective::kAllReduce, 4096);
+  algoStats_.verifyExact(comm, "AllReduce", "LL_TREE");
+}
+
+// Size+topology-keyed matching, out-of-range case ("unchanged vs default"
+// model): a rule with a [0, 1 MiB] size range does NOT match an 8 MiB
+// AllReduce, so the tuner ignores it. Create a no-tuner comm and run an 8 MiB
+// AllReduce on it, then create a comm carrying the out-of-range rule and run
+// the SAME 8 MiB AllReduce on it. verifyEqual asserts both comms selected the
+// same set of algorithms, proving the non-matching rule changed nothing.
+TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyOutOfRange) {
+  // 2097152 floats = 8 MiB, above the rule's 1 MiB max_bytes.
+  constexpr size_t kOutOfRangeCount = 2097152;
+
+  // No-tuner comm: no TunerConfigFile in scope, so the tuner is disabled and
+  // NCCL uses its default selection.
+  ncclx::test::NcclCommRAII noTunerGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t noTunerComm = noTunerGuard.get();
+  assertTopology(noTunerComm);
+  runCollective(noTunerComm, Collective::kAllReduce, kOutOfRangeCount);
+
+  // Rule comm: a rule covering only [0, 1 MiB] forcing tree+LL does not match
+  // the 8 MiB run, so the tuner ignores it. Keep both comms alive until
+  // verifyEqual reads their AlgoStats.
+  TunerConfigFile config(makeRule(
+      Collective::kAllReduce,
+      "tree",
+      "ll",
+      /*channels=*/-1,
+      /*minBytes=*/0,
+      /*maxBytes=*/1048576,
+      /*nNodes=*/kExpectedNodes,
+      /*nLocalRanks=*/kExpectedLocalRanks));
+  ncclx::test::NcclCommRAII ruleGuard(
+      globalRank, numRanks, localRank, bootstrap_.get());
+  ncclComm_t ruleComm = ruleGuard.get();
+  assertTopology(ruleComm);
+  runCollective(ruleComm, Collective::kAllReduce, kOutOfRangeCount);
+
+  algoStats_.verifyEqual(noTunerComm, ruleComm, "AllReduce");
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
@@ -1,0 +1,1002 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include <folly/init/Init.h>
+
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h" // @manual
+#include "meta/tuner/MetaTuner.h"
+
+namespace {
+
+using ncclx::tuner::kMetaTuner;
+using ncclx::tuner::metaTunerEnabled;
+
+// Mirrors the cost-table shape NCCL core hands to the tuner: a row per
+// algorithm, a column per protocol. NCCL_ALGO_PROTO_IGNORE (-1.0) marks
+// unsupported algo/proto combos.
+class CostTable {
+ public:
+  CostTable() {
+    for (auto& row : table_) {
+      row.fill(1.0F);
+    }
+  }
+
+  void setIgnore(const int algo, const int proto) {
+    table_[algo][proto] = NCCL_ALGO_PROTO_IGNORE;
+  }
+
+  float at(const int algo, const int proto) const {
+    return table_[algo][proto];
+  }
+
+  float** asCallbackArg() {
+    return reinterpret_cast<float**>(table_.data());
+  }
+
+ private:
+  std::array<std::array<float, NCCL_NUM_PROTOCOLS>, NCCL_NUM_ALGORITHMS> table_;
+};
+
+// RAII helper that writes a temp config file and points NCCLX_TUNER_CONFIG_FILE
+// at it via EnvRAII, restoring the cvar and removing the file on teardown.
+class TunerConfigFile {
+ public:
+  TunerConfigFile(const std::string& suffix, const std::string& contents)
+      : path_(writeTempFile(suffix, contents)),
+        envGuard_(NCCLX_TUNER_CONFIG_FILE, path_) {}
+
+  ~TunerConfigFile() {
+    std::remove(path_.c_str());
+  }
+
+  const std::string& path() const {
+    return path_;
+  }
+
+ private:
+  static std::string writeTempFile(
+      const std::string& suffix,
+      const std::string& contents) {
+    std::string path = std::string(std::tmpnam(nullptr)) + suffix;
+    std::ofstream out(path);
+    out << contents;
+    return path;
+  }
+
+  std::string path_;
+  EnvRAII<std::string> envGuard_;
+};
+
+// Drives the v6 init callback for a given topology and returns its result,
+// writing the opaque context (nullptr on failure) through `context`. Caller
+// must finalize a successfully-created context.
+ncclResult_t
+tryInitTuner(void** context, const size_t nRanks, const size_t nNodes) {
+  return kMetaTuner.init(
+      context,
+      /* commId */ 0,
+      nRanks,
+      nNodes,
+      /* logFunction */ nullptr,
+      /* nvlDomainInfo */ nullptr,
+      /* constants */ nullptr);
+}
+
+// Initializes the tuner via the v6 init callback for a given topology and
+// returns the opaque context, asserting init succeeds. Caller must finalize.
+void* initTuner(const size_t nRanks, const size_t nNodes) {
+  void* context = nullptr;
+  EXPECT_EQ(tryInitTuner(&context, nRanks, nNodes), ncclSuccess);
+  EXPECT_NE(context, nullptr);
+  return context;
+}
+
+// Resolves the runtime path of a checked-in example config. The BUCK rule maps
+// each example file to an env var via env = {VAR: "$(location :target)"}, so
+// the path is materialized for us at test time.
+std::string exampleConfigPath(const char* const envVar) {
+  const char* const path = std::getenv(envVar);
+  EXPECT_NE(path, nullptr) << "resource env var " << envVar << " is unset";
+  return path == nullptr ? std::string{} : std::string{path};
+}
+
+class MetaTunerTest : public ::testing::Test {};
+
+// Case 8: cvar empty -> tuner disabled.
+TEST_F(MetaTunerTest, DisabledWhenCvarEmpty) {
+  const EnvRAII<std::string> envGuard(NCCLX_TUNER_CONFIG_FILE, std::string{});
+  EXPECT_FALSE(metaTunerEnabled());
+}
+
+TEST_F(MetaTunerTest, EnabledWhenCvarSet) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[0,1024],ring,ll128,-1,*,*\n");
+  EXPECT_TRUE(metaTunerEnabled());
+}
+
+// Case 2: size-range match sets the targeted entry to 0.0, others unchanged;
+// out-of-range leaves the whole table unchanged.
+TEST_F(MetaTunerTest, SizeRangeMatch) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[1024,4096],ring,ll128,-1,*,*\n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  CostTable inRange;
+  int nChannels = 1;
+  EXPECT_EQ(
+      kMetaTuner.getCollInfo(
+          context,
+          ncclFuncAllReduce,
+          /* nBytes */ 2048,
+          /* numPipeOps */ 1,
+          inRange.asCallbackArg(),
+          NCCL_NUM_ALGORITHMS,
+          NCCL_NUM_PROTOCOLS,
+          /* regBuff */ 0,
+          &nChannels),
+      ncclSuccess);
+  EXPECT_EQ(inRange.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+  EXPECT_EQ(inRange.at(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), 1.0F);
+
+  CostTable outOfRange;
+  EXPECT_EQ(
+      kMetaTuner.getCollInfo(
+          context,
+          ncclFuncAllReduce,
+          /* nBytes */ 8192,
+          /* numPipeOps */ 1,
+          outOfRange.asCallbackArg(),
+          NCCL_NUM_ALGORITHMS,
+          NCCL_NUM_PROTOCOLS,
+          /* regBuff */ 0,
+          &nChannels),
+      ncclSuccess);
+  EXPECT_EQ(outOfRange.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
+
+  kMetaTuner.finalize(context);
+}
+
+// Case 3: topology filter (nNodes/nLocalRanks) gates the match. The context
+// derives nLocalRanks = nRanks / nNodes, so a rule keyed nNodes=2,nLocalRanks=8
+// matches a 16-rank/2-node comm (local 8) but not an 8-rank/1-node comm (local
+// 8 but wrong nNodes).
+TEST_F(MetaTunerTest, TopologyFilter) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[0,4096],ring,ll128,-1,2,8\n");
+
+  void* matching = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  CostTable matchTable;
+  int nChannels = 1;
+  EXPECT_EQ(
+      kMetaTuner.getCollInfo(
+          matching,
+          ncclFuncAllReduce,
+          1024,
+          1,
+          matchTable.asCallbackArg(),
+          NCCL_NUM_ALGORITHMS,
+          NCCL_NUM_PROTOCOLS,
+          0,
+          &nChannels),
+      ncclSuccess);
+  EXPECT_EQ(matchTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+  kMetaTuner.finalize(matching);
+
+  void* nonMatching = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  CostTable noMatchTable;
+  EXPECT_EQ(
+      kMetaTuner.getCollInfo(
+          nonMatching,
+          ncclFuncAllReduce,
+          1024,
+          1,
+          noMatchTable.asCallbackArg(),
+          NCCL_NUM_ALGORITHMS,
+          NCCL_NUM_PROTOCOLS,
+          0,
+          &nChannels),
+      ncclSuccess);
+  EXPECT_EQ(noMatchTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
+  kMetaTuner.finalize(nonMatching);
+}
+
+// Case 3b: nLocalRanks gating, isolated from nNodes. A rule keyed only on
+// nLocalRanks=4 (nNodes wildcard) matches a 16-rank/4-node comm (local 4) but
+// NOT a 16-rank/2-node comm (local 8) -- proving the match keys on ranks per
+// node, not total ranks (both comms have nRanks=16).
+TEST_F(MetaTunerTest, LocalRanksFilter) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[0,4096],ring,ll128,-1,*,4\n");
+
+  void* matching = initTuner(/* nRanks */ 16, /* nNodes */ 4);
+  CostTable matchTable;
+  int nChannels = 1;
+  kMetaTuner.getCollInfo(
+      matching,
+      ncclFuncAllReduce,
+      1024,
+      1,
+      matchTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  EXPECT_EQ(matchTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+  kMetaTuner.finalize(matching);
+
+  void* nonMatching = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  CostTable noMatchTable;
+  kMetaTuner.getCollInfo(
+      nonMatching,
+      ncclFuncAllReduce,
+      1024,
+      1,
+      noMatchTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  EXPECT_EQ(noMatchTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
+  kMetaTuner.finalize(nonMatching);
+}
+
+// Helper: drive getCollInfo once and report whether the rule matched (the
+// targeted ring/ll128 entry was forced to 0.0).
+bool ruleMatched(
+    void* context,
+    const ncclFunc_t collType,
+    const size_t nBytes) {
+  CostTable table;
+  int nChannels = 1;
+  kMetaTuner.getCollInfo(
+      context,
+      collType,
+      nBytes,
+      /* numPipeOps */ 1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      /* regBuff */ 0,
+      &nChannels);
+  return table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128) == 0.0F;
+}
+
+// Int64Range bytes matching: a half-open interval [1024,4096) matches its lower
+// endpoint, an interior value, and excludes its upper endpoint and below-range.
+TEST_F(MetaTunerTest, BytesIntervalEndpoints) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[1024,4096),ring,ll128,-1,*,*\n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 1023));
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1024));
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 2048));
+  EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 4096));
+
+  kMetaTuner.finalize(context);
+}
+
+// Open-ended bytes interval (1024,) matches everything strictly above 1024.
+TEST_F(MetaTunerTest, BytesOpenEndedAbove) {
+  const TunerConfigFile config(".csv", "allreduce,(1024,),ring,ll128,-1,*,*\n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 1024));
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1025));
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1073741824));
+
+  kMetaTuner.finalize(context);
+}
+
+// Wildcard bytes (*) matches any size.
+TEST_F(MetaTunerTest, BytesWildcardMatchesAll) {
+  const TunerConfigFile config(".csv", "allreduce,*,ring,ll128,-1,*,*\n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 0));
+  EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1073741824));
+
+  kMetaTuner.finalize(context);
+}
+
+// Range-keyed nNodes: a rule keyed nNodes=(1,) (more than one node) matches a
+// 2-node comm but not a 1-node comm; nLocalRanks/bytes left wildcard.
+TEST_F(MetaTunerTest, NodesRangeKeyed) {
+  const TunerConfigFile config(".csv", "allreduce,*,ring,ll128,-1,(1,),*\n");
+
+  void* multiNode = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  EXPECT_TRUE(ruleMatched(multiNode, ncclFuncAllReduce, 1024));
+  kMetaTuner.finalize(multiNode);
+
+  void* singleNode = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  EXPECT_FALSE(ruleMatched(singleNode, ncclFuncAllReduce, 1024));
+  kMetaTuner.finalize(singleNode);
+}
+
+// Range-keyed nLocalRanks: a rule keyed nLocalRanks=[4,8] matches a comm with 8
+// ranks per node (16 ranks / 2 nodes) but not one with 2 ranks per node.
+TEST_F(MetaTunerTest, LocalRanksRangeKeyed) {
+  const TunerConfigFile config(".csv", "allreduce,*,ring,ll128,-1,*,[4,8]\n");
+
+  void* inRange = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  EXPECT_TRUE(ruleMatched(inRange, ncclFuncAllReduce, 1024));
+  kMetaTuner.finalize(inRange);
+
+  void* outOfRange = initTuner(/* nRanks */ 8, /* nNodes */ 4);
+  EXPECT_FALSE(ruleMatched(outOfRange, ncclFuncAllReduce, 1024));
+  kMetaTuner.finalize(outOfRange);
+}
+
+// Bracket-aware CSV split: commas inside the bytes interval do not split the
+// column, so a row with [0,4096] and topology fields parses into the right
+// columns. The rule matches the topology it targets and not another.
+TEST_F(MetaTunerTest, BracketAwareCsvSplit) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[0,4096],ring,ll128,-1,2,8\n");
+
+  void* matching = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  EXPECT_TRUE(ruleMatched(matching, ncclFuncAllReduce, 1024));
+  EXPECT_FALSE(ruleMatched(matching, ncclFuncAllReduce, 8192)); // above bytes
+  kMetaTuner.finalize(matching);
+
+  void* wrongTopo = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  EXPECT_FALSE(ruleMatched(wrongTopo, ncclFuncAllReduce, 1024));
+  kMetaTuner.finalize(wrongTopo);
+}
+
+// With NCCLX_TUNER_IGNORE_CONFIG_ERRORS set, a rule with an invalid interval
+// (lo > hi) is skipped; a valid rule on the following line still loads and
+// takes effect. (Strict mode rejecting the bad rule is covered separately.)
+TEST_F(MetaTunerTest, InvalidIntervalRuleSkipped) {
+  const EnvRAII<bool> ignoreGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, true);
+  const TunerConfigFile config(
+      ".csv",
+      "allreduce,(4096,1024],ring,ll128,-1,*,*\n"
+      "allgather,[0,4096],tree,simple,-1,*,*\n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  // The bad allreduce rule was dropped: its target is not forced.
+  EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 1024));
+
+  // The valid allgather rule still loaded.
+  CostTable table;
+  int nChannels = 1;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllGather,
+      1024,
+      1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  EXPECT_EQ(table.at(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), 0.0F);
+
+  kMetaTuner.finalize(context);
+}
+
+// Asserts that, in strict mode (NCCLX_TUNER_IGNORE_CONFIG_ERRORS unset), a
+// config with the given contents fails tuner init with ncclInvalidUsage and
+// leaves no context to finalize. Drives the same init callback the tests use.
+void expectStrictInitFails(const std::string& suffix, const std::string& csv) {
+  const EnvRAII<bool> strictGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, false);
+  const TunerConfigFile config(suffix, csv);
+  void* context = nullptr;
+  EXPECT_EQ(
+      tryInitTuner(&context, /* nRanks */ 8, /* nNodes */ 1), ncclInvalidUsage);
+  EXPECT_EQ(context, nullptr);
+}
+
+// Strict mode (default): an unknown collective token fails comm init rather
+// than silently defaulting to allreduce.
+TEST_F(MetaTunerTest, StrictUnknownCollectiveFailsInit) {
+  expectStrictInitFails(".csv", "allReducee,[0,1024],ring,ll128,-1,*,*\n");
+}
+
+// Strict mode (default): an unknown algorithm token fails comm init.
+TEST_F(MetaTunerTest, StrictUnknownAlgorithmFailsInit) {
+  expectStrictInitFails(".csv", "allreduce,[0,1024],rinng,ll128,-1,*,*\n");
+}
+
+// Strict mode (default): an unknown protocol token fails comm init.
+TEST_F(MetaTunerTest, StrictUnknownProtocolFailsInit) {
+  expectStrictInitFails(".csv", "allreduce,[0,1024],ring,ll-128,-1,*,*\n");
+}
+
+// Strict mode (default): an invalid Int64Range (lo > hi) fails comm init.
+TEST_F(MetaTunerTest, StrictInvalidIntervalFailsInit) {
+  expectStrictInitFails(".csv", "allreduce,(4096,1024],ring,ll128,-1,*,*\n");
+}
+
+// Strict mode (default): a present-but-unparseable numeric column (channels)
+// fails comm init rather than silently falling back to the default.
+TEST_F(MetaTunerTest, StrictInvalidNumericFailsInit) {
+  expectStrictInitFails(".csv", "allreduce,[0,1024],ring,ll128,abc,*,*\n");
+}
+
+// Strict mode (default): channels is always an int, so a present-but-out-of-
+// int-range value fails comm init rather than silently truncating to int.
+TEST_F(MetaTunerTest, StrictOutOfRangeChannelsFailsInit) {
+  expectStrictInitFails(
+      ".csv", "allreduce,[0,1024],ring,ll128,99999999999,*,*\n");
+}
+
+// Strict mode (default): a negative chunkSize would wrap to a huge size_t, so
+// it must be rejected like any other present-but-invalid numeric.
+TEST_F(MetaTunerTest, StrictNegativeChunkSizeFailsInit) {
+  expectStrictInitFails(
+      ".csv", "allreduce,[0,1024],ring,ll128,-1,*,*,-1,-1,-5\n");
+}
+
+// Strict mode (default): a non-existent config file fails comm init.
+TEST_F(MetaTunerTest, StrictMissingFileFailsInit) {
+  const EnvRAII<bool> strictGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, false);
+  const EnvRAII<std::string> envGuard(
+      NCCLX_TUNER_CONFIG_FILE, std::string{"/nonexistent/path/to/tuner.csv"});
+  void* context = nullptr;
+  EXPECT_EQ(
+      tryInitTuner(&context, /* nRanks */ 8, /* nNodes */ 1), ncclInvalidUsage);
+  EXPECT_EQ(context, nullptr);
+}
+
+#ifdef NCCLX_TUNER_WITH_FOLLY_JSON
+// Strict mode (default): a JSON rule missing its filter/config object fails
+// comm init.
+TEST_F(MetaTunerTest, StrictJsonMissingFilterConfigFailsInit) {
+  expectStrictInitFails(
+      ".json",
+      R"({"rules": [{"config": {"algorithm": "ring", "protocol": "ll128"}}]})");
+}
+
+// Strict mode (default): a malformed JSON value type must surface as a clean
+// init failure (ncclInvalidUsage), never an escaping folly::TypeError. Covers
+// both a non-numeric array ("channels": [4]) and a non-numeric string
+// ("channels": "abc").
+TEST_F(MetaTunerTest, StrictJsonBadValueTypeArrayFailsInit) {
+  expectStrictInitFails(
+      ".json",
+      R"({"rules": [{"filter": {"collective": "allreduce"},
+          "config": {"algorithm": "ring", "protocol": "ll128",
+                     "channels": [4]}}]})");
+}
+
+TEST_F(MetaTunerTest, StrictJsonBadValueTypeStringFailsInit) {
+  expectStrictInitFails(
+      ".json",
+      R"({"rules": [{"filter": {"collective": "allreduce"},
+          "config": {"algorithm": "ring", "protocol": "ll128",
+                     "channels": "abc"}}]})");
+}
+
+// Ignore mode: the same malformed JSON value type is skipped (not fatal),
+// init succeeds with no rule applied, and no exception escapes.
+TEST_F(MetaTunerTest, IgnoreJsonBadValueTypeSkipsRule) {
+  const EnvRAII<bool> ignoreGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, true);
+  const TunerConfigFile config(
+      ".json",
+      R"({"rules": [{"filter": {"collective": "allreduce"},
+          "config": {"algorithm": "ring", "protocol": "ll128",
+                     "channels": [4]}}]})");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  // The bad rule was dropped: its target is not forced.
+  EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 512));
+
+  kMetaTuner.finalize(context);
+}
+#endif
+
+// Case 4: when two rows match, the first wins (row order = priority).
+TEST_F(MetaTunerTest, RowOrderPriority) {
+  const TunerConfigFile config(
+      ".csv",
+      "allreduce,[0,4096],ring,ll128,-1,*,*\n"
+      "allreduce,[0,4096],tree,simple,-1,*,*\n");
+  void* context = initTuner(8, 1);
+
+  CostTable table;
+  int nChannels = 1;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      1024,
+      1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+  EXPECT_EQ(table.at(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), 1.0F);
+
+  kMetaTuner.finalize(context);
+}
+
+// Case 5: nChannels override -- -1 leaves the value, a positive value sets it.
+TEST_F(MetaTunerTest, ChannelsOverride) {
+  const TunerConfigFile config(
+      ".csv",
+      "allreduce,[0,1024],ring,ll128,-1,*,*\n"
+      "allgather,[0,1024],ring,simple,4,*,*\n");
+  void* context = initTuner(8, 1);
+
+  CostTable defaultTable;
+  int defaultChannels = 7;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      512,
+      1,
+      defaultTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &defaultChannels);
+  EXPECT_EQ(defaultChannels, 7);
+
+  CostTable overrideTable;
+  int overrideChannels = 7;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllGather,
+      512,
+      1,
+      overrideTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &overrideChannels);
+  EXPECT_EQ(overrideChannels, 4);
+
+  kMetaTuner.finalize(context);
+}
+
+// Case 6: an entry preset to NCCL_ALGO_PROTO_IGNORE is never force-selected.
+TEST_F(MetaTunerTest, IgnoreProtection) {
+  const TunerConfigFile config(
+      ".csv", "allreduce,[0,1024],ring,ll128,-1,*,*\n");
+  void* context = initTuner(8, 1);
+
+  CostTable table;
+  table.setIgnore(NCCL_ALGO_RING, NCCL_PROTO_LL128);
+  int nChannels = 1;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      512,
+      1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  // Stays IGNORE; the rule did not force the unsupported combo to 0.0.
+  EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), NCCL_ALGO_PROTO_IGNORE);
+
+  kMetaTuner.finalize(context);
+}
+
+// Case 7: with NCCLX_TUNER_IGNORE_CONFIG_ERRORS set, a missing file -> init
+// succeeds, no rules, outputs untouched. (Strict mode failing on a missing
+// file is covered separately.)
+TEST_F(MetaTunerTest, MissingFileIsNoOp) {
+  const EnvRAII<bool> ignoreGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, true);
+  const EnvRAII<std::string> envGuard(
+      NCCLX_TUNER_CONFIG_FILE, std::string{"/nonexistent/path/to/tuner.csv"});
+  EXPECT_TRUE(metaTunerEnabled());
+
+  void* context = initTuner(8, 1);
+  CostTable table;
+  int nChannels = 5;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      512,
+      1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &nChannels);
+  EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
+  EXPECT_EQ(nChannels, 5);
+
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  size_t chunkSize = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      512,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128,
+      1,
+      &chunkSize);
+  EXPECT_EQ(chunkSize, 16384);
+#endif
+
+  kMetaTuner.finalize(context);
+}
+
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+// Case 9: getChunkSize override -- chunkSize != 0 sets it; 0/omitted leaves it.
+TEST_F(MetaTunerTest, ChunkSizeOverride) {
+  const TunerConfigFile config(
+      ".csv",
+      "allreduce,[0,4096],ring,ll128,-1,*,*,-1,-1,65536\n"
+      "allgather,[0,4096],ring,ll128,-1,*,*,-1,-1,0\n");
+  void* context = initTuner(8, 1);
+
+  size_t overridden = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      1024,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128,
+      1,
+      &overridden);
+  EXPECT_EQ(overridden, 65536);
+
+  size_t untouched = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllGather,
+      1024,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128,
+      1,
+      &untouched);
+  EXPECT_EQ(untouched, 16384);
+
+  kMetaTuner.finalize(context);
+}
+
+// Case 10: getChunkSize keys on algo/proto; only the matching row overrides.
+TEST_F(MetaTunerTest, ChunkSizeAlgoProtoKey) {
+  const TunerConfigFile config(
+      ".csv",
+      "allreduce,[0,4096],ring,ll128,-1,*,*,-1,-1,65536\n"
+      "allreduce,[0,4096],tree,simple,-1,*,*,-1,-1,32768\n");
+  void* context = initTuner(8, 1);
+
+  size_t ringChunk = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      1024,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128,
+      1,
+      &ringChunk);
+  EXPECT_EQ(ringChunk, 65536);
+
+  size_t treeChunk = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      1024,
+      NCCL_ALGO_TREE,
+      NCCL_PROTO_SIMPLE,
+      1,
+      &treeChunk);
+  EXPECT_EQ(treeChunk, 32768);
+
+  // An algo/proto not present in any row leaves the default untouched.
+  size_t otherChunk = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      1024,
+      NCCL_ALGO_NVLS,
+      NCCL_PROTO_SIMPLE,
+      1,
+      &otherChunk);
+  EXPECT_EQ(otherChunk, 16384);
+
+  kMetaTuner.finalize(context);
+}
+#endif // NCCLX_TUNER_HAS_GETCHUNKSIZE
+
+// Case 1: CSV parsing with comments, blank lines and omitted optional columns.
+TEST_F(MetaTunerTest, CsvParsingWithCommentsAndOmittedColumns) {
+  const TunerConfigFile config(
+      ".csv",
+      "# leading comment\n"
+      "\n"
+      "allreduce,[0,1024],ring,ll128,-1,*,*\n"
+      "  allgather, [0, 2048], tree, simple, 4, 1, 8 \n");
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  // First rule (omitted numPipeOps/regBuff/chunkSize default to wildcard / 0).
+  CostTable allreduceTable;
+  int allreduceChannels = 9;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      512,
+      1,
+      allreduceTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &allreduceChannels);
+  EXPECT_EQ(allreduceTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+  EXPECT_EQ(allreduceChannels, 9);
+
+  // Second rule: whitespace trimmed, channels overridden, topology honored.
+  CostTable allgatherTable;
+  int allgatherChannels = 9;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllGather,
+      1024,
+      1,
+      allgatherTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      0,
+      &allgatherChannels);
+  EXPECT_EQ(allgatherTable.at(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), 0.0F);
+  EXPECT_EQ(allgatherChannels, 4);
+
+  kMetaTuner.finalize(context);
+}
+
+// Observable effect of one parsed rule, gathered by driving the public tuner
+// hooks. Two contexts loaded from equivalent tables (CSV vs JSON) must yield
+// the same probe for every authored rule.
+struct RuleProbe {
+  float matchedCost;
+  int channels;
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  size_t chunkSize;
+#endif
+
+  bool operator==(const RuleProbe& other) const {
+    return matchedCost == other.matchedCost && channels == other.channels
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+        && chunkSize == other.chunkSize
+#endif
+        ;
+  }
+};
+
+// Probes a context for the rule keyed on (collType, nBytes, algo, proto):
+// matchedCost / channels come from getCollInfo, chunkSize from getChunkSize.
+RuleProbe probeRule(
+    void* context,
+    const ncclFunc_t collType,
+    const size_t nBytes,
+    const int algo,
+    const int proto) {
+  CostTable table;
+  int channels = -1;
+  kMetaTuner.getCollInfo(
+      context,
+      collType,
+      nBytes,
+      /* numPipeOps */ 1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      /* regBuff */ 0,
+      &channels);
+
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  size_t chunkSize = 0;
+  kMetaTuner.getChunkSize(
+      context, collType, nBytes, algo, proto, /* nChannels */ 1, &chunkSize);
+
+  return RuleProbe{table.at(algo, proto), channels, chunkSize};
+#else
+  return RuleProbe{table.at(algo, proto), channels};
+#endif
+}
+
+#ifdef NCCLX_TUNER_WITH_FOLLY_JSON
+// Case 1b: the SAME tuning table authored as CSV and as JSON must parse to
+// equivalent configs -- verified field-by-field through identical probes.
+TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
+  void* csvContext = nullptr;
+  {
+    const TunerConfigFile csv(
+        ".csv",
+        "allreduce,[0,4096],ring,ll128,4,1,8,-1,-1,65536\n"
+        "allgather,[0,2048],tree,simple,-1,*,*,-1,-1,0\n");
+    csvContext = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  }
+
+  void* jsonContext = nullptr;
+  {
+    // The allreduce row exercises a JSON integer `bytes` field interpreted as
+    // an exact value via the int|string path; the allgather row omits `bytes`
+    // (defaults to the * wildcard). The CSV authors the equivalent intervals.
+    const TunerConfigFile json(
+        ".json",
+        R"({
+          "rules": [
+            {"filter": {"collective": "allreduce", "bytes": "[0,4096]",
+                        "nNodes": 1, "nLocalRanks": 8},
+             "config": {"algorithm": "ring", "protocol": "ll128",
+                        "channels": 4, "chunkSize": 65536}},
+            {"filter": {"collective": "allgather", "bytes": "[0,2048]"},
+             "config": {"algorithm": "tree", "protocol": "simple"}}
+          ]
+        })");
+    jsonContext = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  }
+
+  // Probe each authored row in both contexts; the observable per-row config
+  // (matched cost, channels, chunkSize) must be identical.
+  const RuleProbe csvRow0 = probeRule(
+      csvContext, ncclFuncAllReduce, 1024, NCCL_ALGO_RING, NCCL_PROTO_LL128);
+  const RuleProbe jsonRow0 = probeRule(
+      jsonContext, ncclFuncAllReduce, 1024, NCCL_ALGO_RING, NCCL_PROTO_LL128);
+  EXPECT_EQ(csvRow0, jsonRow0);
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  EXPECT_EQ(csvRow0, (RuleProbe{0.0F, 4, 65536}));
+#else
+  EXPECT_EQ(csvRow0, (RuleProbe{0.0F, 4}));
+#endif
+
+  const RuleProbe csvRow1 = probeRule(
+      csvContext, ncclFuncAllGather, 1024, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE);
+  const RuleProbe jsonRow1 = probeRule(
+      jsonContext, ncclFuncAllGather, 1024, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE);
+  EXPECT_EQ(csvRow1, jsonRow1);
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  EXPECT_EQ(csvRow1, (RuleProbe{0.0F, -1, 0}));
+#else
+  EXPECT_EQ(csvRow1, (RuleProbe{0.0F, -1}));
+#endif
+
+  kMetaTuner.finalize(jsonContext);
+  kMetaTuner.finalize(csvContext);
+}
+#endif
+
+#ifndef NCCLX_TUNER_WITH_FOLLY_JSON
+// Case 1c: in a no-folly build, a .json config is unsupported -- init still
+// succeeds with EMPTY configs (no override applied), while CSV still loads.
+// Guarded by the same macro, so this body compiles only in the OSS no-folly
+// build (the buck build defines the macro and compiles it out).
+TEST_F(MetaTunerTest, JsonUnsupportedInNoFollyBuild) {
+  {
+    // A .json path is unsupported here; with ignore set it is skipped (empty
+    // table, init succeeds) rather than failing comm init.
+    const EnvRAII<bool> ignoreGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, true);
+    const TunerConfigFile json(
+        ".json",
+        R"({"rules": [{"filter": {"collective": "allreduce", "bytes": "[0,4096]"},
+            "config": {"algorithm": "ring", "protocol": "ll128"}}]})");
+    void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+    // No rule was parsed: the targeted entry is left untouched.
+    CostTable table;
+    int channels = 7;
+    kMetaTuner.getCollInfo(
+        context,
+        ncclFuncAllReduce,
+        1024,
+        1,
+        table.asCallbackArg(),
+        NCCL_NUM_ALGORITHMS,
+        NCCL_NUM_PROTOCOLS,
+        0,
+        &channels);
+    EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 1.0F);
+    EXPECT_EQ(channels, 7);
+    kMetaTuner.finalize(context);
+  }
+
+  // CSV still works in the same no-folly build.
+  {
+    const TunerConfigFile csv(".csv", "allreduce,[0,4096],ring,ll128,-1,*,*\n");
+    void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+    CostTable table;
+    int channels = 1;
+    kMetaTuner.getCollInfo(
+        context,
+        ncclFuncAllReduce,
+        1024,
+        1,
+        table.asCallbackArg(),
+        NCCL_NUM_ALGORITHMS,
+        NCCL_NUM_PROTOCOLS,
+        0,
+        &channels);
+    EXPECT_EQ(table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+    kMetaTuner.finalize(context);
+  }
+}
+#endif
+
+// The checked-in CSV example config parses and its rules take effect. Drives
+// getCollInfo to confirm the small-allreduce rule resolves; the large-allreduce
+// chunkSize override is checked only where getChunkSize exists.
+TEST_F(MetaTunerTest, ExampleCsvConfigLoads) {
+  const std::string path = exampleConfigPath("EXAMPLE_TUNER_CONFIG_CSV");
+  const EnvRAII<std::string> envGuard(NCCLX_TUNER_CONFIG_FILE, path);
+  EXPECT_TRUE(metaTunerEnabled());
+
+  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+
+  // Small allreduce: ring/ll128 forced to 0.0.
+  CostTable smallTable;
+  int channels = -1;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllReduce,
+      /* nBytes */ 4096,
+      /* numPipeOps */ 1,
+      smallTable.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      /* regBuff */ 0,
+      &channels);
+  EXPECT_EQ(smallTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
+
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  // Large allreduce: ring/simple carries a 524288-byte chunkSize override.
+  size_t chunkSize = 16384;
+  kMetaTuner.getChunkSize(
+      context,
+      ncclFuncAllReduce,
+      /* nBytes */ 2097152,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_SIMPLE,
+      /* nChannels */ 1,
+      &chunkSize);
+  EXPECT_EQ(chunkSize, 524288);
+#endif
+
+  kMetaTuner.finalize(context);
+}
+
+#ifdef NCCLX_TUNER_WITH_FOLLY_JSON
+// The checked-in JSON example config parses and its allgather rule (channel +
+// topology override) takes effect on a matching topology.
+TEST_F(MetaTunerTest, ExampleJsonConfigLoads) {
+  const std::string path = exampleConfigPath("EXAMPLE_TUNER_CONFIG_JSON");
+  const EnvRAII<std::string> envGuard(NCCLX_TUNER_CONFIG_FILE, path);
+  EXPECT_TRUE(metaTunerEnabled());
+
+  void* context = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+
+  // Allgather on the 2-node / 16-rank topology: tree/simple forced, 4 channels.
+  CostTable table;
+  int channels = 9;
+  kMetaTuner.getCollInfo(
+      context,
+      ncclFuncAllGather,
+      /* nBytes */ 1048576,
+      /* numPipeOps */ 1,
+      table.asCallbackArg(),
+      NCCL_NUM_ALGORITHMS,
+      NCCL_NUM_PROTOCOLS,
+      /* regBuff */ 0,
+      &channels);
+  EXPECT_EQ(table.at(NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE), 0.0F);
+  EXPECT_EQ(channels, 4);
+
+  kMetaTuner.finalize(context);
+}
+#endif
+
+} // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tuner/tests/example_tuner_config.json
+++ b/comms/ncclx/meta/tuner/tests/example_tuner_config.json
@@ -1,0 +1,20 @@
+{
+  "rules": [
+    {
+      "filter": { "collective": "allreduce", "bytes": "[0,1048576]" },
+      "config": { "algorithm": "ring", "protocol": "ll128" }
+    },
+    {
+      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
+    },
+    {
+      "filter": { "collective": "allreduce", "bytes": "(1048576,)" },
+      "config": { "algorithm": "ring", "protocol": "simple", "chunkSize": 524288 }
+    },
+    {
+      "filter": { "collective": "reducescatter", "bytes": "(1048576,)", "nNodes": "(1,)" },
+      "config": { "algorithm": "ring", "protocol": "simple" }
+    }
+  ]
+}

--- a/comms/ncclx/v2_29/src/plugin/tuner.cc
+++ b/comms/ncclx/v2_29/src/plugin/tuner.cc
@@ -14,6 +14,7 @@
 #include "debug.h"
 #include "tuner.h"
 #include "plugin.h"
+#include "meta/tuner/MetaTuner.h"
 
 extern ncclTuner_t* getNcclTuner_v2(void* lib);
 extern ncclTuner_t* getNcclTuner_v3(void* lib);
@@ -39,6 +40,10 @@ ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
   const char* tunerName;
   // Initialize to nullptr by default if plugin tuner cannot be loaded.
   comm->tuner = nullptr;
+  // [META] built-in CSV/JSON tuner takes precedence when set; see meta/tuner/MetaTuner.h
+  if (ncclx::tuner::tryLoadMetaTuner(comm)) {
+    return ncclSuccess;
+  }
   if (tunerPluginLoadFailed == status) {
     return ncclSuccess;
   }

--- a/comms/ncclx/v2_30/src/plugin/tuner.cc
+++ b/comms/ncclx/v2_30/src/plugin/tuner.cc
@@ -14,6 +14,7 @@
 #include "debug.h"
 #include "tuner.h"
 #include "plugin.h"
+#include "meta/tuner/MetaTuner.h"
 
 extern ncclTuner_t* getNcclTuner_v2(void* lib);
 extern ncclTuner_t* getNcclTuner_v3(void* lib);
@@ -40,6 +41,10 @@ ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
   const char* tunerName;
   // Initialize to nullptr by default if plugin tuner cannot be loaded.
   comm->tuner = nullptr;
+  // [META] built-in CSV/JSON tuner takes precedence when set; see meta/tuner/MetaTuner.h
+  if (ncclx::tuner::tryLoadMetaTuner(comm)) {
+    return ncclSuccess;
+  }
   if (tunerPluginLoadFailed == status) {
     return ncclSuccess;
   }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3785,3 +3785,37 @@ cvars:
    type        : int64_t
    default     : -1
    description : Maximum number of P2P peers (added in NCCL 2.30). Uses NCCL_CONFIG_UNDEF_INT as default.
+
+ - name        : NCCLX_TUNER_CONFIG_FILE
+   type        : string
+   default     : ""
+   description : |-
+     Absolute path to a CSV or JSON file (.json extension -> JSON, otherwise
+     CSV) that overrides NCCL core algorithm/protocol/chunkSize selection per
+     (collective, message-size range, topology). When empty, the built-in
+     tuner is disabled and NCCL's default cost-model selection is used.
+     When set, this built-in tuner takes precedence over any external
+     NCCL_TUNER_PLUGIN.
+
+ - name        : NCCLX_TUNER_IGNORE_CONFIG_ERRORS
+   type        : bool
+   default     : false
+   description : |-
+     Controls how the built-in tuner reacts to a malformed NCCLX_TUNER_CONFIG_FILE.
+     When false (default), any tuner config parse error (file cannot be opened,
+     malformed JSON, missing/non-array "rules", an unknown collective/algorithm/
+     protocol, an invalid interval, a present-but-invalid numeric, or a bad JSON
+     value type) fails communicator initialization. When true, parse errors are
+     logged and the offending rule is skipped (or the whole file is ignored) and
+     init continues with the remaining valid rules. An empty/unset
+     NCCLX_TUNER_CONFIG_FILE means the tuner is simply disabled and is never an
+     error regardless of this setting.
+
+ - name        : NCCLX_META_TUNER_LOG_MISMATCH
+   type        : bool
+   default     : false
+   description : |-
+     When true, the built-in meta tuner logs (at INFO, subsys TUNING) the reason
+     a tuning rule did NOT match a collective -- which field disqualified it and
+     the rule's expected value vs the actual value. Useful for debugging why a
+     config rule is not taking effect. Default false (no mismatch logging).


### PR DESCRIPTION
Summary:

Add an NCCLX built-in tuner that overrides NCCL core algorithm/protocol selection (plus `nChannels`, and `chunkSize` on tuner API v6) from a CSV or JSON config file, enabled by the new `NCCLX_TUNER_CONFIG_FILE` cvar.

## Key features
- Extended based on preexisting tuner plugin support in upstream NCCL (1 line change in NCCL to ease future rebasing). Different from upstream `dlopen` based plugin loading, compiled directly into `libnccl.so` and wired into `comm->tuner`.

- Allow to override `algorithm/protocol/nChannels` etc based on a specified topology (nLocalRanks, nNodes) + message size. See full list of tunable fields at https://www.internalfb.com/code/fbsource/[D108663025-V2]/fbcode/comms/ncclx/meta/tuner/MetaTuner.h?lines=22-33

- Allow to override `getChunkSize` in v2.30(v6 tuner API). 
- Support both CSV and JSON based tuner config files. Note that JSON format requires folly dependency. See config file examples at https://www.internalfb.com/code/fbsource/[D108663025-V2]/fbcode/comms/ncclx/meta/tuner/tests/

- Both topology (`nLocalRanks`, `nNodes`) and message size allows range specification, e.g., `[0, 4), [4,), [,1048576]`. Full list of supported format at https://www.internalfb.com/code/fbsource/[D108663025-V2]/fbcode/comms/ncclx/meta/tuner/docs/design.md#interval-grammar-bytes-n

## Design details
See https://www.internalfb.com/code/fbsource/[D108663025-V2]/fbcode/comms/ncclx/meta/tuner/docs/design.md

## How to use
See https://www.internalfb.com/code/fbsource/[D108663025-V2]/fbcode/comms/ncclx/meta/tuner/README.md

Reviewed By: YangZhou1997

Differential Revision: D108663025


