### PR TITLE
Fix enableLocalFlush member naming and consolidate flush default in CtranIb (#2946)

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -47,8 +47,19 @@ constexpr int kGb300CudaArch = 1030;
 thread_local std::unordered_map<void*, std::atomic_bool> epochLockedFlags;
 
 bool CtranIb::shouldEnableLocalFlushByDefault(int cudaArch) {
+#if defined(USE_ROCM)
+  // AMD GPUs always require local flush.
+  // https://ontrack.amd.com/browse/FBA-633
+  return true;
+#else
+  // Turn on flush by default for NVidia GPUs older than H100 and for GB300.
+  // Multi-NIC topologies with cross-NIC DMA ordering hazards must opt in via
+  // NCCL_CTRAN_NET_FORCE_FLUSH=1.
+  // TODO: Replace the GB300 CUDA-arch proxy with a topology query similar to
+  // baseline ncclTopoNeedFlush(); CUDA arch is not precise topology detection.
   return cudaArch < kH100CudaArch || cudaArch == kGb300CudaArch ||
       NCCL_CTRAN_NET_FORCE_FLUSH;
+#endif
 }
 
 commResult_t checkEpochLock(CtranIb* ctranIb) {
@@ -321,35 +332,16 @@ CtranIb::CtranIb(
     std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
     std::optional<int> maxNumCqe)
     : comm(comm) {
-  // enableLocalFlush: whether to support local flush. If true, CtranIb
-  // will enable resource required for local flush.
-  bool enableLocalFlush_ = false;
-  if (enableLocalFlush.has_value()) {
-    // Honor user specified value
-    enableLocalFlush_ = enableLocalFlush.value();
-  } else {
-#if defined(USE_ROCM)
-    // AMD GPUs always require local flush
-    // https://ontrack.amd.com/browse/FBA-633
-    enableLocalFlush_ = true;
-#else
-    // Turn on flush by default for NVidia GPUs older than H100 and for GB300.
-    // Multi-NIC topologies with cross-NIC DMA ordering hazards must opt in via
-    // NCCL_CTRAN_NET_FORCE_FLUSH=1.
-    // TODO: Replace the GB300 CUDA-arch proxy with a topology query similar to
-    // baseline ncclTopoNeedFlush(); CUDA arch is not precise topology
-    // detection.
-    enableLocalFlush_ =
-        CtranIb::shouldEnableLocalFlushByDefault(comm->statex_->cudaArch());
-#endif
-  }
   init(
       comm,
       comm->statex_->rank(),
       comm->statex_->cudaDev(),
       comm->statex_->commHash(),
       comm->statex_->commDesc(),
-      enableLocalFlush_,
+      // Honor a caller-specified value; otherwise use the platform default.
+      enableLocalFlush.has_value()
+          ? *enableLocalFlush
+          : shouldEnableLocalFlushByDefault(comm->statex_->cudaArch()),
       BootstrapMode::kDefaultServer,
       std::nullopt,
       ::ctran::utils::createAbort(/*enabled=*/false),
@@ -361,7 +353,7 @@ CtranIb::CtranIb(
       "CTRAN-IB: Initialized {} from comm {} enableLocalFlush {}",
       (void*)this,
       (void*)comm,
-      this->enableLocalFlush);
+      this->enableLocalFlush_);
 }
 
 CtranIb::CtranIb(
@@ -400,7 +392,7 @@ CtranIb::CtranIb(
       cudaDev,
       commHash,
       commDesc,
-      this->enableLocalFlush);
+      this->enableLocalFlush_);
 }
 
 void CtranIb::init(
@@ -428,7 +420,7 @@ void CtranIb::init(
       .commDesc = commDesc,
       .rank = rank,
       .nRanks = comm ? comm->statex_->nRanks() : 1};
-  this->enableLocalFlush = enableLocalFlush;
+  this->enableLocalFlush_ = enableLocalFlush;
   this->bootstrapMode = bootstrapMode;
   this->devices.resize(NCCL_CTRAN_IB_DEVICES_PER_RANK);
   this->cqs.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
@@ -907,7 +899,7 @@ commResult_t CtranIb::iflush(
     CtranIbRequest* req) {
   FB_COMMCHECK(checkEpochLock(this));
 
-  if (enableLocalFlush) {
+  if (enableLocalFlush_) {
     CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
       auto& vc = localVc;
       return vc->iflush(dbuf, localRegHdl, req);

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -1060,7 +1060,7 @@ class CtranIb {
           continueWhileLoop = true;
         }
 
-        if (enableLocalFlush) {
+        if (enableLocalFlush_) {
           CTRAN_IB_PER_OBJ_LOCK_GUARD(localVcMutex, {
             auto& vc = localVc;
             // First check if it is a local flush CQE
@@ -1117,7 +1117,7 @@ class CtranIb {
   uint64_t commHash{0};
   std::string commDesc;
   CommLogData ncclLogData;
-  bool enableLocalFlush{true};
+  bool enableLocalFlush_{true};
   BootstrapMode bootstrapMode{BootstrapMode::kDefaultServer};
 
   std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory_;


### PR DESCRIPTION
Summary:

Fixes T269219546. The `enableLocalFlush` naming in `CtranIb` had the trailing-underscore convention inverted from Meta C++ style: the private member lacked the underscore while a constructor local had one. This cleanup fixes the naming and removes the awkward local-vs-parameter shadowing that caused it. No behavioral change.

- Private member `bool enableLocalFlush{true};` in `CtranIb.h` is renamed to `enableLocalFlush_` (members take a trailing underscore). All member reads update accordingly: the two `this->enableLocalFlush` log statements, the `init()` assignment, the `if (...)` check in `iflush()` (.cc), and the `if (...)` check in `progressInternal()` (.h).
- The ROCm-always-on rule is folded into `shouldEnableLocalFlushByDefault()` since it is a platform/arch constraint and belongs with the other arch defaults.
- The constructor no longer needs a local to resolve the optional: it inlines `enableLocalFlush.has_value() ? *enableLocalFlush : shouldEnableLocalFlushByDefault(cudaArch)` directly into the `init()` call, so there is no local that mirrors (and would shadow) the `enableLocalFlush` parameter.
- Constructor/`init()` parameters named `enableLocalFlush` are non-members and stay unchanged — including the bare `if (enableLocalFlush)` inside `init()`, which resolves to the parameter, not the member.

Originally raised as inline comment 800204836266138 on D103503273.

Reviewed By: minsii

Differential Revision: D109055206


