### PR TITLE
Refresh IBRC benchmark results (#2987)

### DIFF
--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -640,7 +640,7 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   printResultsTable("IBGDA ThreadScope MultiBlock Put+Flush", results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
+TEST_P(IbgdaBenchmarkFixture, PutWaitCounter) {
   // Measures raw RDMA Write latency (put + transport counter-slot wait).
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -1,8 +1,8 @@
 # IBRC Benchmark Results
 
-Run date: 2026-06-16
+Run date: 2026-06-24
 
-Hosts used: `rtptest2330.nha6`, `rtptest2334.nha6`
+Hosts used: `rtptest2333.nha6.facebook.com`, `rtptest2349.nha6.facebook.com`
 
 Launcher:
 
@@ -11,102 +11,105 @@ python3 comms/testinfra/ncclx_test_launcher.py \
   --launcher mpi \
   --nnode 2 \
   --ppn 1 \
-  --hosts rtptest2330.nha6,rtptest2334.nha6 \
-  --ifname eth1 \
-  --env 'NCCL_DEBUG=WARN' \
-  --testname /home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/065941cadf27ce30/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
+  --hosts rtptest2333.nha6.facebook.com,rtptest2349.nha6.facebook.com \
+  --ifname eth0 \
+  --env 'NCCL_DEBUG=WARN;NCCL_IB_HCA=mlx5_0,mlx5_1' \
+  --gtest_filter 'IbBackend/IbgdaBenchmarkFixture.PutSignalWaitCounter/*:IbBackend/IbgdaBenchmarkFixture.PutSignalComparison/*:IbBackend/IbgdaBenchmarkFixture.PutFlush/*:IbBackend/IbgdaBenchmarkFixture.SignalOnly/*' \
+  --testname /data/users/zhiyongww/fbsource/buck-out/v2/art/fbcode/5b4cba3f80737e3b/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
 ```
 
-The initially suggested hosts, `rtptest2347.nha6` and `rtptest2346.nha6`, were not usable for this run because CUDA context creation failed with `CUDA-capable device(s) is/are busy or unavailable`. The results below use the clean GB200 pair listed above.
+The `rtptest2333`/`rtptest2349` pair was used because both hosts had CUDA ready (`cuInit=0`, two devices, no compute processes) and the MPI hostname smoke test passed. Before launching, the `2803:*` IPv6 address on `eth0` was temporarily removed on both hosts to avoid Open MPI advertising a peer address that did not match DNS. The `2803:*` addresses were restored after the run. The `rtptest2348`/`rtptest2350` pair was rejected because CUDA initialization returned `802`.
 
 ## Current Counter-Slot Results
 
-These results are after switching the counter benchmarks from explicit counter buffers to the transport-owned counter-slot API. IBRC `PutWaitCounter`, `PutSignalWaitCounter`, and `PutSignalComparison` pass with this path.
+These results are from the 2026-06-24 rerun after pinning the IBRC progress thread. The initial filtered run covered `PutFlush`, `PutSignalWaitCounter`, `SignalOnly`, and `PutSignalComparison`. `PutWaitCounter` required a local benchmark test fix from `TEST_F` to `TEST_P` so the backend parameterization works; it was then rebuilt for `aarch64` and rerun separately on the same hosts.
 
 Current logs:
 
 | Run | Log |
 | --- | --- |
-| Expanded sweep through 1GB | `/tmp/ibrc_1gb_sweep.log` |
-| IBRC counter-slot retest | `/tmp/ibrc_counter_slot_tests.log` |
-| IBGDA counter-slot retest | `/tmp/ibgda_counter_slot_tests.log` |
+| 2026-06-24 filtered rerun on `rtptest2333`/`rtptest2349` | `/tmp/ibrc-benchmark-direct-2333-2349-no2803-20260624-151520.log` |
+| 2026-06-24 fixed `PutWaitCounter` rerun on `rtptest2333`/`rtptest2349` | `/tmp/ibrc-benchmark-putwait-fixed-2333-2349-no2803-20260624-160334.log` |
 
 Summary:
 
 | Benchmark | IBGDA | IBRC |
 | --- | ---: | ---: |
-| `PutFlush`, 1GB | 22202.67 us, 48.36 GB/s | 23039.32 us, 46.60 GB/s |
-| `PutWaitCounter`, 1GB | 22209.76 us, 48.35 GB/s | 22987.54 us, 46.71 GB/s |
-| `PutSignalWaitCounter`, 1GB | 22210.01 us, 48.34 GB/s | 22943.53 us, 46.80 GB/s |
-| `PutSignalComparison`, 16MB | 368.99 us | 704.07 us |
-| `MultiPeerCounterFanOut`, 64KB per peer | Not rerun in current retest | N/A: explicit shared-counter-buffer benchmark |
+| `PutFlush`, 1GB | 22197.61 us, 48.37 GB/s | 22203.10 us, 48.36 GB/s |
+| `PutWaitCounter`, 1GB | 22204.56 us, 48.36 GB/s | 22205.06 us, 48.36 GB/s |
+| `PutSignalWaitCounter`, 1GB | 22204.38 us, 48.36 GB/s | 22211.54 us, 48.34 GB/s |
+| `PutSignalComparison`, 16MB | 365.32 us | 374.78 us |
+| `SignalOnly`, average latency | 12.25 us | 30.33 us |
+| `MultiPeerCounterFanOut`, 64KB per peer | Not rerun in 2026-06-24 filtered run | N/A: explicit shared-counter-buffer benchmark |
 
 ## PutWaitCounter
 
+Rerun separately on 2026-06-24 using a locally rebuilt `aarch64` benchmark binary after fixing the test declaration to `TEST_P(IbgdaBenchmarkFixture, PutWaitCounter)`. The previous `TEST_F` declaration aborted before measuring because it called `GetParam()` outside a parameterized test.
+
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 21.27 | 0.00 | 38.28 | 0.00 |
-| 64B | 23.02 | 0.00 | 38.27 | 0.00 |
-| 256B | 23.07 | 0.01 | 38.26 | 0.01 |
-| 1KB | 23.17 | 0.04 | 38.25 | 0.03 |
-| 4KB | 23.48 | 0.17 | 38.31 | 0.11 |
-| 8KB | 23.71 | 0.35 | 38.29 | 0.21 |
-| 16KB | 23.95 | 0.68 | 42.00 | 0.39 |
-| 32KB | 24.43 | 1.34 | 43.70 | 0.75 |
-| 64KB | 25.10 | 2.61 | 44.16 | 1.48 |
-| 128KB | 27.32 | 4.80 | 49.02 | 2.67 |
-| 256KB | 30.02 | 8.73 | 52.46 | 5.00 |
-| 512KB | 35.44 | 14.79 | 65.69 | 7.98 |
-| 1MB | 46.23 | 22.68 | 86.75 | 12.09 |
-| 2MB | 67.83 | 30.92 | 129.09 | 16.25 |
-| 4MB | 110.97 | 37.80 | 216.09 | 19.41 |
-| 8MB | 197.30 | 42.52 | 384.12 | 21.84 |
-| 16MB | 369.71 | 45.38 | 695.64 | 24.12 |
-| 32MB | 714.95 | 46.93 | 1271.31 | 26.39 |
-| 64MB | 1405.48 | 47.75 | 2322.96 | 28.89 |
-| 128MB | 2787.44 | 48.15 | 3521.63 | 38.11 |
-| 256MB | 5572.73 | 48.17 | 6944.67 | 38.65 |
-| 512MB | 11118.86 | 48.28 | 13613.28 | 39.44 |
-| 1GB | 22209.76 | 48.35 | 22987.54 | 46.71 |
+| 8B | 15.63 | 0.00 | 19.88 | 0.00 |
+| 64B | 16.77 | 0.00 | 20.01 | 0.00 |
+| 256B | 17.75 | 0.01 | 19.63 | 0.01 |
+| 1KB | 17.94 | 0.06 | 20.10 | 0.05 |
+| 4KB | 18.03 | 0.23 | 19.99 | 0.20 |
+| 8KB | 18.30 | 0.45 | 20.14 | 0.41 |
+| 16KB | 18.53 | 0.88 | 20.31 | 0.81 |
+| 32KB | 19.06 | 1.72 | 22.65 | 1.45 |
+| 64KB | 19.75 | 3.32 | 22.76 | 2.88 |
+| 128KB | 21.97 | 5.97 | 22.99 | 5.70 |
+| 256KB | 24.66 | 10.63 | 27.89 | 9.40 |
+| 512KB | 30.06 | 17.44 | 33.58 | 15.61 |
+| 1MB | 40.80 | 25.70 | 42.43 | 24.71 |
+| 2MB | 62.35 | 33.64 | 66.19 | 31.68 |
+| 4MB | 105.49 | 39.76 | 109.14 | 38.43 |
+| 8MB | 191.77 | 43.74 | 195.05 | 43.01 |
+| 16MB | 364.31 | 46.05 | 368.27 | 45.56 |
+| 32MB | 709.46 | 47.30 | 713.38 | 47.04 |
+| 64MB | 1400.05 | 47.93 | 1403.72 | 47.81 |
+| 128MB | 2786.51 | 48.17 | 2785.43 | 48.19 |
+| 256MB | 5567.58 | 48.21 | 5568.85 | 48.20 |
+| 512MB | 11113.65 | 48.31 | 11114.50 | 48.30 |
+| 1GB | 22204.56 | 48.36 | 22205.06 | 48.36 |
 
 ## PutSignalWaitCounter
 
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 22.05 | 0.00 | 65.29 | 0.00 |
-| 64B | 23.09 | 0.00 | 65.33 | 0.00 |
-| 256B | 23.22 | 0.01 | 64.58 | 0.00 |
-| 1KB | 23.35 | 0.04 | 65.23 | 0.02 |
-| 4KB | 23.68 | 0.17 | 65.67 | 0.06 |
-| 8KB | 23.94 | 0.34 | 64.94 | 0.13 |
-| 16KB | 24.18 | 0.68 | 64.80 | 0.25 |
-| 32KB | 24.55 | 1.33 | 64.63 | 0.51 |
-| 64KB | 25.24 | 2.60 | 65.06 | 1.01 |
-| 128KB | 27.41 | 4.78 | 72.07 | 1.82 |
-| 256KB | 30.24 | 8.67 | 78.78 | 3.33 |
-| 512KB | 35.43 | 14.80 | 87.25 | 6.01 |
-| 1MB | 46.14 | 22.72 | 111.76 | 9.38 |
-| 2MB | 67.67 | 30.99 | 149.81 | 14.00 |
-| 4MB | 110.66 | 37.90 | 237.82 | 17.64 |
-| 8MB | 196.82 | 42.62 | 406.69 | 20.63 |
-| 16MB | 369.59 | 45.39 | 731.31 | 22.94 |
-| 32MB | 714.92 | 46.93 | 1281.58 | 26.18 |
-| 64MB | 1405.51 | 47.75 | 2324.56 | 28.87 |
-| 128MB | 2787.41 | 48.15 | 3527.65 | 38.05 |
-| 256MB | 5573.03 | 48.17 | 6940.11 | 38.68 |
-| 512MB | 11119.03 | 48.28 | 13555.27 | 39.61 |
-| 1GB | 22210.01 | 48.34 | 22943.53 | 46.80 |
+| 8B | 16.76 | 0.00 | 27.75 | 0.00 |
+| 64B | 18.90 | 0.00 | 27.74 | 0.00 |
+| 256B | 18.98 | 0.01 | 27.80 | 0.01 |
+| 1KB | 19.08 | 0.05 | 27.80 | 0.04 |
+| 4KB | 19.31 | 0.21 | 27.77 | 0.15 |
+| 8KB | 19.50 | 0.42 | 27.73 | 0.30 |
+| 16KB | 19.67 | 0.83 | 27.86 | 0.59 |
+| 32KB | 20.11 | 1.63 | 27.81 | 1.18 |
+| 64KB | 20.80 | 3.15 | 30.52 | 2.15 |
+| 128KB | 23.05 | 5.69 | 31.22 | 4.20 |
+| 256KB | 25.77 | 10.17 | 33.78 | 7.76 |
+| 512KB | 31.19 | 16.81 | 41.46 | 12.65 |
+| 1MB | 42.00 | 24.97 | 50.49 | 20.77 |
+| 2MB | 63.53 | 33.01 | 72.62 | 28.88 |
+| 4MB | 106.72 | 39.30 | 115.90 | 36.19 |
+| 8MB | 192.90 | 43.49 | 201.96 | 41.54 |
+| 16MB | 365.26 | 45.93 | 374.67 | 44.78 |
+| 32MB | 710.34 | 47.24 | 719.73 | 46.62 |
+| 64MB | 1400.89 | 47.90 | 1410.88 | 47.57 |
+| 128MB | 2786.67 | 48.16 | 2793.80 | 48.04 |
+| 256MB | 5567.98 | 48.21 | 5575.46 | 48.15 |
+| 512MB | 11113.82 | 48.31 | 11121.18 | 48.27 |
+| 1GB | 22204.38 | 48.36 | 22211.54 | 48.34 |
 
 ## PutSignalComparison
 
 | Size | IBGDA Counter Latency (us) | IBRC Counter Latency (us) |
 | --- | ---: | ---: |
-| 8B | 21.48 | 64.89 |
-| 64B | 22.26 | 64.81 |
-| 1KB | 22.54 | 64.01 |
-| 64KB | 24.50 | 65.44 |
-| 1MB | 45.78 | 111.09 |
-| 16MB | 368.99 | 704.07 |
+| 8B | 16.78 | 27.42 |
+| 64B | 18.80 | 27.46 |
+| 1KB | 18.94 | 27.38 |
+| 64KB | 20.83 | 31.11 |
+| 1MB | 41.94 | 50.80 |
+| 16MB | 365.32 | 374.78 |
 
 ## PutFlush Baseline
 
@@ -114,29 +117,29 @@ Summary:
 
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 16.89 | 0.00 | 38.64 | 0.00 |
-| 64B | 17.17 | 0.00 | 39.58 | 0.00 |
-| 256B | 17.25 | 0.01 | 38.55 | 0.01 |
-| 1KB | 17.35 | 0.06 | 38.55 | 0.03 |
-| 4KB | 17.67 | 0.23 | 38.54 | 0.11 |
-| 8KB | 17.79 | 0.46 | 38.53 | 0.21 |
-| 16KB | 18.10 | 0.90 | 39.22 | 0.42 |
-| 32KB | 18.47 | 1.77 | 38.60 | 0.85 |
-| 64KB | 19.15 | 3.42 | 43.39 | 1.51 |
-| 128KB | 21.39 | 6.13 | 44.10 | 2.97 |
-| 256KB | 24.09 | 10.88 | 50.02 | 5.24 |
-| 512KB | 29.48 | 17.78 | 61.50 | 8.52 |
-| 1MB | 40.28 | 26.03 | 83.85 | 12.51 |
-| 2MB | 61.86 | 33.90 | 127.60 | 16.44 |
-| 4MB | 105.03 | 39.94 | 207.77 | 20.19 |
-| 8MB | 191.35 | 43.84 | 375.71 | 22.33 |
-| 16MB | 364.00 | 46.09 | 695.80 | 24.11 |
-| 32MB | 709.30 | 47.31 | 1280.02 | 26.21 |
-| 64MB | 1399.92 | 47.94 | 2269.87 | 29.57 |
-| 128MB | 2782.83 | 48.23 | 3535.06 | 37.97 |
-| 256MB | 5566.01 | 48.23 | 6928.67 | 38.74 |
-| 512MB | 11111.88 | 48.32 | 13582.13 | 39.53 |
-| 1GB | 22202.67 | 48.36 | 23039.32 | 46.60 |
+| 8B | 11.81 | 0.00 | 22.67 | 0.00 |
+| 64B | 11.83 | 0.01 | 20.11 | 0.00 |
+| 256B | 12.27 | 0.02 | 20.08 | 0.01 |
+| 1KB | 12.37 | 0.08 | 20.04 | 0.05 |
+| 4KB | 12.58 | 0.33 | 20.13 | 0.20 |
+| 8KB | 12.80 | 0.64 | 19.98 | 0.41 |
+| 16KB | 12.99 | 1.26 | 20.09 | 0.82 |
+| 32KB | 13.48 | 2.43 | 21.50 | 1.52 |
+| 64KB | 14.16 | 4.63 | 22.28 | 2.94 |
+| 128KB | 16.37 | 8.01 | 22.62 | 5.79 |
+| 256KB | 19.07 | 13.74 | 26.74 | 9.80 |
+| 512KB | 24.48 | 21.42 | 33.40 | 15.70 |
+| 1MB | 35.27 | 29.73 | 42.25 | 24.82 |
+| 2MB | 56.86 | 36.89 | 65.69 | 31.92 |
+| 4MB | 100.02 | 41.93 | 108.51 | 38.65 |
+| 8MB | 186.34 | 45.02 | 194.58 | 43.11 |
+| 16MB | 359.00 | 46.73 | 366.93 | 45.72 |
+| 32MB | 704.31 | 47.64 | 712.63 | 47.09 |
+| 64MB | 1394.93 | 48.11 | 1402.98 | 47.83 |
+| 128MB | 2777.88 | 48.32 | 2784.92 | 48.19 |
+| 256MB | 5561.42 | 48.27 | 5567.89 | 48.21 |
+| 512MB | 11107.01 | 48.34 | 11113.06 | 48.31 |
+| 1GB | 22197.61 | 48.37 | 22203.10 | 48.36 |
 
 ## SignalOnly Baseline
 
@@ -144,5 +147,5 @@ Summary:
 
 | Metric | IBGDA | IBRC |
 | --- | ---: | ---: |
-| Average latency (us) | 17.75 | 40.90 |
+| Average latency (us) | 12.25 | 30.33 |
 | Batch iterations | 1000 | 1000 |


### PR DESCRIPTION
Summary:

Refresh `IbrcBenchmarkResults.md` with the 2026-06-24 `rtptest2333`/`rtptest2349` rerun after progress-thread pinning. Fix `PutWaitCounter` to use the parameterized `TEST_P` declaration so `GetParam()` selects IBGDA and IBRC correctly.

Differential Revision: D109635123


