### PR TITLE
Remove forceFree from freeSegment; rely on segment refcount

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -420,7 +420,7 @@ commResult_t ctran::RegCache::globalDeregister(
     bool freed = false;
     bool ncclManaged = false;
     std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElemsFreed;
-    FB_COMMCHECK(freeSegment(segHdl, freed, ncclManaged, regElemsFreed, true));
+    FB_COMMCHECK(freeSegment(segHdl, freed, ncclManaged, regElemsFreed));
 
     if (freed) {
       totalSegmentsFreed++;
@@ -1119,8 +1119,7 @@ commResult_t ctran::RegCache::freeSegment(
     void* segHdl,
     bool& freed,
     bool& ncclManaged,
-    std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems,
-    bool forceFree) {
+    std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems) {
   ctran::regcache::Segment* segment = nullptr;
   {
     // Global lock:
@@ -1148,9 +1147,7 @@ commResult_t ctran::RegCache::freeSegment(
     ncclManaged = segment->ncclManaged;
 
     // Ask for free. False if still in use, then no-op and return.
-    // When forceFree is true (e.g. globalDeregister), skip the refCount check
-    // because the underlying physical memory is about to be freed.
-    if (!forceFree && !segment->askFree()) {
+    if (!segment->askFree()) {
       return commSuccess;
     }
 

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -404,13 +404,9 @@ class RegCache {
   // Thread-safe functions to free a cached segment from the global cache and
   // deregister any associated registration. If the segment is already freed
   // (e.g. by a prior globalDeregister), this is a no-op. If the segment is
-  // still in use by any communicator (refCount > 0), this call is a no-op
-  // unless forceFree is true.
+  // still in use by any communicator (refCount > 0), this call is a no-op.
   // input:
   //   - segHdl: the handle of the cached segment
-  //   - forceFree: if true, skip the refCount check and always free the
-  //                segment. Used by globalDeregister when the underlying
-  //                physical memory is about to be freed.
   // output:
   //   - freed: whether or not the segment is freed from the global cache
   //   - ncclManaged: whether or not the segment is managed by NCCL
@@ -421,8 +417,7 @@ class RegCache {
       void* segHdl,
       bool& freed,
       bool& ncclManaged,
-      std::vector<std::unique_ptr<regcache::RegElem>>& regElems,
-      bool forceFree = false);
+      std::vector<std::unique_ptr<regcache::RegElem>>& regElems);
 
   regcache::Segment* getSegment(void* segHdl);
 

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -190,19 +190,13 @@ decrements it. The segment is only actually freed when the refcount
 reaches zero. If the segment handle is not found (already freed),
 `freeSegment` is a no-op and returns success.
 
-An optional `forceFree` parameter (default `false`) bypasses the
-refcount check and always frees the segment. `globalDeregister` uses
-`forceFree=true` because the underlying physical memory is about to be
-freed, so the segment must be removed from cache regardless of how many
-communicators have cached it.
-
 ```
-freeSegment(segHdl, forceFree=false) -> freed, regElems
+freeSegment(segHdl) -> freed, regElems
 
   1. Acquire both segmentsAvl_ and regElemsMaps_ locks
   2. Lookup Segment from AVL handle
      - Not found -> return (freed=false, commSuccess)
-  3. If !forceFree: askFree() -> decrement refCount
+  3. askFree() -> decrement refCount
      - refCount > 0 -> return (freed=false, commSuccess)
   4. Collect all RegElems via segToRegElemsMap
   5. Transfer ownership from regHdlToElemMap to output vector

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1043,57 +1043,6 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCountInitial) {
   EXPECT_EQ(ipcRegCache->getNumRemReg("test_peer_refcount"), 0);
 }
 
-// Test that forceFree bypasses refcount and always frees the segment
-TEST_F(RegCacheTest, FreeSegmentForceFreeBypassesRefCount) {
-  size_t bufSize = 8192;
-  void* buf = nullptr;
-  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
-
-  // Cache the segment twice to get refcount=2
-  std::vector<ctran::regcache::Segment*> segments1;
-  std::vector<void*> segHdls1;
-  EXPECT_EQ(
-      regCache->cacheSegment(
-          buf, bufSize, cudaDev, false, 0, segments1, segHdls1),
-      commSuccess);
-  EXPECT_EQ(segments1.size(), 1);
-
-  std::vector<ctran::regcache::Segment*> segments2;
-  std::vector<void*> segHdls2;
-  EXPECT_EQ(
-      regCache->cacheSegment(
-          buf, bufSize, cudaDev, false, 0, segments2, segHdls2),
-      commSuccess);
-  EXPECT_EQ(segments1[0], segments2[0]); // same segment, refcount=2
-
-  // Without forceFree, first free should NOT actually free (refcount > 0)
-  bool freed = false;
-  bool ncclManaged = false;
-  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
-  EXPECT_EQ(
-      regCache->freeSegment(segHdls1[0], freed, ncclManaged, regElems, false),
-      commSuccess);
-  EXPECT_FALSE(freed);
-
-  // Re-cache to restore refcount to 2
-  std::vector<ctran::regcache::Segment*> segments3;
-  std::vector<void*> segHdls3;
-  EXPECT_EQ(
-      regCache->cacheSegment(
-          buf, bufSize, cudaDev, false, 0, segments3, segHdls3),
-      commSuccess);
-
-  // With forceFree=true, should free even though refcount > 1
-  freed = false;
-  regElems.clear();
-  EXPECT_EQ(
-      regCache->freeSegment(segHdls3[0], freed, ncclManaged, regElems, true),
-      commSuccess);
-  EXPECT_TRUE(freed);
-
-  CUDACHECK_TEST(cudaFree(buf));
-}
-
 // Verify that memory registration (cacheSegment + regRange, and regDynamic)
 // works correctly during CUDA graph stream capture. The StreamCaptureModeGuard
 // in doRegister() and pinRange() should temporarily exit capture mode so the
@@ -1147,7 +1096,7 @@ TEST_F(RegCacheTest, RegistrationDuringGraphCapture) {
   bool freed = false;
   bool ncclManaged = false;
   std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
-  regCache->freeSegment(buf, freed, ncclManaged, regElems, true);
+  regCache->freeSegment(buf, freed, ncclManaged, regElems);
 
   CUDACHECK_TEST(cudaStreamDestroy(stream));
   CUDACHECK_TEST(cudaFree(buf));


### PR DESCRIPTION
Summary:
`freeSegment` carried an optional `forceFree` parameter that bypassed the `askFree()` refcount check and evicted a segment regardless of how many callers still held a reference. The only user was `globalDeregister`, which passed `forceFree=true`.

Since the global registration path (the CCA hook in `TorchCommNCCLXCCA`) pairs `globalRegister` on `SEGMENT_ALLOC` with `globalDeregister` on `SEGMENT_FREE` one-to-one, the segment `refCount` returns to zero on its own by the time the physical memory is freed, so the override is redundant. Drop `forceFree` entirely:

- `globalDeregister` now takes the standard `askFree()` refcount path like every other `freeSegment` caller.
- Remove the `forceFree` parameter from the `freeSegment` declaration and definition.
- Remove the `FreeSegmentForceFreeBypassesRefCount` unit test, which only existed to exercise the removed argument.
- Update `regcache/docs/design.md`.

This unifies segment teardown on a single code path.

Differential Revision: D109390439


