### PR TITLE
Address benchmark review follow-ups

### DIFF
--- a/comms/uniflow/benchmarks/disagg_accuracy_test.py
+++ b/comms/uniflow/benchmarks/disagg_accuracy_test.py
@@ -548,9 +548,7 @@ class DisaggAccuracyTest:
         try:
             self._model_path = self._download_model()
             gpu_baseline, gpu_prefill, gpu_decode = self._assign_gpus()
-            host_ip = (
-                self._topo.detect_ip() if not self._topo.is_same_node else "127.0.0.1"
-            )
+            host_ip = "127.0.0.1"
             self._log_header()
 
             baseline_outputs = self._run_baseline_phase(gpu_baseline)

--- a/comms/uniflow/benchmarks/disagg_online_test.py
+++ b/comms/uniflow/benchmarks/disagg_online_test.py
@@ -11,6 +11,7 @@ except ImportError:
 
 
 def main(argv: list[str] | None = None) -> None:
+    # Keep the historical entry point name while sharing the maintained runner.
     accuracy_main(argv)
 
 

--- a/comms/uniflow/benchmarks/run_mast_benchmarks.py
+++ b/comms/uniflow/benchmarks/run_mast_benchmarks.py
@@ -352,15 +352,16 @@ class JobResult:
 
     @property
     def passed(self) -> bool:
-        output = "\n".join(self.log_lines)
+        summary = BenchmarkLogParser().parse(self.log_lines)
+        if summary.structured_result is not None:
+            return self.state == "SUCCEEDED" and summary.result_usable_for_comparison
         return (
             self.state == "SUCCEEDED"
-            and "CORRECTNESS PASSED" in output
-            and "ALL ACCURACY TESTS PASSED" in output
-            and "PERFORMANCE:" in output
-            and "Traceback" not in output
-            and "RuntimeError" not in output
-            and "ValueError" not in output
+            and summary.correctness_passed
+            and summary.all_accuracy_passed
+            and summary.performance_seen
+            and summary.mismatch_count == 0
+            and not summary.fatal_runtime_errors
         )
 
 
@@ -2253,7 +2254,13 @@ def parse_args() -> argparse.Namespace:
 def make_job_specs(args: argparse.Namespace, package: str) -> list[JobSpec]:
     connectors = list(CONNECTORS) if args.connector == "both" else [args.connector]
     layouts = ["sn", "cn"] if args.layout == "both" else [args.layout]
-    tp_values = args.tp_values if args.tp_values is not None else [args.tp]
+    if args.tp_values is not None and args.tp != 1:
+        logger.warning(
+            "--tp=%d is ignored because --tp-values=%s was supplied",
+            args.tp,
+            args.tp_values,
+        )
+    tp_values = args.tp_values or [args.tp]
     package_suffix = package_hash_suffix(package)
     run_suffix = time.strftime("%m%d%H%M%S")
     specs: list[JobSpec] = []
@@ -2422,7 +2429,7 @@ def print_summary(package: str, results: Sequence[JobResult]) -> None:
     for result in results:
         status = "PASS" if result.passed else "FAIL"
         logger.info(
-            "%s: %s %s TP=%d %s %s",
+            "status=%s layout=%s connector=%s tp=%d state=%s app_uri=%s",
             status,
             result.spec.layout.upper(),
             result.spec.connector_class,

--- a/comms/uniflow/benchmarks/run_mast_benchmarks_test.py
+++ b/comms/uniflow/benchmarks/run_mast_benchmarks_test.py
@@ -303,6 +303,61 @@ class RunMastBenchmarksTest(unittest.TestCase):
         self.assertEqual(failures, ["1 fatal runtime log lines"])
         self.assertEqual(warnings, ["1 post-result runtime log lines"])
 
+    def test_job_result_passed_uses_structured_result(self) -> None:
+        result = {
+            "benchmark": "disagg_prefill_decode",
+            "connector": "UniflowConnector",
+            "correctness": {"mismatches": 0, "passed": True, "total_checked": 2},
+            "mode": "accuracy",
+            "performance": {
+                "median_s": 10.0,
+                "req_per_s": 4.0,
+            },
+            "schema_version": 1,
+            "status": "passed",
+        }
+        job = run_mast_benchmarks.JobResult(
+            spec=self.job_spec(),
+            app_uri="mast://torchx/torchx-bench-cn-uni-tp1",
+            state="SUCCEEDED",
+            log_lines=[
+                "trainer/0 [0]:BENCHMARK_RESULT_JSON: " + json.dumps(result),
+                "trainer/0 [0]:previous run had RuntimeError but recovered",
+            ],
+        )
+
+        self.assertTrue(job.passed)
+
+    def test_make_job_specs_logs_when_tp_values_shadow_tp(self) -> None:
+        args = argparse.Namespace(
+            connector="uniflow",
+            layout="cn",
+            tp=4,
+            tp_values=[1, 2],
+            job_prefix="bench",
+            nixl_kv_buffer_device="cuda",
+            pytorch_cuda_alloc_conf="expandable_segments:True",
+        )
+
+        with self.assertLogs(run_mast_benchmarks.logger, level="WARNING") as logs:
+            specs = run_mast_benchmarks.make_job_specs(args, "pkg:abcdef0")
+
+        self.assertEqual([spec.tp for spec in specs], [1, 2])
+        self.assertIn("--tp=4 is ignored", "\n".join(logs.output))
+
+    @staticmethod
+    def job_spec() -> run_mast_benchmarks.JobSpec:
+        return run_mast_benchmarks.JobSpec(
+            connector_key="uniflow",
+            connector_class="UniflowConnector",
+            layout="cn",
+            tp=1,
+            nixl_kv_buffer_device="cuda",
+            pytorch_cuda_alloc_conf="expandable_segments:True",
+            name="bench-cn-uni-tp1",
+            session_id="codex-abcdef0-cn-uniflow-tp1",
+        )
+
     @staticmethod
     def progress_line(*, completed_iters: int, completed_requests: int) -> str:
         payload = {


### PR DESCRIPTION
Summary: Address benchmark review feedback after the original benchmark stack by keeping accuracy-mode GPU memory split within the requested budget, running the standalone accuracy baseline with the requested TP size, limiting NIXL side-channel environment setup to NIXL jobs with loopback for same-node runs, simplifying legacy same-node accuracy host handling, making MAST job pass/fail consume structured benchmark JSON when available, and cleaning TP-matrix logging.

Reviewed By: saifhhasan

Differential Revision: D107570062


