### PR TITLE
Add Folly IBGDA send/recv multiprocess benchmark

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -18,6 +18,12 @@ __device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
   return (nbytes + 15ULL) & ~15ULL;
 }
 
+__device__ __forceinline__ std::size_t section_bytes(
+    P2pIbgdaTransportDevice* transport,
+    std::size_t totalBytes) {
+  return min(transport->send_recv_state().dataBufferSize, totalBytes);
+}
+
 __device__ __forceinline__ std::size_t
 protocol_bytes_for_tiled_group_per_launch(
     std::size_t totalBytes,
@@ -59,8 +65,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
 
   // Section size = transport's staging slot size (dataBufferSize).
   // Clamp to totalBytes for small transfers.
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -93,6 +98,85 @@ void launch_ibgda_send_recv(
   if (err != cudaSuccess) {
     printf("[PIPES] Kernel launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+  auto [role, sub] = group.partition(2);
+  const bool isSender = (role == 0);
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    const std::size_t offset = s * sectionBytes;
+
+    if (isSender) {
+      TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
+      transport->init_send_progress(
+          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      while (transport->progress_send_once(
+                 sub,
+                 tiles.data(),
+                 tiles.bytes(),
+                 numBlocks,
+                 maxSignalBytes,
+                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+      }
+    } else {
+      TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
+      transport->init_recv_progress(
+          sub, tiles.bytes(), numBlocks, maxSignalBytes);
+      while (transport->progress_recv_once(
+                 sub,
+                 tiles.data(),
+                 tiles.bytes(),
+                 numBlocks,
+                 maxSignalBytes,
+                 timeout) != IbgdaSendRecvProgressStatus::Done) {
+      }
+    }
+  }
+}
+#endif
+
+void launch_ibgda_progress_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)dst;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress send/recv benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_send_recv_kernel<<<2 * numBlocks, 512, 0, stream>>>(
+      transport, src, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] progress sendrecv kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+#endif
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
@@ -184,8 +268,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
     Timeout timeout) {
   auto group = make_block_group();
 
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -204,8 +287,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
     Timeout timeout) {
   auto group = make_block_group();
 
-  const std::size_t sectionBytes =
-      min(transport->send_recv_state().dataBufferSize, totalBytes);
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
   const std::size_t totalSections = totalBytes / sectionBytes;
 
   for (std::size_t s = 0; s < totalSections; ++s) {
@@ -333,6 +415,108 @@ void launch_ibgda_reset_send_recv(
   if (err != cudaSuccess) {
     printf("[PIPES] Reset launch failed: %s\n", cudaGetErrorString(err));
   }
+}
+
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
+    transport->init_send_progress(
+        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    while (transport->progress_send_once(
+               group,
+               tiles.data(),
+               tiles.bytes(),
+               numBlocks,
+               maxSignalBytes,
+               timeout) != IbgdaSendRecvProgressStatus::Done) {
+    }
+  }
+}
+
+__global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+  auto group = make_block_group();
+
+  const std::size_t sectionBytes = section_bytes(transport, totalBytes);
+  const std::size_t totalSections = totalBytes / sectionBytes;
+
+  for (std::size_t s = 0; s < totalSections; ++s) {
+    TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
+    transport->init_recv_progress(
+        group, tiles.bytes(), numBlocks, maxSignalBytes);
+    while (transport->progress_recv_once(
+               group,
+               tiles.data(),
+               tiles.bytes(),
+               numBlocks,
+               maxSignalBytes,
+               timeout) != IbgdaSendRecvProgressStatus::Done) {
+    }
+  }
+}
+#endif
+
+void launch_ibgda_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)src;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress send benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+#endif
+}
+
+void launch_ibgda_progress_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes,
+    Timeout timeout) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)dst;
+  (void)nbytes;
+  (void)numBlocks;
+  (void)stream;
+  (void)maxSignalBytes;
+  (void)timeout;
+  printf("[PIPES] progress recv benchmark is NVIDIA-only\n");
+#else
+  ibgda_progress_recv_kernel<<<numBlocks, 512, 0, stream>>>(
+      transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+#endif
 }
 
 __global__ void ibgda_snapshot_step_state_kernel(

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -307,6 +307,10 @@ void launch_ibgda_send(
     Timeout timeout) {
   ibgda_send_kernel<<<numBlocks, 512, 0, stream>>>(
       transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[PIPES] send kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
 }
 
 void launch_ibgda_recv(
@@ -319,6 +323,10 @@ void launch_ibgda_recv(
     Timeout timeout) {
   ibgda_recv_kernel<<<numBlocks, 512, 0, stream>>>(
       transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[PIPES] recv kernel launch failed: %s\n", cudaGetErrorString(err));
+  }
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_drain_send_recv_kernel(
@@ -493,6 +501,12 @@ void launch_ibgda_progress_send(
 #else
   ibgda_progress_send_kernel<<<numBlocks, 512, 0, stream>>>(
       transport, src, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] progress send kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
 #endif
 }
 
@@ -516,6 +530,12 @@ void launch_ibgda_progress_recv(
 #else
   ibgda_progress_recv_kernel<<<numBlocks, 512, 0, stream>>>(
       transport, dst, nbytes, numBlocks, maxSignalBytes, timeout);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "[PIPES] progress recv kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
 #endif
 }
 

--- a/comms/prims/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cuh
@@ -29,6 +29,17 @@ __global__ void ibgda_send_recv_kernel(
     std::size_t maxSignalBytes,
     Timeout timeout);
 
+#ifndef __HIP_PLATFORM_AMD__
+__global__ void ibgda_progress_send_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+#endif
+
 __global__ void ibgda_send_recv_two_call_kernel(
     P2pIbgdaTransportDevice* transport,
     char* src,
@@ -63,5 +74,31 @@ __global__ void ibgda_recv_kernel(
     int numBlocks,
     std::size_t maxSignalBytes,
     Timeout timeout);
+
+#ifndef __HIP_PLATFORM_AMD__
+/**
+ * Unidirectional progress send kernel. All blocks send.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_progress_send_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+
+/**
+ * Unidirectional progress recv kernel. All blocks receive.
+ * Grid: numBlocks. Block: 512 threads.
+ */
+__global__ void ibgda_progress_recv_kernel(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t totalBytes,
+    int numBlocks,
+    std::size_t maxSignalBytes,
+    Timeout timeout);
+#endif
 
 } // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -40,6 +40,22 @@ void launch_ibgda_send_recv(
     Timeout timeout = Timeout());
 
 /**
+ * Launch bidirectional progress-send/recv kernel for IBGDA transport.
+ *
+ * Uses the resumable init/progress API and loops until each initialized
+ * transfer reaches Done.
+ */
+void launch_ibgda_progress_send_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
  * Launch bidirectional tile sendrecv kernel that performs two back-to-back
  * send()/recv() calls with independent maxSignalBytes values.
  */
@@ -99,6 +115,30 @@ void launch_ibgda_reset_send_recv(
     P2pIbgdaTransportDevice* transport,
     int maxGroups,
     cudaStream_t stream);
+
+/**
+ * Launch unidirectional progress send kernel. All blocks send.
+ */
+void launch_ibgda_progress_send(
+    P2pIbgdaTransportDevice* transport,
+    char* src,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
+
+/**
+ * Launch unidirectional progress recv kernel. All blocks receive.
+ */
+void launch_ibgda_progress_recv(
+    P2pIbgdaTransportDevice* transport,
+    char* dst,
+    std::size_t nbytes,
+    int numBlocks,
+    cudaStream_t stream,
+    std::size_t maxSignalBytes = 0,
+    Timeout timeout = Timeout());
 
 /**
  * Snapshot the transport send/recv byte cursors into device memory.

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -1,997 +1,409 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include <gtest/gtest.h>
-
 #include <cuda_runtime.h>
+#include <mpi.h>
+
+#include <folly/Benchmark.h>
 #include <folly/init/Init.h>
-#include <folly/logging/xlog.h>
+#include <folly/portability/GFlags.h>
+#include <glog/logging.h>
 
 #include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <string>
-#include <vector>
+#include <utility>
 
 #include "comms/prims/benchmarks/IbgdaSendRecv.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
-#include "comms/testinfra/BenchmarkTestFixture.h"
+#include "comms/testinfra/ITestBootstrap.h"
+#include "comms/testinfra/TcpStoreBootstrap.h"
+#include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/utils/CudaRAII.h"
 
-using meta::comms::BenchmarkEnvironment;
-using meta::comms::BenchmarkTestFixture;
 using meta::comms::DeviceBuffer;
-
-#define ASSERT_CUDA_SUCCESS(cmd)                                    \
-  do {                                                              \
-    cudaError_t ret;                                                \
-    ASSERT_EQ(cudaSuccess, ret = (cmd)) << cudaGetErrorString(ret); \
-  } while (0)
+using meta::comms::ITestBootstrap;
+using meta::comms::MpiBootstrap;
+using meta::comms::TcpStoreBootstrap;
 
 namespace comms::prims::benchmark {
-
-using SendRecvConfig = MultipeerIbgdaTransportConfig::SendRecvConfig;
-
 namespace {
 
-constexpr std::size_t alignProtocolBytes(std::size_t nbytes) {
-  return (nbytes + 15ULL) & ~15ULL;
-}
-
-struct SendRecvBenchmarkGeometry {
-  int activeBlocks;
-  int maxGroups;
-  const char* label;
-};
-
-constexpr std::array<SendRecvBenchmarkGeometry, 2> kSendRecvBenchmarkGeometries{
-    {{1, 2, "activeBlocks=1/maxGroups=2"},
-     {2, 2, "activeBlocks=2/maxGroups=2"}}};
+constexpr int kWorldSize = 2;
+constexpr int kNumBlocks = 2;
+constexpr std::size_t kSlotSize = 8 * 1024 * 1024;
+constexpr int kPipelineDepth = 2;
+constexpr int kWarmupIters = 5;
+constexpr const char* kDefaultBenchmarkIters = "20";
+constexpr const char* kDefaultBenchmarkMaxIters = "21";
 
 enum class SendRecvApi {
   Blocking,
   Progress,
 };
 
-const char* sendRecvApiName(SendRecvApi api) {
+enum class SendRecvDirection {
+  Bidirectional,
+  Unidirectional,
+};
+
+bool isTcpEnvironment() {
+  return std::getenv("MASTER_ADDR") != nullptr &&
+      std::getenv("MASTER_PORT") != nullptr && std::getenv("RANK") != nullptr &&
+      std::getenv("WORLD_SIZE") != nullptr;
+}
+
+class DistributedBenchmarkEnvironment {
+ public:
+  DistributedBenchmarkEnvironment() {
+    if (isTcpEnvironment()) {
+      return;
+    }
+    int initialized = 0;
+    MPI_Initialized(&initialized);
+    if (!initialized) {
+      MPI_Init(nullptr, nullptr);
+      ownsMpi_ = true;
+    }
+  }
+
+  ~DistributedBenchmarkEnvironment() {
+    if (!ownsMpi_) {
+      return;
+    }
+    int finalized = 0;
+    MPI_Finalized(&finalized);
+    if (!finalized) {
+      MPI_Finalize();
+    }
+  }
+
+  DistributedBenchmarkEnvironment(const DistributedBenchmarkEnvironment&) =
+      delete;
+  DistributedBenchmarkEnvironment& operator=(
+      const DistributedBenchmarkEnvironment&) = delete;
+  DistributedBenchmarkEnvironment(DistributedBenchmarkEnvironment&&) = delete;
+  DistributedBenchmarkEnvironment& operator=(
+      DistributedBenchmarkEnvironment&&) = delete;
+
+ private:
+  bool ownsMpi_{false};
+};
+
+std::shared_ptr<ITestBootstrap> makeBootstrap() {
+  if (isTcpEnvironment()) {
+    return std::make_shared<TcpStoreBootstrap>();
+  }
+  return std::make_shared<MpiBootstrap>();
+}
+
+void setDefaultBenchmarkFlags() {
+  folly::gflags::SetCommandLineOptionWithMode(
+      "bm_min_iters",
+      kDefaultBenchmarkIters,
+      folly::gflags::SET_FLAG_IF_DEFAULT);
+  folly::gflags::SetCommandLineOptionWithMode(
+      "bm_max_iters",
+      kDefaultBenchmarkMaxIters,
+      folly::gflags::SET_FLAG_IF_DEFAULT);
+  folly::gflags::SetCommandLineOptionWithMode(
+      "bm_max_trials", "1", folly::gflags::SET_FLAG_IF_DEFAULT);
+}
+
+struct BenchmarkSize {
+  const char* name;
+  std::size_t nbytes;
+};
+
+constexpr std::array<BenchmarkSize, 13> kBenchmarkSizes{{
+    {"1MB", 1ULL << 20},
+    {"2MB", 2ULL << 20},
+    {"4MB", 4ULL << 20},
+    {"8MB", 8ULL << 20},
+    {"16MB", 16ULL << 20},
+    {"32MB", 32ULL << 20},
+    {"64MB", 64ULL << 20},
+    {"128MB", 128ULL << 20},
+    {"256MB", 256ULL << 20},
+    {"512MB", 512ULL << 20},
+    {"1GB", 1ULL << 30},
+    {"2GB", 2ULL << 30},
+    {"4GB", 4ULL << 30},
+}};
+
+constexpr std::size_t kMaxBenchmarkBytes = 4ULL << 30;
+
+const char* apiName(SendRecvApi api) {
   switch (api) {
     case SendRecvApi::Blocking:
-      return "send/recv";
+      return "blocking";
     case SendRecvApi::Progress:
       return "progress";
   }
   return "unknown";
 }
 
-std::vector<SendRecvApi> benchmarkApis() {
-  std::vector<SendRecvApi> apis{SendRecvApi::Blocking};
-#ifndef __HIP_PLATFORM_AMD__
-  apis.push_back(SendRecvApi::Progress);
-#endif
-  return apis;
+const char* directionName(SendRecvDirection direction) {
+  switch (direction) {
+    case SendRecvDirection::Bidirectional:
+      return "bidirectional";
+    case SendRecvDirection::Unidirectional:
+      return "unidirectional";
+  }
+  return "unknown";
 }
 
-std::string formatMessageSize(std::size_t nbytes) {
-  if (nbytes >= (1ULL << 30)) {
-    return fmt::format("{}GB", nbytes >> 30);
-  }
-  if (nbytes >= (1ULL << 20)) {
-    return fmt::format("{}MB", nbytes >> 20);
-  }
-  if (nbytes >= (1ULL << 10)) {
-    return fmt::format("{}KB", nbytes >> 10);
-  }
-  return fmt::format("{}B", nbytes);
+std::string benchmarkName(
+    SendRecvApi api,
+    SendRecvDirection direction,
+    const char* sizeName) {
+  std::string name = "ibgdaSendRecv(";
+  name += apiName(api);
+  name += "_";
+  name += directionName(direction);
+  name += "_";
+  name += sizeName;
+  name += ")";
+  return name;
 }
 
-std::vector<std::size_t> makePowerOfTwoMessageSizes(
-    std::size_t firstBytes,
-    std::size_t lastBytes) {
-  std::vector<std::size_t> messageSizes;
-  for (std::size_t sz = firstBytes; sz <= lastBytes; sz <<= 1) {
-    messageSizes.push_back(sz);
+class IbgdaSendRecvBenchmarkContext {
+ public:
+  IbgdaSendRecvBenchmarkContext(
+      std::shared_ptr<ITestBootstrap> bootstrap,
+      std::size_t maxBytes)
+      : bootstrap_(std::move(bootstrap)), maxBytes_(maxBytes) {
+    CHECK(bootstrap_ != nullptr);
+    CHECK_GT(maxBytes_, 0);
+    globalRank_ = bootstrap_->getGlobalRank();
+    worldSize_ = bootstrap_->getWorldSize();
+    localRank_ = bootstrap_->getLocalRank();
+
+    CHECK_EQ(worldSize_, kWorldSize)
+        << "IBGDA send/recv benchmark requires exactly two ranks";
+    int deviceCount = 0;
+    CHECK_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    CHECK_GT(deviceCount, localRank_)
+        << "Not enough visible CUDA devices for local rank";
+    CHECK_EQ(cudaSetDevice(localRank_), cudaSuccess);
+    CHECK_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank_,
+        .dataBufferSize = kSlotSize,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = kNumBlocks,
+                .pipelineDepth = kPipelineDepth,
+            },
+    };
+    transport_ = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank_, worldSize_, bootstrap_, transportConfig);
+    transport_->exchange();
+
+    sendBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
+    recvBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
+    CHECK_EQ(cudaMemset(sendBuf_->get(), 0xAA, maxBytes_), cudaSuccess);
+    CHECK_EQ(cudaMemset(recvBuf_->get(), 0, maxBytes_), cudaSuccess);
+    CHECK_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    deviceTransport_ = transport_->getP2pTransportDevice(1 - globalRank_);
   }
-  return messageSizes;
-}
 
-std::vector<int64_t> snapshotStepState(
-    P2pIbgdaTransportDevice* transport,
-    int maxGroups,
-    cudaStream_t stream) {
-  DeviceBuffer stepBuf(2 * maxGroups * sizeof(int64_t));
-  launch_ibgda_snapshot_step_state(
-      transport, static_cast<int64_t*>(stepBuf.get()), 2 * maxGroups, stream);
+  ~IbgdaSendRecvBenchmarkContext() {
+    CHECK_EQ(cudaSetDevice(localRank_), cudaSuccess);
+    if (stream_ != nullptr) {
+      CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+    }
+    if (bootstrap_) {
+      bootstrap_->barrierAll();
+    }
+    if (stream_ != nullptr) {
+      CHECK_EQ(cudaStreamDestroy(stream_), cudaSuccess);
+      stream_ = nullptr;
+    }
+    recvBuf_.reset();
+    sendBuf_.reset();
+    transport_.reset();
+    bootstrap_.reset();
+  }
 
-  cudaError_t err = cudaStreamSynchronize(stream);
-  EXPECT_EQ(err, cudaSuccess)
-      << "Step-state snapshot failed: " << cudaGetErrorString(err);
+  IbgdaSendRecvBenchmarkContext(const IbgdaSendRecvBenchmarkContext&) = delete;
+  IbgdaSendRecvBenchmarkContext& operator=(
+      const IbgdaSendRecvBenchmarkContext&) = delete;
+  IbgdaSendRecvBenchmarkContext(IbgdaSendRecvBenchmarkContext&&) = delete;
+  IbgdaSendRecvBenchmarkContext& operator=(IbgdaSendRecvBenchmarkContext&&) =
+      delete;
 
-  std::vector<int64_t> hostSteps(2 * maxGroups, -1);
-  err = cudaMemcpy(
-      hostSteps.data(),
-      stepBuf.get(),
-      hostSteps.size() * sizeof(int64_t),
-      cudaMemcpyDeviceToHost);
-  EXPECT_EQ(err, cudaSuccess)
-      << "Step-state copy failed: " << cudaGetErrorString(err);
-  return hostSteps;
-}
+  void
+  warmup(std::size_t nbytes, SendRecvApi api, SendRecvDirection direction) {
+    CHECK_LE(nbytes, maxBytes_);
+    bootstrap_->barrierAll();
+    for (int i = 0; i < kWarmupIters; ++i) {
+      launchOperation(nbytes, api, direction);
+      CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+    }
+  }
 
-void expectUniformBuffer(
-    const DeviceBuffer& buf,
+  float runLocalElapsed(
+      uint32_t iters,
+      std::size_t nbytes,
+      SendRecvApi api,
+      SendRecvDirection direction) {
+    CHECK_LE(nbytes, maxBytes_);
+
+    cudaEvent_t start{};
+    cudaEvent_t stop{};
+    CHECK_EQ(cudaEventCreate(&start), cudaSuccess);
+    CHECK_EQ(cudaEventCreate(&stop), cudaSuccess);
+
+    CHECK_EQ(cudaEventRecord(start, stream_), cudaSuccess);
+    for (uint32_t i = 0; i < iters; ++i) {
+      launchOperation(nbytes, api, direction);
+    }
+    CHECK_EQ(cudaEventRecord(stop, stream_), cudaSuccess);
+    CHECK_EQ(cudaEventSynchronize(stop), cudaSuccess);
+
+    float elapsedMs = 0.0f;
+    CHECK_EQ(cudaEventElapsedTime(&elapsedMs, start, stop), cudaSuccess);
+    CHECK_EQ(cudaEventDestroy(start), cudaSuccess);
+    CHECK_EQ(cudaEventDestroy(stop), cudaSuccess);
+
+    return elapsedMs;
+  }
+
+ private:
+  void launchOperation(
+      std::size_t nbytes,
+      SendRecvApi api,
+      SendRecvDirection direction) {
+    auto* sendBuf = static_cast<char*>(sendBuf_->get());
+    auto* recvBuf = static_cast<char*>(recvBuf_->get());
+
+    if (direction == SendRecvDirection::Bidirectional) {
+      if (api == SendRecvApi::Blocking) {
+        launch_ibgda_send_recv(
+            deviceTransport_, sendBuf, recvBuf, nbytes, kNumBlocks, stream_);
+      } else {
+        launch_ibgda_progress_send_recv(
+            deviceTransport_, sendBuf, recvBuf, nbytes, kNumBlocks, stream_);
+      }
+      return;
+    }
+
+    if (globalRank_ == 0) {
+      if (api == SendRecvApi::Blocking) {
+        launch_ibgda_send(
+            deviceTransport_, sendBuf, nbytes, kNumBlocks, stream_);
+      } else {
+        launch_ibgda_progress_send(
+            deviceTransport_, sendBuf, nbytes, kNumBlocks, stream_);
+      }
+      return;
+    }
+
+    if (api == SendRecvApi::Blocking) {
+      launch_ibgda_recv(deviceTransport_, recvBuf, nbytes, kNumBlocks, stream_);
+    } else {
+      launch_ibgda_progress_recv(
+          deviceTransport_, recvBuf, nbytes, kNumBlocks, stream_);
+    }
+  }
+
+  std::shared_ptr<ITestBootstrap> bootstrap_;
+  std::unique_ptr<MultipeerIbgdaTransport> transport_;
+  std::unique_ptr<DeviceBuffer> sendBuf_;
+  std::unique_ptr<DeviceBuffer> recvBuf_;
+  P2pIbgdaTransportDevice* deviceTransport_{nullptr};
+  std::size_t maxBytes_{0};
+  cudaStream_t stream_{};
+  int globalRank_{0};
+  int worldSize_{0};
+  int localRank_{0};
+};
+
+static unsigned int ibgdaSendRecv(
+    IbgdaSendRecvBenchmarkContext& context,
+    uint32_t iters,
     std::size_t nbytes,
-    uint8_t expected,
-    int rank) {
-  std::vector<uint8_t> hostBuf(nbytes);
-  cudaError_t err =
-      cudaMemcpy(hostBuf.data(), buf.get(), nbytes, cudaMemcpyDeviceToHost);
-  ASSERT_EQ(err, cudaSuccess)
-      << "cudaMemcpy failed: " << cudaGetErrorString(err);
+    SendRecvApi api,
+    SendRecvDirection direction,
+    folly::UserCounters& counters) {
+  CHECK_GT(iters, 0);
 
-  for (std::size_t i = 0; i < nbytes; ++i) {
-    ASSERT_EQ(hostBuf[i], expected)
-        << "Rank " << rank << ": data mismatch at byte " << i << ", expected "
-        << static_cast<int>(expected) << ", got "
-        << static_cast<int>(hostBuf[i]);
+  BENCHMARK_SUSPEND {
+    context.warmup(nbytes, api, direction);
   }
+
+  const float elapsedMs =
+      context.runLocalElapsed(iters, nbytes, api, direction);
+  folly::doNotOptimizeAway(elapsedMs);
+
+  BENCHMARK_SUSPEND {
+    const double totalBytes =
+        (direction == SendRecvDirection::Bidirectional ? 2.0 : 1.0) *
+        static_cast<double>(nbytes) * iters;
+    const double elapsedSec = static_cast<double>(elapsedMs) / 1000.0;
+    counters["latency_us"] = folly::UserMetric(
+        static_cast<double>(elapsedMs) * 1000.0 / iters,
+        folly::UserMetric::Type::METRIC);
+    counters["bandwidth_GBps"] = folly::UserMetric(
+        (totalBytes / 1e9) / elapsedSec, folly::UserMetric::Type::METRIC);
+    counters["message_size"] = folly::UserMetric(
+        static_cast<double>(nbytes), folly::UserMetric::Type::METRIC);
+  }
+  return iters;
 }
 
-void expectUniformBufferRange(
-    const DeviceBuffer& buf,
-    std::size_t offset,
-    std::size_t nbytes,
-    uint8_t expected,
-    int rank,
-    const char* label) {
-  std::vector<uint8_t> hostBuf(nbytes);
-  cudaError_t err = cudaMemcpy(
-      hostBuf.data(),
-      static_cast<const char*>(buf.get()) + offset,
-      nbytes,
-      cudaMemcpyDeviceToHost);
-  ASSERT_EQ(err, cudaSuccess)
-      << "cudaMemcpy failed: " << cudaGetErrorString(err);
-
-  for (std::size_t i = 0; i < nbytes; ++i) {
-    ASSERT_EQ(hostBuf[i], expected)
-        << "Rank " << rank << ": " << label << " data mismatch at byte " << i
-        << ", expected " << static_cast<int>(expected) << ", got "
-        << static_cast<int>(hostBuf[i]);
-  }
+void registerBenchmark(
+    IbgdaSendRecvBenchmarkContext& context,
+    const BenchmarkSize& size,
+    SendRecvApi api,
+    SendRecvDirection direction) {
+  folly::addBenchmark(
+      __FILE__,
+      benchmarkName(api, direction, size.name),
+      [&context, nbytes = size.nbytes, api, direction](
+          folly::UserCounters& counters, unsigned int iters) -> unsigned int {
+        return ibgdaSendRecv(context, iters, nbytes, api, direction, counters);
+      });
 }
 
-void expectStepState(
-    const std::vector<int64_t>& steps,
-    int maxGroups,
-    int64_t expected) {
-  ASSERT_EQ(steps.size(), 2 * maxGroups);
-  for (int i = 0; i < 2 * maxGroups; ++i) {
-    EXPECT_EQ(steps[i], expected)
-        << "Unexpected stepState[" << i << "], expected " << expected;
+void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
+  for (const auto& size : kBenchmarkSizes) {
+    registerBenchmark(
+        context, size, SendRecvApi::Blocking, SendRecvDirection::Bidirectional);
+    registerBenchmark(
+        context, size, SendRecvApi::Progress, SendRecvDirection::Bidirectional);
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Blocking,
+        SendRecvDirection::Unidirectional);
+    registerBenchmark(
+        context,
+        size,
+        SendRecvApi::Progress,
+        SendRecvDirection::Unidirectional);
   }
 }
 
 } // namespace
-
-class IbgdaSendRecvTest : public BenchmarkTestFixture {
- protected:
-  void SetUp() override {
-    BenchmarkTestFixture::SetUp();
-    ASSERT_CUDA_SUCCESS(cudaSetDevice(localRank));
-    ASSERT_CUDA_SUCCESS(cudaStreamCreate(&stream_));
-  }
-
-  void TearDown() override {
-    if (stream_ != nullptr) {
-      ASSERT_CUDA_SUCCESS(cudaStreamDestroy(stream_));
-    }
-    BenchmarkTestFixture::TearDown();
-  }
-
-  cudaStream_t stream_{};
-
-  void runBidirectionalBandwidth(
-      std::size_t firstMessageBytes,
-      const char* benchmarkLabel) {
-    if (worldSize != 2) {
-      XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-      return;
-    }
-
-    constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
-    constexpr int kPipelineDepth = 2;
-    constexpr int kWarmupIters = 5;
-    constexpr int kBenchIters = 20;
-
-    std::vector<std::size_t> messageSizes =
-        makePowerOfTwoMessageSizes(firstMessageBytes, 4ULL << 30);
-
-    int peerRank = (globalRank == 0) ? 1 : 0;
-    std::size_t maxBytes = messageSizes.back();
-
-    cudaEvent_t start, stop;
-    ASSERT_CUDA_SUCCESS(cudaEventCreate(&start));
-    ASSERT_CUDA_SUCCESS(cudaEventCreate(&stop));
-
-    for (const auto& geometry : kSendRecvBenchmarkGeometries) {
-      MultipeerIbgdaTransportConfig transportConfig{
-          .cudaDevice = localRank,
-          .dataBufferSize = kSlotSize,
-          .sendRecv =
-              SendRecvConfig{
-                  .maxGroups = geometry.maxGroups,
-                  .pipelineDepth = kPipelineDepth,
-              },
-      };
-
-      MultipeerIbgdaTransport transport(
-          globalRank, worldSize, bootstrap, transportConfig);
-      transport.exchange();
-
-      DeviceBuffer sendBuf(maxBytes);
-      DeviceBuffer recvBuf(maxBytes);
-      ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), 0xAA, maxBytes));
-      ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, maxBytes));
-      ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
-      auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-      if (globalRank == 0) {
-        XLOGF(INFO, "");
-        XLOGF(
-            INFO,
-            "================================================================");
-        XLOGF(
-            INFO,
-            "  IBGDA Tile SendRecv Bandwidth {} ({})",
-            benchmarkLabel,
-            geometry.label);
-        XLOGF(
-            INFO,
-            "  activeBlocks={}, maxGroups={}, slotSize={}MB, pipelineDepth={}, range={}..4GB",
-            geometry.activeBlocks,
-            geometry.maxGroups,
-            kSlotSize / (1024 * 1024),
-            kPipelineDepth,
-            formatMessageSize(firstMessageBytes));
-        XLOGF(
-            INFO,
-            "================================================================");
-        XLOGF(
-            INFO,
-            "{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}",
-            "API",
-            "MsgSize",
-            "Sections",
-            "BaseMod",
-            "BW (GB/s)");
-        XLOGF(
-            INFO,
-            "------------------------------------------------------------");
-      }
-
-      for (auto api : benchmarkApis()) {
-        for (auto nBytes : messageSizes) {
-          const std::size_t baseMod = 0;
-
-          launch_ibgda_reset_send_recv(
-              deviceTransport, geometry.maxGroups, stream_);
-          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-          bootstrap->barrierAll();
-
-          // Warmup
-          for (int i = 0; i < kWarmupIters; ++i) {
-            if (api == SendRecvApi::Blocking) {
-              launch_ibgda_send_recv(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  static_cast<char*>(recvBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            } else {
-              launch_ibgda_progress_send_recv(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  static_cast<char*>(recvBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            }
-            ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-            bootstrap->barrierAll();
-          }
-          launch_ibgda_drain_send_recv(
-              deviceTransport,
-              geometry.activeBlocks,
-              nBytes,
-              kWarmupIters,
-              stream_);
-          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-          launch_ibgda_reset_send_recv(
-              deviceTransport, geometry.maxGroups, stream_);
-          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-
-          bootstrap->barrierAll();
-
-          // Benchmark
-          ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-          for (int i = 0; i < kBenchIters; ++i) {
-            if (api == SendRecvApi::Blocking) {
-              launch_ibgda_send_recv(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  static_cast<char*>(recvBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            } else {
-              launch_ibgda_progress_send_recv(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  static_cast<char*>(recvBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            }
-          }
-          launch_ibgda_drain_send_recv(
-              deviceTransport,
-              geometry.activeBlocks,
-              nBytes,
-              kBenchIters,
-              stream_);
-          ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-          ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
-
-          bootstrap->barrierAll();
-
-          float totalMs = 0;
-          ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-          float avgMs = totalMs / kBenchIters;
-
-          float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
-          std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
-
-          if (globalRank == 0) {
-            std::string sizeStr = formatMessageSize(nBytes);
-            XLOGF(
-                INFO,
-                "{:>10s}  {:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
-                sendRecvApiName(api),
-                sizeStr,
-                numSections,
-                baseMod,
-                bwGBs);
-          }
-
-          launch_ibgda_reset_send_recv(
-              deviceTransport, geometry.maxGroups, stream_);
-          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-          bootstrap->barrierAll();
-        }
-      }
-
-      if (globalRank == 0) {
-        XLOGF(
-            INFO,
-            "================================================================");
-      }
-
-      bootstrap->barrierAll();
-    }
-
-    ASSERT_CUDA_SUCCESS(cudaEventDestroy(start));
-    ASSERT_CUDA_SUCCESS(cudaEventDestroy(stop));
-  }
-};
-
-TEST_F(IbgdaSendRecvTest, Correctness) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr std::size_t kDataBytes = 4 * 1024 * 1024; // 4MB
-  constexpr int kNumBlocks = 4;
-  constexpr std::size_t kSlotSize = kDataBytes; // 1 section = 1 slot
-  constexpr int kPipelineDepth = 2;
-  constexpr int kMaxBlocks = kNumBlocks;
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kMaxBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(kDataBytes);
-  DeviceBuffer recvBuf(kDataBytes);
-
-  uint8_t fillPattern = 0xA0 + globalRank;
-  ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
-  ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, kDataBytes));
-  ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
-
-  bootstrap->barrierAll();
-
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-  launch_ibgda_send_recv(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kDataBytes,
-      kNumBlocks,
-      stream_);
-
-  cudaError_t err = cudaStreamSynchronize(stream_);
-  ASSERT_EQ(err, cudaSuccess)
-      << "Kernel execution failed: " << cudaGetErrorString(err);
-
-  bootstrap->barrierAll();
-
-  uint8_t expectedPattern = 0xA0 + peerRank;
-  std::vector<uint8_t> hostBuf(kDataBytes);
-  ASSERT_CUDA_SUCCESS(cudaMemcpy(
-      hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
-
-  bool correct = true;
-  for (std::size_t i = 0; i < kDataBytes; i++) {
-    if (hostBuf[i] != expectedPattern) {
-      XLOGF(
-          ERR,
-          "Rank {}: data mismatch at byte {}: expected 0x{:02X}, got 0x{:02X}",
-          globalRank,
-          i,
-          expectedPattern,
-          hostBuf[i]);
-      correct = false;
-      break;
-    }
-  }
-  EXPECT_TRUE(correct) << "Rank " << globalRank
-                       << ": tile sendrecv data correctness failed";
-  if (correct) {
-    XLOGF(
-        INFO,
-        "Rank {}: tile sendrecv correctness OK ({} bytes)",
-        globalRank,
-        kDataBytes);
-  }
-}
-
-TEST_F(IbgdaSendRecvTest, UnalignedPayloadAdvancesAlignedProtocol) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr std::size_t kDataBytes = 100;
-  constexpr int kNumBlocks = 1;
-  constexpr std::size_t kSlotSize = 1024;
-  constexpr int kPipelineDepth = 2;
-  constexpr int kMaxBlocks = kNumBlocks;
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kMaxBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(kDataBytes);
-  DeviceBuffer recvBuf(kDataBytes);
-
-  const uint8_t fillPattern = static_cast<uint8_t>(0x70 + globalRank);
-  ASSERT_EQ(cudaMemset(sendBuf.get(), fillPattern, kDataBytes), cudaSuccess);
-  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kDataBytes), cudaSuccess);
-  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-
-  bootstrap->barrierAll();
-
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-  launch_ibgda_send_recv(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kDataBytes,
-      kNumBlocks,
-      stream_);
-
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-  bootstrap->barrierAll();
-
-  expectUniformBuffer(
-      recvBuf, kDataBytes, static_cast<uint8_t>(0x70 + peerRank), globalRank);
-  expectStepState(
-      snapshotStepState(deviceTransport, kMaxBlocks, stream_),
-      kMaxBlocks,
-      alignProtocolBytes(kDataBytes));
-}
-
-TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossKernelLaunches) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr int kNumBlocks = 4;
-  constexpr int kPipelineDepth = 2;
-  constexpr std::size_t kSlotSize = 1 * 1024 * 1024;
-  constexpr std::size_t kSectionsFirst = 3;
-  constexpr std::size_t kSectionsSecond = 2;
-  constexpr std::size_t kBytesFirst = kSectionsFirst * kSlotSize;
-  constexpr std::size_t kBytesSecond = kSectionsSecond * kSlotSize;
-  constexpr std::size_t kBytesPerGroupPerSection = kSlotSize / kNumBlocks;
-  constexpr std::size_t kMaxBytes = kBytesFirst;
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kNumBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(kMaxBytes);
-  DeviceBuffer recvBuf(kMaxBytes);
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-  bootstrap->barrierAll();
-
-  const uint8_t firstPattern = static_cast<uint8_t>(0x40 + globalRank);
-  ASSERT_EQ(cudaMemset(sendBuf.get(), firstPattern, kBytesFirst), cudaSuccess);
-  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kBytesFirst), cudaSuccess);
-
-  launch_ibgda_send_recv(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kBytesFirst,
-      kNumBlocks,
-      stream_);
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-  bootstrap->barrierAll();
-
-  expectUniformBuffer(
-      recvBuf, kBytesFirst, static_cast<uint8_t>(0x40 + peerRank), globalRank);
-  expectStepState(
-      snapshotStepState(deviceTransport, kNumBlocks, stream_),
-      kNumBlocks,
-      static_cast<int64_t>(kSectionsFirst * kBytesPerGroupPerSection));
-
-  const uint8_t secondPattern = static_cast<uint8_t>(0x50 + globalRank);
-  ASSERT_EQ(
-      cudaMemset(sendBuf.get(), secondPattern, kBytesSecond), cudaSuccess);
-  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kBytesSecond), cudaSuccess);
-
-  launch_ibgda_send_recv(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kBytesSecond,
-      kNumBlocks,
-      stream_);
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-  bootstrap->barrierAll();
-
-  expectUniformBuffer(
-      recvBuf, kBytesSecond, static_cast<uint8_t>(0x50 + peerRank), globalRank);
-  expectStepState(
-      snapshotStepState(deviceTransport, kNumBlocks, stream_),
-      kNumBlocks,
-      static_cast<int64_t>(
-          (kSectionsFirst + kSectionsSecond) * kBytesPerGroupPerSection));
-}
-
-TEST_F(IbgdaSendRecvTest, ChangingMaxSignalBytesWithinKernelUsesByteCursor) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr int kNumBlocks = 4;
-  constexpr int kPipelineDepth = 2;
-  constexpr std::size_t kPerBlockSlot = 64 * 1024;
-  constexpr std::size_t kSlotSize = kPerBlockSlot * kNumBlocks;
-  constexpr std::size_t kFirstBytes = kSlotSize;
-  constexpr std::size_t kSecondBytes = (kPerBlockSlot / 2) * kNumBlocks;
-  constexpr std::size_t kTotalBytes = kFirstBytes + kSecondBytes;
-  constexpr std::size_t kFirstMaxSignalBytes = kPerBlockSlot;
-  constexpr std::size_t kSecondMaxSignalBytes = 16 * 1024;
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kNumBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(kTotalBytes);
-  DeviceBuffer recvBuf(kTotalBytes);
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-  const uint8_t firstPattern = static_cast<uint8_t>(0x60 + globalRank);
-  const uint8_t secondPattern = static_cast<uint8_t>(0x70 + globalRank);
-  ASSERT_EQ(cudaMemset(sendBuf.get(), firstPattern, kFirstBytes), cudaSuccess);
-  ASSERT_EQ(
-      cudaMemset(
-          static_cast<char*>(sendBuf.get()) + kFirstBytes,
-          secondPattern,
-          kSecondBytes),
-      cudaSuccess);
-  ASSERT_EQ(cudaMemset(recvBuf.get(), 0, kTotalBytes), cudaSuccess);
-  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-
-  bootstrap->barrierAll();
-
-  launch_ibgda_send_recv_two_call(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kFirstBytes,
-      kSecondBytes,
-      kNumBlocks,
-      kFirstMaxSignalBytes,
-      kSecondMaxSignalBytes,
-      stream_);
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-  bootstrap->barrierAll();
-
-  expectUniformBufferRange(
-      recvBuf,
-      0,
-      kFirstBytes,
-      static_cast<uint8_t>(0x60 + peerRank),
-      globalRank,
-      "first");
-  expectUniformBufferRange(
-      recvBuf,
-      kFirstBytes,
-      kSecondBytes,
-      static_cast<uint8_t>(0x70 + peerRank),
-      globalRank,
-      "second");
-  expectStepState(
-      snapshotStepState(deviceTransport, kNumBlocks, stream_),
-      kNumBlocks,
-      static_cast<int64_t>(kPerBlockSlot + kPerBlockSlot / 2));
-}
-
-TEST_F(IbgdaSendRecvTest, StepStatePersistsAcrossCudaGraphReplays) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr int kNumBlocks = 4;
-  constexpr int kPipelineDepth = 2;
-  constexpr std::size_t kSlotSize = 1 * 1024 * 1024;
-  constexpr std::size_t kSectionsPerReplay = 2;
-  constexpr std::size_t kBytesPerReplay = kSectionsPerReplay * kSlotSize;
-  constexpr std::size_t kBytesPerGroupPerSection = kSlotSize / kNumBlocks;
-  constexpr int kReplays = 3;
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-
-  MultipeerIbgdaTransportConfig transportConfig{
-      .cudaDevice = localRank,
-      .dataBufferSize = kSlotSize,
-      .sendRecv =
-          SendRecvConfig{
-              .maxGroups = kNumBlocks,
-              .pipelineDepth = kPipelineDepth,
-          },
-  };
-
-  MultipeerIbgdaTransport transport(
-      globalRank, worldSize, bootstrap, transportConfig);
-  transport.exchange();
-
-  DeviceBuffer sendBuf(kBytesPerReplay);
-  DeviceBuffer recvBuf(kBytesPerReplay);
-  auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-  ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-  cudaGraph_t graph{};
-  cudaGraphExec_t graphExec{};
-  ASSERT_EQ(
-      cudaStreamBeginCapture(stream_, cudaStreamCaptureModeGlobal),
-      cudaSuccess);
-  launch_ibgda_send_recv(
-      deviceTransport,
-      static_cast<char*>(sendBuf.get()),
-      static_cast<char*>(recvBuf.get()),
-      kBytesPerReplay,
-      kNumBlocks,
-      stream_);
-  ASSERT_EQ(cudaStreamEndCapture(stream_, &graph), cudaSuccess);
-  ASSERT_NE(graph, nullptr);
-  ASSERT_EQ(
-      cudaGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0),
-      cudaSuccess);
-
-  bootstrap->barrierAll();
-
-  for (int replay = 0; replay < kReplays; ++replay) {
-    const uint8_t sendPattern =
-        static_cast<uint8_t>(0x70 + replay * 8 + globalRank);
-    ASSERT_EQ(
-        cudaMemsetAsync(sendBuf.get(), sendPattern, kBytesPerReplay, stream_),
-        cudaSuccess);
-    ASSERT_EQ(
-        cudaMemsetAsync(recvBuf.get(), 0, kBytesPerReplay, stream_),
-        cudaSuccess);
-    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-
-    bootstrap->barrierAll();
-    ASSERT_EQ(cudaGraphLaunch(graphExec, stream_), cudaSuccess);
-    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
-    bootstrap->barrierAll();
-
-    expectUniformBuffer(
-        recvBuf,
-        kBytesPerReplay,
-        static_cast<uint8_t>(0x70 + replay * 8 + peerRank),
-        globalRank);
-    expectStepState(
-        snapshotStepState(deviceTransport, kNumBlocks, stream_),
-        kNumBlocks,
-        static_cast<int64_t>(
-            (replay + 1) * kSectionsPerReplay * kBytesPerGroupPerSection));
-  }
-
-  ASSERT_EQ(cudaGraphExecDestroy(graphExec), cudaSuccess);
-  ASSERT_EQ(cudaGraphDestroy(graph), cudaSuccess);
-}
-
-TEST_F(IbgdaSendRecvTest, BandwidthFrom4B) {
-  runBidirectionalBandwidth(4, "(from 4B)");
-}
-
-TEST_F(IbgdaSendRecvTest, BandwidthFrom1MB) {
-  runBidirectionalBandwidth(1ULL << 20, "(from 1MB)");
-}
-
-TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
-  if (worldSize != 2) {
-    XLOGF(INFO, "Skipping: requires exactly 2 ranks, got {}", worldSize);
-    return;
-  }
-
-  constexpr std::size_t kSlotSize = 8 * 1024 * 1024; // 8MB
-  constexpr int kPipelineDepth = 2;
-  constexpr int kWarmupIters = 5;
-  constexpr int kBenchIters = 20;
-
-  std::vector<std::size_t> messageSizes;
-  for (std::size_t sz = 4; sz <= 4ULL << 30; sz <<= 1) {
-    messageSizes.push_back(sz);
-  }
-
-  int peerRank = (globalRank == 0) ? 1 : 0;
-  std::size_t maxBytes = messageSizes.back();
-
-  cudaEvent_t start, stop;
-  ASSERT_CUDA_SUCCESS(cudaEventCreate(&start));
-  ASSERT_CUDA_SUCCESS(cudaEventCreate(&stop));
-
-  for (const auto& geometry : kSendRecvBenchmarkGeometries) {
-    MultipeerIbgdaTransportConfig transportConfig{
-        .cudaDevice = localRank,
-        .dataBufferSize = kSlotSize,
-        .sendRecv =
-            SendRecvConfig{
-                .maxGroups = geometry.maxGroups,
-                .pipelineDepth = kPipelineDepth,
-            },
-    };
-
-    MultipeerIbgdaTransport transport(
-        globalRank, worldSize, bootstrap, transportConfig);
-    transport.exchange();
-
-    DeviceBuffer sendBuf(maxBytes);
-    DeviceBuffer recvBuf(maxBytes);
-    ASSERT_CUDA_SUCCESS(cudaMemset(sendBuf.get(), 0xAA, maxBytes));
-    ASSERT_CUDA_SUCCESS(cudaMemset(recvBuf.get(), 0, maxBytes));
-    ASSERT_CUDA_SUCCESS(cudaDeviceSynchronize());
-
-    auto* deviceTransport = transport.getP2pTransportDevice(peerRank);
-
-    if (globalRank == 0) {
-      XLOGF(INFO, "");
-      XLOGF(
-          INFO,
-          "================================================================");
-      XLOGF(
-          INFO,
-          "  IBGDA Tile Unidirectional Bandwidth ({}, rank 0 -> rank 1)",
-          geometry.label);
-      XLOGF(
-          INFO,
-          "  activeBlocks={}, maxGroups={}, slotSize={}MB, pipelineDepth={}",
-          geometry.activeBlocks,
-          geometry.maxGroups,
-          kSlotSize / (1024 * 1024),
-          kPipelineDepth);
-      XLOGF(
-          INFO,
-          "================================================================");
-      XLOGF(
-          INFO,
-          "{:>10s}  {:>10s}  {:>10s}  {:>12s}",
-          "API",
-          "MsgSize",
-          "Sections",
-          "BW (GB/s)");
-      XLOGF(INFO, "----------------------------------------------");
-    }
-
-    for (auto api : benchmarkApis()) {
-      for (auto nBytes : messageSizes) {
-        bootstrap->barrierAll();
-
-        // Warmup
-        for (int i = 0; i < kWarmupIters; ++i) {
-          if (globalRank == 0) {
-            if (api == SendRecvApi::Blocking) {
-              launch_ibgda_send(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            } else {
-              launch_ibgda_progress_send(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            }
-          } else if (api == SendRecvApi::Blocking) {
-            launch_ibgda_recv(
-                deviceTransport,
-                static_cast<char*>(recvBuf.get()),
-                nBytes,
-                geometry.activeBlocks,
-                stream_);
-          } else {
-            launch_ibgda_progress_recv(
-                deviceTransport,
-                static_cast<char*>(recvBuf.get()),
-                nBytes,
-                geometry.activeBlocks,
-                stream_);
-          }
-          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-          bootstrap->barrierAll();
-        }
-
-        bootstrap->barrierAll();
-
-        // Benchmark
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-        for (int i = 0; i < kBenchIters; ++i) {
-          if (globalRank == 0) {
-            if (api == SendRecvApi::Blocking) {
-              launch_ibgda_send(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            } else {
-              launch_ibgda_progress_send(
-                  deviceTransport,
-                  static_cast<char*>(sendBuf.get()),
-                  nBytes,
-                  geometry.activeBlocks,
-                  stream_);
-            }
-          } else if (api == SendRecvApi::Blocking) {
-            launch_ibgda_recv(
-                deviceTransport,
-                static_cast<char*>(recvBuf.get()),
-                nBytes,
-                geometry.activeBlocks,
-                stream_);
-          } else {
-            launch_ibgda_progress_recv(
-                deviceTransport,
-                static_cast<char*>(recvBuf.get()),
-                nBytes,
-                geometry.activeBlocks,
-                stream_);
-          }
-        }
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
-
-        bootstrap->barrierAll();
-
-        float totalMs = 0;
-        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-        float avgMs = totalMs / kBenchIters;
-
-        // Unidirectional: only one direction.
-        float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
-        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
-
-        if (globalRank == 0) {
-          std::string sizeStr = formatMessageSize(nBytes);
-          XLOGF(
-              INFO,
-              "{:>10s}  {:>10s}  {:>10d}  {:>12.2f}",
-              sendRecvApiName(api),
-              sizeStr,
-              numSections,
-              bwGBs);
-        }
-      }
-    }
-
-    if (globalRank == 0) {
-      XLOGF(
-          INFO,
-          "================================================================");
-    }
-
-    bootstrap->barrierAll();
-  }
-
-  ASSERT_CUDA_SUCCESS(cudaEventDestroy(start));
-  ASSERT_CUDA_SUCCESS(cudaEventDestroy(stop));
-}
-
 } // namespace comms::prims::benchmark
 
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleTest(&argc, argv);
+int main(int argc, char** argv) {
   if (const char* localRank = std::getenv("LOCAL_RANK")) {
     cudaError_t ret = cudaSetDevice(std::atoi(localRank));
     CHECK_EQ(ret, cudaSuccess) << cudaGetErrorString(ret);
   }
   folly::Init init(&argc, &argv);
-  if (!meta::comms::isTcpEnvironment()) {
-    ::testing::AddGlobalTestEnvironment(new BenchmarkEnvironment());
-  }
-  return RUN_ALL_TESTS();
+  comms::prims::benchmark::setDefaultBenchmarkFlags();
+  comms::prims::benchmark::DistributedBenchmarkEnvironment environment;
+  auto bootstrap = comms::prims::benchmark::makeBootstrap();
+  comms::prims::benchmark::IbgdaSendRecvBenchmarkContext context(
+      std::move(bootstrap), comms::prims::benchmark::kMaxBenchmarkBytes);
+  comms::prims::benchmark::registerBenchmarks(context);
+  folly::runBenchmarks();
+  return 0;
 }

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -48,6 +48,29 @@ constexpr std::array<SendRecvBenchmarkGeometry, 2> kSendRecvBenchmarkGeometries{
     {{1, 2, "activeBlocks=1/maxGroups=2"},
      {2, 2, "activeBlocks=2/maxGroups=2"}}};
 
+enum class SendRecvApi {
+  Blocking,
+  Progress,
+};
+
+const char* sendRecvApiName(SendRecvApi api) {
+  switch (api) {
+    case SendRecvApi::Blocking:
+      return "send/recv";
+    case SendRecvApi::Progress:
+      return "progress";
+  }
+  return "unknown";
+}
+
+std::vector<SendRecvApi> benchmarkApis() {
+  std::vector<SendRecvApi> apis{SendRecvApi::Blocking};
+#ifndef __HIP_PLATFORM_AMD__
+  apis.push_back(SendRecvApi::Progress);
+#endif
+  return apis;
+}
+
 std::string formatMessageSize(std::size_t nbytes) {
   if (nbytes >= (1ULL << 30)) {
     return fmt::format("{}GB", nbytes >> 30);
@@ -235,7 +258,8 @@ class IbgdaSendRecvTest : public BenchmarkTestFixture {
             "================================================================");
         XLOGF(
             INFO,
-            "{:>10s}  {:>10s}  {:>12s}  {:>12s}",
+            "{:>10s}  {:>10s}  {:>10s}  {:>12s}  {:>12s}",
+            "API",
             "MsgSize",
             "Sections",
             "BaseMod",
@@ -245,83 +269,106 @@ class IbgdaSendRecvTest : public BenchmarkTestFixture {
             "------------------------------------------------------------");
       }
 
-      for (auto nBytes : messageSizes) {
-        const std::size_t baseMod = 0;
+      for (auto api : benchmarkApis()) {
+        for (auto nBytes : messageSizes) {
+          const std::size_t baseMod = 0;
 
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        bootstrap->barrierAll();
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          bootstrap->barrierAll();
 
-        // Warmup
-        for (int i = 0; i < kWarmupIters; ++i) {
-          launch_ibgda_send_recv(
+          // Warmup
+          for (int i = 0; i < kWarmupIters; ++i) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+            ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+            bootstrap->barrierAll();
+          }
+          launch_ibgda_drain_send_recv(
               deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
               geometry.activeBlocks,
+              nBytes,
+              kWarmupIters,
               stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+
+          bootstrap->barrierAll();
+
+          // Benchmark
+          ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+          for (int i = 0; i < kBenchIters; ++i) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send_recv(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  static_cast<char*>(recvBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          }
+          launch_ibgda_drain_send_recv(
+              deviceTransport,
+              geometry.activeBlocks,
+              nBytes,
+              kBenchIters,
+              stream_);
+          ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+          ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
+
+          bootstrap->barrierAll();
+
+          float totalMs = 0;
+          ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+          float avgMs = totalMs / kBenchIters;
+
+          float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
+          std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+          if (globalRank == 0) {
+            std::string sizeStr = formatMessageSize(nBytes);
+            XLOGF(
+                INFO,
+                "{:>10s}  {:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
+                sendRecvApiName(api),
+                sizeStr,
+                numSections,
+                baseMod,
+                bwGBs);
+          }
+
+          launch_ibgda_reset_send_recv(
+              deviceTransport, geometry.maxGroups, stream_);
           ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
           bootstrap->barrierAll();
         }
-        launch_ibgda_drain_send_recv(
-            deviceTransport,
-            geometry.activeBlocks,
-            nBytes,
-            kWarmupIters,
-            stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-
-        bootstrap->barrierAll();
-
-        // Benchmark
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-        for (int i = 0; i < kBenchIters; ++i) {
-          launch_ibgda_send_recv(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        }
-        launch_ibgda_drain_send_recv(
-            deviceTransport,
-            geometry.activeBlocks,
-            nBytes,
-            kBenchIters,
-            stream_);
-        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
-
-        bootstrap->barrierAll();
-
-        float totalMs = 0;
-        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-        float avgMs = totalMs / kBenchIters;
-
-        float bwGBs = (2.0f * nBytes / 1e9f) / (avgMs / 1000.0f);
-        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
-
-        if (globalRank == 0) {
-          std::string sizeStr = formatMessageSize(nBytes);
-          XLOGF(
-              INFO,
-              "{:>10s}  {:>10d}  {:>12d}  {:>12.2f}",
-              sizeStr,
-              numSections,
-              baseMod,
-              bwGBs);
-        }
-
-        launch_ibgda_reset_send_recv(
-            deviceTransport, geometry.maxGroups, stream_);
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
-        bootstrap->barrierAll();
       }
 
       if (globalRank == 0) {
@@ -809,74 +856,115 @@ TEST_F(IbgdaSendRecvTest, UnidirectionalBandwidth) {
           "================================================================");
       XLOGF(
           INFO,
-          "{:>10s}  {:>10s}  {:>12s}",
+          "{:>10s}  {:>10s}  {:>10s}  {:>12s}",
+          "API",
           "MsgSize",
           "Sections",
           "BW (GB/s)");
       XLOGF(INFO, "----------------------------------------------");
     }
 
-    for (auto nBytes : messageSizes) {
-      bootstrap->barrierAll();
-
-      // Warmup
-      for (int i = 0; i < kWarmupIters; ++i) {
-        if (globalRank == 0) {
-          launch_ibgda_send(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        } else {
-          launch_ibgda_recv(
-              deviceTransport,
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        }
-        ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+    for (auto api : benchmarkApis()) {
+      for (auto nBytes : messageSizes) {
         bootstrap->barrierAll();
-      }
 
-      bootstrap->barrierAll();
-
-      // Benchmark
-      ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
-      for (int i = 0; i < kBenchIters; ++i) {
-        if (globalRank == 0) {
-          launch_ibgda_send(
-              deviceTransport,
-              static_cast<char*>(sendBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
-        } else {
-          launch_ibgda_recv(
-              deviceTransport,
-              static_cast<char*>(recvBuf.get()),
-              nBytes,
-              geometry.activeBlocks,
-              stream_);
+        // Warmup
+        for (int i = 0; i < kWarmupIters; ++i) {
+          if (globalRank == 0) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          } else if (api == SendRecvApi::Blocking) {
+            launch_ibgda_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          } else {
+            launch_ibgda_progress_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          }
+          ASSERT_CUDA_SUCCESS(cudaStreamSynchronize(stream_));
+          bootstrap->barrierAll();
         }
-      }
-      ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
-      ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
 
-      bootstrap->barrierAll();
+        bootstrap->barrierAll();
 
-      float totalMs = 0;
-      ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
-      float avgMs = totalMs / kBenchIters;
+        // Benchmark
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(start, stream_));
+        for (int i = 0; i < kBenchIters; ++i) {
+          if (globalRank == 0) {
+            if (api == SendRecvApi::Blocking) {
+              launch_ibgda_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            } else {
+              launch_ibgda_progress_send(
+                  deviceTransport,
+                  static_cast<char*>(sendBuf.get()),
+                  nBytes,
+                  geometry.activeBlocks,
+                  stream_);
+            }
+          } else if (api == SendRecvApi::Blocking) {
+            launch_ibgda_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          } else {
+            launch_ibgda_progress_recv(
+                deviceTransport,
+                static_cast<char*>(recvBuf.get()),
+                nBytes,
+                geometry.activeBlocks,
+                stream_);
+          }
+        }
+        ASSERT_CUDA_SUCCESS(cudaEventRecord(stop, stream_));
+        ASSERT_CUDA_SUCCESS(cudaEventSynchronize(stop));
 
-      // Unidirectional: only one direction
-      float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
-      std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+        bootstrap->barrierAll();
 
-      if (globalRank == 0) {
-        std::string sizeStr = formatMessageSize(nBytes);
-        XLOGF(INFO, "{:>10s}  {:>10d}  {:>12.2f}", sizeStr, numSections, bwGBs);
+        float totalMs = 0;
+        ASSERT_CUDA_SUCCESS(cudaEventElapsedTime(&totalMs, start, stop));
+        float avgMs = totalMs / kBenchIters;
+
+        // Unidirectional: only one direction.
+        float bwGBs = (nBytes / 1e9f) / (avgMs / 1000.0f);
+        std::size_t numSections = (nBytes + kSlotSize - 1) / kSlotSize;
+
+        if (globalRank == 0) {
+          std::string sizeStr = formatMessageSize(nBytes);
+          XLOGF(
+              INFO,
+              "{:>10s}  {:>10s}  {:>10d}  {:>12.2f}",
+              sendRecvApiName(api),
+              sizeStr,
+              numSections,
+              bwGBs);
+        }
       }
     }
 

--- a/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/P2pNvlSendRecvBenchmark.cc
@@ -672,39 +672,22 @@ TEST_F(P2pSendRecvBenchmarkFixture, UnidirectionalBenchmark) {
     });
   };
 
+  std::vector<std::size_t> benchmarkSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    benchmarkSizes.push_back(sizeBytes);
+  }
+
   // === BLOCK-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024, "8K", SyncScope::BLOCK, "Block");
-  addNcclConfig(16 * 1024, "16K", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024, "64K", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024, "128K", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024, "256K", SyncScope::BLOCK, "Block");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::BLOCK, "Block");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::BLOCK, "Block");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::BLOCK, "Block");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::BLOCK, "Block");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::BLOCK, "Block");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::BLOCK, "Block");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::BLOCK, "Block");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::BLOCK, "Block");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::BLOCK, "Block");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(sizeBytes, formatSize(sizeBytes), SyncScope::BLOCK, "Block");
+  }
 
   // === CLUSTER-BASED CONFIGURATIONS ===
-  addNcclConfig(4 * 1024, "4K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024, "8K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(16 * 1024, "16K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024, "64K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024, "128K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024, "256K", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1 * 1024 * 1024, "1M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(2 * 1024 * 1024, "2M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(8 * 1024 * 1024, "8M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(32 * 1024 * 1024, "32M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(64 * 1024 * 1024, "64M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(128 * 1024 * 1024, "128M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(256 * 1024 * 1024, "256M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(512 * 1024 * 1024, "512M", SyncScope::CLUSTER, "Cluster");
-  addNcclConfig(1024 * 1024 * 1024, "1G", SyncScope::CLUSTER, "Cluster");
+  for (std::size_t sizeBytes : benchmarkSizes) {
+    addNcclConfig(
+        sizeBytes, formatSize(sizeBytes), SyncScope::CLUSTER, "Cluster");
+  }
 
   std::vector<BenchmarkResult> results;
 
@@ -773,25 +756,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
   std::vector<BenchmarkConfig> configs;
 
   // NCCL-like bidirectional configs at all message sizes
-  std::vector<std::pair<std::size_t, std::string>> bidiSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> bidiSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    bidiSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : bidiSizes) {
     configs.push_back({
         .nBytes = sz,
@@ -821,25 +790,11 @@ TEST_F(P2pSendRecvBenchmarkFixture, BidirectionalBenchmark) {
     });
   };
 
-  std::vector<std::pair<std::size_t, std::string>> tileSizes = {
-      {8 * 1024, "8K"},
-      {16 * 1024, "16K"},
-      {64 * 1024, "64K"},
-      {128 * 1024, "128K"},
-      {256 * 1024, "256K"},
-      {512 * 1024, "512K"},
-      {1 * 1024 * 1024, "1M"},
-      {2 * 1024 * 1024, "2M"},
-      {4 * 1024 * 1024, "4M"},
-      {8 * 1024 * 1024, "8M"},
-      {16 * 1024 * 1024, "16M"},
-      {32 * 1024 * 1024, "32M"},
-      {64 * 1024 * 1024, "64M"},
-      {128 * 1024 * 1024, "128M"},
-      {256 * 1024 * 1024, "256M"},
-      {512 * 1024 * 1024, "512M"},
-      {1024 * 1024 * 1024, "1G"},
-  };
+  std::vector<std::pair<std::size_t, std::string>> tileSizes;
+  for (std::size_t sizeBytes = 4; sizeBytes <= 1024ULL * 1024 * 1024;
+       sizeBytes <<= 1) {
+    tileSizes.emplace_back(sizeBytes, formatSize(sizeBytes));
+  }
   for (const auto& [sz, nm] : tileSizes) {
     addTileConfig(sz, "Tile_" + nm);
   }

--- a/comms/prims/tests/P2pNvlTransportTest.cc
+++ b/comms/prims/tests/P2pNvlTransportTest.cc
@@ -640,6 +640,19 @@ static unsigned char multiCallPattern(int rank, int call) {
   return static_cast<unsigned char>(0x30 + rank * 0x20 + call);
 }
 
+static size_t alignTileProtocolBytes(size_t nbytes) {
+  return (nbytes + 15ULL) & ~15ULL;
+}
+
+static size_t
+validPayloadBytes(size_t byteOffset, size_t chunkBytes, size_t payloadBytes) {
+  if (byteOffset >= payloadBytes) {
+    return 0;
+  }
+  const size_t remaining = payloadBytes - byteOffset;
+  return chunkBytes < remaining ? chunkBytes : remaining;
+}
+
 static std::vector<char> makeTwoCallPatternBuffer(
     size_t firstCallBytes,
     size_t secondCallBytes,
@@ -713,21 +726,24 @@ static void expectPersistentTwoCallStagingPattern(
     uint64_t baseByte = 0;
     for (int call = 0; call < 2; ++call) {
       const unsigned char expected = multiCallPattern(sourceRank, call);
-      for (size_t dataOff = 0; dataOff < callBytes[call];) {
+      const size_t protocolBytes = alignTileProtocolBytes(callBytes[call]);
+      for (size_t dataOff = 0; dataOff < protocolBytes;) {
         const uint64_t streamStart = baseByte + dataOff;
         const size_t pipelineOff =
             static_cast<size_t>(streamStart % pipelineBytes);
         const size_t slot = pipelineOff / perBlockSlotSize;
         const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
         const size_t slotRemaining = perBlockSlotSize - chunkOff;
-        const size_t dataRemaining = callBytes[call] - dataOff;
+        const size_t dataRemaining = protocolBytes - dataOff;
         size_t chunkBytes =
             effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
         chunkBytes = chunkBytes < slotRemaining ? chunkBytes : slotRemaining;
+        const size_t validBytes =
+            validPayloadBytes(dataOff, chunkBytes, callBytes[call]);
         const size_t offset =
             slot * slotSize + block * perBlockSlotSize + chunkOff;
 
-        for (size_t i = 0; i < chunkBytes; ++i) {
+        for (size_t i = 0; i < validBytes; ++i) {
           EXPECT_EQ(static_cast<unsigned char>(data[offset + i]), expected)
               << label << ": block=" << block << " call=" << call
               << " dataOff=" << dataOff << " byte=" << i;
@@ -737,7 +753,7 @@ static void expectPersistentTwoCallStagingPattern(
         }
         dataOff += chunkBytes;
       }
-      baseByte += callBytes[call];
+      baseByte += protocolBytes;
     }
   }
 }
@@ -844,6 +860,10 @@ class LocalTileHarness {
 
   DeviceBuffer& stagingBuffer() {
     return stagingBuf_;
+  }
+
+  DeviceBuffer& stepStateBuffer() {
+    return stepStateBuf_;
   }
 
   size_t stagingBytes() const {
@@ -1195,6 +1215,223 @@ TEST_F(
       numBlocks,
       0,
       "tile recv persistent cursor");
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+
+  LocalTileHarness sendHarness(options, numBlocks);
+  const std::vector<char> hostSend =
+      makeTwoCallPatternBuffer(firstCallBytes, secondCallBytes, numBlocks, 0);
+  DeviceBuffer sendBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendBuf.get(), hostSend.data(), totalBytes, cudaMemcpyHostToDevice));
+
+  auto sendOnlyP2p = sendHarness.stagingDevice();
+  TiledBuffer<char> sendTiles(
+      static_cast<char*>(sendBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallSendOnly(
+      sendOnlyP2p,
+      sendTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostStaging(sendHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostStaging.data(),
+      sendHarness.stagingBuffer().get(),
+      sendHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile send unaligned protocol staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostStaging[i]), 0)
+        << "padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> sendStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      sendStepState.data(),
+      sendHarness.stepStateBuffer().get(),
+      sendStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(sendStepState[0], static_cast<int64_t>(expectedStep));
+
+  LocalTileHarness loopbackHarness(options, numBlocks);
+  DeviceBuffer recvBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, totalBytes));
+  auto loopbackP2p = loopbackHarness.loopbackDevice();
+  TiledBuffer<char> recvTiles(
+      static_cast<char*>(recvBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallVariableSignalSendRecv(
+      loopbackP2p,
+      sendTiles,
+      recvTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      maxSignalBytes,
+      true,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostRecv(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostRecv.data(), recvBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostRecv,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile sendrecv unaligned protocol");
+
+  std::vector<int64_t> loopbackStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      loopbackStepState.data(),
+      loopbackHarness.stepStateBuffer().get(),
+      loopbackStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(loopbackStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(loopbackStepState[numBlocks], static_cast<int64_t>(expectedStep));
+}
+
+TEST_F(
+    P2pNvlTransportTestFixture,
+    TileForwardUnalignedPayloadAdvancesAlignedProtocol) {
+  const int numBlocks = 1;
+  const int threadCount = 256;
+  const size_t perBlockSlotSize = 256;
+  const size_t firstCallBytes = 100;
+  const size_t secondCallBytes = 100;
+  const size_t maxSignalBytes = 64;
+  const size_t tileBytes = firstCallBytes + secondCallBytes;
+  const size_t totalBytes = tileBytes * numBlocks;
+  const size_t expectedStep = alignTileProtocolBytes(firstCallBytes) +
+      alignTileProtocolBytes(secondCallBytes);
+
+  P2pNvlTransportOptions options{
+      .dataBufferSize = perBlockSlotSize * numBlocks,
+      .chunkSize = maxSignalBytes,
+      .pipelineDepth = 2,
+  };
+  LocalTileHarness predHarness(options, numBlocks);
+  LocalTileHarness succHarness(options, numBlocks);
+
+  auto pred = predHarness.device(predHarness.staging(), nullptr);
+  auto succ = succHarness.device(nullptr, succHarness.staging());
+
+  test::testPrepareTileTwoCallStaging(
+      pred,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      0,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceBuffer dstBuf(totalBytes);
+  CUDACHECK_TEST(cudaMemset(dstBuf.get(), 0, totalBytes));
+  TiledBuffer<char> dstTiles(
+      static_cast<char*>(dstBuf.get()), totalBytes, numBlocks);
+
+  test::testTileTwoCallForward(
+      pred,
+      succ,
+      dstTiles,
+      numBlocks,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      threadCount);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  std::vector<char> hostDst(totalBytes);
+  CUDACHECK_TEST(cudaMemcpy(
+      hostDst.data(), dstBuf.get(), totalBytes, cudaMemcpyDeviceToHost));
+  expectTwoCallPattern(
+      hostDst,
+      firstCallBytes,
+      secondCallBytes,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol dst");
+
+  std::vector<char> hostSuccStaging(succHarness.stagingBytes());
+  CUDACHECK_TEST(cudaMemcpy(
+      hostSuccStaging.data(),
+      succHarness.stagingBuffer().get(),
+      succHarness.stagingBytes(),
+      cudaMemcpyDeviceToHost));
+  expectPersistentTwoCallStagingPattern(
+      hostSuccStaging,
+      options.dataBufferSize,
+      firstCallBytes,
+      secondCallBytes,
+      maxSignalBytes,
+      options.pipelineDepth,
+      numBlocks,
+      0,
+      "tile forward unaligned protocol successor staging");
+  for (size_t i = firstCallBytes; i < alignTileProtocolBytes(firstCallBytes);
+       ++i) {
+    EXPECT_EQ(static_cast<unsigned char>(hostSuccStaging[i]), 0)
+        << "forward padding byte " << i
+        << " between unaligned calls should stay transport-private";
+  }
+
+  std::vector<int64_t> predStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      predStepState.data(),
+      predHarness.stepStateBuffer().get(),
+      predStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(predStepState[0], 0);
+  EXPECT_EQ(predStepState[numBlocks], static_cast<int64_t>(expectedStep));
+
+  std::vector<int64_t> succStepState(numBlocks * 2);
+  CUDACHECK_TEST(cudaMemcpy(
+      succStepState.data(),
+      succHarness.stepStateBuffer().get(),
+      succStepState.size() * sizeof(int64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(succStepState[0], static_cast<int64_t>(expectedStep));
+  EXPECT_EQ(succStepState[numBlocks], 0);
 }
 
 TEST_F(

--- a/comms/prims/tests/P2pNvlTransportTest.cu
+++ b/comms/prims/tests/P2pNvlTransportTest.cu
@@ -183,6 +183,7 @@ __device__ void wait_for_second_call_signal(
   if (!enabled) {
     return;
   }
+  const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
   const size_t perBlockSlotSize =
       (p2p.options().dataBufferSize / activeBlocks) & ~15ULL;
   const size_t chunkSize =
@@ -190,8 +191,8 @@ __device__ void wait_for_second_call_signal(
       ? (maxSignalBytes & ~15ULL)
       : perBlockSlotSize;
   const size_t effectiveChunk = chunkSize > 0 ? chunkSize : perBlockSlotSize;
-  const uint64_t secondCallStarted = bytesPerCall +
-      (bytesPerCall < effectiveChunk ? bytesPerCall : effectiveChunk);
+  const uint64_t secondCallStarted = protocolBytes +
+      (protocolBytes < effectiveChunk ? protocolBytes : effectiveChunk);
   p2p.tile_state().local_signals[blockId].wait_until(
       group, CmpOp::CMP_GE, secondCallStarted, timeout);
 }
@@ -485,25 +486,31 @@ __global__ void testPrepareTileStagingKernel(
   uint64_t baseByte = 0;
   for (int call = 0; call < numCalls; ++call) {
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < bytesPerCall;) {
+    const size_t protocolBytes = (bytesPerCall + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = bytesPerCall - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < bytesPerCall) {
+        const size_t remaining = bytesPerCall - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += bytesPerCall;
+    baseByte += protocolBytes;
   }
 
   group.sync();
@@ -540,25 +547,31 @@ __global__ void testPrepareTileTwoCallStagingKernel(
   for (int call = 0; call < 2; ++call) {
     const size_t callBytes = call == 0 ? firstCallBytes : secondCallBytes;
     const char pattern = static_cast<char>(0x30 + sourceRank * 0x20 + call);
-    for (size_t dataOff = 0; dataOff < callBytes;) {
+    const size_t protocolBytes = (callBytes + 15ULL) & ~15ULL;
+    for (size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const size_t pipelineOff =
           static_cast<size_t>(streamStart % pipelineBytes);
       const size_t slot = pipelineOff / perBlockSlotSize;
       const size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const size_t dataRemaining = callBytes - dataOff;
+      const size_t dataRemaining = protocolBytes - dataOff;
       size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
+      size_t validBytes = 0;
+      if (dataOff < callBytes) {
+        const size_t remaining = callBytes - dataOff;
+        validBytes = copyBytes < remaining ? copyBytes : remaining;
+      }
       const size_t bufferOff = slot * slotSize + stagingOff + chunkOff;
-      for (size_t idx = group.thread_id_in_group; idx < copyBytes;
+      for (size_t idx = group.thread_id_in_group; idx < validBytes;
            idx += group.group_size) {
         staging[bufferOff + idx] = pattern;
       }
       dataOff += copyBytes;
     }
-    baseByte += callBytes;
+    baseByte += protocolBytes;
   }
 
   group.sync();

--- a/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/P2pNvlTransportDevice.cuh
@@ -101,8 +101,9 @@ struct NvlinkTransportTileState {
   // Persistent byte cursors:
   //   [0, tile_max_groups) tracks send progress per tile group.
   //   [tile_max_groups, 2 * tile_max_groups) tracks recv progress.
-  // The byte cursor is independent of max_signal_bytes, so callers may change
-  // signal granularity between calls as long as active_blocks is unchanged.
+  // The byte cursor advances in 16-byte protocol quanta and is independent of
+  // max_signal_bytes, so callers may change signal granularity between calls
+  // as long as active_blocks is unchanged.
   DeviceSpan<int64_t> step_state;
   int tile_max_groups{0};
   DeviceSpan<SignalState> local_signals;
@@ -1490,7 +1491,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1498,7 +1500,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1509,11 +1511,13 @@ class P2pNvlTransportDevice {
             group, CmpOp::CMP_GE, streamEnd - pipelineBytes, timeout);
       }
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         memcpy_vectorized(
             stagBuf + slotOff + stagingOff + chunkOff,
             srcPtr + dataOff,
-            copyBytes,
+            validBytes,
             group);
       }
 
@@ -1526,7 +1530,8 @@ class P2pNvlTransportDevice {
     }
 
     if (group.is_leader()) {
-      tile_state_.step_state[groupId] = static_cast<int64_t>(baseByte + nbytes);
+      tile_state_.step_state[groupId] =
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1599,7 +1604,8 @@ class P2pNvlTransportDevice {
     const uint64_t baseByte =
         static_cast<uint64_t>(tile_state_.step_state[max_groups + groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t streamStart = baseByte + dataOff;
       const std::size_t pipelineOff =
           static_cast<std::size_t>(streamStart % pipelineBytes);
@@ -1607,7 +1613,7 @@ class P2pNvlTransportDevice {
       const std::size_t slotOff = slot * slotSize;
       const std::size_t chunkOff = pipelineOff - slot * perBlockSlotSize;
       const std::size_t slotRemaining = perBlockSlotSize - chunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < slotRemaining ? copyBytes : slotRemaining;
@@ -1616,11 +1622,13 @@ class P2pNvlTransportDevice {
       tile_state_.local_signals[tailSignalId].wait_until(
           group, CmpOp::CMP_GE, streamEnd, timeout);
 
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::recv(
             dstPtr + dataOff,
             stagBuf + slotOff + stagingOff + chunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1629,7 +1637,7 @@ class P2pNvlTransportDevice {
       group.sync();
       if (group.is_leader()) {
         if (chunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, streamEnd);
         }
@@ -1639,7 +1647,7 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(baseByte + nbytes);
+          static_cast<int64_t>(baseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -1753,7 +1761,8 @@ class P2pNvlTransportDevice {
     const uint64_t sendBaseByte =
         static_cast<uint64_t>(successor.tile_state_.step_state[groupId]);
 
-    for (std::size_t dataOff = 0; dataOff < nbytes;) {
+    const std::size_t protocolBytes = align_tile_protocol_bytes(nbytes);
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
       const uint64_t recvStreamStart = recvBaseByte + dataOff;
       const std::size_t recvPipelineOff =
           static_cast<std::size_t>(recvStreamStart % pipelineBytes);
@@ -1770,7 +1779,7 @@ class P2pNvlTransportDevice {
           sendPipelineOff - sendSlot * perBlockSlotSize;
       const std::size_t recvSlotRemaining = perBlockSlotSize - recvChunkOff;
       const std::size_t sendSlotRemaining = perBlockSlotSize - sendChunkOff;
-      const std::size_t dataRemaining = nbytes - dataOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
       std::size_t copyBytes =
           effectiveChunk < dataRemaining ? effectiveChunk : dataRemaining;
       copyBytes = copyBytes < recvSlotRemaining ? copyBytes : recvSlotRemaining;
@@ -1791,12 +1800,14 @@ class P2pNvlTransportDevice {
 
       // 3. Dual-dst copy: predecessor staging → local user buf +
       //    successor remote staging
-      if (copyBytes > 0) {
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, copyBytes, nbytes);
+      if (validBytes > 0) {
         CopyOp::forward(
             dstPtr ? dstPtr + dataOff : nullptr,
             sendBuf + sendSlotOff + stagingOff + sendChunkOff,
             recvBuf + recvSlotOff + stagingOff + recvChunkOff,
-            copyBytes,
+            validBytes,
             group,
             dataOff,
             args...);
@@ -1811,7 +1822,7 @@ class P2pNvlTransportDevice {
         // 5. ACK predecessor that buffer is free (recv semantic: only at
         //    slot boundaries).
         if (recvChunkOff + copyBytes == perBlockSlotSize ||
-            dataOff + copyBytes == nbytes) {
+            dataOff + copyBytes == protocolBytes) {
           tile_state_.remote_signals[headSignalId].signal(
               SignalOp::SIGNAL_SET, recvStreamEnd);
         }
@@ -1821,9 +1832,9 @@ class P2pNvlTransportDevice {
 
     if (group.is_leader()) {
       tile_state_.step_state[max_groups + groupId] =
-          static_cast<int64_t>(recvBaseByte + nbytes);
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
       successor.tile_state_.step_state[groupId] =
-          static_cast<int64_t>(sendBaseByte + nbytes);
+          static_cast<int64_t>(sendBaseByte + protocolBytes);
     }
     group.sync();
 #endif
@@ -2061,6 +2072,22 @@ class P2pNvlTransportDevice {
   }
 
  private:
+  __device__ __forceinline__ static std::size_t align_tile_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
+
   const int myRank_{-1};
   const int peerRank_{-1};
   const P2pNvlTransportOptions options_{};


### PR DESCRIPTION
Summary:
- Replace the gtest-style IBGDA send/recv sweep with a Folly benchmark binary so the same benchmark can be run directly from local two-rank `TcpStore` launches.
- Keep both blocking send/recv and progress send/recv APIs, and report `bandwidth_GBps`, `latency_us`, and `message_size` counters for bidirectional and unidirectional cases from 1MB through 4GB.
- Addressed the review concern by not adding a per-send drain to the unidirectional send kernels; this diff only adds CUDA launch-error checks for the unidirectional blocking/progress launch helpers.

Reviewed By: goelayu

Differential Revision: D107728823


