### PR TITLE
Add POSIX-FD shareable handles + kPosixFd mode to NvlMemExchange/GpuMemHandler (#2986)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -142,6 +142,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -150,6 +150,8 @@ LIBSRCFILES += $(wildcard ${BASE_DIR}/comms/ctran/algos/RMA/*.cc)
 
 ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc

--- a/comms/prims/memory/CuMemAllocation.cc
+++ b/comms/prims/memory/CuMemAllocation.cc
@@ -1,0 +1,276 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/CuMemAllocation.h"
+
+#include "comms/common/BitOps.cuh"
+#include "comms/prims/core/Checks.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace comms::prims {
+
+namespace {
+
+bool isPowerOfTwo(std::size_t x) {
+  return x != 0 && (x & (x - 1)) == 0;
+}
+
+} // namespace
+
+CUmemAllocationProp makeVmmAllocationProp(
+    CUdevice cuDev,
+    unsigned int requestedHandleTypesMask) {
+  CUmemAllocationProp prop = {};
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  prop.location.id = cuDev;
+  prop.requestedHandleTypes =
+      static_cast<CUmemAllocationHandleType>(requestedHandleTypesMask);
+
+  int rdmaSupported = 0;
+  pfn_cuDeviceGetAttribute(
+      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
+  if (rdmaSupported) {
+    prop.allocFlags.gpuDirectRDMACapable = 1;
+  }
+#else
+  (void)cuDev;
+  (void)requestedHandleTypesMask;
+#endif
+  return prop;
+}
+
+CuMemAllocation::CuMemAllocation(
+    CUmemGenericAllocationHandle handle,
+    CUdevice device,
+    std::size_t size,
+    std::size_t granularity,
+    unsigned int supportedHandleTypes) noexcept
+    : handle_(handle),
+      device_(device),
+      size_(size),
+      granularity_(granularity),
+      supportedHandleTypes_(supportedHandleTypes) {}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::create(
+    CUdevice cuDev,
+    std::size_t size,
+    unsigned int requestedHandleTypesMask,
+    std::size_t alignFloor) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cuDev;
+  (void)size;
+  (void)requestedHandleTypesMask;
+  (void)alignFloor;
+  throw std::runtime_error("CuMemAllocation::create requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: CUDA driver not available");
+  }
+  if (alignFloor != 0 && !isPowerOfTwo(alignFloor)) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: alignFloor must be zero or a power of two");
+  }
+
+  unsigned int mask = requestedHandleTypesMask;
+  auto prop = makeVmmAllocationProp(cuDev, mask);
+
+  std::size_t driverGranularity = 0;
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &driverGranularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED),
+      "cuMemGetAllocationGranularity failed");
+  if (!isPowerOfTwo(driverGranularity)) {
+    throw std::runtime_error(
+        "CuMemAllocation::create: driver allocation granularity is not a power of two");
+  }
+
+  // Both granularities are powers of two, so the effective granularity is a
+  // multiple of the driver granularity and cuMemCreate's size requirement is
+  // satisfied. alignFloor lets the caller raise the size/alignment floor so a
+  // single physical allocation can satisfy a larger granularity requirement
+  // (e.g. a multicast object's granularity).
+  const std::size_t effGran = std::max(driverGranularity, alignFloor);
+  const std::size_t allocatedSize = comms::bitops::roundUp(size, effGran);
+
+  CUmemGenericAllocationHandle handle = 0;
+  CUresult createResult = pfn_cuMemCreate(&handle, allocatedSize, &prop, 0);
+  if ((createResult == CUDA_ERROR_NOT_PERMITTED ||
+       createResult == CUDA_ERROR_NOT_SUPPORTED) &&
+      (mask & CU_MEM_HANDLE_TYPE_FABRIC)) {
+    // Fabric requested but unavailable (e.g. single host without IMEX). Drop
+    // fabric and retry with the remaining handle types (mirrors ncclx
+    // allocator.cc).
+    mask &= ~static_cast<unsigned int>(CU_MEM_HANDLE_TYPE_FABRIC);
+    prop = makeVmmAllocationProp(cuDev, mask);
+    createResult = pfn_cuMemCreate(&handle, allocatedSize, &prop, 0);
+  }
+  checkCuError(createResult, "cuMemCreate failed");
+
+  // From here on the factory owns `handle`. `new` can throw bad_alloc;
+  // release the handle so we never leak a raw allocation on storage exhaust.
+  try {
+    return std::unique_ptr<CuMemAllocation>(
+        new CuMemAllocation(handle, cuDev, allocatedSize, effGran, mask));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::retain(void* ptr) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)ptr;
+  throw std::runtime_error("CuMemAllocation::retain requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "CuMemAllocation::retain: CUDA driver not available");
+  }
+
+  CUmemGenericAllocationHandle handle = 0;
+  checkCuError(
+      pfn_cuMemRetainAllocationHandle(&handle, ptr),
+      "cuMemRetainAllocationHandle failed");
+
+  // After cuMemRetainAllocationHandle succeeds we own one retain reference on
+  // `handle`. Any failure from here on must release that reference exactly
+  // once — funnel through one try/catch instead of the per-call cleanup that
+  // was easy to miss.
+  try {
+    CUdeviceptr base = 0;
+    std::size_t size = 0;
+    checkCuError(
+        pfn_cuMemGetAddressRange(
+            &base, &size, reinterpret_cast<CUdeviceptr>(ptr)),
+        "cuMemGetAddressRange failed");
+
+    CUmemAllocationProp prop = {};
+    checkCuError(
+        pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle),
+        "cuMemGetAllocationPropertiesFromHandle failed");
+
+    std::size_t granularity = 0;
+    checkCuError(
+        pfn_cuMemGetAllocationGranularity(
+            &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+        "cuMemGetAllocationGranularity failed");
+
+    return std::unique_ptr<CuMemAllocation>(new CuMemAllocation(
+        handle,
+        static_cast<CUdevice>(prop.location.id),
+        size,
+        granularity,
+        static_cast<unsigned int>(prop.requestedHandleTypes)));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+std::unique_ptr<CuMemAllocation> CuMemAllocation::adopt(
+    CUmemGenericAllocationHandle handle,
+    CUdevice device,
+    std::size_t size) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)handle;
+  (void)device;
+  (void)size;
+  throw std::runtime_error("CuMemAllocation::adopt requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    pfn_cuMemRelease(handle);
+    throw std::runtime_error(
+        "CuMemAllocation::adopt: CUDA driver not available");
+  }
+  // adopt() takes ownership of `handle` on entry. Query the handle's
+  // properties + granularity so the caller never has to hold the raw handle
+  // past this call; on any internal failure (CUDA error, `new` bad_alloc)
+  // release the handle and rethrow so no raw-handle window leaks out.
+  try {
+    CUmemAllocationProp prop = {};
+    checkCuError(
+        pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle),
+        "CuMemAllocation::adopt: cuMemGetAllocationPropertiesFromHandle failed");
+    std::size_t granularity = 0;
+    checkCuError(
+        pfn_cuMemGetAllocationGranularity(
+            &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+        "CuMemAllocation::adopt: cuMemGetAllocationGranularity failed");
+    return std::unique_ptr<CuMemAllocation>(new CuMemAllocation(
+        handle,
+        device,
+        size,
+        granularity,
+        static_cast<unsigned int>(prop.requestedHandleTypes)));
+  } catch (...) {
+    pfn_cuMemRelease(handle);
+    throw;
+  }
+#endif
+}
+
+CuMemAllocation::~CuMemAllocation() {
+  release();
+}
+
+CuMemAllocation::CuMemAllocation(CuMemAllocation&& other) noexcept
+    : handle_(other.handle_),
+      device_(other.device_),
+      size_(other.size_),
+      granularity_(other.granularity_),
+      supportedHandleTypes_(other.supportedHandleTypes_) {
+  other.handle_ = 0;
+  other.size_ = 0;
+}
+
+CuMemAllocation& CuMemAllocation::operator=(CuMemAllocation&& other) noexcept {
+  if (this != &other) {
+    release();
+    handle_ = other.handle_;
+    device_ = other.device_;
+    size_ = other.size_;
+    granularity_ = other.granularity_;
+    supportedHandleTypes_ = other.supportedHandleTypes_;
+    other.handle_ = 0;
+    other.size_ = 0;
+  }
+  return *this;
+}
+
+bool CuMemAllocation::supportsFabric() const {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  return (supportedHandleTypes_ & CU_MEM_HANDLE_TYPE_FABRIC) != 0;
+#else
+  return false;
+#endif
+}
+
+void CuMemAllocation::release() noexcept {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (handle_ == 0) {
+    return;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return;
+  }
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+  pfn_cuMemRelease(handle_);
+  handle_ = 0;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemAllocation.h
+++ b/comms/prims/memory/CuMemAllocation.h
@@ -1,0 +1,166 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD the
+// concrete VMM driver-API calls are unavailable and the impl bodies throw;
+// stub the driver-API typedefs below so this header (and downstream consumers)
+// still compiles. Mirrors NvlMemExchange.h.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <memory>
+
+namespace comms::prims {
+
+#if defined(__HIP_PLATFORM_AMD__)
+// Stub CUDA driver-API typedefs the always-declared API references; concrete
+// VMM calls are NVIDIA-only and live behind
+// `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030` in the .cc.
+// Types match real CUDA driver-API typedefs (`unsigned long long` /
+// `int` / empty struct placeholder for CUmemAllocationProp).
+using CUdevice = int;
+using CUmemGenericAllocationHandle = unsigned long long;
+using CUdeviceptr = unsigned long long;
+struct CUmemAllocationProp {
+  unsigned char _padding[1];
+};
+#endif
+
+/**
+ * Builds a CUmemAllocationProp for a PINNED device allocation on `cuDev` with
+ * the given requested handle-types mask. Sets gpuDirectRDMACapable when the
+ * device reports GPUDirect-RDMA support. `requestedHandleTypesMask` may combine
+ * multiple CU_MEM_HANDLE_TYPE_* flags so cuMemCreate can request both fabric
+ * and POSIX FD support at once.
+ *
+ * Lives with CuMemAllocation (the physical-allocation owner) so that both
+ * CuMemAllocation and NvlMemExchange can build props without a dependency
+ * cycle.
+ */
+CUmemAllocationProp makeVmmAllocationProp(
+    CUdevice cuDev,
+    unsigned int requestedHandleTypesMask);
+
+/**
+ * CuMemAllocation - RAII owner of ONE physical CUDA VMM allocation handle
+ * (`CUmemGenericAllocationHandle`).
+ *
+ * It owns only the physical handle: it does not reserve or map any virtual
+ * address (that is CuMemMapping's job). It is meant to be co-owned via
+ * std::shared_ptr by the things that map it (CuMemMapping) and by the higher
+ * level handlers (GpuMemHandler's unicast allocation, MultimemHandler's
+ * backing), so one physical allocation can be shared by value-RAII rather than
+ * by leaking the raw handle.
+ *
+ * Three ways to obtain one — all three factories return a `unique_ptr` that
+ * the caller can either keep as unique ownership or promote to `shared_ptr`
+ * via implicit conversion:
+ *  - create(): cuMemCreate a fresh physical allocation (requests fabric + POSIX
+ *    FD with a POSIX-FD-only fallback when fabric is unavailable).
+ *  - retain(ptr): cuMemRetainAllocationHandle an existing externally-mapped VMM
+ *    buffer (the returned object owns that retain reference).
+ *  - adopt(handle, ...): take ownership of an already-owned handle (e.g. one
+ *    returned by NvlMemExchange::importShareableHandle).
+ *
+ * Each factory takes ownership of any handle it touches atomically: on
+ * internal failure (CUDA error, allocator `bad_alloc`) the handle is released
+ * before the exception propagates, so the caller never sees a leaked raw
+ * handle and never has to write release-on-throw bookkeeping.
+ *
+ * In every case the destructor cuMemRelease()s the owned reference once. Not
+ * copyable; movable (the moved-from object releases nothing). Requires CUDA
+ * 12.3+; the factories throw on older toolkits.
+ */
+class CuMemAllocation {
+ public:
+  /**
+   * cuMemCreate a fresh physical allocation on `cuDev`. Queries the RECOMMENDED
+   * granularity, rounds `size` up to max(driverGranularity, alignFloor), then
+   * cuMemCreate requesting `requestedHandleTypesMask`. If fabric was requested
+   * but cuMemCreate reports CUDA_ERROR_NOT_PERMITTED / NOT_SUPPORTED (e.g. a
+   * fabric-capable GPU without IMEX) it drops fabric and retries with the
+   * remaining types. `alignFloor` must be 0 or a power of two; it raises the
+   * size/granularity floor so the allocation can satisfy a larger granularity
+   * requirement (e.g. a multicast object's granularity).
+   */
+  static std::unique_ptr<CuMemAllocation> create(
+      CUdevice cuDev,
+      std::size_t size,
+      unsigned int requestedHandleTypesMask,
+      std::size_t alignFloor = 0);
+
+  /**
+   * Retain the physical handle backing an existing VMM device pointer via
+   * cuMemRetainAllocationHandle. The size is taken from cuMemGetAddressRange
+   * and the supported handle types / device from the allocation properties.
+   * Throws if `ptr` is not a VMM allocation.
+   */
+  static std::unique_ptr<CuMemAllocation> retain(void* ptr);
+
+  /**
+   * Take ownership of an already-owned physical handle (the caller transfers
+   * one reference; the destructor releases it). Queries the handle's
+   * properties + granularity internally so the caller does not have to hold
+   * the raw handle past this call. Used for handles produced by
+   * NvlMemExchange::importShareableHandle.
+   */
+  static std::unique_ptr<CuMemAllocation>
+  adopt(CUmemGenericAllocationHandle handle, CUdevice device, std::size_t size);
+
+  ~CuMemAllocation();
+
+  CuMemAllocation(CuMemAllocation&& other) noexcept;
+  CuMemAllocation& operator=(CuMemAllocation&& other) noexcept;
+
+  CuMemAllocation(const CuMemAllocation&) = delete;
+  CuMemAllocation& operator=(const CuMemAllocation&) = delete;
+
+  CUmemGenericAllocationHandle handle() const {
+    return handle_;
+  }
+
+  CUdevice device() const {
+    return device_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+  std::size_t granularity() const {
+    return granularity_;
+  }
+
+  unsigned int supportedHandleTypes() const {
+    return supportedHandleTypes_;
+  }
+
+  bool supportsFabric() const;
+
+ private:
+  // Pure scalar field init — cannot throw. Marked noexcept so the factories'
+  // release-on-throw try/catch only has to worry about the `new` storage
+  // allocation (the only remaining throw window), not the construction itself.
+  CuMemAllocation(
+      CUmemGenericAllocationHandle handle,
+      CUdevice device,
+      std::size_t size,
+      std::size_t granularity,
+      unsigned int supportedHandleTypes) noexcept;
+
+  void release() noexcept;
+
+  CUmemGenericAllocationHandle handle_{0};
+  CUdevice device_{0};
+  std::size_t size_{0};
+  std::size_t granularity_{0};
+  unsigned int supportedHandleTypes_{0};
+};
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemMapping.cc
+++ b/comms/prims/memory/CuMemMapping.cc
@@ -1,0 +1,116 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/CuMemMapping.h"
+
+#include "comms/prims/core/Checks.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <utility>
+
+namespace comms::prims {
+
+CuMemMapping::CuMemMapping(
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle handle,
+    std::size_t size,
+    std::size_t granularity,
+    std::shared_ptr<void> keepAlive)
+    : size_(size), keepAlive_(std::move(keepAlive)) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cuDev;
+  (void)handle;
+  (void)granularity;
+  throw std::runtime_error("CuMemMapping requires CUDA 12.3+");
+#else
+  try {
+    checkCuError(
+        pfn_cuMemAddressReserve(&devicePtr_, size_, granularity, 0, 0),
+        "cuMemAddressReserve failed");
+
+    checkCuError(
+        pfn_cuMemMap(devicePtr_, size_, 0, handle, 0), "cuMemMap failed");
+    mapped_ = true;
+
+    CUmemAccessDesc accessDesc = {};
+    accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    accessDesc.location.id = cuDev;
+    accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    checkCuError(
+        pfn_cuMemSetAccess(devicePtr_, size_, &accessDesc, 1),
+        "cuMemSetAccess failed");
+  } catch (...) {
+    cleanup();
+    throw;
+  }
+#endif
+}
+
+CuMemMapping CuMemMapping::overAllocation(
+    std::shared_ptr<CuMemAllocation> alloc,
+    std::size_t size,
+    std::size_t granularity) {
+  if (!alloc) {
+    throw std::runtime_error(
+        "CuMemMapping::overAllocation: alloc must be non-null");
+  }
+  const CUdevice cuDev = alloc->device();
+  const CUmemGenericAllocationHandle handle = alloc->handle();
+  return CuMemMapping(cuDev, handle, size, granularity, std::move(alloc));
+}
+
+CuMemMapping::~CuMemMapping() {
+  cleanup();
+}
+
+CuMemMapping::CuMemMapping(CuMemMapping&& other) noexcept
+    : devicePtr_(other.devicePtr_),
+      size_(other.size_),
+      mapped_(other.mapped_),
+      keepAlive_(std::move(other.keepAlive_)) {
+  other.devicePtr_ = 0;
+  other.size_ = 0;
+  other.mapped_ = false;
+}
+
+CuMemMapping& CuMemMapping::operator=(CuMemMapping&& other) noexcept {
+  if (this != &other) {
+    cleanup();
+    devicePtr_ = other.devicePtr_;
+    size_ = other.size_;
+    mapped_ = other.mapped_;
+    keepAlive_ = std::move(other.keepAlive_);
+    other.devicePtr_ = 0;
+    other.size_ = 0;
+    other.mapped_ = false;
+  }
+  return *this;
+}
+
+void CuMemMapping::cleanup() noexcept {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (devicePtr_ == 0) {
+    return;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return;
+  }
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    return;
+  }
+
+  if (mapped_) {
+    pfn_cuMemUnmap(devicePtr_, size_);
+    mapped_ = false;
+  }
+  pfn_cuMemAddressFree(devicePtr_, size_);
+  devicePtr_ = 0;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMemMapping.h
+++ b/comms/prims/memory/CuMemMapping.h
@@ -1,0 +1,87 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD the
+// concrete VMM driver-API calls are unavailable and the impl bodies throw;
+// `CuMemAllocation.h` declares the matching AMD stub typedefs for `CUdevice`
+// etc., which this header reuses transitively.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <memory>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+
+namespace comms::prims {
+
+class CuMemAllocation;
+
+// RAII virtual-address mapping over a physical / multicast allocation.
+//
+// Runs the standard reserve/map/setAccess sequence used by both per-rank
+// backing allocations (CuMemAllocation) and multicast objects
+// (CuMulticastAllocation):
+//
+//   cuMemAddressReserve -> virtual address
+//   cuMemMap            -> bind handle to virtual address
+//   cuMemSetAccess      -> RW from the allocation's device
+//
+// The mapping does NOT release the handle: destruction only tears down the VA
+// (cuMemUnmap + cuMemAddressFree). It DOES co-own the allocation that produced
+// the handle, via a type-erased std::shared_ptr<void> keepAlive_, so the
+// physical / multicast handle stays alive at least as long as this VA mapping.
+// Drop order is correct: ~CuMemMapping unmaps/frees the VA first, then the
+// keepAlive_ shared_ptr drops (releasing the handle only after the VA is gone).
+//
+// Construct via overAllocation() / overMulticast(). Movable so peer mappings
+// can live in a std::vector. Not copyable. Requires CUDA 12.3+; the factories
+// throw on older toolkits.
+class CuMemMapping {
+ public:
+  // Map `alloc`'s physical handle into a fresh VA of `size` bytes aligned to
+  // `granularity`, granting RW access on the allocation's device. The returned
+  // mapping co-owns `alloc`.
+  static CuMemMapping overAllocation(
+      std::shared_ptr<CuMemAllocation> alloc,
+      std::size_t size,
+      std::size_t granularity);
+
+  ~CuMemMapping();
+
+  CuMemMapping(CuMemMapping&& other) noexcept;
+  CuMemMapping& operator=(CuMemMapping&& other) noexcept;
+
+  CuMemMapping(const CuMemMapping&) = delete;
+  CuMemMapping& operator=(const CuMemMapping&) = delete;
+
+  CUdeviceptr devicePtr() const {
+    return devicePtr_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+ private:
+  CuMemMapping(
+      CUdevice cuDev,
+      CUmemGenericAllocationHandle handle,
+      std::size_t size,
+      std::size_t granularity,
+      std::shared_ptr<void> keepAlive);
+
+  void cleanup() noexcept;
+
+  CUdeviceptr devicePtr_{0};
+  std::size_t size_{0};
+  bool mapped_{false};
+  std::shared_ptr<void> keepAlive_;
+};
+
+} // namespace comms::prims

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -16,6 +16,7 @@
 #include "comms/prims/core/Checks.h"
 
 #include <glog/logging.h>
+
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -162,10 +163,23 @@ bool GpuMemHandler::isFabricHandleSupported() {
 }
 
 MemSharingMode GpuMemHandler::detectBestMode() {
-  if (isFabricHandleSupported()) {
-    return MemSharingMode::kFabric;
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  return MemSharingMode::kCudaIpc;
+#else
+  int cudaDev = 0;
+  if (cudaGetDevice(&cudaDev) != cudaSuccess) {
+    return MemSharingMode::kCudaIpc;
+  }
+  switch (selectShareableHandleType(cudaDev)) {
+    case ShareableHandleType::kFabric:
+      return MemSharingMode::kFabric;
+    case ShareableHandleType::kPosixFd:
+      return MemSharingMode::kPosixFd;
+    case ShareableHandleType::kUnsupported:
+      break;
   }
   return MemSharingMode::kCudaIpc;
+#endif
 }
 
 GpuMemHandler::GpuMemHandler(
@@ -273,14 +287,14 @@ const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
 }
 
 // ============================================================================
-// VMM Mode Implementation (kFabric)
+// VMM Mode Implementation (kFabric / kPosixFd)
 // ============================================================================
 
 void GpuMemHandler::allocateVmmMemory(size_t size, std::size_t alignFloor) {
 #if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
   (void)size;
   (void)alignFloor;
-  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
+  throw std::runtime_error("VMM shareable handles require CUDA 12.3+");
 #else
   if (cuda_driver_lazy_init() != 0) {
     throw std::runtime_error("CUDA driver not available");
@@ -292,15 +306,22 @@ void GpuMemHandler::allocateVmmMemory(size_t size, std::size_t alignFloor) {
   checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
   checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
 
-  // CuMemAllocation::create allocates the physical handle requesting fabric
-  // support. The shareable-handle export is deferred to exchangeMemPtrs() so a
-  // handler used purely as a multicast backing (no P2P) does no export.
-  //
-  // create() returns unique_ptr; the implicit promotion to shared_ptr keeps
-  // exception safety -- if the control-block allocation throws, the
-  // unique_ptr's destructor releases the physical handle.
-  allocation_ = CuMemAllocation::create(
-      cuDev, size, CU_MEM_HANDLE_TYPE_FABRIC, alignFloor);
+  // Derive the requested handle-types mask directly from mode_ instead of
+  // re-probing the device attribute. mode_ already encodes the result of a
+  // full export+import+map probe (via detectBestMode() or the 6-arg ctor's
+  // isFabricHandleSupported() check), which is strictly stronger than
+  // CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED (the attribute is true
+  // on fabric-capable GPUs without IMEX, where cuMemCreate then rejects the
+  // fabric request). Always request POSIX FD so a fabric-mode handler retains
+  // POSIX FD as a fallback wire format. The shareable-handle export is
+  // deferred to exchangeMemPtrs() so a handler used purely as a multicast
+  // backing (no P2P) does no export and opens no posix-fd.
+  unsigned int mask = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  if (mode_ == MemSharingMode::kFabric) {
+    mask |= CU_MEM_HANDLE_TYPE_FABRIC;
+  }
+
+  allocation_ = CuMemAllocation::create(cuDev, size, mask, alignFloor);
   allocatedSize_ = allocation_->size();
 
   // CuMemMapping reserves and maps the unicast VA and grants access. It co-owns
@@ -312,7 +333,7 @@ void GpuMemHandler::allocateVmmMemory(size_t size, std::size_t alignFloor) {
 
 void GpuMemHandler::exchangeVmmHandles() {
 #if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
+  throw std::runtime_error("VMM shareable handles require CUDA 12.3+");
 #else
   if (cuda_driver_lazy_init() != 0) {
     throw std::runtime_error("CUDA driver not available");
@@ -330,7 +351,8 @@ void GpuMemHandler::exchangeVmmHandles() {
       cuDev,
       allocation_->handle(),
       getLocalDeviceMemPtr(),
-      allocation_->size());
+      allocation_->size(),
+      mode_ == MemSharingMode::kFabric);
 #endif
 }
 

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -14,11 +14,14 @@
 #endif
 
 #include "comms/prims/core/Checks.h"
-#include "comms/prims/memory/NvlMemExchange.h"
 
 #include <glog/logging.h>
+#include <cstddef>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace comms::prims {
 
@@ -182,44 +185,41 @@ GpuMemHandler::GpuMemHandler(
     int32_t selfRank,
     int32_t nRanks,
     size_t size,
-    MemSharingMode mode)
+    MemSharingMode mode,
+    std::size_t alignFloor)
     : bootstrap_(std::move(bootstrap)),
       selfRank_(selfRank),
       nRanks_(nRanks),
-      mode_(mode),
-      fabricPeerPtrs_(nRanks, 0),
-      fabricPeerAllocHandles_(nRanks, 0),
-      fabricPeerAllocatedSizes_(nRanks, 0),
-      cudaIpcPeerPtrs_(nRanks, nullptr) {
+      mode_(mode) {
   if (mode_ == MemSharingMode::kFabric && !isFabricHandleSupported()) {
     throw std::runtime_error(
         "Fabric handle mode requested but not supported on this system. "
         "Requires Hopper (H100) or newer GPU with CUDA 12.3+.");
   }
 
-  init(size);
+  init(size, alignFloor);
 }
 
 GpuMemHandler::~GpuMemHandler() {
-  if (mode_ == MemSharingMode::kFabric) {
-    cleanupFabric();
+  if (isVmmMode()) {
+    cleanupVmm();
   } else {
     cleanupCudaIpc();
   }
 }
 
-void GpuMemHandler::init(size_t size) {
-  if (mode_ == MemSharingMode::kFabric) {
-    allocateFabricMemory(size);
+void GpuMemHandler::init(size_t size, std::size_t alignFloor) {
+  if (isVmmMode()) {
+    allocateVmmMemory(size, alignFloor);
   } else {
     allocateCudaIpcMemory(size);
   }
 }
 
 void* GpuMemHandler::getLocalDeviceMemPtr() const {
-  if (mode_ == MemSharingMode::kFabric) {
+  if (isVmmMode()) {
     // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
-    return reinterpret_cast<void*>(fabricLocalPtr_);
+    return reinterpret_cast<void*>(unicastMapping_->devicePtr());
   } else {
     return cudaIpcLocalPtr_;
   }
@@ -236,12 +236,12 @@ void* GpuMemHandler::getPeerDeviceMemPtr(int32_t rank) const {
         "GpuMemHandler: Must call exchangeMemPtrs() before accessing peer memory");
   }
 
-  if (mode_ == MemSharingMode::kFabric) {
-    // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
-    return reinterpret_cast<void*>(fabricPeerPtrs_[rank]);
-  } else {
-    return cudaIpcPeerPtrs_[rank];
+  // The self pointer is always available (even before exchange / single-rank);
+  // peers_.peerPtrs is only populated by exchangeMemPtrs().
+  if (rank == selfRank_) {
+    return getLocalDeviceMemPtr();
   }
+  return peers_.peerPtrs[static_cast<std::size_t>(rank)];
 }
 
 void GpuMemHandler::exchangeMemPtrs() {
@@ -255,8 +255,8 @@ void GpuMemHandler::exchangeMemPtrs() {
     return;
   }
 
-  if (mode_ == MemSharingMode::kFabric) {
-    exchangeFabricHandles();
+  if (isVmmMode()) {
+    exchangeVmmHandles();
   } else {
     exchangeCudaIpcHandles();
   }
@@ -265,20 +265,22 @@ void GpuMemHandler::exchangeMemPtrs() {
 }
 
 const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
-  if (mode_ == MemSharingMode::kFabric) {
+  if (isVmmMode()) {
     throw std::runtime_error(
-        "GpuMemHandler::getLocalIpcHandle: not available in kFabric mode");
+        "GpuMemHandler::getLocalIpcHandle: not available in VMM (fabric/posix-fd) mode");
   }
   return cudaIpcLocalHandle_;
 }
 
 // ============================================================================
-// Fabric Mode Implementation
+// VMM Mode Implementation (kFabric)
 // ============================================================================
 
-void GpuMemHandler::allocateFabricMemory(size_t size) {
+void GpuMemHandler::allocateVmmMemory(size_t size, std::size_t alignFloor) {
 #if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+  (void)size;
+  (void)alignFloor;
+  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
 #else
   if (cuda_driver_lazy_init() != 0) {
     throw std::runtime_error("CUDA driver not available");
@@ -290,120 +292,56 @@ void GpuMemHandler::allocateFabricMemory(size_t size) {
   checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
   checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
 
-  // Set up allocation properties with fabric handle support
-  CUmemAllocationProp prop = {};
-  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-  prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  prop.location.id = cuDev;
-  prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  // CuMemAllocation::create allocates the physical handle requesting fabric
+  // support. The shareable-handle export is deferred to exchangeMemPtrs() so a
+  // handler used purely as a multicast backing (no P2P) does no export.
+  //
+  // create() returns unique_ptr; the implicit promotion to shared_ptr keeps
+  // exception safety -- if the control-block allocation throws, the
+  // unique_ptr's destructor releases the physical handle.
+  allocation_ = CuMemAllocation::create(
+      cuDev, size, CU_MEM_HANDLE_TYPE_FABRIC, alignFloor);
+  allocatedSize_ = allocation_->size();
 
-  // Check for GPUDirect RDMA support
-  int rdmaSupported = 0;
-  pfn_cuDeviceGetAttribute(
-      &rdmaSupported, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED, cuDev);
-  if (rdmaSupported) {
-    prop.allocFlags.gpuDirectRDMACapable = 1;
-  }
-
-  // Get allocation granularity
-  size_t granularity = 0;
-  checkCuError(
-      pfn_cuMemGetAllocationGranularity(
-          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-      "cuMemGetAllocationGranularity failed");
-
-  // Round up size to granularity
-  allocatedSize_ = ((size + granularity - 1) / granularity) * granularity;
-
-  // Create the physical memory allocation
-  checkCuError(
-      pfn_cuMemCreate(&fabricLocalAllocHandle_, allocatedSize_, &prop, 0),
-      "cuMemCreate failed");
-
-  // Reserve virtual address space
-  checkCuError(
-      pfn_cuMemAddressReserve(
-          &fabricLocalPtr_, allocatedSize_, granularity, 0, 0),
-      "cuMemAddressReserve failed");
-
-  // Map the physical memory to virtual address
-  checkCuError(
-      pfn_cuMemMap(
-          fabricLocalPtr_, allocatedSize_, 0, fabricLocalAllocHandle_, 0),
-      "cuMemMap failed");
-
-  // Set access permissions
-  CUmemAccessDesc accessDesc = {};
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  accessDesc.location.id = cuDev;
-  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  checkCuError(
-      pfn_cuMemSetAccess(fabricLocalPtr_, allocatedSize_, &accessDesc, 1),
-      "cuMemSetAccess failed");
-
-  // Export to fabric handle for sharing with peers
-  checkCuError(
-      pfn_cuMemExportToShareableHandle(
-          &fabricLocalHandle_,
-          fabricLocalAllocHandle_,
-          CU_MEM_HANDLE_TYPE_FABRIC,
-          0),
-      "cuMemExportToShareableHandle failed");
-
-  // Store local pointer in peer array for uniform access
-  fabricPeerPtrs_[selfRank_] = fabricLocalPtr_;
-  fabricPeerAllocHandles_[selfRank_] = fabricLocalAllocHandle_;
+  // CuMemMapping reserves and maps the unicast VA and grants access. It co-owns
+  // allocation_ so the physical handle outlives the VA.
+  unicastMapping_ = std::make_unique<CuMemMapping>(CuMemMapping::overAllocation(
+      allocation_, allocation_->size(), allocation_->granularity()));
 #endif
 }
 
-void GpuMemHandler::exchangeFabricHandles() {
-  nvlMemExchangeVmm(
+void GpuMemHandler::exchangeVmmHandles() {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  throw std::runtime_error("VMM fabric handles require CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error("CUDA driver not available");
+  }
+
+  int cudaDev = 0;
+  CUdevice cuDev;
+  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
+
+  peers_ = nvlMemExchangeVmm(
       *bootstrap_,
       selfRank_,
       nRanks_,
-      fabricLocalHandle_,
-      allocatedSize_,
-      fabricPeerPtrs_,
-      fabricPeerAllocHandles_,
-      fabricPeerAllocatedSizes_);
+      cuDev,
+      allocation_->handle(),
+      getLocalDeviceMemPtr(),
+      allocation_->size());
+#endif
 }
 
-void GpuMemHandler::cleanupFabric() {
+void GpuMemHandler::cleanupVmm() {
 #if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
-  // Check if CUDA context is still valid
-  CUcontext ctx = nullptr;
-  if (pfn_cuCtxGetCurrent == nullptr ||
-      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
-    return;
-  }
-
-  // Release peer mappings
-  for (int32_t rank = 0; rank < nRanks_; ++rank) {
-    if (rank == selfRank_) {
-      continue;
-    }
-    if (fabricPeerPtrs_[rank] != 0) {
-      pfn_cuMemUnmap(fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
-      pfn_cuMemAddressFree(
-          fabricPeerPtrs_[rank], fabricPeerAllocatedSizes_[rank]);
-      fabricPeerPtrs_[rank] = 0;
-    }
-    if (fabricPeerAllocHandles_[rank] != 0) {
-      pfn_cuMemRelease(fabricPeerAllocHandles_[rank]);
-      fabricPeerAllocHandles_[rank] = 0;
-    }
-  }
-
-  // Release local allocation
-  if (fabricLocalPtr_ != 0) {
-    pfn_cuMemUnmap(fabricLocalPtr_, allocatedSize_);
-    pfn_cuMemAddressFree(fabricLocalPtr_, allocatedSize_);
-    fabricLocalPtr_ = 0;
-  }
-  if (fabricLocalAllocHandle_ != 0) {
-    pfn_cuMemRelease(fabricLocalAllocHandle_);
-    fabricLocalAllocHandle_ = 0;
-  }
+  // RAII teardown: unicast VA first, then peer VAs (each co-owns its imported
+  // allocation), then the shared physical allocation (released when the last
+  // shared_ptr owner drops).
+  unicastMapping_.reset();
+  peers_.vmmMappings.clear();
+  allocation_.reset();
 #endif
 }
 
@@ -424,35 +362,35 @@ void GpuMemHandler::allocateCudaIpcMemory(size_t size) {
   } else {
     checkCudaError(cudaMalloc(&cudaIpcLocalPtr_, size), "cudaMalloc failed");
   }
-  allocatedSize_ = size;
-
-  // Get IPC handle for local memory
+  // Cache the local IPC handle for getLocalIpcHandle(). It depends only on the
+  // local allocation, so deriving it here makes it valid before exchange too.
   checkCudaError(
       cudaIpcGetMemHandle(&cudaIpcLocalHandle_, cudaIpcLocalPtr_),
       "cudaIpcGetMemHandle failed");
-
-  // Store local pointer in peer array
-  cudaIpcPeerPtrs_[selfRank_] = cudaIpcLocalPtr_;
+  allocatedSize_ = size;
 }
 
 void GpuMemHandler::exchangeCudaIpcHandles() {
-  nvlMemExchangeCudaIpc(
-      *bootstrap_, selfRank_, nRanks_, cudaIpcLocalHandle_, cudaIpcPeerPtrs_);
+  peers_ =
+      nvlMemExchangeCudaIpc(*bootstrap_, selfRank_, nRanks_, cudaIpcLocalPtr_);
 }
 
 void GpuMemHandler::cleanupCudaIpc() {
-  // Close peer handles
+  // Close peer handles opened by cudaIpcOpenMemHandle. The self slot holds the
+  // local pointer (freed below), not an opened handle.
   for (int32_t rank = 0; rank < nRanks_; ++rank) {
     if (rank == selfRank_) {
       continue;
     }
-    if (cudaIpcPeerPtrs_[rank] != nullptr) {
-      cudaError_t err = cudaIpcCloseMemHandle(cudaIpcPeerPtrs_[rank]);
+    void* peerPtr = peers_.peerPtrs.empty()
+        ? nullptr
+        : peers_.peerPtrs[static_cast<std::size_t>(rank)];
+    if (peerPtr != nullptr) {
+      cudaError_t err = cudaIpcCloseMemHandle(peerPtr);
       if (err != cudaSuccess) {
         LOG(ERROR) << "cudaIpcCloseMemHandle failed for rank " << rank << ": "
                    << cudaGetErrorString(err);
       }
-      cudaIpcPeerPtrs_[rank] = nullptr;
     }
   }
 

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -20,7 +20,11 @@
 #include <cuda_runtime.h>
 #endif
 
+#include <memory>
+
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
 #include "comms/prims/memory/NvlMemExchange.h"
 
 namespace comms::prims {
@@ -110,6 +114,12 @@ class GpuMemHandler {
    * @param nRanks Total number of ranks
    * @param size Size of memory to allocate
    * @param mode Explicitly select fabric or cudaIpc mode
+   * @param alignFloor Optional minimum allocation alignment/size floor. Must be
+   * 0 (no floor) or a power of two. In a VMM mode it raises the physical
+   * allocation's granularity/size floor so the allocation can satisfy a larger
+   * granularity requirement (e.g. so it can later be bound into a multicast
+   * object - see MultimemHandler::backingGranularity()). Ignored in cudaIpc
+   * mode.
    *
    * @throws std::runtime_error if requested mode is not supported or allocation
    * fails
@@ -119,7 +129,8 @@ class GpuMemHandler {
       int32_t selfRank,
       int32_t nRanks,
       size_t size,
-      MemSharingMode mode);
+      MemSharingMode mode,
+      std::size_t alignFloor = 0);
 
   ~GpuMemHandler();
 
@@ -164,7 +175,7 @@ class GpuMemHandler {
    * Get the local IPC handle (cudaIpc / hipIpc). Only valid in `kCudaIpc` /
    * `kCudaIpcUncached` mode.
    *
-   * @throws std::runtime_error when mode is `kFabric`.
+   * @throws std::runtime_error when called in a VMM (fabric / posix-fd) mode.
    */
   const cudaIpcMemHandle_t& getLocalIpcHandle() const;
 
@@ -184,6 +195,17 @@ class GpuMemHandler {
   }
 
   /**
+   * Returns this handler's shared physical VMM allocation in the kFabric mode,
+   * or nullptr in cudaIpc mode (cudaMalloc has no VMM handle). The allocation
+   * is co-owned via shared_ptr; the multicast overlay (exchangeMulticast) binds
+   * the same allocation so the unicast and multicast views share one physical
+   * backing. Valid after construction.
+   */
+  std::shared_ptr<CuMemAllocation> allocation() const {
+    return allocation_;
+  }
+
+  /**
    * Check if the current GPU supports fabric handles.
    *
    * @return true if Hopper+ GPU with CUDA 12.3+ and fabric support enabled
@@ -196,17 +218,25 @@ class GpuMemHandler {
   static MemSharingMode detectBestMode();
 
  private:
-  void init(size_t size);
+  void init(size_t size, std::size_t alignFloor);
 
-  // Fabric mode methods
-  void allocateFabricMemory(size_t size);
-  void exchangeFabricHandles();
-  void cleanupFabric();
+  // VMM (fabric) mode methods. The physical allocation is owned by a
+  // CuMemAllocation co-owned via shared_ptr; the unicast VA is a CuMemMapping;
+  // the peer exchange is delegated to NvlMemExchange.
+  void allocateVmmMemory(size_t size, std::size_t alignFloor);
+  void exchangeVmmHandles();
+  void cleanupVmm();
 
   // CudaIpc mode methods
   void allocateCudaIpcMemory(size_t size);
   void exchangeCudaIpcHandles();
   void cleanupCudaIpc();
+
+  // True for the VMM-backed mode (kFabric), which uses the NvlMemExchange-based
+  // code path. False for kCudaIpc.
+  bool isVmmMode() const {
+    return mode_ == MemSharingMode::kFabric;
+  }
 
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
   const int32_t selfRank_{-1};
@@ -217,18 +247,20 @@ class GpuMemHandler {
   size_t allocatedSize_{0};
   bool exchanged_{false};
 
-  // ---- Fabric mode state ----
-  CUdeviceptr fabricLocalPtr_{0};
-  CUmemGenericAllocationHandle fabricLocalAllocHandle_{0};
-  FabricHandle fabricLocalHandle_{};
-  std::vector<CUdeviceptr> fabricPeerPtrs_;
-  std::vector<CUmemGenericAllocationHandle> fabricPeerAllocHandles_;
-  std::vector<size_t> fabricPeerAllocatedSizes_;
+  // ---- VMM mode state (kFabric) ----
+  // The local physical allocation (co-owned via shared_ptr so a multicast
+  // overlay can share it) and its unicast VA mapping (which also co-owns the
+  // allocation via keepAlive).
+  std::shared_ptr<CuMemAllocation> allocation_;
+  std::unique_ptr<CuMemMapping> unicastMapping_;
+  // Peer mappings + pointers, produced by nvlMemExchange during
+  // exchangeMemPtrs(). For VMM mode the peer mappings co-own their imported
+  // allocations; for cudaIpc only the peer pointers (owned by the IPC runtime).
+  NvlPeerMem peers_;
 
   // ---- CudaIpc mode state ----
   void* cudaIpcLocalPtr_{nullptr};
   cudaIpcMemHandle_t cudaIpcLocalHandle_{};
-  std::vector<void*> cudaIpcPeerPtrs_;
 };
 
 // Backwards compatibility alias

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -38,6 +38,13 @@ enum class MemSharingMode {
   // Supports: Multi-node NVLink (GB200 NVL72)
   kFabric,
 
+  // Use CUDA VMM allocations shared via POSIX file descriptors
+  // (CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR).
+  // Requires: CUDA 12.3+ VMM support.
+  // Limitation: Intra-node only (descriptors are duplicated via pidfd_getfd).
+  // Used for single-host H100 NVLink where fabric handles are unavailable.
+  kPosixFd,
+
   // Use cudaIpcMemHandle_t
   // Works on: All CUDA GPUs
   // Limitation: Intra-node only
@@ -195,11 +202,11 @@ class GpuMemHandler {
   }
 
   /**
-   * Returns this handler's shared physical VMM allocation in the kFabric mode,
-   * or nullptr in cudaIpc mode (cudaMalloc has no VMM handle). The allocation
-   * is co-owned via shared_ptr; the multicast overlay (exchangeMulticast) binds
-   * the same allocation so the unicast and multicast views share one physical
-   * backing. Valid after construction.
+   * Returns this handler's shared physical VMM allocation in a VMM-backed mode
+   * (kFabric or kPosixFd), or nullptr in cudaIpc mode (cudaMalloc has no VMM
+   * handle). The allocation is co-owned via shared_ptr; the multicast overlay
+   * (exchangeMulticast) binds the same allocation so the unicast and multicast
+   * views share one physical backing. Valid after construction.
    */
   std::shared_ptr<CuMemAllocation> allocation() const {
     return allocation_;
@@ -220,9 +227,9 @@ class GpuMemHandler {
  private:
   void init(size_t size, std::size_t alignFloor);
 
-  // VMM (fabric) mode methods. The physical allocation is owned by a
-  // CuMemAllocation co-owned via shared_ptr; the unicast VA is a CuMemMapping;
-  // the peer exchange is delegated to NvlMemExchange.
+  // VMM mode methods (shared by kFabric and kPosixFd). The physical allocation
+  // requests both handle types when the device allows it; the actual exported
+  // shareable-handle type is chosen at exchange time via supportsFabric().
   void allocateVmmMemory(size_t size, std::size_t alignFloor);
   void exchangeVmmHandles();
   void cleanupVmm();
@@ -232,10 +239,11 @@ class GpuMemHandler {
   void exchangeCudaIpcHandles();
   void cleanupCudaIpc();
 
-  // True for the VMM-backed mode (kFabric), which uses the NvlMemExchange-based
-  // code path. False for kCudaIpc.
+  // True for the VMM-backed modes (kFabric / kPosixFd), which share the same
+  // NvlMemExchange-based code path. False for kCudaIpc.
   bool isVmmMode() const {
-    return mode_ == MemSharingMode::kFabric;
+    return mode_ == MemSharingMode::kFabric ||
+        mode_ == MemSharingMode::kPosixFd;
   }
 
   std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
@@ -247,14 +255,15 @@ class GpuMemHandler {
   size_t allocatedSize_{0};
   bool exchanged_{false};
 
-  // ---- VMM mode state (kFabric) ----
+  // ---- VMM mode state (kFabric / kPosixFd) ----
   // The local physical allocation (co-owned via shared_ptr so a multicast
   // overlay can share it) and its unicast VA mapping (which also co-owns the
-  // allocation via keepAlive).
+  // allocation via keepAlive). The actual exported shareable-handle type is
+  // chosen at exchange time via allocation_->supportsFabric().
   std::shared_ptr<CuMemAllocation> allocation_;
   std::unique_ptr<CuMemMapping> unicastMapping_;
   // Peer mappings + pointers, produced by nvlMemExchange during
-  // exchangeMemPtrs(). For VMM mode the peer mappings co-own their imported
+  // exchangeMemPtrs(). For VMM modes the peer mappings co-own their imported
   // allocations; for cudaIpc only the peer pointers (owned by the IPC runtime).
   NvlPeerMem peers_;
 

--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -3,196 +3,165 @@
 #include "comms/prims/memory/NvlMemExchange.h"
 
 #include "comms/prims/core/Checks.h"
-
-#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/platform/CudaDriverLazy.h"
-#endif
 
+#include <cstddef>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace comms::prims {
 
 namespace {
 
-// Import + map one peer's fabric memory into a fresh local virtual address with
-// RW access. Writes the imported handle and mapped pointer into the per-rank
-// output vectors at index `rank`. Caller (nvlMemExchangeVmm) pre-sizes both
-// output vectors to `nRanks` and bounds-checks at the public entry point;
-// `.at()` is used at the write sites as a second proof of bounds for the
-// clang-tidy ParameterUncheckedArrayBounds checker.
-void importFabricPeerMemory(
+// Import one peer's fabric handle, wrap it in a co-ownable CuMemAllocation, map
+// it into a fresh peer VA, and record the mapping + pointer in `result`. The
+// imported handle is owned by the CuMemAllocation that the peer VA mapping
+// co-owns, so dropping the mapping releases the handle -- no separate handle
+// bookkeeping.
+void importAndMapPeerMemory(
     int32_t rank,
     const FabricHandle& handle,
     std::size_t peerAllocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+    CUdevice cuDev,
+    NvlPeerMem& result) {
+#if CUDART_VERSION < 12030
   (void)rank;
   (void)handle;
   (void)peerAllocatedSize;
-  (void)peerPtrs;
-  (void)peerAllocHandles;
+  (void)cuDev;
+  (void)result;
   throw std::runtime_error("Fabric handles require CUDA 12.3+");
 #else
-  if (cuda_driver_lazy_init() != 0) {
-    throw std::runtime_error("CUDA driver not available");
-  }
-
-  int cudaDev = 0;
-  CUdevice cuDev;
-
-  checkCudaError(cudaGetDevice(&cudaDev), "cudaGetDevice failed");
-  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDev), "cuDeviceGet failed");
-
-  // Import the fabric handle to get allocation handle
+  CUmemGenericAllocationHandle peerHandle = 0;
   checkCuError(
       pfn_cuMemImportFromShareableHandle(
-          &peerAllocHandles.at(rank),
+          &peerHandle,
           const_cast<void*>(static_cast<const void*>(&handle)),
           CU_MEM_HANDLE_TYPE_FABRIC),
       "cuMemImportFromShareableHandle failed");
 
-  // Get allocation properties for granularity
-  CUmemAllocationProp prop = {};
-  checkCuError(
-      pfn_cuMemGetAllocationPropertiesFromHandle(
-          &prop, peerAllocHandles.at(rank)),
-      "cuMemGetAllocationPropertiesFromHandle failed");
+  // CuMemAllocation::adopt() takes ownership of `peerHandle` on entry: on
+  // internal failure (CUDA query, allocator bad_alloc) it releases the handle
+  // and rethrows, so there is no raw-handle window for the caller to guard.
+  // The returned unique_ptr promotes implicitly to shared_ptr for
+  // CuMemMapping::overAllocation's keep-alive contract.
+  std::shared_ptr<CuMemAllocation> peerAlloc =
+      CuMemAllocation::adopt(peerHandle, cuDev, peerAllocatedSize);
+  const std::size_t granularity = peerAlloc->granularity();
 
-  std::size_t granularity = 0;
-  checkCuError(
-      pfn_cuMemGetAllocationGranularity(
-          &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-      "cuMemGetAllocationGranularity failed");
-
-  // Reserve virtual address space for peer memory
-  checkCuError(
-      pfn_cuMemAddressReserve(
-          &peerPtrs.at(rank), peerAllocatedSize, granularity, 0, 0),
-      "cuMemAddressReserve for peer failed");
-
-  // Map peer's physical memory to our virtual address
-  checkCuError(
-      pfn_cuMemMap(
-          peerPtrs.at(rank),
-          peerAllocatedSize,
-          0,
-          peerAllocHandles.at(rank),
-          0),
-      "cuMemMap for peer failed");
-
-  // Set access permissions for peer memory
-  CUmemAccessDesc accessDesc = {};
-  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-  accessDesc.location.id = cuDev;
-  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-  checkCuError(
-      pfn_cuMemSetAccess(peerPtrs.at(rank), peerAllocatedSize, &accessDesc, 1),
-      "cuMemSetAccess for peer failed");
+  result.vmmMappings.push_back(
+      CuMemMapping::overAllocation(
+          std::move(peerAlloc), peerAllocatedSize, granularity));
+  result.peerPtrs.at(static_cast<std::size_t>(rank)) =
+      // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer
+      reinterpret_cast<void*>(result.vmmMappings.back().devicePtr());
 #endif
 }
 
 } // namespace
 
-void nvlMemExchangeVmm(
+NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const FabricHandle& localHandle,
-    std::size_t allocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
-    std::vector<std::size_t>& peerAllocatedSizes) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle localHandle,
+    void* localPtr,
+    std::size_t allocatedSize) {
+  NvlPeerMem result;
+  result.peerPtrs.assign(static_cast<std::size_t>(nRanks), nullptr);
+  result.peerPtrs[static_cast<std::size_t>(rank)] = localPtr;
+
+#if CUDART_VERSION < 12030
   (void)bootstrap;
-  (void)selfRank;
-  (void)nRanks;
+  (void)cuDev;
   (void)localHandle;
   (void)allocatedSize;
-  (void)peerPtrs;
-  (void)peerAllocHandles;
-  (void)peerAllocatedSizes;
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+  throw std::runtime_error("nvlMemExchangeVmm requires CUDA 12.3+");
 #else
-  if (static_cast<std::size_t>(nRanks) > peerPtrs.size() ||
-      static_cast<std::size_t>(nRanks) > peerAllocHandles.size() ||
-      static_cast<std::size_t>(nRanks) > peerAllocatedSizes.size()) {
-    throw std::runtime_error(
-        "nvlMemExchangeVmm: output vectors must each have size >= nRanks");
-  }
+  // Export the local handle once as a fabric handle.
+  FabricHandle localFabric{};
+  checkCuError(
+      pfn_cuMemExportToShareableHandle(
+          &localFabric, localHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0),
+      "cuMemExportToShareableHandle for fabric handle failed");
 
-  // Prepare data for allGather: fabric handle + allocation size
   struct ExchangeData {
-    FabricHandle handle;
-    std::size_t allocatedSize;
+    FabricHandle handle{};
+    std::size_t allocatedSize{};
   };
 
-  std::vector<ExchangeData> allData(nRanks);
-  allData[selfRank].handle = localHandle;
-  allData[selfRank].allocatedSize = allocatedSize;
+  std::vector<ExchangeData> allData(static_cast<std::size_t>(nRanks));
+  allData[static_cast<std::size_t>(rank)].handle = localFabric;
+  allData[static_cast<std::size_t>(rank)].allocatedSize = allocatedSize;
 
-  // Exchange fabric handles with all ranks
-  auto result =
-      bootstrap
-          .allGather(allData.data(), sizeof(ExchangeData), selfRank, nRanks)
+  auto gatherResult =
+      bootstrap.allGather(allData.data(), sizeof(ExchangeData), rank, nRanks)
           .get();
-  if (result != 0) {
+  if (gatherResult != 0) {
     throw std::runtime_error("nvlMemExchangeVmm allGather failed");
   }
 
-  // Import peer memory from received fabric handles
-  for (int32_t rank = 0; rank < nRanks; ++rank) {
-    if (rank == selfRank) {
+  for (int32_t peer = 0; peer < nRanks; ++peer) {
+    if (peer == rank) {
       continue;
     }
-    peerAllocatedSizes.at(rank) = allData[rank].allocatedSize;
-    importFabricPeerMemory(
-        rank,
-        allData[rank].handle,
-        allData[rank].allocatedSize,
-        peerPtrs,
-        peerAllocHandles);
+    const auto peerIdx = static_cast<std::size_t>(peer);
+    importAndMapPeerMemory(
+        peer,
+        allData[peerIdx].handle,
+        allData[peerIdx].allocatedSize,
+        cuDev,
+        result);
   }
+
+  return result;
 #endif
 }
 
-void nvlMemExchangeCudaIpc(
+NvlPeerMem nvlMemExchangeCudaIpc(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const cudaIpcMemHandle_t& localHandle,
-    std::vector<void*>& peerPtrs) {
-  if (static_cast<std::size_t>(nRanks) > peerPtrs.size()) {
-    throw std::runtime_error(
-        "nvlMemExchangeCudaIpc: peerPtrs must have size >= nRanks");
-  }
+    void* localPtr) {
+  NvlPeerMem result;
+  result.peerPtrs.assign(static_cast<std::size_t>(nRanks), nullptr);
+  result.peerPtrs[static_cast<std::size_t>(rank)] = localPtr;
 
-  // Exchange IPC handles with all ranks
-  std::vector<cudaIpcMemHandle_t> allHandles(nRanks);
-  allHandles[selfRank] = localHandle;
+  cudaIpcMemHandle_t localHandle{};
+  checkCudaError(
+      cudaIpcGetMemHandle(&localHandle, localPtr),
+      "cudaIpcGetMemHandle failed");
 
-  auto result =
+  std::vector<cudaIpcMemHandle_t> allHandles(static_cast<std::size_t>(nRanks));
+  allHandles[static_cast<std::size_t>(rank)] = localHandle;
+
+  auto gatherResult =
       bootstrap
           .allGather(
-              allHandles.data(), sizeof(cudaIpcMemHandle_t), selfRank, nRanks)
+              allHandles.data(), sizeof(cudaIpcMemHandle_t), rank, nRanks)
           .get();
-  if (result != 0) {
+  if (gatherResult != 0) {
     throw std::runtime_error("nvlMemExchangeCudaIpc allGather failed");
   }
 
-  // Open peer memory handles
-  for (int32_t rank = 0; rank < nRanks; ++rank) {
-    if (rank == selfRank) {
+  for (int32_t peer = 0; peer < nRanks; ++peer) {
+    if (peer == rank) {
       continue;
     }
+    const auto peerIdx = static_cast<std::size_t>(peer);
     checkCudaError(
         cudaIpcOpenMemHandle(
-            &peerPtrs.at(rank),
-            allHandles[rank],
+            &result.peerPtrs[peerIdx],
+            allHandles[peerIdx],
             cudaIpcMemLazyEnablePeerAccess),
         "cudaIpcOpenMemHandle failed");
   }
+
+  return result;
 }
 
 } // namespace comms::prims

--- a/comms/prims/memory/NvlMemExchange.cc
+++ b/comms/prims/memory/NvlMemExchange.cc
@@ -2,66 +2,455 @@
 
 #include "comms/prims/memory/NvlMemExchange.h"
 
+#include "comms/common/BitOps.cuh"
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/platform/CudaDriverLazy.h"
 
+#include <glog/logging.h>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <system_error>
 #include <utility>
-#include <vector>
+
+#include <sys/syscall.h>
+#include <unistd.h>
 
 namespace comms::prims {
 
 namespace {
 
-// Import one peer's fabric handle, wrap it in a co-ownable CuMemAllocation, map
-// it into a fresh peer VA, and record the mapping + pointer in `result`. The
-// imported handle is owned by the CuMemAllocation that the peer VA mapping
-// co-owns, so dropping the mapping releases the handle -- no separate handle
-// bookkeeping.
+// RAII guard for an owned POSIX file descriptor. ::close()s on scope exit
+// (and only on scope exit -- no detach escape hatch; copy + move are deleted
+// so the fd cannot escape this scope). Used for the local POSIX-FD shareable
+// handle that nvlMemExchangeVmm exports before allGather: keeps the fd closed
+// on every exit path (success, allGather throw, import throw, barrier throw)
+// without the try/catch boilerplate. C++ has no std::scope_exit — P0052 /
+// <experimental/scope> never landed — so we roll a 5-line guard rather than
+// reach for folly (comms/prims is zero-folly).
+class FdGuard {
+ public:
+  explicit FdGuard(int fd) : fd_(fd) {}
+  ~FdGuard() {
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
+  }
+  FdGuard(const FdGuard&) = delete;
+  FdGuard& operator=(const FdGuard&) = delete;
+  FdGuard(FdGuard&&) = delete;
+  FdGuard& operator=(FdGuard&&) = delete;
+
+ private:
+  int fd_{-1};
+};
+
+// pidfd_open / pidfd_getfd are available in glibc 2.36+ but the syscall numbers
+// are defined in <sys/syscall.h>. Hardcoding fallbacks here is unsafe on archs
+// where the numbers differ (e.g. mips, riscv); fail at compile time instead so
+// we never silently issue the wrong syscall.
+#if !defined(SYS_pidfd_open) || !defined(SYS_pidfd_getfd)
+#error \
+    "SYS_pidfd_open / SYS_pidfd_getfd not defined for this architecture; NvlMemExchange POSIX-FD import requires Linux 5.6+ and glibc with the syscall numbers exposed."
+#endif
+
+constexpr std::size_t kTrialAllocSize = 2 * 1024 * 1024;
+
+std::string errnoMessage(int err) {
+  return std::error_code(err, std::generic_category()).message();
+}
+
+void* posixFdShareableHandle(int fd) {
+  // CUDA's driver API encodes POSIX FD shareable handles in a `void*`.
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  return reinterpret_cast<void*>(static_cast<uintptr_t>(fd));
+}
+
+int duplicateRemoteFd(pid_t pid, int fd) {
+  const int pidfd = static_cast<int>(syscall(SYS_pidfd_open, pid, 0));
+  if (pidfd < 0) {
+    throw std::runtime_error(
+        "pidfd_open failed for POSIX FD import: " + errnoMessage(errno));
+  }
+
+  const int importedFd =
+      static_cast<int>(syscall(SYS_pidfd_getfd, pidfd, fd, 0));
+  const int savedErrno = errno;
+  close(pidfd);
+  if (importedFd < 0) {
+    throw std::runtime_error(
+        "pidfd_getfd failed for POSIX FD import: " + errnoMessage(savedErrno));
+  }
+  return importedFd;
+}
+
+#if CUDART_VERSION >= 12030
+// Trial map + setAccess on the just-created allocation. Mirrors the legacy
+// checkFabricHandleSupportedImpl probe so a device where create / export /
+// import succeed but VA reservation / mapping / access setup fails (e.g.
+// constrained VA space, IMEX/access policy issues) is classified as
+// unsupported up front, instead of failing later in nvlMemExchangeVmm /
+// importAndMapPeerMemory. Returns true if the full reserve+map+setAccess
+// chain succeeds; cleans up everything it touched on either outcome.
+bool trialMapAndSetAccess(
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle handle,
+    std::size_t allocSize,
+    std::size_t granularity) {
+  CUdeviceptr ptr = 0;
+  auto err = pfn_cuMemAddressReserve(&ptr, allocSize, granularity, 0, 0);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+  err = pfn_cuMemMap(ptr, allocSize, 0, handle, 0);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemAddressFree(ptr, allocSize);
+    return false;
+  }
+  CUmemAccessDesc accessDesc = {};
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+  accessDesc.location.id = cuDev;
+  accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+  err = pfn_cuMemSetAccess(ptr, allocSize, &accessDesc, 1);
+  pfn_cuMemUnmap(ptr, allocSize);
+  pfn_cuMemAddressFree(ptr, allocSize);
+  return err == CUDA_SUCCESS;
+}
+#endif
+
+bool fabricHandleSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int fabricSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &fabricSupported,
+      CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+      cuDev);
+  if (err != CUDA_SUCCESS || fabricSupported == 0) {
+    return false;
+  }
+
+  auto prop = makeVmmAllocationProp(cuDev, CU_MEM_HANDLE_TYPE_FABRIC);
+  std::size_t granularity = 0;
+  err = pfn_cuMemGetAllocationGranularity(
+      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  const std::size_t allocSize =
+      comms::bitops::roundUp(kTrialAllocSize, granularity);
+  CUmemGenericAllocationHandle handle = 0;
+  err = pfn_cuMemCreate(&handle, allocSize, &prop, 0);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  FabricHandle fabricHandle = {};
+  err = pfn_cuMemExportToShareableHandle(
+      &fabricHandle, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  CUmemGenericAllocationHandle importedHandle = 0;
+  err = pfn_cuMemImportFromShareableHandle(
+      &importedHandle, &fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  const bool mapOk =
+      trialMapAndSetAccess(cuDev, handle, allocSize, granularity);
+  pfn_cuMemRelease(importedHandle);
+  pfn_cuMemRelease(handle);
+  return mapOk;
+#endif
+}
+
+// Probe whether the runtime sandbox permits the pidfd_open + pidfd_getfd pair
+// that duplicateRemoteFd uses to import a peer's POSIX FD. seccomp policies,
+// older kernels, or container restrictions can block these syscalls even when
+// CUDA's POSIX-FD export/import + map round-trip succeeds; without this check
+// selectShareableHandleType would return kPosixFd and the failure would only
+// surface at exchange time as a thrown runtime_error with no fallback. Probes
+// against the current process (self pidfd_getfd on a real fd) so we exercise
+// the exact syscalls duplicateRemoteFd issues at exchange time.
+bool pidfdGetfdSupported(int fd) {
+  const int pidfd = static_cast<int>(syscall(SYS_pidfd_open, getpid(), 0));
+  if (pidfd < 0) {
+    return false;
+  }
+  const int dupedFd = static_cast<int>(syscall(SYS_pidfd_getfd, pidfd, fd, 0));
+  close(pidfd);
+  if (dupedFd < 0) {
+    return false;
+  }
+  close(dupedFd);
+  return true;
+}
+
+bool posixFdHandleSupported(CUdevice cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  auto prop =
+      makeVmmAllocationProp(cuDev, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  std::size_t granularity = 0;
+  auto err = pfn_cuMemGetAllocationGranularity(
+      &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  const std::size_t allocSize =
+      comms::bitops::roundUp(kTrialAllocSize, granularity);
+  CUmemGenericAllocationHandle handle = 0;
+  err = pfn_cuMemCreate(&handle, allocSize, &prop, 0);
+  if (err != CUDA_SUCCESS) {
+    return false;
+  }
+
+  int fd = -1;
+  err = pfn_cuMemExportToShareableHandle(
+      &fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  // Probe pidfd_open + pidfd_getfd against ourselves while the exported fd is
+  // still open. Mirrors duplicateRemoteFd's two-syscall pair so the capability
+  // check matches what the cross-process exchange will actually do.
+  if (!pidfdGetfdSupported(fd)) {
+    close(fd);
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  CUmemGenericAllocationHandle importedHandle = 0;
+  err = pfn_cuMemImportFromShareableHandle(
+      &importedHandle,
+      posixFdShareableHandle(fd),
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  close(fd);
+  if (err != CUDA_SUCCESS) {
+    pfn_cuMemRelease(handle);
+    return false;
+  }
+
+  const bool mapOk =
+      trialMapAndSetAccess(cuDev, handle, allocSize, granularity);
+  pfn_cuMemRelease(importedHandle);
+  pfn_cuMemRelease(handle);
+  return mapOk;
+#endif
+}
+
+// Import one peer's shareable handle (duplicates the peer fd internally for
+// POSIX FD), wrap it in a co-ownable CuMemAllocation, map it into a fresh peer
+// VA, and record the mapping + pointer in `result`. The imported handle is
+// owned by the CuMemAllocation that the peer VA mapping co-owns, so dropping
+// the mapping releases the handle -- no separate handle bookkeeping. cuMem
+// granularity for the mapping is queried from the imported handle's properties.
 void importAndMapPeerMemory(
-    int32_t rank,
-    const FabricHandle& handle,
+    int32_t peer,
+    const ShareableHandle& handle,
     std::size_t peerAllocatedSize,
     CUdevice cuDev,
     NvlPeerMem& result) {
 #if CUDART_VERSION < 12030
-  (void)rank;
+  (void)peer;
   (void)handle;
   (void)peerAllocatedSize;
   (void)cuDev;
   (void)result;
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
+  throw std::runtime_error("nvlMemExchangeVmm requires CUDA 12.3+");
 #else
-  CUmemGenericAllocationHandle peerHandle = 0;
-  checkCuError(
-      pfn_cuMemImportFromShareableHandle(
-          &peerHandle,
-          const_cast<void*>(static_cast<const void*>(&handle)),
-          CU_MEM_HANDLE_TYPE_FABRIC),
-      "cuMemImportFromShareableHandle failed");
-
-  // CuMemAllocation::adopt() takes ownership of `peerHandle` on entry: on
-  // internal failure (CUDA query, allocator bad_alloc) it releases the handle
-  // and rethrows, so there is no raw-handle window for the caller to guard.
-  // The returned unique_ptr promotes implicitly to shared_ptr for
+  // CuMemAllocation::adopt() takes ownership of the imported handle on entry:
+  // on internal failure (CUDA query, allocator bad_alloc) it releases the
+  // handle and rethrows, so there is no raw-handle window for the caller to
+  // guard. The returned unique_ptr promotes implicitly to shared_ptr for
   // CuMemMapping::overAllocation's keep-alive contract.
-  std::shared_ptr<CuMemAllocation> peerAlloc =
-      CuMemAllocation::adopt(peerHandle, cuDev, peerAllocatedSize);
+  std::shared_ptr<CuMemAllocation> peerAlloc = CuMemAllocation::adopt(
+      importShareableHandle(handle), cuDev, peerAllocatedSize);
   const std::size_t granularity = peerAlloc->granularity();
 
   result.vmmMappings.push_back(
       CuMemMapping::overAllocation(
           std::move(peerAlloc), peerAllocatedSize, granularity));
-  result.peerPtrs.at(static_cast<std::size_t>(rank)) =
+  result.peerPtrs.at(static_cast<std::size_t>(peer)) =
       // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer
       reinterpret_cast<void*>(result.vmmMappings.back().devicePtr());
 #endif
 }
 
 } // namespace
+
+CUmemAllocationHandleType toCudaHandleType(ShareableHandleType type) {
+#if CUDART_VERSION < 12030
+  (void)type;
+  throw std::runtime_error("NvlMemExchange requires CUDA 12.3+");
+#else
+  switch (type) {
+    case ShareableHandleType::kFabric:
+      return CU_MEM_HANDLE_TYPE_FABRIC;
+    case ShareableHandleType::kPosixFd:
+      return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    case ShareableHandleType::kUnsupported:
+      break;
+  }
+  throw std::runtime_error("NvlMemExchange: unsupported handle type");
+#endif
+}
+
+namespace {
+
+// Per-device cache for selectShareableHandleType. Each probe runs full
+// cuMemCreate/export/import/map trials so re-running per handler construction
+// is expensive; cache the result per cudaDevice (matches
+// MultimemHandler::isMultimemSupported's pattern and the legacy
+// isFabricHandleSupported caching in GpuMemHandler.cc). Devices >=
+// kSelectCacheSize fall through to the uncached path; in practice we have <8.
+constexpr int kSelectCacheSize = 8;
+
+ShareableHandleType selectShareableHandleTypeUncached(int cudaDevice) {
+#if CUDART_VERSION < 12030
+  (void)cudaDevice;
+  return ShareableHandleType::kUnsupported;
+#else
+  if (cudaDevice < 0) {
+    return ShareableHandleType::kUnsupported;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return ShareableHandleType::kUnsupported;
+  }
+
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    return ShareableHandleType::kUnsupported;
+  }
+
+  if (fabricHandleSupported(cuDev)) {
+    return ShareableHandleType::kFabric;
+  }
+  if (posixFdHandleSupported(cuDev)) {
+    return ShareableHandleType::kPosixFd;
+  }
+  return ShareableHandleType::kUnsupported;
+#endif
+}
+
+} // namespace
+
+ShareableHandleType selectShareableHandleType(int cudaDevice) {
+  if (cudaDevice < 0 || cudaDevice >= kSelectCacheSize) {
+    // < 0 is a caller bug; the uncached impl returns kUnsupported for it.
+    // >= kSelectCacheSize is "valid but exceeds the cache" — every handler
+    // construction will now pay the full probe cost instead of hitting the
+    // cache. Warn once (per process) so the developer notices and bumps
+    // kSelectCacheSize.
+    if (cudaDevice >= kSelectCacheSize) {
+      LOG_FIRST_N(WARNING, 1)
+          << "selectShareableHandleType: cudaDevice=" << cudaDevice
+          << " exceeds the per-device cache size (kSelectCacheSize="
+          << kSelectCacheSize
+          << "); falling through to the uncached probe on every call. "
+             "Consider bumping kSelectCacheSize.";
+    }
+    return selectShareableHandleTypeUncached(cudaDevice);
+  }
+  // Pack the resolved type + a "computed" sentinel into a single atomic; -1
+  // means uncomputed, otherwise the lower 8 bits hold the ShareableHandleType.
+  static std::array<std::atomic<int>, kSelectCacheSize> cache{};
+  static std::once_flag initFlag;
+  std::call_once(initFlag, [] {
+    for (auto& slot : cache) {
+      slot.store(-1, std::memory_order_relaxed);
+    }
+  });
+  auto& slot = cache[static_cast<std::size_t>(cudaDevice)];
+  const int cached = slot.load(std::memory_order_acquire);
+  if (cached >= 0) {
+    return static_cast<ShareableHandleType>(cached);
+  }
+  const auto resolved = selectShareableHandleTypeUncached(cudaDevice);
+  slot.store(static_cast<int>(resolved), std::memory_order_release);
+  return resolved;
+}
+
+ShareableHandle exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    ShareableHandleType type) {
+  ShareableHandle result;
+#if CUDART_VERSION < 12030
+  (void)handle;
+  (void)type;
+  throw std::runtime_error("NvlMemExchange requires CUDA 12.3+");
+#else
+  result.type = type;
+  if (type == ShareableHandleType::kFabric) {
+    checkCuError(
+        pfn_cuMemExportToShareableHandle(
+            &result.fabric, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0),
+        "cuMemExportToShareableHandle for fabric handle failed");
+  } else if (type == ShareableHandleType::kPosixFd) {
+    int fd = -1;
+    checkCuError(
+        pfn_cuMemExportToShareableHandle(
+            &fd, handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0),
+        "cuMemExportToShareableHandle for POSIX FD failed");
+    result.pid = getpid();
+    result.fd = fd;
+  } else {
+    throw std::runtime_error(
+        "NvlMemExchange: cannot export unsupported handle type");
+  }
+#endif
+  return result;
+}
+
+CUmemGenericAllocationHandle importShareableHandle(const ShareableHandle& h) {
+  CUmemGenericAllocationHandle imported = 0;
+#if CUDART_VERSION < 12030
+  (void)h;
+  throw std::runtime_error("NvlMemExchange requires CUDA 12.3+");
+#else
+  if (h.type == ShareableHandleType::kFabric) {
+    auto fabric = h.fabric;
+    checkCuError(
+        pfn_cuMemImportFromShareableHandle(
+            &imported, &fabric, CU_MEM_HANDLE_TYPE_FABRIC),
+        "cuMemImportFromShareableHandle for fabric handle failed");
+  } else if (h.type == ShareableHandleType::kPosixFd) {
+    const int dupFd = duplicateRemoteFd(h.pid, h.fd);
+    const auto importResult = pfn_cuMemImportFromShareableHandle(
+        &imported,
+        posixFdShareableHandle(dupFd),
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+    close(dupFd);
+    checkCuError(
+        importResult, "cuMemImportFromShareableHandle for POSIX FD failed");
+  } else {
+    throw std::runtime_error(
+        "NvlMemExchange: cannot import unsupported handle type");
+  }
+#endif
+  return imported;
+}
 
 NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
@@ -70,7 +459,8 @@ NvlPeerMem nvlMemExchangeVmm(
     CUdevice cuDev,
     CUmemGenericAllocationHandle localHandle,
     void* localPtr,
-    std::size_t allocatedSize) {
+    std::size_t allocatedSize,
+    bool preferFabric) {
   NvlPeerMem result;
   result.peerPtrs.assign(static_cast<std::size_t>(nRanks), nullptr);
   result.peerPtrs[static_cast<std::size_t>(rank)] = localPtr;
@@ -80,22 +470,38 @@ NvlPeerMem nvlMemExchangeVmm(
   (void)cuDev;
   (void)localHandle;
   (void)allocatedSize;
+  (void)preferFabric;
   throw std::runtime_error("nvlMemExchangeVmm requires CUDA 12.3+");
 #else
-  // Export the local handle once as a fabric handle.
-  FabricHandle localFabric{};
-  checkCuError(
-      pfn_cuMemExportToShareableHandle(
-          &localFabric, localHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0),
-      "cuMemExportToShareableHandle for fabric handle failed");
+  // Export the local handle once, as fabric if requested/supported, otherwise
+  // as a POSIX file descriptor (single-host).
+  const ShareableHandleType exportType = preferFabric
+      ? ShareableHandleType::kFabric
+      : ShareableHandleType::kPosixFd;
+  ShareableHandle localShareable =
+      exportShareableHandle(localHandle, exportType);
+
+  // The local POSIX-FD export owns a file descriptor that must stay open
+  // through the import barrier so peers can pidfd_getfd it, then be closed on
+  // every exit path. FdGuard wraps it for RAII; it's a no-op for fabric
+  // exports (fd stays -1). Constructed BEFORE the allGather so an allGather
+  // throw also closes the fd.
+  FdGuard localFdGuard(
+      localShareable.type == ShareableHandleType::kPosixFd ? localShareable.fd
+                                                           : -1);
 
   struct ExchangeData {
-    FabricHandle handle{};
+    ShareableHandle handle{};
     std::size_t allocatedSize{};
   };
 
   std::vector<ExchangeData> allData(static_cast<std::size_t>(nRanks));
-  allData[static_cast<std::size_t>(rank)].handle = localFabric;
+  // ExchangeData has padding between ShareableHandle (mixed enum + union +
+  // ints) and allocatedSize (size_t). Value-init does not guarantee zeroed
+  // padding bytes, and the buffer is broadcast verbatim via allGather — zero
+  // it out before filling so peers don't receive uninitialized stack bytes.
+  std::memset(allData.data(), 0, allData.size() * sizeof(ExchangeData));
+  allData[static_cast<std::size_t>(rank)].handle = localShareable;
   allData[static_cast<std::size_t>(rank)].allocatedSize = allocatedSize;
 
   auto gatherResult =
@@ -105,6 +511,10 @@ NvlPeerMem nvlMemExchangeVmm(
     throw std::runtime_error("nvlMemExchangeVmm allGather failed");
   }
 
+  // Import peer memory from received shareable handles. For POSIX FD exports
+  // the local fd must stay open through this import loop so peers can
+  // duplicate it via pidfd_getfd; localFdGuard's destructor closes it on
+  // every exit (import throw, barrier throw, or success).
   for (int32_t peer = 0; peer < nRanks; ++peer) {
     if (peer == rank) {
       continue;
@@ -116,6 +526,14 @@ NvlPeerMem nvlMemExchangeVmm(
         allData[peerIdx].allocatedSize,
         cuDev,
         result);
+  }
+
+  // Hold all ranks here until every peer has finished importing, so no rank
+  // closes its exported POSIX FD before others have duplicated it. Mirrors
+  // the keep-fd-open-until-barrier ordering in MultiPeerTransport.
+  auto barrierResult = bootstrap.barrier(rank, nRanks).get();
+  if (barrierResult != 0) {
+    throw std::runtime_error("nvlMemExchangeVmm post-import barrier failed");
   }
 
   return result;

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -2,104 +2,85 @@
 
 #pragma once
 
-// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD,
-// fabric-handle support is unavailable; only the cudaIpc path is used, and its
-// `cudaIpcMemHandle_t` parameter is HIPify-rewritten to `hipIpcMemHandle_t`
-// (provided by `<hip/hip_runtime.h>`).
-#ifdef __HIP_PLATFORM_AMD__
-#include <hip/hip_runtime.h>
-#else
 #include <cuda.h>
 #include <cuda_runtime.h>
-#endif
 
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
 #include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemMapping.h"
 
 namespace comms::prims {
 
-#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+#if CUDART_VERSION >= 12030
 using FabricHandle = CUmemFabricHandle;
 #else
 struct FabricHandle {
   unsigned char data[64]; // CU_IPC_HANDLE_SIZE
 };
-// Stub the CUDA driver-API typedefs referenced by the always-declared VMM
-// signature so the header (and downstream consumers like GpuMemHandler)
-// compiles on AMD / pre-CUDA-12.3. The concrete VMM driver-API code lives
-// behind `#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030` in
-// the .cc; on these platforms `nvlMemExchangeVmm` is a throwing stub. Types
-// match the real CUDA driver-API typedefs (`unsigned long long`).
-#if defined(__HIP_PLATFORM_AMD__)
-using CUdeviceptr = unsigned long long;
-using CUmemGenericAllocationHandle = unsigned long long;
-#endif
 #endif
 
 /**
  * NvlMemExchange - NVLink-domain peer-exchange building blocks.
  *
- * The peer exchange (export -> all-gather -> import -> map) that gives every
- * rank a VA onto every peer's backing allocation, for both VMM (fabric) and
- * cudaIpc modes. Used by GpuMemHandler. The VMM/fabric path is NVIDIA-only
- * (CUDA driver API + CUDA 12.3+); on AMD or pre-12.3, `nvlMemExchangeVmm` is
- * declared but its body throws. The cudaIpc path is HIPify-rewritten to
- * hipIpc on AMD.
+ * The consolidated peer exchange (export -> all-gather -> import -> map) that
+ * gives every rank a VA onto every peer's backing allocation, for both VMM
+ * (fabric) and cudaIpc modes. Used by GpuMemHandler. The `cuMem*` fabric
+ * driver-API paths are guarded by `#if CUDART_VERSION >= 12030`; on AMD only
+ * the cudaIpc path (HIPify-rewritten) is used. Provides the FabricHandle
+ * typedef.
  */
 
 /**
- * VMM (fabric) peer exchange. all-gathers this rank's exported fabric handle
- * and allocation size, then imports + maps every peer's physical memory into a
- * fresh local virtual address with RW access. Results are written into the
- * per-rank output vectors (indexed by rank); the self slot of `peerPtrs` is
- * left untouched (the caller stores its own local VA there).
+ * The per-rank peer memory state produced by an NVLink-domain exchange.
  *
- * COLLECTIVE OPERATION: all ranks must call. Throws on AMD or pre-CUDA-12.3.
- *
- * Output vectors must each have size `>= nRanks`.
- *
- * @param bootstrap Bootstrap interface for the allGather
- * @param selfRank This rank's ID (0..nRanks-1)
- * @param nRanks Total number of ranks
- * @param localHandle This rank's exported fabric handle
- * @param allocatedSize This rank's allocation size
- * @param peerPtrs [out] per-rank mapped peer pointers (size nRanks)
- * @param peerAllocHandles [out] per-rank imported allocation handles (size
- * nRanks)
- * @param peerAllocatedSizes [out] per-rank allocation sizes (size nRanks)
+ * `peerPtrs[rank]` is a VA usable in local kernels to access rank `rank`'s
+ * backing allocation; the self slot holds the local pointer. For VMM modes,
+ * `vmmMappings` holds the RAII peer VAs; each mapping co-owns the imported peer
+ * CuMemAllocation (via CuMemMapping's keepAlive), so releasing a mapping also
+ * releases the imported physical handle -- there is no separate handle vector
+ * to track. For cudaIpc mode `vmmMappings` is empty and the peer pointers are
+ * owned by the CUDA IPC runtime (closed via cudaIpcCloseMemHandle by the
+ * caller).
  */
-void nvlMemExchangeVmm(
-    meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
-    int32_t nRanks,
-    const FabricHandle& localHandle,
-    std::size_t allocatedSize,
-    std::vector<CUdeviceptr>& peerPtrs,
-    std::vector<CUmemGenericAllocationHandle>& peerAllocHandles,
-    std::vector<std::size_t>& peerAllocatedSizes);
+struct NvlPeerMem {
+  std::vector<void*> peerPtrs;
+  std::vector<CuMemMapping> vmmMappings;
+};
 
 /**
- * cudaIpc peer exchange. all-gathers this rank's cudaIpc handle, then opens
- * every peer's handle into `peerPtrs` (indexed by rank). Intra-node only.
+ * VMM (fabric) peer exchange.
  *
- * COLLECTIVE OPERATION: all ranks must call.
- *
- * `peerPtrs` must have size `>= nRanks`.
- *
- * @param bootstrap Bootstrap interface for the allGather
- * @param selfRank This rank's ID (0..nRanks-1)
- * @param nRanks Total number of ranks
- * @param localHandle This rank's cudaIpc handle
- * @param peerPtrs [out] per-rank opened peer pointers (size nRanks)
+ * Exports `localHandle` as a fabric handle, all-gathers every rank's handle +
+ * allocated size, then imports and maps each peer's backing allocation into a
+ * fresh peer VA. `peerPtrs[rank]` is null for self; the caller fills the self
+ * slot with `localPtr`. Throws std::runtime_error on any failure. Requires CUDA
+ * 12.3+.
  */
-void nvlMemExchangeCudaIpc(
+NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
-    int32_t selfRank,
+    int32_t rank,
     int32_t nRanks,
-    const cudaIpcMemHandle_t& localHandle,
-    std::vector<void*>& peerPtrs);
+    CUdevice cuDev,
+    CUmemGenericAllocationHandle localHandle,
+    void* localPtr,
+    std::size_t allocatedSize);
+
+/**
+ * cudaIpc peer exchange.
+ *
+ * Exports `localPtr`'s cudaIpc handle, all-gathers handles, and opens each
+ * peer's handle. The self slot of `peerPtrs` is filled with `localPtr`; peer
+ * slots are owned by the CUDA IPC runtime (the caller closes them via
+ * cudaIpcCloseMemHandle). `vmmMappings` is empty. Throws std::runtime_error on
+ * any failure.
+ */
+NvlPeerMem nvlMemExchangeCudaIpc(
+    meta::comms::IBootstrap& bootstrap,
+    int32_t rank,
+    int32_t nRanks,
+    void* localPtr);
 
 } // namespace comms::prims

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -5,6 +5,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+#include <sys/types.h>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -23,15 +24,86 @@ struct FabricHandle {
 #endif
 
 /**
- * NvlMemExchange - NVLink-domain peer-exchange building blocks.
+ * NvlMemExchange - NVLink-domain shared-memory building blocks.
  *
- * The consolidated peer exchange (export -> all-gather -> import -> map) that
- * gives every rank a VA onto every peer's backing allocation, for both VMM
- * (fabric) and cudaIpc modes. Used by GpuMemHandler. The `cuMem*` fabric
- * driver-API paths are guarded by `#if CUDART_VERSION >= 12030`; on AMD only
- * the cudaIpc path (HIPify-rewritten) is used. Provides the FabricHandle
- * typedef.
+ * Bundles the two pieces needed to share a GPU buffer across NVLink-local
+ * ranks:
+ *
+ *  1. Shareable-handle export/import for CUDA VMM allocation handles. The same
+ *     export/import logic is needed in two places:
+ *       - GpuMemHandler exports its unicast backing handle so peers can map the
+ *         same physical allocation.
+ *       - MultimemHandler exports the multicast object handle so peers can join
+ *         the same multicast team.
+ *  2. The consolidated peer exchange (export -> all-gather -> import -> map)
+ *     used by GpuMemHandler to give every rank a VA onto every peer's backing
+ *     allocation, for both VMM (fabric / POSIX FD) and cudaIpc modes.
+ *
+ * Two shareable-handle mechanisms are supported, selected by capability:
+ *  - kFabric: CU_MEM_HANDLE_TYPE_FABRIC, works across hosts (e.g. GB200 MNNVL).
+ *  - kPosixFd: CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, intra-host only (e.g.
+ *    single-host H100 without IMEX). The descriptor number is process-local, so
+ *    peers duplicate the exporter's fd via pidfd_open/pidfd_getfd before
+ * import.
  */
+enum class ShareableHandleType : uint8_t {
+  kUnsupported,
+  kFabric,
+  kPosixFd,
+};
+
+/**
+ * A shareable handle ready to be exchanged across ranks.
+ *
+ * For kFabric, `fabric` is the exported fabric handle and can be copied between
+ * processes verbatim. For kPosixFd, `pid` and `fd` identify an open file
+ * descriptor in the exporter's process; peers duplicate it before importing.
+ */
+struct ShareableHandle {
+  ShareableHandleType type{ShareableHandleType::kUnsupported};
+  FabricHandle fabric{}; // valid iff type == kFabric
+  int32_t pid{-1}; // valid iff type == kPosixFd
+  int32_t fd{-1}; // exporter-local fd; valid iff type == kPosixFd
+};
+
+/**
+ * Maps a ShareableHandleType to the corresponding CUDA handle type. Throws
+ * std::runtime_error for kUnsupported.
+ */
+CUmemAllocationHandleType toCudaHandleType(ShareableHandleType type);
+
+/**
+ * Selects the best shareable-handle type for `cudaDevice`: fabric if supported,
+ * else POSIX FD, else kUnsupported. Initializes the CUDA driver lazily and
+ * resolves the CUdevice internally.
+ */
+ShareableHandleType selectShareableHandleType(int cudaDevice);
+
+/**
+ * Exports `handle` as the given shareable-handle `type`.
+ *
+ * For kFabric the returned handle is self-contained. For kPosixFd the returned
+ * ShareableHandle carries {pid=getpid(), fd=<newly exported fd>}; the CALLER
+ * owns that fd and must keep it open until all peers have imported it, then
+ * close it.
+ *
+ * Throws std::runtime_error on kUnsupported or any CUDA driver error.
+ */
+ShareableHandle exportShareableHandle(
+    CUmemGenericAllocationHandle handle,
+    ShareableHandleType type);
+
+/**
+ * Imports the physical handle described by `h`.
+ *
+ * For kFabric the fabric handle is imported directly. For kPosixFd the
+ * exporter's fd is duplicated into this process via duplicateRemoteFd(), the
+ * handle is imported, and the duplicated fd is closed before returning.
+ *
+ * Returns the imported physical handle (the caller owns the reference and must
+ * eventually cuMemRelease it). Throws std::runtime_error on any failure.
+ */
+CUmemGenericAllocationHandle importShareableHandle(const ShareableHandle& h);
 
 /**
  * The per-rank peer memory state produced by an NVLink-domain exchange.
@@ -51,13 +123,16 @@ struct NvlPeerMem {
 };
 
 /**
- * VMM (fabric) peer exchange.
+ * VMM (fabric / POSIX FD) peer exchange.
  *
- * Exports `localHandle` as a fabric handle, all-gathers every rank's handle +
- * allocated size, then imports and maps each peer's backing allocation into a
- * fresh peer VA. `peerPtrs[rank]` is null for self; the caller fills the self
- * slot with `localPtr`. Throws std::runtime_error on any failure. Requires CUDA
- * 12.3+.
+ * Exports `localHandle` (as fabric when `preferFabric`, else POSIX FD),
+ * all-gathers every rank's shareable handle + allocated size, imports and maps
+ * each peer's backing allocation, holds a post-import barrier so no rank closes
+ * its exported POSIX FD before peers have duplicated it, then closes the local
+ * exported fd.
+ *
+ * `peerPtrs[rank]` is null for self; the caller fills the self slot with
+ * `localPtr`. Throws std::runtime_error on any failure. Requires CUDA 12.3+.
  */
 NvlPeerMem nvlMemExchangeVmm(
     meta::comms::IBootstrap& bootstrap,
@@ -66,7 +141,8 @@ NvlPeerMem nvlMemExchangeVmm(
     CUdevice cuDev,
     CUmemGenericAllocationHandle localHandle,
     void* localPtr,
-    std::size_t allocatedSize);
+    std::size_t allocatedSize,
+    bool preferFabric);
 
 /**
  * cudaIpc peer exchange.
@@ -74,8 +150,8 @@ NvlPeerMem nvlMemExchangeVmm(
  * Exports `localPtr`'s cudaIpc handle, all-gathers handles, and opens each
  * peer's handle. The self slot of `peerPtrs` is filled with `localPtr`; peer
  * slots are owned by the CUDA IPC runtime (the caller closes them via
- * cudaIpcCloseMemHandle). `vmmMappings` is empty. Throws std::runtime_error on
- * any failure.
+ * cudaIpcCloseMemHandle). `vmmMappings` is empty. Throws
+ * std::runtime_error on any failure.
  */
 NvlPeerMem nvlMemExchangeCudaIpc(
     meta::comms::IBootstrap& bootstrap,

--- a/comms/prims/tests/CuMemAllocationTest.cc
+++ b/comms/prims/tests/CuMemAllocationTest.cc
@@ -1,0 +1,112 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+// Resolves a CUdevice on device 0 and returns false (skip) if VMM / CUDA 12.3
+// is unavailable.
+bool vmmDevice(CUdevice& cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  if (cudaSetDevice(0) != cudaSuccess) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, 0) == CUDA_SUCCESS;
+#endif
+}
+
+unsigned int requestMask() {
+  return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC;
+}
+
+bool isPowerOfTwo(std::size_t x) {
+  return x != 0 && (x & (x - 1)) == 0;
+}
+
+} // namespace
+
+TEST(CuMemAllocationTest, CreateProducesUsableHandle) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+
+  auto alloc = CuMemAllocation::create(cuDev, /*size=*/4096, requestMask());
+  EXPECT_NE(alloc->handle(), 0u);
+  EXPECT_GE(alloc->size(), std::size_t{4096});
+  EXPECT_TRUE(isPowerOfTwo(alloc->granularity()));
+  EXPECT_EQ(alloc->device(), cuDev);
+  // The surviving cuMemCreate always keeps POSIX FD; fabric is kept only when
+  // the device/driver permit it.
+  EXPECT_NE(
+      alloc->supportedHandleTypes() &
+          static_cast<unsigned int>(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+      0u);
+}
+
+TEST(CuMemAllocationTest, RoundsSizeUpToAlignFloor) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+
+  // A 2 MiB power-of-two alignFloor must round the allocation up to a multiple
+  // of it (the granularity becomes max(driverGranularity, alignFloor)).
+  constexpr std::size_t kAlignFloor = 2u * 1024u * 1024u;
+  auto alloc =
+      CuMemAllocation::create(cuDev, /*size=*/4096, requestMask(), kAlignFloor);
+  EXPECT_GE(alloc->granularity(), kAlignFloor);
+  EXPECT_EQ(alloc->size() % alloc->granularity(), 0u);
+  EXPECT_GE(alloc->size(), kAlignFloor);
+}
+
+TEST(CuMemAllocationTest, RejectsNonPowerOfTwoAlignFloor) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  EXPECT_THROW(
+      CuMemAllocation::create(cuDev, 4096, requestMask(), /*alignFloor=*/3),
+      std::runtime_error);
+}
+
+TEST(CuMemAllocationTest, MoveLeavesSourceInert) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  // Move-construct out of the owned object (not the unique_ptr) to exercise
+  // CuMemAllocation's own move ctor + moved-from inert state.
+  auto a = CuMemAllocation::create(cuDev, 4096, requestMask());
+  const auto handle = a->handle();
+  CuMemAllocation b = std::move(*a);
+  EXPECT_EQ(b.handle(), handle);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(a->handle(), 0u);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/CuMemMappingTest.cc
+++ b/comms/prims/tests/CuMemMappingTest.cc
@@ -1,0 +1,151 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+bool vmmDevice(CUdevice& cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  if (cudaSetDevice(0) != cudaSuccess) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, 0) == CUDA_SUCCESS;
+#endif
+}
+
+std::shared_ptr<CuMemAllocation> makeAlloc(CUdevice cuDev, std::size_t size) {
+  return CuMemAllocation::create(
+      cuDev,
+      size,
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC);
+}
+
+void* asPtr(CUdeviceptr p) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(p);
+}
+
+} // namespace
+
+TEST(CuMemMappingTest, MapsAndAccessesAllocation) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto mapping =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  ASSERT_NE(mapping.devicePtr(), 0u);
+
+  ASSERT_EQ(
+      cudaMemset(asPtr(mapping.devicePtr()), 0xAB, alloc->size()), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  std::vector<uint8_t> host(alloc->size(), 0);
+  ASSERT_EQ(
+      cudaMemcpy(
+          host.data(),
+          asPtr(mapping.devicePtr()),
+          alloc->size(),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  for (auto b : host) {
+    ASSERT_EQ(b, 0xAB);
+  }
+}
+
+TEST(CuMemMappingTest, TwoMappingsShareSamePhysical) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto m1 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  auto m2 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  // Distinct virtual addresses onto the same physical allocation.
+  EXPECT_NE(m1.devicePtr(), m2.devicePtr());
+
+  ASSERT_EQ(
+      cudaMemset(asPtr(m1.devicePtr()), 0x5C, alloc->size()), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  std::vector<uint8_t> host(alloc->size(), 0);
+  ASSERT_EQ(
+      cudaMemcpy(
+          host.data(),
+          asPtr(m2.devicePtr()),
+          alloc->size(),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  for (auto b : host) {
+    ASSERT_EQ(b, 0x5C) << "write via mapping 1 must be visible via mapping 2";
+  }
+}
+
+TEST(CuMemMappingTest, KeepAliveOutlivesAllocationOwner) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  std::weak_ptr<CuMemAllocation> weak = alloc;
+  auto mapping = std::make_unique<CuMemMapping>(
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity()));
+  const std::size_t size = alloc->size();
+
+  // Drop the caller's reference; the mapping's keepAlive must keep the physical
+  // allocation alive so the VA stays valid.
+  alloc.reset();
+  EXPECT_FALSE(weak.expired());
+  ASSERT_EQ(cudaMemset(asPtr(mapping->devicePtr()), 0, size), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+  // Releasing the mapping drops the last reference to the allocation.
+  mapping.reset();
+  EXPECT_TRUE(weak.expired());
+}
+
+TEST(CuMemMappingTest, MoveLeavesSourceInert) {
+  CUdevice cuDev = 0;
+  if (!vmmDevice(cuDev)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  auto alloc = makeAlloc(cuDev, 4096);
+  auto m1 =
+      CuMemMapping::overAllocation(alloc, alloc->size(), alloc->granularity());
+  const auto ptr = m1.devicePtr();
+  CuMemMapping m2 = std::move(m1);
+  EXPECT_EQ(m2.devicePtr(), ptr);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(m1.devicePtr(), 0u);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/NvlMemExchangeTest.cc
+++ b/comms/prims/tests/NvlMemExchangeTest.cc
@@ -1,0 +1,159 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <unistd.h>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
+#include "comms/prims/memory/NvlMemExchange.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+bool vmmDevice(CUdevice& cuDev, int& cudaDevice) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  (void)cudaDevice;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  cudaDevice = 0;
+  if (cudaSetDevice(cudaDevice) != cudaSuccess) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, cudaDevice) == CUDA_SUCCESS;
+#endif
+}
+
+void* asPtr(CUdeviceptr p) {
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(p);
+}
+
+} // namespace
+
+TEST(NvlMemExchangeTest, ToCudaHandleTypeMapsAndThrows) {
+#if CUDART_VERSION >= 12030
+  EXPECT_EQ(
+      toCudaHandleType(ShareableHandleType::kFabric),
+      CU_MEM_HANDLE_TYPE_FABRIC);
+  EXPECT_EQ(
+      toCudaHandleType(ShareableHandleType::kPosixFd),
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+  EXPECT_THROW(
+      toCudaHandleType(ShareableHandleType::kUnsupported), std::runtime_error);
+#else
+  GTEST_SKIP() << "CUDA 12.3+ required";
+#endif
+}
+
+TEST(NvlMemExchangeTest, MakeVmmAllocationPropFields) {
+  CUdevice cuDev = 0;
+  int cudaDevice = 0;
+  if (!vmmDevice(cuDev, cudaDevice)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+#if CUDART_VERSION >= 12030
+  const unsigned int mask = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+  auto prop = makeVmmAllocationProp(cuDev, mask);
+  EXPECT_EQ(prop.type, CU_MEM_ALLOCATION_TYPE_PINNED);
+  EXPECT_EQ(prop.location.type, CU_MEM_LOCATION_TYPE_DEVICE);
+  EXPECT_EQ(prop.location.id, cuDev);
+  EXPECT_EQ(static_cast<unsigned int>(prop.requestedHandleTypes), mask);
+#endif
+}
+
+TEST(NvlMemExchangeTest, SelectShareableHandleTypeReturnsSupported) {
+  CUdevice cuDev = 0;
+  int cudaDevice = 0;
+  if (!vmmDevice(cuDev, cudaDevice)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+  const auto type = selectShareableHandleType(cudaDevice);
+  // On a Hopper+ GPU this is fabric or POSIX FD; on older GPUs it may be
+  // unsupported, in which case there is nothing to assert.
+  if (type == ShareableHandleType::kUnsupported) {
+    GTEST_SKIP() << "no shareable handle type supported on this device";
+  }
+  EXPECT_TRUE(
+      type == ShareableHandleType::kFabric ||
+      type == ShareableHandleType::kPosixFd);
+}
+
+TEST(NvlMemExchangeTest, PosixFdExportImportRoundTripSharesMemory) {
+  CUdevice cuDev = 0;
+  int cudaDevice = 0;
+  if (!vmmDevice(cuDev, cudaDevice)) {
+    GTEST_SKIP() << "VMM / CUDA 12.3+ unavailable";
+  }
+#if CUDART_VERSION >= 12030
+  std::shared_ptr<CuMemAllocation> original = CuMemAllocation::create(
+      cuDev, /*size=*/4096, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+
+  // Export then re-import within this process (the importer duplicates the
+  // exporter's fd via pidfd_getfd). Skip if the sandbox forbids pidfd_getfd.
+  ShareableHandle shareable;
+  CUmemGenericAllocationHandle importedHandle = 0;
+  try {
+    shareable = exportShareableHandle(
+        original->handle(), ShareableHandleType::kPosixFd);
+    importedHandle = importShareableHandle(shareable);
+  } catch (const std::runtime_error& ex) {
+    if (shareable.type == ShareableHandleType::kPosixFd && shareable.fd >= 0) {
+      close(shareable.fd);
+    }
+    GTEST_SKIP() << "posix-fd export/import unavailable: " << ex.what();
+  }
+  if (shareable.fd >= 0) {
+    close(shareable.fd);
+  }
+
+  std::shared_ptr<CuMemAllocation> imported =
+      CuMemAllocation::adopt(importedHandle, cuDev, original->size());
+
+  auto mOrig = CuMemMapping::overAllocation(
+      original, original->size(), original->granularity());
+  auto mImported = CuMemMapping::overAllocation(
+      imported, imported->size(), imported->granularity());
+
+  ASSERT_EQ(
+      cudaMemset(asPtr(mOrig.devicePtr()), 0x3D, original->size()),
+      cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  std::vector<uint8_t> host(original->size(), 0);
+  ASSERT_EQ(
+      cudaMemcpy(
+          host.data(),
+          asPtr(mImported.devicePtr()),
+          original->size(),
+          cudaMemcpyDeviceToHost),
+      cudaSuccess);
+  for (auto b : host) {
+    ASSERT_EQ(b, 0x3D)
+        << "imported handle must map the same physical memory as the exporter";
+  }
+#endif
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -899,10 +899,13 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/ibrc/.*")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/MultiPeerIbTransport\\.")
 # Exclude window files — they depend on IbgdaBuffer.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/window/.*")
-# Exclude GpuMemHandler, NvlMemExchange, and CudaDriverLazy — they depend on
-# cudaTypedefs.h / the CUDA driver API which is not available here.
+# Exclude GpuMemHandler, NvlMemExchange, CuMemAllocation, CuMemMapping, and
+# CudaDriverLazy — they depend on cudaTypedefs.h / the CUDA driver API which
+# is not available here.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "GpuMemHandler\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "NvlMemExchange\\.")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemAllocation\\.")
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemMapping\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")


### PR DESCRIPTION
Summary:

Adds the intra-host POSIX file-descriptor shareable-handle path, completing the foundation. The original `GpuMemHandler` had only fabric (cross-host) and cudaIpc; single-host H100 without IMEX has no fabric, so VMM sharing previously fell back to cudaIpc and could not back a multicast object. The POSIX-FD path gives single-host H100 a real VMM allocation to share (and later bind into multicast).

`NvlMemExchange` gains:
- `ShareableHandleType` / `ShareableHandle` and `toCudaHandleType`.
- `selectShareableHandleType` (fabric -> POSIX FD -> unsupported), with `fabricHandleSupported` / `posixFdHandleSupported` trial probes.
- `exportShareableHandle` / `importShareableHandle` (POSIX FD uses `pidfd_open`/`pidfd_getfd` to duplicate the exporter's fd before import).
- `nvlMemExchangeVmm` now takes `preferFabric`, exports as fabric or POSIX FD accordingly, and holds a post-import barrier so no rank closes its exported fd before peers have duplicated it.

`GpuMemHandler` gains the `kPosixFd` mode; `detectBestMode` now uses `selectShareableHandleType`, and `allocateVmmMemory` requests both `FABRIC | POSIX_FILE_DESCRIPTOR` so the export type can be chosen at exchange time via `allocation_->supportsFabric()`.

The per-peer import remains factored into `importAndMapPeerMemory` (now keyed on `ShareableHandle`), keeping `nvlMemExchangeVmm` a thin orchestrator. Adds unit test `NvlMemExchangeTest`.

Reviewed By: goelayu, saifhhasan

Differential Revision: D107718241


