### PR TITLE
AllGatherP pipeline: bail when local peers are non-NVL

### DIFF
--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -202,6 +202,21 @@ commResult_t AlgoImpl::execPipeline(
   // the remote address
   if (nLocalRanks > 1) {
     FB_COMMCHECK(waitInit());
+
+    // Pipeline broadcasts intra-node only via nvlCeBcast (no IB fallback), so
+    // bail cleanly here -- before any GPE work -- if a local peer is non-NVL,
+    // rather than failing inside nvlCeBcast. Mirrors nvlCeBcast's own check.
+    for (int r = 1; r < nLocalRanks; r++) {
+      const auto localPeer = (statex->localRank() + r) % nLocalRanks;
+      const auto peer = statex->localRankToRank(localPeer);
+      if (pArgs.remoteAccessKeys[peer].backend != CtranMapperBackend::NVL) {
+        FB_ERRORRETURN(
+            commInvalidUsage,
+            "AllGatherP pipeline requires an NVL backend for all local peers; "
+            "peer {} has a non-NVL backend",
+            peer);
+      }
+    }
   }
 
   auto config = KernelConfig(

--- a/comms/ctran/benchmarks/AllgatherPBench.cc
+++ b/comms/ctran/benchmarks/AllgatherPBench.cc
@@ -382,10 +382,12 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
     printHeader();
     printTableHeader();
 
-    // Check nNodes for pipeline support
+    // pipelineSupported is decided after init by probing the algo once (below).
     const auto statex = ctranComm_->statex_.get();
     const auto nNodes = statex->nNodes();
-    const bool pipelineSupported = nNodes > 1;
+    const bool wantPipeline =
+        (FLAGS_algo == "ctpipeline" || FLAGS_algo == "all");
+    bool pipelineSupported = false;
 
     // Generate size range (powers of 2)
     std::vector<size_t> sizes;
@@ -442,6 +444,27 @@ class AllgatherPBenchmark : public ctran::CtranDistTestFixture {
       CUDACHECK_TEST(cudaStreamSynchronize(stream_));
       CUDACHECK_TEST(cudaDeviceSynchronize());
       ctranComm_->bootstrap_->barrier(globalRank, numRanks).get();
+
+      // Probe pipeline once: execPipeline fail-fasts with commInvalidUsage when
+      // intra-node NVL is unavailable, so skip the pipeline measurement then.
+      if (wantPipeline && nNodes > 1) {
+        EnvRAII algoEnv(
+            NCCL_ALLGATHER_P_ALGO, NCCL_ALLGATHER_P_ALGO::ctpipeline);
+        commResult_t probeRc = ctran::allGatherPExec(
+            FLAGS_in_place ? recvbuf : sendbuf, /*count=*/1, dt_, request);
+        CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+        if (probeRc == commInvalidUsage) {
+          if (globalRank == 0) {
+            std::cout
+                << "Skipping AllGatherP_Pipeline: intra-node NVL backend "
+                   "unavailable (pipeline requires NVL for all local peers)."
+                << std::endl;
+          }
+        } else {
+          COMMCHECK_TEST(probeRc); // commSuccess, or surface a real error
+          pipelineSupported = true;
+        }
+      }
     }
 
     // Run benchmarks for all sizes using the same persistent request


### PR DESCRIPTION
Summary:
Fixes the failing test `fbcode//comms/ctran/benchmarks:allgatherp_bench_4x8` (TestX 562950276156131, T271903813), which was `DISABLED_FAILING` with zero passes.

Root cause: AllgatherPBench runs the AllGatherP `ctpipeline` algo whenever `nNodes > 1`. `execPipeline` distributes intra-node data exclusively via `nvlCeBcast`, which `FB_ERRORRETURN(commInvalidArgument)` ("Peer N has non-NVL backend in nvlCeBcast") unless every local peer's realized backend (`pArgs.remoteAccessKeys[peer].backend`) is NVL. In the 4x8 RE multi-process environment, intra-host NVL IPC import fails and local peers come up on IB, so the pipeline aborts mid-execution. `ctdirect` passes (its IB put-loop serves all peers). DirectImpl already guards its `nvlCeBcast` call (commit 013c577e51ae); PipelineImpl was never guarded and, unlike Direct, has no IB intra-node fallback, so it cannot simply skip the broadcast.

This diff:
- `PipelineImpl.cc`: in `execPipeline`, after `waitInit()` and before submitting any GPE work, check every local peer's `remoteAccessKeys[peer].backend == NVL` (mirroring `nvlCeBcast`'s own check); if any is non-NVL, `FB_ERRORRETURN(commInvalidUsage)` early. This is a clean fail-fast with no dangling GPE op, instead of crashing mid-execution inside `nvlCeBcast`, so the caller can fall back to another algorithm.
- `AllgatherPBench.cc`: add `pipelineProbe()`, which runs the pipeline algo once and skips the pipeline measurement when it returns `commInvalidUsage` (globally ANDed so all ranks agree). When skipped, Direct + NCCL still run and the benchmark passes. A `getBackend()` pre-check is unreliable here (it reports P2P capability, not the realized backend) and a raw mapper `allGatherCtrl` probe segfaults, so probing the algo directly is the robust approach.

Reviewed By: srinathb-meta

Differential Revision: D108702039


