### PR TITLE
Introduce CuMemAllocation/CuMemMapping RAII; rewire NvlMemExchange + GpuMemHandler (#2985)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -142,6 +142,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -150,6 +150,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc

--- a/comms/prims/memory/CuMemAllocation.cc
+++ b/comms/prims/memory/CuMemAllocation.cc
@@ -1,0 +1,276 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/CuMemAllocation.h"
+
+#include "comms/common/BitOps.cuh"
+#include "comms/prims/core/Checks.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace comms::prims {
+
+namespace {
+
+bool isPowerOfTwo(std::size_t x) {
+  return x != 0 && (x & (x - 1)) == 0;
+}
+
+} // namespace
+
+CUmemAllocationProp makeVmmAllocationProp(
+    CUdevice cuDev,
+    unsigned int requestedHandleTypesMask) {
+  CUmemAllocationProp prop = {};
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = cuDev;
+  prop.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(requestedHandleTypesMask);
+
+  int rdmaSupported = 0;
+  pfn_cuDeviceGetAttribute(
+      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
+  if (rdmaSupported) {
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+  }
+#else
+  (void)cuDev;
+  (void)requestedHandleTypesMask;
+#endif
+  return prop;
+}
+
+CuMemAllocation::CuMemAllocation(
+    CUmemGenericAllocationHandle handle,
+    CUdevice device,
+    std::size_t size,
+    std::size_t granularity,
+    unsigned int supportedHandleTypes) noexcept
+    : handle_(handle),
+      device_(device),
+      size_(size),
+      granularity_(granularity),
+      supportedHandleTypes_(supportedHandleTypes) {}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::create(
+    CUdevice cuDev,
+    std::size_t size,
+    unsigned int requestedHandleTypesMask,
+    std::size_t alignFloor) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cuDev;
+  (void)size;
+  (void)requestedHandleTypesMask;
+  (void)alignFloor;
+  throw std::runtime_error("CuMemAllocation::create requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: CUDA driver not available");
+  }
+  if (alignFloor != 0 && !isPowerOfTwo(alignFloor)) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: alignFloor must be zero or a power of two");
+  }
+
+  unsigned int mask = requestedHandleTypesMask;
+  auto prop = makeVmmAllocationProp(cuDev, mask);
+
+  std::size_t driverGranularity = 0;
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &driverGranularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED),
+      "cuMemGetAllocationGranularity failed");
+  if (!isPowerOfTwo(driverGranularity)) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: driver allocation granularity is not a power of two");
+  }
+
+  // Both granularities are powers of two, so the effective granularity is a
+  // multiple of the driver granularity and cuMemCreate's size requirement is
+  // satisfied. alignFloor lets the caller raise the size/alignment floor so a
+  // single physical allocation can satisfy a larger granularity requirement
+  // (e.g. a multicast object's granularity).
+  const std::size_t effGran = std::max(driverGranularity, alignFloor);
+  const std::size_t allocatedSize = comms::bitops::roundUp(size, effGran);
+
+  CUmemGenericAllocationHandle handle = 0;
+  CUresult createResult = pfn_cuMemCreate(&handle, allocatedSize, &prop, 0);
+  if ((createResult == CUDA_ERROR_NOT_PERMITTED ||
+       createResult == CUDA_ERROR_NOT_SUPPORTED) &&
+      (mask & CU_MEM_HANDLE_TYPE_FABRIC)) {
+    // Fabric requested but unavailable (e.g. single host without IMEX). Drop
+    // fabric and retry with the remaining handle types (mirrors ncclx
+    // allocator.cc).
+    mask &= ~static_cast<unsigned int>(CU_MEM_HANDLE_TYPE_FABRIC);
+    prop = makeVmmAllocationProp(cuDev, mask);
+    createResult = pfn_cuMemCreate(&handle, allocatedSize, &prop, 0);
+  }
+  checkCuError(createResult, "cuMemCreate failed");
+
+  // From here on the factory owns `handle`. `new` can throw bad_alloc;
+  // release the handle so we never leak a raw allocation on storage exhaust.
+  try {
+    return std::unique_ptr<CuMemAllocation>(
+        new CuMemAllocation(handle, cuDev, allocatedSize, effGran, mask));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::retain(void* ptr) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)ptr;
+  throw std::runtime_error("CuMemAllocation::retain requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "CuMemAllocation::retain: CUDA driver not available");
+  }
+
+  CUmemGenericAllocationHandle handle = 0;
+  checkCuError(
+      pfn_cuMemRetainAllocationHandle(&handle, ptr),
+      "cuMemRetainAllocationHandle failed");
+
+  // After cuMemRetainAllocationHandle succeeds we own one retain reference on
+  // `handle`. Any failure from here on must release that reference exactly
+  // once — funnel through one try/catch instead of the per-call cleanup that
+  // was easy to miss.
+  try {
+    CUdeviceptr base = 0;
+    std::size_t size = 0;
+    checkCuError(
+        pfn_cuMemGetAddressRange(
+            &base, &size, reinterpret_cast<CUdeviceptr>(ptr)),
+        "cuMemGetAddressRange failed");
+
+    CUmemAllocationProp prop = {};
+    checkCuError(
+        pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle),
+        "cuMemGetAllocationPropertiesFromHandle failed");
+
+    std::size_t granularity = 0;
+    checkCuError(
+        pfn_cuMemGetAllocationGranularity(
+            &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+        "cuMemGetAllocationGranularity failed");
+
+    return std::unique_ptr<CuMemAllocation>(new CuMemAllocation(
+        handle,
+        static_cast<CUdevice>(prop.location.id),
+        size,
+        granularity,
+        static_cast<unsigned int>(prop.requestedHandleTypes)));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::adopt(
+    CUmemGenericAllocationHandle handle,
+    CUdevice device,
+    std::size_t size) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)handle;
+  (void)device;
+  (void)size;
+  throw std::runtime_error("CuMemAllocation::adopt requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    pfn_cuMemRelease(handle);
+    throw std::runtime_error(
+        "CuMemAllocation::adopt: CUDA driver not available");
+  }
+  // adopt() takes ownership of `handle` on entry. Query the handle's
+  // properties + granularity so the caller never has to hold the raw handle
+  // past this call; on any internal failure (CUDA error, `new` bad_alloc)
+  // release the handle and rethrow so no raw-handle window leaks out.
+  try {
+    CUmemAllocationProp prop = {};
+    checkCuError(
+        pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle),
+        "CuMemAllocation::adopt: cuMemGetAllocationPropertiesFromHandle failed");
+    std::size_t granularity = 0;
+    checkCuError(
+        pfn_cuMemGetAllocationGranularity(
+            &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+        "CuMemAllocation::adopt: cuMemGetAllocationGranularity failed");
+    return std::unique_ptr<CuMemAllocation>(new CuMemAllocation(
+        handle,
+        device,
+        size,
+        granularity,
+        static_cast<unsigned int>(prop.requestedHandleTypes)));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+CuMemAllocation::~CuMemAllocation() {
+  release();
+}
+
+CuMemAllocation::CuMemAllocation(CuMemAllocation&& other) noexcept
+    : handle_(other.handle_),
+      device_(other.device_),
+      size_(other.size_),
+      granularity_(other.granularity_),
+      supportedHandleTypes_(other.supportedHandleTypes_) {
+  other.handle_ = 0;
+  other.size_ = 0;
+}
+
+CuMemAllocation& CuMemAllocation::operator=(CuMemAllocation&& other) noexcept {
+  if (this != &other) {
+    release();
+    handle_ = other.handle_;
+    device_ = other.device_;
+    size_ = other.size_;
+    granularity_ = other.granularity_;
+    supportedHandleTypes_ = other.supportedHandleTypes_;
+    other.handle_ = 0;
+    other.size_ = 0;
+  }
+  return *this;
+}
+
+bool CuMemAllocation::supportsFabric() const {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  return (supportedHandleTypes_ & CU_MEM_HANDLE_TYPE_FABRIC) != 0;
+#else
+  return false;
+#endif
+}
+
+void CuMemAllocation::release() noexcept {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (handle_ == 0) {
+    return;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return;
+  }
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+  pfn_cuMemRelease(handle_);
+  handle_ = 0;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemAllocation.h
+++ b/comms/prims/memory/CuMemAllocation.h
@@ -1,0 +1,166 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD the
+// concrete VMM driver-API calls are unavailable and the impl bodies throw;
+// stub the driver-API typedefs below so this header (and downstream consumers)
+// still compiles. Mirrors NvlMemExchange.h.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <memory>
+
+namespace comms::prims {
+
+#if defined(__HIP_PLATFORM_AMD__)
+// Stub CUDA driver-API typedefs the always-declared API references; concrete
+// VMM calls are NVIDIA-only and live behind
+// `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030` in the .cc.
+// Types match real CUDA driver-API typedefs (`unsigned long long` /
+// `int` / empty struct placeholder for CUmemAllocationProp).
+using CUdevice = int;
+using CUmemGenericAllocationHandle = unsigned long long;
+using CUdeviceptr = unsigned long long;
+struct CUmemAllocationProp {
+  unsigned char _padding[1];
+};
+#endif
+
+/**
+ * Builds a CUmemAllocationProp for a PINNED device allocation on `cuDev` with
+ * the given requested handle-types mask. Sets gpuDirectRDMACapable when the
+ * device reports GPUDirect-RDMA support. `requestedHandleTypesMask` may combine
+ * multiple CU_MEM_HANDLE_TYPE_* flags so cuMemCreate can request both fabric
+ * and POSIX FD support at once.
+ *
+ * Lives with CuMemAllocation (the physical-allocation owner) so that both
+ * CuMemAllocation and NvlMemExchange can build props without a dependency
+ * cycle.
+ */
+CUmemAllocationProp makeVmmAllocationProp(
+    CUdevice cuDev,
+    unsigned int requestedHandleTypesMask);
+
+/**
+ * CuMemAllocation - RAII owner of ONE physical CUDA VMM allocation handle
+ * (`CUmemGenericAllocationHandle`).
+ *
+ * It owns only the physical handle: it does not reserve or map any virtual
+ * address (that is CuMemMapping's job). It is meant to be co-owned via
+ * std::shared_ptr by the things that map it (CuMemMapping) and by the higher
+ * level handlers (GpuMemHandler's unicast allocation, MultimemHandler's
+ * backing), so one physical allocation can be shared by value-RAII rather than
+ * by leaking the raw handle.
+ *
+ * Three ways to obtain one — all three factories return a `unique_ptr` that
+ * the caller can either keep as unique ownership or promote to `shared_ptr`
+ * via implicit conversion:
+ *  - create(): cuMemCreate a fresh physical allocation (requests fabric + POSIX
+ *    FD with a POSIX-FD-only fallback when fabric is unavailable).
+ *  - retain(ptr): cuMemRetainAllocationHandle an existing externally-mapped VMM
+ *    buffer (the returned object owns that retain reference).
+ *  - adopt(handle, ...): take ownership of an already-owned handle (e.g. one
+ *    returned by NvlMemExchange::importShareableHandle).
+ *
+ * Each factory takes ownership of any handle it touches atomically: on
+ * internal failure (CUDA error, allocator `bad_alloc`) the handle is released
+ * before the exception propagates, so the caller never sees a leaked raw
+ * handle and never has to write release-on-throw bookkeeping.
+ *
+ * In every case the destructor cuMemRelease()s the owned reference once. Not
+ * copyable; movable (the moved-from object releases nothing). Requires CUDA
+ * 12.3+; the factories throw on older toolkits.
+ */
+class CuMemAllocation {
+ public:
+  /**
+   * cuMemCreate a fresh physical allocation on `cuDev`. Queries the RECOMMENDED
+   * granularity, rounds `size` up to max(driverGranularity, alignFloor), then
+   * cuMemCreate requesting `requestedHandleTypesMask`. If fabric was requested
+   * but cuMemCreate reports CUDA_ERROR_NOT_PERMITTED / NOT_SUPPORTED (e.g. a
+   * fabric-capable GPU without IMEX) it drops fabric and retries with the
+   * remaining types. `alignFloor` must be 0 or a power of two; it raises the
+   * size/granularity floor so the allocation can satisfy a larger granularity
+   * requirement (e.g. a multicast object's granularity).
+   */
+  static std::unique_ptr<CuMemAllocation> create(
+      CUdevice cuDev,
+      std::size_t size,
+      unsigned int requestedHandleTypesMask,
+      std::size_t alignFloor = 0);
+
+  /**
+   * Retain the physical handle backing an existing VMM device pointer via
+   * cuMemRetainAllocationHandle. The size is taken from cuMemGetAddressRange
+   * and the supported handle types / device from the allocation properties.
+   * Throws if `ptr` is not a VMM allocation.
+   */
+  static std::unique_ptr<CuMemAllocation> retain(void* ptr);
+
+  /**
+   * Take ownership of an already-owned physical handle (the caller transfers
+   * one reference; the destructor releases it). Queries the handle's
+   * properties + granularity internally so the caller does not have to hold
+   * the raw handle past this call. Used for handles produced by
+   * NvlMemExchange::importShareableHandle.
+   */
+  static std::unique_ptr<CuMemAllocation>
+  adopt(CUmemGenericAllocationHandle handle, CUdevice device, std::size_t size);
+
+  ~CuMemAllocation();
+
+  CuMemAllocation(CuMemAllocation&& other) noexcept;
+  CuMemAllocation& operator=(CuMemAllocation&& other) noexcept;
+
+  CuMemAllocation(const CuMemAllocation&) = delete;
+  CuMemAllocation& operator=(const CuMemAllocation&) = delete;
+
+  CUmemGenericAllocationHandle handle() const {
+    return handle_;
+  }
+
+  CUdevice device() const {
+    return device_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+  std::size_t granularity() const {
+    return granularity_;
+  }
+
+  unsigned int supportedHandleTypes() const {
+    return supportedHandleTypes_;
+  }
+
+  bool supportsFabric() const;
+
+ private:
+  // Pure scalar field init — cannot throw. Marked noexcept so the factories'
+  // release-on-throw try/catch only has to worry about the `new` storage
+  // allocation (the only remaining throw window), not the construction itself.
+  CuMemAllocation(
+      CUmemGenericAllocationHandle handle,
+      CUdevice device,
+      std::size_t size,
+      std::size_t granularity,
+      unsigned int supportedHandleTypes) noexcept;
+
+  void release() noexcept;
+
+  CUmemGenericAllocationHandle handle_{0};
+  CUdevice device_{0};
+  std::size_t size_{0};
+  std::size_t granularity_{0};
+  unsigned int supportedHandleTypes_{0};
+};
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemMapping.cc
+++ b/comms/prims/memory/CuMemMapping.cc
@@ -1,0 +1,116 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/CuMemMapping.h"
+
+#include "comms/prims/core/Checks.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <utility>
+
+namespace comms::prims {
+
+CuMemMapping::CuMemMapping(
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle handle,
+    std::size_t size,
+    std::size_t granularity,
+    std::shared_ptr<void> keepAlive)
+    : size_(size), keepAlive_(std::move(keepAlive)) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cuDev;
+  (void)handle;
+  (void)granularity;
+  throw std::runtime_error("CuMemMapping requires CUDA 12.3+");
+#else
+  try {
+    checkCuError(
+        pfn_cuMemAddressReserve(&devicePtr_, size_, granularity, 0, 0),
+        "cuMemAddressReserve failed");
+
+    checkCuError(
+        pfn_cuMemMap(devicePtr_, size_, 0, handle, 0), "cuMemMap failed");
+    mapped_ = true;
+
+    CUmemAccessDesc accessDesc = {};
+    accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    accessDesc.location.id = cuDev;
+    accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    checkCuError(
+        pfn_cuMemSetAccess(devicePtr_, size_, &accessDesc, 1),
+        "cuMemSetAccess failed");
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+#endif
+}
+
+CuMemMapping CuMemMapping::overAllocation(
+    std::shared_ptr<CuMemAllocation> alloc,
+    std::size_t size,
+    std::size_t granularity) {
+  if (!alloc) {
+    throw std::runtime_error(
+        "CuMemMapping::overAllocation: alloc must be non-null");
+  }
+  const CUdevice cuDev = alloc->device();
+  const CUmemGenericAllocationHandle handle = alloc->handle();
+  return CuMemMapping(cuDev, handle, size, granularity, std::move(alloc));
+}
+
+CuMemMapping::~CuMemMapping() {
+  cleanup();
+}
+
+CuMemMapping::CuMemMapping(CuMemMapping&& other) noexcept
+    : devicePtr_(other.devicePtr_),
+      size_(other.size_),
+      mapped_(other.mapped_),
+      keepAlive_(std::move(other.keepAlive_)) {
+  other.devicePtr_ = 0;
+  other.size_ = 0;
+  other.mapped_ = false;
+}
+
+CuMemMapping& CuMemMapping::operator=(CuMemMapping&& other) noexcept {
+  if (this != &other) {
+    cleanup();
+    devicePtr_ = other.devicePtr_;
+    size_ = other.size_;
+    mapped_ = other.mapped_;
+    keepAlive_ = std::move(other.keepAlive_);
+    other.devicePtr_ = 0;
+    other.size_ = 0;
+    other.mapped_ = false;
+  }
+  return *this;
+}
+
+void CuMemMapping::cleanup() noexcept {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (devicePtr_ == 0) {
+    return;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return;
+  }
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+
+  if (mapped_) {
+    pfn_cuMemUnmap(devicePtr_, size_);
+    mapped_ = false;
+  }
+  pfn_cuMemAddressFree(devicePtr_, size_);
+  devicePtr_ = 0;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemMapping.h
+++ b/comms/prims/memory/CuMemMapping.h
@@ -1,0 +1,87 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD the
+// concrete VMM driver-API calls are unavailable and the impl bodies throw;
+// `CuMemAllocation.h` declares the matching AMD stub typedefs for `CUdevice`
+// etc., which this header reuses transitively.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <memory>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+
+namespace comms::prims {
+
+class CuMemAllocation;
+
+// RAII virtual-address mapping over a physical / multicast allocation.
+//
+// Runs the standard reserve/map/setAccess sequence used by both per-rank
+// backing allocations (CuMemAllocation) and multicast objects
+// (CuMulticastAllocation):
+//
+//   cuMemAddressReserve -> virtual address
+//   cuMemMap            -> bind handle to virtual address
+//   cuMemSetAccess      -> RW from the allocation's device
+//
+// The mapping does NOT release the handle: destruction only tears down the VA
+// (cuMemUnmap + cuMemAddressFree). It DOES co-own the allocation that produced
+// the handle, via a type-erased std::shared_ptr<void> keepAlive_, so the
+// physical / multicast handle stays alive at least as long as this VA mapping.
+// Drop order is correct: ~CuMemMapping unmaps/frees the VA first, then the
+// keepAlive_ shared_ptr drops (releasing the handle only after the VA is gone).
+//
+// Construct via overAllocation() / overMulticast(). Movable so peer mappings
+// can live in a std::vector. Not copyable. Requires CUDA 12.3+; the factories
+// throw on older toolkits.
+class CuMemMapping {
+ public:
+  // Map `alloc`'s physical handle into a fresh VA of `size` bytes aligned to
+  // `granularity`, granting RW access on the allocation's device. The returned
+  // mapping co-owns `alloc`.
+  static CuMemMapping overAllocation(
+      std::shared_ptr<CuMemAllocation> alloc,
+      std::size_t size,
+      std::size_t granularity);
+
+  ~CuMemMapping();
+
+  CuMemMapping(CuMemMapping&& other) noexcept;
+  CuMemMapping& operator=(CuMemMapping&& other) noexcept;
+
+  CuMemMapping(const CuMemMapping&) = delete;
+  CuMemMapping& operator=(const CuMemMapping&) = delete;
+
+  CUdeviceptr devicePtr() const {
+    return devicePtr_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+ private:
+  CuMemMapping(
+      CUdevice cuDev,
+      CUmemGenericAllocationHandle handle,
+      std::size_t size,
+      std::size_t granularity,
+      std::shared_ptr<void> keepAlive);
+
+  void cleanup() noexcept;
+
+  CUdeviceptr devicePtr_{0};
+  std::size_t size_{0};
+  bool mapped_{false};
+  std::shared_ptr<void> keepAlive_;
+};
+
+} // namespace comms::prims

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -14,11 +14,14 @@
 #endif
 
 #include "comms/prims/core/Checks.h"
-#include "comms/prims/memory/NvlMemExchange.h"
 
 #include <glog/logging.h>
+#include <cstddef>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace comms::prims {
 
@@ -182,44 +185,41 @@ GpuMemHandler::GpuMemHandler(
     int32_t selfRank,
     int32_t nRanks,
     size_t size,
-    MemSharingMode mode)
+    MemSharingMode mode,
+    std::size_t alignFloor)
     : bootstrap_(std::move(bootstrap)),
       selfRank_(selfRank),
       nRanks_(nRanks),
-      mode_(mode),
-      fabricPeerPtrs_(nRanks, 0),
-      fabricPeerAllocHandles_(nRanks, 0),
-      fabricPeerAllocatedSizes_(nRanks, 0),
-      cudaIpcPeerPtrs_(nRanks, nullptr) {
+      mode_(mode) {
   if (mode_ == MemSharingMode::kFabric && !isFabricHandleSupported()) {
     throw std::runtime_error(
         "Fabric handle mode requested but not supported on this system. "
         "Requires Hopper (H100) or newer GPU with CUDA 12.3+.");
   }
 
-  init(size);
+  init(size, alignFloor);
 }
 
 GpuMemHandler::~GpuMemHandler() {
-  if (mode_ == MemSharingMode::kFabric) {
-    cleanupFabric();
+  if (isVmmMode()) {
+    cleanupVmm();
   } else {
     cleanupCudaIpc();
   }
 }
 
-void GpuMemHandler::init(size_t size) {
-  if (mode_ == MemSharingMode::kFabric) {
-    allocateFabricMemory(size);
+void GpuMemHandler::init(size_t size, std::size_t alignFloor) {
+  if (isVmmMode()) {
+    allocateVmmMemory(size, alignFloor);
   } else {
     allocateCudaIpcMemory(size);
   }
 }
 
 void* GpuMemHandler::getLocalDeviceMemPtr() const {
-  if (mode_ == MemSharingMode::kFabric) {
+  if (isVmmMode()) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
-    return reinterpret_cast<void*>(fabricLocalPtr_);
+    return reinterpret_cast<void*>(unicastMapping_->devicePtr());
   } else {
     return cudaIpcLocalPtr_;
   }
@@ -236,12 +236,12 @@ void* GpuMemHandler::getPeerDeviceMemPtr(int32_t rank) const {
         "GpuMemHandler: Must call exchangeMemPtrs() before accessing peer memory");
   }
 
-  if (mode_ == MemSharingMode::kFabric) {
-    // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
-    return reinterpret_cast<void*>(fabricPeerPtrs_[rank]);
-  } else {
-    return cudaIpcPeerPtrs_[rank];
+  // The self pointer is always available (even before exchange / single-rank);
+  // peers_.peerPtrs is only populated by exchangeMemPtrs().
+  if (rank == selfRank_) {
+    return getLocalDeviceMemPtr();
   }
+  return peers_.peerPtrs[static_cast<std::size_t>(rank)];
 }
 
 void GpuMemHandler::exchangeMemPtrs() {
@@ -255,8 +255,8 @@ void GpuMemHandler::exchangeMemPtrs() {
     return;
   }
 
-  if (mode_ == MemSharingMode::kFabric) {
-    exchangeFabricHandles();
+  if (isVmmMode()) {
+    exchangeVmmHandles();
   } else {
     exchangeCudaIpcHandles();
   }
@@ -265,20 +265,22 @@ void GpuMemHandler::exchangeMemPtrs() {
 }
 
 const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
-  if (mode_ == MemSharingMode::kFabric) {
+  if (isVmmMode()) {
     throw std::runtime_error(
-        "GpuMemHandler::getLocalIpcHandle: not available in kFabric mode");
+        "GpuMemHandler::getLocalIpcHandle: not available in VMM (fabric/posix-fd) mode");
   }
   return cudaIpcLocalHandle_;
 }
 
 // ============================================================================
-// Fabric Mode Implementation
+// VMM Mode Implementation (kFabric)
 // ============================================================================
 
-void GpuMemHandler::allocateFabricMemory(size_t size) {
+void GpuMemHandler::allocateVmmMemory(size_t size, std::size_t alignFloor) {
 #if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+  (void)size;
+  (void)alignFloor;
+  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
 #else
   if (cuda_driver_lazy_init() != 0) {
     throw std::runtime_error("CUDA driver not available");
@@ -290,120 +292,56 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
   checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
   checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
 
-  // Set up allocation properties with fabric handle support
-  CUmemAllocationProp prop = {};
-  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  prop.location.id = cuDev;
-  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  // CuMemAllocation::create allocates the physical handle requesting fabric
+  // support. The shareable-handle export is deferred to exchangeMemPtrs() so a
+  // handler used purely as a multicast backing (no P2P) does no export.
+  //
+  // create() returns unique_ptr; the implicit promotion to shared_ptr keeps
+  // exception safety -- if the control-block allocation throws, the
+  // unique_ptr's destructor releases the physical handle.
+  allocation_ = CuMemAllocation::create(
+      cuDev, size, CU_MEM_HANDLE_TYPE_FABRIC, alignFloor);
+  allocatedSize_ = allocation_->size();
 
-  // Check for GPUDirect RDMA support
-  int rdmaSupported = 0;
-  pfn_cuDeviceGetAttribute(
-      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
-  if (rdmaSupported) {
-    prop.allocFlags.gpuDirectRDMACapable = 1;
-  }
-
-  // Get allocation granularity
-  size_t granularity = 0;
-  checkCuError(
-      pfn_cuMemGetAllocationGranularity(
-          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-      "cuMemGetAllocationGranularity failed");
-
-  // Round up size to granularity
-  allocatedSize_ = ((size + granularity - 1) / granularity) * granularity;
-
-  // Create the physical memory allocation
-  checkCuError(
-      pfn_cuMemCreate(&fabricLocalAllocHandle_, allocatedSize_, &prop, 0),
-      "cuMemCreate failed");
-
-  // Reserve virtual address space
-  checkCuError(
-      pfn_cuMemAddressReserve(
-          &fabricLocalPtr_, allocatedSize_, granularity, 0, 0),
-      "cuMemAddressReserve failed");
-
-  // Map the physical memory to virtual address
-  checkCuError(
-      pfn_cuMemMap(
-          fabricLocalPtr_, allocatedSize_, 0, fabricLocalAllocHandle_, 0),
-      "cuMemMap failed");
-
-  // Set access permissions
-  CUmemAccessDesc accessDesc = {};
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  accessDesc.location.id = cuDev;
-  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  checkCuError(
-      pfn_cuMemSetAccess(fabricLocalPtr_, allocatedSize_, &accessDesc, 1),
-      "cuMemSetAccess failed");
-
-  // Export to fabric handle for sharing with peers
-  checkCuError(
-      pfn_cuMemExportToShareableHandle(
-          &fabricLocalHandle_,
-          fabricLocalAllocHandle_,
-          CU_MEM_HANDLE_TYPE_FABRIC,
-          0),
-      "cuMemExportToShareableHandle failed");
-
-  // Store local pointer in peer array for uniform access
-  fabricPeerPtrs_[selfRank_] = fabricLocalPtr_;
-  fabricPeerAllocHandles_[selfRank_] = fabricLocalAllocHandle_;
+  // CuMemMapping reserves and maps the unicast VA and grants access. It co-owns
+  // allocation_ so the physical handle outlives the VA.
+  unicastMapping_ = std::make_unique<CuMemMapping>(CuMemMapping::overAllocation(
+      allocation_, allocation_->size(), allocation_->granularity()));
 #endif
 }
 
-void GpuMemHandler::exchangeFabricHandles() {
-  nvlMemExchangeVmm(
+void GpuMemHandler::exchangeVmmHandles() {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("CUDA driver not available");
+  }
+
+  int cudaDev = 0;
+  CUdevice cuDev;
+  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+
+  peers_ = nvlMemExchangeVmm(
       *bootstrap_,
       selfRank_,
       nRanks_,
-      fabricLocalHandle_,
-      allocatedSize_,
-      fabricPeerPtrs_,
-      fabricPeerAllocHandles_,
-      fabricPeerAllocatedSizes_);
+      cuDev,
+      allocation_->handle(),
+      getLocalDeviceMemPtr(),
+      allocation_->size());
+#endif
 }
 
-void GpuMemHandler::cleanupFabric() {
+void GpuMemHandler::cleanupVmm() {
 #if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
-  // Check if CUDA context is still valid
-  CUcontext ctx = nullptr;
-  if (pfn_cuCtxGetCurrent == nullptr ||
-      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
-    return;
-  }
-
-  // Release peer mappings
-  for (int32_t rank = 0; rank < nRanks_; ++rank) {
-    if (rank == selfRank_) {
-      continue;
-    }
-    if (fabricPeerPtrs_[rank] != 0) {
-      pfn_cuMemUnmap(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
-      pfn_cuMemAddressFree(
-          fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
-      fabricPeerPtrs_[rank] = 0;
-    }
-    if (fabricPeerAllocHandles_[rank] != 0) {
-      pfn_cuMemRelease(fabricPeerAllocHandles_[rank]);
-      fabricPeerAllocHandles_[rank] = 0;
-    }
-  }
-
-  // Release local allocation
-  if (fabricLocalPtr_ != 0) {
-    pfn_cuMemUnmap(fabricLocalPtr_, allocatedSize_);
-    pfn_cuMemAddressFree(fabricLocalPtr_, allocatedSize_);
-    fabricLocalPtr_ = 0;
-  }
-  if (fabricLocalAllocHandle_ != 0) {
-    pfn_cuMemRelease(fabricLocalAllocHandle_);
-    fabricLocalAllocHandle_ = 0;
-  }
+  // RAII teardown: unicast VA first, then peer VAs (each co-owns its imported
+  // allocation), then the shared physical allocation (released when the last
+  // shared_ptr owner drops).
+  unicastMapping_.reset();
+  peers_.vmmMappings.clear();
+  allocation_.reset();
 #endif
 }
 
@@ -424,35 +362,35 @@ void GpuMemHandler::allocateCudaIpcMemory(size_t size) {
   } else {
     checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
   }
-  allocatedSize_ = size;
-
-  // Get IPC handle for local memory
+  // Cache the local IPC handle for getLocalIpcHandle(). It depends only on the
+  // local allocation, so deriving it here makes it valid before exchange too.
   checkCudaError(
       cudaIpcGetMemHandle(&cudaIpcLocalHandle_, cudaIpcLocalPtr_),
       "cudaIpcGetMemHandle failed");
-
-  // Store local pointer in peer array
-  cudaIpcPeerPtrs_[selfRank_] = cudaIpcLocalPtr_;
+  allocatedSize_ = size;
 }
 
 void GpuMemHandler::exchangeCudaIpcHandles() {
-  nvlMemExchangeCudaIpc(
-      *bootstrap_, selfRank_, nRanks_, cudaIpcLocalHandle_, cudaIpcPeerPtrs_);
+  peers_ =
+      nvlMemExchangeCudaIpc(*bootstrap_, selfRank_, nRanks_, cudaIpcLocalPtr_);
 }
 
 void GpuMemHandler::cleanupCudaIpc() {
-  // Close peer handles
+  // Close peer handles opened by cudaIpcOpenMemHandle. The self slot holds the
+  // local pointer (freed below), not an opened handle.
   for (int32_t rank = 0; rank < nRanks_; ++rank) {
     if (rank == selfRank_) {
       continue;
     }
-    if (cudaIpcPeerPtrs_[rank] != nullptr) {
-      cudaError_t err = cudaIpcCloseMemHandle(cudaIpcPeerPtrs_[rank]);
+    void* peerPtr = peers_.peerPtrs.empty()
+        ? nullptr
+        : peers_.peerPtrs[static_cast<std::size_t>(rank)];
+    if (peerPtr != nullptr) {
+      cudaError_t err = cudaIpcCloseMemHandle(peerPtr);
       if (err != cudaSuccess) {
         LOG(ERROR) << "cudaIpcCloseMemHandle failed for rank " << rank << ": "
                    << cudaGetErrorString(err);
       }
-      cudaIpcPeerPtrs_[rank] = nullptr;
     }
   }
 

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -20,7 +20,11 @@
 #include <cuda_runtime.h>
 #endif
 
+#include <memory>
+
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
 #include "comms/prims/memory/NvlMemExchange.h"
 
 namespace comms::prims {
@@ -110,6 +114,12 @@ class GpuMemHandler {
    * @param nRanks Total number of ranks
    * @param size Size of memory to allocate
    * @param mode Explicitly select fabric or cudaIpc mode
+   * @param alignFloor Optional minimum allocation alignment/size floor. Must be
+   * 0 (no floor) or a power of two. In a VMM mode it raises the physical
+   * allocation's granularity/size floor so the allocation can satisfy a larger
+   * granularity requirement (e.g. so it can later be bound into a multicast
+   * object - see MultimemHandler::backingGranularity()). Ignored in cudaIpc
+   * mode.
    *
    * @throws std::runtime_error if requested mode is not supported or allocation
    * fails
@@ -119,7 +129,8 @@ class GpuMemHandler {
       int32_t selfRank,
       int32_t nRanks,
       size_t size,
-      MemSharingMode mode);
+      MemSharingMode mode,
+      std::size_t alignFloor = 0);
 
   ~GpuMemHandler();
 
@@ -164,7 +175,7 @@ class GpuMemHandler {
    * Get the local IPC handle (cudaIpc / hipIpc). Only valid in `kCudaIpc` /
    * `kCudaIpcUncached` mode.
    *
-   * @throws std::runtime_error when mode is `kFabric`.
+   * @throws std::runtime_error when called in a VMM (fabric / posix-fd) mode.
    */
   const cudaIpcMemHandle_t& getLocalIpcHandle() const;
 
@@ -184,6 +195,17 @@ class GpuMemHandler {
   }
 
   /**
+   * Returns this handler's shared physical VMM allocation in the kFabric mode,
+   * or nullptr in cudaIpc mode (cudaMalloc has no VMM handle). The allocation
+   * is co-owned via shared_ptr; the multicast overlay (exchangeMulticast) binds
+   * the same allocation so the unicast and multicast views share one physical
+   * backing. Valid after construction.
+   */
+  std::shared_ptr<CuMemAllocation> allocation() const {
+    return allocation_;
+  }
+
+  /**
    * Check if the current GPU supports fabric handles.
    *
    * @return true if Hopper+ GPU with CUDA 12.3+ and fabric support enabled
@@ -196,17 +218,25 @@ class GpuMemHandler {
   static MemSharingMode detectBestMode();
 
  private:
-  void init(size_t size);
+  void init(size_t size, std::size_t alignFloor);
 
-  // Fabric mode methods
-  void allocateFabricMemory(size_t size);
-  void exchangeFabricHandles();
-  void cleanupFabric();
+  // VMM (fabric) mode methods. The physical allocation is owned by a
+  // CuMemAllocation co-owned via shared_ptr; the unicast VA is a CuMemMapping;
+  // the peer exchange is delegated to NvlMemExchange.
+  void allocateVmmMemory(size_t size, std::size_t alignFloor);
+  void exchangeVmmHandles();
+  void cleanupVmm();
 
   // CudaIpc mode methods
   void allocateCudaIpcMemory(size_t size);
   void exchangeCudaIpcHandles();
   void cleanupCudaIpc();
+
+  // True for the VMM-backed mode (kFabric), which uses the NvlMemExchange-based
+  // code path. False for kCudaIpc.
+  bool isVmmMode() const {
+    return mode_ == MemSharingMode::kFabric;
+  }
 
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const int32_t selfRank_{-1};
@@ -217,18 +247,20 @@ class GpuMemHandler {
   size_t allocatedSize_{0};
   bool exchanged_{false};
 
-  // ---- Fabric mode state ----
-  CUdeviceptr fabricLocalPtr_{0};
-  CUmemGenericAllocationHandle fabricLocalAllocHandle_{0};
-  FabricHandle fabricLocalHandle_{};
-  std::vector<CUdeviceptr> fabricPeerPtrs_;
-  std::vector<CUmemGenericAllocationHandle> fabricPeerAllocHandles_;
-  std::vector<size_t> fabricPeerAllocatedSizes_;
+  // ---- VMM mode state (kFabric) ----
+  // The local physical allocation (co-owned via shared_ptr so a multicast
+  // overlay can share it) and its unicast VA mapping (which also co-owns the
+  // allocation via keepAlive).
+  std::shared_ptr<CuMemAllocation> allocation_;
+  std::unique_ptr<CuMemMapping> unicastMapping_;
+  // Peer mappings + pointers, produced by nvlMemExchange during
+  // exchangeMemPtrs(). For VMM mode the peer mappings co-own their imported
+  // allocations; for cudaIpc only the peer pointers (owned by the IPC runtime).
+  NvlPeerMem peers_;
 
   // ---- CudaIpc mode state ----
   void* cudaIpcLocalPtr_{nullptr};
   cudaIpcMemHandle_t cudaIpcLocalHandle_{};
-  std::vector<void*> cudaIpcPeerPtrs_;
 };
 
 // Backwards compatibility alias

--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -3,196 +3,165 @@
 #include "comms/prims/memory/NvlMemExchange.h"
 
 #include "comms/prims/core/Checks.h"
-
-#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/platform/CudaDriverLazy.h"
-#endif
 
+#include <cstddef>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace comms::prims {
 
 namespace {
 
-// Import + map one peer's fabric memory into a fresh local virtual address with
-// RW access. Writes the imported handle and mapped pointer into the per-rank
-// output vectors at index `rank`. Caller (nvlMemExchangeVmm) pre-sizes both
-// output vectors to `nRanks` and bounds-checks at the public entry point;
-// `.at()` is used at the write sites as a second proof of bounds for the
-// clang-tidy ParameterUncheckedArrayBounds checker.
-void importFabricPeerMemory(
+// Import one peer's fabric handle, wrap it in a co-ownable CuMemAllocation, map
+// it into a fresh peer VA, and record the mapping + pointer in `result`. The
+// imported handle is owned by the CuMemAllocation that the peer VA mapping
+// co-owns, so dropping the mapping releases the handle -- no separate handle
+// bookkeeping.
+void importAndMapPeerMemory(
     int32_t rank,
     const FabricHandle& handle,
     std::size_t peerAllocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+    CUdevice cuDev,
+    NvlPeerMem& result) {
+#if CUDART_VERSION < 12030
   (void)rank;
   (void)handle;
   (void)peerAllocatedSize;
-  (void)peerPtrs;
-  (void)peerAllocHandles;
+  (void)cuDev;
+  (void)result;
   throw std::runtime_error("Fabric handles require CUDA 12.3+");
 #else
-  if (cuda_driver_lazy_init() != 0) {
-    throw std::runtime_error("CUDA driver not available");
-  }
-
-  int cudaDev = 0;
-  CUdevice cuDev;
-
-  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
-  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
-
-  // Import the fabric handle to get allocation handle
+  CUmemGenericAllocationHandle peerHandle = 0;
   checkCuError(
       pfn_cuMemImportFromShareableHandle(
-          &peerAllocHandles.at(rank),
+          &peerHandle,
           const_cast<void*>(static_cast<const void*>(&handle)),
           CU_MEM_HANDLE_TYPE_FABRIC),
       "cuMemImportFromShareableHandle failed");
 
-  // Get allocation properties for granularity
-  CUmemAllocationProp prop = {};
-  checkCuError(
-      pfn_cuMemGetAllocationPropertiesFromHandle(
-          &prop, peerAllocHandles.at(rank)),
-      "cuMemGetAllocationPropertiesFromHandle failed");
+  // CuMemAllocation::adopt() takes ownership of `peerHandle` on entry: on
+  // internal failure (CUDA query, allocator bad_alloc) it releases the handle
+  // and rethrows, so there is no raw-handle window for the caller to guard.
+  // The returned unique_ptr promotes implicitly to shared_ptr for
+  // CuMemMapping::overAllocation's keep-alive contract.
+  std::shared_ptr<CuMemAllocation> peerAlloc =
+      CuMemAllocation::adopt(peerHandle, cuDev, peerAllocatedSize);
+  const std::size_t granularity = peerAlloc->granularity();
 
-  std::size_t granularity = 0;
-  checkCuError(
-      pfn_cuMemGetAllocationGranularity(
-          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-      "cuMemGetAllocationGranularity failed");
-
-  // Reserve virtual address space for peer memory
-  checkCuError(
-      pfn_cuMemAddressReserve(
-          &peerPtrs.at(rank), peerAllocatedSize, granularity, 0, 0),
-      "cuMemAddressReserve for peer failed");
-
-  // Map peer's physical memory to our virtual address
-  checkCuError(
-      pfn_cuMemMap(
-          peerPtrs.at(rank),
-          peerAllocatedSize,
-          0,
-          peerAllocHandles.at(rank),
-          0),
-      "cuMemMap for peer failed");
-
-  // Set access permissions for peer memory
-  CUmemAccessDesc accessDesc = {};
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  accessDesc.location.id = cuDev;
-  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  checkCuError(
-      pfn_cuMemSetAccess(peerPtrs.at(rank), peerAllocatedSize, &accessDesc, 1),
-      "cuMemSetAccess for peer failed");
+  result.vmmMappings.push_back(
+      CuMemMapping::overAllocation(
+          std::move(peerAlloc), peerAllocatedSize, granularity));
+  result.peerPtrs.at(static_cast<std::size_t>(rank)) =
+      // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer
+      reinterpret_cast<void*>(result.vmmMappings.back().devicePtr());
 #endif
 }
 
 } // namespace
 
-void nvlMemExchangeVmm(
+NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const FabricHandle& localHandle,
-    std::size_t allocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
-    std::vector<std::size_t>& peerAllocatedSizes) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle localHandle,
+    void* localPtr,
+    std::size_t allocatedSize) {
+  NvlPeerMem result;
+  result.peerPtrs.assign(static_cast<std::size_t>(nRanks), nullptr);
+  result.peerPtrs[static_cast<std::size_t>(rank)] = localPtr;
+
+#if CUDART_VERSION < 12030
   (void)bootstrap;
-  (void)selfRank;
-  (void)nRanks;
+  (void)cuDev;
   (void)localHandle;
   (void)allocatedSize;
-  (void)peerPtrs;
-  (void)peerAllocHandles;
-  (void)peerAllocatedSizes;
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+  throw std::runtime_error("nvlMemExchangeVmm requires CUDA 12.3+");
 #else
-  if (static_cast<std::size_t>(nRanks) > peerPtrs.size() ||
-      static_cast<std::size_t>(nRanks) > peerAllocHandles.size() ||
-      static_cast<std::size_t>(nRanks) > peerAllocatedSizes.size()) {
-    throw std::runtime_error(
-        "nvlMemExchangeVmm: output vectors must each have size >= nRanks");
-  }
+  // Export the local handle once as a fabric handle.
+  FabricHandle localFabric{};
+  checkCuError(
+      pfn_cuMemExportToShareableHandle(
+          &localFabric, localHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0),
+      "cuMemExportToShareableHandle for fabric handle failed");
 
-  // Prepare data for allGather: fabric handle + allocation size
   struct ExchangeData {
-    FabricHandle handle;
-    std::size_t allocatedSize;
+    FabricHandle handle{};
+    std::size_t allocatedSize{};
   };
 
-  std::vector<ExchangeData> allData(nRanks);
-  allData[selfRank].handle = localHandle;
-  allData[selfRank].allocatedSize = allocatedSize;
+  std::vector<ExchangeData> allData(static_cast<std::size_t>(nRanks));
+  allData[static_cast<std::size_t>(rank)].handle = localFabric;
+  allData[static_cast<std::size_t>(rank)].allocatedSize = allocatedSize;
 
-  // Exchange fabric handles with all ranks
-  auto result =
-      bootstrap
-          .allGather(allData.data(), sizeof(ExchangeData), selfRank, nRanks)
+  auto gatherResult =
+      bootstrap.allGather(allData.data(), sizeof(ExchangeData), rank, nRanks)
           .get();
-  if (result != 0) {
+  if (gatherResult != 0) {
     throw std::runtime_error("nvlMemExchangeVmm allGather failed");
   }
 
-  // Import peer memory from received fabric handles
-  for (int32_t rank = 0; rank < nRanks; ++rank) {
-    if (rank == selfRank) {
+  for (int32_t peer = 0; peer < nRanks; ++peer) {
+    if (peer == rank) {
       continue;
     }
-    peerAllocatedSizes.at(rank) = allData[rank].allocatedSize;
-    importFabricPeerMemory(
-        rank,
-        allData[rank].handle,
-        allData[rank].allocatedSize,
-        peerPtrs,
-        peerAllocHandles);
+    const auto peerIdx = static_cast<std::size_t>(peer);
+    importAndMapPeerMemory(
+        peer,
+        allData[peerIdx].handle,
+        allData[peerIdx].allocatedSize,
+        cuDev,
+        result);
   }
+
+  return result;
 #endif
 }
 
-void nvlMemExchangeCudaIpc(
+NvlPeerMem nvlMemExchangeCudaIpc(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const cudaIpcMemHandle_t& localHandle,
-    std::vector<void*>& peerPtrs) {
-  if (static_cast<std::size_t>(nRanks) > peerPtrs.size()) {
-    throw std::runtime_error(
-        "nvlMemExchangeCudaIpc: peerPtrs must have size >= nRanks");
-  }
+    void* localPtr) {
+  NvlPeerMem result;
+  result.peerPtrs.assign(static_cast<std::size_t>(nRanks), nullptr);
+  result.peerPtrs[static_cast<std::size_t>(rank)] = localPtr;
 
-  // Exchange IPC handles with all ranks
-  std::vector<cudaIpcMemHandle_t> allHandles(nRanks);
-  allHandles[selfRank] = localHandle;
+  cudaIpcMemHandle_t localHandle{};
+  checkCudaError(
+      cudaIpcGetMemHandle(&localHandle, localPtr),
+      "cudaIpcGetMemHandle failed");
 
-  auto result =
+  std::vector<cudaIpcMemHandle_t> allHandles(static_cast<std::size_t>(nRanks));
+  allHandles[static_cast<std::size_t>(rank)] = localHandle;
+
+  auto gatherResult =
       bootstrap
           .allGather(
-              allHandles.data(), sizeof(cudaIpcMemHandle_t), selfRank, nRanks)
+              allHandles.data(), sizeof(cudaIpcMemHandle_t), rank, nRanks)
           .get();
-  if (result != 0) {
+  if (gatherResult != 0) {
     throw std::runtime_error("nvlMemExchangeCudaIpc allGather failed");
   }
 
-  // Open peer memory handles
-  for (int32_t rank = 0; rank < nRanks; ++rank) {
-    if (rank == selfRank) {
+  for (int32_t peer = 0; peer < nRanks; ++peer) {
+    if (peer == rank) {
       continue;
     }
+    const auto peerIdx = static_cast<std::size_t>(peer);
     checkCudaError(
         cudaIpcOpenMemHandle(
-            &peerPtrs.at(rank),
-            allHandles[rank],
+            &result.peerPtrs[peerIdx],
+            allHandles[peerIdx],
             cudaIpcMemLazyEnablePeerAccess),
         "cudaIpcOpenMemHandle failed");
   }
+
+  return result;
 }
 
 } // namespace comms::prims

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -2,104 +2,85 @@
 
 #pragma once
 
-// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD,
-// fabric-handle support is unavailable; only the cudaIpc path is used, and its
-// `cudaIpcMemHandle_t` parameter is HIPify-rewritten to `hipIpcMemHandle_t`
-// (provided by `<hip/hip_runtime.h>`).
-#ifdef __HIP_PLATFORM_AMD__
-#include <hip/hip_runtime.h>
-#else
 #include <cuda.h>
 #include <cuda_runtime.h>
-#endif
 
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemMapping.h"
 
 namespace comms::prims {
 
-#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+#if CUDART_VERSION >= 12030
 using FabricHandle = CUmemFabricHandle;
 #else
 struct FabricHandle {
   unsigned char data[64]; // CU_IPC_HANDLE_SIZE
 };
-// Stub the CUDA driver-API typedefs referenced by the always-declared VMM
-// signature so the header (and downstream consumers like GpuMemHandler)
-// compiles on AMD / pre-CUDA-12.3. The concrete VMM driver-API code lives
-// behind `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030` in
-// the .cc; on these platforms `nvlMemExchangeVmm` is a throwing stub. Types
-// match the real CUDA driver-API typedefs (`unsigned long long`).
-#if defined(__HIP_PLATFORM_AMD__)
-using CUdeviceptr = unsigned long long;
-using CUmemGenericAllocationHandle = unsigned long long;
-#endif
 #endif
 
 /**
  * NvlMemExchange - NVLink-domain peer-exchange building blocks.
  *
- * The peer exchange (export -> all-gather -> import -> map) that gives every
- * rank a VA onto every peer's backing allocation, for both VMM (fabric) and
- * cudaIpc modes. Used by GpuMemHandler. The VMM/fabric path is NVIDIA-only
- * (CUDA driver API + CUDA 12.3+); on AMD or pre-12.3, `nvlMemExchangeVmm` is
- * declared but its body throws. The cudaIpc path is HIPify-rewritten to
- * hipIpc on AMD.
+ * The consolidated peer exchange (export -> all-gather -> import -> map) that
+ * gives every rank a VA onto every peer's backing allocation, for both VMM
+ * (fabric) and cudaIpc modes. Used by GpuMemHandler. The `cuMem*` fabric
+ * driver-API paths are guarded by `#if CUDART_VERSION >= 12030`; on AMD only
+ * the cudaIpc path (HIPify-rewritten) is used. Provides the FabricHandle
+ * typedef.
  */
 
 /**
- * VMM (fabric) peer exchange. all-gathers this rank's exported fabric handle
- * and allocation size, then imports + maps every peer's physical memory into a
- * fresh local virtual address with RW access. Results are written into the
- * per-rank output vectors (indexed by rank); the self slot of `peerPtrs` is
- * left untouched (the caller stores its own local VA there).
+ * The per-rank peer memory state produced by an NVLink-domain exchange.
  *
- * COLLECTIVE OPERATION: all ranks must call. Throws on AMD or pre-CUDA-12.3.
- *
- * Output vectors must each have size `>= nRanks`.
- *
- * @param bootstrap Bootstrap interface for the allGather
- * @param selfRank This rank's ID (0..nRanks-1)
- * @param nRanks Total number of ranks
- * @param localHandle This rank's exported fabric handle
- * @param allocatedSize This rank's allocation size
- * @param peerPtrs [out] per-rank mapped peer pointers (size nRanks)
- * @param peerAllocHandles [out] per-rank imported allocation handles (size
- * nRanks)
- * @param peerAllocatedSizes [out] per-rank allocation sizes (size nRanks)
+ * `peerPtrs[rank]` is a VA usable in local kernels to access rank `rank`'s
+ * backing allocation; the self slot holds the local pointer. For VMM modes,
+ * `vmmMappings` holds the RAII peer VAs; each mapping co-owns the imported peer
+ * CuMemAllocation (via CuMemMapping's keepAlive), so releasing a mapping also
+ * releases the imported physical handle -- there is no separate handle vector
+ * to track. For cudaIpc mode `vmmMappings` is empty and the peer pointers are
+ * owned by the CUDA IPC runtime (closed via cudaIpcCloseMemHandle by the
+ * caller).
  */
-void nvlMemExchangeVmm(
-    meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
-    int32_t nRanks,
-    const FabricHandle& localHandle,
-    std::size_t allocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
-    std::vector<std::size_t>& peerAllocatedSizes);
+struct NvlPeerMem {
+  std::vector<void*> peerPtrs;
+  std::vector<CuMemMapping> vmmMappings;
+};
 
 /**
- * cudaIpc peer exchange. all-gathers this rank's cudaIpc handle, then opens
- * every peer's handle into `peerPtrs` (indexed by rank). Intra-node only.
+ * VMM (fabric) peer exchange.
  *
- * COLLECTIVE OPERATION: all ranks must call.
- *
- * `peerPtrs` must have size `>= nRanks`.
- *
- * @param bootstrap Bootstrap interface for the allGather
- * @param selfRank This rank's ID (0..nRanks-1)
- * @param nRanks Total number of ranks
- * @param localHandle This rank's cudaIpc handle
- * @param peerPtrs [out] per-rank opened peer pointers (size nRanks)
+ * Exports `localHandle` as a fabric handle, all-gathers every rank's handle +
+ * allocated size, then imports and maps each peer's backing allocation into a
+ * fresh peer VA. `peerPtrs[rank]` is null for self; the caller fills the self
+ * slot with `localPtr`. Throws std::runtime_error on any failure. Requires CUDA
+ * 12.3+.
  */
-void nvlMemExchangeCudaIpc(
+NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const cudaIpcMemHandle_t& localHandle,
-    std::vector<void*>& peerPtrs);
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle localHandle,
+    void* localPtr,
+    std::size_t allocatedSize);
+
+/**
+ * cudaIpc peer exchange.
+ *
+ * Exports `localPtr`'s cudaIpc handle, all-gathers handles, and opens each
+ * peer's handle. The self slot of `peerPtrs` is filled with `localPtr`; peer
+ * slots are owned by the CUDA IPC runtime (the caller closes them via
+ * cudaIpcCloseMemHandle). `vmmMappings` is empty. Throws std::runtime_error on
+ * any failure.
+ */
+NvlPeerMem nvlMemExchangeCudaIpc(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t rank,
+    int32_t nRanks,
+    void* localPtr);
 
 } // namespace comms::prims

--- a/comms/prims/tests/CuMemAllocationTest.cc
+++ b/comms/prims/tests/CuMemAllocationTest.cc
@@ -1,0 +1,112 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+// Resolves a CUdevice on device 0 and returns false (skip) if VMM / CUDA 12.3
+// is unavailable.
+bool vmmDevice(CUdevice& cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  if (cudaSetDevice(0) != cudaSuccess) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, 0) == CUDA_SUCCESS;
+#endif
+}
+
+unsigned int requestMask() {
+  return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC;
+}
+
+bool isPowerOfTwo(std::size_t x) {
+  return x != 0 && (x & (x - 1)) == 0;
+}
+
+} // namespace
+
+TEST(CuMemAllocationTest, CreateProducesUsableHandle) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+
+  auto alloc = CuMemAllocation::create(cuDev, /*size=*/4096, requestMask());
+  EXPECT_NE(alloc->handle(), 0u);
+  EXPECT_GE(alloc->size(), std::size_t{4096});
+  EXPECT_TRUE(isPowerOfTwo(alloc->granularity()));
+  EXPECT_EQ(alloc->device(), cuDev);
+  // The surviving cuMemCreate always keeps POSIX FD; fabric is kept only when
+  // the device/driver permit it.
+  EXPECT_NE(
+      alloc->supportedHandleTypes() &
+          static_cast<unsigned int>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+      0u);
+}
+
+TEST(CuMemAllocationTest, RoundsSizeUpToAlignFloor) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+
+  // A 2 MiB power-of-two alignFloor must round the allocation up to a multiple
+  // of it (the granularity becomes max(driverGranularity, alignFloor)).
+  constexpr std::size_t kAlignFloor = 2u * 1024u * 1024u;
+  auto alloc =
+      CuMemAllocation::create(cuDev, /*size=*/4096, requestMask(), kAlignFloor);
+  EXPECT_GE(alloc->granularity(), kAlignFloor);
+  EXPECT_EQ(alloc->size() % alloc->granularity(), 0u);
+  EXPECT_GE(alloc->size(), kAlignFloor);
+}
+
+TEST(CuMemAllocationTest, RejectsNonPowerOfTwoAlignFloor) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  EXPECT_THROW(
+      CuMemAllocation::create(cuDev, 4096, requestMask(), /*alignFloor=*/3),
+      std::runtime_error);
+}
+
+TEST(CuMemAllocationTest, MoveLeavesSourceInert) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  // Move-construct out of the owned object (not the unique_ptr) to exercise
+  // CuMemAllocation's own move ctor + moved-from inert state.
+  auto a = CuMemAllocation::create(cuDev, 4096, requestMask());
+  const auto handle = a->handle();
+  CuMemAllocation b = std::move(*a);
+  EXPECT_EQ(b.handle(), handle);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(a->handle(), 0u);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/CuMemMappingTest.cc
+++ b/comms/prims/tests/CuMemMappingTest.cc
@@ -1,0 +1,151 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+bool vmmDevice(CUdevice& cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  if (cudaSetDevice(0) != cudaSuccess) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, 0) == CUDA_SUCCESS;
+#endif
+}
+
+std::shared_ptr<CuMemAllocation> makeAlloc(CUdevice cuDev, std::size_t size) {
+  return CuMemAllocation::create(
+      cuDev,
+      size,
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC);
+}
+
+void* asPtr(CUdeviceptr p) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(p);
+}
+
+} // namespace
+
+TEST(CuMemMappingTest, MapsAndAccessesAllocation) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto mapping =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  ASSERT_NE(mapping.devicePtr(), 0u);
+
+  ASSERT_EQ(
+      cudaMemset(asPtr(mapping.devicePtr()), 0xAB, alloc->size()), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  std::vector<uint8_t> host(alloc->size(), 0);
+  ASSERT_EQ(
+      cudaMemcpy(
+          host.data(),
+          asPtr(mapping.devicePtr()),
+          alloc->size(),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  for (auto b : host) {
+    ASSERT_EQ(b, 0xAB);
+  }
+}
+
+TEST(CuMemMappingTest, TwoMappingsShareSamePhysical) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto m1 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  auto m2 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  // Distinct virtual addresses onto the same physical allocation.
+  EXPECT_NE(m1.devicePtr(), m2.devicePtr());
+
+  ASSERT_EQ(
+      cudaMemset(asPtr(m1.devicePtr()), 0x5C, alloc->size()), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  std::vector<uint8_t> host(alloc->size(), 0);
+  ASSERT_EQ(
+      cudaMemcpy(
+          host.data(),
+          asPtr(m2.devicePtr()),
+          alloc->size(),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  for (auto b : host) {
+    ASSERT_EQ(b, 0x5C) << "write via mapping 1 must be visible via mapping 2";
+  }
+}
+
+TEST(CuMemMappingTest, KeepAliveOutlivesAllocationOwner) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  std::weak_ptr<CuMemAllocation> weak = alloc;
+  auto mapping = std::make_unique<CuMemMapping>(
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity()));
+  const std::size_t size = alloc->size();
+
+  // Drop the caller's reference; the mapping's keepAlive must keep the physical
+  // allocation alive so the VA stays valid.
+  alloc.reset();
+  EXPECT_FALSE(weak.expired());
+  ASSERT_EQ(cudaMemset(asPtr(mapping->devicePtr()), 0, size), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // Releasing the mapping drops the last reference to the allocation.
+  mapping.reset();
+  EXPECT_TRUE(weak.expired());
+}
+
+TEST(CuMemMappingTest, MoveLeavesSourceInert) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto m1 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  const auto ptr = m1.devicePtr();
+  CuMemMapping m2 = std::move(m1);
+  EXPECT_EQ(m2.devicePtr(), ptr);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(m1.devicePtr(), 0u);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -899,10 +899,13 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/ibrc/.*")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/MultiPeerIbTransport\\.")
 # Exclude window files — they depend on IbgdaBuffer.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/window/.*")
-# Exclude GpuMemHandler, NvlMemExchange, and CudaDriverLazy — they depend on
-# cudaTypedefs.h / the CUDA driver API which is not available here.
+# Exclude GpuMemHandler, NvlMemExchange, CuMemAllocation, CuMemMapping, and
+# CudaDriverLazy — they depend on cudaTypedefs.h / the CUDA driver API which
+# is not available here.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "GpuMemHandler\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "NvlMemExchange\\.")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemAllocation\\.")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemMapping\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")


### PR DESCRIPTION
Summary:

Introduces the two RAII building blocks and rewires the relocated peer exchange onto them. No behavior change beyond the new ownership model (still fabric + cudaIpc only; the POSIX-FD path is added in the next diff).

New building blocks:
- `CuMemAllocation` - RAII owner of one physical `CUmemGenericAllocationHandle` (create / retain / adopt; releases via `cuMemRelease`). Co-owned via `shared_ptr`. Also hosts `makeVmmAllocationProp`.
- `CuMemMapping` - RAII virtual-address mapping (reserve+map+setAccess / unmap+free) that co-owns the `CuMemAllocation` it maps via a type-erased `shared_ptr` keepAlive, so the physical handle outlives the VA.

`NvlMemExchange` now returns a `NvlPeerMem { peerPtrs, vmmMappings }` from `nvlMemExchangeVmm`/`nvlMemExchangeCudaIpc`. The per-peer import is factored into a file-local `importAndMapPeerMemory` helper that imports the handle, wraps it in `CuMemAllocation::adopt`, and maps it via `CuMemMapping::overAllocation` - so each peer VA co-owns its imported physical handle and there is no separate handle bookkeeping. The fabric export moves from allocation time into the exchange.

`GpuMemHandler` drops the scattered fabric peer vectors in favor of `allocation_` (`shared_ptr<CuMemAllocation>`), `unicastMapping_` (`unique_ptr<CuMemMapping>`), and `peers_` (`NvlPeerMem`); `cleanupVmm` is pure RAII teardown. Adds the `alignFloor` constructor parameter and the `allocation()` accessor (so a multicast overlay can later share the same physical backing).

Adds unit tests `CuMemAllocationTest` and `CuMemMappingTest`.

Reviewed By: goelayu, saifhhasan

Differential Revision: D107718239


