### PR TITLE
Make DeviceApiTest.GetMultimemAddress 2-rank guard refactor-proof

### DIFF
--- a/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
+++ b/comms/torchcomms/tests/integration/cpp/DeviceApiTest.cpp
@@ -906,7 +906,33 @@ TEST_F(DeviceApiTest, PutHalf) {
 // --- Address query tests ---
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)
-TEST_F(DeviceApiTest, GetMultimemAddress) {
+// Multimem (NVLS multicast) is gated on > 2 LSA ranks by the device backend
+// (NCCLDeviceBackend::create_device_window sets
+//   reqs.lsaMultimem = multimemSupport(...) && teamLsa(nccl_comm).nRanks > 2,
+// mirroring NCCL's internal gating). On <=2-rank configs the device-side
+// multimem pointer is null by design while the host side returns a valid NVLS
+// address, so the device-vs-host comparison is only meaningful with > 2 ranks.
+// The guard lives in this fixture's SetUp() — not inline in the test body — so
+// it cannot be silently dropped when the test bodies are refactored (the inline
+// GTEST_SKIP had been lost four times; see T277264786). Mirrors the Python
+// sibling test_e2e.py::test_get_multimem_address.
+class DeviceApiMultimemTest : public DeviceApiTest {
+ protected:
+  void SetUp() override {
+    DeviceApiTest::SetUp();
+    if (IsSkipped()) {
+      // Base SetUp already skipped (e.g. stress tests disabled); num_ranks_ is
+      // not populated, so don't evaluate the rank guard.
+      return;
+    }
+    if (num_ranks_ <= 2) {
+      GTEST_SKIP() << "get_multimem_address requires LSA team size > 2 "
+                      "(lsaMultimem is gated off for <=2-rank configs)";
+    }
+  }
+};
+
+TEST_F(DeviceApiMultimemTest, GetMultimemAddress) {
   testGetMultimemAddress();
 }
 #endif


### PR DESCRIPTION
Summary:
The `num_ranks_ <= 2` skip for `DeviceApiTest.GetMultimemAddress` has now been lost FOUR times — it landed in D102704460, D106054760, D107022052, and is being re-added inline again in D109643690 after the previous one was dropped when `DeviceApiTest.cpp` was refactored into the stress functional suite. Re-applying an inline `GTEST_SKIP()` at the top of the test body fixes the symptom, not the recurrence. This makes the guard structural so refactors of the test bodies cannot silently drop it (T277264786).

Root cause of the divergence (by design — verified in product code):
- Device side: `NCCLDeviceBackend::create_device_window` sets `reqs.lsaMultimem = nccl_api->multimemSupport(nccl_comm) && nccl_api->teamLsa(nccl_comm).nRanks > 2` (`comms/torchcomms/device/ncclx/NCCLDeviceBackend.cpp:115-120`), mirroring NCCL's internal gating. For <=2 ranks `lsaMultimem` is never requested, so the device-side `get_multimem_address()` returns null (`TorchCommDeviceNCCLX.cuh`).
- Host side: `TorchCommWindowNCCLXGin::get_multimem_address` -> `winGetLsaMultimemDevicePointer` has NO rank guard (`comms/torchcomms/ncclx/TorchCommWindowNCCLX.cpp:595-616`) and returns a valid NVLS address unconditionally.
- So on <=2 ranks `ASSERT_EQ(device_addr, host_addr)` fails (device=0, host=non-zero) by design; the comparison is only meaningful with > 2 ranks. The Python sibling `test_e2e.py::test_get_multimem_address` already skips this exact case.

Fix: move `GetMultimemAddress` onto a dedicated `DeviceApiMultimemTest` fixture whose `SetUp()` performs the `num_ranks_ <= 2` skip. The guard now lives in a lifecycle hook, separate from the test body that kept getting refactored, so it cannot be silently dropped. This supersedes the inline re-add in D109643690 (symptom-only).

Why this is non-flaky and cannot regress:
- Deterministic `num_ranks_ <= 2` check — not flaky.
- No product/behavior change — purely a test-side skip, so nothing it covers can regress.
- Only `GetMultimemAddress` moves to the new fixture; all other tests stay on `DeviceApiTest`/`DeviceApiPutTest`/etc. and are unchanged. On > 2 ranks `GetMultimemAddress` runs identically; on <=2 ranks it now skips (it was failing before).
- `IsSkipped()` guard returns early if the base `SetUp()` already skipped (stress tests disabled) so the rank guard never reads an unpopulated `num_ranks_`.
- gtest case rename `DeviceApiTest.GetMultimemAddress` -> `DeviceApiMultimemTest.GetMultimemAddress` is safe: no external references (disabled-test lists/configs) name the case (verified via search).

Resolves T277264786 and the 1x2 failure T277130539 (durably, vs the inline D109643690). Does NOT address the 1x8 variant T277130541 — that fails for a different reason (multimem divergence at > 2 ranks under p2p_disabled) and needs separate analysis.

Differential Revision: D109776261


