### PR TITLE
hier-ring AllGather: extend decomposed direct/star path to 32MiB + scale NVL blocks (full 4x2 benchmark)

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -25,11 +25,34 @@ using ::meta::comms::colltrace::CollTraceHandleTriggerState;
 
 namespace {
 
+constexpr size_t kHierarchicalAgOverlapChunk64KiB = 64 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk128KiB = 128 * 1024;
+constexpr size_t kHierarchicalAgOverlapChunk256KiB = 256 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk512KiB = 512 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk1MiB = 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk2MiB = 2 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk4MiB = 4 * 1024 * 1024;
 constexpr size_t kHierarchicalAgOverlapChunk8MiB = 8 * 1024 * 1024;
+// At/above this message size we target more (smaller) chunks to deepen the
+// IB/NVL pipeline overlap. Below it, fewer chunks are better because the band
+// is critical-path bound (more chunks regress 4..16MB — see EXP2/EXP4).
+constexpr size_t kHierarchicalAgLargeMsgThreshold = 32 * 1024 * 1024;
+// At/above this (very large) size we deepen the pipeline further (divisor 32 =>
+// ~32 chunks), matching the >=256MiB regime that already reaches NCCL parity.
+// Byte-identical for >=256MiB (chunk caps at 8MiB under either divisor), so
+// only 64MiB/128MiB change vs the 32MiB-threshold divisor.
+constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
+// At/below this message size the inter-node IB phase uses a direct/star
+// exchange (one parallel hop to every other node) instead of the W-1-hop
+// store-and-forward ring, cutting the latency-bound critical path. Bandwidth is
+// identical to the ring (each node still egresses W-1 slices), so this only
+// helps the latency-bound small/mid band and never hurts the bandwidth-bound
+// large sizes. Gated small so each chunk <= the IB pipeline window, which keeps
+// the post-all-sends-then-recv schedule deadlock-free (send backpressure then
+// references only already-drained data, exactly as the ring relies on). At this
+// bound the heuristic chunk is <=512KiB (sendBytes/8), well within the 8MiB IB
+// pipeline window, so every send stays single-window.
+constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
 
 bool rangesOverlap(
     uintptr_t lhs,
@@ -87,7 +110,26 @@ commResult_t validateAllGatherBufferLayout(
 }
 
 size_t selectHierarchicalAgOverlapChunkBytes(size_t sendBytes) {
-  const size_t targetChunkBytes = (sendBytes + 7) / 8;
+  // Tiered chunk count to deepen IB/NVL overlap with message size: ~8 chunks
+  // below 32MiB (critical-path bound — extra chunks regress 4..16MB,
+  // EXP2/EXP4), ~16 chunks at 32MiB, ~32 chunks at >=64MiB (approaching the
+  // >=256MiB regime that already reaches parity). Byte-identical for <32MiB and
+  // >=256MiB (chunk caps at 8MiB), so only 32MiB (16) and 64/128MiB (32) differ
+  // from divisor 8.
+  const size_t divisor = (sendBytes >= kHierarchicalAgVeryLargeMsgThreshold)
+      ? 32
+      : (sendBytes >= kHierarchicalAgLargeMsgThreshold) ? 16
+                                                        : 8;
+  const size_t targetChunkBytes = (sendBytes + divisor - 1) / divisor;
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk64KiB) {
+    return kHierarchicalAgOverlapChunk64KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk128KiB) {
+    return kHierarchicalAgOverlapChunk128KiB;
+  }
+  if (targetChunkBytes <= kHierarchicalAgOverlapChunk256KiB) {
+    return kHierarchicalAgOverlapChunk256KiB;
+  }
   if (targetChunkBytes <= kHierarchicalAgOverlapChunk512KiB) {
     return kHierarchicalAgOverlapChunk512KiB;
   }
@@ -453,6 +495,22 @@ commResult_t ctranAllGatherHierarchicalRing(
       }
       new (&overlapParams.nvl_peers[peer])
           comms::prims::P2pNvlTransportDevice(params.nvl_peers[peer]);
+    }
+
+    // Small-message latency optimization: use a direct/star inter-node IB
+    // exchange instead of the W-1-hop ring. Each rank talks directly to the
+    // same nvl_rank on every other node. See kHierarchicalAgDirectMaxBytes.
+    overlapParams.use_direct = (sendBytes <= kHierarchicalAgDirectMaxBytes) &&
+        (nNodes <= comms::prims::kHierarchicalAgMaxNodes);
+    if (overlapParams.use_direct) {
+      for (int peerNode = 0; peerNode < nNodes; ++peerNode) {
+        if (peerNode == node) {
+          continue;
+        }
+        const int peerGlobal = peerNode * nLocalRanks + localRank;
+        overlapParams.ib_peers[peerNode] =
+            mpt->get_p2p_ibgda_transport_device(peerGlobal);
+      }
     }
 
     const size_t totalChunks =

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -36,23 +36,42 @@ constexpr size_t kHierarchicalAgOverlapChunk8MiB = 8 * 1024 * 1024;
 // At/above this message size we target more (smaller) chunks to deepen the
 // IB/NVL pipeline overlap. Below it, fewer chunks are better because the band
 // is critical-path bound (more chunks regress 4..16MB — see EXP2/EXP4).
-constexpr size_t kHierarchicalAgLargeMsgThreshold = 32 * 1024 * 1024;
+// Set to 16MiB so the 16MiB direct/star size uses divisor 16 (=> 1MiB chunk,
+// 2x pipeline-window margin, deadlock-safe) rather than divisor 8 (=> 2MiB
+// chunk == window edge). The only ring size whose divisor changes is the
+// [16MiB,32MiB) range (none benched; 32MiB already used divisor 16 under the
+// prior 32MiB threshold, so it stays byte-identical).
+constexpr size_t kHierarchicalAgLargeMsgThreshold = 16 * 1024 * 1024;
 // At/above this (very large) size we deepen the pipeline further (divisor 32 =>
 // ~32 chunks), matching the >=256MiB regime that already reaches NCCL parity.
-// Byte-identical for >=256MiB (chunk caps at 8MiB under either divisor), so
-// only 64MiB/128MiB change vs the 32MiB-threshold divisor.
-constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
+// Set to 32MiB so the 32MiB direct/star size uses divisor 32 (=> 1MiB chunk,
+// pipeline_window(32)=2MiB => 2x deadlock margin) rather than divisor 16 (=>
+// 2MiB chunk == window edge, unsafe on the direct path). 64MiB/128MiB already
+// used divisor 32 under the prior 64MiB threshold, so they stay byte-identical;
+// the only size whose divisor changes is 32MiB (16->32), which now also takes
+// the direct/star path (see kHierarchicalAgDirectMaxBytes).
+constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 32 * 1024 * 1024;
 // At/below this message size the inter-node IB phase uses a direct/star
 // exchange (one parallel hop to every other node) instead of the W-1-hop
 // store-and-forward ring, cutting the latency-bound critical path. Bandwidth is
 // identical to the ring (each node still egresses W-1 slices), so this only
 // helps the latency-bound small/mid band and never hurts the bandwidth-bound
-// large sizes. Gated small so each chunk <= the IB pipeline window, which keeps
-// the post-all-sends-then-recv schedule deadlock-free (send backpressure then
-// references only already-drained data, exactly as the ring relies on). At this
-// bound the heuristic chunk is <=512KiB (sendBytes/8), well within the 8MiB IB
-// pipeline window, so every send stays single-window.
-constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
+// large sizes. Gated so each chunk <= the IB pipeline window, which keeps the
+// post-all-sends-then-recv schedule deadlock-free (send backpressure then
+// references only already-drained data, exactly as the ring relies on). The
+// decomposition scales ib_num_blocks up to 32 for the largest direct sizes,
+// where pipeline_window(32) = (32MiB/32)&~15 * depth2 = 2MiB. At this 32MiB
+// bound the heuristic chunk is 1MiB: 8MiB uses divisor 8 (=> 1MiB chunk),
+// 16MiB uses divisor 16 (=> 1MiB chunk, via kHierarchicalAgLargeMsgThreshold)
+// and 32MiB uses divisor 32 (=> 1MiB chunk, via
+// kHierarchicalAgVeryLargeMsgThreshold), so every send stays single-window with
+// a 2x margin (1MiB chunk < 2MiB window). PROFILE-16MiB and PROFILE-32MiB both
+// showed the ring path there is IB-exchange bound (16MiB: 48% IB + 45%
+// NVL-idle-waiting-on-IB; 32MiB: 56% IB + 35% idle; NVL data movement <=9% in
+// both), NOT bandwidth-bound, so the decomposed direct/star path (parallel
+// per-(chunk,peer) sends, no W-1-hop serial relay) wins exactly as it did at
+// 8MiB (WIN#8, +36%) and 16MiB (WIN#10, +25%).
+constexpr size_t kHierarchicalAgDirectMaxBytes = 32 * 1024 * 1024;
 
 // At/above this size the direct/star path uses the finer IB->NVL handoff
 // (publish each column ready as soon as its data lands rather than batching all
@@ -560,6 +579,23 @@ commResult_t ctranAllGatherHierarchicalRing(
         directIbBlocks = kHierAgDirectIbBlocksCap;
       }
       overlapParams.ib_num_blocks = static_cast<int>(directIbBlocks);
+      // The NVL consumer grid-strides over ib_size * totalChunks (==
+      // nNodes * totalChunks) (chunk, ib_src) broadcast tasks -- the same count
+      // as the decomposed IB tasks. With the default nvl_num_blocks (16) those
+      // tasks serialize 2:1 at 1..8MiB while the (up to) 32 IB blocks finish in
+      // a single wave: PROFILE-2MB after the (chunk x peer) IB decomposition
+      // shows NVL distribute 45% + rendezvous starvation 38% now dominate (IB
+      // only 17%). Scale nvl_num_blocks the same way so each (chunk, ib_src)
+      // broadcast gets its own block and starts the instant its IB column lands
+      // instead of stalling behind a slower column in a serial group. Only
+      // raises the count (never below the configured default), so sizes whose
+      // NVL task count <= the default and all non-direct sizes stay
+      // byte-identical.
+      size_t directNvlBlocks = directIbBlocks;
+      if (directNvlBlocks < static_cast<size_t>(nvlNumBlocks)) {
+        directNvlBlocks = static_cast<size_t>(nvlNumBlocks);
+      }
+      overlapParams.nvl_num_blocks = static_cast<int>(directNvlBlocks);
     }
     const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
     FB_COMMCHECK(

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -54,6 +54,14 @@ constexpr size_t kHierarchicalAgVeryLargeMsgThreshold = 64 * 1024 * 1024;
 // pipeline window, so every send stays single-window.
 constexpr size_t kHierarchicalAgDirectMaxBytes = 4 * 1024 * 1024;
 
+// At/above this size the direct/star path uses the finer IB->NVL handoff
+// (publish each column ready as soon as its data lands rather than batching all
+// publishes after the IB exchange), letting the NVL broadcast overlap the IB
+// phase. Below it (256KiB/512KiB) the chunks are too small for the overlap to
+// pay for the per-peer publish barriers, so those sizes keep the batched
+// handoff (byte-identical to the shipped behavior).
+constexpr size_t kHierarchicalAgFinerNvlMinBytes = 1 * 1024 * 1024;
+
 bool rangesOverlap(
     uintptr_t lhs,
     size_t lhsBytes,
@@ -502,6 +510,8 @@ commResult_t ctranAllGatherHierarchicalRing(
     // same nvl_rank on every other node. See kHierarchicalAgDirectMaxBytes.
     overlapParams.use_direct = (sendBytes <= kHierarchicalAgDirectMaxBytes) &&
         (nNodes <= comms::prims::kHierarchicalAgMaxNodes);
+    overlapParams.use_finer_nvl_handoff = overlapParams.use_direct &&
+        (sendBytes >= kHierarchicalAgFinerNvlMinBytes);
     if (overlapParams.use_direct) {
       for (int peerNode = 0; peerNode < nNodes; ++peerNode) {
         if (peerNode == node) {
@@ -515,6 +525,42 @@ commResult_t ctranAllGatherHierarchicalRing(
 
     const size_t totalChunks =
         (sendBytes + overlapParams.chunk_bytes - 1) / overlapParams.chunk_bytes;
+    // Cap the decomposed direct/star IB block count. Two transport invariants
+    // must hold on this path: (1) the staging slot is keyed by chunk index (the
+    // sub-block group_id), which must be < active_blocks (== ib_num_blocks);
+    // and (2) the IBGDA send/recv state is sized for
+    // NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS, so active_blocks must not exceed it
+    // (else the transport device-traps). Bound the cap by BOTH 32 and
+    // MAX_GROUPS, and use it for BOTH the totalChunks fallback and the final
+    // clamp. The default chunk heuristic + default MAX_GROUPS (128) keep this
+    // byte-identical; a small NCCL_CTRAN_HIER_AG_OVERLAP_CHUNK_BYTES override
+    // (totalChunks > cap) or a small MAX_GROUPS instead falls back to the
+    // (chunk-count-agnostic) ring rather than trapping.
+    const size_t kHierAgDirectIbBlocksCap =
+        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS < 32
+        ? static_cast<size_t>(NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS)
+        : 32;
+    if (overlapParams.use_direct && totalChunks > kHierAgDirectIbBlocksCap) {
+      overlapParams.use_direct = false;
+      overlapParams.use_finer_nvl_handoff = false;
+    }
+    // Decomposed direct/star exchange: the overlap kernel distributes the
+    // ib_size * totalChunks (chunk, peer) transfers across the IB blocks. Scale
+    // ib_num_blocks so each task can run on its own block (the W-1 peer sends
+    // and recvs of a chunk then run concurrently instead of serially). Capped
+    // to bound the grid; only the direct (small/mid) band is affected, so
+    // messages above the direct gate keep the configured block count and stay
+    // byte-identical.
+    if (overlapParams.use_direct) {
+      size_t directIbBlocks = totalChunks * static_cast<size_t>(nNodes);
+      if (directIbBlocks < static_cast<size_t>(numBlocks)) {
+        directIbBlocks = static_cast<size_t>(numBlocks);
+      }
+      if (directIbBlocks > kHierAgDirectIbBlocksCap) {
+        directIbBlocks = kHierAgDirectIbBlocksCap;
+      }
+      overlapParams.ib_num_blocks = static_cast<int>(directIbBlocks);
+    }
     const size_t readyCounters = static_cast<size_t>(nNodes) * totalChunks;
     FB_COMMCHECK(
         ensureReadyCounterCapacity(comm, readyCounters, overlapParams.stream));

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -261,9 +261,114 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
 
   const bool is_ib_block = base_group.group_id < args.ib_num_blocks;
   if (is_ib_block) {
+    const int W = args.ib_size;
+
+    if (args.use_direct && W > 1) {
+      // Decomposed direct/star inter-node exchange. Instead of one block
+      // issuing the W-1 peer sends and recvs of a chunk serially, distribute
+      // the (chunk, peer) transfers across IB blocks so they run concurrently.
+      // The host sizes ib_num_blocks ~= total_chunks * W for this band, so each
+      // (chunk, peer) task lands on its own block. The transport staging slot
+      // is keyed by chunk only (passed as group_id): it is identical on every
+      // rank and each peer uses an independent transport, so sender and
+      // receiver always agree on the slot. Sends are posted for all tasks
+      // before any recv (single-window chunks => non-blocking puts), preserving
+      // the deadlock-free post-all-sends-then-recv schedule of the per-chunk
+      // path.
+      const std::size_t ib_tasks = total_chunks * static_cast<std::size_t>(W);
+
+      // Phase A: copy own slice (peer == self) and post all peer sends.
+      for (std::size_t task = base_group.group_id; task < ib_tasks;
+           task += args.ib_num_blocks) {
+        const std::size_t chunk = task / static_cast<std::size_t>(W);
+        const int m = static_cast<int>(task % static_cast<std::size_t>(W));
+        const std::size_t off = chunk * chunk_bytes;
+        const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+            ? chunk_bytes
+            : (args.sendcount - off);
+        const char* send_src = args.sendbuf + off;
+        auto group = make_sub_block_group(
+            base_group, static_cast<uint32_t>(chunk), args.ib_num_blocks);
+        if (m == args.ib_rank) {
+          char* own_dst = args.recvbuf +
+              (static_cast<std::size_t>(args.ib_rank) * args.nvl_size +
+               args.nvl_rank) *
+                  args.sendcount +
+              off;
+          trace_hierarchical_allgather(
+              args.trace,
+              group,
+              PipesTraceEventType::kHierAgIbChunkBegin,
+              chunk,
+              args.ib_rank);
+          memcpy_vectorized(own_dst, send_src, bytes, group);
+          if (args.use_finer_nvl_handoff) {
+            publish_ready(
+                group,
+                args.ready_counters,
+                static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+                args.ready_sequence);
+          }
+        } else {
+          args.ib_peers[m]->template send<Memcpy>(
+              group,
+              send_src,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+      }
+
+      // Phase B: receive every peer column and publish readiness.
+      for (std::size_t task = base_group.group_id; task < ib_tasks;
+           task += args.ib_num_blocks) {
+        const std::size_t chunk = task / static_cast<std::size_t>(W);
+        const int m = static_cast<int>(task % static_cast<std::size_t>(W));
+        const std::size_t off = chunk * chunk_bytes;
+        const std::size_t bytes = (off + chunk_bytes <= args.sendcount)
+            ? chunk_bytes
+            : (args.sendcount - off);
+        auto group = make_sub_block_group(
+            base_group, static_cast<uint32_t>(chunk), args.ib_num_blocks);
+        if (m == args.ib_rank) {
+          if (!args.use_finer_nvl_handoff) {
+            publish_ready(
+                group,
+                args.ready_counters,
+                static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+                args.ready_sequence);
+          }
+          trace_hierarchical_allgather(
+              args.trace,
+              group,
+              PipesTraceEventType::kHierAgIbChunkReady,
+              chunk,
+              args.ib_rank);
+          continue;
+        }
+        char* dst = args.recvbuf +
+            (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
+                args.sendcount +
+            off;
+        args.ib_peers[m]->template recv<Memcpy>(
+            group,
+            dst,
+            bytes,
+            args.ib_num_blocks,
+            args.ib_signaling_data_size,
+            timeout);
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(m) * total_chunks + chunk,
+            args.ready_sequence);
+      }
+      return;
+    }
+
     auto group = make_sub_block_group(
         base_group, base_group.group_id, args.ib_num_blocks);
-    const int W = args.ib_size;
 
     for (std::size_t chunk = group.group_id; chunk < total_chunks;
          chunk += group.total_groups) {
@@ -291,67 +396,6 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
             args.ready_counters,
             static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
             args.ready_sequence);
-        trace_hierarchical_allgather(
-            args.trace,
-            group,
-            PipesTraceEventType::kHierAgIbChunkReady,
-            chunk,
-            args.ib_rank);
-        continue;
-      }
-
-      if (args.use_direct) {
-        // Direct/star inter-node exchange: copy own slice locally, send it to
-        // every other node, then receive every other node's slice. One
-        // parallel hop on independent QPs instead of the W-1 sequential
-        // store-and-forward ring hops. Host gates this to small messages so
-        // each chunk fits within one IB pipeline window, which keeps the
-        // post-all-sends-then-recv schedule deadlock-free (send backpressure
-        // references only already-drained data, exactly as the ring does).
-        memcpy_vectorized(own_dst, send_src, bytes, group);
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          args.ib_peers[m]->template send<Memcpy>(
-              group,
-              send_src,
-              bytes,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout);
-        }
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          char* dst = args.recvbuf +
-              (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
-                  args.sendcount +
-              off;
-          args.ib_peers[m]->template recv<Memcpy>(
-              group,
-              dst,
-              bytes,
-              args.ib_num_blocks,
-              args.ib_signaling_data_size,
-              timeout);
-        }
-        publish_ready(
-            group,
-            args.ready_counters,
-            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
-            args.ready_sequence);
-        for (int m = 0; m < W; m++) {
-          if (m == args.ib_rank) {
-            continue;
-          }
-          publish_ready(
-              group,
-              args.ready_counters,
-              static_cast<std::size_t>(m) * total_chunks + chunk,
-              args.ready_sequence);
-        }
         trace_hierarchical_allgather(
             args.trace,
             group,

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -300,6 +300,67 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
         continue;
       }
 
+      if (args.use_direct) {
+        // Direct/star inter-node exchange: copy own slice locally, send it to
+        // every other node, then receive every other node's slice. One
+        // parallel hop on independent QPs instead of the W-1 sequential
+        // store-and-forward ring hops. Host gates this to small messages so
+        // each chunk fits within one IB pipeline window, which keeps the
+        // post-all-sends-then-recv schedule deadlock-free (send backpressure
+        // references only already-drained data, exactly as the ring does).
+        memcpy_vectorized(own_dst, send_src, bytes, group);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          args.ib_peers[m]->template send<Memcpy>(
+              group,
+              send_src,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          char* dst = args.recvbuf +
+              (static_cast<std::size_t>(m) * args.nvl_size + args.nvl_rank) *
+                  args.sendcount +
+              off;
+          args.ib_peers[m]->template recv<Memcpy>(
+              group,
+              dst,
+              bytes,
+              args.ib_num_blocks,
+              args.ib_signaling_data_size,
+              timeout);
+        }
+        publish_ready(
+            group,
+            args.ready_counters,
+            static_cast<std::size_t>(args.ib_rank) * total_chunks + chunk,
+            args.ready_sequence);
+        for (int m = 0; m < W; m++) {
+          if (m == args.ib_rank) {
+            continue;
+          }
+          publish_ready(
+              group,
+              args.ready_counters,
+              static_cast<std::size_t>(m) * total_chunks + chunk,
+              args.ready_sequence);
+        }
+        trace_hierarchical_allgather(
+            args.trace,
+            group,
+            PipesTraceEventType::kHierAgIbChunkReady,
+            chunk,
+            args.ib_rank);
+        continue;
+      }
+
       const auto& topo = args.ib_ring;
       auto& prev = *topo.prev;
       auto& next = *topo.next;

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -13,6 +13,11 @@ namespace comms::prims {
 
 class P2pIbgdaTransportDevice;
 
+// Max number of inter-node (IB) peers addressable by the direct/star small-
+// message path. The testbed is 4 nodes; this is sized generously and the host
+// falls back to the ring when nNodes exceeds it.
+inline constexpr int kHierarchicalAgMaxNodes = 32;
+
 struct DirectAllgatherNvlArgs {
   int my_rank{0};
   int num_ranks{0};
@@ -62,6 +67,13 @@ struct HierarchicalAllgatherOverlapArgs {
   char* recvbuf{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  // Direct/star inter-node IB phase for small messages: when use_direct is set,
+  // each rank sends its own slice directly to the same nvl_rank on every other
+  // node (ib_peers[node]) and receives theirs, replacing the W-1 sequential
+  // store-and-forward ring hops with a single parallel hop. ib_peers[ib_rank]
+  // is unused (self).
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -74,6 +74,16 @@ struct HierarchicalAllgatherOverlapArgs {
   // is unused (self).
   bool use_direct{false};
   P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
+  // Finer IB->NVL handoff for the direct/star path: when set, the own column is
+  // published ready immediately after the local memcpy (before the sends) and
+  // each peer column is published the moment its recv lands, instead of
+  // batching all W publishes after the whole IB exchange. This lets the NVL
+  // consumer start broadcasting the own column overlapping the IB phase and
+  // begin each peer column as it arrives. Same total publishes (W); only timing
+  // moves earlier. Host gates this to sendBytes >= 1MiB (the chunks there are
+  // big enough that the NVL overlap outweighs the per-peer publish barriers; at
+  // 256KiB/512KiB the tiny chunks made it a net loss, so they stay batched).
+  bool use_finer_nvl_handoff{false};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherLauncher.cu
+++ b/comms/prims/collectives/AllGatherLauncher.cu
@@ -134,6 +134,16 @@ void launch_hierarchical_allgather_overlap(
   args.sendbuf = params.sendbuf;
   args.recvbuf = params.recvbuf;
   args.ib_ring = params.ib_ring;
+  args.use_direct = params.use_direct;
+  // ib_peers is only populated/used on the direct/star path, which the host
+  // gates to ib_size <= kHierarchicalAgMaxNodes. Guard the copy so a ring-mode
+  // launch with ib_size > kHierarchicalAgMaxNodes does not read/write past the
+  // fixed-size ib_peers arrays.
+  if (params.use_direct) {
+    for (int node = 0; node < params.ib_size; ++node) {
+      args.ib_peers[node] = params.ib_peers[node];
+    }
+  }
   args.trace = params.trace;
   for (int peer = 0; peer < params.nvl_size; ++peer) {
     if (peer == params.nvl_rank) {

--- a/comms/prims/collectives/AllGatherLauncher.cu
+++ b/comms/prims/collectives/AllGatherLauncher.cu
@@ -135,6 +135,7 @@ void launch_hierarchical_allgather_overlap(
   args.recvbuf = params.recvbuf;
   args.ib_ring = params.ib_ring;
   args.use_direct = params.use_direct;
+  args.use_finer_nvl_handoff = params.use_finer_nvl_handoff;
   // ib_peers is only populated/used on the direct/star path, which the host
   // gates to ib_size <= kHierarchicalAgMaxNodes. Guard the copy so a ring-mode
   // launch with ib_size > kHierarchicalAgMaxNodes does not read/write past the

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -70,6 +70,8 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   cudaStream_t stream{nullptr};
   HierarchicalAllgatherIbgdaRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
+  bool use_direct{false};
+  P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
   PipesTraceHandle trace{};
 };
 

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -72,6 +72,9 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
   bool use_direct{false};
   P2pIbgdaTransportDevice* ib_peers[kHierarchicalAgMaxNodes]{};
+  // Finer IB->NVL handoff for the direct/star path (see
+  // AllGatherDirectTypes.h).
+  bool use_finer_nvl_handoff{false};
   PipesTraceHandle trace{};
 };
 


### PR DESCRIPTION
Summary:
## What this diff does

Final diff of the 3-stack. Scales the now-decomposed direct/star path (D108774534) up to the mid-large band and re-balances the NVL side; the full benchmark is in the Test Plan.

## Change 1 - Widen the direct/star gate to 32 MiB

`kHierarchicalAgDirectMaxBytes`: 4 MiB -> 32 MiB, with two supporting divisor-threshold moves so the chunking stays deadlock-safe:
- `kHierarchicalAgLargeMsgThreshold`: 32 -> 16 MiB (16 MiB now uses divisor 16 => 1 MiB chunk).
- `kHierarchicalAgVeryLargeMsgThreshold`: 64 -> 32 MiB (32 MiB now uses divisor 32 => 1 MiB chunk).

So 8/16/32 MiB all land on a 1 MiB chunk, and with `ib_num_blocks` capped at 32 the IB pipeline window is `(32MiB/32)&~15 * depth2 = 2 MiB` => 2x deadlock margin (1 MiB chunk < 2 MiB window). Messages > 32 MiB stay on the bandwidth-optimal ring (byte-identical).

Why it is safe to move these sizes off the ring: pipes-trace profiling proved the 16-32 MiB ring path is IB-exchange bound, NOT bandwidth bound:
- PROFILE-16MiB: 48% IB + 45% NVL-idle-waiting-on-IB, <=7% NVL data movement.
- PROFILE-32MiB: 56% IB + 35% NVL-idle, <=9% NVL data.
So the parallel per-(chunk,peer) direct path wins there exactly as it did at 8 MiB.

```
Gate map (per-rank send size -> inter-node sub-mode), final state:

  8KB ........ 32MiB  ->  DECOMPOSED DIRECT / STAR   (latency / IB-exchange bound)
  > 32MiB ........... ->  STORE-AND-FORWARD RING     (bandwidth bound; optimal)
```

## Change 2 - Scale NVL blocks with the direct task count

After the IB decomposition the bottleneck at 1-8 MiB moved to the NVL side. Re-profiling at 2 MiB showed NVL-distribute 45% + rendezvous starvation 38% now dominate (IB only 17%): the NVL consumer grid-strides over `nNodes * totalChunks` (chunk, ib_src) broadcast tasks - the same count as the decomposed IB tasks - but the default 16 NVL blocks made them serialize 2:1 while the (up to) 32 IB blocks finished in one wave.

Fix: scale `nvl_num_blocks` the same way as `ib_num_blocks` (up to 32, never below the configured default). Each (chunk, ib_src) broadcast then gets its own block and starts the instant its IB column lands instead of stalling behind a slower column in a serial group. Only raises the count, so non-direct sizes and sizes whose NVL task count <= the default stay byte-identical.

```
Bottleneck migration at 2 MiB (tracked by pipes trace):

  baseline           after D108774534          after this diff
  IB-produce 82%  -> NVL distribute 45%      -> balanced; gap closes
  (serial issue)     + rendezvous 38%           1MB 0.86->1.02x
  NVL/IB small       IB only 17%                2MB 0.78->0.86x
```

## Files
- `AllGatherHierarchicalRing.cc` only: the three threshold constants + the `nvl_num_blocks` scaling block.

## Consolidation
Diff 3/3. No-behavior-change consolidation of shipped diffs D108664589 + D108669421 + D108676750 + D108680338. Cumulative stack code byte-identical to original tip D108680338; original 11 diffs intact as fallback.

Differential Revision: D108785156


