### PR TITLE
Unify IB put benchmarks across IBGDA and IBRC (#2978)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -149,6 +149,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/rdma/IbHcaParser.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -157,6 +157,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerIbTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
 LIBSRCFILES += ${BASE_DIR}/comms/prims/topology/TopologyDiscovery.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/window/HostWindow.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/rdma/IbHcaParser.cc

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -19,6 +19,7 @@
 #endif
 #include "comms/prims/benchmarks/IbgdaBenchmark.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
 #include "comms/testinfra/mpi/MpiTestUtils.h"
 #ifndef __HIP_PLATFORM_AMD__
@@ -54,6 +55,73 @@ inline std::string benchIbHca() {
   const char* hca = std::getenv("NCCL_IB_HCA");
   return hca ? std::string(hca) : std::string();
 }
+
+enum class BenchIbBackend {
+  IBGDA,
+  IBRC,
+};
+
+inline const char* benchIbBackendName(BenchIbBackend backend) {
+  switch (backend) {
+    case BenchIbBackend::IBGDA:
+      return "IBGDA";
+    case BenchIbBackend::IBRC:
+      return "IBRC";
+  }
+  return "UNKNOWN";
+}
+
+// Backend-agnostic transport handle for the benchmark. Holds exactly one of the
+// two multi-peer IB transports (IBGDA or IBRC, selected by test parameter) and
+// dispatches the small surface the benchmark needs. getP2pTransportDevice()
+// returns the common P2pIbTransportDevice so the same kernels run over either
+// backend. registerBuffer()/exchangeBuffer() are inherited from the shared
+// MultiPeerIbTransportBase and are identical for both backends.
+class BenchIbTransport {
+ public:
+  BenchIbTransport(
+      BenchIbBackend backend,
+      int globalRank,
+      int numRanks,
+      const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+      const MultipeerIbTransportConfig& config) {
+    XLOGF(INFO, "BenchIbTransport: backend={}", benchIbBackendName(backend));
+    if (backend == BenchIbBackend::IBRC) {
+      ibrc_ = std::make_unique<MultipeerIbrcTransport>(
+          globalRank, numRanks, bootstrap, config);
+    } else {
+      ibgda_ = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, numRanks, bootstrap, config);
+    }
+  }
+
+  void exchange() {
+    if (ibrc_) {
+      ibrc_->exchange();
+    } else {
+      ibgda_->exchange();
+    }
+  }
+
+  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size) {
+    return ibrc_ ? ibrc_->registerBuffer(ptr, size)
+                 : ibgda_->registerBuffer(ptr, size);
+  }
+
+  std::vector<IbgdaRemoteBuffer> exchangeBuffer(const IbgdaLocalBuffer& buf) {
+    return ibrc_ ? ibrc_->exchangeBuffer(buf) : ibgda_->exchangeBuffer(buf);
+  }
+
+  P2pIbTransportDevice getP2pTransportDevice(int peerRank) {
+    return ibrc_
+        ? P2pIbTransportDevice(ibrc_->getP2pTransportDevice(peerRank))
+        : P2pIbTransportDevice(ibgda_->getP2pTransportDevice(peerRank));
+  }
+
+ private:
+  std::unique_ptr<MultipeerIbgdaTransport> ibgda_;
+  std::unique_ptr<MultipeerIbrcTransport> ibrc_;
+};
 
 // CUDA error checking macro for void functions
 #define CUDA_CHECK_VOID(call)        \
@@ -101,8 +169,22 @@ struct IbgdaBenchmarkResult {
   float latency{}; // microseconds
 };
 
