### PR TITLE
comms/rcclx: sync snapshot RcclxScubaLogger to develop ((void) cudaGetDevice)

### DIFF
--- a/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/meta/scuba/RcclxScubaLogger.h
+++ b/comms/rcclx/snapshots/last-stable/comms/rcclx/develop/meta/scuba/RcclxScubaLogger.h
@@ -158,7 +158,7 @@ static void initNcclLogger() {
               meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
           .threadContextFn = []() {
             int cudaDev = -1;
-            cudaGetDevice(&cudaDev);
+            (void)cudaGetDevice(&cudaDev);
             return cudaDev;
           }});
   // Init logging for NCCL header inside meta directory.
@@ -176,7 +176,7 @@ static void initNcclLogger() {
               meta::comms::logger::getLoggerDebugLevel(NCCL_DEBUG)),
           .threadContextFn = []() {
             int cudaDev = -1;
-            cudaGetDevice(&cudaDev);
+            (void)cudaGetDevice(&cudaDev);
             return cudaDev;
           }});
 }


### PR DESCRIPTION
Summary: Add some now-required (void) casts.

Differential Revision: D109648567


