### PR TITLE
Add external regMem callback function for regCache (#2960)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -1027,6 +1027,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         return "SOCKET";
       case CtranMapperBackend::TCPDM:
         return "TCPDM";
+      case CtranMapperBackend::EXTERNAL:
+        return "EXTERNAL";
       default:
         return "UNKNOWN";
     }

--- a/comms/ctran/mapper/CtranMapperTypes.h
+++ b/comms/ctran/mapper/CtranMapperTypes.h
@@ -33,6 +33,8 @@ constexpr const char* CtranMapperBackendToString(CtranMapperBackend backend) {
       return "SOCKET";
     case CtranMapperBackend::TCPDM:
       return "TCPDM";
+    case CtranMapperBackend::EXTERNAL:
+      return "EXTERNAL";
     case CtranMapperBackend::NUM_BACKENDS:
       return "NUM_BACKENDS";
     default:

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -199,17 +199,21 @@ void ctran::RegCache::init() {
       case NCCL_CTRAN_BACKENDS::tcpdm:
         globalBackends_[CommBackend::TCPDM] = true;
         break;
+      case NCCL_CTRAN_BACKENDS::external:
+        globalBackends_[CommBackend::EXTERNAL] = true;
+        break;
     }
   }
   CLOGF_SUBSYS(
       INFO,
       INIT,
       "CTRAN-REGCACHE: Global backends initialized from NCCL_CTRAN_BACKENDS: "
-      "IB={} NVL={} SOCKET={} TCPDM={}",
+      "IB={} NVL={} SOCKET={} TCPDM={} EXTERNAL={}",
       static_cast<bool>(globalBackends_[CommBackend::IB]),
       static_cast<bool>(globalBackends_[CommBackend::NVL]),
       static_cast<bool>(globalBackends_[CommBackend::SOCKET]),
-      static_cast<bool>(globalBackends_[CommBackend::TCPDM]));
+      static_cast<bool>(globalBackends_[CommBackend::TCPDM]),
+      static_cast<bool>(globalBackends_[CommBackend::EXTERNAL]));
 
   // Acquire a reference to CtranIbSingleton to establish dependency ordering,
   // but only when IB backend is configured. By holding this shared_ptr, we
@@ -264,7 +268,7 @@ commResult_t ctran::RegCache::destroy() {
           regElem->buf,
           regElem->len,
           regElem->isDynamic_);
-      FB_COMMCHECKIGNORE(regElem->doDeregister());
+      FB_COMMCHECKIGNORE(regElem->doDeregister(externalDeregMemFn_));
       it = regHdlToElemMap.erase(it);
     }
 
@@ -304,6 +308,9 @@ commResult_t ctran::RegCache::destroy() {
     profiler.rlock()->reportSnapshot();
   }
 
+  externalRegMemFn_ = nullptr;
+  externalDeregMemFn_ = nullptr;
+
   return commSuccess;
 }
 
@@ -312,7 +319,8 @@ commResult_t ctran::RegCache::globalRegister(
     size_t len,
     bool forceReg,
     bool ncclManaged,
-    int deviceId) {
+    int deviceId,
+    std::optional<std::vector<bool>> backends) {
   if (buf == nullptr || len == 0) {
     return commSuccess;
   }
@@ -355,7 +363,7 @@ commResult_t ctran::RegCache::globalRegister(
         cudaDev,
         "eagerGlobalRegister",
         globalLogData,
-        globalBackends_,
+        backends ? backends.value() : globalBackends_,
         didRegister,
         &regHdl,
         ncclManaged));
@@ -564,6 +572,25 @@ void ctran::RegCache::waitAsyncRegComplete() {
   }
 }
 
