### PR TITLE
hier-ring AllGather: parallelize direct/star IB via (chunk x peer) block decomposition + finer IB->NVL handoff

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -25,11 +25,34 @@ using ::meta::comms::colltrace::CollTraceHandleTriggerState;
 
 namespace {
 
+constexpr size_t kHierarchicalAgOverlapChunk64KiB = 64 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk128KiB = 128 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk256KiB = 256 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk512KiB = 512 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk1MiB = 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk2MiB = 2 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk4MiB = 4 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk8MiB = 8 * 1024 * 1024;
+// At/above this message size we target more (smaller) chunks to deepen the
+// IB/NVL pipeline overlap. Below it, fewer chunks are better because the band
+// is critical-path bound (more chunks regress 4..16MB — see EXP2/EXP4).
+constexpr size_t kHierarchicalAgLargeMsgThreshold = 32 * 1024 * 1024;
+// At/above this (very large) size we deepen the pipeline further (divisor 32 =>
+// ~32 chunks), matching the >=256MiB regime that already reaches NCCL parity.
+// Byte-identical for >=256MiB (chunk caps at 8MiB under either divisor), so
+// only 64MiB/128MiB change vs the 32MiB-threshold divisor.
+constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
+// At/below this message size the inter-node IB phase uses a direct/star
+// exchange (one parallel hop to every other node) instead of the W-1-hop
+// store-and-forward ring, cutting the latency-bound critical path. Bandwidth is
+// identical to the ring (each node still egresses W-1 slices), so this only
+// helps the latency-bound small/mid band and never hurts the bandwidth-bound
+// large sizes. Gated small so each chunk <= the IB pipeline window, which keeps
+// the post-all-sends-then-recv schedule deadlock-free (send backpressure then
+// references only already-drained data, exactly as the ring relies on). At this
+// bound the heuristic chunk is <=512KiB (sendBytes/8), well within the 8MiB IB
+// pipeline window, so every send stays single-window.
+constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
 
 bool rangesOverlap(
     uintptr_t lhs,
@@ -87,7 +110,26 @@ commResult_t validateAllGatherBufferLayout(
 }
 
 size_t selectHierarchicalAgOverlapChunkBytes(size_t sendBytes) {
-  const size_t targetChunkBytes = (sendBytes + 7) / 8;
+  // Tiered chunk count to deepen IB/NVL overlap with message size: ~8 chunks
+  // below 32MiB (critical-path bound — extra chunks regress 4..16MB,
+  // EXP2/EXP4), ~16 chunks at 32MiB, ~32 chunks at >=64MiB (approaching the
+  // >=256MiB regime that already reaches parity). Byte-identical for <32MiB and
+  // >=256MiB (chunk caps at 8MiB), so only 32MiB (16) and 64/128MiB (32) differ
+  // from divisor 8.
+  const size_t divisor = (sendBytes >= kHierarchicalAgVeryLargeMsgThreshold)
+      ? 32
+      : (sendBytes >= kHierarchicalAgLargeMsgThreshold) ? 16
+                                                        : 8;
+  const size_t targetChunkBytes = (sendBytes + divisor - 1) / divisor;
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk64KiB) {
+    return kHierarchicalAgOverlapChunk64KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk128KiB) {
+    return kHierarchicalAgOverlapChunk128KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk256KiB) {
+    return kHierarchicalAgOverlapChunk256KiB;
+  }
   if (targetChunkBytes <= kHierarchicalAgOverlapChunk512KiB) {
     return kHierarchicalAgOverlapChunk512KiB;
   }
@@ -453,6 +495,22 @@ commResult_t ctranAllGatherHierarchicalRing(
       }
       new (&overlapParams.nvl_peers[peer])
           comms::prims::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    // Small-message latency optimization: use a direct/star inter-node IB
+    // exchange instead of the W-1-hop ring. Each rank talks directly to the
+    // same nvl_rank on every other node. See kHierarchicalAgDirectMaxBytes.
+    overlapParams.use_direct = (sendBytes <= kHierarchicalAgDirectMaxBytes) &&
+        (nNodes <= comms::prims::kHierarchicalAgMaxNodes);
+    if (overlapParams.use_direct) {
+      for (int peerNode = 0; peerNode < nNodes; ++peerNode) {
+        if (peerNode == node) {
+          continue;
+        }
+        const int peerGlobal = peerNode * nLocalRanks + localRank;
+        overlapParams.ib_peers[peerNode] =
+            mpt->get_p2p_ibgda_transport_device(peerGlobal);
+      }
     }
 
     const size_t totalChunks =

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -54,6 +54,14 @@ constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
 // pipeline window, so every send stays single-window.
 constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
 
+// At/above this size the direct/star path uses the finer IB->NVL handoff
+// (publish each column ready as soon as its data lands rather than batching all
+// publishes after the IB exchange), letting the NVL broadcast overlap the IB
+// phase. Below it (256KiB/512KiB) the chunks are too small for the overlap to
+// pay for the per-peer publish barriers, so those sizes keep the batched
+// handoff (byte-identical to the shipped behavior).
+constexpr size_t kHierarchicalAgFinerNvlMinBytes = 1 * 1024 * 1024;
+
 bool rangesOverlap(
     uintptr_t lhs,
     size_t lhsBytes,
@@ -502,6 +510,8 @@ commResult_t ctranAllGatherHierarchicalRing(
     // same nvl_rank on every other node. See kHierarchicalAgDirectMaxBytes.
     overlapParams.use_direct = (sendBytes <= kHierarchicalAgDirectMaxBytes) &&
         (nNodes <= comms::prims::kHierarchicalAgMaxNodes);
+    overlapParams.use_finer_nvl_handoff = overlapParams.use_direct &&
+        (sendBytes >= kHierarchicalAgFinerNvlMinBytes);
     if (overlapParams.use_direct) {
       for (int peerNode = 0; peerNode < nNodes; ++peerNode) {
         if (peerNode == node) {
@@ -515,6 +525,42 @@ commResult_t ctranAllGatherHierarchicalRing(
 
     const size_t totalChunks =
         (sendBytes + overlapParams.chunk_bytes - 1) / overlapParams.chunk_bytes;
+    // Cap the decomposed direct/star IB block count. Two transport invariants
+    // must hold on this path: (1) the staging slot is keyed by chunk index (the
+    // sub-block group_id), which must be < active_blocks (== ib_num_blocks);
+    // and (2) the IBGDA send/recv state is sized for
+    // NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS, so active_blocks must not exceed it
+    // (else the transport device-traps). Bound the cap by BOTH 32 and
+    // MAX_GROUPS, and use it for BOTH the totalChunks fallback and the final
+    // clamp. The default chunk heuristic + default MAX_GROUPS (128) keep this
+    // byte-identical; a small NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES override
+    // (totalChunks > cap) or a small MAX_GROUPS instead falls back to the
+    // (chunk-count-agnostic) ring rather than trapping.
+    const size_t kHierAgDirectIbBlocksCap =
+        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS < 32
+        ? static_cast<size_t>(NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS)
+        : 32;
+    if (overlapParams.use_direct && totalChunks > kHierAgDirectIbBlocksCap) {
+      overlapParams.use_direct = false;
+      overlapParams.use_finer_nvl_handoff = false;
+    }
+    // Decomposed direct/star exchange: the overlap kernel distributes the
+    // ib_size * totalChunks (chunk, peer) transfers across the IB blocks. Scale
+    // ib_num_blocks so each task can run on its own block (the W-1 peer sends
+    // and recvs of a chunk then run concurrently instead of serially). Capped
+    // to bound the grid; only the direct (small/mid) band is affected, so
+    // messages above the direct gate keep the configured block count and stay
+    // byte-identical.
+    if (overlapParams.use_direct) {
+      size_t directIbBlocks = totalChunks * static_cast<size_t>(nNodes);
+      if (directIbBlocks < static_cast<size_t>(numBlocks)) {
+        directIbBlocks = static_cast<size_t>(numBlocks);
+      }
+      if (directIbBlocks > kHierAgDirectIbBlocksCap) {
+        directIbBlocks = kHierAgDirectIbBlocksCap;
+      }
+      overlapParams.ib_num_blocks = static_cast<int>(directIbBlocks);
+    }
     const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
     FB_COMMCHECK(
         ensureReadyCounterCapacity(comm, readyCounters, overlapParams.stream));

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -261,9 +261,114 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
 
   const bool is_ib_block = base_group.group_id < args.ib_num_blocks;
   if (is_ib_block) {
+    const int W = args.ib_size;
+
+    if (args.use_direct && W > 1) {
+      // Decomposed direct/star inter-node exchange. Instead of one block
+      // issuing the W-1 peer sends and recvs of a chunk serially, distribute
+      // the (chunk, peer) transfers across IB blocks so they run concurrently.
+      // The host sizes ib_num_blocks ~= total_chunks * W for this band, so each
+      // (chunk, peer) task lands on its own block. The transport staging slot
+      // is keyed by chunk only (passed as group_id): it is identical on every
+      // rank and each peer uses an independent transport, so sender and
+      // receiver always agree on the slot. Sends are posted for all tasks
+      // before any recv (single-window chunks => non-blocking puts), preserving
+      // the deadlock-free post-all-sends-then-recv schedule of the per-chunk
+      // path.
+      const std::size_t ib_tasks = total_chunks * static_cast<std::size_t>(W);
+
+      // Phase A: copy own slice (peer == self) and post all peer sends.
+      for (std::size_t task = base_group.group_id; task < ib_tasks;
+           task += args.ib_num_blocks) {
+        const std::size_t chunk = task / static_cast<std::size_t>(W);
+        const int m = static_cast<int>(task % static_cast<std::size_t>(W));
+        const std::size_t off = chunk * chunk_bytes;
+        const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+            ? chunk_bytes
+            : (args.sendcount - off);
+        const char* send_src = args.sendbuf + off;
+        auto group = make_sub_block_group(
+            base_group, static_cast<uint32_t>(chunk), args.ib_num_blocks);
+        if (m == args.ib_rank) {
+          char* own_dst = args.recvbuf +
+              (static_cast<std::size_t>(args.ib_rank) * args.nvl_size +
+               args.nvl_rank) *
+                  args.sendcount +
+              off;
+          trace_hierarchical_allgather(
+              args.trace,
+              group,
+              PipesTraceEventType::kHierAgIbChunkBegin,
+              chunk,
+              args.ib_rank);
+          memcpy_vectorized(own_dst, send_src, bytes, group);
+          if (args.use_finer_nvl_handoff) {
+            publish_ready(
+                group,
+                args.ready_counters,
+                static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+                args.ready_sequence);
+          }
+        } else {
+          args.ib_peers[m]->template send<Memcpy>(
+              group,
+              send_src,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+      }
+
+      // Phase B: receive every peer column and publish readiness.
+      for (std::size_t task = base_group.group_id; task < ib_tasks;
+           task += args.ib_num_blocks) {
+        const std::size_t chunk = task / static_cast<std::size_t>(W);
+        const int m = static_cast<int>(task % static_cast<std::size_t>(W));
+        const std::size_t off = chunk * chunk_bytes;
+        const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+            ? chunk_bytes
+            : (args.sendcount - off);
+        auto group = make_sub_block_group(
+            base_group, static_cast<uint32_t>(chunk), args.ib_num_blocks);
+        if (m == args.ib_rank) {
+          if (!args.use_finer_nvl_handoff) {
+            publish_ready(
+                group,
+                args.ready_counters,
+                static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+                args.ready_sequence);
+          }
+          trace_hierarchical_allgather(
+              args.trace,
+              group,
+              PipesTraceEventType::kHierAgIbChunkReady,
+              chunk,
+              args.ib_rank);
+          continue;
+        }
+        char* dst = args.recvbuf +
+            (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
+                args.sendcount +
+            off;
+        args.ib_peers[m]->template recv<Memcpy>(
+            group,
+            dst,
+            bytes,
+            args.ib_num_blocks,
+            args.ib_signaling_data_size,
+            timeout);
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(m) * total_chunks + chunk,
+            args.ready_sequence);
+      }
+      return;
+    }
+
     auto group = make_sub_block_group(
         base_group, base_group.group_id, args.ib_num_blocks);
-    const int W = args.ib_size;
 
     for (std::size_t chunk = group.group_id; chunk < total_chunks;
          chunk += group.total_groups) {
@@ -291,67 +396,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             args.ready_counters,
             static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
             args.ready_sequence);
-        trace_hierarchical_allgather(
-            args.trace,
-            group,
-            PipesTraceEventType::kHierAgIbChunkReady,
-            chunk,
-            args.ib_rank);
-        continue;
-      }
-
-      if (args.use_direct) {
-        // Direct/star inter-node exchange: copy own slice locally, send it to
-        // every other node, then receive every other node's slice. One
-        // parallel hop on independent QPs instead of the W-1 sequential
-        // store-and-forward ring hops. Host gates this to small messages so
-        // each chunk fits within one IB pipeline window, which keeps the
-        // post-all-sends-then-recv schedule deadlock-free (send backpressure
-        // references only already-drained data, exactly as the ring does).
-        memcpy_vectorized(own_dst, send_src, bytes, group);
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          args.ib_peers[m]->template send<Memcpy>(
-              group,
-              send_src,
-              bytes,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout);
-        }
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          char* dst = args.recvbuf +
-              (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
-                  args.sendcount +
-              off;
-          args.ib_peers[m]->template recv<Memcpy>(
-              group,
-              dst,
-              bytes,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout);
-        }
-        publish_ready(
-            group,
-            args.ready_counters,
-            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
-            args.ready_sequence);
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          publish_ready(
-              group,
-              args.ready_counters,
-              static_cast<std::size_t>(m) * total_chunks + chunk,
-              args.ready_sequence);
-        }
         trace_hierarchical_allgather(
             args.trace,
             group,

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -300,6 +300,67 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         continue;
       }
 
+      if (args.use_direct) {
+        // Direct/star inter-node exchange: copy own slice locally, send it to
+        // every other node, then receive every other node's slice. One
+        // parallel hop on independent QPs instead of the W-1 sequential
+        // store-and-forward ring hops. Host gates this to small messages so
+        // each chunk fits within one IB pipeline window, which keeps the
+        // post-all-sends-then-recv schedule deadlock-free (send backpressure
+        // references only already-drained data, exactly as the ring does).
+        memcpy_vectorized(own_dst, send_src, bytes, group);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          args.ib_peers[m]->template send<Memcpy>(
+              group,
+              send_src,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          char* dst = args.recvbuf +
+              (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
+                  args.sendcount +
+              off;
+          args.ib_peers[m]->template recv<Memcpy>(
+              group,
+              dst,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+            args.ready_sequence);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          publish_ready(
+              group,
+              args.ready_counters,
+              static_cast<std::size_t>(m) * total_chunks + chunk,
+              args.ready_sequence);
+        }
+        trace_hierarchical_allgather(
+            args.trace,
+            group,
+            PipesTraceEventType::kHierAgIbChunkReady,
+            chunk,
+            args.ib_rank);
+        continue;
+      }
+
       const auto& topo = args.ib_ring;
       auto& prev = *topo.prev;
       auto& next = *topo.next;

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -13,6 +13,11 @@ namespace comms::prims {
 
 class P2pIbgdaTransportDevice;
 
+// Max number of inter-node (IB) peers addressable by the direct/star small-
+// message path. The testbed is 4 nodes; this is sized generously and the host
+// falls back to the ring when nNodes exceeds it.
+inline constexpr int kHierarchicalAgMaxNodes = 32;
+
 struct DirectAllgatherNvlArgs {
   int my_rank{0};
   int num_ranks{0};
@@ -62,6 +67,13 @@ struct HierarchicalAllgatherOverlapArgs {
   char* recvbuf{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  // Direct/star inter-node IB phase for small messages: when use_direct is set,
+  // each rank sends its own slice directly to the same nvl_rank on every other
+  // node (ib_peers[node]) and receives theirs, replacing the W-1 sequential
+  // store-and-forward ring hops with a single parallel hop. ib_peers[ib_rank]
+  // is unused (self).
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -74,6 +74,16 @@ struct HierarchicalAllgatherOverlapArgs {
   // is unused (self).
   bool use_direct{false};
   P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
+  // Finer IB->NVL handoff for the direct/star path: when set, the own column is
+  // published ready immediately after the local memcpy (before the sends) and
+  // each peer column is published the moment its recv lands, instead of
+  // batching all W publishes after the whole IB exchange. This lets the NVL
+  // consumer start broadcasting the own column overlapping the IB phase and
+  // begin each peer column as it arrives. Same total publishes (W); only timing
+  // moves earlier. Host gates this to sendBytes >= 1MiB (the chunks there are
+  // big enough that the NVL overlap outweighs the per-peer publish barriers; at
+  // 256KiB/512KiB the tiny chunks made it a net loss, so they stay batched).
+  bool use_finer_nvl_handoff{false};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherLauncher.cu
+++ b/comms/prims/collectives/AllGatherLauncher.cu
@@ -134,6 +134,16 @@ void launch_hierarchical_allgather_overlap(
   args.sendbuf = params.sendbuf;
   args.recvbuf = params.recvbuf;
   args.ib_ring = params.ib_ring;
+  args.use_direct = params.use_direct;
+  // ib_peers is only populated/used on the direct/star path, which the host
+  // gates to ib_size <= kHierarchicalAgMaxNodes. Guard the copy so a ring-mode
+  // launch with ib_size > kHierarchicalAgMaxNodes does not read/write past the
+  // fixed-size ib_peers arrays.
+  if (params.use_direct) {
+    for (int node = 0; node < params.ib_size; ++node) {
+      args.ib_peers[node] = params.ib_peers[node];
+    }
+  }
   args.trace = params.trace;
   for (int peer = 0; peer < params.nvl_size; ++peer) {
     if (peer == params.nvl_rank) {

--- a/comms/prims/collectives/AllGatherLauncher.cu
+++ b/comms/prims/collectives/AllGatherLauncher.cu
@@ -135,6 +135,7 @@ void launch_hierarchical_allgather_overlap(
   args.recvbuf = params.recvbuf;
   args.ib_ring = params.ib_ring;
   args.use_direct = params.use_direct;
+  args.use_finer_nvl_handoff = params.use_finer_nvl_handoff;
   // ib_peers is only populated/used on the direct/star path, which the host
   // gates to ib_size <= kHierarchicalAgMaxNodes. Guard the copy so a ring-mode
   // launch with ib_size > kHierarchicalAgMaxNodes does not read/write past the

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -70,6 +70,8 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   cudaStream_t stream{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -72,6 +72,9 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
   bool use_direct{false};
   P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
+  // Finer IB->NVL handoff for the direct/star path (see
+  // AllGatherDirectTypes.h).
+  bool use_finer_nvl_handoff{false};
   PipesTraceHandle trace{};
 };
 


### PR DESCRIPTION
Summary:
## Problem this diff solves

After D108785157 introduced the direct/star inter-node exchange, a single IB block still issued the W-1 peer SENDS and W-1 RECVS of a chunk SERIALLY. Pipes-trace profiling at 2 MiB showed the inter-node "IB-produce" phase was 82% of wall time, dominated by per-call fixed overhead (staging copy + signal post + barrier) multiplied by the serial call count: ~6 serial ~16us calls per block (3 send + 3 recv).

That is *issue serialization inside one block*, not wire latency (the send posts-and-returns; the wire transfer already overlaps). So the lever is to spread those calls across blocks.

## Change 1 - (chunk x peer) block decomposition

Grid-stride the inter-node producers over `ib_size * totalChunks` (chunk, peer) tasks across the IB blocks, so each block issues exactly ONE send + ONE recv. The W-1 peer transfers of a chunk now run CONCURRENTLY across blocks instead of serially within one. The host scales `ib_num_blocks ~= totalChunks * nNodes` (capped at 32) so each task gets its own block.

```
Per chunk, before vs after (W=4 -> 3 peers):

  BEFORE (one block, serial)            AFTER (chunk x peer, across blocks)
  block b: send p1; send p2; send p3;   blk(c,p1): send p1 ; recv p1
           recv p1; recv p2; recv p3    blk(c,p2): send p2 ; recv p2   (concurrent)
  = 6 serial ~16us calls (~100us)       blk(c,p3): send p3 ; recv p3
                                        = 1 send + 1 recv per block (~16-35us)
```

Correctness / deadlock invariants (preserved):
- The transport staging slot is keyed by CHUNK (passed as `group_id`): identical on every rank, and each peer uses an independent transport, so sender and receiver always agree on the slot.
- Two-phase schedule: Phase A posts all sends, Phase B does all recvs + publishes. Chunks are single-window (host gate), so puts are non-blocking - preserving the deadlock-free post-all-sends-then-recv property.

## Change 2 - Finer IB -> NVL handoff (gated >= 1 MiB)

Previously all W readiness publishes happened AFTER the whole IB exchange. Now each column is published the moment its data lands - the OWN column right after the local memcpy, each PEER column right after its recv. The NVL broadcast can then start overlapping the IB phase and begin each peer column as it arrives. Same total publishes (W); only timing moves earlier. Gated `sendBytes >= 1 MiB` (at 256/512 KiB the tiny chunks don't amortize the per-peer publish barriers, so they keep the batched handoff - byte-identical there).

## Result

Re-profiling at 2 MiB after this diff: IB-produce 82% -> 17% - the serial issue-overhead collapsed exactly as predicted. This is the single biggest win in the stack (e.g. 64KB 0.84x -> 1.67x, 256KB 0.62x -> 1.18x, 2MB 0.50x -> 0.75x vs NCCL).

## Files
- `AllGatherDirect.cu`: the decomposed (chunk x peer) IB branch replaces the per-chunk serial loop; finer-handoff publish points.
- `AllGatherHierarchicalRing.cc`: `ib_num_blocks` scaling for the direct band; `use_finer_nvl_handoff` gate.
- `AllGatherDirectTypes.h` / `AllGatherLauncher.{cu,h}`: `use_finer_nvl_handoff` plumbing.

## Consolidation
Diff 2/3. No-behavior-change consolidation of shipped diffs D108645268 + D108661961. Kept standalone - it is the highest-value, most-scrutinized change. Cumulative stack code byte-identical to original tip D108680338.

Differential Revision: D108774534


