### PR TITLE
Align tile send/recv protocol bytes (#2925)

### DIFF
--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -672,39 +672,22 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     });
   };
 
+  std::vector<std::size_t> benchmarkSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    benchmarkSizes.push_back(sizeBytes);
+  }
+
   // === BLOCK-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024, "8K", SyncScope::BLOCK, "Block");
-  addNcclConfig(16 * 1024, "16K", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024, "64K", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024, "128K", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024, "256K", SyncScope::BLOCK, "Block");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::BLOCK, "Block");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::BLOCK, "Block");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::BLOCK, "Block");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::BLOCK, "Block");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::BLOCK, "Block");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(sizeBytes, formatSize(sizeBytes), SyncScope::BLOCK, "Block");
+  }
 
   // === CLUSTER-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024, "8K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(16 * 1024, "16K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024, "64K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024, "128K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024, "256K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::CLUSTER, "Cluster");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(
+        sizeBytes, formatSize(sizeBytes), SyncScope::CLUSTER, "Cluster");
+  }
 
   std::vector<BenchmarkResult> results;
 
@@ -773,25 +756,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   std::vector<BenchmarkConfig> configs;
 
   // NCCL-like bidirectional configs at all message sizes
-  std::vector<std::pair<std::size_t, std::string>> bidiSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> bidiSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    bidiSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : bidiSizes) {
     configs.push_back({
         .nBytes = sz,
@@ -821,25 +790,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
     });
   };
 
-  std::vector<std::pair<std::size_t, std::string>> tileSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1 * 1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> tileSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    tileSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : tileSizes) {
     addTileConfig(sz, "Tile_" + nm);
   }

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -640,6 +640,19 @@ static unsigned char multiCallPattern(int rank, int call) {
   return static_cast<unsigned char>(0x30 + rank * 0x20 + call);
 }
 
