### PR TITLE
Add tag field to Send/Recv options and thread through BackendWrapper (#2991)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -568,16 +568,18 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
 }
 
-c10::intrusive_ptr<c10d::Work> BackendWrapper::send(
-    std::vector<at::Tensor>& tensors,
-    int dstRank,
-    int /*tag*/) {
+c10::intrusive_ptr<c10d::Work>
+BackendWrapper::send(std::vector<at::Tensor>& tensors, int dstRank, int tag) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
   if (coalescing_batch_.has_value()) {
+    // NOTE: `tag` is intentionally not threaded through the coalesced path.
+    // BatchSendRecv/P2POp carry no per-op tag, and only the Gloo backend
+    // consumes SendOptions::tag; coalescing is used for NCCL-style grouped
+    // P2P (batch_isend_irecv), which matches by order, not tag.
     coalescing_batch_->send(tensors.at(0), dstRank);
     // Per-op Work returned during coalescing is a no-op sentinel; the real
     // Work covering the whole batch is returned by endCoalescing(). c10d's
@@ -585,26 +587,31 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::send(
     return c10::make_intrusive<WorkWrapper>(
         c10::make_intrusive<TorchWorkCompleted>(), tensors);
   }
+  SendOptions opts;
+  opts.timeout = options_->timeout;
+  opts.tag = tag;
   return c10::make_intrusive<WorkWrapper>(
-      comm_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
+      comm_->send(tensors.at(0), dstRank, /*async_op=*/true, opts), tensors);
 }
 
-c10::intrusive_ptr<c10d::Work> BackendWrapper::recv(
-    std::vector<at::Tensor>& tensors,
-    int srcRank,
-    int /*tag*/) {
+c10::intrusive_ptr<c10d::Work>
+BackendWrapper::recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
   if (coalescing_batch_.has_value()) {
+    // See the note in send(): the coalesced path does not thread `tag`.
     coalescing_batch_->recv(tensors.at(0), srcRank);
     return c10::make_intrusive<WorkWrapper>(
         c10::make_intrusive<TorchWorkCompleted>(), tensors);
   }
+  RecvOptions opts;
+  opts.timeout = options_->timeout;
+  opts.tag = tag;
   return c10::make_intrusive<WorkWrapper>(
-      comm_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
+      comm_->recv(tensors.at(0), srcRank, /*async_op=*/true, opts), tensors);
 }
 
 void BackendWrapper::startCoalescing() {

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -19,6 +19,7 @@ class SendOptions {
  public:
   std::unordered_map<std::string, std::string> hints;
   std::chrono::milliseconds timeout;
+  int tag{0};
 
   SendOptions() : timeout(kNoTimeout) {}
 };
@@ -27,6 +28,7 @@ class RecvOptions {
  public:
   std::unordered_map<std::string, std::string> hints;
   std::chrono::milliseconds timeout;
+  int tag{0};
 
   RecvOptions() : timeout(kNoTimeout) {}
 };

--- a/comms/torchcomms/fake/TorchCommFake.cpp
+++ b/comms/torchcomms/fake/TorchCommFake.cpp
@@ -104,17 +104,21 @@ std::string_view TorchCommFake::getBackendName() const {
 
 c10::intrusive_ptr<TorchWork> TorchCommFake::send(
     const at::Tensor& /* tensor */,
-    int /* dst */,
+    int dst,
     bool /* async_op */,
-    const SendOptions& /* options */) {
+    const SendOptions& options) {
+  lastSendOptions_ = options;
+  lastSendDst_ = dst;
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 
 c10::intrusive_ptr<TorchWork> TorchCommFake::recv(
     at::Tensor& /* tensor */,
-    int /* src */,
+    int src,
     bool /* async_op */,
-    const RecvOptions& /* options */) {
+    const RecvOptions& options) {
+  lastRecvOptions_ = options;
+  lastRecvSrc_ = src;
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 

--- a/comms/torchcomms/fake/TorchCommFake.hpp
+++ b/comms/torchcomms/fake/TorchCommFake.hpp
@@ -4,6 +4,7 @@
 
 #include <comms/torchcomms/TorchCommBackend.hpp>
 #include <comms/torchcomms/TorchWork.hpp>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -223,6 +224,21 @@ class TorchCommFake : public TorchCommBackend {
     return registered_addrs_.count(tensor.data_ptr()) > 0;
   }
 
+  // P2P capture — records the most recent send/recv so tests can verify that
+  // options (e.g. tag) are threaded through to the backend.
+  std::optional<SendOptions> getLastSendOptionsForTest() const {
+    return lastSendOptions_;
+  }
+  int getLastSendDstForTest() const {
+    return lastSendDst_;
+  }
+  std::optional<RecvOptions> getLastRecvOptionsForTest() const {
+    return lastRecvOptions_;
+  }
+  int getLastRecvSrcForTest() const {
+    return lastRecvSrc_;
+  }
+
  private:
   bool initialized_;
   at::Device device_;
@@ -236,6 +252,10 @@ class TorchCommFake : public TorchCommBackend {
   std::unordered_map<std::string, std::string> hints_;
   bool shouldFailReconfigure_{false};
   std::unordered_set<void*> registered_addrs_;
+  std::optional<SendOptions> lastSendOptions_;
+  int lastSendDst_{-1};
+  std::optional<RecvOptions> lastRecvOptions_;
+  int lastRecvSrc_{-1};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ target_include_directories(TorchCommOptionsTest PRIVATE
 target_compile_features(TorchCommOptionsTest PRIVATE cxx_std_20)
 target_link_libraries(TorchCommOptionsTest PRIVATE
     torchcomms
+    ${TORCH_LIBRARIES}
     GTest::gtest_main
     GTest::gmock
     atomic
@@ -79,9 +80,17 @@ target_link_options(TorchCommFactoryTest PRIVATE
 # Add dependency so fake backend is built before factory test runs
 add_dependencies(TorchCommFactoryTest fake_test_backend)
 
+# TorchCommOptionsTest's BackendWrapper tag tests load the fake backend
+# dynamically via new_comm("fake_test"), so it also needs the fake backend
+# built and its path exported through FAKE_TEST_BACKEND_LIB_PATH.
+add_dependencies(TorchCommOptionsTest fake_test_backend)
+
 # Register tests with CTest
 include(GoogleTest)
-gtest_discover_tests(TorchCommOptionsTest)
+gtest_discover_tests(TorchCommOptionsTest
+    PROPERTIES
+    ENVIRONMENT "FAKE_TEST_BACKEND_LIB_PATH=$<TARGET_FILE:fake_test_backend>"
+)
 
 # For TorchCommFactoryTest, we need to set the environment variable
 # pointing to the fake backend library

--- a/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
@@ -3,6 +3,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <ATen/ATen.h>
+#include <cstdlib>
+
+#include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommOptions.hpp"
+#include "comms/torchcomms/fake/TorchCommFake.hpp"
 #include "comms/torchcomms/utils/Utils.hpp"
 
 using ::testing::_;
@@ -72,6 +79,69 @@ TEST(TorchCommOptionsTest, StringToBool) {
   EXPECT_THROW(torch::comms::string_to_bool("yess"), std::runtime_error);
   EXPECT_THROW(torch::comms::string_to_bool("nope"), std::runtime_error);
   EXPECT_THROW(torch::comms::string_to_bool("falsey"), std::runtime_error);
+}
+
+namespace {
+constexpr const char* kBackendName = "fake_test";
+constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";
+} // namespace
+
+// Verifies the behavior the tag field exists for: BackendWrapper::send/recv
+// must thread the c10d `tag` into SendOptions/RecvOptions and pass it down to
+// the backend. Uses the fake backend to capture the options actually received.
+class BackendWrapperTagTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* lib_path = std::getenv("FAKE_TEST_BACKEND_LIB_PATH");
+    ASSERT_NE(lib_path, nullptr) << "FAKE_TEST_BACKEND_LIB_PATH not set";
+    setenv(kBackendEnvKey, lib_path, 1);
+
+    comm_ = new_comm(kBackendName, at::Device(at::kCPU), "tag_test");
+    ASSERT_NE(comm_, nullptr);
+    // Widen the world so send/recv rank validation accepts non-zero peers.
+    auto* fake = getFakeBackend();
+    ASSERT_NE(fake, nullptr);
+    fake->setSize(4);
+    wrapper_ = c10::make_intrusive<BackendWrapper>(comm_);
+  }
+
+  void TearDown() override {
+    wrapper_.reset();
+    comm_.reset();
+    unsetenv(kBackendEnvKey);
+  }
+
+  // Callers must ASSERT_NE the result before use: ASSERT_* cannot live in this
+  // non-void helper, so a failed cast would otherwise fall through to a null
+  // dereference instead of a clean gtest failure.
+  TorchCommFake* getFakeBackend() {
+    return dynamic_cast<TorchCommFake*>(comm_->getBackendImpl().get());
+  }
+
+  std::shared_ptr<TorchComm> comm_;
+  c10::intrusive_ptr<BackendWrapper> wrapper_;
+};
+
+TEST_F(BackendWrapperTagTest, SendThreadsTagToBackend) {
+  std::vector<at::Tensor> tensors = {at::ones({4}, at::kFloat)};
+  wrapper_->send(tensors, /*dstRank=*/1, /*tag=*/123);
+
+  auto* fake = getFakeBackend();
+  ASSERT_NE(fake, nullptr);
+  ASSERT_TRUE(fake->getLastSendOptionsForTest().has_value());
+  EXPECT_EQ(fake->getLastSendOptionsForTest()->tag, 123);
+  EXPECT_EQ(fake->getLastSendDstForTest(), 1);
+}
+
+TEST_F(BackendWrapperTagTest, RecvThreadsTagToBackend) {
+  std::vector<at::Tensor> tensors = {at::empty({4}, at::kFloat)};
+  wrapper_->recv(tensors, /*srcRank=*/2, /*tag=*/456);
+
+  auto* fake = getFakeBackend();
+  ASSERT_NE(fake, nullptr);
+  ASSERT_TRUE(fake->getLastRecvOptionsForTest().has_value());
+  EXPECT_EQ(fake->getLastRecvOptionsForTest()->tag, 456);
+  EXPECT_EQ(fake->getLastRecvSrcForTest(), 2);
 }
 
 } // namespace torch::comms::test


### PR DESCRIPTION
Summary:

Adds an `int tag` field (default 0) to `SendOptions` and `RecvOptions`, and threads it through `BackendWrapper::send`/`recv` from the c10d `tag` argument so the point-to-point tag is passed down to the backend send/recv calls.

Previously the c10d `tag` parameter was dropped (the signatures took `int /*tag*/`). With this change BackendWrapper builds `SendOptions`/`RecvOptions` with `opts.tag = tag` and forwards them to `comm_->send`/`recv`.

## Context

P2P
operations that relied on tags to disambiguate concurrent transfers
(e.g. sglang PP metadata exchange, which uses distinct tags per
tensor dict key) would match the wrong messages.

**How discovered.** sglang PP metadata exchange under TC=1 produced
garbled dict values. `send_tensor_dict` / `recv_tensor_dict` use
per-key tags to multiplex multiple tensors over the same gloo group.
With tags silently dropped, all sends matched the first recv regardless
of key.

Reviewed By: d4l3k, kapilsh

Differential Revision: D109625548


