### PR TITLE
Wrap NCCL P2P send/recv in ncclGroupStart/End to fix event ordering (#2993)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -568,16 +568,18 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
 }
 
-c10::intrusive_ptr<c10d::Work> BackendWrapper::send(
-    std::vector<at::Tensor>& tensors,
-    int dstRank,
-    int /*tag*/) {
+c10::intrusive_ptr<c10d::Work>
+BackendWrapper::send(std::vector<at::Tensor>& tensors, int dstRank, int tag) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
   if (coalescing_batch_.has_value()) {
+    // NOTE: `tag` is intentionally not threaded through the coalesced path.
+    // BatchSendRecv/P2POp carry no per-op tag, and only the Gloo backend
+    // consumes SendOptions::tag; coalescing is used for NCCL-style grouped
+    // P2P (batch_isend_irecv), which matches by order, not tag.
     coalescing_batch_->send(tensors.at(0), dstRank);
     // Per-op Work returned during coalescing is a no-op sentinel; the real
     // Work covering the whole batch is returned by endCoalescing(). c10d's
@@ -585,26 +587,31 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::send(
     return c10::make_intrusive<WorkWrapper>(
         c10::make_intrusive<TorchWorkCompleted>(), tensors);
   }
+  SendOptions opts;
+  opts.timeout = options_->timeout;
+  opts.tag = tag;
   return c10::make_intrusive<WorkWrapper>(
-      comm_->send(tensors.at(0), dstRank, /*async_op=*/true), tensors);
+      comm_->send(tensors.at(0), dstRank, /*async_op=*/true, opts), tensors);
 }
 