+void ctran::RegCache::registerExternalRegMemFn(
+    regcache::ExternalRegMemFn regMem,
+    regcache::ExternalDeregMemFn deregMem) {
+  if (regMem && deregMem) {
+    externalRegMemFn_ = std::move(regMem);
+    externalDeregMemFn_ = std::move(deregMem);
+  } else {
+    XLOGF(
+        WARN,
+        "RegCache: registerExternalRegMemFn called with null callback(s), "
+        "both regMem and deregMem are required — ignoring");
+  }
+}
+
+void ctran::RegCache::resetExternalRegMemFn() {
+  externalRegMemFn_ = nullptr;
+  externalDeregMemFn_ = nullptr;
+}
+
 ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
     const void* ptr,
     const size_t len) {
@@ -642,6 +669,46 @@ void* ctran::RegCache::searchIbRegHandle(
     return nullptr;
   }
   return regHdl->ibRegElem;
+}
+
+void* ctran::RegCache::searchExternalRegHandle(
+    const void* ptr,
+    size_t len,
+    int deviceId) {
+  int cudaDev = 0;
+  if (deviceId != -1) {
+    cudaDev = deviceId;
+  } else {
+    // Same as globalRegister, auto-detect cudaDev from buffer pointer.
+    commResult_t devResult = getCudaDevFromPtr(ptr, cudaDev);
+    if (devResult != commSuccess) {
+      // Fall back to current CUDA device for CPU memory
+      FB_CUDACHECK_RETURN(cudaGetDevice(&cudaDev), nullptr);
+    }
+  }
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  bool didRegister = false;
+  CommLogData logMetaData{};
+  logMetaData.commDesc = "global";
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS);
+  backends[CommBackend::EXTERNAL] = true;
+  auto res = regRangeCached(
+      ptr,
+      len,
+      cudaDev,
+      "searchExternalRegHandle",
+      logMetaData,
+      backends,
+      didRegister,
+      &regHdl);
+
+  if (res != commSuccess || regHdl == nullptr ||
+      regHdl->externalRegElem == nullptr) {
+    return nullptr;
+  }
+  return regHdl->externalRegElem;
 }
 
 std::vector<void*> ctran::RegCache::getSegments() const {
@@ -857,7 +924,7 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
       ptr, len, cudaDev, segments, ncclManaged);
 
   // Backend registration
-  FB_COMMCHECK(newRegElem->doRegister(backends));
+  FB_COMMCHECK(newRegElem->doRegister(backends, externalRegMemFn_));
 
   auto regHdlPtr = newRegElem.get();
 
@@ -1144,7 +1211,7 @@ commResult_t ctran::RegCache::freeSegment(
 
 commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   auto dur = CtranMapperTimer();
-  FB_COMMCHECK(regElem->doDeregister());
+  FB_COMMCHECK(regElem->doDeregister(externalDeregMemFn_));
   profiler.wlock()->record(ctran::regcache::EventType::kDeregMemEvent, dur);
   return commSuccess;
 }
@@ -1182,7 +1249,7 @@ commResult_t ctran::RegCache::regRange(
       ncclManaged);
 
   // Registration (expensive)
-  FB_COMMCHECK(newRegElem_->doRegister(backends));
+  FB_COMMCHECK(newRegElem_->doRegister(backends, externalRegMemFn_));
 
   *regElem = newRegElem_.get();
 
