### PR TITLE
Add memType column to regcache scuba logging (#2958)

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -407,6 +407,7 @@ commResult_t ctran::RegCache::globalDeregister(
   // Free each segment
   size_t totalSegmentsFreed = 0;
   size_t totalRegElemsFreed = 0;
+  std::optional<DevMemType> firstFreedType;
   for (auto segHdl : segHdls) {
     bool freed = false;
     bool ncclManaged = false;
@@ -415,6 +416,9 @@ commResult_t ctran::RegCache::globalDeregister(
 
     if (freed) {
       totalSegmentsFreed++;
+    }
+    if (!firstFreedType.has_value() && !regElemsFreed.empty()) {
+      firstFreedType = regElemsFreed.front()->getType();
     }
     totalRegElemsFreed += regElemsFreed.size();
   }
@@ -432,7 +436,10 @@ commResult_t ctran::RegCache::globalDeregister(
         totalSegmentsFreed,
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - timerBegin)
-            .count());
+            .count(),
+        firstFreedType.has_value()
+            ? std::optional<std::string>(devMemTypeStr(firstFreedType.value()))
+            : std::nullopt);
   }
 
   return commSuccess;
@@ -899,6 +906,7 @@ commResult_t ctran::RegCache::regRangeCached(
   size_t lenToReg = 0;
   void* ptrToReg = nullptr;
   size_t numSegmentsToReg = 0;
+  std::optional<DevMemType> regMemType;
 
   {
     // Global lock:
@@ -947,6 +955,7 @@ commResult_t ctran::RegCache::regRangeCached(
       // range.
       ptrToReg = const_cast<void*>(segments.at(0)->range.buf);
       numSegmentsToReg = segments.size();
+      regMemType = segments.at(0)->getType();
 
       // Use helper to perform backend registration and update maps
       FB_COMMCHECK(registerSegmentsTogether(
@@ -976,7 +985,10 @@ commResult_t ctran::RegCache::regRangeCached(
       numSegmentsToReg,
       std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::steady_clock::now() - timerBegin)
-          .count());
+          .count(),
+      regMemType.has_value()
+          ? std::optional<std::string>(devMemTypeStr(regMemType.value()))
+          : std::nullopt);
 
   profiler.wlock()->record(ctran::regcache::EventType::kRegMemEvent, dur);
   return commSuccess;
@@ -1189,7 +1201,8 @@ commResult_t ctran::RegCache::regRange(
         ranges.size(),
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - timerBegin)
-            .count());
+            .count(),
+        devMemTypeStr(ranges.at(0).type));
   }
 
   return commSuccess;
@@ -1337,6 +1350,7 @@ commResult_t ctran::RegCache::regAll() {
   size_t totalLenRegistered = 0;
   size_t totalSegmentsRegistered = 0;
   size_t numContiguousRegions = 0;
+  std::optional<DevMemType> regMemType;
 
   {
     // Global lock:
@@ -1376,6 +1390,7 @@ commResult_t ctran::RegCache::regAll() {
     SetCudaDevRAII setCudaDev(cudaDev);
 
     numContiguousRegions = contiguousRegions.size();
+    regMemType = contiguousRegions.front().front()->getType();
 
     // Register each contiguous region separately using the helper
     for (size_t regionIdx = 0; regionIdx < contiguousRegions.size();
@@ -1435,7 +1450,10 @@ commResult_t ctran::RegCache::regAll() {
         totalSegmentsRegistered,
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::steady_clock::now() - timerBegin)
-            .count());
+            .count(),
+        regMemType.has_value()
+            ? std::optional<std::string>(devMemTypeStr(regMemType.value()))
+            : std::nullopt);
   }
 
   CLOGF_TRACE(

--- a/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
+++ b/comms/ncclx/meta/tests/MemoryTraceDistTest.cc
@@ -212,6 +212,30 @@ class MemoryTraceTestFixture : public NcclxBaseTestFixture,
     }
   }
 
