### PR TITLE
Respect env-provided ROCm toolchain paths; fix amd transport includes; disable PyTorch NCCL symm-mem on ROCm

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -363,7 +363,15 @@ fi
 # CUDART_CB (the CUDA host-callback calling-convention macro, empty on Linux)
 # is likewise not mapped by hipify; define it empty so callbacks like
 # drainPipesTraceCallback in comms/prims/trace/PipesTrace.cc parse correctly.
-export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -I${BASE_DIR} -DSO_INCOMING_NAPI_ID=56 -DCUDART_CB= -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
+#
+# ${BASE_DIR} (fbsource/fbcode) must be searched for comms/* headers, but it also
+# contains fbcode's in-tree copies of OSS third-party (folly, snappy, ...). Those
+# track fbsource HEAD and diverge from the pinned OSS deps we build + link into
+# librccl (e.g. folly::IntervalRateLimiter::checkSlow gained a `long` arg),
+# producing undefined symbols at load time. Pass ${BASE_DIR} via -idirafter so it
+# is the lowest-priority include path: the conda-built OSS headers (which we link)
+# win for folly/snappy/etc., while comms/* (only in fbcode) still resolves.
+export CXXFLAGS="-I${CONDA_INCLUDE_DIR} -idirafter ${BASE_DIR} -DSO_INCOMING_NAPI_ID=56 -DCUDART_CB= -DcudaEventWaitDefault=0x00 -DcudaEventWaitExternal=0x01 -DcudaEventRecordDefault=0x00 -DcudaEventRecordExternal=0x01"
 
 # Create linker version script to hide gflags/glog symbols from librccl.so.
 # These get pulled in via static libs (libfolly.a, libthriftcpp2.a) but conflict
@@ -384,8 +392,9 @@ export LDFLAGS="${LDFLAGS:-} -Wl,--version-script=/tmp/rccl_hide_gflags.lds"
 
 mkdir -p "$BUILDDIR"
 pushd "${NCCL_HOME}"
-export ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0
-export CXX=/usr/local/fbcode/platform010/lib/rocm-7.0/lib/llvm/bin/amdclang++
+export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
+export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"
+export CC="${CC:-$ROCM_PATH/lib/llvm/bin/amdclang}"
 
 
 function build_rccl {

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -889,6 +889,14 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/.*/benchmarks/.*")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/collectives/.*")
 # Exclude rdma files — they depend on spdlog which is not available in this build.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/rdma/.*")
+# Exclude the ibrc transport and the MultiPeerIbTransport CRTP base. They are
+# the last remaining piece of the multi-peer IB stack (ibgda/rdma/amd are already
+# excluded above) and instantiate comms::prims::GpuNicDiscovery, whose definition
+# lives in the excluded comms/prims/transport/rdma/NicDiscovery.cc (needs spdlog).
+# Leaving them in produces an undefined vtable for GpuNicDiscovery in librccl at
+# load time. No other compiled source references them.
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/ibrc/.*")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/MultiPeerIbTransport\\.")
 # Exclude window files — they depend on IbgdaBuffer.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/window/.*")
 # Exclude GpuMemHandler and CudaDriverLazy — they depend on cudaTypedefs.h which is not available.
@@ -1399,6 +1407,11 @@ target_include_directories(rccl PRIVATE ${ROCMCORE_PATH}/include)
 target_include_directories(rccl PRIVATE ${HIPIFY_DIR}/comms/rcclx/develop/meta/ctran)
 target_include_directories(rccl PRIVATE ${HIPIFY_DIR}/comms/ctran/utils)
 target_include_directories(rccl PRIVATE ${HIPIFY_DIR}/comms/ctran)
+# comms/prims/transport/amd/ is excluded from sources (not hipified), but its
+# headers (HipDeviceCompat.h, nic/NicConfig.h) are included by compiled
+# transport/ibrc code via bare paths, so put the original source dir on the
+# include path. See the EXCLUDE for comms/prims/transport/amd/.* above.
+target_include_directories(rccl PRIVATE ${FBCODE_DIR}/comms/prims/transport/amd)
 
 if(DEMANGLE_DIR)
   target_include_directories(rccl PRIVATE ${DEMANGLE_DIR})


### PR DESCRIPTION
Summary:
Three rcclx OSS conda build fixes that unblock remote-execution builds.

