### PR TITLE
Add resumable forward (init_forward_progress / progress_forward_once)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -43,14 +43,25 @@ bool ctranAllReduceSupport(CtranComm* comm, enum NCCL_ALLREDUCE_ALGO algo) {
       }
       return true;
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
-      // The real support predicate and implementation land in the next stacked
-      // diff. Return false for now so explicit selection falls back at the
-      // McclComm layer (non-silent WARN) rather than reaching the
-      // not-yet-implemented stub.
-      CLOGF(
-          WARN,
-          "cthierarchical_ring algo is not yet implemented; falling back to baseline");
-      return false;
+      // Coarse runtime knobs only: this gates on Pipes/IBGDA being enabled but
+      // does NOT prove the selected peer transport is actually P2P_IBGDA, nor
+      // that the (datatype, redOp) are supported. Exact dtype/op/transport
+      // compatibility is validated inside ctranAllReduceHierarchicalRing, which
+      // surfaces unsupported cases as a hard commInvalidArgument (no silent
+      // fallback).
+      if (!NCCL_CTRAN_USE_PIPES) {
+        CLOGF(
+            WARN,
+            "cthierarchical_ring algo requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+        return false;
+      }
+      if (comm->statex_->nNodes() > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+        CLOGF(
+            WARN,
+            "cthierarchical_ring algo requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+        return false;
+      }
+      return true;
     default: // invalid query
       return false;
   }

--- a/comms/ctran/algos/AllReduce/AllReduceFused.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.cc
@@ -4,6 +4,9 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstdlib>
+#include <memory>
+#include <vector>
 
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/utils/Checks.h"
@@ -43,14 +46,32 @@ int compute_num_blocks(size_t totalBytes, int cap) {
 }
 
 int compute_num_blocks_ring(size_t segmentBytes, int cap) {
+  // Measurement-only override (env NCCL_CTRAN_ALLREDUCE_RING_FORCE_NBLOCKS,
+  // unset/<=0 = disabled). When > 0, force exactly that many blocks,
+  // cap-bounded, bypassing BOTH the size-tier below AND compute_num_blocks's
+  // small-size reduction (routing a forced value through compute_num_blocks
+  // would collapse e.g. 32 -> 1 at 64K, defeating a block sweep). Read via
+  // getenv rather than a CVAR: this is a debug/retuning knob (used to derive
+  // and re-confirm the tiers below), and a CVAR would force a cvars-wide
+  // recompile. Production behavior is unchanged when unset.
+  if (const char* forcedEnv =
+          std::getenv("NCCL_CTRAN_ALLREDUCE_RING_FORCE_NBLOCKS")) {
+    const int forced = std::atoi(forcedEnv);
+    if (forced > 0) {
+      return std::min(cap, forced);
+    }
+  }
   // Size-aware tier on Phase-2 owner-segment bytes. The hierarchical ring does
   // 2(W-1) serialized IB steps per pipeline window; fewer blocks at
   // small/medium sizes amortize per-WQE overhead, while large segments use the
   // cap. Keyed on segmentBytes (not totalBytes) because Phase 2 operates per
-  // owner segment (segmentBytes ~= totalBytes/pMin in HYBRID). Tiers are a
-  // starting point and should be re-confirmed against a post-redesign block
-  // sweep. The per-block threshold and reduction loop live in
-  // compute_num_blocks (single source of truth); this just caps the tier
+  // owner segment (segmentBytes ~= totalBytes/pMin in HYBRID). Tiers validated
+  // by a force-NBLOCKS busbw sweep (8xH100, nolocal/IB_ONLY, W=8, fp32, OOP):
+  // nb=4 best at 64K-1M, nb=8 best at 4M-16M, nb=16 best at >=64M (nb=32 gives
+  // no further gain), and over-blocking regresses (e.g. at 16M nb=8=25 vs
+  // nb=16=19 GB/s). Caveats: H100/fp32/nolocal only; HYBRID (pMin>1), fp16, and
+  // block-count x W not swept. The per-block threshold and reduction loop live
+  // in compute_num_blocks (single source of truth); this just caps the tier
   // ceiling before delegating.
   int tier;
   if (segmentBytes <= (1ull << 20)) { // <= 1 MB

--- a/comms/ctran/algos/AllReduce/AllReduceFused.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.cc
@@ -42,6 +42,27 @@ int compute_num_blocks(size_t totalBytes, int cap) {
   return numBlocks;
 }
 
+int compute_num_blocks_ring(size_t segmentBytes, int cap) {
+  // Size-aware tier on Phase-2 owner-segment bytes. The hierarchical ring does
+  // 2(W-1) serialized IB steps per pipeline window; fewer blocks at
+  // small/medium sizes amortize per-WQE overhead, while large segments use the
+  // cap. Keyed on segmentBytes (not totalBytes) because Phase 2 operates per
+  // owner segment (segmentBytes ~= totalBytes/pMin in HYBRID). Tiers are a
+  // starting point and should be re-confirmed against a post-redesign block
+  // sweep. The per-block threshold and reduction loop live in
+  // compute_num_blocks (single source of truth); this just caps the tier
+  // ceiling before delegating.
+  int tier;
+  if (segmentBytes <= (1ull << 20)) { // <= 1 MB
+    tier = 4;
+  } else if (segmentBytes <= (32ull << 20)) { // <= 32 MB
+    tier = 8;
+  } else {
+    tier = 16;
+  }
+  return compute_num_blocks(segmentBytes, std::min(cap, tier));
+}
+
 void* compute_phase2_buf(
     void* recvbuff,
     int localRank,

--- a/comms/ctran/algos/AllReduce/AllReduceFused.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.cuh
@@ -41,18 +41,18 @@ __device__ __forceinline__ void runAllReduceFused(
     const common::CommonKernArgs& args,
     comms::prims::ThreadGroup& group,
     IbAllReduce&& ibAllReduce) {
-  NvlOps::template nvlReduceScatter<T>(args, group);
+  NvlOps::template nvlReduceScatter<T>(args, group); // Phase 1
   if (args.nLocalRanks > 1) {
     group.sync();
   }
   if (args.nNodes > 1) {
-    ibAllReduce(group);
+    ibAllReduce(group); // Phase 2
     if (args.nLocalRanks > 1) {
       group.sync();
     }
   }
   if (args.nLocalRanks > 1) {
-    NvlOps::template nvlAllGather<T>(args, group);
+    NvlOps::template nvlAllGather<T>(args, group); // Phase 3
   }
 }
 

--- a/comms/ctran/algos/AllReduce/AllReduceFused.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFused.h
@@ -18,6 +18,7 @@ bool is_supported_fused_type(commDataType_t datatype);
 int compute_p_min(CtranComm* comm);
 int get_num_block_cap();
 int compute_num_blocks(size_t totalBytes, int cap);
+int compute_num_blocks_ring(size_t segmentBytes, int cap);
 
 void* compute_phase2_buf(
     void* recvbuff,

--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -69,7 +69,12 @@ struct CommonKernArgs {
 
   /** Total number of elements in the user tensor. */
   size_t count;
-  /** Elements per owner segment, equal to `ceil(count / pMin)`. */
+  /**
+   * Elements per owner segment. The base value is `ceil(count / pMin)`, but
+   * some algorithms round it up for alignment (e.g. hierring rounds up to a
+   * 16-byte multiple so sub-shard offsets are 16-aligned); over-padding past
+   * `count` is handled by `actualSegElems`.
+   */
   size_t segmentElems;
 
   /** Number of nodes in the communicator. */

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
@@ -90,10 +90,10 @@ commResult_t ctranAllReduceHierarchicalRing(
     return commInvalidArgument;
   }
 
-  if (datatype != commFloat32) {
+  if (datatype != commFloat32 && datatype != commFloat16) {
     CLOGF(
         ERR,
-        "AllReduce cthierarchical_ring currently supports commFloat32 only, got {}",
+        "AllReduce cthierarchical_ring currently supports commFloat32/commFloat16 only, got {}",
         commDataTypeToString(datatype));
     return commInvalidArgument;
   }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cc
@@ -1,26 +1,250 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <algorithm>
 #include <chrono>
 #include <optional>
 
 #include "comms/ctran/CtranComm.h"
+#include "comms/ctran/algos/AllReduce/AllReduceFused.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
-// Stub for the Pipes-backed hierarchical ring AllReduce (NVL ReduceScatter +
-// inter-node IBGDA ring + NVL AllGather). The wiring (enum, AlgoStrConv,
-// dispatch) lands in this diff; the real implementation lands in the next
-// stacked diff. Until then `ctranAllReduceSupport` returns false for
-// `cthierarchical_ring`, so this path is not reached in practice.
-commResult_t ctranAllReduceHierarchicalRing(
-    const void* /* sendbuff */,
-    void* /* recvbuff */,
-    size_t /* count */,
-    commDataType_t /* datatype */,
-    commRedOp_t /* redOp */,
-    CtranComm* /* comm */,
-    cudaStream_t /* stream */,
-    std::optional<std::chrono::milliseconds> /* timeout */) {
-  CLOGF(ERR, "AllReduce cthierarchical_ring is not yet implemented");
+// AllReduceIbRing.cuh exposes the host-safe `hierring::RingTopology` (used
+// below regardless of ENABLE_PRIMS) outside its ENABLE_PRIMS guard; the device
+// `KernArgs` / kernel entry inside the guard are used only on the PIPES path.
+#include "comms/ctran/algos/AllReduce/AllReduceIbRing.cuh"
+
+#if defined(ENABLE_PRIMS)
+#include "comms/prims/transport/MultiPeerTransport.h"
+#endif
+
+namespace fused = ctran::allreduce::fused;
+
+#if defined(ENABLE_PRIMS)
+namespace {
+// Validates that an IB ring neighbor (`peerRank`) resolves to a P2P_IBGDA
+// transport. The kernel dereferences `transports[peerRank].p2p_ib.ibgda`
+// (AllReduceIbRing.cu), so a non-IBGDA peer — e.g. a comm using the IBRC
+// backend, where the same union holds `.ibrc` — would reinterpret the wrong
+// union member and trap/hang at kernel time. The coarse
+// NCCL_CTRAN_IBGDA_SENDRECV_ENABLE knob does not catch this. Mirrors
+// AllReduceIbTree.cc's validateAllReduceTreeIbPeer (file-local, not reusable).
+commResult_t validateHierRingIbPeer(
+    const comms::prims::MultiPeerTransport& transport,
+    int rank,
+    int peerRank,
+    const char* edgeName) {
+  const auto type = transport.get_transport_type(peerRank);
+  if (type == comms::prims::TransportType::P2P_IBGDA) {
+    return commSuccess;
+  }
+  CLOGF(
+      ERR,
+      "AllReduce cthierarchical_ring requires P2P_IBGDA transport for {} edge "
+      "rank {} -> peer {}; got {}",
+      edgeName,
+      rank,
+      peerRank,
+      comms::prims::transport_type_name(type));
   return commInvalidArgument;
+}
+} // namespace
+#endif
+
+commResult_t ctranAllReduceHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  if (count == 0) {
+    return commSuccess;
+  }
+
+  const auto* statex = comm->statex_.get();
+  const int rank = statex->rank();
+  const int nRanks = statex->nRanks();
+  const int nNodes = statex->nNodes();
+  const int localRank = statex->localRank();
+  const int nodeId = statex->node();
+
+  if (nRanks == 1) {
+    // Degenerate case: device-to-device memcpy short-circuit
+    if (sendbuff != recvbuff) {
+      FB_CUDACHECK(cudaMemcpyAsync(
+          recvbuff,
+          sendbuff,
+          count * commTypeSize(datatype),
+          cudaMemcpyDeviceToDevice,
+          stream));
+    }
+    return commSuccess;
+  }
+
+  if (redOp != commSum) {
+    CLOGF(ERR, "AllReduce cthierarchical_ring currently supports commSum only");
+    return commInvalidArgument;
+  }
+
+  if (datatype != commFloat32) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring currently supports commFloat32 only, got {}",
+        commDataTypeToString(datatype));
+    return commInvalidArgument;
+  }
+
+  if (nNodes > 1 && !NCCL_CTRAN_IBGDA_SENDRECV_ENABLE) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring requires NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1 for inter-node IB transfers");
+    return commInvalidArgument;
+  }
+  if (!NCCL_CTRAN_USE_PIPES) {
+    CLOGF(
+        ERR,
+        "AllReduce cthierarchical_ring requires NCCL_CTRAN_USE_PIPES=1 for Pipes transports");
+    return commInvalidArgument;
+  }
+
+  const int pMin = fused::compute_p_min(comm);
+
+  const size_t rawSegmentElems = (count + pMin - 1) / pMin; // ceil(count/pMin)
+  const size_t elemSz = commTypeSize(datatype);
+  const size_t alignElems = 16 / elemSz;
+  const size_t segmentElems =
+      (rawSegmentElems + alignElems - 1) & ~(alignElems - 1); // round up to 16B
+  const bool participatesInIB = (localRank < pMin);
+
+  ctran::allreduce::hierring::RingTopology ring{};
+  if (participatesInIB && nNodes > 1) {
+    int prevNode = (nodeId - 1 + nNodes) % nNodes;
+    int nextNode = (nodeId + 1) % nNodes;
+    ring.prevRank = statex->localRankToRank(localRank, prevNode);
+    ring.nextRank = statex->localRankToRank(localRank, nextNode);
+    ring.nNodes = nNodes;
+    ring.myNodeIdx = nodeId;
+  }
+
+  CLOGF(
+      DBG,
+      "AllReduce cthierarchical_ring: rank {} localRank {} nNodes {} pMin {} "
+      "segmentElems {} participatesInIB {} ring[prev={} next={} myNode={}]",
+      rank,
+      localRank,
+      nNodes,
+      pMin,
+      segmentElems,
+      participatesInIB,
+      ring.prevRank,
+      ring.nextRank,
+      ring.myNodeIdx);
+
+#if defined(ENABLE_PRIMS)
+  const int nLocalRanks = statex->nLocalRanks();
+  const size_t elementSize = commTypeSize(datatype);
+  const size_t totalBytes = count * elementSize;
+  const size_t segmentBytes = segmentElems * elementSize;
+  const bool hasIbPhase = participatesInIB && nNodes > 1;
+
+  // Size-tiered count that drives block tiling (i.e., bucket the
+  // owner-segment size into the 4/8/16 tiers, then cap it and reduce).
+  // Larger segments get more blocks (more tile parallelism).
+  // Small segments get fewer (avoids too much per-block/WQE overhead).
+  const int numBlocks =
+      fused::compute_num_blocks_ring(segmentBytes, fused::get_num_block_cap());
+
+  if (hasIbPhase) {
+    // Validate the IB transport before launching: the kernel blindly
+    // dereferences `transports[prev/next].p2p_ib.ibgda`, so a missing
+    // MultiPeerTransport, lazy (unmaterialized) connect, or a non-IBGDA peer
+    // would trap/hang on device. Fail fast on the host instead.
+    if (!comm->multiPeerTransport_) {
+      CLOGF(
+          ERR,
+          "AllReduce cthierarchical_ring requires MultiPeerTransport for inter-node IB transfers");
+      return commInvalidArgument;
+    }
+    if (comm->multiPeerTransport_->is_lazy_mode()) {
+      CLOGF(
+          ERR,
+          "AllReduce cthierarchical_ring requires eager IB connect (NCCL_CTRAN_IBGDA_LAZY_CONNECT=0); lazy mode is not supported");
+      return commInvalidArgument;
+    }
+    commResult_t prevValid = validateHierRingIbPeer(
+        *comm->multiPeerTransport_, rank, ring.prevRank, "prev");
+    if (prevValid != commSuccess) {
+      return prevValid;
+    }
+    commResult_t nextValid = validateHierRingIbPeer(
+        *comm->multiPeerTransport_, rank, ring.nextRank, "next");
+    if (nextValid != commSuccess) {
+      return nextValid;
+    }
+
+    const int maxIbGroups = NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS;
+    const int requiredIbGroups =
+        numBlocks * ctran::allreduce::hierring::kRingLanes;
+    if (requiredIbGroups > maxIbGroups) {
+      CLOGF(
+          ERR,
+          "AllReduce cthierarchical_ring requires {} IBGDA send/recv groups, "
+          "exceeding NCCL_CTRAN_IBGDA_SENDRECV_MAX_GROUPS={}",
+          requiredIbGroups,
+          maxIbGroups);
+      return commInvalidArgument;
+    }
+  }
+
+  void* phase2Buf = fused::compute_phase2_buf(
+      recvbuff, localRank, segmentBytes, participatesInIB);
+
+  CLOGF(
+      DBG,
+      "AllReduce cthierarchical_ring launch: totalBytes {} segmentBytes {} "
+      "numBlocks {} threadsPerBlock {} hasIbPhase {}",
+      totalBytes,
+      segmentBytes,
+      numBlocks,
+      ctran::allreduce::hierring::kBlockSize,
+      hasIbPhase);
+
+  auto opCount = comm->ctran_->getOpCount();
+
+  ctran::allreduce::hierring::KernArgs kernArgs{};
+  FB_COMMCHECK(
+      fused::fill_common_kern_args(
+          kernArgs.common,
+          sendbuff,
+          recvbuff,
+          phase2Buf,
+          count,
+          segmentElems,
+          nNodes,
+          pMin,
+          nLocalRanks,
+          localRank,
+          numBlocks,
+          datatype,
+          redOp,
+          comm));
+  kernArgs.ring = ring;
+
+  return fused::submit_fused_kernel(
+      comm,
+      stream,
+      "AllReduceHierarchicalRing",
+      opCount,
+      numBlocks,
+      ctran::allreduce::hierring::kBlockSize,
+      &kernArgs,
+      reinterpret_cast<const void*>(ctranKernelAllReduceHierarchicalRing));
+#else
+  CLOGF(ERR, "AllReduce cthierarchical_ring requires ENABLE_PRIMS");
+  return commInternalError;
+#endif
 }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
@@ -1,0 +1,425 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#if defined(ENABLE_PRIMS)
+
+#include <cstdint>
+
+#include "comms/ctran/algos/AllReduce/AllReduceFused.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceIbRing.cuh"
+#include "comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh"
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/transport/Transport.cuh"
+#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+
+using namespace ctran::allreduce::common;
+
+namespace {
+
+// Bytes of `nbytes` that fall within the valid window `[byte_offset,
+// valid_window)` (0 if the window starts at/after valid_window). Shared by the
+// valid-masked send/recv/forward paths below.
+__device__ __forceinline__ size_t
+validClampBytes(size_t nbytes, size_t byte_offset, size_t valid_window) {
+  if (byte_offset >= valid_window) {
+    return 0;
+  }
+  const size_t rem = valid_window - byte_offset;
+  return nbytes < rem ? nbytes : rem;
+}
+
+template <typename T>
+struct ValidReduceStaged {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      const char*,
+      size_t valid_window,
+      Args...) {
+    size_t copyBytes = validClampBytes(nbytes, byte_offset, valid_window);
+    if (copyBytes > 0) {
+      comms::prims::memcpy_vectorized(staging, src, copyBytes, group);
+    }
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      const char* local_input,
+      size_t valid_window,
+      Args...) {
+    size_t validN =
+        validClampBytes(nbytes, byte_offset, valid_window) / sizeof(T);
+    T* d = reinterpret_cast<T*>(dst);
+    const T* s = reinterpret_cast<const T*>(staging);
+    const T* l = reinterpret_cast<const T*>(local_input + byte_offset);
+    for (size_t i = group.thread_id_in_group; i < validN;
+         i += group.group_size) {
+      d[i] = s[i] + l[i];
+    }
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char*,
+      char* fwd_staging,
+      const char* staging,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      const char* local_input,
+      size_t valid_window,
+      Args...) {
+    size_t validN =
+        validClampBytes(nbytes, byte_offset, valid_window) / sizeof(T);
+    T* f = reinterpret_cast<T*>(fwd_staging);
+    const T* s = reinterpret_cast<const T*>(staging);
+    const T* l = reinterpret_cast<const T*>(local_input + byte_offset);
+    for (size_t i = group.thread_id_in_group; i < validN;
+         i += group.group_size) {
+      f[i] = s[i] + l[i];
+    }
+  }
+};
+
+struct ValidMemcpy {
+  template <typename... Args>
+  __device__ __forceinline__ static void send(
+      char* staging,
+      const char* src,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      size_t valid_window,
+      Args...) {
+    size_t copyBytes = validClampBytes(nbytes, byte_offset, valid_window);
+    if (copyBytes > 0) {
+      comms::prims::memcpy_vectorized(staging, src, copyBytes, group);
+    }
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void recv(
+      char* dst,
+      const char* staging,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      size_t valid_window,
+      Args...) {
+    size_t copyBytes = validClampBytes(nbytes, byte_offset, valid_window);
+    if (copyBytes > 0) {
+      comms::prims::memcpy_vectorized(dst, staging, copyBytes, group);
+    }
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* dst,
+      char* fwd_staging,
+      const char* staging,
+      size_t nbytes,
+      comms::prims::ThreadGroup& group,
+      size_t byte_offset,
+      size_t valid_window,
+      Args...) {
+    size_t copyBytes = validClampBytes(nbytes, byte_offset, valid_window);
+    if (copyBytes > 0) {
+      if (dst) {
+        comms::prims::memcpy_vectorized(
+            dst, fwd_staging, staging, copyBytes, group);
+      } else {
+        comms::prims::memcpy_vectorized(fwd_staging, staging, copyBytes, group);
+      }
+    }
+  }
+};
+
+// One of W node sub-shards within a block's owner-segment tile. TiledBuffer
+// rounds tile_elements up to 16B, so every sub-shard offset is 16B-spaced and
+// each non-empty interior sub-shard is exactly tile_elements. At most one
+// non-empty sub-shard (the last non-empty one) may be short/non-16B; for tiny
+// tiles that can be sub-shard 0 (with the remaining sub-shards empty), not
+// necessarily sub-shard W-1.
+struct RingShard {
+  size_t offsetBytes;
+  size_t bytes;
+};
+
+__device__ __forceinline__ RingShard
+ringShard(size_t tileBytes, int W, int shardIdx) {
+  comms::prims::TiledBuffer<char> sh(nullptr, tileBytes, W);
+  return RingShard{
+      .offsetBytes = static_cast<size_t>(shardIdx) * sh.tile_elements,
+      .bytes = sh.tile_bytes(shardIdx),
+  };
+}
+
+// Largest of the W sub-shards — the pipeline-loop upper bound.
+__device__ __forceinline__ size_t maxRingShardBytes(size_t tileBytes, int W) {
+  size_t m = 0;
+  for (int k = 0; k < W; k++) {
+    const size_t b = ringShard(tileBytes, W, k).bytes;
+    m = b > m ? b : m;
+  }
+  return m;
+}
+
+// Non-negative (base - s) mod W.
+__device__ __forceinline__ int ringRotate(int base, int s, int W) {
+  return ((base - s) % W + W) % W;
+}
+
+// Valid bytes of sub-shard `k` at pipeline offset `off` (0 if past the end).
+__device__ __forceinline__ size_t
+shardWindow(size_t tileBytes, int W, int k, size_t off, size_t pipelineWindow) {
+  const size_t b = ringShard(tileBytes, W, k).bytes;
+  if (off >= b) {
+    return 0;
+  }
+  const size_t rem = b - off;
+  return pipelineWindow < rem ? pipelineWindow : rem;
+}
+
+template <typename T>
+__device__ __noinline__ void phase2IbRing(
+    const ctran::allreduce::hierring::KernArgs& args,
+    comms::prims::ThreadGroup& blockGroup) {
+  if (args.common.localRank >= args.common.pMin) {
+    return;
+  }
+  if (args.common.nNodes <= 1) {
+    return;
+  }
+
+  const int W = args.ring.nNodes;
+  const int me = args.ring.myNodeIdx;
+  const size_t actualElems = actualSegElems(
+      args.common.count, args.common.segmentElems, args.common.localRank);
+  const auto tile = segmentTile(actualElems * sizeof(T), blockGroup);
+  const size_t tileBytes = tile.bytes;
+
+  if (tileBytes == 0) {
+    // Block whoses tile/tail partition are empty (tiny counts, trailing blocks,
+    // exhausted shards) do no Phase-2 work.
+    return;
+  }
+
+  auto& prev = *args.common.transports[args.ring.prevRank].p2p_ib.ibgda;
+  auto& next = *args.common.transports[args.ring.nextRank].p2p_ib.ibgda;
+  const int activeGroups =
+      args.common.numBlocks * ctran::allreduce::hierring::kRingLanes;
+
+  // Cross-node pairing maps block b on each node to ring group b: ringGroup
+  // carries the per-block group_id and the lane dimension is NOT folded into
+  // it. This is only correct for a single ring lane; raising kRingLanes would
+  // require reworking group_id so its id space spans [0, activeGroups).
+  static_assert(
+      ctran::allreduce::hierring::kRingLanes == 1,
+      "phase2IbRing assumes kRingLanes == 1 for cross-node ring-group pairing; "
+      "raising it requires folding the lane dimension into ringGroup.group_id");
+  auto ringGroup = blockGroup;
+  ringGroup.group_id = blockGroup.group_id;
+  ringGroup.total_groups = static_cast<uint32_t>(activeGroups);
+
+  const size_t pipelineWindow = next.pipeline_window(activeGroups);
+  PIPES_DEVICE_CHECK_MSG(
+      pipelineWindow != 0, "phase2IbRing: pipeline window is zero");
+
+  char* tileBuf = static_cast<char*>(args.common.phase2Buf) + tile.offsetBytes;
+  comms::prims::Timeout timeout{};
+
+  // tileBuf is a view into the user's recvbuff, so it inherits recvbuff's
+  // alignment. The AllReduce API only guarantees element alignment
+  // (alignof(T)), NOT 16-byte alignment.
+  //
+  // Element alignment is all we require, and all we assert below: it is the
+  // minimum the valid-masking path needs for its typed T* loads. We do NOT
+  // require 16-byte alignment, because the fast uint4/TileReduceStaged path is
+  // opt-in per window via the isAligned16(buf) check in the fork below. A
+  // tileBuf that is element- but not 16-aligned therefore just routes every
+  // window through the valid-masking path (correct, only slightly slower).
+  PIPES_DEVICE_CHECK_MSG(
+      reinterpret_cast<uintptr_t>(tileBuf) % alignof(T) == 0,
+      "phase2IbRing: tileBuf must be element-aligned");
+
+  const size_t maxShardBytes = maxRingShardBytes(tileBytes, W);
+
+  // Peer-symmetry invariant (correctness-critical): the per-window fork below
+  // is `v % 16 == 0 && isAligned16(buf)`, but the WIRE byte count it issues
+  // depends only on `v % 16` (a pure function of shard size, hence globally
+  // agreed): the fast path uses nbytes=v and the valid path uses
+  // nbytes=roundUp16(v), which are equal when v%16==0, and when v%16!=0 BOTH
+  // peers take the valid path. So even if two ranks differ in buffer alignment
+  // (see the tileBuf alignment note above), the sender and receiver of a
+  // sub-shard always agree on the wire byte count, keeping the persistent
+  // stepState cursors in lock-step.
+  //
+  // Shard-size facts used below: among non-empty sub-shards at most one (the
+  // last non-empty one) is non-16 in size; interior non-empty sub-shards are
+  // exactly tile_elements. For tiny tiles that short shard can be sub-shard 0
+  // (with the remaining sub-shards empty), not necessarily sub-shard W-1. And
+  // wire <= pipelineWindow always (v <= pipelineWindow; pipelineWindow is
+  // 16-aligned, so roundUp16(v) <= pipelineWindow), so no transfer exceeds the
+  // staging ring (no deadlock). All control flow below is uniform across the
+  // block's threads.
+  using ReduceOp = comms::prims::TileReduceStaged<
+      T,
+      comms::prims::SumOp,
+      kIbTileElems,
+      ctran::allreduce::hierring::kBlockSize>;
+
+  // ============================ Reduce-scatter ============================
+  // Per window: send(shard me) + forward(shard me-1 .. me-(W-2)) + recv(shard
+  // me+1). Each forward reduces this node's local sub-shard into the running
+  // partial and passes it on; the final recv lands the fully reduced sub-shard
+  // (me+1) in tileBuf. Other sub-shards in tileBuf keep this node's local data
+  // until all-gather fills them in.
+  for (size_t off = 0; off < maxShardBytes; off += pipelineWindow) {
+    // step 0: initiate own owner sub-shard (raw local data).
+    {
+      const int k = me;
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(buf)) {
+          next.send(ringGroup, buf, v, activeGroups, 0, timeout);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          next.template send<ValidReduceStaged<T>>(
+              ringGroup, buf, wire, activeGroups, 0, timeout, buf, v);
+        }
+      }
+    }
+    // steps 1..W-2: receive partial for shard (me-s), reduce local, forward.
+    for (int s = 1; s <= W - 2; ++s) {
+      const int k = ringRotate(me, s, W);
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* lin = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(lin)) {
+          prev.template forward<ReduceOp>(
+              ringGroup, nullptr, next, v, activeGroups, 0, timeout, lin);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          prev.template forward<ValidReduceStaged<T>>(
+              ringGroup, nullptr, next, wire, activeGroups, 0, timeout, lin, v);
+        }
+      }
+    }
+    // step W-1: final receive-reduce of shard (me+1) into tileBuf.
+    {
+      const int k =
+          ringRotate(me, W - 1, W); // (me - (W-1)) mod W = (me+1) mod W
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(buf)) {
+          prev.template recv<ReduceOp>(
+              ringGroup, buf, v, activeGroups, 0, timeout, buf);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          prev.template recv<ValidReduceStaged<T>>(
+              ringGroup, buf, wire, activeGroups, 0, timeout, buf, v);
+        }
+      }
+    }
+  }
+
+  // Block-local phase transition: shard (me+1) is now reduced in tileBuf and is
+  // read by all-gather step 0 below.
+  blockGroup.sync();
+
+  // ============================== All-gather =============================
+  // Per window: send(shard me+1) + forward(shard me .. me+1-(W-2), storing each
+  // into tileBuf) + recv(shard me+2 into tileBuf). All-gather never reduces.
+  for (size_t off = 0; off < maxShardBytes; off += pipelineWindow) {
+    // step 0: broadcast own reduced sub-shard (me+1).
+    {
+      const int k = ringRotate(me + 1, 0, W);
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(buf)) {
+          next.send(ringGroup, buf, v, activeGroups, 0, timeout);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          next.template send<ValidMemcpy>(
+              ringGroup, buf, wire, activeGroups, 0, timeout, v);
+        }
+      }
+    }
+    // steps 1..W-2: receive shard (me+1-s), store into tileBuf, forward.
+    for (int s = 1; s <= W - 2; ++s) {
+      const int k = ringRotate(me + 1, s, W);
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(buf)) {
+          prev.forward(ringGroup, buf, next, v, activeGroups, 0, timeout);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          prev.template forward<ValidMemcpy>(
+              ringGroup, buf, next, wire, activeGroups, 0, timeout, v);
+        }
+      }
+    }
+    // step W-1: final receive of shard (me+2) into tileBuf.
+    {
+      const int k = ringRotate(me + 1, W - 1, W); // (me+2) mod W
+      const auto sh = ringShard(tileBytes, W, k);
+      const size_t v = shardWindow(tileBytes, W, k, off, pipelineWindow);
+      if (v > 0) {
+        char* buf = tileBuf + sh.offsetBytes + off;
+        if (v % 16 == 0 && isAligned16(buf)) {
+          prev.recv(ringGroup, buf, v, activeGroups, 0, timeout);
+        } else {
+          const size_t wire = (v + 15) & ~size_t(15);
+          prev.template recv<ValidMemcpy>(
+              ringGroup, buf, wire, activeGroups, 0, timeout, v);
+        }
+      }
+    }
+  }
+}
+
+} // namespace
+
+__global__
+__launch_bounds__(ctran::allreduce::hierring::kBlockSize, 1) void ctranKernelAllReduceHierarchicalRing(
+    int* /* flag */,
+    CtranAlgoDeviceState* /* devState */,
+    ctran::allreduce::hierring::KernArgs args) {
+  // Maps the physical block to a logical data group.
+  auto blockGroup = comms::prims::make_block_group();
+  const int blockId = static_cast<int>(blockIdx.x);
+  if (blockId >= args.common.numBlocks) {
+    return;
+  }
+  auto group = logicalDataGroup(blockGroup, blockId, args.common.numBlocks);
+
+  if (args.common.datatype == commFloat32) {
+    ctran::allreduce::fused::
+        runAllReduceFused<float, ctran::allreduce::nvl::direct::Ops>(
+            args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
+              phase2IbRing<float>(args, phaseGroup);
+            });
+  }
+}
+
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
@@ -2,6 +2,8 @@
 
 #if defined(ENABLE_PRIMS)
 
