### PR TITLE
fix torchcomms symbol issue

### DIFF
--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -47,7 +47,6 @@ separate_arguments(FOLLY_LDFLAGS NATIVE_COMMAND "${FOLLY_LDFLAGS_RAW}")
 # /path/to/libglog.a — the simple substring match handles all forms.
 list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "glog")
 list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "gflags")
-list(FILTER FOLLY_LDFLAGS EXCLUDE REGEX "libfmt")
 
 execute_process(
     COMMAND pkg-config --libs --static absl_log absl_check
@@ -143,11 +142,16 @@ target_link_libraries(torchcomms_comms_ncclx PRIVATE
     ${TORCH_PYTHON_LIB}
 )
 if(USE_SYSTEM_LIBS)
+    # Link libfmt explicitly: torchcomms compiles with FMT_HEADER_ONLY=1
+    # (via fmt::fmt INTERFACE target) so most fmt symbols are inlined, but
+    # a few (assert_fail, thousands_sep_impl) still emit out-of-line
+    # references.
     target_link_libraries(torchcomms_comms_ncclx PRIVATE
         ${NCCLX_SHARED_LIB}
         ${FOLLY_LDFLAGS}
         "-lboost_program_options"
         "-lboost_filesystem"
+        "-lfmt"
     )
 else()
     set(TORCHCOMMS_NCCLX_PRIMS_LINK_LIBS "")


### PR DESCRIPTION
Summary:
1. Resolve the torchcomms linking issue: `ImportError: /packages/xlformers_msl_rl_gb200_conda/conda/lib/python3.12/site-packages/torchcomms/comms_ncclx.cpython-312-aarch64-linux-gnu.so: undefined symbol: _ZN3fmt2v96detail11assert_failEPKciS3`

2. Fix the gb200 conda build issue, similar to h100 fix in D109035929.

Differential Revision: D109189033


