### PR TITLE
Align send/recv protocol bytes

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -11,6 +11,38 @@
 
 namespace comms::prims::benchmark {
 
+namespace {
+
+__device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
+    std::size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+__device__ __forceinline__ std::size_t
+protocol_bytes_for_tiled_group_per_launch(
+    std::size_t totalBytes,
+    int activeBlocks,
+    std::size_t slotSize,
+    int groupId) {
+  const std::size_t sectionBytes = min(slotSize, totalBytes);
+  if (sectionBytes == 0) {
+    return 0;
+  }
+
+  const std::size_t totalSections = totalBytes / sectionBytes;
+  const std::size_t tileElements =
+      (((sectionBytes + activeBlocks - 1) / activeBlocks) + 15ULL) & ~15ULL;
+  const std::size_t tileOffset = groupId * tileElements;
+  if (tileOffset >= sectionBytes) {
+    return 0;
+  }
+
+  const std::size_t tileBytes = min(tileElements, sectionBytes - tileOffset);
+  return totalSections * benchmark_align_protocol_bytes(tileBytes);
+}
+
+} // namespace
+
 __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
     P2pIbgdaTransportDevice* transport,
     char* src,
@@ -205,6 +237,102 @@ void launch_ibgda_recv(
     Timeout timeout) {
   ibgda_recv_kernel<<<numBlocks, 512, 0, stream>>>(
       transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    int activeBlocks,
+    std::size_t totalBytes,
+    int iterations,
+    Timeout timeout) {
+  auto group = make_block_group();
+  if (group.group_id >= static_cast<uint32_t>(activeBlocks)) {
+    return;
+  }
+
+  const int groupId = static_cast<int>(group.group_id);
+  const auto& state = transport->send_recv_state();
+  const std::size_t expectedBytes =
+      protocol_bytes_for_tiled_group_per_launch(
+          totalBytes, activeBlocks, state.dataBufferSize, groupId) *
+      iterations;
+  if (expectedBytes == 0) {
+    return;
+  }
+  transport->wait_counter(
+      group,
+      state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
+      expectedBytes,
+      timeout);
+  transport->wait_signal(
+      group,
+      state.localSignalBuf.subBuffer(
+          (state.maxGroups + groupId) * sizeof(uint64_t)),
+      expectedBytes,
+      timeout);
+}
+
+void launch_ibgda_drain_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    int activeBlocks,
+    std::size_t totalBytes,
+    int iterations,
+    cudaStream_t stream,
+    Timeout timeout) {
+  if (totalBytes == 0 || iterations == 0) {
+    return;
+  }
+  ibgda_drain_send_recv_kernel<<<activeBlocks, 512, 0, stream>>>(
+      transport, activeBlocks, totalBytes, iterations, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[PIPES] Drain launch failed: %s\n", cudaGetErrorString(err));
+  }
+}
+
+__global__ void __launch_bounds__(256, 1) ibgda_reset_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    int maxGroups) {
+  const auto& state = transport->send_recv_state();
+  const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto stride = blockDim.x * gridDim.x;
+
+  auto* signalSlots = static_cast<uint64_t*>(state.localSignalBuf.ptr);
+  auto* counterSlots = static_cast<uint64_t*>(state.localCounterBuf.ptr);
+
+  for (auto slot = idx; slot < static_cast<uint32_t>(2 * maxGroups);
+       slot += stride) {
+    if (signalSlots != nullptr) {
+      signalSlots[slot] = 0;
+    }
+    if (slot < state.state.size()) {
+      state.state[slot] = IbSendRecvState::ProgressSlot{};
+    }
+  }
+
+  for (auto slot = idx; slot < static_cast<uint32_t>(maxGroups);
+       slot += stride) {
+    if (counterSlots != nullptr) {
+      counterSlots[slot] = 0;
+    }
+  }
+}
+
+void launch_ibgda_reset_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    int maxGroups,
+    cudaStream_t stream) {
+  if (maxGroups == 0) {
+    return;
+  }
+  constexpr int kThreads = 256;
+  const int blocks = (2 * maxGroups + kThreads - 1) / kThreads;
+  ibgda_reset_send_recv_kernel<<<blocks, kThreads, 0, stream>>>(
+      transport, maxGroups);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[PIPES] Reset launch failed: %s\n", cudaGetErrorString(err));
+  }
 }
 
 __global__ void ibgda_snapshot_step_state_kernel(

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -80,6 +80,27 @@ void launch_ibgda_recv(
     Timeout timeout = Timeout());
 
 /**
+ * Drain outstanding bidirectional send/recv transport work for benchmark
+ * measurement and safe teardown.
+ */
+void launch_ibgda_drain_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    int activeBlocks,
+    std::size_t totalBytes,
+    int iterations,
+    cudaStream_t stream,
+    Timeout timeout = Timeout());
+
+/**
+ * Reset benchmark-owned send/recv transport state after outstanding work has
+ * been drained.
+ */
+void launch_ibgda_reset_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    int maxGroups,
+    cudaStream_t stream);
+
+/**
  * Snapshot the transport send/recv byte cursors into device memory.
  *
  * @param transport  GPU-resident P2pIbgdaTransportDevice pointer

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -6,8 +6,11 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <array>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "comms/prims/benchmarks/IbgdaSendRecv.h"
@@ -19,11 +22,54 @@ using meta::comms::BenchmarkEnvironment;
 using meta::comms::BenchmarkTestFixture;
 using meta::comms::DeviceBuffer;
 
+#define ASSERT_CUDA_SUCCESS(cmd)                                    \
+  do {                                                              \
+    cudaError_t ret;                                                \
+    ASSERT_EQ(cudaSuccess, ret = (cmd)) << cudaGetErrorString(ret); \
+  } while (0)
+
 namespace comms::prims::benchmark {
 
 using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
 
 namespace {
+
+constexpr std::size_t alignProtocolBytes(std::size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+struct SendRecvBenchmarkGeometry {
+  int activeBlocks;
+  int maxGroups;
+  const char* label;
+};
+
+constexpr std::array<SendRecvBenchmarkGeometry, 2> kSendRecvBenchmarkGeometries{
+    {{1, 2, "activeBlocks=1/maxGroups=2"},
+     {2, 2, "activeBlocks=2/maxGroups=2"}}};
+
+std::string formatMessageSize(std::size_t nbytes) {
+  if (nbytes >= (1ULL << 30)) {
+    return fmt::format("{}GB", nbytes >> 30);
+  }
+  if (nbytes >= (1ULL << 20)) {
+    return fmt::format("{}MB", nbytes >> 20);
+  }
+  if (nbytes >= (1ULL << 10)) {
+    return fmt::format("{}KB", nbytes >> 10);
+  }
+  return fmt::format("{}B", nbytes);
+}
+
+std::vector<std::size_t> makePowerOfTwoMessageSizes(
+    std::size_t firstBytes,
+    std::size_t lastBytes) {
+  std::vector<std::size_t> messageSizes;
+  for (std::size_t sz = firstBytes; sz <= lastBytes; sz <<= 1) {
+    messageSizes.push_back(sz);
+  }
+  return messageSizes;
+}
 
 std::vector<int64_t> snapshotStepState(
     P2pIbgdaTransportDevice* transport,
@@ -108,16 +154,188 @@ class IbgdaSendRecvTest : public BenchmarkTestFixture {
  protected:
   void SetUp() override {
     BenchmarkTestFixture::SetUp();
-    cudaSetDevice(localRank);
-    cudaStreamCreate(&stream_);
+    ASSERT_CUDA_SUCCESS(cudaSetDevice(localRank));
+    ASSERT_CUDA_SUCCESS(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
-    cudaStreamDestroy(stream_);
+    if (stream_ != nullptr) {
+      ASSERT_CUDA_SUCCESS(cudaStreamDestroy(stream_));
+    }
     BenchmarkTestFixture::TearDown();
   }
 
   cudaStream_t stream_{};
+
+  void runBidirectionalBandwidth(
+      std::size_t firstMessageBytes,
+      const char* benchmarkLabel) {
+    if (worldSize != 2) {
+      XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+      return;
+    }
+
+    constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
+    constexpr int kPipelineDepth = 2;
+    constexpr int kWarmupIters = 5;
+    constexpr int kBenchIters = 20;
+
+    std::vector<std::size_t> messageSizes =
+        makePowerOfTwoMessageSizes(firstMessageBytes, 4ULL << 30);
+
+    int peerRank = (globalRank == 0) ? 1 : 0;
+    std::size_t maxBytes = messageSizes.back();
+
+    cudaEvent_t start, stop;
+    ASSERT_CUDA_SUCCESS(cudaEventCreate(&start));
+    ASSERT_CUDA_SUCCESS(cudaEventCreate(&stop));
+
+    for (const auto& geometry : kSendRecvBenchmarkGeometries) {
+      MultipeerIbgdaTransportConfig transportConfig{
+          .cudaDevice = localRank,
+          .dataBufferSize = kSlotSize,
+          .sendRecv =
+              SendRecvConfig{
+                  .maxGroups = geometry.maxGroups,
+                  .pipelineDepth = kPipelineDepth,
+              },
+      };
+
+      MultipeerIbgdaTransport transport(
+          globalRank, worldSize, bootstrap, transportConfig);
+      transport.exchange();
+
+      DeviceBuffer sendBuf(maxBytes);
+      DeviceBuffer recvBuf(maxBytes);
+      ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), 0xAA, maxBytes));
+      ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, maxBytes));
+      ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
+      auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+
+      if (globalRank == 0) {
+        XLOGF(INFO, "");
+        XLOGF(
+            INFO,
+            "================================================================");
+        XLOGF(
+            INFO,
+            "  IBGDA Tile SendRecv Bandwidth {} ({})",
+            benchmarkLabel,
+            geometry.label);
+        XLOGF(
+            INFO,
+            "  activeBlocks={}, maxGroups={}, slotSize={}MB, pipelineDepth={}, range={}..4GB",
+            geometry.activeBlocks,
+            geometry.maxGroups,
+            kSlotSize / (1024 * 1024),
+            kPipelineDepth,
+            formatMessageSize(firstMessageBytes));
+        XLOGF(
+            INFO,
+            "================================================================");
+        XLOGF(
+            INFO,
+            "{:>10s}  {:>10s}  {:>12s}  {:>12s}",
+            "MsgSize",
+            "Sections",
+            "BaseMod",
+            "BW (GB/s)");
+        XLOGF(
+            INFO,
+            "------------------------------------------------------------");
+      }
+
+      for (auto nBytes : messageSizes) {
+        const std::size_t baseMod = 0;
+
+        launch_ibgda_reset_send_recv(
+            deviceTransport, geometry.maxGroups, stream_);
+        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+        bootstrap->barrierAll();
+
+        // Warmup
+        for (int i = 0; i < kWarmupIters; ++i) {
+          launch_ibgda_send_recv(
+              deviceTransport,
+              static_cast<char*>(sendBuf.get()),
+              static_cast<char*>(recvBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          bootstrap->barrierAll();
+        }
+        launch_ibgda_drain_send_recv(
+            deviceTransport,
+            geometry.activeBlocks,
+            nBytes,
+            kWarmupIters,
+            stream_);
+        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+        launch_ibgda_reset_send_recv(
+            deviceTransport, geometry.maxGroups, stream_);
+        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+
+        bootstrap->barrierAll();
+
+        // Benchmark
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+        for (int i = 0; i < kBenchIters; ++i) {
+          launch_ibgda_send_recv(
+              deviceTransport,
+              static_cast<char*>(sendBuf.get()),
+              static_cast<char*>(recvBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+        }
+        launch_ibgda_drain_send_recv(
+            deviceTransport,
+            geometry.activeBlocks,
+            nBytes,
+            kBenchIters,
+            stream_);
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
+
+        bootstrap->barrierAll();
+
+        float totalMs = 0;
+        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+        float avgMs = totalMs / kBenchIters;
+
+        float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
+        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+        if (globalRank == 0) {
+          std::string sizeStr = formatMessageSize(nBytes);
+          XLOGF(
+              INFO,
+              "{:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
+              sizeStr,
+              numSections,
+              baseMod,
+              bwGBs);
+        }
+
+        launch_ibgda_reset_send_recv(
+            deviceTransport, geometry.maxGroups, stream_);
+        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+        bootstrap->barrierAll();
+      }
+
+      if (globalRank == 0) {
+        XLOGF(
+            INFO,
+            "================================================================");
+      }
+
+      bootstrap->barrierAll();
+    }
+
+    ASSERT_CUDA_SUCCESS(cudaEventDestroy(start));
+    ASSERT_CUDA_SUCCESS(cudaEventDestroy(stop));
+  }
 };
 
 TEST_F(IbgdaSendRecvTest, Correctness) {
@@ -152,9 +370,9 @@ TEST_F(IbgdaSendRecvTest, Correctness) {
   DeviceBuffer recvBuf(kDataBytes);
 
   uint8_t fillPattern = 0xA0 + globalRank;
-  cudaMemset(sendBuf.get(), fillPattern, kDataBytes);
-  cudaMemset(recvBuf.get(), 0, kDataBytes);
-  cudaDeviceSynchronize();
+  ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+  ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, kDataBytes));
+  ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
 
   bootstrap->barrierAll();
 
@@ -176,7 +394,8 @@ TEST_F(IbgdaSendRecvTest, Correctness) {
 
   uint8_t expectedPattern = 0xA0 + peerRank;
   std::vector<uint8_t> hostBuf(kDataBytes);
-  cudaMemcpy(hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost);
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
 
   bool correct = true;
   for (std::size_t i = 0; i < kDataBytes; i++) {
@@ -201,6 +420,64 @@ TEST_F(IbgdaSendRecvTest, Correctness) {
         globalRank,
         kDataBytes);
   }
+}
+
+TEST_F(IbgdaSendRecvTest, UnalignedPayloadAdvancesAlignedProtocol) {
+  if (worldSize != 2) {
+    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 100;
+  constexpr int kNumBlocks = 1;
+  constexpr std::size_t kSlotSize = 1024;
+  constexpr int kPipelineDepth = 2;
+  constexpr int kMaxBlocks = kNumBlocks;
+
+  int peerRank = (globalRank == 0) ? 1 : 0;
+
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = kSlotSize,
+      .sendRecv =
+          SendRecvConfig{
+              .maxGroups = kMaxBlocks,
+              .pipelineDepth = kPipelineDepth,
+          },
+  };
+
+  MultipeerIbgdaTransport transport(
+      globalRank, worldSize, bootstrap, transportConfig);
+  transport.exchange();
+
+  DeviceBuffer sendBuf(kDataBytes);
+  DeviceBuffer recvBuf(kDataBytes);
+
+  const uint8_t fillPattern = static_cast<uint8_t>(0x70 + globalRank);
+  ASSERT_EQ(cudaMemset(sendBuf.get(), fillPattern, kDataBytes), cudaSuccess);
+  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kDataBytes), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  bootstrap->barrierAll();
+
+  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
+  launch_ibgda_send_recv(
+      deviceTransport,
+      static_cast<char*>(sendBuf.get()),
+      static_cast<char*>(recvBuf.get()),
+      kDataBytes,
+      kNumBlocks,
+      stream_);
+
+  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+  bootstrap->barrierAll();
+
+  expectUniformBuffer(
+      recvBuf, kDataBytes, static_cast<uint8_t>(0x70 + peerRank), globalRank);
+  expectStepState(
+      snapshotStepState(deviceTransport, kMaxBlocks, stream_),
+      kMaxBlocks,
+      alignProtocolBytes(kDataBytes));
 }
 
 TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
@@ -457,134 +734,12 @@ TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
   ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
 }
 
-TEST_F(IbgdaSendRecvTest, Bandwidth) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
+TEST_F(IbgdaSendRecvTest, BandwidthFrom4B) {
+  runBidirectionalBandwidth(4, "(from 4B)");
+}
 
-  constexpr int kNumBlocks = 2;
-  constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
-  constexpr int kPipelineDepth = 2;
-  constexpr int kMaxBlocks = kNumBlocks;
-  constexpr int kWarmupIters = 5;
-  constexpr int kBenchIters = 20;
-
-  // Message sizes: 1MB to 4GB
-  std::vector<std::size_t> messageSizes;
-  for (std::size_t sz = 1ULL << 20; sz <= 4ULL << 30; sz <<= 1) {
-    messageSizes.push_back(sz);
-  }
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-  std::size_t maxBytes = messageSizes.back();
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kMaxBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(maxBytes);
-  DeviceBuffer recvBuf(maxBytes);
-  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
-  cudaMemset(recvBuf.get(), 0, maxBytes);
-  cudaDeviceSynchronize();
-
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-  cudaEvent_t start, stop;
-  cudaEventCreate(&start);
-  cudaEventCreate(&stop);
-
-  if (globalRank == 0) {
-    XLOGF(INFO, "");
-    XLOGF(
-        INFO,
-        "================================================================");
-    XLOGF(INFO, "  IBGDA Tile SendRecv Bandwidth");
-    XLOGF(
-        INFO,
-        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
-        kNumBlocks,
-        kSlotSize / (1024 * 1024),
-        kPipelineDepth);
-    XLOGF(
-        INFO,
-        "================================================================");
-    XLOGF(
-        INFO, "{:>10s}  {:>10s}  {:>12s}", "MsgSize", "Sections", "BW (GB/s)");
-    XLOGF(INFO, "----------------------------------------------");
-  }
-
-  for (auto nBytes : messageSizes) {
-    bootstrap->barrierAll();
-
-    // Warmup
-    for (int i = 0; i < kWarmupIters; ++i) {
-      launch_ibgda_send_recv(
-          deviceTransport,
-          static_cast<char*>(sendBuf.get()),
-          static_cast<char*>(recvBuf.get()),
-          nBytes,
-          kNumBlocks,
-          stream_);
-      cudaStreamSynchronize(stream_);
-      bootstrap->barrierAll();
-    }
-
-    bootstrap->barrierAll();
-
-    // Benchmark
-    cudaEventRecord(start, stream_);
-    for (int i = 0; i < kBenchIters; ++i) {
-      launch_ibgda_send_recv(
-          deviceTransport,
-          static_cast<char*>(sendBuf.get()),
-          static_cast<char*>(recvBuf.get()),
-          nBytes,
-          kNumBlocks,
-          stream_);
-    }
-    cudaEventRecord(stop, stream_);
-    cudaEventSynchronize(stop);
-
-    bootstrap->barrierAll();
-
-    float totalMs = 0;
-    cudaEventElapsedTime(&totalMs, start, stop);
-    float avgMs = totalMs / kBenchIters;
-
-    float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
-    std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
-
-    if (globalRank == 0) {
-      std::string sizeStr;
-      if (nBytes >= 1ULL << 30) {
-        sizeStr = fmt::format("{}GB", nBytes >> 30);
-      } else {
-        sizeStr = fmt::format("{}MB", nBytes >> 20);
-      }
-      XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
-    }
-  }
-
-  if (globalRank == 0) {
-    XLOGF(
-        INFO,
-        "================================================================");
-  }
-
-  cudaEventDestroy(start);
-  cudaEventDestroy(stop);
+TEST_F(IbgdaSendRecvTest, BandwidthFrom1MB) {
+  runBidirectionalBandwidth(1ULL << 20, "(from 1MB)");
 }
 
 TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
@@ -593,150 +748,159 @@ TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
     return;
   }
 
-  constexpr int kNumBlocks = 2;
   constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
   constexpr int kPipelineDepth = 2;
-  constexpr int kMaxBlocks = kNumBlocks;
   constexpr int kWarmupIters = 5;
   constexpr int kBenchIters = 20;
 
   std::vector<std::size_t> messageSizes;
-  for (std::size_t sz = 1ULL << 20; sz <= 4ULL << 30; sz <<= 1) {
+  for (std::size_t sz = 4; sz <= 4ULL << 30; sz <<= 1) {
     messageSizes.push_back(sz);
   }
 
   int peerRank = (globalRank == 0) ? 1 : 0;
   std::size_t maxBytes = messageSizes.back();
 
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kMaxBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(maxBytes);
-  DeviceBuffer recvBuf(maxBytes);
-  cudaMemset(sendBuf.get(), 0xAA, maxBytes);
-  cudaMemset(recvBuf.get(), 0, maxBytes);
-  cudaDeviceSynchronize();
-
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
   cudaEvent_t start, stop;
-  cudaEventCreate(&start);
-  cudaEventCreate(&stop);
+  ASSERT_CUDA_SUCCESS(cudaEventCreate(&start));
+  ASSERT_CUDA_SUCCESS(cudaEventCreate(&stop));
 
-  if (globalRank == 0) {
-    XLOGF(INFO, "");
-    XLOGF(
-        INFO,
-        "================================================================");
-    XLOGF(INFO, "  IBGDA Tile Unidirectional Bandwidth (rank 0 → rank 1)");
-    XLOGF(
-        INFO,
-        "  numBlocks={}, slotSize={}MB, pipelineDepth={}",
-        kNumBlocks,
-        kSlotSize / (1024 * 1024),
-        kPipelineDepth);
-    XLOGF(
-        INFO,
-        "================================================================");
-    XLOGF(
-        INFO, "{:>10s}  {:>10s}  {:>12s}", "MsgSize", "Sections", "BW (GB/s)");
-    XLOGF(INFO, "----------------------------------------------");
-  }
+  for (const auto& geometry : kSendRecvBenchmarkGeometries) {
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank,
+        .dataBufferSize = kSlotSize,
+        .sendRecv =
+            SendRecvConfig{
+                .maxGroups = geometry.maxGroups,
+                .pipelineDepth = kPipelineDepth,
+            },
+    };
 
-  for (auto nBytes : messageSizes) {
-    bootstrap->barrierAll();
+    MultipeerIbgdaTransport transport(
+        globalRank, worldSize, bootstrap, transportConfig);
+    transport.exchange();
 
-    // Warmup
-    for (int i = 0; i < kWarmupIters; ++i) {
-      if (globalRank == 0) {
-        launch_ibgda_send(
-            deviceTransport,
-            static_cast<char*>(sendBuf.get()),
-            nBytes,
-            kNumBlocks,
-            stream_);
-      } else {
-        launch_ibgda_recv(
-            deviceTransport,
-            static_cast<char*>(recvBuf.get()),
-            nBytes,
-            kNumBlocks,
-            stream_);
-      }
-      cudaStreamSynchronize(stream_);
-      bootstrap->barrierAll();
-    }
+    DeviceBuffer sendBuf(maxBytes);
+    DeviceBuffer recvBuf(maxBytes);
+    ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), 0xAA, maxBytes));
+    ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, maxBytes));
+    ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
 
-    bootstrap->barrierAll();
-
-    // Benchmark
-    cudaEventRecord(start, stream_);
-    for (int i = 0; i < kBenchIters; ++i) {
-      if (globalRank == 0) {
-        launch_ibgda_send(
-            deviceTransport,
-            static_cast<char*>(sendBuf.get()),
-            nBytes,
-            kNumBlocks,
-            stream_);
-      } else {
-        launch_ibgda_recv(
-            deviceTransport,
-            static_cast<char*>(recvBuf.get()),
-            nBytes,
-            kNumBlocks,
-            stream_);
-      }
-    }
-    cudaEventRecord(stop, stream_);
-    cudaEventSynchronize(stop);
-
-    bootstrap->barrierAll();
-
-    float totalMs = 0;
-    cudaEventElapsedTime(&totalMs, start, stop);
-    float avgMs = totalMs / kBenchIters;
-
-    // Unidirectional: only one direction
-    float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
-    std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+    auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
 
     if (globalRank == 0) {
-      std::string sizeStr;
-      if (nBytes >= 1ULL << 30) {
-        sizeStr = fmt::format("{}GB", nBytes >> 30);
-      } else {
-        sizeStr = fmt::format("{}MB", nBytes >> 20);
-      }
-      XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+      XLOGF(INFO, "");
+      XLOGF(
+          INFO,
+          "================================================================");
+      XLOGF(
+          INFO,
+          "  IBGDA Tile Unidirectional Bandwidth ({}, rank 0 -> rank 1)",
+          geometry.label);
+      XLOGF(
+          INFO,
+          "  activeBlocks={}, maxGroups={}, slotSize={}MB, pipelineDepth={}",
+          geometry.activeBlocks,
+          geometry.maxGroups,
+          kSlotSize / (1024 * 1024),
+          kPipelineDepth);
+      XLOGF(
+          INFO,
+          "================================================================");
+      XLOGF(
+          INFO,
+          "{:>10s}  {:>10s}  {:>12s}",
+          "MsgSize",
+          "Sections",
+          "BW (GB/s)");
+      XLOGF(INFO, "----------------------------------------------");
     }
+
+    for (auto nBytes : messageSizes) {
+      bootstrap->barrierAll();
+
+      // Warmup
+      for (int i = 0; i < kWarmupIters; ++i) {
+        if (globalRank == 0) {
+          launch_ibgda_send(
+              deviceTransport,
+              static_cast<char*>(sendBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+        } else {
+          launch_ibgda_recv(
+              deviceTransport,
+              static_cast<char*>(recvBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+        }
+        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+        bootstrap->barrierAll();
+      }
+
+      bootstrap->barrierAll();
+
+      // Benchmark
+      ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+      for (int i = 0; i < kBenchIters; ++i) {
+        if (globalRank == 0) {
+          launch_ibgda_send(
+              deviceTransport,
+              static_cast<char*>(sendBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+        } else {
+          launch_ibgda_recv(
+              deviceTransport,
+              static_cast<char*>(recvBuf.get()),
+              nBytes,
+              geometry.activeBlocks,
+              stream_);
+        }
+      }
+      ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+      ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
+
+      bootstrap->barrierAll();
+
+      float totalMs = 0;
+      ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+      float avgMs = totalMs / kBenchIters;
+
+      // Unidirectional: only one direction
+      float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
+      std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+      if (globalRank == 0) {
+        std::string sizeStr = formatMessageSize(nBytes);
+        XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+      }
+    }
+
+    if (globalRank == 0) {
+      XLOGF(
+          INFO,
+          "================================================================");
+    }
+
+    bootstrap->barrierAll();
   }
 
-  if (globalRank == 0) {
-    XLOGF(
-        INFO,
-        "================================================================");
-  }
-
-  cudaEventDestroy(start);
-  cudaEventDestroy(stop);
+  ASSERT_CUDA_SUCCESS(cudaEventDestroy(start));
+  ASSERT_CUDA_SUCCESS(cudaEventDestroy(stop));
 }
 
 } // namespace comms::prims::benchmark
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
+  if (const char* localRank = std::getenv("LOCAL_RANK")) {
+    cudaError_t ret = cudaSetDevice(std::atoi(localRank));
+    CHECK_EQ(ret, cudaSuccess) << cudaGetErrorString(ret);
+  }
   folly::Init init(&argc, &argv);
   if (!meta::comms::isTcpEnvironment()) {
     ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -452,8 +452,9 @@ enum class IbSendRecvProgressStage : uint8_t {
  *     If max_signal_bytes is smaller than perBlockSlot, each per-block region
  *     is further subdivided into signaled sub-chunks:
  *       chunkSize = floor16(min(perBlockSlot, max_signal_bytes))
- *     state[].nextStep counts bytes, not sub-chunks, so max_signal_bytes may
- *     change between calls as long as active_blocks is unchanged.
+ *     state[].nextStep counts 16-byte-aligned protocol bytes, not sub-chunks,
+ *     so max_signal_bytes may change between calls as long as active_blocks is
+ *     unchanged.
  *
  *   signalBuf: 2 * maxGroups * sizeof(uint64_t).
  *     [0, maxGroups)             — DATA_READY (sender -> receiver)
@@ -466,9 +467,10 @@ enum class IbSendRecvProgressStage : uint8_t {
  *     [0, maxGroups)             — sender state slots
  *     [maxGroups, 2*maxGroups)   — receiver state slots
  *
- *     nextStep is the persistent byte cursor used by both blocking and async
- *     send/recv APIs. The active* fields describe at most one outstanding
- *     async progress operation or blocking call in that direction/group.
+ *     nextStep is the persistent protocol-byte cursor used by both blocking
+ *     and async send/recv APIs. The active* fields describe at most one
+ *     outstanding async progress operation or blocking call in that
+ *     direction/group.
  *     Static transfer geometry is passed to init/progress calls and computed
  *     in registers.
  */
