### PR TITLE
hier-ring AllGather: size-adaptive chunk heuristic + direct/star inter-node IB exchange (small/mid msgs)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -25,11 +25,34 @@ using ::meta::comms::colltrace::CollTraceHandleTriggerState;
 
 namespace {
 
+constexpr size_t kHierarchicalAgOverlapChunk64KiB = 64 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk128KiB = 128 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk256KiB = 256 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk512KiB = 512 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk1MiB = 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk2MiB = 2 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk4MiB = 4 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk8MiB = 8 * 1024 * 1024;
+// At/above this message size we target more (smaller) chunks to deepen the
+// IB/NVL pipeline overlap. Below it, fewer chunks are better because the band
+// is critical-path bound (more chunks regress 4..16MB — see EXP2/EXP4).
+constexpr size_t kHierarchicalAgLargeMsgThreshold = 32 * 1024 * 1024;
+// At/above this (very large) size we deepen the pipeline further (divisor 32 =>
+// ~32 chunks), matching the >=256MiB regime that already reaches NCCL parity.
+// Byte-identical for >=256MiB (chunk caps at 8MiB under either divisor), so
+// only 64MiB/128MiB change vs the 32MiB-threshold divisor.
+constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
+// At/below this message size the inter-node IB phase uses a direct/star
+// exchange (one parallel hop to every other node) instead of the W-1-hop
+// store-and-forward ring, cutting the latency-bound critical path. Bandwidth is
+// identical to the ring (each node still egresses W-1 slices), so this only
+// helps the latency-bound small/mid band and never hurts the bandwidth-bound
+// large sizes. Gated small so each chunk <= the IB pipeline window, which keeps
+// the post-all-sends-then-recv schedule deadlock-free (send backpressure then
+// references only already-drained data, exactly as the ring relies on). At this
+// bound the heuristic chunk is <=512KiB (sendBytes/8), well within the 8MiB IB
+// pipeline window, so every send stays single-window.
+constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
 
 bool rangesOverlap(
     uintptr_t lhs,
@@ -87,7 +110,26 @@ commResult_t validateAllGatherBufferLayout(
 }
 
 size_t selectHierarchicalAgOverlapChunkBytes(size_t sendBytes) {
-  const size_t targetChunkBytes = (sendBytes + 7) / 8;
+  // Tiered chunk count to deepen IB/NVL overlap with message size: ~8 chunks
+  // below 32MiB (critical-path bound — extra chunks regress 4..16MB,
+  // EXP2/EXP4), ~16 chunks at 32MiB, ~32 chunks at >=64MiB (approaching the
+  // >=256MiB regime that already reaches parity). Byte-identical for <32MiB and
+  // >=256MiB (chunk caps at 8MiB), so only 32MiB (16) and 64/128MiB (32) differ
+  // from divisor 8.
+  const size_t divisor = (sendBytes >= kHierarchicalAgVeryLargeMsgThreshold)
+      ? 32
+      : (sendBytes >= kHierarchicalAgLargeMsgThreshold) ? 16
+                                                        : 8;
+  const size_t targetChunkBytes = (sendBytes + divisor - 1) / divisor;
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk64KiB) {
+    return kHierarchicalAgOverlapChunk64KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk128KiB) {
+    return kHierarchicalAgOverlapChunk128KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk256KiB) {
+    return kHierarchicalAgOverlapChunk256KiB;
+  }
   if (targetChunkBytes <= kHierarchicalAgOverlapChunk512KiB) {
     return kHierarchicalAgOverlapChunk512KiB;
   }
@@ -453,6 +495,22 @@ commResult_t ctranAllGatherHierarchicalRing(
       }
       new (&overlapParams.nvl_peers[peer])
           comms::prims::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    // Small-message latency optimization: use a direct/star inter-node IB
+    // exchange instead of the W-1-hop ring. Each rank talks directly to the
+    // same nvl_rank on every other node. See kHierarchicalAgDirectMaxBytes.
+    overlapParams.use_direct = (sendBytes <= kHierarchicalAgDirectMaxBytes) &&
+        (nNodes <= comms::prims::kHierarchicalAgMaxNodes);
+    if (overlapParams.use_direct) {
+      for (int peerNode = 0; peerNode < nNodes; ++peerNode) {
+        if (peerNode == node) {
+          continue;
+        }
+        const int peerGlobal = peerNode * nLocalRanks + localRank;
+        overlapParams.ib_peers[peerNode] =
+            mpt->get_p2p_ibgda_transport_device(peerGlobal);
+      }
     }
 
     const size_t totalChunks =

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -300,6 +300,67 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         continue;
       }
 
+      if (args.use_direct) {
+        // Direct/star inter-node exchange: copy own slice locally, send it to
+        // every other node, then receive every other node's slice. One
+        // parallel hop on independent QPs instead of the W-1 sequential
+        // store-and-forward ring hops. Host gates this to small messages so
+        // each chunk fits within one IB pipeline window, which keeps the
+        // post-all-sends-then-recv schedule deadlock-free (send backpressure
+        // references only already-drained data, exactly as the ring does).
+        memcpy_vectorized(own_dst, send_src, bytes, group);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          args.ib_peers[m]->template send<Memcpy>(
+              group,
+              send_src,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          char* dst = args.recvbuf +
+              (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
+                  args.sendcount +
+              off;
+          args.ib_peers[m]->template recv<Memcpy>(
+              group,
+              dst,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+            args.ready_sequence);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          publish_ready(
+              group,
+              args.ready_counters,
+              static_cast<std::size_t>(m) * total_chunks + chunk,
+              args.ready_sequence);
+        }
+        trace_hierarchical_allgather(
+            args.trace,
+            group,
+            PipesTraceEventType::kHierAgIbChunkReady,
+            chunk,
+            args.ib_rank);
+        continue;
+      }
+
       const auto& topo = args.ib_ring;
       auto& prev = *topo.prev;
       auto& next = *topo.next;

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -13,6 +13,11 @@ namespace comms::prims {
 
 class P2pIbgdaTransportDevice;
 
+// Max number of inter-node (IB) peers addressable by the direct/star small-
+// message path. The testbed is 4 nodes; this is sized generously and the host
+// falls back to the ring when nNodes exceeds it.
+inline constexpr int kHierarchicalAgMaxNodes = 32;
+
 struct DirectAllgatherNvlArgs {
   int my_rank{0};
   int num_ranks{0};
@@ -62,6 +67,13 @@ struct HierarchicalAllgatherOverlapArgs {
   char* recvbuf{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  // Direct/star inter-node IB phase for small messages: when use_direct is set,
+  // each rank sends its own slice directly to the same nvl_rank on every other
+  // node (ib_peers[node]) and receives theirs, replacing the W-1 sequential
+  // store-and-forward ring hops with a single parallel hop. ib_peers[ib_rank]
+  // is unused (self).
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherLauncher.cu
+++ b/comms/prims/collectives/AllGatherLauncher.cu
@@ -134,6 +134,16 @@ void launch_hierarchical_allgather_overlap(
   args.sendbuf = params.sendbuf;
   args.recvbuf = params.recvbuf;
   args.ib_ring = params.ib_ring;
+  args.use_direct = params.use_direct;
+  // ib_peers is only populated/used on the direct/star path, which the host
+  // gates to ib_size <= kHierarchicalAgMaxNodes. Guard the copy so a ring-mode
+  // launch with ib_size > kHierarchicalAgMaxNodes does not read/write past the
+  // fixed-size ib_peers arrays.
+  if (params.use_direct) {
+    for (int node = 0; node < params.ib_size; ++node) {
+      args.ib_peers[node] = params.ib_peers[node];
+    }
+  }
   args.trace = params.trace;
   for (int peer = 0; peer < params.nvl_size; ++peer) {
     if (peer == params.nvl_rank) {

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -70,6 +70,8 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   cudaStream_t stream{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 


### PR DESCRIPTION
Summary:
## Context

`CtranAllGatherHierarchicalRing` is a 2-level (2D) AllGather on an N-node x L-GPU mesh (testbed: 4 nodes x 2 GPU = 8 ranks):
- Inter-node phase (IB / IBGDA): exchange each local-GPU "column" across the N nodes.
- Intra-node phase (NVLink): broadcast the gathered columns across the L local GPUs.
The *overlap* kernel pipelines these two phases by splitting the per-rank payload into chunks.

This diff lands two foundational changes to that overlap path. They are prerequisites for the (chunk x peer) decomposition (D108774534) and the gate-widening (D108785156).

## Change 1 - Size-adaptive overlap chunk heuristic

`selectHierarchicalAgOverlapChunkBytes` previously used `chunk = ceil(sendBytes / 8)` with a 512 KiB floor. Consequence: every message <= ~512 KiB collapsed to a SINGLE chunk, so the IB and NVL phases could not overlap and 7 of 8 IB blocks sat idle.

New heuristic:
- Lower the floor to 64 KiB (adds 64/128/256 KiB buckets) so small/mid messages get enough chunks to pipeline IB<->NVL.
- Size-tiered divisors for the large band: 8 below 32 MiB, 16 at >=32 MiB, 32 at >=64 MiB - more chunks = deeper pipeline where the size can amortize it.
- Byte-identical for the previously-shipped large regime (>=256 MiB caps at an 8 MiB chunk under any divisor).

## Change 2 - Direct/star inter-node IB exchange (gated, small/mid)

The inter-node phase historically used a store-and-forward RING: each node forwards a slice to its neighbor, so a column travels W-1 = (nNodes-1) SEQUENTIAL hops. Bandwidth-optimal, but latency is W-1 serial hops - which dominates the small/mid band.

This diff adds a direct/STAR sub-mode (`use_direct`), gated to `sendBytes <= 4 MiB` here (widened later): each rank sends its own slice directly, in parallel, to the same `nvl_rank` on every other node and receives theirs; the NVL broadcast then runs unchanged.

```
Inter-node exchange of one column across 4 nodes (W=4):

  RING relay (before)                  DIRECT / star (this diff)
  n0 -> n1 -> n2 -> n3 -> n0           n0 --+--> n1
                                            +--> n2      (1 parallel hop)
  3 sequential hops (latency ~ 3)           +--> n3
  each link carries 1/4 at a time      each node egresses W-1 slices in parallel
  bandwidth-optimal, latency-bound     same bandwidth, latency ~ 1 hop
```

Invariants preserved:
- Same collective & kernel - still the 2-level hierarchical ring; only the inter-node TOPOLOGY changes for the gated band. The NVL phase is untouched.
- Same bandwidth - each node still egresses W-1 slices; only the schedule differs. So this never hurts the bandwidth-bound large sizes (which stay on the ring).
- Deadlock-free - gated small so each chunk <= the IB pipeline window; the post-all-sends-then-recv schedule has send backpressure reference only already-drained data (the same property the ring relies on). Falls back to the ring when `nNodes > kHierarchicalAgMaxNodes` (32).

## Files
- `AllGatherHierarchicalRing.cc`: new chunk heuristic + `use_direct` gate + `ib_peers[]` wiring.
- `AllGatherDirect.cu`: the direct/star branch in the overlap kernel's IB block.
- `AllGatherDirectTypes.h` / `AllGatherLauncher.{cu,h}`: `use_direct` + `ib_peers[]` plumbing, `kHierarchicalAgMaxNodes`.

## Consolidation
Diff 1/3. No-behavior-change consolidation of shipped diffs D108585862 + D108603358 + D108604712 + D108632488 + D108634337. Cumulative stack code verified byte-identical to original tip D108680338; originals kept intact as fallback.

Differential Revision: D108785157


