### PR TITLE
expose if a buffer is cache hit or registration (#2953)

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -215,6 +215,10 @@ class RdmaMemory : folly::MoveOnly {
     return remoteKey_;
   }
 
+  bool reusedRegistration() const {
+    return cacheReg_;
+  }
+
   int getDevice() const {
     return cudaDev_;
   }

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -305,6 +305,16 @@ TEST_F(RdmaMemoryTest, BasicConstruction) {
   EXPECT_FALSE(memory.contains(buffer_, bufferSize_ + 1));
 }
 
+TEST_F(RdmaMemoryTest, ReportsRegistrationReuse) {
+  RdmaMemory firstMemory(buffer_, bufferSize_, cudaDev_);
+  EXPECT_FALSE(firstMemory.reusedRegistration());
+
+  RdmaMemory secondMemory(buffer_, bufferSize_, cudaDev_);
+  EXPECT_TRUE(secondMemory.reusedRegistration());
+  EXPECT_EQ(secondMemory.localKey(), firstMemory.localKey());
+  EXPECT_EQ(secondMemory.remoteKey(), firstMemory.remoteKey());
+}
+
 TEST_F(RdmaMemoryTest, ViewCreation) {
   RdmaMemory memory(buffer_, bufferSize_, cudaDev_);
 


### PR DESCRIPTION
Summary:

Expose whether `RdmaMemory` reused an existing `RegCache` registration.

`RdmaMemory` already checks `RegCache` before calling `globalRegister()`. This diff exposes the resulting registration ownership state via `reusedRegistration()`, which returns the existing `cacheReg_` flag, so callers can distinguish a new IB registration from a cached registration reuse. Added a torchcomms unit test that constructs two `RdmaMemory` wrappers for the same buffer and verifies the second wrapper reports reuse and shares the same lkey/rkey.

Reviewed By: tanquer

Differential Revision: D109192357


