### PR TITLE
ctran: add splitShare local comm split (#3011)

### DIFF
--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -152,6 +152,23 @@ class CtranComm {
     return ctranOpCount_;
   }
 
+  inline bool isSplitShare() const {
+    return isSplitShare_;
+  }
+
+  inline CtranComm* resourceComm() {
+    return resourceComm_ == nullptr ? this : resourceComm_;
+  }
+
+  inline const CtranComm* resourceComm() const {
+    return resourceComm_ == nullptr ? this : resourceComm_;
+  }
+
+  // For splitShare children: child-rank -> parent-rank map. Empty otherwise.
+  inline const std::vector<int>& parentRanks() const {
+    return parentRanks_;
+  }
+
   // Get a pointer to the Transport array from MultiPeerTransport,
   // indexed by global rank. Returns nullptr if MultiPeerTransport is not
   // initialized.
@@ -194,6 +211,15 @@ class CtranComm {
   // TODO: change shared_prt to unique_ptr after refactor all ctran code using
   // CtranComm
   std::shared_ptr<ICtran> ctran_;
+
+  // Split-share comms define a rank group over a parent comm and share the
+  // parent's Ctran resources. They must not be used directly for
+  // collectives/RMA.
+  // Persistent window internals can borrow resourceComm_ for registration.
+  bool isSplitShare_{false};
+  CtranComm* resourceComm_{nullptr};
+  std::vector<int> parentRanks_;
+
   std::unique_ptr<meta::comms::ICtranBootstrap> bootstrap_;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;

--- a/comms/ctran/CtranCommSplit.cc
+++ b/comms/ctran/CtranCommSplit.cc
@@ -1,0 +1,243 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CtranCommSplit.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <folly/String.h>
+
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/Utils.h"
+
+namespace {
+
+class SplitBootstrapAdapter final : public meta::comms::ICtranBootstrap {
+ public:
+  SplitBootstrapAdapter(
+      meta::comms::ICtranBootstrap* bootstrap,
+      std::vector<int> childRankToParentRank)
+      : bootstrap_(bootstrap),
+        childRankToParentRank_(std::move(childRankToParentRank)) {}
+
+  folly::SemiFuture<int> allGather(void* buf, int len, int rank, int nranks)
+      override {
+    return bootstrap_->allGatherNvlDomain(
+        buf, len, rank, nranks, childRankToParentRank_);
+  }
+
+  folly::SemiFuture<int> barrier(int rank, int nranks) override {
+    return bootstrap_->barrierNvlDomain(rank, nranks, childRankToParentRank_);
+  }
+
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return bootstrap_->allGatherNvlDomain(
+        buf,
+        len,
+        nvlLocalRank,
+        nvlNranks,
+        mapChildRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return bootstrap_->barrierNvlDomain(
+        nvlLocalRank, nvlNranks, mapChildRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> send(void* buf, int len, int peer, int tag) override {
+    return bootstrap_->send(buf, len, childRankToParentRank_.at(peer), tag);
+  }
+
+  folly::SemiFuture<int> recv(void* buf, int len, int peer, int tag) override {
+    return bootstrap_->recv(buf, len, childRankToParentRank_.at(peer), tag);
+  }
+
+ private:
+  std::vector<int> mapChildRanks(std::vector<int> childRanks) const {
+    for (auto& rank : childRanks) {
+      rank = childRankToParentRank_.at(rank);
+    }
+    return childRanks;
+  }
+
+  meta::comms::ICtranBootstrap* bootstrap_{nullptr};
+  std::vector<int> childRankToParentRank_;
+};
+
+uint64_t makeSplitCommHash(
+    const ncclx::CommStateX* statex,
+    const std::vector<int>& parentRanks,
+    const std::string& commDesc) {
+  const std::string hashInput = folly::to<std::string>(
+      statex->commHash(), ":", commDesc, ":", folly::join(",", parentRanks));
+  return ctran::utils::getHash(
+      hashInput.data(), static_cast<int>(hashInput.size()));
+}
+
+commResult_t buildSplitShareChild(
+    CtranComm* parent,
+    std::vector<int> parentRanks,
+    const std::string& descSuffix,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr ||
+      parent->bootstrap_ == nullptr || childOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare CtranComm without parent statex/bootstrap or child output");
+  }
+  if (parent->isSplitShare()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "Cannot splitShare a splitShare CtranComm");
+  }
+  if (parentRanks.empty()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "Cannot splitShare CtranComm with no ranks");
+  }
+
+  auto* parentStatex = parent->statex_.get();
+  const int parentRank = parentStatex->rank();
+  int childRank = -1;
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    if (parentRanks[r] == parentRank) {
+      childRank = r;
+      break;
+    }
+  }
+  if (childRank == -1) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "splitShare ranks do not contain this parent rank {}",
+        parentRank);
+  }
+
+  const auto& parentTopologies = parentStatex->rankTopologiesRef();
+  std::vector<ncclx::RankTopology> childTopologies;
+  childTopologies.reserve(parentRanks.size());
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    auto topology = parentTopologies.at(parentRanks[r]);
+    topology.rank = r;
+    childTopologies.push_back(topology);
+  }
+
+  // Compose world ranks via parent's rank-to-world map so child->gRank() is
+  // honest. Falls back to parent rank when parent has no world-rank map set
+  // (lazy/non-eager init).
+  std::vector<int> worldRanks(parentRanks.size());
+  const bool parentHasWorldRanks =
+      !parentStatex->commRanksToWorldRanksRef().empty();
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    worldRanks[r] = parentHasWorldRanks ? parentStatex->gRank(parentRanks[r])
+                                        : parentRanks[r];
+  }
+
+  const std::string commDesc = parentStatex->commDesc() + descSuffix;
+  const uint64_t commHash =
+      makeSplitCommHash(parentStatex, parentRanks, commDesc);
+
+  auto child = std::make_shared<CtranComm>(parent->getAbort(), parent->config_);
+  child->config_.commDesc = commDesc;
+  child->logMetaData_ = parent->logMetaData_;
+  child->logMetaData_.commHash = commHash;
+  child->logMetaData_.commDesc = commDesc;
+  child->logMetaData_.rank = childRank;
+  child->logMetaData_.nRanks = parentRanks.size();
+  child->opCount_ = parent->opCount_;
+  child->runtimeConn_ = parent->runtimeConn_;
+  child->colltraceNew_ = parent->colltraceNew_;
+  child->memCache_ = parent->memCache_;
+  child->isSplitShare_ = true;
+  child->resourceComm_ = parent;
+  child->parentRanks_ = parentRanks;
+  child->bootstrap_ = std::make_unique<SplitBootstrapAdapter>(
+      parent->bootstrap_.get(), parentRanks);
+  child->statex_ = std::make_unique<ncclx::CommStateX>(
+      childRank,
+      static_cast<int>(parentRanks.size()),
+      parentStatex->cudaDev(),
+      parentStatex->cudaArch(),
+      parentStatex->busId(),
+      commHash,
+      std::move(childTopologies),
+      std::move(worldRanks),
+      commDesc,
+      false /* noLocal */,
+      static_cast<int>(parentRanks.size()) /* vCliqueSize */);
+
+  *childOut = std::move(child);
+  return commSuccess;
+}
+
+} // namespace
+
+commResult_t ctranCommSplitShare(
+    CtranComm* parent,
+    int color,
+    int key,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr ||
+      parent->bootstrap_ == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare CtranComm without parent statex/bootstrap");
+  }
+
+  struct Entry {
+    int color;
+    int key;
+  };
+
+  const int parentNRanks = parent->statex_->nRanks();
+  const int parentRank = parent->statex_->rank();
+  std::vector<Entry> entries(parentNRanks);
+  entries[parentRank] = Entry{color, key};
+  FB_COMMCHECK(
+      static_cast<commResult_t>(
+          parent->bootstrap_
+              ->allGather(
+                  entries.data(), sizeof(Entry), parentRank, parentNRanks)
+              .get()));
+
+  // Ranks with matching color, sorted by (key, parent_rank).
+  std::vector<std::pair<int, int>> matches;
+  matches.reserve(parentNRanks);
+  for (int r = 0; r < parentNRanks; ++r) {
+    if (entries[r].color == color) {
+      matches.emplace_back(entries[r].key, r);
+    }
+  }
+  std::sort(matches.begin(), matches.end());
+
+  std::vector<int> parentRanks;
+  parentRanks.reserve(matches.size());
+  for (const auto& m : matches) {
+    parentRanks.push_back(m.second);
+  }
+
+  return buildSplitShareChild(
+      parent, std::move(parentRanks), "/splitShare", childOut);
+}
+
+commResult_t ctranCommSplitLocalNvl(
+    CtranComm* parent,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare local NVL CtranComm without parent statex");
+  }
+  return buildSplitShareChild(
+      parent, parent->statex_->localRankToRanks(), "/local-nvl", childOut);
+}

