### PR TITLE
ctran/tcpdm: Retire failed counted recv notifications (#2948)

### DIFF
--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -14,6 +14,7 @@
 #include "folly/synchronization/CallOnce.h"
 
 #include <cerrno>
+#include <exception>
 
 namespace ctran {
 
@@ -313,6 +314,8 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
       recvComms;
   size_t queuedRecvCount = 0;
   size_t cancelledQueuedRecvCount = 0;
+  size_t pendingRecvNotifyCount = 0;
+  size_t cancelledPendingRecvNotifyCount = 0;
   {
     std::lock_guard lock(mutex_);
     queuedRecvCount = queuedRecv_.size();
@@ -328,6 +331,14 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         ++cancelledQueuedRecvCount;
       }
     }
+    for (auto& [peerRank, pending] : pendingRecvNotifies_) {
+      pendingRecvNotifyCount += pending.size();
+      if (!pending.empty()) {
+        recvNotifyErrorCount_[peerRank] += pending.size();
+        cancelledPendingRecvNotifyCount += pending.size();
+        pending.clear();
+      }
+    }
     queuedRecv_.clear();
     queuedCtrlRecv_.clear();
     sendComms.swap(sendComms_);
@@ -338,7 +349,7 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
   if (forceClose) {
     CLOGF(
         WARN,
-        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {}",
+        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
         rank_,
         commHash_,
@@ -348,11 +359,13 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         sendComms.size(),
         recvComms.size(),
         queuedRecvCount,
-        cancelledQueuedRecvCount);
+        cancelledQueuedRecvCount,
+        pendingRecvNotifyCount,
+        cancelledPendingRecvNotifyCount);
   } else {
     CLOGF(
         INFO,
-        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {}",
+        "CTRAN-TCPDM: closing backend {} rank {} commHash {:x} commDesc {} reason {} flags {:#x} sendComms {} recvComms {} queuedRecvs {} cancelledQueuedRecvs {} pendingRecvNotifies {} cancelledPendingRecvNotifies {}",
         (void*)this,
         rank_,
         commHash_,
@@ -362,7 +375,9 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         sendComms.size(),
         recvComms.size(),
         queuedRecvCount,
-        cancelledQueuedRecvCount);
+        cancelledQueuedRecvCount,
+        pendingRecvNotifyCount,
+        cancelledPendingRecvNotifyCount);
   }
 
   auto transport = CtranTcpDmSingleton::getTransport();
