### PR TITLE
Poll bootstrap socket health

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3199,6 +3199,16 @@ cvars:
      Usage: If the NCCL_CTRAN_BACKENS is set with certain values,
      this config will allow MCCL to override backends.
 
+ - name        : MCCL_BOOTSTRAP_SOCKET_HEALTH_POLL_ENABLED
+   type        : bool
+   default     : true
+   description : |-
+     Enable MCCL Bootstrap READY-socket health polling. When enabled, Bootstrap
+     polls established peer sockets and converts kernel-observed socket errors
+     or peer close into communicator abort. Disable this as a kill switch for
+     the socket-health polling path; active Bootstrap socket I/O errors still
+     use the separate callback path.
+
  - name        : MCCL_SCUBA_ENABLED
    type        : bool
    default     : true


### PR DESCRIPTION
Summary:
Start a dedicated Bootstrap socket-health coroutine for Bootstrap instances and poll initialized READY peer sockets for kernel-observed socket failures. The poll uses getSocketError(), which reports latched SO_ERROR values, closed/not-good sockets, and readable EOF detected with non-consuming MSG_PEEK.

Enable this path by default through the new MCCL_BOOTSTRAP_SOCKET_HEALTH_POLL_ENABLED cvar. The cvar is a kill switch for socket-health polling, while socketHealthPollInterval controls the polling cadence and non-positive values fall back to the existing retry delay instead of disabling the routine. Detected errors go through abortFromSocketError(), which keeps duplicate detection idempotent and only sets the shared abort flag.

Also skip polling once the shared abort is already set, so a communicator that has already observed one failure does not keep emitting duplicate health-poll logs.

This complements the parent fast-abort diff. Active ready-socket read/write/EOF failures are handled by the callback path in D107917005; this diff adds an out-of-band idle health path for cases where the kernel detects a dead peer or peer close while no Bootstrap operation is actively touching the socket.

Enable the IB peer-destroy AllReduce regression. The receiver-side ranks previously waited for the 5s collective timeout because they did not receive local RDMA errors. With Bootstrap socket health polling enabled by default, the surviving ranks observe rank 0's Bootstrap socket close, set communicator abort, and the AllReduce exits before the collective timeout.

Important caveats:
- Health polling detects peer close/process exit/communicator teardown when it closes an established READY Bootstrap socket; it does not by itself detect host power loss or network blackhole when the kernel has not surfaced an error.
- A higher-level heartbeat is still needed for blackhole-style failures.
- Detection latency is bounded by socketHealthPollInterval plus kernel error surfacing time.
- Polling is O(number of READY Bootstrap peer sockets) per interval.
- Only READY peer sockets are polled; setup/UUID mismatch/retry paths are left to the existing Bootstrap operation error handling.

Reviewed By: saifhhasan

Differential Revision: D107946036


