### PR TITLE
move shared CUDA error-check macros into Checks.h (#2967)

### DIFF
--- a/comms/prims/core/Checks.h
+++ b/comms/prims/core/Checks.h
@@ -2,8 +2,21 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
 #include <stdexcept>
 #include <string>
+
+// <cuda.h> (driver API) and CudaDriverLazy.h (real-cuda pfn_*, a non-hipified
+// cpp_library) are NVIDIA-only. On AMD this header is hipified and consumed
+// alongside <hip/hip_runtime.h>, so pulling the real driver headers would clash
+// (ROCm vector-type aliases vs CUDA structs). Only checkCuError needs them, and
+// no AMD code path uses checkCuError.
+#if !defined(__HIP_PLATFORM_AMD__)
+#include <cuda.h>
+
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
 
 #define PIPES_CUDA_CHECK(EXPR)                      \
   do {                                              \
@@ -21,3 +34,32 @@
   } while (0)
 
 #define PIPES_KERNEL_LAUNCH_CHECK() PIPES_CUDA_CHECK(cudaGetLastError())
+
+namespace comms::prims {
+
+// Throws std::runtime_error if `err` is not cudaSuccess. The thrown message is
+// `"<msg>: <cudaGetErrorString(err)>"`. Callers typically pass a literal that
+// identifies the failing CUDA runtime call. Prefer PIPES_CUDA_CHECK when source
+// location is useful.
+inline void checkCudaError(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+// Throws std::runtime_error if `err` is not CUDA_SUCCESS. The thrown message is
+// `"<msg>: <cuGetErrorString(err)>"`. Requires cuda_driver_lazy_init() to have
+// resolved pfn_cuGetErrorString. NVIDIA-only (CUDA driver API); not available
+// on AMD/HIP, where no caller references it.
+#if !defined(__HIP_PLATFORM_AMD__)
+inline void checkCuError(CUresult err, const char* msg) {
+  if (err != CUDA_SUCCESS) {
+    const char* errStr = nullptr;
+    pfn_cuGetErrorString(err, &errStr);
+    throw std::runtime_error(
+        std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
+  }
+}
+#endif // !defined(__HIP_PLATFORM_AMD__)
+
+} // namespace comms::prims

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -13,6 +13,8 @@
 #include "comms/prims/platform/CudaDriverLazy.h"
 #endif
 
+#include "comms/prims/core/Checks.h"
+
 #include <glog/logging.h>
 #include <mutex>
 #include <stdexcept>
@@ -20,23 +22,6 @@
 namespace comms::prims {
 
 namespace {
-
-void checkCudaError(cudaError_t err, const char* msg) {
-  if (err != cudaSuccess) {
-    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
-  }
-}
-
-#ifndef __HIP_PLATFORM_AMD__
-void checkCuError(CUresult err, const char* msg) {
-  if (err != CUDA_SUCCESS) {
-    const char* errStr = nullptr;
-    pfn_cuGetErrorString(err, &errStr);
-    throw std::runtime_error(
-        std::string(msg) + ": " + (errStr ? errStr : "unknown error"));
-  }
-}
-#endif
 
 // Minimum allocation size for trial allocation (matches ctran)
 constexpr size_t kTrialAllocSize = 2097152UL; // 2MB

--- a/comms/prims/platform/CudaDriverLazy.h
+++ b/comms/prims/platform/CudaDriverLazy.h
@@ -14,6 +14,14 @@
 //   }
 //   CUresult err = comms::prims::pfn_cuMemCreate(&handle, size, &prop, 0);
 
+// NVIDIA-only: the lazy CUDA driver API has no HIP equivalent, and every caller
+// guards its use behind `#if CUDART_VERSION >= 12030` / `#ifndef
+// __HIP_PLATFORM_AMD__` (the VMM / fabric paths, compiled out on AMD). Compile
+// to nothing under HIP so a hipified TU that transitively includes this header
+// (e.g. via Checks.h) doesn't pull real <cuda_runtime.h> alongside
+// <hip/hip_runtime.h> (the ROCm vector-type alias vs CUDA struct clash).
+#if !defined(__HIP_PLATFORM_AMD__)
+
 #include <cuda.h>
 
 #include <cudaTypedefs.h>
@@ -68,3 +76,5 @@ extern PFN_cuMemGetHandleForAddressRange_v11070
     pfn_cuMemGetHandleForAddressRange;
 
 } // namespace comms::prims
+
+#endif // !defined(__HIP_PLATFORM_AMD__)


### PR DESCRIPTION
Summary:

Move the shared CUDA error-check helpers (`checkCudaError`, `checkCuError`) and the `PIPES_CUDA_CHECK` / `PIPES_KERNEL_LAUNCH_CHECK` macros into `Checks.h` so `GpuMemHandler` — and the upcoming `CuMemAllocation` / `MultimemHandler` — reuse one definition instead of private copies. `GpuMemHandler.cc` drops its file-local `checkCudaError` / `checkCuError` and includes `Checks.h`. Because `Checks.h` includes `CudaDriverLazy.h` for `pfn_cuGetErrorString`, the `checks` target gains an exported dep on `:cuda_driver_lazy`, and `gpu_mem_handler` now depends on `:checks`. Pure refactor; no behavior change.

This is commit 1 of a split of the original `MultimemHandler` commit (D105264759) into reviewable, build-correct logical commits.

Reviewed By: saifhhasan

Differential Revision: D107578129