+  void verifyEventMemType(
+      const std::string& output,
+      const std::string& use,
+      const std::string& expectedMemType) {
+    bool found = false;
+    std::istringstream iss(output);
+    std::string line;
+    while (std::getline(iss, line)) {
+      folly::dynamic jsonLog = folly::parseJson(line);
+      if (jsonLog["normal"]["use"].asString().find(use) != std::string::npos) {
+        ASSERT_EQ(jsonLog["normal"].count("memType"), 1)
+            << "use " << use << " missing memType column on globalRank "
+            << this->globalRank;
+        EXPECT_EQ(jsonLog["normal"]["memType"].asString(), expectedMemType)
+            << "use " << use << " unexpected memType on globalRank "
+            << this->globalRank;
+        found = true;
+      }
+    }
+    EXPECT_TRUE(found) << "use " << use
+                       << " not found for memType check on globalRank "
+                       << this->globalRank;
+  }
+
  protected:
   void runNcclInternalBufferLogTest();
   void runUserBufferLoggingTest();
@@ -417,6 +441,7 @@ void MemoryTraceTestFixture::runUserBufferLoggingTest() {
     verifyEventsUse(
         output,
         {"eagerRegMem", "deregMem", "ncclCommRegister", "ncclCommDeregister"});
+    verifyEventMemType(output, "eagerRegMem", "cudaMalloc");
   } else {
     // Expect other ranks to have no events logged
     EXPECT_EQ(output, "");

--- a/comms/torchcomms/transport/RdmaTransportCCA.cpp
+++ b/comms/torchcomms/transport/RdmaTransportCCA.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/torchcomms/transport/RdmaTransportCCA.hpp"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <folly/logging/xlog.h>
+#include <folly/synchronization/CallOnce.h>
+
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/utils/commSpecs.h"
+
+namespace torch::comms {
+
+namespace {
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+folly::once_flag attachHookFlag;
+
+// Trace callback invoked by the CUDA caching allocator on every segment
+// alloc/free. Registers on alloc/map and deregisters on free/unmap.
+void regDeregMem(const c10::cuda::CUDACachingAllocator::TraceEntry& te) {
+  using Action = c10::cuda::CUDACachingAllocator::TraceEntry::Action;
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  void* addr = reinterpret_cast<void*>(static_cast<uintptr_t>(te.addr_));
+  const size_t len = te.size_;
+  const auto regCache = ctran::RegCache::getInstance();
+  if (regCache == nullptr) {
+    return;
+  }
+  if (te.action_ == Action::SEGMENT_ALLOC ||
+      te.action_ == Action::SEGMENT_MAP) {
+    const auto result = regCache->globalRegister(
+        addr, len, /*forceReg=*/false, /*ncclManaged=*/false);
+    if (result != commSuccess) {
+      XLOGF(
+          WARN,
+          "[RDMA] Failed to register memory with RegCache (addr={}, len={})",
+          addr,
+          len);
+    }
+  } else if (
+      te.action_ == Action::SEGMENT_FREE ||
+      te.action_ == Action::SEGMENT_UNMAP) {
+    const auto result = regCache->globalDeregister(addr, len);
+    if (result != commSuccess) {
+      XLOGF(
+          WARN,
+          "[RDMA] Failed to deregister memory with RegCache (addr={}, len={})",
+          addr,
+          len);
+    }
+  }
+}
+
+// Register all segments already allocated by the caching allocator before the
+// trace hook was attached. Device is auto-detected from the pointer.
+void registerMemPreHook() {
+  const auto snapshot = c10::cuda::CUDACachingAllocator::snapshot();
+  const auto regCache = ctran::RegCache::getInstance();
+  if (regCache == nullptr) {
+    return;
+  }
+  for (const auto& segmentInfo : snapshot.segments) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    void* addr = reinterpret_cast<void*>(segmentInfo.address);
+    const size_t len = segmentInfo.total_size;
+    const auto result = regCache->globalRegister(
+        addr, len, /*forceReg=*/false, /*ncclManaged=*/false);
+    if (result != commSuccess) {
+      XLOGF(
+          WARN,
+          "[RDMA] Failed to register pre-existing memory with RegCache (addr={}, len={})",
+          addr,
+          len);
+    }
+  }
+}
+
+} // namespace
+
+void attachRdmaMemoryHook() {
+  folly::call_once(attachHookFlag, [] {
+    at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+    registerMemPreHook();
+    c10::cuda::CUDACachingAllocator::attachAllocatorTraceTracker(&regDeregMem);
+  });
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/RdmaTransportCCA.hpp
+++ b/comms/torchcomms/transport/RdmaTransportCCA.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace torch::comms {
+
+// Installs a CUDA caching-allocator trace hook that registers and deregisters
+// allocator segments with ctran::RegCache for the RDMA transport. Registration
+// is lazy (forceReg=false): segments are cached and the IB handle is
+// materialized on the first searchIbRegHandle() lookup. Idempotent — only the
+// first call installs the hook.
+void attachRdmaMemoryHook();
+
+} // namespace torch::comms

--- a/comms/torchcomms/transport/RdmaTransportPy.cpp
+++ b/comms/torchcomms/transport/RdmaTransportPy.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/utils/pybind.h>
 
 #include "comms/torchcomms/transport/RdmaTransport.h"
+#include "comms/torchcomms/transport/RdmaTransportCCA.hpp"
 
 using namespace torch::comms;
 
@@ -129,4 +130,11 @@ PYBIND11_MODULE(_transport, m, py::mod_gil_not_used()) {
         return RdmaRemoteBuffer{
             const_cast<void*>(self.data()), self.length(), self.remoteKey()};
       });
+
+  m.def(
+      "attach_rdma_memory_hook",
+      &torch::comms::attachRdmaMemoryHook,
+      "Install the CUDA caching-allocator hook that registers allocator "
+      "segments with RegCache for the RDMA transport. Idempotent: only the "
+      "first call installs the hook.");
 }

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportCCATest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportCCATest.cc
@@ -1,0 +1,103 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include "comms/ctran/regcache/RegCache.h"
+#include "comms/torchcomms/transport/RdmaTransport.h"
+#include "comms/torchcomms/transport/RdmaTransportCCA.hpp"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace torch::comms;
+
+class RdmaTransportCCATest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ncclCvarInit();
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+    if (!RdmaTransport::supported()) {
+      GTEST_SKIP() << "RDMA/IB not supported on this platform";
+    }
+    int deviceCount = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
+    c10::cuda::CUDACachingAllocator::init(deviceCount);
+  }
+};
+
+// Allocating a buffer through the CUDA caching allocator and then installing
+// the hook registers the pre-existing segment with RegCache via
+// registerMemPreHook(). searchIbRegHandle() returns null before the hook runs
+// (segment not cached) and a valid handle afterwards (the IB registration is
+// materialized lazily on lookup).
+TEST_F(RdmaTransportCCATest, HookRegistersExistingCachingAllocatorSegments) {
+  const int cudaDev = 0;
+  const size_t bufferSize = 4 * 1024 * 1024; // 4MB, forces a large-pool segment
+
+  void* buffer = c10::cuda::CUDACachingAllocator::raw_alloc(bufferSize);
+  ASSERT_NE(buffer, nullptr);
+
+  const auto regCache = ctran::RegCache::getInstance();
+  ASSERT_NE(regCache, nullptr);
+
+  // Before the hook runs the segment is not registered in RegCache.
+  EXPECT_EQ(regCache->searchIbRegHandle(buffer, bufferSize, cudaDev), nullptr);
+
+  // Installing the hook snapshots and registers all pre-existing segments.
+  attachRdmaMemoryHook();
+
+  // The segment is now registered; the IB handle is materialized lazily.
+  EXPECT_NE(regCache->searchIbRegHandle(buffer, bufferSize, cudaDev), nullptr);
+
+  c10::cuda::CUDACachingAllocator::raw_delete(buffer);
+}
+
+// Reproduces the torchcomm (NCCLX) hook and the RDMA hook both being installed:
+// both ultimately call RegCache::globalRegister on SEGMENT_ALLOC and
+// RegCache::globalDeregister on SEGMENT_FREE for the same caching-allocator
+// segment. Two registrants must share a single registration, and the paired
+// deregisters must not double-free: the first releases it, the second is a safe
+// no-op. This verifies RegCache refcounts the shared segment correctly.
+TEST_F(RdmaTransportCCATest, RegCacheRefCountWithTwoRegistrants) {
+  const int cudaDev = 0;
+  const size_t bufferSize = 4 * 1024 * 1024; // 4MB, forces a large-pool segment
+
+  void* buffer = c10::cuda::CUDACachingAllocator::raw_alloc(bufferSize);
+  ASSERT_NE(buffer, nullptr);
+
+  const auto regCache = ctran::RegCache::getInstance();
+  ASSERT_NE(regCache, nullptr);
+
+  // Both registrants (NCCLX hook + RDMA hook) register the same buffer.
+  EXPECT_EQ(
+      regCache->globalRegister(
+          buffer,
+          bufferSize,
+          /*forceReg=*/false,
+          /*ncclManaged=*/false,
+          cudaDev),
+      commSuccess);
+  EXPECT_EQ(
+      regCache->globalRegister(
+          buffer,
+          bufferSize,
+          /*forceReg=*/false,
+          /*ncclManaged=*/false,
+          cudaDev),
+      commSuccess);
+
+  // The segment is shared: a single IB handle is materialized for both.
+  EXPECT_NE(regCache->searchIbRegHandle(buffer, bufferSize, cudaDev), nullptr);
+
+  // Both registrants deregister (as both hooks fire on the same SEGMENT_FREE).
+  // Neither call may abort or double-free; the second is a safe no-op.
+  EXPECT_EQ(regCache->globalDeregister(buffer, bufferSize), commSuccess);
+  EXPECT_EQ(regCache->globalDeregister(buffer, bufferSize), commSuccess);
+
+  // End state is clean: the buffer is fully deregistered.
+  EXPECT_EQ(regCache->searchIbRegHandle(buffer, bufferSize, cudaDev), nullptr);
+
+  c10::cuda::CUDACachingAllocator::raw_delete(buffer);
+}

