### PR TITLE
nccl/xccl: map Bool tensor dtype to uint8

### DIFF
--- a/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLUtils.cpp
@@ -30,6 +30,8 @@ ncclDataType_t getNcclDataTypeInternal(const at::Tensor& tensor) {
       return ncclInt8;
     case at::ScalarType::Byte:
       return ncclUint8;
+    case at::ScalarType::Bool:
+      return ncclUint8;
     default:
       throw std::runtime_error("Unsupported tensor data type for NCCL");
   }

--- a/comms/torchcomms/tests/integration/helpers/TorchCommTestHelpers.py
+++ b/comms/torchcomms/tests/integration/helpers/TorchCommTestHelpers.py
@@ -36,6 +36,8 @@ def get_dtype_name(dtype):
         return "Int"
     elif dtype == torch.int8:
         return "SignedChar"
+    elif dtype == torch.bool:
+        return "Bool"
     else:
         return "Unknown"
 

--- a/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
+++ b/comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
@@ -19,7 +19,11 @@ class AllGatherSingleTest(unittest.TestCase):
 
     # Class variables for test parameters
     counts = [0, 4, 1024, 1024 * 1024] if is_full_sweep() else [4, 1024 * 1024]
-    dtypes = [torch.float, torch.int, torch.int8] if is_full_sweep() else [torch.float]
+    dtypes = (
+        [torch.float, torch.int, torch.int8, torch.bool]
+        if is_full_sweep()
+        else [torch.float]
+    )
     num_replays = 4
 
     def get_wrapper(self):
@@ -215,6 +219,11 @@ class AllGatherSingleTest(unittest.TestCase):
             return torch.ones(count, **options) * int(self.rank + 1)
         elif dtype == torch.int8:
             return torch.ones(count, **options) * int(self.rank + 1)
+        elif dtype == torch.bool:
+            # bool can't encode the rank as a magnitude, so use an alternating
+            # per-rank pattern (even ranks True, odd ranks False) that keeps each
+            # section distinguishable after the gather.
+            return torch.full((count,), (self.rank % 2) == 0, **options)
         return None
 
     def _create_output_tensor(self, count, dtype):
@@ -237,6 +246,12 @@ class AllGatherSingleTest(unittest.TestCase):
                 self.assertTrue(
                     torch.allclose(section.cpu(), expected),
                     f"Tensors not close enough for rank {i} section",
+                )
+            elif section.dtype == torch.bool:
+                expected = torch.full((count,), (i % 2) == 0, dtype=torch.bool)
+                self.assertTrue(
+                    torch.equal(section.cpu(), expected),
+                    f"Tensors not equal for rank {i} section",
                 )
             else:
                 expected = torch.ones(count, dtype=section.dtype) * int(i + 1)

--- a/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
+++ b/comms/torchcomms/xccl/TorchCommXCCLUtils.cpp
@@ -29,6 +29,8 @@ onecclDataType_t getXcclDataTypeInternal(const at::Tensor& tensor) {
       return onecclInt8;
     case at::ScalarType::Byte:
       return onecclUint8;
+    case at::ScalarType::Bool:
+      return onecclUint8;
     default:
       throw std::runtime_error("Unsupported tensor data type for XCCL");
   }


### PR DESCRIPTION
## Summary

The NCCL and XCCL backends' `get{Nccl,Xccl}DataTypeInternal` had no case for `at::ScalarType::Bool`, so any collective on a bool tensor fell through to the `default:` branch and threw `RuntimeError: Unsupported tensor data type for {NCCL,XCCL}`.

This fixes it by mapping `Bool -> {nccl,oneccl}Uint8`, matching the **NCCLX** backend (`TorchCommNCCLXUtils.cpp`), the **Gloo** backend (`TorchCommGloo.cpp`), and PyTorch's own `ProcessGroupNCCL` / `ProcessGroupXCCL`, all of which already treat bool as uint8.

## Root cause

Surfaced as a trunk-wide failure of the torchtitan `FSDP+CP+PP+compile with torchcomms` integration test in pytorch/pytorch `torchtitan-test` CI (`--comm.mode torchcomms`), e.g. [this run](https://github.com/pytorch/pytorch/actions/runs/28049671436/job/83042845517). It also reproduces on pytorch/pytorch `main` and many unrelated PRs, so it is **not** caused by any single PR.

The chain:
1. torchtitan's `Linear.init_weights` calls `nn.init.trunc_normal_(self.weight, ...)`.
2. `_no_grad_trunc_normal_` uses a rejection-sampling loop: `mask = (result < lo) | (result > hi); if not mask.any(): break`.
3. The model weight is a sharded `DTensor` (3D parallelism), so `mask` is a **bool** `DTensor`. `mask.any()` redistributes Shard -> Replicate, issuing `all_gather_into_tensor` on a bool tensor.
4. The torchcomms NCCL backend had no bool mapping -> throw on every rank.

```
nn.init.trunc_normal_ -> _no_grad_trunc_normal_ -> mask.any()
  -> DTensor _to_replicate_tensor -> funcol.all_gather_single
  -> _c10d_functional.all_gather_into_tensor
  -> RuntimeError: Unsupported tensor data type for NCCL
```

`bool -> uint8` is safe for data-movement collectives (all_gather/broadcast/send/recv) and matches upstream PyTorch semantics for reductions.

## Test

`AllGatherSingleTest` now sweeps `torch.bool` (the exact op that failed in torchtitan), and `get_dtype_name` learns about bool. The test is backend-agnostic, so it also covers XCCL when run with `TEST_BACKEND=xccl`.

## Test plan

- `lintrunner` clean on the changed C++ and Python files
- `AllGatherSingleTest` reproduces the bug on the pre-fix build: bool subtests fail with `RuntimeError: Unsupported tensor data type for NCCL` while float/int/int8 pass
- After the fix (rebuilt + reinstalled nccl libs), the full test passes on 2x H100:
  ```
  TEST_BACKEND=nccl torchrun --nproc_per_node=2 \
    comms/torchcomms/tests/integration/py/AllGatherSingleTest.py
  # Ran 7 tests ... OK (skipped=2)   # bool included in the sweep
  ```
- The XCCL change mirrors the NCCL fix; not built locally (no Intel oneAPI/XPU in this environment)