### PR TITLE
Add block-owned QP lanes (#2927)

### DIFF
--- a/comms/ctran/CtranPipes.cc
+++ b/comms/ctran/CtranPipes.cc
@@ -113,17 +113,17 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
           config.nvlConfig.ll128BufferSize);
     }
 
-    // IBGDA config (ordered to match MultipeerIbgdaTransportConfig fields)
-    config.ibgdaConfig.cudaDevice = comm->statex_->cudaDev();
+    // IB config (ordered to match MultipeerIbTransportConfig fields)
+    config.ibConfig.cudaDevice = comm->statex_->cudaDev();
     if (NCCL_IB_GID_INDEX >= 0) {
-      config.ibgdaConfig.gidIndex = static_cast<int>(NCCL_IB_GID_INDEX);
+      config.ibConfig.gidIndex = static_cast<int>(NCCL_IB_GID_INDEX);
     }
     if (!NCCL_IB_ADDR_FAMILY.empty()) {
-      config.ibgdaConfig.addressFamily = (NCCL_IB_ADDR_FAMILY == "IPV4")
+      config.ibConfig.addressFamily = (NCCL_IB_ADDR_FAMILY == "IPV4")
           ? comms::prims::AddressFamily::IPV4
           : comms::prims::AddressFamily::IPV6;
     }
-    // Pass raw NCCL_IB_HCA string to ibgdaConfig; NicDiscovery's ibHcaParser
+    // Pass raw NCCL_IB_HCA string to ibConfig; NicDiscovery's ibHcaParser
     // handles prefix semantics and port suffixes internally.
     if (!NCCL_IB_HCA.empty()) {
       std::string hcaStr = NCCL_IB_HCA_PREFIX;
@@ -133,7 +133,7 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         }
         hcaStr += NCCL_IB_HCA[i];
       }
-      config.ibgdaConfig.ibHca = std::move(hcaStr);
+      config.ibConfig.ibHca = std::move(hcaStr);
     }
     uint64_t ibgdaDataBufferSize = (pc.ibgdaDataBufferSize > 0)
         ? static_cast<size_t>(pc.ibgdaDataBufferSize)
@@ -142,51 +142,58 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
       ibgdaDataBufferSize = std::max(
           ibgdaDataBufferSize, NCCL_CTRAN_HIER_AG_IBGDA_DATA_BUFFER_SIZE);
     }
-    config.ibgdaConfig.dataBufferSize =
-        static_cast<size_t>(ibgdaDataBufferSize);
-    config.ibgdaConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
+    config.ibConfig.dataBufferSize = static_cast<size_t>(ibgdaDataBufferSize);
+    config.ibConfig.qpDepth = NCCL_CTRAN_IBGDA_QP_DEPTH;
     if (NCCL_IB_TIMEOUT != NCCL_IB_TIMEOUT_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
+      config.ibConfig.timeout = static_cast<uint8_t>(NCCL_IB_TIMEOUT);
     }
     if (NCCL_IB_RETRY_CNT != NCCL_IB_RETRY_CNT_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.retryCount = static_cast<uint8_t>(NCCL_IB_RETRY_CNT);
+      config.ibConfig.retryCount = static_cast<uint8_t>(NCCL_IB_RETRY_CNT);
     }
     if (NCCL_IB_TC != NCCL_IB_TC_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.trafficClass = static_cast<uint8_t>(NCCL_IB_TC);
+      config.ibConfig.trafficClass = static_cast<uint8_t>(NCCL_IB_TC);
     }
     if (NCCL_IB_SL != NCCL_IB_SL_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.serviceLevel = static_cast<uint8_t>(NCCL_IB_SL);
+      config.ibConfig.serviceLevel = static_cast<uint8_t>(NCCL_IB_SL);
     }
     if (NCCL_CTRAN_IBGDA_MIN_RNR_TIMER !=
         NCCL_CTRAN_IBGDA_MIN_RNR_TIMER_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.minRnrTimer =
+      config.ibConfig.minRnrTimer =
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_MIN_RNR_TIMER);
     }
     if (NCCL_CTRAN_IBGDA_RNR_RETRY !=
         NCCL_CTRAN_IBGDA_RNR_RETRY_DEFAULTCVARVALUE) {
-      config.ibgdaConfig.rnrRetry =
+      config.ibConfig.rnrRetry =
           static_cast<uint8_t>(NCCL_CTRAN_IBGDA_RNR_RETRY);
     }
-    config.ibgdaConfig.ibLazyConnect = pc.ibLazyConnect;
-    config.ibgdaConfig.materializePeerTimeoutMs =
+    config.ibConfig.ibLazyConnect = pc.ibLazyConnect;
+    config.ibConfig.materializePeerTimeoutMs =
         NCCL_CTRAN_IBGDA_MATERIALIZE_PEER_TIMEOUT_MS;
+    if (NCCL_CTRAN_IB_MAX_GROUPS <= 0) {
+      CLOGF(
+          ERR,
+          "NCCL_CTRAN_IB_MAX_GROUPS must be positive, got {}",
+          NCCL_CTRAN_IB_MAX_GROUPS);
+      return commInvalidArgument;
+    }
+    if (NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC <= 0) {
+      CLOGF(
+          ERR,
+          "NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC must be positive, got {}",
+          NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
+      return commInvalidArgument;
+    }
+    config.ibConfig.maxGroups = static_cast<int>(NCCL_CTRAN_IB_MAX_GROUPS);
+    config.ibConfig.qpsPerBlockPerNic =
+        static_cast<int>(NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC);
 
     if (NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
-      config.ibgdaConfig.numQpsPerPeerPerNic =
-          static_cast<int>(NCCL_CTRAN_HIER_AG_IB_QPS_PER_PEER_PER_NIC);
-      if (config.ibgdaConfig.dataBufferSize == 0) {
+      if (config.ibConfig.dataBufferSize == 0) {
         CLOGF(
             ERR,
             "NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 requires a positive "
             "IBGDA data-buffer size via NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE "
             "or the per-communicator IBGDA data-buffer override");
-        return commInvalidArgument;
-      }
-      if (NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS <= 0) {
-        CLOGF(
-            ERR,
-            "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS must be positive, got {}",
-            NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
         return commInvalidArgument;
       }
       if (NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH <= 0) {
@@ -196,19 +203,18 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
             NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH);
         return commInvalidArgument;
       }
-      config.ibgdaConfig.sendRecv =
-          comms::prims::MultipeerIbgdaTransportConfig::SendRecvConfig{
-              .maxGroups =
-                  static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS),
+      config.ibConfig.sendRecv =
+          comms::prims::MultipeerIbTransportConfig::SendRecvConfig{
+              .maxGroups = config.ibConfig.maxGroups,
               .pipelineDepth =
                   static_cast<int>(NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH),
           };
       CLOGF(
           INFO,
           "Prims IBGDA sendRecv configured: maxGroups={}, pipelineDepth={}, dataBufferSize={}",
-          config.ibgdaConfig.sendRecv->maxGroups,
-          config.ibgdaConfig.sendRecv->pipelineDepth,
-          config.ibgdaConfig.dataBufferSize);
+          config.ibConfig.sendRecv->maxGroups,
+          config.ibConfig.sendRecv->pipelineDepth,
+          config.ibConfig.dataBufferSize);
     }
 
     if (NCCL_CTRAN_PIPES_IB_MODE == NCCL_CTRAN_PIPES_IB_MODE::ibrc) {
@@ -236,10 +242,10 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
         config.disableIb,
         config.topoConfig.p2pDisable,
         static_cast<int>(config.topoConfig.mnnvlMode),
-        config.ibgdaConfig.dataBufferSize,
-        config.ibgdaConfig.qpDepth,
-        config.ibgdaConfig.ibLazyConnect,
-        config.ibgdaConfig.materializePeerTimeoutMs);
+        config.ibConfig.dataBufferSize,
+        config.ibConfig.qpDepth,
+        config.ibConfig.ibLazyConnect,
+        config.ibConfig.materializePeerTimeoutMs);
 
     CLOGF(
         INFO,
@@ -283,9 +289,9 @@ commResult_t ctranInitializePipes(CtranComm* comm) {
             config);
     CLOGF(
         INFO,
-        "Prims MultiPeerTransport initialized: nvlPeers={}, ibgdaPeers={}, p2pDisable={}",
+        "Prims MultiPeerTransport initialized: nvlPeers={}, ibPeers={}, p2pDisable={}",
         comm->multiPeerTransport_->nvl_n_ranks() - 1,
-        comm->multiPeerTransport_->ibgda_peer_ranks().size(),
+        comm->multiPeerTransport_->ib_peer_ranks().size(),
         config.topoConfig.p2pDisable);
   } catch (const std::exception& e) {
     CLOGF(ERR, "Failed to initialize Prims MultiPeerTransport: {}", e.what());
@@ -408,11 +414,11 @@ commResult_t ctranInitPipesResources(CtranAlgo* algo) {
   int nvlNRanks = comm->multiPeerTransport_->nvl_n_ranks();
   CLOGF(
       INFO,
-      "CTRAN-PRIMS: resource topology rank={} nvlNRanks={} nvlPeers={} ibgdaPeers={}",
+      "CTRAN-PRIMS: resource topology rank={} nvlNRanks={} nvlPeers={} ibPeers={}",
       statex->rank(),
       nvlNRanks,
       nvlNRanks - 1,
-      comm->multiPeerTransport_->ibgda_peer_ranks().size());
+      comm->multiPeerTransport_->ib_peer_ranks().size());
 
   // Wire staging buffers only when there are NVL peers. When P2P is disabled
   // (NCCL_P2P_DISABLE=1), nvlNRanks == 1 (self only) while nLocalRanks may

--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -131,14 +131,14 @@ commResult_t validateHierarchicalRingParams(CtranComm* comm, int numBlocks) {
         numBlocks);
     return commInvalidArgument;
   }
