### PR TITLE
ctranIB interleave use IB devices: 30+% medium-size msg busbw gain for ctran AR AG on GB200

### DIFF
--- a/comms/ctran/backends/ib/CtranIbVc.cc
+++ b/comms/ctran/backends/ib/CtranIbVc.cc
@@ -50,6 +50,8 @@ inline commResult_t CtranIbVirtualConn::setDefaultQPConfig() {
   qpScalingTh_ = NCCL_CTRAN_IB_QP_SCALING_THRESHOLD;
   vcMode_ = NCCL_CTRAN_IB_VC_MODE;
   maxQpMsgs_ = NCCL_CTRAN_IB_QP_MAX_MSGS;
+  qpInterleaveDevices_ = NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE;
+  qpInterleaveMinWqeSize_ = NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE;
   ConnectionType connTyp = ConnectionType::NO_STATEX;
   std::vector<std::string>* configList{nullptr};
   if (comm_ && comm_->statex_) {

--- a/comms/ctran/backends/ib/CtranIbVc.h
+++ b/comms/ctran/backends/ib/CtranIbVc.h
@@ -482,6 +482,50 @@ class CtranIbVirtualConn {
     return activeDevices_[getActiveDevIdxFromQpIdx(qpIdx)];
   }
 
+  // Map a logical round-robin position to a physical (device-major) data-QP
+  // index that interleaves consecutive sub-chunks across the VC's D NICs.
+  // ibvDataQps_ is stored device-major ([dev0: qp0..K-1, dev1: qpK..2K-1, ...,
+  // dev(D-1): qp(D-1)K..DK-1]), so the default sequential walk fills one NIC's
+  // K QPs before spilling to the next. Interleaving advances the device first,
+  // remapping logical 0,1,2,... to physical 0,K,2K,...,(D-1)K,1,K+1,... so a
+  // single op spanning a few sub-chunks drives all NICs (for D==2 this is
+  // 0,K,1,K+1,...).
+  //
+  // numActive (= D) = activeDevices_.size();
+  // numQpsPerDevice (= K) = maxNumQps_ / numActive.
+  // For numActive == 1 this is the identity. The result is always
+  // < numActive * numQpsPerDevice (== maxNumQps_) for any logical < maxNumQps_,
+  // so it stays in-bounds for pendingWqeQs_ even when the free-running qpIdxRR_
+  // briefly exceeds a smaller per-op qps.
+  static inline int
+  interleaveQpIdx(int logical, int numActive, int numQpsPerDevice) {
+    return (logical % numActive) * numQpsPerDevice + (logical / numActive);
+  }
+
+  // Whether a single op's WQEs should be interleaved across the VC's NICs.
+  // Worth it only when the VC spans >1 NIC and each posted WQE is large enough
+  // (> minWqeSize) to be bandwidth-bound -- then spreading WQEs across NICs
+  // adds bandwidth. WQEs <= minWqeSize (e.g. the 64K pieces a NUM_SPLIT=2
+  // AllGather ring makes from a 128K per-rank chunk) are latency-bound: one NIC
+  // handles them fine, and interleaving them only pays cross-NIC
+  // ordering/straggler cost for no gain. Pure function for unit testing.
+  static inline bool shouldInterleaveQp(
+      bool interleaveDevices,
+      int numActive,
+      uint64_t wqeSize,
+      uint64_t minWqeSize) {
+    return interleaveDevices && numActive > 1 && wqeSize > minWqeSize;
+  }
+
+  // Size of the next WQE the front op would post, mirroring the maxWqeSize
+  // logic in queueWriteOnQp / queueReadOnQp. Used to gate interleaving.
+  template <typename OpPtr>
+  inline uint64_t nextWqeSize(const OpPtr& op) {
+    const uint64_t remData = op->len - op->offset;
+    const auto opQps = std::min(getOpQps(op->config), maxNumQps_);
+    return std::min(remData, maxWqeSizeFor(op->config, op->len, opQps));
+  }
+
   // Returns the IB device that hosts the control QPs for this VC.
   // Always equals activeDevices_.front() today.
   inline int getCtrlDevice() const {
@@ -630,6 +674,18 @@ class CtranIbVirtualConn {
         config, &CtranIbConfig::qpScalingTh, qpScalingTh_);
   }
 
+  // Max size of a single WQE for an op of total size `len` whose payload is
+  // spread across `qps` QPs: the configured per-QP scaling threshold if set,
+  // else an equal split (len / qps); clamped to [mtu_, maxMsgSize_]. The
+  // single-WQE fast path passes qps=1 (no QP scaling, so the fallback is the
+  // whole message).
+  inline uint64_t
+  maxWqeSizeFor(const CtranIbConfig* config, uint64_t len, int qps) {
+    const auto scalingTh = getOpScalingTh(config);
+    const uint64_t raw = scalingTh > 0 ? scalingTh : len / std::max(qps, 1);
+    return std::min(maxMsgSize_, std::max(raw, mtu_));
+  }
+
   template <typename PerfConfig = DefaultPerfCollConfig>
   inline bool
   isFastPutValid(CtranIbConfig* config, size_t len, size_t numMessages) {
@@ -651,10 +707,7 @@ class CtranIbVirtualConn {
       return false;
     }
 
-    auto perPutScalingTh = getOpScalingTh(config);
-    uint64_t maxWqeSize = perPutScalingTh > 0 ? perPutScalingTh : len;
-    // Lock max WQE size to the range [1MTU, (max size supported by port)]
-    maxWqeSize = std::min(maxMsgSize_, std::max(maxWqeSize, mtu_));
+    uint64_t maxWqeSize = maxWqeSizeFor(config, len, /*qps=*/1);
 
     if (len > maxWqeSize) {
       CLOGF(
@@ -947,10 +1000,7 @@ class CtranIbVirtualConn {
         return commSystemError;
       }
 
-      auto perGetScalingTh = getOpScalingTh(config);
-      uint64_t maxWqeSize = perGetScalingTh > 0 ? perGetScalingTh : len;
-      // Lock max WQE size to the range [1MTU, (max size supported by port)]
-      maxWqeSize = std::min(maxMsgSize_, std::max(maxWqeSize, mtu_));
+      uint64_t maxWqeSize = maxWqeSizeFor(config, len, /*qps=*/1);
 
       if (len > maxWqeSize) {
         CLOGF(
@@ -1331,19 +1381,35 @@ class CtranIbVirtualConn {
       FastOpQueue& outstandingFastQueue,
       QueueOpFunc queueOpOnQp,
       int fastQpIdx) {
+    const int numActive = static_cast<int>(activeDevices_.size());
     bool sent = true;
     while (sent && (pendingOpQueue.size() > 0)) {
       sent = false;
       auto& op = pendingOpQueue.front();
       auto qps = std::min(getOpQps(op->config), maxNumQps_);
       auto maxmsgs = std::min(getOpMaxQpMsgs(op->config), maxQpMsgs_);
+      // Interleave this op's WQEs across NICs only when enabled, the VC spans
+      // >1 NIC, and each WQE is large enough to be bandwidth-bound. Small WQEs
+      // (<= qpInterleaveMinWqeSize_) are latency-bound; spreading them across
+      // NICs only adds cross-NIC ordering/straggler cost for no bandwidth gain.
+      const bool doInterleave = shouldInterleaveQp(
+          qpInterleaveDevices_,
+          numActive,
+          nextWqeSize(op),
+          qpInterleaveMinWqeSize_);
       for (int i = 0; i < qps; i++) {
-        auto pendingWqeSize = pendingWqeQs_.at(qpIdxRR_).size();
-        if (qpIdxRR_ == fastQpIdx) {
+        // qpIdxRR_ steps logically; translate it to a physical device-major QP
+        // index so a single op's sub-chunks interleave across NICs. The map is
+        // the identity when doInterleave is false, preserving the legacy walk.
+        const int qpIdx = doInterleave
+            ? interleaveQpIdx(qpIdxRR_, numActive, numQpsPerDevice_)
+            : qpIdxRR_;
+        auto pendingWqeSize = pendingWqeQs_.at(qpIdx).size();
+        if (qpIdx == fastQpIdx) {
           pendingWqeSize += outstandingFastQueue.size();
         }
         if (pendingWqeSize < maxmsgs) {
-          FB_COMMCHECK(queueOpOnQp(qpIdxRR_));
+          FB_COMMCHECK(queueOpOnQp(qpIdx));
           sent = true;
         }
         qpIdxRR_ = (qpIdxRR_ + 1) % qps;
@@ -1364,14 +1430,9 @@ class CtranIbVirtualConn {
     auto& put = pendingPuts_.front();
 
     uint64_t remData = put->len - put->offset;
-    // Write WQEs of max size qpScalingTh_ unless the threshold is 0. If it
-    // is, divide message equally among QPs.
-    auto perPutScalingTh = getOpScalingTh(put->config);
-    auto putqps = std::min(getOpQps(put->config), maxNumQps_);
-    uint64_t maxWqeSize =
-        perPutScalingTh > 0 ? perPutScalingTh : put->len / putqps;
-    // Lock max WQE size to the range [1MTU, (max size supported by port)]
-    maxWqeSize = std::min(maxMsgSize_, std::max(maxWqeSize, mtu_));
+    // Write WQEs of max size qpScalingTh_, else divide the message among QPs.
+    uint64_t maxWqeSize = maxWqeSizeFor(
+        put->config, put->len, std::min(getOpQps(put->config), maxNumQps_));
     auto toSend = std::min(remData, maxWqeSize);
     bool finalWriteOfPut = toSend == remData;
 
@@ -1444,14 +1505,9 @@ class CtranIbVirtualConn {
     auto& get = pendingGets_.front();
 
     uint64_t remData = get->len - get->offset;
-    // Write WQEs of max size qpScalingTh_ unless the threshold is 0. If it
-    // is, divide message equally among QPs.
-    auto perGetScalingTh = getOpScalingTh(get->config);
-    auto getqps = std::min(getOpQps(get->config), maxNumQps_);
-    uint64_t maxWqeSize =
-        perGetScalingTh > 0 ? perGetScalingTh : get->len / getqps;
-    // Lock max WQE size to the range [1MTU, (max size supported by port)]
-    maxWqeSize = std::min(maxMsgSize_, std::max(maxWqeSize, mtu_));
+    // Write WQEs of max size qpScalingTh_, else divide the message among QPs.
+    uint64_t maxWqeSize = maxWqeSizeFor(
+        get->config, get->len, std::min(getOpQps(get->config), maxNumQps_));
     auto toSend = std::min(remData, maxWqeSize);
     bool finalReadOfGet = toSend == remData;
 
@@ -1871,6 +1927,17 @@ class CtranIbVirtualConn {
   int numQpsPerDevice_{0};
   size_t qpScalingTh_{NCCL_CTRAN_IB_QP_SCALING_THRESHOLD};
   enum NCCL_CTRAN_IB_VC_MODE vcMode_ { NCCL_CTRAN_IB_VC_MODE::spray };
+  // When true and the VC spans multiple NICs, tryToPostOp interleaves a single
+  // op's QP-scaling sub-chunks across all NICs (visit order qp0, qpK, qp2K, ...
+  // advancing the device first, where K = maxNumQps_ / numActiveDevices)
+  // instead of filling one NIC's QPs first. Read from
+  // NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE in setDefaultQPConfig. No effect
+  // when activeDevices_.size() == 1 (the mapping is the identity).
+  bool qpInterleaveDevices_{false};
+  // Minimum per-WQE size for interleaving to kick in. WQEs at or below this are
+  // latency-bound; interleaving them regresses (the 64K-per-put AllGather
+  // case). Read from NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE.
+  uint64_t qpInterleaveMinWqeSize_{NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE};
   int maxQpMsgs_;
   uint64_t mtu_{4096};
   uint64_t maxMsgSize_{CTRAN_IB_FAST_PATH_MSG_MAX_SIZE};

--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -5,7 +5,10 @@
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
 #include <unistd.h>
+#include <chrono>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <folly/init/Init.h>
 
@@ -312,6 +315,126 @@ static void BM_CtranIb_IGet(benchmark::State& state, CtranIbConfig config) {
 }
 
 //------------------------------------------------------------------------------
+// Multi-put per-arrival benchmark (interleave on vs off)
+//
+// Issues `numPuts` concurrent CtranIb::iput ops (each `chunkSize` bytes, to
+// distinct offsets of the receive buffer) on the single per-peer VC, then
+// records the elapsed time at which each put's notify arrives at the receiver
+// (notify1_us = first arrival ... notifyN_us = last). Uses only the high-level
+// CtranIb iput/progress/checkNotify API on the simple kExternal setup -- no
+// multi-VC / control-message transport.
+//
+// Purpose: expose NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE, which only has an
+// effect when the VC spans >1 NIC (DEVICES_PER_RANK=2, default on GB200). With
+// K = MAX_QPS/devices QPs per NIC and a chunk whose QP-scaling sub-chunks
+// number <= K, interleave OFF packs each put onto a single NIC (consecutive
+// small puts can pile onto the same NIC, leaving the other idle), while
+// interleave ON spreads every put across both NICs. Aggregate BW can look
+// identical; the per-put arrival times do not.
+//------------------------------------------------------------------------------
+
+static void benchmarkMultiPut(benchmark::State& state, int numPuts) {
+  const size_t chunkSize = state.range(0);
+  // Reuse the kExternal single-VC setup; one contiguous region holds all
+  // chunks (setupBenchmarkContext page-aligns and registers the buffers).
+  auto ctx = setupBenchmarkContext(numPuts * chunkSize);
+
+  CtranIbConfig config{
+      .numQps = 16,
+      .qpScalingTh = 524288,
+      .qpMsgs = 128,
+  };
+
+  std::vector<double> sumDeltaUs(numPuts, 0.0);
+
+  for (auto _ : state) {
+    CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+    std::vector<CtranIbRequest> putReq(numPuts);
+    const auto t0 = std::chrono::steady_clock::now();
+
+    // Issue all puts back-to-back; each notifies the receiver on completion.
+    for (int i = 0; i < numPuts; ++i) {
+      const void* sbuf =
+          static_cast<const char*>(ctx.sendBuffer) + i * chunkSize;
+      void* dbuf = static_cast<char*>(ctx.recvBuffer) + i * chunkSize;
+      if (ctx.senderIb->iput(
+              sbuf,
+              dbuf,
+              chunkSize,
+              kDummyRank,
+              ctx.senderRegHdl,
+              ctx.ibReceiveKey,
+              true /* notify */,
+              &config,
+              &putReq[i],
+              false /* fast */) != commSuccess) {
+        throw ctran::utils::Exception("iput failed", commSystemError);
+      }
+    }
+
+    // Drive sender progress + receiver notify polling; timestamp each arrival.
+    int seen = 0;
+    std::vector<double> deltaUs(numPuts, 0.0);
+    while (seen < numPuts) {
+      if (ctx.senderIb->progress() != commSuccess) {
+        throw ctran::utils::Exception("progress failed", commSystemError);
+      }
+      bool notified = false;
+      if (ctx.receiverIb->checkNotify(kDummyRank, &notified) != commSuccess) {
+        throw ctran::utils::Exception("checkNotify failed", commSystemError);
+      }
+      if (notified) {
+        deltaUs[seen++] = std::chrono::duration<double, std::micro>(
+                              std::chrono::steady_clock::now() - t0)
+                              .count();
+      }
+    }
+
+    // Drain the sender's outstanding iputs before putReq leaves scope.
+    bool allComplete = false;
+    while (!allComplete) {
+      if (ctx.senderIb->progress() != commSuccess) {
+        throw ctran::utils::Exception("progress failed", commSystemError);
+      }
+      allComplete = true;
+      for (int i = 0; i < numPuts; ++i) {
+        if (!putReq[i].isComplete()) {
+          allComplete = false;
+          break;
+        }
+      }
+    }
+
+    for (int i = 0; i < numPuts; ++i) {
+      sumDeltaUs[i] += deltaUs[i];
+    }
+  }
+
+  const double iters = static_cast<double>(state.iterations());
+  for (int i = 0; i < numPuts; ++i) {
+    state.counters["notify" + std::to_string(i + 1) + "_us"] =
+        sumDeltaUs[i] / iters;
+  }
+  const double totalBytes = iters * numPuts * static_cast<double>(chunkSize);
+  state.counters["BW_GBps"] =
+      benchmark::Counter(totalBytes / 1e9, benchmark::Counter::kIsRate);
+  // Self-document the resolved config in the output row.
+  state.counters["interleave"] =
+      NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE ? 1 : 0;
+  state.counters["devs"] = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+
+  cleanupBenchmarkContext(ctx);
+}
+
+static void BM_CtranIb_MultiPut2(benchmark::State& state) {
+  benchmarkMultiPut(state, 2);
+}
+
+static void BM_CtranIb_MultiPut4(benchmark::State& state) {
+  benchmarkMultiPut(state, 4);
+}
+
+//------------------------------------------------------------------------------
 // Benchmark Registration
 //------------------------------------------------------------------------------
 
@@ -396,6 +519,45 @@ static auto* registered_iget_512k = benchmark::RegisterBenchmark(
                                         ->Range(kMinBufferSize, kMaxBufferSize)
                                         ->UseRealTime()
                                         ->Unit(benchmark::kMicrosecond);
+
+// Multi-put per-arrival: 2 and 4 concurrent puts across the
+// interleave-sensitive chunk-size range. Run twice -- with
+// NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE 0 then 1 (and
+// NCCL_CTRAN_IB_DEVICES_PER_RANK=2) -- and compare the notify*_us columns.
+const size_t kMultiPut32K = 32 * 1024;
+const size_t kMultiPut64K = 64 * 1024;
+const size_t kMultiPut128K = 128 * 1024;
+const size_t kMultiPut256K = 256 * 1024;
+const size_t kMultiPut512K = 512 * 1024;
+const size_t kMultiPut1M = 1 * 1024 * 1024;
+const size_t kMultiPut2M = 2 * 1024 * 1024;
+const size_t kMultiPut4M = 4 * 1024 * 1024;
+
+static auto* registered_multiput2 =
+    benchmark::RegisterBenchmark("BM_CtranIb_MultiPut2", BM_CtranIb_MultiPut2)
+        ->Arg(kMultiPut32K)
+        ->Arg(kMultiPut64K)
+        ->Arg(kMultiPut128K)
+        ->Arg(kMultiPut256K)
+        ->Arg(kMultiPut512K)
+        ->Arg(kMultiPut1M)
+        ->Arg(kMultiPut2M)
+        ->Arg(kMultiPut4M)
+        ->UseRealTime()
+        ->Unit(benchmark::kMicrosecond);
+
+static auto* registered_multiput4 =
+    benchmark::RegisterBenchmark("BM_CtranIb_MultiPut4", BM_CtranIb_MultiPut4)
+        ->Arg(kMultiPut32K)
+        ->Arg(kMultiPut64K)
+        ->Arg(kMultiPut128K)
+        ->Arg(kMultiPut256K)
+        ->Arg(kMultiPut512K)
+        ->Arg(kMultiPut1M)
+        ->Arg(kMultiPut2M)
+        ->Arg(kMultiPut4M)
+        ->UseRealTime()
+        ->Unit(benchmark::kMicrosecond);
 
 //------------------------------------------------------------------------------
 // Main Function

--- a/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
+++ b/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc
@@ -4,12 +4,14 @@
 #include <cuda_runtime.h>
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
+#include <unistd.h>
 #include <memory>
 
 #include <folly/init/Init.h>
 
 #include "comms/ctran/backends/ib/BootstrapExternal.h"
 #include "comms/ctran/backends/ib/CtranIb.h"
+#include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Exception.h"
 
 using namespace ctran;
@@ -84,6 +86,13 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
   const int cudaDev0 = 0;
   const int cudaDev1 = 1;
 
+  // GB200 (aarch64) uses 64KB pages; dma-buf registration via
+  // cuMemGetHandleForAddressRange requires a page-aligned length (sub-page
+  // lengths fail with CUDA_ERROR_INVALID_VALUE). Register a page-aligned region
+  // while still transferring `bufferSize` bytes.
+  const size_t pageSize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  const size_t regLen = ((bufferSize + pageSize - 1) / pageSize) * pageSize;
+
   // Initialize senderIb and receiverIb
   auto senderIb = std::make_unique<CtranIb>(
       kDummyRank,
@@ -114,23 +123,42 @@ static BenchmarkContext setupBenchmarkContext(size_t bufferSize) {
           senderVcIdentifier, kDummyRank),
       commSuccess);
 
-  // Allocate memory on the sender side
+  // Allocate RDMA-registerable device buffers with commCudaMalloc, the same
+  // auto-selecting allocator CTRAN algos use: a GPUDirect-RDMA-capable CUDA VMM
+  // allocation when cuMem is supported (matching production and ncclMemAlloc,
+  // both POSIX|FABRIC on GB200), falling back to cudaMalloc otherwise. The
+  // dma-buf fd export used by regMem (cuMemGetHandleForAddressRange) operates
+  // on the VMM address range and is independent of the POSIX/FABRIC handle
+  // type. Allocate/register the page-aligned regLen while still transferring
+  // bufferSize bytes.
   CHECK_EQ(cudaSetDevice(cudaDev0), cudaSuccess);
   void* sendBuffer = nullptr;
-  CHECK_EQ(cudaMalloc(&sendBuffer, bufferSize), cudaSuccess);
+  CHECK_EQ(
+      ctran::utils::commCudaMalloc(
+          reinterpret_cast<char**>(&sendBuffer),
+          regLen,
+          /*logMetaData=*/nullptr,
+          "CtranIbBench"),
+      commSuccess);
   void* senderRegHdl = nullptr;
-  if (CtranIb::regMem(sendBuffer, bufferSize, cudaDev0, &senderRegHdl) !=
+  if (CtranIb::regMem(sendBuffer, regLen, cudaDev0, &senderRegHdl) !=
       commSuccess) {
     throw ctran::utils::Exception(
         "regMem failed for sendBuffer", commSystemError);
   }
 
-  // Allocate memory on the receiver side
+  // Allocate memory on the receiver side (see sender note above).
   CHECK_EQ(cudaSetDevice(cudaDev1), cudaSuccess);
   void* recvBuffer = nullptr;
-  CHECK_EQ(cudaMalloc(&recvBuffer, bufferSize), cudaSuccess);
+  CHECK_EQ(
+      ctran::utils::commCudaMalloc(
+          reinterpret_cast<char**>(&recvBuffer),
+          regLen,
+          /*logMetaData=*/nullptr,
+          "CtranIbBench"),
+      commSuccess);
   void* receiverRegHdl = nullptr;
-  if (CtranIb::regMem(recvBuffer, bufferSize, cudaDev1, &receiverRegHdl) !=
+  if (CtranIb::regMem(recvBuffer, regLen, cudaDev1, &receiverRegHdl) !=
       commSuccess) {
     throw ctran::utils::Exception(
         "regMem failed for recvBuffer", commSystemError);
@@ -169,8 +197,12 @@ static void cleanupBenchmarkContext(BenchmarkContext& ctx) {
     XLOGF(ERR, "deregMem failed for receiverRegHdl");
   }
 
-  CHECK_EQ(cudaFree(ctx.sendBuffer), cudaSuccess);
-  CHECK_EQ(cudaFree(ctx.recvBuffer), cudaSuccess);
+  // Free each buffer on the device it was allocated on (CUDA VMM unmap is
+  // context-sensitive): sendBuffer on cudaDev0, recvBuffer on cudaDev1.
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  CHECK_EQ(ctran::utils::commCudaFree(ctx.sendBuffer), commSuccess);
+  CHECK_EQ(cudaSetDevice(1), cudaSuccess);
+  CHECK_EQ(ctran::utils::commCudaFree(ctx.recvBuffer), commSuccess);
 }
 
 static void

--- a/comms/ctran/backends/ib/docs/ctranib_qp_interleave_devices_sweep_gb200.md
+++ b/comms/ctran/backends/ib/docs/ctranib_qp_interleave_devices_sweep_gb200.md
@@ -1,0 +1,366 @@
+# CTRAN-IB NIC-interleaved QP round-robin — GB200 sweep
+
+`NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE` distributes a single op's QP-scaling
+sub-chunks round-robin across a VC's NICs. Data QPs are stored device-major
+(`[NIC0: qp0..K-1, NIC1: qpK..2K-1, ...]`), so the default walk fills one NIC's
+K QPs before the next; interleaving remaps the visit order to
+`qp0, qpK, qp2K, ..., qp1, qpK+1, ...` so an op fans out across all NICs. Gated
+by `NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` (default 64K). Change under test:
+D108913561. GB200 (`b200a`, CUDA 12.8, 2 NICs/rank), ppn=2 nolocal, gated fbpkg
+`nccl_tests_suite:8e4174e24577b70749b8013f56765893`.
+
+---
+
+## 1. TL;DR
+
+**Microbench (`BM_CtranIb_MultiPut`, see §2).** With N concurrent puts,
+interleave gives up to **+70% aggregate BW** in a mid-size window (~128K–2M for
+2 puts, ~128K–1M for 4 puts) and lands the first put up to ~50% sooner (2-put
+1M: 55 → 29 µs). Outside the window it is flat to slightly negative (≤64K,
+latency-bound) — the region the per-WQE gate (default 64K) excludes. The upper
+bound is NIC saturation: a put with ≥ `K=8` sub-chunks already spans both NICs
+even OFF, which is why toggling the cvar on one big put shows nothing.
+
+**Algo sweeps (see §3), interleave OFF→ON on multi-NIC GB200/nolocal:**
+
+- **AllGather `ctring`** — peak **+56% / +81% / +87% / +74%** (n=2/4/8/16); the
+  benefit band moves right with scale (8–16 MiB at n=2 → 64–128 MiB at n=16).
+- **AllGather `ctsrd`** — peak **+33% / +38% / +36% / +27%** (4–32 MiB).
+- **AllReduce `ctring` (fp32)** — peak **+27% / +36% / +34% / +27%** (8–64 MiB).
+- **No regression (gated).** At ≤64K the microbench is flat-to-slightly-negative
+  and the AG `ctring` *collective* regresses ~5–11% at per-rank `sendSize=128K`
+  without a gate (64K pieces from `NUM_SPLIT=2` + dqplb in-order notify). The
+  per-WQE gate (`NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE`, default 64K) skips
+  interleave for WQEs ≤ 64K, so ON matches OFF there (≈±0.1%) while keeping the
+  wins; AllReduce never hit it (WQEs ≥256K). Small (<1 MiB) and very-large
+  (≥512 MiB) sizes are neutral.
+
+**Recommendation:** enable for multi-NIC CTRAN collectives
+(`NCCL_CTRAN_IB_DEVICES_PER_RANK > 1`); with the gate there is no downside —
+worth considering on-by-default when a VC spans multiple NICs. Keep
+`NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` (default 64K) to avoid the loss at
+small, latency-bound messages where one NIC already suffices and interleave is
+not needed.
+
+---
+
+## 2. CtranIB bench result
+
+### What
+
+`BM_CtranIb_MultiPut2` / `BM_CtranIb_MultiPut4` in
+`fbcode/comms/ctran/backends/ib/benchmarks/CtranIbBench.cc` measure the effect of
+`NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE`, which a single large put cannot
+reveal. Each issues N concurrent `CtranIb::iput`s (distinct offsets), drives
+`progress()` while polling `checkNotify()`, and timestamps each put's notify
+arrival (`notify1_us` … `notifyN_us`) plus aggregate `BW_GBps`. High-level iput
+API only, on the existing `kExternal` single-VC setup.
+
+### Results (GB200, `DEVICES_PER_RANK=2`, `MAX_QPS=16`, `qpScalingTh=512K`)
+
+Aggregate BW (GB/s) and per-put notify arrival (µs), interleave OFF vs ON,
+devs=2, swept 32K→4M. `1st-put` = `notify1_us` (first of the N puts arrives),
+`last-put` = `notifyN_us` (all N complete).
+
+**2 concurrent puts**
+
+| Size | BW OFF | BW ON | ON/OFF | 1st-put OFF→ON | last-put OFF→ON |
+|---|---|---|---|---|---|
+| 32K | 3.53 | 3.46 | ×0.98 | 14.1 → 14.3 | 15.2 → 15.4 |
+| 64K | 7.10 | 6.63 | ×0.93 | 14.9 → 15.2 | 16.2 → 16.2 |
+| 128K | 11.68 | 12.88 | ×1.10 ← win starts | 17.8 → 17.4 | 19.1 → 17.9 |
+| 256K | 18.82 | 21.20 | ×1.13 | 21.4 → 20.1 | 24.5 → 21.2 |
+| 512K | 28.05 | 34.68 | ×1.24 | 28.4 → **25.6** | 35.2 → **26.7** |
+| 1M | 34.69 | 52.85 | ×1.52 | 55.2 → **29.3** | 57.1 → **36.2** |
+| 2M | 40.43 | **68.62** | **×1.70** ← peak | 94.2 → **54.7** | 100.4 → **57.7** |
+| 4M | 77.41 | 79.50 | ×1.03 ← converged | 101.7 → 98.9 | 105.1 → 102.0 |
+
+**4 concurrent puts**
+
+| Size | BW OFF | BW ON | ON/OFF | 1st-put OFF→ON | last-put OFF→ON |
+|---|---|---|---|---|---|
+| 32K | 6.34 | 6.24 | ×0.98 | 14.2 → 14.4 | 17.6 → 18.0 |
+| 64K | 11.68 | 11.95 | ×1.02 | 16.0 → 15.3 | 19.1 → 18.9 |
+| 128K | 18.75 | 24.09 | ×1.28 ← win starts | 21.1 → 18.1 | 24.6 → 20.0 |
+| 256K | 26.71 | 35.73 | ×1.34 | 25.6 → 22.8 | 36.0 → **25.9** |
+| 512K | 34.45 | 52.13 | ×1.51 | 45.8 → **28.8** | 57.5 → **36.7** |
+| 1M | 40.10 | **68.44** | **×1.71** ← peak | 92.2 → **43.9** | 101.3 → **57.7** |
+| 2M | 77.17 | 78.76 | ×1.02 ← converged | 95.2 → 97.6 | 105.4 → 103.0 |
+| 4M | 85.91 | 87.42 | ×1.02 | 118.3 → 115.3 | 192.0 → 188.4 |
+
+In the win band interleave lands the **first** put much sooner — 2-put 1M:
+55.2 → 29.3 µs (−47%); 4-put 1M: 92.2 → 43.9 µs (−52%) — the latency benefit
+that matters for the pipelined collective. At ≤64K, ON ≈ OFF (within noise,
+slightly negative at 2-put 64K) — the latency-bound region the gate excludes.
+
+### Key finding
+
+- **The win window is bounded on both sides.** 2 puts: starts ~128K, peaks at 2M (**+70%**), converged by 4M. 4 puts: starts ~128K, peaks at 1M (**+71%**), converged by 2M.
+  - **Lower bound (latency floor):** at ≤64K interleave is flat to slightly negative (2-put 64K ×0.93, 4-put 64K ×1.02) — the transfer is latency-bound, one NIC finishes in ~the same time, and splitting across NICs can cost a little. This is exactly the region the per-WQE gate (default 64K) excludes.
+  - **Upper bound (NIC saturation):** once each put has ≥ `K=8` sub-chunks (`qpScalingTh=512K` → 4M for 2 puts, 2M for 4 puts) interleave-OFF *already* spreads across both NICs, so the gap closes. Also why toggling the cvar on a single large put shows nothing.
+- **The upper bound halves as the put count doubles** (converges at 4M for 2 puts vs 2M for 4 puts): more concurrent puts saturate both NICs at smaller per-put sizes.
+- **Why the min-size gate.** Both signals point to gating small WQEs: the microbench is flat-to-slightly-negative at ≤64K (above), and the AG `ctring` *collective* regresses harder — ~5–11% at per-rank `sendSize=128K`, ungated (n4 @1MiB −8%, n8 @2MiB −9%, n16 @4MiB −11%). The microbench fires *independent* puts, so spreading is mostly harmless; the AG ring is a dependency pipeline with dqplb in-order notify, and `NUM_SPLIT=2` makes each step two 64K puts that interleave splits 1-per-NIC — a cross-NIC straggler / head-of-line stall with no bandwidth to offset it. `NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` (default 64K) skips interleave for WQEs ≤ 64K: removes the collective regression while keeping the win (the §3 AllGather tables are gated, so the dip is gone).
+
+### Reproduce
+
+```bash
+# interleave OFF, then re-run with ...ENABLE=1
+NCCL_CTRAN_IB_DEVICES_PER_RANK=2 NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=0 \
+  buck2 run @fbcode//mode/opt -c fbcode.arch=aarch64 \
+  -c fbcode.platform010-aarch64_clang=17 -c fbcode.nvcc_arch=b200 \
+  -c fbcode.platform010_cuda_version=12.8 \
+  -m ovr_config//third-party/cuda/constraints:12.8 \
+  fbcode//comms/ctran/backends/ib/benchmarks:ctranib_bench -- \
+  --benchmark_filter=BM_CtranIb_MultiPut
+```
+
+---
+
+## 3. Algo bench — config & result
+
+### Configs
+
+| Sweep | Collective | Algo | Interleave |
+|---|---|---|---|
+| `ag ctring OFF` | AllGather | `ctring` | off |
+| `ag ctring ON`  | AllGather | `ctring` | `NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=1` |
+| `ag ctsrd OFF`  | AllGather | `ctsrd`  | off |
+| `ag ctsrd ON`   | AllGather | `ctsrd`  | `NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=1` |
+| `ar ctring OFF` | AllReduce | `ctring` | off |
+| `ar ctring ON`  | AllReduce | `ctring` | `NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=1` |
+
+Interleave ON additionally requires each posted WQE to exceed
+`NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` (default 64K); WQEs at or below it
+fall back to the sequential QP walk.
+
+### MAST jobs (ppn=2 nolocal, GB200)
+
+AllGather:
+
+| Nodes | GPUs | MAST job |
+|---|---|---|
+| 2 | 4 | [torchx-nccltests-gb200-ag-n2ppn2-nolocal-815](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ag-n2ppn2-nolocal-815) |
+| 4 | 8 | [torchx-nccltests-gb200-ag-n4ppn2-nolocal-527](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ag-n4ppn2-nolocal-527) |
+| 8 | 16 | [torchx-nccltests-gb200-ag-n8ppn2-nolocal-542](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ag-n8ppn2-nolocal-542) |
+| 16 | 32 | [torchx-nccltests-gb200-ag-n16ppn2-nolocal-557](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ag-n16ppn2-nolocal-557) |
+
+AllReduce:
+
+| Nodes | GPUs | MAST job |
+|---|---|---|
+| 2 | 4 | [torchx-nccltests-gb200-ar-n2ppn2-nolocal-724](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ar-n2ppn2-nolocal-724) |
+| 4 | 8 | [torchx-nccltests-gb200-ar-n4ppn2-nolocal-763](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ar-n4ppn2-nolocal-763) |
+| 8 | 16 | [torchx-nccltests-gb200-ar-n8ppn2-nolocal-778](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ar-n8ppn2-nolocal-778) |
+| 16 | 32 | [torchx-nccltests-gb200-ar-n16ppn2-nolocal-793](https://www.internalfb.com/mlhub/pipelines/runs/mast/torchx-nccltests-gb200-ar-n16ppn2-nolocal-793) |
+
+### Setup
+
+- **Hardware / topology:** GenAI GB200 cluster (`MastGenAICluster`, `gb200`),
+  ppn=2 with `--nolocal` (SHM/P2P disabled), `--bha 2`,
+  `NCCL_CTRAN_IB_DEVICES_PER_RANK=2`.
+- **Entitlement / locality / DP:** `msl_tbd_iris` / `region;nao` /
+  `genai_llm_research-llama`.
+- **Build:** `nvcc_arch=b200a`, CUDA 12.8 (`use_ncclx=stable`, local stack incl.
+  D108913561 + the per-WQE interleave gate). fbpkg `nccl_tests_suite:8e4174e24577b70749b8013f56765893` (gated; both AG/AR).
+- **Interleave gate:** `NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` = 65536 (64K).
+- **NCCL test args:** `-b 4 -e 1G -n 500 -w 50 -d <dtype> -c 1 -z 1 -f 2 -R 1 -M 1 -u 1`
+  (AllGather: `bfloat16`; AllReduce: `float`/fp32 — `ctring` AllReduce rejects
+  bfloat16).
+- **Reported column:** out-of-place BusBW (GB/s), via `read_sweep_result.py`.
+  Δ = (ON − OFF) / OFF.
+
+### AllGather — per-scale tables (out-of-place BusBW, GB/s; interleave gated)
+
+#### n=2 (4 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring | ctsrd OFF | ctsrd ON | Δ ctsrd |
+|---|---|---|---|---|---|---|
+| 4 KiB | 0.05 | 0.05 | +0.0% | 0.06 | 0.06 | +0.0% |
+| 8 KiB | 0.10 | 0.10 | +0.0% | 0.12 | 0.12 | +0.0% |
+| 16 KiB | 0.19 | 0.20 | +5.3% | 0.24 | 0.24 | +0.0% |
+| 32 KiB | 0.37 | 0.37 | +0.0% | 0.46 | 0.47 | +2.2% |
+| 64 KiB | 0.68 | 0.69 | +1.5% | 0.89 | 0.90 | +1.1% |
+| 128 KiB | 1.33 | 1.34 | +0.8% | 1.82 | 1.85 | +1.6% |
+| 256 KiB | 2.62 | 2.66 | +1.5% | 3.51 | 3.60 | +2.6% |
+| 512 KiB | 5.00 | 5.06 | +1.2% | 6.50 | 6.64 | +2.2% |
+| 1 MiB | 8.75 | 9.25 | +5.7% | 11.64 | 11.82 | +1.5% |
+| 2 MiB | 15.06 | 16.56 | +10.0% | 19.75 | 19.99 | +1.2% |
+| 4 MiB | 25.00 | 28.34 | +13.4% | 28.83 | 37.92 | +31.5% |
+| 8 MiB | 31.38 | 49.11 | +56.5% | 39.17 | 52.04 | +32.9% |
+| 16 MiB | 38.47 | 61.43 | +59.7% | 61.29 | 68.80 | +12.3% |
+| 32 MiB | 71.91 | 76.41 | +6.3% | 78.80 | 80.09 | +1.6% |
+| 64 MiB | 87.93 | 87.96 | +0.0% | 87.66 | 88.19 | +0.6% |
+| 128 MiB | 91.60 | 91.81 | +0.2% | 91.94 | 92.13 | +0.2% |
+| 256 MiB | 93.72 | 93.66 | -0.1% | 94.09 | 94.07 | -0.0% |
+| 512 MiB | 95.15 | 95.18 | +0.0% | 95.25 | 95.22 | -0.0% |
+| 1 GiB | 95.85 | 95.87 | +0.0% | 95.84 | 95.82 | -0.0% |
+
+#### n=4 (8 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring | ctsrd OFF | ctsrd ON | Δ ctsrd |
+|---|---|---|---|---|---|---|
+| 4 KiB | 0.04 | 0.04 | +0.0% | 0.06 | 0.06 | +0.0% |
+| 8 KiB | 0.07 | 0.07 | +0.0% | 0.11 | 0.11 | +0.0% |
+| 16 KiB | 0.14 | 0.14 | +0.0% | 0.21 | 0.21 | +0.0% |
+| 32 KiB | 0.26 | 0.26 | +0.0% | 0.42 | 0.42 | +0.0% |
+| 64 KiB | 0.50 | 0.50 | +0.0% | 0.80 | 0.80 | +0.0% |
+| 128 KiB | 0.94 | 0.94 | +0.0% | 1.56 | 1.57 | +0.6% |
+| 256 KiB | 1.68 | 1.69 | +0.6% | 2.87 | 2.85 | -0.7% |
+| 512 KiB | 3.31 | 3.30 | -0.3% | 5.70 | 5.68 | -0.4% |
+| 1 MiB | 6.49 | 6.45 | -0.6% | 10.53 | 10.55 | +0.2% |
+| 2 MiB | 11.31 | 11.42 | +1.0% | 18.65 | 18.35 | -1.6% |
+| 4 MiB | 19.85 | 21.56 | +8.6% | 30.52 | 30.67 | +0.5% |
+| 8 MiB | 31.14 | 35.22 | +13.1% | 39.28 | 54.09 | +37.7% |
+| 16 MiB | 33.96 | 61.35 | +80.7% | 49.88 | 65.64 | +31.6% |
+| 32 MiB | 41.45 | 67.79 | +63.5% | 66.11 | 79.75 | +20.6% |
+| 64 MiB | 77.56 | 84.21 | +8.6% | 87.08 | 87.73 | +0.7% |
+| 128 MiB | 92.71 | 92.79 | +0.1% | 92.80 | 92.91 | +0.1% |
+| 256 MiB | 94.26 | 94.35 | +0.1% | 94.78 | 94.83 | +0.1% |
+| 512 MiB | 95.42 | 95.42 | +0.0% | 95.85 | 95.78 | -0.1% |
+| 1 GiB | 96.12 | 96.15 | +0.0% | 96.40 | 96.37 | -0.0% |
+
+#### n=8 (16 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring | ctsrd OFF | ctsrd ON | Δ ctsrd |
+|---|---|---|---|---|---|---|
+| 4 KiB | 0.02 | 0.02 | +0.0% | 0.05 | 0.05 | +0.0% |
+| 8 KiB | 0.04 | 0.04 | +0.0% | 0.09 | 0.10 | +11.1% |
+| 16 KiB | 0.08 | 0.08 | +0.0% | 0.19 | 0.19 | +0.0% |
+| 32 KiB | 0.16 | 0.16 | +0.0% | 0.35 | 0.37 | +5.7% |
+| 64 KiB | 0.31 | 0.31 | +0.0% | 0.72 | 0.72 | +0.0% |
+| 128 KiB | 0.59 | 0.58 | -1.7% | 1.41 | 1.46 | +3.5% |
+| 256 KiB | 1.03 | 1.04 | +1.0% | 2.12 | 2.59 | +22.2% |
+| 512 KiB | 1.84 | 1.82 | -1.1% | 4.72 | 4.67 | -1.1% |
+| 1 MiB | 3.58 | 3.63 | +1.4% | 9.23 | 9.39 | +1.7% |
+| 2 MiB | 7.10 | 7.09 | -0.1% | 16.67 | 17.13 | +2.8% |
+| 4 MiB | 12.27 | 12.30 | +0.2% | 28.95 | 29.41 | +1.6% |
+| 8 MiB | 22.35 | 22.90 | +2.5% | 36.79 | 44.65 | +21.4% |
+| 16 MiB | 33.66 | 37.49 | +11.4% | 50.18 | 68.26 | +36.0% |
+| 32 MiB | 35.55 | 66.52 | +87.1% | 64.84 | 78.88 | +21.7% |
+| 64 MiB | 45.24 | 70.46 | +55.7% | 84.26 | 88.87 | +5.5% |
+| 128 MiB | 79.55 | 89.40 | +12.4% | 91.92 | 92.60 | +0.7% |
+| 256 MiB | 94.89 | 94.91 | +0.0% | 94.88 | 95.04 | +0.2% |
+| 512 MiB | 95.84 | 95.75 | -0.1% | 95.93 | 96.04 | +0.1% |
+| 1 GiB | 96.36 | 96.30 | -0.1% | 96.54 | 96.55 | +0.0% |
+
+#### n=16 (32 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring | ctsrd OFF | ctsrd ON | Δ ctsrd |
+|---|---|---|---|---|---|---|
+| 4 KiB | 0.01 | 0.01 | +0.0% | 0.04 | 0.04 | +0.0% |
+| 8 KiB | 0.02 | 0.02 | +0.0% | 0.08 | 0.08 | +0.0% |
+| 16 KiB | 0.05 | 0.05 | +0.0% | 0.16 | 0.17 | +6.3% |
+| 32 KiB | 0.09 | 0.09 | +0.0% | 0.33 | 0.33 | +0.0% |
+| 64 KiB | 0.18 | 0.18 | +0.0% | 0.64 | 0.65 | +1.6% |
+| 128 KiB | 0.35 | 0.35 | +0.0% | 1.27 | 1.32 | +3.9% |
+| 256 KiB | 0.65 | 0.65 | +0.0% | 2.52 | 2.53 | +0.4% |
+| 512 KiB | 1.10 | 1.10 | +0.0% | 4.49 | 4.49 | +0.0% |
+| 1 MiB | 1.88 | 1.91 | +1.6% | 8.07 | 8.08 | +0.1% |
+| 2 MiB | 3.74 | 3.75 | +0.3% | 15.97 | 15.91 | -0.4% |
+| 4 MiB | 7.36 | 7.35 | -0.1% | 28.08 | 28.50 | +1.5% |
+| 8 MiB | 12.82 | 12.85 | +0.2% | 40.67 | 44.01 | +8.2% |
+| 16 MiB | 22.67 | 23.61 | +4.1% | 48.45 | 55.86 | +15.3% |
+| 32 MiB | 32.55 | 37.46 | +15.1% | 60.64 | 76.89 | +26.8% |
+| 64 MiB | 37.83 | 65.86 | +74.1% | 78.10 | 86.23 | +10.4% |
+| 128 MiB | 54.43 | 82.14 | +50.9% | 87.95 | 92.46 | +5.1% |
+| 256 MiB | 80.66 | 93.40 | +15.8% | 94.83 | 94.83 | +0.0% |
+| 512 MiB | 96.13 | 96.08 | -0.1% | 95.90 | 95.84 | -0.1% |
+| 1 GiB | 96.54 | 96.56 | +0.0% | 96.56 | 96.58 | +0.0% |
+
+### AllReduce `ctring` (float32) — per-scale tables (out-of-place BusBW, GB/s; interleave gated)
+
+#### n=2 (4 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring |
+|---|---|---|---|
+| 4 KiB | 0.05 | 0.05 | +0.0% |
+| 8 KiB | 0.10 | 0.10 | +0.0% |
+| 16 KiB | 0.19 | 0.19 | +0.0% |
+| 32 KiB | 0.36 | 0.36 | +0.0% |
+| 64 KiB | 0.63 | 0.61 | -3.2% |
+| 128 KiB | 1.18 | 1.18 | +0.0% |
+| 256 KiB | 2.42 | 2.40 | -0.8% |
+| 512 KiB | 4.84 | 4.82 | -0.4% |
+| 1 MiB | 9.19 | 9.06 | -1.4% |
+| 2 MiB | 16.29 | 16.60 | +1.9% |
+| 4 MiB | 26.32 | 30.28 | +15.0% |
+| 8 MiB | 37.79 | 47.89 | +26.7% |
+| 16 MiB | 56.82 | 67.57 | +18.9% |
+| 32 MiB | 82.61 | 82.69 | +0.1% |
+| 64 MiB | 87.75 | 87.85 | +0.1% |
+| 128 MiB | 90.27 | 90.32 | +0.1% |
+| 256 MiB | 90.71 | 90.77 | +0.1% |
+| 512 MiB | 90.92 | 90.96 | +0.0% |
+| 1 GiB | 91.07 | 91.13 | +0.1% |
+
+#### n=4 (8 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring |
+|---|---|---|---|
+| 4 KiB | 0.03 | 0.03 | +0.0% |
+| 8 KiB | 0.06 | 0.06 | +0.0% |
+| 16 KiB | 0.12 | 0.12 | +0.0% |
+| 32 KiB | 0.23 | 0.23 | +0.0% |
+| 64 KiB | 0.42 | 0.42 | +0.0% |
+| 128 KiB | 0.71 | 0.72 | +1.4% |
+| 256 KiB | 1.38 | 1.38 | +0.0% |
+| 512 KiB | 2.78 | 2.79 | +0.4% |
+| 1 MiB | 5.57 | 5.57 | +0.0% |
+| 2 MiB | 10.49 | 10.44 | -0.5% |
+| 4 MiB | 18.40 | 18.77 | +2.0% |
+| 8 MiB | 29.33 | 34.39 | +17.3% |
+| 16 MiB | 41.28 | 53.68 | +30.0% |
+| 32 MiB | 55.54 | 75.44 | +35.8% |
+| 64 MiB | 89.46 | 89.79 | +0.4% |
+| 128 MiB | 92.60 | 92.76 | +0.2% |
+| 256 MiB | 94.05 | 94.12 | +0.1% |
+| 512 MiB | 94.29 | 94.36 | +0.1% |
+| 1 GiB | 94.44 | 94.50 | +0.1% |
+
+#### n=8 (16 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring |
+|---|---|---|---|
+| 4 KiB | 0.02 | 0.02 | +0.0% |
+| 8 KiB | 0.03 | 0.03 | +0.0% |
+| 16 KiB | 0.07 | 0.07 | +0.0% |
+| 32 KiB | 0.13 | 0.13 | +0.0% |
+| 64 KiB | 0.25 | 0.25 | +0.0% |
+| 128 KiB | 0.45 | 0.45 | +0.0% |
+| 256 KiB | 0.75 | 0.75 | +0.0% |
+| 512 KiB | 1.45 | 1.46 | +0.7% |
+| 1 MiB | 2.94 | 2.94 | +0.0% |
+| 2 MiB | 5.88 | 5.90 | +0.3% |
+| 4 MiB | 11.00 | 11.01 | +0.1% |
+| 8 MiB | 19.34 | 19.60 | +1.3% |
+| 16 MiB | 30.55 | 36.15 | +18.3% |
+| 32 MiB | 41.96 | 56.22 | +34.0% |
+| 64 MiB | 60.88 | 78.35 | +28.7% |
+| 128 MiB | 92.70 | 92.55 | -0.2% |
+| 256 MiB | 95.25 | 95.26 | +0.0% |
+| 512 MiB | 96.09 | 96.09 | +0.0% |
+| 1 GiB | 96.25 | 96.25 | +0.0% |
+
+#### n=16 (32 GPUs)
+
+| Size | ctring OFF | ctring ON | Δ ctring |
+|---|---|---|---|
+| 4 KiB | 0.01 | 0.01 | +0.0% |
+| 8 KiB | 0.02 | 0.02 | +0.0% |
+| 16 KiB | 0.04 | 0.04 | +0.0% |
+| 32 KiB | 0.07 | 0.07 | +0.0% |
+| 64 KiB | 0.13 | 0.13 | +0.0% |
+| 128 KiB | 0.25 | 0.25 | +0.0% |
+| 256 KiB | 0.45 | 0.45 | +0.0% |
+| 512 KiB | 0.76 | 0.76 | +0.0% |
+| 1 MiB | 1.47 | 1.47 | +0.0% |
+| 2 MiB | 2.95 | 2.96 | +0.3% |
+| 4 MiB | 5.89 | 5.87 | -0.3% |
+| 8 MiB | 10.98 | 11.06 | +0.7% |
+| 16 MiB | 19.26 | 19.60 | +1.8% |
+| 32 MiB | 30.80 | 36.32 | +17.9% |
+| 64 MiB | 44.44 | 56.27 | +26.6% |
+| 128 MiB | 77.74 | 79.13 | +1.8% |
+| 256 MiB | 94.52 | 94.66 | +0.1% |
+| 512 MiB | 95.38 | 95.44 | +0.1% |
+| 1 GiB | 96.35 | 96.39 | +0.0% |

--- a/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbQpConfigUT.cc
@@ -2,7 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <numeric>
+#include <utility>
 #include <vector>
 
 #include "comms/ctran/backends/ib/CtranIb.h"
@@ -109,4 +111,103 @@ TEST(CtranIbDefaultFlushTest, EnablesFlushForOldNvidiaGb300AndForceFlush) {
     EnvRAII envNetForceFlush(NCCL_CTRAN_NET_FORCE_FLUSH, 0);
     EXPECT_FALSE(CtranIb::shouldEnableLocalFlushByDefault(900));
   }
+}
+
+// Build the physical QP visit order produced by the NIC-interleaved
+// round-robin for the first `steps` logical positions.
+static std::vector<int>
+interleavedOrder(int numActive, int numQpsPerDevice, int steps) {
+  std::vector<int> order;
+  order.reserve(steps);
+  for (int logical = 0; logical < steps; ++logical) {
+    order.push_back(
+        CtranIbVirtualConn::interleaveQpIdx(
+            logical, numActive, numQpsPerDevice));
+  }
+  return order;
+}
+
+// D=2, K=8, full cycle (qps=16): consecutive sub-chunks alternate NIC0/NIC1
+// (physical 0,8,1,9,...) instead of filling NIC0's qp0..7 first.
+TEST(CtranIbQpInterleaveTest, TwoNicsFullCycle) {
+  const std::vector<int> expected = {
+      0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15};
+  EXPECT_EQ(
+      interleavedOrder(/*numActive=*/2, /*numQpsPerDevice=*/8, /*steps=*/16),
+      expected);
+}
+
+// D=2, K=8, partial walk (per-op qps=8): the chunk lands 4 QPs on each NIC
+// instead of all 8 on NIC0 — this is the qps < maxNumQps_ skew the change
+// fixes.
+TEST(CtranIbQpInterleaveTest, TwoNicsHalfCycleSpreadsBothNics) {
+  const std::vector<int> expected = {0, 8, 1, 9, 2, 10, 3, 11};
+  EXPECT_EQ(
+      interleavedOrder(/*numActive=*/2, /*numQpsPerDevice=*/8, /*steps=*/8),
+      expected);
+}
+
+// D=1 (single-NIC VC, e.g. H100 default): interleaving is the identity.
+TEST(CtranIbQpInterleaveTest, SingleNicIsIdentity) {
+  std::vector<int> expected(16);
+  std::iota(expected.begin(), expected.end(), 0);
+  EXPECT_EQ(
+      interleavedOrder(/*numActive=*/1, /*numQpsPerDevice=*/16, /*steps=*/16),
+      expected);
+}
+
+// Over a full cycle the interleaved order is a permutation of [0, maxQps), so
+// every physical QP is visited exactly once and the result stays in-bounds.
+TEST(CtranIbQpInterleaveTest, FullCycleIsPermutation) {
+  const std::vector<std::pair<int, int>> configs = {
+      {2, 8}, {4, 4}, {2, 1}, {3, 5}};
+  for (const auto& [numActive, numQpsPerDevice] : configs) {
+    const int maxQps = numActive * numQpsPerDevice;
+    auto order = interleavedOrder(numActive, numQpsPerDevice, maxQps);
+    std::sort(order.begin(), order.end());
+    std::vector<int> identity(maxQps);
+    std::iota(identity.begin(), identity.end(), 0);
+    EXPECT_EQ(order, identity)
+        << "numActive=" << numActive << " numQpsPerDevice=" << numQpsPerDevice;
+  }
+}
+
+// shouldInterleaveQp gates interleaving on enable + >1 NIC + per-WQE size
+// (interleave only when wqeSize > minWqeSize).
+TEST(CtranIbQpInterleaveTest, ShouldInterleaveQpGate) {
+  constexpr uint64_t k64K = 65536;
+  constexpr uint64_t k128K = 131072;
+  constexpr uint64_t k512K = 524288;
+
+  // Disabled -> never interleave, regardless of size.
+  EXPECT_FALSE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/false, /*numActive=*/2, k512K, k64K));
+
+  // Single NIC -> nothing to spread across.
+  EXPECT_FALSE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/1, k512K, k64K));
+
+  // Enabled, multi-NIC: gate purely on wqeSize > minWqeSize.
+  // 64K piece (== threshold) is latency-bound -> skip (AllGather regression).
+  EXPECT_FALSE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/2, k64K, k64K));
+  // Below threshold -> skip.
+  EXPECT_FALSE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/2, k64K / 2, k64K));
+  // Above threshold -> interleave (preserves the mid/large-message wins).
+  EXPECT_TRUE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/2, k128K, k64K));
+  EXPECT_TRUE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/2, k512K, k64K));
+
+  // More than 2 NICs is fine too.
+  EXPECT_TRUE(
+      CtranIbVirtualConn::shouldInterleaveQp(
+          /*interleaveDevices=*/true, /*numActive=*/4, k128K, k64K));
 }

--- a/comms/utils/cvars/nccl_cvars.yaml
+++ b/comms/utils/cvars/nccl_cvars.yaml
@@ -1640,6 +1640,32 @@ cvars:
      complete and CQEs are generated, new messages will be posted to keep the
      send queue full of this many WQEs.
 
+ - name        : NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE
+   type        : bool
+   default     : True
+   description : |-
+     When a VC spans multiple NICs (NCCL_CTRAN_IB_DEVICES_PER_RANK > 1 with a
+     single VC striped across them), distribute a single put/get's QP-scaling
+     sub-chunks round-robin across all NICs first (interleaved visit order
+     qp0, qpK, qp2K, ... advancing the device before the next QP on a device,
+     where K = MAX_QPS / devices, instead of filling one NIC's qp0..K-1 before
+     the next). This lets a put smaller than
+     NCCL_CTRAN_IB_QP_SCALING_THRESHOLD * (MAX_QPS / devices) still drive all
+     NICs, capturing the multi-NIC bandwidth without extra QP or channel setup.
+     No effect when the VC is bound to a single NIC (the mapping is the
+     identity).
+
+ - name        : NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE
+   type        : uint64_t
+   default     : 65536
+   description : |-
+     Minimum per-WQE size (bytes) for NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE
+     to take effect. A single op's WQEs are interleaved across NICs only when
+     each WQE exceeds this size. WQEs at or below it (e.g. the 64K pieces a
+     NUM_SPLIT=2 AllGather ring produces from a 128K per-rank chunk) are
+     latency-bound -- one NIC handles them fine and spreading them across NICs
+     only adds cross-NIC ordering/straggler cost, so interleaving is skipped.
+
  - name        : NCCL_CTRAN_IB_MAX_NUM_CQE
    type        : int
    default     : -1


### PR DESCRIPTION
Summary:
This diff enables `CtranIB` to spread a single put/get's QP-scaling sub-chunks across all of a VC's
NICs instead of filling one NIC's QPs before the next.

`ibvDataQps_` is stored device-major ([NIC0: qp0..K-1, NIC1: qpK..2K-1, ...],
K = MAX_QPS/devices), so the default round-robin packs an op's WQEs onto one NIC
until its K QPs fill, leaving the other NIC(s) idle for puts with < K sub-chunks.
`interleaveQpIdx()` remaps the visit order to qp0, qpK, qp2K, ... (advance device
first) so every op fans out across all NICs, capturing multi-NIC bandwidth with
no extra QP/channel setup. Identity (no-op) when the VC owns a single NIC.

Gated by per-WQE size: interleave applies only when enabled, the VC spans >1 NIC,
AND each posted WQE exceeds `NCCL_CTRAN_IB_QP_INTERLEAVE_MIN_WQE_SIZE` (default
64K). Small (<=64K) WQEs -- e.g. the 64K pieces a `NUM_SPLIT=2` AllGather ring
makes from a 128K per-rank chunk -- are latency-bound; one NIC handles them fine
and spreading them only adds cross-NIC ordering/straggler cost. Gating them out
removes a 5-11% AllGather ctring regression while keeping the mid/large wins.

Defaults: `NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE = true`, so interleave is ON
by default for messages whose per-WQE size > 64K on multi-NIC ranks
(`NCCL_CTRAN_IB_DEVICES_PER_RANK > 1`); single-NIC ranks are unaffected.

Also refactors the duplicated WQE-size computation into `maxWqeSizeFor()`, adds the
`BM_CtranIb_MultiPut` microbenchmark, unit tests, and a GB200 sweep doc.

Reviewed By: arttianezhu

Differential Revision: D108913561


