### PR TITLE
Fix cuda-bindings crash in CUDA-graph tests (dep + skip-when-unused)

### DIFF
--- a/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
+++ b/comms/torchcomms/tests/helpers/py/cuda_graph_test_helpers.py
@@ -368,8 +368,9 @@ class GraphTestBuilder:
     def _run(  # noqa: C901
         self,
         inputs: list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]],
-        expected: list[torch.Tensor]
-        | Callable[["GraphTestBuilder"], list[torch.Tensor]],
+        expected: (
+            list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]]
+        ),
         pipeline_fn: Callable[["GraphTestBuilder"], list[PipelineStep]],
         graph_assertions: Callable[["GraphTestBuilder"], None] | None = None,
     ) -> None:
@@ -422,22 +423,32 @@ class GraphTestBuilder:
                     params = "_".join(f"{k}={v}" for k, v in subtest.params.items())
                     test_name = f"{test_name}_{params}"
 
-                # Analyze captured graphs, optionally saving SVGs
+                # Analyze captured graphs only when the result is consumed —
+                # i.e. graph_assertions inspect graph_infos, or SVG export is
+                # requested. analyze_cuda_graph() calls graph.debug_dump(), which
+                # requires the optional `cuda-bindings` package (torch
+                # _dump_graph_dot -> _require_cuda_bindings); running it
+                # unconditionally makes tests that don't inspect graph structure
+                # fail when that package is absent (T277288124). graph_infos
+                # defaults to [] and is only ever read inside graph_assertions.
                 svg_dir = os.environ.get("CUDA_GRAPH_SVG_DIR")
-                if svg_dir:
-                    os.makedirs(svg_dir, exist_ok=True)
-                self.graph_infos = [
-                    analyze_cuda_graph(
-                        g,
-                        svg_path=os.path.join(
-                            svg_dir,
-                            f"{test_name}_graph{i}_rank{rank}.svg",
+                if graph_assertions is not None or svg_dir:
+                    if svg_dir:
+                        os.makedirs(svg_dir, exist_ok=True)
+                    self.graph_infos = [
+                        analyze_cuda_graph(
+                            g,
+                            svg_path=(
+                                os.path.join(
+                                    svg_dir,
+                                    f"{test_name}_graph{i}_rank{rank}.svg",
+                                )
+                                if svg_dir
+                                else None
+                            ),
                         )
-                        if svg_dir
-                        else None,
-                    )
-                    for i, g in enumerate(self.graphs)
-                ]
+                        for i, g in enumerate(self.graphs)
+                    ]
 
                 if graph_assertions is not None:
                     graph_assertions(self)
@@ -486,8 +497,9 @@ class GraphTestBuilder:
     def run_serial(
         self,
         inputs: list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]],
-        expected: list[torch.Tensor]
-        | Callable[["GraphTestBuilder"], list[torch.Tensor]],
+        expected: (
+            list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]]
+        ),
         graph_assertions: Callable[["GraphTestBuilder"], None] | None = None,
     ) -> None:
         """
@@ -503,8 +515,9 @@ class GraphTestBuilder:
     def run_concurrent(
         self,
         inputs: list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]],
-        expected: list[torch.Tensor]
-        | Callable[["GraphTestBuilder"], list[torch.Tensor]],
+        expected: (
+            list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]]
+        ),
         graph_assertions: Callable[["GraphTestBuilder"], None] | None = None,
     ) -> None:
         """
@@ -528,8 +541,9 @@ class GraphTestBuilder:
         self,
         pipeline: Callable[["GraphTestBuilder"], list[PipelineStep]],
         inputs: list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]],
-        expected: list[torch.Tensor]
-        | Callable[["GraphTestBuilder"], list[torch.Tensor]],
+        expected: (
+            list[torch.Tensor] | Callable[["GraphTestBuilder"], list[torch.Tensor]]
+        ),
         graph_assertions: Callable[["GraphTestBuilder"], None] | None = None,
     ) -> None:
         """


### PR DESCRIPTION
Summary:
All ncclx CUDA-graph integration tests were failing with:

  RuntimeError: This CUDAGraph API requires the cuda-bindings package;
  install it with `pip install cuda-bindings`.

from the shared helper `cuda_graph_test_helpers.py` `analyze_cuda_graph()` -> `graph.debug_dump()`, which (after a torch change) routes through `torch/cuda/graphs.py _dump_graph_dot -> _require_cuda_bindings()`; the `cuda-bindings` package was absent from the test environment.

Affected (all reproduced with the same traceback): T277288124 (CudaGraphsAllGatherAwareTest), T277295435 (CudaGraphsSingleTest), T277295685 (CudaGraphsMultipleTest), T277295276 (CudaGraphsConcurrencyTest), T277295274 (CudaGraphsLifecycleTest), T277295819 (TimeoutTest).

Two complementary fixes:
1. **BUCK dep** — add `fbsource//third-party/pypi/cuda-bindings:cuda-bindings` (resolves 12.9.5, which satisfies torch's `>=12.9.4,<13`) to the shared `cuda_graph_test_helpers` library so `debug_dump()` works. This fixes the assertion-based tests (CudaGraphsSingle/Multiple/Concurrency/Lifecycle, TimeoutTest), which call `analyze_cuda_graph` via `graph_assertions` and genuinely need the graph analysis.
2. **Helper gating** — only run `analyze_cuda_graph` when its result is consumed (`graph_assertions` provided or `CUDA_GRAPH_SVG_DIR` set). This fixes CudaGraphsAllGatherAwareTest (T277288124), which passes no `graph_assertions`, and avoids unnecessary `debug_dump` work.

Why this is safe (no regression) and not flaky:
- Verified every read of `b.graph_infos` across all CUDA-graph tests is inside a `graph_assertions` callback; `graph_infos` defaults to `[]`. So the gating only skips genuinely-unused analysis.
- `cuda-bindings` 12.9.5 satisfies torch's version constraint (no conflict).
- Deterministic conditions; test-only change.

Differential Revision: D109777003


