### PR TITLE
Add timeout support to RdmaTransport read() and waitForWrite()

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -276,15 +276,25 @@ folly::SemiFuture<commResult_t> RdmaTransport::write(
   return sf;
 }
 
-folly::SemiFuture<commResult_t> RdmaTransport::waitForWrite() {
-  CHECK_THROW(connected(), std::runtime_error);
+folly::SemiFuture<commResult_t> RdmaTransport::waitForWrite(
+    std::optional<std::chrono::milliseconds> timeout) {
+  auto currentMockType = mockContext_.rlock()->type;
+
+  if (currentMockType == MockType::None) {
+    CHECK_THROW(connected(), std::runtime_error);
+  }
   CHECK_THROW(evb_, std::runtime_error);
 
   auto work = std::make_unique<Work>();
   work->type = Work::Type::WaitForWrite;
+  work->mockContext.type = currentMockType;
   auto sf = work->promise.getSemiFuture();
 
-  // Add work to pending list and schedule progress
+  if (timeout.has_value()) {
+    work->timeout = timeout;
+    work->creationTime = std::chrono::steady_clock::now();
+  }
+
   auto pendingWorks = pendingWorks_.wlock();
   pendingWorks->emplace_back(std::move(work));
   evb_->runInEventBaseThread([this]() { progress(); });
@@ -294,30 +304,43 @@ folly::SemiFuture<commResult_t> RdmaTransport::waitForWrite() {
 
 folly::SemiFuture<commResult_t> RdmaTransport::read(
     RdmaMemory::MutableView& localBuffer,
-    const RdmaRemoteBuffer& remoteBuffer) {
-  CHECK_THROW(connected(), std::runtime_error);
+    const RdmaRemoteBuffer& remoteBuffer,
+    std::optional<std::chrono::milliseconds> timeout) {
+  auto currentMockType = mockContext_.rlock()->type;
+
+  if (currentMockType == MockType::None) {
+    CHECK_THROW(connected(), std::runtime_error);
+  }
   CHECK_THROW(evb_, std::runtime_error);
 
   CHECK_EQ(cudaDev_, localBuffer->getDevice());
 
   auto work = std::make_unique<Work>();
   work->type = Work::Type::Read;
+  work->mockContext.type = currentMockType;
   auto sf = work->promise.getSemiFuture();
 
-  auto ibRemoteKey = CtranIbRemoteAccessKey::fromString(remoteBuffer.accessKey);
-  CtranIbEpochRAII epochRAII(ib_.get());
-  FB_COMMCHECK(ib_->iget(
-      remoteBuffer.ptr,
-      localBuffer.mutable_data(),
-      localBuffer.size(),
-      kDummyRank,
-      localBuffer->localKey(),
-      ibRemoteKey,
-      nullptr,
-      &work->ibReq,
-      false));
+  if (currentMockType == MockType::None) {
+    auto ibRemoteKey =
+        CtranIbRemoteAccessKey::fromString(remoteBuffer.accessKey);
+    CtranIbEpochRAII epochRAII(ib_.get());
+    FB_COMMCHECK(ib_->iget(
+        remoteBuffer.ptr,
+        localBuffer.mutable_data(),
+        localBuffer.size(),
+        kDummyRank,
+        localBuffer->localKey(),
+        ibRemoteKey,
+        nullptr,
+        &work->ibReq,
+        false));
+  }
 
-  // Add work to pending list and schedule progress
+  if (timeout.has_value()) {
+    work->timeout = timeout;
+    work->creationTime = std::chrono::steady_clock::now();
+  }
+
   auto pendingWorks = pendingWorks_.wlock();
   pendingWorks->emplace_back(std::move(work));
   evb_->runInEventBaseThread([this]() { progress(); });
@@ -375,8 +398,7 @@ void RdmaTransport::progress() {
       continue;
     }
 
-    // Check write timeout (production path only — mock timeout handled above)
-    if ((*it)->type == Work::Type::Write && (*it)->timeout.has_value()) {
+    if ((*it)->timeout.has_value()) {
       auto elapsed = std::chrono::steady_clock::now() - (*it)->creationTime;
       if (elapsed >= (*it)->timeout.value()) {
         (*it)->promise.setValue(commTimeout);

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -382,6 +382,11 @@ class __attribute__((visibility("default"))) RdmaTransport {
   /*
    * [Remote Op] Check the arrival of incoming put transfer from the remote
    * rank.
+   *
+   * @param timeout Optional timeout duration for the waitForWrite operation.
+   *                When specified, the operation will complete with commTimeout
+   *                if the remote write does not arrive within this duration.
+   *                If not specified (nullopt), the wait continues indefinitely.
    */
   folly::SemiFuture<commResult_t> waitForWrite(
       std::optional<std::chrono::milliseconds> timeout = std::nullopt);
@@ -389,6 +394,11 @@ class __attribute__((visibility("default"))) RdmaTransport {
   /*
    * [Remote Op] Transfer data from remote buffer on the peer rank to local
    * buffer via RDMA.
+   *
+   * @param timeout Optional timeout duration for the read operation. When
+   *                specified, the operation will complete with commTimeout if
+   *                the RDMA read does not finish within this duration. If not
+   *                specified (nullopt), the read waits indefinitely.
    */
   folly::SemiFuture<commResult_t> read(
       RdmaMemory::MutableView& localBuffer,

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -300,7 +300,7 @@ struct RdmaRemoteBuffer {
  *     write(), read(), waitForWrite(), connect()
  *
  *   commTimeout — operation exceeded its timeout duration:
- *     write()
+ *     write(), read(), waitForWrite()
  *
  *   commInternalError — IB / transport-level failure:
  *     write(), read(), waitForWrite()
@@ -383,7 +383,8 @@ class __attribute__((visibility("default"))) RdmaTransport {
    * [Remote Op] Check the arrival of incoming put transfer from the remote
    * rank.
    */
-  folly::SemiFuture<commResult_t> waitForWrite();
+  folly::SemiFuture<commResult_t> waitForWrite(
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
   /*
    * [Remote Op] Transfer data from remote buffer on the peer rank to local
@@ -391,7 +392,8 @@ class __attribute__((visibility("default"))) RdmaTransport {
    */
   folly::SemiFuture<commResult_t> read(
       RdmaMemory::MutableView& localBuffer,
-      const RdmaRemoteBuffer& remoteBuffer);
+      const RdmaRemoteBuffer& remoteBuffer,
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
   /*
    * Mock type for testing RDMA transport error scenarios

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -924,6 +924,74 @@ TEST_F(RdmaTransportTest, DestructorCancelsPendingWorks) {
   EXPECT_EQ(cudaFree(buffer), cudaSuccess);
 }
 
+TEST_F(RdmaTransportTest, ReadMockTypeTimeoutWithDuration) {
+  const size_t bufferSize = 1024;
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  std::string myUrl = transport->bind();
+  EXPECT_FALSE(myUrl.empty());
+
+  void* buffer = nullptr;
+  EXPECT_EQ(cudaMalloc(&buffer, bufferSize), cudaSuccess);
+  torch::comms::RdmaMemory rdmaMemory(buffer, bufferSize, cudaDev);
+
+  transport->setMockForTest(
+      {.type = torch::comms::RdmaTransport::MockType::Timeout});
+
+  torch::comms::RdmaRemoteBuffer remoteBuffer{
+      .ptr = buffer, .len = bufferSize, .accessKey = rdmaMemory.remoteKey()};
+
+  auto startTime = std::chrono::steady_clock::now();
+  auto readView = rdmaMemory.createMutableView();
+  auto readFuture =
+      transport->read(readView, remoteBuffer, std::chrono::milliseconds(100));
+
+  auto result = std::move(readFuture).get();
+  auto endTime = std::chrono::steady_clock::now();
+
+  EXPECT_EQ(result, commTimeout);
+
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
+          .count();
+  EXPECT_GE(elapsed, 75);
+
+  EXPECT_EQ(cudaFree(buffer), cudaSuccess);
+}
+
+TEST_F(RdmaTransportTest, WaitForWriteMockTypeTimeoutWithDuration) {
+  const int cudaDev = 0;
+  EXPECT_EQ(cudaSetDevice(cudaDev), cudaSuccess);
+
+  auto evbThread = std::make_unique<folly::ScopedEventBaseThread>();
+
+  auto transport = std::make_unique<torch::comms::RdmaTransport>(
+      cudaDev, evbThread->getEventBase());
+  std::string myUrl = transport->bind();
+  EXPECT_FALSE(myUrl.empty());
+
+  transport->setMockForTest(
+      {.type = torch::comms::RdmaTransport::MockType::Timeout});
+
+  auto startTime = std::chrono::steady_clock::now();
+  auto waitFuture = transport->waitForWrite(std::chrono::milliseconds(100));
+
+  auto result = std::move(waitFuture).get();
+  auto endTime = std::chrono::steady_clock::now();
+
+  EXPECT_EQ(result, commTimeout);
+
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
+          .count();
+  EXPECT_GE(elapsed, 75);
+}
+
 // Test that a production write with a timeout returns commTimeout when IB
 // cannot complete the operation (peer has disconnected).
 TEST_F(RdmaTransportTest, WriteTimeoutProductionDisconnectedPeer) {


### PR DESCRIPTION
 Extend `read()` and `waitForWrite()` with the same optional timeout that `write()` already supports. Generalize the timeout check in `progress()` to all work types instead of gating on `Write`.

Test Plan - 
New mock timeout tests for `read()` and `waitForWrite()`