--- a/comms/ctran/CtranCommSplit.h
+++ b/comms/ctran/CtranCommSplit.h
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+
+#include "comms/ctran/CtranComm.h"
+
+// Build a splitShare CtranComm: a "virtual" child that defines a subset of
+// parent ranks while sharing the parent's ctran_ resources (mapper/algo/gpe).
+// The child has ctran_ == nullptr by design — it must not be used for direct
+// collectives or RMA. It is intended for internal persistent-collective
+// machinery that needs to register a window over a subset of parent ranks.
+// The parent must outlive the child.
+//
+// MPI-style split: parent ranks with the same color end up in the same child
+// comm, ordered by key (ties broken by parent rank). Every parent rank must
+// participate.
+commResult_t ctranCommSplitShare(
+    CtranComm* parent,
+    int color,
+    int key,
+    std::shared_ptr<CtranComm>* childOut);
+
+// Convenience: splitShare for the caller's local NVL domain.
+commResult_t ctranCommSplitLocalNvl(
+    CtranComm* parent,
+    std::shared_ptr<CtranComm>* childOut);

--- a/comms/ctran/tests/CtranCommSplitTest.cc
+++ b/comms/ctran/tests/CtranCommSplitTest.cc
@@ -1,0 +1,117 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <folly/ScopeGuard.h>
+#include <folly/init/Init.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranCommSplit.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/testinfra/TestUtils.h"
+
+namespace {
+
+class CtranCommSplitTest : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    ctran::CtranDistTestFixture::SetUp();
+    parentComm_ = makeCtranComm();
+  }
+
+ protected:
+  std::unique_ptr<CtranComm> parentComm_;
+};
+
+TEST_F(CtranCommSplitTest, LocalNvlSplitMapsRanksAndBootstrap) {
+  std::shared_ptr<CtranComm> childComm;
+  COMMCHECK_TEST(ctranCommSplitLocalNvl(parentComm_.get(), &childComm));
+  ASSERT_NE(nullptr, childComm);
+
+  auto* parentStatex = parentComm_->statex_.get();
+  auto* childStatex = childComm->statex_.get();
+  const auto parentRanks = parentStatex->localRankToRanks();
+
+  EXPECT_TRUE(childComm->isSplitShare());
+  EXPECT_EQ(parentComm_.get(), childComm->resourceComm());
+  EXPECT_FALSE(ctranInitialized(childComm.get()));
+  EXPECT_EQ(nullptr, childComm->ctran_);
+  EXPECT_FALSE(
+      ctranAllGatherSupport(childComm.get(), NCCL_ALLGATHER_ALGO::ctdirect));
+
+  EXPECT_EQ(parentStatex->localRank(), childStatex->rank());
+  EXPECT_EQ(parentStatex->nLocalRanks(), childStatex->nRanks());
+  EXPECT_EQ(parentRanks, childComm->parentRanks());
+  // init_none leaves the parent without a world-rank map (gRank() would abort
+  // via CHECK_RANKMAP_SET); mirror buildSplitShareChild()'s fallback to the
+  // parent comm rank when the parent has no world-rank map.
+  const bool parentHasWorldRanks =
+      !parentStatex->commRanksToWorldRanksRef().empty();
+  for (int rank = 0; rank < childStatex->nRanks(); ++rank) {
+    const int parentRank = parentRanks[rank];
+    const int expectedWorldRank =
+        parentHasWorldRanks ? parentStatex->gRank(parentRank) : parentRank;
+    EXPECT_EQ(expectedWorldRank, childStatex->gRank(rank));
+  }
+
+  std::vector<int> gathered(childStatex->nRanks(), -1);
+  gathered[childStatex->rank()] = parentStatex->rank();
+  auto allGather = childComm->bootstrap_->allGather(
+      gathered.data(), sizeof(int), childStatex->rank(), childStatex->nRanks());
+  COMMCHECK_TEST(static_cast<commResult_t>(std::move(allGather).get()));
+  EXPECT_EQ(parentRanks, gathered);
+}
+
+TEST_F(CtranCommSplitTest, LocalNvlSplitSupportsWindowRegistration) {
+  std::shared_ptr<CtranComm> childComm;
+  COMMCHECK_TEST(ctranCommSplitLocalNvl(parentComm_.get(), &childComm));
+
+  constexpr size_t kBufferBytes = 8192;
+  void* buffer = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buffer, kBufferBytes));
+  auto bufferGuard = folly::makeGuard([&]() {
+    if (buffer != nullptr) {
+      cudaFree(buffer);
+    }
+  });
+
+  ctran::CtranWin* win = nullptr;
+  COMMCHECK_TEST(
+      ctran::ctranWinRegister(buffer, kBufferBytes, childComm.get(), &win));
+  auto winGuard = folly::makeGuard([&]() {
+    if (win != nullptr) {
+      ctran::ctranWinFree(win);
+    }
+  });
+
+  ASSERT_NE(nullptr, win);
+  EXPECT_TRUE(win->comm->isSplitShare());
+  EXPECT_EQ(parentComm_.get(), win->comm->resourceComm());
+  ASSERT_EQ(win->remWinInfo.size(), childComm->statex_->nRanks());
+  const int childRank = childComm->statex_->rank();
+  for (int rank = 0; rank < static_cast<int>(win->remWinInfo.size()); ++rank) {
+    EXPECT_NE(nullptr, win->remWinInfo[rank].dataAddr);
+    if (rank != childRank) {
+      EXPECT_NE(
+          CtranMapperBackend::UNSET, win->remWinInfo[rank].dataRkey.backend);
+    }
+  }
+
+  COMMCHECK_TEST(ctran::ctranWinFree(win));
+  win = nullptr;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <memory>
+#include <numeric>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
@@ -21,6 +22,130 @@
 using ctran::window::RemWinInfo;
 
 namespace ctran {
+namespace {
+
+commResult_t getWindowMapper(CtranComm* comm, CtranMapper** mapperOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || mapperOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or mapper output is null");
+  }
+
+  auto* resourceComm = comm->resourceComm();
+  if (!ctranInitialized(resourceComm) ||
+      resourceComm->ctran_->mapper == nullptr) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: window resource communicator has no initialized mapper");
+  }
+
+  *mapperOut = resourceComm->ctran_->mapper.get();
+  return commSuccess;
+}
+
+commResult_t getWindowResourceRanks(
+    CtranComm* comm,
+    std::vector<int>* ranksOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || ranksOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or rank output is null");
+  }
+
+  const int nRanks = comm->statex_->nRanks();
+  ranksOut->resize(nRanks);
+  if (!comm->isSplitShare()) {
+    std::iota(ranksOut->begin(), ranksOut->end(), 0);
+    return commSuccess;
+  }
+
+  const auto& resourceRanks = comm->parentRanks();
+  if (resourceRanks.size() != static_cast<size_t>(nRanks)) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window rank map size {} does not match nRanks {}",
+        resourceRanks.size(),
+        nRanks);
+  }
+
+  *ranksOut = resourceRanks;
+  return commSuccess;
+}
+
+commResult_t getWindowResourceRank(CtranComm* comm, int rank, int* rankOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || rankOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or rank output is null");
+  }
+  if (rank < 0 || rank >= comm->statex_->nRanks()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "CTRAN-WINDOW: rank {} is out of range", rank);
+  }
+  if (!comm->isSplitShare()) {
+    *rankOut = rank;
+    return commSuccess;
+  }
+
+  const auto& resourceRanks = comm->parentRanks();
+  if (resourceRanks.size() != static_cast<size_t>(comm->statex_->nRanks())) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window rank map size {} does not match nRanks {}",
+        resourceRanks.size(),
+        comm->statex_->nRanks());
+  }
+  *rankOut = resourceRanks[rank];
+  return commSuccess;
+}
+
+commResult_t windowBarrier(CtranComm* comm, CtranMapper* mapper) {
+  if (comm == nullptr || comm->statex_ == nullptr || mapper == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: cannot run window barrier without comm/statex/mapper");
+  }
+  if (!comm->isSplitShare()) {
+    return mapper->barrier();
+  }
+
+  std::vector<int> ranks;
+  FB_COMMCHECK(getWindowResourceRanks(comm, &ranks));
+  if (ranks.size() <= 1) {
+    return commSuccess;
+  }
+
+  const int myResourceRank = comm->resourceComm()->statex_->rank();
+  bool foundSelf = false;
+  for (const int rank : ranks) {
+    if (rank == myResourceRank) {
+      foundSelf = true;
+      break;
+    }
+  }
+  if (!foundSelf) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window ranks do not contain resource rank {}",
+        myResourceRank);
+  }
+
+  std::vector<CtranMapperRequest> reqs((ranks.size() - 1) * 2);
+  int reqIdx = 0;
+  for (const int peerRank : ranks) {
+    if (peerRank == myResourceRank) {
+      continue;
+    }
+    FB_COMMCHECK(mapper->irecvCtrl(peerRank, &reqs[reqIdx++]));
+    FB_COMMCHECK(mapper->isendCtrl(peerRank, &reqs[reqIdx++]));
+  }
+  for (auto& req : reqs) {
+    FB_COMMCHECK(mapper->waitRequest(&req));
+  }
+  return commSuccess;
+}
+
+} // namespace
 
 // Defined here (not in header) so that unique_ptr<HostWindow> destructor
 // sees the complete HostWindow type.
