### PR TITLE
c++|codemod|ez| rename set/preferIoUring to set/preferAsyncIoUringSocket (#2939)

### DIFF
--- a/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
+++ b/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
@@ -53,7 +53,7 @@ std::unique_ptr<apache::thrift::util::ScopedServerThread> startAndGetService(
 #endif
   // Workaround to avoid using libevent backend for EventBase. Currently
   // folly has bug with libevent backend with libevent 2.1.12.
-  server->setPreferIoUring(true);
+  server->setPreferAsyncIoUringSocket(true);
   server->setUseDefaultIoUringExecutor(true);
 
   // Use fewer resources to run faster


### PR DESCRIPTION
Summary:

**WHAT**

codemod renaming set/preferIoUring from the ThriftServer to be called set/preferAsyncIoUringSocket.

**WHY**

With the migration to `AsyncSocket` from `AsyncIoUringSocket`, the set/preferIoUring flags were really behaving as a control between asyncSocket and AsyncIoUringSocket so renaming it to be something clearer.

**FOLLOW-UPS**
- go service-by-service turning it off so that we use `AsyncSocket` and using IoUring is then driven by the attached backend (EpollBackend vs IoUringBackend).
- clean up all these flags from everywhere.

Differential Revision: D109032629


