### PR TITLE
Add Reduce numerical canary for NCCL upgrades

### DIFF
--- a/comms/ncclx/meta/tests/AllReduceNumericalTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceNumericalTest.cc
@@ -1,0 +1,218 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Numerical canaries for NCCL AllReduce. These tests are intended to catch NCCL
+// upgrade regressions by comparing forced-algorithm results against an
+// independently computed FP64 host reference.
+
+#include <comm.h>
+#include <cuda_bf16.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "comms/ncclx/meta/algoconf/AlgoStrConv.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/ReductionNumericalTestUtils.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+#include "meta/NcclxConfig.h"
+
+namespace {
+
+enum class AllReduceNumericalAlgo {
+  Ring,
+  Tree,
+  CtranDirect,
+};
+
+struct AllReduceNumericalParam {
+  AllReduceNumericalAlgo algo;
+  size_t count;
+  ncclDataType_t datatype;
+
+  std::string name() const {
+    std::string algoName;
+    switch (algo) {
+      case AllReduceNumericalAlgo::Ring:
+        algoName = "Ring";
+        break;
+      case AllReduceNumericalAlgo::Tree:
+        algoName = "Tree";
+        break;
+      case AllReduceNumericalAlgo::CtranDirect:
+        algoName = "CtranDirect";
+        break;
+    }
+
+    const std::string dtypeName =
+        datatype == ncclFloat32 ? "Float32" : "Bfloat16";
+    return algoName + "_" + dtypeName + "_" +
+        ncclx::test::numerics::countName(count);
+  }
+};
+
+class AllReduceNumericalTest
+    : public NcclxBaseTestFixture,
+      public ::testing::WithParamInterface<AllReduceNumericalParam> {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"},
+    });
+    ncclAlgoStats_.enable();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  template <typename T>
+  void run(const AllReduceNumericalParam& param) {
+    ncclx::Hints hints;
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+
+    std::optional<SysEnvRAII> ncclAlgoGuard;
+    if (param.algo == AllReduceNumericalAlgo::Ring) {
+      hints.set("allreduceAlgo", "orig");
+      ncclAlgoGuard.emplace("NCCL_ALGO", "RING");
+    } else if (param.algo == AllReduceNumericalAlgo::Tree) {
+      hints.set("allreduceAlgo", "orig");
+      ncclAlgoGuard.emplace("NCCL_ALGO", "TREE");
+    } else {
+      hints.set(
+          "allreduceAlgo",
+          ncclx::algoconf::algoValToStr(NCCL_ALLREDUCE_ALGO::ctdirect));
+    }
+    config.hints = &hints;
+
+    ncclx::test::NcclCommRAII comm{
+        globalRank, numRanks, localRank, bootstrap_.get(), false, &config};
+    if (param.algo == AllReduceNumericalAlgo::CtranDirect) {
+      EXPECT_EQ(
+          NCCLX_CONFIG_FIELD(comm->config, allreduceAlgo),
+          NCCL_ALLREDUCE_ALGO::ctdirect);
+      ASSERT_NE(comm->ctranComm_, nullptr);
+    }
+
+    T* sendBuf = nullptr;
+    T* recvBuf = nullptr;
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBuf, param.count * sizeof(T)));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBuf, param.count * sizeof(T)));
+
+    const auto hostInput =
+        ncclx::test::numerics::makeAllReduceInput<T>(globalRank, param.count);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        sendBuf,
+        hostInput.data(),
+        param.count * sizeof(T),
+        cudaMemcpyDefault,
+        stream_));
+
+    void* sendHandle = nullptr;
+    void* recvHandle = nullptr;
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, sendBuf, param.count * sizeof(T), &sendHandle));
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, recvBuf, param.count * sizeof(T), &recvHandle));
+
+    const auto result = ncclAllReduce(
+        sendBuf, recvBuf, param.count, param.datatype, ncclSum, comm, stream_);
+    ASSERT_EQ(result, ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    const auto expected =
+        ncclx::test::numerics::allReduceExpected<T>(param.count, numRanks);
+    const size_t mismatches = ncclx::test::numerics::countMismatches(
+        recvBuf, expected, stream_, globalRank, param.name());
+    EXPECT_EQ(mismatches, 0) << param.name() << " rank=" << globalRank;
+
+    if (param.algo == AllReduceNumericalAlgo::Ring) {
+      ncclAlgoStats_.verify(comm, "AllReduce", "RING");
+    } else if (param.algo == AllReduceNumericalAlgo::Tree) {
+      ncclAlgoStats_.verify(comm, "AllReduce", "TREE");
+    }
+
+    NCCLCHECK_TEST(ncclCommDeregister(comm, sendHandle));
+    NCCLCHECK_TEST(ncclCommDeregister(comm, recvHandle));
+    NCCLCHECK_TEST(ncclMemFree(sendBuf));
+    NCCLCHECK_TEST(ncclMemFree(recvBuf));
+  }
+
+  cudaStream_t stream_{nullptr};
+  ncclx::test::VerifyAlgoStatsHelper ncclAlgoStats_;
+};
+
+TEST_P(AllReduceNumericalTest, MatchesFp64Reference) {
+  const auto& param = GetParam();
+  if (param.datatype == ncclFloat32) {
+    run<float>(param);
+  } else if (param.datatype == ncclBfloat16) {
+    run<__nv_bfloat16>(param);
+  } else {
+    FAIL() << "Unhandled datatype in " << param.name();
+  }
+}
+
+const auto kAllReduceNumericalParams = ::testing::Values(
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Ring,
+        .count = 1,
+        .datatype = ncclFloat32},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Ring,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Ring,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Tree,
+        .count = 1,
+        .datatype = ncclFloat32},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Tree,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::Tree,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::CtranDirect,
+        .count = 1024,
+        .datatype = ncclFloat32},
+    AllReduceNumericalParam{
+        .algo = AllReduceNumericalAlgo::CtranDirect,
+        .count = 4099,
+        .datatype = ncclBfloat16});
+
+INSTANTIATE_TEST_SUITE_P(
+    AllReduce,
+    AllReduceNumericalTest,
+    kAllReduceNumericalParams,
+    [](const ::testing::TestParamInfo<AllReduceNumericalParam>& info) {
+      return info.param.name();
+    });
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/ReduceNumericalTest.cc
+++ b/comms/ncclx/meta/tests/ReduceNumericalTest.cc
@@ -1,0 +1,218 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Numerical canaries for NCCL Reduce. These tests are intended to catch NCCL
+// upgrade regressions by comparing forced-algorithm root output against an
+// independently computed FP64 host reference.
+
+#include <comm.h>
+#include <cuda_bf16.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/ReductionNumericalTestUtils.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestUtils.h"
+
+namespace {
+
+enum class ReduceNumericalAlgo {
+  Default,
+  Ring,
+  TreeUnsupported,
+  PatUnsupported,
+  CtranUnsupported,
+};
+
+struct ReduceNumericalParam {
+  ReduceNumericalAlgo algo;
+  size_t count;
+  ncclDataType_t datatype;
+
+  std::string name() const {
+    std::string algoName;
+    switch (algo) {
+      case ReduceNumericalAlgo::Default:
+        algoName = "Default";
+        break;
+      case ReduceNumericalAlgo::Ring:
+        algoName = "Ring";
+        break;
+      case ReduceNumericalAlgo::TreeUnsupported:
+        algoName = "TreeUnsupported";
+        break;
+      case ReduceNumericalAlgo::PatUnsupported:
+        algoName = "PatUnsupported";
+        break;
+      case ReduceNumericalAlgo::CtranUnsupported:
+        algoName = "CtranUnsupported";
+        break;
+    }
+
+    const std::string dtypeName =
+        datatype == ncclFloat32 ? "Float32" : "Bfloat16";
+    return algoName + "_" + dtypeName + "_" +
+        ncclx::test::numerics::countName(count);
+  }
+};
+
+class ReduceNumericalTest
+    : public NcclxBaseTestFixture,
+      public ::testing::WithParamInterface<ReduceNumericalParam> {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp();
+    algoStats_.enable();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  template <typename T>
+  void run(const ReduceNumericalParam& param) {
+    if (param.algo == ReduceNumericalAlgo::PatUnsupported) {
+      GTEST_SKIP() << "PAT is not a selectable NCCL Reduce algorithm";
+    }
+    if (param.algo == ReduceNumericalAlgo::TreeUnsupported) {
+      GTEST_SKIP() << "TREE is not a selectable NCCL Reduce algorithm";
+    }
+    if (param.algo == ReduceNumericalAlgo::CtranUnsupported) {
+      GTEST_SKIP() << "NCCLX does not provide a CTRAN Reduce path";
+    }
+
+    std::optional<SysEnvRAII> ncclAlgoGuard;
+    if (param.algo == ReduceNumericalAlgo::Ring) {
+      ncclAlgoGuard.emplace("NCCL_ALGO", "RING");
+    }
+
+    ncclx::test::NcclCommRAII comm{
+        globalRank, numRanks, localRank, bootstrap_.get()};
+
+    constexpr int kRoot = 0;
+    T* sendBuf = nullptr;
+    T* recvBuf = nullptr;
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBuf, param.count * sizeof(T)));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBuf, param.count * sizeof(T)));
+
+    const auto hostInput = ncclx::test::numerics::makeReduceInput<T>(
+        globalRank, param.count, kRoot);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        sendBuf,
+        hostInput.data(),
+        param.count * sizeof(T),
+        cudaMemcpyDefault,
+        stream_));
+
+    void* sendHandle = nullptr;
+    void* recvHandle = nullptr;
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, sendBuf, param.count * sizeof(T), &sendHandle));
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, recvBuf, param.count * sizeof(T), &recvHandle));
+
+    const auto result = ncclReduce(
+        sendBuf,
+        recvBuf,
+        param.count,
+        param.datatype,
+        ncclSum,
+        kRoot,
+        comm,
+        stream_);
+    ASSERT_EQ(result, ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    if (globalRank == kRoot) {
+      const auto expected = ncclx::test::numerics::reduceExpected<T>(
+          param.count, numRanks, kRoot);
+      const size_t mismatches = ncclx::test::numerics::countMismatches(
+          recvBuf, expected, stream_, globalRank, param.name());
+      EXPECT_EQ(mismatches, 0) << param.name() << " rank=" << globalRank;
+    }
+
+    if (param.algo == ReduceNumericalAlgo::Ring) {
+      algoStats_.verify(comm, "Reduce", "RING");
+    }
+
+    NCCLCHECK_TEST(ncclCommDeregister(comm, sendHandle));
+    NCCLCHECK_TEST(ncclCommDeregister(comm, recvHandle));
+    NCCLCHECK_TEST(ncclMemFree(sendBuf));
+    NCCLCHECK_TEST(ncclMemFree(recvBuf));
+  }
+
+  cudaStream_t stream_{nullptr};
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+};
+
+TEST_P(ReduceNumericalTest, MatchesFp64Reference) {
+  const auto& param = GetParam();
+  if (param.datatype == ncclFloat32) {
+    run<float>(param);
+  } else if (param.datatype == ncclBfloat16) {
+    run<__nv_bfloat16>(param);
+  } else {
+    FAIL() << "Unhandled datatype in " << param.name();
+  }
+}
+
+const auto kReduceNumericalParams = ::testing::Values(
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::Default,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::Default,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::Ring,
+        .count = 1,
+        .datatype = ncclFloat32},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::Ring,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::Ring,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::TreeUnsupported,
+        .count = 1024,
+        .datatype = ncclFloat32},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::PatUnsupported,
+        .count = 1024,
+        .datatype = ncclFloat32},
+    ReduceNumericalParam{
+        .algo = ReduceNumericalAlgo::CtranUnsupported,
+        .count = 1024,
+        .datatype = ncclFloat32});
+
+INSTANTIATE_TEST_SUITE_P(
+    Reduce,
+    ReduceNumericalTest,
+    kReduceNumericalParams,
+    [](const ::testing::TestParamInfo<ReduceNumericalParam>& info) {
+      return info.param.name();
+    });
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/ReduceScatterNumericalTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterNumericalTest.cc
@@ -1,0 +1,218 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Numerical canaries for NCCL ReduceScatter. These tests are intended to catch
+// NCCL upgrade regressions by comparing forced-algorithm results against an
+// independently computed FP64 host reference for each rank's output chunk.
+
+#include <comm.h>
+#include <cuda_bf16.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <stdlib.h>
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ncclx/meta/tests/NcclCommUtils.h"
+#include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/tests/ReductionNumericalTestUtils.h"
+#include "comms/ncclx/meta/tests/VerifyAlgoStatsUtil.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace {
+
+enum class ReduceScatterNumericalAlgo {
+  Ring,
+  Pat,
+  CtranDirect,
+};
+
+struct ReduceScatterNumericalParam {
+  ReduceScatterNumericalAlgo algo;
+  size_t count;
+  ncclDataType_t datatype;
+
+  std::string name() const {
+    std::string algoName;
+    switch (algo) {
+      case ReduceScatterNumericalAlgo::Ring:
+        algoName = "Ring";
+        break;
+      case ReduceScatterNumericalAlgo::Pat:
+        algoName = "Pat";
+        break;
+      case ReduceScatterNumericalAlgo::CtranDirect:
+        algoName = "CtranDirect";
+        break;
+    }
+
+    const std::string dtypeName =
+        datatype == ncclFloat32 ? "Float32" : "Bfloat16";
+    return algoName + "_" + dtypeName + "_" +
+        ncclx::test::numerics::countName(count);
+  }
+};
+
+class ReduceScatterNumericalTest
+    : public NcclxBaseTestFixture,
+      public ::testing::WithParamInterface<ReduceScatterNumericalParam> {
+ public:
+  void SetUp() override {
+    NcclxBaseTestFixture::SetUp({
+        {"NCCL_CTRAN_ENABLE", "1"},
+        {"NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET", "1"},
+        {"NCCL_PAT_ENABLE", "1"},
+    });
+    algoStats_.enable();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(stream_));
+    NcclxBaseTestFixture::TearDown();
+  }
+
+ protected:
+  template <typename T>
+  void run(const ReduceScatterNumericalParam& param) {
+    std::optional<EnvRAII<enum NCCL_REDUCESCATTER_ALGO>> reduceScatterAlgoGuard;
+    std::optional<SysEnvRAII> ncclAlgoGuard;
+    std::optional<SysEnvRAII> ncclProtoGuard;
+
+    if (param.algo == ReduceScatterNumericalAlgo::Ring) {
+      reduceScatterAlgoGuard.emplace(
+          NCCL_REDUCESCATTER_ALGO, NCCL_REDUCESCATTER_ALGO::orig);
+      ncclAlgoGuard.emplace("NCCL_ALGO", "RING");
+    } else if (param.algo == ReduceScatterNumericalAlgo::Pat) {
+      reduceScatterAlgoGuard.emplace(
+          NCCL_REDUCESCATTER_ALGO, NCCL_REDUCESCATTER_ALGO::orig);
+      ncclAlgoGuard.emplace("NCCL_ALGO", "PAT");
+      ncclProtoGuard.emplace("NCCL_PROTO", "Simple");
+    } else {
+      reduceScatterAlgoGuard.emplace(
+          NCCL_REDUCESCATTER_ALGO, NCCL_REDUCESCATTER_ALGO::ctdirect);
+    }
+
+    ncclx::test::NcclCommRAII comm{
+        globalRank, numRanks, localRank, bootstrap_.get()};
+    if (param.algo == ReduceScatterNumericalAlgo::CtranDirect &&
+        !ctranReduceScatterSupport(
+            comm->ctranComm_.get(), NCCL_REDUCESCATTER_ALGO::ctdirect)) {
+      GTEST_SKIP() << "Ctran ReduceScatter direct is not supported for this "
+                      "topology";
+    }
+
+    T* sendBuf = nullptr;
+    T* recvBuf = nullptr;
+    const size_t sendCount = param.count * static_cast<size_t>(numRanks);
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&sendBuf, sendCount * sizeof(T)));
+    NCCLCHECK_TEST(ncclMemAlloc((void**)&recvBuf, param.count * sizeof(T)));
+
+    const auto hostInput = ncclx::test::numerics::makeReduceScatterInput<T>(
+        globalRank, param.count, numRanks);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        sendBuf,
+        hostInput.data(),
+        sendCount * sizeof(T),
+        cudaMemcpyDefault,
+        stream_));
+
+    void* sendHandle = nullptr;
+    void* recvHandle = nullptr;
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, sendBuf, sendCount * sizeof(T), &sendHandle));
+    NCCLCHECK_TEST(
+        ncclCommRegister(comm, recvBuf, param.count * sizeof(T), &recvHandle));
+
+    const auto result = ncclReduceScatter(
+        sendBuf, recvBuf, param.count, param.datatype, ncclSum, comm, stream_);
+    ASSERT_EQ(result, ncclSuccess);
+    CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+
+    const auto expected = ncclx::test::numerics::reduceScatterExpected<T>(
+        param.count, numRanks, globalRank);
+    const size_t mismatches = ncclx::test::numerics::countMismatches(
+        recvBuf, expected, stream_, globalRank, param.name());
+    EXPECT_EQ(mismatches, 0) << param.name() << " rank=" << globalRank;
+
+    if (param.algo == ReduceScatterNumericalAlgo::Ring) {
+      algoStats_.verify(comm, "ReduceScatter", "RING");
+    } else if (param.algo == ReduceScatterNumericalAlgo::Pat) {
+      algoStats_.verify(comm, "ReduceScatter", "PAT");
+    }
+
+    NCCLCHECK_TEST(ncclCommDeregister(comm, sendHandle));
+    NCCLCHECK_TEST(ncclCommDeregister(comm, recvHandle));
+    NCCLCHECK_TEST(ncclMemFree(sendBuf));
+    NCCLCHECK_TEST(ncclMemFree(recvBuf));
+  }
+
+  cudaStream_t stream_{nullptr};
+  ncclx::test::VerifyAlgoStatsHelper algoStats_;
+};
+
+TEST_P(ReduceScatterNumericalTest, MatchesFp64Reference) {
+  const auto& param = GetParam();
+  if (param.datatype == ncclFloat32) {
+    run<float>(param);
+  } else if (param.datatype == ncclBfloat16) {
+    run<__nv_bfloat16>(param);
+  } else {
+    FAIL() << "Unhandled datatype in " << param.name();
+  }
+}
+
+const auto kReduceScatterNumericalParams = ::testing::Values(
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Ring,
+        .count = 1,
+        .datatype = ncclFloat32},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Ring,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Ring,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Pat,
+        .count = 1,
+        .datatype = ncclFloat32},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Pat,
+        .count = 8193,
+        .datatype = ncclFloat32},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::Pat,
+        .count = 1024,
+        .datatype = ncclBfloat16},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::CtranDirect,
+        .count = 1024,
+        .datatype = ncclFloat32},
+    ReduceScatterNumericalParam{
+        .algo = ReduceScatterNumericalAlgo::CtranDirect,
+        .count = 4099,
+        .datatype = ncclBfloat16});
+
+INSTANTIATE_TEST_SUITE_P(
+    ReduceScatter,
+    ReduceScatterNumericalTest,
+    kReduceScatterNumericalParams,
+    [](const ::testing::TestParamInfo<ReduceScatterNumericalParam>& info) {
+      return info.param.name();
+    });
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new DistEnvironmentBase);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
+++ b/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
@@ -113,6 +113,33 @@ std::vector<ExpectedValue> allReduceExpected(size_t count, int numRanks) {
 }
 
 template <typename T>