@@ -1554,11 +1621,28 @@ commResult_t ctran::RegCache::deregAll() {
 }
 
 commResult_t ctran::regcache::RegElem::doRegister(
-    const std::vector<bool>& backends) {
+    const std::vector<bool>& backends,
+    const ExternalRegMemFn& externalRegMemFn) {
   meta::comms::StreamCaptureModeGuard captureGuard{
       cudaStreamCaptureModeRelaxed};
 
   auto stat = stateMnger.wlock();
+
+  if (backends[CommBackend::EXTERNAL] && externalRegMemFn) {
+    try {
+      FB_COMMCHECK(externalRegMemFn(buf, len, cudaDev_, &externalRegElem));
+    } catch (const std::exception& e) {
+      CLOGF(
+          WARN,
+          "CTRAN-REGCACHE: external backend registration failed for buf {} len {}, error: {}",
+          (void*)buf,
+          len,
+          e.what());
+      return commSystemError;
+    }
+    // external registration is exclusive to other registration backends
+    goto exit;
+  }
 
   // Register to backends
   if (type_ != DevMemType::kHostUnregistered &&
@@ -1602,6 +1686,7 @@ commResult_t ctran::regcache::RegElem::doRegister(
         ctran::CtranTcpDm::regMem((void*)buf, len, cudaDev_, &tcpRegElem));
   }
 
+exit:
   stat->state = ctran::regcache::RegElemState::REGISTERED;
   CLOGF_SUBSYS(
       INFO,
@@ -1613,7 +1698,8 @@ commResult_t ctran::regcache::RegElem::doRegister(
   return commSuccess;
 }
 
-commResult_t ctran::regcache::RegElem::doDeregister() {
+commResult_t ctran::regcache::RegElem::doDeregister(
+    const ExternalDeregMemFn& externalDeregMemFn) {
   auto stat = stateMnger.wlock();
 
   FB_CHECKABORT(
@@ -1635,6 +1721,10 @@ commResult_t ctran::regcache::RegElem::doDeregister() {
   if (tcpRegElem) {
     FB_COMMCHECK(ctran::CtranTcpDm::deregMem(tcpRegElem));
     tcpRegElem = nullptr;
+  }
+  if (externalRegElem && externalDeregMemFn) {
+    FB_COMMCHECK(externalDeregMemFn(externalRegElem));
+    externalRegElem = nullptr;
   }
 
   stat->state = ctran::regcache::RegElemState::DEREGISTERED;

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -24,6 +24,14 @@ class RegCache;
 
 namespace regcache {
 
+using ExternalRegMemFn = std::function<commResult_t(
+    const void* buf,
+    const size_t len,
+    const int cudaDev,
+    void** regElem)>;
+
+using ExternalDeregMemFn = std::function<commResult_t(void* regElem)>;
+
 struct SegmentRange {
   const void* buf{nullptr};
   const std::size_t len{0};
@@ -104,6 +112,7 @@ struct RegElem {
   void* ibRegElem{nullptr};
   void* ipcRegElem{nullptr};
   void* tcpRegElem{nullptr};
+  void* externalRegElem{nullptr};
 
   // The state of the segment to ensure thread-safe access.
   // Concurrent writes:
@@ -177,11 +186,14 @@ struct RegElem {
   // It internally locks the stateMnger to ensure thread-safe access.
   // The segment should be registered only once by the first thread and reused
   // by all later calls before deregistration.
-  commResult_t doRegister(const std::vector<bool>& backends);
+  commResult_t doRegister(
+      const std::vector<bool>& backends,
+      const ExternalRegMemFn& externalRegMemFn = nullptr);
 
   // Thread-safe function to deregister the segment.
   // It internally locks the stateMnger to ensure thread-safe access.
-  commResult_t doDeregister();
+  commResult_t doDeregister(
+      const ExternalDeregMemFn& externalDeregMemFn = nullptr);
 
   // Thread-unsafe function to print internal fields.
   // It is only used for debugging purpose. Caller should ensure thread-safety
@@ -281,7 +293,8 @@ class RegCache {
       size_t len,
       bool forceReg = false,
       bool ncclManaged = false,
-      int deviceId = -1);
+      int deviceId = -1,
+      std::optional<std::vector<bool>> backends = std::nullopt);
 
   // Global deregistration using pointer lookup.
   // Frees cached segments and their associated registrations.
@@ -468,9 +481,24 @@ class RegCache {
   // cached.
   void* searchIbRegHandle(const void* ptr, size_t len, int deviceId = -1);
 
+  // Thread-safe function to search for a RegElem containing [ptr, ptr+len)
+  // and return its externalRegElem. If the buffer is cached but not yet
+  // registered, it will perform registration via regRangeCached(). Returns
+  // nullptr if not cached.
+  void* searchExternalRegHandle(const void* ptr, size_t len, int deviceId = -1);
+
   // Thread-safe function to wait on all async registration requests to finish.
   // Used by test only.
   void waitAsyncRegComplete();
+
+  // Register external memory registration/deregistration callbacks.
+  // Threading: must be called at init time before any concurrent
+  // regRangeCached/deregElem calls. Not safe for concurrent mutation.
+  void registerExternalRegMemFn(
+      regcache::ExternalRegMemFn regMem,
+      regcache::ExternalDeregMemFn deregMem);
+
+  void resetExternalRegMemFn();
 
   // Global API to register all cached segments. This is useful in lazy
   // registration mode where segments are cached but not immediately registered.
@@ -540,6 +568,9 @@ class RegCache {
         segToRegElemsMap;
   };
   folly::Synchronized<RegElemMaps> regElemsMaps_;
+
+  regcache::ExternalRegMemFn externalRegMemFn_;
+  regcache::ExternalDeregMemFn externalDeregMemFn_;
 
   // Thread and cmd queue to handle async registration requests
   struct AsyncRegCmd {

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1432,6 +1432,234 @@ TEST_F(RegCacheTest, GetRegHandleReturnsHandleForRegisteredBuffer) {
 
   CUDACHECK_TEST(cudaFree(buf));
 }
+// --- External backend registration tests ---
+
+TEST_F(RegCacheTest, ExternalRegMemCallbackIsInvoked) {
+  bool regCalled = false;
+  bool deregCalled = false;
+  void* capturedRegElem = nullptr;
+
+  regCache->registerExternalRegMemFn(
+      [&](const void* buf, const size_t len, const int cudaDev, void** regElem)
+          -> commResult_t {
+        regCalled = true;
+        *regElem = reinterpret_cast<void*>(0xDEAD);
+        return commSuccess;
+      },
+      [&](void* regElem) -> commResult_t {
+        deregCalled = true;
+        capturedRegElem = regElem;
+        return commSuccess;
+      });
+
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  // Register with EXTERNAL backend only
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false);
+  backends[CommBackend::EXTERNAL] = true;
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logData{};
+  logData.commDesc = "test";
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logData,
+          backends,
+          didRegister,
+          &regHdl,
+          false),
+      commSuccess);
+  EXPECT_TRUE(regCalled);
+  EXPECT_TRUE(didRegister);
+  ASSERT_NE(regHdl, nullptr);
+  EXPECT_EQ(regHdl->externalRegElem, reinterpret_cast<void*>(0xDEAD));
+
+  // Deregister via globalDeregister (deregElem is private)
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_TRUE(deregCalled);
+  EXPECT_EQ(capturedRegElem, reinterpret_cast<void*>(0xDEAD));
+
+  // Cleanup
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems);
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(RegCacheTest, ExternalRegMemNotCalledWhenDeregIsNull) {
+  bool regCalled = false;
+
+  // Passing null deregMem causes registerExternalRegMemFn to drop both
+  // callbacks.
+  regCache->registerExternalRegMemFn(
+      [&](const void*, const size_t, const int, void**) -> commResult_t {
+        regCalled = true;
+        return commSuccess;
+      },
+      nullptr);
+
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  // Request EXTERNAL backend — but callbacks were dropped, so regMem won't
+  // fire.
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false);
+  backends[CommBackend::EXTERNAL] = true;
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logData{};
+  logData.commDesc = "test";
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logData,
+          backends,
+          didRegister,
+          &regHdl,
+          false),
+      commSuccess);
+  EXPECT_FALSE(regCalled);
+
+  // Cleanup via globalDeregister
+  if (regHdl) {
+    regCache->globalDeregister(buf, bufSize);
+  }
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems);
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(RegCacheTest, ExternalRegMemNotCalledWhenBackendDisabled) {
+  bool regCalled = false;
+
+  regCache->registerExternalRegMemFn(
+      [&](const void*, const size_t, const int, void**) -> commResult_t {
+        regCalled = true;
+        return commSuccess;
+      },
+      [](void*) -> commResult_t { return commSuccess; });
+
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  // Register with IB backend only (not EXTERNAL)
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false);
+  backends[CommBackend::IB] = true;
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logData{};
+  logData.commDesc = "test";
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logData,
+          backends,
+          didRegister,
+          &regHdl,
+          false),
+      commSuccess);
+  EXPECT_FALSE(regCalled);
+
+  // Cleanup via globalDeregister
+  if (regHdl) {
+    regCache->globalDeregister(buf, bufSize);
+  }
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems);
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(RegCacheTest, ExternalRegMemFailureIsHandledGracefully) {
+  regCache->registerExternalRegMemFn(
+      [](const void*, const size_t, const int, void**) -> commResult_t {
+        return commSystemError;
+      },
+      [](void*) -> commResult_t { return commSuccess; });
+
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false);
+  backends[CommBackend::EXTERNAL] = true;
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logData{};
+  logData.commDesc = "test";
+
+  // The registration should fail but not crash
+  auto res = regCache->regRangeCached(
+      buf,
+      bufSize,
+      cudaDev,
+      "test",
+      logData,
+      backends,
+      didRegister,
+      &regHdl,
+      false);
+  // External registration failure returns error
+  EXPECT_NE(res, commSuccess);
+
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems);
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);