+static size_t alignTileProtocolBytes(size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+static size_t
+validPayloadBytes(size_t byteOffset, size_t chunkBytes, size_t payloadBytes) {
+  if (byteOffset >= payloadBytes) {
+    return 0;
+  }
+  const size_t remaining = payloadBytes - byteOffset;
+  return chunkBytes < remaining ? chunkBytes : remaining;
+}
+
 static std::vector<char> makeTwoCallPatternBuffer(
     size_t firstCallBytes,
     size_t secondCallBytes,
@@ -713,21 +726,24 @@ static void expectPersistentTwoCallStagingPattern(
     uint64_t baseByte = 0;
     for (int call = 0; call < 2; ++call) {
       const unsigned char expected = multiCallPattern(sourceRank, call);
-      for (size_t dataOff = 0; dataOff < callBytes[call];) {
+      const size_t protocolBytes = alignTileProtocolBytes(callBytes[call]);
+      for (size_t dataOff = 0; dataOff < protocolBytes;) {
         const uint64_t streamStart = baseByte + dataOff;
         const size_t pipelineOff =
             static_cast<size_t>(streamStart % pipelineBytes);
         const size_t slot = pipelineOff / perBlockSlotSize;
         const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
         const size_t slotRemaining = perBlockSlotSize - chunkOff;
-        const size_t dataRemaining = callBytes[call] - dataOff;
+        const size_t dataRemaining = protocolBytes - dataOff;
         size_t chunkBytes =
             effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
         chunkBytes = chunkBytes < slotRemaining ? chunkBytes : slotRemaining;
+        const size_t validBytes =
+            validPayloadBytes(dataOff, chunkBytes, callBytes[call]);
         const size_t offset =
             slot * slotSize + block * perBlockSlotSize + chunkOff;
 
-        for (size_t i = 0; i < chunkBytes; ++i) {
+        for (size_t i = 0; i < validBytes; ++i) {
           EXPECT_EQ(static_cast<unsigned char>(data[offset + i]), expected)
               << label << ": block=" << block << " call=" << call
               << " dataOff=" << dataOff << " byte=" << i;
@@ -737,7 +753,7 @@ static void expectPersistentTwoCallStagingPattern(
         }
         dataOff += chunkBytes;
       }
-      baseByte += callBytes[call];
+      baseByte += protocolBytes;
     }
   }
 }
@@ -844,6 +860,10 @@ class LocalTileHarness {
 
   DeviceBuffer& stagingBuffer() {
     return stagingBuf_;
+  }
+
+  DeviceBuffer& stepStateBuffer() {
+    return stepStateBuf_;
   }
 
   size_t stagingBytes() const {
@@ -1195,6 +1215,223 @@ TEST_F(
       numBlocks,
       0,
       "tile recv persistent cursor");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+
+  LocalTileHarness sendHarness(options, numBlocks);
+  const std::vector<char> hostSend =
+      makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
+  DeviceBuffer sendBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+
+  auto sendOnlyP2p = sendHarness.stagingDevice();
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallSendOnly(
+      sendOnlyP2p,
+      sendTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostStaging(sendHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostStaging.data(),
+      sendHarness.stagingBuffer().get(),
+      sendHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile send unaligned protocol staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostStaging[i]), 0)
+        << "padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> sendStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendStepState.data(),
+      sendHarness.stepStateBuffer().get(),
+      sendStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(sendStepState[0], static_cast<int64_t>(expectedStep));
+
+  LocalTileHarness loopbackHarness(options, numBlocks);
+  DeviceBuffer recvBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+  auto loopbackP2p = loopbackHarness.loopbackDevice();
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallVariableSignalSendRecv(
+      loopbackP2p,
+      sendTiles,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      maxSignalBytes,
+      true,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile sendrecv unaligned protocol");
+
+  std::vector<int64_t> loopbackStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      loopbackStepState.data(),
+      loopbackHarness.stepStateBuffer().get(),
+      loopbackStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(loopbackStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(loopbackStepState[numBlocks], static_cast<int64_t>(expectedStep));
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileForwardUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+  LocalTileHarness predHarness(options, numBlocks);
+  LocalTileHarness succHarness(options, numBlocks);
+
+  auto pred = predHarness.device(predHarness.staging(), nullptr);
+  auto succ = succHarness.device(nullptr, succHarness.staging());
+
+  test::testPrepareTileTwoCallStaging(
+      pred,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceBuffer dstBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, totalBytes));
+  TiledBuffer<char> dstTiles(
+      static_cast<char*>(dstBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallForward(
+      pred,
+      succ,
+      dstTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostDst(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(), dstBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostDst,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol dst");
+
+  std::vector<char> hostSuccStaging(succHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostSuccStaging.data(),
+      succHarness.stagingBuffer().get(),
+      succHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostSuccStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol successor staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostSuccStaging[i]), 0)
+        << "forward padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> predStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      predStepState.data(),
+      predHarness.stepStateBuffer().get(),
+      predStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(predStepState[0], 0);
+  EXPECT_EQ(predStepState[numBlocks], static_cast<int64_t>(expectedStep));
+
+  std::vector<int64_t> succStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      succStepState.data(),
+      succHarness.stepStateBuffer().get(),
+      succStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(succStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(succStepState[numBlocks], 0);
 }
 
 TEST_F(

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -183,6 +183,7 @@ __device__ void wait_for_second_call_signal(
   if (!enabled) {
     return;
   }
+  const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
   const size_t perBlockSlotSize =
       (p2p.options().dataBufferSize / activeBlocks) & ~15ULL;
   const size_t chunkSize =
@@ -190,8 +191,8 @@ __device__ void wait_for_second_call_signal(
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
   const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
-  const uint64_t secondCallStarted = bytesPerCall +
-      (bytesPerCall < effectiveChunk ? bytesPerCall : effectiveChunk);
+  const uint64_t secondCallStarted = protocolBytes +
+      (protocolBytes < effectiveChunk ? protocolBytes : effectiveChunk);
   p2p.tile_state().local_signals[blockId].wait_until(
       group, CmpOp::CMP_GE, secondCallStarted, timeout);
 }
@@ -485,25 +486,31 @@ __global__ void testPrepareTileStagingKernel(
   uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < bytesPerCall;) {
+    const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = bytesPerCall - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < bytesPerCall) {
+        const size_t remaining = bytesPerCall - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += bytesPerCall;
+    baseByte += protocolBytes;
   }
 
   group.sync();
@@ -540,25 +547,31 @@ __global__ void testPrepareTileTwoCallStagingKernel(
   for (int call = 0; call < 2; ++call) {
     const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < callBytes;) {
+    const size_t protocolBytes = (callBytes + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = callBytes - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < callBytes) {
+        const size_t remaining = callBytes - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += callBytes;
+    baseByte += protocolBytes;
   }
 
   group.sync();

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -101,8 +101,9 @@ struct NvlinkTransportTileState {
   // Persistent byte cursors:
   //   [0, tile_max_groups) tracks send progress per tile group.
   //   [tile_max_groups, 2 * tile_max_groups) tracks recv progress.
-  // The byte cursor is independent of max_signal_bytes, so callers may change
-  // signal granularity between calls as long as active_blocks is unchanged.
+  // The byte cursor advances in 16-byte protocol quanta and is independent of
+  // max_signal_bytes, so callers may change signal granularity between calls
+  // as long as active_blocks is unchanged.
   DeviceSpan<int64_t> step_state;
   int tile_max_groups{0};
   DeviceSpan<SignalState> local_signals;
@@ -1490,7 +1491,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1498,7 +1500,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1509,11 +1511,13 @@ class P2pNvlTransportDevice {
             group, CmpOp::CMP_GE, streamEnd - pipelineBytes, timeout);
       }
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         memcpy_vectorized(
             stagBuf + slotOff + stagingOff + chunkOff,
             srcPtr + dataOff,
-            copyBytes,
+            validBytes,
             group);
       }
 
@@ -1526,7 +1530,8 @@ class P2pNvlTransportDevice {
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[groupId] = static_cast<int64_t>(baseByte + nbytes);
+      tile_state_.step_state[groupId] =
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1599,7 +1604,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[max_groups + groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1607,7 +1613,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1616,11 +1622,13 @@ class P2pNvlTransportDevice {
       tile_state_.local_signals[tailSignalId].wait_until(
           group, CmpOp::CMP_GE, streamEnd, timeout);
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1629,7 +1637,7 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         if (chunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, streamEnd);
         }
@@ -1639,7 +1647,7 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(baseByte + nbytes);
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1753,7 +1761,8 @@ class P2pNvlTransportDevice {
     const uint64_t sendBaseByte =
         static_cast<uint64_t>(successor.tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t recvStreamStart = recvBaseByte + dataOff;
       const std::size_t recvPipelineOff =
           static_cast<std::size_t>(recvStreamStart % pipelineBytes);
@@ -1770,7 +1779,7 @@ class P2pNvlTransportDevice {
           sendPipelineOff - sendSlot * perBlockSlotSize;
       const std::size_t recvSlotRemaining = perBlockSlotSize - recvChunkOff;
       const std::size_t sendSlotRemaining = perBlockSlotSize - sendChunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < recvSlotRemaining ? copyBytes : recvSlotRemaining;
@@ -1791,12 +1800,14 @@ class P2pNvlTransportDevice {
 
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::forward(
             dstPtr ? dstPtr + dataOff : nullptr,
             sendBuf + sendSlotOff + stagingOff + sendChunkOff,
             recvBuf + recvSlotOff + stagingOff + recvChunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1811,7 +1822,7 @@ class P2pNvlTransportDevice {
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
         if (recvChunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, recvStreamEnd);
         }
@@ -1821,9 +1832,9 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(recvBaseByte + nbytes);
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
       successor.tile_state_.step_state[groupId] =
-          static_cast<int64_t>(sendBaseByte + nbytes);
+          static_cast<int64_t>(sendBaseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -2061,6 +2072,22 @@ class P2pNvlTransportDevice {
   }
 
  private:
+  __device__ __forceinline__ static std::size_t align_tile_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
+
   const int myRank_{-1};
   const int peerRank_{-1};
   const P2pNvlTransportOptions options_{};


### PR DESCRIPTION
Summary:

- Align NVL tile `send()`, `recv()`, and `forward()` persistent `step_state` cursors to 16-byte protocol quanta while keeping `CopyOp` callbacks payload-sized.
- Prevent an unaligned payload size, for example `100B`, from shifting the next collective call to a misaligned staging offset and degrading subsequent vectorized NVLink staging copies.
- Keep padding bytes transport-private: staging padding is not copied from or to user buffers, but signals and persistent cursors still advance by aligned protocol bytes.
- Add unaligned protocol coverage for send-only staging, two-call send/recv, two-call forward, private padding bytes, and aligned step-state advancement.
- Extend `P2pNvlSendRecvBenchmark` message coverage down to `4B` for unidirectional, bidirectional, and tile sweeps.
- Alignment-width decision: keep the protocol quantum at `16B`. Temporary H100 experiments with `32B`, `64B`, `128B`, `256B`, `512B`, and `1024B` did not produce a stable improvement over `16B` across Tile/TileClus rows, so no tuning diff is proposed.
- Benchmark note: the NVL benchmark target launches correctly in `fbcode//mode/opt`, so no prerequisite benchmark-launch code change is needed. For aligned power-of-two sizes, this correctness fix is performance-neutral within run noise; the expected benefit is avoiding misaligned follow-on calls after unaligned payloads.

Reviewed By: goelayu

Differential Revision: D108669496


