### PR TITLE
Fix OSS folly CXXFLAGS passthrough and rccl host-compiler leak

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -25,7 +25,7 @@ function do_cmake_build() {
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=20 \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.22 \
-    -DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1" \
+    -DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1 ${CXXFLAGS:-}" \
     $extra_flags \
     -S "${source_dir}"
   ninja
@@ -393,8 +393,18 @@ export LDFLAGS="${LDFLAGS:-} -Wl,--version-script=/tmp/rccl_hide_gflags.lds"
 mkdir -p "$BUILDDIR"
 pushd "${NCCL_HOME}"
 export ROCM_PATH="${ROCM_PATH:-/usr/local/fbcode/platform010/lib/rocm-7.0}"
-export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"
-export CC="${CC:-$ROCM_PATH/lib/llvm/bin/amdclang}"
+# RCCL's CMakeLists (projects/rccl/CMakeLists.txt) requires CMAKE_CXX_COMPILER to
+# be amdclang++/clang++/hipcc. Drop the conda-activated host compiler
+# (x86_64-conda-linux-gnu-c++/-gcc) that leaks in on local builds and trips the
+# "RCCL can be built only with hipcc or amdclang++" check. Any other env-provided
+# CXX/CC -- including the remote build harness's injected ROCm toolchain -- is
+# honored exactly as before.
+case "$(basename "${CXX:-}")" in
+  *-conda-linux-gnu-c++|"") export CXX="$ROCM_PATH/lib/llvm/bin/amdclang++" ;;
+esac
+case "$(basename "${CC:-}")" in
+  *-conda-linux-gnu-cc|*-conda-linux-gnu-gcc|"") export CC="$ROCM_PATH/lib/llvm/bin/amdclang" ;;
+esac
 
 
 function build_rccl {


### PR DESCRIPTION
Summary:
Two related fixes that unblock the local OSS conda rcclx build
(CONDA_BUILD_RCCLX=1 USE_RE=0).

1) Pass env CXXFLAGS through do_cmake_build for the OSS folly build.

The build failed while compiling folly:

  /tmp/third-party/folly/folly/io/async/AsyncSocketTransport.cpp:32:46:
  error: 'SO_INCOMING_NAPI_ID' was not declared in this scope

folly's getNapiId() uses SO_INCOMING_NAPI_ID guarded only by
`#if defined(__linux__)`, not by `#ifdef SO_INCOMING_NAPI_ID`. The conda
cross-toolchain sysroot ships kernel-headers 3.10 (sysroot_linux-64 2.17),
whose asm-generic/socket.h tops out at SO_BPF_EXTENSIONS (48) and does not
define SO_INCOMING_NAPI_ID (56, added in Linux 4.12), so folly fails to
compile against the conda headers.

build_rcclx.sh already tried to work around this by exporting
`CXXFLAGS="... -DSO_INCOMING_NAPI_ID=56 -msse4.2"` around the folly build,
but the workaround was silently defeated: do_cmake_build passed
`-DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1"` explicitly on the cmake command
line, and CMake ignores the CXXFLAGS environment variable when
CMAKE_CXX_FLAGS is set via -D. Fold the env CXXFLAGS into CMAKE_CXX_FLAGS
so it is no longer dropped while preserving -DFMT_HEADER_ONLY=1:

  -DCMAKE_CXX_FLAGS="-DFMT_HEADER_ONLY=1 ${CXXFLAGS:-}"

For non-folly libs CXXFLAGS is empty at that point, so behavior is unchanged.

2) Drop the conda host compiler that leaks into the rccl configure.

With folly fixed, the rccl configure then failed:

  CMake Error at CMakeLists.txt:163 (message):
    RCCL can be built only with hipcc or amdclang++

rccl's CMakeLists requires CMAKE_CXX_COMPILER to be amdclang++/clang++/hipcc,
and install.sh lets cmake take the compiler from $CXX. conda activation
exports CXX=x86_64-conda-linux-gnu-c++ (the same compiler that builds the
OSS third-party libs), and the env-respecting
`export CXX="${CXX:-$ROCM_PATH/lib/llvm/bin/amdclang++}"` keeps that conda
value instead of falling back to amdclang++ on local builds.

Use a denylist that overrides only the conda compiler (or an empty value),
so any other env-provided CXX/CC -- including the remote build harness's
injected ROCm toolchain -- is honored exactly as before. Remote toolchain
selection is unchanged.

Differential Revision: D108981994