--- a/comms/utils/commSpecs.h
+++ b/comms/utils/commSpecs.h
@@ -311,7 +311,8 @@ enum CommBackend {
   NVL = 2,
   SOCKET = 3,
   TCPDM = 4,
-  NUM_BACKENDS = 5
+  EXTERNAL = 5,
+  NUM_BACKENDS = 6
 };
 
 class CommsError {

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1985,7 +1985,7 @@ cvars:
  - name        : NCCL_CTRAN_BACKENDS
    type        : enumlist
    default     : ib, nvl, socket
-   choices     : ib, nvl, socket, tcpdm
+   choices     : ib, nvl, socket, tcpdm, external
    description : |-
      Backends to enable for ctran
      ib - RoCE/IB backend


### PR DESCRIPTION
Summary:

Adds an `EXTERNAL` backend to `RegCache` along with a caller-supplied `regMem`/`deregMem` callback pair (`ExternalRegMemFn`/`ExternalDeregMemFn`), registered via the new `RegCache::registerExternalRegMemFn()` and stored in `externalRegMemFn_`/`externalDeregMemFn_`. When a registration is requested with the `EXTERNAL` backend selected, `RegElem::doRegister`/`doDeregister` invoke these callbacks instead of the built-in IB/IPC/TCPDM paths and cache the resulting handle in `externalRegElem`, which callers can later retrieve via the new `searchExternalRegHandle()`; `globalRegister` also gains an optional `backends` override so callers can target just the external backend. This lets a client supply its own memory-registration implementation so it can reuse `RegCache`'s caching and lifecycle management while registering memory through its own stack, and wires it into `uniflow-light` where `RdmaTransportFactory` registers its `ibverbx`-based `regMem`/`deregMem` with the shared `RegCache` and routes registration through the `EXTERNAL` backend. Also adds a public `RegisteredSegment` constructor (taking an `RdmaRegistrationHandle*`) plus `RegCacheUT` and `uniflow-light` unit/integration test coverage.

Differential Revision: D109233114


