### PR TITLE
Add HIPification and RCCLX backend for AllGatherP collectives

### DIFF
--- a/comms/rcclx/develop/projects/rccl/src/register/register.cc
+++ b/comms/rcclx/develop/projects/rccl/src/register/register.cc
@@ -12,6 +12,8 @@
 #include "transport.h"
 #include "group.h"
 #include "api_trace.h"
+#include "rccl_vars.h"
+#include "MetaFactory.h"
 #ifdef ENABLE_MSCCLPP
 #include "mscclpp/mscclpp_nccl.h"
 #endif
@@ -123,13 +125,24 @@ NCCL_API(ncclResult_t, ncclCommRegister, const ncclComm_t comm, void* buff, size
 ncclResult_t ncclCommRegister_impl(const ncclComm_t comm, void* buff, size_t size, void** handle) {
   ncclResult_t ret = ncclSuccess;
 
+  // Route through CTRAN's commRegister so the buffer is inserted into CTRAN's
+  // regcache. Without this, buffers registered via ncclCommRegister (e.g. from
+  // ProcessGroupNCCLX::registerMemPool) are invisible to CTRAN and algorithms
+  // such as allGatherPInit fail to find them. Mirrors NCCLX register.cc.
+  // Ref: MAST aps-f1094287477-1094294264.
+  *handle = NULL;
+  if (NCCL_CTRAN_ENABLE && ctranInitialized(comm->ctranComm_.get())) {
+    NCCLCHECKGOTO(metaCommToNccl(comm->ctranComm_->ctran_->commRegister(buff, size, handle)), ret, end);
+    goto end;
+  }
+
   if (!ncclParamLocalRegister())
     *handle = NULL;
   else {
     #ifdef ENABLE_MSCCLPP
     if (comm->mscclppCompatible) {
       if (comm->mscclCompatible && size > 0){
-        bool isManagedBuffer = false; 
+        bool isManagedBuffer = false;
         CUDACHECK(hipPointerGetAttribute(&isManagedBuffer, HIP_POINTER_ATTRIBUTE_IS_MANAGED, const_cast<void*>(buff)));
         if(!isManagedBuffer){
           INFO(NCCL_INIT, "MSCCL++: ncclCommRegister");
@@ -183,6 +196,15 @@ exit:
 NCCL_API(ncclResult_t, ncclCommDeregister, const ncclComm_t comm, void* handle);
 ncclResult_t ncclCommDeregister_impl(const ncclComm_t comm, void *handle) {
   NCCLCHECK(Recorder::instance().record(rrCommDeregister, comm, handle));
+
+  // Symmetric with ncclCommRegister_impl: when CTRAN is enabled and
+  // initialized, the handle came from CTRAN and must be returned to it.
+  // Reinterpreting a CTRAN handle as ncclReg* would corrupt memory.
+  if (NCCL_CTRAN_ENABLE && ctranInitialized(comm->ctranComm_.get())) {
+    if (handle == NULL) return ncclSuccess;
+    NCCLCHECK(metaCommToNccl(comm->ctranComm_->ctran_->commDeregister(handle)));
+    return ncclSuccess;
+  }
 
   #ifdef ENABLE_MSCCLPP
   if (comm->mscclppCompatible) {


### PR DESCRIPTION
Summary:
# Enable NCCLX C++ Code on AMD/ROCm Platforms

This diff enables NCCLX C++ code to compile and run on AMD/ROCm platforms by combining build system HIPification (from [D106327331](https://www.internalfb.com/diff/D106327331)) and C++ backend ROCm adaptations (from [D106327371](https://www.internalfb.com/diff/D106327371)). This is a foundational change to support persistent AllGather collectives on AMD MI350 hardware.

## Changes Overview

### 1. Build System HIPification (comms/ncclx/pg/BUCK)

#### HIPify Rules
- Added `custom_rule` for `ncclx_utils_hipify_gen` - HIPifies NCCLXUtils.cpp/hpp for AMD
- Added `custom_rule` for `ncclx_c10d_pg_lib_hipify_gen` - HIPifies ProcessGroupNCCLX.cpp and WindowNCCLX.cpp for AMD
- Uses `fb_caffe2_hipify` to transform CUDA code to HIP at build time

#### Dual-Build Architecture
- **CUDA targets**: `ncclx_utils_cuda`, `ncclx_c10d_pg_lib_cuda` - Original source files with full NCCLX functionality
- **HIP targets**: `ncclx_utils_hip`, `ncclx_c10d_pg_lib_hip` - HIPified generated files for AMD/ROCm
- **Platform-aware aliases**: `ncclx_utils`, `ncclx_c10d_pg_lib` - Automatically select CUDA/HIP variants via `select_accelerator`

#### Build Configuration
- Added `use_rcclx` buckconfig flag (`hpc_comms/use_rcclx`)
- Enable RCCLX support via `-c hpc_comms.use_rcclx=true`
- AMD builds define `USE_ROCM` and `SKIP_NCCLX_GLOBAL_SETTING_HELPER` compiler flags

### 2. C++ Backend ROCm Adaptations

#### Header Compatibility
- NCCLXUtils.hpp, ProcessGroupNCCLX.hpp, WindowNCCLX.hpp: Include `<rccl.h>` on AMD builds instead of NCCLX headers
- Added fallback definitions for NCCLX-specific macros (`NCCL_SPLIT_NOCOLOR`, `ncclCmpOp_t`) when not available

#### Data Type Handling (ProcessGroupNCCLX.cpp)
- Float8 types (`kFloat8_e5m2`, `kFloat8_e4m3fn`): Map to native `ncclFloat8e5m2`/`ncclFloat8e4m3` on NCCLX, fall back to `ncclUint8` on RCCLX
- **Important**: Float8 fallback only works for byte-moving collectives (AllGather, Broadcast); arithmetic reductions (AllReduce) are **not supported** on RCCLX until native Float8 support is added

#### Feature-Specific Adaptations

**NCCLX-Specific Features (Stubbed on AMD):**
- `NCCLXGlobalSettingHelper`: Wrapped in `#ifndef SKIP_NCCLX_GLOBAL_SETTING_HELPER`; returns no-op stubs on AMD (RCCLX lacks `getNcclxInfo`, `setGlobalHint` APIs)
- `_alltoall_p_init`, `_alltoall_p_execute`: Throw `NotImplementedError` on AMD (persistent AllToAll not yet supported in RCCLX)
- `_free_request`: Throw `NotImplementedError` on AMD
- `_alltoallv_dedup_init`, `_alltoallv_dedup_exec`: Throw `NotImplementedError` on AMD (deduplication not supported)

**Unified Features (Work on Both Platforms):**
- `_allgather_p_init`: Uses `ncclx::allGatherInit` (provided by both NCCLX and RCCLX ctran)
- `_allgather_p` (execute): Different implementations for CUDA/HIP but both call `ncclx::allGatherExec`
- `PersistentRequest` destructor: Calls `ncclx::pFree` on both platforms (RCCLX provides this in `comms/rcclx/develop/meta/ctran/PersistentCollectives.cc`)

#### Memory Allocation
- **NCCLX builds**: Use `ncclMemAlloc`/`ncclMemFree` (NCCLX-specific RMA APIs)
- **RCCLX builds**: Fall back to native `hipMalloc`/`hipFree`
- `supportsTensorAlloc`: On AMD, runtime probe `hipMalloc`/`hipFree` capability (no AMD equivalent to CUDA multicast check)

#### Communicator Initialization
- Updated log messages to distinguish "NCCL" vs "RCCL (AMD)" communicators
- Added `#ifdef IS_NCCLX` guard around `ncclx::Hints` usage (not available in RCCLX)
- Force blocking mode on AMD in eager init (non-blocking mode causes collective execution issues)

### 3. RCCLX Registration Routing (comms/rcclx/develop/projects/rccl/src/register/register.cc)

#### Critical Fix for CTRAN Integration
- `ncclCommRegister_impl`: Route through CTRAN's `commRegister` when CTRAN is enabled so buffers are inserted into CTRAN's regcache
- `ncclCommDeregister_impl`: Symmetric routing through CTRAN's `commDeregister`

**Rationale**: Without this, buffers registered via `ncclCommRegister` (e.g., from `ProcessGroupNCCLX::registerMemPool`) are invisible to CTRAN, causing algorithms like `allGatherPInit` to fail (mirrors NCCLX register.cc behavior)

Differential Revision: D108571639