1) build_rcclx.sh: two changes.
   a. It hardcoded the ROCm toolchain paths:

    export ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0
    export CXX=.../amdclang++

   This unconditionally clobbers ROCM_PATH/CXX that the remote/conda build
   harness injects to point at the sandbox toolchain location. The hardcoded
   path only exists on local devservers, so remote conda builds failed to find
   amdclang++/ROCm. Switch to the env-respecting ${VAR:-default} idiom (matching
   build_rccl.sh and rcclx install.sh), and add the missing CC export:

    export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
    export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"
    export CC="${CC:-$ROCM_PATH/lib/llvm/bin/amdclang}"

   Local builds keep working via the default; remote builds now honor the
   harness-provided paths.
   b. Pass ${BASE_DIR} (fbsource/fbcode) to the rccl compile via -idirafter
      instead of -I. ${BASE_DIR} is required to find comms/* headers, but it
      also exposes fbcode's in-tree OSS third-party (folly, snappy, ...), which
      track fbsource HEAD and diverge from the pinned OSS deps we build and link
      into librccl. CMake passes conda/include as -isystem, which demotes it
      below a plain -I ${BASE_DIR}, so comms TUs compiled against fbcode/folly
      (e.g. IntervalRateLimiter::checkSlow(long)) while librccl links the older
      OSS libfolly.a (checkSlow()) -> undefined symbols (folly + snappy) at
      load time (surfaced when torchaudio/torchvision import torch). -idirafter
      makes ${BASE_DIR} the lowest-priority search path so the conda OSS headers
      (which we link) win for folly/snappy, while comms/* still resolves.

2) CMakeLists.txt: two changes to the rcclx ROCm source set.
   a. comms/prims/transport/amd/ is excluded from hipified sources, but its
      headers (HipDeviceCompat.h, nic/NicConfig.h) are included by compiled
      transport code via bare paths. Add the original source dir to the rccl
      target include path so those includes resolve.
   b. Exclude the ibrc transport and the MultiPeerIbTransport CRTP base. They
      are the last remaining piece of the multi-peer IB stack (ibgda/rdma/amd
      are already excluded) and instantiate comms::prims::GpuNicDiscovery, whose
      definition lives in the excluded transport/rdma/NicDiscovery.cc (needs
      spdlog). Leaving them in produced an undefined vtable for GpuNicDiscovery
      in librccl at load time (surfaced when PyTorch's torchaudio/torchvision
      build imports torch). No other compiled source references them.

3) llama4_rocm.sh: disable PyTorch NCCL symmetric-memory support entirely on
   ROCm. PyTorch keys symm-mem off NCCL_VERSION_CODE in
   torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp (>= 2.27 host, >= 2.28
   device), and rcclx reports 2.28.3, so both get enabled. But rcclx does not
   support symm-mem today:
     - GENERATE_SYM_KERNELS is OFF in rccl's CMakeLists (no symmetric kernels
       are generated), so the host path would be non-functional at runtime.
     - its nccl_device API is older/partial (no
       ncclDevCommRequirements::railGinBarrierCount, etc.), so the device path
       fails to even compile (NCCLSymmetricMemory.cu / nccl_extension.cu:
       "no member named 'railGinBarrierCount'", "use of undeclared identifier
       'ncclGetLsaPointer'").
   Add a rocm::patch_pytorch step (in llama4_rocm.sh, mirroring patch_apex /
   patch_primus_turbo and the rocm:: namespace) that gates both NCCL_VERSION
   checks on !defined(USE_ROCM), compiling out all symm-mem on ROCm (equivalent
   to building against NCCL < 2.27, a supported config; every
   NCCL_HAS_SYMMEM_SUPPORT use in PyTorch is behind #ifdef). It is invoked
   (memoized, applies once) at the start of rocm::build_and_install_pytorch, so
   the fix is fully contained in llama4_rocm.sh with no change to the shared
   llama4.sh. The patch lives in the recipe because the symm_mem .cu files are
   compiled
   unconditionally (no USE_* toggle) and the PyTorch source is a pinned external
   fork (Alkaid-Benetnash/pytorch, v2.11.0-expseg) cloned fresh by the build.
   Revisit if rcclx enables GENERATE_SYM_KERNELS with a matching device API.

   Note: an earlier iteration of this diff instead installed RCCL's nccl_device.h
   / nccl.h headers so the device path could find its includes; that was reverted
   since symm-mem is unsupported on rcclx and is now compiled out on ROCm.

Reviewed By: JinghanHuang

Differential Revision: D108788232


