### PR TITLE
Use isolated dynamic registration for RdmaMemory cache-miss path (#2981)

### DIFF
--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <string>
+#include <vector>
 
 #include <folly/logging/xlog.h>
 #include <folly/synchronization/CallOnce.h>
@@ -18,6 +19,7 @@
 #include "comms/ctran/utils/CudaWrap.h"
 #include "comms/ctran/utils/LogInit.h"
 #include "comms/utils/checks.h"
+#include "comms/utils/commSpecs.h"
 
 namespace {
 
@@ -100,13 +102,6 @@ RdmaMemory::RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg)
   // scope
   regCache_ = ctran::RegCache::getInstance();
 
-  REG_VERBOSE_LOG(
-      "RdmaMemory regcache={} buf={} len={} cudaDev={}",
-      fmt::ptr(regCache_.get()),
-      buf_,
-      len_,
-      cudaDev_);
-
   // Try to find an existing registration first.
   regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
 
@@ -119,17 +114,30 @@ RdmaMemory::RdmaMemory(const void* buf, size_t len, int cudaDev, bool cacheReg)
     throw std::runtime_error(
         "Failed to fetch the IB handle from regCache. The buffer may not be registered");
   } else {
-    // Not registered yet; do it now.
-    FB_COMMCHECKTHROW(regCache_->globalRegister(
-        buf_, len_, true /* forceReg */, false /* ncclManaged */, cudaDev_));
-    regHdl_ = regCache_->searchIbRegHandle(buf_, len_, cudaDev_);
-    if (regHdl_ == nullptr) {
-      FB_COMMCHECKIGNORE(regCache_->globalDeregister(
-          buf_, len_, false /* skipRemRelease */, cudaDev_));
-      throw std::runtime_error("Failed to fetch the IB handle from regCache.");
-    }
+    // Not registered/cached yet. Register dynamically with an IB-only backend
+    // set: an isolated registration that is NOT cached and NOT reused
+    // (searchRegElem skips dynamic RegElems), so a transient per-buffer
+    // registration never pollutes the shared segment cache or force-frees a
+    // segment another buffer still needs. The RDMA transport only needs IB.
+    std::vector<bool> backends(CommBackend::NUM_BACKENDS, false);
+    backends[CommBackend::IB] = true;
+    ctran::regcache::RegElem* dynHdl = nullptr;
+    FB_COMMCHECKTHROW(
+        regCache_->regDynamic(buf_, len_, cudaDev_, backends, &dynHdl));
+    dynRegHdl_ = dynHdl;
+    regHdl_ = dynHdl->ibRegElem;
   }
   remoteKey_ = CtranIb::getRemoteAccessKey(regHdl_).toString();
+  REG_VERBOSE_LOG(
+      "RdmaMemory regcache={} buf={} len={} cudaDev={} cacheReg_={} regHdl={} dynRegHdl={} remoteKey={}",
+      fmt::ptr(regCache_.get()),
+      buf_,
+      len_,
+      cudaDev_,
+      cacheReg_,
+      fmt::ptr(regHdl_),
+      fmt::ptr(dynRegHdl_),
+      remoteKey_);
 }
 
 RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
@@ -137,6 +145,7 @@ RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
       len_(other.len_),
       cudaDev_(other.cudaDev_),
       regHdl_(other.regHdl_),
