### PR TITLE
Add per-collective env gates for FP8 low-precision collectives

### DIFF
--- a/comms/rcclx/develop/meta/lpcoll/low_precision_common.h
+++ b/comms/rcclx/develop/meta/lpcoll/low_precision_common.h
@@ -13,10 +13,57 @@
 #include "low_precision_kernels.h"
 #include "low_precision_utility.h"
 
-// Helper function to check if low precision FP8 E4M3 is enabled
+// Returns true if the named environment variable is set to "1".
+inline bool isLowPrecisionEnvFlagSet(const char* envName) {
+  const char* value = getenv(envName);
+  return (value && strcmp(value, "1") == 0);
+}
+
+// Global switch: enables FP8 E4M3 low precision for ALL collectives.
 inline bool isLowPrecisionFp8E4M3Enabled() {
-  const char* lowPrecisionEnable = getenv("RCCL_LOW_PRECISION_ENABLE");
-  return (lowPrecisionEnable && strcmp(lowPrecisionEnable, "1") == 0);
+  return isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE");
+}
+
+// Forces the per-comm low precision buffer pool to be pre-allocated at comm
+// init regardless of whether any LP collective is currently enabled. The pool
+// must exist before any LP collective runs (e.g. it cannot be allocated during
+// CUDA graph capture), so setting this lets the per-collective LP switches be
+// toggled dynamically at runtime without restarting the job.
+inline bool isLowPrecisionInitEnabled() {
+  return isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE_INIT");
+}
+
+// Per-collective switches. A collective uses low precision if the global
+// switch (RCCL_LOW_PRECISION_ENABLE) OR its dedicated switch is set.
+inline bool isLowPrecisionFp8E4M3AllGatherEnabled() {
+  return isLowPrecisionFp8E4M3Enabled() ||
+      isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE_ALLGATHER");
+}
+
+inline bool isLowPrecisionFp8E4M3AllReduceEnabled() {
+  return isLowPrecisionFp8E4M3Enabled() ||
+      isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE_ALLREDUCE");
+}
+
+inline bool isLowPrecisionFp8E4M3ReduceScatterEnabled() {
+  return isLowPrecisionFp8E4M3Enabled() ||
+      isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE_REDUCESCATTER");
+}
+
+inline bool isLowPrecisionFp8E4M3AllToAllEnabled() {
+  return isLowPrecisionFp8E4M3Enabled() ||
+      isLowPrecisionEnvFlagSet("RCCL_LOW_PRECISION_ENABLE_ALLTOALL");
+}
+
+// True if low precision is enabled for the whole comm (global switch) or for
+// any individual collective. Used to decide whether the per-comm low precision
+// buffer pool must be pre-allocated at init time (required for CUDA graph
+// compatibility, since the pool cannot be allocated during graph capture).
+inline bool isAnyLowPrecisionFp8E4M3Enabled() {
+  return isLowPrecisionFp8E4M3AllGatherEnabled() ||
+      isLowPrecisionFp8E4M3AllReduceEnabled() ||
+      isLowPrecisionFp8E4M3ReduceScatterEnabled() ||
+      isLowPrecisionFp8E4M3AllToAllEnabled();
 }
 
 /**

--- a/comms/rcclx/develop/projects/rccl/src/collectives.cc
+++ b/comms/rcclx/develop/projects/rccl/src/collectives.cc
@@ -105,7 +105,7 @@ NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
   // Check if low precision is enabled
-  if (isLowPrecisionFp8E4M3Enabled()) {
+  if (isLowPrecisionFp8E4M3AllGatherEnabled()) {
     int nRanks;
     NCCLCHECK(ncclCommCount(comm, &nRanks));
     size_t messageSize = nRanks * sendcount * ncclTypeSize(datatype);
@@ -212,7 +212,7 @@ NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_
 ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
   // Check for quantized ARG alltoall via environment variable
-  if (isLowPrecisionFp8E4M3Enabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16)) {
+  if (isLowPrecisionFp8E4M3AllToAllEnabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16)) {
     int nRanks;
     NCCLCHECK(ncclCommCount(comm, &nRanks));
     if (nRanks * count * ncclTypeSize(datatype) >=
@@ -336,7 +336,7 @@ NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size
 ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t count,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
 // Check for quantized ARG allreduce via environment variable
-if (isLowPrecisionFp8E4M3Enabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16) &&
+if (isLowPrecisionFp8E4M3AllReduceEnabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16) &&
     op == ncclSum &&
     count * ncclTypeSize(datatype) >= LOW_PRECISION_MSG_SIZE_THRESHOLD) {
   TRACE(
@@ -589,7 +589,7 @@ NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, 
 ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount,
     ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   // Check for quantized ARG reduce-scatter via environment variable
-  if (isLowPrecisionFp8E4M3Enabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16) &&
+  if (isLowPrecisionFp8E4M3ReduceScatterEnabled() && (datatype == ncclFloat32 || datatype == ncclBfloat16) &&
       op == ncclSum) {
     int nRanks;
     NCCLCHECK(ncclCommCount(comm, &nRanks));

--- a/comms/rcclx/develop/projects/rccl/src/init.cc
+++ b/comms/rcclx/develop/projects/rccl/src/init.cc
@@ -886,8 +886,10 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
       0,
       sizeof(struct ncclLowPrecisionBufferPool));
 
-  // Only pre-allocate low precision buffer pool if RCCL_LOW_PRECISION_ENABLE=1
-  if (isLowPrecisionFp8E4M3Enabled()) {
+  // Pre-allocate the low precision buffer pool if low precision is enabled
+  // globally or for any individual collective, or if RCCL_LOW_PRECISION_ENABLE_INIT
+  // forces it (so the per-collective LP switches can be toggled at runtime).
+  if (isAnyLowPrecisionFp8E4M3Enabled() || isLowPrecisionInitEnabled()) {
     // Pre-allocate low precision buffer pool for 2G elements support (8 GPU
     // single node)
     NCCLCHECK(ncclInitLowPrecisionBufferPoolForComm(comm, ndev));


### PR DESCRIPTION
Summary:
Today RCCLX FP8 E4M3 low-precision (LP) collectives are gated by a single
process-global env var, RCCL_LOW_PRECISION_ENABLE, which turns LP on for all
of allgather/allreduce/reduce-scatter/alltoall at once. That is too coarse for
perf-vs-NE experiments where we want to quantize only specific collectives.

This adds four per-collective env vars that can independently enable LP:
- RCCL_LOW_PRECISION_ENABLE_ALLGATHER
- RCCL_LOW_PRECISION_ENABLE_ALLREDUCE
- RCCL_LOW_PRECISION_ENABLE_REDUCESCATTER
- RCCL_LOW_PRECISION_ENABLE_ALLTOALL

A given collective uses LP if the global switch OR its dedicated switch is set,
so existing RCCL_LOW_PRECISION_ENABLE behavior is unchanged. The internal
16 MiB message-size threshold and dtype/op constraints (FP32/BF16, SUM) are
left as-is.

It also adds RCCL_LOW_PRECISION_ENABLE_INIT, which forces the per-comm LP
buffer pool to be pre-allocated at comm init even when no LP collective is
currently enabled. Because the pool must exist before any LP collective runs
(it cannot be allocated during CUDA graph capture), this lets the per-collective
LP switches be toggled dynamically at runtime without restarting the job.

- low_precision_common.h: factor out isLowPrecisionEnvFlagSet(); keep
  isLowPrecisionFp8E4M3Enabled() (global); add four per-collective helpers,
  isLowPrecisionInitEnabled(), and an isAnyLowPrecisionFp8E4M3Enabled()
  aggregate.
- collectives.cc: each *_impl now gates on its per-collective helper.
- init.cc: pre-allocate the per-comm LP buffer pool when any LP path can run
  (global or per-collective) OR when RCCL_LOW_PRECISION_ENABLE_INIT is set.
  The pool free path already keys off pool.initialized, so it stays consistent.

Reviewed By: JinghanHuang

Differential Revision: D109039887