@@ -800,10 +815,15 @@ commResult_t CtranTcpDm::irecvCounted(
     void* unpackPool) {
   auto req = std::make_unique<CtranTcpDmRequest>();
   auto* rawReq = req.get();
-  pendingRecvNotifies_[peerRank].push_back(std::move(req));
 
   {
     std::unique_lock lock(mutex_);
+    if (aborted_.load()) {
+      return commRemoteError;
+    }
+
+    pendingRecvNotifies_[peerRank].push_back(std::move(req));
+
     if (recvComms_.find(peerRank) == recvComms_.end()) {
       auto recvReq = std::make_unique<RecvRequest>();
       recvReq->peerRank = peerRank;
@@ -818,12 +838,38 @@ commResult_t CtranTcpDm::irecvCounted(
     }
   }
 
-  return irecvConnected(peerRank, handle, data, size, *rawReq, unpackPool);
+  auto result =
+      irecvConnected(peerRank, handle, data, size, *rawReq, unpackPool);
+  if (result != commSuccess) {
+    rawReq->complete(::comms::tcp_devmem::Status::RemoteError);
+  }
+  return result;
 }
 
 void CtranTcpDm::recvNotifyProgress() {
   for (auto& [peerRank, pending] : pendingRecvNotifies_) {
-    while (!pending.empty() && pending.front()->isComplete()) {
+    while (!pending.empty()) {
+      bool complete = false;
+      try {
+        complete = pending.front()->isComplete();
+      } catch (const std::exception& e) {
+        CLOGF(
+            WARN,
+            "CTRAN-TCPDM: counted recv notify failed for peer {} rank {} commHash {:x} commDesc {} error {}",
+            peerRank,
+            rank_,
+            commHash_,
+            commDesc_,
+            e.what());
+        pending.pop_front();
+        recvNotifyErrorCount_[peerRank]++;
+        continue;
+      }
+
+      if (!complete) {
+        break;
+      }
+
       pending.pop_front();
       recvNotifyCount_[peerRank]++;
     }
@@ -832,6 +878,13 @@ void CtranTcpDm::recvNotifyProgress() {
 
 commResult_t CtranTcpDm::checkNotify(int peerRank, bool* done) {
   recvNotifyProgress();
+  auto errIt = recvNotifyErrorCount_.find(peerRank);
+  if (errIt != recvNotifyErrorCount_.end() && errIt->second > 0) {
+    errIt->second--;
+    *done = false;
+    return commRemoteError;
+  }
+
   auto it = recvNotifyCount_.find(peerRank);
   if (it != recvNotifyCount_.end() && it->second > 0) {
     it->second--;

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.cc
@@ -164,21 +164,6 @@ void CtranTcpDm::bootstrapAccept() {
 
     auto transport = CtranTcpDmSingleton::getTransport();
 
-    // Negative rank = ctrl socket connection (bufSync)
-    if (peerRank < 0) {
-      int actualPeer = -(peerRank + 1);
-      int ctrlFd = socket.getFd();
-      std::lock_guard lock(mutex_);
-      ctrlSocks_.emplace(actualPeer, std::move(socket));
-      CLOGF_SUBSYS(
-          INFO,
-          INIT,
-          "CTRAN-TCPDM: ctrl socket accepted from peer {} fd={}",
-          actualPeer,
-          ctrlFd);
-      continue;
-    }
-
     ::comms::tcp_devmem::Handle handle{};
     ::comms::tcp_devmem::ListenerInterface* listenComm{};
     COMMCHECKTHROW(transport->listen(netdev_, &handle, &listenComm));
@@ -271,34 +256,6 @@ commResult_t CtranTcpDm::bootstrapConnect(
   return res;
 }
 
-void CtranTcpDm::ensureCtrlSocket(int peerRank) {
-  {
-    std::lock_guard lock(mutex_);
-    if (ctrlSocks_.count(peerRank)) {
-      return;
-    }
-  }
-
-  folly::SocketAddress peerAddr;
-  peerAddr.setFromSockaddr(
-      reinterpret_cast<sockaddr_in6*>(&allListenSocketAddrs_[peerRank]));
-  ctran::bootstrap::Socket sock;
-  FB_SYSCHECKTHROW_EX(
-      sock.connect(
-          peerAddr,
-          NCCL_CLIENT_SOCKET_IFNAME,
-          std::chrono::milliseconds(NCCL_SOCKET_RETRY_SLEEP_MSEC),
-          NCCL_SOCKET_RETRY_CNT),
-      rank_,
-      commHash_,
-      commDesc_);
-  int marker = -(rank_ + 1);
-  FB_SYSCHECKTHROW_EX(
-      sock.send(&marker, sizeof(int)), rank_, commHash_, commDesc_);
-  std::lock_guard lock(mutex_);
-  ctrlSocks_.emplace(peerRank, std::move(sock));
-}
-
 CtranTcpDm::CtranTcpDm(CtranComm* comm, ctran::Profiler* profiler) {
   comm_ = comm;
   cudaDev_ = comm->statex_->cudaDev();
@@ -365,7 +322,14 @@ void CtranTcpDm::closeComms(const char* reason, uint32_t closeFlags) {
         ++cancelledQueuedRecvCount;
       }
     }
+    for (auto& ctrlReq : queuedCtrlRecv_) {
+      if (ctrlReq->req != nullptr) {
+        ctrlReq->req->complete(::comms::tcp_devmem::Status::RemoteError);
+        ++cancelledQueuedRecvCount;
+      }
+    }
     queuedRecv_.clear();
+    queuedCtrlRecv_.clear();
     sendComms.swap(sendComms_);
     recvComms.swap(recvComms_);
   }
@@ -562,26 +526,62 @@ commResult_t CtranTcpDm::connectPeer(int peerRank) {
   return bootstrapConnect(peerRank, peerAddr);
 }
 
-void CtranTcpDm::ctrlSyncProgress() {
-  for (auto& [peerRank, sock] : ctrlSocks_) {
-    auto& pending = pendingSyncRecvs_[peerRank];
-    while (!pending.empty()) {
-      uint8_t sync;
-      int ret = ::recv(sock.getFd(), &sync, sizeof(sync), MSG_DONTWAIT);
-      if (ret <= 0) {
+commResult_t CtranTcpDm::irecvCtrlMsgConnected(
+    int peerRank,
+    std::shared_ptr<std::array<uint8_t, 1>> storage,
+    CtranTcpDmRequest& req) {
+  ::comms::tcp_devmem::CommunicatorInterface* comm = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
+    auto it = recvComms_.find(peerRank);
+    if (it == recvComms_.end()) {
+      return commInternalError;
+    }
+    comm = it->second;
+  }
+
+  auto transport = CtranTcpDmSingleton::getTransport();
+  ::comms::tcp_devmem::RequestInterface* request{nullptr};
+  COMMCHECK_TCP(transport->queueRequest(
+      comm,
+      ::comms::tcp_devmem::Transport::Op::RecvCtrl,
+      storage->data(),
+      storage->size(),
+      nullptr,
+      &request));
+  req.track(transport.get(), request, std::move(storage));
+  return commSuccess;
+}
+
+void CtranTcpDm::ctrlRecvProgress() {
+  while (true) {
+    std::unique_ptr<CtrlRecvRequest> ctrlReq;
+    {
+      std::unique_lock lock(mutex_);
+      for (auto it = queuedCtrlRecv_.begin(); it != queuedCtrlRecv_.end();
+           ++it) {
+        if (recvComms_.find((*it)->peerRank) == recvComms_.end()) {
+          continue;
+        }
+        ctrlReq = std::move(*it);
+        queuedCtrlRecv_.erase(it);
         break;
       }
-      syncRecvCount_[peerRank]++;
-      pending.front()->complete();
-      pending.pop_front();
-      CLOGF_SUBSYS(
-          INFO,
-          COLL,
-          "CTRAN-TCPDM: ctrlSyncProgress completed sync from peer {}, total={}, remaining={}, fd={}",
-          peerRank,
-          syncRecvCount_[peerRank],
-          pending.size(),
-          sock.getFd());
+    }
+
+    if (ctrlReq == nullptr) {
+      return;
+    }
+
+    auto result = irecvCtrlMsgConnected(
+        ctrlReq->peerRank, std::move(ctrlReq->storage), *ctrlReq->req);
+    if (result != commSuccess) {
+      ctrlReq->req->complete(::comms::tcp_devmem::Status::RemoteError);
+      return;
     }
   }
 }
@@ -590,18 +590,45 @@ commResult_t CtranTcpDm::isendCtrlMsg(
     const ControlMsg& msg,
     int peerRank,
     CtranTcpDmRequest& req) {
-  // only allow sync messages to be sent on the ctrl socket
   if (msg.type != ControlMsgType::SYNC) {
     req.complete();
     return commSuccess;
   }
-  // only sendeer can do lazy connect to avoid deadlock.
-  ensureCtrlSocket(peerRank);
-  std::lock_guard lock(mutex_);
-  auto& sock = ctrlSocks_.at(peerRank);
-  uint8_t sync = 1;
-  sock.send(&sync, sizeof(sync));
-  req.complete();
+
+  const auto connectResult = connectPeer(peerRank);
+  if (connectResult != commSuccess) {
+    if (connectResult == commRemoteError) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+    }
+    return connectResult;
+  }
+
+  ::comms::tcp_devmem::CommunicatorInterface* comm = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
+    auto it = sendComms_.find(peerRank);
+    if (it == sendComms_.end()) {
+      return commInternalError;
+    }
+    comm = it->second;
+  }
+
+  auto storage = std::make_shared<std::array<uint8_t, 1>>();
+  (*storage)[0] = 1;
+  auto transport = CtranTcpDmSingleton::getTransport();
+  ::comms::tcp_devmem::RequestInterface* request{nullptr};
+  COMMCHECK_TCP(transport->queueRequest(
+      comm,
+      ::comms::tcp_devmem::Transport::Op::SendCtrl,
+      storage->data(),
+      storage->size(),
+      nullptr,
+      &request));
+  req.track(transport.get(), request, std::move(storage));
   return commSuccess;
 }
 
@@ -613,13 +640,31 @@ commResult_t CtranTcpDm::irecvCtrlMsg(
     req.complete();
     return commSuccess;
   }
-  std::lock_guard lock(mutex_);
-  pendingSyncRecvs_[peerRank].push_back(&req);
-  return commSuccess;
+
+  auto storage = std::make_shared<std::array<uint8_t, 1>>();
+  {
+    std::unique_lock lock(mutex_);
+    if (aborted_.load()) {
+      req.complete(::comms::tcp_devmem::Status::RemoteError);
+      return commRemoteError;
+    }
+
+    if (recvComms_.find(peerRank) == recvComms_.end()) {
+      auto ctrlReq = std::make_unique<CtrlRecvRequest>();
+      ctrlReq->peerRank = peerRank;
+      ctrlReq->storage = storage;
+      ctrlReq->req = &req;
+      req.markQueuedRecv(storage);
+      queuedCtrlRecv_.push_back(std::move(ctrlReq));
+      return commSuccess;
+    }
+  }
+
+  return irecvCtrlMsgConnected(peerRank, std::move(storage), req);
 }
 
 commResult_t CtranTcpDm::progress() {
-  ctrlSyncProgress();
+  ctrlRecvProgress();
   recvNotifyProgress();
 
   while (true) {

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -160,6 +160,7 @@ class CtranTcpDm {
       pendingRecvNotifies_;
   // Per-peer count of completed data recvs, decremented by checkNotify.
   std::unordered_map<int, int> recvNotifyCount_;
+  std::unordered_map<int, int> recvNotifyErrorCount_;
 
   void recvNotifyProgress();
   void ctrlRecvProgress();

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDm.h
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <deque>
+#include <list>
+#include <memory>
 #include <unordered_map>
 
 #include "comms/ctran/CtranComm.h"
@@ -144,18 +147,12 @@ class CtranTcpDm {
   };
   std::list<std::unique_ptr<RecvRequest>> queuedRecv_;
 
-  // Lazy per-peer TCP connections for sync-only control messages.
-  // Created on-demand by ensureCtrlSocket() on first isendCtrlMsg/irecvCtrlMsg.
-  // Smaller rank initiates; larger rank's bootstrapAccept thread accepts.
-  std::unordered_map<int, ctran::bootstrap::Socket> ctrlSocks_;
-  void ensureCtrlSocket(int peerRank);
-
-  // Per-peer queue of pending sync recv requests (from irecvCtrlMsg).
-  // Completed in FIFO order as sync bytes arrive on ctrlSocks_.
-  std::unordered_map<int, std::deque<CtranTcpDmRequest*>> pendingSyncRecvs_;
-
-  // Per-peer count of received sync bytes (for debugging).
-  std::unordered_map<int, int> syncRecvCount_;
+  struct CtrlRecvRequest {
+    int peerRank{-1};
+    std::shared_ptr<std::array<uint8_t, 1>> storage;
+    CtranTcpDmRequest* req{nullptr};
+  };
+  std::list<std::unique_ptr<CtrlRecvRequest>> queuedCtrlRecv_;
 
   // Counter-based recv notification (analogous to IB's notifyCount_).
   // Internally-owned requests for irecvCounted; completed in FIFO order.
@@ -165,7 +162,7 @@ class CtranTcpDm {
   std::unordered_map<int, int> recvNotifyCount_;
 
   void recvNotifyProgress();
-  void ctrlSyncProgress();
+  void ctrlRecvProgress();
 
   commResult_t connectPeer(int peerRank);
   void closeComms(const char* reason, uint32_t closeFlags);
@@ -189,6 +186,11 @@ class CtranTcpDm {
       size_t size,
       CtranTcpDmRequest& req,
       void* unpackPool);
+
+  commResult_t irecvCtrlMsgConnected(
+      int peerRank,
+      std::shared_ptr<std::array<uint8_t, 1>> storage,
+      CtranTcpDmRequest& req);
 };
 
 } // namespace ctran

--- a/comms/ctran/backends/tcpdevmem/CtranTcpDmBase.h
+++ b/comms/ctran/backends/tcpdevmem/CtranTcpDmBase.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "comms/tcp_devmem/transport.h"
 
@@ -18,6 +19,9 @@ class CtranTcpDmRequest {
     if (request_ == nullptr) {
       // Pending irecv where sender has not been connected yet or send/recv
       // control.
+      if (done_) {
+        lifetime_.reset();
+      }
       if (done_ && status_ != ::comms::tcp_devmem::Status::Ok) {
         COMMCHECKTHROW(status_);
       }
@@ -42,6 +46,7 @@ class CtranTcpDmRequest {
 
         COMMCHECKTHROW(transport_->consumedRequest(request_));
       }
+      lifetime_.reset();
     }
 
     return done_;
@@ -51,27 +56,34 @@ class CtranTcpDmRequest {
       ::comms::tcp_devmem::Status status = ::comms::tcp_devmem::Status::Ok) {
     status_ = status;
     done_ = true;
+    if (request_ == nullptr) {
+      lifetime_.reset();
+    }
   }
 
-  void markQueuedRecv() {
+  void markQueuedRecv(std::shared_ptr<void> lifetime = nullptr) {
     done_ = false;
     status_ = ::comms::tcp_devmem::Status::Ok;
     request_ = nullptr;
+    lifetime_ = std::move(lifetime);
   }
 
   void track(
       ::comms::tcp_devmem::TransportInterface* transport,
-      ::comms::tcp_devmem::RequestInterface* request) {
+      ::comms::tcp_devmem::RequestInterface* request,
+      std::shared_ptr<void> lifetime = nullptr) {
     done_ = false;
     status_ = ::comms::tcp_devmem::Status::Ok;
     transport_ = transport;
     request_ = request;
+    lifetime_ = std::move(lifetime);
   }
 
  private:
   ::comms::tcp_devmem::RequestInterface* request_{nullptr};
   ::comms::tcp_devmem::TransportInterface* transport_{nullptr};
   ::comms::tcp_devmem::Status status_{::comms::tcp_devmem::Status::Ok};
+  std::shared_ptr<void> lifetime_;
   bool done_{false};
 };
 

--- a/comms/ctran/gpe/CtranGpe.h
+++ b/comms/ctran/gpe/CtranGpe.h
@@ -76,7 +76,8 @@ struct OpElem {
   bool isDevice{true};
 
   // TCP Device Memory unpack pool for this operation.
-  // Allocated by prepareUnpackConsumer() and freed during GPE kernel teardown.
+  // Allocated by prepareUnpackConsumer(). Eager operations return it during
+  // GPE kernel teardown; CUDA graph captures keep it until graph destruction.
   // Used by algorithm implementations to populate CtranMapperContext and
   // pass it down to CtranTcpDm::irecvConnected().
   void* unpackPool{nullptr};

--- a/comms/ctran/gpe/CtranGpeImpl.cc
+++ b/comms/ctran/gpe/CtranGpeImpl.cc
@@ -297,8 +297,9 @@ commResult_t CtranGpe::Impl::submit(
   // can synchronize with the kernel before running cleanup. During graph
   // capture the cleanup is retained directly on the graph via
   // retainUserObject, avoiding host-node overhead.
-  bool needsKernelFlag =
-      !opGroup.empty() || (kernelConfig.postKernelCleanup && !isCapturing);
+  bool needsKernelFlag = !opGroup.empty() ||
+      kernelConfig.unpackPool != nullptr ||
+      (kernelConfig.postKernelCleanup && !isCapturing);
 
   auto kernelFlag = needsKernelFlag ? this->kernelFlagPool->pop() : nullptr;
   volatile int* flag = nullptr;
@@ -388,6 +389,31 @@ commResult_t CtranGpe::Impl::submit(
     if (isCapturing) {
       FB_COMMCHECK(preLaunchGraphPrepare(cmd, graphPrepareFn));
       cmd->persistent = true;
+      if (cmd->unpackPool != nullptr) {
+        auto existingCleanup = std::move(cmd->postKernelCleanup);
+        auto* unpackPool = cmd->unpackPool;
+        cmd->postKernelCleanup = [comm = comm,
+                                  unpackPool,
+                                  existingCleanup =
+                                      std::move(existingCleanup)]() mutable {
+          if (existingCleanup) {
+            existingCleanup();
+          }
+          if (!ctranInitialized(comm) || comm->ctran_->mapper == nullptr) {
+            return;
+          }
+          auto result =
+              comm->ctran_->mapper->teardownUnpackConsumer(unpackPool);
+          if (result != commSuccess) {
+            CLOGF_SUBSYS(
+                WARN,
+                COLL,
+                "CTRAN-GPE: failed to teardown graph unpack pool {}: result {}",
+                unpackPool,
+                static_cast<int>(result));
+          }
+        };
+      }
       // Mark the flag as persistent so reclaim() won't steal it between
       // graph replays (the kernel writes KERNEL_UNSET after each replay).
       if (kernelFlag) {
@@ -916,11 +942,10 @@ void CtranGpe::Impl::gpeThreadFn() {
               comm->testAbort() ? KERNEL_HOST_ABORT : KERNEL_TERMINATE);
           gpeProfiler_->mark(ctran::GpeTracePoint::TERMINATE_KERNEL);
         }
-        // Teardown unpack queue if it was allocated for this operation (TcpDM
-        // backend). Don't wait for kernel to finish, the pool manages
-        // the allocations in the round robin fashion to avoid immediate
-        // reuse.
-        if (cmd->unpackPool != nullptr) {
+        // Teardown eager unpack queues after this kernel. Persistent graph
+        // commands keep the pool alive across replays and release it from
+        // cmdDestroy when the graph is destroyed.
+        if (cmd->unpackPool != nullptr && !cmd->persistent) {
           FB_COMMCHECKTHROW_EX(
               comm->ctran_->mapper->teardownUnpackConsumer(cmd->unpackPool),
               comm->logMetaData_);

--- a/comms/ctran/gpe/CtranGpeImpl.h
+++ b/comms/ctran/gpe/CtranGpeImpl.h
@@ -158,7 +158,8 @@ class CtranGpeCmd {
 
   std::optional<std::chrono::milliseconds> timeout{std::nullopt};
 
-  // Unpack queue to teardown after kernel completes (for TcpDM backend)
+  // Unpack queue to teardown after the eager kernel completes, or when
+  // a persistent CUDA graph command is destroyed (for TcpDM backend).
   void* unpackPool{nullptr};
 
   // Post-kernel cleanup callback. Called by GPE thread after kernel finishes.

--- a/comms/ctran/gpe/tests/CtranGpeUT.cc
+++ b/comms/ctran/gpe/tests/CtranGpeUT.cc
@@ -2246,6 +2246,7 @@ TEST_F(CtranGpeTest, PostKernelCleanupGraphWithOpGroup) {
   ctranKernelSetAllGatherArgs(
       a, expectedValPtr, commInt8, count, dummyDevState_d, &config.args);
   config.postKernelCleanup = [&cleanupRan]() { cleanupRan.store(true); };
+  config.unpackPool = reinterpret_cast<void*>(0x1234);
 
   std::vector<std::unique_ptr<OpElem>> ops;
   auto* op = new OpElem(OpElem::opType::RECV, dummyComm, dummyOpCount);


### PR DESCRIPTION
Summary:

TCPDM counted recv notifications can remain posted when a PAFT/MCCL peer exits or when the backend is force-closed. Track failed counted recvs separately from successful notifications so `checkNotify` can return `commRemoteError` instead of leaving the collective waiting forever. Also make close drain pending counted recv notifications and fix two worker close races: retire worker state before publishing a response to the proxy, and keep `closePendingFd_` iterator ownership inside `progressOps` so close handling cannot double-erase its unordered_set entry.

Reviewed By: erfan111

Differential Revision: D108923591


