### PR TITLE
Isolate `BackendWrapperShutdownTest` rendezvous stores

### DIFF
--- a/comms/torchcomms/tests/integration/helpers/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/helpers/TorchCommTestHelpers.py
@@ -186,6 +186,43 @@ def create_store():
     return PrefixStore(f"test_comm_{NEXT_STORE_ID}", _root_store)
 
 
+def create_store_on_free_port(torchcomm):
+    """Create a PrefixStore on an ephemeral port coordinated by torchcomm."""
+    maybe_set_rank_envs()
+
+    global _root_store, NEXT_STORE_ID
+    if _root_store is None:
+        rank, _ = get_rank_and_size()
+        host = os.environ["MASTER_ADDR"]
+        port = 0
+
+        if rank == 0:
+            _root_store = TCPStore(
+                host_name=host,
+                port=0,
+                is_master=True,
+                wait_for_workers=False,
+            )
+            port = _root_store.port
+
+        port_tensor = torch.tensor(
+            [float(port)], dtype=torch.float, device=torchcomm.get_device()
+        )
+        torchcomm.broadcast(port_tensor, 0, False)
+        port = int(port_tensor.cpu().item())
+
+        if rank != 0:
+            _root_store = TCPStore(
+                host_name=host,
+                port=port,
+                is_master=False,
+                wait_for_workers=False,
+            )
+
+    NEXT_STORE_ID += 1
+    return PrefixStore(f"test_comm_{NEXT_STORE_ID}", _root_store)
+
+
 def wrap_prefix_store(name, store):
     """Wrap a store with a PrefixStore using the given name."""
     return PrefixStore(name, store)

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -22,6 +22,8 @@ Two regressions guarded against:
 from __future__ import annotations
 
 import os
+import tempfile
+import time
 import unittest
 
 import torch
@@ -53,6 +55,65 @@ def _local_rank() -> int:
     return int(os.environ.get("LOCAL_RANK", get_rank_and_size()[0]))
 
 