+#include <cuda_fp16.h>
+
 #include <cstdint>
 
 #include "comms/ctran/algos/AllReduce/AllReduceFused.cuh"
@@ -418,6 +420,12 @@ __launch_bounds__(ctran::allreduce::hierring::kBlockSize, 1) void ctranKernelAll
         runAllReduceFused<float, ctran::allreduce::nvl::direct::Ops>(
             args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
               phase2IbRing<float>(args, phaseGroup);
+            });
+  } else if (args.common.datatype == commFloat16) {
+    ctran::allreduce::fused::
+        runAllReduceFused<__half, ctran::allreduce::nvl::direct::Ops>(
+            args.common, group, [&](comms::prims::ThreadGroup& phaseGroup) {
+              phase2IbRing<__half>(args, phaseGroup);
             });
   }
 }

--- a/comms/ctran/algos/AllReduce/AllReduceIbRing.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceIbRing.cuh
@@ -1,0 +1,51 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace ctran::allreduce::hierring {
+
+// Host-safe ring topology POD shared by the host launcher (AllReduceIbRing.cc)
+// and the device KernArgs below. Kept outside the ENABLE_PRIMS guard so it is
+// visible on host-only builds where ENABLE_PRIMS is undefined (e.g. AMD/HIP),
+// mirroring how ctran::allreduce::TreeTopology lives in Types.h.
+struct RingTopology {
+  int prevRank{-1};
+  int nextRank{-1};
+  int nNodes{0};
+  int myNodeIdx{0};
+};
+
+} // namespace ctran::allreduce::hierring
+
+#if defined(ENABLE_PRIMS)
+
+#include "comms/ctran/algos/AllReduce/AllReduceFusedTypes.h"
+#include "comms/ctran/algos/CtranAlgoDev.h"
+#include "comms/utils/commSpecs.h"
+
+namespace ctran::allreduce::hierring {
+
+static constexpr int kRingLanes = 1;
+static constexpr int kBlockSize = ctran::allreduce::common::kBlockSize;
+
+struct KernArgs {
+  ctran::allreduce::common::CommonKernArgs common;
+
+  /**
+   * Per-NVL-variant device-state slot. Empty for NvlDirect; the orchestrator
+   * dispatches the NVL phases through `nvl::direct::Ops`.
+   * `[[no_unique_address]]` keeps `sizeof(KernArgs)` unchanged while empty.
+   */
+  [[no_unique_address]] ctran::allreduce::nvl::direct::ExtraArgs nvl;
+
+  RingTopology ring;
+};
+
+} // namespace ctran::allreduce::hierring
+
+__global__ void ctranKernelAllReduceHierarchicalRing(
+    int* flag,
+    CtranAlgoDeviceState* devState,
+    ctran::allreduce::hierring::KernArgs args);
+
+#endif // ENABLE_PRIMS

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -75,7 +75,7 @@ static inline const std::string allReduceAlgoName(
     case NCCL_ALLREDUCE_ALGO::ctree:
       return "CtranAllReduceTreeDirect";
     case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
-      return "CtranAllReduceRingDirect";
+      return "CtranAllReduceHierarchicalRingDirect";
     default:
       return "Unknown";
   }

