### PR TITLE
StagedRdmaTransport: Use plain IbvQp/IbvCq instead of virtual QP/CQ

### DIFF
--- a/comms/torchcomms/transport/StagedRdmaTransport.cpp
+++ b/comms/torchcomms/transport/StagedRdmaTransport.cpp
@@ -14,8 +14,6 @@
 #include <folly/json.h>
 #include <folly/synchronization/CallOnce.h>
 
-#include <climits>
-
 #include <comms/ctran/ibverbx/IbvPd.h>
 #include <comms/ctran/ibverbx/Ibverbx.h>
 #include <comms/ctran/utils/CudaWrap.h>
@@ -95,14 +93,14 @@ static uint64_t kRecvReadyValue = 1;
 // to JSON. Staging info allows the peer to populate peerStaging_ during
 // connectQp() for subsequent one-sided RDMA operations.
 std::string serializeConnectionInfo(
-    const ibverbx::IbvVirtualQpBusinessCard& busCard,
+    uint32_t qpNum,
     uint64_t subnetPrefix,
     uint64_t interfaceId,
     uint8_t port,
     ibv_mtu mtu,
     const torch::comms::StagingRendezvousInfo& staging) {
   folly::dynamic obj = folly::dynamic::object;
-  obj["busCard"] = busCard.serialize();
+  obj["qpNum"] = static_cast<int64_t>(qpNum);
   obj["subnetPrefix"] = static_cast<int64_t>(subnetPrefix);
   obj["interfaceId"] = static_cast<int64_t>(interfaceId);
   obj["port"] = port;
@@ -128,23 +126,16 @@ std::string serializeConnectionInfo(
 }
 
 struct ConnectionInfo {
-  ibverbx::IbvVirtualQpBusinessCard busCard;
-  uint64_t subnetPrefix;
-  uint64_t interfaceId;
-  uint8_t port;
-  ibv_mtu mtu;
+  uint32_t qpNum{};
+  uint64_t subnetPrefix{};
+  uint64_t interfaceId{};
+  uint8_t port{};
+  ibv_mtu mtu{};
   torch::comms::StagingRendezvousInfo staging;
 };
 
 ConnectionInfo deserializeConnectionInfo(const std::string& json) {
   auto obj = folly::parseJson(json);
-  auto busCard =
-      ibverbx::IbvVirtualQpBusinessCard::deserialize(obj["busCard"].asString());
-  if (!busCard) {
-    throw std::runtime_error(
-        "Failed to deserialize IbvVirtualQpBusinessCard: " +
-        busCard.error().errStr);
-  }
 
   torch::comms::StagingRendezvousInfo staging;
   if (obj.count("stagingBuf")) {
@@ -163,7 +154,7 @@ ConnectionInfo deserializeConnectionInfo(const std::string& json) {
   }
 
   return ConnectionInfo{
-      .busCard = std::move(*busCard),
+      .qpNum = static_cast<uint32_t>(obj["qpNum"].asInt()),
       .subnetPrefix = static_cast<uint64_t>(obj["subnetPrefix"].asInt()),
       .interfaceId = static_cast<uint64_t>(obj["interfaceId"].asInt()),
       .port = static_cast<uint8_t>(obj["port"].asInt()),
@@ -325,14 +316,6 @@ StagedRdmaTransportBase::~StagedRdmaTransportBase() {
   }
 }
 
-int32_t StagedRdmaTransportBase::getDeviceId() const {
-  if (!pd_.has_value()) {
-    throw std::runtime_error(
-        "getDeviceId() called before setupLocalTransport()");
-  }
-  return pd_->getDeviceId();
-}
-
 void StagedRdmaTransportBase::initIbResources() {
   // Initialize CUDA driver PFN symbols (only needed for GPU staging mode
   // which uses getCuMemDmaBufFd for dmabuf export)
@@ -380,46 +363,30 @@ void StagedRdmaTransportBase::initIbResources() {
   }
   pd_.emplace(std::move(*maybePd));
 
-  // 3. Create virtual CQ
+  // 3. Create CQ
   int cqe = 2 * kTotalQps * kMaxMsgCntPerQp;
-  auto maybeVcq = device_->createVirtualCq(cqe, nullptr, nullptr, 0);
-  if (!maybeVcq) {
-    throw std::runtime_error(
-        "Failed to create virtual CQ: " + maybeVcq.error().errStr);
+  auto maybeCq = device_->createCq(cqe, nullptr, nullptr, 0);
+  if (!maybeCq) {
+    throw std::runtime_error("Failed to create CQ: " + maybeCq.error().errStr);
   }
-  vcq_.emplace(std::move(*maybeVcq));
+  cq_.emplace(std::move(*maybeCq));
 
-  // 4. Create virtual QP with DQPLB load balancing
+  // 4. Create RC QP wired to the CQ
   ibv_qp_init_attr initAttr = {};
   initAttr.qp_type = IBV_QPT_RC;
   initAttr.sq_sig_all = 0;
-  auto& physCqs = vcq_->getPhysicalCqsRef();
-  initAttr.send_cq = physCqs.at(0).cq();
-  initAttr.recv_cq = physCqs.at(0).cq();
+  initAttr.send_cq = cq_->cq();
+  initAttr.recv_cq = cq_->cq();
   initAttr.cap.max_send_wr = kMaxMsgCntPerQp;
   initAttr.cap.max_recv_wr = kMaxMsgCntPerQp;
   initAttr.cap.max_send_sge = kMaxSge;
   initAttr.cap.max_recv_sge = kMaxSge;
 
-  if (config_.stagingBufSize > static_cast<size_t>(INT_MAX)) {
-    throw std::runtime_error(
-        fmt::format(
-            "stagingBufSize {} exceeds INT_MAX for VirtualQP maxMsgSize",
-            config_.stagingBufSize));
+  auto maybeQp = pd_->createQp(&initAttr);
+  if (!maybeQp) {
+    throw std::runtime_error("Failed to create QP: " + maybeQp.error().errStr);
   }
-
-  auto maybeVqp = pd_->createVirtualQp(
-      kTotalQps,
-      &initAttr,
-      &*vcq_,
-      kMaxMsgCntPerQp,
-      static_cast<int>(config_.stagingBufSize),
-      ibverbx::LoadBalancingScheme::DQPLB);
-  if (!maybeVqp) {
-    throw std::runtime_error(
-        "Failed to create virtual QP: " + maybeVqp.error().errStr);
-  }
-  vqp_.emplace(std::move(*maybeVqp));
+  qp_.emplace(std::move(*maybeQp));
 
   // 5. Transition QP to INIT
   ibv_qp_attr initQpAttr = {};
@@ -430,7 +397,7 @@ void StagedRdmaTransportBase::initIbResources() {
   initQpAttr.pkey_index = qpConfig_.pkeyIndex;
   initQpAttr.port_num = kPortNum;
 
-  auto initResult = vqp_->modifyVirtualQp(
+  auto initResult = qp_->modifyQp(
       &initQpAttr,
       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
   if (!initResult) {
@@ -464,7 +431,7 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   ibv_qp_attr rtrAttr = {};
   rtrAttr.qp_state = IBV_QPS_RTR;
   rtrAttr.path_mtu = peer.mtu;
-  rtrAttr.dest_qp_num = 0; // overridden per-QP by business card
+  rtrAttr.dest_qp_num = peer.qpNum;
   rtrAttr.rq_psn = 0;
   rtrAttr.max_dest_rd_atomic = kMaxRdAtomic;
   rtrAttr.min_rnr_timer = kMinRnrTimer;
@@ -479,11 +446,10 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   rtrAttr.ah_attr.src_path_bits = 0;
   rtrAttr.ah_attr.port_num = peer.port;
 
-  auto rtrResult = vqp_->modifyVirtualQp(
+  auto rtrResult = qp_->modifyQp(
       &rtrAttr,
       IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN |
-          IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER,
-      peer.busCard);
+          IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER);
   if (!rtrResult) {
     throw std::runtime_error(
         "Failed to transition QP to RTR: " + rtrResult.error().errStr);
@@ -498,7 +464,7 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
   rtsAttr.sq_psn = 0;
   rtsAttr.max_rd_atomic = kMaxRdAtomic;
 
-  auto rtsResult = vqp_->modifyVirtualQp(
+  auto rtsResult = qp_->modifyQp(
       &rtsAttr,
       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
           IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC);
@@ -510,7 +476,7 @@ void StagedRdmaTransportBase::connectQp(const std::string& peerConnInfo) {
 
 std::string StagedRdmaTransportBase::serializeConnInfo(
     const StagingRendezvousInfo& localStaging) {
-  auto busCard = vqp_->getVirtualQpBusinessCard();
+  uint32_t qpNum = qp_->getQpNum();
 
   auto maybeGid = device_->queryGid(kPortNum, qpConfig_.gidIndex);
   if (!maybeGid) {
@@ -525,7 +491,7 @@ std::string StagedRdmaTransportBase::serializeConnInfo(
   }
 
   return serializeConnectionInfo(
-      busCard,
+      qpNum,
       gid.global.subnet_prefix,
       gid.global.interface_id,
       kPortNum,
@@ -592,7 +558,6 @@ folly::SemiFuture<commResult_t> StagedRdmaServerTransport::send(
       [this, src, numChunks, totalBytes, p = std::move(promise)]() mutable {
         try {
           ensureCudaStream();
-          int32_t deviceId = getDeviceId();
           auto deadline =
               std::chrono::steady_clock::now() + config_.chunkTimeout;
 
@@ -648,18 +613,22 @@ folly::SemiFuture<commResult_t> StagedRdmaServerTransport::send(
             CUDA_CHECK(cudaStreamSynchronize(stream_));
 
             // 3. Post RDMA_WRITE_WITH_IMM
-            ibverbx::IbvVirtualSendWr sendWr = {};
-            sendWr.wrId = chunk;
-            sendWr.localAddr = stagingBuf_->data();
-            sendWr.length = static_cast<uint32_t>(chunkSize);
-            sendWr.remoteAddr = peerStaging_.stagingBuf.addr;
-            sendWr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
-            sendWr.sendFlags = IBV_SEND_SIGNALED;
-            sendWr.immData = static_cast<uint32_t>(chunk);
-            sendWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{
-                stagingBuf_->lkey(), peerStaging_.stagingBuf.rkey};
+            ibv_sge sge = {};
+            sge.addr = reinterpret_cast<uint64_t>(stagingBuf_->data());
+            sge.length = static_cast<uint32_t>(chunkSize);
+            sge.lkey = stagingBuf_->lkey();
 
-            auto postResult = vqp_->postSend(sendWr);
+            ibv_send_wr sendWr = {};
+            sendWr.wr_id = chunk;
+            sendWr.sg_list = &sge;
+            sendWr.num_sge = 1;
+            sendWr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+            sendWr.send_flags = IBV_SEND_SIGNALED;
+            sendWr.imm_data = static_cast<uint32_t>(chunk);
+            sendWr.wr.rdma.remote_addr = peerStaging_.stagingBuf.addr;
+            sendWr.wr.rdma.rkey = peerStaging_.stagingBuf.rkey;
+
+            auto postResult = qp_->postSend(&sendWr, nullptr);
             if (!postResult) {
               p.setValue(commInternalError);
               return;
@@ -667,7 +636,7 @@ folly::SemiFuture<commResult_t> StagedRdmaServerTransport::send(
 
             // Drain send completion to free QP slot
             while (true) {
-              auto maybeWcs = vcq_->pollCq();
+              auto maybeWcs = cq_->pollCq(kMaxMsgCntPerQp);
               if (!maybeWcs) {
                 p.setValue(commInternalError);
                 return;
@@ -732,15 +701,13 @@ void StagedRdmaClientTransport::connectRemoteTransport(
   }
   recvReadyClientMr_.emplace(std::move(*maybeSrcMr));
 
-  // Post initial dummy recv to trigger initializeDqplbReceiver on multi-QP
-  int32_t deviceId = getDeviceId();
-  ibverbx::IbvVirtualRecvWr recvWr = {};
-  recvWr.wrId = 0;
-  recvWr.localAddr = nullptr;
-  recvWr.length = 0;
-  recvWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{0, 0};
+  // Pre-post a recv WR to absorb the server's first RDMA_WRITE_WITH_IMM.
+  ibv_recv_wr recvWr = {};
+  recvWr.wr_id = 0;
+  recvWr.sg_list = nullptr;
+  recvWr.num_sge = 0;
 
-  auto postResult = vqp_->postRecv(recvWr);
+  auto postResult = qp_->postRecv(&recvWr, nullptr);
   if (!postResult) {
     throw std::runtime_error(
         "Failed to post initial recv: " + postResult.error().errStr);
@@ -762,7 +729,6 @@ folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
       [this, dst, numChunks, totalBytes, p = std::move(promise)]() mutable {
         try {
           ensureCudaStream();
-          int32_t deviceId = getDeviceId();
           auto deadline =
               std::chrono::steady_clock::now() + config_.chunkTimeout;
 
@@ -774,7 +740,7 @@ folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
             // 1. Poll CQ for RECV_RDMA_WITH_IMM (data arrived)
             bool readyToRecv = false;
             while (!readyToRecv) {
-              auto maybeWcs = vcq_->pollCq();
+              auto maybeWcs = cq_->pollCq(kMaxMsgCntPerQp);
               if (!maybeWcs) {
                 p.setValue(commInternalError);
                 return;
@@ -803,13 +769,12 @@ folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
 
             // 2. Replenish recv WR for next chunk
             {
-              ibverbx::IbvVirtualRecvWr recvWr = {};
-              recvWr.wrId = chunk + 1;
-              recvWr.localAddr = nullptr;
-              recvWr.length = 0;
-              recvWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{0, 0};
+              ibv_recv_wr recvWr = {};
+              recvWr.wr_id = chunk + 1;
+              recvWr.sg_list = nullptr;
+              recvWr.num_sge = 0;
 
-              auto postResult = vqp_->postRecv(recvWr);
+              auto postResult = qp_->postRecv(&recvWr, nullptr);
               if (!postResult) {
                 p.setValue(commInternalError);
                 return;
@@ -857,17 +822,22 @@ folly::SemiFuture<commResult_t> StagedRdmaClientTransport::recv(
             // 4. Signal server: staging buffer consumed (always, including last
             // chunk, to ensure next transfer can start safely)
             {
-              ibverbx::IbvVirtualSendWr flagWr = {};
-              flagWr.wrId = numChunks + chunk;
-              flagWr.localAddr = const_cast<uint64_t*>(&kRecvReadyValue);
-              flagWr.length = sizeof(uint64_t);
-              flagWr.remoteAddr = peerStaging_.recvReady->addr;
-              flagWr.opcode = IBV_WR_RDMA_WRITE;
-              flagWr.sendFlags = IBV_SEND_SIGNALED;
-              flagWr.deviceKeys[deviceId] = ibverbx::MemoryRegionKeys{
-                  recvReadyClientMr_->mr()->lkey, peerStaging_.recvReady->rkey};
+              ibv_sge sge = {};
+              sge.addr = reinterpret_cast<uint64_t>(
+                  const_cast<uint64_t*>(&kRecvReadyValue));
+              sge.length = sizeof(uint64_t);
+              sge.lkey = recvReadyClientMr_->mr()->lkey;
 
-              auto postResult = vqp_->postSend(flagWr);
+              ibv_send_wr flagWr = {};
+              flagWr.wr_id = numChunks + chunk;
+              flagWr.sg_list = &sge;
+              flagWr.num_sge = 1;
+              flagWr.opcode = IBV_WR_RDMA_WRITE;
+              flagWr.send_flags = IBV_SEND_SIGNALED;
+              flagWr.wr.rdma.remote_addr = peerStaging_.recvReady->addr;
+              flagWr.wr.rdma.rkey = peerStaging_.recvReady->rkey;
+
+              auto postResult = qp_->postSend(&flagWr, nullptr);
               if (!postResult) {
                 p.setValue(commInternalError);
                 return;

--- a/comms/torchcomms/transport/StagedRdmaTransport.h
+++ b/comms/torchcomms/transport/StagedRdmaTransport.h
@@ -14,12 +14,11 @@
 #include <folly/io/async/EventBase.h>
 
 #include <comms/ctran/ibverbx/IbvCommon.h>
+#include <comms/ctran/ibverbx/IbvCq.h>
 #include <comms/ctran/ibverbx/IbvDevice.h>
 #include <comms/ctran/ibverbx/IbvMr.h>
 #include <comms/ctran/ibverbx/IbvPd.h>
-#include <comms/ctran/ibverbx/IbvVirtualCq.h>
-#include <comms/ctran/ibverbx/IbvVirtualQp.h>
-#include <comms/ctran/ibverbx/IbvVirtualWr.h>
+#include <comms/ctran/ibverbx/IbvQp.h>
 #include <comms/utils/commSpecs.h>
 
 namespace torch::comms {
@@ -188,15 +187,12 @@ class StagedRdmaTransportBase {
   // IB resources (H100: single device/PD; GB200 diff expands to vectors)
   std::optional<ibverbx::IbvDevice> device_;
   std::optional<ibverbx::IbvPd> pd_;
-  std::optional<ibverbx::IbvVirtualCq> vcq_;
+  std::optional<ibverbx::IbvCq> cq_;
   std::optional<StagedBuffer> stagingBuf_;
   cudaStream_t stream_{nullptr};
 
-  // Virtual QP — declared last so it is destroyed first.
-  std::optional<ibverbx::IbvVirtualQp> vqp_;
-
-  // Get the device ID for building deviceKeys maps.
-  int32_t getDeviceId() const;
+  // QP — declared last so it is destroyed first.
+  std::optional<ibverbx::IbvQp> qp_;
 
   // Protected helpers — called explicitly by subclasses, no virtual dispatch.
 
@@ -206,7 +202,7 @@ class StagedRdmaTransportBase {
   // that first creates the stream, not on other threads that get a cache hit.
   void ensureCudaStream();
 
-  // Initialize IB resources: device, PD, CQ, VirtualQP, staging buffer.
+  // Initialize IB resources: device, PD, CQ, QP, staging buffer.
   // Must be called before connectQp().
   void initIbResources();
 


### PR DESCRIPTION
Summary:
Low-level foundation for refactoring StagedRdmaTransport on QP usage. Replaces ibverbx IbvVirtualQp/IbvVirtualCq with the plain ibverbx IbvQp/IbvCq in the staged-RDMA transport.

For now, StagedRdma always uses a single QP (kTotalQps = 1), so the virtual layer's DQPLB multi-QP striping and completion aggregation were unused. Collapsing to a single plain QP/CQ is behavior-preserving for the single-QP path and removes a layer of indirection:
- createVirtualQp(... DQPLB) -> pd_->createQp(&initAttr) with initAttr.send_cq/recv_cq = cq_->cq().
- createVirtualCq -> device_->createCq.
- modifyVirtualQp -> qp_->modifyQp; the INIT->RTR transition sets dest_qp_num from the peer's raw qp_num.
- Connection exchange carries the raw qp_num instead of the opaque IbvVirtualQpBusinessCard.
- IbvVirtualSendWr/IbvVirtualRecvWr + per-device deviceKeys -> raw ibv_send_wr/ibv_recv_wr + ibv_sge (single device, so lkey/rkey passed directly; getDeviceId() removed).
- vcq_->pollCq() -> cq_->pollCq(cnt) (native libibverbs).

Reviewed By: saifhhasan

Differential Revision: D108809908