-class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
+class IbgdaBenchmarkFixture
+    : public MpiBaseTestFixture,
+      public ::testing::WithParamInterface<BenchIbBackend> {
  protected:
+  BenchIbBackend backend() const {
+    return GetParam();
+  }
+
+  const char* backendName() const {
+    return benchIbBackendName(backend());
+  }
+
+  std::string backendTitle(const std::string& suffix) const {
+    return std::string(backendName()) + " " + suffix;
+  }
+
   void SetUp() override {
     MpiBaseTestFixture::SetUp();
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
@@ -153,11 +235,9 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
   // Run put + signal + counter benchmark using batched kernel. Populates
   // latencyUs, excludes kernel launch overhead.
   void runPutSignalBenchmark(
-      P2pIbgdaTransportDevice* deviceTransportPtr,
+      P2pIbTransportDevice deviceTransport,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
-      const IbgdaRemoteBuffer& remoteSignalBuf,
-      const IbgdaLocalBuffer& localCounterBuf,
       const IbgdaBenchmarkConfig& config,
       unsigned long long* d_totalCycles,
       float& latencyUs) {
@@ -169,13 +249,11 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
     // Only rank 0 (sender) runs the batched benchmark
     if (globalRank == 0) {
       launchIbgdaPutSignalWaitCounterBatch(
-          deviceTransportPtr,
+          deviceTransport,
           localBuf,
           remoteBuf,
           config.nBytes,
-          remoteSignalBuf,
           kSignalId,
-          localCounterBuf,
           kCounterId,
           kIbgdaBatchIters,
           d_totalCycles,
@@ -254,6 +332,9 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
         {.nBytes = 32 * 1024 * 1024, .name = "32MB"},
         {.nBytes = 64 * 1024 * 1024, .name = "64MB"},
         {.nBytes = 128 * 1024 * 1024, .name = "128MB"},
+        {.nBytes = std::size_t{256} * 1024 * 1024, .name = "256MB"},
+        {.nBytes = std::size_t{512} * 1024 * 1024, .name = "512MB"},
+        {.nBytes = std::size_t{1} * 1024 * 1024 * 1024, .name = "1GB"},
     };
   }
 
@@ -267,13 +348,11 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
   template <typename LaunchFn>
   void verifyPutDataCorrectness(
       LaunchFn launchFn,
-      P2pIbgdaTransportDevice* deviceTransportPtr,
+      P2pIbTransportDevice deviceTransport,
       void* localBufferPtr,
       const IbgdaLocalBuffer& localBuf,
       const IbgdaRemoteBuffer& remoteBuf,
       std::size_t nbytes,
-      const IbgdaRemoteBuffer& remoteSignalBuf,
-      const IbgdaLocalBuffer& localCounterBuf,
       uint8_t fillPattern,
       const std::string& methodName) {
     constexpr int kSignalId = 0;
@@ -289,20 +368,15 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
     CUDA_CHECK_VOID(cudaDeviceSynchronize());
     MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-    // Sender: exactly one put+signal+counter (no warmup, no loop). The
-    // sender resets its local counter to 0 first so the kernel's spin sees
-    // the fresh increment.
+    // Sender: exactly one put+signal+counter (no warmup, no loop). The kernel
+    // resets the transport-owned local counter slot before posting the put.
     if (globalRank == 0) {
-      CUDA_CHECK_VOID(
-          cudaMemsetAsync(localCounterBuf.ptr, 0, sizeof(uint64_t), stream_));
       launchFn(
-          deviceTransportPtr,
+          deviceTransport,
           localBuf,
           remoteBuf,
           nbytes,
-          remoteSignalBuf,
           kSignalId,
-          localCounterBuf,
           kCounterId,
           stream_);
       CUDA_CHECK_VOID(cudaStreamSynchronize(stream_));
@@ -338,7 +412,7 @@ class IbgdaBenchmarkFixture : public MpiBaseTestFixture {
   }
 };
 
-TEST_F(IbgdaBenchmarkFixture, PutFlush) {
+TEST_P(IbgdaBenchmarkFixture, PutFlush) {
   // Measures raw RDMA Write latency as put + flush.
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -359,10 +433,11 @@ TEST_F(IbgdaBenchmarkFixture, PutFlush) {
     MultipeerIbgdaTransportConfig transportConfig{
         .cudaDevice = localRank,
     };
+    transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     DeviceBuffer dataBuffer(maxBufferSize);
@@ -378,7 +453,7 @@ TEST_F(IbgdaBenchmarkFixture, PutFlush) {
     }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
-    P2pIbgdaTransportDevice* deviceTransportPtr =
+    P2pIbTransportDevice deviceTransport =
         transport.getP2pTransportDevice(peerRank);
 
     unsigned long long* d_totalCycles;
@@ -395,7 +470,7 @@ TEST_F(IbgdaBenchmarkFixture, PutFlush) {
 
       if (globalRank == 0) {
         launchIbgdaPutFlushBatch(
-            deviceTransportPtr,
+            deviceTransport,
             localDataBuf,
             remoteDataBuf,
             config.nBytes,
@@ -434,13 +509,13 @@ TEST_F(IbgdaBenchmarkFixture, PutFlush) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 
-  printResultsTable("IBGDA Put+Flush (RDMA Write)", results);
+  printResultsTable(backendTitle("Put+Flush (RDMA Write)"), results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
+TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   // One thread per block uses the no-ThreadGroup put()+flush() API on a
   // block-private slice. This checks that thread-scope wrappers inherit the
   // physical block id instead of routing all blocks through block 0's QPs.
@@ -566,7 +641,7 @@ TEST_F(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
 }
 
 TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
-  // Measures raw RDMA Write latency (put + counter wait via companion QP)
+  // Measures raw RDMA Write latency (put + transport counter-slot wait).
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
@@ -591,8 +666,8 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     DeviceBuffer dataBuffer(maxBufferSize);
@@ -608,14 +683,7 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
-    // Counter buffer (local only — companion QP atomically increments via
-    // loopback when each put completes at the NIC).
-    DeviceBuffer counterBuffer(sizeof(uint64_t));
-    CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-    auto localCounterBuf =
-        transport.registerBuffer(counterBuffer.get(), sizeof(uint64_t));
-
-    P2pIbgdaTransportDevice* deviceTransportPtr =
+    P2pIbTransportDevice deviceTransport =
         transport.getP2pTransportDevice(peerRank);
 
     // Allocate device memory for cycle counter output
@@ -631,21 +699,13 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     for (const auto& config : configs) {
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-      // Reset counter buffer before each size — kernel uses an absolute
-      // expected sequence (1, 2, 3, ...) starting from 0.
-      if (globalRank == 0) {
-        CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-        CUDA_CHECK_VOID(cudaDeviceSynchronize());
-      }
-
       // Only rank 0 sends
       if (globalRank == 0) {
         launchIbgdaPutWaitCounterBatch(
-            deviceTransportPtr,
+            deviceTransport,
             localDataBuf,
             remoteDataBuf,
             config.nBytes,
-            localCounterBuf,
             kCounterId,
             kIbgdaBatchIters,
             d_totalCycles,
@@ -682,13 +742,13 @@ TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 
-  printResultsTable("IBGDA Put+WaitCounter (RDMA Write)", results);
+  printResultsTable(backendTitle("Put+WaitCounter (RDMA Write)"), results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
+TEST_P(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
   // Measures RDMA Write + atomic signal latency (put + signal + counter wait)
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -709,14 +769,15 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
 
   try {
     MultipeerIbgdaTransportConfig transportConfig{
+        .numSignalSlots = 1,
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     DeviceBuffer dataBuffer(maxBufferSize);
@@ -732,22 +793,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
     }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
-    // Allocate and exchange signal buffer (1 signal slot)
-    DeviceBuffer signalBuffer(sizeof(uint64_t));
-    CUDA_CHECK_VOID(cudaMemset(signalBuffer.get(), 0, sizeof(uint64_t)));
-    auto localSignalBuf =
-        transport.registerBuffer(signalBuffer.get(), sizeof(uint64_t));
-    auto remoteSignalBufs = transport.exchangeBuffer(localSignalBuf);
-    auto remoteSignalBuf = remoteSignalBufs[peerIndex];
-
-    // Counter buffer (local only — companion QP atomically increments via
-    // loopback when each put+signal completes at the NIC).
-    DeviceBuffer counterBuffer(sizeof(uint64_t));
-    CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-    auto localCounterBuf =
-        transport.registerBuffer(counterBuffer.get(), sizeof(uint64_t));
-
-    P2pIbgdaTransportDevice* deviceTransportPtr =
+    P2pIbTransportDevice deviceTransport =
         transport.getP2pTransportDevice(peerRank);
 
     // Allocate device memory for cycle counter output
@@ -763,23 +809,14 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
     for (const auto& config : configs) {
       MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
 
-      // Reset counter buffer before each size — kernel uses an absolute
-      // expected sequence (1, 2, 3, ...) starting from 0.
-      if (globalRank == 0) {
-        CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-        CUDA_CHECK_VOID(cudaDeviceSynchronize());
-      }
-
       // Only rank 0 sends
       if (globalRank == 0) {
         launchIbgdaPutSignalWaitCounterBatch(
-            deviceTransportPtr,
+            deviceTransport,
             localDataBuf,
             remoteDataBuf,
             config.nBytes,
-            remoteSignalBuf,
             kSignalId,
-            localCounterBuf,
             kCounterId,
             kIbgdaBatchIters,
             d_totalCycles,
@@ -816,14 +853,14 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalWaitCounter) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 
   printResultsTable(
-      "IBGDA Put+Signal+WaitCounter (RDMA Write + Atomic)", results);
+      backendTitle("Put+Signal+WaitCounter (RDMA Write + Atomic)"), results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
+TEST_P(IbgdaBenchmarkFixture, SignalOnly) {
   // Measures atomic signal-only latency (no data transfer)
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
@@ -841,8 +878,8 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
     transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     int peerIndex = (peerRank < globalRank) ? peerRank : (peerRank - 1);
@@ -855,7 +892,7 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
     auto remoteSignalBufs = transport.exchangeBuffer(localSignalBuf);
     auto remoteSignalBuf = remoteSignalBufs[peerIndex];
 
-    P2pIbgdaTransportDevice* deviceTransportPtr =
+    P2pIbTransportDevice deviceTransport =
         transport.getP2pTransportDevice(peerRank);
 
     // Allocate device memory for cycle counter output
@@ -875,7 +912,7 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
     // Only rank 0 sends
     if (globalRank == 0) {
       launchIbgdaSignalOnlyBatch(
-          deviceTransportPtr,
+          deviceTransport,
           remoteSignalBuf,
           kSignalId,
           kIbgdaBatchIters,
@@ -894,7 +931,8 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
 
       XLOGF(
           INFO,
-          "\n=== Signal-Only Latency (Raw, no kernel launch overhead) ===");
+          "\n=== {} Signal-Only Latency (Raw, no kernel launch overhead) ===",
+          backendName());
       XLOGF(INFO, "Average latency: {:.2f} us", latencyUs);
       XLOGF(INFO, "Batch iterations: {}", kIbgdaBatchIters);
       XLOGF(
@@ -907,13 +945,13 @@ TEST_F(IbgdaBenchmarkFixture, SignalOnly) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 }
 
 // put+signal+counter latency benchmark
-// Counter = put + signal + companion-QP counter loopback + local poll
-TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
+// Counter = put + signal + transport counter-slot completion + local poll.
+TEST_P(IbgdaBenchmarkFixture, PutSignalComparison) {
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);
     return;
@@ -946,14 +984,15 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
 
   try {
     MultipeerIbgdaTransportConfig transportConfig{
+        .numSignalSlots = 1,
         .numCounterSlots = 1,
         .cudaDevice = localRank,
     };
     transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     DeviceBuffer dataBuffer(maxBufferSize);
@@ -968,21 +1007,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
     }
     auto remoteDataBuf = remoteDataBufs[peerIndex];
 
-    // Allocate and exchange signal buffer (1 signal slot)
-    DeviceBuffer signalBuffer(sizeof(uint64_t));
-    CUDA_CHECK_VOID(cudaMemset(signalBuffer.get(), 0, sizeof(uint64_t)));
-    auto localSignalBuf =
-        transport.registerBuffer(signalBuffer.get(), sizeof(uint64_t));
-    auto remoteSignalBufs = transport.exchangeBuffer(localSignalBuf);
-    auto remoteSignalBuf = remoteSignalBufs[peerIndex];
-
-    // Counter buffer (local only — companion QP loopback target).
-    DeviceBuffer counterBuffer(sizeof(uint64_t));
-    CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-    auto localCounterBuf =
-        transport.registerBuffer(counterBuffer.get(), sizeof(uint64_t));
-
-    P2pIbgdaTransportDevice* deviceTransportPtr =
+    P2pIbTransportDevice deviceTransport =
         transport.getP2pTransportDevice(peerRank);
 
     // Allocate device memory for cycle counter output
@@ -1001,13 +1026,11 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
 
       verifyPutDataCorrectness(
           launchIbgdaPutSignalSingle,
-          deviceTransportPtr,
+          deviceTransport,
           dataBuffer.get(),
           localDataBuf,
           remoteDataBuf,
           cfg.nBytes,
-          remoteSignalBuf,
-          localCounterBuf,
           static_cast<uint8_t>(basePattern + 1),
           "put+signal+counter [" + cfg.name + "]");
     }
@@ -1016,7 +1039,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
       XLOGF(
           INFO,
           "\n================================================================================");
-      XLOGF(INFO, "    put+signal+counter latency");
+      XLOGF(INFO, "    {} put+signal+counter latency", backendName());
       XLOGF(INFO, "    (Using batched kernels - no kernel launch overhead)");
       XLOGF(
           INFO,
@@ -1030,19 +1053,10 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
     for (const auto& config : configs) {
       float counterLatency = 0.0f;
 
-      // Reset counter buffer before each size — kernel uses an absolute
-      // expected sequence (1, 2, 3, ...) starting from 0.
-      if (globalRank == 0) {
-        CUDA_CHECK_VOID(cudaMemset(counterBuffer.get(), 0, sizeof(uint64_t)));
-        CUDA_CHECK_VOID(cudaDeviceSynchronize());
-      }
-
       runPutSignalBenchmark(
-          deviceTransportPtr,
+          deviceTransport,
           localDataBuf,
           remoteDataBuf,
-          remoteSignalBuf,
-          localCounterBuf,
           config,
           d_totalCycles,
           counterLatency);
@@ -1058,7 +1072,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
           "================================================================================");
       XLOGF(
           INFO,
-          "Counter = put + signal + counter (companion-QP loopback) + local poll");
+          "Counter = put + signal + transport counter-slot completion + local poll");
       XLOGF(
           INFO,
           "================================================================================\n");
@@ -1067,7 +1081,7 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 }
 
@@ -1082,11 +1096,16 @@ TEST_F(IbgdaBenchmarkFixture, PutSignalComparison) {
 //
 // Expected: FanOut per-iter latency stays roughly constant as numPeers grows,
 //           while Serial scales linearly with numPeers.
-TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
+TEST_P(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
   const int numPeers = numRanks - 1;
   if (numPeers < 1) {
     XLOGF(INFO, "Skipping test: requires >= 2 ranks, got {}", numRanks);
     return;
+  }
+  if (backend() == BenchIbBackend::IBRC) {
+    GTEST_SKIP()
+        << "Shared explicit counter-buffer fan-out is IBGDA-only; IBRC "
+           "counters use per-peer transport-owned host/device slots.";
   }
 
   constexpr std::size_t kDataSize = 64 * 1024; // 64KB per peer
@@ -1101,8 +1120,8 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
     transportConfig.ibHca = benchIbHca();
 
     auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
-    MultipeerIbgdaTransport transport(
-        globalRank, numRanks, bootstrap, transportConfig);
+    BenchIbTransport transport(
+        backend(), globalRank, numRanks, bootstrap, transportConfig);
     transport.exchange();
 
     // Data buffer
@@ -1141,29 +1160,24 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
         numPeers * sizeof(IbgdaRemoteBuffer),
         cudaMemcpyHostToDevice));
 
-    P2pIbgdaTransportDevice* transportsBase = transport.getDeviceTransportPtr();
-    // Compute transport element stride from the base pointer returned by
-    // getP2pTransportDevice(). peerIndex 0 starts at transportsBase, so the
-    // distance from base to peerIndex=1 gives the element stride.
-    // For numPeers >= 2 we can measure it; for numPeers == 1, the stride is
-    // not used (only index [0] accessed) so any value is fine.
-    std::size_t transportStride = 0;
-    {
-      // peerIndexToRank(0) is rank 0 if globalRank > 0, else rank 1
-      int peerIdx0Rank = (0 < globalRank) ? 0 : 1;
-      auto* ptr0 = transport.getP2pTransportDevice(peerIdx0Rank);
-      transportStride = static_cast<std::size_t>(
-          reinterpret_cast<char*>(ptr0) -
-          reinterpret_cast<char*>(transportsBase));
-      if (transportStride == 0 && numPeers >= 2) {
-        // peerIdx0 == base; use peerIdx 1 instead
-        int peerIdx1Rank = (1 < globalRank) ? 1 : 2;
-        transportStride = static_cast<std::size_t>(
-            reinterpret_cast<char*>(
-                transport.getP2pTransportDevice(peerIdx1Rank)) -
-            reinterpret_cast<char*>(ptr0));
-      }
+    // Build a contiguous device array of per-peer transport handles. IBRC has
+    // no getDeviceTransportPtr()/contiguous device-array accessor, so build the
+    // array from the per-peer getP2pTransportDevice() (works for both
+    // backends). Index p holds the handle for peer p (peerIndexToRank: rank p
+    // if p < globalRank, else p + 1).
+    std::vector<P2pIbTransportDevice> hostTransports(numPeers);
+    for (int p = 0; p < numPeers; p++) {
+      int peerRank = (p < globalRank) ? p : (p + 1);
+      hostTransports[p] = transport.getP2pTransportDevice(peerRank);
     }
+    DeviceBuffer transportsDevice(numPeers * sizeof(P2pIbTransportDevice));
+    CUDA_CHECK_VOID(cudaMemcpy(
+        transportsDevice.get(),
+        hostTransports.data(),
+        numPeers * sizeof(P2pIbTransportDevice),
+        cudaMemcpyHostToDevice));
+    const auto* transports =
+        static_cast<const P2pIbTransportDevice*>(transportsDevice.get());
 
     unsigned long long* d_totalCycles;
     CUDA_CHECK_VOID(cudaMalloc(&d_totalCycles, sizeof(unsigned long long)));
@@ -1174,8 +1188,7 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
 
     if (globalRank == 0) {
       launchMultiPeerSerialCounterFanOutBatch(
-          transportsBase,
-          transportStride,
+          transports,
           numPeers,
           localDataBuf,
           static_cast<IbgdaRemoteBuffer*>(remoteDataBufsDevice.get()),
@@ -1210,8 +1223,7 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
 
     if (globalRank == 0) {
       launchMultiPeerCounterFanOutBatch(
-          transportsBase,
-          transportStride,
+          transports,
           numPeers,
           localDataBuf,
           static_cast<IbgdaRemoteBuffer*>(remoteDataBufsDevice.get()),
@@ -1243,7 +1255,8 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
           "\n================================================================================");
       XLOGF(
           INFO,
-          "    Multi-Peer Counter Fan-Out ({} peers, {} per peer)",
+          "    {} Multi-Peer Counter Fan-Out ({} peers, {} per peer)",
+          backendName(),
           numPeers,
           formatSize(kDataSize));
       XLOGF(
@@ -1284,9 +1297,17 @@ TEST_F(IbgdaBenchmarkFixture, MultiPeerCounterFanOut) {
     CUDA_CHECK_VOID(cudaFree(d_totalCycles));
 
   } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+    GTEST_SKIP() << "IB transport not available: " << e.what();
   }
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    IbBackend,
+    IbgdaBenchmarkFixture,
+    ::testing::Values(BenchIbBackend::IBGDA, BenchIbBackend::IBRC),
+    [](const ::testing::TestParamInfo<BenchIbBackend>& info) {
+      return std::string(benchIbBackendName(info.param));
+    });
 } // namespace comms::prims::benchmark
 
 int main(int argc, char* argv[]) {

--- a/comms/prims/benchmarks/IbgdaBenchmark.cu
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cu
@@ -28,29 +28,17 @@ constexpr int kMaxPeers = 128;
 // local counter slot. No warmup, no loop.
 
 __global__ void ibgdaPutSignalWaitCounterKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    auto resolvedSignalBuf =
-        remoteSignalBuf.subBuffer(signalId * sizeof(uint64_t));
-    auto resolvedCounterBuf =
-        localCounterBuf.subBuffer(counterId * sizeof(uint64_t));
-    transport->put(
-        localBuf,
-        remoteBuf,
-        nbytes,
-        resolvedSignalBuf,
-        1,
-        resolvedCounterBuf,
-        1);
-    transport->wait_counter(resolvedCounterBuf, 1);
+    transport.reset_counter(counterId);
+    transport.put(localBuf, remoteBuf, nbytes, signalId, 1, counterId, 1);
+    transport.wait_counter(counterId, 1);
   }
 }
 
@@ -59,34 +47,24 @@ __global__ void ibgdaPutSignalWaitCounterKernel(
 // for accurate timing.
 
 __global__ void ibgdaPutWaitCounterBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    auto resolvedCounterBuf =
-        localCounterBuf.subBuffer(counterId * sizeof(uint64_t));
+    transport.reset_counter(counterId);
     uint64_t expected = 1;
 
-    // Counter-only put: signalBuf={} (ptr==nullptr disables signaling), the
-    // companion QP loopback atomically increments the local counter when the
-    // put completes at the NIC. GPU waits on the local counter slot.
+    // Counter-only put: signalId=-1 disables signaling. The put completion
+    // increments the transport-owned local counter slot.
     // Warmup - do a few iterations to warm up the path
     for (int i = 0; i < 10; i++) {
-      transport->put(
-          localBuf,
-          remoteBuf,
-          nbytes,
-          IbgdaRemoteBuffer{},
-          0,
-          resolvedCounterBuf,
-          1);
-      transport->wait_counter(resolvedCounterBuf, expected);
+      transport.put(localBuf, remoteBuf, nbytes, -1, 0, counterId, 1);
+      transport.wait_counter(counterId, expected);
       expected++;
     }
 
@@ -94,15 +72,8 @@ __global__ void ibgdaPutWaitCounterBatchKernel(
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      transport->put(
-          localBuf,
-          remoteBuf,
-          nbytes,
-          IbgdaRemoteBuffer{},
-          0,
-          resolvedCounterBuf,
-          1);
-      transport->wait_counter(resolvedCounterBuf, expected);
+      transport.put(localBuf, remoteBuf, nbytes, -1, 0, counterId, 1);
+      transport.wait_counter(counterId, expected);
       expected++;
     }
 
@@ -112,7 +83,7 @@ __global__ void ibgdaPutWaitCounterBatchKernel(
 }
 
 __global__ void ibgdaPutFlushBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
@@ -120,16 +91,17 @@ __global__ void ibgdaPutFlushBatchKernel(
     unsigned long long* totalCycles) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
+    // Raw write (no signal, no counter), completion observed via flush().
     for (int i = 0; i < 10; i++) {
-      transport->put(localBuf, remoteBuf, nbytes);
-      transport->flush();
+      transport.put(localBuf, remoteBuf, nbytes, IbgdaRemoteBuffer{}, 0);
+      transport.flush();
     }
 
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      transport->put(localBuf, remoteBuf, nbytes);
-      transport->flush();
+      transport.put(localBuf, remoteBuf, nbytes, IbgdaRemoteBuffer{}, 0);
+      transport.flush();
     }
 
     unsigned long long endCycle = BENCHMARK_CLOCK64();
@@ -167,35 +139,23 @@ __global__ void ibgdaThreadScopeMultiBlockPutFlushBatchKernel(
 }
 
 __global__ void ibgdaPutSignalWaitCounterBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    auto resolvedSignalBuf =
-        remoteSignalBuf.subBuffer(signalId * sizeof(uint64_t));
-    auto resolvedCounterBuf =
-        localCounterBuf.subBuffer(counterId * sizeof(uint64_t));
+    transport.reset_counter(counterId);
     uint64_t expected = 1;
 
     // Warmup - do a few iterations to warm up the path
     for (int i = 0; i < 10; i++) {
-      transport->put(
-          localBuf,
-          remoteBuf,
-          nbytes,
-          resolvedSignalBuf,
-          1,
-          resolvedCounterBuf,
-          1);
-      transport->wait_counter(resolvedCounterBuf, expected);
+      transport.put(localBuf, remoteBuf, nbytes, signalId, 1, counterId, 1);
+      transport.wait_counter(counterId, expected);
       expected++;
     }
 
@@ -203,15 +163,8 @@ __global__ void ibgdaPutSignalWaitCounterBatchKernel(
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      transport->put(
-          localBuf,
-          remoteBuf,
-          nbytes,
-          resolvedSignalBuf,
-          1,
-          resolvedCounterBuf,
-          1);
-      transport->wait_counter(resolvedCounterBuf, expected);
+      transport.put(localBuf, remoteBuf, nbytes, signalId, 1, counterId, 1);
+      transport.wait_counter(counterId, expected);
       expected++;
     }
 
@@ -221,7 +174,7 @@ __global__ void ibgdaPutSignalWaitCounterBatchKernel(
 }
 
 __global__ void ibgdaSignalOnlyBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
     int numIters,
@@ -233,16 +186,16 @@ __global__ void ibgdaSignalOnlyBatchKernel(
 
     // Warmup - do a few iterations to warm up the path
     for (int i = 0; i < 10; i++) {
-      transport->signal(resolvedSignalBuf, 1);
-      transport->flush();
+      transport.signal(resolvedSignalBuf, 1);
+      transport.flush();
     }
 
     // Timed iterations using GPU cycle counter
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      transport->signal(resolvedSignalBuf, 1);
-      transport->flush();
+      transport.signal(resolvedSignalBuf, 1);
+      transport.flush();
     }
 
     unsigned long long endCycle = BENCHMARK_CLOCK64();
@@ -250,11 +203,12 @@ __global__ void ibgdaSignalOnlyBatchKernel(
   }
 }
 
-// Multi-peer kernel implementations
+// Multi-peer kernel implementations. `transports[p]` is the handle for peer p;
+// it is copied to a local (a small trivially-copyable tagged-union handle) so
+// device calls dispatch on the backend tag regardless of method const-ness.
 
 __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     IbgdaLocalBuffer localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -266,13 +220,12 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
     unsigned long long* totalCycles) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    // Helper to index into transport array by byte stride
-    auto getTransport = [&](int peerIdx) -> P2pIbgdaTransportDevice* {
-      return reinterpret_cast<P2pIbgdaTransportDevice*>(
-          reinterpret_cast<char*>(transportsBase) + peerIdx * transportStride);
+    // Per-peer handle accessor (returns a copy of the handle for peer p).
+    auto T = [&](int peerIdx) -> P2pIbTransportDevice {
+      return transports[peerIdx];
     };
 
-    // Per-peer counter slot p; each companion QP increments its own slot.
+    // Per-peer counter slot p; each peer's completion increments its own slot.
     auto perPeerCounter = [&](int p) {
       return localCounterBuf.subBuffer(p * sizeof(uint64_t));
     };
@@ -282,7 +235,7 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
     // Warmup
     for (int i = 0; i < 10; i++) {
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->put(
+        T(p).put(
             localBuf,
             remoteDataBufs[p],
             nbytes,
@@ -293,7 +246,7 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
       }
       // O(N) waits — one wait_counter per peer
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->wait_counter(perPeerCounter(p), expected);
+        T(p).wait_counter(perPeerCounter(p), expected);
       }
       expected++;
     }
@@ -301,10 +254,10 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      // Fire put+signal+counter to all peers — each peer's companion QP
+      // Fire put+signal+counter to all peers — each peer's completion
       // increments its OWN per-peer counter slot
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->put(
+        T(p).put(
             localBuf,
             remoteDataBufs[p],
             nbytes,
@@ -315,7 +268,7 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
       }
       // O(N) waits — one wait_counter per peer
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->wait_counter(perPeerCounter(p), expected);
+        T(p).wait_counter(perPeerCounter(p), expected);
       }
       expected++;
     }
@@ -326,8 +279,7 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
 }
 
 __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     IbgdaLocalBuffer localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -340,9 +292,8 @@ __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
     unsigned long long* totalCycles) {
   auto group = make_block_group();
   if (group.is_global_leader()) {
-    auto getTransport = [&](int peerIdx) -> P2pIbgdaTransportDevice* {
-      return reinterpret_cast<P2pIbgdaTransportDevice*>(
-          reinterpret_cast<char*>(transportsBase) + peerIdx * transportStride);
+    auto T = [&](int peerIdx) -> P2pIbTransportDevice {
+      return transports[peerIdx];
     };
 
     auto resolvedCounterBuf =
@@ -352,7 +303,7 @@ __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
     // Warmup
     for (int i = 0; i < 10; i++) {
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->put(
+        T(p).put(
             localBuf,
             remoteDataBufs[p],
             nbytes,
@@ -361,19 +312,19 @@ __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
             resolvedCounterBuf,
             1);
       }
-      // Single wait — all numPeers companion QPs increment the same slot.
-      // Any transport works (counter buf is local); use peer 0.
-      getTransport(0)->wait_counter(resolvedCounterBuf, expected);
+      // Single wait — all numPeers completions increment the same slot.
+      // Any handle works (counter buf is local); use peer 0.
+      T(0).wait_counter(resolvedCounterBuf, expected);
       expected += numPeers;
     }
 
     unsigned long long startCycle = BENCHMARK_CLOCK64();
 
     for (int i = 0; i < numIters; i++) {
-      // Fire put+signal+counter to all peers — all companion QPs write to
-      // the SAME counter slot via loopback atomic fetch-add
+      // Fire put+signal+counter to all peers — all completions write to
+      // the SAME counter slot via fetch-add
       for (int p = 0; p < numPeers; p++) {
-        getTransport(p)->put(
+        T(p).put(
             localBuf,
             remoteDataBufs[p],
             nbytes,
@@ -383,7 +334,7 @@ __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
             1);
       }
       // O(1) wait — single counter wait until it reaches expected
-      getTransport(0)->wait_counter(resolvedCounterBuf, expected);
+      T(0).wait_counter(resolvedCounterBuf, expected);
       expected += numPeers;
     }
 
@@ -398,24 +349,15 @@ __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
 // put+signal+counter)
 
 void launchIbgdaPutSignalSingle(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     cudaStream_t stream) {
   ibgdaPutSignalWaitCounterKernel<<<1, 32, 0, stream>>>(
-      transport,
-      localBuf,
-      remoteBuf,
-      nbytes,
-      remoteSignalBuf,
-      signalId,
-      localCounterBuf,
-      counterId);
+      transport, localBuf, remoteBuf, nbytes, signalId, counterId);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(
@@ -426,28 +368,20 @@ void launchIbgdaPutSignalSingle(
 // Batched launchers for performance measurement
 
 void launchIbgdaPutWaitCounterBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles,
     cudaStream_t stream) {
   ibgdaPutWaitCounterBatchKernel<<<1, 32, 0, stream>>>(
-      transport,
-      localBuf,
-      remoteBuf,
-      nbytes,
-      localCounterBuf,
-      counterId,
-      numIters,
-      totalCycles);
+      transport, localBuf, remoteBuf, nbytes, counterId, numIters, totalCycles);
 }
 
 void launchIbgdaPutFlushBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
@@ -482,13 +416,11 @@ void launchIbgdaThreadScopeMultiBlockPutFlushBatch(
 }
 
 void launchIbgdaPutSignalWaitCounterBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles,
@@ -498,16 +430,14 @@ void launchIbgdaPutSignalWaitCounterBatch(
       localBuf,
       remoteBuf,
       nbytes,
-      remoteSignalBuf,
       signalId,
-      localCounterBuf,
       counterId,
       numIters,
       totalCycles);
 }
 
 void launchIbgdaSignalOnlyBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
     int numIters,
@@ -518,8 +448,7 @@ void launchIbgdaSignalOnlyBatch(
 }
 
 void launchMultiPeerSerialCounterFanOutBatch(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -531,8 +460,7 @@ void launchMultiPeerSerialCounterFanOutBatch(
     unsigned long long* totalCycles,
     cudaStream_t stream) {
   ibgdaMultiPeerSerialCounterFanOutBatchKernel<<<1, 32, 0, stream>>>(
-      transportsBase,
-      transportStride,
+      transports,
       numPeers,
       localBuf,
       remoteDataBufs,
@@ -550,8 +478,7 @@ void launchMultiPeerSerialCounterFanOutBatch(
 }
 
 void launchMultiPeerCounterFanOutBatch(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -564,8 +491,7 @@ void launchMultiPeerCounterFanOutBatch(
     unsigned long long* totalCycles,
     cudaStream_t stream) {
   ibgdaMultiPeerCounterFanOutBatchKernel<<<1, 32, 0, stream>>>(
-      transportsBase,
-      transportStride,
+      transports,
       numPeers,
       localBuf,
       remoteDataBufs,

--- a/comms/prims/benchmarks/IbgdaBenchmark.cuh
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cuh
@@ -5,44 +5,45 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 // Include host-safe header for the public API
 #include "comms/prims/benchmarks/IbgdaBenchmark.h"
 
 namespace comms::prims::benchmark {
 
-// Internal kernel declarations - only visible to CUDA compilation units
+// Internal kernel declarations - only visible to CUDA compilation units.
+//
+// Kernels take the backend-agnostic P2pIbTransportDevice handle by value so the
+// same kernel runs over either IBGDA (GPU-initiated) or IBRC (CPU-proxy); the
+// handle dispatches each device call on its embedded backend tag.
 
 __global__ void ibgdaPutSignalWaitCounterKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId);
 
 __global__ void ibgdaPutWaitCounterKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes);
 
 __global__ void ibgdaPutWaitCounterBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles);
 
 __global__ void ibgdaPutFlushBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
@@ -58,29 +59,31 @@ __global__ void ibgdaThreadScopeMultiBlockPutFlushBatchKernel(
     unsigned long long* blockCycles);
 
 __global__ void ibgdaPutSignalWaitCounterBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaLocalBuffer localBuf,
     IbgdaRemoteBuffer remoteBuf,
     std::size_t nbytes,
-    IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
-    IbgdaLocalBuffer localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles);
 
 __global__ void ibgdaSignalOnlyBatchKernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     IbgdaRemoteBuffer remoteSignalBuf,
     int signalId,
     int numIters,
     unsigned long long* totalCycles);
 
-// Multi-peer kernels for counter fan-out validation
+// Multi-peer kernels for counter fan-out validation.
+//
+// `transports` is a contiguous device array of one P2pIbTransportDevice handle
+// per peer (peer p at index p). This replaces the IBGDA-only
+// getDeviceTransportPtr()+stride layout so the multi-peer path works for both
+// backends (IBRC exposes only per-peer getP2pTransportDevice()).
 
 __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     IbgdaLocalBuffer localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -92,8 +95,7 @@ __global__ void ibgdaMultiPeerSerialCounterFanOutBatchKernel(
     unsigned long long* totalCycles);
 
 __global__ void ibgdaMultiPeerCounterFanOutBatchKernel(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     IbgdaLocalBuffer localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,

--- a/comms/prims/benchmarks/IbgdaBenchmark.h
+++ b/comms/prims/benchmarks/IbgdaBenchmark.h
@@ -5,14 +5,17 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
-namespace comms::prims {
-// Forward declaration
-class P2pIbgdaTransportDevice;
-} // namespace comms::prims
-
 namespace comms::prims::benchmark {
+
+inline constexpr int kIbgdaCounterWarmupIters = 10;
+
+// All launchers take the backend-agnostic P2pIbTransportDevice handle (by value
+// for single-peer, as a contiguous device array for multi-peer) so the same
+// benchmark drives either IBGDA (GPU-initiated) or IBRC (CPU-proxy). The handle
+// dispatches each device call on its embedded backend tag.
 
 /**
  * Single-shot launchers for correctness verification.
@@ -20,22 +23,20 @@ namespace comms::prims::benchmark {
  * counter slot. No warmup, no loop.
  */
 void launchIbgdaPutSignalSingle(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     cudaStream_t stream);
 
 /**
  * Launch batched kernel: Multiple put + counter iterations
  *
- * Counter-only put (no peer signal): companion-QP loopback atomically
- * increments the local counter when the put completes at the NIC. GPU spins
- * on the local counter slot.
+ * Counter-only put (no peer signal): the put completion increments the local
+ * counter (IBGDA companion-QP loopback; IBRC CPU proxy). GPU spins on the local
+ * counter slot.
  *
  * Avoids per-operation kernel launch overhead and uses GPU cycle counters
  * for accurate timing of raw RDMA operations.
@@ -43,11 +44,10 @@ void launchIbgdaPutSignalSingle(
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
 void launchIbgdaPutWaitCounterBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles,
@@ -62,7 +62,7 @@ void launchIbgdaPutWaitCounterBatch(
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
 void launchIbgdaPutFlushBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
@@ -93,19 +93,17 @@ void launchIbgdaThreadScopeMultiBlockPutFlushBatch(
 /**
  * Launch batched kernel: Multiple put + signal + counter iterations
  *
- * Companion-QP loopback atomically increments the local counter when the
- * put+signal completes at the NIC. GPU spins on the local counter slot.
+ * The put+signal completion increments the local counter (IBGDA companion-QP
+ * loopback; IBRC CPU proxy). GPU spins on the local counter slot.
  *
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
 void launchIbgdaPutSignalWaitCounterBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer& remoteBuf,
     std::size_t nbytes,
-    const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
-    const IbgdaLocalBuffer& localCounterBuf,
     int counterId,
     int numIters,
     unsigned long long* totalCycles,
@@ -114,13 +112,13 @@ void launchIbgdaPutSignalWaitCounterBatch(
 /**
  * Launch batched kernel: Multiple signal-only iterations
  *
- * Signal-only path uses fence() for completion (no counter primitive applies
+ * Signal-only path uses flush() for completion (no counter primitive applies
  * to signal-only ops).
  *
  * @param totalCycles Output: total GPU cycles for numIters operations
  */
 void launchIbgdaSignalOnlyBatch(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     const IbgdaRemoteBuffer& remoteSignalBuf,
     int signalId,
     int numIters,
@@ -135,13 +133,13 @@ void launchIbgdaSignalOnlyBatch(
  * Launch multi-peer serial counter fan-out: put+signal+counter to each peer
  * with a per-peer counter slot, then wait_counter on each slot serially.
  *
- * O(N) wait_counter calls (one per peer, each peer's companion QP increments
- * its own counter slot). This is the per-peer baseline for comparison against
- * the shared-counter fan-out path (launchMultiPeerCounterFanOutBatch), which
+ * O(N) wait_counter calls (one per peer, each peer's completion increments its
+ * own counter slot). This is the per-peer baseline for comparison against the
+ * shared-counter fan-out path (launchMultiPeerCounterFanOutBatch), which
  * collapses the N waits into a single wait on a shared slot.
  *
- * @param transportsBase Base pointer to P2pIbgdaTransportDevice array (GPU mem)
- * @param transportStride Byte stride between consecutive transports
+ * @param transports Device array of per-peer P2pIbTransportDevice handles
+ *                   (index p == peer p)
  * @param numPeers Number of peers
  * @param localBuf Source data buffer (same for all peers)
  * @param remoteDataBufs Device array of per-peer remote data buffers
@@ -149,13 +147,12 @@ void launchIbgdaSignalOnlyBatch(
  * @param remoteSignalBufs Device array of per-peer remote signal buffers
  * @param signalId Signal slot index
  * @param localCounterBuf Local counter buffer with at least numPeers slots;
- *                        slot p is used by peer p's companion QP
+ *                        slot p is used by peer p's completion
  * @param numIters Batch iterations
  * @param totalCycles Output: total GPU cycles
  */
 void launchMultiPeerSerialCounterFanOutBatch(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,
@@ -171,26 +168,25 @@ void launchMultiPeerSerialCounterFanOutBatch(
  * Launch multi-peer counter fan-out kernel: put+signal+counter to all peers,
  * single counter poll
  *
- * GPU thread fires put() with signal+counter to all peers (each companion
- * QP atomically increments the SAME counter slot), then polls one counter
- * value until it reaches numPeers. Total wait ≈ max(peer latency) + loopback.
+ * GPU thread fires put() with signal+counter to all peers (each peer's
+ * completion increments the SAME counter slot), then polls one counter value
+ * until it reaches numPeers. Total wait ≈ max(peer latency) + loopback.
  *
- * @param transportsBase Base pointer to P2pIbgdaTransportDevice array (GPU mem)
- * @param transportStride Byte stride between consecutive transports
+ * @param transports Device array of per-peer P2pIbTransportDevice handles
+ *                   (index p == peer p)
  * @param numPeers Number of peers
  * @param localBuf Source data buffer (same for all peers)
  * @param remoteDataBufs Device array of per-peer remote data buffers
  * @param nbytes Data size per peer
  * @param remoteSignalBufs Device array of per-peer remote signal buffers
  * @param signalId Signal slot index
- * @param localCounterBuf Local counter buffer (shared by all companion QPs)
+ * @param localCounterBuf Local counter buffer (shared by all peers)
  * @param counterId Counter slot index
  * @param numIters Batch iterations
  * @param totalCycles Output: total GPU cycles
  */
 void launchMultiPeerCounterFanOutBatch(
-    P2pIbgdaTransportDevice* transportsBase,
-    std::size_t transportStride,
+    const P2pIbTransportDevice* transports,
     int numPeers,
     const IbgdaLocalBuffer& localBuf,
     const IbgdaRemoteBuffer* remoteDataBufs,

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -1,0 +1,148 @@
+# IBRC Benchmark Results
+
+Run date: 2026-06-16
+
+Hosts used: `rtptest2330.nha6`, `rtptest2334.nha6`
+
+Launcher:
+
+```bash
+python3 comms/testinfra/ncclx_test_launcher.py \
+  --launcher mpi \
+  --nnode 2 \
+  --ppn 1 \
+  --hosts rtptest2330.nha6,rtptest2334.nha6 \
+  --ifname eth1 \
+  --env 'NCCL_DEBUG=WARN' \
+  --testname /home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/065941cadf27ce30/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
+```
+
+The initially suggested hosts, `rtptest2347.nha6` and `rtptest2346.nha6`, were not usable for this run because CUDA context creation failed with `CUDA-capable device(s) is/are busy or unavailable`. The results below use the clean GB200 pair listed above.
+
+## Current Counter-Slot Results
+
+These results are after switching the counter benchmarks from explicit counter buffers to the transport-owned counter-slot API. IBRC `PutWaitCounter`, `PutSignalWaitCounter`, and `PutSignalComparison` pass with this path.
+
+Current logs:
+
+| Run | Log |
+| --- | --- |
+| Expanded sweep through 1GB | `/tmp/ibrc_1gb_sweep.log` |
+| IBRC counter-slot retest | `/tmp/ibrc_counter_slot_tests.log` |
+| IBGDA counter-slot retest | `/tmp/ibgda_counter_slot_tests.log` |
+
+Summary:
+
+| Benchmark | IBGDA | IBRC |
+| --- | ---: | ---: |
+| `PutFlush`, 1GB | 22202.67 us, 48.36 GB/s | 23039.32 us, 46.60 GB/s |
+| `PutWaitCounter`, 1GB | 22209.76 us, 48.35 GB/s | 22987.54 us, 46.71 GB/s |
+| `PutSignalWaitCounter`, 1GB | 22210.01 us, 48.34 GB/s | 22943.53 us, 46.80 GB/s |
+| `PutSignalComparison`, 16MB | 368.99 us | 704.07 us |
+| `MultiPeerCounterFanOut`, 64KB per peer | Not rerun in current retest | N/A: explicit shared-counter-buffer benchmark |
+
+## PutWaitCounter
+
+| Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
+| --- | ---: | ---: | ---: | ---: |
+| 8B | 21.27 | 0.00 | 38.28 | 0.00 |
+| 64B | 23.02 | 0.00 | 38.27 | 0.00 |
+| 256B | 23.07 | 0.01 | 38.26 | 0.01 |
+| 1KB | 23.17 | 0.04 | 38.25 | 0.03 |
+| 4KB | 23.48 | 0.17 | 38.31 | 0.11 |
+| 8KB | 23.71 | 0.35 | 38.29 | 0.21 |
+| 16KB | 23.95 | 0.68 | 42.00 | 0.39 |
+| 32KB | 24.43 | 1.34 | 43.70 | 0.75 |
+| 64KB | 25.10 | 2.61 | 44.16 | 1.48 |
+| 128KB | 27.32 | 4.80 | 49.02 | 2.67 |
+| 256KB | 30.02 | 8.73 | 52.46 | 5.00 |
+| 512KB | 35.44 | 14.79 | 65.69 | 7.98 |
+| 1MB | 46.23 | 22.68 | 86.75 | 12.09 |
+| 2MB | 67.83 | 30.92 | 129.09 | 16.25 |
+| 4MB | 110.97 | 37.80 | 216.09 | 19.41 |
+| 8MB | 197.30 | 42.52 | 384.12 | 21.84 |
+| 16MB | 369.71 | 45.38 | 695.64 | 24.12 |
+| 32MB | 714.95 | 46.93 | 1271.31 | 26.39 |
+| 64MB | 1405.48 | 47.75 | 2322.96 | 28.89 |
+| 128MB | 2787.44 | 48.15 | 3521.63 | 38.11 |
+| 256MB | 5572.73 | 48.17 | 6944.67 | 38.65 |
+| 512MB | 11118.86 | 48.28 | 13613.28 | 39.44 |
+| 1GB | 22209.76 | 48.35 | 22987.54 | 46.71 |
+
+## PutSignalWaitCounter
+
+| Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
+| --- | ---: | ---: | ---: | ---: |
+| 8B | 22.05 | 0.00 | 65.29 | 0.00 |
+| 64B | 23.09 | 0.00 | 65.33 | 0.00 |
+| 256B | 23.22 | 0.01 | 64.58 | 0.00 |
+| 1KB | 23.35 | 0.04 | 65.23 | 0.02 |
+| 4KB | 23.68 | 0.17 | 65.67 | 0.06 |
+| 8KB | 23.94 | 0.34 | 64.94 | 0.13 |
+| 16KB | 24.18 | 0.68 | 64.80 | 0.25 |
+| 32KB | 24.55 | 1.33 | 64.63 | 0.51 |
+| 64KB | 25.24 | 2.60 | 65.06 | 1.01 |
+| 128KB | 27.41 | 4.78 | 72.07 | 1.82 |
+| 256KB | 30.24 | 8.67 | 78.78 | 3.33 |
+| 512KB | 35.43 | 14.80 | 87.25 | 6.01 |
+| 1MB | 46.14 | 22.72 | 111.76 | 9.38 |
+| 2MB | 67.67 | 30.99 | 149.81 | 14.00 |
+| 4MB | 110.66 | 37.90 | 237.82 | 17.64 |
+| 8MB | 196.82 | 42.62 | 406.69 | 20.63 |
+| 16MB | 369.59 | 45.39 | 731.31 | 22.94 |
+| 32MB | 714.92 | 46.93 | 1281.58 | 26.18 |
+| 64MB | 1405.51 | 47.75 | 2324.56 | 28.87 |
+| 128MB | 2787.41 | 48.15 | 3527.65 | 38.05 |
+| 256MB | 5573.03 | 48.17 | 6940.11 | 38.68 |
+| 512MB | 11119.03 | 48.28 | 13555.27 | 39.61 |
+| 1GB | 22210.01 | 48.34 | 22943.53 | 46.80 |
+
+## PutSignalComparison
+
+| Size | IBGDA Counter Latency (us) | IBRC Counter Latency (us) |
+| --- | ---: | ---: |
+| 8B | 21.48 | 64.89 |
+| 64B | 22.26 | 64.81 |
+| 1KB | 22.54 | 64.01 |
+| 64KB | 24.50 | 65.44 |
+| 1MB | 45.78 | 111.09 |
+| 16MB | 368.99 | 704.07 |
+
+## PutFlush Baseline
+
+`PutFlush` completed for both backends. This path does not use the counter API.
+
+| Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
+| --- | ---: | ---: | ---: | ---: |
+| 8B | 16.89 | 0.00 | 38.64 | 0.00 |
+| 64B | 17.17 | 0.00 | 39.58 | 0.00 |
+| 256B | 17.25 | 0.01 | 38.55 | 0.01 |
+| 1KB | 17.35 | 0.06 | 38.55 | 0.03 |
+| 4KB | 17.67 | 0.23 | 38.54 | 0.11 |
+| 8KB | 17.79 | 0.46 | 38.53 | 0.21 |
+| 16KB | 18.10 | 0.90 | 39.22 | 0.42 |
+| 32KB | 18.47 | 1.77 | 38.60 | 0.85 |
+| 64KB | 19.15 | 3.42 | 43.39 | 1.51 |
+| 128KB | 21.39 | 6.13 | 44.10 | 2.97 |
+| 256KB | 24.09 | 10.88 | 50.02 | 5.24 |
+| 512KB | 29.48 | 17.78 | 61.50 | 8.52 |
+| 1MB | 40.28 | 26.03 | 83.85 | 12.51 |
+| 2MB | 61.86 | 33.90 | 127.60 | 16.44 |
+| 4MB | 105.03 | 39.94 | 207.77 | 20.19 |
+| 8MB | 191.35 | 43.84 | 375.71 | 22.33 |
+| 16MB | 364.00 | 46.09 | 695.80 | 24.11 |
+| 32MB | 709.30 | 47.31 | 1280.02 | 26.21 |
+| 64MB | 1399.92 | 47.94 | 2269.87 | 29.57 |
+| 128MB | 2782.83 | 48.23 | 3535.06 | 37.97 |
+| 256MB | 5566.01 | 48.23 | 6928.67 | 38.74 |
+| 512MB | 11111.88 | 48.32 | 13582.13 | 39.53 |
+| 1GB | 22202.67 | 48.36 | 23039.32 | 46.60 |
+
+## SignalOnly Baseline
+
+`SignalOnly` completed for both backends. This path does not use the counter API.
+
+| Metric | IBGDA | IBRC |
+| --- | ---: | ---: |
+| Average latency (us) | 17.75 | 40.90 |
+| Batch iterations | 1000 | 1000 |

--- a/comms/prims/collectives/Ring.cuh
+++ b/comms/prims/collectives/Ring.cuh
@@ -4,15 +4,15 @@
 
 #include <cstddef>
 
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 
 namespace comms::prims {
 
 struct RingTopology {
   int prev_rank{0};
   int next_rank{0};
-  P2pIbgdaTransportDevice* prev{nullptr};
-  P2pIbgdaTransportDevice* next{nullptr};
+  P2pIbTransportDevice prev{};
+  P2pIbTransportDevice next{};
 };
 
 template <int NumRings>

--- a/comms/prims/collectives/RingAllgather.cu
+++ b/comms/prims/collectives/RingAllgather.cu
@@ -18,8 +18,8 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_allgather_kernel(
   auto group = make_block_group();
   auto [ring_id, ring_group] = group.partition(NumRings);
   const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
+  auto prev = topo.prev;
+  auto next = topo.next;
 
   const int W = args.num_ranks;
   const std::size_t chunk_bytes = args.sendcount;

--- a/comms/prims/collectives/RingAllgatherLauncher.h
+++ b/comms/prims/collectives/RingAllgatherLauncher.h
@@ -4,9 +4,9 @@
 
 #include <cstddef>
 
-namespace comms::prims {
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
-class P2pIbgdaTransportDevice;
+namespace comms::prims {
 
 struct RingAllgatherLaunchParams {
   int my_rank{0};
@@ -22,8 +22,8 @@ struct RingAllgatherLaunchParams {
   struct RingParams {
     int prev_rank{0};
     int next_rank{0};
-    P2pIbgdaTransportDevice* prev{nullptr};
-    P2pIbgdaTransportDevice* next{nullptr};
+    P2pIbTransportDevice prev{};
+    P2pIbTransportDevice next{};
   };
   static constexpr int kMaxRings = 4;
   RingParams rings[kMaxRings]{};

--- a/comms/prims/collectives/RingReduceScatter.cu
+++ b/comms/prims/collectives/RingReduceScatter.cu
@@ -23,8 +23,8 @@ __global__ __launch_bounds__(kBlockSize, 1) void ring_reduce_scatter_kernel(
   auto group = make_block_group();
   auto [ring_id, ring_group] = group.partition(NumRings);
   const auto& topo = args.rings[ring_id];
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
+  auto prev = topo.prev;
+  auto next = topo.next;
 
   const int W = args.num_ranks;
   const std::size_t chunk_elems = args.chunk_elements;

--- a/comms/prims/collectives/RingReduceScatterLauncher.h
+++ b/comms/prims/collectives/RingReduceScatterLauncher.h
@@ -4,9 +4,9 @@
 
 #include <cstddef>
 
-namespace comms::prims {
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
-class P2pIbgdaTransportDevice;
+namespace comms::prims {
 
 struct RingReduceScatterLaunchParams {
   int my_rank{0};
@@ -22,8 +22,8 @@ struct RingReduceScatterLaunchParams {
   struct RingParams {
     int prev_rank{0};
     int next_rank{0};
-    P2pIbgdaTransportDevice* prev{nullptr};
-    P2pIbgdaTransportDevice* next{nullptr};
+    P2pIbTransportDevice prev{};
+    P2pIbTransportDevice next{};
   };
   static constexpr int kMaxRings = 4;
   RingParams rings[kMaxRings]{};

--- a/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingAllGatherBenchmark.cc
@@ -1,10 +1,12 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
+#include <glog/logging.h>
 #include <nccl.h>
 
-#include <algorithm>
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -13,6 +15,7 @@
 #include "comms/prims/collectives/RingAllgatherLauncher.h"
 #include "comms/prims/collectives/RingUtils.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 #include "comms/testinfra/BenchmarkTestFixture.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -30,6 +33,7 @@ struct RingAllGatherBenchmarkConfig {
   std::size_t data_buffer_size;
   int pipeline_depth;
   int num_qps;
+  bool use_ibrc{false};
   std::string name;
 };
 
@@ -38,10 +42,10 @@ struct RingAllGatherBenchmarkResult {
   std::size_t sendcount{};
   std::size_t total_bytes{};
   int num_rings{};
-  float nccl_bandwidth{};
-  float ring_bandwidth{};
-  float nccl_latency{};
-  float ring_latency{};
+  float baseline_bandwidth{};
+  float candidate_bandwidth{};
+  float baseline_latency{};
+  float candidate_latency{};
   float speedup{};
 };
 
@@ -52,13 +56,10 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     setenv("NCCL_P2P_DISABLE", "1", 1);
-    NCCL_CHECK_VOID(
-        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
-    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
     BenchmarkTestFixture::TearDown();
   }
@@ -96,6 +97,16 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
     CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
 
+    ncclComm_t nccl_comm{};
+    NCCL_CHECK(
+        ncclCommInitRank(&nccl_comm, worldSize, get_nccl_id(), globalRank));
+    auto ncclCommGuard = folly::makeGuard([&] {
+      const ncclResult_t res = ncclCommDestroy(nccl_comm);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+      }
+    });
+
     CudaEvent start, stop;
     const int n_warmup = 5;
     const int n_iter = 100;
@@ -107,7 +118,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           recv_buf.get(),
           config.sendcount,
           ncclChar,
-          nccl_comm_,
+          nccl_comm,
           stream_));
     }
 
@@ -118,7 +129,7 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
           recv_buf.get(),
           config.sendcount,
           ncclChar,
-          nccl_comm_,
+          nccl_comm,
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
@@ -144,27 +155,39 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     CUDA_CHECK(cudaMemset(send_buf.get(), 1, config.sendcount));
     CUDA_CHECK(cudaMemset(recv_buf.get(), 0, recvcount));
 
-    std::unique_ptr<MultipeerIbgdaTransport> transport;
-    try {
-      const int maxGroups = config.num_blocks * config.num_rings;
-      MultipeerIbgdaTransportConfig transport_config{
-          .cudaDevice = localRank,
-          .dataBufferSize = config.data_buffer_size,
-          .maxGroups = maxGroups,
-          .sendRecv =
-              MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .pipelineDepth = config.pipeline_depth,
-              },
-          .qpsPerBlockPerNic = config.num_qps,
-      };
-      transport = std::make_unique<MultipeerIbgdaTransport>(
+    const int maxGroups = config.num_blocks * config.num_rings;
+    MultipeerIbgdaTransportConfig transport_config{
+        .cudaDevice = localRank,
+        .dataBufferSize = config.data_buffer_size,
+        .maxGroups = maxGroups,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .pipelineDepth = config.pipeline_depth,
+            },
+        .qpsPerBlockPerNic = config.num_qps,
+    };
+
+    if (config.use_ibrc) {
+      MultipeerIbrcTransport transport(
           globalRank, worldSize, bootstrap, transport_config);
-      transport->exchange();
-    } catch (const std::exception& e) {
-      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
-      latency_us = 0.0f;
-      return 0.0f;
+      return run_ring_benchmark_with_transport(
+          config, send_buf, recv_buf, recvcount, latency_us, transport);
     }
+    MultipeerIbgdaTransport transport(
+        globalRank, worldSize, bootstrap, transport_config);
+    return run_ring_benchmark_with_transport(
+        config, send_buf, recv_buf, recvcount, latency_us, transport);
+  }
+
+  template <typename Transport>
+  float run_ring_benchmark_with_transport(
+      const RingAllGatherBenchmarkConfig& config,
+      DeviceBuffer& send_buf,
+      DeviceBuffer& recv_buf,
+      std::size_t recvcount,
+      float& latency_us,
+      Transport& transport) {
+    transport.exchange();
 
     auto rings_opt =
         make_standard_rings(worldSize, globalRank, config.num_rings);
@@ -192,14 +215,16 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       auto& rp = launch_params.rings[r];
       rp.prev_rank = rings[r].prev_rank;
       rp.next_rank = rings[r].next_rank;
-      transport->queuePeerForMaterialization(rp.prev_rank);
-      transport->queuePeerForMaterialization(rp.next_rank);
+      transport.queuePeerForMaterialization(rp.prev_rank);
+      transport.queuePeerForMaterialization(rp.next_rank);
     }
-    transport->connectPeers();
+    transport.connectPeers();
     for (int r = 0; r < config.num_rings; r++) {
       auto& rp = launch_params.rings[r];
-      rp.prev = transport->getP2pTransportDevice(rp.prev_rank);
-      rp.next = transport->getP2pTransportDevice(rp.next_rank);
+      rp.prev =
+          P2pIbTransportDevice(transport.getP2pTransportDevice(rp.prev_rank));
+      rp.next =
+          P2pIbTransportDevice(transport.getP2pTransportDevice(rp.next_rank));
     }
 
     CudaEvent start, stop;
@@ -230,7 +255,10 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     return bw;
   }
 
-  void print_results(const std::vector<RingAllGatherBenchmarkResult>& results) {
+  void print_results(
+      const std::vector<RingAllGatherBenchmarkResult>& results,
+      const char* baselineLabel,
+      const char* candidateLabel) {
     if (globalRank != 0) {
       return;
     }
@@ -248,17 +276,27 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
       return std::to_string(bytes) + "B";
     };
 
+    auto fmt_float = [](float value, int precision) -> std::string {
+      if (value <= 0.0f) {
+        return "n/a";
+      }
+      std::stringstream value_ss;
+      value_ss << std::fixed << std::setprecision(precision) << value;
+      return value_ss.str();
+    };
+
     std::stringstream ss;
     ss << "\n";
     ss << "================================================================================\n";
-    ss << "           NCCL AllGather vs Ring AllGather (IBGDA) Benchmark\n";
+    ss << "             Ring AllGather Benchmark (" << candidateLabel << " vs "
+       << baselineLabel << ")\n";
     ss << "================================================================================\n";
     ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
        << "Size" << std::right << std::setw(6) << "Rings" << std::right
-       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
-       << std::right << std::setw(10) << "Speedup" << std::right
-       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
-       << "Ring Lat\n";
+       << std::setw(10) << baselineLabel << std::right << std::setw(10)
+       << candidateLabel << std::right << std::setw(10) << "Speedup"
+       << std::right << std::setw(12) << "Base Lat" << std::right
+       << std::setw(12) << "Cand Lat\n";
     ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
        << std::right << std::setw(6) << "" << std::right << std::setw(10)
        << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
@@ -268,15 +306,14 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
 
     for (const auto& r : results) {
       ss << std::left << std::setw(14) << r.test_name << std::right
-         << std::setw(10) << fmt_bytes(r.sendcount) << std::right
+         << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
          << std::setw(6) << r.num_rings << std::right << std::setw(10)
-         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
-         << std::setw(10) << std::fixed << std::setprecision(2)
-         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.speedup << "x" << std::right
-         << std::setw(12) << std::fixed << std::setprecision(1)
-         << r.nccl_latency << std::right << std::setw(12) << std::fixed
-         << std::setprecision(1) << r.ring_latency << "\n";
+         << fmt_float(r.baseline_bandwidth, 2) << std::right << std::setw(10)
+         << fmt_float(r.candidate_bandwidth, 2) << std::right << std::setw(10)
+         << (r.speedup > 0.0f ? fmt_float(r.speedup, 2) + "x" : "n/a")
+         << std::right << std::setw(12) << fmt_float(r.baseline_latency, 1)
+         << std::right << std::setw(12) << fmt_float(r.candidate_latency, 1)
+         << "\n";
     }
 
     ss << "================================================================================\n";
@@ -286,131 +323,183 @@ class RingAllGatherBenchmarkFixture : public meta::comms::BenchmarkTestFixture {
     XLOG(INFO) << ss.str();
   }
 
-  ncclComm_t nccl_comm_{};
+  std::vector<RingAllGatherBenchmarkConfig> make_benchmark_configs(
+      bool useIbrc) {
+    // Matched config for a fair IBRC-vs-IBGDA comparison: same QP count and
+    // staging buffer size for both backends.
+    std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+    int kNumQps = 4;
+
+    auto configs = std::vector<RingAllGatherBenchmarkConfig>{
+        {.sendcount = 256 * 1024,
+         .num_blocks = 8,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256K_8B"},
+        {.sendcount = 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "1M_16B"},
+        {.sendcount = 4 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "4M_16B"},
+        {.sendcount = 16 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "16M_16B"},
+        {.sendcount = 64 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "64M_16B"},
+        {.sendcount = 128 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "128M_16B"},
+        {.sendcount = 256 * 1024 * 1024,
+         .num_blocks = 32,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256M_32B"},
+        {.sendcount = 512UL * 1024 * 1024,
+         .num_blocks = 32,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "512M_32B"},
+        {.sendcount = 4 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "4M_16B_2R"},
+        {.sendcount = 16 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "16M_16B_2R"},
+        {.sendcount = 64 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "64M_16B_2R"},
+        {.sendcount = 256 * 1024 * 1024,
+         .num_blocks = 32,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256M_32B_2R"},
+    };
+    for (auto& config : configs) {
+      config.use_ibrc = useIbrc;
+    }
+    return configs;
+  }
+
+  RingAllGatherBenchmarkResult make_benchmark_result(
+      const RingAllGatherBenchmarkConfig& config,
+      float baselineBw,
+      float baselineLatencyUs,
+      float candidateBw,
+      float candidateLatencyUs) {
+    return {
+        .test_name = config.name,
+        .sendcount = config.sendcount,
+        .total_bytes = config.sendcount * static_cast<std::size_t>(worldSize),
+        .num_rings = config.num_rings,
+        .baseline_bandwidth = baselineBw,
+        .candidate_bandwidth = candidateBw,
+        .baseline_latency = baselineLatencyUs,
+        .candidate_latency = candidateLatencyUs,
+        .speedup = (baselineBw > 0) ? candidateBw / baselineBw : 0.0f,
+    };
+  }
+
+  void run_ibgda_vs_nccl_benchmark_suite() {
+    if (globalRank == 0) {
+      XLOG(INFO) << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
+    }
+
+    std::vector<RingAllGatherBenchmarkResult> results;
+    for (const auto& config : make_benchmark_configs(false)) {
+      float ncclLatencyUs = 0.0f;
+      float ncclBw = run_nccl_benchmark(config, ncclLatencyUs);
+      float ringLatencyUs = 0.0f;
+      float ringBw = run_ring_benchmark(config, ringLatencyUs);
+      if (globalRank == 0) {
+        results.push_back(make_benchmark_result(
+            config, ncclBw, ncclLatencyUs, ringBw, ringLatencyUs));
+      }
+      bootstrap->barrierAll();
+    }
+
+    print_results(results, "NCCL", "IBGDA");
+  }
+
+  void run_ibrc_vs_ibgda_benchmark_suite() {
+    if (globalRank == 0) {
+      XLOG(INFO) << "\n=== Ring AllGather (IBRC) vs IBGDA Comparison ===\n";
+    }
+
+    std::vector<RingAllGatherBenchmarkResult> results;
+    auto ibgdaConfigs = make_benchmark_configs(false);
+    auto ibrcConfigs = make_benchmark_configs(true);
+    CHECK_EQ(ibgdaConfigs.size(), ibrcConfigs.size());
+    for (std::size_t i = 0; i < ibrcConfigs.size(); ++i) {
+      const auto& ibgdaConfig = ibgdaConfigs.at(i);
+      const auto& ibrcConfig = ibrcConfigs.at(i);
+
+      float ibgdaLatencyUs = 0.0f;
+      float ibgdaBw = run_ring_benchmark(ibgdaConfig, ibgdaLatencyUs);
+
+      float ibrcLatencyUs = 0.0f;
+      float ibrcBw = run_ring_benchmark(ibrcConfig, ibrcLatencyUs);
+
+      if (globalRank == 0) {
+        results.push_back(make_benchmark_result(
+            ibrcConfig, ibgdaBw, ibgdaLatencyUs, ibrcBw, ibrcLatencyUs));
+      }
+      bootstrap->barrierAll();
+    }
+
+    print_results(results, "IBGDA", "IBRC");
+  }
+
   cudaStream_t stream_{};
 };
 
 TEST_F(RingAllGatherBenchmarkFixture, VsNccl) {
-  if (globalRank == 0) {
-    XLOG(INFO) << "\n=== Ring AllGather (IBGDA) vs NCCL Comparison ===\n";
-  }
+  run_ibgda_vs_nccl_benchmark_suite();
+}
 
-  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
-  int kNumQps = 4;
-
-  std::vector<RingAllGatherBenchmarkConfig> configs = {
-      {.sendcount = 256 * 1024,
-       .num_blocks = 8,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256K_8B"},
-      {.sendcount = 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "1M_16B"},
-      {.sendcount = 4 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4M_16B"},
-      {.sendcount = 16 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "16M_16B"},
-      {.sendcount = 64 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "64M_16B"},
-      {.sendcount = 128 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "128M_16B"},
-      {.sendcount = 256 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256M_32B"},
-      {.sendcount = 512UL * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "512M_32B"},
-      {.sendcount = 4 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4M_16B_2R"},
-      {.sendcount = 16 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "16M_16B_2R"},
-      {.sendcount = 64 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "64M_16B_2R"},
-      {.sendcount = 256 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256M_32B_2R"},
-  };
-
-  std::vector<RingAllGatherBenchmarkResult> results;
-
-  for (const auto& config : configs) {
-    float nccl_lat = 0.0f;
-    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
-
-    float ring_lat = 0.0f;
-    float ring_bw = run_ring_benchmark(config, ring_lat);
-
-    if (globalRank == 0) {
-      results.push_back({
-          .test_name = config.name,
-          .sendcount = config.sendcount,
-          .total_bytes = config.sendcount * static_cast<std::size_t>(worldSize),
-          .num_rings = config.num_rings,
-          .nccl_bandwidth = nccl_bw,
-          .ring_bandwidth = ring_bw,
-          .nccl_latency = nccl_lat,
-          .ring_latency = ring_lat,
-          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
-      });
-    }
-    bootstrap->barrierAll();
-  }
-
-  print_results(results);
+TEST_F(RingAllGatherBenchmarkFixture, IbrcVsIbgda) {
+  run_ibrc_vs_ibgda_benchmark_suite();
 }
 
 } // namespace

--- a/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -1,10 +1,12 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <folly/ScopeGuard.h>
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
+#include <glog/logging.h>
 #include <nccl.h>
 
-#include <algorithm>
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 #include <vector>
@@ -13,6 +15,7 @@
 #include "comms/prims/collectives/RingReduceScatterLauncher.h"
 #include "comms/prims/collectives/RingUtils.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 #include "comms/testinfra/BenchmarkTestFixture.h"
 #include "comms/utils/CudaRAII.h"
 
@@ -30,6 +33,7 @@ struct RingReduceScatterBenchmarkConfig {
   std::size_t data_buffer_size;
   int pipeline_depth;
   int num_qps;
+  bool use_ibrc{false};
   std::string name;
 };
 
@@ -38,10 +42,10 @@ struct RingReduceScatterBenchmarkResult {
   std::size_t chunk_elements{};
   std::size_t total_bytes{};
   int num_rings{};
-  float nccl_bandwidth{};
-  float ring_bandwidth{};
-  float nccl_latency{};
-  float ring_latency{};
+  float baseline_bandwidth{};
+  float candidate_bandwidth{};
+  float baseline_latency{};
+  float candidate_latency{};
   float speedup{};
 };
 
@@ -53,13 +57,10 @@ class RingReduceScatterBenchmarkFixture
     CUDA_CHECK_VOID(cudaSetDevice(localRank));
 
     setenv("NCCL_P2P_DISABLE", "1", 1);
-    NCCL_CHECK_VOID(
-        ncclCommInitRank(&nccl_comm_, worldSize, get_nccl_id(), globalRank));
     CUDA_CHECK_VOID(cudaStreamCreate(&stream_));
   }
 
   void TearDown() override {
-    NCCL_CHECK_VOID(ncclCommDestroy(nccl_comm_));
     CUDA_CHECK_VOID(cudaStreamDestroy(stream_));
     BenchmarkTestFixture::TearDown();
   }
@@ -99,6 +100,16 @@ class RingReduceScatterBenchmarkFixture
     CUDA_CHECK(
         cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
 
+    ncclComm_t nccl_comm{};
+    NCCL_CHECK(
+        ncclCommInitRank(&nccl_comm, worldSize, get_nccl_id(), globalRank));
+    auto ncclCommGuard = folly::makeGuard([&] {
+      const ncclResult_t res = ncclCommDestroy(nccl_comm);
+      if (res != ncclSuccess) {
+        XLOGF(ERR, "ncclCommDestroy failed: {}", ncclGetErrorString(res));
+      }
+    });
+
     CudaEvent start, stop;
     const int n_warmup = 5;
     const int n_iter = 100;
@@ -111,7 +122,7 @@ class RingReduceScatterBenchmarkFixture
           config.chunk_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          nccl_comm,
           stream_));
     }
 
@@ -123,7 +134,7 @@ class RingReduceScatterBenchmarkFixture
           config.chunk_elements,
           ncclFloat,
           ncclSum,
-          nccl_comm_,
+          nccl_comm,
           stream_));
     }
     CUDA_CHECK(cudaEventRecord(stop.get(), stream_));
@@ -151,27 +162,39 @@ class RingReduceScatterBenchmarkFixture
     CUDA_CHECK(
         cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
 
-    std::unique_ptr<MultipeerIbgdaTransport> transport;
-    try {
-      const int maxGroups = config.num_blocks * config.num_rings;
-      MultipeerIbgdaTransportConfig transport_config{
-          .cudaDevice = localRank,
-          .dataBufferSize = config.data_buffer_size,
-          .maxGroups = maxGroups,
-          .sendRecv =
-              MultipeerIbgdaTransportConfig::SendRecvConfig{
-                  .pipelineDepth = config.pipeline_depth,
-              },
-          .qpsPerBlockPerNic = config.num_qps,
-      };
-      transport = std::make_unique<MultipeerIbgdaTransport>(
+    const int maxGroups = config.num_blocks * config.num_rings;
+    MultipeerIbgdaTransportConfig transport_config{
+        .cudaDevice = localRank,
+        .dataBufferSize = config.data_buffer_size,
+        .maxGroups = maxGroups,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .pipelineDepth = config.pipeline_depth,
+            },
+        .qpsPerBlockPerNic = config.num_qps,
+    };
+
+    if (config.use_ibrc) {
+      MultipeerIbrcTransport transport(
           globalRank, worldSize, bootstrap, transport_config);
-      transport->exchange();
-    } catch (const std::exception& e) {
-      XLOGF(ERR, "IBGDA transport not available: {}", e.what());
-      latency_us = 0.0f;
-      return 0.0f;
+      return run_ring_benchmark_with_transport(
+          config, send_buf, recv_buf, total_bytes, latency_us, transport);
     }
+    MultipeerIbgdaTransport transport(
+        globalRank, worldSize, bootstrap, transport_config);
+    return run_ring_benchmark_with_transport(
+        config, send_buf, recv_buf, total_bytes, latency_us, transport);
+  }
+
+  template <typename Transport>
+  float run_ring_benchmark_with_transport(
+      const RingReduceScatterBenchmarkConfig& config,
+      DeviceBuffer& send_buf,
+      DeviceBuffer& recv_buf,
+      std::size_t total_bytes,
+      float& latency_us,
+      Transport& transport) {
+    transport.exchange();
 
     auto rings_opt =
         make_standard_rings(worldSize, globalRank, config.num_rings);
@@ -199,14 +222,16 @@ class RingReduceScatterBenchmarkFixture
       auto& rp = launch_params.rings[r];
       rp.prev_rank = rings[r].prev_rank;
       rp.next_rank = rings[r].next_rank;
-      transport->queuePeerForMaterialization(rp.prev_rank);
-      transport->queuePeerForMaterialization(rp.next_rank);
+      transport.queuePeerForMaterialization(rp.prev_rank);
+      transport.queuePeerForMaterialization(rp.next_rank);
     }
-    transport->connectPeers();
+    transport.connectPeers();
     for (int r = 0; r < config.num_rings; r++) {
       auto& rp = launch_params.rings[r];
-      rp.prev = transport->getP2pTransportDevice(rp.prev_rank);
-      rp.next = transport->getP2pTransportDevice(rp.next_rank);
+      rp.prev =
+          P2pIbTransportDevice(transport.getP2pTransportDevice(rp.prev_rank));
+      rp.next =
+          P2pIbTransportDevice(transport.getP2pTransportDevice(rp.next_rank));
     }
 
     CudaEvent start, stop;
@@ -238,7 +263,9 @@ class RingReduceScatterBenchmarkFixture
   }
 
   void print_results(
-      const std::vector<RingReduceScatterBenchmarkResult>& results) {
+      const std::vector<RingReduceScatterBenchmarkResult>& results,
+      const char* baselineLabel,
+      const char* candidateLabel) {
     if (globalRank != 0) {
       return;
     }
@@ -256,17 +283,27 @@ class RingReduceScatterBenchmarkFixture
       return std::to_string(bytes) + "B";
     };
 
+    auto fmt_float = [](float value, int precision) -> std::string {
+      if (value <= 0.0f) {
+        return "n/a";
+      }
+      std::stringstream value_ss;
+      value_ss << std::fixed << std::setprecision(precision) << value;
+      return value_ss.str();
+    };
+
     std::stringstream ss;
     ss << "\n";
     ss << "================================================================================\n";
-    ss << "         NCCL ReduceScatter vs Ring ReduceScatter (IBGDA) Benchmark\n";
+    ss << "             Ring ReduceScatter Benchmark (" << candidateLabel
+       << " vs " << baselineLabel << ")\n";
     ss << "================================================================================\n";
     ss << std::left << std::setw(14) << "Test" << std::right << std::setw(10)
        << "Size" << std::right << std::setw(6) << "Rings" << std::right
-       << std::setw(10) << "NCCL" << std::right << std::setw(10) << "Ring"
-       << std::right << std::setw(10) << "Speedup" << std::right
-       << std::setw(12) << "NCCL Lat" << std::right << std::setw(12)
-       << "Ring Lat\n";
+       << std::setw(10) << baselineLabel << std::right << std::setw(10)
+       << candidateLabel << std::right << std::setw(10) << "Speedup"
+       << std::right << std::setw(12) << "Base Lat" << std::right
+       << std::setw(12) << "Cand Lat\n";
     ss << std::left << std::setw(14) << "" << std::right << std::setw(10) << ""
        << std::right << std::setw(6) << "" << std::right << std::setw(10)
        << "(GB/s)" << std::right << std::setw(10) << "(GB/s)" << std::right
@@ -278,13 +315,12 @@ class RingReduceScatterBenchmarkFixture
       ss << std::left << std::setw(14) << r.test_name << std::right
          << std::setw(10) << fmt_bytes(r.total_bytes) << std::right
          << std::setw(6) << r.num_rings << std::right << std::setw(10)
-         << std::fixed << std::setprecision(2) << r.nccl_bandwidth << std::right
-         << std::setw(10) << std::fixed << std::setprecision(2)
-         << r.ring_bandwidth << std::right << std::setw(9) << std::fixed
-         << std::setprecision(2) << r.speedup << "x" << std::right
-         << std::setw(12) << std::fixed << std::setprecision(1)
-         << r.nccl_latency << std::right << std::setw(12) << std::fixed
-         << std::setprecision(1) << r.ring_latency << "\n";
+         << fmt_float(r.baseline_bandwidth, 2) << std::right << std::setw(10)
+         << fmt_float(r.candidate_bandwidth, 2) << std::right << std::setw(10)
+         << (r.speedup > 0.0f ? fmt_float(r.speedup, 2) + "x" : "n/a")
+         << std::right << std::setw(12) << fmt_float(r.baseline_latency, 1)
+         << std::right << std::setw(12) << fmt_float(r.candidate_latency, 1)
+         << "\n";
     }
 
     ss << "================================================================================\n";
@@ -294,125 +330,177 @@ class RingReduceScatterBenchmarkFixture
     XLOG(INFO) << ss.str();
   }
 
-  ncclComm_t nccl_comm_{};
+  std::vector<RingReduceScatterBenchmarkConfig> make_benchmark_configs(
+      bool useIbrc) {
+    // Matched config for a fair IBRC-vs-IBGDA comparison: same QP count and
+    // staging buffer size for both backends.
+    std::size_t kDataBufferSize = 32UL * 1024 * 1024;
+    int kNumQps = 4;
+
+    auto configs = std::vector<RingReduceScatterBenchmarkConfig>{
+        {.chunk_elements = 64 * 1024,
+         .num_blocks = 8,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256K_8B"},
+        {.chunk_elements = 256 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "1M_16B"},
+        {.chunk_elements = 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "4M_16B"},
+        {.chunk_elements = 4 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "16M_16B"},
+        {.chunk_elements = 16 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "64M_16B"},
+        {.chunk_elements = 32 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "128M_16B"},
+        {.chunk_elements = 64 * 1024 * 1024,
+         .num_blocks = 32,
+         .num_rings = 1,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256M_32B"},
+        {.chunk_elements = 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "4M_16B_2R"},
+        {.chunk_elements = 4 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "16M_16B_2R"},
+        {.chunk_elements = 16 * 1024 * 1024,
+         .num_blocks = 16,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "64M_16B_2R"},
+        {.chunk_elements = 64 * 1024 * 1024,
+         .num_blocks = 32,
+         .num_rings = 2,
+         .data_buffer_size = kDataBufferSize,
+         .pipeline_depth = 2,
+         .num_qps = kNumQps,
+         .name = "256M_32B_2R"},
+    };
+    for (auto& config : configs) {
+      config.use_ibrc = useIbrc;
+    }
+    return configs;
+  }
+
+  RingReduceScatterBenchmarkResult make_benchmark_result(
+      const RingReduceScatterBenchmarkConfig& config,
+      float baselineBw,
+      float baselineLatencyUs,
+      float candidateBw,
+      float candidateLatencyUs) {
+    return {
+        .test_name = config.name,
+        .chunk_elements = config.chunk_elements,
+        .total_bytes = config.chunk_elements *
+            static_cast<std::size_t>(worldSize) * sizeof(float),
+        .num_rings = config.num_rings,
+        .baseline_bandwidth = baselineBw,
+        .candidate_bandwidth = candidateBw,
+        .baseline_latency = baselineLatencyUs,
+        .candidate_latency = candidateLatencyUs,
+        .speedup = (baselineBw > 0) ? candidateBw / baselineBw : 0.0f,
+    };
+  }
+
+  void run_ibgda_vs_nccl_benchmark_suite() {
+    if (globalRank == 0) {
+      XLOG(INFO) << "\n=== Ring ReduceScatter (IBGDA) vs NCCL Comparison ===\n";
+    }
+
+    std::vector<RingReduceScatterBenchmarkResult> results;
+    for (const auto& config : make_benchmark_configs(false)) {
+      float ncclLatencyUs = 0.0f;
+      float ncclBw = run_nccl_benchmark(config, ncclLatencyUs);
+      float ringLatencyUs = 0.0f;
+      float ringBw = run_ring_benchmark(config, ringLatencyUs);
+      if (globalRank == 0) {
+        results.push_back(make_benchmark_result(
+            config, ncclBw, ncclLatencyUs, ringBw, ringLatencyUs));
+      }
+      bootstrap->barrierAll();
+    }
+
+    print_results(results, "NCCL", "IBGDA");
+  }
+
+  void run_ibrc_vs_ibgda_benchmark_suite() {
+    if (globalRank == 0) {
+      XLOG(INFO) << "\n=== Ring ReduceScatter (IBRC) vs IBGDA Comparison ===\n";
+    }
+
+    std::vector<RingReduceScatterBenchmarkResult> results;
+    auto ibgdaConfigs = make_benchmark_configs(false);
+    auto ibrcConfigs = make_benchmark_configs(true);
+    CHECK_EQ(ibgdaConfigs.size(), ibrcConfigs.size());
+    for (std::size_t i = 0; i < ibrcConfigs.size(); ++i) {
+      const auto& ibgdaConfig = ibgdaConfigs.at(i);
+      const auto& ibrcConfig = ibrcConfigs.at(i);
+
+      float ibgdaLatencyUs = 0.0f;
+      float ibgdaBw = run_ring_benchmark(ibgdaConfig, ibgdaLatencyUs);
+
+      float ibrcLatencyUs = 0.0f;
+      float ibrcBw = run_ring_benchmark(ibrcConfig, ibrcLatencyUs);
+
+      if (globalRank == 0) {
+        results.push_back(make_benchmark_result(
+            ibrcConfig, ibgdaBw, ibgdaLatencyUs, ibrcBw, ibrcLatencyUs));
+      }
+      bootstrap->barrierAll();
+    }
+
+    print_results(results, "IBGDA", "IBRC");
+  }
+
   cudaStream_t stream_{};
 };
 
-TEST_F(RingReduceScatterBenchmarkFixture, VsNccl) {
-  if (globalRank == 0) {
-    XLOG(INFO) << "\n=== Ring ReduceScatter (IBGDA) vs NCCL Comparison ===\n";
-  }
+TEST_F(RingReduceScatterBenchmarkFixture, IbgdaVsNccl) {
+  run_ibgda_vs_nccl_benchmark_suite();
+}
 
-  std::size_t kDataBufferSize = 32UL * 1024 * 1024;
-  int kNumQps = 4;
-
-  std::vector<RingReduceScatterBenchmarkConfig> configs = {
-      {.chunk_elements = 64 * 1024,
-       .num_blocks = 8,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256K_8B"},
-      {.chunk_elements = 256 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "1M_16B"},
-      {.chunk_elements = 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4M_16B"},
-      {.chunk_elements = 4 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "16M_16B"},
-      {.chunk_elements = 16 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "64M_16B"},
-      {.chunk_elements = 32 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "128M_16B"},
-      {.chunk_elements = 64 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 1,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256M_32B"},
-      {.chunk_elements = 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "4M_16B_2R"},
-      {.chunk_elements = 4 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "16M_16B_2R"},
-      {.chunk_elements = 16 * 1024 * 1024,
-       .num_blocks = 16,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "64M_16B_2R"},
-      {.chunk_elements = 64 * 1024 * 1024,
-       .num_blocks = 32,
-       .num_rings = 2,
-       .data_buffer_size = kDataBufferSize,
-       .pipeline_depth = 2,
-       .num_qps = kNumQps,
-       .name = "256M_32B_2R"},
-  };
-
-  std::vector<RingReduceScatterBenchmarkResult> results;
-
-  for (const auto& config : configs) {
-    float nccl_lat = 0.0f;
-    float nccl_bw = run_nccl_benchmark(config, nccl_lat);
-
-    float ring_lat = 0.0f;
-    float ring_bw = run_ring_benchmark(config, ring_lat);
-
-    if (globalRank == 0) {
-      results.push_back({
-          .test_name = config.name,
-          .chunk_elements = config.chunk_elements,
-          .total_bytes = config.chunk_elements *
-              static_cast<std::size_t>(worldSize) * sizeof(float),
-          .num_rings = config.num_rings,
-          .nccl_bandwidth = nccl_bw,
-          .ring_bandwidth = ring_bw,
-          .nccl_latency = nccl_lat,
-          .ring_latency = ring_lat,
-          .speedup = (nccl_bw > 0) ? ring_bw / nccl_bw : 0.0f,
-      });
-    }
-    bootstrap->barrierAll();
-  }
-
-  print_results(results);
+TEST_F(RingReduceScatterBenchmarkFixture, IbrcVsIbgda) {
+  run_ibrc_vs_ibgda_benchmark_suite();
 }
 
 } // namespace

--- a/comms/prims/collectives/tests/RingAllGatherTest.cc
+++ b/comms/prims/collectives/tests/RingAllGatherTest.cc
@@ -91,8 +91,10 @@ TEST_P(RingAllGatherTest, Correctness) {
   transport->connectPeers();
   for (int r = 0; r < params.num_rings; r++) {
     auto& ringParams = launchParams.rings[r];
-    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+    ringParams.prev = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.prev_rank));
+    ringParams.next = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.next_rank));
   }
 
   bootstrap->barrierAll();

--- a/comms/prims/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/RingReduceScatterTest.cc
@@ -3,10 +3,14 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <memory>
+#include <vector>
+
 #include "comms/prims/collectives/RingReduceScatterLauncher.h"
 #include "comms/prims/collectives/RingUtils.h"
 #include "comms/prims/collectives/tests/ReduceScatterTestHarness.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 
 using meta::comms::DeviceBuffer;
 
@@ -20,12 +24,68 @@ struct RingReduceScatterTestParams {
   std::size_t data_buffer_size;
   int pipeline_depth;
   bool ibLazyConnect{false};
+  bool useIbrc{false};
 };
 
 std::string param_name(
     const ::testing::TestParamInfo<RingReduceScatterTestParams>& info) {
   return info.param.config.name;
 }
+
+class RingReduceScatterIbTransport {
+ public:
+  RingReduceScatterIbTransport(
+      bool useIbrc,
+      int globalRank,
+      int worldSize,
+      const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+      const MultipeerIbgdaTransportConfig& transportConfig) {
+    if (useIbrc) {
+      ibrcTransport_ = std::make_unique<MultipeerIbrcTransport>(
+          globalRank, worldSize, bootstrap, transportConfig);
+    } else {
+      ibgdaTransport_ = std::make_unique<MultipeerIbgdaTransport>(
+          globalRank, worldSize, bootstrap, transportConfig);
+    }
+  }
+
+  void exchange() {
+    if (ibrcTransport_) {
+      ibrcTransport_->exchange();
+    } else {
+      ibgdaTransport_->exchange();
+    }
+  }
+
+  void queuePeerForMaterialization(int peerRank) {
+    if (ibrcTransport_) {
+      ibrcTransport_->queuePeerForMaterialization(peerRank);
+    } else {
+      ibgdaTransport_->queuePeerForMaterialization(peerRank);
+    }
+  }
+
+  void connectPeers() {
+    if (ibrcTransport_) {
+      ibrcTransport_->connectPeers();
+    } else {
+      ibgdaTransport_->connectPeers();
+    }
+  }
+
+  P2pIbTransportDevice getP2pTransportDevice(int peerRank) {
+    if (ibrcTransport_) {
+      return P2pIbTransportDevice(
+          ibrcTransport_->getP2pTransportDevice(peerRank));
+    }
+    return P2pIbTransportDevice(
+        ibgdaTransport_->getP2pTransportDevice(peerRank));
+  }
+
+ private:
+  std::unique_ptr<MultipeerIbgdaTransport> ibgdaTransport_;
+  std::unique_ptr<MultipeerIbrcTransport> ibrcTransport_;
+};
 
 class RingReduceScatterTest
     : public ReduceScatterTestBase,
@@ -39,24 +99,19 @@ TEST_P(RingReduceScatterTest, Correctness) {
     GTEST_SKIP() << "Ring reduce-scatter requires at least 2 ranks";
   }
 
-  std::unique_ptr<MultipeerIbgdaTransport> transport;
-  try {
-    MultipeerIbgdaTransportConfig transportConfig{
-        .cudaDevice = localRank,
-        .dataBufferSize = params.data_buffer_size,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = config.num_blocks * params.num_rings,
-                .pipelineDepth = params.pipeline_depth,
-            },
-        .ibLazyConnect = params.ibLazyConnect,
-    };
-    transport = std::make_unique<MultipeerIbgdaTransport>(
-        globalRank, worldSize, bootstrap, transportConfig);
-    transport->exchange();
-  } catch (const std::exception& e) {
-    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
-  }
+  MultipeerIbgdaTransportConfig transportConfig{
+      .cudaDevice = localRank,
+      .dataBufferSize = params.data_buffer_size,
+      .sendRecv =
+          MultipeerIbgdaTransportConfig::SendRecvConfig{
+              .maxGroups = config.num_blocks * params.num_rings,
+              .pipelineDepth = params.pipeline_depth,
+          },
+      .ibLazyConnect = params.ibLazyConnect,
+  };
+  auto transport = std::make_unique<RingReduceScatterIbTransport>(
+      params.useIbrc, globalRank, worldSize, bootstrap, transportConfig);
+  transport->exchange();
 
   const std::size_t total_elements = config.chunk_elements * worldSize;
   DeviceBuffer inputBuf(total_elements * sizeof(float));
@@ -93,10 +148,8 @@ TEST_P(RingReduceScatterTest, Correctness) {
   transport->connectPeers();
   for (int r = 0; r < params.num_rings; r++) {
     auto& ringParams = launchParams.rings[r];
-    ringParams.prev = P2pIbTransportDevice(
-        transport->getP2pTransportDevice(ringParams.prev_rank));
-    ringParams.next = P2pIbTransportDevice(
-        transport->getP2pTransportDevice(ringParams.next_rank));
+    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
+    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
   }
 
   bootstrap->barrierAll();
@@ -108,95 +161,96 @@ TEST_P(RingReduceScatterTest, Correctness) {
       static_cast<const float*>(outputBuf.get()), config.chunk_elements);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Ring1,
-    RingReduceScatterTest,
-    ::testing::Values(
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 16 * 1024,
-                 .num_blocks = 4,
-                 .name = "64KB_4B"},
-            .num_rings = 1,
-            .data_buffer_size = 1024 * 1024,
-            .pipeline_depth = 2,
-        },
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 64 * 1024,
-                 .num_blocks = 8,
-                 .name = "256KB_8B"},
-            .num_rings = 1,
-            .data_buffer_size = 1024 * 1024,
-            .pipeline_depth = 2,
-        },
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 256 * 1024,
-                 .num_blocks = 16,
-                 .name = "1MB_16B"},
-            .num_rings = 1,
-            .data_buffer_size = 2 * 1024 * 1024,
-            .pipeline_depth = 2,
-        },
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 1024 * 1024,
-                 .num_blocks = 16,
-                 .name = "4MB_16B"},
-            .num_rings = 1,
-            .data_buffer_size = 4 * 1024 * 1024,
-            .pipeline_depth = 2,
-        },
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 4 * 1024 * 1024,
-                 .num_blocks = 16,
-                 .name = "16MB_16B"},
-            .num_rings = 1,
-            .data_buffer_size = 8 * 1024 * 1024,
-            .pipeline_depth = 2,
-        }),
-    param_name);
+std::vector<RingReduceScatterTestParams> all_test_params() {
+  std::vector<RingReduceScatterTestParams> base{
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 16 * 1024, .num_blocks = 4, .name = "64KB_4B"},
+          .num_rings = 1,
+          .data_buffer_size = 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 64 * 1024,
+               .num_blocks = 8,
+               .name = "256KB_8B"},
+          .num_rings = 1,
+          .data_buffer_size = 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 256 * 1024,
+               .num_blocks = 16,
+               .name = "1MB_16B"},
+          .num_rings = 1,
+          .data_buffer_size = 2 * 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 1024 * 1024,
+               .num_blocks = 16,
+               .name = "4MB_16B"},
+          .num_rings = 1,
+          .data_buffer_size = 4 * 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 4 * 1024 * 1024,
+               .num_blocks = 16,
+               .name = "16MB_16B"},
+          .num_rings = 1,
+          .data_buffer_size = 8 * 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 64 * 1024,
+               .num_blocks = 8,
+               .name = "256KB_8B_2R"},
+          .num_rings = 2,
+          .data_buffer_size = 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 1024 * 1024,
+               .num_blocks = 16,
+               .name = "4MB_16B_2R"},
+          .num_rings = 2,
+          .data_buffer_size = 4 * 1024 * 1024,
+          .pipeline_depth = 2,
+      },
+      RingReduceScatterTestParams{
+          .config =
+              {.chunk_elements = 64 * 1024,
+               .num_blocks = 8,
+               .name = "256KB_8B_lazy"},
+          .num_rings = 1,
+          .data_buffer_size = 1024 * 1024,
+          .pipeline_depth = 2,
+          .ibLazyConnect = true,
+      },
+  };
+
+  std::vector<RingReduceScatterTestParams> expanded;
+  expanded.reserve(base.size() * 2);
+  for (auto params : base) {
+    expanded.push_back(params);
+    params.useIbrc = true;
+    params.config.name += "_ibrc";
+    expanded.push_back(params);
+  }
+  return expanded;
+}
 
 INSTANTIATE_TEST_SUITE_P(
-    Ring2,
+    AllBackends,
     RingReduceScatterTest,
-    ::testing::Values(
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 64 * 1024,
-                 .num_blocks = 8,
-                 .name = "256KB_8B_2R"},
-            .num_rings = 2,
-            .data_buffer_size = 1024 * 1024,
-            .pipeline_depth = 2,
-        },
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 1024 * 1024,
-                 .num_blocks = 16,
-                 .name = "4MB_16B_2R"},
-            .num_rings = 2,
-            .data_buffer_size = 4 * 1024 * 1024,
-            .pipeline_depth = 2,
-        }),
-    param_name);
-
-INSTANTIATE_TEST_SUITE_P(
-    LazyMode,
-    RingReduceScatterTest,
-    ::testing::Values(
-        RingReduceScatterTestParams{
-            .config =
-                {.chunk_elements = 64 * 1024,
-                 .num_blocks = 8,
-                 .name = "256KB_8B_lazy"},
-            .num_rings = 1,
-            .data_buffer_size = 1024 * 1024,
-            .pipeline_depth = 2,
-            .ibLazyConnect = true,
-        }),
+    ::testing::ValuesIn(all_test_params()),
     param_name);
 
 } // namespace

--- a/comms/prims/collectives/tests/RingReduceScatterTest.cc
+++ b/comms/prims/collectives/tests/RingReduceScatterTest.cc
@@ -93,8 +93,10 @@ TEST_P(RingReduceScatterTest, Correctness) {
   transport->connectPeers();
   for (int r = 0; r < params.num_rings; r++) {
     auto& ringParams = launchParams.rings[r];
-    ringParams.prev = transport->getP2pTransportDevice(ringParams.prev_rank);
-    ringParams.next = transport->getP2pTransportDevice(ringParams.next_rank);
+    ringParams.prev = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.prev_rank));
+    ringParams.next = P2pIbTransportDevice(
+        transport->getP2pTransportDevice(ringParams.next_rank));
   }
 
   bootstrap->barrierAll();

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -27,11 +27,15 @@
 #include <hip/hip_runtime.h>
 
 #include "comms/prims/transport/amd/DocaCompat.h"
+// meta::comms::DeviceBuffer (HIP shim) for the send/recv staging bulks.
+#include "comms/prims/transport/amd/HipHostCompat.h"
 #else
 #include <cuda_runtime.h>
 
 #include "comms/prims/platform/CudaDriverLazy.h"
 #include "comms/prims/platform/DocaHostUtils.h"
+// meta::comms::DeviceBuffer (CUDA RAII) for the send/recv staging bulks.
+#include "comms/utils/CudaRAII.h"
 #endif
 
 namespace comms::prims {
@@ -199,6 +203,375 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
   numNics_ = n;
   VLOG(1) << "MultiPeerIbTransport: numNics_=" << numNics_
           << " (source=" << source << ")";
+}
+
+// Out-of-line so the unique_ptr<DeviceBuffer> send/recv members destruct
+// against a complete type (DeviceBuffer is only forward-declared in the
+// header).
+MultiPeerIbTransportBase::~MultiPeerIbTransportBase() = default;
+
+// ---- shared send/recv staging-ring lifecycle (eager mode) ----
+
+const MultipeerIbTransportConfig::SendRecvConfig&
+MultiPeerIbTransportBase::sendRecvConfig() const {
+  if (!config_.sendRecv.has_value()) {
+    throw std::runtime_error("MultiPeerIbTransport: send/recv not configured");
+  }
+  return *config_.sendRecv;
+}
+
+void MultiPeerIbTransportBase::validateSendRecvConfig() const {
+  const auto& sr = sendRecvConfig();
+  if (sr.pipelineDepth < 1) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: sendRecv.pipelineDepth must be >= 1");
+  }
+  if (sr.maxGroups < 1) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: sendRecv.maxGroups must be >= 1");
+  }
+  if (config_.dataBufferSize == 0) {
+    throw std::invalid_argument(
+        "MultiPeerIbTransport: dataBufferSize must be > 0 when sendRecv is "
+        "enabled");
+  }
+  if ((config_.dataBufferSize / static_cast<std::size_t>(sr.maxGroups)) < 16) {
+    throw std::invalid_argument(
+        fmt::format(
+            "MultiPeerIbTransport: dataBufferSize / maxGroups must be >= 16, "
+            "got {} / {} = {}",
+            config_.dataBufferSize,
+            sr.maxGroups,
+            config_.dataBufferSize / sr.maxGroups));
+  }
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvStagingBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return static_cast<std::size_t>(sr.pipelineDepth) * config_.dataBufferSize;
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvSignalBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return 2 * static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvCounterBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return static_cast<std::size_t>(sr.maxGroups) * sizeof(uint64_t);
+}
+
+std::size_t MultiPeerIbTransportBase::sendRecvStateBytesPerPeer() const {
+  const auto& sr = sendRecvConfig();
+  return 2 * static_cast<std::size_t>(sr.maxGroups) *
+      sizeof(IbSendRecvState::ProgressSlot);
+}
+
+IbSendRecvState MultiPeerIbTransportBase::sendRecvStateForPeer(
+    int peerIndex) const {
+  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty() ||
+      peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return {};
+  }
+  const auto& pb = sendRecvPeerBuffers_[peerIndex];
+  return IbSendRecvState{
+      .sendStagingBuf = pb.sendStaging,
+      .recvStagingBuf = pb.remoteRecvStaging,
+      .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
+      .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
+      .localSignalBuf = pb.signal,
+      .remoteSignalBuf = pb.remoteSignal,
+      .localCounterBuf = pb.counter,
+      .localCounterCompletionBuf = pb.counterCompletion,
+      .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
+      .maxGroups = config_.sendRecv->maxGroups,
+      .pipelineDepth = config_.sendRecv->pipelineDepth,
+      .dataBufferSize = config_.dataBufferSize,
+  };
+}
+
+void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
+    IbCounterStorage counterStorage) {
+  if (!config_.sendRecv.has_value()) {
+    return;
+  }
+  validateSendRecvConfig();
+
+  const int numPeers = nRanks_ - 1;
+  if (numPeers <= 0) {
+    return;
+  }
+  sendRecvCounterStorage_ = counterStorage;
+
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+  const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
+  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
+  const auto stateSlotsPerPeer =
+      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
+          2 * config_.sendRecv->maxGroups);
+
+  auto allocateBulk = [&](std::size_t perPeer, const char* label) {
+    auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
+    checkSlotGpu(
+        slotGpuMemset(buf->get(), 0, perPeer * numPeers),
+        fmt::format("MultiPeerIbTransport: zero send/recv {}", label));
+    return buf;
+  };
+
+  sendRecvPeerBuffers_.resize(numPeers);
+
+  sendRecvSendStagingBulk_ = allocateBulk(stagingPerPeer, "send staging bulk");
+  sendRecvRecvStagingBulk_ = allocateBulk(stagingPerPeer, "recv staging bulk");
+  sendRecvSignalBulk_ = allocateBulk(signalPerPeer, "signal bulk");
+  sendRecvStateBulk_ = allocateBulk(statePerPeer, "state bulk");
+
+  auto sendStagingBulkReg = registerBuffer(
+      sendRecvSendStagingBulk_->get(), stagingPerPeer * numPeers);
+  sendRecvRecvStagingBulkReg_ = registerBuffer(
+      sendRecvRecvStagingBulk_->get(), stagingPerPeer * numPeers);
+  sendRecvSignalBulkReg_ =
+      registerBuffer(sendRecvSignalBulk_->get(), signalPerPeer * numPeers);
+
+  IbgdaLocalBuffer counterBulkBuf;
+  IbgdaLocalBuffer counterCompletionBulkBuf;
+  if (counterStorage == IbCounterStorage::Device) {
+    // Device counter: transport-allocated + registered. The NIC bumps it via a
+    // loopback RDMA atomic (IBGDA).
+    sendRecvCounterBulk_ = allocateBulk(counterPerPeer, "counter bulk");
+    sendRecvCounterBulkReg_ =
+        registerBuffer(sendRecvCounterBulk_->get(), counterPerPeer * numPeers);
+    counterBulkBuf = sendRecvCounterBulkReg_;
+    counterCompletionBulkBuf = sendRecvCounterBulkReg_;
+  } else {
+    // Host counter: transport-allocated host-mapped (cudaHostAllocMapped). The
+    // CPU proxy writes the host alias on CQE; the device reads via the mapped
+    // pointer (IBRC). lkeys are unused (no RDMA target), so wrap with empty
+    // keys.
+    sendRecvHostCounterAllocation_ = allocateCounterSlotAllocation(
+        IbCounterStorage::HostPinned,
+        counterPerPeer * numPeers,
+        "send/recv host counter");
+    counterBulkBuf = IbgdaLocalBuffer(
+        sendRecvHostCounterAllocation_.devicePtr, NetworkLKeys{});
+    counterCompletionBulkBuf = IbgdaLocalBuffer(
+        sendRecvHostCounterAllocation_.hostPtr, NetworkLKeys{});
+    sendRecvCounterBulkReg_ = counterBulkBuf;
+  }
+
+  for (int i = 0; i < numPeers; ++i) {
+    auto& pb = sendRecvPeerBuffers_[i];
+    pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
+    pb.recvStaging = sendRecvRecvStagingBulkReg_.subBuffer(i * stagingPerPeer);
+    pb.signal = sendRecvSignalBulkReg_.subBuffer(i * signalPerPeer);
+    pb.counter = counterBulkBuf.subBuffer(i * counterPerPeer);
+    pb.counterCompletion =
+        counterCompletionBulkBuf.subBuffer(i * counterPerPeer);
+    auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(
+        static_cast<char*>(sendRecvStateBulk_->get()) + i * statePerPeer);
+    pb.state.emplace(statePtr, stateSlotsPerPeer);
+  }
+
+  VLOG(1) << "MultiPeerIbTransport: rank " << myRank_
+          << " allocated send/recv staging for " << numPeers
+          << " peers (staging=" << stagingPerPeer << "B per peer, counter="
+          << (counterStorage == IbCounterStorage::Device ? "device" : "host")
+          << ")";
+}
+
+void MultiPeerIbTransportBase::exchangeSendRecvBuffersEager() {
+  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
+    return;
+  }
+
+  const int numPeers = nRanks_ - 1;
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+
+  auto recvStagingRemotes = exchangeBuffer(sendRecvRecvStagingBulkReg_);
+  auto signalRemotes = exchangeBuffer(sendRecvSignalBulkReg_);
+
+  for (int i = 0; i < numPeers; ++i) {
+    const int peerRank = peerIndexToRank(i);
+    const int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
+    sendRecvPeerBuffers_[i].remoteRecvStaging =
+        recvStagingRemotes[i].subBuffer(remotePeerIndex * stagingPerPeer);
+    sendRecvPeerBuffers_[i].remoteSignal =
+        signalRemotes[i].subBuffer(remotePeerIndex * signalPerPeer);
+  }
+
+  VLOG(1) << "MultiPeerIbTransport: rank " << myRank_
+          << " exchanged send/recv staging with " << numPeers << " peers";
+}
+
+void MultiPeerIbTransportBase::cleanupSendRecvBuffers() noexcept {
+  auto deregisterNoexcept = [&](void* ptr) noexcept {
+    if (ptr == nullptr) {
+      return;
+    }
+    try {
+      deregisterBuffer(ptr);
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultiPeerIbTransport: failed to deregister send/recv "
+                    "buffer: "
+                 << ex.what();
+    }
+  };
+
+  deregisterNoexcept(
+      sendRecvSendStagingBulk_ ? sendRecvSendStagingBulk_->get() : nullptr);
+  deregisterNoexcept(
+      sendRecvRecvStagingBulk_ ? sendRecvRecvStagingBulk_->get() : nullptr);
+  deregisterNoexcept(
+      sendRecvSignalBulk_ ? sendRecvSignalBulk_->get() : nullptr);
+  // Device counter is transport-owned + registered; host counter is host-mapped
+  // and freed via freeCounterSlotAllocation below (never registered).
+  if (sendRecvCounterStorage_ == IbCounterStorage::Device) {
+    deregisterNoexcept(
+        sendRecvCounterBulk_ ? sendRecvCounterBulk_->get() : nullptr);
+  }
+
+  sendRecvSendStagingBulk_.reset();
+  sendRecvRecvStagingBulk_.reset();
+  sendRecvSignalBulk_.reset();
+  sendRecvStateBulk_.reset();
+  sendRecvCounterBulk_.reset();
+  freeCounterSlotAllocation(sendRecvHostCounterAllocation_);
+  sendRecvRecvStagingBulkReg_ = IbgdaLocalBuffer{};
+  sendRecvSignalBulkReg_ = IbgdaLocalBuffer{};
+  sendRecvCounterBulkReg_ = IbgdaLocalBuffer{};
+  // Lazy per-peer allocations (empty in eager mode).
+  for (auto& buf : lazyPeerBufs_) {
+    deregisterNoexcept(buf ? buf->get() : nullptr);
+    buf.reset();
+  }
+  lazyPeerBufs_.clear();
+  for (auto& counter : lazySendRecvHostCounters_) {
+    freeCounterSlotAllocation(counter);
+  }
+  lazySendRecvHostCounters_.clear();
+  sendRecvCounterStorage_ = IbCounterStorage::Device;
+  sendRecvPeerBuffers_.clear();
+}
+
+void MultiPeerIbTransportBase::allocateSendRecvBufferForPeer(
+    int peerIndex,
+    PeerBufferPayload& payload,
+    IbCounterStorage counterStorage) {
+  if (!config_.sendRecv.has_value()) {
+    return;
+  }
+  validateSendRecvConfig();
+  const int numPeers = nRanks_ - 1;
+  if (peerIndex < 0 || peerIndex >= numPeers) {
+    throw std::invalid_argument(
+        fmt::format(
+            "allocateSendRecvBufferForPeer: invalid peerIndex={}", peerIndex));
+  }
+  sendRecvPeerBuffers_.resize(numPeers);
+  lazyPeerBufs_.resize(numPeers);
+  lazySendRecvHostCounters_.resize(numPeers);
+  sendRecvCounterStorage_ = counterStorage;
+
+  const std::size_t stagingPerPeer = sendRecvStagingBytesPerPeer();
+  const std::size_t signalPerPeer = sendRecvSignalBytesPerPeer();
+  const std::size_t counterPerPeer = sendRecvCounterBytesPerPeer();
+  const std::size_t statePerPeer = sendRecvStateBytesPerPeer();
+  const auto stateSlots =
+      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
+          2 * config_.sendRecv->maxGroups);
+  const bool deviceCounter = (counterStorage == IbCounterStorage::Device);
+
+  // One contiguous device buffer: sendStaging | recvStaging | signal | state,
+  // plus the counter when it is device-resident. A HostPinned counter is
+  // allocated separately (host-mapped, never RDMA-registered).
+  std::size_t total = 2 * stagingPerPeer + signalPerPeer + statePerPeer;
+  if (deviceCounter) {
+    total += counterPerPeer;
+  }
+  auto buf = std::make_unique<meta::comms::DeviceBuffer>(total);
+  checkSlotGpu(
+      slotGpuMemset(buf->get(), 0, total),
+      "MultiPeerIbTransport: zero per-peer send/recv buffer");
+  auto reg = registerBuffer(buf->get(), total);
+
+  char* p = static_cast<char*>(buf->get());
+  std::size_t off = 0;
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.sendStaging = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
+  off += stagingPerPeer;
+  void* recvStagingPtr = p + off;
+  pb.recvStaging = IbgdaLocalBuffer(recvStagingPtr, reg.lkey_per_device);
+  off += stagingPerPeer;
+  void* signalPtr = p + off;
+  pb.signal = IbgdaLocalBuffer(signalPtr, reg.lkey_per_device);
+  off += signalPerPeer;
+  auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(p + off);
+  off += statePerPeer;
+  pb.state.emplace(statePtr, stateSlots);
+  if (deviceCounter) {
+    pb.counter = IbgdaLocalBuffer(p + off, reg.lkey_per_device);
+    pb.counterCompletion = pb.counter;
+  } else {
+    auto alloc = allocateCounterSlotAllocation(
+        IbCounterStorage::HostPinned,
+        counterPerPeer,
+        "lazy send/recv host counter");
+    pb.counter = IbgdaLocalBuffer(alloc.devicePtr, NetworkLKeys{});
+    pb.counterCompletion = IbgdaLocalBuffer(alloc.hostPtr, NetworkLKeys{});
+    lazySendRecvHostCounters_[peerIndex] = std::move(alloc);
+  }
+
+  // The peer RDMA-writes into our recvStaging ring and signal inbox; publish
+  // their addr + per-NIC rkeys (whole per-peer regions, no slicing).
+  payload.recvStaging = registeredSlotMemoryExchInfo(recvStagingPtr);
+  payload.srSignal = registeredSlotMemoryExchInfo(signalPtr);
+  lazyPeerBufs_[peerIndex] = std::move(buf);
+}
+
+void MultiPeerIbTransportBase::applyRemoteSendRecvBuffer(
+    int peerIndex,
+    const PeerBufferPayload& remotePayload) {
+  if (!config_.sendRecv.has_value() || peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return;
+  }
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
+  pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
+}
+
+void MultiPeerIbTransportBase::cleanupSendRecvBufferForPeer(
+    int peerIndex) noexcept {
+  if (peerIndex < 0 ||
+      peerIndex >= static_cast<int>(sendRecvPeerBuffers_.size())) {
+    return;
+  }
+  if (peerIndex < static_cast<int>(lazyPeerBufs_.size()) &&
+      lazyPeerBufs_[peerIndex]) {
+    try {
+      deregisterBuffer(lazyPeerBufs_[peerIndex]->get());
+    } catch (const std::exception& ex) {
+      LOG(ERROR) << "MultiPeerIbTransport: failed to deregister per-peer "
+                    "send/recv buffer: "
+                 << ex.what();
+    }
+    lazyPeerBufs_[peerIndex].reset();
+  }
+  if (peerIndex < static_cast<int>(lazySendRecvHostCounters_.size())) {
+    freeCounterSlotAllocation(lazySendRecvHostCounters_[peerIndex]);
+  }
+  // Reset the per-peer views field-wise (IbSendRecvPeerBuffers is not
+  // copy-assignable due to its optional<DeviceSpan> state member).
+  auto& pb = sendRecvPeerBuffers_[peerIndex];
+  pb.sendStaging = IbgdaLocalBuffer{};
+  pb.recvStaging = IbgdaLocalBuffer{};
+  pb.signal = IbgdaLocalBuffer{};
+  pb.counter = IbgdaLocalBuffer{};
+  pb.remoteRecvStaging = IbgdaRemoteBuffer{};
+  pb.remoteSignal = IbgdaRemoteBuffer{};
+  pb.state.reset();
 }
 
 void MultiPeerIbTransportBase::openNics() {

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -16,7 +16,12 @@
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/ctran/ibverbx/Ibvcore.h"
+#include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+
+namespace meta::comms {
+class DeviceBuffer;
+} // namespace meta::comms
 
 namespace comms::prims {
 
@@ -239,9 +244,31 @@ struct PeerBufferPayload {
   IbgdaBufferExchInfo slotDiscard;
 };
 
+// Which memory a NIC completion counter lives in. Shared by the slot counter
+// (#16) and the send/recv NIC_DONE counter:
+//   Device     - GPU device memory, allocated and registered by the transport.
+//                The NIC bumps it via a loopback RDMA atomic (IBGDA).
+//   HostPinned - host-mapped (cudaHostAllocMapped) memory, allocated by the
+//                transport; the CPU progress thread writes it and the device
+//                reads via the mapped pointer (IBRC). Never MR-registered.
 enum class IbCounterStorage {
   Device,
   HostPinned,
+};
+
+// Per-peer send/recv staging-ring views. Eager mode owns the bulk allocations
+// and slices these; the device side reads them via sendRecvStateForPeer().
+struct IbSendRecvPeerBuffers {
+  IbgdaLocalBuffer sendStaging;
+  IbgdaLocalBuffer recvStaging;
+  IbgdaLocalBuffer signal;
+  IbgdaLocalBuffer counter;
+  IbgdaLocalBuffer counterCompletion;
+  // DeviceSpan has a const data_ member (no copy-assign), so wrap in optional
+  // and emplace() the per-peer slice.
+  std::optional<DeviceSpan<IbSendRecvState::ProgressSlot>> state;
+  IbgdaRemoteBuffer remoteRecvStaging;
+  IbgdaRemoteBuffer remoteSignal;
 };
 
 /**
@@ -321,8 +348,10 @@ class MultiPeerIbTransportBase {
       MultipeerIbTransportConfig config);
 
   // Non-virtual protected dtor: the base is never owned/deleted polymorphically
-  // (the dispatcher holds the concrete backend type).
-  ~MultiPeerIbTransportBase() = default;
+  // (the dispatcher holds the concrete backend type). Defined out-of-line in
+  // the .cc so the unique_ptr<DeviceBuffer> members destruct against a complete
+  // type.
+  ~MultiPeerIbTransportBase();
 
   MultiPeerIbTransportBase(const MultiPeerIbTransportBase&) = delete;
   MultiPeerIbTransportBase& operator=(const MultiPeerIbTransportBase&) = delete;
@@ -372,6 +401,52 @@ class MultiPeerIbTransportBase {
       void* remotePayload,
       std::size_t bytes,
       int tag);
+
+  // ---- shared send/recv staging-ring lifecycle (eager mode) ----
+  // Backend-agnostic host send/recv buffer management, shared by IBGDA (Device
+  // counter, NIC loopback atomic) and IBRC (Host counter, CPU proxy). Staging
+  // = pipelineDepth * dataBufferSize per direction; signal/state are sized off
+  // maxGroups. Per-peer staging + signal are device-registered; recvStaging +
+  // signal are collectively exchanged so peers can RDMA into our ring.
+  bool sendRecvBuffersEnabled() const {
+    return config_.sendRecv.has_value();
+  }
+  IbSendRecvState sendRecvStateForPeer(int peerIndex) const;
+  // Allocate + register the per-peer staging/signal/state bulks and slice them.
+  // counterStorage selects the NIC_DONE counter: Device (transport-allocated,
+  // registered) or HostPinned (transport-allocated host-mapped, never
+  // registered).
+  void allocateSendRecvBuffersEager(IbCounterStorage counterStorage);
+  // COLLECTIVE. allGather recvStaging + signal so each peer holds our remote
+  // views. Must be called after allocateSendRecvBuffersEager().
+  void exchangeSendRecvBuffersEager();
+  void cleanupSendRecvBuffers() noexcept;
+
+  // ---- per-peer (lazy) send/recv: shared by IBGDA + IBRC ----
+  // Allocate + register ONE peer's send/recv rings on demand (lazy connect) and
+  // fill the outbound payload's recvStaging/srSignal exch info. counterStorage
+  // selects the NIC_DONE counter: Device (a registered slice of the contiguous
+  // per-peer buffer; NIC loopback atomic — IBGDA) or HostPinned (a separate
+  // host-mapped allocation written by the CPU proxy — IBRC). The per-peer
+  // buffer is dedicated to this peer pair, so no numPeers slicing is needed.
+  void allocateSendRecvBufferForPeer(
+      int peerIndex,
+      PeerBufferPayload& payload,
+      IbCounterStorage counterStorage);
+  // Apply a peer's payload: remote recvStaging/signal views are used whole.
+  void applyRemoteSendRecvBuffer(
+      int peerIndex,
+      const PeerBufferPayload& remotePayload);
+  // Per-peer teardown: deregister + free this peer's lazy allocation and reset
+  // its views. Safe on an unmaterialized peer.
+  void cleanupSendRecvBufferForPeer(int peerIndex) noexcept;
+
+  const MultipeerIbTransportConfig::SendRecvConfig& sendRecvConfig() const;
+  void validateSendRecvConfig() const;
+  std::size_t sendRecvStagingBytesPerPeer() const;
+  std::size_t sendRecvSignalBytesPerPeer() const;
+  std::size_t sendRecvCounterBytesPerPeer() const;
+  std::size_t sendRecvStateBytesPerPeer() const;
 
   void allocateSignalCounterResources(
       IbCounterStorage counterStorage,
@@ -432,6 +507,20 @@ class MultiPeerIbTransportBase {
   // Maps allocation base address -> cached MR covering the full allocation.
   // Ordered map enables O(log n) containment lookup via upper_bound.
   std::map<uintptr_t, CachedMr> registeredBuffers_;
+
+  // Shared send/recv staging-ring state (eager mode). Owns the bulk
+  // allocations; sendRecvPeerBuffers_ slices them per peer.
+  std::vector<IbSendRecvPeerBuffers> sendRecvPeerBuffers_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvSendStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvRecvStagingBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvSignalBulk_;
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvStateBulk_;
+  // Device counter bulk (counterStorage == Device). Null for Host counters.
+  std::unique_ptr<meta::comms::DeviceBuffer> sendRecvCounterBulk_;
+  IbgdaLocalBuffer sendRecvRecvStagingBulkReg_;
+  IbgdaLocalBuffer sendRecvSignalBulkReg_;
+  IbgdaLocalBuffer sendRecvCounterBulkReg_;
+  IbCounterStorage sendRecvCounterStorage_{IbCounterStorage::Device};
 
   // Lazy materialization state machine.
   std::vector<int> pendingPeers_;
@@ -512,9 +601,19 @@ class MultiPeerIbTransportBase {
   DeviceSlotAllocation slotSignalAllocation_;
   CounterSlotAllocation slotCounterAllocation_;
   DeviceSlotAllocation slotDiscardSignalAllocation_;
+  // Host-mapped send/recv NIC_DONE counter (counterStorage == Host). Owns the
+  // host-pinned allocation; sliced per peer into IbSendRecvPeerBuffers.counter.
+  CounterSlotAllocation sendRecvHostCounterAllocation_;
   std::vector<DeviceSlotAllocation> lazySlotSignalAllocations_;
   std::vector<CounterSlotAllocation> lazySlotCounterAllocations_;
   std::vector<DeviceSlotAllocation> lazySlotDiscardSignalAllocations_;
+  // Lazy per-peer send/recv allocations: one contiguous device buffer per
+  // materialized peer (sendStaging|recvStaging|signal|state, plus the counter
+  // when device-resident). Empty in eager mode. Shared by IBGDA (Device
+  // counter) and IBRC, which additionally allocates a per-peer host-mapped
+  // NIC_DONE counter below.
+  std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
+  std::vector<CounterSlotAllocation> lazySendRecvHostCounters_;
 };
 
 /**

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -487,4 +487,145 @@ __device__ __forceinline__ void P2pIbTransportDevice::fence() {
   flush();
 }
 
+// ===========================================================================
+// Pipelined send/recv — forwarded to the active backend.
+// ===========================================================================
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::send(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->send<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->send<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::recv(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->recv<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->recv<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::forward(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    P2pIbTransportDevice& fwd,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->forward<CopyOp>(
+        group,
+        dst,
+        *fwd.ibrc,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  } else {
+    ibgda->forward<CopyOp>(
+        group,
+        dst,
+        *fwd.ibgda,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+}
+
+__device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window(
+    int active_blocks) const {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->pipeline_window(active_blocks);
+  }
+  return ibgda->pipeline_window(active_blocks);
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::init_send_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+  } else {
+    ibgda->init_send_progress(group, nbytes, active_blocks, max_signal_bytes);
+  }
+}
+
+__device__ __forceinline__ void P2pIbTransportDevice::init_recv_progress(
+    ThreadGroup& group,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+  } else {
+    ibgda->init_recv_progress(group, nbytes, active_blocks, max_signal_bytes);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_send_once(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_send_once<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_send_once<CopyOp>(
+      group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ IbgdaSendRecvProgressStatus
+P2pIbTransportDevice::progress_recv_once(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->progress_recv_once<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+  return ibgda->progress_recv_once<CopyOp>(
+      group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+}
+
 } // namespace comms::prims

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -6,11 +6,15 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "comms/prims/core/DeviceMacros.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/trace/PipesTraceTypes.h"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
+
+struct Memcpy;
 
 class P2pIbgdaTransportDevice;
 class P2pIbrcTransportDevice;
@@ -18,6 +22,1688 @@ class P2pIbrcTransportDevice;
 enum class P2pIbBackendType : uint8_t {
   IBGDA,
   IBRC,
+};
+
+/**
+ * Result of one bounded send/recv progress attempt.
+ *
+ * `progress_send_once()` and `progress_recv_once()` are intended for callers
+ * that multiplex several independent transfers from one kernel. A single call
+ * may complete immediately, advance one protocol step, or find that the next
+ * signal/counter dependency is not ready yet.
+ *
+ * `Waiting` means no user-visible data movement or protocol signal was
+ * issued. The caller may retry the same transport operation later after
+ * making progress on another lane. `Progressed` means the call advanced the
+ * operation but more calls are required. `Done` means the transfer has
+ * completed the byte range reserved by the corresponding init call.
+ */
+enum class IbgdaSendRecvProgressStatus : uint8_t {
+  Waiting,
+  Progressed,
+  Done,
+};
+
+#if PIPES_IS_DEVICE_COMPILE
+__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
+  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
+  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
+}
+
+__device__ __forceinline__ void trace_ibgda_event(
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    PipesTraceEventType type,
+    uint32_t step,
+    uint16_t group_id) {
+  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
+  // unconfigured handle has effectively no cost.
+  write_pipes_trace(trace, type, step, group_id, self_rank);
+}
+#endif
+
+/**
+ * IbSendRecvDevice — transport-agnostic pipelined RDMA send/recv.
+ *
+ * This class owns master's full async send/recv algorithm: the blocking
+ * `send`/`recv`/`forward`, the resumable `init_*_progress` /
+ * `progress_*_once` pair, and all of their private helpers. The send/recv
+ * algorithm is independent of the underlying transport: it only needs the
+ * common explicit-buffer IB device ops `put` (fused signal+counter),
+ * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
+ *
+ * Every public method takes the owning transport as a `Transport& transport`
+ * parameter and routes every transport op through it. `P2pIbgdaTransportDevice`
+ * and `P2pIbrcTransportDevice` hold one `IbSendRecvDevice sendRecv_` member and
+ * delegate their `send`/`recv`/`forward`/progress methods to it, passing
+ * `*this` as the transport. The send/recv protocol state lives in
+ * `sendRecvState_`, populated by the host transport builder.
+ */
+class IbSendRecvDevice {
+ public:
+  IbSendRecvState sendRecvState_{};
+
+  __host__ __device__ IbSendRecvDevice() = default;
+
+  __host__ __device__ explicit IbSendRecvDevice(IbSendRecvState initialState)
+      : sendRecvState_(initialState) {}
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const {
+    return sendRecvState_;
+  }
+
+  /**
+   * Initialize transport-owned state for one pipelined send operation.
+   *
+   * The transport reserves the sender-side byte stream for `group.group_id`
+   * and starts the internal state in the sender state machine unless
+   * `nbytes == 0`. It does not capture the source pointer; callers pass the
+   * pointer to each `progress_send_once()` call.
+   *
+   * The send progress slot for this group must be idle. Re-initializing a
+   * group while a previous send is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * `active_blocks == 0` means all configured groups participate. Non-zero
+   * values must match the peer's recv-side initialization for the same logical
+   * transfer. `max_signal_bytes == 0` sends one signal per per-block staging
+   * partition; smaller non-zero values split that partition into multiple
+   * signaled sub-chunks for finer overlap with the receiver.
+   *
+   * Zero-byte sends mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `send()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to send for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_send_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "send");
+    IbSendRecvState::ProgressSlot state{};
+    state.activeStage = nbytes == 0
+        ? detail::IbSendRecvProgressStage::Done
+        : detail::IbSendRecvProgressStage::WaitNicDone;
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    // Validate the transfer before reserving the transport byte cursor.
+    const ProgressGeometry geometry = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
+    store_progress_state(group, progressIndex, state);
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+#endif
+  }
+
+  /**
+   * Initialize transport-owned state for one pipelined recv operation.
+   *
+   * The transport reserves the receiver-side byte stream for `group.group_id`
+   * and starts the internal state in the receiver state machine unless
+   * `nbytes == 0`. It does not capture the destination pointer; callers pass
+   * the pointer to each `progress_recv_once()` call.
+   *
+   * The recv progress slot for this group must be idle. Re-initializing a
+   * group while a previous recv is outstanding traps with a diagnostic instead
+   * of silently overwriting the in-flight byte range.
+   *
+   * The sender and receiver must use the same `active_blocks` and compatible
+   * `max_signal_bytes` for a logical transfer. The staging offset and protocol
+   * signal values are derived from those values, so a mismatch can make one
+   * side wait on a different byte range than the other side produced.
+   *
+   * Zero-byte receives mark the internal state `Done` without reading or
+   * validating staging geometry. This matches the blocking `recv()` no-op
+   * behavior and lets schedulers treat empty operations uniformly.
+   *
+   * @param group Thread group that will execute all later progress calls.
+   * @param nbytes Number of user-buffer bytes to receive for this group.
+   * @param active_blocks Number of participating groups, or 0 for maxGroups.
+   * @param max_signal_bytes Maximum signaled sub-chunk size, or 0 for default.
+   */
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const int progressIndex = progress_recv_index(group);
+    auto& slot = progress_state_slot(group, progressIndex);
+    assert_progress_slot_idle(group, slot, "recv");
+    IbSendRecvState::ProgressSlot state{};
+    state.activeStage = nbytes == 0
+        ? detail::IbSendRecvProgressStage::Done
+        : detail::IbSendRecvProgressStage::WaitDataReady;
+    if (nbytes == 0) {
+      store_progress_state(group, progressIndex, state);
+      return;
+    }
+    // Validate the transfer before reserving the transport byte cursor.
+    const ProgressGeometry geometry = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
+    state.activeBaseStep =
+        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
+    store_progress_state(group, progressIndex, state);
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized send.
+   *
+   * This method advances at most one staged copy plus one RDMA put for the
+   * current chunk. It never spins on NIC_DONE or SLOT_FREE: if either
+   * dependency is not ready, it returns immediately so a higher-level scheduler
+   * can try another independent lane. If a `Timeout` is enabled, it is checked
+   * only at those readiness points and should already have been started by the
+   * caller.
+   *
+   * The send path first waits for NIC_DONE before reusing the local
+   * send-staging range, then copies user data into send-staging through
+   * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
+   * range, and finally issues an RDMA put that piggybacks DATA_READY and
+   * records NIC_DONE in the local counter. Returning `Done` means the reserved
+   * byte range has completed.
+   *
+   * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param transport Owning transport used for every transport op.
+   * @param group Thread group matching the one used during initialization.
+   * @param src Source user buffer. The range `[src, src + nbytes)` must remain
+   *            valid until `Done`.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param active_blocks Number of participating groups from init.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::send`.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      Transport& transport,
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::progress_send_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_send_index(group);
+    IbSendRecvState::ProgressSlot state =
+        progress_state_slot(group, progressIndex);
+    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    const ProgressGeometry progress_params = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
+            static_cast<unsigned long long>(state.activeNextByte),
+            static_cast<unsigned long long>(progress_params.protocolBytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_send_progress_stage(group, state);
+
+    const detail::IbSendRecvProgressStage initialStage = state.activeStage;
+    const std::size_t initialNextByte = state.activeNextByte;
+    const std::size_t pipelineBytes = progress_params.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+
+    if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
+      const ProgressChunk chunk = next_chunk(state, progress_params);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              transport.read_counter(sendRecvState_.localCounterBuf.subBuffer(
+                  progress_params.groupId * sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for NIC_DONE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      const std::size_t validBytes = valid_payload_bytes(
+          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + chunk.stagingOff,
+            static_cast<const char*>(src) + chunk.dataOff,
+            validBytes,
+            group,
+            chunk.dataOff,
+            args...);
+      }
+      group.sync();
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
+    }
+
+    if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
+      const ProgressChunk chunk = next_chunk(state, progress_params);
+      if (chunk.streamEnd > pipelineBytes) {
+        const uint64_t expected = chunk.streamEnd - pipelineBytes;
+        uint32_t ready = 1;
+        unsigned long long current = 0;
+        if (group.is_leader()) {
+          current = static_cast<unsigned long long>(
+              transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
+                  (sendRecvState_.maxGroups + progress_params.groupId) *
+                  sizeof(uint64_t))));
+          ready = current >= expected ? 1U : 0U;
+          if (!ready) {
+            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+                timeout,
+                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
+                "current=%llu",
+                static_cast<unsigned long long>(expected),
+                current);
+          }
+        }
+        ready = group.broadcast<uint32_t>(ready);
+        if (!ready) {
+          if (state.activeStage != initialStage ||
+              state.activeNextByte != initialNextByte) {
+            store_progress_state(group, progressIndex, state);
+            return IbgdaSendRecvProgressStatus::Progressed;
+          }
+          return IbgdaSendRecvProgressStatus::Waiting;
+        }
+      }
+
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        transport.put(
+            solo,
+            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
+            chunk.bytes,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                progress_params.groupId * sizeof(uint64_t)),
+            chunk.bytes,
+            sendRecvState_.localCounterCompletionBuf.subBuffer(
+                progress_params.groupId * sizeof(uint64_t)),
+            chunk.bytes);
+      }
+      group.sync();
+
+      state.activeNextByte += chunk.bytes;
+      if (state.activeNextByte >= progress_params.protocolBytes) {
+        transition_progress_stage(
+            group, state, detail::IbSendRecvProgressStage::Done);
+        store_progress_state(group, progressIndex, state);
+        return IbgdaSendRecvProgressStatus::Done;
+      }
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
+    }
+
+    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
+    // WaitNicDone in one call, leaving the stage unchanged while nextByte
+    // advances. Check both fields so that case reports Progressed.
+    if (state.activeStage != initialStage ||
+        state.activeNextByte != initialNextByte) {
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Progressed;
+    }
+    return IbgdaSendRecvProgressStatus::Waiting;
+#else
+    (void)transport;
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * Attempt bounded progress on one initialized recv.
+   *
+   * This method advances at most one recv-staging copy for the current chunk.
+   * It never spins on DATA_READY: if the sender has not signaled the next
+   * chunk, it returns `Waiting` immediately. If a `Timeout` is enabled, it is
+   * checked only while the DATA_READY dependency is not ready and should
+   * already have been started by the caller.
+   *
+   * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
+   * transport-owned recv-staging into the caller's destination through
+   * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
+   * means the reserved byte range has completed.
+   *
+   * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
+   * The default `Memcpy` copies bytes cooperatively across the supplied
+   * `ThreadGroup`; custom copy ops may use `args` to pass reduction or
+   * conversion context.
+   *
+   * @param transport Owning transport used for every transport op.
+   * @param group Thread group matching the one used during initialization.
+   * @param dst Destination user buffer. The range `[dst, dst + nbytes)` must
+   *            remain valid until `Done`.
+   * @param nbytes Number of user-buffer bytes from the matching init call.
+   * @param active_blocks Number of participating groups from init.
+   * @param max_signal_bytes Maximum signaled sub-chunk size from init.
+   * @param timeout Optional device timeout checked while dependencies wait.
+   * @param args Additional arguments forwarded to `CopyOp::recv`.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::progress_recv_once() requires NVIDIA GPU");
+#endif
+    const int progressIndex = progress_recv_index(group);
+    IbSendRecvState::ProgressSlot state =
+        progress_state_slot(group, progressIndex);
+    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+    const ProgressGeometry progress_params = make_progress_geometry(
+        group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
+            "protocolBytes=%llu without Done stage\n",
+            static_cast<unsigned long long>(state.activeNextByte),
+            static_cast<unsigned long long>(progress_params.protocolBytes));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    validate_recv_progress_stage(group, state);
+
+    const ProgressChunk chunk = next_chunk(state, progress_params);
+    const uint64_t expected = chunk.streamEnd;
+    uint32_t ready = 1;
+    unsigned long long current = 0;
+    if (group.is_leader()) {
+      current = static_cast<unsigned long long>(
+          transport.read_signal(sendRecvState_.localSignalBuf.subBuffer(
+              progress_params.groupId * sizeof(uint64_t))));
+      ready = current >= expected ? 1U : 0U;
+      if (!ready) {
+        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
+            timeout,
+            "progress_recv_once waiting for DATA_READY expected>=%llu, "
+            "current=%llu",
+            static_cast<unsigned long long>(expected),
+            current);
+      }
+    }
+    ready = group.broadcast<uint32_t>(ready);
+    if (!ready) {
+      return IbgdaSendRecvProgressStatus::Waiting;
+    }
+
+    const std::size_t validBytes = valid_payload_bytes(
+        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
+    if (validBytes > 0) {
+      CopyOp::recv(
+          static_cast<char*>(dst) + chunk.dataOff,
+          sendRecvState_.recvStagingPtr + chunk.stagingOff,
+          validBytes,
+          group,
+          chunk.dataOff,
+          args...);
+    }
+    group.sync();
+
+    transport.signal(
+        group,
+        sendRecvState_.remoteSignalBuf.subBuffer(
+            (sendRecvState_.maxGroups + progress_params.groupId) *
+            sizeof(uint64_t)),
+        chunk.bytes);
+
+    state.activeNextByte += chunk.bytes;
+    if (state.activeNextByte >= progress_params.protocolBytes) {
+      transition_progress_stage(
+          group, state, detail::IbSendRecvProgressStage::Done);
+      store_progress_state(group, progressIndex, state);
+      return IbgdaSendRecvProgressStatus::Done;
+    }
+
+    store_progress_state(group, progressIndex, state);
+    return IbgdaSendRecvProgressStatus::Progressed;
+#else
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+    return IbgdaSendRecvProgressStatus::Done;
+#endif
+  }
+
+  /**
+   * send — send one block's tile via pipelined RDMA.
+   *
+   * Copies src -> sendStaging, then RDMA puts sendStaging -> peer's
+   * recvStaging. For this call, each logical slot contributes one
+   * perBlockSlot-sized region for this group. If nbytes > perBlockSlot, send()
+   * advances through multiple ring positions. max_signal_bytes can further
+   * subdivide each perBlockSlot into multiple signaled sub-chunks, enabling
+   * finer-grained overlap at the receiver.
+   *
+   * Signaling protocol (per group):
+   *   NIC_DONE   — loopback counter incremented by NIC after each RDMA put.
+   *                send waits on this before overwriting local sendStaging.
+   *   SLOT_FREE  — receiver increments by bytesThis for each signaled byte
+   *                range. send waits before overwriting recvStaging.
+   *   DATA_READY — sender increments by bytesThis, piggybacked on put.
+   *                recv waits on this before reading recvStaging.
+   *
+   * state[].nextStep persists across calls, so send() resumes the staging-ring
+   * cursor and protocol sequence numbers on each invocation. This allows
+   * callers to pipeline across repeated send() calls without a separate drain.
+   *
+   * The caller must keep the staging layout stable while a sequence is in
+   * flight. Changing active_blocks changes the per-block staging partition, so
+   * both sides must perform a higher-level barrier/quiescence step first.
+   * max_signal_bytes may vary across calls with the same active_blocks.
+   *
+   * @param transport       Owning transport used for every transport op.
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does RDMA ops).
+   * @param src             Source data for this block's tile.
+   * @param nbytes          Bytes to send for this group. Internally consumed
+   *                        in perBlockSlot-sized pieces, or smaller sub-chunks
+   *                        when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      Transport& transport,
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)transport;
+    (void)group;
+    (void)src;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int stateIndex = progress_send_index(group);
+    auto& state = progress_state_slot(group, stateIndex);
+    assert_progress_slot_idle(group, state, "send");
+    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+    if (group.is_leader()) {
+      state.activeStage = detail::IbSendRecvProgressStage::Busy;
+      state.activeBaseStep = static_cast<int64_t>(baseByte);
+      state.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const uint64_t streamEnd = streamStart + bytesThis;
+
+      // (1) Wait for NIC to finish with this slot's local sendStaging.
+      if (streamEnd > pipelineBytes) {
+        transport.wait_counter(
+            group,
+            sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            streamEnd - pipelineBytes,
+            timeout);
+      }
+
+      // (2) Cooperative copy: src -> local sendStaging via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::send(
+            sendRecvState_.sendStagingPtr + stagingOff,
+            static_cast<const char*>(src) + dataOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (3) Backpressure: wait for receiver to free this byte range's
+      //     recvStaging offset. Symmetric with DATA_READY.
+      if (streamEnd > pipelineBytes) {
+        transport.wait_signal(
+            group,
+            sendRecvState_.localSignalBuf.subBuffer(
+                (maxGroups + groupId) * sizeof(uint64_t)),
+            streamEnd - pipelineBytes,
+            timeout);
+      }
+
+      // (4) threadfence_system + leader-only single-WQE RDMA put with
+      //     fused signal+counter. All threads fence to ensure memcpy
+      //     stores are visible to the NIC before the leader posts the WQE.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        transport.put(
+            solo,
+            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
+            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
+            bytesThis,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis,
+            sendRecvState_.localCounterCompletionBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis);
+      }
+      group.sync();
+      dataOff += bytesThis;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * recv — receive one block's tile from pipelined RDMA.
+   *
+   * Waits for data to arrive in recvStaging, then copies recvStaging -> dst.
+   * For this call, each logical slot contributes one perBlockSlot-sized region
+   * for this group. If nbytes > perBlockSlot, recv() advances through multiple
+   * ring positions. max_signal_bytes controls sub-chunk granularity and must
+   * match the sender.
+   *
+   * Signaling protocol (per group, symmetric with send):
+   *   DATA_READY — sender increments by bytesThis after RDMA put completes.
+   *                recv waits on this before copying from recvStaging.
+   *   SLOT_FREE  — recv increments by bytesThis (symmetric with DATA_READY)
+   *                to release backpressure on sender.
+   *
+   * @param transport       Owning transport used for every transport op.
+   * @param group           ThreadGroup (all threads participate in memcpy,
+   *                        leader does signal ops).
+   * @param dst             Destination for this block's tile.
+   * @param nbytes          Bytes to receive for this group. Internally
+   *                        consumed in perBlockSlot-sized pieces, or smaller
+   *                        sub-chunks when max_signal_bytes is set.
+   * @param active_blocks   Number of block-groups sharing each logical slot in
+   *                        this call. 0 means use maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk within one
+   *                        perBlockSlot. 0 means one signal per perBlockSlot.
+   *                        Must match the sender's value.
+   * @param timeout         Optional timeout for wait operations.
+   */
+  template <typename Transport, typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if !PIPES_IS_DEVICE_COMPILE
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#else
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv active_blocks=%d > maxGroups=%d\n",
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv group_id=%u >= active_blocks=%d\n",
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: recv perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+
+    const int pipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
+    const int maxGroups = sendRecvState_.maxGroups;
+    const int stateIndex = progress_recv_index(group);
+    auto& state = progress_state_slot(group, stateIndex);
+    assert_progress_slot_idle(group, state, "recv");
+    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
+    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
+    if (group.is_leader()) {
+      state.activeStage = detail::IbSendRecvProgressStage::Busy;
+      state.activeBaseStep = static_cast<int64_t>(baseByte);
+      state.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      const uint64_t streamStart = baseByte + dataOff;
+      const std::size_t pipelineOff =
+          static_cast<std::size_t>(streamStart % pipelineBytes);
+      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
+      const std::size_t slotOff = slot * dataBufferSize;
+      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
+      const std::size_t slotRemaining = perBlockSlot - chunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          chunkSize < dataRemaining ? chunkSize : dataRemaining;
+      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
+      const std::size_t stagingOff =
+          slotOff + groupId * perBlockSlot + chunkOff;
+      const uint64_t streamEnd = streamStart + bytesThis;
+
+      // (1) Wait for sender's DATA_READY signal.
+      transport.wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          streamEnd,
+          timeout);
+
+      // (2) Cooperative copy: local recvStaging -> dst via CopyOp.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::recv(
+            static_cast<char*>(dst) + dataOff,
+            sendRecvState_.recvStagingPtr + stagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
+      //     threshold before reusing remote recvStaging at the same offset.
+      transport.signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (maxGroups + groupId) * sizeof(uint64_t)),
+          bytesThis);
+      dataOff += bytesThis;
+    }
+
+    if (group.is_leader()) {
+      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
+      state.activeStage = detail::IbSendRecvProgressStage::Done;
+      state.activeBaseStep = 0;
+      state.activeNextByte = 0;
+    }
+    group.sync();
+#endif
+  }
+
+  /**
+   * forward — receive data and forward it to the next peer in a ring.
+   *
+   * Combines recv + send in a single method, sharing the staging buffer to
+   * avoid an extra copy. The CopyOp::forward() method receives three
+   * buffers: dst (application output), fwd_staging (next peer's send staging),
+   * and staging (this transport's recv staging). This enables fused
+   * receive-reduce-forward patterns.
+   *
+   * Signal ordering invariant (critical for ring deadlock avoidance):
+   *   1. Wait DATA_READY from sender (this transport)
+   *   2. Wait NIC_DONE on fwd transport's sendStaging (backpressure)
+   *   3. CopyOp::forward(dst, fwd_staging, staging, ...)
+   *   4. Signal SLOT_FREE to sender (this transport) — BEFORE step 5
+   *   5. Wait SLOT_FREE from fwd transport's receiver
+   *   6. threadfence_system + RDMA put via fwd transport
+   *
+   * Step 4 before step 5 breaks the circular dependency in rings: each rank
+   * releases its predecessor's staging before waiting on its successor.
+   *
+   * Protocol compatibility with send() and recv():
+   *
+   * forward acts as a recv on "this" transport and a send on "fwd".
+   * The signal protocol is wire-compatible:
+   *
+   *   Recv side (this transport):
+   *     - Reads state[maxGroups + groupId].nextStep (same index as recv)
+   *     - Waits DATA_READY on localSignalBuf[groupId] (matches send's
+   *       piggybacked signal on remoteSignalBuf[groupId])
+   *     - Signals SLOT_FREE on remoteSignalBuf[maxGroups + groupId]
+   *       (matches send's backpressure wait on localSignalBuf[maxGroups +
+   *       groupId])
+   *
+   *   Fwd side (fwd transport):
+   *     - Reads state[groupId].nextStep (same index as send)
+   *     - Waits NIC_DONE on localCounterBuf[groupId] (matches send's
+   *       self-counter)
+   *     - Waits SLOT_FREE on localSignalBuf[maxGroups + groupId]
+   *       (matches recv's backpressure release)
+   *     - RDMA puts with DATA_READY on remoteSignalBuf[groupId]
+   *       + NIC_DONE on localCounterBuf[groupId]
+   *       (matches recv's DATA_READY wait)
+   *
+   * Any chain of send → forward* → recv is therefore valid: each
+   * forward consumes exactly the signals its predecessor produces
+   * and produces exactly the signals its successor expects.
+   *
+   * @param transport       Recv-side transport (this peer's receiver).
+   * @param group           ThreadGroup (all threads participate).
+   * @param dst             Application destination (may be nullptr if
+   *                        CopyOp handles it, e.g. reduce-scatter).
+   * @param fwdDevice       Forward-side send/recv device (next peer).
+   * @param fwdTransport    Forward transport (sends to next peer in ring).
+   * @param nbytes          Bytes to receive and forward.
+   * @param active_blocks   Number of block-groups sharing the slot. 0 =
+   * maxGroups.
+   * @param max_signal_bytes Max bytes per signaled sub-chunk. 0 = perBlockSlot.
+   * @param timeout         Optional timeout for wait operations.
+   * @param args            Extra args forwarded to CopyOp::forward.
+   */
+  template <typename CopyOp = Memcpy, typename Transport, typename... Args>
+  __device__ __forceinline__ void forward(
+      Transport& transport,
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      IbSendRecvDevice& fwdDevice,
+      Transport& fwdTransport,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+#if PIPES_IS_DEVICE_COMPILE
+#ifdef __HIP_PLATFORM_AMD__
+    static_assert(
+        sizeof(CopyOp) == 0,
+        "IbSendRecvDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
+#endif
+    if (nbytes == 0) {
+      return;
+    }
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+
+    const int groupId = group.group_id;
+
+    // --- recv side (this transport) ---
+    const int recvEffActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward recv active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            recvEffActive,
+            sendRecvState_.maxGroups,
+            groupId);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t recvPerBlockSlot =
+        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
+    if (recvPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    // --- fwd side (fwd transport) ---
+    const int fwdEffActive =
+        active_blocks > 0 ? active_blocks : fwdDevice.sendRecvState_.maxGroups;
+    if (fwdEffActive > fwdDevice.sendRecvState_.maxGroups ||
+        groupId >= fwdEffActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: forward fwd active_blocks=%d "
+            "maxGroups=%d groupId=%u\n",
+            fwdEffActive,
+            fwdDevice.sendRecvState_.maxGroups,
+            groupId);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t fwdPerBlockSlot =
+        (fwdDevice.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
+    if (fwdPerBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    // Chunk sizes for recv and fwd sides
+    std::size_t recvChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : recvPerBlockSlot;
+    if (recvChunkSize == 0) {
+      recvChunkSize = recvPerBlockSlot;
+    }
+    std::size_t fwdChunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : fwdPerBlockSlot;
+    if (fwdChunkSize == 0) {
+      fwdChunkSize = fwdPerBlockSlot;
+    }
+
+    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
+    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
+    const int recvMaxGroups = sendRecvState_.maxGroups;
+    const int recvStateIndex = progress_recv_index(group);
+    auto& recvSlotState = progress_state_slot(group, recvStateIndex);
+    assert_progress_slot_idle(group, recvSlotState, "forward recv");
+    const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
+    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
+
+    const int fwdPipelineDepth = fwdDevice.sendRecvState_.pipelineDepth;
+    const std::size_t fwdDataBufSize = fwdDevice.sendRecvState_.dataBufferSize;
+    const int fwdMaxGroups = fwdDevice.sendRecvState_.maxGroups;
+    const int fwdStateIndex = fwdDevice.progress_send_index(group);
+    auto& fwdSlotState = fwdDevice.progress_state_slot(group, fwdStateIndex);
+    fwdDevice.assert_progress_slot_idle(group, fwdSlotState, "forward send");
+    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
+    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
+    if (group.is_leader()) {
+      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+      recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
+      recvSlotState.activeNextByte = 0;
+      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
+      fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
+      fwdSlotState.activeNextByte = 0;
+    }
+
+    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
+      // --- Recv side offsets ---
+      const uint64_t recvStreamStart = recvBaseByte + dataOff;
+      const std::size_t recvPipelineOff =
+          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
+      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
+      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
+      const std::size_t recvChunkOff =
+          recvPipelineOff - recvSlot * recvPerBlockSlot;
+      const std::size_t recvStagingOff =
+          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
+
+      // --- Fwd side offsets ---
+      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
+      const std::size_t fwdPipelineOff =
+          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
+      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
+      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
+      const std::size_t fwdChunkOff =
+          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
+      const std::size_t fwdStagingOff =
+          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
+      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
+      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
+      const std::size_t dataRemaining = protocolBytes - dataOff;
+      std::size_t bytesThis =
+          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
+      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
+      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
+      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
+      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
+      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
+
+      // (1) Wait for sender's DATA_READY.
+      transport.wait_signal(
+          group,
+          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
+          recvStreamEnd,
+          timeout);
+
+      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        fwdTransport.wait_counter(
+            group,
+            fwdDevice.sendRecvState_.localCounterBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            fwdStreamEnd - fwdPipelineBytes,
+            timeout);
+      }
+
+      // (3) CopyOp::forward — transform recv staging -> dst + fwd staging.
+      const std::size_t validBytes =
+          valid_payload_bytes(dataOff, bytesThis, nbytes);
+      if (validBytes > 0) {
+        CopyOp::forward(
+            dst ? static_cast<char*>(dst) + dataOff : nullptr,
+            fwdDevice.sendRecvState_.sendStagingPtr + fwdStagingOff,
+            sendRecvState_.recvStagingPtr + recvStagingOff,
+            validBytes,
+            group,
+            dataOff,
+            args...);
+      }
+      group.sync();
+
+      // (4) Signal SLOT_FREE to sender (this transport).
+      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
+      //     to break circular ring dependency.
+      transport.signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (recvMaxGroups + groupId) * sizeof(uint64_t)),
+          bytesThis);
+
+      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
+      //     recvStaging).
+      if (fwdStreamEnd > fwdPipelineBytes) {
+        fwdTransport.wait_signal(
+            group,
+            fwdDevice.sendRecvState_.localSignalBuf.subBuffer(
+                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
+            fwdStreamEnd - fwdPipelineBytes,
+            timeout);
+      }
+
+      // (6) threadfence_system + RDMA put via fwd transport.
+      __threadfence_system();
+      group.sync();
+      if (group.is_leader()) {
+        ThreadGroup solo{
+            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
+        fwdTransport.put(
+            solo,
+            fwdDevice.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
+            fwdDevice.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
+            bytesThis,
+            fwdDevice.sendRecvState_.remoteSignalBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis,
+            fwdDevice.sendRecvState_.localCounterCompletionBuf.subBuffer(
+                groupId * sizeof(uint64_t)),
+            bytesThis);
+      }
+      group.sync();
+      dataOff += bytesThis;
+    }
+
+    // Update shared byte cursors for both recv and fwd sides.
+    if (group.is_leader()) {
+      recvSlotState.nextStep =
+          static_cast<int64_t>(recvBaseByte + protocolBytes);
+      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+      recvSlotState.activeBaseStep = 0;
+      recvSlotState.activeNextByte = 0;
+      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
+      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
+      fwdSlotState.activeBaseStep = 0;
+      fwdSlotState.activeNextByte = 0;
+    }
+    group.sync();
+#else
+    (void)transport;
+    (void)group;
+    (void)dst;
+    (void)fwdDevice;
+    (void)fwdTransport;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)timeout;
+#endif
+  }
+
+  /**
+   * Maximum bytes a block can send without blocking on pipeline backpressure.
+   *
+   * The staging buffer is split into pipelineDepth slots, each divided evenly
+   * across active_blocks. A block can fill all its slots before the NIC must
+   * drain any of them, so the non-blocking window is:
+   *   (dataBufferSize / active_blocks) * pipelineDepth
+   *
+   * Callers should loop over their data in pipeline_window-sized chunks so
+   * that send()/forward() never stall waiting for a free slot.
+   *
+   * @param active_blocks  Total blocks sharing this transport (typically
+   *                       gridDim.x).
+   */
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    const std::size_t per_block_slot =
+        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
+    return per_block_slot * sendRecvState_.pipelineDepth;
+  }
+
+ private:
+  /**
+   * Physical staging range for the next resumable progress step.
+   *
+   * `stagingOff` is an offset into the transport-owned send/recv staging
+   * buffers. `dataOff` is the matching protocol offset into the caller's user
+   * buffer. `bytes` never crosses a per-block staging partition or the
+   * reserved protocol byte count. `streamEnd` is the absolute protocol byte
+   * value after this chunk and is used as the DATA_READY, SLOT_FREE, and
+   * NIC_DONE readiness threshold. `dataOff` is a protocol offset; callers mask
+   * it against the payload byte count before invoking user-buffer copy
+   * callbacks.
+   */
+  struct ProgressChunk {
+    std::size_t stagingOff;
+    std::size_t dataOff;
+    std::size_t bytes;
+    uint64_t streamEnd;
+  };
+
+  /**
+   * Register-only geometry for one resumable progress call.
+   *
+   * This is intentionally not stored in `IbSendRecvState::ProgressSlot`:
+   * callers pass the same static geometry to init and progress, and each
+   * progress call derives these values in registers instead of reloading
+   * duplicated fields from HBM-backed progress state.
+   */
+  struct ProgressGeometry {
+    int groupId;
+    std::size_t payloadBytes;
+    std::size_t protocolBytes;
+    std::size_t perBlockSlot;
+    std::size_t chunkSize;
+  };
+
+  /**
+   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
+   * the staging stream on the same granularity as the vectorized local staging
+   * copies while preserving caller-facing payload byte counts; padding is
+   * transport-private and is never exposed to CopyOp callbacks.
+   */
+  __device__ __forceinline__ static std::size_t align_protocol_bytes(
+      std::size_t nbytes) {
+    return (nbytes + 15ULL) & ~15ULL;
+  }
+
+  __device__ __forceinline__ static std::size_t valid_payload_bytes(
+      std::size_t byteOffset,
+      std::size_t chunkBytes,
+      std::size_t payloadBytes) {
+    if (byteOffset >= payloadBytes) {
+      return 0;
+    }
+    const std::size_t remaining = payloadBytes - byteOffset;
+    return chunkBytes < remaining ? chunkBytes : remaining;
+  }
+
+  /**
+   * Return the internal send progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, 0);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return the internal recv progress slot index for `group`.
+   */
+  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return progress_index_for_group(group, sendRecvState_.maxGroups);
+#else
+    (void)group;
+    return 0;
+#endif
+  }
+
+  /**
+   * Validate a progress group and map it into the transport-owned slot array.
+   */
+  __device__ __forceinline__ int progress_index_for_group(
+      ThreadGroup& group,
+      int baseIndex) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (sendRecvState_.state.empty() ||
+        sendRecvState_.state.data() == nullptr) {
+      if (group.is_leader()) {
+        printf("[PIPES] FATAL: send/recv state is null\n");
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (sendRecvState_.maxGroups <= 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const auto requiredStateSlots =
+        static_cast<uint32_t>(2 * sendRecvState_.maxGroups);
+    if (sendRecvState_.state.size() < requiredStateSlots ||
+        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
+            "state slots=%u\n",
+            group.group_id,
+            sendRecvState_.maxGroups,
+            static_cast<unsigned>(sendRecvState_.state.size()));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    return baseIndex + static_cast<int>(group.group_id);
+#else
+    (void)group;
+    (void)baseIndex;
+    return 0;
+#endif
+  }
+
+  /**
+   * Return a reference to a transport-owned progress state slot.
+   */
+  __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
+      ThreadGroup& group,
+      int progressIndex) const {
+    (void)group;
+    return sendRecvState_.state[progressIndex];
+  }
+
+  /**
+   * Trap if a caller tries to start a second send/recv before the first ends.
+   *
+   * The broadcast is the ordering point for init callers: if the leader sees a
+   * non-idle slot, every thread traps before any caller can store new state.
+   */
+  __device__ __forceinline__ void assert_progress_slot_idle(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state,
+      const char* direction) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    uint32_t idle = 1;
+    if (group.is_leader()) {
+      const auto activeStage = state.activeStage;
+      idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
+      if (!idle) {
+        printf(
+            "[PIPES] FATAL: %s requested with outstanding %s progress "
+            "for group_id=%u stage=%d nextByte=%llu\n",
+            direction,
+            direction,
+            group.group_id,
+            static_cast<int>(activeStage),
+            static_cast<unsigned long long>(state.activeNextByte));
+      }
+    }
+    idle = group.broadcast<uint32_t>(idle);
+    if (!idle) {
+      PIPES_DEVICE_TRAP();
+    }
+#else
+    (void)group;
+    (void)state;
+    (void)direction;
+#endif
+  }
+
+  /**
+   * Commit an updated local progress state back to its transport-owned slot.
+   * The trailing sync orders the leader's store before later group work.
+   */
+  __device__ __forceinline__ void store_progress_state(
+      ThreadGroup& group,
+      int progressIndex,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (group.is_leader()) {
+      auto& slot = sendRecvState_.state[progressIndex];
+      slot.activeNextByte = state.activeNextByte;
+      slot.activeBaseStep = state.activeBaseStep;
+      slot.activeStage = state.activeStage;
+    }
+    group.sync();
+#else
+    (void)group;
+    (void)progressIndex;
+    (void)state;
+#endif
+  }
+
+  /**
+   * Validate and return the static staging geometry for one progress call.
+   *
+   * This helper is called by the public init APIs and each progress attempt. It
+   * verifies that the group participates in this transfer and that the
+   * requested active block count can fit at least one 16-byte-aligned region in
+   * each staging slot.
+   *
+   * On success, `perBlockSlot` is the caller's partition within each logical
+   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
+   * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
+   * rounded down to the same 16-byte alignment used by the blocking send/recv
+   * path. Invalid geometry traps on device because continuing would corrupt
+   * another block group's staging partition.
+   *
+   * The public init methods handle zero-byte operations before calling this
+   * helper. A progress call should only see zero bytes when its state is
+   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
+   * protocol counts here; copy callbacks still see only valid payload bytes.
+   */
+  __device__ __forceinline__ ProgressGeometry make_progress_geometry(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const char* opName) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (nbytes == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
+            "transfer\n",
+            opName);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    const int groupId = static_cast<int>(group.group_id);
+    const int effActive =
+        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
+    if (effActive > sendRecvState_.maxGroups) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s active_blocks=%d > maxGroups=%d\n",
+            opName,
+            effActive,
+            sendRecvState_.maxGroups);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    if (groupId < 0 || groupId >= effActive) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s group_id=%d >= active_blocks=%d\n",
+            opName,
+            groupId,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t perBlockSlot =
+        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
+    if (perBlockSlot == 0) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: %s perBlockSlot=0 "
+            "(dataBufferSize=%llu, active_blocks=%d)\n",
+            opName,
+            (unsigned long long)sendRecvState_.dataBufferSize,
+            effActive);
+      }
+      PIPES_DEVICE_TRAP();
+    }
+
+    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
+    std::size_t chunkSize =
+        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
+        ? (max_signal_bytes & ~15ULL)
+        : perBlockSlot;
+    if (chunkSize == 0) {
+      chunkSize = perBlockSlot;
+    }
+    return ProgressGeometry{
+        .groupId = groupId,
+        .payloadBytes = nbytes,
+        .protocolBytes = protocolBytes,
+        .perBlockSlot = perBlockSlot,
+        .chunkSize = chunkSize,
+    };
+#else
+    (void)group;
+    (void)nbytes;
+    (void)active_blocks;
+    (void)max_signal_bytes;
+    (void)opName;
+    return {};
+#endif
+  }
+
+  /**
+   * Reserve a non-overlapping protocol byte range for one progress state.
+   *
+   * Blocking send()/recv() read `state[].nextStep` at call entry and commit it
+   * at completion. Progress init cannot wait until completion because progress
+   * operations may complete across many bounded calls. Reserving at init gives
+   * the transport-owned state a stable byte-stream base and makes later
+   * blocking calls start after all in-flight progress ranges.
+   */
+  __device__ __forceinline__ int64_t reserve_progress_step(
+      ThreadGroup& group,
+      int stateIndex,
+      std::size_t nbytes) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    uint64_t baseStep = 0;
+    if (group.is_leader()) {
+      auto& slot = sendRecvState_.state[stateIndex];
+      baseStep = static_cast<uint64_t>(slot.nextStep);
+      slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
+    }
+    baseStep = group.broadcast<uint64_t>(baseStep);
+    return static_cast<int64_t>(baseStep);
+#else
+    (void)group;
+    (void)stateIndex;
+    (void)nbytes;
+    return 0;
+#endif
+  }
+
+  /**
+   * Trap if a send progress state is not in a sender-owned stage.
+   *
+   * Without this check, corrupted or mismatched transport-owned state could
+   * return `Waiting` forever because no send-side transition would match.
+   * Trapping turns that misuse into an immediate device failure with a clear
+   * diagnostic.
+   */
+  __device__ __forceinline__ void validate_send_progress_stage(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
+        state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
+        state.activeStage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
+            static_cast<int>(state.activeStage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Trap if a recv progress state is not in a receiver-owned stage.
+   *
+   * Receiver progress is only valid while waiting for DATA_READY. Sender
+   * stages are protocol misuse and cannot make progress on the recv path.
+   */
+  __device__ __forceinline__ void validate_recv_progress_stage(
+      ThreadGroup& group,
+      const IbSendRecvState::ProgressSlot& state) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
+        state.activeStage != detail::IbSendRecvProgressStage::Done) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
+            static_cast<int>(state.activeStage));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+#endif
+  }
+
+  /**
+   * Return whether `current -> next` is a valid progress-state transition.
+   */
+  __device__ __forceinline__ bool is_valid_progress_transition(
+      detail::IbSendRecvProgressStage current,
+      detail::IbSendRecvProgressStage next) const {
+    switch (current) {
+      case detail::IbSendRecvProgressStage::WaitNicDone:
+        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
+      case detail::IbSendRecvProgressStage::WaitSlotFree:
+        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
+            next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::WaitDataReady:
+        return next == detail::IbSendRecvProgressStage::Done;
+      case detail::IbSendRecvProgressStage::Done:
+        return false;
+      case detail::IbSendRecvProgressStage::Busy:
+        return false;
+    }
+    return false;
+  }
+
+  /**
+   * Apply one legal progress-state transition.
+   *
+   * The explicit transition table keeps the send/recv state machine local and
+   * auditable. If future progress states are added, this switch must opt into
+   * each new legal edge instead of allowing silent fallthrough.
+   */
+  __device__ __forceinline__ void transition_progress_stage(
+      ThreadGroup& group,
+      IbSendRecvState::ProgressSlot& state,
+      detail::IbSendRecvProgressStage next) const {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const detail::IbSendRecvProgressStage current = state.activeStage;
+    if (!is_valid_progress_transition(current, next)) {
+      if (group.is_leader()) {
+        printf(
+            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
+            static_cast<int>(current),
+            static_cast<int>(next));
+      }
+      PIPES_DEVICE_TRAP();
+    }
+    state.activeStage = next;
+#endif
+  }
+
+  /**
+   * Map the state's logical protocol byte cursor to the next staging-ring
+   * chunk.
+   *
+   * The transport stores each logical slot as `dataBufferSize` bytes, split
+   * into geometry-specific per-group partitions. The protocol cursor advances
+   * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
+   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
+   *
+   * The returned chunk is clipped by three boundaries: the configured
+   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
+   * current per-block staging partition. This keeps every progress call
+   * bounded and prevents a single RDMA put or recv copy from spanning two
+   * staging slots.
+   */
+  __device__ __forceinline__ ProgressChunk next_chunk(
+      const IbSendRecvState::ProgressSlot& state,
+      const ProgressGeometry& geometry) const {
+    const uint64_t streamStart =
+        static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
+    const std::size_t pipelineBytes = geometry.perBlockSlot *
+        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
+    const std::size_t pipelineOff =
+        static_cast<std::size_t>(streamStart % pipelineBytes);
+    const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
+    const std::size_t slotOff =
+        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
+    const std::size_t chunkOff =
+        pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
+    const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
+    const std::size_t dataRemaining =
+        geometry.protocolBytes - state.activeNextByte;
+    std::size_t bytes =
+        geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
+    bytes = bytes < slotRemaining ? bytes : slotRemaining;
+    return ProgressChunk{
+        .stagingOff = slotOff +
+            static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
+            chunkOff,
+        .dataOff = state.activeNextByte,
+        .bytes = bytes,
+        .streamEnd = streamStart + bytes,
+    };
+  }
 };
 
 struct P2pIbTransportDevice {
@@ -199,6 +1885,74 @@ struct P2pIbTransportDevice {
   __device__ void fence(ThreadGroup& group);
 
   __device__ void fence();
+
+  // Pipelined send/recv — forwarded to the active backend's IbSendRecvDevice.
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  // Per-block pipelined staging window — forwarded to the active backend.
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const;
+
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0);
+
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args);
 };
 
 static_assert(std::is_standard_layout_v<P2pIbTransportDevice>);

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -500,7 +500,8 @@ struct IbSendRecvState {
       nullptr}; ///< Raw local recvStaging pointer (recv memcpy)
   IbgdaLocalBuffer localSignalBuf; ///< Signal inbox (DATA_READY + SLOT_FREE)
   IbgdaRemoteBuffer remoteSignalBuf; ///< Peer's signal inbox
-  IbgdaLocalBuffer localCounterBuf; ///< NIC_DONE counter inbox
+  IbgdaLocalBuffer localCounterBuf; ///< GPU-readable NIC_DONE counter inbox
+  IbgdaLocalBuffer localCounterCompletionBuf; ///< Transport completion target
   DeviceSpan<ProgressSlot> state; ///< Protocol cursors + async state
   int maxGroups{0}; ///< Layout size for signal/state arrays
   int pipelineDepth{0}; ///< Number of pipeline slots in the ring

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.cc
@@ -51,38 +51,6 @@ constexpr int kMaxQpLanesPerBlock = 64;
 
 } // namespace
 
-struct PeerBufferSizes {
-  std::size_t staging{0};
-  std::size_t srSignal{0};
-  std::size_t srCounter{0};
-  std::size_t srState{0};
-
-  // Pointers into a contiguous allocation (set by layout())
-  void* sendStagingPtr{nullptr};
-  void* recvStagingPtr{nullptr};
-  void* srSignalPtr{nullptr};
-  void* srCounterPtr{nullptr};
-  void* srStatePtr{nullptr};
-
-  std::size_t total() const {
-    return staging * 2 + srSignal + srCounter + srState;
-  }
-
-  void layout(void* base) {
-    char* p = static_cast<char*>(base);
-    sendStagingPtr = p;
-    p += staging;
-    recvStagingPtr = p;
-    p += staging;
-    srSignalPtr = p;
-    p += srSignal;
-    srCounterPtr = p;
-    p += srCounter;
-    srStatePtr = p;
-    p += srState;
-  }
-};
-
 namespace {
 
 // Convert ibverbx::ibv_mtu enum to doca_verbs_mtu_size enum.
@@ -596,43 +564,13 @@ void MultipeerIbgdaTransport::connectPeerLoopback(int peerIndex) {
   }
 }
 
-PeerBufferSizes MultipeerIbgdaTransport::computePeerBufferSizes() const {
-  PeerBufferSizes sizes;
-  if (config_.sendRecv.has_value()) {
-    const auto& sr = *config_.sendRecv;
-    sizes.staging = sr.pipelineDepth * config_.dataBufferSize;
-    sizes.srSignal = 2 * sr.maxGroups * sizeof(uint64_t);
-    sizes.srCounter = sr.maxGroups * sizeof(uint64_t);
-    sizes.srState = 2 * sr.maxGroups * sizeof(IbSendRecvState::ProgressSlot);
-  }
-  return sizes;
-}
-
 P2pIbgdaTransportBuildParams MultipeerIbgdaTransport::buildPeerTransportParams(
     int peerIndex) const {
   const int mainQpsPerPeerPerNic =
       config_.maxGroups * config_.qpsPerBlockPerNic;
-  auto makeSendRecvState = [&]() -> IbSendRecvState {
-    if (sendRecvPeerBuffers_.empty()) {
-      return {};
-    }
-    const auto& pb = sendRecvPeerBuffers_[peerIndex];
-    return IbSendRecvState{
-        .sendStagingBuf = pb.sendStaging,
-        .recvStagingBuf = pb.remoteRecvStaging,
-        .sendStagingPtr = static_cast<char*>(pb.sendStaging.ptr),
-        .recvStagingPtr = static_cast<char*>(pb.recvStaging.ptr),
-        .localSignalBuf = pb.signal,
-        .remoteSignalBuf = pb.remoteSignal,
-        .localCounterBuf = pb.counter,
-        .state = pb.state.value_or(DeviceSpan<IbSendRecvState::ProgressSlot>()),
-        .maxGroups = config_.sendRecv->maxGroups,
-        .pipelineDepth = config_.sendRecv->pipelineDepth,
-        .dataBufferSize = config_.dataBufferSize,
-    };
-  };
-
-  P2pIbgdaTransportBuildParams params(makeSendRecvState());
+  // Build the device-side send/recv state from the shared base (delegates to
+  // the inherited sendRecvPeerBuffers_).
+  P2pIbgdaTransportBuildParams params(sendRecvStateForPeer(peerIndex));
   params.maxGroups = config_.maxGroups;
   params.qpsPerBlockPerNic = config_.qpsPerBlockPerNic;
   params.h_nicDeviceIbgdaResources.resize(numNics_);
@@ -789,7 +727,6 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
         nic.loopbackCompanionQps.resize(
             static_cast<size_t>(numPeers) * config.maxGroups);
       }
-      lazyPeerBufs_.resize(numPeers);
       peerMaterialized_.resize(numPeers, false);
     }
 
@@ -797,8 +734,17 @@ MultipeerIbgdaTransport::MultipeerIbgdaTransport(
     allocateResources();
     registerMemory();
 
-    // Allocate tile sendrecv buffers (if configured)
-    allocate_send_recv_buffers();
+    // Allocate send/recv staging buffers (if configured). Eager mode delegates
+    // to the shared base (Device counter: NIC loopback atomic); lazy mode only
+    // sizes the inherited per-peer view vector — the shared base
+    // allocateSendRecvBufferForPeer() fills it per peer at materialization.
+    if (config_.sendRecv.has_value()) {
+      if (!config_.ibLazyConnect) {
+        allocateSendRecvBuffersEager(IbCounterStorage::Device);
+      } else {
+        sendRecvPeerBuffers_.resize(nRanks_ - 1);
+      }
+    }
   } catch (const std::exception&) {
     // Destructor won't run for a partially-constructed object, so clean up
     // all resources allocated by the init methods above.
@@ -830,8 +776,9 @@ void MultipeerIbgdaTransport::cleanup() {
   gpuAllocations_.clear();
   peerTransportsGpu_ = nullptr;
 
-  // Free tile sendrecv buffers
-  cleanup_send_recv_buffers();
+  // Free send/recv staging buffers (eager bulks + any lazy per-peer
+  // allocations) via the shared base cleanup.
+  cleanupSendRecvBuffers();
 
   // Destroy per-NIC QPs and loopback responders.
   for (auto& nic : nicDoca_) {
@@ -1087,7 +1034,7 @@ void MultipeerIbgdaTransport::exchange() {
   allocateSignalCounterResources(
       IbCounterStorage::Device, /*allocateDiscardSignal=*/true);
 
-  exchange_send_recv_buffers();
+  exchangeSendRecvBuffersEager();
 
   // Build device transports on GPU
   std::vector<P2pIbgdaTransportBuildParams> buildParams;
@@ -1163,146 +1110,10 @@ int MultipeerIbgdaTransport::qpsPerBlockPerNic() const {
 // Send/recv buffer lifecycle
 // =============================================================================
 
-void MultipeerIbgdaTransport::allocate_send_recv_buffers() {
-  if (!config_.sendRecv.has_value()) {
-    return;
-  }
-  const auto& sr = *config_.sendRecv;
-  if (sr.pipelineDepth < 1) {
-    throw std::invalid_argument("sendRecv.pipelineDepth must be >= 1");
-  }
-  if (sr.maxGroups < 1) {
-    throw std::invalid_argument("sendRecv.maxGroups must be >= 1");
-  }
-  if (config_.dataBufferSize == 0) {
-    throw std::invalid_argument(
-        "dataBufferSize must be > 0 when sendRecv is enabled");
-  }
-  if ((config_.dataBufferSize / sr.maxGroups) < 16) {
-    throw std::invalid_argument(
-        fmt::format(
-            "dataBufferSize / maxGroups must be >= 16, got {} / {} = {}",
-            config_.dataBufferSize,
-            sr.maxGroups,
-            config_.dataBufferSize / sr.maxGroups));
-  }
-
-  const int numPeers = nRanks_ - 1;
-  auto sizes = computePeerBufferSizes();
-  const auto stagingPerPeer = sizes.staging;
-  const auto signalPerPeer = sizes.srSignal;
-  const auto counterPerPeer = sizes.srCounter;
-  const auto statePerPeer = sizes.srState;
-  const auto stateSlotsPerPeer =
-      static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-          2 * sr.maxGroups);
-
-  auto allocateBulk = [&](std::size_t perPeer) {
-    auto buf = std::make_unique<meta::comms::DeviceBuffer>(perPeer * numPeers);
-    auto err = cudaMemset(buf->get(), 0, perPeer * numPeers);
-    if (err != cudaSuccess) {
-      throw std::runtime_error(
-          fmt::format(
-              "Failed to zero send/recv buffer: {}", cudaGetErrorString(err)));
-    }
-    return buf;
-  };
-
-  sendRecvPeerBuffers_.resize(numPeers);
-
-  if (!config_.ibLazyConnect) {
-    sendStagingBulk_ = allocateBulk(stagingPerPeer);
-    recvStagingBulk_ = allocateBulk(stagingPerPeer);
-    signalBulk_ = allocateBulk(signalPerPeer);
-    counterBulk_ = allocateBulk(counterPerPeer);
-    stateBulk_ = allocateBulk(statePerPeer);
-
-    auto sendStagingBulkReg =
-        registerBuffer(sendStagingBulk_->get(), stagingPerPeer * numPeers);
-    recvStagingBulkReg_ =
-        registerBuffer(recvStagingBulk_->get(), stagingPerPeer * numPeers);
-    signalBulkReg_ =
-        registerBuffer(signalBulk_->get(), signalPerPeer * numPeers);
-    counterBulkReg_ =
-        registerBuffer(counterBulk_->get(), counterPerPeer * numPeers);
-
-    for (int i = 0; i < numPeers; ++i) {
-      auto& pb = sendRecvPeerBuffers_[i];
-      pb.sendStaging = sendStagingBulkReg.subBuffer(i * stagingPerPeer);
-      pb.recvStaging = recvStagingBulkReg_.subBuffer(i * stagingPerPeer);
-      pb.signal = signalBulkReg_.subBuffer(i * signalPerPeer);
-      pb.counter = counterBulkReg_.subBuffer(i * counterPerPeer);
-      auto* statePtr = reinterpret_cast<IbSendRecvState::ProgressSlot*>(
-          static_cast<char*>(stateBulk_->get()) + i * statePerPeer);
-      pb.state.emplace(statePtr, stateSlotsPerPeer);
-    }
-
-    VLOG(1) << "MultipeerIbgdaTransport: eager mode — allocated tile buffers "
-            << "for " << numPeers << " peers (staging=" << stagingPerPeer
-            << "B per peer, 5 bulks)";
-  } else {
-    VLOG(1) << "MultipeerIbgdaTransport: lazy mode — per-peer allocation "
-            << "deferred to materializePeer";
-  }
-}
-
-void MultipeerIbgdaTransport::exchange_send_recv_buffers() {
-  if (!config_.sendRecv.has_value() || sendRecvPeerBuffers_.empty()) {
-    return;
-  }
-
-  const int numPeers = nRanks_ - 1;
-  const std::size_t stagingPerPeer =
-      config_.sendRecv->pipelineDepth * config_.dataBufferSize;
-
-  const std::size_t signalPerPeer =
-      2 * config_.sendRecv->maxGroups * sizeof(uint64_t);
-
-  auto recvStagingRemotes = exchangeBuffer(recvStagingBulkReg_);
-  auto signalRemotes = exchangeBuffer(signalBulkReg_);
-
-  for (int i = 0; i < numPeers; ++i) {
-    int peerRank = peerIndexToRank(i);
-    int remotePeerIndex = (myRank_ < peerRank) ? myRank_ : (myRank_ - 1);
-
-    sendRecvPeerBuffers_[i].remoteRecvStaging =
-        recvStagingRemotes[i].subBuffer(remotePeerIndex * stagingPerPeer);
-    sendRecvPeerBuffers_[i].remoteSignal =
-        signalRemotes[i].subBuffer(remotePeerIndex * signalPerPeer);
-  }
-
-  VLOG(1) << "MultipeerIbgdaTransport: exchanged tile buffers with " << numPeers
-          << " peers";
-}
-
-void MultipeerIbgdaTransport::cleanup_send_recv_buffers() {
-  for (auto& buf : lazyPeerBufs_) {
-    if (buf) {
-      deregisterBuffer(buf->get());
-      buf.reset();
-    }
-  }
-  sendRecvPeerBuffers_.clear();
-
-  if (sendStagingBulk_) {
-    deregisterBuffer(sendStagingBulk_->get());
-  }
-  if (recvStagingBulk_) {
-    deregisterBuffer(recvStagingBulk_->get());
-  }
-  if (signalBulk_) {
-    deregisterBuffer(signalBulk_->get());
-  }
-  if (counterBulk_) {
-    deregisterBuffer(counterBulk_->get());
-  }
-
-  sendStagingBulk_.reset();
-  recvStagingBulk_.reset();
-  signalBulk_.reset();
-  counterBulk_.reset();
-  stateBulk_.reset();
-}
+// Eager send/recv staging allocation, exchange, and cleanup are now provided by
+// MultiPeerIbTransportBase (allocateSendRecvBuffersEager(Device) /
+// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers()). The lazy per-peer
+// path below fills the inherited sendRecvPeerBuffers_ directly.
 
 PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
     int peerIndex) const {
@@ -1345,62 +1156,6 @@ PeerQpPayload MultipeerIbgdaTransport::buildLocalQpPayload(
   return payload;
 }
 
-void MultipeerIbgdaTransport::allocatePeerBuffers(
-    int peerIndex,
-    PeerBufferPayload& payload) {
-  auto sizes = computePeerBufferSizes();
-  const std::size_t totalPerPeer = sizes.total();
-  if (totalPerPeer == 0) {
-    return;
-  }
-
-  lazyPeerBufs_[peerIndex] =
-      std::make_unique<meta::comms::DeviceBuffer>(totalPerPeer);
-  cudaError_t cudaErr =
-      cudaMemset(lazyPeerBufs_[peerIndex]->get(), 0, totalPerPeer);
-  if (cudaErr != cudaSuccess) {
-    throw std::runtime_error("Failed to zero per-peer buffer");
-  }
-
-  auto& peerBuf = lazyPeerBufs_[peerIndex];
-  sizes.layout(peerBuf->get());
-
-  auto reg = registerBuffer(peerBuf->get(), totalPerPeer);
-
-  auto addr = reinterpret_cast<uintptr_t>(peerBuf->get());
-  auto mrIt = registeredBuffers_.upper_bound(addr);
-  CHECK(mrIt != registeredBuffers_.begin())
-      << "materializePeer: peerBuf MR not found after registerBuffer";
-  --mrIt;
-  auto& mr = mrIt->second;
-
-  if (config_.sendRecv.has_value()) {
-    auto& pb = sendRecvPeerBuffers_[peerIndex];
-    pb.sendStaging =
-        IbgdaLocalBuffer(sizes.sendStagingPtr, reg.lkey_per_device);
-    pb.recvStaging =
-        IbgdaLocalBuffer(sizes.recvStagingPtr, reg.lkey_per_device);
-    pb.signal = IbgdaLocalBuffer(sizes.srSignalPtr, reg.lkey_per_device);
-    pb.counter = IbgdaLocalBuffer(sizes.srCounterPtr, reg.lkey_per_device);
-    auto* statePtr =
-        reinterpret_cast<IbSendRecvState::ProgressSlot*>(sizes.srStatePtr);
-    const auto stateSlots =
-        static_cast<DeviceSpan<IbSendRecvState::ProgressSlot>::size_type>(
-            2 * config_.sendRecv->maxGroups);
-    pb.state.emplace(statePtr, stateSlots);
-
-    payload.recvStaging.addr = reinterpret_cast<uint64_t>(sizes.recvStagingPtr);
-    payload.recvStaging.numNics = numNics_;
-    payload.srSignal.addr = reinterpret_cast<uint64_t>(sizes.srSignalPtr);
-    payload.srSignal.numNics = numNics_;
-    for (int n = 0; n < numNics_; ++n) {
-      auto rkey = HostRKey(mr.mrs[n]->rkey);
-      payload.recvStaging.rkey_per_device[n] = rkey;
-      payload.srSignal.rkey_per_device[n] = rkey;
-    }
-  }
-}
-
 void MultipeerIbgdaTransport::connectPeerMainQps(
     int peerIndex,
     const PeerQpPayload& remotePayload) {
@@ -1430,16 +1185,6 @@ void MultipeerIbgdaTransport::connectPeerMainQps(
   }
 }
 
-void MultipeerIbgdaTransport::applyRemoteViews(
-    int peerIndex,
-    const PeerBufferPayload& remotePayload) {
-  if (config_.sendRecv.has_value()) {
-    auto& pb = sendRecvPeerBuffers_[peerIndex];
-    pb.remoteRecvStaging = remotePayload.recvStaging.toRemoteBuffer();
-    pb.remoteSignal = remotePayload.srSignal.toRemoteBuffer();
-  }
-}
-
 void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
   for (int nic = 0; nic < numNics_; nic++) {
     auto& nicQps = nicDoca_[nic].blockQpGroups;
@@ -1466,11 +1211,7 @@ void MultipeerIbgdaTransport::cleanupPeerOnFailure(int peerIndex) {
       }
     }
   }
-  auto& buf = lazyPeerBufs_[peerIndex];
-  if (buf) {
-    deregisterBuffer(buf->get());
-    buf.reset();
-  }
+  cleanupSendRecvBufferForPeer(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
   peerMaterialized_[peerIndex] = false;
   if (peerTransportsGpu_ != nullptr && peerTransportSize_ != 0) {
@@ -1521,7 +1262,7 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
 
   // Phase 2: exchange buffer info (acts as QP-ready barrier).
   PeerBufferPayload localBuf{};
-  allocatePeerBuffers(peerIndex, localBuf);
+  allocateSendRecvBufferForPeer(peerIndex, localBuf, IbCounterStorage::Device);
   allocatePeerSignalCounterResources(
       peerIndex,
       localBuf,
@@ -1529,7 +1270,7 @@ void MultipeerIbgdaTransport::doMaterializePeer(int peerRank) {
       /*allocateDiscardSignal=*/true);
   auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
-  applyRemoteViews(peerIndex, remoteBuf);
+  applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   applyRemoteSignalCounterResources(
       peerIndex, remoteBuf, /*hasDiscardSignal=*/true);
 

--- a/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
+++ b/comms/prims/transport/ibgda/MultipeerIbgdaTransport.h
@@ -37,7 +37,6 @@ struct MultipeerIbgdaDeviceTransport;
 struct P2pIbgdaTransportBuildParams;
 struct PeerQpPayload;
 struct PeerBufferPayload;
-struct PeerBufferSizes;
 } // namespace comms::prims
 
 namespace comms::prims {
@@ -222,9 +221,6 @@ class MultipeerIbgdaTransport
   void allocateResources();
   void registerMemory();
   void createQpGroups();
-  void allocate_send_recv_buffers();
-  void exchange_send_recv_buffers();
-  void cleanup_send_recv_buffers();
   void cleanup();
   // Connect a QP to a peer (or self for loopback). The nic argument selects
   // which local NIC's AH attrs / port to use; the peerInfo carries the
@@ -241,14 +237,10 @@ class MultipeerIbgdaTransport
   void connectPeerLoopback(int peerIndex);
   P2pIbgdaTransportBuildParams buildPeerTransportParams(int peerIndex) const;
 
-  PeerBufferSizes computePeerBufferSizes() const;
-
   void doMaterializePeer(int peerRank);
 
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
-  void allocatePeerBuffers(int peerIndex, PeerBufferPayload& payload);
   void connectPeerMainQps(int peerIndex, const PeerQpPayload& remotePayload);
-  void applyRemoteViews(int peerIndex, const PeerBufferPayload& remotePayload);
   void cleanupPeerOnFailure(int peerIndex);
 
   // MultiPeerIbTransport drives the shared control plane (config, MR registry,
@@ -310,32 +302,12 @@ class MultipeerIbgdaTransport
   // Exchange info received from peers
   std::vector<IbgdaTransportExchInfo> peerExchInfo_;
 
-  // Per-peer send/recv buffer views (populated by both modes).
-  struct SendRecvPeerBuffers {
-    IbgdaLocalBuffer sendStaging;
-    IbgdaLocalBuffer recvStaging;
-    IbgdaLocalBuffer signal;
-    IbgdaLocalBuffer counter;
-    std::optional<DeviceSpan<IbSendRecvState::ProgressSlot>> state;
-    IbgdaRemoteBuffer remoteRecvStaging;
-    IbgdaRemoteBuffer remoteSignal;
-  };
-  std::vector<SendRecvPeerBuffers> sendRecvPeerBuffers_;
-
-  // Eager mode: bulk allocations for all peers. Null in lazy mode.
-  std::unique_ptr<meta::comms::DeviceBuffer> sendStagingBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> recvStagingBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> signalBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> counterBulk_;
-  std::unique_ptr<meta::comms::DeviceBuffer> stateBulk_;
-  IbgdaLocalBuffer recvStagingBulkReg_;
-  IbgdaLocalBuffer signalBulkReg_;
-  IbgdaLocalBuffer counterBulkReg_;
-
-  // Lazy mode: per-peer contiguous allocation (staging + signal + counter +
-  // state + slot-index). Null for unmaterialized peers.
-  // Empty in eager mode.
-  std::vector<std::unique_ptr<meta::comms::DeviceBuffer>> lazyPeerBufs_;
+  // Per-peer send/recv buffer views (IbSendRecvPeerBuffers) and the eager-mode
+  // bulk allocations now live in MultiPeerIbTransportBase
+  // (sendRecvPeerBuffers_). Eager allocation/exchange/cleanup delegate to the
+  // base's allocateSendRecvBuffersEager(Device)/exchangeSendRecvBuffersEager()/
+  // cleanupSendRecvBuffers(); the lazy path below fills the inherited
+  // sendRecvPeerBuffers_ directly.
 
   // Lazy state (pendingPeers_/peerMaterialized_/materializationFailed_) is
   // inherited (protected) from MultiPeerIbTransport.

--- a/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
+++ b/comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh
@@ -30,7 +30,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
-#include "comms/prims/trace/PipesTraceTypes.h"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 
 namespace comms::prims {
@@ -39,46 +39,13 @@ struct Memcpy;
 
 inline constexpr uint64_t kDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 
-#if PIPES_IS_DEVICE_COMPILE
-__device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
-  constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
-  return value > kMaxTraceStep ? UINT32_MAX : static_cast<uint32_t>(value);
-}
-
-__device__ __forceinline__ void trace_ibgda_event(
-    PipesTraceHandle trace,
-    uint8_t self_rank,
-    PipesTraceEventType type,
-    uint32_t step,
-    uint16_t group_id) {
-  // write_pipes_trace short-circuits when trace.ring == nullptr, so an
-  // unconfigured handle has effectively no cost.
-  write_pipes_trace(trace, type, step, group_id, self_rank);
-}
-#endif
-
 // `PIPES_DEVICE_TRAP()` is defined in `comms/prims/core/DeviceMacros.cuh` and
 // is intentionally available across all `comms/prims` device headers.
-
-/**
- * Result of one bounded send/recv progress attempt.
- *
- * `progress_send_once()` and `progress_recv_once()` are intended for callers
- * that multiplex several independent transfers from one kernel. A single call
- * may complete immediately, advance one protocol step, or find that the next
- * signal/counter dependency is not ready yet.
- *
- * `Waiting` means no user-visible data movement or protocol signal was
- * issued. The caller may retry the same transport operation later after
- * making progress on another lane. `Progressed` means the call advanced the
- * operation but more calls are required. `Done` means the transfer has
- * completed the byte range reserved by the corresponding init call.
- */
-enum class IbgdaSendRecvProgressStatus : uint8_t {
-  Waiting,
-  Progressed,
-  Done,
-};
+//
+// `IbgdaSendRecvProgressStatus` and the pipelined send/recv algorithm now live
+// in the shared `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh); this class
+// delegates its send/recv/forward/init/progress methods to a `sendRecv_`
+// member.
 
 // Slot-id bounds checks for the slot-index API. Catches both
 // out-of-range slot ids and slot-index calls made when the transport was
@@ -251,7 +218,7 @@ class P2pIbgdaTransportDevice {
         maxGroups_(maxGroups),
         qpsPerBlockPerNic_(qpsPerBlockPerNic),
         blockQpState_(blockQpState),
-        sendRecvState_(sendRecvState) {}
+        sendRecv_(sendRecvState) {}
 
   // =========================================================================
   // Slot-Index API (resolves owned buffers, forwards to explicit-buffer API)
@@ -1979,25 +1946,8 @@ class P2pIbgdaTransportDevice {
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_send_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
-    assert_progress_slot_idle(group, slot, "send");
-    IbSendRecvState::ProgressSlot state{};
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitNicDone;
-    if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_send_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
-#endif
+    sendRecv_.init_send_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
   }
 
   /**
@@ -2034,25 +1984,8 @@ class P2pIbgdaTransportDevice {
       std::size_t nbytes,
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const int progressIndex = progress_recv_index(group);
-    auto& slot = progress_state_slot(group, progressIndex);
-    assert_progress_slot_idle(group, slot, "recv");
-    IbSendRecvState::ProgressSlot state{};
-    state.activeStage = nbytes == 0
-        ? detail::IbSendRecvProgressStage::Done
-        : detail::IbSendRecvProgressStage::WaitDataReady;
-    if (nbytes == 0) {
-      store_progress_state(group, progressIndex, state);
-      return;
-    }
-    // Validate the transfer before reserving the transport byte cursor.
-    const ProgressGeometry geometry = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "init_recv_progress");
-    state.activeBaseStep =
-        reserve_progress_step(group, progressIndex, geometry.protocolBytes);
-    store_progress_state(group, progressIndex, state);
-#endif
+    sendRecv_.init_recv_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
   }
 
   /**
@@ -2097,152 +2030,15 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "P2pIbgdaTransportDevice::progress_send_once() requires NVIDIA GPU");
-#endif
-    const int progressIndex = progress_send_index(group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_send_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_send_progress_stage(group, state);
-
-    const detail::IbSendRecvProgressStage initialStage = state.activeStage;
-    const std::size_t initialNextByte = state.activeNextByte;
-    const std::size_t pipelineBytes = progress_params.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitNicDone) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              read_counter(sendRecvState_.localCounterBuf.subBuffer(
-                  progress_params.groupId * sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for NIC_DONE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      const std::size_t validBytes = valid_payload_bytes(
-          chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState_.sendStagingPtr + chunk.stagingOff,
-            static_cast<const char*>(src) + chunk.dataOff,
-            validBytes,
-            group,
-            chunk.dataOff,
-            args...);
-      }
-      group.sync();
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitSlotFree);
-    }
-
-    if (state.activeStage == detail::IbSendRecvProgressStage::WaitSlotFree) {
-      const ProgressChunk chunk = next_chunk(state, progress_params);
-      if (chunk.streamEnd > pipelineBytes) {
-        const uint64_t expected = chunk.streamEnd - pipelineBytes;
-        uint32_t ready = 1;
-        unsigned long long current = 0;
-        if (group.is_leader()) {
-          current = static_cast<unsigned long long>(
-              read_signal(sendRecvState_.localSignalBuf.subBuffer(
-                  (sendRecvState_.maxGroups + progress_params.groupId) *
-                  sizeof(uint64_t))));
-          ready = current >= expected ? 1U : 0U;
-          if (!ready) {
-            TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-                timeout,
-                "progress_send_once waiting for SLOT_FREE expected>=%llu, "
-                "current=%llu",
-                static_cast<unsigned long long>(expected),
-                current);
-          }
-        }
-        ready = group.broadcast<uint32_t>(ready);
-        if (!ready) {
-          if (state.activeStage != initialStage ||
-              state.activeNextByte != initialNextByte) {
-            store_progress_state(group, progressIndex, state);
-            return IbgdaSendRecvProgressStatus::Progressed;
-          }
-          return IbgdaSendRecvProgressStatus::Waiting;
-        }
-      }
-
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        put(solo,
-            sendRecvState_.sendStagingBuf.subBuffer(chunk.stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(chunk.stagingOff),
-            chunk.bytes,
-            sendRecvState_.remoteSignalBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes,
-            sendRecvState_.localCounterBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes);
-      }
-      group.sync();
-
-      state.activeNextByte += chunk.bytes;
-      if (state.activeNextByte >= progress_params.protocolBytes) {
-        transition_progress_stage(
-            group, state, detail::IbSendRecvProgressStage::Done);
-        store_progress_state(group, progressIndex, state);
-        return IbgdaSendRecvProgressStatus::Done;
-      }
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::WaitNicDone);
-    }
-
-    // A full non-final chunk can cycle WaitNicDone -> WaitSlotFree ->
-    // WaitNicDone in one call, leaving the stage unchanged while nextByte
-    // advances. Check both fields so that case reports Progressed.
-    if (state.activeStage != initialStage ||
-        state.activeNextByte != initialNextByte) {
-      store_progress_state(group, progressIndex, state);
-      return IbgdaSendRecvProgressStatus::Progressed;
-    }
-    return IbgdaSendRecvProgressStatus::Waiting;
-#else
-    return IbgdaSendRecvProgressStatus::Done;
-#endif
+    return sendRecv_.progress_send_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2284,88 +2080,15 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        sizeof(CopyOp) == 0,
-        "P2pIbgdaTransportDevice::progress_recv_once() requires NVIDIA GPU");
-#endif
-    const int progressIndex = progress_recv_index(group);
-    IbSendRecvState::ProgressSlot state =
-        progress_state_slot(group, progressIndex);
-    if (state.activeStage == detail::IbSendRecvProgressStage::Done) {
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-    const ProgressGeometry progress_params = make_progress_geometry(
-        group, nbytes, active_blocks, max_signal_bytes, "progress_recv_once");
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once nextByte=%llu >= "
-            "protocolBytes=%llu without Done stage\n",
-            static_cast<unsigned long long>(state.activeNextByte),
-            static_cast<unsigned long long>(progress_params.protocolBytes));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    validate_recv_progress_stage(group, state);
-
-    const ProgressChunk chunk = next_chunk(state, progress_params);
-    const uint64_t expected = chunk.streamEnd;
-    uint32_t ready = 1;
-    unsigned long long current = 0;
-    if (group.is_leader()) {
-      current = static_cast<unsigned long long>(
-          read_signal(sendRecvState_.localSignalBuf.subBuffer(
-              progress_params.groupId * sizeof(uint64_t))));
-      ready = current >= expected ? 1U : 0U;
-      if (!ready) {
-        TIMEOUT_TRAP_IF_EXPIRED_SINGLE(
-            timeout,
-            "progress_recv_once waiting for DATA_READY expected>=%llu, "
-            "current=%llu",
-            static_cast<unsigned long long>(expected),
-            current);
-      }
-    }
-    ready = group.broadcast<uint32_t>(ready);
-    if (!ready) {
-      return IbgdaSendRecvProgressStatus::Waiting;
-    }
-
-    const std::size_t validBytes = valid_payload_bytes(
-        chunk.dataOff, chunk.bytes, progress_params.payloadBytes);
-    if (validBytes > 0) {
-      CopyOp::recv(
-          static_cast<char*>(dst) + chunk.dataOff,
-          sendRecvState_.recvStagingPtr + chunk.stagingOff,
-          validBytes,
-          group,
-          chunk.dataOff,
-          args...);
-    }
-    group.sync();
-
-    signal(
+    return sendRecv_.progress_recv_once<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
         group,
-        sendRecvState_.remoteSignalBuf.subBuffer(
-            (sendRecvState_.maxGroups + progress_params.groupId) *
-            sizeof(uint64_t)),
-        chunk.bytes);
-
-    state.activeNextByte += chunk.bytes;
-    if (state.activeNextByte >= progress_params.protocolBytes) {
-      transition_progress_stage(
-          group, state, detail::IbSendRecvProgressStage::Done);
-      store_progress_state(group, progressIndex, state);
-      return IbgdaSendRecvProgressStatus::Done;
-    }
-
-    store_progress_state(group, progressIndex, state);
-    return IbgdaSendRecvProgressStatus::Progressed;
-#else
-    return IbgdaSendRecvProgressStatus::Done;
-#endif
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
   }
 
   /**
@@ -2417,14 +2140,6 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)group;
-    (void)src;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
     sendWithTrace<CopyOp>(
         group,
         src,
@@ -2435,7 +2150,6 @@ class P2pIbgdaTransportDevice {
         {},
         0,
         args...);
-#endif
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2462,162 +2176,31 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send active_blocks=%d > maxGroups=%d\n",
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send group_id=%u >= active_blocks=%d\n",
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int maxGroups = sendRecvState_.maxGroups;
-    const int stateIndex = progress_send_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
-    assert_progress_slot_idle(group, state, "send");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbSendBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for NIC to finish with this slot's local sendStaging.
-      if (streamEnd > pipelineBytes) {
-        wait_counter(
-            group,
-            sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (2) Cooperative copy: src → local sendStaging via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::send(
-            sendRecvState_.sendStagingPtr + stagingOff,
-            static_cast<const char*>(src) + dataOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Backpressure: wait for receiver to free this byte range's
-      //     recvStaging offset. Symmetric with DATA_READY.
-      if (streamEnd > pipelineBytes) {
-        wait_signal(
-            group,
-            sendRecvState_.localSignalBuf.subBuffer(
-                (maxGroups + groupId) * sizeof(uint64_t)),
-            streamEnd - pipelineBytes,
-            timeout);
-      }
-
-      // (4) threadfence_system + leader-only single-WQE RDMA put with
-      //     fused signal+counter. All threads fence to ensure memcpy
-      //     stores are visible to the NIC before the leader posts the WQE.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        put(solo,
-            sendRecvState_.sendStagingBuf.subBuffer(stagingOff),
-            sendRecvState_.recvStagingBuf.subBuffer(stagingOff),
-            bytesThis,
-            sendRecvState_.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis,
-            sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
-      }
-      group.sync();
-      dataOff += bytesThis;
-    }
-
+    sendRecv_.send<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbSendEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
@@ -2659,14 +2242,6 @@ class P2pIbgdaTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args) {
-#if !PIPES_IS_DEVICE_COMPILE
-    (void)group;
-    (void)dst;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)timeout;
-#else
     recvWithTrace<CopyOp>(
         group,
         dst,
@@ -2677,7 +2252,6 @@ class P2pIbgdaTransportDevice {
         {},
         0,
         args...);
-#endif
   }
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -2704,135 +2278,31 @@ class P2pIbgdaTransportDevice {
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv active_blocks=%d > maxGroups=%d\n",
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv group_id=%u >= active_blocks=%d\n",
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: recv perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-
-    const int pipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t dataBufferSize = sendRecvState_.dataBufferSize;
-    const int maxGroups = sendRecvState_.maxGroups;
-    const int stateIndex = progress_recv_index(group);
-    auto& state = progress_state_slot(group, stateIndex);
-    assert_progress_slot_idle(group, state, "recv");
-    const uint64_t baseByte = static_cast<uint64_t>(state.nextStep);
-    const std::size_t pipelineBytes = perBlockSlot * pipelineDepth;
-    if (group.is_leader()) {
-      state.activeStage = detail::IbSendRecvProgressStage::Busy;
-      state.activeBaseStep = static_cast<int64_t>(baseByte);
-      state.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbRecvBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      const uint64_t streamStart = baseByte + dataOff;
-      const std::size_t pipelineOff =
-          static_cast<std::size_t>(streamStart % pipelineBytes);
-      const int slot = static_cast<int>(pipelineOff / perBlockSlot);
-      const std::size_t slotOff = slot * dataBufferSize;
-      const std::size_t chunkOff = pipelineOff - slot * perBlockSlot;
-      const std::size_t slotRemaining = perBlockSlot - chunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          chunkSize < dataRemaining ? chunkSize : dataRemaining;
-      bytesThis = bytesThis < slotRemaining ? bytesThis : slotRemaining;
-      const std::size_t stagingOff =
-          slotOff + groupId * perBlockSlot + chunkOff;
-      const uint64_t streamEnd = streamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY signal.
-      wait_signal(
-          group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          streamEnd,
-          timeout);
-
-      // (2) Cooperative copy: local recvStaging → dst via CopyOp.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::recv(
-            static_cast<char*>(dst) + dataOff,
-            sendRecvState_.recvStagingPtr + stagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
-      //     threshold before reusing remote recvStaging at the same offset.
-      signal(
-          group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (maxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis);
-      dataOff += bytesThis;
-    }
-
+    sendRecv_.recv<P2pIbgdaTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      state.nextStep = static_cast<int64_t>(baseByte + protocolBytes);
-      state.activeStage = detail::IbSendRecvProgressStage::Done;
-      state.activeBaseStep = 0;
-      state.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbRecvEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
@@ -2931,251 +2401,43 @@ class P2pIbgdaTransportDevice {
       uint8_t self_rank,
       Args... args) {
 #if PIPES_IS_DEVICE_COMPILE
-#ifdef __HIP_PLATFORM_AMD__
-    static_assert(
-        false,
-        "P2pIbgdaTransportDevice::forward() requires NVIDIA GPU (DOCA/IBGDA)");
-#endif
     if (nbytes == 0) {
       return;
     }
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-
-    const int groupId = group.group_id;
-
-    // --- recv side (this transport) ---
-    const int recvEffActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-    if (recvEffActive > sendRecvState_.maxGroups || groupId >= recvEffActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward recv active_blocks=%d "
-            "maxGroups=%d groupId=%u\n",
-            recvEffActive,
-            sendRecvState_.maxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t recvPerBlockSlot =
-        (sendRecvState_.dataBufferSize / recvEffActive) & ~15ULL;
-    if (recvPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward recvPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // --- fwd side (fwd transport) ---
-    const int fwdEffActive =
-        active_blocks > 0 ? active_blocks : fwd.sendRecvState_.maxGroups;
-    if (fwdEffActive > fwd.sendRecvState_.maxGroups ||
-        groupId >= fwdEffActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: forward fwd active_blocks=%d "
-            "maxGroups=%d groupId=%u\n",
-            fwdEffActive,
-            fwd.sendRecvState_.maxGroups,
-            groupId);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t fwdPerBlockSlot =
-        (fwd.sendRecvState_.dataBufferSize / fwdEffActive) & ~15ULL;
-    if (fwdPerBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: forward fwdPerBlockSlot=0\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    // Chunk sizes for recv and fwd sides
-    std::size_t recvChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < recvPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : recvPerBlockSlot;
-    if (recvChunkSize == 0) {
-      recvChunkSize = recvPerBlockSlot;
-    }
-    std::size_t fwdChunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < fwdPerBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : fwdPerBlockSlot;
-    if (fwdChunkSize == 0) {
-      fwdChunkSize = fwdPerBlockSlot;
-    }
-
-    const int recvPipelineDepth = sendRecvState_.pipelineDepth;
-    const std::size_t recvDataBufSize = sendRecvState_.dataBufferSize;
-    const int recvMaxGroups = sendRecvState_.maxGroups;
-    const int recvStateIndex = progress_recv_index(group);
-    auto& recvSlotState = progress_state_slot(group, recvStateIndex);
-    assert_progress_slot_idle(group, recvSlotState, "forward recv");
-    const uint64_t recvBaseByte = static_cast<uint64_t>(recvSlotState.nextStep);
-    const std::size_t recvPipelineBytes = recvPerBlockSlot * recvPipelineDepth;
-
-    const int fwdPipelineDepth = fwd.sendRecvState_.pipelineDepth;
-    const std::size_t fwdDataBufSize = fwd.sendRecvState_.dataBufferSize;
-    const int fwdMaxGroups = fwd.sendRecvState_.maxGroups;
-    const int fwdStateIndex = fwd.progress_send_index(group);
-    auto& fwdSlotState = fwd.progress_state_slot(group, fwdStateIndex);
-    fwd.assert_progress_slot_idle(group, fwdSlotState, "forward send");
-    const uint64_t fwdBaseByte = static_cast<uint64_t>(fwdSlotState.nextStep);
-    const std::size_t fwdPipelineBytes = fwdPerBlockSlot * fwdPipelineDepth;
-    if (group.is_leader()) {
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      recvSlotState.activeBaseStep = static_cast<int64_t>(recvBaseByte);
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Busy;
-      fwdSlotState.activeBaseStep = static_cast<int64_t>(fwdBaseByte);
-      fwdSlotState.activeNextByte = 0;
-    }
-
     if (group.is_leader()) {
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbForwardBegin,
           /*step=*/0,
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-
-    for (std::size_t dataOff = 0; dataOff < protocolBytes;) {
-      // --- Recv side offsets ---
-      const uint64_t recvStreamStart = recvBaseByte + dataOff;
-      const std::size_t recvPipelineOff =
-          static_cast<std::size_t>(recvStreamStart % recvPipelineBytes);
-      const int recvSlot = static_cast<int>(recvPipelineOff / recvPerBlockSlot);
-      const std::size_t recvSlotOff = recvSlot * recvDataBufSize;
-      const std::size_t recvChunkOff =
-          recvPipelineOff - recvSlot * recvPerBlockSlot;
-      const std::size_t recvStagingOff =
-          recvSlotOff + groupId * recvPerBlockSlot + recvChunkOff;
-
-      // --- Fwd side offsets ---
-      const uint64_t fwdStreamStart = fwdBaseByte + dataOff;
-      const std::size_t fwdPipelineOff =
-          static_cast<std::size_t>(fwdStreamStart % fwdPipelineBytes);
-      const int fwdSlot = static_cast<int>(fwdPipelineOff / fwdPerBlockSlot);
-      const std::size_t fwdSlotOff = fwdSlot * fwdDataBufSize;
-      const std::size_t fwdChunkOff =
-          fwdPipelineOff - fwdSlot * fwdPerBlockSlot;
-      const std::size_t fwdStagingOff =
-          fwdSlotOff + groupId * fwdPerBlockSlot + fwdChunkOff;
-      const std::size_t recvSlotRemaining = recvPerBlockSlot - recvChunkOff;
-      const std::size_t fwdSlotRemaining = fwdPerBlockSlot - fwdChunkOff;
-      const std::size_t dataRemaining = protocolBytes - dataOff;
-      std::size_t bytesThis =
-          recvChunkSize < fwdChunkSize ? recvChunkSize : fwdChunkSize;
-      bytesThis = bytesThis < dataRemaining ? bytesThis : dataRemaining;
-      bytesThis = bytesThis < recvSlotRemaining ? bytesThis : recvSlotRemaining;
-      bytesThis = bytesThis < fwdSlotRemaining ? bytesThis : fwdSlotRemaining;
-      const uint64_t recvStreamEnd = recvStreamStart + bytesThis;
-      const uint64_t fwdStreamEnd = fwdStreamStart + bytesThis;
-
-      // (1) Wait for sender's DATA_READY.
-      wait_signal(
-          group,
-          sendRecvState_.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)),
-          recvStreamEnd,
-          timeout);
-
-      // (2) Wait for NIC_DONE on fwd's sendStaging (backpressure).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwd.wait_counter(
-            group,
-            fwd.sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (3) CopyOp::forward — transform recv staging → dst + fwd staging.
-      const std::size_t validBytes =
-          valid_payload_bytes(dataOff, bytesThis, nbytes);
-      if (validBytes > 0) {
-        CopyOp::forward(
-            dst ? static_cast<char*>(dst) + dataOff : nullptr,
-            fwd.sendRecvState_.sendStagingPtr + fwdStagingOff,
-            sendRecvState_.recvStagingPtr + recvStagingOff,
-            validBytes,
-            group,
-            dataOff,
-            args...);
-      }
-      group.sync();
-
-      // (4) Signal SLOT_FREE to sender (this transport).
-      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
-      //     to break circular ring dependency.
-      signal(
-          group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (recvMaxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis);
-
-      // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
-      //     recvStaging).
-      if (fwdStreamEnd > fwdPipelineBytes) {
-        fwd.wait_signal(
-            group,
-            fwd.sendRecvState_.localSignalBuf.subBuffer(
-                (fwdMaxGroups + groupId) * sizeof(uint64_t)),
-            fwdStreamEnd - fwdPipelineBytes,
-            timeout);
-      }
-
-      // (6) threadfence_system + RDMA put via fwd transport.
-      __threadfence_system();
-      group.sync();
-      if (group.is_leader()) {
-        ThreadGroup solo{
-            0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
-        fwd.put(
-            solo,
-            fwd.sendRecvState_.sendStagingBuf.subBuffer(fwdStagingOff),
-            fwd.sendRecvState_.recvStagingBuf.subBuffer(fwdStagingOff),
-            bytesThis,
-            fwd.sendRecvState_.remoteSignalBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis,
-            fwd.sendRecvState_.localCounterBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
-      }
-      group.sync();
-      dataOff += bytesThis;
-    }
-
-    // Update shared byte cursors for both recv and fwd sides.
+    sendRecv_.forward<CopyOp>(
+        *this,
+        group,
+        dst,
+        fwd.sendRecv_,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
     if (group.is_leader()) {
-      recvSlotState.nextStep =
-          static_cast<int64_t>(recvBaseByte + protocolBytes);
-      recvSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      recvSlotState.activeBaseStep = 0;
-      recvSlotState.activeNextByte = 0;
-      fwdSlotState.nextStep = static_cast<int64_t>(fwdBaseByte + protocolBytes);
-      fwdSlotState.activeStage = detail::IbSendRecvProgressStage::Done;
-      fwdSlotState.activeBaseStep = 0;
-      fwdSlotState.activeNextByte = 0;
       trace_ibgda_event(
           trace,
           self_rank,
           PipesTraceEventType::kIbForwardEnd,
           trace_ibgda_step(nbytes),
-          static_cast<uint16_t>(groupId));
+          static_cast<uint16_t>(group.group_id));
     }
-    group.sync();
 #endif
   }
 
   // Send/recv state accessors
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const {
-    return sendRecvState_;
+    return sendRecv_.send_recv_state();
   }
 
   /**
@@ -3194,476 +2456,10 @@ class P2pIbgdaTransportDevice {
    */
   __device__ __forceinline__ std::size_t pipeline_window(
       int active_blocks) const {
-    const std::size_t per_block_slot =
-        (sendRecvState_.dataBufferSize / active_blocks) & ~15ULL;
-    return per_block_slot * sendRecvState_.pipelineDepth;
+    return sendRecv_.pipeline_window(active_blocks);
   }
 
  private:
-  /**
-   * Physical staging range for the next resumable progress step.
-   *
-   * `stagingOff` is an offset into the transport-owned send/recv staging
-   * buffers. `dataOff` is the matching protocol offset into the caller's user
-   * buffer.
-   * `bytes` never crosses a per-block staging partition or the reserved
-   * protocol byte count. `streamEnd` is the absolute protocol byte value after
-   * this chunk and is used as the DATA_READY, SLOT_FREE, and NIC_DONE
-   * readiness threshold. `dataOff` is a protocol offset; callers mask it
-   * against the payload byte count before invoking user-buffer copy callbacks.
-   */
-  struct ProgressChunk {
-    std::size_t stagingOff;
-    std::size_t dataOff;
-    std::size_t bytes;
-    uint64_t streamEnd;
-  };
-
-  /**
-   * Register-only geometry for one resumable progress call.
-   *
-   * This is intentionally not stored in `IbSendRecvState::ProgressSlot`:
-   * callers pass the same static geometry to init and progress, and each
-   * progress call derives these values in registers instead of reloading
-   * duplicated fields from HBM-backed progress state.
-   */
-  struct ProgressGeometry {
-    int groupId;
-    std::size_t payloadBytes;
-    std::size_t protocolBytes;
-    std::size_t perBlockSlot;
-    std::size_t chunkSize;
-  };
-
-  /**
-   * Stateful send/recv cursors advance in 16-byte protocol quanta. That keeps
-   * the staging stream on the same granularity as the vectorized local staging
-   * copies while preserving caller-facing payload byte counts; padding is
-   * transport-private and is never exposed to CopyOp callbacks.
-   */
-  __device__ __forceinline__ static std::size_t align_protocol_bytes(
-      std::size_t nbytes) {
-    return (nbytes + 15ULL) & ~15ULL;
-  }
-
-  __device__ __forceinline__ static std::size_t valid_payload_bytes(
-      std::size_t byteOffset,
-      std::size_t chunkBytes,
-      std::size_t payloadBytes) {
-    if (byteOffset >= payloadBytes) {
-      return 0;
-    }
-    const std::size_t remaining = payloadBytes - byteOffset;
-    return chunkBytes < remaining ? chunkBytes : remaining;
-  }
-
-  /**
-   * Return the internal send progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_send_index(ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, 0);
-#else
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return the internal recv progress slot index for `group`.
-   */
-  __device__ __forceinline__ int progress_recv_index(ThreadGroup& group) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    return progress_index_for_group(group, sendRecvState_.maxGroups);
-#else
-    (void)group;
-    return 0;
-#endif
-  }
-
-  /**
-   * Validate a progress group and map it into the transport-owned slot array.
-   */
-  __device__ __forceinline__ int progress_index_for_group(
-      ThreadGroup& group,
-      int baseIndex) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (sendRecvState_.state.empty() ||
-        sendRecvState_.state.data() == nullptr) {
-      if (group.is_leader()) {
-        printf("[PIPES] FATAL: send/recv state is null\n");
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (sendRecvState_.maxGroups <= 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: send/recv maxGroups must be > 0, got %d\n",
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const auto requiredStateSlots =
-        static_cast<uint32_t>(2 * sendRecvState_.maxGroups);
-    if (sendRecvState_.state.size() < requiredStateSlots ||
-        group.group_id >= static_cast<uint32_t>(sendRecvState_.maxGroups)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress group_id=%u out of range [0, %d), "
-            "state slots=%u\n",
-            group.group_id,
-            sendRecvState_.maxGroups,
-            static_cast<unsigned>(sendRecvState_.state.size()));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    return baseIndex + static_cast<int>(group.group_id);
-#else
-    (void)group;
-    (void)baseIndex;
-    return 0;
-#endif
-  }
-
-  /**
-   * Return a reference to a transport-owned progress state slot.
-   */
-  __device__ __forceinline__ IbSendRecvState::ProgressSlot& progress_state_slot(
-      ThreadGroup& group,
-      int progressIndex) const {
-    (void)group;
-    return sendRecvState_.state[progressIndex];
-  }
-
-  /**
-   * Trap if a caller tries to start a second send/recv before the first ends.
-   *
-   * The broadcast is the ordering point for init callers: if the leader sees a
-   * non-idle slot, every thread traps before any caller can store new state.
-   */
-  __device__ __forceinline__ void assert_progress_slot_idle(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state,
-      const char* direction) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint32_t idle = 1;
-    if (group.is_leader()) {
-      const auto activeStage = state.activeStage;
-      idle = activeStage == detail::IbSendRecvProgressStage::Done ? 1U : 0U;
-      if (!idle) {
-        printf(
-            "[PIPES] FATAL: %s requested with outstanding %s progress "
-            "for group_id=%u stage=%d nextByte=%llu\n",
-            direction,
-            direction,
-            group.group_id,
-            static_cast<int>(activeStage),
-            static_cast<unsigned long long>(state.activeNextByte));
-      }
-    }
-    idle = group.broadcast<uint32_t>(idle);
-    if (!idle) {
-      PIPES_DEVICE_TRAP();
-    }
-#else
-    (void)group;
-    (void)state;
-    (void)direction;
-#endif
-  }
-
-  /**
-   * Commit an updated local progress state back to its transport-owned slot.
-   * The trailing sync orders the leader's store before later group work.
-   */
-  __device__ __forceinline__ void store_progress_state(
-      ThreadGroup& group,
-      int progressIndex,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[progressIndex];
-      slot.activeNextByte = state.activeNextByte;
-      slot.activeBaseStep = state.activeBaseStep;
-      slot.activeStage = state.activeStage;
-    }
-    group.sync();
-#else
-    (void)group;
-    (void)progressIndex;
-    (void)state;
-#endif
-  }
-
-  /**
-   * Validate and return the static staging geometry for one progress call.
-   *
-   * This helper is called by the public init APIs and each progress attempt. It
-   * verifies that the group participates in this transfer and that the
-   * requested active block count can fit at least one 16-byte-aligned region in
-   * each staging slot.
-   *
-   * On success, `perBlockSlot` is the caller's partition within each logical
-   * staging slot and `chunkSize` is the maximum signaled sub-chunk size. A zero
-   * `maxSignalBytes` means one chunk per `perBlockSlot`; otherwise the value is
-   * rounded down to the same 16-byte alignment used by the blocking send/recv
-   * path. Invalid geometry traps on device because continuing would corrupt
-   * another block group's staging partition.
-   *
-   * The public init methods handle zero-byte operations before calling this
-   * helper. A progress call should only see zero bytes when its state is
-   * already `Done`. Non-empty payload byte counts are rounded up to 16-byte
-   * protocol counts here; copy callbacks still see only valid payload bytes.
-   */
-  __device__ __forceinline__ ProgressGeometry make_progress_geometry(
-      ThreadGroup& group,
-      std::size_t nbytes,
-      int active_blocks,
-      std::size_t max_signal_bytes,
-      const char* opName) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (nbytes == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s saw non-Done progress state for zero-byte "
-            "transfer\n",
-            opName);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    const int groupId = static_cast<int>(group.group_id);
-    const int effActive =
-        active_blocks > 0 ? active_blocks : sendRecvState_.maxGroups;
-    if (effActive > sendRecvState_.maxGroups) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s active_blocks=%d > maxGroups=%d\n",
-            opName,
-            effActive,
-            sendRecvState_.maxGroups);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    if (groupId < 0 || groupId >= effActive) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s group_id=%d >= active_blocks=%d\n",
-            opName,
-            groupId,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t perBlockSlot =
-        (sendRecvState_.dataBufferSize / effActive) & ~15ULL;
-    if (perBlockSlot == 0) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: %s perBlockSlot=0 "
-            "(dataBufferSize=%llu, active_blocks=%d)\n",
-            opName,
-            (unsigned long long)sendRecvState_.dataBufferSize,
-            effActive);
-      }
-      PIPES_DEVICE_TRAP();
-    }
-
-    const std::size_t protocolBytes = align_protocol_bytes(nbytes);
-    std::size_t chunkSize =
-        (max_signal_bytes > 0 && max_signal_bytes < perBlockSlot)
-        ? (max_signal_bytes & ~15ULL)
-        : perBlockSlot;
-    if (chunkSize == 0) {
-      chunkSize = perBlockSlot;
-    }
-    return ProgressGeometry{
-        .groupId = groupId,
-        .payloadBytes = nbytes,
-        .protocolBytes = protocolBytes,
-        .perBlockSlot = perBlockSlot,
-        .chunkSize = chunkSize,
-    };
-#else
-    (void)group;
-    (void)nbytes;
-    (void)active_blocks;
-    (void)max_signal_bytes;
-    (void)opName;
-    return {};
-#endif
-  }
-
-  /**
-   * Reserve a non-overlapping protocol byte range for one progress state.
-   *
-   * Blocking send()/recv() read `state[].nextStep` at call entry and commit it
-   * at completion. Progress init cannot wait until completion because progress
-   * operations may complete across many bounded calls. Reserving at init gives
-   * the transport-owned state a stable byte-stream base and makes later
-   * blocking calls start after all in-flight progress ranges.
-   */
-  __device__ __forceinline__ int64_t reserve_progress_step(
-      ThreadGroup& group,
-      int stateIndex,
-      std::size_t nbytes) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    uint64_t baseStep = 0;
-    if (group.is_leader()) {
-      auto& slot = sendRecvState_.state[stateIndex];
-      baseStep = static_cast<uint64_t>(slot.nextStep);
-      slot.nextStep = static_cast<int64_t>(baseStep + nbytes);
-    }
-    baseStep = group.broadcast<uint64_t>(baseStep);
-    return static_cast<int64_t>(baseStep);
-#else
-    (void)group;
-    (void)stateIndex;
-    (void)nbytes;
-    return 0;
-#endif
-  }
-
-  /**
-   * Trap if a send progress state is not in a sender-owned stage.
-   *
-   * Without this check, corrupted or mismatched transport-owned state could
-   * return `Waiting` forever because no send-side transition would match.
-   * Trapping turns that misuse into an immediate device failure with a clear
-   * diagnostic.
-   */
-  __device__ __forceinline__ void validate_send_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitNicDone &&
-        state.activeStage != detail::IbSendRecvProgressStage::WaitSlotFree &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_send_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Trap if a recv progress state is not in a receiver-owned stage.
-   *
-   * Receiver progress is only valid while waiting for DATA_READY. Sender
-   * stages are protocol misuse and cannot make progress on the recv path.
-   */
-  __device__ __forceinline__ void validate_recv_progress_stage(
-      ThreadGroup& group,
-      const IbSendRecvState::ProgressSlot& state) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    if (state.activeStage != detail::IbSendRecvProgressStage::WaitDataReady &&
-        state.activeStage != detail::IbSendRecvProgressStage::Done) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: progress_recv_once invalid stage=%d\n",
-            static_cast<int>(state.activeStage));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-#endif
-  }
-
-  /**
-   * Return whether `current -> next` is a valid progress-state transition.
-   */
-  __device__ __forceinline__ bool is_valid_progress_transition(
-      detail::IbSendRecvProgressStage current,
-      detail::IbSendRecvProgressStage next) const {
-    switch (current) {
-      case detail::IbSendRecvProgressStage::WaitNicDone:
-        return next == detail::IbSendRecvProgressStage::WaitSlotFree;
-      case detail::IbSendRecvProgressStage::WaitSlotFree:
-        return next == detail::IbSendRecvProgressStage::WaitNicDone ||
-            next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::WaitDataReady:
-        return next == detail::IbSendRecvProgressStage::Done;
-      case detail::IbSendRecvProgressStage::Done:
-        return false;
-      case detail::IbSendRecvProgressStage::Busy:
-        return false;
-    }
-    return false;
-  }
-
-  /**
-   * Apply one legal progress-state transition.
-   *
-   * The explicit transition table keeps the send/recv state machine local and
-   * auditable. If future progress states are added, this switch must opt into
-   * each new legal edge instead of allowing silent fallthrough.
-   */
-  __device__ __forceinline__ void transition_progress_stage(
-      ThreadGroup& group,
-      IbSendRecvState::ProgressSlot& state,
-      detail::IbSendRecvProgressStage next) const {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-    const detail::IbSendRecvProgressStage current = state.activeStage;
-    if (!is_valid_progress_transition(current, next)) {
-      if (group.is_leader()) {
-        printf(
-            "[PIPES] FATAL: invalid progress transition stage=%d -> %d\n",
-            static_cast<int>(current),
-            static_cast<int>(next));
-      }
-      PIPES_DEVICE_TRAP();
-    }
-    state.activeStage = next;
-#endif
-  }
-
-  /**
-   * Map the state's logical protocol byte cursor to the next staging-ring
-   * chunk.
-   *
-   * The transport stores each logical slot as `dataBufferSize` bytes, split
-   * into geometry-specific per-group partitions. The protocol cursor advances
-   * in bytes, not slots, so `baseStep + nextByte` is reduced modulo
-   * `perBlockSlot * pipelineDepth` to pick the ring slot and per-group offset.
-   *
-   * The returned chunk is clipped by three boundaries: the configured
-   * sub-chunk size, remaining protocol bytes, and remaining bytes in the
-   * current per-block staging partition. This keeps every progress call
-   * bounded and prevents a single RDMA put or recv copy from spanning two
-   * staging slots.
-   */
-  __device__ __forceinline__ ProgressChunk next_chunk(
-      const IbSendRecvState::ProgressSlot& state,
-      const ProgressGeometry& geometry) const {
-    const uint64_t streamStart =
-        static_cast<uint64_t>(state.activeBaseStep) + state.activeNextByte;
-    const std::size_t pipelineBytes = geometry.perBlockSlot *
-        static_cast<std::size_t>(sendRecvState_.pipelineDepth);
-    const std::size_t pipelineOff =
-        static_cast<std::size_t>(streamStart % pipelineBytes);
-    const int slot = static_cast<int>(pipelineOff / geometry.perBlockSlot);
-    const std::size_t slotOff =
-        static_cast<std::size_t>(slot) * sendRecvState_.dataBufferSize;
-    const std::size_t chunkOff =
-        pipelineOff - static_cast<std::size_t>(slot) * geometry.perBlockSlot;
-    const std::size_t slotRemaining = geometry.perBlockSlot - chunkOff;
-    const std::size_t dataRemaining =
-        geometry.protocolBytes - state.activeNextByte;
-    std::size_t bytes =
-        geometry.chunkSize < dataRemaining ? geometry.chunkSize : dataRemaining;
-    bytes = bytes < slotRemaining ? bytes : slotRemaining;
-    return ProgressChunk{
-        .stagingOff = slotOff +
-            static_cast<std::size_t>(geometry.groupId) * geometry.perBlockSlot +
-            chunkOff,
-        .dataOff = state.activeNextByte,
-        .bytes = bytes,
-        .streamEnd = streamStart + bytes,
-    };
-  }
-
   // --- Members ---
   // Per-NIC bundles (qps + companion_qps + sink_lkey + device_id).
   DeviceSpan<NicDeviceIbgdaResources> nicDevices_{};