+def _store_port_file(store_name: str) -> str:
+    return os.path.join(
+        tempfile.gettempdir(),
+        f"torchcomms_backend_wrapper_shutdown_{os.environ['MASTER_PORT']}_{store_name}.port",
+    )
+
+
+def _create_store_on_free_port(store_name: str) -> dist.TCPStore:
+    rank, world_size = get_rank_and_size()
+    host = os.environ["MASTER_ADDR"]
+    port_file = _store_port_file(store_name)
+
+    if rank == 0:
+        try:
+            os.unlink(port_file)
+        except FileNotFoundError:
+            pass
+
+        store = dist.TCPStore(
+            host_name=host,
+            port=0,
+            world_size=world_size,
+            is_master=True,
+            wait_for_workers=False,
+        )
+        with open(port_file, "w", encoding="utf-8") as f:
+            f.write(str(store.port))
+        return store
+
+    deadline = time.monotonic() + 120
+    while True:
+        try:
+            with open(port_file, encoding="utf-8") as f:
+                port = int(f.read().strip())
+            break
+        except (FileNotFoundError, ValueError):
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"Timed out waiting for store port file {port_file}")
+            time.sleep(0.05)
+
+    return dist.TCPStore(
+        host_name=host,
+        port=port,
+        world_size=world_size,
+        is_master=False,
+        wait_for_workers=False,
+    )
+
+
+def _cleanup_store_port_file(store_name: str) -> None:
+    if get_rank_and_size()[0] != 0:
+        return
+
+    try:
+        os.unlink(_store_port_file(store_name))
+    except FileNotFoundError:
+        pass
+
+
 @unittest.skipUnless(
     _TORCHCOMMS_CONFIG_AVAILABLE,
     "dist.config.use_torchcomms not available in this PyTorch version",
@@ -63,7 +124,7 @@ class TestBackendWrapperShutdown(unittest.TestCase):
     it down — no shared setUpClass, since the goal is to exercise the
     init+destroy cycle itself."""
 
-    def _init_pg(self, backend: str) -> None:
+    def _init_pg(self, backend: str, store_name: str) -> None:
         rank, world_size = get_rank_and_size()
         # NCCL requires a CUDA device to be bound to this rank before
         # ``init_process_group`` so that the per-rank communicator gets
@@ -75,19 +136,26 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         if torch.accelerator.is_available():
             torch.accelerator.set_device_index(_local_rank())
         dist.config.use_torchcomms = True
-        dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+        dist.init_process_group(
+            backend=backend,
+            store=_create_store_on_free_port(store_name),
+            rank=rank,
+            world_size=world_size,
+        )
         torch.set_default_device(device)
 
     def test_destroy_after_collective_no_hang(self):
         """A simple init → all_reduce → destroy cycle finishes without
         hanging. Catches the original ``ncclCommDestroy`` deadlock."""
-        self._init_pg(os.environ["TEST_BACKEND"])
+        store_name = "destroy_after_collective_no_hang"
+        self._init_pg(os.environ["TEST_BACKEND"], store_name)
         try:
             tensor = torch.ones(8, dtype=torch.float32)
             dist.all_reduce(tensor)
             self.assertEqual(tensor[0].item(), float(dist.get_world_size()))
         finally:
             dist.destroy_process_group()
+            _cleanup_store_port_file(store_name)
 
     def test_mixed_backend_destroy_idempotent(self):
         """Mixed ``cpu:gloo,cuda:nccl`` PG: ``destroy_process_group``
@@ -108,8 +176,10 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         local_rank = _local_rank()
         torch.cuda.set_device(local_rank)
         dist.config.use_torchcomms = True
+        store_name = "mixed_backend_destroy_idempotent"
         dist.init_process_group(
             backend="cpu:gloo,cuda:nccl",
+            store=_create_store_on_free_port(store_name),
             rank=rank,
             world_size=world_size,
             device_id=torch.device(f"cuda:{local_rank}"),
@@ -127,6 +197,7 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         finally:
             # Must not raise even though both sub-backends share the comm.
             dist.destroy_process_group()
+            _cleanup_store_port_file(store_name)
 
 
 if __name__ == "__main__":

--- a/comms/torchcomms/tests/integration/py/MultiCommTest.py
+++ b/comms/torchcomms/tests/integration/py/MultiCommTest.py
@@ -8,6 +8,7 @@ import torch
 from torchcomms import ReduceOp
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
     create_store,
+    create_store_on_free_port,
     destroy_root_store,
     TorchCommTestWrapper,
     verify_tensor_equality,
@@ -321,18 +322,16 @@ class MultiCommTest(unittest.TestCase):
         wrappers = []
         comms = []
 
-        # Create first communicator using explicit store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Destroy all store references and free MASTER_PORT
-        store = None
+        # Ensure the no-store communicator is ready to coordinate the explicit store.
         store_deletion_barrier(comms[0])
-        destroy_root_store()
 
-        # Create second communicator with no store (internal bootstrap)
-        wrappers.append(TorchCommTestWrapper())
+        # Create second communicator using explicit store
+        store = create_store_on_free_port(comms[0])
+        wrappers.append(TorchCommTestWrapper(store=store))
         comms.append(wrappers[-1].get_torchcomm())
 
         # Test communication on each communicator individually
@@ -342,13 +341,25 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
+        # Clean up the explicit store for subsequent tests.
+        store = None
+        store_deletion_barrier(comms[-1])
+        destroy_root_store()
+
     def test_three_comms_mixed_store(self):
         """Test with three communicators with mixed store (two explicit, one no-store)."""
         wrappers = []
         comms = []
 
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
+        comms.append(wrappers[-1].get_torchcomm())
+
+        # Ensure the no-store communicator is ready to coordinate the explicit store.
+        store_deletion_barrier(comms[0])
+
         # Create first two communicators using PrefixStore wrappers
-        store = create_store()
+        store = create_store_on_free_port(comms[0])
         store1 = wrap_prefix_store("comm1", store)
         store2 = wrap_prefix_store("comm2", store)
 
@@ -358,17 +369,6 @@ class MultiCommTest(unittest.TestCase):
         wrappers.append(TorchCommTestWrapper(store=store2))
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Destroy all store references and free MASTER_PORT
-        store1 = None
-        store2 = None
-        store = None
-        store_deletion_barrier(comms[0])
-        destroy_root_store()
-
-        # Create third communicator with no store (internal bootstrap)
-        wrappers.append(TorchCommTestWrapper())
-        comms.append(wrappers[-1].get_torchcomm())
-
         # Test communication on each communicator individually
         for wrapper in wrappers:
             self._verify_communication(wrapper)
@@ -376,23 +376,28 @@ class MultiCommTest(unittest.TestCase):
         # Test simultaneous communication across all communicators
         self._verify_simultaneous_communication(wrappers)
 
+        # Clean up the explicit store for subsequent tests.
+        store1 = None
+        store2 = None
+        store = None
+        store_deletion_barrier(comms[-1])
+        destroy_root_store()
+
     def test_mixed_ops_mixed_store(self):
         """Test mixed operations across multiple communicators with mixed store."""
         wrappers = []
         comms = []
 
-        # Create first communicator using explicit store
-        store = create_store()
-        wrappers.append(TorchCommTestWrapper(store=store))
+        # Create first communicator with no store (internal bootstrap)
+        wrappers.append(TorchCommTestWrapper())
         comms.append(wrappers[-1].get_torchcomm())
 
-        # Destroy all store references and free MASTER_PORT
-        store = None
+        # Ensure the no-store communicator is ready to coordinate the explicit store.
         store_deletion_barrier(comms[0])
-        destroy_root_store()
 
-        # Create second communicator with no store (internal bootstrap)
-        wrappers.append(TorchCommTestWrapper())
+        # Create second communicator using explicit store
+        store = create_store_on_free_port(comms[0])
+        wrappers.append(TorchCommTestWrapper(store=store))
         comms.append(wrappers[-1].get_torchcomm())
 
         device0 = comms[0].get_device()
@@ -420,6 +425,11 @@ class MultiCommTest(unittest.TestCase):
         # Verify results
         verify_tensor_equality(input1.cpu(), expected1, "comm_0 all_reduce result")
         verify_tensor_equality(input2.cpu(), broadcast_value, "comm_1 broadcast result")
+
+        # Clean up the explicit store for subsequent tests.
+        store = None
+        store_deletion_barrier(comms[-1])
+        destroy_root_store()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Fix `BackendWrapperShutdownTest_1x8_backend_nccl` flakiness by avoiding reuse of the launcher `MASTER_PORT` across multiple `init_process_group` calls in the same test process. Each test now creates an explicit `TCPStore` on an ephemeral port, with rank 0 publishing the selected port to the other local ranks before process-group initialization.

Differential Revision: D109076283


