### PR TITLE
Add bootstrap TCP keepalive options

### DIFF
--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -3209,6 +3209,15 @@ cvars:
      the socket-health polling path; active Bootstrap socket I/O errors still
      use the separate callback path.
 
+ - name        : MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED
+   type        : bool
+   default     : false
+   description : |-
+     Enable TCP keepalive on MCCL Bootstrap sockets. When enabled, Bootstrap
+     applies its TCP keepalive options to outgoing and accepted CoroSocket
+     instances so the kernel can surface half-open peer failures. Disabled by
+     default so production behavior is unchanged unless explicitly opted in.
+
  - name        : MCCL_SCUBA_ENABLED
    type        : bool
    default     : true

--- a/comms/utils/cvars/tests/CvarInitUT.cc
+++ b/comms/utils/cvars/tests/CvarInitUT.cc
@@ -48,12 +48,29 @@ class CvarInitTest : public ::testing::Test {
     unsetenv("NCCL_P2P_DISABLE");
     unsetenv("CUDA_LAUNCH_BLOCKING");
     unsetenv("NCCL_MIN_CTAS");
+    unsetenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED");
   }
 };
 
 TEST_F(CvarInitTest, BasicInitialization) {
   // Test basic ncclCvarInit functionality
   EXPECT_NO_THROW(ncclCvarInit());
+}
+
+TEST_F(CvarInitTest, McclBootstrapTcpKeepaliveDisabledByDefault) {
+  EXPECT_NO_THROW(ncclCvarInit());
+
+  EXPECT_FALSE(MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED);
+  EXPECT_FALSE(MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED_DEFAULT_LITERAL);
+}
+
+TEST_F(CvarInitTest, McclBootstrapTcpKeepaliveCanBeEnabled) {
+  setenv("MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED", "1", 1);
+
+  EXPECT_NO_THROW(ncclCvarInit());
+
+  EXPECT_TRUE(MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED);
+  EXPECT_FALSE(MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED_DEFAULT_LITERAL);
 }
 
 TEST_F(CvarInitTest, InitWithStringCvar) {


### PR DESCRIPTION
Summary:
Add optional TCP keepalive configuration for MCCL Bootstrap sockets. TCP keepalive remains disabled by default: when no options are provided, CoroSocket explicitly clears SO_KEEPALIVE so accepted sockets do not inherit an enabled keepalive setting from the server/socket stack.

When options are provided, outgoing and accepted CoroSocket instances set SO_KEEPALIVE, TCP_KEEPIDLE, TCP_KEEPINTVL, and TCP_KEEPCNT. The opt-in defaults are idle=1s, interval=1s, count=5, which gives a conservative detection deadline of roughly six seconds after a half-open peer stops responding to probes.

Default McclComm bootstrap keeps TCP keepalive off unless MCCL_BOOTSTRAP_TCP_KEEPALIVE_ENABLED=1 is explicitly set. This keeps production behavior unchanged while giving us an env/cvar gate to opt into the keepalive path.

This is intentionally separate from the default-on Bootstrap socket health poll in the parent diff. TCP keepalive controls when the kernel surfaces half-open socket errors; the parent health poll observes those errors through getSocketError() and routes them through the shared Bootstrap abort path.

Reviewed By: saifhhasan

Differential Revision: D109327476


