### PR TITLE
Polyfill NCCL_WIN_COLL_SYMMETRIC for older NCCL versions

### DIFF
--- a/comms/torchcomms/nccl/NcclApi.hpp
+++ b/comms/torchcomms/nccl/NcclApi.hpp
@@ -25,6 +25,10 @@
 typedef struct ncclWindow_vidmem* ncclWindow_t;
 #endif
 
+#ifndef NCCL_WIN_COLL_SYMMETRIC
+#define NCCL_WIN_COLL_SYMMETRIC 0x01
+#endif
+
 namespace torch::comms {
 /**
  * Abstract interface for NCCL API operations.


### PR DESCRIPTION
Summary:
NCCL_WIN_COLL_SYMMETRIC (0x01) was introduced in NCCL 2.29 headers but
is referenced unconditionally in TorchCommNCCL.cpp (ensureSegmentWindow).
This breaks the [hpc_comms/param](https://www.internalfb.com/conveyor/hpc_comms/param/pipelines/main/nodes/Build%3A%20hpc_comms.param.2.25) conveyor build for NCCL <2.29 variants
(2.23, 2.24, 2.25) with:

  error: use of undeclared identifier 'NCCL_WIN_COLL_SYMMETRIC'

Add a #ifndef polyfill in NcclApi.hpp alongside the existing ncclWindow_t
and NCCL_SHRINK_ABORT polyfills. The window API wrapper already returns
ncclInvalidUsage on older NCCL at runtime, so the constant value is only
needed for compilation.

Differential Revision: D109458535


