### PR TITLE
build_torchcomms.sh: avoid vendored pybind11 ABI mismatch

### DIFF
--- a/comms/torchcomms/gloo/CMakeLists.txt
+++ b/comms/torchcomms/gloo/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(torchcomms_comms_gloo PRIVATE
     ${Python3_INCLUDE_DIRS}
     ${gloo_SOURCE_DIR}
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_gloo)
 target_compile_features(torchcomms_comms_gloo PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_gloo PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_gloo PRIVATE

--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(torchcomms_comms_nccl PRIVATE
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_nccl)
 target_compile_features(torchcomms_comms_nccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_nccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_nccl PRIVATE

--- a/comms/torchcomms/ncclx/CMakeLists.txt
+++ b/comms/torchcomms/ncclx/CMakeLists.txt
@@ -120,6 +120,7 @@ target_include_directories(torchcomms_comms_ncclx PRIVATE
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_ncclx)
 target_compile_features(torchcomms_comms_ncclx PRIVATE cxx_std_20)
 
 # Add device API compile definition if headers are available

--- a/comms/torchcomms/rccl/CMakeLists.txt
+++ b/comms/torchcomms/rccl/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(torchcomms_comms_rccl PRIVATE
     ${ROCM_INCLUDE}
     ${ROCM_INCLUDE}/hip
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_rccl)
 target_compile_features(torchcomms_comms_rccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rccl PRIVATE

--- a/comms/torchcomms/rcclx/CMakeLists.txt
+++ b/comms/torchcomms/rcclx/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(torchcomms_comms_rcclx PRIVATE
     ${ROCM_INCLUDE}
     ${ROCM_INCLUDE}/hip
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_rcclx)
 target_compile_features(torchcomms_comms_rcclx PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_rcclx PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_rcclx PRIVATE

--- a/comms/torchcomms/transport/CMakeLists.txt
+++ b/comms/torchcomms/transport/CMakeLists.txt
@@ -82,6 +82,7 @@ target_include_directories(torchcomms_transport PRIVATE
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms_transport)
 target_compile_features(torchcomms_transport PRIVATE cxx_std_20)
 target_link_directories(torchcomms_transport PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_transport PRIVATE

--- a/comms/torchcomms/xccl/CMakeLists.txt
+++ b/comms/torchcomms/xccl/CMakeLists.txt
@@ -41,6 +41,7 @@ target_include_directories(torchcomms_comms_xccl PRIVATE
     ${CONDA_INCLUDE}
     ${Python3_INCLUDE_DIRS}
 )
+torchcomms_use_torch_pybind11(torchcomms_comms_xccl)
 target_compile_features(torchcomms_comms_xccl PRIVATE cxx_std_20)
 target_link_directories(torchcomms_comms_xccl PRIVATE ${CONDA_LIB})
 target_link_libraries(torchcomms_comms_xccl PRIVATE


### PR DESCRIPTION
Summary:
The torchcomms iterative build copies ncclx build outputs into the conda environment before running `pip install`. That include copy can overwrite the environment pybind11 headers with ncclx vendored pybind11 v2 headers, which use the v5 internals tag. Torch in the same environment is built with pybind11 v3.0.1 / internals v11, so `_comms.so` is compiled against a different pybind11 registry from torch `_C.so`. At import time that shows up as `_BackendWrapper` referencing an unknown `c10d::Backend` base, or as `RedOpType is already registered` when `torch.distributed` is imported first.

After installing ncclx headers and libraries, remove `$CONDA_PREFIX/include/pybind11` so the torchcomms extension resolves `pybind11/*` from torch bundled headers via `$TORCH_INSTALL_PREFIX/include`, matching torch ABI. Also copy all top-level text metadata from `comms/github` into the build directory, not only `version.txt`, so the local pip build has the same requirements files as the source tree.

Reviewed By: dboyda

Differential Revision: D109042936