--- a/comms/ctran/algos/AllReduce/benchmarks/benchmark_ctree_allreduce.sh
+++ b/comms/ctran/algos/AllReduce/benchmarks/benchmark_ctree_allreduce.sh
@@ -23,7 +23,8 @@ Usage: benchmark_ctree_allreduce.sh [options]
 Options:
   --world-sizes CSV   World sizes to run locally (default: 1,2,3,4,5,6,7,8)
   --topologies CSV    NVL_ONLY,IB_ONLY, or both (default: NVL_ONLY,IB_ONLY)
-  --algorithms CSV    nccl,nccl_tree,nccl_tree_simple,ctree (default: nccl_tree,nccl_tree_simple,ctree)
+  --algorithms CSV    nccl,nccl_tree,nccl_tree_simple,ctree,cthierarchical_ring (default: nccl_tree,nccl_tree_simple,ctree)
+                      (despite the script name, it is multi-algorithm)
   --arch NAME         auto,h100,gb200,gb300 (default: auto)
   --min-bytes VALUE   nccl_allreduce_perf -b value (default: 4)
   --max-bytes VALUE   nccl_allreduce_perf -e value (default: 1G)
@@ -113,6 +114,13 @@ build_perf_binary() {
   )
   if [[ "$arch" == "gb200" || "$arch" == "gb300" ]]; then
     build_flags+=(-c fbcode.platform010-aarch64_clang=17)
+  fi
+  if [[ -n "${USE_MCCL_ADAPTER:-}" ]]; then
+    # Link the MCCL adapter so the binary exercises the LOCAL comms/ctran
+    # AllReduce code (e.g. cthierarchical_ring and the measurement-only
+    # NCCL_CTRAN_ALLREDUCE_RING_FORCE_NBLOCKS override) instead of the pinned
+    # use_ncclx=stable build. Required when sweeping uncommitted kernel changes.
+    build_flags+=(-c hpc_comms.nccl_testonly_override=nccl_adapter -c nccl.enable_profapi=True)
   fi
   if ! buck2 build "${build_flags[@]}" \
     "$BUCK_TARGET" --show-full-json-output >"$json_file"; then
