### PR TITLE
Rename high_priority_stream to is_high_priority_stream

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -710,7 +710,7 @@ c10::intrusive_ptr<c10d::Backend> BackendWrapper::split(
     commOpts.abort_process_on_timeout_or_error =
         backendOpts->abort_process_on_timeout_or_error;
     commOpts.timeout = backendOpts->timeout;
-    commOpts.high_priority_stream = backendOpts->high_priority_stream;
+    commOpts.is_high_priority_stream = backendOpts->is_high_priority_stream;
     commOpts.store = backendOpts->store;
     commOpts.hints = backendOpts->hints;
   }

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -41,7 +41,7 @@ class BackendWrapper : public c10d::Backend {
   struct TORCH_API Options : c10d::Backend::Options {
     bool abort_process_on_timeout_or_error{true};
     std::chrono::milliseconds timeout{kDefaultTimeout};
-    bool high_priority_stream{false};
+    bool is_high_priority_stream{false};
     c10::intrusive_ptr<c10d::Store> store{nullptr};
     std::unordered_map<std::string, std::string> hints;
 

--- a/comms/torchcomms/README.md
+++ b/comms/torchcomms/README.md
@@ -443,7 +443,7 @@ arguments:
 
 **Backend-Specific Hints:**
 
-- **"high_priority_stream"**: Set to "true" to enable high priority CUDA stream
+- **"is_high_priority_stream"**: Set to "true" to enable high priority CUDA stream
   for NCCL operations (default: not set, equivalent to false)
 
 #### Communicator Options
@@ -597,7 +597,7 @@ comm = torchcomms.new_comm(
     timeout=torch.timedelta(seconds=60),
     abort_process_on_timeout_or_error=False,
     hints={
-        "high_priority_stream": "true",
+        "is_high_priority_stream": "true",
         "backend_option": "value"
     },
 )

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -155,7 +155,7 @@ class CommOptions {
  public:
   bool abort_process_on_timeout_or_error{true};
   std::chrono::milliseconds timeout{kDefaultTimeout};
-  bool high_priority_stream{false};
+  bool is_high_priority_stream{false};
   c10::intrusive_ptr<c10d::Store> store{nullptr};
   /**
    * If true, enables reconfigure() for fault tolerance.

--- a/comms/torchcomms/TorchCommPy.cpp
+++ b/comms/torchcomms/TorchCommPy.cpp
@@ -1120,7 +1120,7 @@ Args:
          const std::string& name,
          std::optional<bool> abort_process_on_timeout_or_error,
          std::optional<std::chrono::milliseconds> timeout,
-         std::optional<bool> high_priority_stream,
+         std::optional<bool> is_high_priority_stream,
          std::optional<c10::intrusive_ptr<c10d::Store>> store,
          bool enable_reconfigure,
          std::optional<std::unordered_map<std::string, std::string>> hints) {
@@ -1146,8 +1146,8 @@ Args:
           if (timeout) {
             opts.timeout = *timeout;
           }
-          if (high_priority_stream) {
-            opts.high_priority_stream = *high_priority_stream;
+          if (is_high_priority_stream) {
+            opts.is_high_priority_stream = *is_high_priority_stream;
           }
           if (store) {
             opts.store = *store;
@@ -1182,7 +1182,7 @@ Args:
   name (str): The name of the communicator. This must be unique within the process.
   abort_process_on_timeout_or_error (bool): Whether to abort process on timeout or error.
   timeout (timedelta): Timeout for initialization.
-  high_priority_stream (bool): Whether to use high priority stream.
+  is_high_priority_stream (bool): Whether to use high priority stream.
   store (torch.distributed.Store): Store used to initialize the communicator between processes.
   enable_reconfigure (bool): If True, enables reconfigure() for fault tolerance.
       With reconfigure enabled, the communicator is not initialized until
@@ -1194,7 +1194,7 @@ Args:
       py::arg("name"),
       py::arg("abort_process_on_timeout_or_error") = std::nullopt,
       py::arg("timeout") = std::nullopt,
-      py::arg("high_priority_stream") = std::nullopt,
+      py::arg("is_high_priority_stream") = std::nullopt,
       py::arg("store") = nullptr,
       py::arg("enable_reconfigure") = false,
       py::arg("hints") = std::nullopt);

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -152,12 +152,12 @@ void TorchCommNCCL::initNcclResources() {
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  high_priority_stream_ =
-      options_.getHint<bool>(kHintHighPriorityStream, false);
+  is_high_priority_stream_ =
+      options_.getHint<bool>(kHintIsHighPriorityStream, false);
 
   int stream_priority = 0;
 
-  if (high_priority_stream_) {
+  if (is_high_priority_stream_) {
     int leastPriority, greatestPriority;
     CUDA_CHECK(
         cuda_api_,

--- a/comms/torchcomms/nccl/TorchCommNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.hpp
@@ -28,7 +28,8 @@
 namespace torch::comms {
 
 // Hint key names for NCCL backend configuration
-constexpr std::string_view kHintHighPriorityStream = "high_priority_stream";
+constexpr std::string_view kHintIsHighPriorityStream =
+    "is_high_priority_stream";
 constexpr std::string_view kHintMaxEventPoolSize = "max_event_pool_size";
 
 constexpr size_t kDefaultMaxEventPoolSize = 1000;
@@ -491,7 +492,7 @@ class TorchCommNCCL : public TorchCommBackend,
   std::condition_variable timeout_cv_;
   std::mutex timeout_mutex_;
 
-  bool high_priority_stream_{false};
+  bool is_high_priority_stream_{false};
   std::string name_;
 
   // Graph capture mode work references

--- a/comms/torchcomms/nccl/TorchCommNCCLBootstrap.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLBootstrap.cpp
@@ -194,7 +194,7 @@ void TorchCommNCCLBootstrap::cleanupTCPStore(ncclComm_t nccl_comm) {
 // (TorchCommNCCL::init), not by ncclConfig.  Skip them here to avoid
 // spurious "unsupported hint" warnings.
 static const std::set<std::string> kTorchCommLayerHints = {
-    std::string(kHintHighPriorityStream),
+    std::string(kHintIsHighPriorityStream),
     std::string(kHintMaxEventPoolSize),
 };
 

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.cpp
@@ -301,12 +301,12 @@ void TorchCommNCCLX::initNcclxResources() {
       cuda_api_->memGetInfo(&free_memory, &total_memory),
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
-  high_priority_stream_ =
-      options_.getHint<bool>(kHintHighPriorityStream, false);
+  is_high_priority_stream_ =
+      options_.getHint<bool>(kHintIsHighPriorityStream, false);
 
   int stream_priority = 0;
 
-  if (high_priority_stream_) {
+  if (is_high_priority_stream_) {
     int leastPriority, greatestPriority;
     CUDA_CHECK(
         cuda_api_,

--- a/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLX.hpp
@@ -32,7 +32,8 @@
 namespace torch::comms {
 
 // Hint key names for NCCLX backend configuration
-constexpr std::string_view kHintHighPriorityStream = "high_priority_stream";
+constexpr std::string_view kHintIsHighPriorityStream =
+    "is_high_priority_stream";
 constexpr std::string_view kHintMaxEventPoolSize = "max_event_pool_size";
 constexpr std::string_view kHintGarbageCollectIntervalMs =
     "garbage_collect_interval_ms";
@@ -400,7 +401,7 @@ class TorchCommNCCLX : public TorchCommBackend,
   };
   Configs configs_;
 
-  bool high_priority_stream_{false};
+  bool is_high_priority_stream_{false};
 
  private:
   // Helper that automatically cleans up premul sums.

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
@@ -210,7 +210,7 @@ void TorchCommNCCLXBootstrap::cleanupTCPStore(ncclComm_t nccl_comm) {
 // (TorchCommNCCLX::init), not by ncclConfig.  Skip them here to avoid
 // spurious "unsupported hint" warnings.
 static const std::set<std::string> kTorchCommLayerHints = {
-    std::string(kHintHighPriorityStream),
+    std::string(kHintIsHighPriorityStream),
     std::string(kHintMaxEventPoolSize),
     std::string(kHintGarbageCollectIntervalMs),
     std::string(kHintEnableCudaGraphSupport),

--- a/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/HintParsingTest.cpp
@@ -32,7 +32,7 @@ TEST_F(HintParsingTest, DefaultConfigValues) {
   const auto options = createOptions();
   comm->init(*device_, "test_defaults", options);
 
-  EXPECT_FALSE(comm->testGetHighPriorityStream());
+  EXPECT_FALSE(comm->testGetIsHighPriorityStream());
   EXPECT_EQ(comm->testGetMaxEventPoolSize(), 1000);
   EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 100);
   EXPECT_TRUE(comm->testGetEnableCudaGraphSupport());
@@ -102,7 +102,7 @@ TEST_F(HintParsingTest, AllHintsCombined) {
   cuda_mock_->setupDefaultBehaviors();
   nccl_mock_->setupDefaultBehaviors();
 
-  // high_priority_stream hint triggers getStreamPriorityRange call
+  // is_high_priority_stream hint triggers getStreamPriorityRange call
   ON_CALL(*cuda_mock_, getStreamPriorityRange(_, _))
       .WillByDefault(DoAll(
           SetArgPointee<0>(0), SetArgPointee<1>(-10), Return(cudaSuccess)));
@@ -111,11 +111,11 @@ TEST_F(HintParsingTest, AllHintsCombined) {
   options.hints["max_event_pool_size"] = "2000";
   options.hints["garbage_collect_interval_ms"] = "50";
   options.hints["enable_cuda_graph_support"] = "false";
-  options.hints["high_priority_stream"] = "true";
+  options.hints["is_high_priority_stream"] = "true";
   options.hints["graph_timeout_check_interval_ms"] = "3000";
   comm->init(*device_, "test_all_hints", options);
 
-  EXPECT_TRUE(comm->testGetHighPriorityStream());
+  EXPECT_TRUE(comm->testGetIsHighPriorityStream());
   EXPECT_EQ(comm->testGetMaxEventPoolSize(), 2000);
   EXPECT_EQ(comm->testGetGarbageCollectIntervalMs(), 50);
   EXPECT_FALSE(comm->testGetEnableCudaGraphSupport());

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -575,7 +575,7 @@ TEST_F(TorchCommNCCLXTest, Getters) {
   comm->finalize();
 }
 
-TEST_F(TorchCommNCCLXTest, HighPriorityStreamCreation) {
+TEST_F(TorchCommNCCLXTest, IsHighPriorityStreamCreation) {
   // Default priority for stream creation.
   {
     setupRankAndSize(0, 2); // rank 0, size 2
@@ -612,7 +612,7 @@ TEST_F(TorchCommNCCLXTest, HighPriorityStreamCreation) {
     setupRankAndSize(0, 2); // rank 0, size 2
 
     auto options = CommOptions();
-    options.hints[std::string(kHintHighPriorityStream)] = "true";
+    options.hints[std::string(kHintIsHighPriorityStream)] = "true";
     options.store = store_;
     auto comm = createMockedTorchComm();
 

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTestBase.hpp
@@ -89,8 +89,8 @@ class TorchCommNCCLXTest : public ::testing::Test {
     }
 
     // Hint parsing test accessors
-    bool testGetHighPriorityStream() const {
-      return high_priority_stream_;
+    bool testGetIsHighPriorityStream() const {
+      return is_high_priority_stream_;
     }
 
     size_t testGetMaxEventPoolSize() const {

--- a/comms/torchcomms/rccl/TorchCommRCCL.cpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.cpp
@@ -166,8 +166,8 @@ void TorchCommRCCL::initRcclResources() {
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
   // Read hints and store them
-  high_priority_stream_ =
-      options_.getHint<bool>(kHintHighPriorityStream, false);
+  is_high_priority_stream_ =
+      options_.getHint<bool>(kHintIsHighPriorityStream, false);
 
   // Create internal stream
   //
@@ -175,7 +175,7 @@ void TorchCommRCCL::initRcclResources() {
   int stream_priority = 0;
 
   // Check for high priority stream hint
-  if (high_priority_stream_) {
+  if (is_high_priority_stream_) {
     int leastPriority, greatestPriority;
     HIP_CHECK(
         hip_api_,

--- a/comms/torchcomms/rccl/TorchCommRCCL.hpp
+++ b/comms/torchcomms/rccl/TorchCommRCCL.hpp
@@ -28,7 +28,8 @@
 namespace torch::comms {
 
 // Hint key names for RCCL backend configuration
-constexpr std::string_view kHintHighPriorityStream = "high_priority_stream";
+constexpr std::string_view kHintIsHighPriorityStream =
+    "is_high_priority_stream";
 constexpr std::string_view kHintMaxEventPoolSize = "max_event_pool_size";
 
 constexpr size_t kDefaultMaxEventPoolSize = 1000;
@@ -418,7 +419,7 @@ class TorchCommRCCL : public TorchCommBackend,
   std::condition_variable timeout_cv_;
   std::mutex timeout_mutex_;
 
-  bool high_priority_stream_{false};
+  bool is_high_priority_stream_{false};
   std::string name_;
   // UUID of the current communicator quorum, set at end of reconfigure().
   // Embedded in getInitHandle() so findQuorum() can identify which ranks

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.cpp
@@ -179,8 +179,8 @@ void TorchCommRCCLX::initRcclxResources() {
       fmt::format("Failed to get memory info for device {}", device_.index()));
 
   // Read hints and store them
-  high_priority_stream_ =
-      options_.getHint<bool>(kHintHighPriorityStream, false);
+  is_high_priority_stream_ =
+      options_.getHint<bool>(kHintIsHighPriorityStream, false);
 
   // Create internal stream
   //
@@ -188,7 +188,7 @@ void TorchCommRCCLX::initRcclxResources() {
   int stream_priority = 0;
 
   // Check for high priority stream hint
-  if (high_priority_stream_) {
+  if (is_high_priority_stream_) {
     int leastPriority, greatestPriority;
     HIP_CHECK(
         hip_api_,

--- a/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
+++ b/comms/torchcomms/rcclx/TorchCommRCCLX.hpp
@@ -28,7 +28,8 @@
 namespace torch::comms {
 
 // Hint key names for RCCLX backend configuration
-constexpr std::string_view kHintHighPriorityStream = "high_priority_stream";
+constexpr std::string_view kHintIsHighPriorityStream =
+    "is_high_priority_stream";
 constexpr std::string_view kHintMaxEventPoolSize = "max_event_pool_size";
 
 constexpr size_t kDefaultMaxEventPoolSize = 1000;
@@ -449,7 +450,7 @@ class TorchCommRCCLX : public TorchCommBackend,
   std::condition_variable timeout_cv_;
   std::mutex timeout_mutex_;
 
-  bool high_priority_stream_{false};
+  bool is_high_priority_stream_{false};
   std::string name_;
   // UUID of the current communicator quorum, set at end of reconfigure().
   // Embedded in getInitHandle() so findQuorum() can identify which ranks

--- a/comms/torchcomms/xccl/TorchCommXCCL.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.cpp
@@ -318,14 +318,14 @@ void TorchCommXCCL::init(
           std::to_string(device_.index()));
 
   // Read hints and store them
-  high_priority_stream_ =
-      options_.getHint<bool>(kHintHighPriorityStream, false);
+  is_high_priority_stream_ =
+      options_.getHint<bool>(kHintIsHighPriorityStream, false);
 
   // Create internal stream
   int stream_priority = 0;
 
   // Check for high priority stream hint
-  if (high_priority_stream_) {
+  if (is_high_priority_stream_) {
     stream_priority = -1;
   }
 

--- a/comms/torchcomms/xccl/TorchCommXCCL.hpp
+++ b/comms/torchcomms/xccl/TorchCommXCCL.hpp
@@ -27,7 +27,8 @@
 namespace torch::comms {
 
 // Hint key names for XCCL backend configuration
-constexpr std::string_view kHintHighPriorityStream = "high_priority_stream";
+constexpr std::string_view kHintIsHighPriorityStream =
+    "is_high_priority_stream";
 constexpr std::string_view kHintMaxEventPoolSize = "max_event_pool_size";
 
 constexpr size_t kDefaultMaxEventPoolSize = 1000;
@@ -277,7 +278,7 @@ class TorchCommXCCL : public TorchCommBackend,
       dependency_event_; // Pre-allocated event for stream dependencies
 
   size_t max_event_pool_size_{};
-  bool high_priority_stream_{false};
+  bool is_high_priority_stream_{false};
 
  private:
   // Helper that automatically cleans up premul sums.

--- a/comms/torchcomms/xccl/TorchCommXCCLBootstrap.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLBootstrap.cpp
@@ -199,7 +199,7 @@ void TorchCommXCCLBootstrap::cleanupTCPStore(onecclComm_t xccl_comm) {
 // (TorchCommXCCL::init), not by onecclConfig.  Skip them here to avoid
 // spurious "unsupported hint" warnings.
 static const std::set<std::string> kTorchCommLayerHints = {
-    std::string(kHintHighPriorityStream),
+    std::string(kHintIsHighPriorityStream),
     std::string(kHintMaxEventPoolSize),
 };
 

--- a/comms/torchcomms/xccl/tests/unit/cpp/HintParsingTest.cpp
+++ b/comms/torchcomms/xccl/tests/unit/cpp/HintParsingTest.cpp
@@ -22,23 +22,23 @@ TEST_F(HintParsingTest, DefaultConfigValues) {
   const auto options = createOptions();
   comm->init(*device_, "test_defaults", options);
 
-  EXPECT_FALSE(comm->testGetHighPriorityStream());
+  EXPECT_FALSE(comm->testGetIsHighPriorityStream());
   EXPECT_EQ(comm->testGetMaxEventPoolSize(), 1000);
 
   comm->finalize();
 }
 
-TEST_F(HintParsingTest, HighPriorityStreamHint) {
+TEST_F(HintParsingTest, IsHighPriorityStreamHint) {
   setupRankAndSize(0, 2);
   xpu_mock_->setupDefaultBehaviors();
   xccl_mock_->setupDefaultBehaviors();
 
   auto comm = createMockedTorchComm();
   auto options = createOptions();
-  options.hints["high_priority_stream"] = "true";
+  options.hints["is_high_priority_stream"] = "true";
   comm->init(*device_, "test_high_priority", options);
 
-  EXPECT_TRUE(comm->testGetHighPriorityStream());
+  EXPECT_TRUE(comm->testGetIsHighPriorityStream());
 
   comm->finalize();
 }
@@ -65,11 +65,11 @@ TEST_F(HintParsingTest, AllHintsCombined) {
 
   auto comm = createMockedTorchComm();
   auto options = createOptions();
-  options.hints["high_priority_stream"] = "true";
+  options.hints["is_high_priority_stream"] = "true";
   options.hints["max_event_pool_size"] = "2000";
   comm->init(*device_, "test_all_hints", options);
 
-  EXPECT_TRUE(comm->testGetHighPriorityStream());
+  EXPECT_TRUE(comm->testGetIsHighPriorityStream());
   EXPECT_EQ(comm->testGetMaxEventPoolSize(), 2000);
 
   comm->finalize();
@@ -87,7 +87,7 @@ TEST_F(HintParsingTest, UnknownHintsIgnored) {
   comm->init(*device_, "test_unknown_hints", options);
 
   // Defaults unchanged
-  EXPECT_FALSE(comm->testGetHighPriorityStream());
+  EXPECT_FALSE(comm->testGetIsHighPriorityStream());
   EXPECT_EQ(comm->testGetMaxEventPoolSize(), 1000);
 
   comm->finalize();

--- a/comms/torchcomms/xccl/tests/unit/cpp/TorchCommXCCLTestBase.hpp
+++ b/comms/torchcomms/xccl/tests/unit/cpp/TorchCommXCCLTestBase.hpp
@@ -78,8 +78,8 @@ class TorchCommXCCLTest : public ::testing::Test {
       return dependency_event_.value();
     }
 
-    bool testGetHighPriorityStream() const {
-      return high_priority_stream_;
+    bool testGetIsHighPriorityStream() const {
+      return is_high_priority_stream_;
     }
 
     size_t testGetMaxEventPoolSize() const {


### PR DESCRIPTION
Summary: Rename the `high_priority_stream` option/hint to `is_high_priority_stream` consistently across all torchcomms backends to follow the boolean `is_` naming convention. This touches: the public `TorchCommOptions`/`BackendWrapper::Options` member, the `TorchCommPy` pybind argument and docstring, the per-backend hint key constant (`kHintHighPriorityStream` -> `kHintIsHighPriorityStream`, with the hint string value `"high_priority_stream"` -> `"is_high_priority_stream"`), the per-backend `high_priority_stream_` member and bootstrap `kTorchCommLayerHints` allowlist for NCCL, NCCLX, RCCL, RCCLX, and XCCL, plus the README docs. Tests are updated to match: the `testGetHighPriorityStream` accessor, the renamed test cases, and the hint map keys in `HintParsingTest`.

Differential Revision: D108954695


