### PR TITLE
Remove unused imports from nccl4py setup.py (F401)

### DIFF
--- a/comms/ncclx/v2_29/bindings/nccl4py/setup.py
+++ b/comms/ncclx/v2_29/bindings/nccl4py/setup.py
@@ -1,6 +1,4 @@
 import os
-import re
-import subprocess
 from pathlib import Path
 
 from Cython.Build import cythonize


### PR DESCRIPTION
Summary:
Resolves the Ruff F401 code-quality task T277182004 (`'re' imported but unused` at `comms/ncclx/v2_29/bindings/nccl4py/setup.py:2`).

Removes the unused `import re` (the flagged line) and also the adjacent unused `import subprocess` — both are dead imports verified unreferenced anywhere in the 105-line file (each appears only on its own `import` line). Pure dead-import cleanup; no behavior change. Removing both leaves the file F401-clean rather than fixing one and leaving the sibling warning.

Differential Revision: D109854347