@@ -226,12 +234,27 @@ run_one() {
     fi
   fi
 
-  if [[ "$algorithm" == "ctree" ]]; then
+  # ctree and cthierarchical_ring share the same CTran selection env; the
+  # algorithm name is the NCCL_ALLREDUCE_ALGO CVAR token for both.
+  if [[ "$algorithm" == "ctree" || "$algorithm" == "cthierarchical_ring" ]]; then
     envs+=("NCCL_CTRAN_ENABLE=1")
-    envs+=("NCCL_ALLREDUCE_ALGO=ctree")
+    envs+=("NCCL_ALLREDUCE_ALGO=${algorithm}")
     envs+=("NCCL_CTRAN_USE_PIPES=1")
     envs+=("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE=${NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE:-33554432}")
     envs+=("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1")
+  fi
+
+  # Forward optional ring-tuning knobs (only when set in the caller's env) so a
+  # parameter sweep can vary block count / pipeline / QP depth without further
+  # script edits. Applies to cthierarchical_ring only.
+  if [[ "$algorithm" == "cthierarchical_ring" ]]; then
+    local knob
+    for knob in NCCL_CTRAN_ALLREDUCE_RING_FORCE_NBLOCKS NCCL_CTRAN_MAX_NBLOCKS \
+      NCCL_CTRAN_IBGDA_SENDRECV_PIPELINE_DEPTH NCCL_CTRAN_IBGDA_QP_DEPTH; do
+      if [[ -n "${!knob:-}" ]]; then
+        envs+=("${knob}=${!knob}")
+      fi
+    done
   fi
 
   local -a mpi_envs=()
@@ -246,12 +269,21 @@ run_one() {
     echo "== ${algorithm} ${topology} np=${np} arch=${arch} size=${min_bytes}..${max_bytes} =="
   fi
 
+  # cthierarchical_ring is fp32/sum-only; its support gate does NOT check
+  # dtype/op, so a non-fp32/non-sum run passes the gate then hard-fails inside
+  # ctranAllReduceHierarchicalRing. Pin -d float -o sum (-c 1 = explicit check).
+  # Leave ctree/nccl* on binary defaults to preserve current behavior.
+  local -a dtype_args=()
+  if [[ "$algorithm" == "cthierarchical_ring" ]]; then
+    dtype_args+=("-d" "float" "-o" "sum" "-c" "1")
+  fi
+
   local -a cmd=(
     env "${envs[@]}" "$MPI_BIN" --allow-run-as-root --bind-to none
     --mca btl "^openib" -np "$np" -host "localhost:${np}"
     "${mpi_envs[@]}"
     "$perf_bin" -b "$min_bytes" -e "$max_bytes" -f "$FACTOR" -g 1
-    -n "$ITERS" -w "$WARMUP"
+    -n "$ITERS" -w "$WARMUP" ${dtype_args[@]+"${dtype_args[@]}"}
   )
 
   print_command "${cmd[@]}"
@@ -277,7 +309,7 @@ main() {
 
   local -a algorithm_values
   read_csv_values "$ALGORITHMS" algorithm_values
-  validate_csv_values "algorithm" algorithm_values nccl nccl_tree nccl_tree_simple ctree
+  validate_csv_values "algorithm" algorithm_values nccl nccl_tree nccl_tree_simple ctree cthierarchical_ring
 
   local arch
   arch="$(detect_arch)"

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -299,6 +299,9 @@ class CtranAllReduceTest : public ctran::CtranDistTestFixture,
       case NCCL_ALLREDUCE_ALGO::ctree:
         return ctranAllReduceTree(
             sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
+      case NCCL_ALLREDUCE_ALGO::cthierarchical_ring:
+        return ctranAllReduceHierarchicalRing(
+            sendbuf, recvbuf, count, datatype, redOp, comm, stream, timeout);
       default:
         return commInvalidArgument;
     }
@@ -415,6 +418,16 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     nvlTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    HierRing,
+    NVL_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
+        ::testing::Values(commFloat32),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    nvlTestName);
 #endif
 
 #if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY)
@@ -442,6 +455,77 @@ TEST_P(IB_ONLY, Correctness) {
   runCorrectnessTest(algo, datatype, count, inPlace);
 }
 
+// Locks in the intentional no-fallback contract: cthierarchical_ring rejects
+// unsupported reduction ops and datatypes with commInvalidArgument rather than
+// silently mis-reducing or falling back (see AllReduceIbRing.cc). Runs its
+// assertions exactly once: on the hierring fp32 count==1 out-of-place param at
+// numRanks > 1. globalRank/numRanks are fixture members (see
+// runCorrectnessTest).
+TEST_P(IB_ONLY, HierRingRejectsUnsupported) {
+  const auto algo = std::get<0>(GetParam());
+  const auto datatype = std::get<1>(GetParam());
+  const auto count = std::get<2>(GetParam());
+  const auto inPlace = std::get<3>(GetParam());
+  if (algo != NCCL_ALLREDUCE_ALGO::cthierarchical_ring || count != 1 ||
+      datatype != commFloat32 || inPlace) {
+    GTEST_SKIP()
+        << "negative-path check runs once on hierring fp32 count==1 OOP";
+  }
+  // The (datatype, redOp) guards are only reachable at numRanks > 1; at
+  // numRanks==1 the function returns commSuccess via the memcpy short-circuit
+  // before the guards (e.g. on the IB_ONLY_1x1 target). numRanks is a fixture
+  // member.
+  if (numRanks < 2) {
+    GTEST_SKIP() << "negative-path check requires numRanks > 1";
+  }
+
+  // Guards return commInvalidArgument before dereferencing buffers, so null
+  // buffers are safe here (mirrors the zero-element no-op case above) -- no raw
+  // CUDA allocation needed.
+
+  // Unsupported reduction op (fp32 + commProd) -> explicit invalid argument.
+  EXPECT_EQ(
+      runAllReduce(
+          NCCL_ALLREDUCE_ALGO::cthierarchical_ring,
+          /*sendbuf=*/nullptr,
+          /*recvbuf=*/nullptr,
+          count,
+          commFloat32,
+          commProd,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt),
+      commInvalidArgument)
+      << "rank=" << globalRank << " expected commProd to be rejected";
+
+  // Unsupported datatype (commFloat64 + commSum) -> explicit invalid argument.
+  // commFloat64 stays unsupported even after fp16 lands in Part 2.
+  EXPECT_EQ(
+      runAllReduce(
+          NCCL_ALLREDUCE_ALGO::cthierarchical_ring,
+          /*sendbuf=*/nullptr,
+          /*recvbuf=*/nullptr,
+          count,
+          commFloat64,
+          commSum,
+          ctranComm.get(),
+          testStream,
+          /*timeout=*/std::nullopt),
+      commInvalidArgument)
+      << "rank=" << globalRank << " expected commFloat64 to be rejected";
+}
+
+// NOTE: the host-side IB-transport guards in ctranAllReduceHierarchicalRing
+// (null multiPeerTransport_, lazy-connect mode, and non-P2P_IBGDA ring
+// neighbor) are intentionally NOT exercised here -- they are defensive guards
+// against misconfiguration. None is cleanly reachable from this distributed
+// fixture: a lazy-connect comm (NCCL_CTRAN_IBGDA_LAZY_CONNECT=1) crashes during
+// CtranComm teardown with unmaterialized peers (a separate comm-lifecycle issue
+// unrelated to this algo), and forcing an IBRC/socket-only or null-transport
+// ring neighbor is impractical in this harness. The guards are simple
+// host-side type/null checks that return commInvalidArgument before the kernel
+// dereferences transports[...].p2p_ib.ibgda; see AllReduceIbRing.cc.
+
 inline std::string ibTestName(
     const testing::TestParamInfo<IB_ONLY::ParamType>& info) {
   auto [algo, datatype, count, inPlace] = info.param;
@@ -454,6 +538,16 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
         ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    ibTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    HierRing,
+    IB_ONLY,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
+        ::testing::Values(commFloat32),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     ibTestName);
@@ -483,6 +577,16 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::ctree),
         ::testing::ValuesIn(allReduceDataTypes()),
+        ::testing::ValuesIn(allReduceElementCounts()),
+        ::testing::Bool()),
+    hybridTestName);
+
+INSTANTIATE_TEST_SUITE_P(
+    HierRing,
+    HYBRID,
+    ::testing::Combine(
+        ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
+        ::testing::Values(commFloat32),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     hybridTestName);

--- a/comms/ctran/tests/CtranAllReduceTreeTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTreeTest.cc
@@ -424,7 +424,7 @@ INSTANTIATE_TEST_SUITE_P(
     NVL_ONLY,
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
-        ::testing::Values(commFloat32),
+        ::testing::ValuesIn(allReduceDataTypes()),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     nvlTestName);
@@ -547,7 +547,7 @@ INSTANTIATE_TEST_SUITE_P(
     IB_ONLY,
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
-        ::testing::Values(commFloat32),
+        ::testing::ValuesIn(allReduceDataTypes()),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     ibTestName);
@@ -586,7 +586,7 @@ INSTANTIATE_TEST_SUITE_P(
     HYBRID,
     ::testing::Combine(
         ::testing::Values(NCCL_ALLREDUCE_ALGO::cthierarchical_ring),
-        ::testing::Values(commFloat32),
+        ::testing::ValuesIn(allReduceDataTypes()),
         ::testing::ValuesIn(allReduceElementCounts()),
         ::testing::Bool()),
     hybridTestName);

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -99,6 +99,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
 endif
 ## CollTrace plugin source files

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -107,6 +107,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/utils/hrdw_ring_buffer/GpuClockCalibration.cu
 LIBSRCFILES += ${BASE_DIR}/comms/utils/colltrace/HRDWRingBufferInstantiations.cu
 ifeq ($(ENABLE_PRIMS),1)
 ## CTRAN CUDA source files
+LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbRing.cu
 LIBSRCFILES += ${BASE_DIR}/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
 endif
 ## CollTrace plugin source files

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cu
@@ -416,4 +416,229 @@ void runTestWaitSignalNoTimeout(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+// =============================================================================
+// Resumable-forward (init_forward_progress / progress_forward_once) unit tests
+//
+// These exercise ONLY the no-NIC paths: zero-byte init, init state layout, and
+// the first DATA_READY yield (which returns before any signal/put). The
+// NIC-touching paths (CopyOp::forward, prev SLOT_FREE signal, fwd put, and the
+// NIC_DONE/SLOT_FREE backpressure waits — which only arise once the pipeline
+// fills) require real QPs and are covered by the distributed
+// recv_forward_chain_test. Guarded NVIDIA-only because progress_forward_once
+// carries a dependent `static_assert(sizeof(CopyOp)==0)` on AMD.
+// =============================================================================
+#ifndef __HIP_PLATFORM_AMD__
+namespace {
+
+// Build a transport handle over caller-provided device buffers, with a
+// populated IbSendRecvState but an empty NIC span (no QPs).
+__device__ __forceinline__ P2pIbgdaTransportDevice makeUnitForwardTransport(
+    IbSendRecvState::ProgressSlot* state,
+    uint64_t* signalBuf,
+    uint64_t* counterBuf,
+    char* sendStaging,
+    char* recvStaging,
+    int maxGroups,
+    int pipelineDepth,
+    std::size_t dataBufferSize) {
+  // Aggregate (designated) init: DeviceSpan has a const data member, so its
+  // copy-assignment is deleted — `s.state = ...` won't compile; set every field
+  // at construction instead. Designators are in declaration order.
+  IbSendRecvState s = {
+      .sendStagingPtr = sendStaging,
+      .recvStagingPtr = recvStaging,
+      .localSignalBuf = IbgdaLocalBuffer(signalBuf, NetworkLKeys{}),
+      .localCounterBuf = IbgdaLocalBuffer(counterBuf, NetworkLKeys{}),
+      .state = DeviceSpan<IbSendRecvState::ProgressSlot>(
+          state, static_cast<uint32_t>(2 * maxGroups)),
+      .maxGroups = maxGroups,
+      .pipelineDepth = pipelineDepth,
+      .dataBufferSize = dataBufferSize,
+  };
+  return P2pIbgdaTransportDevice(
+      DeviceSpan<NicDeviceIbgdaResources>{},
+      IbgdaRemoteBuffer{},
+      IbgdaLocalBuffer{},
+      IbgdaLocalBuffer{},
+      /*numSignalSlots=*/0,
+      /*numCounterSlots=*/0,
+      s);
+}
+
+} // namespace
+
+// scenario: 0 = zero-byte init -> Done; 1 = init state layout; 2 = DATA_READY
+// yield (recvSignal[groupId] preset just below the chunk's streamEnd by host).
+__global__ void testForwardProgressNoQp(
+    IbSendRecvState::ProgressSlot* recvState,
+    uint64_t* recvSignal,
+    uint64_t* recvCounter,
+    char* recvStaging,
+    IbSendRecvState::ProgressSlot* fwdState,
+    uint64_t* fwdSignal,
+    uint64_t* fwdCounter,
+    char* fwdStaging,
+    int maxGroups,
+    int pipelineDepth,
+    std::size_t dataBufferSize,
+    int scenario,
+    std::size_t nbytes,
+    bool* success) {
+  auto group = make_block_group();
+  P2pIbgdaTransportDevice self = makeUnitForwardTransport(
+      recvState,
+      recvSignal,
+      recvCounter,
+      /*sendStaging=*/recvStaging,
+      /*recvStaging=*/recvStaging,
+      maxGroups,
+      pipelineDepth,
+      dataBufferSize);
+  P2pIbgdaTransportDevice fwd = makeUnitForwardTransport(
+      fwdState,
+      fwdSignal,
+      fwdCounter,
+      /*sendStaging=*/fwdStaging,
+      /*recvStaging=*/fwdStaging,
+      maxGroups,
+      pipelineDepth,
+      dataBufferSize);
+
+  // Self's recv slot index and fwd's send slot index for group_id 0.
+  const int recvSlotIdx = maxGroups; // recv base + group_id(0)
+  const int sendSlotIdx = 0; // send base + group_id(0)
+
+  if (scenario == 0) {
+    self.init_forward_progress(group, fwd, /*nbytes=*/0, maxGroups);
+    group.sync();
+    IbgdaSendRecvProgressStatus st = self.progress_forward_once(
+        group, nullptr, fwd, /*nbytes=*/0, maxGroups);
+    if (group.is_leader()) {
+      if (recvState[recvSlotIdx].activeStage !=
+          detail::IbSendRecvProgressStage::Done) {
+        *success = false;
+      }
+      if (fwdState[sendSlotIdx].activeStage !=
+          detail::IbSendRecvProgressStage::Done) {
+        *success = false;
+      }
+      if (st != IbgdaSendRecvProgressStatus::Done) {
+        *success = false;
+      }
+    }
+  } else if (scenario == 1) {
+    self.init_forward_progress(group, fwd, nbytes, maxGroups);
+    group.sync();
+    if (group.is_leader()) {
+      const auto& rs = recvState[recvSlotIdx];
+      const auto& fs = fwdState[sendSlotIdx];
+      if (rs.activeStage != detail::IbSendRecvProgressStage::FwdWaitDataReady) {
+        *success = false;
+      }
+      if (rs.activeNextByte != 0 || rs.activeBaseStep != 0) {
+        *success = false;
+      }
+      if (rs.nextStep != static_cast<int64_t>(nbytes)) {
+        *success = false; // recv cursor reserved at init
+      }
+      if (fs.activeStage != detail::IbSendRecvProgressStage::Busy) {
+        *success = false;
+      }
+      if (fs.activeNextByte != 0 || fs.activeBaseStep != 0) {
+        *success = false;
+      }
+      if (fs.nextStep != static_cast<int64_t>(nbytes)) {
+        *success = false; // send cursor reserved at init (lockstep base)
+      }
+    }
+  } else if (scenario == 2) {
+    // scenario 2: DATA_READY not yet at the chunk's streamEnd -> Waiting, no
+    // side effect, stage unchanged.
+    self.init_forward_progress(group, fwd, nbytes, maxGroups);
+    group.sync();
+    IbgdaSendRecvProgressStatus st =
+        self.progress_forward_once(group, nullptr, fwd, nbytes, maxGroups);
+    if (group.is_leader()) {
+      if (st != IbgdaSendRecvProgressStatus::Waiting) {
+        *success = false;
+      }
+      if (recvState[recvSlotIdx].activeStage !=
+          detail::IbSendRecvProgressStage::FwdWaitDataReady) {
+        *success = false;
+      }
+      if (recvState[recvSlotIdx].activeNextByte != 0) {
+        *success = false;
+      }
+    }
+  } else {
+    // scenario 3: DATA_READY satisfied (recvSignal preset >= streamEnd) but fwd
+    // NIC_DONE not ready -> the call advances FwdWaitDataReady ->
+    // FwdWaitNicDone (a side-effect-free transition) and returns Progressed
+    // with the new stage persisted. To make the NIC_DONE wait actually run on
+    // the first chunk (otherwise skipped while the pipeline is not full),
+    // pre-advance the fwd send slot's reserved base so fwdStreamEnd >
+    // fwdPipelineBytes. No NIC: the counter/signal reads are plain memory; the
+    // call returns before any put.
+    const std::size_t perBlockSlot =
+        (dataBufferSize / maxGroups) & ~static_cast<std::size_t>(15);
+    const std::size_t fwdPipelineBytes =
+        perBlockSlot * static_cast<std::size_t>(pipelineDepth);
+    if (group.is_leader()) {
+      fwdState[sendSlotIdx].nextStep =
+          static_cast<int64_t>(8 * fwdPipelineBytes);
+    }
+    group.sync();
+    self.init_forward_progress(group, fwd, nbytes, maxGroups);
+    group.sync();
+    IbgdaSendRecvProgressStatus st =
+        self.progress_forward_once(group, nullptr, fwd, nbytes, maxGroups);
+    if (group.is_leader()) {
+      if (st != IbgdaSendRecvProgressStatus::Progressed) {
+        *success = false;
+      }
+      if (recvState[recvSlotIdx].activeStage !=
+          detail::IbSendRecvProgressStage::FwdWaitNicDone) {
+        *success = false;
+      }
+      if (recvState[recvSlotIdx].activeNextByte != 0) {
+        *success = false;
+      }
+    }
+  }
+}
+
+void runTestForwardProgressNoQp(
+    IbSendRecvState::ProgressSlot* recvState,
+    uint64_t* recvSignal,
+    uint64_t* recvCounter,
+    char* recvStaging,
+    IbSendRecvState::ProgressSlot* fwdState,
+    uint64_t* fwdSignal,
+    uint64_t* fwdCounter,
+    char* fwdStaging,
+    int maxGroups,
+    int pipelineDepth,
+    std::size_t dataBufferSize,
+    int scenario,
+    std::size_t nbytes,
+    bool* d_success) {
+  testForwardProgressNoQp<<<1, 128>>>(
+      recvState,
+      recvSignal,
+      recvCounter,
+      recvStaging,
+      fwdState,
+      fwdSignal,
+      fwdCounter,
+      fwdStaging,
+      maxGroups,
+      pipelineDepth,
+      dataBufferSize,
+      scenario,
+      nbytes,
+      d_success);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTest.cuh
@@ -94,4 +94,31 @@ void runTestWaitSignalNoTimeout(
     uint32_t timeout_ms,
     bool* d_success);
 
+// =============================================================================
+// Resumable-forward (init_forward_progress / progress_forward_once) unit tests
+// =============================================================================
+
+#ifndef __HIP_PLATFORM_AMD__
+// Drive a single no-NIC resumable-forward scenario over caller-provided device
+// buffers (two transport handles with populated IbSendRecvState, empty NIC
+// span). scenario: 0 = zero-byte init -> Done; 1 = init state layout; 2 =
+// DATA_READY yield (recvSignal[0] must be preset just below the chunk's
+// streamEnd). Writes false to *d_success on any mismatch.
+void runTestForwardProgressNoQp(
+    IbSendRecvState::ProgressSlot* recvState,
+    uint64_t* recvSignal,
+    uint64_t* recvCounter,
+    char* recvStaging,
+    IbSendRecvState::ProgressSlot* fwdState,
+    uint64_t* fwdSignal,
+    uint64_t* fwdCounter,
+    char* fwdStaging,
+    int maxGroups,
+    int pipelineDepth,
+    std::size_t dataBufferSize,
+    int scenario,
+    std::size_t nbytes,
+    bool* d_success);
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests

--- a/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
+++ b/comms/prims/tests/P2pIbgdaTransportDeviceTestMain.cc
@@ -392,6 +392,128 @@ TEST_F(P2pIbgdaWaitSignalTimeoutTest, WaitSignalNoTimeoutWhenSatisfied) {
 
 #endif // !__HIP_PLATFORM_AMD__
 
+// =============================================================================
+// Resumable-forward (init_forward_progress / progress_forward_once) unit tests
+//
+// No-NIC coverage only: zero-byte init, init state layout, and the first
+// DATA_READY yield. The NIC-touching reduce/signal/put paths and the
+// NIC_DONE/SLOT_FREE backpressure waits need real QPs and live in the
+// distributed recv_forward_chain_test (ForwardWithCopyProgress / etc.).
+// =============================================================================
+#ifndef __HIP_PLATFORM_AMD__
+namespace {
+
+// maxGroups=1, pipelineDepth=2, dataBufferSize=256 => perBlockSlot=256, so a
+// single 128-byte chunk has streamEnd=128 (< pipelineBytes=512: the
+// backpressure waits are skipped, keeping every path no-NIC).
+void runForwardNoQpScenario(int scenario, std::size_t nbytes) {
+  using ProgressSlot = IbSendRecvState::ProgressSlot;
+  constexpr int kMaxGroups = 1;
+  constexpr int kPipelineDepth = 2;
+  constexpr std::size_t kDataBufferSize = 256;
+  const std::size_t kStateBytes = 2 * kMaxGroups * sizeof(ProgressSlot);
+  const std::size_t kSignalBytes = 2 * kMaxGroups * sizeof(uint64_t);
+  const std::size_t kCounterBytes = kMaxGroups * sizeof(uint64_t);
+  const std::size_t kStagingBytes = kPipelineDepth * kDataBufferSize;
+
+  DeviceBuffer recvStateBuf(kStateBytes);
+  DeviceBuffer recvSignalBuf(kSignalBytes);
+  DeviceBuffer recvCounterBuf(kCounterBytes);
+  DeviceBuffer recvStagingBuf(kStagingBytes);
+  DeviceBuffer fwdStateBuf(kStateBytes);
+  DeviceBuffer fwdSignalBuf(kSignalBytes);
+  DeviceBuffer fwdCounterBuf(kCounterBytes);
+  DeviceBuffer fwdStagingBuf(kStagingBytes);
+
+  // Zero everything: zeroed ProgressSlot => activeStage Done (idle), nextStep
+  // 0.
+  CUDACHECK_TEST(cudaMemset(recvStateBuf.get(), 0, kStateBytes));
+  CUDACHECK_TEST(cudaMemset(recvSignalBuf.get(), 0, kSignalBytes));
+  CUDACHECK_TEST(cudaMemset(recvCounterBuf.get(), 0, kCounterBytes));
+  CUDACHECK_TEST(cudaMemset(recvStagingBuf.get(), 0, kStagingBytes));
+  CUDACHECK_TEST(cudaMemset(fwdStateBuf.get(), 0, kStateBytes));
+  CUDACHECK_TEST(cudaMemset(fwdSignalBuf.get(), 0, kSignalBytes));
+  CUDACHECK_TEST(cudaMemset(fwdCounterBuf.get(), 0, kCounterBytes));
+  CUDACHECK_TEST(cudaMemset(fwdStagingBuf.get(), 0, kStagingBytes));
+
+  // scenario 2: preset DATA_READY (recv signal slot group_id 0) just below the
+  // chunk's streamEnd (== nbytes for a single sub-pipeline chunk) so the first
+  // progress call yields Waiting without touching a NIC.
+  if (scenario == 2) {
+    const uint64_t dataReady = static_cast<uint64_t>(nbytes) - 1;
+    CUDACHECK_TEST(cudaMemcpy(
+        recvSignalBuf.get(),
+        &dataReady,
+        sizeof(uint64_t),
+        cudaMemcpyHostToDevice));
+  } else if (scenario == 3) {
+    // DATA_READY satisfied (>= streamEnd == nbytes for the first chunk) so the
+    // call clears DATA_READY and reaches the (unsatisfied) NIC_DONE wait.
+    const uint64_t dataReady = static_cast<uint64_t>(nbytes);
+    CUDACHECK_TEST(cudaMemcpy(
+        recvSignalBuf.get(),
+        &dataReady,
+        sizeof(uint64_t),
+        cudaMemcpyHostToDevice));
+  }
+
+  DeviceBuffer successBuf(sizeof(bool));
+  auto* d_success = static_cast<bool*>(successBuf.get());
+  bool initSuccess = true;
+  CUDACHECK_TEST(cudaMemcpy(
+      d_success, &initSuccess, sizeof(bool), cudaMemcpyHostToDevice));
+
+  runTestForwardProgressNoQp(
+      static_cast<ProgressSlot*>(recvStateBuf.get()),
+      static_cast<uint64_t*>(recvSignalBuf.get()),
+      static_cast<uint64_t*>(recvCounterBuf.get()),
+      static_cast<char*>(recvStagingBuf.get()),
+      static_cast<ProgressSlot*>(fwdStateBuf.get()),
+      static_cast<uint64_t*>(fwdSignalBuf.get()),
+      static_cast<uint64_t*>(fwdCounterBuf.get()),
+      static_cast<char*>(fwdStagingBuf.get()),
+      kMaxGroups,
+      kPipelineDepth,
+      kDataBufferSize,
+      scenario,
+      nbytes,
+      d_success);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  bool success = false;
+  CUDACHECK_TEST(
+      cudaMemcpy(&success, d_success, sizeof(bool), cudaMemcpyDeviceToHost));
+  EXPECT_TRUE(success);
+}
+
+} // namespace
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressZeroByteInit) {
+  // Zero-byte init marks both slots Done; progress returns Done immediately.
+  runForwardNoQpScenario(/*scenario=*/0, /*nbytes=*/0);
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressInitState) {
+  // init reserves both byte cursors, sets prev-recv slot FwdWaitDataReady and
+  // next-send slot Busy, with lockstep zero activeNextByte/activeBaseStep.
+  runForwardNoQpScenario(/*scenario=*/1, /*nbytes=*/128);
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressDataReadyYield) {
+  // DATA_READY below the chunk streamEnd => Waiting, no side effect, stage
+  // unchanged (also validates the recv-side geometry / streamEnd computation).
+  runForwardNoQpScenario(/*scenario=*/2, /*nbytes=*/128);
+}
+
+TEST_F(P2pIbgdaTransportDeviceTestFixture, ForwardProgressNicDoneYield) {
+  // DATA_READY satisfied but fwd NIC_DONE not ready => the call transitions
+  // FwdWaitDataReady -> FwdWaitNicDone and returns Progressed (not Waiting),
+  // with the new stage persisted. Asserts the return-status contract for a
+  // side-effect-free transition without needing a NIC.
+  runForwardNoQpScenario(/*scenario=*/3, /*nbytes=*/128);
+}
+#endif // !__HIP_PLATFORM_AMD__
+
 } // namespace comms::prims::tests
 
 int main(int argc, char** argv) {

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -355,6 +355,371 @@ TEST_F(RecvForwardChainTest, MultiSection) {
   }
 }
 
+// =============================================================================
+// Resumable-forward parity tests: identical setup/checks to the blocking
+// chain tests above, but intermediates drive init_forward_progress /
+// progress_forward_once. A green result is byte-parity with blocking forward.
+// =============================================================================
+
+// Parity with ForwardWithCopy (dst != nullptr; every rank but rank 0 receives).
+TEST_F(RecvForwardChainTest, ForwardWithCopyProgress) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xCA;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_progress(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches (resumable forward)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Parity with ForwardOnly (dst == nullptr; only the last rank receives).
+TEST_F(RecvForwardChainTest, ForwardOnlyProgress) {
+  if (worldSize < 3) {
+    XLOGF(INFO, "Skipping: requires >= 3 ranks for forward-only test");
+    return;
+  }
+
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024;
+  constexpr int kNumBlocks = 4;
+
+  try {
+    auto transport = create_transport(kDataBytes, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xBE;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_progress_no_dst(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank == worldSize - 1) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Last rank: " << errors
+                           << " byte mismatches (resumable forward-only)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Parity with MultiSection: transfer spans several pipeline windows so the
+// resumable forward exercises the NIC_DONE / SLOT_FREE backpressure waits and
+// multi-chunk replay (the no-QP unit tests cannot reach these).
+TEST_F(RecvForwardChainTest, MultiSectionProgress) {
+  if (worldSize < 2) {
+    XLOGF(INFO, "Skipping: requires >= 2 ranks, got {}", worldSize);
+    return;
+  }
+
+  constexpr std::size_t kSlotSize = 512 * 1024;
+  constexpr std::size_t kDataBytes = 4 * kSlotSize; // 4 sections
+  constexpr int kNumBlocks = 2;
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xDD;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_progress(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches (resumable multi-section)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Non-16B-aligned resumable forward: a single-group (num_blocks=1) chain with a
+// transfer size that is not a multiple of 16 exercises the non-aligned tail of
+// CopyOp::forward / the RDMA put through the resumable path. Byte-parity with
+// the source pattern is the check.
+TEST_F(RecvForwardChainTest, ForwardWithCopyProgressNonAligned) {
+  if (worldSize < 3) {
+    XLOGF(INFO, "Skipping: requires >= 3 ranks to exercise a forward");
+    return;
+  }
+
+  constexpr std::size_t kSlotSize = 256 * 1024;
+  constexpr std::size_t kDataBytes = 65537; // not a multiple of 16
+  constexpr int kNumBlocks = 1;
+
+  try {
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0xA7;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_progress(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches (resumable non-16B forward)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+// Interleaved multi-lane: a single block per rank multiplexes 2 forwards over
+// distinct group_ids (the resumable API's purpose). Byte-parity confirms the
+// two lanes do not corrupt each other's staging/cursors.
+TEST_F(RecvForwardChainTest, ForwardInterleaved2LaneProgress) {
+  if (worldSize < 3) {
+    XLOGF(INFO, "Skipping: requires >= 3 ranks to exercise a forward");
+    return;
+  }
+
+  constexpr std::size_t kSlotSize = 256 * 1024;
+  constexpr std::size_t kDataBytes = 1 * 1024 * 1024; // 2 lanes x multi-window
+  constexpr int kMaxGroups = 2; // == kLanes in the kernel
+
+  try {
+    auto transport = create_transport(kSlotSize, kMaxGroups);
+
+    DeviceBuffer sendBuf(kDataBytes);
+    DeviceBuffer recvBuf(kDataBytes);
+
+    const uint8_t fillPattern = 0x3C;
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), fillPattern, kDataBytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, kDataBytes));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peer_transports(worldSize, nullptr);
+    for (int r = 0; r < worldSize; ++r) {
+      if (r != globalRank) {
+        peer_transports[r] = transport->getP2pTransportDevice(r);
+      }
+    }
+    DeviceBuffer d_transports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        d_transports.get(),
+        peer_transports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_chain_2lane_progress(
+        static_cast<P2pIbgdaTransportDevice**>(d_transports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        kDataBytes,
+        globalRank,
+        worldSize,
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0) {
+      std::vector<uint8_t> hostBuf(kDataBytes);
+      CUDACHECK_TEST(cudaMemcpy(
+          hostBuf.data(), recvBuf.get(), kDataBytes, cudaMemcpyDeviceToHost));
+
+      int errors = 0;
+      for (std::size_t i = 0; i < kDataBytes; ++i) {
+        if (hostBuf[i] != fillPattern) {
+          ++errors;
+        }
+      }
+      EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
+                           << " byte mismatches (interleaved 2-lane forward)";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
 } // namespace comms::prims::tests
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -94,4 +94,195 @@ void launch_recv_forward_chain_no_dst(
   }
 }
 
+// Resumable-forward variant of the chain. Intermediate ranks drive the
+// yield-able init_forward_progress / progress_forward_once to completion on a
+// single lane (loop until Done); endpoints keep blocking send()/recv(), which
+// are wire-compatible (a send -> forward* -> recv chain is valid regardless of
+// whether each forward is blocking or resumable). Byte-parity with the blocking
+// chain validates the resumable forward's fused recv+reduce+send residency, the
+// step-4-before-step-5 ordering, and the replay-safe yields (the dependency
+// waits on later pipeline chunks exercise the real signal/counter/put paths).
+__global__ void recv_forward_chain_progress_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    bool use_dst) {
+  auto group = make_block_group();
+  const auto num_blocks = gridDim.x;
+
+  const std::size_t per_block = (nbytes / num_blocks) & ~15ULL;
+  const std::size_t my_off = group.group_id * per_block;
+  const std::size_t my_bytes =
+      (group.group_id == num_blocks - 1) ? (nbytes - my_off) : per_block;
+
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    // First rank: send to next (blocking endpoint).
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    next.send(group, send_buf + my_off, my_bytes, num_blocks);
+  } else if (my_rank == world_size - 1) {
+    // Last rank: receive from prev (blocking endpoint).
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    prev.recv(group, recv_buf + my_off, my_bytes, num_blocks);
+  } else {
+    // Intermediate rank: resumable forward (this=prev/recv, fwd=next/send).
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    char* dst = use_dst ? (recv_buf + my_off) : nullptr;
+    prev.init_forward_progress(group, next, my_bytes, num_blocks);
+    IbgdaSendRecvProgressStatus status = IbgdaSendRecvProgressStatus::Waiting;
+    do {
+      status =
+          prev.progress_forward_once(group, dst, next, my_bytes, num_blocks);
+    } while (status != IbgdaSendRecvProgressStatus::Done);
+  }
+}
+
+void launch_recv_forward_chain_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_progress_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_progress kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+void launch_recv_forward_chain_progress_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream) {
+  recv_forward_chain_progress_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/false);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_progress_no_dst kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+// Interleaved multi-lane resumable-forward chain. A SINGLE CUDA block per rank
+// drives kLanes (2) independent transfers over distinct transport group_ids
+// (0 and 1), round-robining progress_forward_once so a stalled lane yields to
+// the other — the multiplexing that motivates the resumable API. Endpoints use
+// blocking send/recv per lane (wire-compatible). active_blocks = kLanes. Data
+// is split into 2 lane slices; byte-parity validates that two concurrent
+// forwards on distinct group_ids do not corrupt each other's staging/cursors.
+__global__ void recv_forward_chain_2lane_progress_kernel(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    bool use_dst) {
+  constexpr int kLanes = 2;
+  const std::size_t lane0 = (nbytes / kLanes) & ~15ULL;
+  const std::size_t laneBytes[kLanes] = {lane0, nbytes - lane0};
+  const std::size_t laneOff[kLanes] = {0, lane0};
+
+  // One block-scope group per lane, with distinct group_ids 0..kLanes-1 and
+  // total_groups = kLanes (= active_blocks passed to the transport).
+  ThreadGroup lanes[kLanes];
+  for (int L = 0; L < kLanes; ++L) {
+    lanes[L] = ThreadGroup{
+        .thread_id_in_group = threadIdx.x,
+        .group_size = blockDim.x,
+        .group_id = static_cast<uint32_t>(L),
+        .total_groups = static_cast<uint32_t>(kLanes),
+        .scope = SyncScope::BLOCK};
+  }
+
+  const int prev_rank = (my_rank - 1 + world_size) % world_size;
+  const int next_rank = (my_rank + 1) % world_size;
+
+  if (my_rank == 0) {
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    for (int L = 0; L < kLanes; ++L) {
+      next.send(lanes[L], send_buf + laneOff[L], laneBytes[L], kLanes);
+    }
+  } else if (my_rank == world_size - 1) {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    for (int L = 0; L < kLanes; ++L) {
+      prev.recv(lanes[L], recv_buf + laneOff[L], laneBytes[L], kLanes);
+    }
+  } else {
+    P2pIbgdaTransportDevice& prev = *transports[prev_rank];
+    P2pIbgdaTransportDevice& next = *transports[next_rank];
+    char* dst[kLanes] = {
+        use_dst ? recv_buf + laneOff[0] : nullptr,
+        use_dst ? recv_buf + laneOff[1] : nullptr};
+    for (int L = 0; L < kLanes; ++L) {
+      prev.init_forward_progress(lanes[L], next, laneBytes[L], kLanes);
+    }
+    bool done[kLanes] = {laneBytes[0] == 0, laneBytes[1] == 0};
+    while (!done[0] || !done[1]) {
+      for (int L = 0; L < kLanes; ++L) {
+        if (!done[L]) {
+          done[L] = prev.progress_forward_once(
+                        lanes[L], dst[L], next, laneBytes[L], kLanes) ==
+              IbgdaSendRecvProgressStatus::Done;
+        }
+      }
+    }
+  }
+}
+
+void launch_recv_forward_chain_2lane_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    cudaStream_t stream) {
+  // Single block per rank: the 2 lanes are multiplexed within one block.
+  recv_forward_chain_2lane_progress_kernel<<<1, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/true);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_chain_2lane_progress kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
 } // namespace comms::prims::test

--- a/comms/prims/tests/RecvForwardChainTest.h
+++ b/comms/prims/tests/RecvForwardChainTest.h
@@ -49,4 +49,50 @@ void launch_recv_forward_chain_no_dst(
     int num_blocks,
     cudaStream_t stream);
 
+/**
+ * Resumable-forward variant of launch_recv_forward_chain: intermediates drive
+ * init_forward_progress / progress_forward_once to completion (single lane);
+ * endpoints use blocking send/recv. Used to assert byte-parity with the
+ * blocking forward chain.
+ */
+void launch_recv_forward_chain_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Resumable-forward, forward-only (dst=nullptr for intermediates). Only the
+ * last rank writes to recv_buf.
+ */
+void launch_recv_forward_chain_progress_no_dst(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Interleaved multi-lane resumable-forward chain: a single block per rank
+ * drives 2 lanes (distinct group_ids) round-robin. active_blocks = 2; data is
+ * split into 2 lane slices. Validates that concurrent forwards on distinct
+ * group_ids multiplex without corrupting each other. Always uses dst !=
+ * nullptr.
+ */
+void launch_recv_forward_chain_2lane_progress(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    cudaStream_t stream);
+
 } // namespace comms::prims::test

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -418,12 +418,26 @@ struct IbgdaBufferExchInfo {
 namespace detail {
 
 /**
- * Internal stage for one transport-owned resumable send/recv operation.
+ * Internal stage for one transport-owned resumable send/recv/forward operation.
  *
  * `Done` is intentionally zero so freshly zeroed transport memory starts idle.
  * Send operations use `WaitNicDone` and `WaitSlotFree`; recv operations use
  * `WaitDataReady`. Blocking send/recv temporarily use `Busy` to make
  * same-direction overlap fail explicitly instead of sharing a cursor.
+ *
+ * Resumable `forward` (`init_forward_progress`/`progress_forward_once`) bridges
+ * two transports — `this` (the prev/recv side) and `fwd` (the next/send side).
+ * Its combined yield-point stage is stored **only in the prev-recv slot's**
+ * `activeStage` and takes the `Fwd*` values below (the three wait points plus
+ * `Done`). The `Fwd*` stages are durable yield points only: the non-idempotent
+ * side effects (the fused `CopyOp::forward`, the prev SLOT_FREE signal, and the
+ * fwd RDMA put) run *during* a transition and the new stage is persisted only
+ * *after* them, so a re-entry never replays a side effect. The **next-send
+ * slot** stays `Busy` for the whole forward (a non-resumable ownership marker,
+ * exactly as the blocking `forward`/`send`/`recv` use it) and is cleared to
+ * `Done` only when the entire forward completes. The send/recv progress
+ * validators/transition table deliberately reject every `Fwd*` value, and the
+ * forward path uses its own dedicated validator/transition table.
  */
 enum class IbSendRecvProgressStage : uint8_t {
   Done,
@@ -431,6 +445,12 @@ enum class IbSendRecvProgressStage : uint8_t {
   WaitSlotFree,
   WaitDataReady,
   Busy,
+  // Resumable-forward yield points (prev-recv slot only). Appended after the
+  // existing values so the on-HBM encoding of Done/Wait*/Busy is unchanged.
+  FwdWaitDataReady, // step 1: waiting on prev DATA_READY (no side effect yet)
+  FwdWaitNicDone, // step 2: DATA_READY cleared; waiting on fwd NIC_DONE
+  FwdWaitSlotFree, // steps 3-4 done (reduce + prev SLOT_FREE); waiting fwd
+                   // SLOT_FREE before the put
 };
 
 } // namespace detail

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -1642,6 +1642,21 @@ class P2pIbgdaTransportDevice {
    * `group.group_id` and direction. A caller may have one send and one recv in
    * flight for the same group, but a second send or second recv init for the
    * same group before the previous operation reaches `Done` traps on device.
+   *
+   * Resumable forward (`init_forward_progress`/`progress_forward_once`) is the
+   * yield-able counterpart of the blocking `forward()`. It bridges two
+   * transports — `this` (prev/recv) and `fwd` (next/send) — and reuses **both**
+   * `this`'s recv slot and `fwd`'s send slot (no third slot, no allocation
+   * change). The combined forward stage machine lives in the **prev-recv
+   * slot's** `activeStage` and cycles `FwdWaitDataReady -> FwdWaitNicDone ->
+   * FwdWaitSlotFree -> {FwdWaitDataReady (next chunk) | Done}`; the **next-send
+   * slot** stays `Busy` for the whole operation. Both slots' `nextStep` byte
+   * cursors are **reserved once at init** (unlike blocking send/recv/forward,
+   * which commit `nextStep` at completion) and `progress_forward_once` advances
+   * only `activeNextByte`, in lockstep across the two slots. The fused
+   * recv+reduce+send residency (partial stays in `fwd`'s send staging) is
+   * identical to blocking `forward()`, so a single-lane forward chain is
+   * protocol- and performance-equivalent while remaining multiplexable.
    */
 
   /**
@@ -2868,6 +2883,427 @@ class P2pIbgdaTransportDevice {
 #endif
   }
 
+  /**
+   * Initialize transport-owned state for one resumable (yield-able) forward.
+   *
+   * This is the resumable counterpart of the blocking `forward()`: it fuses a
+   * recv on `this` (the prev side) with a send on `fwd` (the next side) while
+   * being driven across many bounded `progress_forward_once()` calls so a
+   * scheduler can multiplex several independent lanes from one kernel.
+   *
+   * Like the blocking `forward()`, it uses **two** transport slots — `this`'s
+   * recv slot and `fwd`'s send slot — and reserves **both** byte cursors up
+   * front (blocking `forward()` instead commits them at completion). The fused
+   * recv+reduce+send residency is identical to `forward()`: the partial lives
+   * in `fwd`'s send staging, so there is no extra scratch buffer.
+   *
+   * State model: the combined forward stage lives in the **prev-recv slot's**
+   * `activeStage` (the `Fwd*` values); the **next-send slot** is marked `Busy`
+   * for the whole operation and both slots' `activeNextByte` advance in
+   * lockstep. Both slots must be idle (re-initializing a busy slot traps).
+   * `init` is all-or-nothing: it asserts both slots idle and validates both
+   * geometries before reserving either cursor, so a bad geometry never leaves
+   * one cursor half-reserved.
+   *
+   * Zero-byte forwards mark both slots `Done` without reading or validating
+   * staging geometry, matching the blocking
+   * `forward()`/`init_send/recv_progress` no-op behavior so schedulers can
+   * treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param fwd Forward transport (sends to the next peer in the ring).
+   * @param nbytes Number of user-buffer bytes to receive-and-forward.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_forward_progress(
+      ThreadGroup& group,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int recvIndex = progress_recv_index(group);
+    const int fwdIndex = fwd.progress_send_index(group);
+    auto& recvSlot = progress_state_slot(group, recvIndex);
+    auto& fwdSlot = fwd.progress_state_slot(group, fwdIndex);
+    // All-or-nothing ordering: assert BOTH slots idle, then validate BOTH
+    // geometries, only then reserve BOTH cursors. Any failure traps before a
+    // cursor is reserved, so the two slots never diverge.
+    assert_progress_slot_idle(group, recvSlot, "forward recv");
+    fwd.assert_progress_slot_idle(group, fwdSlot, "forward send");
+
+    IbSendRecvState::ProgressSlot recvState{};
+    IbSendRecvState::ProgressSlot fwdState{};
+    if (nbytes == 0) {
+      recvState.activeStage = detail::IbSendRecvProgressStage::Done;
+      fwdState.activeStage = detail::IbSendRecvProgressStage::Done;
+      store_progress_state(group, recvIndex, recvState);
+      fwd.store_progress_state(group, fwdIndex, fwdState);
+      return;
+    }
+
+    // Validate both transfers before reserving either transport byte cursor.
+    (void)make_progress_geometry(
+        group,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        "init_forward_progress");
+    (void)fwd.make_progress_geometry(
+        group,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        "init_forward_progress");
+
+    recvState.activeBaseStep = reserve_progress_step(group, recvIndex, nbytes);
+    recvState.activeStage = detail::IbSendRecvProgressStage::FwdWaitDataReady;
+    fwdState.activeBaseStep =
+        fwd.reserve_progress_step(group, fwdIndex, nbytes);
+    fwdState.activeStage = detail::IbSendRecvProgressStage::Busy;
+
+    store_progress_state(group, recvIndex, recvState);
+    fwd.store_progress_state(group, fwdIndex, fwdState);
+#else
+    (void)group;
+    (void)fwd;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized resumable forward.
+   *
+   * Advances at most one fused recv+reduce+send chunk and never spins: at each
+   * of the three wait points (prev DATA_READY, fwd NIC_DONE, fwd SLOT_FREE) it
+   * returns immediately if the dependency is not ready so a scheduler can try
+   * another lane. The 6-step ordering matches the blocking `forward()`:
+   *   1. wait prev DATA_READY            (FwdWaitDataReady)
+   *   2. wait fwd NIC_DONE               (FwdWaitNicDone)
+   *   3. CopyOp::forward (reduce recv staging -> fwd staging [+ dst])
+   *   4. signal SLOT_FREE to prev        (before step 5 — ring deadlock break)
+   *   5. wait fwd SLOT_FREE              (FwdWaitSlotFree)
+   *   6. fence + RDMA put via fwd (piggyback DATA_READY + record NIC_DONE)
+   * Steps 3-4 run during the FwdWaitNicDone->FwdWaitSlotFree transition and the
+   * new stage is persisted only afterwards; step 6 runs during the
+   * FwdWaitSlotFree->{FwdWaitDataReady|Done} transition. So a `Waiting`/resume
+   * never replays a side effect.
+   *
+   * `CopyOp` must expose `forward(dst, fwd_staging, staging, bytes, group,
+   * dataOffset, args...)`. `dst == nullptr` is forward-only (reduce-scatter
+   * middle); a non-null `dst` additionally writes the application output
+   * (store-and-forward / all-gather). `args` is forwarded verbatim, so
+   * reduce/valid-masking copy ops behave exactly as under blocking `forward()`.
+   *
+   * @param group Thread group matching the one used during initialization.
+   * @param dst Application destination, or nullptr for forward-only.
+   * @param fwd Forward transport matching the init call.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param active_blocks Number of participating groups from init.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::forward`.
+   */
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_forward_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbgdaTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "P2pIbgdaTransportDevice::progress_forward_once() requires NVIDIA GPU");
+#endif
+    const int groupId = group.group_id;
+    const int recvIndex = progress_recv_index(group);
+    const int fwdIndex = fwd.progress_send_index(group);
+    IbSendRecvState::ProgressSlot recvState =
+        progress_state_slot(group, recvIndex);
+    IbSendRecvState::ProgressSlot fwdState =
+        fwd.progress_state_slot(group, fwdIndex);
+    if (recvState.activeStage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    // Two independent geometries (recv side = this, fwd side = fwd); the chunk
+    // is clamped to fit BOTH staging partitions, exactly like blocking forward.
+    const ProgressGeometry recvGeom = make_progress_geometry(
+        group,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        "progress_forward_once");
+    const ProgressGeometry fwdGeom = fwd.make_progress_geometry(
+        group,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        "progress_forward_once");
+    if (recvState.activeNextByte >= recvGeom.protocolBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_forward_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
+            static_cast<unsigned long long>(recvState.activeNextByte),
+            static_cast<unsigned long long>(recvGeom.protocolBytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_forward_progress_stage(group, recvState);
+    validate_forward_send_slot(
+        group, fwdState, recvState, recvGeom.protocolBytes);
+
+    const detail::IbSendRecvProgressStage initialStage = recvState.activeStage;
+    const std::size_t initialNextByte = recvState.activeNextByte;
+
+    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
+    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const std::size_t recvPipelineBytes =
+        recvGeom.perBlockSlot * static_cast<std::size_t>(recvPipelineDepth);
+
+    const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
+    const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
+    const std::size_t fwdPipelineBytes =
+        fwdGeom.perBlockSlot * static_cast<std::size_t>(fwdPipelineDepth);
+
+    // Per-chunk geometry from the lockstep cursor (recvState.activeNextByte ==
+    // fwdState.activeNextByte). Mirrors blocking forward's per-iteration math.
+    const std::size_t dataOff = recvState.activeNextByte;
+    const uint64_t recvBaseByte =
+        static_cast<uint64_t>(recvState.activeBaseStep);
+    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdState.activeBaseStep);
+
+    const uint64_t recvStreamStart = recvBaseByte + dataOff;
+    const std::size_t recvPipelineOff =
+        static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+    const int recvSlot =
+        static_cast<int>(recvPipelineOff / recvGeom.perBlockSlot);
+    const std::size_t recvSlotOff =
+        static_cast<std::size_t>(recvSlot) * recvDataBufSize;
+    const std::size_t recvChunkOff = recvPipelineOff -
+        static_cast<std::size_t>(recvSlot) * recvGeom.perBlockSlot;
+    const std::size_t recvStagingOff = recvSlotOff +
+        static_cast<std::size_t>(groupId) * recvGeom.perBlockSlot +
+        recvChunkOff;
+
+    const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
+    const std::size_t fwdPipelineOff =
+        static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+    const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdGeom.perBlockSlot);
+    const std::size_t fwdSlotOff =
+        static_cast<std::size_t>(fwdSlot) * fwdDataBufSize;
+    const std::size_t fwdChunkOff = fwdPipelineOff -
+        static_cast<std::size_t>(fwdSlot) * fwdGeom.perBlockSlot;
+    const std::size_t fwdStagingOff = fwdSlotOff +
+        static_cast<std::size_t>(groupId) * fwdGeom.perBlockSlot + fwdChunkOff;
+
+    const std::size_t recvSlotRemaining = recvGeom.perBlockSlot - recvChunkOff;
+    const std::size_t fwdSlotRemaining = fwdGeom.perBlockSlot - fwdChunkOff;
+    const std::size_t dataRemaining = recvGeom.protocolBytes - dataOff;
+    std::size_t bytesThis = recvGeom.chunkSize < fwdGeom.chunkSize
+        ? recvGeom.chunkSize
+        : fwdGeom.chunkSize;
+    bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+    bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+    bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+    // Stream-end thresholds come from the FINAL bytesThis on each side (NOT a
+    // per-side next_chunk().streamEnd, which would use that side's own larger
+    // chunkSize).
+    const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
+    const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
+
+    // (1) Wait for prev DATA_READY (this transport, recv side). Unconditional,
+    //     matching blocking forward step 1.
+    if (recvState.activeStage ==
+        detail::IbSendRecvProgressStage::FwdWaitDataReady) {
+      uint32_t ready = 1;
+      unsigned long long current = 0;
+      if (group.is_leader()) {
+        current = static_cast<unsigned long long>(
+            read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                static_cast<std::size_t>(groupId) * sizeof(uint64_t))));
+        ready = current >= recvStreamEnd ? 1U : 0U;
+        if (!ready) {
+          TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+              timeout,
+              "progress_forward_once waiting for DATA_READY expected>=%llu, "
+              "current=%llu",
+              static_cast<unsigned long long>(recvStreamEnd),
+              current);
+        }
+      }
+      ready = group.broadcast<uint32_t>(ready);
+      if (!ready) {
+        // First wait, before any side effect: no state change to persist.
+        return IbgdaSendRecvProgressStatus::Waiting;
+      }
+      // DATA_READY satisfied; advance to the next yield point (no side effect).
+      transition_forward_stage(
+          group, recvState, detail::IbSendRecvProgressStage::FwdWaitNicDone);
+    }
+
+    // (2) Wait for fwd NIC_DONE (backpressure on fwd's sendStaging), then
+    //     (3) fuse recv+reduce+send and (4) release prev's staging.
+    if (recvState.activeStage ==
+        detail::IbSendRecvProgressStage::FwdWaitNicDone) {
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              fwd.read_counter(fwd.sendRecvState_.localCounterBuf.subBuffer(
+                  static_cast<std::size_t>(groupId) * sizeof(uint64_t))));
+          ready = current >= fwdStreamEnd - fwdPipelineBytes ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_forward_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(
+                    fwdStreamEnd - fwdPipelineBytes),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          if (recvState.activeStage != initialStage ||
+              recvState.activeNextByte != initialNextByte) {
+            store_progress_state(group, recvIndex, recvState);
+            fwd.store_progress_state(group, fwdIndex, fwdState);
+            return IbgdaSendRecvProgressStatus::Progressed;
+          }
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      // (3) CopyOp::forward — reduce recv staging into fwd send staging (+dst).
+      CopyOp::forward(
+          dst ? static_cast<char*>(dst) + dataOff : nullptr,
+          fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
+          sendRecvState_.recvStagingPtr + recvStagingOff,
+          bytesThis,
+          group,
+          dataOff,
+          args...);
+      group.sync();
+
+      // (4) Signal SLOT_FREE to prev — BEFORE waiting on fwd SLOT_FREE (step 5)
+      //     to break the circular ring dependency.
+      signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              static_cast<std::size_t>(recvMaxGroups + groupId) *
+              sizeof(uint64_t)),
+          bytesThis);
+
+      // Persist the new stage AFTER both side effects so a resume never
+      // replays the reduce or the prev SLOT_FREE signal.
+      transition_forward_stage(
+          group, recvState, detail::IbSendRecvProgressStage::FwdWaitSlotFree);
+    }
+
+    // (5) Wait for fwd receiver's SLOT_FREE, then (6) fence + RDMA put.
+    if (recvState.activeStage ==
+        detail::IbSendRecvProgressStage::FwdWaitSlotFree) {
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              fwd.read_signal(fwd.sendRecvState_.localSignalBuf.subBuffer(
+                  static_cast<std::size_t>(fwdMaxGroups + groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= fwdStreamEnd - fwdPipelineBytes ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_forward_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(
+                    fwdStreamEnd - fwdPipelineBytes),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          if (recvState.activeStage != initialStage ||
+              recvState.activeNextByte != initialNextByte) {
+            store_progress_state(group, recvIndex, recvState);
+            fwd.store_progress_state(group, fwdIndex, fwdState);
+            return IbgdaSendRecvProgressStatus::Progressed;
+          }
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      // (6) threadfence_system + RDMA put via fwd transport.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{0, 1, group.group_id, 1, SyncScope::THREAD};
+        fwd.put(
+            solo,
+            fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwd.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            bytesThis,
+            fwd.sendRecvState_.remoteSignalBuf.subBuffer(
+                static_cast<std::size_t>(groupId) * sizeof(uint64_t)),
+            bytesThis,
+            fwd.sendRecvState_.localCounterBuf.subBuffer(
+                static_cast<std::size_t>(groupId) * sizeof(uint64_t)),
+            bytesThis);
+      }
+      group.sync();
+
+      // Advance BOTH cursors in lockstep (nextStep stays reserved-at-init).
+      recvState.activeNextByte += bytesThis;
+      fwdState.activeNextByte += bytesThis;
+      if (recvState.activeNextByte >= recvGeom.protocolBytes) {
+        // Mark both slots idle; nextStep is NOT rewritten (reserved at init).
+        recvState.activeStage = detail::IbSendRecvProgressStage::Done;
+        recvState.activeBaseStep = 0;
+        recvState.activeNextByte = 0;
+        fwdState.activeStage = detail::IbSendRecvProgressStage::Done;
+        fwdState.activeBaseStep = 0;
+        fwdState.activeNextByte = 0;
+        store_progress_state(group, recvIndex, recvState);
+        fwd.store_progress_state(group, fwdIndex, fwdState);
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      transition_forward_stage(
+          group, recvState, detail::IbSendRecvProgressStage::FwdWaitDataReady);
+    }
+
+    if (recvState.activeStage != initialStage ||
+        recvState.activeNextByte != initialNextByte) {
+      store_progress_state(group, recvIndex, recvState);
+      fwd.store_progress_state(group, fwdIndex, fwdState);
+      return IbgdaSendRecvProgressStatus::Progressed;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
+#else
+    (void)group;
+    (void)dst;
+    (void)fwd;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
@@ -3285,6 +3721,15 @@ class P2pIbgdaTransportDevice {
         return false;
       case detail::IbSendRecvProgressStage::Busy:
         return false;
+      // The resumable-forward stages are owned by the dedicated forward
+      // validator/transition table (is_valid_forward_transition); the send/recv
+      // state machine rejects them. Listed explicitly so this switch stays
+      // exhaustive over IbSendRecvProgressStage (no silent -Wswitch
+      // fallthrough).
+      case detail::IbSendRecvProgressStage::FwdWaitDataReady:
+      case detail::IbSendRecvProgressStage::FwdWaitNicDone:
+      case detail::IbSendRecvProgressStage::FwdWaitSlotFree:
+        return false;
     }
     return false;
   }
@@ -3306,6 +3751,134 @@ class P2pIbgdaTransportDevice {
       if (group.is_leader()) {
         printf(
             "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
+            static_cast<int>(current),
+            static_cast<int>(next));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    state.activeStage = next;
+#endif
+  }
+
+  /**
+   * Trap if a forward progress state is not in a forward-owned stage.
+   *
+   * The combined forward stage lives in the prev-recv slot and may only be one
+   * of the `Fwd*` yield points (or `Done`). Any send/recv stage or `Busy` in
+   * this slot is protocol misuse (e.g. a recv/send init aliased onto a group
+   * already running a forward) and traps with a diagnostic.
+   */
+  __device__ __forceinline__ void validate_forward_progress_stage(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.activeStage !=
+            detail::IbSendRecvProgressStage::FwdWaitDataReady &&
+        state.activeStage != detail::IbSendRecvProgressStage::FwdWaitNicDone &&
+        state.activeStage != detail::IbSendRecvProgressStage::FwdWaitSlotFree &&
+        state.activeStage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_forward_once invalid stage=%d\n",
+            static_cast<int>(state.activeStage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Trap if the forward's next-send slot is not the matching active slot.
+   *
+   * `progress_forward_once` derives send-side staging offsets from `fwdState`
+   * and advances its cursor in lockstep with the prev-recv slot. This guards
+   * the lockstep contract before any of that: the next-send slot must be `Busy`
+   * (owned by this forward for its whole lifetime), its `activeNextByte` must
+   * equal the prev-recv slot's (advanced together), and both slots' reserved
+   * ranges must match `nbytes` (`nextStep == activeBaseStep + nbytes`, set once
+   * by `init_forward_progress`). Catches progressing with the wrong `fwd`
+   * transport, an `nbytes` mismatch vs init, or corrupted/stale state, instead
+   * of silently issuing puts/signals on the wrong byte stream. Mirrors the
+   * trap-on-misuse philosophy of `validate_send/recv_progress_stage`.
+   */
+  __device__ __forceinline__ void validate_forward_send_slot(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& fwdState,
+      const IbSendRecvState::ProgressSlot& recvState,
+      std::size_t nbytes) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const bool ok =
+        fwdState.activeStage == detail::IbSendRecvProgressStage::Busy &&
+        fwdState.activeNextByte == recvState.activeNextByte &&
+        fwdState.nextStep ==
+            fwdState.activeBaseStep + static_cast<int64_t>(nbytes) &&
+        recvState.nextStep ==
+            recvState.activeBaseStep + static_cast<int64_t>(nbytes);
+    if (!ok) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_forward_once fwd-slot invariant violated "
+            "(fwdStage=%d fwdNextByte=%llu recvNextByte=%llu fwdNextStep=%lld "
+            "fwdBase=%lld recvNextStep=%lld recvBase=%lld nbytes=%llu)\n",
+            static_cast<int>(fwdState.activeStage),
+            static_cast<unsigned long long>(fwdState.activeNextByte),
+            static_cast<unsigned long long>(recvState.activeNextByte),
+            static_cast<long long>(fwdState.nextStep),
+            static_cast<long long>(fwdState.activeBaseStep),
+            static_cast<long long>(recvState.nextStep),
+            static_cast<long long>(recvState.activeBaseStep),
+            static_cast<unsigned long long>(nbytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Return whether `current -> next` is a valid forward-state transition.
+   *
+   * Dedicated to the resumable forward so the send/recv transition table
+   * (is_valid_progress_transition) stays unchanged for its own stages. The
+   * forward cycles FwdWaitDataReady -> FwdWaitNicDone -> FwdWaitSlotFree ->
+   * {FwdWaitDataReady (next chunk) | Done}.
+   */
+  __device__ __forceinline__ bool is_valid_forward_transition(
+      detail::IbSendRecvProgressStage current,
+      detail::IbSendRecvProgressStage next) const {
+    switch (current) {
+      case detail::IbSendRecvProgressStage::FwdWaitDataReady:
+        return next == detail::IbSendRecvProgressStage::FwdWaitNicDone;
+      case detail::IbSendRecvProgressStage::FwdWaitNicDone:
+        return next == detail::IbSendRecvProgressStage::FwdWaitSlotFree;
+      case detail::IbSendRecvProgressStage::FwdWaitSlotFree:
+        return next == detail::IbSendRecvProgressStage::FwdWaitDataReady ||
+            next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::Done:
+      case detail::IbSendRecvProgressStage::Busy:
+      case detail::IbSendRecvProgressStage::WaitNicDone:
+      case detail::IbSendRecvProgressStage::WaitSlotFree:
+      case detail::IbSendRecvProgressStage::WaitDataReady:
+        return false;
+    }
+    return false;
+  }
+
+  /**
+   * Apply one legal forward-state transition (prev-recv slot's activeStage).
+   *
+   * Mirrors transition_progress_stage but gates on is_valid_forward_transition.
+   * Keeping the two tables separate makes each state machine locally auditable.
+   */
+  __device__ __forceinline__ void transition_forward_stage(
+      ThreadGroup& group,
+      IbSendRecvState::ProgressSlot& state,
+      detail::IbSendRecvProgressStage next) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const detail::IbSendRecvProgressStage current = state.activeStage;
+    if (!is_valid_forward_transition(current, next)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: invalid forward transition stage=%d -> %d\n",
             static_cast<int>(current),
             static_cast<int>(next));
       }


### PR DESCRIPTION
Summary:
Adds a yield-able counterpart of the blocking `forward()` to the IBGDA prims transport, so a single kernel can multiplex several inter-node ring transfers (the lever for HierRing AllReduce's multi-lane Phase 2). This is Part 2.1a of the HierRing Perf-v2 roadmap; Part 2.1b (refactoring `phase2IbRing` to drive it) is a separate follow-up.

The motivation is decisive: a resumable ring built by decomposing `forward` into separate resumable recv+send (`D108620719`) is +14-30% slower at small/medium than the blocking-`forward` rewrite (`D107918920`) because `forward` fuses recv+reduce+send (the partial stays in transport staging). So the multi-lane ring must keep that fusion while becoming yield-able — which requires a resumable `forward`, not a send/recv decomposition. This also avoids any `fwdScratch` machinery.

Design (mirrors the blocking `forward` exactly, made resumable):
- Reuses `this`'s recv slot + `fwd`'s send slot — no third slot, no allocation change (`state` stays `2*maxGroups`).
- The combined forward stage lives in the prev-recv slot's `activeStage` via three new `IbSendRecvProgressStage` values (`FwdWaitDataReady`, `FwdWaitNicDone`, `FwdWaitSlotFree`); the next-send slot stays `Busy` for the whole op. The new enum values are appended, so the on-HBM encoding of the existing values is unchanged.
- Durable stages are yield points only: the non-idempotent side effects (`CopyOp::forward`, the prev SLOT_FREE signal, the fwd RDMA put) run during a transition and the new stage is persisted only after them, so a `Waiting`/resume never replays a side effect.
- Two `ProgressGeometry` (recv side = `this`, fwd side = `fwd`); `bytesThis = min` over both sides; stream-end thresholds recomputed from the final `bytesThis` (not a per-side `next_chunk().streamEnd`). Both `nextStep` cursors are reserved once at init; `progress_forward_once` advances only `activeNextByte`, in lockstep across the two slots. Init is all-or-nothing (assert both slots idle + validate both geometries before reserving either cursor). Zero-byte forwards mark both slots `Done`.
- A dedicated forward transition table/validator keeps the send/recv state machine unchanged for its own stages; `is_valid_progress_transition` gains explicit `Fwd*` reject cases so its `switch` stays exhaustive (avoids `-Wswitch`). The send/recv stage validators already reject the new values.
- AMD: `progress_forward_once` carries a dependent `static_assert(sizeof(CopyOp)==0)` (like its send/recv siblings) plus the host/device compile guards, so the prims library still compiles on AMD (the template is never instantiated there).

Differential Revision: D108772570


