### PR TITLE
Reject unregistered host memory in CudaPtrCheck (#2969)

### DIFF
--- a/comms/ncclx/v2_29/src/misc/argcheck.cc
+++ b/comms/ncclx/v2_29/src/misc/argcheck.cc
@@ -17,6 +17,10 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 10000
+  if (attr.type == cudaMemoryTypeUnregistered) {
+    WARN("%s : %s %p is unregistered host memory, not a valid device pointer", opname, ptrname, pointer);
+    return ncclInvalidArgument;
+  }
   if (attr.type == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
 #else
   if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {

--- a/comms/ncclx/v2_30/src/misc/argcheck.cc
+++ b/comms/ncclx/v2_30/src/misc/argcheck.cc
@@ -17,6 +17,10 @@ ncclResult_t CudaPtrCheck(const void* pointer, struct ncclComm* comm, const char
     return ncclInvalidArgument;
   }
 #if CUDART_VERSION >= 10000
+  if (attr.type == cudaMemoryTypeUnregistered) {
+    WARN("%s : %s %p is unregistered host memory, not a valid device pointer", opname, ptrname, pointer);
+    return ncclInvalidArgument;
+  }
   if (attr.type == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {
 #else
   if (attr.memoryType == cudaMemoryTypeDevice && attr.device != comm->cudaDev) {


### PR DESCRIPTION
Summary:

The `allreduce_sparse_block_arg_check_test` pointer-validation cases (`InvalidSendBuff`, `InvalidRecvBuff`, `InvalidRecvIndices`) fail on the `v2_29` and `v2_30` variants on ATS-capable (system-memory-addressable) GPU hosts. These tests pass a host stack pointer as the "invalid" buffer and expect `ncclAllReduceSparseBlock` to return `ncclInvalidArgument`, but it returns `ncclSuccess` (and then SIGSEGVs when the kernel dereferences the host address).

Root cause: `CudaPtrCheck` rejects a pointer only when `cudaPointerGetAttributes` errors or `attr.devicePointer == NULL`. On ATS hardware, `cudaPointerGetAttributes` on an unregistered host/stack pointer returns `cudaSuccess` with `attr.type == cudaMemoryTypeUnregistered` and a non-NULL `attr.devicePointer` (it equals the host pointer, since system memory is GPU-addressable). The existing check therefore accepts the host pointer. Confirmed at runtime: `sendbuff=0x7fff... err=0 type=0(Unregistered) devicePointer=0x7fff...(non-NULL)`.

Fix: also reject `attr.type == cudaMemoryTypeUnregistered` in `CudaPtrCheck`, restoring the intended contract (reject non-CUDA pointers) on ATS hardware. `CudaPtrCheck` only runs when `comm->checkMode != ncclCheckModeDefault` (the opt-in `NCCL_CHECK_MODE` / deprecated `NCCL_CHECK_POINTERS` debug path), so production default behavior is unchanged. Real device buffers (`type == cudaMemoryTypeDevice`) are unaffected.

Note: `argcheck.cc` is upstream NVIDIA-licensed code; this is a local ncclx patch that must be carried across rebases. Applied to both `v2_29` and `v2_30`.

Reviewed By: pavanbalaji

Differential Revision: D109378319


