### PR TITLE
Guard against IsNvLink. (#2919)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -1,6 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #include "comms/uniflow/MultiTransport.h"
+#include "comms/uniflow/drivers/DeviceAdapter.h"
 #include "comms/uniflow/drivers/TopologyDiscovery.h"
 #include "comms/uniflow/logging/Logger.h"
 
@@ -140,7 +141,7 @@ MultiTransportFactory::MultiTransportFactory(
       std::runtime_error);
 
 #ifndef __HIP_PLATFORM_AMD__
-  if (deviceId_ >= 0) {
+  if (deviceId_ >= 0 && isNvlinkAvailable()) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
         deviceId, eventBaseThread_->getEventBase());
     factories_.emplace_back(std::move(nvlink));

--- a/comms/uniflow/drivers/DeviceAdapter.h
+++ b/comms/uniflow/drivers/DeviceAdapter.h
@@ -95,4 +95,11 @@ std::shared_ptr<DeviceAdapter> createDeviceAdapter(
     std::shared_ptr<CudaApi> cudaApi = nullptr,
     std::shared_ptr<CudaDriverApi> cudaDriverApi = nullptr);
 
+/// Whether the NVLink transport is usable on this build's accelerator.
+/// Selected at link time by the platform's backend: true for CUDA (NVLink
+/// is an NVIDIA technology), false for backends with no NVLink. Prefer this
+/// over constructing a DeviceAdapter to read the constant, since adapter
+/// construction may load backend runtimes (e.g. libcuda) unnecessarily.
+bool isNvlinkAvailable();
+
 } // namespace uniflow

--- a/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
+++ b/comms/uniflow/drivers/cuda/CudaDeviceAdapter.cpp
@@ -36,6 +36,10 @@ Result<bool> CudaDeviceAdapter::isDmaBuffSupported(int deviceId) {
   return cudaDriverApi_->isDmaBufSupported(deviceId);
 }
 
+bool isNvlinkAvailable() {
+  return true;
+}
+
 Result<DmaBuff>
 CudaDeviceAdapter::exportDmaBuff(int /* deviceId */, void* ptr, size_t len) {
   if (!cudaDriverApi_) {


### PR DESCRIPTION
Summary:

This PR ensures accelerator without nvlink don't have it enabled.

Reviewed By: saifhhasan

Differential Revision: D108324748