@@ -499,7 +501,7 @@ struct IbSendRecvState {
   IbgdaLocalBuffer localSignalBuf; ///< Signal inbox (DATA_READY + SLOT_FREE)
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
   IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
-  DeviceSpan<ProgressSlot> state; ///< Per-direction byte cursors + async state
+  DeviceSpan<ProgressSlot> state; ///< Protocol cursors + async state
   int maxGroups{0}; ///< Layout size for signal/state arrays
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring
   std::size_t dataBufferSize{0}; ///< Size of one pipeline slot in bytes

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1556,9 +1556,10 @@ class P2pIbgdaTransportDevice {
   //                      perBlockSlot. Otherwise:
   //                        chunkSize = floor16(min(perBlockSlot,
   //                                             max_signal_bytes))
-  //   state[].nextStep = persistent byte cursor. DATA_READY, SLOT_FREE, and
-  //                      NIC_DONE counters also advance by bytes, which keeps
-  //                      cursor state independent of max_signal_bytes.
+  //   state[].nextStep = persistent 16-byte-aligned protocol cursor.
+  //                      DATA_READY, SLOT_FREE, and NIC_DONE counters also
+  //                      advance by protocol bytes, which keeps cursor state
+  //                      independent of max_signal_bytes.
   //
   // Typical usage:
   //   auto [role, sub] = group.partition(2);
@@ -1631,11 +1632,11 @@ class P2pIbgdaTransportDevice {
    * `Done`, so callers can use the same loop shape for empty and non-empty
    * transfers.
    *
-   * The transport-owned state slot stores the shared persistent byte cursor and
-   * only the active async stage, `activeNextByte`, and reserved stream base.
-   * Immutable geometry such as `nbytes`, active block count, and chunk sizing
-   * is intentionally kept out of HBM-backed state and recomputed by each
-   * progress call from its arguments.
+   * The transport-owned state slot stores the shared persistent protocol byte
+   * cursor and only the active async stage, `activeNextByte`, and reserved
+   * stream base. Immutable geometry such as `nbytes`, active block count, and
+   * chunk sizing is intentionally kept out of HBM-backed state and recomputed
+   * by each progress call from its arguments.
    *
    * The progress state is a property of this transport, indexed by
    * `group.group_id` and direction. A caller may have one send and one recv in
@@ -1646,10 +1647,11 @@ class P2pIbgdaTransportDevice {
   /**
    * Initialize transport-owned state for one pipelined send operation.
    *
-   * The transport reserves the sender-side byte stream for `group.group_id`
-   * and starts the internal state in the sender state machine unless
-   * `nbytes == 0`. It does not capture the source pointer; callers pass the
-   * pointer to each `progress_send_once()` call.
+   * The transport reserves the sender-side protocol byte stream for
+   * `group.group_id` and starts the internal state in the sender state machine
+   * unless `nbytes == 0`. Non-empty payload byte counts are rounded up to the
+   * 16-byte wire granularity internally. It does not capture the source
+   * pointer; callers pass the pointer to each `progress_send_once()` call.
    *
    * The send progress slot for this group must be idle. Re-initializing a
    * group while a previous send is outstanding traps with a diagnostic instead
@@ -1667,7 +1669,8 @@ class P2pIbgdaTransportDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to send for this group.
-   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param active_blocks Number of participating transport lanes, or 0 for
+   *                      maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_send_progress(
@@ -1688,9 +1691,10 @@ class P2pIbgdaTransportDevice {
       return;
     }
     // Validate the transfer before reserving the transport byte cursor.
-    (void)make_progress_geometry(
+    const ProgressGeometry geometry = make_progress_geometry(
         group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
-    state.activeBaseStep = reserve_progress_step(group, progressIndex, nbytes);
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
     store_progress_state(group, progressIndex, state);
 #endif
   }
@@ -1698,10 +1702,12 @@ class P2pIbgdaTransportDevice {
   /**
    * Initialize transport-owned state for one pipelined recv operation.
    *
-   * The transport reserves the receiver-side byte stream for `group.group_id`
-   * and starts the internal state in the receiver state machine unless
-   * `nbytes == 0`. It does not capture the destination pointer; callers pass
-   * the pointer to each `progress_recv_once()` call.
+   * The transport reserves the receiver-side protocol byte stream for
+   * `group.group_id` and starts the internal state in the receiver state
+   * machine unless `nbytes == 0`. Non-empty payload byte counts are rounded up
+   * to the 16-byte wire granularity internally. It does not capture the
+   * destination pointer; callers pass the pointer to each
+   * `progress_recv_once()` call.
    *
    * The recv progress slot for this group must be idle. Re-initializing a
    * group while a previous recv is outstanding traps with a diagnostic instead
@@ -1718,7 +1724,8 @@ class P2pIbgdaTransportDevice {
    *
    * @param group Thread group that will execute all later progress calls.
    * @param nbytes Number of user-buffer bytes to receive for this group.
-   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param active_blocks Number of participating transport lanes, or 0 for
+   *                      maxGroups.
    * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
    */
   __device__ __forceinline__ void init_recv_progress(
@@ -1739,9 +1746,10 @@ class P2pIbgdaTransportDevice {
       return;
     }
     // Validate the transfer before reserving the transport byte cursor.
-    (void)make_progress_geometry(
+    const ProgressGeometry geometry = make_progress_geometry(
         group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
-    state.activeBaseStep = reserve_progress_step(group, progressIndex, nbytes);
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
     store_progress_state(group, progressIndex, state);
 #endif
   }
@@ -1761,7 +1769,9 @@ class P2pIbgdaTransportDevice {
    * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
    * range, and finally issues an RDMA put that piggybacks DATA_READY and
    * records NIC_DONE in the local counter. Returning `Done` means the reserved
-   * byte range has completed.
+   * protocol byte range has completed. For unaligned payload sizes, the final
+   * WQE may include transport-private padding; `CopyOp` is invoked only for
+   * valid payload bytes.
    *
    * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
    * The default `Memcpy` copies bytes cooperatively across the supplied
@@ -1800,13 +1810,13 @@ class P2pIbgdaTransportDevice {
     }
     const ProgressGeometry progress_params = make_progress_geometry(
         group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
-    if (state.activeNextByte >= progress_params.nbytes) {
+    if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
-            "[PIPES] FATAL: progress_send_once nextByte=%llu >= nbytes=%llu "
-            "without Done stage\n",
+            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
             static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.nbytes));
+            static_cast<unsigned long long>(progress_params.protocolBytes));
       }
       PIPES_DEVICE_TRAP();
     }
@@ -1843,13 +1853,17 @@ class P2pIbgdaTransportDevice {
         }
       }
 
-      CopyOp::send(
-          sendRecvState_.sendStagingPtr + chunk.stagingOff,
-          static_cast<const char*>(src) + chunk.dataOff,
-          chunk.bytes,
-          group,
-          chunk.dataOff,
-          args...);
+      const std::size_t validBytes = valid_payload_bytes(
+          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + chunk.stagingOff,
+            static_cast<const char*>(src) + chunk.dataOff,
+            validBytes,
+            group,
+            chunk.dataOff,
+            args...);
+      }
       group.sync();
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
@@ -1905,7 +1919,7 @@ class P2pIbgdaTransportDevice {
       group.sync();
 
       state.activeNextByte += chunk.bytes;
-      if (state.activeNextByte >= progress_params.nbytes) {
+      if (state.activeNextByte >= progress_params.protocolBytes) {
         transition_progress_stage(
             group, state, detail::IbSendRecvProgressStage::Done);
         store_progress_state(group, progressIndex, state);
@@ -1941,7 +1955,9 @@ class P2pIbgdaTransportDevice {
    * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
    * transport-owned recv-staging into the caller's destination through
    * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
-   * means the reserved byte range has completed.
+   * means the reserved protocol byte range has completed. For unaligned
+   * payload sizes, the final WQE may include transport-private padding;
+   * `CopyOp` is invoked only for valid payload bytes.
    *
    * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
    * The default `Memcpy` copies bytes cooperatively across the supplied
@@ -1980,13 +1996,13 @@ class P2pIbgdaTransportDevice {
     }
     const ProgressGeometry progress_params = make_progress_geometry(
         group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
-    if (state.activeNextByte >= progress_params.nbytes) {
+    if (state.activeNextByte >= progress_params.protocolBytes) {
       if (group.is_leader()) {
         printf(
-            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= nbytes=%llu "
-            "without Done stage\n",
+            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
             static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.nbytes));
+            static_cast<unsigned long long>(progress_params.protocolBytes));
       }
       PIPES_DEVICE_TRAP();
     }
@@ -2015,13 +2031,17 @@ class P2pIbgdaTransportDevice {
       return IbgdaSendRecvProgressStatus::Waiting;
     }
 
-    CopyOp::recv(
-        static_cast<char*>(dst) + chunk.dataOff,
-        sendRecvState_.recvStagingPtr + chunk.stagingOff,
-        chunk.bytes,
-        group,
-        chunk.dataOff,
-        args...);
+    const std::size_t validBytes = valid_payload_bytes(
+        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+    if (validBytes > 0) {
+      CopyOp::recv(
+          static_cast<char*>(dst) + chunk.dataOff,
+          sendRecvState_.recvStagingPtr + chunk.stagingOff,
+          validBytes,
+          group,
+          chunk.dataOff,
+          args...);
+    }
     group.sync();
 
     signal(
@@ -2032,7 +2052,7 @@ class P2pIbgdaTransportDevice {
         chunk.bytes);
 
     state.activeNextByte += chunk.bytes;
-    if (state.activeNextByte >= progress_params.nbytes) {
+    if (state.activeNextByte >= progress_params.protocolBytes) {
       transition_progress_stage(
           group, state, detail::IbSendRecvProgressStage::Done);
       store_progress_state(group, progressIndex, state);
@@ -2076,9 +2096,10 @@ class P2pIbgdaTransportDevice {
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does RDMA ops).
    * @param src             Source data for this block's tile.
-   * @param nbytes          Bytes to send for this group. Internally consumed
-   *                        in perBlockSlot-sized pieces, or smaller sub-chunks
-   *                        when max_signal_bytes is set.
+   * @param nbytes          Payload bytes to send for this group. The internal
+   *                        protocol byte count is rounded up to 16 bytes and
+   *                        consumed in perBlockSlot-sized pieces, or smaller
+   *                        sub-chunks when max_signal_bytes is set.
    * @param active_blocks   Number of block-groups sharing each logical slot in
    *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
@@ -2139,6 +2160,7 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
     const int effActive =
@@ -2207,7 +2229,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(groupId));
     }
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -2215,7 +2237,7 @@ class P2pIbgdaTransportDevice {
       const std::size_t slotOff = slot * dataBufferSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
       const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t bytesThis =
           chunkSize < dataRemaining ? chunkSize : dataRemaining;
       bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
@@ -2234,13 +2256,17 @@ class P2pIbgdaTransportDevice {
       }
 
       // (2) Cooperative copy: src → local sendStaging via CopyOp.
-      CopyOp::send(
-          sendRecvState_.sendStagingPtr + stagingOff,
-          static_cast<const char*>(src) + dataOff,
-          bytesThis,
-          group,
-          dataOff,
-          args...);
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + stagingOff,
+            static_cast<const char*>(src) + dataOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
       group.sync();
 
       // (3) Backpressure: wait for receiver to free this byte range's
@@ -2277,7 +2303,7 @@ class P2pIbgdaTransportDevice {
     }
 
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + nbytes);
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
@@ -2310,9 +2336,10 @@ class P2pIbgdaTransportDevice {
    * @param group           ThreadGroup (all threads participate in memcpy,
    *                        leader does signal ops).
    * @param dst             Destination for this block's tile.
-   * @param nbytes          Bytes to receive for this group. Internally
-   *                        consumed in perBlockSlot-sized pieces, or smaller
-   *                        sub-chunks when max_signal_bytes is set.
+   * @param nbytes          Payload bytes to receive for this group. The
+   *                        internal protocol byte count is rounded up to 16
+   *                        bytes and consumed in perBlockSlot-sized pieces, or
+   *                        smaller sub-chunks when max_signal_bytes is set.
    * @param active_blocks   Number of block-groups sharing each logical slot in
    *                        this call. 0 means use maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk within one
@@ -2374,6 +2401,7 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
     const int effActive =
@@ -2442,7 +2470,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(groupId));
     }
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -2450,7 +2478,7 @@ class P2pIbgdaTransportDevice {
       const std::size_t slotOff = slot * dataBufferSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
       const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t bytesThis =
           chunkSize < dataRemaining ? chunkSize : dataRemaining;
       bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
@@ -2466,13 +2494,17 @@ class P2pIbgdaTransportDevice {
           timeout);
 
       // (2) Cooperative copy: local recvStaging → dst via CopyOp.
-      CopyOp::recv(
-          static_cast<char*>(dst) + dataOff,
-          sendRecvState_.recvStagingPtr + stagingOff,
-          bytesThis,
-          group,
-          dataOff,
-          args...);
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::recv(
+            static_cast<char*>(dst) + dataOff,
+            sendRecvState_.recvStagingPtr + stagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
       group.sync();
 
       // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
@@ -2486,7 +2518,7 @@ class P2pIbgdaTransportDevice {
     }
 
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + nbytes);
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
       state.activeStage = detail::IbSendRecvProgressStage::Done;
       state.activeBaseStep = 0;
       state.activeNextByte = 0;
@@ -2552,7 +2584,8 @@ class P2pIbgdaTransportDevice {
    * @param dst             Application destination (may be nullptr if
    *                        CopyOp handles it, e.g. reduce-scatter).
    * @param fwd             Forward transport (sends to next peer in ring).
-   * @param nbytes          Bytes to receive and forward.
+   * @param nbytes          Payload bytes to receive and forward. The internal
+   *                        protocol byte count is rounded up to 16 bytes.
    * @param active_blocks   Number of block-groups sharing the slot. 0 =
    * maxGroups.
    * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
@@ -2603,6 +2636,7 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
 
     const int groupId = group.group_id;
 
@@ -2706,7 +2740,7 @@ class P2pIbgdaTransportDevice {
           static_cast<uint16_t>(groupId));
     }
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       // --- Recv side offsets ---
       const uint64_t recvStreamStart = recvBaseByte + dataOff;
       const std::size_t recvPipelineOff =
@@ -2730,7 +2764,7 @@ class P2pIbgdaTransportDevice {
           fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
       const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
       const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t bytesThis =
           recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
       bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
@@ -2757,14 +2791,18 @@ class P2pIbgdaTransportDevice {
       }
 
       // (3) CopyOp::forward — transform recv staging → dst + fwd staging.
-      CopyOp::forward(
-          dst ? static_cast<char*>(dst) + dataOff : nullptr,
-          fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
-          sendRecvState_.recvStagingPtr + recvStagingOff,
-          bytesThis,
-          group,
-          dataOff,
-          args...);
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::forward(
+            dst ? static_cast<char*>(dst) + dataOff : nullptr,
+            fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
+            sendRecvState_.recvStagingPtr + recvStagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
       group.sync();
 
       // (4) Signal SLOT_FREE to sender (this transport).
@@ -2810,11 +2848,12 @@ class P2pIbgdaTransportDevice {
 
     // Update shared byte cursors for both recv and fwd sides.
     if (group.is_leader()) {
-      recvSlotState.nextStep = static_cast<int64_t>(recvBaseByte + nbytes);
+      recvSlotState.nextStep =
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
       recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
       recvSlotState.activeBaseStep = 0;
       recvSlotState.activeNextByte = 0;
-      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + nbytes);
+      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
       fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
       fwdSlotState.activeBaseStep = 0;
       fwdSlotState.activeNextByte = 0;
@@ -2861,10 +2900,13 @@ class P2pIbgdaTransportDevice {
    * Physical staging range for the next resumable progress step.
    *
    * `stagingOff` is an offset into the transport-owned send/recv staging
-   * buffers. `dataOff` is the matching offset into the caller's user buffer.
-   * `bytes` never crosses a per-block staging partition or the requested byte
-   * count. `streamEnd` is the absolute protocol byte value after this chunk and
-   * is used as the DATA_READY, SLOT_FREE, and NIC_DONE readiness threshold.
+   * buffers. `dataOff` is the matching protocol offset into the caller's user
+   * buffer.
+   * `bytes` never crosses a per-block staging partition or the reserved
+   * protocol byte count. `streamEnd` is the absolute protocol byte value after
+   * this chunk and is used as the DATA_READY, SLOT_FREE, and NIC_DONE
+   * readiness threshold. `dataOff` is a protocol offset; callers mask it
+   * against the payload byte count before invoking user-buffer copy callbacks.
    */
   struct ProgressChunk {
     std::size_t stagingOff;
@@ -2883,10 +2925,33 @@ class P2pIbgdaTransportDevice {
    */
   struct ProgressGeometry {
     int groupId;
-    std::size_t nbytes;
+    std::size_t payloadBytes;
+    std::size_t protocolBytes;
     std::size_t perBlockSlot;
     std::size_t chunkSize;
   };
+
+  /**
+   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
+   * the staging stream on the same granularity as the vectorized local staging
+   * copies while preserving caller-facing payload byte counts; padding is
+   * transport-private and is never exposed to CopyOp callbacks.
+   */
+  __device__ __forceinline__ static std::size_t align_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
 
   /**
    * Return the internal send progress slot index for `group`.
@@ -3043,7 +3108,8 @@ class P2pIbgdaTransportDevice {
    *
    * The public init methods handle zero-byte operations before calling this
    * helper. A progress call should only see zero bytes when its state is
-   * already `Done`.
+   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
+   * protocol counts here; copy callbacks still see only valid payload bytes.
    */
   __device__ __forceinline__ ProgressGeometry make_progress_geometry(
       ThreadGroup& group,
@@ -3099,6 +3165,7 @@ class P2pIbgdaTransportDevice {
       PIPES_DEVICE_TRAP();
     }
 
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
     std::size_t chunkSize =
         (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
         ? (max_signal_bytes & ~15ULL)
@@ -3108,7 +3175,8 @@ class P2pIbgdaTransportDevice {
     }
     return ProgressGeometry{
         .groupId = groupId,
-        .nbytes = nbytes,
+        .payloadBytes = nbytes,
+        .protocolBytes = protocolBytes,
         .perBlockSlot = perBlockSlot,
         .chunkSize = chunkSize,
     };
@@ -3248,7 +3316,8 @@ class P2pIbgdaTransportDevice {
   }
 
   /**
-   * Map the state's logical byte cursor to the next staging-ring chunk.
+   * Map the state's logical protocol byte cursor to the next staging-ring
+   * chunk.
    *
    * The transport stores each logical slot as `dataBufferSize` bytes, split
    * into geometry-specific per-group partitions. The protocol cursor advances
@@ -3256,9 +3325,10 @@ class P2pIbgdaTransportDevice {
    * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
    *
    * The returned chunk is clipped by three boundaries: the configured
-   * sub-chunk size, remaining user bytes, and remaining bytes in the current
-   * per-block staging partition. This keeps every progress call bounded and
-   * prevents a single RDMA put or recv copy from spanning two staging slots.
+   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
+   * current per-block staging partition. This keeps every progress call
+   * bounded and prevents a single RDMA put or recv copy from spanning two
+   * staging slots.
    */
   __device__ __forceinline__ ProgressChunk next_chunk(
       const IbSendRecvState::ProgressSlot& state,
@@ -3275,7 +3345,8 @@ class P2pIbgdaTransportDevice {
     const std::size_t chunkOff =
         pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
     const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
-    const std::size_t dataRemaining = geometry.nbytes - state.activeNextByte;
+    const std::size_t dataRemaining =
+        geometry.protocolBytes - state.activeNextByte;
     std::size_t bytes =
         geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
     bytes = bytes < slotRemaining ? bytes : slotRemaining;


### PR DESCRIPTION
Summary:
- Make the IBGDA send/recv benchmark runnable again on the H100 devgpu path by selecting the `LOCAL_RANK` CUDA device before `folly::Init`/TCPStore setup.
- Split `IbgdaSendRecvTest.Bandwidth` into `BandwidthFrom4B` and `BandwidthFrom1MB` so the benchmark directly compares a full sweep against a sweep that starts at `1MB`.
- Add benchmark-local drain/reset helpers for row isolation: drain outstanding NIC completion, then reset local signals, counters, and send/recv progress slots before each measured row.
- Keep the transport ownership model intact: no benchmark-owned IBGDA send/recv staging buffers and no send/recv API signature changes.
- Debug finding: the old full sweep measured common message sizes with inherited protocol cursor state. After row isolation, all common rows start at `BaseMod=0`; `1MB..4GB` full-sweep and exact-sweep bandwidth now matches within normal noise.

Reviewed By: goelayu

Differential Revision: D108444748


