### PR TITLE
Extract NVL peer exchange into NvlMemExchange (no behavior change) (#2982)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -143,6 +143,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -151,6 +151,7 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -14,6 +14,7 @@
 #endif
 
 #include "comms/prims/core/Checks.h"
+#include "comms/prims/memory/NvlMemExchange.h"
 
 #include <glog/logging.h>
 #include <mutex>
@@ -356,105 +357,15 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
 }
 
 void GpuMemHandler::exchangeFabricHandles() {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
-#else
-  // Prepare data for allGather: fabric handle + allocated size
-  struct ExchangeData {
-    FabricHandle handle;
-    size_t allocatedSize;
-  };
-
-  std::vector<ExchangeData> allData(nRanks_);
-  allData[selfRank_].handle = fabricLocalHandle_;
-  allData[selfRank_].allocatedSize = allocatedSize_;
-
-  // Exchange fabric handles with all ranks
-  auto result =
-      bootstrap_
-          ->allGather(allData.data(), sizeof(ExchangeData), selfRank_, nRanks_)
-          .get();
-  if (result != 0) {
-    throw std::runtime_error(
-        "GpuMemHandler::exchangeFabricHandles allGather failed");
-  }
-
-  // Import peer memory from received fabric handles
-  for (int32_t rank = 0; rank < nRanks_; ++rank) {
-    if (rank == selfRank_) {
-      continue;
-    }
-    fabricPeerAllocatedSizes_[rank] = allData[rank].allocatedSize;
-    importFabricPeerMemory(
-        rank, allData[rank].handle, allData[rank].allocatedSize);
-  }
-#endif
-}
-
-void GpuMemHandler::importFabricPeerMemory(
-    int32_t rank,
-    const FabricHandle& handle,
-    size_t peerAllocatedSize) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
-#else
-  if (cuda_driver_lazy_init() != 0) {
-    throw std::runtime_error("CUDA driver not available");
-  }
-
-  int cudaDev = 0;
-  CUdevice cuDev;
-
-  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
-  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
-
-  // Import the fabric handle to get allocation handle
-  checkCuError(
-      pfn_cuMemImportFromShareableHandle(
-          &fabricPeerAllocHandles_[rank],
-          const_cast<void*>(static_cast<const void*>(&handle)),
-          CU_MEM_HANDLE_TYPE_FABRIC),
-      "cuMemImportFromShareableHandle failed");
-
-  // Get allocation properties for granularity
-  CUmemAllocationProp prop = {};
-  checkCuError(
-      pfn_cuMemGetAllocationPropertiesFromHandle(
-          &prop, fabricPeerAllocHandles_[rank]),
-      "cuMemGetAllocationPropertiesFromHandle failed");
-
-  size_t granularity = 0;
-  checkCuError(
-      pfn_cuMemGetAllocationGranularity(
-          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-      "cuMemGetAllocationGranularity failed");
-
-  // Reserve virtual address space for peer memory
-  checkCuError(
-      pfn_cuMemAddressReserve(
-          &fabricPeerPtrs_[rank], peerAllocatedSize, granularity, 0, 0),
-      "cuMemAddressReserve for peer failed");
-
-  // Map peer's physical memory to our virtual address
-  checkCuError(
-      pfn_cuMemMap(
-          fabricPeerPtrs_[rank],
-          peerAllocatedSize,
-          0,
-          fabricPeerAllocHandles_[rank],
-          0),
-      "cuMemMap for peer failed");
-
-  // Set access permissions for peer memory
-  CUmemAccessDesc accessDesc = {};
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  accessDesc.location.id = cuDev;
-  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  checkCuError(
-      pfn_cuMemSetAccess(
-          fabricPeerPtrs_[rank], peerAllocatedSize, &accessDesc, 1),
-      "cuMemSetAccess for peer failed");
-#endif
+  nvlMemExchangeVmm(
+      *bootstrap_,
+      selfRank_,
+      nRanks_,
+      fabricLocalHandle_,
+      allocatedSize_,
+      fabricPeerPtrs_,
+      fabricPeerAllocHandles_,
+      fabricPeerAllocatedSizes_);
 }
 
 void GpuMemHandler::cleanupFabric() {
@@ -525,32 +436,8 @@ void GpuMemHandler::allocateCudaIpcMemory(size_t size) {
 }
 
 void GpuMemHandler::exchangeCudaIpcHandles() {
-  // Exchange IPC handles with all ranks
-  std::vector<cudaIpcMemHandle_t> allHandles(nRanks_);
-  allHandles[selfRank_] = cudaIpcLocalHandle_;
-
-  auto result =
-      bootstrap_
-          ->allGather(
-              allHandles.data(), sizeof(cudaIpcMemHandle_t), selfRank_, nRanks_)
-          .get();
-  if (result != 0) {
-    throw std::runtime_error(
-        "GpuMemHandler::exchangeCudaIpcHandles allGather failed");
-  }
-
-  // Open peer memory handles
-  for (int32_t rank = 0; rank < nRanks_; ++rank) {
-    if (rank == selfRank_) {
-      continue;
-    }
-    checkCudaError(
-        cudaIpcOpenMemHandle(
-            &cudaIpcPeerPtrs_[rank],
-            allHandles[rank],
-            cudaIpcMemLazyEnablePeerAccess),
-        "cudaIpcOpenMemHandle failed");
-  }
+  nvlMemExchangeCudaIpc(
+      *bootstrap_, selfRank_, nRanks_, cudaIpcLocalHandle_, cudaIpcPeerPtrs_);
 }
 
 void GpuMemHandler::cleanupCudaIpc() {

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -21,16 +21,9 @@
 #endif
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/NvlMemExchange.h"
 
 namespace comms::prims {
-
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-struct FabricHandle {
-  unsigned char data[64]; // CU_IPC_HANDLE_SIZE
-};
-#else
-using FabricHandle = CUmemFabricHandle;
-#endif
 
 /**
  * Memory sharing mode - determines which IPC mechanism to use.
@@ -208,10 +201,6 @@ class GpuMemHandler {
   // Fabric mode methods
   void allocateFabricMemory(size_t size);
   void exchangeFabricHandles();
-  void importFabricPeerMemory(
-      int32_t rank,
-      const FabricHandle& handle,
-      size_t peerAllocatedSize);
   void cleanupFabric();
 
   // CudaIpc mode methods

--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -1,0 +1,198 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/NvlMemExchange.h"
+
+#include "comms/prims/core/Checks.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <stdexcept>
+#include <vector>
+
+namespace comms::prims {
+
+namespace {
+
+// Import + map one peer's fabric memory into a fresh local virtual address with
+// RW access. Writes the imported handle and mapped pointer into the per-rank
+// output vectors at index `rank`. Caller (nvlMemExchangeVmm) pre-sizes both
+// output vectors to `nRanks` and bounds-checks at the public entry point;
+// `.at()` is used at the write sites as a second proof of bounds for the
+// clang-tidy ParameterUncheckedArrayBounds checker.
+void importFabricPeerMemory(
+    int32_t rank,
+    const FabricHandle& handle,
+    std::size_t peerAllocatedSize,
+    std::vector<CUdeviceptr>& peerPtrs,
+    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)rank;
+  (void)handle;
+  (void)peerAllocatedSize;
+  (void)peerPtrs;
+  (void)peerAllocHandles;
+  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("CUDA driver not available");
+  }
+
+  int cudaDev = 0;
+  CUdevice cuDev;
+
+  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+
+  // Import the fabric handle to get allocation handle
+  checkCuError(
+      pfn_cuMemImportFromShareableHandle(
+          &peerAllocHandles.at(rank),
+          const_cast<void*>(static_cast<const void*>(&handle)),
+          CU_MEM_HANDLE_TYPE_FABRIC),
+      "cuMemImportFromShareableHandle failed");
+
+  // Get allocation properties for granularity
+  CUmemAllocationProp prop = {};
+  checkCuError(
+      pfn_cuMemGetAllocationPropertiesFromHandle(
+          &prop, peerAllocHandles.at(rank)),
+      "cuMemGetAllocationPropertiesFromHandle failed");
+
+  std::size_t granularity = 0;
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+      "cuMemGetAllocationGranularity failed");
+
+  // Reserve virtual address space for peer memory
+  checkCuError(
+      pfn_cuMemAddressReserve(
+          &peerPtrs.at(rank), peerAllocatedSize, granularity, 0, 0),
+      "cuMemAddressReserve for peer failed");
+
+  // Map peer's physical memory to our virtual address
+  checkCuError(
+      pfn_cuMemMap(
+          peerPtrs.at(rank),
+          peerAllocatedSize,
+          0,
+          peerAllocHandles.at(rank),
+          0),
+      "cuMemMap for peer failed");
+
+  // Set access permissions for peer memory
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cuDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  checkCuError(
+      pfn_cuMemSetAccess(peerPtrs.at(rank), peerAllocatedSize, &accessDesc, 1),
+      "cuMemSetAccess for peer failed");
+#endif
+}
+
+} // namespace
+
+void nvlMemExchangeVmm(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    const FabricHandle& localHandle,
+    std::size_t allocatedSize,
+    std::vector<CUdeviceptr>& peerPtrs,
+    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
+    std::vector<std::size_t>& peerAllocatedSizes) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)bootstrap;
+  (void)selfRank;
+  (void)nRanks;
+  (void)localHandle;
+  (void)allocatedSize;
+  (void)peerPtrs;
+  (void)peerAllocHandles;
+  (void)peerAllocatedSizes;
+  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+#else
+  if (static_cast<std::size_t>(nRanks) > peerPtrs.size() ||
+      static_cast<std::size_t>(nRanks) > peerAllocHandles.size() ||
+      static_cast<std::size_t>(nRanks) > peerAllocatedSizes.size()) {
+    throw std::runtime_error(
+        "nvlMemExchangeVmm: output vectors must each have size >= nRanks");
+  }
+
+  // Prepare data for allGather: fabric handle + allocation size
+  struct ExchangeData {
+    FabricHandle handle;
+    std::size_t allocatedSize;
+  };
+
+  std::vector<ExchangeData> allData(nRanks);
+  allData[selfRank].handle = localHandle;
+  allData[selfRank].allocatedSize = allocatedSize;
+
+  // Exchange fabric handles with all ranks
+  auto result =
+      bootstrap
+          .allGather(allData.data(), sizeof(ExchangeData), selfRank, nRanks)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error("nvlMemExchangeVmm allGather failed");
+  }
+
+  // Import peer memory from received fabric handles
+  for (int32_t rank = 0; rank < nRanks; ++rank) {
+    if (rank == selfRank) {
+      continue;
+    }
+    peerAllocatedSizes.at(rank) = allData[rank].allocatedSize;
+    importFabricPeerMemory(
+        rank,
+        allData[rank].handle,
+        allData[rank].allocatedSize,
+        peerPtrs,
+        peerAllocHandles);
+  }
+#endif
+}
+
+void nvlMemExchangeCudaIpc(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    const cudaIpcMemHandle_t& localHandle,
+    std::vector<void*>& peerPtrs) {
+  if (static_cast<std::size_t>(nRanks) > peerPtrs.size()) {
+    throw std::runtime_error(
+        "nvlMemExchangeCudaIpc: peerPtrs must have size >= nRanks");
+  }
+
+  // Exchange IPC handles with all ranks
+  std::vector<cudaIpcMemHandle_t> allHandles(nRanks);
+  allHandles[selfRank] = localHandle;
+
+  auto result =
+      bootstrap
+          .allGather(
+              allHandles.data(), sizeof(cudaIpcMemHandle_t), selfRank, nRanks)
+          .get();
+  if (result != 0) {
+    throw std::runtime_error("nvlMemExchangeCudaIpc allGather failed");
+  }
+
+  // Open peer memory handles
+  for (int32_t rank = 0; rank < nRanks; ++rank) {
+    if (rank == selfRank) {
+      continue;
+    }
+    checkCudaError(
+        cudaIpcOpenMemHandle(
+            &peerPtrs.at(rank),
+            allHandles[rank],
+            cudaIpcMemLazyEnablePeerAccess),
+        "cudaIpcOpenMemHandle failed");
+  }
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -1,0 +1,105 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD,
+// fabric-handle support is unavailable; only the cudaIpc path is used, and its
+// `cudaIpcMemHandle_t` parameter is HIPify-rewritten to `hipIpcMemHandle_t`
+// (provided by `<hip/hip_runtime.h>`).
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+
+namespace comms::prims {
+
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+using FabricHandle = CUmemFabricHandle;
+#else
+struct FabricHandle {
+  unsigned char data[64]; // CU_IPC_HANDLE_SIZE
+};
+// Stub the CUDA driver-API typedefs referenced by the always-declared VMM
+// signature so the header (and downstream consumers like GpuMemHandler)
+// compiles on AMD / pre-CUDA-12.3. The concrete VMM driver-API code lives
+// behind `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030` in
+// the .cc; on these platforms `nvlMemExchangeVmm` is a throwing stub. Types
+// match the real CUDA driver-API typedefs (`unsigned long long`).
+#if defined(__HIP_PLATFORM_AMD__)
+using CUdeviceptr = unsigned long long;
+using CUmemGenericAllocationHandle = unsigned long long;
+#endif
+#endif
+
+/**
+ * NvlMemExchange - NVLink-domain peer-exchange building blocks.
+ *
+ * The peer exchange (export -> all-gather -> import -> map) that gives every
+ * rank a VA onto every peer's backing allocation, for both VMM (fabric) and
+ * cudaIpc modes. Used by GpuMemHandler. The VMM/fabric path is NVIDIA-only
+ * (CUDA driver API + CUDA 12.3+); on AMD or pre-12.3, `nvlMemExchangeVmm` is
+ * declared but its body throws. The cudaIpc path is HIPify-rewritten to
+ * hipIpc on AMD.
+ */
+
+/**
+ * VMM (fabric) peer exchange. all-gathers this rank's exported fabric handle
+ * and allocation size, then imports + maps every peer's physical memory into a
+ * fresh local virtual address with RW access. Results are written into the
+ * per-rank output vectors (indexed by rank); the self slot of `peerPtrs` is
+ * left untouched (the caller stores its own local VA there).
+ *
+ * COLLECTIVE OPERATION: all ranks must call. Throws on AMD or pre-CUDA-12.3.
+ *
+ * Output vectors must each have size `>= nRanks`.
+ *
+ * @param bootstrap Bootstrap interface for the allGather
+ * @param selfRank This rank's ID (0..nRanks-1)
+ * @param nRanks Total number of ranks
+ * @param localHandle This rank's exported fabric handle
+ * @param allocatedSize This rank's allocation size
+ * @param peerPtrs [out] per-rank mapped peer pointers (size nRanks)
+ * @param peerAllocHandles [out] per-rank imported allocation handles (size
+ * nRanks)
+ * @param peerAllocatedSizes [out] per-rank allocation sizes (size nRanks)
+ */
+void nvlMemExchangeVmm(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    const FabricHandle& localHandle,
+    std::size_t allocatedSize,
+    std::vector<CUdeviceptr>& peerPtrs,
+    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
+    std::vector<std::size_t>& peerAllocatedSizes);
+
+/**
+ * cudaIpc peer exchange. all-gathers this rank's cudaIpc handle, then opens
+ * every peer's handle into `peerPtrs` (indexed by rank). Intra-node only.
+ *
+ * COLLECTIVE OPERATION: all ranks must call.
+ *
+ * `peerPtrs` must have size `>= nRanks`.
+ *
+ * @param bootstrap Bootstrap interface for the allGather
+ * @param selfRank This rank's ID (0..nRanks-1)
+ * @param nRanks Total number of ranks
+ * @param localHandle This rank's cudaIpc handle
+ * @param peerPtrs [out] per-rank opened peer pointers (size nRanks)
+ */
+void nvlMemExchangeCudaIpc(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t selfRank,
+    int32_t nRanks,
+    const cudaIpcMemHandle_t& localHandle,
+    std::vector<void*>& peerPtrs);
+
+} // namespace comms::prims

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -899,8 +899,10 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/ibrc/.*")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/MultiPeerIbTransport\\.")
 # Exclude window files — they depend on IbgdaBuffer.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/window/.*")
-# Exclude GpuMemHandler and CudaDriverLazy — they depend on cudaTypedefs.h which is not available.
+# Exclude GpuMemHandler, NvlMemExchange, and CudaDriverLazy — they depend on
+# cudaTypedefs.h / the CUDA driver API which is not available here.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "GpuMemHandler\\.")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "NvlMemExchange\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")


### PR DESCRIPTION
Summary:

Pure relocation, no behavior change. This extracted logic is later reused by other nvl transport exchanges as well.

Moves the VMM (fabric) and cudaIpc peer-exchange routines out of `GpuMemHandler` into a new free-function module `NvlMemExchange.{h,cc}`, and moves the `FabricHandle` type alias along with them.

`GpuMemHandler::exchangeFabricHandles()` and `exchangeCudaIpcHandles()` become thin forwarders to the new `nvlMemExchangeVmm()` / `nvlMemExchangeCudaIpc()` free functions; the per-peer import+map helper (`importFabricPeerMemory`) moves into `NvlMemExchange.cc` as a file-local helper. The relocated bodies are the original `GpuMemHandler` implementations parameterized over out-vectors instead of mutating members directly. Allocation (`allocateFabricMemory`/`allocateCudaIpcMemory`), cleanup, and the fabric-support probe stay in `GpuMemHandler` for now.

This is the first of three diffs that decompose the old monolithic foundation: (1) this move, (2) introduce the `CuMemAllocation`/`CuMemMapping` RAII abstractions, (3) add the POSIX-FD shareable-handle path. Splitting this way makes the reuse from `GpuMemHandler` visible as a relocation rather than a rewrite.

Reviewed By: goelayu, saifhhasan

Differential Revision: D107705515


