### PR TITLE
Use kRdmaVersion in PutAcceptsAllNicHandlesWhenQpCountIsSmaller

### DIFF
--- a/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
+++ b/comms/uniflow/transport/rdma/tests/unit/RdmaTransportTest.cpp
@@ -339,7 +339,7 @@ TEST_F(RdmaTransportTest, PutAcceptsAllNicHandlesWhenQpCountIsSmaller) {
   transport.bind();
 
   RdmaTransportInfo remoteInfo;
-  remoteInfo.header.version = 1;
+  remoteInfo.header.version = kRdmaVersion;
   remoteInfo.header.numQps = 1;
   remoteInfo.header.numNics = 2;
   remoteInfo.header.domainId = kRemoteDomainId;


### PR DESCRIPTION
Summary:
`RdmaTransportTest.PutAcceptsAllNicHandlesWhenQpCountIsSmaller` fails 2/2 configs (T277306510) with `connect: failed to deserialize remote info: Unsupported RdmaTransportInfo version`.

Root cause: the subtest hardcodes `remoteInfo.header.version = 1`, but `kRdmaVersion` was bumped to 2 (`RdmaTransport.h:25`) and `RdmaTransportInfo::deserialize` rejects any `header.version != kRdmaVersion` (`RdmaTransport.cpp:172`). Every other subtest in this file sets `remoteInfo.header.version = kRdmaVersion`; this one used a stale literal and broke on the version bump.

Fix: set `remoteInfo.header.version = kRdmaVersion` (matching all sibling tests). Test-only; no product change. With the correct version the test deserializes and exercises its intended path (`put` when numQps (1) < numNics (2)).

Differential Revision: D109855459