--- a/comms/utils/logger/EventMgr.cc
+++ b/comms/utils/logger/EventMgr.cc
@@ -74,6 +74,9 @@ NcclScubaSample MemoryEvent::toSample() {
   if (durationUs.has_value()) {
     sample.addInt("durationUs", durationUs.value());
   }
+  if (memType.has_value()) {
+    sample.addNormal("memType", memType.value());
+  }
   sample.addNormal("callsite", callsite);
   sample.addNormal("use", use);
   sample.addInt("iteration", iteration);

--- a/comms/utils/logger/EventMgr.h
+++ b/comms/utils/logger/EventMgr.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "comms/utils/commSpecs.h"
 #include "comms/utils/logger/NcclScubaSample.h"
@@ -125,6 +126,7 @@ class MemoryEvent : public LoggerEvent {
       std::optional<int64_t> bytes = std::nullopt,
       std::optional<int> numSegments = std::nullopt,
       std::optional<int64_t> durationUs = std::nullopt,
+      std::optional<std::string> memType = std::nullopt,
       bool isRegMemEvent = false)
       : commHash(logMetaData.commHash),
         commDesc(logMetaData.commDesc),
@@ -136,6 +138,7 @@ class MemoryEvent : public LoggerEvent {
         bytes(bytes),
         numSegments(numSegments),
         durationUs(durationUs),
+        memType(std::move(memType)),
         isRegMemEvent(isRegMemEvent) {
     iteration = ncclxGetIteration();
   }
@@ -172,6 +175,7 @@ class MemoryEvent : public LoggerEvent {
   std::optional<int64_t> bytes;
   std::optional<int> numSegments;
   std::optional<int64_t> durationUs;
+  std::optional<std::string> memType;
   bool isRegMemEvent = false;
 };
 

--- a/comms/utils/logger/alloc.cc
+++ b/comms/utils/logger/alloc.cc
@@ -17,6 +17,7 @@ void logMemoryEvent(
     std::optional<int64_t> bytes,
     std::optional<int> numSegments,
     std::optional<int64_t> durationUs,
+    const std::optional<std::string>& memType,
     bool isRegMemEvent) {
   auto memoryEvent = std::make_unique<MemoryEvent>(
       logMetaData,
@@ -26,6 +27,7 @@ void logMemoryEvent(
       bytes,
       numSegments,
       durationUs,
+      memType,
       isRegMemEvent);
   if (memoryEvent->shouldLog()) {
     NcclScubaEvent event(std::move(memoryEvent));

--- a/comms/utils/logger/alloc.h
+++ b/comms/utils/logger/alloc.h
@@ -17,4 +17,5 @@ void logMemoryEvent(
     std::optional<int64_t> bytes = std::nullopt,
     std::optional<int> numSegments = std::nullopt,
     std::optional<int64_t> durationUs = std::nullopt,
+    const std::optional<std::string>& memType = std::nullopt,
     bool isRegMemEvent = false);

--- a/comms/utils/logger/tests/EventMgrTest.cc
+++ b/comms/utils/logger/tests/EventMgrTest.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/utils/logger/EventMgr.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/portability/GTest.h>
+
+#include "comms/utils/commSpecs.h"
+
+namespace {
+
+constexpr uint64_t kCommHash = 0xabc123;
+constexpr const char* kCommDesc = "test_pg:0";
+constexpr int kRank = 0;
+constexpr int kNRanks = 8;
+constexpr uintptr_t kMemoryAddr = 0xdeadbeef;
+constexpr int64_t kBytes = 1024;
+const std::string kMemType = "cudaMalloc";
+
+CommLogData makeCommLogData() {
+  return CommLogData{/*commId=*/0, kCommHash, kCommDesc, kRank, kNRanks};
+}
+
+MemoryEvent makeMemoryEvent(std::optional<std::string> memType) {
+  return MemoryEvent(
+      makeCommLogData(),
+      /*callsite=*/"testCallsite",
+      /*use=*/"testUse",
+      kMemoryAddr,
+      /*bytes=*/kBytes,
+      /*numSegments=*/std::nullopt,
+      /*durationUs=*/std::nullopt,
+      std::move(memType));
+}
+
+} // namespace
+
+// When a memType is supplied, toSample() emits a "memType" normal column
+// carrying that exact value.
+TEST(MemoryEventTest, ToSampleEmitsMemTypeWhenSet) {
+  auto event = makeMemoryEvent(kMemType);
+
+  auto sample = event.toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"]["memType"].asString(), kMemType);
+}
+
+// When memType is nullopt, the "memType" column must be absent entirely.
+TEST(MemoryEventTest, ToSampleOmitsMemTypeWhenNullopt) {
+  auto event = makeMemoryEvent(std::nullopt);
+
+  auto sample = event.toSample();
+  const auto json = folly::parseJson(sample.toJson());
+
+  EXPECT_EQ(json["normal"].count("memType"), 0);
+}

--- a/comms/utils/memtrace/MemoryTrace.cc
+++ b/comms/utils/memtrace/MemoryTrace.cc
@@ -108,7 +108,8 @@ void recordReg(
     uintptr_t addr,
     std::optional<int64_t> bytes,
     std::optional<int> numSegments,
-    std::optional<int64_t> durationUs) {
+    std::optional<int64_t> durationUs,
+    const std::optional<std::string>& memType) {
   if (!NCCL_MEMTRACE_ENABLE) {
     return;
   }
@@ -120,6 +121,7 @@ void recordReg(
       bytes,
       numSegments,
       durationUs,
+      memType,
       /*isRegMemEvent=*/true);
 }
 

--- a/comms/utils/memtrace/MemoryTrace.h
+++ b/comms/utils/memtrace/MemoryTrace.h
@@ -45,7 +45,8 @@ void recordReg(
     uintptr_t addr,
     std::optional<int64_t> bytes = std::nullopt,
     std::optional<int> numSegments = std::nullopt,
-    std::optional<int64_t> durationUs = std::nullopt);
+    std::optional<int64_t> durationUs = std::nullopt,
+    const std::optional<std::string>& memType = std::nullopt);
 
 // --- Per-communicator in-memory stats ---
 


### PR DESCRIPTION
Summary:

Extend regcache's memory-event scuba logging ("MemoryEvent" dataset) to record the memory type of each registration:
- Thread an optional `memType` string through the recording chain `recordReg` -> `logMemoryEvent` -> `MemoryEvent::toSample`, emitting a new `memType` normal column only when set.
- Populate `memType` at all four regcache `recordReg` call sites by converting the in-scope `DevMemType` via `devMemTypeStr`: `regRangeCached` (first segment), `regRange` (first range), `regAll` (first contiguous region), and `globalDeregister` (first freed reg element; column omitted when none captured).
- Keep the logger/memtrace headers CUDA-free: the `DevMemType`->string conversion happens only in `RegCache.cc`, and the chain carries a plain `std::optional<std::string>`.
- All new parameters are trailing optionals defaulting to `std::nullopt`, so `recordAlloc`/`recordFree` and existing callers are unaffected and the column is omitted when unset.

Possible `memType` values: `cudaMalloc`, `managed`, `hostPinned`, `hostUnregistered`, `cuMem`, `unknown`.

Reviewed By: tanquer

Differential Revision: D109226615