@@ -3679,7 +2475,7 @@ class P2pIbgdaTransportDevice {
   int qpsPerBlockPerNic_{1};
   DeviceSpan<IbgdaBlockQpState> blockQpState_{};
 
-  IbSendRecvState sendRecvState_{};
+  IbSendRecvDevice sendRecv_{};
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/IbrcTypes.h
+++ b/comms/prims/transport/ibrc/IbrcTypes.h
@@ -88,4 +88,11 @@ struct IbrcCmdQueueDevice {
 static_assert(std::is_standard_layout_v<IbrcCmdQueueDevice>);
 static_assert(std::is_trivially_copyable_v<IbrcCmdQueueDevice>);
 
+struct IbrcBlockQpState {
+  uint32_t put_rr{0};
+};
+
+static_assert(std::is_standard_layout_v<IbrcBlockQpState>);
+static_assert(std::is_trivially_copyable_v<IbrcBlockQpState>);
+
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.cc
@@ -25,7 +25,12 @@
 #include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
-#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
+// Device-handle construction lives in MultipeerIbrcTransportCuda.cu: the full
+// P2pIbrcTransportDevice pulls hip_bf16 (via the send/recv CopyOp) which a host
+// .cc can't compile on AMD, so it's built in device context there (mirrors
+// IBGDA's MultipeerIbgdaTransportCuda). This .cc only needs the host-callable
+// builder declarations.
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh"
 
 namespace comms::prims {
 
@@ -65,6 +70,10 @@ GpuError gpuFreeHost(void* ptr) {
 GpuError gpuSetDevice(int device) {
   return hipSetDevice(device);
 }
+
+GpuError gpuMemset(void* ptr, int value, std::size_t bytes) {
+  return hipMemset(ptr, value, bytes);
+}
 #else
 using GpuError = cudaError_t;
 constexpr GpuError kGpuSuccess = cudaSuccess;
@@ -87,6 +96,10 @@ GpuError gpuFreeHost(void* ptr) {
 
 GpuError gpuSetDevice(int device) {
   return cudaSetDevice(device);
+}
+
+GpuError gpuMemset(void* ptr, int value, std::size_t bytes) {
+  return cudaMemset(ptr, value, bytes);
 }
 #endif
 
@@ -252,6 +265,13 @@ void MultipeerIbrcTransport::exchange() {
     exchangeAndConnectQps();
     allocateSignalCounterResources(
         IbCounterStorage::HostPinned, /*allocateDiscardSignal=*/false);
+    // Allocate + collectively exchange send/recv staging before building the
+    // device transports, so updatePeerDeviceTransport can embed the resulting
+    // IbSendRecvState. Delegated to the shared base; IBRC uses a host-mapped
+    // NIC_DONE counter (CPU proxy writes it) via the HostPinned counter
+    // storage.
+    allocateSendRecvBuffersEager(IbCounterStorage::HostPinned);
+    exchangeSendRecvBuffersEager();
     allocateCmdQueuesForAllPeers();
     VLOG(1) << "MultipeerIbrcTransport: rank " << myRank_ << " allocated "
             << allocatedCmdQueueCount() << " command queues";
@@ -272,6 +292,7 @@ void MultipeerIbrcTransport::cleanup() {
     cleanupPeerCmdQueues(peerIndex);
     cleanupPeerQps(peerIndex);
   }
+  cleanupSendRecvBuffers();
   cleanupSignalCounterResources();
 
   auto& symbols = ibverbx::ibvSymbols;
@@ -783,12 +804,9 @@ void MultipeerIbrcTransport::allocatePeerCmdQueues(int peerIndex) {
 void MultipeerIbrcTransport::initializeDeviceTransportSlots() {
   const std::size_t numPeers = static_cast<std::size_t>(nRanks_ - 1);
   p2pTransportDevices_ = allocateMapped(
-      numPeers * sizeof(P2pIbrcTransportDevice),
-      "P2pIbrcTransportDevice slots");
-  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
-  for (std::size_t peerIndex = 0; peerIndex < numPeers; ++peerIndex) {
-    new (&slots[peerIndex]) P2pIbrcTransportDevice();
-  }
+      numPeers * ibrcDeviceSlotSize(), "P2pIbrcTransportDevice slots");
+  constructIbrcDeviceSlots(
+      p2pTransportDevices_.host, static_cast<int>(numPeers));
 }
 
 void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
@@ -797,10 +815,12 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
     return;
   }
 
-  auto* slots = static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.host);
   auto& peer = peerResources_[peerIndex];
   if (!peer.cmdQueuesAllocated || peer.cmdQueueDevices.device == nullptr) {
-    new (&slots[peerIndex]) P2pIbrcTransportDevice();
+    constructIbrcDeviceSlots(
+        static_cast<char*>(p2pTransportDevices_.host) +
+            peerIndex * ibrcDeviceSlotSize(),
+        1);
     return;
   }
 
@@ -817,7 +837,9 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
     counterHostBuf = slotCounterHostView(peerIndex);
   }
 
-  new (&slots[peerIndex]) P2pIbrcTransportDevice(
+  writeIbrcDeviceSlot(
+      p2pTransportDevices_.host,
+      peerIndex,
       DeviceSpan<IbrcCmdQueueDevice>(
           static_cast<IbrcCmdQueueDevice*>(peer.cmdQueueDevices.device),
           static_cast<uint32_t>(peer.cmdQueues.size())),
@@ -832,7 +854,8 @@ void MultipeerIbrcTransport::updatePeerDeviceTransport(int peerIndex) noexcept {
       counterDeviceBuf,
       counterHostBuf,
       config_.numSignalSlots,
-      config_.numCounterSlots);
+      config_.numCounterSlots,
+      sendRecvStateForPeer(peerIndex));
 }
 
 std::size_t MultipeerIbrcTransport::allocatedCmdQueueCount() const {
@@ -878,6 +901,12 @@ MultipeerIbrcTransport::MappedAllocation MultipeerIbrcTransport::allocateMapped(
 
   return allocation;
 }
+
+// Send/recv staging allocation, exchange, cleanup, and IbSendRecvState
+// construction are provided by MultiPeerIbTransportBase. IBRC delegates via
+// allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) /
+// exchangeSendRecvBuffersEager() / cleanupSendRecvBuffers() /
+// sendRecvStateForPeer().
 
 void MultipeerIbrcTransport::destroyPeerQps(
     std::vector<PeerQpResource>& qpResources) noexcept {
@@ -1339,8 +1368,9 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDeviceSlot(
         "getP2pTransportDeviceSlot: IBRC device transport slots are not initialized");
   }
   const int peerIndex = rankToPeerIndex(peerRank);
-  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
-      peerIndex;
+  return reinterpret_cast<P2pIbrcTransportDevice*>(
+      static_cast<char*>(p2pTransportDevices_.device) +
+      peerIndex * ibrcDeviceSlotSize());
 }
 
 P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
@@ -1353,8 +1383,9 @@ P2pIbrcTransportDevice* MultipeerIbrcTransport::getP2pTransportDevice(
         "getP2pTransportDevice: IBRC device transport slots are not initialized");
   }
   const int peerIndex = rankToPeerIndex(peerRank);
-  return static_cast<P2pIbrcTransportDevice*>(p2pTransportDevices_.device) +
-      peerIndex;
+  return reinterpret_cast<P2pIbrcTransportDevice*>(
+      static_cast<char*>(p2pTransportDevices_.device) +
+      peerIndex * ibrcDeviceSlotSize());
 }
 
 void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
@@ -1371,10 +1402,17 @@ void MultipeerIbrcTransport::doMaterializePeer(int peerRank) {
       localBuf,
       IbCounterStorage::HostPinned,
       /*allocateDiscardSignal=*/false);
+  // Allocate this peer's send/recv rings on demand (HostPinned NIC_DONE
+  // counter, CPU-proxy written) and publish them on the same bilateral round,
+  // so sendRecvStateForPeer(peerIndex) is populated when allocatePeerCmdQueues
+  // -> updatePeerDeviceTransport bakes it into the device slot.
+  allocateSendRecvBufferForPeer(
+      peerIndex, localBuf, IbCounterStorage::HostPinned);
   auto remoteBuf =
       exchangeWithPeer(peerRank, localBuf, kIbPeerBufferExchangeTag);
   applyRemoteSignalCounterResources(
       peerIndex, remoteBuf, /*hasDiscardSignal=*/false);
+  applyRemoteSendRecvBuffer(peerIndex, remoteBuf);
   allocatePeerCmdQueues(peerIndex);
   startProgressThread();
   peerMaterialized_[peerIndex] = true;
@@ -1386,6 +1424,7 @@ void MultipeerIbrcTransport::cleanupPeerOnFailure(int peerIndex) {
   cleanupPeerCmdQueues(peerIndex);
   cleanupPeerQps(peerIndex);
   cleanupPeerSignalCounterResources(peerIndex);
+  cleanupSendRecvBufferForPeer(peerIndex);
   if (peerIndex >= 0 &&
       peerIndex < static_cast<int>(peerMaterialized_.size())) {
     peerMaterialized_[peerIndex] = false;

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransport.h
@@ -6,11 +6,22 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <vector>
 
+// `meta::comms::DeviceBuffer`: HIP shim on AMD, CUDA RAII on NVIDIA (mirrors
+// MultipeerIbgdaTransport.h).
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
+
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/MultiPeerIbTransport.h"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
 
 namespace comms::prims {
@@ -172,6 +183,16 @@ class MultipeerIbrcTransport
   std::size_t allocatedCmdQueueCount() const;
   MappedAllocation allocateMapped(std::size_t bytes, const char* label);
 
+  // ---- Pipelined send/recv staging (eager mode only) ----
+  //
+  // Host send/recv buffer management is shared with IBGDA in
+  // MultiPeerIbTransportBase. IBRC delegates to
+  // allocateSendRecvBuffersEager(IbCounterStorage::HostPinned) — the NIC_DONE
+  // counter is host-mapped and updated by the CPU proxy (NCCL GIN style)
+  // instead of an IBGDA companion-QP loopback counter — plus
+  // exchangeSendRecvBuffersEager(), sendRecvStateForPeer(), and
+  // cleanupSendRecvBuffers().
+
   void createPeerQps(int peerIndex);
   PeerQpPayload buildLocalQpPayload(int peerIndex) const;
   void connectPeerQps(int peerIndex, const PeerQpPayload& remotePayload);
@@ -204,6 +225,9 @@ class MultipeerIbrcTransport
   std::size_t cmdQueueControlBytes_{0};
   std::atomic<bool> stopProgress_{false};
   std::thread progressThread_;
+
+  // Send/recv staging state (eager mode) lives in MultiPeerIbTransportBase
+  // (sendRecvPeerBuffers_ + bulks); IBRC delegates allocation/exchange/cleanup.
 };
 
 } // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cu
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh"
+
+#include <new>
+
+#include "comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh"
+
+namespace comms::prims {
+
+std::size_t ibrcDeviceSlotSize() {
+  return sizeof(P2pIbrcTransportDevice);
+}
+
+void constructIbrcDeviceSlots(void* slotsHost, int numSlots) {
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
+  for (int i = 0; i < numSlots; ++i) {
+    new (&slots[i]) P2pIbrcTransportDevice();
+  }
+}
+
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxGroups,
+    uint32_t numQpsPerPeerPerNic,
+    DeviceSpan<IbrcBlockQpState> blockQpState,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbSendRecvState sendRecvState) {
+  auto* slots = static_cast<P2pIbrcTransportDevice*>(slotsHost);
+  new (&slots[peerIndex]) P2pIbrcTransportDevice(
+      queues,
+      numNics,
+      maxGroups,
+      numQpsPerPeerPerNic,
+      blockQpState,
+      remoteSignalBuf,
+      localSignalBuf,
+      counterDeviceBuf,
+      counterHostBuf,
+      numSignalSlots,
+      numCounterSlots,
+      sendRecvState);
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
+++ b/comms/prims/transport/ibrc/MultipeerIbrcTransportCuda.cuh
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/ibrc/IbrcTypes.h"
+
+namespace comms::prims {
+
+// Forward declaration: the full definition lives in P2pIbrcTransportDevice.cuh,
+// which transitively pulls device-only headers (CopyOp.cuh -> Tile.cuh ->
+// hip/hip_bf16.h) that a host `.cc` cannot compile on AMD. Host callers only
+// ever name `P2pIbrcTransportDevice*` (a pointer) and use these builders to
+// construct/size the slots inside the `.cu` (mirrors IBGDA's
+// MultipeerIbgdaTransportCuda).
+class P2pIbrcTransportDevice;
+
+// Size of one P2pIbrcTransportDevice slot (for host-side pointer arithmetic
+// into the host-pinned mapped array of device handles).
+std::size_t ibrcDeviceSlotSize();
+
+// Default-construct (placement-new) each P2pIbrcTransportDevice slot in a
+// host-pinned mapped array.
+void constructIbrcDeviceSlots(void* slotsHost, int numSlots);
+
+// Placement-new a single populated P2pIbrcTransportDevice into the host-pinned
+// mapped array. Args mirror the device-handle constructor; all are plain-data
+// host-safe types.
+void writeIbrcDeviceSlot(
+    void* slotsHost,
+    int peerIndex,
+    DeviceSpan<IbrcCmdQueueDevice> queues,
+    uint32_t numNics,
+    uint32_t maxGroups,
+    uint32_t numQpsPerPeerPerNic,
+    DeviceSpan<IbrcBlockQpState> blockQpState,
+    IbgdaRemoteBuffer remoteSignalBuf,
+    IbgdaLocalBuffer localSignalBuf,
+    IbgdaLocalBuffer counterDeviceBuf,
+    IbgdaLocalBuffer counterHostBuf,
+    int numSignalSlots,
+    int numCounterSlots,
+    IbSendRecvState sendRecvState);
+
+} // namespace comms::prims

--- a/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
+++ b/comms/prims/transport/ibrc/P2pIbrcTransportDevice.cuh
@@ -18,6 +18,7 @@
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Timeout.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
 #include "comms/prims/transport/ibrc/IbrcTypes.h"
 
@@ -54,10 +55,6 @@ inline constexpr uint64_t kIbrcDefaultDeviceTimeoutCycles = 10'000'000'000ULL;
 #define IBRC_CHECK_SLOT_ID(id, count, kind) assert((id) >= 0 && (id) < (count))
 #endif
 
-struct IbrcBlockQpState {
-  uint32_t put_rr{0};
-};
-
 /**
  * Device-side IBRC peer handle.
  *
@@ -82,7 +79,8 @@ class P2pIbrcTransportDevice {
       IbgdaLocalBuffer ownedCounterDeviceBuf = {},
       IbgdaLocalBuffer ownedCounterHostBuf = {},
       int numSignalSlots = 0,
-      int numCounterSlots = 0)
+      int numCounterSlots = 0,
+      IbSendRecvState sendRecvState = {})
       : cmdQueues(queues),
         numNics(nics),
         maxGroups_(maxGroups),
@@ -93,7 +91,8 @@ class P2pIbrcTransportDevice {
         ownedCounterDeviceBuf_(ownedCounterDeviceBuf),
         ownedCounterHostBuf_(ownedCounterHostBuf),
         numSignalSlots_(numSignalSlots),
-        numCounterSlots_(numCounterSlots) {}
+        numCounterSlots_(numCounterSlots),
+        sendRecv_(sendRecvState) {}
 
   __device__ void put(
       ThreadGroup& group,
@@ -449,6 +448,144 @@ class P2pIbrcTransportDevice {
     flush();
   }
 
+  // ===========================================================================
+  // Pipelined send/recv — delegated to the shared IbSendRecvDevice.
+  // ===========================================================================
+  //
+  // The send/recv algorithm is transport-agnostic and lives in
+  // `IbSendRecvDevice` (P2pIbTransportDeviceDecl.cuh). Each method routes every
+  // transport op through `*this`, so IBRC reuses IBGDA's send/recv unchanged.
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const {
+    return sendRecv_.send_recv_state();
+  }
+
+  __device__ __forceinline__ std::size_t pipeline_window(
+      int active_blocks) const {
+    return sendRecv_.pipeline_window(active_blocks);
+  }
+
+  __device__ __forceinline__ void init_send_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+    sendRecv_.init_send_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
+  }
+
+  __device__ __forceinline__ void init_recv_progress(
+      ThreadGroup& group,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0) {
+    sendRecv_.init_recv_progress(
+        group, nbytes, active_blocks, max_signal_bytes);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_send_once(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    return sendRecv_.progress_send_once<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ IbgdaSendRecvProgressStatus progress_recv_once(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    return sendRecv_.progress_recv_once<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void send(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.send<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recv(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.recv<P2pIbrcTransportDevice, CopyOp>(
+        *this,
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forward(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbrcTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks = 0,
+      std::size_t max_signal_bytes = 0,
+      const Timeout& timeout = Timeout(),
+      Args... args) {
+    sendRecv_.forward<CopyOp>(
+        *this,
+        group,
+        dst,
+        fwd.sendRecv_,
+        fwd,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  }
+
  private:
   __device__ __forceinline__ uint32_t num_qp_lanes() const {
     return numNics * qpsPerBlockPerNic_;
@@ -761,6 +898,7 @@ class P2pIbrcTransportDevice {
   IbgdaLocalBuffer ownedCounterHostBuf_{};
   int numSignalSlots_{0};
   int numCounterSlots_{0};
+  IbSendRecvDevice sendRecv_{};
 };
 
 static_assert(std::is_standard_layout_v<P2pIbrcTransportDevice>);


### PR DESCRIPTION
Summary:

Parameterize `IbgdaBenchmark` over IBGDA and IBRC so the same put, flush, signal, and counter microbenchmarks run through the shared `P2pIbTransportDevice` surface. Add the benchmark target dependency on `MultipeerIbrcTransport`, keep NIC selection compatible with the existing IBGDA path, and record the GB200 comparison data in `IbrcBenchmarkResults.md`.

Reviewed By: goelayu

Differential Revision: D108932288