-c10::intrusive_ptr<c10d::Work> BackendWrapper::recv(
-    std::vector<at::Tensor>& tensors,
-    int srcRank,
-    int /*tag*/) {
+c10::intrusive_ptr<c10d::Work>
+BackendWrapper::recv(std::vector<at::Tensor>& tensors, int srcRank, int tag) {
   TORCH_CHECK(
       tensors.size() == 1,
       "Only single tensor supported, but got ",
       tensors.size(),
       " tensors");
   if (coalescing_batch_.has_value()) {
+    // See the note in send(): the coalesced path does not thread `tag`.
     coalescing_batch_->recv(tensors.at(0), srcRank);
     return c10::make_intrusive<WorkWrapper>(
         c10::make_intrusive<TorchWorkCompleted>(), tensors);
   }
+  RecvOptions opts;
+  opts.timeout = options_->timeout;
+  opts.tag = tag;
   return c10::make_intrusive<WorkWrapper>(
-      comm_->recv(tensors.at(0), srcRank, /*async_op=*/true), tensors);
+      comm_->recv(tensors.at(0), srcRank, /*async_op=*/true, opts), tensors);
 }
 
 void BackendWrapper::startCoalescing() {

--- a/comms/torchcomms/TorchCommOptions.hpp
+++ b/comms/torchcomms/TorchCommOptions.hpp
@@ -19,6 +19,7 @@ class SendOptions {
  public:
   std::unordered_map<std::string, std::string> hints;
   std::chrono::milliseconds timeout;
+  int tag{0};
 
   SendOptions() : timeout(kNoTimeout) {}
 };
@@ -27,6 +28,7 @@ class RecvOptions {
  public:
   std::unordered_map<std::string, std::string> hints;
   std::chrono::milliseconds timeout;
+  int tag{0};
 
   RecvOptions() : timeout(kNoTimeout) {}
 };

--- a/comms/torchcomms/fake/TorchCommFake.cpp
+++ b/comms/torchcomms/fake/TorchCommFake.cpp
@@ -104,17 +104,21 @@ std::string_view TorchCommFake::getBackendName() const {
 
 c10::intrusive_ptr<TorchWork> TorchCommFake::send(
     const at::Tensor& /* tensor */,
-    int /* dst */,
+    int dst,
     bool /* async_op */,
-    const SendOptions& /* options */) {
+    const SendOptions& options) {
+  lastSendOptions_ = options;
+  lastSendDst_ = dst;
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 
 c10::intrusive_ptr<TorchWork> TorchCommFake::recv(
     at::Tensor& /* tensor */,
-    int /* src */,
+    int src,
     bool /* async_op */,
-    const RecvOptions& /* options */) {
+    const RecvOptions& options) {
+  lastRecvOptions_ = options;
+  lastRecvSrc_ = src;
   return c10::make_intrusive<TorchWorkCompleted>();
 }
 

--- a/comms/torchcomms/fake/TorchCommFake.hpp
+++ b/comms/torchcomms/fake/TorchCommFake.hpp
@@ -4,6 +4,7 @@
 
 #include <comms/torchcomms/TorchCommBackend.hpp>
 #include <comms/torchcomms/TorchWork.hpp>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -223,6 +224,21 @@ class TorchCommFake : public TorchCommBackend {
     return registered_addrs_.count(tensor.data_ptr()) > 0;
   }
 
+  // P2P capture — records the most recent send/recv so tests can verify that
+  // options (e.g. tag) are threaded through to the backend.
+  std::optional<SendOptions> getLastSendOptionsForTest() const {
+    return lastSendOptions_;
+  }
+  int getLastSendDstForTest() const {
+    return lastSendDst_;
+  }
+  std::optional<RecvOptions> getLastRecvOptionsForTest() const {
+    return lastRecvOptions_;
+  }
+  int getLastRecvSrcForTest() const {
+    return lastRecvSrc_;
+  }
+
  private:
   bool initialized_;
   at::Device device_;
@@ -236,6 +252,10 @@ class TorchCommFake : public TorchCommBackend {
   std::unordered_map<std::string, std::string> hints_;
   bool shouldFailReconfigure_{false};
   std::unordered_set<void*> registered_addrs_;
+  std::optional<SendOptions> lastSendOptions_;
+  int lastSendDst_{-1};
+  std::optional<RecvOptions> lastRecvOptions_;
+  int lastRecvSrc_{-1};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/gloo/TorchCommGloo.cpp
+++ b/comms/torchcomms/gloo/TorchCommGloo.cpp
@@ -462,27 +462,28 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::send(
 
   TracingGuard tracingGuard(name_, comm_size_, "send", dst, tensor, tensor);
 
-  // Convert tensor to CPU for Gloo compatibility
   auto tensorCPU = tensor.to(at::kCPU);
+  uint64_t tag = static_cast<uint64_t>(options.tag);
 
-  // Note on tensor lifetime: tensorCPU is captured by value in the lambda.
-  // Since at::Tensor uses reference counting, this ensures the storage remains
-  // alive until the async work completes.
-  return createWork(
-      [tensorCPU, dst, options, context = context_, tag = nextTag()]() {
-        const auto& scalarType = tensorCPU.scalar_type();
+  // Initiate the send immediately via gloo's unbound buffer, matching native
+  // ProcessGroupGloo::send semantics. buf->send() registers with the gloo
+  // transport layer and returns without blocking.
+  auto ptr = tensorCPU.const_data_ptr();
+  auto size = tensorCPU.numel() * tensorCPU.element_size();
+  auto buf = context_->createUnboundBuffer(const_cast<void*>(ptr), size);
+  buf->send(dst, tag);
 
-        // Use type dispatch to send tensor
-        GENERATE_ALL_TYPES(
-            scalarType,
-            sendTensor,
-            context,
-            tensorCPU,
-            dst,
-            tag,
-            options.timeout);
-      },
-      async_op);
+  if (!async_op) {
+    if (options.timeout == kNoTimeout) {
+      buf->waitSend();
+    } else {
+      buf->waitSend(options.timeout);
+    }
+    return c10::make_intrusive<TorchWorkCompleted>();
+  }
+
+  return c10::make_intrusive<TorchWorkGlooSend>(
+      std::move(tensorCPU), std::move(buf), options.timeout);
 }
 
 c10::intrusive_ptr<TorchWork> TorchCommGloo::recv(
@@ -504,39 +505,31 @@ c10::intrusive_ptr<TorchWork> TorchCommGloo::recv(
 
   TracingGuard tracingGuard(name_, comm_size_, "recv", src, tensor, tensor);
 
-  // Convert tensor to CPU for Gloo compatibility
   auto tensorCPU = tensor.to(at::kCPU);
+  uint64_t tag = static_cast<uint64_t>(options.tag);
 
-  // Note on tensor lifetime: Both 'tensor' and 'tensorCPU' are captured by
-  // value in the lambda below. Since at::Tensor uses reference counting
-  // (intrusive_ptr to TensorImpl), capturing by value increments the refcount
-  // and ensures the underlying storage remains alive until the async work
-  // completes. This is the intended and correct pattern for async operations.
-  return createWork(
-      [tensor,
-       tensorCPU,
-       src,
-       options = options,
-       context = context_,
-       tag = nextTag()]() mutable {
-        const auto& scalarType = tensorCPU.scalar_type();
+  // Initiate the recv immediately via gloo's unbound buffer, matching native
+  // ProcessGroupGloo::recv semantics. buf->recv() registers with the gloo
+  // transport layer and returns without blocking.
+  auto ptr = tensorCPU.mutable_data_ptr();
+  auto size = tensorCPU.numel() * tensorCPU.element_size();
+  auto buf = context_->createUnboundBuffer(ptr, size);
+  buf->recv(src, tag);
 
-        // Use type dispatch to receive tensor
-        GENERATE_ALL_TYPES(
-            scalarType,
-            recvTensor,
-            context,
-            tensorCPU,
-            src,
-            tag,
-            options.timeout);
+  if (!async_op) {
+    if (options.timeout == kNoTimeout) {
+      buf->waitRecv();
+    } else {
+      buf->waitRecv(options.timeout);
+    }
+    if (tensorCPU.device() != tensor.device()) {
+      tensor.copy_(tensorCPU);
+    }
+    return c10::make_intrusive<TorchWorkCompleted>();
+  }
 
-        if (tensorCPU.device() != tensor.device()) {
-          // Copy back to original device if needed
-          tensor.copy_(tensorCPU);
-        }
-      },
-      async_op);
+  return c10::make_intrusive<TorchWorkGlooRecv>(
+      tensor, std::move(tensorCPU), std::move(buf), options.timeout);
 }
 
 // Batch P2P Operations

--- a/comms/torchcomms/gloo/TorchWorkGloo.cpp
+++ b/comms/torchcomms/gloo/TorchWorkGloo.cpp
@@ -22,4 +22,67 @@ void TorchWorkGloo::wait() {
   runWaitPostHooks();
 }
 
+// --- P2P Send Work ---
+
+TorchWorkGlooSend::TorchWorkGlooSend(
+    at::Tensor tensor,
+    std::unique_ptr<gloo::transport::UnboundBuffer> buf,
+    std::chrono::milliseconds timeout)
+    : tensor_(std::move(tensor)), buf_(std::move(buf)), timeout_(timeout) {
+  setStatus(WorkStatus::INPROGRESS);
+}
+
+void TorchWorkGlooSend::wait() {
+  // Single-caller contract: wait() is not safe to call concurrently on the
+  // same work object. buf_->waitSend() is not thread-safe and waited_ is a
+  // plain guard, matching native ProcessGroupGloo::SendWork semantics.
+  if (waited_) {
+    return;
+  }
+  waited_ = true;
+  runWaitPreHooks();
+  if (timeout_ == kNoTimeout) {
+    buf_->waitSend();
+  } else {
+    buf_->waitSend(timeout_);
+  }
+  setStatus(WorkStatus::COMPLETED);
+  runWaitPostHooks();
+}
+
+// --- P2P Recv Work ---
+
+TorchWorkGlooRecv::TorchWorkGlooRecv(
+    at::Tensor originalTensor,
+    at::Tensor cpuTensor,
+    std::unique_ptr<gloo::transport::UnboundBuffer> buf,
+    std::chrono::milliseconds timeout)
+    : originalTensor_(std::move(originalTensor)),
+      cpuTensor_(std::move(cpuTensor)),
+      buf_(std::move(buf)),
+      timeout_(timeout) {
+  setStatus(WorkStatus::INPROGRESS);
+}
+
+void TorchWorkGlooRecv::wait() {
+  // Single-caller contract: wait() is not safe to call concurrently on the
+  // same work object. buf_->waitRecv() is not thread-safe and waited_ is a
+  // plain guard, matching native ProcessGroupGloo::RecvWork semantics.
+  if (waited_) {
+    return;
+  }
+  waited_ = true;
+  runWaitPreHooks();
+  if (timeout_ == kNoTimeout) {
+    buf_->waitRecv();
+  } else {
+    buf_->waitRecv(timeout_);
+  }
+  if (cpuTensor_.device() != originalTensor_.device()) {
+    originalTensor_.copy_(cpuTensor_);
+  }
+  setStatus(WorkStatus::COMPLETED);
+  runWaitPostHooks();
+}
+
 } // namespace torch::comms

--- a/comms/torchcomms/gloo/TorchWorkGloo.hpp
+++ b/comms/torchcomms/gloo/TorchWorkGloo.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <ATen/ATen.h>
+#include <gloo/transport/unbound_buffer.h>
 #include "comms/torchcomms/TorchWork.hpp"
 #include "comms/torchcomms/utils/TracingGuard.hpp"
 
@@ -28,6 +29,42 @@ class TorchWorkGloo : public TorchWork {
  protected:
   friend class TorchCommGloo;
   friend class TorchWorkGlooQueue;
+};
+
+// P2P send work: buf->send() already called inline; wait() calls waitSend().
+// Matches native ProcessGroupGloo::SendWork semantics.
+class TorchWorkGlooSend : public TorchWork {
+ public:
+  TorchWorkGlooSend(
+      at::Tensor tensor,
+      std::unique_ptr<gloo::transport::UnboundBuffer> buf,
+      std::chrono::milliseconds timeout);
+  void wait() override;
+
+ private:
+  at::Tensor tensor_;
+  std::unique_ptr<gloo::transport::UnboundBuffer> buf_;
+  std::chrono::milliseconds timeout_;
+  bool waited_{false};
+};
+
+// P2P recv work: buf->recv() already called inline; wait() calls waitRecv()
+// then copies back to original device if needed.
+class TorchWorkGlooRecv : public TorchWork {
+ public:
+  TorchWorkGlooRecv(
+      at::Tensor originalTensor,
+      at::Tensor cpuTensor,
+      std::unique_ptr<gloo::transport::UnboundBuffer> buf,
+      std::chrono::milliseconds timeout);
+  void wait() override;
+
+ private:
+  at::Tensor originalTensor_;
+  at::Tensor cpuTensor_;
+  std::unique_ptr<gloo::transport::UnboundBuffer> buf_;
+  std::chrono::milliseconds timeout_;
+  bool waited_{false};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchCommNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCL.cpp
@@ -454,17 +454,34 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::send(
   // Record start event before NCCL operation
   work->recordStart("send");
 
+  // Wrap in ncclGroupStart/End so the kernel is enqueued on the stream
+  // before we record the end event.  Without the group wrapper,
+  // non-blocking NCCL comms may defer kernel launch past the event
+  // record, causing the end event to fire before the data transfer
+  // completes.  (Matches c10d ProcessGroupNCCL::pointToPoint.)
   NCCL_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->send(
-          tensor.data_ptr(),
-          tensor.numel(),
-          getNcclDataType(tensor),
-          dst,
-          nccl_comm_,
-          stream),
-      "NCCL Send failed");
+      nccl_api_, nccl_comm_, nccl_api_->groupStart(), "NCCL GroupStart failed");
+  try {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->send(
+            tensor.data_ptr(),
+            tensor.numel(),
+            getNcclDataType(tensor),
+            dst,
+            nccl_comm_,
+            stream),
+        "NCCL Send failed");
+  } catch (...) {
+    // Close the group even on failure so the comm is not left mid-group for
+    // subsequent operations on this thread. groupEnd's own error is only logged
+    // (not thrown) since we are already propagating the original error.
+    NCCL_CHECK_IGNORE(nccl_api_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
+    throw;
+  }
+  NCCL_CHECK(
+      nccl_api_, nccl_comm_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
 
   // Record end event after NCCL operation
   work->recordEnd();
@@ -494,17 +511,30 @@ c10::intrusive_ptr<TorchWork> TorchCommNCCL::recv(
   // Record start event before NCCL operation
   work->recordStart("recv");
 
+  // Wrap in ncclGroupStart/End — see send() comment for rationale.
   NCCL_CHECK(
-      nccl_api_,
-      nccl_comm_,
-      nccl_api_->recv(
-          tensor.data_ptr(),
-          tensor.numel(),
-          getNcclDataType(tensor),
-          src,
-          nccl_comm_,
-          stream),
-      "NCCL Recv failed");
+      nccl_api_, nccl_comm_, nccl_api_->groupStart(), "NCCL GroupStart failed");
+  try {
+    NCCL_CHECK(
+        nccl_api_,
+        nccl_comm_,
+        nccl_api_->recv(
+            tensor.data_ptr(),
+            tensor.numel(),
+            getNcclDataType(tensor),
+            src,
+            nccl_comm_,
+            stream),
+        "NCCL Recv failed");
+  } catch (...) {
+    // Close the group even on failure so the comm is not left mid-group for
+    // subsequent operations on this thread. groupEnd's own error is only logged
+    // (not thrown) since we are already propagating the original error.
+    NCCL_CHECK_IGNORE(nccl_api_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
+    throw;
+  }
+  NCCL_CHECK(
+      nccl_api_, nccl_comm_, nccl_api_->groupEnd(), "NCCL GroupEnd failed");
 
   // Record end event after NCCL operation
   work->recordEnd();

--- a/comms/torchcomms/tests/integration/py/SendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/SendRecvTest.py
@@ -315,6 +315,67 @@ class SendRecvTest(unittest.TestCase):
                 # Verify the results after each replay
                 self._verify_results(recv_tensor, recv_rank)
 
+    def _async_send_recv_loop(self, count, dtype, num_iters, description_prefix):
+        """Issue num_iters async send/recv pairs with distinct per-iteration
+        values and verify each result immediately after wait().
+
+        Shared by the Gloo work-object regression (_async_send_recv_repeated)
+        and the NCCL event-ordering regression (_async_send_recv_event_ordering).
+        The per-iteration fill value is rank + 1 + i; for the tested world sizes
+        and iteration counts it stays well within the narrow int8 range, so the
+        values remain distinct per iteration (which is what makes stale/partial
+        data observable) without silently overflowing the dtype.
+        """
+        send_rank = (self.rank + 1) % self.num_ranks
+        recv_rank = (self.rank + self.num_ranks - 1) % self.num_ranks
+
+        for i in range(num_iters):
+            send_tensor = torch.ones(count, dtype=dtype, device=self.device) * int(
+                self.rank + 1 + i
+            )
+            recv_tensor = torch.zeros(count, dtype=dtype, device=self.device)
+
+            # Alternate order based on rank to avoid deadlock
+            if self.rank % 2 == 0:
+                send_work = self.torchcomm.send(send_tensor, send_rank, True)
+                recv_work = self.torchcomm.recv(recv_tensor, recv_rank, True)
+            else:
+                recv_work = self.torchcomm.recv(recv_tensor, recv_rank, True)
+                send_work = self.torchcomm.send(send_tensor, send_rank, True)
+
+            send_work.wait()
+            recv_work.wait()
+
+            expected = torch.ones(count, dtype=dtype) * int(recv_rank + 1 + i)
+            description = f"{description_prefix} iter {i} from rank {recv_rank}"
+            if dtype == torch.float:
+                self.assertTrue(
+                    torch.allclose(recv_tensor.cpu(), expected),
+                    f"Tensors not close enough for {description}",
+                )
+            else:
+                self.assertTrue(
+                    torch.equal(recv_tensor.cpu(), expected),
+                    f"Tensors not equal for {description}",
+                )
+
+    def _async_send_recv_repeated(self, count, dtype):
+        """Repeatedly issue async send/recv pairs with distinct per-iteration
+        values.
+
+        Exercises the rewritten Gloo P2P path, which initiates the transfer
+        inline on a gloo unbound buffer and returns a TorchWorkGlooSend/
+        TorchWorkGlooRecv work object completed on wait(). Looping creates and
+        waits on many of these work objects, which the single-shot tests do
+        not cover.
+        """
+        print(
+            f"Testing repeated async send/recv with count={count} and dtype={get_dtype_name(dtype)}"
+        )
+        self._async_send_recv_loop(
+            count, dtype, num_iters=4, description_prefix="repeated async"
+        )
+
     def _create_send_tensor(self, count, dtype):
         """Create send tensor with rank-specific values."""
         options = {"dtype": dtype, "device": self.device}
@@ -387,6 +448,12 @@ class SendRecvTest(unittest.TestCase):
         for count, dtype in itertools.product(self.counts, self.dtypes):
             with self.subTest(count=count, dtype=dtype):
                 self._send_recv_input_deleted(count, dtype)
+
+    def test_async_send_recv_repeated(self):
+        """Test repeated async send/recv create/wait cycles."""
+        for count, dtype in itertools.product(self.counts, self.dtypes):
+            with self.subTest(count=count, dtype=dtype):
+                self._async_send_recv_repeated(count, dtype)
 
     @unittest.skipIf(os.getenv("TEST_BACKEND") != "ncclx", "Skipping NCCLX-only tests")
     def test_graph_send_recv(self):

--- a/comms/torchcomms/tests/integration/py/SendRecvTest.py
+++ b/comms/torchcomms/tests/integration/py/SendRecvTest.py
@@ -376,6 +376,24 @@ class SendRecvTest(unittest.TestCase):
             count, dtype, num_iters=4, description_prefix="repeated async"
         )
 
+    def _async_send_recv_event_ordering(self, count, dtype):
+        """Regression test for NCCL P2P event ordering.
+
+        Issues async send/recv, waits on the work, and immediately reads back
+        the received data. work.wait() synchronizes on the end CUDA event
+        recorded after the NCCL call. Without wrapping the send/recv in
+        ncclGroupStart/End, a non-blocking NCCL comm may defer the kernel launch
+        past the end-event record, so the event can fire before the transfer
+        completes and wait() would return with stale/partial data. Looping with
+        distinct values makes such an early completion observable.
+        """
+        print(
+            f"Testing async send/recv event ordering with count={count} and dtype={get_dtype_name(dtype)}"
+        )
+        self._async_send_recv_loop(
+            count, dtype, num_iters=8, description_prefix="event ordering"
+        )
+
     def _create_send_tensor(self, count, dtype):
         """Create send tensor with rank-specific values."""
         options = {"dtype": dtype, "device": self.device}
@@ -454,6 +472,12 @@ class SendRecvTest(unittest.TestCase):
         for count, dtype in itertools.product(self.counts, self.dtypes):
             with self.subTest(count=count, dtype=dtype):
                 self._async_send_recv_repeated(count, dtype)
+
+    def test_async_send_recv_event_ordering(self):
+        """Regression test for NCCL P2P send/recv event ordering."""
+        for count, dtype in itertools.product(self.counts, self.dtypes):
+            with self.subTest(count=count, dtype=dtype):
+                self._async_send_recv_event_ordering(count, dtype)
 
     @unittest.skipIf(os.getenv("TEST_BACKEND") != "ncclx", "Skipping NCCLX-only tests")
     def test_graph_send_recv(self):

--- a/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/tests/unit/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ target_include_directories(TorchCommOptionsTest PRIVATE
 target_compile_features(TorchCommOptionsTest PRIVATE cxx_std_20)
 target_link_libraries(TorchCommOptionsTest PRIVATE
     torchcomms
+    ${TORCH_LIBRARIES}
     GTest::gtest_main
     GTest::gmock
     atomic
@@ -79,9 +80,17 @@ target_link_options(TorchCommFactoryTest PRIVATE
 # Add dependency so fake backend is built before factory test runs
 add_dependencies(TorchCommFactoryTest fake_test_backend)
 
+# TorchCommOptionsTest's BackendWrapper tag tests load the fake backend
+# dynamically via new_comm("fake_test"), so it also needs the fake backend
+# built and its path exported through FAKE_TEST_BACKEND_LIB_PATH.
+add_dependencies(TorchCommOptionsTest fake_test_backend)
+
 # Register tests with CTest
 include(GoogleTest)
-gtest_discover_tests(TorchCommOptionsTest)
+gtest_discover_tests(TorchCommOptionsTest
+    PROPERTIES
+    ENVIRONMENT "FAKE_TEST_BACKEND_LIB_PATH=$<TARGET_FILE:fake_test_backend>"
+)
 
 # For TorchCommFactoryTest, we need to set the environment variable
 # pointing to the fake backend library

--- a/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchCommOptionsTest.cpp
@@ -3,6 +3,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <ATen/ATen.h>
+#include <cstdlib>
+
+#include "comms/torchcomms/BackendWrapper.hpp"
+#include "comms/torchcomms/TorchComm.hpp"
+#include "comms/torchcomms/TorchCommOptions.hpp"
+#include "comms/torchcomms/fake/TorchCommFake.hpp"
 #include "comms/torchcomms/utils/Utils.hpp"
 
 using ::testing::_;
@@ -72,6 +79,69 @@ TEST(TorchCommOptionsTest, StringToBool) {
   EXPECT_THROW(torch::comms::string_to_bool("yess"), std::runtime_error);
   EXPECT_THROW(torch::comms::string_to_bool("nope"), std::runtime_error);
   EXPECT_THROW(torch::comms::string_to_bool("falsey"), std::runtime_error);
+}
+
+namespace {
+constexpr const char* kBackendName = "fake_test";
+constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";
+} // namespace
+
+// Verifies the behavior the tag field exists for: BackendWrapper::send/recv
+// must thread the c10d `tag` into SendOptions/RecvOptions and pass it down to
+// the backend. Uses the fake backend to capture the options actually received.
+class BackendWrapperTagTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* lib_path = std::getenv("FAKE_TEST_BACKEND_LIB_PATH");
+    ASSERT_NE(lib_path, nullptr) << "FAKE_TEST_BACKEND_LIB_PATH not set";
+    setenv(kBackendEnvKey, lib_path, 1);
+
+    comm_ = new_comm(kBackendName, at::Device(at::kCPU), "tag_test");
+    ASSERT_NE(comm_, nullptr);
+    // Widen the world so send/recv rank validation accepts non-zero peers.
+    auto* fake = getFakeBackend();
+    ASSERT_NE(fake, nullptr);
+    fake->setSize(4);
+    wrapper_ = c10::make_intrusive<BackendWrapper>(comm_);
+  }
+
+  void TearDown() override {
+    wrapper_.reset();
+    comm_.reset();
+    unsetenv(kBackendEnvKey);
+  }
+
+  // Callers must ASSERT_NE the result before use: ASSERT_* cannot live in this
+  // non-void helper, so a failed cast would otherwise fall through to a null
+  // dereference instead of a clean gtest failure.
+  TorchCommFake* getFakeBackend() {
+    return dynamic_cast<TorchCommFake*>(comm_->getBackendImpl().get());
+  }
+
+  std::shared_ptr<TorchComm> comm_;
+  c10::intrusive_ptr<BackendWrapper> wrapper_;
+};
+
+TEST_F(BackendWrapperTagTest, SendThreadsTagToBackend) {
+  std::vector<at::Tensor> tensors = {at::ones({4}, at::kFloat)};
+  wrapper_->send(tensors, /*dstRank=*/1, /*tag=*/123);
+
+  auto* fake = getFakeBackend();
+  ASSERT_NE(fake, nullptr);
+  ASSERT_TRUE(fake->getLastSendOptionsForTest().has_value());
+  EXPECT_EQ(fake->getLastSendOptionsForTest()->tag, 123);
+  EXPECT_EQ(fake->getLastSendDstForTest(), 1);
+}
+
+TEST_F(BackendWrapperTagTest, RecvThreadsTagToBackend) {
+  std::vector<at::Tensor> tensors = {at::empty({4}, at::kFloat)};
+  wrapper_->recv(tensors, /*srcRank=*/2, /*tag=*/456);
+
+  auto* fake = getFakeBackend();
+  ASSERT_NE(fake, nullptr);
+  ASSERT_TRUE(fake->getLastRecvOptionsForTest().has_value());
+  EXPECT_EQ(fake->getLastRecvOptionsForTest()->tag, 456);
+  EXPECT_EQ(fake->getLastRecvSrcForTest(), 2);
 }
 
 } // namespace torch::comms::test


### PR DESCRIPTION
Summary:

Wraps the NCCL point-to-point `send`/`recv` calls in `ncclGroupStart()`/`ncclGroupEnd()`.

Without the group wrapper, a non-blocking NCCL communicator may defer the kernel launch past the point where we record the operation's end CUDA event. The end event can then complete before the data transfer finishes, so `work.wait()` (which syncs on that event) can return with stale/partial data. Wrapping the enqueue in a group forces the kernel onto the stream before the end event is recorded, matching c10d `ProcessGroupNCCL::pointToPoint`.

## Context

**Problem.** `TorchCommNCCL::send()` and `recv()` issued the NCCL
call directly without wrapping it in `ncclGroupStart()`/`ncclGroupEnd()`.
With non-blocking NCCL communicators (the default for NCCL 2.19+), the
NCCL runtime may defer the kernel launch past the point where the
operation's end CUDA event is recorded. The end event can then complete
before the data transfer actually finishes, so `work.wait()` (which
syncs on that event) returns with stale or partial data.

**How discovered.** Intermittent data corruption in NCCL P2P transfers
under TC=1. Megatron PP send/recv and sglang NCCL tensor exchange
occasionally produced wrong values that were not reproducible on every
run — a classic symptom of a race between event recording and kernel
launch.

Reviewed By: d4l3k

Differential Revision: D109625550