+      dynRegHdl_(other.dynRegHdl_),
       remoteKey_(std::move(other.remoteKey_)),
       cacheReg_(other.cacheReg_),
       regCache_(std::move(other.regCache_)) {
@@ -146,18 +155,20 @@ RdmaMemory::RdmaMemory(RdmaMemory&& other) noexcept
   other.len_ = 0;
   other.cudaDev_ = -1;
   other.regHdl_ = nullptr;
+  other.dynRegHdl_ = nullptr;
   other.cacheReg_ = false;
   // Note: remoteKey_ is already moved, leaving other.remoteKey_ empty
 }
 
 RdmaMemory::~RdmaMemory() noexcept {
   if (cacheReg_) {
-    // cacheReg path only queried the handle; caller owns registration lifetime
+    // cacheReg/HIT path only queried the handle
     return;
   }
-  if (remoteKey_.size() > 0 && regHdl_) {
-    FB_COMMCHECKIGNORE(regCache_->globalDeregister(
-        buf_, len_, false /* skipRemRelease */, cudaDev_));
+  if (dynRegHdl_ != nullptr) {
+    FB_COMMCHECKIGNORE(regCache_->deregDynamic(
+        static_cast<ctran::regcache::RegElem*>(dynRegHdl_)));
+    dynRegHdl_ = nullptr;
     regHdl_ = nullptr;
   }
 }

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -248,6 +248,10 @@ class RdmaMemory : folly::MoveOnly {
   int cudaDev_{-1};
 
   void* regHdl_{nullptr};
+  // Opaque handle to the dynamic ctran::regcache::RegElem when this RdmaMemory
+  // owns a dynamic (non-cached) registration; null on the cacheReg/HIT path.
+  // Stored as void* to keep the regcache type out of this header.
+  void* dynRegHdl_{nullptr};
   std::string remoteKey_;
   bool cacheReg_{false};
   std::shared_ptr<ctran::RegCache> regCache_;

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -306,13 +306,54 @@ TEST_F(RdmaMemoryTest, BasicConstruction) {
 }
 
 TEST_F(RdmaMemoryTest, ReportsRegistrationReuse) {
-  RdmaMemory firstMemory(buffer_, bufferSize_, cudaDev_);
-  EXPECT_FALSE(firstMemory.reusedRegistration());
+  auto regCache = ctran::RegCache::getInstance();
+  // A cacheReg=true ctor on an unregistered buffer initializes the ctran/IB
+  // environment (initEnvironment) and then throws because the buffer is not yet
+  // cached. This mirrors CacheRegConstruction and ensures globalRegister below
+  // runs with CUDA/IB initialized.
+  EXPECT_THROW(
+      RdmaMemory(buffer_, bufferSize_, cudaDev_, /*cacheReg=*/true),
+      std::runtime_error);
 
+  // Pre-register (cache) the buffer; both RdmaMemory instances then HIT and
+  // reuse the same cached registration. (After the dynamic-MISS change, reuse
+  // happens only via the cache, not via the isolated dynamic path.)
+  ASSERT_EQ(
+      regCache->globalRegister(
+          buffer_,
+          bufferSize_,
+          /*forceReg=*/false,
+          /*ncclManaged=*/false,
+          cudaDev_),
+      commSuccess);
+
+  RdmaMemory firstMemory(buffer_, bufferSize_, cudaDev_);
+  EXPECT_TRUE(firstMemory.reusedRegistration());
   RdmaMemory secondMemory(buffer_, bufferSize_, cudaDev_);
   EXPECT_TRUE(secondMemory.reusedRegistration());
   EXPECT_EQ(secondMemory.localKey(), firstMemory.localKey());
   EXPECT_EQ(secondMemory.remoteKey(), firstMemory.remoteKey());
+
+  EXPECT_EQ(regCache->globalDeregister(buffer_, bufferSize_), commSuccess);
+}
+
+TEST_F(RdmaMemoryTest, CacheMissDynamicRegistrationsAreNotReused) {
+  auto regCache = ctran::RegCache::getInstance();
+
+  // The buffer is never globalRegister'd, so it is not in the segment cache.
+  // Both RdmaMemory instances take the cache-MISS path, which creates an
+  // isolated dynamic registration that is neither cached nor reused. As a
+  // result, even two registrations over the SAME buffer each register
+  // independently and neither reports a reused registration.
+  RdmaMemory firstMemory(buffer_, bufferSize_, cudaDev_);
+  EXPECT_FALSE(firstMemory.reusedRegistration());
+
+  RdmaMemory secondMemory(buffer_, bufferSize_, cudaDev_);
+  EXPECT_FALSE(secondMemory.reusedRegistration());
+
+  // The dynamic registrations never pollute the shared segment cache.
+  EXPECT_EQ(
+      regCache->searchIbRegHandle(buffer_, bufferSize_, cudaDev_), nullptr);
 }
 
 TEST_F(RdmaMemoryTest, ViewCreation) {


### PR DESCRIPTION
Summary:

RdmaMemory's cache-MISS path previously called `RegCache::globalRegister(forceReg=true)` (which caches the segment + registers a non-dynamic RegElem) and `globalDeregister` (which force-frees the whole shared segment). That let a transient per-buffer registration pollute the shared segment cache and force-free a segment another buffer/pin still needs. Switch the MISS path to `ctran::RegCache::regDynamic` with an IB-only backend set: an isolated dynamic RegElem that `searchRegElem` skips (never reused), is not inserted into the segment cache, and is torn down via `deregDynamic` on destruction (no force-free). The HIT/cacheReg path (e.g. buffers pre-registered by the RDMA caching-allocator hook) is unchanged and still reused. The dynamic handle is stored as an opaque `void*` in the header to keep the `ctran::regcache` type out of `RdmaTransport.h`.

Reviewed By: tanquer

Differential Revision: D109453934