@@ -48,7 +173,8 @@ commResult_t CtranWin::exchange() {
 
   remWinInfo.resize(nRanks);
 
-  auto mapper = comm->ctran_->mapper.get();
+  CtranMapper* mapper = nullptr;
+  FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
   // Registration via ctran mapper.
   FB_COMMCHECK(mapper->regMem(
@@ -104,30 +230,50 @@ commResult_t CtranWin::exchange() {
       nRanks);
   std::vector<struct CtranMapperRemoteAccessKey> remoteUserBufAccessKeys(
       nRanks);
+  std::vector<int> exchangeRanks;
+  FB_COMMCHECK(getWindowResourceRanks(comm, &exchangeRanks));
+  if (comm->isSplitShare()) {
+    const auto resourceNRanks = comm->resourceComm()->statex_->nRanks();
+    remoteBaseBufs.resize(resourceNRanks);
+    remoteUserBufs.resize(resourceNRanks);
+    remoteBaseBufAccessKeys.resize(resourceNRanks);
+    remoteUserBufAccessKeys.resize(resourceNRanks);
+  }
 
   FB_COMMCHECK(mapper->allGatherCtrl(
-      winBasePtr, baseRegHdl, remoteBaseBufs, remoteBaseBufAccessKeys));
+      winBasePtr,
+      baseRegHdl,
+      exchangeRanks,
+      remoteBaseBufs,
+      remoteBaseBufAccessKeys));
 
   if (!allocDataBuf_) {
     // if data buffer is provided by user, extra round of handler exchange is
     // needed
     FB_COMMCHECK(mapper->allGatherCtrl(
-        winDataPtr, dataRegHdl, remoteUserBufs, remoteUserBufAccessKeys));
+        winDataPtr,
+        dataRegHdl,
+        exchangeRanks,
+        remoteUserBufs,
+        remoteUserBufAccessKeys));
   }
 
   for (auto r = 0; r < nRanks; r++) {
+    const int exchangeRank = exchangeRanks[r];
     remWinInfo[r].dataBytes = allRankSizes[r];
     if (allocDataBuf_) {
-      remWinInfo[r].dataAddr = remoteBaseBufs[r];
-      remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[r];
+      remWinInfo[r].dataAddr = remoteBaseBufs[exchangeRank];
+      remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[exchangeRank];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
-          reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
+          reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
+          allRankSizes[r]);
+      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     } else {
-      remWinInfo[r].dataAddr = remoteUserBufs[r];
-      remWinInfo[r].dataRkey = remoteUserBufAccessKeys[r];
-      remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(remoteBaseBufs[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
+      remWinInfo[r].dataAddr = remoteUserBufs[exchangeRank];
+      remWinInfo[r].dataRkey = remoteUserBufAccessKeys[exchangeRank];
+      remWinInfo[r].signalAddr =
+          reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     }
   }
   CLOGF_SUBSYS(
@@ -152,12 +298,12 @@ commResult_t CtranWin::exchange() {
 
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
-  FB_COMMCHECK(mapper->barrier());
+  FB_COMMCHECK(windowBarrier(comm, mapper));
   return commSuccess;
 }
 
 bool CtranWin::allGatherPSupported(CtranComm* comm) {
-  if (!ctranInitialized(comm)) {
+  if (comm == nullptr || comm->isSplitShare() || !ctranInitialized(comm)) {
     return false;
   }
   auto statex = comm->statex_.get();
@@ -242,7 +388,8 @@ commResult_t CtranWin::free(bool skipBarrier) {
   if (statex == nullptr) {
     FB_ERRORRETURN(commInternalError, "Empty communicator statex.");
   }
-  auto mapper = comm->ctran_->mapper.get();
+  CtranMapper* mapper = nullptr;
+  FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
   CLOGF_SUBSYS(
@@ -261,7 +408,7 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // ensure the host process waits for CUDA streams where put/wait operations
   // are launched.
   if (!skipBarrier) {
-    FB_COMMCHECK(mapper->barrier());
+    FB_COMMCHECK(windowBarrier(comm, mapper));
   }
 
   auto nRanks = statex->nRanks();
@@ -320,8 +467,14 @@ commResult_t CtranWin::free(bool skipBarrier) {
 }
 
 bool CtranWin::nvlEnabled(int rank) const {
+  CtranMapper* mapper = nullptr;
+  int resourceRank = -1;
+  if (getWindowMapper(comm, &mapper) != commSuccess ||
+      getWindowResourceRank(comm, rank, &resourceRank) != commSuccess) {
+    return false;
+  }
   return isGpuMem() &&
-      comm->ctran_->mapper->hasBackend(rank, CtranMapperBackend::NVL);
+      mapper->hasBackend(resourceRank, CtranMapperBackend::NVL);
 }
 
 #if defined(ENABLE_PRIMS)


### PR DESCRIPTION
Summary:

Add a reusable splitShare CtranComm mode that describes a subset of parent ranks while sharing the parent comm resources instead of constructing Ctran resources on the child. The child remaps bootstrap operations to parent ranks and keeps ctran_ null with resourceComm_ pointing at the parent, so direct collectives/RMA see the child as uninitialized while persistent window registration can borrow the parent mapper internally.

Reviewed By: minsii

Differential Revision: D105884518


