### PR TITLE
RoCE GID auto-selection, env tunables, and netdev-prefix NIC selection (#2945)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -29,7 +29,7 @@ bool isCpu(int deviceId) {
 
 std::vector<std::string> MultiTransportFactory::selectCpuNics() {
   auto& topo = sharedTopology();
-  auto nics = topo.selectCpuNics(nicFilter_);
+  auto nics = topo.selectCpuNics(options_.nicFilter, options_.netdevPrefix);
   const auto candidateNicCount = nics.size();
   if (options_.cpuNicSelectionPolicy == CpuNicSelectionPolicy::kAll) {
     UNIFLOW_LOG_INFO(
@@ -39,7 +39,7 @@ std::vector<std::string> MultiTransportFactory::selectCpuNics() {
   }
 
   auto localNics =
-      topo.selectCpuNicsForNumaNodes(nicFilter_, options_.maxCpuNics);
+      topo.selectCpuNicsForNumaNodes(options_.nicFilter, options_.maxCpuNics);
   if (localNics.empty()) {
     localNics = std::move(nics);
     if (options_.maxCpuNics > 0 && localNics.size() > options_.maxCpuNics) {
@@ -62,7 +62,8 @@ std::vector<std::string> MultiTransportFactory::selectNics() {
   if (isCpu(deviceId_)) {
     return selectCpuNics();
   }
-  return topo.selectGpuNics(deviceId_, nicFilter_);
+  return topo.selectGpuNics(
+      deviceId_, options_.nicFilter, options_.netdevPrefix);
 }
 
 Status MultiTransportFactory::supported(TransportType type) {
@@ -129,18 +130,16 @@ Transport* MultiTransport::findTransport(TransportType type) const {
 
 MultiTransportFactory::MultiTransportFactory(
     int deviceId,
-    NicFilter nicFilter,
     MultiTransportFactoryOptions options)
     : deviceId_(deviceId),
-      nicFilter_(std::move(nicFilter)),
-      options_(options),
+      options_(std::move(options)),
       eventBaseThread_(std::make_shared<ScopedEventBaseThread>()) {
   auto& topo = sharedTopology();
   CHECK_THROW_EXCEPTION(
       deviceId_ >= -1 && deviceId_ < static_cast<int>(topo.gpuCount()),
       std::runtime_error);
+
 #ifndef __HIP_PLATFORM_AMD__
-  // NVLink is NVIDIA-only.
   if (deviceId_ >= 0) {
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
         deviceId, eventBaseThread_->getEventBase());
@@ -151,6 +150,8 @@ MultiTransportFactory::MultiTransportFactory(
   auto nics = selectNics();
   if (!nics.empty()) {
     RdmaTransportConfig config;
+    config.gidIndex = options_.gidIndex;
+    config.trafficClass = options_.trafficClass;
     config.numQps = static_cast<uint32_t>(nics.size());
     auto rdma = std::make_shared<RdmaTransportFactory>(
         std::move(nics), eventBaseThread_->getEventBase(), config);

--- a/comms/uniflow/MultiTransport.h
+++ b/comms/uniflow/MultiTransport.h
@@ -17,6 +17,10 @@ enum class CpuNicSelectionPolicy {
 };
 
 struct MultiTransportFactoryOptions {
+  NicFilter nicFilter;
+  std::string netdevPrefix{"beth"};
+  int16_t gidIndex{-1};
+  uint8_t trafficClass{0};
   CpuNicSelectionPolicy cpuNicSelectionPolicy{
       CpuNicSelectionPolicy::kNumaLocalBounded};
   size_t maxCpuNics{2};
@@ -106,7 +110,6 @@ class MultiTransportFactory {
  public:
   explicit MultiTransportFactory(
       int deviceId,
-      NicFilter nicFilter = NicFilter(),
       MultiTransportFactoryOptions options = {});
 
   Result<RegisteredSegment> registerSegment(Segment& segment);
@@ -139,7 +142,6 @@ class MultiTransportFactory {
   std::vector<std::string> selectCpuNics();
 
   int deviceId_{-1};
-  NicFilter nicFilter_;
   MultiTransportFactoryOptions options_;
   std::shared_ptr<ScopedEventBaseThread> eventBaseThread_;
   std::vector<std::shared_ptr<TransportFactory>> factories_;

--- a/comms/uniflow/UniflowPy.cpp
+++ b/comms/uniflow/UniflowPy.cpp
@@ -540,15 +540,13 @@ PYBIND11_MODULE(_core, m) {
                       CpuNicSelectionPolicy cpuNicSelectionPolicy,
                       size_t maxCpuNics) {
             MultiTransportFactoryOptions options{
+                .nicFilter =
+                    nicFilter.empty() ? NicFilter() : NicFilter(nicFilter),
                 .cpuNicSelectionPolicy = cpuNicSelectionPolicy,
                 .maxCpuNics = maxCpuNics,
             };
-            if (nicFilter.empty()) {
-              return std::make_shared<MultiTransportFactory>(
-                  deviceId, NicFilter(), options);
-            }
             return std::make_shared<MultiTransportFactory>(
-                deviceId, NicFilter(nicFilter), options);
+                deviceId, std::move(options));
           }),
           "Create a MultiTransportFactory for the given device.",
           py::arg("device_id"),

--- a/comms/uniflow/drivers/cuda/CudaTopologyDiscovery.cpp
+++ b/comms/uniflow/drivers/cuda/CudaTopologyDiscovery.cpp
@@ -109,6 +109,14 @@ int readNumaNode(SysfsApi& sysfs, std::string_view pciDevicePath) {
   return static_cast<int>(val);
 }
 
+/// Read the backing netdev name for an IB device by listing
+/// /sys/class/infiniband/<dev>/device/net/. Vendor-neutral (works for mlx5,
+/// bnxt_re, etc.). Returns the first entry, or empty if none is found.
+std::string readNetdevName(SysfsApi& sysfs, const std::string& ibdevPath) {
+  auto entries = sysfs.listDir(ibdevPath + "/device/net");
+  return entries.empty() ? std::string{} : entries.front();
+}
+
 /// Convert a sysfs max_link_speed string to Mbps per lane.
 /// Handles both old ("16 GT/s") and new ("16.0 GT/s PCIe") kernel formats.
 /// Encoding overhead is already baked into the returned value.
@@ -609,6 +617,7 @@ Result<std::vector<NicDiscovery>> discoverNics(
                     .numaNode = 0,
                     .port = activePort,
                     .portSpeedMbps = portSpeedMbps,
+                    .netdevName = readNetdevName(sysfs, ibdevPath),
                 },
             .sysfsPath = ibdevPath,
             .ancestorChain = {},
@@ -623,6 +632,7 @@ Result<std::vector<NicDiscovery>> discoverNics(
                     .numaNode = readNumaNode(sysfs, pciDevicePath),
                     .port = activePort,
                     .portSpeedMbps = portSpeedMbps,
+                    .netdevName = readNetdevName(sysfs, ibdevPath),
                 },
             .sysfsPath = pciDevicePath,
             .ancestorChain = buildAncestorChain(sysfs, pciDevicePath),

--- a/comms/uniflow/drivers/ibverbs/IbvApi.cpp
+++ b/comms/uniflow/drivers/ibverbs/IbvApi.cpp
@@ -11,6 +11,18 @@
 #include <mutex>
 #include <string>
 
+namespace {
+std::string safeStrerror(int errnum) {
+  char buf[256];
+#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+  return std::string(strerror_r(errnum, buf, sizeof(buf)));
+#else
+  strerror_r(errnum, buf, sizeof(buf));
+  return std::string(buf);
+#endif
+}
+} // namespace
+
 namespace uniflow {
 
 // ---------------------------------------------------------------------------
@@ -103,6 +115,15 @@ UNIFLOW_IBV_FN(
     ibv_query_gid,
     int,
     (ibv_context * context, uint8_t port_num, int index, ibv_gid* gid))
+UNIFLOW_IBV_FN(
+    _ibv_query_gid_ex,
+    int,
+    (ibv_context * context,
+     uint32_t port_num,
+     uint32_t gid_index,
+     ibv_gid_entry* entry,
+     uint32_t flags,
+     size_t entry_size))
 
 #undef UNIFLOW_IBV_FN
 #undef UNIFLOW_IBV_FN_WRAP
@@ -192,6 +213,9 @@ void doInit() {
 
   // Optional symbols — fail silently (pointer stays nullptr).
   LOAD_SYM_OPTIONAL(libHandle, ibv_reg_dmabuf_mr, "IBVERBS_1.12");
+  // ibv_query_gid_ex is a static-inline wrapper around the exported
+  // _ibv_query_gid_ex symbol (IBVERBS_1.11+); load the real symbol.
+  LOAD_SYM_OPTIONAL(libHandle, _ibv_query_gid_ex, "IBVERBS_1.11");
 
   // Deliberately never dlclose — the loaded object remains in memory
   // until the process terminates.
@@ -236,14 +260,14 @@ void doInit() {
 
 /// Check an already-obtained errno return; expect ret == 0. Return Status.
 /// Used for hot-path ops vtable calls that bypass init/symbol checks.
-#define IBV_CHECK_ERRNO(name, ret)                                \
-  do {                                                            \
-    if ((ret) != 0) {                                             \
-      return Err(                                                 \
-          ErrCode::DriverError,                                   \
-          std::string(#name "() failed: ") + std::strerror(ret)); \
-    }                                                             \
-    return Ok();                                                  \
+#define IBV_CHECK_ERRNO(name, ret)                               \
+  do {                                                           \
+    if ((ret) != 0) {                                            \
+      return Err(                                                \
+          ErrCode::DriverError,                                  \
+          std::string(#name "() failed: ") + safeStrerror(ret)); \
+    }                                                            \
+    return Ok();                                                 \
   } while (0)
 
 /// Call pfn_##name(__VA_ARGS__); expect ret == 0 (returns errno on failure).
@@ -272,17 +296,17 @@ void doInit() {
 /// Call pfn_##name(__VA_ARGS__); expect ret != nullptr.
 /// Error message includes strerror(errno). Matches nccl
 /// IBV_CHECK_PTR_ERRNO.
-#define IBV_CHECK_PTR_ERRNO(name, ...)                              \
-  do {                                                              \
-    IBV_ENSURE_INIT();                                              \
-    IBV_CHECK_FN(name);                                             \
-    auto _ptr = pfn_##name(__VA_ARGS__);                            \
-    if (_ptr == nullptr) {                                          \
-      return Err(                                                   \
-          ErrCode::DriverError,                                     \
-          std::string(#name "() failed: ") + std::strerror(errno)); \
-    }                                                               \
-    return _ptr;                                                    \
+#define IBV_CHECK_PTR_ERRNO(name, ...)                             \
+  do {                                                             \
+    IBV_ENSURE_INIT();                                             \
+    IBV_CHECK_FN(name);                                            \
+    auto _ptr = pfn_##name(__VA_ARGS__);                           \
+    if (_ptr == nullptr) {                                         \
+      return Err(                                                  \
+          ErrCode::DriverError,                                    \
+          std::string(#name "() failed: ") + safeStrerror(errno)); \
+    }                                                              \
+    return _ptr;                                                   \
   } while (0)
 
 /// Call pfn_##name(__VA_ARGS__); expect ret != nullptr.
@@ -450,6 +474,24 @@ Status IbvApi::queryGid(
     int index,
     ibv_gid* gid) {
   IBV_CHECK_INT_ERRNO(ibv_query_gid, context, portNum, index, gid);
+}
+
+Status IbvApi::queryGidEx(
+    ibv_context* context,
+    uint32_t portNum,
+    uint32_t index,
+    ibv_gid_entry* entry,
+    uint32_t flags) {
+  IBV_ENSURE_INIT();
+  IBV_CHECK_FN(_ibv_query_gid_ex);
+  int ret = pfn__ibv_query_gid_ex(
+      context, portNum, index, entry, flags, sizeof(*entry));
+  IBV_CHECK_ERRNO(_ibv_query_gid_ex, ret);
+}
+
+bool IbvApi::isQueryGidExSupported() {
+  init();
+  return pfn__ibv_query_gid_ex != nullptr;
 }
 
 // --- MLX5 direct verbs ---

--- a/comms/uniflow/drivers/ibverbs/IbvApi.h
+++ b/comms/uniflow/drivers/ibverbs/IbvApi.h
@@ -85,6 +85,19 @@ class IbvApi {
   virtual Status
   queryGid(ibv_context* context, uint8_t portNum, int index, ibv_gid* gid);
 
+  /// Query an extended GID table entry (type, ndev, etc.) via
+  /// _ibv_query_gid_ex. Optional: only available when rdma-core exports the
+  /// symbol (IBVERBS_1.11+). Check isQueryGidExSupported() first.
+  virtual Status queryGidEx(
+      ibv_context* context,
+      uint32_t portNum,
+      uint32_t index,
+      ibv_gid_entry* entry,
+      uint32_t flags);
+
+  /// Returns true if ibv_query_gid_ex is available in the loaded rdma-core.
+  virtual bool isQueryGidExSupported();
+
   // --- MLX5 direct verbs ---
 
   /// Check if an IB device supports mlx5 direct verbs.

--- a/comms/uniflow/drivers/ibverbs/IbvCore.h
+++ b/comms/uniflow/drivers/ibverbs/IbvCore.h
@@ -28,6 +28,20 @@ union ibv_gid {
   } global;
 };
 
+enum ibv_gid_type {
+  IBV_GID_TYPE_IB,
+  IBV_GID_TYPE_ROCE_V1,
+  IBV_GID_TYPE_ROCE_V2,
+};
+
+struct ibv_gid_entry {
+  union ibv_gid gid;
+  uint32_t gid_index;
+  uint32_t port_num;
+  uint32_t gid_type; /* enum ibv_gid_type */
+  uint32_t ndev_ifindex;
+};
+
 #ifndef container_of
 /**
  * container_of - cast a member of a structure out to the containing structure

--- a/comms/uniflow/drivers/ibverbs/mock/MockIbvApi.h
+++ b/comms/uniflow/drivers/ibverbs/mock/MockIbvApi.h
@@ -116,6 +116,16 @@ class MockIbvApi : public IbvApi {
       queryGid,
       (ibv_context * context, uint8_t portNum, int index, ibv_gid* gid),
       (override));
+  MOCK_METHOD(
+      Status,
+      queryGidEx,
+      (ibv_context * context,
+       uint32_t portNum,
+       uint32_t index,
+       ibv_gid_entry* entry,
+       uint32_t flags),
+      (override));
+  MOCK_METHOD(bool, isQueryGidExSupported, (), (override));
 
   // MLX5 direct verbs
   MOCK_METHOD(

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -34,7 +34,7 @@ class MultiTransportFactoryTest : public ::testing::Test {
     auto factory =
         std::unique_ptr<MultiTransportFactory>(new MultiTransportFactory({}));
     factory->deviceId_ = deviceId;
-    factory->nicFilter_ = std::move(nicFilter);
+    factory->options_.nicFilter = std::move(nicFilter);
     return factory;
   }
 

--- a/comms/uniflow/transport/Topology.cpp
+++ b/comms/uniflow/transport/Topology.cpp
@@ -4,8 +4,11 @@
 
 #include <algorithm>
 #include <queue>
+#include <string_view>
 #include <tuple>
 #include <utility>
+
+#include "comms/uniflow/logging/Logger.h"
 
 namespace uniflow {
 
@@ -17,39 +20,56 @@ bool isBetterPath(const TopoPath& a, const TopoPath& b) {
   return std::tie(a.type, b.bw) < std::tie(b.type, a.bw);
 }
 
-template <typename SourceNodeIdFn>
-std::vector<std::string> selectNicsByBestPath(
+/// Shared NIC-selection core. Ranks NICs by the path returned from @p pathFor
+/// and returns all NICs tied for the best (lowest) path type and bandwidth.
+///
+/// When @p netdevPrefix is non-empty AND the topology has known netdev names,
+/// NICs are first restricted to those whose backing netdev name starts with the
+/// prefix; if that yields nothing, it logs a warning and falls back to
+/// filter-only selection (the legacy behavior). Topologies that do not populate
+/// netdev names skip the prefix predicate entirely (no warning).
+template <typename PathFor>
+std::vector<std::string> selectNicsImpl(
     const Topology& topo,
     const NicFilter& filter,
-    size_t maxNics,
-    SourceNodeIdFn sourceNodeId) {
-  int count = static_cast<int>(topo.nicCount());
-  std::vector<std::string> nics;
-  PathType bestType = PathType::DIS;
-  uint32_t maxBw = 0;
-  for (int i = 0; i < count; ++i) {
-    if (!topo.filterNic(i, filter)) {
-      continue;
+    std::string_view netdevPrefix,
+    PathFor&& pathFor) {
+  const auto pick = [&](bool requirePrefix) {
+    std::vector<std::string> nics;
+    PathType bestType = PathType::DIS;
+    uint32_t maxBw = 0;
+    const int count = static_cast<int>(topo.nicCount());
+    for (int i = 0; i < count; ++i) {
+      if (!topo.filterNic(i, filter)) {
+        continue;
+      }
+      if (requirePrefix && !topo.matchesNetdevPrefix(i, netdevPrefix)) {
+        continue;
+      }
+      const auto& nicNode = topo.getNicNode(i);
+      const auto& path = pathFor(nicNode);
+      if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
+        nics.clear();
+        nics.push_back(nicNode.name);
+        bestType = path.type;
+        maxBw = path.bw;
+      } else if (path.type == bestType && path.bw == maxBw) {
+        nics.push_back(nicNode.name);
+      }
     }
-    const auto& nicNode = topo.getNicNode(i);
-    auto srcNodeId = sourceNodeId(nicNode);
-    if (!srcNodeId) {
-      continue;
+    return nics;
+  };
+
+  if (!netdevPrefix.empty() && topo.hasNetdevNames()) {
+    auto preferred = pick(/*requirePrefix=*/true);
+    if (!preferred.empty()) {
+      return preferred;
     }
-    const auto& path = topo.getPath(*srcNodeId, nicNode.id, {.allowC2C = true});
-    if (path.type < bestType || (path.type == bestType && path.bw > maxBw)) {
-      nics.clear();
-      nics.push_back(nicNode.name);
-      bestType = path.type;
-      maxBw = path.bw;
-    } else if (path.type == bestType && path.bw == maxBw) {
-      nics.push_back(nicNode.name);
-    }
+    UNIFLOW_LOG_WARN(
+        "No NIC matched netdev prefix '{}'; falling back to filter-only NIC selection",
+        netdevPrefix);
   }
-  if (maxNics > 0 && nics.size() > maxNics) {
-    nics.resize(maxNics);
-  }
-  return nics;
+  return pick(/*requirePrefix=*/false);
 }
 
 } // namespace
@@ -373,12 +393,51 @@ bool Topology::filterNic(int nicIndex, const NicFilter& filter) const {
   return filter.matches(nodes_[nicNodeIds_[nicIndex]].name);
 }
 
+bool Topology::matchesNetdevPrefix(int nicIndex, std::string_view netdevPrefix)
+    const {
+  if (netdevPrefix.empty()) {
+    return true;
+  }
+  const auto& nicData = std::get<TopoNode::NicData>(getNicNode(nicIndex).data);
+  return std::string_view(nicData.netdevName).starts_with(netdevPrefix);
+}
+
+bool Topology::hasNetdevNames() const {
+  const int count = static_cast<int>(nicCount());
+  for (int i = 0; i < count; ++i) {
+    const auto& nicData = std::get<TopoNode::NicData>(getNicNode(i).data);
+    if (!nicData.netdevName.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::vector<std::string> Topology::selectCpuNics(
-    const NicFilter& filter) const {
-  return selectNicsByBestPath(
-      *this, filter, 0, [this](const TopoNode& nicNode) {
-        const auto numaId = std::get<TopoNode::NicData>(nicNode.data).numaNode;
-        return std::optional<int>(getCpuNode(numaId).id);
+    const NicFilter& filter,
+    std::string_view netdevPrefix) const {
+  return selectNicsImpl(
+      *this,
+      filter,
+      netdevPrefix,
+      [this](const TopoNode& nicNode) -> const TopoPath& {
+        const auto& numaNode =
+            getCpuNode(std::get<TopoNode::NicData>(nicNode.data).numaNode);
+        return getPath(numaNode.id, nicNode.id, {.allowC2C = true});
+      });
+}
+
+std::vector<std::string> Topology::selectGpuNics(
+    int cudaDeviceId,
+    const NicFilter& filter,
+    std::string_view netdevPrefix) const {
+  const auto& gpuNode = getGpuNode(cudaDeviceId);
+  return selectNicsImpl(
+      *this,
+      filter,
+      netdevPrefix,
+      [this, &gpuNode](const TopoNode& nicNode) -> const TopoPath& {
+        return getPath(gpuNode.id, nicNode.id, {.allowC2C = true});
       });
 }
 
@@ -390,12 +449,18 @@ std::vector<std::string> Topology::selectCpuNicsForNuma(
       cpuNodeIds_[numaId] < 0) {
     return {};
   }
-
   const auto& numaNode = getCpuNode(numaId);
-  return selectNicsByBestPath(
-      *this, filter, maxNics, [cpuNodeId = numaNode.id](const TopoNode&) {
-        return std::optional<int>(cpuNodeId);
+  auto nics = selectNicsImpl(
+      *this,
+      filter,
+      "",
+      [this, &numaNode](const TopoNode& nicNode) -> const TopoPath& {
+        return getPath(numaNode.id, nicNode.id, {.allowC2C = true});
       });
+  if (maxNics > 0 && nics.size() > maxNics) {
+    nics.resize(maxNics);
+  }
+  return nics;
 }
 
 std::vector<std::string> Topology::selectCpuNicsForNumaNodes(
@@ -412,16 +477,6 @@ std::vector<std::string> Topology::selectCpuNicsForNumaNodes(
     }
   }
   return nics;
-}
-
-std::vector<std::string> Topology::selectGpuNics(
-    int cudaDeviceId,
-    const NicFilter& filter) const {
-  const auto& gpuNode = getGpuNode(cudaDeviceId);
-  return selectNicsByBestPath(
-      *this, filter, 0, [gpuNodeId = gpuNode.id](const TopoNode&) {
-        return std::optional<int>(gpuNodeId);
-      });
 }
 
 // --- NicFilter ---

--- a/comms/uniflow/transport/Topology.h
+++ b/comms/uniflow/transport/Topology.h
@@ -119,6 +119,7 @@ struct TopoNode {
     int numaNode{-1};
     int port{-1}; // Active port numbers
     uint32_t portSpeedMbps{0}; // RDMA port speed from ibv_query_port (Mbps)
+    std::string netdevName; // Backing netdev (e.g. "beth0"); empty = unknown
   };
 
   std::variant<GpuData, CpuData, NicData> data;
@@ -200,12 +201,22 @@ class Topology {
   /// Check if a NIC passes the given filter.
   bool filterNic(int nicIndex, const NicFilter& filter) const;
 
-  // --- NIC selection ---
+  /// Returns true if the NIC's backing netdev name starts with @p netdevPrefix.
+  /// An empty prefix matches everything (predicate disabled).
+  bool matchesNetdevPrefix(int nicIndex, std::string_view netdevPrefix) const;
 
-  /// Select NICs with the best path from their own NUMA node, filtered by
-  /// NicFilter. Returns multiple NICs when they share the same best path
-  /// type and bandwidth.
-  std::vector<std::string> selectCpuNics(const NicFilter& filter = {}) const;
+  /// Returns true if any NIC has a known backing netdev name. Backends that do
+  /// not populate netdev names return false, letting callers skip netdev-prefix
+  /// filtering instead of warning on every NIC selection.
+  bool hasNetdevNames() const;
+
+  // --- NIC selection ---
+  /// When @p netdevPrefix is non-empty, only NICs whose backing netdev name
+  /// starts with the prefix (e.g. "beth") are considered; if none match, it
+  /// falls back to filter-only selection and logs a warning.
+  std::vector<std::string> selectCpuNics(
+      const NicFilter& filter = {},
+      std::string_view netdevPrefix = "") const;
 
   /// Select NICs with the best path from the given NUMA node, filtered by
   /// NicFilter. Returns an empty vector when the NUMA node is unknown.
@@ -223,10 +234,11 @@ class Topology {
 
   /// Select NICs closest to the given GPU, filtered by NicFilter.
   /// Returns multiple NICs when they share the same best path (e.g. GB200:
-  /// 2 NICs per GPU).
+  /// 2 NICs per GPU). See selectCpuNics for @p netdevPrefix semantics.
   std::vector<std::string> selectGpuNics(
       int cudaDeviceId,
-      const NicFilter& filter = {}) const;
+      const NicFilter& filter = {},
+      std::string_view netdevPrefix = "") const;
 
   // --- Mutation API (used by discovery backends) ---
 

--- a/comms/uniflow/transport/rdma/RdmaResources.cpp
+++ b/comms/uniflow/transport/rdma/RdmaResources.cpp
@@ -2,7 +2,35 @@
 
 #include "comms/uniflow/transport/rdma/RdmaResources.h"
 
+#include "comms/uniflow/logging/Logger.h"
+
 namespace uniflow {
+
+namespace {
+
+constexpr uint8_t kDefaultRoceV2GidIndex = 3;
+
+/// True if @p gid is an IPv4-mapped IPv6 address (::ffff:a.b.c.d).
+bool isIpv4MappedGid(const ibv_gid& gid) {
+  for (int i = 0; i < 10; ++i) {
+    if (gid.raw[i] != 0) {
+      return false;
+    }
+  }
+  return gid.raw[10] == 0xff && gid.raw[11] == 0xff;
+}
+
+/// True if @p gid is a link-local address that cannot be routed across NICs or
+/// hosts: IPv6 link-local (fe80::/10) or IPv4-mapped IPv4 link-local
+/// (169.254.0.0/16). Such GIDs are unusable for cross-NIC/cross-host RoCE.
+bool isLinkLocalGid(const ibv_gid& gid) {
+  if (gid.raw[0] == 0xfe && (gid.raw[1] & 0xc0) == 0x80) {
+    return true;
+  }
+  return isIpv4MappedGid(gid) && gid.raw[12] == 169 && gid.raw[13] == 254;
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // NicResources
@@ -12,7 +40,7 @@ NicResources::NicResources(
     ibv_device* device,
     std::shared_ptr<IbvApi> api,
     int numaNode,
-    uint8_t gidIndex,
+    int configuredGidIndex,
     std::optional<uint8_t> port)
     : numaNode(numaNode), ibvApi(std::move(api)) {
   try {
@@ -56,6 +84,8 @@ NicResources::NicResources(
     mtu = portAttr.active_mtu;
     linkLayer = portAttr.link_layer;
 
+    gidIndex = resolveGidIndex(configuredGidIndex, portAttr);
+
     auto gidStatus = ibvApi->queryGid(ctx, portNum, gidIndex, &gid);
     if (gidStatus.hasError()) {
       throw std::runtime_error("NicResources: failed to query GID");
@@ -71,6 +101,7 @@ NicResources::NicResources(NicResources&& other) noexcept
       pd(other.pd),
       lid(other.lid),
       gid(other.gid),
+      gidIndex(other.gidIndex),
       mtu(other.mtu),
       linkLayer(other.linkLayer),
       portNum(other.portNum),
@@ -116,6 +147,89 @@ uint8_t NicResources::findActivePort() const {
     }
   }
   return 0;
+}
+
+uint8_t NicResources::resolveGidIndex(
+    int configuredGidIndex,
+    const ibv_port_attr& portAttr) const {
+  if (configuredGidIndex >= 0) {
+    if (configuredGidIndex >= portAttr.gid_tbl_len) {
+      throw std::runtime_error(
+          "NicResources: configured GID index " +
+          std::to_string(configuredGidIndex) +
+          " out of range (gid_tbl_len=" + std::to_string(portAttr.gid_tbl_len) +
+          "); check configured gidIndex");
+    }
+    return static_cast<uint8_t>(configuredGidIndex);
+  }
+
+  // The GID index only matters for RoCE (Ethernet) addressing; IB ports use
+  // LID-based address vectors. Auto-selection also requires ibv_query_gid_ex,
+  // which older rdma-core may not export.
+  if (linkLayer != IBV_LINK_LAYER_ETHERNET ||
+      !ibvApi->isQueryGidExSupported()) {
+    if (portAttr.gid_tbl_len > 0 &&
+        kDefaultRoceV2GidIndex >= portAttr.gid_tbl_len) {
+      throw std::runtime_error(
+          "NicResources: default GID index " +
+          std::to_string(kDefaultRoceV2GidIndex) +
+          " out of range (gid_tbl_len=" + std::to_string(portAttr.gid_tbl_len) +
+          "); set gidIndex explicitly");
+    }
+    return kDefaultRoceV2GidIndex;
+  }
+  int firstGlobalRoceV2 = -1;
+  for (int i = 0; i < portAttr.gid_tbl_len; ++i) {
+    ibv_gid_entry entry{};
+    auto status =
+        ibvApi->queryGidEx(ctx, portNum, static_cast<uint32_t>(i), &entry, 0);
+    if (status.hasError() || entry.gid_type != IBV_GID_TYPE_ROCE_V2) {
+      continue;
+    }
+    // Link-local GIDs are not routable across NICs/hosts; skip them so that
+    // cross-NIC and cross-host RoCE connections use a globally routable GID.
+    if (isLinkLocalGid(entry.gid)) {
+      continue;
+    }
+    // Prefer an IPv4-mapped RoCEv2 entry; otherwise remember the first global.
+    if (isIpv4MappedGid(entry.gid)) {
+      UNIFLOW_LOG_INFO(
+          "Selected IPv4-mapped RoCEv2 GID index {} on port {}", i, portNum);
+      return static_cast<uint8_t>(i);
+    }
+    if (firstGlobalRoceV2 < 0) {
+      firstGlobalRoceV2 = i;
+    }
+  }
+
+  if (firstGlobalRoceV2 >= 0) {
+    if (firstGlobalRoceV2 > 255) {
+      UNIFLOW_LOG_WARN(
+          "GID index {} exceeds uint8_t range on port {}; using default",
+          firstGlobalRoceV2,
+          portNum);
+    } else {
+      UNIFLOW_LOG_INFO(
+          "Selected RoCEv2 GID index {} on port {}",
+          firstGlobalRoceV2,
+          portNum);
+      return static_cast<uint8_t>(firstGlobalRoceV2);
+    }
+  }
+
+  if (kDefaultRoceV2GidIndex < portAttr.gid_tbl_len) {
+    UNIFLOW_LOG_WARN(
+        "No global RoCEv2 GID found on port {}; falling back to GID index {}",
+        portNum,
+        kDefaultRoceV2GidIndex);
+    return kDefaultRoceV2GidIndex;
+  }
+
+  throw std::runtime_error(
+      "NicResources: no global RoCEv2 GID found on port " +
+      std::to_string(portNum) + " and default GID index " +
+      std::to_string(kDefaultRoceV2GidIndex) + " out of range (gid_tbl_len=" +
+      std::to_string(portAttr.gid_tbl_len) + ")");
 }
 
 } // namespace uniflow

--- a/comms/uniflow/transport/rdma/RdmaResources.h
+++ b/comms/uniflow/transport/rdma/RdmaResources.h
@@ -20,17 +20,26 @@ struct NicResources {
   ibv_pd* pd{nullptr}; /* Protection domain on this device. */
   uint16_t lid{0}; /* Local identifier (IB fabrics). */
   ibv_gid gid{}; /* GID for RoCE / IB with GRH. */
+  uint8_t gidIndex{3}; /* Resolved GID table index used for this NIC. */
   ibv_mtu mtu{IBV_MTU_4096}; /* Active MTU from port query. */
   int linkLayer{IBV_LINK_LAYER_ETHERNET}; /* IB or Ethernet (RoCE). */
   uint8_t portNum{1}; /* Physical port number on the HCA. */
   bool dmaBufSupported{false}; /* Kernel supports DMA-BUF MR registration. */
   int numaNode{-1}; /* NUMA node of the NIC, from Topology (-1 = unknown). */
 
+  /*
+   * Full-init constructor.
+   *
+   * @param configuredGidIndex  Forced RoCE GID index, or -1 to auto-select a
+   *                            RoCEv2 entry by scanning the GID table (falls
+   *                            back to index 3 when ibv_query_gid_ex is
+   *                            unavailable or no RoCEv2 entry is found).
+   */
   NicResources(
       ibv_device* device,
       std::shared_ptr<IbvApi> api,
       int numaNode = -1,
-      uint8_t gidIndex = 3,
+      int configuredGidIndex = -1,
       std::optional<uint8_t> port = std::nullopt);
 
   ~NicResources();
@@ -42,6 +51,11 @@ struct NicResources {
 
  private:
   uint8_t findActivePort() const;
+  /// Resolve the RoCE GID table index for an Ethernet port. Returns the
+  /// configured index when >= 0; otherwise scans for a RoCEv2 entry (preferring
+  /// IPv4-mapped); falls back to index 3.
+  uint8_t resolveGidIndex(int configuredGidIndex, const ibv_port_attr& portAttr)
+      const;
   void cleanup();
   std::shared_ptr<IbvApi> ibvApi{nullptr};
 };

--- a/comms/uniflow/transport/rdma/RdmaTransport.cpp
+++ b/comms/uniflow/transport/rdma/RdmaTransport.cpp
@@ -482,7 +482,7 @@ Status RdmaTransport::connect(std::span<const uint8_t> remoteInfo) {
     if (remoteNic.linkLayer == IBV_LINK_LAYER_ETHERNET) {
       rtrAttr.ah_attr.is_global = 1;
       rtrAttr.ah_attr.grh.dgid = remoteNic.gid;
-      rtrAttr.ah_attr.grh.sgid_index = config_.gidIndex;
+      rtrAttr.ah_attr.grh.sgid_index = localNic.gidIndex;
       rtrAttr.ah_attr.grh.hop_limit = 255;
       rtrAttr.ah_attr.grh.flow_label = 0;
       rtrAttr.ah_attr.grh.traffic_class = config_.trafficClass;

--- a/comms/uniflow/transport/rdma/RdmaTransport.h
+++ b/comms/uniflow/transport/rdma/RdmaTransport.h
@@ -42,7 +42,9 @@ class RdmaSlabPool;
  */
 struct RdmaTransportConfig {
   uint32_t numQps{1}; /* Total QPs distributed round-robin across NICs. */
-  uint8_t gidIndex{3}; /* GID table index for RoCE addressing (3 = RoCEv2). */
+  /* RoCE GID table index. -1 = auto-select a RoCEv2 entry by scanning the GID
+   * table; >= 0 forces that index (3 is the Mellanox RoCEv2 convention). */
+  int16_t gidIndex{-1};
   uint8_t timeout{14}; /* IB timeout exponent for QP retransmission. */
   uint8_t retryCnt{7}; /* Number of retries before reporting an error. */
   uint8_t trafficClass{0}; /* Traffic class for GRH (QoS / DSCP). */

--- a/comms/uniflow/transport/rdma/tests/integration/SingleHostTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/integration/SingleHostTest.cpp
@@ -77,6 +77,10 @@ class SingleHostTest : public ::testing::Test {
 
   /// Create two factories on different NICs, create transports, connect them.
   /// Returns the two connected transports and their factories.
+  ///
+  /// When a NIC list is empty (the default), the first two enumerated devices
+  /// are used. This keeps the data-path tests vendor-agnostic so they run on
+  /// any RDMA host (mlx5, bnxt_re/Thor2, etc.) without hardcoded device names.
   struct ConnectedPair {
     std::unique_ptr<RdmaTransportFactory> factory0;
     std::unique_ptr<RdmaTransportFactory> factory1;
@@ -85,8 +89,14 @@ class SingleHostTest : public ::testing::Test {
   };
 
   ConnectedPair connectPair(
-      const std::vector<std::string>& nicVec0 = {"mlx5_0"},
-      const std::vector<std::string>& nicVec1 = {"mlx5_3"}) {
+      std::vector<std::string> nicVec0 = {},
+      std::vector<std::string> nicVec1 = {}) {
+    if (nicVec0.empty()) {
+      nicVec0 = {deviceNames_[0]};
+    }
+    if (nicVec1.empty()) {
+      nicVec1 = {deviceNames_[1]};
+    }
     ConnectedPair pair;
     auto* evb = evbThread_->getEventBase();
     pair.factory0 = std::make_unique<RdmaTransportFactory>(

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaRegistrationHandleTest.cpp
@@ -22,6 +22,9 @@ using ::testing::Return;
 
 // --- RdmaRegistrationHandle tests ---
 
+constexpr uint8_t kTestGidIndex = 3;
+constexpr uint8_t kMockGidTblLen = kTestGidIndex + 1;
+
 class RdmaRegistrationHandleTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -355,9 +358,11 @@ class RdmaFactoryRegistrationTest : public ::testing::Test {
           attr->active_mtu = IBV_MTU_4096;
           attr->link_layer = IBV_LINK_LAYER_ETHERNET;
           attr->state = IBV_PORT_ACTIVE;
+          attr->gid_tbl_len = kMockGidTblLen;
           return Ok();
         });
-    EXPECT_CALL(*ibv_, queryGid(&fakeCtx_, 1, 3, _)).WillOnce(Return(Ok()));
+    EXPECT_CALL(*ibv_, queryGid(&fakeCtx_, 1, kTestGidIndex, _))
+        .WillOnce(Return(Ok()));
     EXPECT_CALL(*ibv_, freeDeviceList(_)).WillOnce(Return(Ok()));
     // Cleanup on destruction.
     EXPECT_CALL(*ibv_, deallocPd(&fakePd_)).WillOnce(Return(Ok()));
@@ -606,10 +611,12 @@ class RdmaFactoryMultiNicTest : public ::testing::Test {
           attr->lid = 1;
           attr->active_mtu = IBV_MTU_4096;
           attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+          attr->gid_tbl_len = kMockGidTblLen;
           attr->state = IBV_PORT_ACTIVE;
           return Ok();
         });
-    EXPECT_CALL(*ibv_, queryGid(_, 1, 3, _)).WillRepeatedly(Return(Ok()));
+    EXPECT_CALL(*ibv_, queryGid(_, 1, kTestGidIndex, _))
+        .WillRepeatedly(Return(Ok()));
     EXPECT_CALL(*ibv_, freeDeviceList(_)).WillOnce(Return(Ok()));
     EXPECT_CALL(*ibv_, deallocPd(&fakePd0_)).WillOnce(Return(Ok()));
     EXPECT_CALL(*ibv_, deallocPd(&fakePd1_)).WillOnce(Return(Ok()));

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaSlabPoolTest.cpp
@@ -54,6 +54,9 @@ class RdmaSlabPoolTest : public ::testing::Test {
   ibv_mr fakeMr0_{};
   ibv_mr fakeMr1_{};
 
+  static constexpr uint8_t kTestGidIndex = 3;
+  static constexpr uint8_t kMockGidTblLen = kTestGidIndex + 1;
+
   std::shared_ptr<std::vector<NicResources>> makeNics(size_t count = 1) {
     auto nics = std::make_shared<std::vector<NicResources>>();
 
@@ -70,6 +73,7 @@ class RdmaSlabPoolTest : public ::testing::Test {
             attr->lid = 0;
             attr->active_mtu = IBV_MTU_4096;
             attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+            attr->gid_tbl_len = kMockGidTblLen;
             return Ok();
           });
       ON_CALL(*mockIbvApi_, queryGid(ctx, 1, _, _)).WillByDefault(Return(Ok()));
@@ -84,10 +88,11 @@ class RdmaSlabPoolTest : public ::testing::Test {
 
     nics->reserve(count);
     setupNic(&fakeDev0_, &fakeCtx0_, &fakePd0_);
-    nics->emplace_back(&fakeDev0_, mockIbvApi_, -1, 3, uint8_t{1});
+    nics->emplace_back(&fakeDev0_, mockIbvApi_, -1, kTestGidIndex, uint8_t{1});
     if (count > 1) {
       setupNic(&fakeDev1_, &fakeCtx1_, &fakePd1_);
-      nics->emplace_back(&fakeDev1_, mockIbvApi_, -1, 3, uint8_t{1});
+      nics->emplace_back(
+          &fakeDev1_, mockIbvApi_, -1, kTestGidIndex, uint8_t{1});
     }
     return nics;
   }

--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -8,7 +8,9 @@
 #include "comms/uniflow/executor/ScopedEventBaseThread.h"
 
 #include <cstring>
+#include <map>
 #include <queue>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -192,6 +194,7 @@ NicResources makeNic(
         attr->active_mtu = IBV_MTU_4096;
         attr->link_layer = IBV_LINK_LAYER_ETHERNET;
         attr->state = IBV_PORT_ACTIVE;
+        attr->gid_tbl_len = 8;
         return Ok();
       });
   ON_CALL(*mockApi, queryGid(ctx, port, _, _))
@@ -208,6 +211,196 @@ NicResources makeNic(
   ON_CALL(*mockApi, closeDevice(ctx)).WillByDefault(Return(Ok()));
 
   return NicResources(dev, mockApi, numaNode, 3, port);
+}
+
+// Configures the common NicResources ON_CALLs for an Ethernet (RoCE) port with
+// the given GID table length. Callers set queryGidEx / isQueryGidExSupported
+// behavior separately before constructing the NicResources.
+void setupGidNicMock(
+    testing::NiceMock<MockIbvApi>& api,
+    ibv_device* dev,
+    ibv_context* ctx,
+    ibv_pd* pd,
+    int gidTblLen) {
+  ON_CALL(api, openDevice(dev))
+      .WillByDefault(Return(Result<ibv_context*>(ctx)));
+  ON_CALL(api, allocPd(ctx)).WillByDefault(Return(Result<ibv_pd*>(pd)));
+  ON_CALL(api, isDmaBufSupported(pd))
+      .WillByDefault(Return(Result<bool>(false)));
+  ON_CALL(api, queryPort(ctx, 1, _))
+      .WillByDefault([gidTblLen](ibv_context*, uint8_t, ibv_port_attr* attr) {
+        attr->link_layer = IBV_LINK_LAYER_ETHERNET;
+        attr->active_mtu = IBV_MTU_4096;
+        attr->state = IBV_PORT_ACTIVE;
+        attr->gid_tbl_len = gidTblLen;
+        return Ok();
+      });
+  ON_CALL(api, queryGid(ctx, 1, _, _))
+      .WillByDefault([](ibv_context*, uint8_t, int, ibv_gid* out) {
+        *out = ibv_gid{};
+        return Ok();
+      });
+  ON_CALL(api, deallocPd(pd)).WillByDefault(Return(Ok()));
+  ON_CALL(api, closeDevice(ctx)).WillByDefault(Return(Ok()));
+}
+
+// Builds a queryGidEx stub from a {index -> gid_type} table, marking the entry
+// at @p ipv4Index (if >= 0) as IPv4-mapped, the entry at @p linkLocalIndex (if
+// >= 0) as an IPv6 link-local (fe80::) address, and the entry at @p
+// ipv4LinkLocalIndex (if >= 0) as an IPv4-mapped IPv4 link-local (169.254.x.x)
+// address.
+auto makeGidExStub(
+    std::map<uint32_t, uint32_t> typesByIndex,
+    int ipv4Index,
+    int linkLocalIndex = -1,
+    int ipv4LinkLocalIndex = -1) {
+  return [typesByIndex = std::move(typesByIndex),
+          ipv4Index,
+          linkLocalIndex,
+          ipv4LinkLocalIndex](
+             ibv_context*,
+             uint32_t,
+             uint32_t index,
+             ibv_gid_entry* entry,
+             uint32_t) -> Status {
+    auto it = typesByIndex.find(index);
+    if (it == typesByIndex.end()) {
+      return Err(ErrCode::DriverError, "empty GID entry");
+    }
+    *entry = ibv_gid_entry{};
+    entry->gid_index = index;
+    entry->gid_type = it->second;
+    if (static_cast<int>(index) == ipv4Index) {
+      entry->gid.raw[10] = 0xff;
+      entry->gid.raw[11] = 0xff;
+    }
+    if (static_cast<int>(index) == linkLocalIndex) {
+      entry->gid.raw[0] = 0xfe;
+      entry->gid.raw[1] = 0x80;
+    }
+    if (static_cast<int>(index) == ipv4LinkLocalIndex) {
+      entry->gid.raw[10] = 0xff;
+      entry->gid.raw[11] = 0xff;
+      entry->gid.raw[12] = 169;
+      entry->gid.raw[13] = 254;
+    }
+    return Ok();
+  };
+}
+
+class NicResourcesGidTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    api_ = std::make_shared<testing::NiceMock<MockIbvApi>>();
+    ctx_.device = &dev_;
+  }
+
+  void setupMock(int gidTblLen = 8) {
+    setupGidNicMock(*api_, &dev_, &ctx_, &pd_, gidTblLen);
+  }
+
+  std::shared_ptr<testing::NiceMock<MockIbvApi>> api_;
+  ibv_device dev_{};
+  ibv_context ctx_{};
+  ibv_pd pd_{};
+};
+
+TEST_F(NicResourcesGidTest, AutoSelectPrefersIpv4MappedRoceV2) {
+  setupMock(/*gidTblLen=*/8);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  // index 2: RoCEv2 (not IPv4); index 5: RoCEv2 IPv4-mapped (preferred).
+  ON_CALL(*api_, queryGidEx(&ctx_, 1, _, _, _))
+      .WillByDefault(makeGidExStub(
+          {{0, IBV_GID_TYPE_ROCE_V1},
+           {2, IBV_GID_TYPE_ROCE_V2},
+           {5, IBV_GID_TYPE_ROCE_V2}},
+          /*ipv4Index=*/5));
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1);
+  EXPECT_EQ(nic.gidIndex, 5);
+}
+
+TEST_F(NicResourcesGidTest, AutoSelectFallsBackWhenGidExUnsupported) {
+  setupMock(/*gidTblLen=*/8);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(false));
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1);
+  EXPECT_EQ(nic.gidIndex, 3); // Mellanox RoCEv2 default.
+}
+
+TEST_F(NicResourcesGidTest, ForcedIndexSkipsScan) {
+  setupMock(/*gidTblLen=*/8);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  EXPECT_CALL(*api_, queryGidEx(_, _, _, _, _)).Times(0);
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/5, 1);
+  EXPECT_EQ(nic.gidIndex, 5);
+}
+
+TEST_F(NicResourcesGidTest, AutoSelectFallsBackWhenNoRoceV2) {
+  setupMock(/*gidTblLen=*/4);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  ON_CALL(*api_, queryGidEx(&ctx_, 1, _, _, _))
+      .WillByDefault(makeGidExStub(
+          {{0, IBV_GID_TYPE_IB},
+           {1, IBV_GID_TYPE_ROCE_V1},
+           {2, IBV_GID_TYPE_ROCE_V1}},
+          /*ipv4Index=*/-1));
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1);
+  EXPECT_EQ(nic.gidIndex, 3);
+}
+
+TEST_F(NicResourcesGidTest, AutoSelectSkipsLinkLocalRoceV2) {
+  setupMock(/*gidTblLen=*/4);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  // index 1: link-local RoCEv2 (skipped); index 3: global RoCEv2 (selected).
+  ON_CALL(*api_, queryGidEx(&ctx_, 1, _, _, _))
+      .WillByDefault(makeGidExStub(
+          {{1, IBV_GID_TYPE_ROCE_V2}, {3, IBV_GID_TYPE_ROCE_V2}},
+          /*ipv4Index=*/-1,
+          /*linkLocalIndex=*/1));
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1);
+  EXPECT_EQ(nic.gidIndex, 3);
+}
+
+TEST_F(NicResourcesGidTest, AutoSelectSkipsIpv4LinkLocalRoceV2) {
+  setupMock(/*gidTblLen=*/4);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  // index 2: IPv4 link-local (169.254.x.x) RoCEv2 (skipped); index 3: global.
+  ON_CALL(*api_, queryGidEx(&ctx_, 1, _, _, _))
+      .WillByDefault(makeGidExStub(
+          {{2, IBV_GID_TYPE_ROCE_V2}, {3, IBV_GID_TYPE_ROCE_V2}},
+          /*ipv4Index=*/-1,
+          /*linkLocalIndex=*/-1,
+          /*ipv4LinkLocalIndex=*/2));
+
+  NicResources nic(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1);
+  EXPECT_EQ(nic.gidIndex, 3);
+}
+
+TEST_F(NicResourcesGidTest, ForcedIndexOutOfRangeThrows) {
+  setupMock(/*gidTblLen=*/4);
+
+  EXPECT_THROW(
+      NicResources(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/10, 1),
+      std::runtime_error);
+}
+
+TEST_F(NicResourcesGidTest, AutoSelectThrowsWhenNoGlobalAndDefaultOutOfRange) {
+  setupMock(/*gidTblLen=*/2);
+  ON_CALL(*api_, isQueryGidExSupported()).WillByDefault(Return(true));
+  // Only a link-local RoCEv2 entry exists and default index 3 >= gid_tbl_len.
+  ON_CALL(*api_, queryGidEx(&ctx_, 1, _, _, _))
+      .WillByDefault(makeGidExStub(
+          {{0, IBV_GID_TYPE_ROCE_V1}, {1, IBV_GID_TYPE_ROCE_V2}},
+          /*ipv4Index=*/-1,
+          /*linkLocalIndex=*/1));
+
+  EXPECT_THROW(
+      NicResources(&dev_, api_, /*numaNode=*/-1, /*configuredGidIndex=*/-1, 1),
+      std::runtime_error);
 }
 
 // --- Mock-based transport tests ---

--- a/comms/uniflow/transport/tests/unit/TopologyTest.cpp
+++ b/comms/uniflow/transport/tests/unit/TopologyTest.cpp
@@ -951,6 +951,14 @@ class TopologyNicTest : public TopologyTest {
     ON_CALL(*ibv_, closeDevice(_)).WillByDefault(Return(Ok()));
   }
 
+  /// Stub the backing netdev name reported for an IB device via
+  /// /sys/class/infiniband/<dev>/device/net.
+  void setNetdev(const std::string& devName, const std::string& netdev) {
+    ON_CALL(
+        *sysfs_, listDir("/sys/class/infiniband/" + devName + "/device/net", _))
+        .WillByDefault(Return(std::vector<std::string>{netdev}));
+  }
+
   std::string gpu0_, nic0_, nic1_, nic2_, sw0_, sw1_, root_;
   std::vector<ibv_device> nicDevices_;
   std::vector<ibv_device*> nicDevicePtrs_;
@@ -1283,6 +1291,65 @@ TEST_F(TopologyNicTest, MixedPhysicalAndVirtualNics) {
   EXPECT_NE(phys.bdf, "virtual");
   EXPECT_EQ(virt.bdf, "virtual");
   EXPECT_EQ(virt.numaNode, 0);
+}
+
+// --- Netdev-prefix NIC selection ---
+
+TEST_F(TopologyNicTest, NetdevNameCapturedFromSysfs) {
+  setupNics({{"mlx5_0", nic0_}});
+  setNetdev("mlx5_0", "beth0");
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  const auto& data = std::get<TopoNode::NicData>(topo->getNicNode(0).data);
+  EXPECT_EQ(data.netdevName, "beth0");
+}
+
+TEST_F(TopologyNicTest, NetdevPrefixSelectsMatchingNic) {
+  // Two equidistant NICs; only mlx5_0 has a backend-ethernet ("beth") netdev.
+  setupNics({{"mlx5_0", nic0_}, {"mlx5_1", nic1_}});
+  setNetdev("mlx5_0", "beth0");
+  setNetdev("mlx5_1", "eth0");
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  const std::vector<std::string> expected{"mlx5_0"};
+  EXPECT_EQ(topo->selectCpuNics(NicFilter{}, "beth"), expected);
+}
+
+TEST_F(TopologyNicTest, NetdevPrefixFallsBackWhenNoMatch) {
+  // Neither NIC has a "beth" netdev → fall back to filter-only selection.
+  setupNics({{"mlx5_0", nic0_}, {"mlx5_1", nic1_}});
+  setNetdev("mlx5_0", "eth0");
+  setNetdev("mlx5_1", "eth1");
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  const std::vector<std::string> expected{"mlx5_0", "mlx5_1"};
+  EXPECT_EQ(topo->selectCpuNics(NicFilter{}, "beth"), expected);
+}
+
+TEST_F(TopologyNicTest, EmptyNetdevPrefixConsidersAllNics) {
+  setupNics({{"mlx5_0", nic0_}, {"mlx5_1", nic1_}});
+  setNetdev("mlx5_0", "beth0");
+  setNetdev("mlx5_1", "eth0");
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  // Empty prefix disables the predicate: both equidistant NICs are selected.
+  const std::vector<std::string> expected{"mlx5_0", "mlx5_1"};
+  EXPECT_EQ(topo->selectCpuNics(NicFilter{}, ""), expected);
+}
+
+TEST_F(TopologyNicTest, NetdevPrefixIgnoredWhenNoNetdevNames) {
+  // No NIC has a netdev name (e.g. a backend that does not populate it). The
+  // prefix predicate is skipped entirely rather than excluding every NIC.
+  setupNics({{"mlx5_0", nic0_}, {"mlx5_1", nic1_}});
+  auto topo = createTopology();
+  ASSERT_TRUE(topo->available());
+
+  const std::vector<std::string> expected{"mlx5_0", "mlx5_1"};
+  EXPECT_EQ(topo->selectCpuNics(NicFilter{}, "beth"), expected);
 }
 
 } // namespace uniflow


### PR DESCRIPTION
Summary:

- ibverbs: wire ibv_query_gid_ex (IbvApi/IbvCore/MockIbvApi) for GID-table
  introspection.
- RdmaResources: auto-select a RoCEv2 GID for Ethernet/RoCE ports. Skip
  link-local GIDs (IPv6 fe80::/10 and IPv4-mapped 169.254.0.0/16), prefer an
  IPv4-mapped entry, else the first global RoCEv2. Validate forced and default
  GID indices against gid_tbl_len and fail clearly on out-of-range.
- Topology: capture backing netdev name and add netdev-prefix NIC selection
  (default "beth"); skip the predicate when no netdev names are known.
- Integration test: make single-host RDMA test vendor-agnostic by enumerating
  the first two NICs instead of hardcoding mlx5.
- Unit tests for GID selection, env parsing, and netdev-prefix selection.

Reviewed By: rmahidhar

Differential Revision: D108675437
