### PR TITLE
Gate SM100 86GB/s inter-node tier

### DIFF
--- a/comms/ncclx/v2_30/src/graph/search.cc
+++ b/comms/ncclx/v2_30/src/graph/search.cc
@@ -994,8 +994,10 @@ float sm90SpeedArrayInter[] = { 48.0, 45.0, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 
 
 float sm100SpeedArrayIntra[] = { 90.0, 80.0, 70.0, 60.0, 50.0, 45.0, 40.0, 30.0, 24.0, 20.0, 19.0, 18.0 };
 float sm100SpeedArrayInter[] = { 96.0, 86.0, 80.0, 48.0, 45.1, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 17.5, 15.0, 12.0, 6.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
+const float sm100SpeedArrayInterV229[] = { 96.0, 80.0, 48.0, 45.1, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 17.5, 15.0, 12.0, 6.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
 #define NSPEEDSINTRA_SM100 (sizeof(sm100SpeedArrayIntra)/sizeof(float))
 #define NSPEEDSINTER_SM100 (sizeof(sm100SpeedArrayInter)/sizeof(float))
+#define NSPEEDSINTER_SM100_V229 (sizeof(sm100SpeedArrayInterV229)/sizeof(float))
 
 ncclResult_t ncclTopoCheckCrossNicSupport(bool* supported) {
   *supported = (ncclParamCrossNic() != 0);
@@ -1095,13 +1097,17 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
 
   // First try crossnic, then decrease bw and finally increase bwIntra.
   int nspeeds = 0;
-  float* speedArray = NULL;
+  const float* speedArray = NULL;
   if (system->inter == 0) {
     nspeeds = ccMin >= 100 ? NSPEEDSINTRA_SM100 : (ccMin >= 90 ? NSPEEDSINTRA_SM90 : NSPEEDSINTRA);
     speedArray = ccMin >= 100 ? sm100SpeedArrayIntra : (ccMin >= 90 ? sm90SpeedArrayIntra : speedArrayIntra);
+  } else if (ccMin >= 100) {
+    const bool useV229 = NCCL_TOPO_BOND_V229;
+    nspeeds = useV229 ? NSPEEDSINTER_SM100_V229 : NSPEEDSINTER_SM100;
+    speedArray = useV229 ? sm100SpeedArrayInterV229 : sm100SpeedArrayInter;
   } else {
-    nspeeds = ccMin >= 100 ? NSPEEDSINTER_SM100 : (ccMin >= 90 ? NSPEEDSINTER_SM90 : NSPEEDSINTER);
-    speedArray = ccMin >= 100 ? sm100SpeedArrayInter : (ccMin >= 90 ? sm90SpeedArrayInter : speedArrayInter);
+    nspeeds = ccMin >= 90 ? NSPEEDSINTER_SM90 : NSPEEDSINTER;
+    speedArray = ccMin >= 90 ? sm90SpeedArrayInter : speedArrayInter;
   }
   int pass = 1;
   int speedIndex = 0;

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -677,6 +677,14 @@ cvars:
      Blackwell per-channel tuning bandwidths, and uses NET node
      count for system->inter.
 
+ - name        : NCCL_TOPO_BOND_V229
+   type        : bool
+   default     : true
+   description : |-
+     Controls v2.29 vs v2.30 SM100 inter-node topology speed tiers.
+     When true (default, v2.29-like): skips the 86GB/s inter-node
+     speed tier. When false (v2.30 behavior): includes that tier.
+
  - name        : NCCL_NTHREADS
    type        : int64_t
    default     : -2


### PR DESCRIPTION
Summary:
Add `NCCL_TOPO_BOND_V229` as a v2.29 compatibility gate for NCCLX 2.30 SM100 inter-node topology search. The flag semantics now match the name and the prior V228-style pattern: `true` selects the v2.29-like SM100 inter-node speed list and skips the 86GB/s tier; `false` selects the v2.30 speed list and includes the 86GB/s tier.

Because the cvar defaults to `true`, NCCLX 2.30 uses the exact-scale no-86 path by default until the compatibility gate is explicitly disabled. That is the path validated by the patched no-86 conda run against the NCCLX 2.29 exact-scale checksum.

This diff is D109458732 plus the flag gate.

Differential Revision: D109460735


