### PR TITLE
Make NVL P2P kernels launch on H100

### DIFF
--- a/comms/prims/benchmarks/BenchmarkMacros.h
+++ b/comms/prims/benchmarks/BenchmarkMacros.h
@@ -4,7 +4,7 @@
 
 #include <cuda_runtime.h>
 #include <folly/logging/xlog.h>
-#include <nccl.h>
+#include <nccl.h> // @manual=//comms/ncclx:nccl
 
 namespace comms::prims::benchmark {
 


### PR DESCRIPTION
Summary:
- Build `benchmark_kernels` and `tile_sendrecv_kernels` as base-H100 CUDA archives so local H100 dev hosts with compute capability 9.0 do not receive `sm_90a`-only benchmark images.
- Prefer static, link-whole linkage for the CUDA kernel objects so `cudaLaunchKernel` receives the same host stub address that CUDA registered, rather than a shared-library PLT entry.
- Move `BenchmarkMacros.h` ownership to the host benchmark targets and annotate the `nccl.h` include for autodeps.

Differential Revision: D108698500