-  if (numBlocks > NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS) {
+  if (numBlocks > NCCL_CTRAN_IB_MAX_GROUPS) {
     CLOGF_SUBSYS(
         WARN,
         COLL,
-        "AllGather {} numBlocks={} exceeds NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+        "AllGather {} numBlocks={} exceeds NCCL_CTRAN_IB_MAX_GROUPS={}",
         allGatherAlgoName(myAlgo),
         numBlocks,
-        NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS);
+        NCCL_CTRAN_IB_MAX_GROUPS);
     return commInvalidArgument;
   }
   if (dataBufferSize / static_cast<uint64_t>(numBlocks) < 16) {

--- a/comms/ctran/algos/AllReduce/AllReduceIbTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbTree.cc
@@ -270,13 +270,13 @@ commResult_t ctranAllReduceTree(
       return result;
     }
 
-    const int maxIbGroups = NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS;
+    const int maxIbGroups = NCCL_CTRAN_IB_MAX_GROUPS;
     const int requiredIbGroups = numBlocks * ctran::allreduce::tree::kTreeLanes;
     if (requiredIbGroups > maxIbGroups) {
       CLOGF(
           ERR,
           "AllReduce ctree requires {} IBGDA send/recv groups, exceeding "
-          "NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+          "NCCL_CTRAN_IB_MAX_GROUPS={}",
           requiredIbGroups,
           maxIbGroups);
       return commInvalidArgument;

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -358,6 +358,12 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
         {"NCCL_CTRAN_USE_PIPES", "1"},
         {"NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1"},
         {"NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432"},
+        // Keep the parameterized CI target focused on collective correctness.
+        // The default IBGDA group cap creates many block-owned QPs on every
+        // test setup, which makes the 68-case tree sweep timeout before it can
+        // finish.
+        {"NCCL_CTRAN_MAX_NBLOCKS", "8"},
+        {"NCCL_CTRAN_IB_MAX_GROUPS", "16"},
     };
 #ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
     envs.emplace_back("NCCL_CTRAN_BACKENDS", "socket, nvl");

--- a/comms/ctran/window/tests/CtranWinDeviceTest.cc
+++ b/comms/ctran/window/tests/CtranWinDeviceTest.cc
@@ -59,11 +59,14 @@ TEST_F(CtranWinDeviceTest, GetDeviceWin) {
   // Verify peer count is consistent with n_ranks
   EXPECT_EQ(devWin.num_peers(), numRanks - 1);
 
-  // NVL and IBGDA peer sets overlap: IBGDA is the universal transport
-  // covering all non-self peers, while NVL is additionally available for
-  // NVLink-connected peers. Verify each independently.
-  EXPECT_EQ(devWin.num_nvl_peers(), numRanks - 1);
-  EXPECT_EQ(devWin.num_ibgda_peers(), numRanks - 1);
+  // Verify peer counts reflect the transport topology. A fully NVL-local run
+  // does not construct IBGDA resources.
+  EXPECT_EQ(
+      devWin.num_nvl_peers(),
+      static_cast<int>(comm->multiPeerTransport_->nvl_peer_ranks().size()));
+  EXPECT_EQ(
+      devWin.num_ibgda_peers(),
+      static_cast<int>(comm->multiPeerTransport_->ib_peer_ranks().size()));
 
   ctran::ctranWinFree(win);
 }

--- a/comms/ncclx/meta/rma/window.cc
+++ b/comms/ncclx/meta/rma/window.cc
@@ -344,7 +344,7 @@ ncclResult_t ncclWinLocalRegisterBuffer(
   // used for IBGDA WQE construction during RDMA writes; NVLink puts never
   // read them. This mirrors HostWindow::registerLocalBuffer which guards
   // the same call with nIbgdaPeers > 0.
-  if (mpt->ibgda_peer_ranks().empty()) {
+  if (mpt->ib_peer_ranks().empty()) {
     return ncclSuccess;
   }
 

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -440,6 +440,131 @@ TEST_F(IbgdaBenchmarkFixture, PutFlush) {
   printResultsTable("IBGDA Put+Flush (RDMA Write)", results);
 }
 
+TEST_F(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
+  // One thread per block uses the no-ThreadGroup put()+flush() API on a
+  // block-private slice. This checks that thread-scope wrappers inherit the
+  // physical block id instead of routing all blocks through block 0's QPs.
+  if (numRanks != 2) {
+    XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
+    return;
+  }
+
+  constexpr int kNumBlocks = 8;
+  constexpr uint8_t kFillPattern = 0x5A;
+  int peerRank = (globalRank == 0) ? 1 : 0;
+  std::vector<IbgdaBenchmarkConfig> configs = {
+      {.nBytes = 8, .name = "8B"},
+      {.nBytes = 64 * 1024, .name = "64KB"},
+  };
+
+  std::size_t maxBytesPerBlock = 0;
+  for (const auto& config : configs) {
+    maxBytesPerBlock = std::max(maxBytesPerBlock, config.nBytes);
+  }
+  const std::size_t maxBufferSize = maxBytesPerBlock * kNumBlocks;
+
+  std::vector<IbgdaBenchmarkResult> results;
+
+  try {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .maxGroups = kNumBlocks,
+    };
+    transportConfig.ibHca = benchIbHca();
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    MultipeerIbgdaTransport transport(
+        globalRank, numRanks, bootstrap, transportConfig);
+    transport.exchange();
+
+    DeviceBuffer dataBuffer(maxBufferSize);
+    auto localDataBuf =
+        transport.registerBuffer(dataBuffer.get(), maxBufferSize);
+
+    auto remoteDataBufs = transport.exchangeBuffer(localDataBuf);
+    int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
+    if (peerIndex < 0 ||
+        static_cast<std::size_t>(peerIndex) >= remoteDataBufs.size()) {
+      throw std::runtime_error(
+          "Peer index out of range for exchanged remote buffers");
+    }
+    auto remoteDataBuf = remoteDataBufs[peerIndex];
+
+    P2pIbgdaTransportDevice* deviceTransportPtr =
+        transport.getP2pTransportDevice(peerRank);
+
+    unsigned long long* d_blockCycles;
+    CUDA_CHECK_VOID(
+        cudaMalloc(&d_blockCycles, kNumBlocks * sizeof(unsigned long long)));
+    std::vector<unsigned long long> blockCycles(kNumBlocks);
+
+    for (const auto& config : configs) {
+      const std::size_t totalBytes = config.nBytes * kNumBlocks;
+      if (globalRank == 0) {
+        CUDA_CHECK_VOID(cudaMemset(dataBuffer.get(), kFillPattern, totalBytes));
+      } else {
+        CUDA_CHECK_VOID(cudaMemset(dataBuffer.get(), 0, totalBytes));
+      }
+      CUDA_CHECK_VOID(cudaDeviceSynchronize());
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (globalRank == 0) {
+        launchIbgdaThreadScopeMultiBlockPutFlushBatch(
+            deviceTransportPtr,
+            localDataBuf,
+            remoteDataBuf,
+            config.nBytes,
+            kNumBlocks,
+            kIbgdaBatchIters,
+            d_blockCycles,
+            stream_);
+        CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
+        CUDA_CHECK_VOID(cudaMemcpy(
+            blockCycles.data(),
+            d_blockCycles,
+            kNumBlocks * sizeof(unsigned long long),
+            cudaMemcpyDeviceToHost));
+
+        unsigned long long maxCycles = 0;
+        for (unsigned long long cycles : blockCycles) {
+          maxCycles = std::max(maxCycles, cycles);
+        }
+
+        IbgdaBenchmarkResult result;
+        result.testName = config.name;
+        result.messageSize = config.nBytes;
+        result.latency = cyclesToUs(maxCycles) / kIbgdaBatchIters;
+        result.bandwidth =
+            (config.nBytes * kNumBlocks / 1e9f) / (result.latency / 1e6f);
+        results.push_back(result);
+      }
+
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+      if (globalRank == 1) {
+        std::vector<uint8_t> hostBuf(totalBytes);
+        CUDA_CHECK_VOID(cudaMemcpy(
+            hostBuf.data(),
+            dataBuffer.get(),
+            totalBytes,
+            cudaMemcpyDeviceToHost));
+        for (std::size_t i = 0; i < totalBytes; i++) {
+          ASSERT_EQ(hostBuf[i], kFillPattern)
+              << "thread-scope multi-block put mismatch at byte " << i;
+        }
+      }
+      MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+    }
+
+    CUDA_CHECK_VOID(cudaFree(d_blockCycles));
+
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+
+  printResultsTable("IBGDA ThreadScope MultiBlock Put+Flush", results);
+}
+
 TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
   // Measures raw RDMA Write latency (put + counter wait via companion QP)
   if (numRanks != 2) {

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -137,6 +137,35 @@ __global__ void ibgdaPutFlushBatchKernel(
   }
 }
 
+__global__ void ibgdaThreadScopeMultiBlockPutFlushBatchKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytesPerBlock,
+    int numIters,
+    unsigned long long* blockCycles) {
+  if (threadIdx.x == 0) {
+    const std::size_t offset = blockIdx.x * nbytesPerBlock;
+    IbgdaLocalBuffer blockLocalBuf = localBuf.subBuffer(offset);
+    IbgdaRemoteBuffer blockRemoteBuf = remoteBuf.subBuffer(offset);
+
+    for (int i = 0; i < 10; i++) {
+      transport->put(blockLocalBuf, blockRemoteBuf, nbytesPerBlock);
+      transport->flush();
+    }
+
+    unsigned long long startCycle = BENCHMARK_CLOCK64();
+
+    for (int i = 0; i < numIters; i++) {
+      transport->put(blockLocalBuf, blockRemoteBuf, nbytesPerBlock);
+      transport->flush();
+    }
+
+    unsigned long long endCycle = BENCHMARK_CLOCK64();
+    blockCycles[blockIdx.x] = endCycle - startCycle;
+  }
+}
+
 __global__ void ibgdaPutSignalWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,
@@ -427,6 +456,24 @@ void launchIbgdaPutFlushBatch(
     cudaStream_t stream) {
   ibgdaPutFlushBatchKernel<<<1, 32, 0, stream>>>(
       transport, localBuf, remoteBuf, nbytes, numIters, totalCycles);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+}
+
+void launchIbgdaThreadScopeMultiBlockPutFlushBatch(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytesPerBlock,
+    int numBlocks,
+    int numIters,
+    unsigned long long* blockCycles,
+    cudaStream_t stream) {
+  ibgdaThreadScopeMultiBlockPutFlushBatchKernel<<<numBlocks, 32, 0, stream>>>(
+      transport, localBuf, remoteBuf, nbytesPerBlock, numIters, blockCycles);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/benchmarks/IbgdaBenchmark.cuh
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cuh
@@ -49,6 +49,14 @@ __global__ void ibgdaPutFlushBatchKernel(
     int numIters,
     unsigned long long* totalCycles);
 
+__global__ void ibgdaThreadScopeMultiBlockPutFlushBatchKernel(
+    P2pIbgdaTransportDevice* transport,
+    IbgdaLocalBuffer localBuf,
+    IbgdaRemoteBuffer remoteBuf,
+    std::size_t nbytesPerBlock,
+    int numIters,
+    unsigned long long* blockCycles);
+
 __global__ void ibgdaPutSignalWaitCounterBatchKernel(
     P2pIbgdaTransportDevice* transport,
     IbgdaLocalBuffer localBuf,

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -71,6 +71,26 @@ void launchIbgdaPutFlushBatch(
     cudaStream_t stream);
 
 /**
+ * Launch batched kernel: one thread per block uses the thread-scope put +
+ * flush API on a block-private buffer slice.
+ *
+ * This exercises the no-ThreadGroup API from multiple physical blocks, so it
+ * catches regressions where thread-scope wrappers accidentally route every
+ * block through block 0's transport state.
+ *
+ * @param blockCycles Output: one cycle count per launched block
+ */
+void launchIbgdaThreadScopeMultiBlockPutFlushBatch(
+    P2pIbgdaTransportDevice* transport,
+    const IbgdaLocalBuffer& localBuf,
+    const IbgdaRemoteBuffer& remoteBuf,
+    std::size_t nbytesPerBlock,
+    int numBlocks,
+    int numIters,
+    unsigned long long* blockCycles,
+    cudaStream_t stream);
+
+/**
  * Launch batched kernel: Multiple put + signal + counter iterations
  *
  * Companion-QP loopback atomically increments the local counter when the

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -187,6 +187,7 @@ __device__ __forceinline__ ThreadGroup make_sub_block_group(
       .thread_id_in_group = group.thread_id_in_group,
       .group_size = group.group_size,
       .group_id = group_id,
+      .block_id = group.block_id,
       .total_groups = total_groups,
       .scope = group.scope};
 }

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -338,12 +338,13 @@ class HierarchicalAllGatherBenchmarkFixture
       MultipeerIbgdaTransportConfig transport_config{
           .cudaDevice = localRank,
           .dataBufferSize = config.data_buffer_size,
+          .maxGroups = config.num_blocks,
           .sendRecv =
               MultipeerIbgdaTransportConfig::SendRecvConfig{
                   .maxGroups = config.num_blocks,
                   .pipelineDepth = config.pipeline_depth,
               },
-          .numQpsPerPeerPerNic = config.num_qps,
+          .qpsPerBlockPerNic = config.num_qps,
       };
       transport_config.ibHca = config.ib_hca;
       ib_transport = std::make_unique<MultipeerIbgdaTransport>(

--- a/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -4,6 +4,7 @@
 #include <folly/logging/xlog.h>
 #include <nccl.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -145,15 +146,16 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     std::unique_ptr<MultipeerIbgdaTransport> transport;
     try {
+      const int maxGroups = config.num_blocks * config.num_rings;
       MultipeerIbgdaTransportConfig transport_config{
           .cudaDevice = localRank,
           .dataBufferSize = config.data_buffer_size,
+          .maxGroups = maxGroups,
           .sendRecv =
               MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .maxGroups = config.num_blocks * config.num_rings,
                   .pipelineDepth = config.pipeline_depth,
               },
-          .numQpsPerPeerPerNic = config.num_qps,
+          .qpsPerBlockPerNic = config.num_qps,
       };
       transport = std::make_unique<MultipeerIbgdaTransport>(
           globalRank, worldSize, bootstrap, transport_config);

--- a/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -4,6 +4,7 @@
 #include <folly/logging/xlog.h>
 #include <nccl.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -152,15 +153,16 @@ class RingReduceScatterBenchmarkFixture
 
     std::unique_ptr<MultipeerIbgdaTransport> transport;
     try {
+      const int maxGroups = config.num_blocks * config.num_rings;
       MultipeerIbgdaTransportConfig transport_config{
           .cudaDevice = localRank,
           .dataBufferSize = config.data_buffer_size,
+          .maxGroups = maxGroups,
           .sendRecv =
               MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .maxGroups = config.num_blocks * config.num_rings,
                   .pipelineDepth = config.pipeline_depth,
               },
-          .numQpsPerPeerPerNic = config.num_qps,
+          .qpsPerBlockPerNic = config.num_qps,
       };
       transport = std::make_unique<MultipeerIbgdaTransport>(
           globalRank, worldSize, bootstrap, transport_config);

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -83,6 +83,12 @@ struct ThreadGroup {
   // For warps: global warp ID. Use for work distribution.
   uint32_t group_id;
 
+  // block_id - Physical CUDA block ID that owns transport resources.
+  // Unlike group_id, this is preserved when groups are partitioned or
+  // renumbered. IBGDA QP selection uses block_id so logical group routing
+  // cannot accidentally move a group onto another block's QPs.
+  uint32_t block_id;
+
   // total_groups - Total number of groups in entire kernel
   // For warps: gridDim.x × (blockDim.x / 32)
   uint32_t total_groups;
@@ -218,6 +224,7 @@ struct ThreadGroup {
         .thread_id_in_group = lane_id,
         .group_size = kWarpSize,
         .group_id = group_id * warps_per_group + warp_in_group,
+        .block_id = block_id,
         .total_groups = total_groups * warps_per_group,
         .scope = SyncScope::WARP};
 #else
@@ -561,6 +568,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
           .thread_id_in_group = thread_id_in_group,
           .group_size = group_size,
           .group_id = group_id - partition_start,
+          .block_id = block_id,
           .total_groups = partition_size,
           .scope = scope}};
 #endif
@@ -650,6 +658,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
             .thread_id_in_group = thread_id_in_group,
             .group_size = group_size,
             .group_id = group_id,
+            .block_id = block_id,
             .total_groups = total_groups,
             .scope = scope}};
   }
@@ -691,6 +700,7 @@ __device__ inline PartitionResult ThreadGroup::partition(
               .thread_id_in_group = thread_id_in_group,
               .group_size = group_size,
               .group_id = group_id - partition_start,
+              .block_id = block_id,
               .total_groups = partition_end - partition_start,
               .scope = scope}};
     }
@@ -751,6 +761,7 @@ __device__ inline PartitionResult ThreadGroup::partition_interleaved(
           .thread_id_in_group = thread_id_in_group,
           .group_size = group_size,
           .group_id = new_group_id,
+          .block_id = block_id,
           .total_groups = groups_in_partition,
           .scope = scope}};
 #endif
@@ -780,6 +791,7 @@ __device__ inline ThreadGroup make_thread_solo() {
       .thread_id_in_group = 0,
       .group_size = 1,
       .group_id = global_tid,
+      .block_id = blockIdx.x,
       .total_groups = total_threads,
       .scope = SyncScope::THREAD};
 #else
@@ -816,6 +828,7 @@ __device__ inline ThreadGroup make_warp_group() {
       .thread_id_in_group = lane_id,
       .group_size = comms::device::kWarpSize,
       .group_id = global_warp_id,
+      .block_id = blockIdx.x,
       .total_groups = total_warps,
       .scope = SyncScope::WARP};
 #else
@@ -879,6 +892,7 @@ __device__ inline ThreadGroup make_cluster_group() {
       .thread_id_in_group = thread_id_in_cluster,
       .group_size = threads_per_cluster,
       .group_id = cluster_rank,
+      .block_id = blockIdx.x,
       .total_groups = num_clusters_x,
       .scope = SyncScope::CLUSTER};
 #else
@@ -888,6 +902,7 @@ __device__ inline ThreadGroup make_cluster_group() {
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
       .group_id = blockIdx.x,
+      .block_id = blockIdx.x,
       .total_groups = gridDim.x,
       .scope = SyncScope::CLUSTER};
 #endif
@@ -914,6 +929,7 @@ __device__ inline ThreadGroup make_block_group() {
       .thread_id_in_group = threadIdx.x,
       .group_size = blockDim.x,
       .group_id = blockIdx.x,
+      .block_id = blockIdx.x,
       .total_groups = gridDim.x,
       .scope = SyncScope::BLOCK};
 #else
@@ -964,6 +980,7 @@ __device__ inline ThreadGroup make_multiwarp_group() {
       .thread_id_in_group = thread_id_in_multiwarp,
       .group_size = kMultiwarpSize,
       .group_id = global_multiwarp_id,
+      .block_id = blockIdx.x,
       .total_groups = total_multiwarps,
       .scope = SyncScope::MULTIWARP};
 #else

--- a/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
+++ b/comms/prims/tests/MultiPeerTransportIntegrationTest.cc
@@ -38,7 +38,7 @@ class MultiPeerIntegrationTestFixture : public MpiBaseTestFixture {
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
             },
-        .ibgdaConfig =
+        .ibConfig =
             {
                 .cudaDevice = localRank,
             },

--- a/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
+++ b/comms/prims/tests/MultiPeerTransportMultiNodeTest.cc
@@ -113,7 +113,7 @@ class MultiPeerTransportMultiNodeFixture : public MpiBaseTestFixture {
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
             },
-        .ibgdaConfig =
+        .ibConfig =
             {
                 .cudaDevice = localRank,
             },
@@ -137,7 +137,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, TopologyDiscoveryMultiNode) {
   auto states = create_transport_states();
 
   int nvlCount = states->nvl_peer_ranks().size();
-  int ibgdaCount = states->ibgda_peer_ranks().size();
+  int ibgdaCount = states->ib_peer_ranks().size();
 
   // IBGDA is universal — always covers all non-self peers.
   EXPECT_EQ(ibgdaCount, numRanks - 1)
@@ -233,8 +233,8 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
   }
 
   // IBGDA is universal — accessor works for ALL non-self peers.
-  ASSERT_EQ(static_cast<int>(states->ibgda_peer_ranks().size()), numRanks - 1);
-  for (int r : states->ibgda_peer_ranks()) {
+  ASSERT_EQ(static_cast<int>(states->ib_peer_ranks().size()), numRanks - 1);
+  for (int r : states->ib_peer_ranks()) {
     auto* p2p = states->get_p2p_ibgda_transport_device(r);
     EXPECT_NE(p2p, nullptr) << "IBGDA transport device null for peer " << r;
   }
@@ -245,7 +245,7 @@ TEST_F(MultiPeerTransportMultiNodeFixture, HostAccessorsMultiNode) {
       globalRank,
       isMnnvl_,
       states->nvl_peer_ranks().size(),
-      states->ibgda_peer_ranks().size());
+      states->ib_peer_ranks().size());
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -52,7 +52,7 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
             },
-        .ibgdaConfig =
+        .ibConfig =
             {
                 .cudaDevice = localRank,
             },
@@ -74,7 +74,7 @@ class MultiPeerTransportTestFixture : public MpiBaseTestFixture {
                 .pipelineDepth = 4,
                 .p2pSignalCount = 4,
             },
-        .ibgdaConfig =
+        .ibConfig =
             {
                 .cudaDevice = localRank,
             },
@@ -155,8 +155,7 @@ TEST_F(MultiPeerTransportTestFixture, TopologyDiscovery) {
   EXPECT_EQ(transport->get_transport_type(globalRank), TransportType::SELF);
   EXPECT_EQ(transport->get_transport_type(peer), TransportType::P2P_NVL);
   EXPECT_FALSE(transport->nvl_peer_ranks().empty());
-  EXPECT_EQ(
-      static_cast<int>(transport->ibgda_peer_ranks().size()), numRanks - 1);
+  EXPECT_EQ(static_cast<int>(transport->ib_peer_ranks().size()), numRanks - 1);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -644,7 +643,7 @@ TEST_F(MultiPeerTransportTestFixture, DisableIb_AllPeersNvl) {
     }
   }
 
-  EXPECT_TRUE(transport->ibgda_peer_ranks().empty());
+  EXPECT_TRUE(transport->ib_peer_ranks().empty());
   for (int r = 0; r < numRanks; ++r) {
     EXPECT_FALSE(transport->has_ibgda(r));
   }
@@ -778,7 +777,7 @@ TEST(MultiPeerTransportDisableIbTest, SucceedsWhenAllPeersNvl) {
         EXPECT_EQ(transport.get_transport_type(r), TransportType::P2P_NVL);
       }
     }
-    EXPECT_TRUE(transport.ibgda_peer_ranks().empty());
+    EXPECT_TRUE(transport.ib_peer_ranks().empty());
   } catch (const std::exception&) {
     // NVL transport creation failed (expected without GPU).
   }

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -93,7 +93,11 @@ class TestIbTransport {
   }
 
   int numQpsPerPeerPerNic() const {
-    return config_.numQpsPerPeerPerNic;
+    return config_.numQpsPerPeerPerNic();
+  }
+
+  int qpsPerBlockPerNic() const {
+    return ibgda_ ? ibgda_->qpsPerBlockPerNic() : config_.qpsPerBlockPerNic;
   }
 
   int getGidIndex() const {
@@ -174,12 +178,14 @@ std::unique_ptr<TestIbTransport> createTestTransport(
     int localRank,
     int numSignalSlots = 1,
     int numCounterSlots = 1,
-    int numQpsPerPeerPerNic = 1) {
+    int maxGroups = 64,
+    int qpsPerBlockPerNic = 1) {
   MultipeerIbTransportConfig config{
       .cudaDevice = localRank,
       .numSignalSlots = numSignalSlots,
       .numCounterSlots = numCounterSlots,
-      .numQpsPerPeerPerNic = numQpsPerPeerPerNic,
+      .maxGroups = maxGroups,
+      .qpsPerBlockPerNic = qpsPerBlockPerNic,
   };
 
   auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
@@ -203,7 +209,8 @@ class MultipeerIbTransportTestFixture
   std::unique_ptr<TestIbTransport> createTransport(
       int numSignalSlots = 1,
       int numCounterSlots = 1,
-      int numQpsPerPeerPerNic = 1) {
+      int maxGroups = 64,
+      int qpsPerBlockPerNic = 1) {
     return createTestTransport(
         backend(),
         globalRank,
@@ -211,7 +218,8 @@ class MultipeerIbTransportTestFixture
         localRank,
         numSignalSlots,
         numCounterSlots,
-        numQpsPerPeerPerNic);
+        maxGroups,
+        qpsPerBlockPerNic);
   }
 };
 
@@ -1971,9 +1979,9 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
   }
 
   try {
-    auto transport = createTransport(1, 1, 4);
+    auto transport = createTransport(1, 1, 1, 4);
 
-    EXPECT_EQ(transport->numQpsPerPeerPerNic(), 4);
+    EXPECT_EQ(transport->qpsPerBlockPerNic(), 4);
     EXPECT_NE(transport->getDeviceTransportPtr(), nullptr);
 
     // Verify each peer has a valid transport pointer
@@ -1986,9 +1994,9 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpConstructAndExchange) {
 
     XLOGF(
         INFO,
-        "Rank {}: Multi-QP transport created with {} QPs/(peer,NIC)",
+        "Rank {}: Multi-QP transport created with {} QPs/block/NIC",
         globalRank,
-        transport->numQpsPerPeerPerNic());
+        transport->qpsPerBlockPerNic());
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend())
                  << " transport not available: " << e.what();
@@ -2012,7 +2020,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpPutSignalBasic) {
   const uint8_t testPattern = 0x77;
 
   try {
-    auto transport = createTransport(1, 1, numQps);
+    auto transport = createTransport(1, 1, numBlocks, numQps);
 
     DeviceBuffer dataBuffer(nbytes);
     auto localDataBuf = transport->registerBuffer(dataBuffer.get(), nbytes);
@@ -2088,14 +2096,14 @@ TEST_P(MultipeerIbTransportTestFixture, MultiQpPutSignalBasic) {
 // Multi-NIC Aggregate Bandwidth Test
 // =============================================================================
 //
-// Drives put_signal traffic through every (NIC × QP) slot for a single peer
-// pair, then measures aggregate bandwidth across all slots. The slot→NIC
-// commutative hash distributes blocks across both NICs at numNics_>1, so
-// aggregate BW ~doubles vs single-NIC if multi-NIC is wired correctly.
+// Drives put_signal traffic through every (NIC × QP lane) slot for a single
+// peer pair, then measures aggregate bandwidth across all slots. Block-owned
+// NIC-first lane selection distributes blocks across both NICs at numNics_>1,
+// so aggregate BW ~doubles vs single-NIC if multi-NIC is wired correctly.
 //
-// Runs on 2 ranks (1 peer pair); uses numQpsPerPeerPerNic=4 so the slot space
-// is 4 × numNics_ (4 slots on H100, 8 on GB200/GB300). The kernel launches
-// numBlocks > total slots so block-driven dispatch saturates every slot.
+// Runs on 2 ranks (1 peer pair); uses qpsPerBlockPerNic=4 so the slot space is
+// 4 × numNics_ (4 slots on H100, 8 on GB200/GB300). The kernel launches
+// numBlocks > total slots so block-driven dispatch can saturate every slot.
 //
 // Acceptance threshold is conservative — picks a floor that single-NIC
 // (~46 GB/s on 400 Gb/s ConnectX-7) cannot exceed but multi-NIC (~80-92
@@ -2117,7 +2125,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
 
   std::unique_ptr<TestIbTransport> transport;
   try {
-    transport = createTransport(1, 1, numQps);
+    transport = createTransport(1, 1, numBlocks, numQps);
   } catch (const std::exception& e) {
     GTEST_SKIP() << backendName(backend())
                  << " transport not available: " << e.what();
@@ -2190,7 +2198,7 @@ TEST_P(MultipeerIbTransportTestFixture, MultiNicAggregateBandwidth) {
 
     XLOGF(
         INFO,
-        "MultiNicAggregateBandwidth: numNics={} numQpsPerPeerPerNic={} numBlocks={}",
+        "MultiNicAggregateBandwidth: numNics={} qpsPerBlockPerNic={} numBlocks={}",
         detectedNics,
         numQps,
         numBlocks);

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -135,6 +135,9 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
       nRanks_(nRanks),
       bootstrap_(std::move(bootstrap)),
       config_(std::move(config)) {
+  if (config_.sendRecv.has_value() && config_.sendRecv->maxGroups == 0) {
+    config_.sendRecv->maxGroups = config_.maxGroups;
+  }
   if (myRank_ < 0 || myRank_ >= nRanks_) {
     throw std::invalid_argument("Invalid rank");
   }
@@ -1110,14 +1113,27 @@ void MultiPeerIbTransportBase::validatePeerTopology(
               peerInfo.numNics,
               numNics_));
     }
-    if (peerInfo.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
+    const int expectedNumQpsPerPeerPerNic = config_.numQpsPerPeerPerNic();
+    if (peerInfo.numQpsPerPeerPerNic != expectedNumQpsPerPeerPerNic) {
       throw std::runtime_error(
           fmt::format(
               "Peer rank {} reports numQpsPerPeerPerNic={} but mine is {}; all "
               "ranks must use the same numQpsPerPeerPerNic",
               peerRank,
               peerInfo.numQpsPerPeerPerNic,
-              config_.numQpsPerPeerPerNic));
+              expectedNumQpsPerPeerPerNic));
+    }
+    if (peerInfo.maxGroups != config_.maxGroups ||
+        peerInfo.qpsPerBlockPerNic != config_.qpsPerBlockPerNic) {
+      throw std::runtime_error(
+          fmt::format(
+              "Peer rank {} reports maxGroups={} qpsPerBlockPerNic={} but "
+              "mine are {} {}; all ranks must use the same IB QP shape",
+              peerRank,
+              peerInfo.maxGroups,
+              peerInfo.qpsPerBlockPerNic,
+              config_.maxGroups,
+              config_.qpsPerBlockPerNic));
     }
   }
 }

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -69,14 +69,19 @@ struct MultipeerIbTransportConfig {
   // slot-index API. Independent of send/recv's private counter buffers.
   int numCounterSlots{0};
 
+  // Maximum number of physical block groups that may own IB QP resources.
+  // Device-side IB QP selection uses ThreadGroup::block_id and requires
+  // block_id < maxGroups.
+  int maxGroups{64};
+
   // Send/recv configuration. When set, the transport allocates a private
   // pipelined staging ring plus private signal/counter state for send()/recv().
   // When nullopt (default), only the raw put/signal APIs are available.
   struct SendRecvConfig {
     // Maximum number of block-groups that may participate in one send()/recv()
     // call. Sizes the private signal/counter/step arrays and caps
-    // active_blocks.
-    int maxGroups{128};
+    // active_blocks. A value of 0 inherits the top-level maxGroups.
+    int maxGroups{0};
 
     // Number of logical slots in the send/recv staging ring. Total staging
     // bytes per peer per direction: pipelineDepth * dataBufferSize.
@@ -92,10 +97,14 @@ struct MultipeerIbTransportConfig {
   uint32_t qpDepth{1024};
 #endif
 
-  // Number of QP sets per (peer, NIC). Total QPs to a peer =
-  // numQpsPerPeerPerNic * numNics. Multiple QPs let different GPU blocks use
-  // independent QPs.
-  int numQpsPerPeerPerNic{1};
+  // Number of main QPs owned by one physical block on each NIC. IBGDA executes
+  // on the selected QP directly; IBRC enqueues to the selected QP's CPU-proxy
+  // command queue.
+  int qpsPerBlockPerNic{1};
+
+  int numQpsPerPeerPerNic() const {
+    return maxGroups * qpsPerBlockPerNic;
+  }
 
   // InfiniBand Verbs Timeout for QP ACK timeout (4.096us * 2^timeout). Valid
   // 1-31; 0 or >=32 is infinite. Default 20 (similar to NCCL_IB_TIMEOUT).
@@ -156,10 +165,13 @@ struct IbTransportExchInfo {
  */
 constexpr int kMaxRanksForAllGather = 128;
 
-/**
- * Maximum number of QP sets per (peer, NIC) for multi-QP support.
- */
-constexpr int kMaxQpsPerPeerPerNic = 128;
+// Eager allGather QPN exchange uses a compact fixed-size wire format. Larger
+// block-owned QP shapes must use lazy peer materialization.
+constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
+
+constexpr int kMaxIbGroups = 64;
+constexpr int kMaxIbQpsPerBlockPerNic = 128;
+constexpr int kMaxIbQpsPerPeerPerNic = kMaxIbGroups * kMaxIbQpsPerBlockPerNic;
 
 /**
  * Transport exchange info for allGather-based exchange.
@@ -178,7 +190,8 @@ struct IbTransportExchInfoAll {
     uint16_t lid{0};
     // QPN this rank uses on this NIC to connect to (target_rank, q).
     // qpnForRank[myRank][*] is unused (set to 0).
-    uint32_t qpnForRank[kMaxRanksForAllGather][kMaxQpsPerPeerPerNic]{};
+    uint32_t qpnForRank[kMaxRanksForAllGather]
+                       [kMaxEagerExchangeQpsPerPeerPerNic]{};
   };
   NicWireInfo nicInfo[kMaxNicsPerGpu]{};
 
@@ -192,6 +205,10 @@ struct IbTransportExchInfoAll {
 
   // Number of QPs per (peer, NIC) used by this rank.
   int numQpsPerPeerPerNic{1};
+
+  // Block-owned QP shape.
+  int maxGroups{64};
+  int qpsPerBlockPerNic{1};
 };
 
 // Bootstrap tags for the two-phase bilateral exchange in lazy materialization.
@@ -204,13 +221,15 @@ struct PeerQpPayload {
   struct NicQpInfo {
     uint8_t gid[16]{};
     uint16_t lid{0};
-    uint32_t qpns[kMaxQpsPerPeerPerNic]{};
+    uint32_t qpns[kMaxIbQpsPerPeerPerNic]{};
   };
   NicQpInfo nicInfo[kMaxNicsPerGpu]{};
   int gidIndex{0};
   int mtu{0};
   int numNics{0};
   int numQpsPerPeerPerNic{0};
+  int maxGroups{0};
+  int qpsPerBlockPerNic{0};
 };
 
 struct PeerBufferPayload {

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -66,7 +66,7 @@ MultiPeerTransport::MultiPeerTransport(
     : myRank_(myRank),
       nRanks_(nRanks),
       deviceId_(deviceId),
-      ibLazyConnect_(config.ibgdaConfig.ibLazyConnect),
+      ibLazyConnect_(config.ibConfig.ibLazyConnect),
       bootstrap_(std::move(bootstrap)) {
   if (!topo.has_value()) {
     TopologyDiscovery topoDiscovery;
@@ -107,7 +107,7 @@ void MultiPeerTransport::initFromTopology(
             "NCCL_CTRAN_PIPES_DISABLE_IB=1.");
       }
     }
-    // ibgdaPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
+    // ibPeerRanks_ stays empty; ibgdaTransport_ stays nullptr.
   } else {
     const auto ibTransportType = config.ibMode == IbBackendMode::kIbrc
         ? TransportType::P2P_IBRC
@@ -123,8 +123,9 @@ void MultiPeerTransport::initFromTopology(
     }
 
     for (int r = 0; r < nRanks_; ++r) {
-      if (r != myRank_) {
-        ibgdaPeerRanks_.push_back(r);
+      if (typePerRank_.at(r) == TransportType::P2P_IBGDA ||
+          typePerRank_.at(r) == TransportType::P2P_IBRC) {
+        ibPeerRanks_.push_back(r);
       }
     }
   }
@@ -172,20 +173,20 @@ void MultiPeerTransport::initFromTopology(
   // Create the IB sub-transport — the universal fallback for all non-NVL peers.
   // Exactly one backend is built, selected by config.ibMode (kIbgda default;
   // kIbrc selects the CPU-proxy backend).
-  if (!config.disableIb && nRanks_ > 1) {
-    auto ibConfig = config.ibgdaConfig;
+  if (!config.disableIb && !ibPeerRanks_.empty()) {
+    auto ibConfig = config.ibConfig;
     ibConfig.cudaDevice = deviceId_;
     if (config.ibMode == IbBackendMode::kIbrc) {
       ibrcTransport_ = std::make_unique<MultipeerIbrcTransport>(
           myRank_, nRanks_, bootstrap_, ibConfig);
       VLOG(1) << "MultiPeerTransport: rank " << myRank_
-              << " created IBRC sub-transport for " << ibgdaPeerRanks_.size()
+              << " created IBRC sub-transport for " << ibPeerRanks_.size()
               << " peers";
     } else {
       ibgdaTransport_ = std::make_unique<MultipeerIbgdaTransport>(
           myRank_, nRanks_, bootstrap_, ibConfig);
       VLOG(1) << "MultiPeerTransport: rank " << myRank_
-              << " created IBGDA sub-transport for " << ibgdaPeerRanks_.size()
+              << " created IBGDA sub-transport for " << ibPeerRanks_.size()
               << " peers";
     }
   }
@@ -290,7 +291,7 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle() const {
       nRanks_,
       {transportsGpu_, static_cast<uint32_t>(nRanks_)},
       static_cast<int>(nvlPeerRanks_.size()),
-      static_cast<int>(ibgdaPeerRanks_.size()),
+      static_cast<int>(ibPeerRanks_.size()),
   };
 }
 
@@ -306,7 +307,7 @@ MultiPeerDeviceHandle MultiPeerTransport::get_device_handle(
       nRanks_,
       {transportsGpu_, static_cast<uint32_t>(nRanks_)},
       static_cast<int>(nvlPeerRanks_.size()),
-      static_cast<int>(ibgdaPeerRanks_.size()),
+      static_cast<int>(ibPeerRanks_.size()),
   };
 }
 

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -37,7 +37,7 @@ struct MultiPeerDeviceHandle;
 
 struct MultiPeerTransportConfig {
   MultiPeerNvlTransportConfig nvlConfig;
-  MultipeerIbgdaTransportConfig ibgdaConfig;
+  MultipeerIbTransportConfig ibConfig;
 
   // Selects the IB backend for non-NVL peers. Default remains IBGDA.
   IbBackendMode ibMode{IbBackendMode::kIbgda};
@@ -135,9 +135,9 @@ class MultiPeerTransport {
     return nvlPeerRanks_;
   }
 
-  /** @return Global ranks of all non-self peers (IBGDA covers everyone). */
-  const std::vector<int>& ibgda_peer_ranks() const {
-    return ibgdaPeerRanks_;
+  /** @return Global ranks whose preferred transport is IB. */
+  const std::vector<int>& ib_peer_ranks() const {
+    return ibPeerRanks_;
   }
 
   /** @return NVL bootstrap adapter for NVL-scoped collective ops.
@@ -292,7 +292,7 @@ class MultiPeerTransport {
 
   // --- Topology (populated in constructor) ---
   std::vector<int> nvlPeerRanks_;
-  std::vector<int> ibgdaPeerRanks_;
+  std::vector<int> ibPeerRanks_;
   std::vector<TransportType> typePerRank_;
 
   // --- NVLink rank mapping ---

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -345,7 +345,11 @@ __device__ __forceinline__ void P2pIbTransportDevice::put_cooperative(
     uint64_t signalVal,
     const IbgdaLocalBuffer& counterBuf,
     uint64_t counterVal) {
-  ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  ThreadGroup solo{0, 1, 0, blockIdx.x, 1, SyncScope::THREAD};
+#else
+  ThreadGroup solo{0, 1, 0, 0, 1, SyncScope::THREAD};
+#endif
   put_cooperative(
       solo,
       localBuf,

--- a/comms/prims/transport/amd/DocaCompat.h
+++ b/comms/prims/transport/amd/DocaCompat.h
@@ -64,6 +64,7 @@ using doca_gpu_dev_verbs_wqe_ctrl_flags = uint8_t;
 constexpr int DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU = 0;
 constexpr int DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU = 0;
+constexpr int DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD = 0;
 constexpr int DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD = 0;
 constexpr int DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD = 0;
 
@@ -91,6 +92,15 @@ __device__ __forceinline__ uint64_t doca_gpu_dev_verbs_reserve_wq_slots(
 __device__ __forceinline__ doca_gpu_dev_verbs_wqe*
 doca_gpu_dev_verbs_get_wqe_ptr(doca_gpu_dev_verbs_qp* qp, uint64_t wqeIdx) {
   return pipes_gda::pipes_gda_gpu_dev_verbs_get_wqe_ptr(qp, wqeIdx);
+}
+
+__device__ __forceinline__ void doca_gpu_dev_verbs_wqe_prepare_nop(
+    doca_gpu_dev_verbs_qp* qp,
+    doca_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags) {
+  pipes_gda::pipes_gda_gpu_dev_verbs_wqe_prepare_nop(
+      qp, wqe, wqeIdx, ctrlFlags);
 }
 
 __device__ __forceinline__ void doca_gpu_dev_verbs_wqe_prepare_write(

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaOps.h
@@ -842,6 +842,16 @@ pipes_gda_gpu_dev_verbs_get_wqe_ptr(
   return pipes_gda_gpu_dev_verbs_get_wqe_ptr(nic, qp, wqeIdx);
 }
 
+__device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_nop(
+    pipes_gda_gpu_dev_verbs_qp* qp,
+    pipes_gda_gpu_dev_verbs_wqe* wqe,
+    uint64_t wqeIdx,
+    uint8_t ctrlFlags) {
+  (void)ctrlFlags;
+  ActiveNicBackend nic{};
+  pipes_gda_gpu_dev_verbs_wqe_prepare_nop(nic, qp, wqe, wqeIdx);
+}
+
 __device__ __forceinline__ void pipes_gda_gpu_dev_verbs_wqe_prepare_write(
     pipes_gda_gpu_dev_verbs_qp* qp,
     pipes_gda_gpu_dev_verbs_wqe* wqe,

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -43,9 +43,11 @@ namespace {
 
 constexpr int kHopLimit = 255;
 
-// Companion QPs use the same init attributes as main QPs but with smaller
-// depth since they only carry WAIT + atomic operations (2 WQEs per round).
-constexpr uint32_t kCompanionQpDepth = 32;
+// Host loopback QPs are only used to bring each exported companion QP to RTS.
+// The device-visible companion QP is created by create_qp_group_hl() with
+// mainAttr and therefore uses config_.qpDepth.
+constexpr uint32_t kLoopbackCompanionQpDepth = 32;
+constexpr int kMaxQpLanesPerBlock = 64;
 
 } // namespace
 
@@ -383,12 +385,17 @@ void MultipeerIbgdaTransport::registerMemory() {
 }
 void MultipeerIbgdaTransport::createQpGroups() {
   const int numPeers = nRanks_ - 1;
-  const int numQps = config_.numQpsPerPeerPerNic;
-  const int totalQpsPerPeer = numNics_ * numQps;
-  const int totalQpGroups = numPeers * totalQpsPerPeer;
+  const int mainQpsPerPeerPerNic =
+      config_.maxGroups * config_.qpsPerBlockPerNic;
+  const int totalMainQpsPerPeer = numNics_ * mainQpsPerPeerPerNic;
+  const int totalCompanionQpsPerPeer = numNics_ * config_.maxGroups;
   for (auto& nic : nicDoca_) {
-    nic.qpGroups.resize(static_cast<size_t>(numPeers) * numQps);
-    nic.loopbackCompanionQps.resize(static_cast<size_t>(numPeers) * numQps);
+    nic.blockQpGroups.resize(static_cast<size_t>(numPeers) * config_.maxGroups);
+    nic.extraMainQps.resize(
+        static_cast<size_t>(numPeers) * config_.maxGroups *
+        static_cast<size_t>(config_.qpsPerBlockPerNic - 1));
+    nic.loopbackCompanionQps.resize(
+        static_cast<size_t>(numPeers) * config_.maxGroups);
   }
 
   // Verify CUDA device is still set correctly
@@ -411,10 +418,12 @@ void MultipeerIbgdaTransport::createQpGroups() {
             << " max_qp_wr=" << devAttr.max_qp_wr;
   }
 
-  VLOG(1) << "MultipeerIbgdaTransport: creating " << totalQpGroups
-          << " QP groups (" << totalQpsPerPeer << " slots/peer = " << numNics_
-          << " NICs × " << numQps << " QPs, " << numPeers
-          << " peers) gpu_dev=" << (void*)docaGpu_
+  VLOG(1) << "MultipeerIbgdaTransport: creating " << totalMainQpsPerPeer
+          << " main QPs/peer and " << totalCompanionQpsPerPeer
+          << " companion QPs/peer (" << numNics_
+          << " NICs × maxGroups=" << config_.maxGroups
+          << " × qpsPerBlockPerNic=" << config_.qpsPerBlockPerNic
+          << ", peers=" << numPeers << ") gpu_dev=" << (void*)docaGpu_
           << " sq_nwqe=" << config_.qpDepth
           << " nic_handler=AUTO mreg_type=DEFAULT";
 
@@ -529,7 +538,6 @@ void MultipeerIbgdaTransport::connectQp(
 }
 
 void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
-  const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
     doca_gpu_verbs_qp_init_attr_hl mainAttr{};
     mainAttr.gpu_dev = docaGpu_;
@@ -539,25 +547,33 @@ void MultipeerIbgdaTransport::createPeerQps(int peerIndex) {
     mainAttr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
 
     doca_gpu_verbs_qp_init_attr_hl loopbackAttr = mainAttr;
-    loopbackAttr.sq_nwqe = kCompanionQpDepth;
+    loopbackAttr.sq_nwqe = kLoopbackCompanionQpDepth;
 
-    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].blockQpGroups;
+    auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
       doca_error_t err =
-          doca_gpu_verbs_create_qp_group_hl(&mainAttr, &nicQps[qpIdx]);
+          doca_gpu_verbs_create_qp_group_hl(&mainAttr, &nicQps[blockIdx]);
       checkDocaError(err, "Failed to create QP group");
-      err = doca_gpu_verbs_create_qp_hl(&loopbackAttr, &nicLoopback[qpIdx]);
+      err = doca_gpu_verbs_create_qp_hl(&loopbackAttr, &nicLoopback[blockIdx]);
       checkDocaError(err, "Failed to create loopback companion QP");
+      for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+        const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                (config_.qpsPerBlockPerNic - 1) +
+            (lane - 1);
+        err =
+            doca_gpu_verbs_create_qp_hl(&mainAttr, &nicExtraMainQps[extraIdx]);
+        checkDocaError(err, "Failed to create extra main QP");
+      }
     }
   }
 }
 
 void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
-  const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].blockQpGroups;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
 
     IbgdaTransportExchInfo selfInfo;
@@ -570,12 +586,12 @@ void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
       selfInfo.lid = portAttr.lid;
     }
 
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
-      selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[qpIdx]->qp);
-      connectQp(&nicQps[qpIdx]->qp_companion, selfInfo, nic);
-      selfInfo.qpn = doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_companion.qp);
-      connectQp(nicLoopback[qpIdx], selfInfo, nic);
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
+      selfInfo.qpn = doca_verbs_qp_get_qpn(nicLoopback[blockIdx]->qp);
+      connectQp(&nicQps[blockIdx]->qp_companion, selfInfo, nic);
+      selfInfo.qpn = doca_verbs_qp_get_qpn(nicQps[blockIdx]->qp_companion.qp);
+      connectQp(nicLoopback[blockIdx], selfInfo, nic);
     }
   }
 }
@@ -594,7 +610,8 @@ PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
 
 P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
     int peerIndex) const {
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int mainQpsPerPeerPerNic =
+      config_.maxGroups * config_.qpsPerBlockPerNic;
   auto makeSendRecvState = [&]() -> IbSendRecvState {
     if (sendRecvPeerBuffers_.empty()) {
       return {};
@@ -616,27 +633,42 @@ P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
   };
 
   P2pIbgdaTransportBuildParams params(makeSendRecvState());
+  params.maxGroups = config_.maxGroups;
+  params.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
   params.h_nicDeviceIbgdaResources.resize(numNics_);
   for (int n = 0; n < numNics_; ++n) {
     auto& nicSpec = params.h_nicDeviceIbgdaResources[n];
-    nicSpec.qps.resize(numQps);
-    nicSpec.companionQps.resize(numQps);
+    nicSpec.qps.resize(mainQpsPerPeerPerNic);
+    nicSpec.companionQps.resize(config_.maxGroups);
     nicSpec.sinkLkey = NetworkLKey(HostLKey(nicDoca_[n].sinkMr->lkey));
     nicSpec.deviceId = n;
   }
 
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].blockQpGroups;
+    auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
     auto& nicSpec = params.h_nicDeviceIbgdaResources[nic];
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
+      const int lane0MainIdx = block * config_.qpsPerBlockPerNic;
       doca_error_t err = doca_gpu_verbs_get_qp_dev(
-          nicQps[qpIdx]->qp_main.qp_gverbs, &nicSpec.qps[q]);
+          nicQps[blockIdx]->qp_main.qp_gverbs, &nicSpec.qps[lane0MainIdx]);
       checkDocaError(err, "Failed to get GPU QP handle");
 
       err = doca_gpu_verbs_get_qp_dev(
-          nicQps[qpIdx]->qp_companion.qp_gverbs, &nicSpec.companionQps[q]);
+          nicQps[blockIdx]->qp_companion.qp_gverbs,
+          &nicSpec.companionQps[block]);
       checkDocaError(err, "Failed to get companion GPU QP handle");
+
+      for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+        const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                (config_.qpsPerBlockPerNic - 1) +
+            (lane - 1);
+        err = doca_gpu_verbs_get_qp_dev(
+            nicExtraMainQps[extraIdx]->qp_gverbs,
+            &nicSpec.qps[lane0MainIdx + lane]);
+        checkDocaError(err, "Failed to get extra main GPU QP handle");
+      }
     }
   }
 
@@ -665,22 +697,69 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
           nRanks,
           std::move(bootstrap),
           config) {
-  if (config.numQpsPerPeerPerNic < 1 ||
-      config.numQpsPerPeerPerNic > kMaxQpsPerPeerPerNic) {
+  if (config_.maxGroups < 1) {
+    throw std::invalid_argument("maxGroups must be >= 1");
+  }
+  if (config_.qpsPerBlockPerNic < 1) {
+    throw std::invalid_argument("qpsPerBlockPerNic must be >= 1");
+  }
+  if (config_.maxGroups > kMaxIbGroups) {
     throw std::invalid_argument(
         fmt::format(
-            "numQpsPerPeerPerNic must be in [1, {}], got {}",
-            kMaxQpsPerPeerPerNic,
-            config.numQpsPerPeerPerNic));
+            "maxGroups must be <= {}, got {}",
+            kMaxIbGroups,
+            config_.maxGroups));
   }
-  if (config.numQpsPerPeerPerNic * (nRanks - 1) * 3 > 1000) {
+  if (config_.qpsPerBlockPerNic > kMaxIbQpsPerBlockPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "qpsPerBlockPerNic must be <= {}, got {}",
+            kMaxIbQpsPerBlockPerNic,
+            config_.qpsPerBlockPerNic));
+  }
+  const int mainQpsPerPeerPerNic = config_.numQpsPerPeerPerNic();
+  if (mainQpsPerPeerPerNic > kMaxIbQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "maxGroups * qpsPerBlockPerNic must be <= {}, got {} * {} = {}",
+            kMaxIbQpsPerPeerPerNic,
+            config_.maxGroups,
+            config_.qpsPerBlockPerNic,
+            mainQpsPerPeerPerNic));
+  }
+  if (!config_.ibLazyConnect &&
+      mainQpsPerPeerPerNic > kMaxEagerExchangeQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "eager IBGDA allGather exchange supports at most {} QPs per "
+            "(peer,NIC); got {}. Enable ibLazyConnect for larger "
+            "maxGroups * qpsPerBlockPerNic shapes.",
+            kMaxEagerExchangeQpsPerPeerPerNic,
+            mainQpsPerPeerPerNic));
+  }
+  if (config_.sendRecv.has_value() &&
+      config_.sendRecv->maxGroups > config_.maxGroups) {
+    throw std::invalid_argument(
+        fmt::format(
+            "sendRecv.maxGroups ({}) must be <= maxGroups ({})",
+            config_.sendRecv->maxGroups,
+            config_.maxGroups));
+  }
+  if (numNics_ * config_.qpsPerBlockPerNic > kMaxQpLanesPerBlock) {
+    throw std::invalid_argument(
+        fmt::format(
+            "numNics ({}) * qpsPerBlockPerNic ({}) must be <= {}",
+            numNics_,
+            config_.qpsPerBlockPerNic,
+            kMaxQpLanesPerBlock));
+  }
+  if (mainQpsPerPeerPerNic * (nRanks_ - 1) * 3 > 1000) {
     LOG(WARNING) << "MultipeerIbgdaTransport: high QP count: "
-                 << config.numQpsPerPeerPerNic << " QPs/(peer,NIC) * "
-                 << (nRanks - 1) << " peers * 3 = "
-                 << config.numQpsPerPeerPerNic * (nRanks - 1) * 3
+                 << mainQpsPerPeerPerNic << " main QPs/(peer,NIC) * "
+                 << (nRanks_ - 1)
+                 << " peers * 3 ~= " << mainQpsPerPeerPerNic * (nRanks_ - 1) * 3
                  << " total QPs (per NIC)";
   }
-
   try {
 #ifndef __HIP_PLATFORM_AMD__
     // Resolve CUDA driver function pointers (NVIDIA-only; AMD doesn't
@@ -702,10 +781,13 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     } else {
       const int numPeers = nRanks - 1;
       for (auto& nic : nicDoca_) {
-        nic.qpGroups.resize(
-            static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
+        nic.blockQpGroups.resize(
+            static_cast<size_t>(numPeers) * config.maxGroups);
+        nic.extraMainQps.resize(
+            static_cast<size_t>(numPeers) * config.maxGroups *
+            static_cast<size_t>(config.qpsPerBlockPerNic - 1));
         nic.loopbackCompanionQps.resize(
-            static_cast<size_t>(numPeers) * config.numQpsPerPeerPerNic);
+            static_cast<size_t>(numPeers) * config.maxGroups);
       }
       lazyPeerBufs_.resize(numPeers);
       peerMaterialized_.resize(numPeers, false);
@@ -751,14 +833,20 @@ void MultipeerIbgdaTransport::cleanup() {
   // Free tile sendrecv buffers
   cleanup_send_recv_buffers();
 
-  // Destroy per-NIC QP groups (main + companion) and loopback responders.
+  // Destroy per-NIC QPs and loopback responders.
   for (auto& nic : nicDoca_) {
-    for (auto* qpGroup : nic.qpGroups) {
+    for (auto* qpGroup : nic.blockQpGroups) {
       if (qpGroup != nullptr) {
         doca_gpu_verbs_destroy_qp_group_hl(qpGroup);
       }
     }
-    nic.qpGroups.clear();
+    nic.blockQpGroups.clear();
+    for (auto* qpHl : nic.extraMainQps) {
+      if (qpHl != nullptr) {
+        doca_gpu_verbs_destroy_qp_hl(qpHl);
+      }
+    }
+    nic.extraMainQps.clear();
     for (auto* qpHl : nic.loopbackCompanionQps) {
       if (qpHl != nullptr) {
         doca_gpu_verbs_destroy_qp_hl(qpHl);
@@ -847,7 +935,8 @@ void MultipeerIbgdaTransport::cleanup() {
 
 void MultipeerIbgdaTransport::exchange() {
   const int numPeers = nRanks_ - 1;
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int mainQpsPerPeerPerNic =
+      config_.maxGroups * config_.qpsPerBlockPerNic;
   auto& symbols = ibverbx::ibvSymbols;
 
   if (config_.ibLazyConnect) {
@@ -878,7 +967,9 @@ void MultipeerIbgdaTransport::exchange() {
   myInfo.gidIndex = gidIndex_;
   myInfo.mtu = localMtu_;
   myInfo.numNics = numNics_;
-  myInfo.numQpsPerPeerPerNic = numQps;
+  myInfo.numQpsPerPeerPerNic = mainQpsPerPeerPerNic;
+  myInfo.maxGroups = config_.maxGroups;
+  myInfo.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
   for (int n = 0; n < numNics_; ++n) {
     memcpy(
         myInfo.nicInfo[n].gid,
@@ -894,24 +985,32 @@ void MultipeerIbgdaTransport::exchange() {
     }
   }
 
-  // Fill in per-target QPNs for every (nic, q). NIC-fast interleaving:
-  // slot s = q * numNics_ + nic.
-  const int totalQpsPerPeer = numNics_ * numQps;
+  const int totalQpsPerPeer = numNics_ * mainQpsPerPeerPerNic;
   for (int peerIndex = 0; peerIndex < numPeers; peerIndex++) {
     const int peerRank = peerIndexToRank(peerIndex);
     for (int nic = 0; nic < numNics_; nic++) {
-      const auto& nicQps = nicDoca_[nic].qpGroups;
-      for (int q = 0; q < numQps; q++) {
-        const int qpIdx = peerIndex * numQps + q;
-        myInfo.nicInfo[nic].qpnForRank[peerRank][q] =
-            doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp);
+      const auto& nicQps = nicDoca_[nic].blockQpGroups;
+      const auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
+      for (int block = 0; block < config_.maxGroups; block++) {
+        const int blockIdx = peerIndex * config_.maxGroups + block;
+        const int lane0MainIdx = block * config_.qpsPerBlockPerNic;
+        myInfo.nicInfo[nic].qpnForRank[peerRank][lane0MainIdx] =
+            doca_verbs_qp_get_qpn(nicQps[blockIdx]->qp_main.qp);
+        for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+          const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                  (config_.qpsPerBlockPerNic - 1) +
+              (lane - 1);
+          myInfo.nicInfo[nic].qpnForRank[peerRank][lane0MainIdx + lane] =
+              doca_verbs_qp_get_qpn(nicExtraMainQps[extraIdx]->qp);
+        }
       }
     }
   }
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
           << " performing allGather exchange (" << totalQpsPerPeer
-          << " slots/peer = " << numNics_ << " NICs × " << numQps << " QPs)";
+          << " main QPs/peer = " << numNics_ << " NICs × "
+          << mainQpsPerPeerPerNic << " main QPs)";
 
   // allGather (rank-count guarded) + per-peer topology validation (numNics +
   // numQpsPerPeerPerNic) are owned by the base.
@@ -925,6 +1024,16 @@ void MultipeerIbgdaTransport::exchange() {
     int peerRank = peerIndexToRank(peerIndex);
     const IbgdaTransportExchInfoAll& peerInfo = allInfo[peerRank];
 
+    CHECK_EQ(peerInfo.maxGroups, config_.maxGroups)
+        << "Rank " << peerRank << " has maxGroups=" << peerInfo.maxGroups
+        << " but local rank " << myRank_ << " has " << config_.maxGroups
+        << ". All ranks must use the same maxGroups.";
+    CHECK_EQ(peerInfo.qpsPerBlockPerNic, config_.qpsPerBlockPerNic)
+        << "Rank " << peerRank
+        << " has qpsPerBlockPerNic=" << peerInfo.qpsPerBlockPerNic
+        << " but local rank " << myRank_ << " has " << config_.qpsPerBlockPerNic
+        << ". All ranks must use the same qpsPerBlockPerNic.";
+
     // Store common connection info (from QP 0 — same GID/LID for all QPs)
     peerExchInfo_[peerIndex].qpn = peerInfo.nicInfo[0].qpnForRank[myRank_][0];
     memcpy(
@@ -937,7 +1046,8 @@ void MultipeerIbgdaTransport::exchange() {
 
     VLOG(1) << "MultipeerIbgdaTransport: received from peer " << peerRank
             << " numNics=" << peerInfo.numNics
-            << " numQps=" << peerInfo.numQpsPerPeerPerNic
+            << " maxGroups=" << peerInfo.maxGroups
+            << " qpsPerBlockPerNic=" << peerInfo.qpsPerBlockPerNic
             << " slot0_qpn=" << peerExchInfo_[peerIndex].qpn;
   }
 
@@ -947,17 +1057,29 @@ void MultipeerIbgdaTransport::exchange() {
         allInfo[peerIndexToRank(peerIndex)];
 
     for (int nic = 0; nic < numNics_; nic++) {
-      auto& nicQps = nicDoca_[nic].qpGroups;
-      for (int q = 0; q < numQps; q++) {
-        const int qpIdx = peerIndex * numQps + q;
+      auto& nicQps = nicDoca_[nic].blockQpGroups;
+      auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
+      for (int block = 0; block < config_.maxGroups; block++) {
+        const int blockIdx = peerIndex * config_.maxGroups + block;
+        const int lane0MainIdx = block * config_.qpsPerBlockPerNic;
         IbgdaTransportExchInfo qpPeerInfo;
-        qpPeerInfo.qpn = peerInfo.nicInfo[nic].qpnForRank[myRank_][q];
+        qpPeerInfo.qpn =
+            peerInfo.nicInfo[nic].qpnForRank[myRank_][lane0MainIdx];
         memcpy(
             qpPeerInfo.gid, peerInfo.nicInfo[nic].gid, sizeof(qpPeerInfo.gid));
         qpPeerInfo.gidIndex = peerInfo.gidIndex;
         qpPeerInfo.lid = peerInfo.nicInfo[nic].lid;
         qpPeerInfo.mtu = peerInfo.mtu;
-        connectQp(&nicQps[qpIdx]->qp_main, qpPeerInfo, nic);
+        connectQp(&nicQps[blockIdx]->qp_main, qpPeerInfo, nic);
+
+        for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+          const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                  (config_.qpsPerBlockPerNic - 1) +
+              (lane - 1);
+          qpPeerInfo.qpn =
+              peerInfo.nicInfo[nic].qpnForRank[myRank_][lane0MainIdx + lane];
+          connectQp(nicExtraMainQps[extraIdx], qpPeerInfo, nic);
+        }
       }
     }
     connectPeerLoopback(peerIndex);
@@ -980,7 +1102,8 @@ void MultipeerIbgdaTransport::exchange() {
 
   VLOG(1) << "MultipeerIbgdaTransport: rank " << myRank_
           << " exchange complete, connected to " << numPeers << " peers"
-          << " (" << numQps << " QPs/(peer,NIC) × " << numNics_ << " NICs)";
+          << " (" << mainQpsPerPeerPerNic << " main QPs/(peer,NIC) × "
+          << numNics_ << " NICs)";
 }
 
 MultipeerIbgdaDeviceTransport MultipeerIbgdaTransport::getDeviceTransport()
@@ -1028,8 +1151,12 @@ int MultipeerIbgdaTransport::getGidIndex() const {
   return gidIndex_;
 }
 
-int MultipeerIbgdaTransport::numQpsPerPeerPerNic() const {
-  return config_.numQpsPerPeerPerNic;
+int MultipeerIbgdaTransport::maxGroups() const {
+  return config_.maxGroups;
+}
+
+int MultipeerIbgdaTransport::qpsPerBlockPerNic() const {
+  return config_.qpsPerBlockPerNic;
 }
 
 // =============================================================================
@@ -1179,12 +1306,15 @@ void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
 
 PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
     int peerIndex) const {
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int mainQpsPerPeerPerNic =
+      config_.maxGroups * config_.qpsPerBlockPerNic;
   PeerQpPayload payload{};
   payload.gidIndex = gidIndex_;
   payload.mtu = static_cast<int>(localMtu_);
   payload.numNics = numNics_;
-  payload.numQpsPerPeerPerNic = numQps;
+  payload.numQpsPerPeerPerNic = mainQpsPerPeerPerNic;
+  payload.maxGroups = config_.maxGroups;
+  payload.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
 
   auto& symbols = ibverbx::ibvSymbols;
   for (int n = 0; n < numNics_; ++n) {
@@ -1196,11 +1326,20 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
     if (symbols.ibv_internal_query_port(nics_[n].ibvCtx, 1, &portAttr) == 0) {
       payload.nicInfo[n].lid = portAttr.lid;
     }
-    auto& nicQps = nicDoca_[n].qpGroups;
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
-      payload.nicInfo[n].qpns[q] =
-          doca_verbs_qp_get_qpn(nicQps[qpIdx]->qp_main.qp);
+    auto& nicQps = nicDoca_[n].blockQpGroups;
+    auto& nicExtraMainQps = nicDoca_[n].extraMainQps;
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
+      const int lane0MainIdx = block * config_.qpsPerBlockPerNic;
+      payload.nicInfo[n].qpns[lane0MainIdx] =
+          doca_verbs_qp_get_qpn(nicQps[blockIdx]->qp_main.qp);
+      for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+        const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                (config_.qpsPerBlockPerNic - 1) +
+            (lane - 1);
+        payload.nicInfo[n].qpns[lane0MainIdx + lane] =
+            doca_verbs_qp_get_qpn(nicExtraMainQps[extraIdx]->qp);
+      }
     }
   }
   return payload;
@@ -1265,19 +1404,28 @@ void MultipeerIbgdaTransport::allocatePeerBuffers(
 void MultipeerIbgdaTransport::connectPeerMainQps(
     int peerIndex,
     const PeerQpPayload& remotePayload) {
-  const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDoca_[nic].qpGroups;
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
+    auto& nicQps = nicDoca_[nic].blockQpGroups;
+    auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
+      const int lane0MainIdx = block * config_.qpsPerBlockPerNic;
       IbgdaTransportExchInfo peerInfo;
-      peerInfo.qpn = remotePayload.nicInfo[nic].qpns[q];
+      peerInfo.qpn = remotePayload.nicInfo[nic].qpns[lane0MainIdx];
       memcpy(
           peerInfo.gid, remotePayload.nicInfo[nic].gid, sizeof(peerInfo.gid));
       peerInfo.gidIndex = remotePayload.gidIndex;
       peerInfo.lid = remotePayload.nicInfo[nic].lid;
       peerInfo.mtu = static_cast<ibverbx::ibv_mtu>(remotePayload.mtu);
-      connectQp(&nicQps[qpIdx]->qp_main, peerInfo, nic);
+      connectQp(&nicQps[blockIdx]->qp_main, peerInfo, nic);
+
+      for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+        const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                (config_.qpsPerBlockPerNic - 1) +
+            (lane - 1);
+        peerInfo.qpn = remotePayload.nicInfo[nic].qpns[lane0MainIdx + lane];
+        connectQp(nicExtraMainQps[extraIdx], peerInfo, nic);
+      }
     }
   }
 }
@@ -1293,19 +1441,28 @@ void MultipeerIbgdaTransport::applyRemoteViews(
 }
 
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
-  const int numQps = config_.numQpsPerPeerPerNic;
   for (int nic = 0; nic < numNics_; nic++) {
-    auto& nicQps = nicDoca_[nic].qpGroups;
+    auto& nicQps = nicDoca_[nic].blockQpGroups;
+    auto& nicExtraMainQps = nicDoca_[nic].extraMainQps;
     auto& nicLoopback = nicDoca_[nic].loopbackCompanionQps;
-    for (int q = 0; q < numQps; q++) {
-      const int qpIdx = peerIndex * numQps + q;
-      if (nicQps[qpIdx] != nullptr) {
-        doca_gpu_verbs_destroy_qp_group_hl(nicQps[qpIdx]);
-        nicQps[qpIdx] = nullptr;
+    for (int block = 0; block < config_.maxGroups; block++) {
+      const int blockIdx = peerIndex * config_.maxGroups + block;
+      if (nicQps[blockIdx] != nullptr) {
+        doca_gpu_verbs_destroy_qp_group_hl(nicQps[blockIdx]);
+        nicQps[blockIdx] = nullptr;
       }
-      if (nicLoopback[qpIdx] != nullptr) {
-        doca_gpu_verbs_destroy_qp_hl(nicLoopback[qpIdx]);
-        nicLoopback[qpIdx] = nullptr;
+      if (nicLoopback[blockIdx] != nullptr) {
+        doca_gpu_verbs_destroy_qp_hl(nicLoopback[blockIdx]);
+        nicLoopback[blockIdx] = nullptr;
+      }
+      for (int lane = 1; lane < config_.qpsPerBlockPerNic; ++lane) {
+        const int extraIdx = (peerIndex * config_.maxGroups + block) *
+                (config_.qpsPerBlockPerNic - 1) +
+            (lane - 1);
+        if (nicExtraMainQps[extraIdx] != nullptr) {
+          doca_gpu_verbs_destroy_qp_hl(nicExtraMainQps[extraIdx]);
+          nicExtraMainQps[extraIdx] = nullptr;
+        }
       }
     }
   }
@@ -1346,13 +1503,17 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
             remoteQp.numNics,
             numNics_));
   }
-  if (remoteQp.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
+  if (remoteQp.maxGroups != config_.maxGroups ||
+      remoteQp.qpsPerBlockPerNic != config_.qpsPerBlockPerNic) {
     throw std::runtime_error(
         fmt::format(
-            "materializePeer: peer {} numQps={} vs local {}",
+            "materializePeer: peer {} maxGroups={} qpsPerBlockPerNic={} "
+            "vs local maxGroups={} qpsPerBlockPerNic={}",
             peerRank,
-            remoteQp.numQpsPerPeerPerNic,
-            config_.numQpsPerPeerPerNic));
+            remoteQp.maxGroups,
+            remoteQp.qpsPerBlockPerNic,
+            config_.maxGroups,
+            config_.qpsPerBlockPerNic));
   }
 
   connectPeerMainQps(peerIndex, remoteQp);

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -47,10 +47,9 @@ namespace comms::prims {
 // the ctor signature below are unchanged.
 using MultipeerIbgdaTransportConfig = MultipeerIbTransportConfig;
 
-// The exchange wire structs and allGather caps (kMaxRanksForAllGather,
-// kMaxQpsPerPeerPerNic) now live in MultiPeerIbTransport.h so they are shared
-// across IB backends. Keep the historical IBGDA names as aliases so callers and
-// the .cc are unchanged.
+// The exchange wire structs and allGather caps now live in
+// MultiPeerIbTransport.h so they are shared across IB backends. Keep the
+// historical IBGDA names as aliases so callers and the .cc are unchanged.
 using IbgdaTransportExchInfo = IbTransportExchInfo;
 using IbgdaTransportExchInfoAll = IbTransportExchInfoAll;
 
@@ -206,11 +205,8 @@ class MultipeerIbgdaTransport
   // backend supplies the register_mr_on_nics()/lookup_alloc_base()/
   // deregister_mr() hooks below).
 
-  /**
-   * Get the number of QP sets per (peer, NIC).
-   * Total QPs to a peer = numQpsPerPeerPerNic() * numNics().
-   */
-  int numQpsPerPeerPerNic() const;
+  int maxGroups() const;
+  int qpsPerBlockPerNic() const;
 
   // numNics() is inherited from MultiPeerIbTransport.
 
@@ -269,15 +265,18 @@ class MultipeerIbgdaTransport
   // numNics_ is inherited (protected) from MultiPeerIbTransport;
   // nicDevices_.size() == numNics_ after openIbDevice().
 
-  // Per-NIC host-side IB verbs resources. qpGroups and loopbackCompanionQps
-  // are indexed [peer * numQpsPerPeerPerNic + q].
+  // Per-NIC host-side IB verbs resources. blockQpGroups and
+  // loopbackCompanionQps are indexed [peer * maxGroups + block]. The lane-0
+  // main QP comes from blockQpGroups; extra main QPs are indexed
+  // [(peer * maxGroups + block) * (qpsPerBlockPerNic - 1) + (lane - 1)].
   // Backend-specific (DOCA) per-NIC state. The generic per-NIC resources
   // (device name, context, PD, GID) live in MultiPeerIbTransport::nics_,
   // index-aligned with this vector; openIbDevice() fills both.
   struct NicDocaResources {
     doca_verbs_ah_attr* ahAttr{nullptr};
     ibverbx::ibv_mr* sinkMr{nullptr};
-    std::vector<doca_gpu_verbs_qp_group_hl*> qpGroups;
+    std::vector<doca_gpu_verbs_qp_group_hl*> blockQpGroups;
+    std::vector<doca_gpu_verbs_qp_hl*> extraMainQps;
     std::vector<doca_gpu_verbs_qp_hl*> loopbackCompanionQps;
   };
   std::vector<NicDocaResources> nicDoca_;

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cu
@@ -20,33 +20,45 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
   CHECK(!params.empty() && !params[0].h_nicDeviceIbgdaResources.empty())
       << "buildDeviceTransportsOnGpu: empty params or zero NICs";
   int numNics = static_cast<int>(params[0].h_nicDeviceIbgdaResources.size());
-  int qpsPerNic =
+  int mainQpsPerNic =
       static_cast<int>(params[0].h_nicDeviceIbgdaResources[0].qps.size());
+  int companionQpsPerNic = static_cast<int>(
+      params[0].h_nicDeviceIbgdaResources[0].companionQps.size());
   for (int i = 0; i < numPeers; ++i) {
+    CHECK_EQ(params[i].maxGroups, params[0].maxGroups)
+        << "All peers must have the same maxGroups";
+    CHECK_EQ(params[i].qpsPerBlockPerNic, params[0].qpsPerBlockPerNic)
+        << "All peers must have the same qpsPerBlockPerNic";
     CHECK_EQ(
         static_cast<int>(params[i].h_nicDeviceIbgdaResources.size()), numNics)
         << "All peers must have the same numNics";
     for (int n = 0; n < numNics; ++n) {
       CHECK_EQ(
           static_cast<int>(params[i].h_nicDeviceIbgdaResources[n].qps.size()),
-          qpsPerNic)
+          params[i].maxGroups * params[i].qpsPerBlockPerNic)
+          << "Main QP count must equal maxGroups * qpsPerBlockPerNic";
+      CHECK_EQ(
+          static_cast<int>(
+              params[i].h_nicDeviceIbgdaResources[n].companionQps.size()),
+          params[i].maxGroups)
+          << "Companion QP count must equal maxGroups";
+      CHECK_EQ(
+          static_cast<int>(params[i].h_nicDeviceIbgdaResources[n].qps.size()),
+          mainQpsPerNic)
           << "All peers' NICs must have the same QP count";
       CHECK_EQ(
           static_cast<int>(
               params[i].h_nicDeviceIbgdaResources[n].companionQps.size()),
-          qpsPerNic)
-          << "qps and companionQps must match per NIC";
+          companionQpsPerNic)
+          << "All peers' NICs must have the same companion QP count";
     }
   }
 
-  // Each NIC has two QP kinds packed back-to-back: primary + companion.
-  constexpr int kQpKindsPerNic = 2;
-
   // 1. Allocate one contiguous GPU buffer for all QP pointer arrays.
   //    Layout per peer: [nic0_main][nic0_comp][nic1_main][nic1_comp]...
-  //    Total: numPeers * numNics * kQpKindsPerNic * qpsPerNic pointers.
-  std::size_t qpsPerPeer =
-      static_cast<std::size_t>(kQpKindsPerNic) * numNics * qpsPerNic;
+  //    Total: numPeers * numNics * (mainQpsPerNic + companionQpsPerNic).
+  std::size_t qpsPerPeer = static_cast<std::size_t>(numNics) *
+      (static_cast<std::size_t>(mainQpsPerNic) + companionQpsPerNic);
   std::size_t totalQpBytes =
       numPeers * qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
   doca_gpu_dev_verbs_qp** d_allQps = nullptr;
@@ -88,15 +100,14 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
   h_nicResources.reserve(numPeers * numNics);
   for (int i = 0; i < numPeers; ++i) {
     for (int n = 0; n < numNics; ++n) {
-      // QP pointers for this peer/NIC start at offset:
-      //   (i * qpsPerPeer) + (n * kQpKindsPerNic * qpsPerNic) within d_allQps.
-      auto* d_mainQps =
-          d_allQps + (i * qpsPerPeer) + (n * kQpKindsPerNic * qpsPerNic);
-      auto* d_companionQps = d_mainQps + qpsPerNic;
+      auto* d_mainQps = d_allQps + (i * qpsPerPeer) +
+          n * (mainQpsPerNic + companionQpsPerNic);
+      auto* d_companionQps = d_mainQps + mainQpsPerNic;
       h_nicResources.push_back(
           NicDeviceIbgdaResources{
-              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, qpsPerNic),
-              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_companionQps, qpsPerNic),
+              DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, mainQpsPerNic),
+              DeviceSpan<doca_gpu_dev_verbs_qp*>(
+                  d_companionQps, companionQpsPerNic),
               params[i].h_nicDeviceIbgdaResources[n].sinkLkey,
               params[i].h_nicDeviceIbgdaResources[n].deviceId,
           });
@@ -113,6 +124,17 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
 
   // 3. Build transport objects pointing into the contiguous
   // NicDeviceIbgdaResources array.
+  IbgdaBlockQpState* d_allBlockQpState = nullptr;
+  std::size_t blockStateBytes = static_cast<std::size_t>(numPeers) *
+      params[0].maxGroups * sizeof(IbgdaBlockQpState);
+  err = cudaMalloc(&d_allBlockQpState, blockStateBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to allocate GPU block QP state: " << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_allBlockQpState);
+  err = cudaMemset(d_allBlockQpState, 0, blockStateBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to zero GPU block QP state: " << cudaGetErrorString(err);
+
   std::vector<P2pIbgdaTransportDevice> h_transports;
   h_transports.reserve(numPeers);
   for (int i = 0; i < numPeers; ++i) {
@@ -125,6 +147,10 @@ P2pIbgdaTransportDevice* buildDeviceTransportsOnGpu(
         params[i].counterBuf,
         params[i].numSignalSlots,
         params[i].numCounterSlots,
+        params[i].maxGroups,
+        params[i].qpsPerBlockPerNic,
+        DeviceSpan<IbgdaBlockQpState>(
+            d_allBlockQpState + i * params[i].maxGroups, params[i].maxGroups),
         params[i].sendRecvState);
   }
 
@@ -151,12 +177,24 @@ void writeDeviceTransportSlot(
   CHECK(!params.h_nicDeviceIbgdaResources.empty())
       << "writeDeviceTransportSlot needs >= 1 NIC";
   int numNics = static_cast<int>(params.h_nicDeviceIbgdaResources.size());
-  int qpsPerNic =
+  int mainQpsPerNic =
       static_cast<int>(params.h_nicDeviceIbgdaResources[0].qps.size());
-  constexpr int kQpKindsPerNic = 2;
+  int companionQpsPerNic =
+      static_cast<int>(params.h_nicDeviceIbgdaResources[0].companionQps.size());
+  for (int n = 0; n < numNics; ++n) {
+    CHECK_EQ(
+        static_cast<int>(params.h_nicDeviceIbgdaResources[n].qps.size()),
+        mainQpsPerNic)
+        << "All NICs must have the same QP count";
+    CHECK_EQ(
+        static_cast<int>(
+            params.h_nicDeviceIbgdaResources[n].companionQps.size()),
+        companionQpsPerNic)
+        << "All NICs must have the same companion QP count";
+  }
 
-  std::size_t qpsPerPeer =
-      static_cast<std::size_t>(kQpKindsPerNic) * numNics * qpsPerNic;
+  std::size_t qpsPerPeer = static_cast<std::size_t>(numNics) *
+      (static_cast<std::size_t>(mainQpsPerNic) + companionQpsPerNic);
   std::size_t qpBytes = qpsPerPeer * sizeof(doca_gpu_dev_verbs_qp*);
   doca_gpu_dev_verbs_qp** d_qps = nullptr;
   cudaError_t err = cudaMalloc(&d_qps, qpBytes);
@@ -187,12 +225,13 @@ void writeDeviceTransportSlot(
   std::vector<NicDeviceIbgdaResources> h_nicResources;
   h_nicResources.reserve(numNics);
   for (int n = 0; n < numNics; ++n) {
-    auto* d_mainQps = d_qps + (n * kQpKindsPerNic * qpsPerNic);
-    auto* d_companionQps = d_mainQps + qpsPerNic;
+    auto* d_mainQps = d_qps + n * (mainQpsPerNic + companionQpsPerNic);
+    auto* d_companionQps = d_mainQps + mainQpsPerNic;
     h_nicResources.push_back(
         NicDeviceIbgdaResources{
-            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, qpsPerNic),
-            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_companionQps, qpsPerNic),
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(d_mainQps, mainQpsPerNic),
+            DeviceSpan<doca_gpu_dev_verbs_qp*>(
+                d_companionQps, companionQpsPerNic),
             params.h_nicDeviceIbgdaResources[n].sinkLkey,
             params.h_nicDeviceIbgdaResources[n].deviceId,
         });
@@ -203,6 +242,17 @@ void writeDeviceTransportSlot(
       << "Failed to copy per-peer NicDeviceIbgdaResources to GPU: "
       << cudaGetErrorString(err);
 
+  IbgdaBlockQpState* d_blockQpState = nullptr;
+  std::size_t blockStateBytes =
+      static_cast<std::size_t>(params.maxGroups) * sizeof(IbgdaBlockQpState);
+  err = cudaMalloc(&d_blockQpState, blockStateBytes);
+  CHECK(err == cudaSuccess) << "Failed to allocate per-peer block QP state: "
+                            << cudaGetErrorString(err);
+  outGpuAllocations.push_back(d_blockQpState);
+  err = cudaMemset(d_blockQpState, 0, blockStateBytes);
+  CHECK(err == cudaSuccess)
+      << "Failed to zero per-peer block QP state: " << cudaGetErrorString(err);
+
   P2pIbgdaTransportDevice hostTransport(
       DeviceSpan<NicDeviceIbgdaResources>(d_nicResources, numNics),
       params.remoteSignalBuf,
@@ -210,6 +260,9 @@ void writeDeviceTransportSlot(
       params.counterBuf,
       params.numSignalSlots,
       params.numCounterSlots,
+      params.maxGroups,
+      params.qpsPerBlockPerNic,
+      DeviceSpan<IbgdaBlockQpState>(d_blockQpState, params.maxGroups),
       params.sendRecvState);
 
   err = cudaMemcpy(

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransportCuda.cuh
@@ -52,8 +52,9 @@ struct NicDeviceIbgdaResourcesBuildSpec {
  * for the device transport.
  *
  * Single-NIC callers populate `nicResources` with one element.
- * Multi-NIC callers populate `nicResources` with one element per NIC; qps and
- * companionQps within a NicDeviceIbgdaResourcesBuildSpec must be the same size.
+ * Multi-NIC callers populate `nicResources` with one element per NIC. qps
+ * contains maxGroups * qpsPerBlockPerNic main QPs; companionQps contains
+ * maxGroups shared companion QPs.
  */
 struct P2pIbgdaTransportBuildParams {
   P2pIbgdaTransportBuildParams() = default;
@@ -67,6 +68,8 @@ struct P2pIbgdaTransportBuildParams {
   IbgdaRemoteBuffer discardSignalSlot{};
   int numSignalSlots{0};
   int numCounterSlots{0};
+  int maxGroups{0};
+  int qpsPerBlockPerNic{1};
   IbSendRecvState sendRecvState{};
 };
 

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -127,27 +127,61 @@ struct NicDeviceIbgdaResources {
   }
 };
 
+inline constexpr int kIbgdaMaxQpLanesPerBlock = 64;
+
+struct IbgdaBlockQpState {
+  uint32_t put_rr{0};
+  uint64_t pending_flush_lanes_mask{0};
+  uint64_t last_flush_wqe[kIbgdaMaxQpLanesPerBlock]{};
+};
+
 /**
  * P2pIbgdaTransportDevice - Device-side per-peer RDMA transport handle
  *
  * Every method has two overloads:
  *   Group-scope: put(group, ...) — all threads in group must call.
- *     QP selection: single QP for now (multi-QP via group.group_id % numQps
- *     will be added in a follow-up diff).
+ *     QP selection is owned by the physical CUDA block. The block
+ *     round-robins put operations across NIC-first QP lanes and preserves
+ *     signal/flush ordering for operations issued by the same block_id.
  *     Data transfer uses the exact buffer span supplied by the caller.
  *     Threads in the group coordinate the operation; callers that want the
  *     transport to shard a larger buffer should use put_cooperative().
- *     Signal/counter/fence are leader-only with group.sync().
+ *     Signal/counter/flush are leader-only with group.sync().
  *
  *   Thread-scope: put(...) — single thread calls.
- *     QP selection: always QP 0.
- *     Implemented as thin wrapper: creates solo ThreadGroup, forwards.
+ *     QP selection uses the caller's physical blockIdx.x. Implemented as a
+ *     thin wrapper: creates a solo ThreadGroup with block_id=blockIdx.x, then
+ *     forwards to the group-scope implementation.
  *
- * CRITICAL: Do not mix scope families in an ordered sequence.
- *   put(group,...) -> signal(0) is BROKEN (different QPs, FENCE invalid).
- *   put(group,...) -> signal(group,0) is CORRECT (same QP).
+ * CRITICAL: Do not rely on scope-family mixing for synchronization.
+ *   Thread-scope wrappers do not synchronize with other threads in the block.
+ *   put(group,...) -> signal(group,0) does not by itself order prior puts
+ *   issued on other QP lanes. Call fence(group) or flush(group) before a
+ *   standalone signal when the signal is meant to announce completion of prior
+ *   puts.
  *
- * Signal is always fenced (NIC completes prior WQEs before signal).
+ * CRITICAL: Same-block warp-scope batching is not a supported ordering
+ * contract in this implementation. The block_id owns one logical ordered
+ * stream. If multiple independent warps use the same block_id, this transport
+ * does not infer cross-warp order for a later signal() or flush(); the caller
+ * must use a CTA-level barrier or another protocol-level synchronization
+ * before issuing the covering signal/flush. In particular, do not rely on:
+ *
+ *   warp0: put(A); put(B); signal(S);
+ *   warp1: put(C); put(D); signal(S);
+ *
+ * to mean that either signal covers both warps' puts. Each warp only has its
+ * own program order, and the relative order between the warps is unspecified.
+ * A fused put+signal from multiple warps is only self-ordered for each
+ * operation's own put before its own signal; it is not a cross-warp batch
+ * completion signal. Full warp-specialized concurrent issue needs future
+ * per-QP-lane reservation/ordering state.
+ *
+ * Signal WQEs use the IB FENCE bit, which orders the signal after prior WQEs
+ * on the same QP only. A fused put(..., signal) posts the put and signal on
+ * the same QP, so the signal covers that put. A standalone signal uses the
+ * block's control lane and does not cover earlier round-robined puts unless
+ * the caller explicitly calls fence()/flush() first.
  * put() returns void — completion via wait_signal/wait_counter/flush.
  *
  * Two API layers:
@@ -167,18 +201,17 @@ class P2pIbgdaTransportDevice {
    * Construct a per-peer device transport handle.
    *
    * Each P2p instance owns one peer's NICs. Each NicDeviceIbgdaResources
-   * carries its own primary and companion QPs and a sink lkey. The host-side
-   * builder is responsible for peer-rotating the NicDeviceIbgdaResources[]
-   * order so that `nic_qp_for_group(g)`'s nic_id (= g % nicDevices.size())
-   * produces balanced thread-per-peer scatter when nicDevices.size() > 1.
+   * carries its main and companion QPs plus a sink lkey. Lane selection is
+   * block-owned: each physical CUDA block round-robins its puts across
+   * numNics * qpsPerBlockPerNic lanes, using NIC-first lane ordinals.
    *
    * Single-NIC usage: pass a 1-element nicDevices span. All ops fall through
    * to NIC 0.
    *
    * @param nicDevices          GPU span of per-NIC bundles (length =
    *                              numNics). Each NicDeviceIbgdaResources owns
-   *                              numQpsPerPeerPerNic primary + companion QP
-   *                              pointers and the per-NIC sink lkey.
+   *                              maxGroups * qpsPerBlockPerNic main QPs and
+   *                              maxGroups companion QPs.
    * @param ownedRemoteSignalBuf  Remote-side signal outbox: writing here
    *                              targets the peer's local signal inbox.
    *                              Used by the slot-index signal API.
@@ -205,6 +238,9 @@ class P2pIbgdaTransportDevice {
       IbgdaLocalBuffer ownedCounterBuf = {},
       int numSignalSlots = 0,
       int numCounterSlots = 0,
+      int maxGroups = 0,
+      int qpsPerBlockPerNic = 1,
+      DeviceSpan<IbgdaBlockQpState> blockQpState = {},
       IbSendRecvState sendRecvState = {})
       : nicDevices_(nicDevices),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
@@ -212,6 +248,9 @@ class P2pIbgdaTransportDevice {
         ownedCounterBuf_(ownedCounterBuf),
         numSignalSlots_(numSignalSlots),
         numCounterSlots_(numCounterSlots),
+        maxGroups_(maxGroups),
+        qpsPerBlockPerNic_(qpsPerBlockPerNic),
+        blockQpState_(blockQpState),
         sendRecvState_(sendRecvState) {}
 
   // =========================================================================
@@ -294,7 +333,8 @@ class P2pIbgdaTransportDevice {
 
   /**
    * put (thread-scope, slot-index) - Single-thread variant of slot-index put.
-   * Caller is responsible for gating to one thread. Uses QP 0.
+   * Caller is responsible for gating to one thread. Uses the caller's physical
+   * block-owned QP resources.
    * Args match the group-scope overload.
    */
   __device__ void put(
@@ -305,7 +345,7 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal = 1,
       int counterId = -1,
       uint64_t counterVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     put(solo,
         localBuf,
         remoteBuf,
@@ -319,8 +359,10 @@ class P2pIbgdaTransportDevice {
   /**
    * signal (group-scope, slot-index) - Fenced RDMA atomic add by slot index.
    *
-   * Always FENCEd against preceding WQEs on the same QP, so signal arrives
-   * after any prior put() completes at the NIC.
+   * Standalone signal posts on this block's control lane. It does not wait for
+   * prior puts issued on other round-robined QP lanes. If this signal should
+   * announce completion of earlier put() calls, the user/protocol must call
+   * fence(group) or flush(group) before signal(group, ...).
    *
    * @param group     Thread group; all threads must call. Leader posts WQE.
    * @param signalId  Slot index into the peer's signal inbox (>= 0,
@@ -332,9 +374,12 @@ class P2pIbgdaTransportDevice {
     signal(group, remote_signal_slot(signalId), signalVal);
   }
 
-  /** signal (thread-scope, slot-index) - Single-thread variant. Uses QP 0. */
+  /**
+   * signal (thread-scope, slot-index) - Single-thread variant. Uses the
+   * caller's physical block-owned QP resources.
+   */
   __device__ void signal(int signalId, uint64_t signalVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     signal(solo, signalId, signalVal);
   }
 
@@ -362,7 +407,7 @@ class P2pIbgdaTransportDevice {
       int signalId,
       uint64_t expected,
       const Timeout& timeout = Timeout()) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalId, expected, timeout);
   }
 
@@ -388,7 +433,7 @@ class P2pIbgdaTransportDevice {
       int counterId,
       uint64_t expected,
       const Timeout& timeout = Timeout()) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterId, expected, timeout);
   }
 
@@ -405,7 +450,7 @@ class P2pIbgdaTransportDevice {
 
   /** reset_signal (thread-scope, slot-index) - Single-thread variant. */
   __device__ void reset_signal(int signalId) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_signal(solo, signalId);
   }
 
@@ -421,7 +466,7 @@ class P2pIbgdaTransportDevice {
 
   /** reset_counter (thread-scope, slot-index) - Single-thread variant. */
   __device__ void reset_counter(int counterId) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_counter(solo, counterId);
   }
 
@@ -505,7 +550,7 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
-   * put (thread-scope) - Single-thread, QP 0. Caller gates.
+   * put (thread-scope) - Single-thread variant. Caller gates.
    *
    * signalBuf intentionally not defaulted (see group-scope sibling above).
    */
@@ -517,7 +562,7 @@ class P2pIbgdaTransportDevice {
       uint64_t signalVal = 1,
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     put(solo,
         localBuf,
         remoteBuf,
@@ -563,8 +608,12 @@ class P2pIbgdaTransportDevice {
   /**
    * signal (group-scope) - Fenced RDMA atomic add to a remote signal slot.
    *
-   * Always FENCEd against preceding WQEs on the same QP, so signal arrives
-   * after any prior put() completes at the NIC.
+   * Standalone signal posts on this block's control lane. The IB FENCE bit
+   * orders it after earlier WQEs on that same QP only; it does not drain the
+   * block's round-robined put lanes. If this signal is meant to cover previous
+   * put() calls, the user/protocol must call fence(group) or flush(group)
+   * before signal(group, ...). A fused put(..., signal) remains self-ordered
+   * because the put and signal are posted on the same QP.
    *
    * @param group     Thread group; all threads must call. Leader posts WQE,
    *                  all sync.
@@ -577,16 +626,19 @@ class P2pIbgdaTransportDevice {
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1) {
     if (group.is_leader()) {
-      signal_fenced(group.group_id, signalBuf, signalVal);
+      validate_group_scope(group);
+      IbgdaLane lane = control_lane(group.block_id);
+      const uint64_t signalTicket = signal_fenced(lane, signalBuf, signalVal);
+      record_signal_wqe(lane, signalTicket);
     }
     group.sync();
   }
 
-  /** signal (thread-scope) - Single-thread variant. Uses QP 0. */
+  /** signal (thread-scope) - Single-thread variant. */
   __device__ void signal(
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     signal(solo, signalBuf, signalVal);
   }
 
@@ -617,7 +669,7 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
       const Timeout& timeout = Timeout()) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalBuf, expected, timeout);
   }
 
@@ -642,38 +694,39 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
       const Timeout& timeout = Timeout()) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterBuf, expected, timeout);
   }
 
   /**
-   * flush (group-scope) - Wait for all in-flight transport operations to
-   * complete on this group's QP.
+   * flush (group-scope) - Wait for this block's locally tracked transport
+   * operations to complete.
    *
-   * Drains the QP via a NOP WQE. Use this when callers want "wait for
-   * completion" semantics independent of the underlying mechanism, so the
-   * implementation can later evolve (e.g. cross-QP flush) without churning
-   * call sites.
+   * Flush waits for the block's recorded data put and signal WQEs. Counter
+   * WQEs are local-tracking operations and are intentionally not part of the
+   * flush set.
    *
-   * @param group Thread group; all threads must call. Leader issues NOP
-   *              WQE and waits, all sync.
+   * @param group Thread group; all threads must call. Leader waits, all sync.
    */
   __device__ void flush(ThreadGroup& group) {
     if (group.is_leader()) {
-      flush_impl(group.group_id);
+      validate_group_scope(group);
+      drain_flush_lanes(group.block_id);
     }
     group.sync();
   }
 
   /** flush (thread-scope) - Single-thread variant. */
   __device__ void flush() {
-    flush_impl(0);
+    ThreadGroup solo = make_thread_solo();
+    flush(solo);
   }
 
   /**
-   * fence (group-scope) - Drain all pending WQEs on this group's QP.
+   * fence (group-scope) - Drain all locally tracked WQEs for this block.
    *
-   * Aliased to flush(). Prefer flush() in new code.
+   * Aliased to flush(). Use this before a standalone signal when that signal
+   * must announce completion of prior round-robined puts from the same block.
    *
    * @param group Thread group; all threads must call.
    */
@@ -705,7 +758,7 @@ class P2pIbgdaTransportDevice {
 
   /** reset_signal (thread-scope) - Single-thread variant. */
   __device__ void reset_signal(const IbgdaLocalBuffer& signalBuf) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_signal(solo, signalBuf);
   }
 
@@ -723,7 +776,7 @@ class P2pIbgdaTransportDevice {
 
   /** reset_counter (thread-scope) - Single-thread variant. */
   __device__ void reset_counter(const IbgdaLocalBuffer& counterBuf) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_counter(solo, counterBuf);
   }
 
@@ -756,6 +809,20 @@ class P2pIbgdaTransportDevice {
   // =========================================================================
 
  private:
+  struct IbgdaLane {
+    uint32_t nic_id{0};
+    uint32_t qp_index{0};
+    uint32_t lane_ordinal{0};
+    uint32_t block_id{0};
+    doca_gpu_dev_verbs_qp* qp{nullptr};
+    doca_gpu_dev_verbs_qp* companion_qp{nullptr};
+  };
+
+  struct IbgdaPutSignalTickets {
+    uint64_t put_wqe{0};
+    uint64_t signal_wqe{0};
+  };
+
   __device__ __forceinline__ static uint64_t load_acquire_system_u64(
       const void* ptr) {
     auto* slot = static_cast<uint64_t*>(const_cast<void*>(ptr));
@@ -765,6 +832,209 @@ class P2pIbgdaTransportDevice {
     return cuda::atomic_ref<uint64_t, cuda::thread_scope_system>{*slot}.load(
         cuda::memory_order_acquire);
 #endif
+  }
+
+  __device__ __forceinline__ void validate_block_id(uint32_t blockId) const {
+    if (blockIdx.y != 0 || blockIdx.z != 0 || blockDim.y != 1 ||
+        blockDim.z != 1) {
+      printf(
+          "[PIPES] FATAL: IBGDA per-block QP selection currently supports "
+          "only 1D grids and 1D thread blocks, got blockIdx=(%u,%u,%u) "
+          "blockDim=(%u,%u,%u)\n",
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          blockDim.x,
+          blockDim.y,
+          blockDim.z);
+      PIPES_DEVICE_TRAP();
+    }
+    if (blockId >= static_cast<uint32_t>(maxGroups_) || blockQpState_.empty()) {
+      printf(
+          "[PIPES] FATAL: IBGDA block_id=%u out of range [0, %d) "
+          "or block QP state missing\n",
+          blockId,
+          maxGroups_);
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  __device__ __forceinline__ void validate_group_scope(
+      const ThreadGroup& group) const {
+    if (group.scope == SyncScope::CLUSTER) {
+      printf(
+          "[PIPES] FATAL: IBGDA per-block QP selection does not support "
+          "cluster-scope ThreadGroup yet\n");
+      PIPES_DEVICE_TRAP();
+    }
+    validate_block_id(group.block_id);
+  }
+
+  __device__ __forceinline__ IbgdaLane
+  lane_from_ordinal(uint32_t blockId, uint32_t laneOrdinal) const {
+    validate_block_id(blockId);
+    const uint32_t numNics = static_cast<uint32_t>(nicDevices_.size());
+    if (numNics == 0) {
+      printf(
+          "P2pIbgdaTransportDevice: transport not initialized "
+          "(peer not materialized? call get_device_handle(peers) first) "
+          "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          __FILE__,
+          __LINE__,
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          threadIdx.x,
+          threadIdx.y,
+          threadIdx.z);
+      PIPES_DEVICE_TRAP();
+    }
+    const uint32_t nicId = laneOrdinal % numNics;
+    const uint32_t qpIndex = laneOrdinal / numNics;
+    const NicDeviceIbgdaResources& nic = nicDevices_[nicId];
+    const uint32_t qpId = blockId * qpsPerBlockPerNic_ + qpIndex;
+    if (qpIndex >= static_cast<uint32_t>(qpsPerBlockPerNic_) ||
+        qpId >= nic.qps.size() || blockId >= nic.companion_qps.size()) {
+      printf(
+          "[PIPES] FATAL: invalid IBGDA lane block=%u nic=%u qpIndex=%u "
+          "qpsPerBlockPerNic=%d qps=%u companionQps=%u\n",
+          blockId,
+          nicId,
+          qpIndex,
+          qpsPerBlockPerNic_,
+          static_cast<unsigned>(nic.qps.size()),
+          static_cast<unsigned>(nic.companion_qps.size()));
+      PIPES_DEVICE_TRAP();
+    }
+    return IbgdaLane{
+        .nic_id = nicId,
+        .qp_index = qpIndex,
+        .lane_ordinal = laneOrdinal,
+        .block_id = blockId,
+        .qp = nic.qps[qpId],
+        .companion_qp = nic.companion_qps[blockId]};
+  }
+
+  __device__ __forceinline__ uint32_t
+  select_put_lane_ordinal(uint32_t blockId) {
+    validate_block_id(blockId);
+    if (nicDevices_.empty()) {
+      printf(
+          "P2pIbgdaTransportDevice: transport not initialized "
+          "(peer not materialized? call get_device_handle(peers) first) "
+          "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
+          __FILE__,
+          __LINE__,
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          threadIdx.x,
+          threadIdx.y,
+          threadIdx.z);
+      PIPES_DEVICE_TRAP();
+    }
+    const uint32_t numLanes =
+        static_cast<uint32_t>(nicDevices_.size() * qpsPerBlockPerNic_);
+    if (numLanes == 1) {
+      return 0;
+    }
+    uint32_t seq = atomicAdd(&blockQpState_[blockId].put_rr, 1U);
+    return seq % numLanes;
+  }
+
+  __device__ __forceinline__ IbgdaLane select_put_lane(uint32_t blockId) {
+    return lane_from_ordinal(blockId, select_put_lane_ordinal(blockId));
+  }
+
+  __device__ __forceinline__ IbgdaLane control_lane(uint32_t blockId) const {
+    return lane_from_ordinal(blockId, 0);
+  }
+
+  __device__ __forceinline__ uint32_t num_qp_lanes() const {
+    return static_cast<uint32_t>(nicDevices_.size() * qpsPerBlockPerNic_);
+  }
+
+  __device__ __forceinline__ void atomic_max_u64(uint64_t* ptr, uint64_t val) {
+    atomicMax(
+        reinterpret_cast<unsigned long long*>(ptr),
+        static_cast<unsigned long long>(val));
+  }
+
+  __device__ __forceinline__ void atomic_or_u64(uint64_t* ptr, uint64_t val) {
+    atomicOr(
+        reinterpret_cast<unsigned long long*>(ptr),
+        static_cast<unsigned long long>(val));
+  }
+
+  __device__ __forceinline__ uint64_t
+  atomic_exchange_u64(uint64_t* ptr, uint64_t val) {
+    return atomicExch(
+        reinterpret_cast<unsigned long long*>(ptr),
+        static_cast<unsigned long long>(val));
+  }
+
+  __device__ __forceinline__ void record_put_wqe(
+      const IbgdaLane& lane,
+      uint64_t ticket) {
+    record_flush_wqe(lane, ticket);
+  }
+
+  __device__ __forceinline__ void record_flush_wqe(
+      const IbgdaLane& lane,
+      uint64_t ticket) {
+    auto& state = blockQpState_[lane.block_id];
+    atomic_max_u64(&state.last_flush_wqe[lane.lane_ordinal], ticket);
+    atomic_or_u64(&state.pending_flush_lanes_mask, 1ULL << lane.lane_ordinal);
+  }
+
+  __device__ __forceinline__ void record_signal_wqe(
+      const IbgdaLane& lane,
+      uint64_t ticket) {
+    record_flush_wqe(lane, ticket);
+  }
+
+  __device__ void wait_local_on_qp(
+      doca_gpu_dev_verbs_qp* qp,
+      doca_gpu_dev_verbs_ticket_t ticket,
+      Timeout timeout = Timeout()) {
+    if (!timeout.isEnabled()) {
+      doca_gpu_dev_verbs_wait<
+          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, ticket);
+    } else {
+      int status;
+      do {
+        status = doca_gpu_dev_verbs_poll_one_cq_at<
+            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+            doca_gpu_dev_verbs_qp_get_cq_sq(qp), ticket);
+        if (status == EBUSY) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "wait_local_on_qp timed out (ticket=%llu)",
+              static_cast<unsigned long long>(ticket));
+        }
+      } while (status == EBUSY);
+    }
+  }
+
+  __device__ void
+  wait_lanes(uint32_t blockId, uint64_t mask, const uint64_t* tickets) {
+    const uint32_t numLanes =
+        static_cast<uint32_t>(nicDevices_.size() * qpsPerBlockPerNic_);
+    for (uint32_t laneId = 0; laneId < numLanes; ++laneId) {
+      if ((mask & (1ULL << laneId)) == 0) {
+        continue;
+      }
+      IbgdaLane lane = lane_from_ordinal(blockId, laneId);
+      wait_local_on_qp(lane.qp, tickets[laneId]);
+    }
+  }
+
+  __device__ void drain_flush_lanes(uint32_t blockId) {
+    auto& state = blockQpState_[blockId];
+    const uint64_t mask =
+        atomic_exchange_u64(&state.pending_flush_lanes_mask, 0);
+    wait_lanes(blockId, mask, state.last_flush_wqe);
   }
 
   __device__ void put_impl(
@@ -789,10 +1059,12 @@ class P2pIbgdaTransportDevice {
     }
 
     if (group.is_leader()) {
+      validate_group_scope(group);
       const bool hasCounter = counterBuf.ptr != nullptr;
+      IbgdaLane lane = select_put_lane(group.block_id);
       if (hasSignal && hasCounter) {
-        put_signal_counter_single_impl(
-            group.group_id,
+        const auto tickets = put_signal_counter_single_impl(
+            lane,
             localBuf,
             remoteBuf,
             nbytes,
@@ -800,19 +1072,19 @@ class P2pIbgdaTransportDevice {
             signalVal,
             counterBuf,
             counterVal);
+        record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasSignal) {
-        put_signal_single_impl(
-            group.group_id, localBuf, remoteBuf, nbytes, signalBuf, signalVal);
+        const auto tickets = put_signal_single_impl(
+            lane, localBuf, remoteBuf, nbytes, signalBuf, signalVal);
+        record_signal_wqe(lane, tickets.signal_wqe);
       } else if (hasCounter) {
-        put_counter_single_impl(
-            group.group_id,
-            localBuf,
-            remoteBuf,
-            nbytes,
-            counterBuf,
-            counterVal);
+        const uint64_t putTicket = put_counter_single_impl(
+            lane, localBuf, remoteBuf, nbytes, counterBuf, counterVal);
+        record_put_wqe(lane, putTicket);
       } else {
-        put_single_impl(group.group_id, localBuf, remoteBuf, nbytes);
+        const uint64_t putTicket =
+            put_single_impl(lane, localBuf, remoteBuf, nbytes);
+        record_put_wqe(lane, putTicket);
       }
     }
     group.sync();
@@ -839,16 +1111,26 @@ class P2pIbgdaTransportDevice {
       return;
     }
 
-    const uint64_t lastPutWqeIdx =
-        put_cooperative_data_impl(group, localBuf, remoteBuf, nbytes);
+    uint32_t laneOrdinal = 0;
+    uint64_t lastPutWqeIdx = 0;
     if (group.is_leader()) {
+      validate_group_scope(group);
+      laneOrdinal = select_put_lane_ordinal(group.block_id);
+    }
+    laneOrdinal = group.broadcast<uint32_t>(laneOrdinal);
+    IbgdaLane lane = lane_from_ordinal(group.block_id, laneOrdinal);
+
+    lastPutWqeIdx =
+        put_cooperative_data_impl(group, lane, localBuf, remoteBuf, nbytes);
+    if (group.is_leader()) {
+      record_put_wqe(lane, lastPutWqeIdx);
       const bool hasCounter = counterBuf.ptr != nullptr;
       if (hasSignal) {
-        signal_fenced(group.group_id, signalBuf, signalVal);
+        const uint64_t signalTicket = signal_fenced(lane, signalBuf, signalVal);
+        record_signal_wqe(lane, signalTicket);
       }
       if (hasCounter) {
-        counter_after_wqe_impl(
-            group.group_id, lastPutWqeIdx, counterBuf, counterVal);
+        counter_after_wqe_impl(lane, lastPutWqeIdx, counterBuf, counterVal);
       }
     }
     group.sync();
@@ -927,6 +1209,7 @@ class P2pIbgdaTransportDevice {
 
   __device__ uint64_t put_cooperative_data_impl(
       ThreadGroup& group,
+      const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes) {
@@ -939,9 +1222,7 @@ class P2pIbgdaTransportDevice {
     IbgdaLocalBuffer laneBuf = localBuf.subBuffer(offset);
     IbgdaRemoteBuffer laneRemoteBuf = remoteBuf.subBuffer(offset);
 
-    auto idx = nic_qp_for_group(group.group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    auto* qp = nic.qps[idx.qp_id];
+    auto* qp = lane.qp;
 
     // Guard: group_size must fit within QP send queue depth
     if (group.is_leader()) {
@@ -970,18 +1251,26 @@ class P2pIbgdaTransportDevice {
     doca_gpu_dev_verbs_wqe* wqe_ptr =
         doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
 
-    doca_gpu_dev_verbs_wqe_prepare_write(
-        qp,
-        wqe_ptr,
-        static_cast<uint16_t>(wqe_idx),
-        DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
-        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
-        0,
-        reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
-        laneRemoteBuf.rkey_per_device[idx.nic_id].value,
-        reinterpret_cast<uint64_t>(laneBuf.ptr),
-        laneBuf.lkey_per_device[idx.nic_id].value,
-        static_cast<uint32_t>(laneBytes));
+    if (laneBytes == 0) {
+      doca_gpu_dev_verbs_wqe_prepare_nop(
+          qp,
+          wqe_ptr,
+          static_cast<uint16_t>(wqe_idx),
+          DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE);
+    } else {
+      doca_gpu_dev_verbs_wqe_prepare_write(
+          qp,
+          wqe_ptr,
+          static_cast<uint16_t>(wqe_idx),
+          DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+          DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+          0,
+          reinterpret_cast<uint64_t>(laneRemoteBuf.ptr),
+          laneRemoteBuf.rkey_per_device[lane.nic_id].value,
+          reinterpret_cast<uint64_t>(laneBuf.ptr),
+          laneBuf.lkey_per_device[lane.nic_id].value,
+          static_cast<uint32_t>(laneBytes));
+    }
 
     group.sync();
 
@@ -1004,46 +1293,44 @@ class P2pIbgdaTransportDevice {
 
   // --- put_single_impl: one thread, one WQE ---
 
-  __device__ void put_single_impl(
-      uint32_t group_id,
+  __device__ uint64_t put_single_impl(
+      const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
     doca_gpu_dev_verbs_ticket_t ticket;
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[idx.nic_id].value};
+        .key = localBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+        .key = remoteBuf.rkey_per_device[lane.nic_id].value};
 
     doca_gpu_dev_verbs_put<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
         DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
-        nic.qps[idx.qp_id], remoteAddr, localAddr, nbytes, &ticket);
+        lane.qp, remoteAddr, localAddr, nbytes, &ticket);
+    return ticket;
   }
 
-  __device__ void put_signal_single_impl(
-      uint32_t group_id,
+  __device__ IbgdaPutSignalTickets put_signal_single_impl(
+      const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[idx.nic_id].value};
+        .key = localBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+        .key = remoteBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+        .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sigSinkAddr = {
         .addr = 0, .key = nic.sink_lkey.value};
 
@@ -1052,7 +1339,7 @@ class P2pIbgdaTransportDevice {
     uint64_t ticket = 0;
     pipes_gda::pipes_gda_gpu_dev_verbs_put_signal(
         amdNic,
-        nic.qps[idx.qp_id],
+        lane.qp,
         remoteAddr,
         localAddr,
         nbytes,
@@ -1060,40 +1347,85 @@ class P2pIbgdaTransportDevice {
         sigSinkAddr,
         signalVal,
         &ticket);
+    return IbgdaPutSignalTickets{ticket, ticket};
 #else
-    doca_gpu_dev_verbs_put_signal<
-        DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
+    uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
+        nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+    numChunks = numChunks > 1 ? numChunks : 1;
+    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(lane.qp, numChunks + 1);
+    uint64_t wqeIdx = baseWqeIdx;
+    std::size_t remainingSize = nbytes;
+
+#pragma unroll 1
+    for (uint64_t i = 0; i < numChunks; ++i) {
+      wqeIdx = baseWqeIdx + i;
+      const std::size_t chunkSize =
+          remainingSize > DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          ? DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          : remainingSize;
+      doca_gpu_dev_verbs_wqe* wqePtr =
+          doca_gpu_dev_verbs_get_wqe_ptr(lane.qp, wqeIdx);
+      doca_gpu_dev_verbs_wqe_prepare_write(
+          lane.qp,
+          wqePtr,
+          wqeIdx,
+          DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+          DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+          0,
+          remoteAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          remoteAddr.key,
+          localAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          localAddr.key,
+          chunkSize);
+      remainingSize -= chunkSize;
+    }
+    const uint64_t lastPutWqeIdx = wqeIdx;
+
+    ++wqeIdx;
+    doca_gpu_dev_verbs_wqe* wqePtr =
+        doca_gpu_dev_verbs_get_wqe_ptr(lane.qp, wqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_atomic(
+        lane.qp,
+        wqePtr,
+        wqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_OPCODE_ATOMIC_FA,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        sigRemoteAddr.addr,
+        sigRemoteAddr.key,
+        sigSinkAddr.addr,
+        sigSinkAddr.key,
+        sizeof(uint64_t),
+        signalVal,
+        0);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        lane.qp, baseWqeIdx, wqeIdx);
+    doca_gpu_dev_verbs_submit<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
-        DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
-        nic.qps[idx.qp_id],
-        remoteAddr,
-        localAddr,
-        nbytes,
-        sigRemoteAddr,
-        sigSinkAddr,
-        signalVal);
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(lane.qp, wqeIdx + 1);
+    return IbgdaPutSignalTickets{lastPutWqeIdx, wqeIdx};
 #endif
   }
 
-  __device__ void put_counter_single_impl(
-      uint32_t group_id,
+  __device__ uint64_t put_counter_single_impl(
+      const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
+    const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[idx.nic_id].value};
+        .key = localBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+        .key = remoteBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+        .key = counterBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = nic.sink_lkey.value};
 
@@ -1107,34 +1439,105 @@ class P2pIbgdaTransportDevice {
     pipes_gda::ActiveNicBackend amdNic{};
     pipes_gda::pipes_gda_gpu_dev_verbs_put_signal_counter(
         amdNic,
-        nic.qps[idx.qp_id],
+        lane.qp,
         remoteAddr,
         localAddr,
         nbytes,
         noSigRemoteAddr,
         noSigSinkAddr,
         0,
-        nic.companion_qps[idx.qp_id],
+        lane.companion_qp,
         counterRemoteAddr,
         counterSinkAddr,
         counterVal);
+    return 0;
 #else
-    doca_gpu_dev_verbs_put_counter<
+    constexpr unsigned int kNumQps = 2;
+    doca_gpu_dev_verbs_qp* qp = lane.qp;
+    doca_gpu_dev_verbs_qp* companionQp = lane.companion_qp;
+
+    uint64_t numChunks = doca_gpu_dev_verbs_div_ceil_aligned_pow2(
+        nbytes, DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE_SHIFT);
+    numChunks = numChunks > 1 ? numChunks : 1;
+    uint64_t baseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, numChunks);
+    uint64_t wqeIdx = baseWqeIdx;
+    std::size_t remainingSize = nbytes;
+
+#pragma unroll 1
+    for (uint64_t i = 0; i < numChunks; ++i) {
+      wqeIdx = baseWqeIdx + i;
+      const std::size_t chunkSize =
+          remainingSize > DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          ? DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE
+          : remainingSize;
+      doca_gpu_dev_verbs_wqe* wqePtr =
+          doca_gpu_dev_verbs_get_wqe_ptr(qp, wqeIdx);
+      doca_gpu_dev_verbs_wqe_prepare_write(
+          qp,
+          wqePtr,
+          wqeIdx,
+          DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+          DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+          0,
+          remoteAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          remoteAddr.key,
+          localAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          localAddr.key,
+          chunkSize);
+      remainingSize -= chunkSize;
+    }
+    const uint64_t lastPutWqeIdx = wqeIdx;
+
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        qp, baseWqeIdx, lastPutWqeIdx);
+
+    uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
+    uint64_t companionWqeIdx = companionBaseWqeIdx;
+    doca_gpu_dev_verbs_wqe* wqePtr =
+        doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_wait(
+        companionQp,
+        wqePtr,
+        companionWqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        lastPutWqeIdx,
+        qp->cq_sq.cq_num);
+
+    ++companionWqeIdx;
+    wqePtr = doca_gpu_dev_verbs_get_wqe_ptr(companionQp, companionWqeIdx);
+    doca_gpu_dev_verbs_wqe_prepare_atomic(
+        companionQp,
+        wqePtr,
+        companionWqeIdx,
+        DOCA_GPUNETIO_IB_MLX5_OPCODE_ATOMIC_FA,
+        DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+        counterRemoteAddr.addr,
+        counterRemoteAddr.key,
+        counterSinkAddr.addr,
+        counterSinkAddr.key,
+        sizeof(uint64_t),
+        counterVal,
+        0);
+    doca_gpu_dev_verbs_mark_wqes_ready<
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        companionQp, companionBaseWqeIdx, companionWqeIdx);
+
+    doca_gpu_dev_verbs_qp* qps[kNumQps] = {qp, companionQp};
+    uint64_t prodIndices[kNumQps] = {lastPutWqeIdx + 1, companionWqeIdx + 1};
+    doca_gpu_dev_verbs_submit_multi_qps<
+        kNumQps,
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-        nic.qps[idx.qp_id],
-        remoteAddr,
-        localAddr,
-        nbytes,
-        nic.companion_qps[idx.qp_id],
-        counterRemoteAddr,
-        counterSinkAddr,
-        counterVal);
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
+        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
+    return lastPutWqeIdx;
 #endif
   }
 
-  __device__ void put_signal_counter_single_impl(
-      uint32_t group_id,
+  __device__ IbgdaPutSignalTickets put_signal_counter_single_impl(
+      const IbgdaLane& lane,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
@@ -1143,59 +1546,30 @@ class P2pIbgdaTransportDevice {
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
 #ifdef __HIP_PLATFORM_AMD__
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    doca_gpu_dev_verbs_addr localAddr = {
-        .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr remoteAddr = {
-        .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr sigRemoteAddr = {
-        .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr sigSinkAddr = {
-        .addr = 0, .key = nic.sink_lkey.value};
-    doca_gpu_dev_verbs_addr counterRemoteAddr = {
-        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = nic.sink_lkey.value};
-    pipes_gda::ActiveNicBackend amdNic{};
-    pipes_gda::pipes_gda_gpu_dev_verbs_put_signal_counter(
-        amdNic,
-        nic.qps[idx.qp_id],
-        remoteAddr,
-        localAddr,
-        nbytes,
-        sigRemoteAddr,
-        sigSinkAddr,
-        signalVal,
-        nic.companion_qps[idx.qp_id],
-        counterRemoteAddr,
-        counterSinkAddr,
-        counterVal);
+    put_counter_single_impl(
+        lane, localBuf, remoteBuf, nbytes, counterBuf, counterVal);
+    const uint64_t signalTicket = signal_fenced(lane, signalBuf, signalVal);
+    return IbgdaPutSignalTickets{signalTicket, signalTicket};
 #else
     constexpr unsigned int kNumQps = 2;
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
-    doca_gpu_dev_verbs_qp* companionQp = nic.companion_qps[idx.qp_id];
+    const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
+    doca_gpu_dev_verbs_qp* qp = lane.qp;
+    doca_gpu_dev_verbs_qp* companionQp = lane.companion_qp;
 
     doca_gpu_dev_verbs_addr localAddr = {
         .addr = reinterpret_cast<uint64_t>(localBuf.ptr),
-        .key = localBuf.lkey_per_device[idx.nic_id].value};
+        .key = localBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(remoteBuf.ptr),
-        .key = remoteBuf.rkey_per_device[idx.nic_id].value};
+        .key = remoteBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sigRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+        .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sigSinkAddr = {
         .addr = 0, .key = nic.sink_lkey.value};
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+        .key = counterBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = nic.sink_lkey.value};
 
@@ -1216,23 +1590,18 @@ class P2pIbgdaTransportDevice {
           : remainingSize;
       doca_gpu_dev_verbs_wqe* wqePtr =
           doca_gpu_dev_verbs_get_wqe_ptr(qp, wqeIdx);
-      [[likely]] if (chunkSize > 0) {
-        doca_gpu_dev_verbs_wqe_prepare_write(
-            qp,
-            wqePtr,
-            wqeIdx,
-            DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
-            DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
-            0,
-            remoteAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
-            remoteAddr.key,
-            localAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
-            localAddr.key,
-            chunkSize);
-      } else {
-        doca_gpu_dev_verbs_wqe_prepare_nop(
-            qp, wqePtr, wqeIdx, DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE);
-      }
+      doca_gpu_dev_verbs_wqe_prepare_write(
+          qp,
+          wqePtr,
+          wqeIdx,
+          DOCA_GPUNETIO_IB_MLX5_OPCODE_RDMA_WRITE,
+          DOCA_GPUNETIO_IB_MLX5_WQE_CTRL_CQ_UPDATE,
+          0,
+          remoteAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          remoteAddr.key,
+          localAddr.addr + (i * DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE),
+          localAddr.key,
+          chunkSize);
       remainingSize -= chunkSize;
     }
     const uint64_t lastPutWqeIdx = wqeIdx;
@@ -1252,8 +1621,10 @@ class P2pIbgdaTransportDevice {
         sizeof(uint64_t),
         signalVal,
         0);
+    const uint64_t signalWqeIdx = wqeIdx;
     doca_gpu_dev_verbs_mark_wqes_ready<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(qp, baseWqeIdx, wqeIdx);
+        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+        qp, baseWqeIdx, signalWqeIdx);
 
     uint64_t companionBaseWqeIdx = doca_gpu_dev_verbs_reserve_wq_slots<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(companionQp, 2);
@@ -1287,28 +1658,28 @@ class P2pIbgdaTransportDevice {
         companionQp, companionBaseWqeIdx, companionWqeIdx);
 
     doca_gpu_dev_verbs_qp* qps[kNumQps] = {qp, companionQp};
-    uint64_t prodIndices[kNumQps] = {wqeIdx + 1, companionWqeIdx + 1};
+    uint64_t prodIndices[kNumQps] = {signalWqeIdx + 1, companionWqeIdx + 1};
     doca_gpu_dev_verbs_submit_multi_qps<
         kNumQps,
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
         DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qps, prodIndices);
+    return IbgdaPutSignalTickets{lastPutWqeIdx, signalWqeIdx};
 #endif
   }
 
   __device__ void counter_after_wqe_impl(
-      uint32_t group_id,
+      const IbgdaLane& lane,
       uint64_t waitWqeIdx,
       const IbgdaLocalBuffer& counterBuf,
       uint64_t counterVal) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
-    doca_gpu_dev_verbs_qp* companionQp = nic.companion_qps[idx.qp_id];
+    const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
+    doca_gpu_dev_verbs_qp* qp = lane.qp;
+    doca_gpu_dev_verbs_qp* companionQp = lane.companion_qp;
 
     doca_gpu_dev_verbs_addr counterRemoteAddr = {
         .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[idx.nic_id].value};
+        .key = counterBuf.lkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr counterSinkAddr = {
         .addr = 0, .key = nic.sink_lkey.value};
 
@@ -1326,7 +1697,7 @@ class P2pIbgdaTransportDevice {
     pipes_gda::ActiveNicBackend amdNic{};
     pipes_gda::pipes_gda_gpu_dev_verbs_signal_counter(
         amdNic,
-        nic.qps[idx.qp_id],
+        lane.qp,
         noSigRemoteAddr,
         noSigSinkAddr,
         0,
@@ -1375,16 +1746,15 @@ class P2pIbgdaTransportDevice {
 
   // --- signal_fenced: atomic fetch-add with NIC FENCE (always fenced) ---
 
-  __device__ void signal_fenced(
-      uint32_t group_id,
+  __device__ uint64_t signal_fenced(
+      const IbgdaLane& lane,
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    doca_gpu_dev_verbs_qp* qp = nic.qps[idx.qp_id];
+    const NicDeviceIbgdaResources& nic = nicDevices_[lane.nic_id];
+    doca_gpu_dev_verbs_qp* qp = lane.qp;
     doca_gpu_dev_verbs_addr remoteAddr = {
         .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[idx.nic_id].value};
+        .key = signalBuf.rkey_per_device[lane.nic_id].value};
     doca_gpu_dev_verbs_addr sinkAddr = {.addr = 0, .key = nic.sink_lkey.value};
 
     uint64_t wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots<
@@ -1414,78 +1784,9 @@ class P2pIbgdaTransportDevice {
 
     doca_gpu_dev_verbs_submit<
         DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_GPU,
+        DOCA_GPUNETIO_VERBS_SYNC_SCOPE_THREAD,
         DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(qp, wqe_idx + 1);
-  }
-
-  // --- signal_counter: fenced signal + companion QP loopback counter ---
-
-  __device__ void signal_counter(
-      uint32_t group_id,
-      const IbgdaRemoteBuffer& signalBuf,
-      uint64_t signalVal,
-      const IbgdaLocalBuffer& counterBuf,
-      uint64_t counterVal) {
-    auto idx = nic_qp_for_group(group_id);
-    const NicDeviceIbgdaResources& nic = nicDevices_[idx.nic_id];
-    doca_gpu_dev_verbs_addr sigRemoteAddr = {
-        .addr = reinterpret_cast<uint64_t>(signalBuf.ptr),
-        .key = signalBuf.rkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr sigSinkAddr = {
-        .addr = 0, .key = nic.sink_lkey.value};
-
-    doca_gpu_dev_verbs_addr counterRemoteAddr = {
-        .addr = reinterpret_cast<uint64_t>(counterBuf.ptr),
-        .key = counterBuf.lkey_per_device[idx.nic_id].value};
-    doca_gpu_dev_verbs_addr counterSinkAddr = {
-        .addr = 0, .key = nic.sink_lkey.value};
-
-    doca_gpu_dev_verbs_signal_counter<
-        DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD,
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-        nic.qps[idx.qp_id],
-        sigRemoteAddr,
-        sigSinkAddr,
-        signalVal,
-        nic.companion_qps[idx.qp_id],
-        counterRemoteAddr,
-        counterSinkAddr,
-        counterVal);
-  }
-
-  // --- flush_impl: NOP WQE + wait ---
-
-  __device__ void flush_impl(uint32_t group_id) {
-    doca_fence<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(active_qp(group_id));
-  }
-
-  // --- wait_local_impl: CQ poll for specific WQE (internal use only) ---
-
-  __device__ void wait_local_impl(
-      uint32_t group_id,
-      doca_gpu_dev_verbs_ticket_t ticket,
-      Timeout timeout = Timeout()) {
-    if (!timeout.isEnabled()) {
-      doca_gpu_dev_verbs_wait<
-          DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-          DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(active_qp(group_id), ticket);
-    } else {
-      int status;
-      do {
-        status = doca_gpu_dev_verbs_poll_one_cq_at<
-            DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-            doca_gpu_dev_verbs_qp_get_cq_sq(active_qp(group_id)), ticket);
-        if (status == EBUSY) {
-          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-              timeout,
-              "wait_local_impl timed out (ticket=%llu)",
-              static_cast<unsigned long long>(ticket));
-        }
-      } while (status == EBUSY);
-    }
+    return wqe_idx;
   }
 
   // --- Slot resolution helpers ---
@@ -1904,7 +2205,8 @@ class P2pIbgdaTransportDevice {
       __threadfence_system();
       group.sync();
       if (group.is_leader()) {
-        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         put(solo,
             sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
             sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
@@ -2286,7 +2588,8 @@ class P2pIbgdaTransportDevice {
       __threadfence_system();
       group.sync();
       if (group.is_leader()) {
-        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         put(solo,
             sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
             sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
@@ -2829,7 +3132,8 @@ class P2pIbgdaTransportDevice {
       __threadfence_system();
       group.sync();
       if (group.is_leader()) {
-        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         fwd.put(
             solo,
             fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
@@ -3360,65 +3664,6 @@ class P2pIbgdaTransportDevice {
     };
   }
 
-  struct NicQpIndex {
-    int nic_id;
-    int qp_id;
-  };
-
-  /**
-   * nic_qp_for_group - Single lookup: returns NIC/QP ids.
-   *
-   * Round-robin over NIC resources, then within the chosen NIC round-robin over
-   * its QPs.
-   */
-  __device__ NicQpIndex nic_qp_for_group(uint32_t group_id) const {
-    if (nicDevices_.empty()) {
-      printf(
-          "P2pIbgdaTransportDevice: transport not initialized "
-          "(peer not materialized? call get_device_handle(peers) first) "
-          "at %s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
-          __FILE__,
-          __LINE__,
-          blockIdx.x,
-          blockIdx.y,
-          blockIdx.z,
-          threadIdx.x,
-          threadIdx.y,
-          threadIdx.z);
-      PIPES_DEVICE_TRAP();
-    }
-    int nic_id = group_id % nicDevices_.size();
-    const auto& qps = nicDevices_[nic_id].qps;
-    if (qps.empty()) {
-      printf(
-          "P2pIbgdaTransportDevice: NIC %d has no qps at "
-          "%s:%d block=(%u,%u,%u) thread=(%u,%u,%u)\n",
-          nic_id,
-          __FILE__,
-          __LINE__,
-          blockIdx.x,
-          blockIdx.y,
-          blockIdx.z,
-          threadIdx.x,
-          threadIdx.y,
-          threadIdx.z);
-      PIPES_DEVICE_TRAP();
-    }
-    int qp_id = (group_id / nicDevices_.size()) % qps.size();
-    return {nic_id, qp_id};
-  }
-
-  __device__ doca_gpu_dev_verbs_qp* active_qp(uint32_t group_id) const {
-    auto idx = nic_qp_for_group(group_id);
-    return nicDevices_[idx.nic_id].qps[idx.qp_id];
-  }
-
-  __device__ doca_gpu_dev_verbs_qp* active_companion_qp(
-      uint32_t group_id) const {
-    auto idx = nic_qp_for_group(group_id);
-    return nicDevices_[idx.nic_id].companion_qps[idx.qp_id];
-  }
-
   // --- Members ---
   // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id).
   DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
@@ -3430,6 +3675,9 @@ class P2pIbgdaTransportDevice {
 
   int numSignalSlots_{0};
   int numCounterSlots_{0};
+  int maxGroups_{0};
+  int qpsPerBlockPerNic_{1};
+  DeviceSpan<IbgdaBlockQpState> blockQpState_{};
 
   IbSendRecvState sendRecvState_{};
 };

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -184,13 +184,43 @@ MultipeerIbrcTransport::MultipeerIbrcTransport(
           nRanks,
           std::move(bootstrap),
           config) {
-  if (config.numQpsPerPeerPerNic < 1 ||
-      config.numQpsPerPeerPerNic > kMaxQpsPerPeerPerNic) {
+  const int numQpsPerPeerPerNic = config.numQpsPerPeerPerNic();
+  if (config.maxGroups < 1) {
+    throw std::invalid_argument("maxGroups must be >= 1");
+  }
+  if (config.qpsPerBlockPerNic < 1) {
+    throw std::invalid_argument("qpsPerBlockPerNic must be >= 1");
+  }
+  if (config.maxGroups > kMaxIbGroups) {
     throw std::invalid_argument(
         fmt::format(
-            "numQpsPerPeerPerNic must be in [1, {}], got {}",
-            kMaxQpsPerPeerPerNic,
-            config.numQpsPerPeerPerNic));
+            "maxGroups must be <= {}, got {}", kMaxIbGroups, config.maxGroups));
+  }
+  if (config.qpsPerBlockPerNic > kMaxIbQpsPerBlockPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "qpsPerBlockPerNic must be <= {}, got {}",
+            kMaxIbQpsPerBlockPerNic,
+            config.qpsPerBlockPerNic));
+  }
+  if (numQpsPerPeerPerNic > kMaxIbQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "maxGroups * qpsPerBlockPerNic must be <= {}, got {} * {} = {}",
+            kMaxIbQpsPerPeerPerNic,
+            config.maxGroups,
+            config.qpsPerBlockPerNic,
+            numQpsPerPeerPerNic));
+  }
+  if (!config.ibLazyConnect &&
+      numQpsPerPeerPerNic > kMaxEagerExchangeQpsPerPeerPerNic) {
+    throw std::invalid_argument(
+        fmt::format(
+            "eager IBRC allGather exchange supports at most {} QPs per "
+            "(peer,NIC); got {}. Enable ibLazyConnect for larger "
+            "maxGroups * qpsPerBlockPerNic shapes.",
+            kMaxEagerExchangeQpsPerPeerPerNic,
+            numQpsPerPeerPerNic));
   }
 
   peerResources_.resize(nRanks_ - 1);
@@ -563,7 +593,7 @@ void MultipeerIbrcTransport::publishQueueError(
   const int peerRank = peerIndex < myRank_ ? peerIndex : peerIndex + 1;
   const auto queueIndex = static_cast<uint32_t>(
       ((static_cast<uint64_t>(peerIndex) *
-            static_cast<uint64_t>(config_.numQpsPerPeerPerNic) +
+            static_cast<uint64_t>(config_.numQpsPerPeerPerNic()) +
         static_cast<uint64_t>(cmdQueue.qpSlot)) *
        static_cast<uint64_t>(numNics_)) +
       static_cast<uint64_t>(cmdQueue.nic));
@@ -659,6 +689,7 @@ void MultipeerIbrcTransport::cleanupPeerCmdQueues(int peerIndex) noexcept {
   auto& peer = peerResources_[peerIndex];
   peer.cmdQueues.clear();
   peer.cmdQueueDevices.reset();
+  peer.blockQpState.reset();
   peer.cmdQueuesAllocated = false;
   if (p2pTransportDevices_.host != nullptr) {
     updatePeerDeviceTransport(peerIndex);
@@ -683,7 +714,7 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
     return;
   }
 
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int numQps = config_.numQpsPerPeerPerNic();
   const std::size_t cmdQueuesPerPeer = checkedMul(
       static_cast<std::size_t>(numNics_),
       static_cast<std::size_t>(numQps),
@@ -739,6 +770,9 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
       peer.cmdQueueDevices.host,
       deviceCmdQueues.data(),
       deviceCmdQueues.size() * sizeof(IbrcCmdQueueDevice));
+  peer.blockQpState = allocateMapped(
+      static_cast<std::size_t>(config_.maxGroups) * sizeof(IbrcBlockQpState),
+      "per-peer block QP state");
   peer.cmdQueues = std::move(cmdQueues);
   peer.cmdQueuesAllocated = true;
   updatePeerDeviceTransport(peerIndex);
@@ -788,7 +822,11 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
           static_cast<IbrcCmdQueueDevice*>(peer.cmdQueueDevices.device),
           static_cast<uint32_t>(peer.cmdQueues.size())),
       static_cast<uint32_t>(numNics_),
-      static_cast<uint32_t>(config_.numQpsPerPeerPerNic),
+      static_cast<uint32_t>(config_.maxGroups),
+      static_cast<uint32_t>(config_.qpsPerBlockPerNic),
+      DeviceSpan<IbrcBlockQpState>(
+          static_cast<IbrcBlockQpState*>(peer.blockQpState.device),
+          static_cast<uint32_t>(config_.maxGroups)),
       remoteSignalBuf,
       localSignalBuf,
       counterDeviceBuf,
@@ -925,7 +963,7 @@ void MultipeerIbrcTransport::createPeerQps(int peerIndex) {
     return;
   }
 
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int numQps = config_.numQpsPerPeerPerNic();
   std::vector<PeerQpResource> qpResources;
   qpResources.reserve(static_cast<std::size_t>(numNics_) * numQps);
   auto& symbols = ibverbx::ibvSymbols;
@@ -1031,7 +1069,7 @@ const MultipeerIbrcTransport::PeerQpResource&
 MultipeerIbrcTransport::qpResourceAt(int peerIndex, int nic, int qpSlot) const {
   if (peerIndex < 0 || peerIndex >= static_cast<int>(peerResources_.size()) ||
       nic < 0 || nic >= numNics_ || qpSlot < 0 ||
-      qpSlot >= config_.numQpsPerPeerPerNic) {
+      qpSlot >= config_.numQpsPerPeerPerNic()) {
     throw std::invalid_argument(
         fmt::format(
             "qpResourceAt: invalid peerIndex={} nic={} qpSlot={}",
@@ -1053,12 +1091,14 @@ MultipeerIbrcTransport::qpResourceAt(int peerIndex, int nic, int qpSlot) const {
 }
 
 PeerQpPayload MultipeerIbrcTransport::buildLocalQpPayload(int peerIndex) const {
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int numQps = config_.numQpsPerPeerPerNic();
   PeerQpPayload payload{};
   payload.gidIndex = gidIndex_;
   payload.mtu = static_cast<int>(localMtu_);
   payload.numNics = numNics_;
   payload.numQpsPerPeerPerNic = numQps;
+  payload.maxGroups = config_.maxGroups;
+  payload.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
 
   auto& symbols = ibverbx::ibvSymbols;
   for (int n = 0; n < numNics_; ++n) {
@@ -1186,16 +1226,28 @@ void MultipeerIbrcTransport::connectPeerQps(
             remotePayload.numNics,
             numNics_));
   }
-  if (remotePayload.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic) {
+  if (remotePayload.numQpsPerPeerPerNic != config_.numQpsPerPeerPerNic()) {
     throw std::runtime_error(
         fmt::format(
             "IBRC peerIndex={} numQps={} vs local {}",
             peerIndex,
             remotePayload.numQpsPerPeerPerNic,
-            config_.numQpsPerPeerPerNic));
+            config_.numQpsPerPeerPerNic()));
+  }
+  if (remotePayload.maxGroups != config_.maxGroups ||
+      remotePayload.qpsPerBlockPerNic != config_.qpsPerBlockPerNic) {
+    throw std::runtime_error(
+        fmt::format(
+            "IBRC peerIndex={} block-owned QP shape maxGroups={} "
+            "qpsPerBlockPerNic={} vs local {} {}",
+            peerIndex,
+            remotePayload.maxGroups,
+            remotePayload.qpsPerBlockPerNic,
+            config_.maxGroups,
+            config_.qpsPerBlockPerNic));
   }
 
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int numQps = config_.numQpsPerPeerPerNic();
   for (int nic = 0; nic < numNics_; ++nic) {
     for (int q = 0; q < numQps; ++q) {
       connectPeerQp(
@@ -1211,7 +1263,7 @@ void MultipeerIbrcTransport::connectPeerQps(
 
 void MultipeerIbrcTransport::exchangeAndConnectQps() {
   const int numPeers = nRanks_ - 1;
-  const int numQps = config_.numQpsPerPeerPerNic;
+  const int numQps = config_.numQpsPerPeerPerNic();
 
   for (int peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
     createPeerQps(peerIndex);
@@ -1222,6 +1274,8 @@ void MultipeerIbrcTransport::exchangeAndConnectQps() {
   myInfo.mtu = localMtu_;
   myInfo.numNics = numNics_;
   myInfo.numQpsPerPeerPerNic = numQps;
+  myInfo.maxGroups = config_.maxGroups;
+  myInfo.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
 
   auto& symbols = ibverbx::ibvSymbols;
   for (int n = 0; n < numNics_; ++n) {

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -132,6 +132,7 @@ class MultipeerIbrcTransport
     std::vector<PeerQpResource> qpResources;
     std::vector<IbrcCmdQueueHost> cmdQueues;
     MappedAllocation cmdQueueDevices;
+    MappedAllocation blockQpState;
     bool qpsConnected{false};
     bool cmdQueuesAllocated{false};
   };

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -54,6 +54,10 @@ inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 #define IBRC_CHECK_SLOT_ID(id, count, kind) assert((id) >= 0 && (id) < (count))
 #endif
 
+struct IbrcBlockQpState {
+  uint32_t put_rr{0};
+};
+
 /**
  * Device-side IBRC peer handle.
  *
@@ -70,7 +74,9 @@ class P2pIbrcTransportDevice {
   __host__ __device__ P2pIbrcTransportDevice(
       DeviceSpan<IbrcCmdQueueDevice> queues,
       uint32_t nics,
-      uint32_t qpsPerPeerPerNic,
+      uint32_t maxGroups,
+      uint32_t qpsPerBlockPerNic,
+      DeviceSpan<IbrcBlockQpState> blockQpState,
       IbgdaRemoteBuffer ownedRemoteSignalBuf = {},
       IbgdaLocalBuffer ownedLocalSignalBuf = {},
       IbgdaLocalBuffer ownedCounterDeviceBuf = {},
@@ -79,7 +85,9 @@ class P2pIbrcTransportDevice {
       int numCounterSlots = 0)
       : cmdQueues(queues),
         numNics(nics),
-        numQpsPerPeerPerNic(qpsPerPeerPerNic),
+        maxGroups_(maxGroups),
+        qpsPerBlockPerNic_(qpsPerBlockPerNic),
+        blockQpState_(blockQpState),
         ownedRemoteSignalBuf_(ownedRemoteSignalBuf),
         ownedLocalSignalBuf_(ownedLocalSignalBuf),
         ownedCounterDeviceBuf_(ownedCounterDeviceBuf),
@@ -118,7 +126,7 @@ class P2pIbrcTransportDevice {
       uint64_t signalVal = 1,
       int counterId = -1,
       uint64_t counterVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     put(solo,
         localBuf,
         remoteBuf,
@@ -154,7 +162,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ void signal(int signalId, uint64_t signalVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     signal(solo, signalId, signalVal);
   }
 
@@ -170,7 +178,7 @@ class P2pIbrcTransportDevice {
       int signalId,
       uint64_t expected,
       const Timeout& timeout = Timeout()) const {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalId, expected, timeout);
   }
 
@@ -186,7 +194,7 @@ class P2pIbrcTransportDevice {
       int counterId,
       uint64_t expected,
       const Timeout& timeout = Timeout()) const {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterId, expected, timeout);
   }
 
@@ -195,7 +203,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ void reset_signal(int signalId) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_signal(solo, signalId);
   }
 
@@ -204,7 +212,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ void reset_counter(int counterId) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_counter(solo, counterId);
   }
 
@@ -224,7 +232,8 @@ class P2pIbrcTransportDevice {
       if (signalBuf.ptr == nullptr) {
         trap("P2pIbrcTransportDevice: signal buffer is null");
       }
-      const uint32_t queueId = queue_for_group(group.group_id);
+      validate_group_scope(group);
+      const uint32_t queueId = control_queue_id(group.block_id);
       const uint32_t nicId = nic_for_queue(queueId);
       IbrcDesc desc{};
       desc.signal_addr = reinterpret_cast<uint64_t>(signalBuf.ptr);
@@ -241,7 +250,7 @@ class P2pIbrcTransportDevice {
   __device__ void signal(
       const IbgdaRemoteBuffer& signalBuf,
       uint64_t signalVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     signal(solo, signalBuf, signalVal);
   }
 
@@ -266,7 +275,8 @@ class P2pIbrcTransportDevice {
     group.sync();
 
     if (group.is_leader()) {
-      const uint32_t queueId = queue_for_group(group.group_id);
+      validate_group_scope(group);
+      const uint32_t queueId = select_put_queue_id(group.block_id);
       const uint32_t nicId = nic_for_queue(queueId);
       IbrcDesc desc{};
       desc.op = static_cast<uint16_t>(hasData ? IbrcOp::PUT : IbrcOp::SIGNAL);
@@ -306,7 +316,7 @@ class P2pIbrcTransportDevice {
       uint64_t signalVal = 1,
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     put(solo,
         localBuf,
         remoteBuf,
@@ -344,7 +354,7 @@ class P2pIbrcTransportDevice {
       uint64_t signalVal = 1,
       const IbgdaLocalBuffer& counterBuf = {},
       uint64_t counterVal = 1) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     put_cooperative(
         solo,
         localBuf,
@@ -368,7 +378,7 @@ class P2pIbrcTransportDevice {
       const IbgdaLocalBuffer& signalBuf,
       uint64_t expected,
       const Timeout& timeout = Timeout()) const {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_signal(solo, signalBuf, expected, timeout);
   }
 
@@ -379,7 +389,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ void reset_signal(const IbgdaLocalBuffer& signalBuf) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_signal(solo, signalBuf);
   }
 
@@ -390,7 +400,7 @@ class P2pIbrcTransportDevice {
   }
 
   __device__ void reset_counter(const IbgdaLocalBuffer& counterBuf) {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     reset_counter(solo, counterBuf);
   }
 
@@ -406,7 +416,7 @@ class P2pIbrcTransportDevice {
       const IbgdaLocalBuffer& counterBuf,
       uint64_t expected,
       const Timeout& timeout = Timeout()) const {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     wait_counter(solo, counterBuf, expected, timeout);
   }
 
@@ -420,24 +430,14 @@ class P2pIbrcTransportDevice {
 
   __device__ void flush(ThreadGroup& group) {
     if (group.is_leader()) {
-      const uint32_t queueId = queue_for_group(group.group_id);
-      const IbrcCmdQueueDevice& queue = cmdQueues[queueId];
-      const uint64_t target = load_acquire_system_u64(queue.pi);
-      Timeout timeout{kIbrcDefaultDeviceTimeoutCycles};
-      timeout.start();
-      while (load_acquire_system_u64(queue.ci) < target) {
-        check_status(queue);
-        if (timeout.checkExpired()) {
-          printf("P2pIbrcTransportDevice: flush timed out\n");
-          PIPES_DEVICE_TRAP();
-        }
-      }
+      validate_group_scope(group);
+      drain_block_queues(group.block_id);
     }
     group.sync();
   }
 
   __device__ void flush() {
-    ThreadGroup solo{0, 1, 0, 1, SyncScope::THREAD};
+    ThreadGroup solo = make_thread_solo();
     flush(solo);
   }
 
@@ -450,11 +450,89 @@ class P2pIbrcTransportDevice {
   }
 
  private:
-  __device__ __forceinline__ uint32_t queue_for_group(uint32_t groupId) const {
+  __device__ __forceinline__ uint32_t num_qp_lanes() const {
+    return numNics * qpsPerBlockPerNic_;
+  }
+
+  __device__ __forceinline__ uint32_t num_qps_per_peer_per_nic() const {
+    return maxGroups_ * qpsPerBlockPerNic_;
+  }
+
+  __device__ __forceinline__ void validate_block_id(uint32_t blockId) const {
+#if PIPES_IS_DEVICE_COMPILE
+    if (blockIdx.y != 0 || blockIdx.z != 0 || blockDim.y != 1 ||
+        blockDim.z != 1) {
+      printf(
+          "P2pIbrcTransportDevice: block-owned QP selection currently "
+          "supports only 1D grids and 1D thread blocks, got "
+          "blockIdx=(%u,%u,%u) blockDim=(%u,%u,%u)\n",
+          blockIdx.x,
+          blockIdx.y,
+          blockIdx.z,
+          blockDim.x,
+          blockDim.y,
+          blockDim.z);
+      PIPES_DEVICE_TRAP();
+    }
+#endif
     if (cmdQueues.empty()) {
       trap("P2pIbrcTransportDevice: no command queues");
     }
-    return groupId % cmdQueues.size();
+    if (numNics == 0 || qpsPerBlockPerNic_ == 0 || maxGroups_ == 0 ||
+        blockQpState_.empty() || blockId >= maxGroups_) {
+      printf(
+          "P2pIbrcTransportDevice: invalid block-owned QP state block_id=%u "
+          "maxGroups=%u qpsPerBlockPerNic=%u numNics=%u stateSize=%u\n",
+          blockId,
+          maxGroups_,
+          qpsPerBlockPerNic_,
+          numNics,
+          static_cast<unsigned>(blockQpState_.size()));
+      PIPES_DEVICE_TRAP();
+    }
+  }
+
+  __device__ __forceinline__ void validate_group_scope(
+      const ThreadGroup& group) const {
+    if (group.scope == SyncScope::CLUSTER) {
+      trap("P2pIbrcTransportDevice: cluster-scope ThreadGroup unsupported");
+    }
+    validate_block_id(group.block_id);
+  }
+
+  __device__ __forceinline__ uint32_t
+  queue_for_lane(uint32_t blockId, uint32_t laneOrdinal) const {
+    validate_block_id(blockId);
+    const uint32_t lanes = num_qp_lanes();
+    if (laneOrdinal >= lanes) {
+      trap("P2pIbrcTransportDevice: lane ordinal out of range");
+    }
+    const uint32_t nicId = laneOrdinal % numNics;
+    const uint32_t qpIndex = laneOrdinal / numNics;
+    const uint32_t qpSlot = blockId * qpsPerBlockPerNic_ + qpIndex;
+    if (qpSlot >= num_qps_per_peer_per_nic()) {
+      trap("P2pIbrcTransportDevice: QP slot out of range");
+    }
+    const uint32_t queueId = qpSlot * numNics + nicId;
+    if (queueId >= cmdQueues.size()) {
+      trap("P2pIbrcTransportDevice: command queue id out of range");
+    }
+    return queueId;
+  }
+
+  __device__ __forceinline__ uint32_t control_queue_id(uint32_t blockId) const {
+    return queue_for_lane(blockId, 0);
+  }
+
+  __device__ __forceinline__ uint32_t select_put_queue_id(uint32_t blockId) {
+    validate_block_id(blockId);
+    const uint32_t lanes = num_qp_lanes();
+    if (lanes == 1) {
+      return control_queue_id(blockId);
+    }
+    const uint32_t seq =
+        fetch_add_system_u32(&blockQpState_[blockId].put_rr, 1U);
+    return queue_for_lane(blockId, seq % lanes);
   }
 
   __device__ __forceinline__ uint32_t nic_for_queue(uint32_t queueId) const {
@@ -462,6 +540,35 @@ class P2pIbrcTransportDevice {
       trap("P2pIbrcTransportDevice: no NICs");
     }
     return queueId % numNics;
+  }
+
+  __device__ void drain_queue(const IbrcCmdQueueDevice& queue) const {
+    const uint64_t target = load_acquire_system_u64(queue.pi);
+    Timeout timeout{kIbrcDefaultDeviceTimeoutCycles};
+    timeout.start();
+    while (load_acquire_system_u64(queue.ci) < target) {
+      check_status(queue);
+      if (timeout.checkExpired()) {
+        printf("P2pIbrcTransportDevice: flush timed out\n");
+        PIPES_DEVICE_TRAP();
+      }
+    }
+  }
+
+  __device__ void drain_block_queues(uint32_t blockId) const {
+    validate_block_id(blockId);
+    const uint32_t lanes = num_qp_lanes();
+    for (uint32_t lane = 0; lane < lanes; ++lane) {
+      drain_queue(cmdQueues[queue_for_lane(blockId, lane)]);
+    }
+  }
+
+  __device__ void check_block_status(uint32_t blockId) const {
+    validate_block_id(blockId);
+    const uint32_t lanes = num_qp_lanes();
+    for (uint32_t lane = 0; lane < lanes; ++lane) {
+      check_status(cmdQueues[queue_for_lane(blockId, lane)]);
+    }
   }
 
   __device__ __forceinline__ uint64_t reserve(IbrcCmdQueueDevice& queue) const {
@@ -513,10 +620,9 @@ class P2pIbrcTransportDevice {
       trap("P2pIbrcTransportDevice: wait buffer is null");
     }
     if (group.is_leader()) {
-      const uint32_t queueId = queue_for_group(group.group_id);
-      const IbrcCmdQueueDevice& queue = cmdQueues[queueId];
+      validate_group_scope(group);
       while (load_acquire_system_u64(ptr) < expected) {
-        check_status(queue);
+        check_block_status(group.block_id);
         if (timeout.checkExpired()) {
           printf(
               "P2pIbrcTransportDevice: wait_%s timed out expected=%llu\n",
@@ -588,6 +694,18 @@ class P2pIbrcTransportDevice {
 #endif
   }
 
+  __device__ __forceinline__ static uint32_t fetch_add_system_u32(
+      uint32_t* ptr,
+      uint32_t value) {
+#ifdef __HIP_PLATFORM_AMD__
+    return __hip_atomic_fetch_add(
+        ptr, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    return cuda::atomic_ref<uint32_t, cuda::thread_scope_system>{*ptr}
+        .fetch_add(value, cuda::memory_order_relaxed);
+#endif
+  }
+
   __device__ __forceinline__ static void store_release_system_u64(
       uint64_t* ptr,
       uint64_t value) {
@@ -634,7 +752,9 @@ class P2pIbrcTransportDevice {
 
   DeviceSpan<IbrcCmdQueueDevice> cmdQueues{};
   uint32_t numNics{0};
-  uint32_t numQpsPerPeerPerNic{0};
+  uint32_t maxGroups_{0};
+  uint32_t qpsPerBlockPerNic_{0};
+  DeviceSpan<IbrcBlockQpState> blockQpState_{};
   IbgdaRemoteBuffer ownedRemoteSignalBuf_{};
   IbgdaLocalBuffer ownedLocalSignalBuf_{};
   IbgdaLocalBuffer ownedCounterDeviceBuf_{};

--- a/comms/prims/transport/rdma/NicConstants.h
+++ b/comms/prims/transport/rdma/NicConstants.h
@@ -25,9 +25,9 @@ namespace comms::prims {
  *   - CachedMr.mrs
  *
  * Increase this constant only if a future platform supports > 2 NICs per
- * GPU. At that point, also audit the IBGDA wire format
+ * GPU. At that point, also audit the IB wire format
  * (IbgdaTransportExchInfoAll size scales with kMaxNicsPerGpu ×
- * kMaxQpsPerPeerPerNic × kMaxRanksForAllGather).
+ * kMaxEagerExchangeQpsPerPeerPerNic × kMaxRanksForAllGather).
  *
  * Lives in its own minimal header (no doca/ibverbs deps) so lightweight
  * device-side headers like IbgdaBuffer.h can include it without dragging

--- a/comms/prims/window/HostWindow.cc
+++ b/comms/prims/window/HostWindow.cc
@@ -37,7 +37,7 @@ HostWindow::HostWindow(
       nRanks_(transport.n_ranks()),
       config_(config),
       nvlPeerRanks_(transport.nvl_peer_ranks()),
-      ibgdaPeerRanks_(transport.ibgda_peer_ranks()),
+      ibgdaPeerRanks_(transport.ib_peer_ranks()),
       nvlLocalRank_(transport.nvl_local_rank()),
       nvlNRanks_(transport.nvl_n_ranks()),
       userBuffer_(userBuffer),

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1907,6 +1907,21 @@ cvars:
      block-scope). Higher values allow more pipelining but use more
      memory.
 
+ - name        : NCCL_CTRAN_IB_MAX_GROUPS
+   type        : int
+   default     : 64
+   description : |-
+     Maximum number of physical CUDA block groups that may own IB QP
+     resources. Device-side IB QP selection uses ThreadGroup::block_id
+     and requires block_id < NCCL_CTRAN_IB_MAX_GROUPS.
+
+ - name        : NCCL_CTRAN_IB_QPS_PER_BLOCK_PER_NIC
+   type        : int
+   default     : 1
+   description : |-
+     Number of main IB QPs owned by each physical CUDA block on each NIC.
+     Puts from a block round-robin across its NIC-first QP lanes.
+
  - name        : NCCL_CTRAN_IBGDA_SIGNAL_COUNT
    type        : uint64_t
    default     : 1
@@ -1967,13 +1982,6 @@ cvars:
      IBGDA peer. The effective IBGDA data-buffer size must be positive via
      NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE or the per-communicator
      pipesIbgdaDataBufferSize hint.
-
- - name        : NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS
-   type        : int
-   default     : 128
-   description : |-
-     Maximum number of block-groups for IBGDA send/recv staging.
-     Only used when NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1.
 
  - name        : NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH
    type        : int


### PR DESCRIPTION
Summary:

## Summary

- Add block-owned IBGDA QP resources: `maxGroups` physical block groups, `qpsPerBlockPerNic` main QP lanes per block/NIC, and one shared companion QP per block/NIC.
- Track physical `ThreadGroup::block_id` separately from logical `group_id`; QP selection and per-block transport state use `block_id`, while existing protocol/group routing can continue to use `group_id`.
- Make public no-`ThreadGroup` IBGDA thread-scope wrappers synthesize a one-thread group with `block_id = blockIdx.x` instead of hardcoding block 0, so calls from different physical blocks use their own block-owned QP resources.
- Select put lanes with NIC-first round robin: a single active block can use all NICs before moving to the next QP lane on each NIC.
- Add top-level CVARs `NCCL_CTRAN_IBGDA_MAX_GROUPS` and `NCCL_CTRAN_IBGDA_QPS_PER_BLOCK_PER_NIC`; remove the separate send/recv max-groups CVAR so send/recv inherits the transport-level `maxGroups`.
- Make standalone `signal()` explicitly cheap: it posts on the block control lane and does not drain prior round-robined put lanes. If a standalone signal is meant to announce prior puts, the user/protocol must call `fence()` or `flush()` first. Fused `put(..., signal)` remains self-ordered because put and signal are posted on the same QP.
- Keep counters attached to the current put: `put + counter` and `put + signal + counter` make the counter wait on the put WQE, not on the signal WQE.
- Reduce cooperative put leader-to-group lane propagation to one broadcast of the selected lane ordinal; each thread reconstructs the deterministic lane locally.
- Add host/device validation for the new shape: `maxGroups >= 1`, `qpsPerBlockPerNic >= 1`, `maxGroups <= 64`, `qpsPerBlockPerNic <= 128`, `numNics * qpsPerBlockPerNic <= 64`, 1D launches only for now, and no cluster-scope IBGDA groups. Eager all-gather exchange still requires `maxGroups * qpsPerBlockPerNic <= 128`; larger shapes are supported through lazy bilateral exchange.

## Why

This prevents independent CUDA blocks from sharing the same IBGDA QP by default and gives us host-side knobs to scale main QPs per block/NIC without changing the higher-level send/recv API. The default remains one QP per block/NIC, and the explicit `fence()`/`flush()` requirement keeps standalone signal semantics understandable instead of hiding CQ polling in the signal fast path.

Reviewed By: saifhhasan

Differential Revision: D108350656
