### PR TITLE
ez|ncclx|c++| migrate to `ThriftServer::setPreferAsyncIoUringSocket` (#2962)

### DIFF
--- a/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
+++ b/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
@@ -53,7 +53,7 @@ std::unique_ptr<apache::thrift::util::ScopedServerThread> startAndGetService(
 #endif
   // Workaround to avoid using libevent backend for EventBase. Currently
   // folly has bug with libevent backend with libevent 2.1.12.
-  server->setPreferIoUring(true);
+  server->setPreferAsyncIoUringSocket(true);
   server->setUseDefaultIoUringExecutor(true);
 
   // Use fewer resources to run faster


### PR DESCRIPTION
Summary:

renaming this setter/getter for better clarity on its intention.

Differential Revision: D109081581