+std::vector<T> makeReduceScatterInput(int rank, size_t count, int numRanks) {
+  std::vector<T> input(count * numRanks);
+  for (int chunk = 0; chunk < numRanks; ++chunk) {
+    for (size_t i = 0; i < count; ++i) {
+      input[static_cast<size_t>(chunk) * count + i] =
+          makeDeviceInput<T>(rank, i, chunk);
+    }
+  }
+  return input;
+}
+
+template <typename T>
+std::vector<ExpectedValue>
+reduceScatterExpected(size_t count, int numRanks, int outputRank) {
+  std::vector<ExpectedValue> expected(count);
+  for (size_t i = 0; i < count; ++i) {
+    for (int rank = 0; rank < numRanks; ++rank) {
+      const double value = referenceInput<T>(rank, i, outputRank);
+      expected[i].value += value;
+      expected[i].sumAbsInputs += std::abs(value);
+      expected[i].numInputs++;
+    }
+  }
+  return expected;
+}
+
+template <typename T>
 size_t countMismatches(
     const T* deviceBuffer,
     const std::vector<ExpectedValue>& expected,

--- a/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
+++ b/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
@@ -125,6 +125,30 @@ std::vector<T> makeReduceScatterInput(int rank, size_t count, int numRanks) {
 }
 
 template <typename T>
+std::vector<T> makeReduceInput(int rank, size_t count, int root) {
+  std::vector<T> input(count);
+  for (size_t i = 0; i < count; ++i) {
+    input[i] = makeDeviceInput<T>(rank, i, root);
+  }
+  return input;
+}
+
+template <typename T>
+std::vector<ExpectedValue>
+reduceExpected(size_t count, int numRanks, int root) {
+  std::vector<ExpectedValue> expected(count);
+  for (size_t i = 0; i < count; ++i) {
+    for (int rank = 0; rank < numRanks; ++rank) {
+      const double value = referenceInput<T>(rank, i, root);
+      expected[i].value += value;
+      expected[i].sumAbsInputs += std::abs(value);
+      expected[i].numInputs++;
+    }
+  }
+  return expected;
+}
+
+template <typename T>
 std::vector<ExpectedValue>
 reduceScatterExpected(size_t count, int numRanks, int outputRank) {
   std::vector<ExpectedValue> expected(count);

--- a/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
+++ b/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "comms/testinfra/TestUtils.h"
+
+namespace ncclx::test::numerics {
+
+constexpr size_t kMaxPrintedMismatches = 10;
+
+struct ExpectedValue {
+  double value{0.0};
+  double sumAbsInputs{0.0};
+  int numInputs{0};
+};
+
+inline double bf16Ulp(double value) {
+  const double absValue = std::max(std::abs(value), 1e-30);
+  int exponent = 0;
+  std::frexp(absValue, &exponent);
+  return std::ldexp(1.0, exponent - 8);
+}
+
+inline double rawReductionInput(int rank, size_t index, int lane) {
+  const double sign =
+      ((rank + lane + static_cast<int>(index)) % 2 == 0) ? 1.0 : -1.0;
+  const double rankTerm = 0.25 * static_cast<double>(rank + 1);
+  const double laneTerm = 0.03125 * static_cast<double>((lane % 17) - 8);
+  const double indexTerm =
+      0.0009765625 * static_cast<double>(static_cast<int>(index % 257) - 128);
+  const double jitter =
+      0.00013 *
+      static_cast<double>(
+          (static_cast<int>((index * 17) % 97) + rank * 13 + lane * 7) % 41 -
+          20);
+  return sign * (1.0 + rankTerm) + laneTerm + indexTerm + jitter;
+}
+
+template <typename T>
+T makeDeviceInput(int rank, size_t index, int lane) {
+  return DataTypeTraits<T>::toDevice(
+      static_cast<typename DataTypeTraits<T>::HostT>(
+          rawReductionInput(rank, index, lane)));
+}
+
+template <typename T>
+double referenceInput(int rank, size_t index, int lane) {
+  return static_cast<double>(
+      DataTypeTraits<T>::toHost(makeDeviceInput<T>(rank, index, lane)));
+}
+
+template <typename T>
+double observedValue(T value) {
+  return static_cast<double>(DataTypeTraits<T>::toHost(value));
+}
+
+template <typename T>
+double tolerance(const ExpectedValue& expected) {
+  const double eps = static_cast<double>(
+      std::numeric_limits<typename DataTypeTraits<T>::HostT>::epsilon());
+  return std::max(1e-10, expected.sumAbsInputs * eps * 64.0);
+}
+
+template <>
+inline double tolerance<float>(const ExpectedValue& expected) {
+  return std::max(
+      1e-6,
+      expected.sumAbsInputs *
+          static_cast<double>(std::numeric_limits<float>::epsilon()) * 64.0);
+}
+
+template <>
+inline double tolerance<__nv_bfloat16>(const ExpectedValue& expected) {
+  const double outputQuantization = bf16Ulp(expected.value) * 8.0;
+  const double accumulationMargin = expected.sumAbsInputs *
+      std::pow(2.0, -7.0) *
+      static_cast<double>(std::max(expected.numInputs, 1)) * 0.03;
+  return std::max(outputQuantization, accumulationMargin);
+}
+
+template <typename T>
+std::vector<T> makeAllReduceInput(int rank, size_t count) {
+  std::vector<T> input(count);
+  for (size_t i = 0; i < count; ++i) {
+    input[i] = makeDeviceInput<T>(rank, i, 0);
+  }
+  return input;
+}
+
+template <typename T>
+std::vector<ExpectedValue> allReduceExpected(size_t count, int numRanks) {
+  std::vector<ExpectedValue> expected(count);
+  for (size_t i = 0; i < count; ++i) {
+    for (int rank = 0; rank < numRanks; ++rank) {
+      const double value = referenceInput<T>(rank, i, 0);
+      expected[i].value += value;
+      expected[i].sumAbsInputs += std::abs(value);
+      expected[i].numInputs++;
+    }
+  }
+  return expected;
+}
+
+template <typename T>
+size_t countMismatches(
+    const T* deviceBuffer,
+    const std::vector<ExpectedValue>& expected,
+    cudaStream_t stream,
+    int rank,
+    const std::string& caseName) {
+  std::vector<T> observed(expected.size());
+  CUDACHECK_TEST(cudaMemcpyAsync(
+      observed.data(),
+      deviceBuffer,
+      observed.size() * sizeof(T),
+      cudaMemcpyDefault,
+      stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  size_t mismatches = 0;
+  for (size_t i = 0; i < expected.size(); ++i) {
+    const double actual = observedValue(observed[i]);
+    const double limit = tolerance<T>(expected[i]);
+    const double error = std::abs(actual - expected[i].value);
+    if (error > limit) {
+      if (mismatches < kMaxPrintedMismatches) {
+        ADD_FAILURE() << fmt::format(
+            "{} rank={} index={} expected={:.17g} actual={:.17g} error={:.6g} tolerance={:.6g} sumAbsInputs={:.17g}",
+            caseName,
+            rank,
+            i,
+            expected[i].value,
+            actual,
+            error,
+            limit,
+            expected[i].sumAbsInputs);
+      }
+      mismatches++;
+    }
+  }
+  return mismatches;
+}
+
+inline std::string countName(size_t count) {
+  return fmt::format("Count_{}", count);
+}
+
+} // namespace ncclx::test::numerics


### PR DESCRIPTION
Summary:
Adds a distributed `Reduce` numerical canary that reuses the shared reduction numerical helpers.

The test builds deterministic root-aware inputs, computes the root rank output with an independent FP64 host reference, validates `float32` and `bfloat16` output within dtype-aware tolerances, and covers both unforced/default `Reduce` selection and the selectable forced `RING` path.

Forced `NCCL_ALGO=TREE` currently returns `No algorithm/protocol available for function Reduce` for this target shape, and PAT/CTRAN are not selectable `Reduce` algorithms here. Those algorithm requests are represented as explicit unsupported skip cases so the canary stays reliable without implying silent fallback coverage.

Differential Revision: D108695473


