### PR TITLE
Allow override using AR Ring for msgSize<nRanks. (#2965)

### DIFF
--- a/comms/ctran/Ctran.cc
+++ b/comms/ctran/Ctran.cc
@@ -232,6 +232,17 @@ CtranComm::CtranComm(std::shared_ptr<Abort> abort, ctranConfig commConfig)
 void CtranComm::destroy() {
   cudagraphDeferredCleanup.runAll();
 
+  // Free the lazily-allocated small-message AllReduce-ring staging buffers.
+  if (smallMsgStageSrc_ != nullptr) {
+    FB_CUDACHECKIGNORE(cudaFree(smallMsgStageSrc_));
+    smallMsgStageSrc_ = nullptr;
+  }
+  if (smallMsgStageDst_ != nullptr) {
+    FB_CUDACHECKIGNORE(cudaFree(smallMsgStageDst_));
+    smallMsgStageDst_ = nullptr;
+  }
+  smallMsgStageBytes_ = 0;
+
   // All smart pointers are automatically de-initialized, but we want to
   // ensure they do so in a specific order. Therefore, we manually handle
   // their de-initialization here.

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -245,6 +245,16 @@ class CtranComm {
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;
   std::unique_ptr<ncclx::CommStateX> statex_;
+
+  // Persistent staging buffers for the small-message AllReduce-ring padding
+  // path (opt-in via MCCL_FORCE_SMALL_MSG_AR_RING, driven by
+  // ctranAllReduceRingSmallMsg). Lazily allocated on first use, grown on
+  // demand, and reused across collectives; freed in destroy(). Remain nullptr
+  // when the feature is unused.
+  void* smallMsgStageSrc_{nullptr};
+  void* smallMsgStageDst_{nullptr};
+  size_t smallMsgStageBytes_{0};
+
   // AMD carve-out only: ENABLE_PRIMS is on for every non-AMD build (see
   // comms/ctran/def_build.bzl), so these members exist everywhere except AMD.
   // The guard changes CtranComm's layout, so consumers must compile with a

--- a/comms/ctran/algos/AllReduce/AllReduce.cc
+++ b/comms/ctran/algos/AllReduce/AllReduce.cc
@@ -60,6 +60,20 @@ commResult_t ctranAllReduce(
             sendbuff, recvbuff, count, datatype, redOp, comm, stream, timeout);
       }
       if (count < comm->statex_->nRanks()) {
+        // Opt-in: pad the message up to nRanks and run the ring anyway. This
+        // unblocks TCPDM, which is only exposed to the ring path.
+        // TODO: remove once small messages are fully supported through TCPDM.
+        if (MCCL_FORCE_SMALL_MSG_AR_RING) {
+          return ctranAllReduceRingSmallMsg(
+              sendbuff,
+              recvbuff,
+              count,
+              datatype,
+              redOp,
+              comm,
+              stream,
+              timeout);
+        }
         CLOGF(
             DBG,
             "AllReduce ctring requires count {} > nRanks {}, fallback to ctdirect",

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -28,6 +28,28 @@ commResult_t ctranAllReduceRing(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
+/**
+ * Run the ctring AllReduce for messages whose element count is smaller than
+ * nRanks (opt-in via MCCL_FORCE_SMALL_MSG_AR_RING; selected in ctranAllReduce).
+ *
+ * The ring shards data across all ranks and needs at least one element per
+ * rank, so it cannot run for count < nRanks. This pads the input up to nRanks
+ * elements (tail zero-filled) in persistent per-comm staging buffers
+ * (CtranComm::smallMsgStage*_, reused across calls and freed on comm
+ * destruction), runs ctranAllReduceRing over the padded buffers, and copies the
+ * original count of reduced elements back to recvbuff. The padded positions are
+ * reduced independently across ranks and discarded.
+ */
+commResult_t ctranAllReduceRingSmallMsg(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+
 static inline const std::string allReduceAlgoName(
     enum NCCL_ALLREDUCE_ALGO algo) {
   switch (algo) {

--- a/comms/ctran/algos/AllReduce/AllReduceRing.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceRing.cc
@@ -1520,3 +1520,74 @@ commResult_t ctranAllReduceRing(
 
   return commSuccess;
 }
+
+commResult_t ctranAllReduceRingSmallMsg(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout) {
+  const size_t nRanks = static_cast<size_t>(comm->statex_->nRanks());
+  const size_t typeSize = static_cast<size_t>(commTypeSize(datatype));
+
+  // Lazily allocate the persistent staging buffers owned by the comm, reused
+  // across collectives and freed in CtranComm::destroy(). They grow on demand,
+  // so one pair of buffers serves every datatype. (Not valid under CUDA-graph
+  // capture; the first padded call must run eagerly.)
+  const size_t requiredBytes = nRanks * typeSize;
+  if (comm->smallMsgStageBytes_ < requiredBytes) {
+    if (comm->smallMsgStageSrc_ != nullptr) {
+      FB_CUDACHECK(cudaFree(comm->smallMsgStageSrc_));
+      comm->smallMsgStageSrc_ = nullptr;
+    }
+    if (comm->smallMsgStageDst_ != nullptr) {
+      FB_CUDACHECK(cudaFree(comm->smallMsgStageDst_));
+      comm->smallMsgStageDst_ = nullptr;
+    }
+    FB_CUDACHECK(cudaMalloc(&comm->smallMsgStageSrc_, requiredBytes));
+    FB_CUDACHECK(cudaMalloc(&comm->smallMsgStageDst_, requiredBytes));
+    comm->smallMsgStageBytes_ = requiredBytes;
+  }
+
+  // Copy the real input in and zero-fill the padded tail.
+  if (count > 0) {
+    FB_CUDACHECK(cudaMemcpyAsync(
+        comm->smallMsgStageSrc_,
+        sendbuff,
+        count * typeSize,
+        cudaMemcpyDefault,
+        stream));
+  }
+  FB_CUDACHECK(cudaMemsetAsync(
+      static_cast<char*>(comm->smallMsgStageSrc_) + count * typeSize,
+      0,
+      (nRanks - count) * typeSize,
+      stream));
+
+  const commResult_t ret = ctranAllReduceRing(
+      comm->smallMsgStageSrc_,
+      comm->smallMsgStageDst_,
+      nRanks,
+      datatype,
+      redOp,
+      comm,
+      stream,
+      timeout);
+  if (ret != commSuccess) {
+    return ret;
+  }
+
+  // Copy the reduced result for the original element count back to recvbuff.
+  if (count > 0) {
+    FB_CUDACHECK(cudaMemcpyAsync(
+        recvbuff,
+        comm->smallMsgStageDst_,
+        count * typeSize,
+        cudaMemcpyDefault,
+        stream));
+  }
+  return commSuccess;
+}

--- a/comms/ctran/tests/CtranAllReduceTest.cc
+++ b/comms/ctran/tests/CtranAllReduceTest.cc
@@ -26,6 +26,9 @@ using AllReduceMinMsgSizeTestParam = std::tuple<size_t, commDataType_t>;
 enum class CtranAllReduceRingMinSizeTestOpt {
   expect_sufficient,
   expect_insufficient,
+  // count < nRanks, but routed through the small-message padding path
+  // (ctranAllReduceRingSmallMsg), which must succeed instead of throwing.
+  expect_padded_small_msg,
 };
 
 class CtranAllReduceTest
@@ -398,6 +401,22 @@ class CtranAllReduceRingMinSizeTest
                 state.stream);
             EXPECT_EQ(res, commSuccess);
           });
+        } else if (
+            testOpt ==
+            CtranAllReduceRingMinSizeTestOpt::expect_padded_small_msg) {
+          // count < nRanks is padded up to nRanks internally, so the ring
+          // runs successfully instead of throwing.
+          EXPECT_NO_THROW({
+            auto res = ctranAllReduceRingSmallMsg(
+                state.srcBuffer,
+                state.dstBuffer,
+                count,
+                dt,
+                kReduceOpType,
+                state.ctranComm.get(),
+                state.stream);
+            EXPECT_EQ(res, commSuccess);
+          });
         } else {
           // Expect ctran::utils::Exception when count < nRanks
           EXPECT_THROW(
@@ -452,6 +471,18 @@ TEST_P(CtranAllReduceRingMinSizeTest, SufficientElements_NRanksPlus1) {
       numRanks + 1,
       dt,
       CtranAllReduceRingMinSizeTestOpt::expect_sufficient,
+      numRanks);
+}
+
+// count < nRanks succeeds through the small-message padding path instead of
+// throwing (see ctranAllReduceRingSmallMsg / MCCL_FORCE_SMALL_MSG_AR_RING).
+TEST_P(CtranAllReduceRingMinSizeTest, PaddedSmallMsg_NRanksMinus1) {
+  auto [numRanks, dt] = GetParam();
+  ASSERT_GT(numRanks, 1) << "Need at least 2 ranks for this test";
+  runTest(
+      numRanks - 1,
+      dt,
+      CtranAllReduceRingMinSizeTestOpt::expect_padded_small_msg,
       numRanks);
 }
 

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3287,6 +3287,18 @@ cvars:
      reporters from the MCCL level (CTRAN-side defaults for the GPE
      profiler still apply per NCCL_CTRAN_GPE_PROFILING_ENABLE).
 
+ - name        : MCCL_FORCE_SMALL_MSG_AR_RING
+   type        : bool
+   default     : false
+   description : |-
+     Force the ctran ring AllReduce algorithm for small messages whose element
+     count is smaller than nRanks. The ring requires at least one element per
+     rank; when this is enabled, Ctran pads the input up to nRanks elements in a
+     temporary buffer (tail zero-filled), runs ctring, and copies the original
+     count of elements back to the receive buffer. The padded element positions
+     are reduced independently across ranks and discarded. Default: false
+     (small messages fall back to ctdirect as before).
+
  - name        : MCCL_FILTER_PROFILER_LOGGING_BY_RANKS
    type        : stringlist
    default     : "0"


### PR DESCRIPTION
Summary:

Add temporary path for allowing using AR Ring when the `msgSize<nRanks`. Gated by the cvar MCCL_FORCE_SMALL_MSG_AR_RING


Motivation:

This is to unblock the TCPDM prototyping on PAFT since we only expose TCPDM to AR ring.

Reviewed By: fomichev

Differential Revision: D109338837


