### PR TITLE
c++|ncclx| inline io_uring executor+backend+options creation (#2963)

### DIFF
--- a/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
+++ b/comms/ncclx/meta/analyzer/NCCLXCommsTracingServiceUtil.cc
@@ -3,9 +3,13 @@
 #include "meta/analyzer/NCCLXCommsTracingServiceUtil.h"
 
 #include <folly/concurrency/AtomicSharedPtr.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <folly/io/async/IoUringBackend.h>
 #include <folly/io/async/Liburing.h>
 #include <folly/io/async/SSLOptions.h>
-#include <folly/synchronization/CallOnce.h>
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 #include <thrift/lib/cpp2/util/ScopedServerThread.h>
 #include <wangle/ssl/SSLContextConfig.h>
@@ -43,18 +47,29 @@ std::unique_ptr<apache::thrift::util::ScopedServerThread> startAndGetService(
   server->setPort(port);
   server->setInterface(handler);
 
-// Check whether io_uring is available. Please note this does not 100%
-// guarantee that io_uring is available in thrift (which is built separately)
-// but it is a good indicator.
-#ifndef FOLLY_HAS_LIBURING
-  static_assert(
-      false,
-      "FOLLY_HAS_LIBURING is not defined! liburing is required for CommsTracingService to work");
-#endif
   // Workaround to avoid using libevent backend for EventBase. Currently
   // folly has bug with libevent backend with libevent 2.1.12.
   server->setPreferIoUring(true);
-  server->setUseDefaultIoUringExecutor(true);
+#if FOLLY_HAS_LIBURING
+  static folly::EventBaseManager ioUringEbm(
+      folly::EventBase::Options().setBackendFactory(
+          []() -> std::unique_ptr<folly::EventBaseBackendBase> {
+            folly::IoUringBackend::Options options;
+            options.setRegisterRingFd(true)
+                .setInitialProvidedBuffers(2048, 2000)
+                .setUseRegisteredFds(2048)
+                .setDeferTaskRun(true)
+                .setCapacity(512);
+            return std::make_unique<folly::IoUringBackend>(std::move(options));
+          }));
+  server->setIOThreadPool(
+      std::make_shared<folly::IOThreadPoolExecutor>(
+          1,
+          std::make_shared<folly::NamedThreadFactory>("ThriftIO"),
+          &ioUringEbm,
+          folly::IOThreadPoolExecutor::Options().setEnableThreadIdCollection(
+              true)));
+#endif
 
   // Use fewer resources to run faster
   server->setNumIOWorkerThreads(1);


### PR DESCRIPTION
Summary:

**WHAT**

The NCCLX comms tracing service builds and owns its io_uring `IOThreadPoolExecutor` instead of opting into Thrift's shared default via `setUseDefaultIoUringExecutor(true)`. The hand-built `EventBaseManager` + `IoUringBackend` + `IOThreadPoolExecutor` block is gated on `#if FOLLY_HAS_LIBURING`, and the dead `#ifndef FOLLY_HAS_LIBURING` `static_assert` is removed.

**WHY**

Decouples it from `getDefaultIOUringExecutor` (deleted at the top of this stack) and its process-global static `EventBaseManager`. Behavior-preserving for the internal build — identical options, still selects `AsyncIoUringSocket`.

The gating is required because the OSS `meta-pytorch/torchcomms` build compiles this file (`comms/ncclx/v2_*/src/Makefile` globs `${SHAREDDIR}/meta/analyzer/*.cc`) with liburing deliberately disabled (`FOLLY_HAS_LIBURING == 0`), where `folly::IoUringBackend` is not a declared type. Directly naming it broke that build deterministically. The pre-existing `setPreferIoUring(true)` call is unconditional and already compiled there.

Differential Revision: D109081421


