### PR TITLE
ctgraph capture: lazy first-replay rail exchange (#3013)

### DIFF
--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -263,7 +263,8 @@ commResult_t allGatherWinInit(
     CtranWin* win,
     CtranComm* comm,
     cudaStream_t stream,
-    CtranPersistentRequest*& request);
+    CtranPersistentRequest*& request,
+    bool deferRail = false);
 
 commResult_t allGatherWinExec(
     const void* sendbuff,
@@ -272,6 +273,17 @@ commResult_t allGatherWinExec(
     CtranPersistentRequest* request);
 
 commResult_t allGatherWinDestroy(CtranPersistentRequest* request);
+
+// Lazily exchange the cross-node rail IB rkeys on first use, called from the
+// windowed-allgather exec path: the rail entries are left UNSET at win init and
+// filled on the first graph replay. No-op once filled. Defined in
+// WinAllGather.cc.
+namespace allgatherp {
+struct PersistArgs;
+}
+commResult_t ensureRailKeysExchanged(
+    CtranComm* comm,
+    allgatherp::PersistArgs* pArgs);
 
 bool AllToAllPSupport(CtranComm* comm);
 

--- a/comms/ctran/Ctran.h
+++ b/comms/ctran/Ctran.h
@@ -272,6 +272,7 @@ commResult_t allGatherWinExec(
     CtranPersistentRequest* request);
 
 commResult_t allGatherWinDestroy(CtranPersistentRequest* request);
+
 bool AllToAllPSupport(CtranComm* comm);
 
 commResult_t AllToAllPInit(

--- a/comms/ctran/CtranComm.h
+++ b/comms/ctran/CtranComm.h
@@ -152,6 +152,23 @@ class CtranComm {
     return ctranOpCount_;
   }
 
+  inline bool isSplitShare() const {
+    return isSplitShare_;
+  }
+
+  inline CtranComm* resourceComm() {
+    return resourceComm_ == nullptr ? this : resourceComm_;
+  }
+
+  inline const CtranComm* resourceComm() const {
+    return resourceComm_ == nullptr ? this : resourceComm_;
+  }
+
+  // For splitShare children: child-rank -> parent-rank map. Empty otherwise.
+  inline const std::vector<int>& parentRanks() const {
+    return parentRanks_;
+  }
+
   // Get a pointer to the Transport array from MultiPeerTransport,
   // indexed by global rank. Returns nullptr if MultiPeerTransport is not
   // initialized.
@@ -194,6 +211,15 @@ class CtranComm {
   // TODO: change shared_prt to unique_ptr after refactor all ctran code using
   // CtranComm
   std::shared_ptr<ICtran> ctran_;
+
+  // Split-share comms define a rank group over a parent comm and share the
+  // parent's Ctran resources. They must not be used directly for
+  // collectives/RMA.
+  // Persistent window internals can borrow resourceComm_ for registration.
+  bool isSplitShare_{false};
+  CtranComm* resourceComm_{nullptr};
+  std::vector<int> parentRanks_;
+
   std::unique_ptr<meta::comms::ICtranBootstrap> bootstrap_;
   std::shared_ptr<meta::comms::colltrace::ICollTrace> colltraceNew_;
   std::shared_ptr<ncclx::memory::memCacheAllocator> memCache_;

--- a/comms/ctran/CtranCommSplit.cc
+++ b/comms/ctran/CtranCommSplit.cc
@@ -1,0 +1,243 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/CtranCommSplit.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <folly/String.h>
+
+#include "comms/ctran/bootstrap/ICtranBootstrap.h"
+#include "comms/ctran/utils/Checks.h"
+#include "comms/ctran/utils/Utils.h"
+
+namespace {
+
+class SplitBootstrapAdapter final : public meta::comms::ICtranBootstrap {
+ public:
+  SplitBootstrapAdapter(
+      meta::comms::ICtranBootstrap* bootstrap,
+      std::vector<int> childRankToParentRank)
+      : bootstrap_(bootstrap),
+        childRankToParentRank_(std::move(childRankToParentRank)) {}
+
+  folly::SemiFuture<int> allGather(void* buf, int len, int rank, int nranks)
+      override {
+    return bootstrap_->allGatherNvlDomain(
+        buf, len, rank, nranks, childRankToParentRank_);
+  }
+
+  folly::SemiFuture<int> barrier(int rank, int nranks) override {
+    return bootstrap_->barrierNvlDomain(rank, nranks, childRankToParentRank_);
+  }
+
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return bootstrap_->allGatherNvlDomain(
+        buf,
+        len,
+        nvlLocalRank,
+        nvlNranks,
+        mapChildRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return bootstrap_->barrierNvlDomain(
+        nvlLocalRank, nvlNranks, mapChildRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> send(void* buf, int len, int peer, int tag) override {
+    return bootstrap_->send(buf, len, childRankToParentRank_.at(peer), tag);
+  }
+
+  folly::SemiFuture<int> recv(void* buf, int len, int peer, int tag) override {
+    return bootstrap_->recv(buf, len, childRankToParentRank_.at(peer), tag);
+  }
+
+ private:
+  std::vector<int> mapChildRanks(std::vector<int> childRanks) const {
+    for (auto& rank : childRanks) {
+      rank = childRankToParentRank_.at(rank);
+    }
+    return childRanks;
+  }
+
+  meta::comms::ICtranBootstrap* bootstrap_{nullptr};
+  std::vector<int> childRankToParentRank_;
+};
+
+uint64_t makeSplitCommHash(
+    const ncclx::CommStateX* statex,
+    const std::vector<int>& parentRanks,
+    const std::string& commDesc) {
+  const std::string hashInput = folly::to<std::string>(
+      statex->commHash(), ":", commDesc, ":", folly::join(",", parentRanks));
+  return ctran::utils::getHash(
+      hashInput.data(), static_cast<int>(hashInput.size()));
+}
+
+commResult_t buildSplitShareChild(
+    CtranComm* parent,
+    std::vector<int> parentRanks,
+    const std::string& descSuffix,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr ||
+      parent->bootstrap_ == nullptr || childOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare CtranComm without parent statex/bootstrap or child output");
+  }
+  if (parent->isSplitShare()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "Cannot splitShare a splitShare CtranComm");
+  }
+  if (parentRanks.empty()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "Cannot splitShare CtranComm with no ranks");
+  }
+
+  auto* parentStatex = parent->statex_.get();
+  const int parentRank = parentStatex->rank();
+  int childRank = -1;
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    if (parentRanks[r] == parentRank) {
+      childRank = r;
+      break;
+    }
+  }
+  if (childRank == -1) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "splitShare ranks do not contain this parent rank {}",
+        parentRank);
+  }
+
+  const auto& parentTopologies = parentStatex->rankTopologiesRef();
+  std::vector<ncclx::RankTopology> childTopologies;
+  childTopologies.reserve(parentRanks.size());
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    auto topology = parentTopologies.at(parentRanks[r]);
+    topology.rank = r;
+    childTopologies.push_back(topology);
+  }
+
+  // Compose world ranks via parent's rank-to-world map so child->gRank() is
+  // honest. Falls back to parent rank when parent has no world-rank map set
+  // (lazy/non-eager init).
+  std::vector<int> worldRanks(parentRanks.size());
+  const bool parentHasWorldRanks =
+      !parentStatex->commRanksToWorldRanksRef().empty();
+  for (int r = 0; r < static_cast<int>(parentRanks.size()); ++r) {
+    worldRanks[r] = parentHasWorldRanks ? parentStatex->gRank(parentRanks[r])
+                                        : parentRanks[r];
+  }
+
+  const std::string commDesc = parentStatex->commDesc() + descSuffix;
+  const uint64_t commHash =
+      makeSplitCommHash(parentStatex, parentRanks, commDesc);
+
+  auto child = std::make_shared<CtranComm>(parent->getAbort(), parent->config_);
+  child->config_.commDesc = commDesc;
+  child->logMetaData_ = parent->logMetaData_;
+  child->logMetaData_.commHash = commHash;
+  child->logMetaData_.commDesc = commDesc;
+  child->logMetaData_.rank = childRank;
+  child->logMetaData_.nRanks = parentRanks.size();
+  child->opCount_ = parent->opCount_;
+  child->runtimeConn_ = parent->runtimeConn_;
+  child->colltraceNew_ = parent->colltraceNew_;
+  child->memCache_ = parent->memCache_;
+  child->isSplitShare_ = true;
+  child->resourceComm_ = parent;
+  child->parentRanks_ = parentRanks;
+  child->bootstrap_ = std::make_unique<SplitBootstrapAdapter>(
+      parent->bootstrap_.get(), parentRanks);
+  child->statex_ = std::make_unique<ncclx::CommStateX>(
+      childRank,
+      static_cast<int>(parentRanks.size()),
+      parentStatex->cudaDev(),
+      parentStatex->cudaArch(),
+      parentStatex->busId(),
+      commHash,
+      std::move(childTopologies),
+      std::move(worldRanks),
+      commDesc,
+      false /* noLocal */,
+      static_cast<int>(parentRanks.size()) /* vCliqueSize */);
+
+  *childOut = std::move(child);
+  return commSuccess;
+}
+
+} // namespace
+
+commResult_t ctranCommSplitShare(
+    CtranComm* parent,
+    int color,
+    int key,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr ||
+      parent->bootstrap_ == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare CtranComm without parent statex/bootstrap");
+  }
+
+  struct Entry {
+    int color;
+    int key;
+  };
+
+  const int parentNRanks = parent->statex_->nRanks();
+  const int parentRank = parent->statex_->rank();
+  std::vector<Entry> entries(parentNRanks);
+  entries[parentRank] = Entry{color, key};
+  FB_COMMCHECK(
+      static_cast<commResult_t>(
+          parent->bootstrap_
+              ->allGather(
+                  entries.data(), sizeof(Entry), parentRank, parentNRanks)
+              .get()));
+
+  // Ranks with matching color, sorted by (key, parent_rank).
+  std::vector<std::pair<int, int>> matches;
+  matches.reserve(parentNRanks);
+  for (int r = 0; r < parentNRanks; ++r) {
+    if (entries[r].color == color) {
+      matches.emplace_back(entries[r].key, r);
+    }
+  }
+  std::sort(matches.begin(), matches.end());
+
+  std::vector<int> parentRanks;
+  parentRanks.reserve(matches.size());
+  for (const auto& m : matches) {
+    parentRanks.push_back(m.second);
+  }
+
+  return buildSplitShareChild(
+      parent, std::move(parentRanks), "/splitShare", childOut);
+}
+
+commResult_t ctranCommSplitLocalNvl(
+    CtranComm* parent,
+    std::shared_ptr<CtranComm>* childOut) {
+  if (parent == nullptr || parent->statex_ == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Cannot splitShare local NVL CtranComm without parent statex");
+  }
+  return buildSplitShareChild(
+      parent, parent->statex_->localRankToRanks(), "/local-nvl", childOut);
+}

--- a/comms/ctran/CtranCommSplit.h
+++ b/comms/ctran/CtranCommSplit.h
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+
+#include "comms/ctran/CtranComm.h"
+
+// Build a splitShare CtranComm: a "virtual" child that defines a subset of
+// parent ranks while sharing the parent's ctran_ resources (mapper/algo/gpe).
+// The child has ctran_ == nullptr by design — it must not be used for direct
+// collectives or RMA. It is intended for internal persistent-collective
+// machinery that needs to register a window over a subset of parent ranks.
+// The parent must outlive the child.
+//
+// MPI-style split: parent ranks with the same color end up in the same child
+// comm, ordered by key (ties broken by parent rank). Every parent rank must
+// participate.
+commResult_t ctranCommSplitShare(
+    CtranComm* parent,
+    int color,
+    int key,
+    std::shared_ptr<CtranComm>* childOut);
+
+// Convenience: splitShare for the caller's local NVL domain.
+commResult_t ctranCommSplitLocalNvl(
+    CtranComm* parent,
+    std::shared_ptr<CtranComm>* childOut);

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -9,8 +9,11 @@
 // Two registration strategies:
 //
 //   winPersistBuffReg (ctgraph_pipeline/rdpipeline, nLocalRanks > 1):
-//     Both local and remote addresses must be stable across replays.
-//     Uses window: ctranWinRegister → allGatherWinInit → AlgoImpl dispatch.
+//     Local NVL peer addresses must be stable across replays because the
+//     captured CE broadcasts use them. Rail peers exchange IB addr/rkey once
+//     during allGatherWinInit.
+//     Uses local-NVL window registration → allGatherWinInit → AlgoImpl
+//     dispatch.
 //
 //   localPersistBuffReg (ctgraph_ring/rd, nLocalRanks == 1):
 //     Only local registration persists; remote exchange happens at each replay
@@ -23,9 +26,11 @@
 // is destroyed. Graph replay is guaranteed to finish before comm destroy.
 
 #include <folly/ScopeGuard.h>
+#include <memory>
+#include <utility>
 
 #include "comms/ctran/Ctran.h"
-#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/CtranCommSplit.h"
 #include "comms/ctran/algos/AllGather/AllGatherImpl.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
@@ -37,24 +42,37 @@
 
 namespace {
 
-// winPersistBuffReg: register recvbuff as a window, exchange handles with
-// all peers. Both local and remote addresses must be stable across replays.
+// winPersistBuffReg: register recvbuff as a window on the caller-provided
+// local-NVL clique comm (nvlComm), persisting only the NVL peers' addresses,
+// then run allGatherWinInit on the parent comm. allGatherWinInit fills the
+// cross-node rail IB keys before graph replay can use them, so the execution
+// path never needs to access a nonlocal window key. Registering on the
+// local-NVL comm preserves normal whole-communicator window registration
+// semantics within that domain.
 commResult_t winPersistBuffReg(
     void* recvbuff,
     size_t recvBytes,
     CtranComm* comm,
+    CtranComm* nvlComm,
     cudaStream_t stream,
-    ctran::CtranWin** winOut,
+    ctran::CtranWin** nvlWinOut,
     CtranPersistentRequest** requestOut) {
-  FB_COMMCHECK(ctran::ctranWinRegister(recvbuff, recvBytes, comm, winOut));
+  FB_COMMCHECK(
+      ctran::ctranWinRegister(recvbuff, recvBytes, nvlComm, nvlWinOut));
 
-  auto winGuard = folly::makeGuard([winOut]() { delete *winOut; });
+  auto winGuard = folly::makeGuard([nvlWinOut]() {
+    if (*nvlWinOut != nullptr) {
+      (*nvlWinOut)->free(true /* skipBarrier */);
+      delete *nvlWinOut;
+      *nvlWinOut = nullptr;
+    }
+  });
 
   CtranPersistentRequest* request = nullptr;
   {
     meta::comms::StreamCaptureModeGuard captureGuard{
         cudaStreamCaptureModeRelaxed};
-    FB_COMMCHECK(ctran::allGatherWinInit(*winOut, comm, stream, request));
+    FB_COMMCHECK(ctran::allGatherWinInit(*nvlWinOut, comm, stream, request));
   }
 
   winGuard.dismiss();
@@ -123,21 +141,29 @@ commResult_t ctranAllGatherCudagraphAware(
   switch (algo) {
     case NCCL_ALLGATHER_ALGO::ctgraph_pipeline:
     case NCCL_ALLGATHER_ALGO::ctgraph_rdpipeline: {
-      ctran::CtranWin* win = nullptr;
+      // Split a local-NVL clique comm to register the recvbuff window on, so
+      // only the NVL peers' addresses are persisted; the cross-node rail rkeys
+      // are exchanged in allGatherWinInit. nvlComm must outlive all graph
+      // replays, so it is moved into the deferred-cleanup closure below.
+      std::shared_ptr<CtranComm> nvlComm;
+      FB_COMMCHECK(ctranCommSplitLocalNvl(comm, &nvlComm));
+
+      ctran::CtranWin* nvlWin = nullptr;
       CtranPersistentRequest* request = nullptr;
-      FB_COMMCHECK(
-          winPersistBuffReg(recvbuff, recvBytes, comm, stream, &win, &request));
+      FB_COMMCHECK(winPersistBuffReg(
+          recvbuff, recvBytes, comm, nvlComm.get(), stream, &nvlWin, &request));
       FB_CHECKABORT(
-          win != nullptr, "winPersistBuffReg succeeded but win is null");
+          nvlWin != nullptr, "winPersistBuffReg succeeded but nvlWin is null");
       FB_CHECKABORT(
           request != nullptr,
           "winPersistBuffReg succeeded but request is null");
 
-      auto cleanup = [request, win]() {
+      auto cleanup = [request, nvlWin, nvlComm = std::move(nvlComm)]() mutable {
         ctran::allGatherWinDestroy(request);
         delete request;
-        win->free(true /* skipBarrier */);
-        delete win;
+        nvlWin->free(true /* skipBarrier */);
+        delete nvlWin;
+        nvlComm.reset();
       };
       auto cleanupGuard = folly::makeGuard(cleanup);
 

--- a/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
+++ b/comms/ctran/algos/AllGather/AllGatherCudagraphAware.cc
@@ -43,12 +43,14 @@
 namespace {
 
 // winPersistBuffReg: register recvbuff as a window on the caller-provided
-// local-NVL clique comm (nvlComm), persisting only the NVL peers' addresses,
-// then run allGatherWinInit on the parent comm. allGatherWinInit fills the
-// cross-node rail IB keys before graph replay can use them, so the execution
-// path never needs to access a nonlocal window key. Registering on the
-// local-NVL comm preserves normal whole-communicator window registration
-// semantics within that domain.
+// local-NVL clique comm (nvlComm), persisting only the NVL peers' addresses.
+// The cross-node rail IB rkeys are NOT exchanged here: allGatherWinInit leaves
+// them UNSET (deferRail) and they are filled lazily on the first graph replay
+// by ensureRailKeysExchanged() in the exec path. At replay all ranks are in
+// lockstep, so that in-line allGatherCtrl is quick and never gated by a
+// straggler's capture-time cuMemImport. Registering on the local-NVL comm
+// preserves normal whole-communicator window registration semantics within
+// that domain.
 commResult_t winPersistBuffReg(
     void* recvbuff,
     size_t recvBytes,
@@ -72,7 +74,9 @@ commResult_t winPersistBuffReg(
   {
     meta::comms::StreamCaptureModeGuard captureGuard{
         cudaStreamCaptureModeRelaxed};
-    FB_COMMCHECK(ctran::allGatherWinInit(*nvlWinOut, comm, stream, request));
+    FB_COMMCHECK(
+        ctran::allGatherWinInit(
+            *nvlWinOut, comm, stream, request, /*deferRail=*/true));
   }
 
   winGuard.dismiss();

--- a/comms/ctran/algos/AllGatherP/AlgoImpl.h
+++ b/comms/ctran/algos/AllGatherP/AlgoImpl.h
@@ -7,6 +7,10 @@
 
 namespace ctran::allgatherp {
 
+// Rail ranks of this rank: the same local rank on every node. Used by both the
+// window init rail key exchange and the early-rail-exchange prefetch path.
+std::vector<int> computeRailRanks(const ncclx::CommStateX* statex);
+
 class AlgoImpl {
  public:
   PersistArgs pArgs;

--- a/comms/ctran/algos/AllGatherP/PipelineImpl.cc
+++ b/comms/ctran/algos/AllGatherP/PipelineImpl.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <iostream>
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/AllGatherP/CommUtils.h"
@@ -33,6 +34,12 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   const auto sendSize =
       op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
   CtranComm* comm = opGroup.front()->comm_;
+
+  // Lazily exchange the cross-node rail IB rkeys on the first replay (win init
+  // leaves them UNSET). At replay all ranks are in lockstep, so this in-line
+  // exchange is quick and never gated by a straggler's capture-time
+  // cuMemImport. A no-op on later replays (rail entries already set).
+  FB_COMMCHECK(ctran::ensureRailKeysExchanged(comm, pArgs));
 
   const auto statex = comm->statex_.get();
   const auto rank = statex->rank();

--- a/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
+++ b/comms/ctran/algos/AllGatherP/StreamedRecursiveDoublingImpl.cc
@@ -5,6 +5,7 @@
 
 #include <folly/ScopeGuard.h>
 
+#include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGather/StreamedRd/Common.h"
 #include "comms/ctran/algos/AllGather/StreamedRd/Plan.h"
@@ -102,6 +103,12 @@ commResult_t gpeFn(const std::vector<std::unique_ptr<struct OpElem>>& opGroup) {
   const auto sendSize =
       op->allgatherP.count * commTypeSize(op->allgatherP.datatype);
   CtranComm* comm = opGroup.front()->comm_;
+
+  // Lazily exchange the cross-node rail IB rkeys on the first replay (win init
+  // leaves them UNSET). At replay all ranks are in lockstep, so this in-line
+  // exchange is quick and never gated by a straggler's capture-time
+  // cuMemImport. A no-op on later replays (rail entries already set).
+  FB_COMMCHECK(ctran::ensureRailKeysExchanged(comm, pArgs));
 
   const auto statex = comm->statex_.get();
   const auto rank = statex->rank();

--- a/comms/ctran/algos/AllGatherP/Types.h
+++ b/comms/ctran/algos/AllGatherP/Types.h
@@ -16,6 +16,12 @@ struct PersistArgs {
   std::vector<void*> remoteRecvBuffs;
   std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys;
 
+  // When set, populateWinPArgs populates only
+  // the local NVL window and marks initialized; the cross-node rail
+  // remoteRecvBuffs/remoteAccessKeys are left UNSET and filled later by the
+  // first-replay drain registered on the comm in winPersistBuffReg.
+  bool railDeferred{false};
+
   // Initialization offloads the remote handle exchange to GPE thread to avoid
   // potential deadlock on mapper epoch lock, if init is called again on the
   // main thread while there is an outstanding exec. Init returns without

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -178,9 +178,24 @@ commResult_t populateWinPArgs(
   const auto statex = comm->statex_.get();
   const auto railRanks = allgatherp::computeRailRanks(statex);
 
-  // Exchange the cross-node rail IB rkeys in-line during win init, on the GPE
-  // thread, before the captured graph can replay. populateRemoteInfoFromWindow
-  // has already filled the local NVL window entries; this fills the rail ones.
+  // Deferred rail wait (production / cudagraph capture path): the local NVL
+  // window info is already populated by populateRemoteInfoFromWindow. The
+  // cross-node rail entries stay UNSET here and are filled lazily on the first
+  // graph replay by ensureRailKeysExchanged() in the exec path. Skip the
+  // in-line allGatherCtrl/railBarrier path.
+  if (pArgs->railDeferred) {
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "allGatherWinInit: rank {} deferred rail rkey wait (filled at first replay)",
+        statex->rank());
+    pArgs->initialized.store(true);
+    return commSuccess;
+  }
+
+  // Direct (non-deferred) init: exchange the rail IB rkeys in-line. Only direct
+  // callers that do not defer (the windowed-allgather unit tests) reach this;
+  // the cudagraph capture path always defers above and fills lazily at replay.
   if (needsRailExchange(pArgs, railRanks, statex->rank())) {
     auto mapper = comm->ctran_->mapper.get();
     FB_COMMCHECK(mapper->allGatherCtrl(
@@ -205,11 +220,45 @@ commResult_t populateWinPArgs(
 }
 } // namespace
 
+// Lazily exchange the cross-node rail IB rkeys on first use. winPersistBuffReg
+// leaves the rail entries UNSET (populateWinPArgs only fills the local NVL
+// window); the first graph replay's exec gpeFn calls this to fill them in-line
+// before reading remote rail keys. At replay all ranks are in lockstep, so the
+// allGatherCtrl + barrier is quick and not gated by any straggler's
+// capture-time cuMemImport. Subsequent replays find the entries set (the
+// needsRailExchange null-check returns false) and this is a no-op.
+commResult_t ensureRailKeysExchanged(
+    CtranComm* comm,
+    allgatherp::PersistArgs* pArgs) {
+  const auto statex = comm->statex_.get();
+  const auto railRanks = allgatherp::computeRailRanks(statex);
+  if (!needsRailExchange(pArgs, railRanks, statex->rank())) {
+    return commSuccess;
+  }
+  auto mapper = comm->ctran_->mapper.get();
+  FB_COMMCHECK(mapper->allGatherCtrl(
+      pArgs->recvbuff,
+      pArgs->recvHdl,
+      railRanks,
+      pArgs->remoteRecvBuffs,
+      pArgs->remoteAccessKeys,
+      CtranMapperBackend::IB));
+  FB_COMMCHECK(railBarrier(mapper, railRanks, statex->rank()));
+  CLOGF_SUBSYS(
+      INFO,
+      INIT,
+      "ensureRailKeysExchanged: rank {} lazily exchanged rail IB rkeys over {} ranks",
+      statex->rank(),
+      railRanks.size());
+  return commSuccess;
+}
+
 commResult_t allGatherWinInit(
     CtranWin* win,
     CtranComm* comm,
     cudaStream_t stream,
-    CtranPersistentRequest*& request) {
+    CtranPersistentRequest*& request,
+    bool deferRail) {
   FB_COMMCHECK(validateWindowRemoteInfo(win, comm));
 
   auto algo = std::make_unique<AlgoImpl>(comm, stream);
@@ -217,6 +266,14 @@ commResult_t allGatherWinInit(
   algo->pArgs.recvbuff = win->winDataPtr;
   algo->pArgs.recvHdl = win->dataRegHdl;
   algo->pArgs.initialized.store(false);
+
+  // Deferred rail wait: the rail IB key exchange was issued in
+  // winPersistBuffReg but is NOT waited here. Mark the rail entries deferred so
+  // populateWinPArgs skips the in-line allGatherCtrl; the rail entries are
+  // filled later by the first-replay drain registered on the comm.
+  if (deferRail) {
+    algo->pArgs.railDeferred = true;
+  }
 
   FB_COMMCHECK(algo->initResources());
 

--- a/comms/ctran/algos/AllGatherP/WinAllGather.cc
+++ b/comms/ctran/algos/AllGatherP/WinAllGather.cc
@@ -1,9 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <vector>
+
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllGatherP/AlgoImpl.h"
 #include "comms/ctran/algos/AllGatherP/Types.h"
 #include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/window/CtranWin.h"
 #include "comms/utils/cvars/nccl_cvars.h"
@@ -30,8 +33,133 @@ using ctran::allgatherp::PersistArgs;
 
 namespace ctran {
 
+namespace allgatherp {
+std::vector<int> computeRailRanks(const ncclx::CommStateX* statex) {
+  const int localRank = statex->localRank();
+  const int nNodes = statex->nNodes();
+
+  std::vector<int> ranks;
+  ranks.reserve(nNodes);
+  for (int node = 0; node < nNodes; ++node) {
+    ranks.push_back(statex->localRankToRank(localRank, node));
+  }
+  return ranks;
+}
+} // namespace allgatherp
+
 namespace {
 const std::string algoWinInitName = "CtranAllGatherWinInit";
+
+bool needsRailExchange(
+    const PersistArgs* pArgs,
+    const std::vector<int>& railRanks,
+    int myRank) {
+  for (const int rank : railRanks) {
+    if (rank != myRank &&
+        pArgs->remoteAccessKeys[rank].backend == CtranMapperBackend::UNSET) {
+      return true;
+    }
+  }
+  return false;
+}
+
+commResult_t railBarrier(
+    CtranMapper* mapper,
+    const std::vector<int>& railRanks,
+    int myRank) {
+  if (railRanks.size() <= 1) {
+    return commSuccess;
+  }
+  std::vector<CtranMapperRequest> reqs((railRanks.size() - 1) * 2);
+  int reqIdx = 0;
+  for (const int peerRank : railRanks) {
+    if (peerRank == myRank) {
+      continue;
+    }
+    FB_COMMCHECK(mapper->irecvCtrl(peerRank, &reqs[reqIdx++]));
+    FB_COMMCHECK(mapper->isendCtrl(peerRank, &reqs[reqIdx++]));
+  }
+  for (auto& req : reqs) {
+    FB_COMMCHECK(mapper->waitRequest(&req));
+  }
+  return commSuccess;
+}
+
+commResult_t validateWindowRemoteInfo(const CtranWin* win, CtranComm* comm) {
+  const auto nRanks = comm->statex_->nRanks();
+  const auto winRanks = static_cast<int>(win->remWinInfo.size());
+  if (winRanks == 0) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Window remWinInfo not populated. Was exchange() called?");
+  }
+  if (winRanks == nRanks) {
+    return commSuccess;
+  }
+
+  if (win->comm == nullptr || win->comm->statex_ == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Window was registered on a communicator without statex");
+  }
+  const auto& windowRanksToCommRanks = win->comm->parentRanks();
+  if (windowRanksToCommRanks.size() != win->remWinInfo.size()) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "Window remWinInfo size {} does not match window rank map size {}",
+        win->remWinInfo.size(),
+        windowRanksToCommRanks.size());
+  }
+
+  std::vector<bool> seenRanks(nRanks, false);
+  for (const auto commRank : windowRanksToCommRanks) {
+    if (commRank < 0 || commRank >= nRanks) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "Window rank map contains parent rank {} outside [0, {})",
+          commRank,
+          nRanks);
+    }
+    if (seenRanks[commRank]) {
+      FB_ERRORRETURN(
+          commInvalidArgument,
+          "Window rank map contains duplicate parent rank {}",
+          commRank);
+    }
+    seenRanks[commRank] = true;
+  }
+
+  return commSuccess;
+}
+
+commResult_t populateRemoteInfoFromWindow(
+    const CtranWin* win,
+    CtranComm* comm,
+    PersistArgs* pArgs) {
+  FB_COMMCHECK(validateWindowRemoteInfo(win, comm));
+
+  const auto nRanks = comm->statex_->nRanks();
+  pArgs->remoteRecvBuffs.assign(nRanks, nullptr);
+  pArgs->remoteAccessKeys.assign(nRanks, CtranMapperRemoteAccessKey{});
+
+  if (static_cast<int>(win->remWinInfo.size()) == nRanks) {
+    for (int r = 0; r < nRanks; r++) {
+      pArgs->remoteRecvBuffs[r] = win->remWinInfo[r].dataAddr;
+      pArgs->remoteAccessKeys[r] = win->remWinInfo[r].dataRkey;
+    }
+    return commSuccess;
+  }
+
+  const auto& windowRanksToCommRanks = win->comm->parentRanks();
+  for (int winRank = 0; winRank < static_cast<int>(win->remWinInfo.size());
+       ++winRank) {
+    const int commRank = windowRanksToCommRanks[winRank];
+    pArgs->remoteRecvBuffs[commRank] = win->remWinInfo[winRank].dataAddr;
+    pArgs->remoteAccessKeys[commRank] = win->remWinInfo[winRank].dataRkey;
+  }
+
+  return commSuccess;
+}
 
 // GPE callback: populate pArgs remote info from window, then mark initialized.
 // Runs on GPE thread to avoid races between init and exec on the mapper epoch
@@ -43,15 +171,33 @@ commResult_t populateWinPArgs(
   auto* win = op->allgatherp_init.win;
   CtranComm* comm = opGroup.front()->comm_;
 
-  const auto nRanks = comm->statex_->nRanks();
-
   CtranAlgoLogger logger(algoWinInitName, op->opCount, comm);
 
-  pArgs->remoteRecvBuffs.resize(nRanks);
-  pArgs->remoteAccessKeys.resize(nRanks);
-  for (int r = 0; r < nRanks; r++) {
-    pArgs->remoteRecvBuffs[r] = win->remWinInfo[r].dataAddr;
-    pArgs->remoteAccessKeys[r] = win->remWinInfo[r].dataRkey;
+  FB_COMMCHECK(populateRemoteInfoFromWindow(win, comm, pArgs));
+
+  const auto statex = comm->statex_.get();
+  const auto railRanks = allgatherp::computeRailRanks(statex);
+
+  // Exchange the cross-node rail IB rkeys in-line during win init, on the GPE
+  // thread, before the captured graph can replay. populateRemoteInfoFromWindow
+  // has already filled the local NVL window entries; this fills the rail ones.
+  if (needsRailExchange(pArgs, railRanks, statex->rank())) {
+    auto mapper = comm->ctran_->mapper.get();
+    FB_COMMCHECK(mapper->allGatherCtrl(
+        pArgs->recvbuff,
+        pArgs->recvHdl,
+        railRanks,
+        pArgs->remoteRecvBuffs,
+        pArgs->remoteAccessKeys,
+        CtranMapperBackend::IB));
+    FB_COMMCHECK(railBarrier(mapper, railRanks, statex->rank()));
+
+    CLOGF_SUBSYS(
+        INFO,
+        INIT,
+        "allGatherWinInit: rank {} exchanged rail IB rkeys over {} ranks",
+        statex->rank(),
+        railRanks.size());
   }
 
   pArgs->initialized.store(true);
@@ -64,17 +210,7 @@ commResult_t allGatherWinInit(
     CtranComm* comm,
     cudaStream_t stream,
     CtranPersistentRequest*& request) {
-  const auto statex = comm->statex_.get();
-  const auto nRanks = statex->nRanks();
-
-  if (win->remWinInfo.empty() ||
-      static_cast<int>(win->remWinInfo.size()) != nRanks) {
-    FB_ERRORRETURN(
-        commInvalidArgument,
-        "Window remWinInfo not populated (size {}). "
-        "Was exchange() called?",
-        win->remWinInfo.size());
-  }
+  FB_COMMCHECK(validateWindowRemoteInfo(win, comm));
 
   auto algo = std::make_unique<AlgoImpl>(comm, stream);
 

--- a/comms/ctran/tests/CtranCommSplitTest.cc
+++ b/comms/ctran/tests/CtranCommSplitTest.cc
@@ -1,0 +1,117 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <folly/ScopeGuard.h>
+#include <folly/init/Init.h>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranCommSplit.h"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/window/CtranWin.h"
+#include "comms/testinfra/TestUtils.h"
+
+namespace {
+
+class CtranCommSplitTest : public ctran::CtranDistTestFixture {
+ public:
+  void SetUp() override {
+    setenv("NCCL_CTRAN_ENABLE", "1", 0);
+    ctran::CtranDistTestFixture::SetUp();
+    parentComm_ = makeCtranComm();
+  }
+
+ protected:
+  std::unique_ptr<CtranComm> parentComm_;
+};
+
+TEST_F(CtranCommSplitTest, LocalNvlSplitMapsRanksAndBootstrap) {
+  std::shared_ptr<CtranComm> childComm;
+  COMMCHECK_TEST(ctranCommSplitLocalNvl(parentComm_.get(), &childComm));
+  ASSERT_NE(nullptr, childComm);
+
+  auto* parentStatex = parentComm_->statex_.get();
+  auto* childStatex = childComm->statex_.get();
+  const auto parentRanks = parentStatex->localRankToRanks();
+
+  EXPECT_TRUE(childComm->isSplitShare());
+  EXPECT_EQ(parentComm_.get(), childComm->resourceComm());
+  EXPECT_FALSE(ctranInitialized(childComm.get()));
+  EXPECT_EQ(nullptr, childComm->ctran_);
+  EXPECT_FALSE(
+      ctranAllGatherSupport(childComm.get(), NCCL_ALLGATHER_ALGO::ctdirect));
+
+  EXPECT_EQ(parentStatex->localRank(), childStatex->rank());
+  EXPECT_EQ(parentStatex->nLocalRanks(), childStatex->nRanks());
+  EXPECT_EQ(parentRanks, childComm->parentRanks());
+  // init_none leaves the parent without a world-rank map (gRank() would abort
+  // via CHECK_RANKMAP_SET); mirror buildSplitShareChild()'s fallback to the
+  // parent comm rank when the parent has no world-rank map.
+  const bool parentHasWorldRanks =
+      !parentStatex->commRanksToWorldRanksRef().empty();
+  for (int rank = 0; rank < childStatex->nRanks(); ++rank) {
+    const int parentRank = parentRanks[rank];
+    const int expectedWorldRank =
+        parentHasWorldRanks ? parentStatex->gRank(parentRank) : parentRank;
+    EXPECT_EQ(expectedWorldRank, childStatex->gRank(rank));
+  }
+
+  std::vector<int> gathered(childStatex->nRanks(), -1);
+  gathered[childStatex->rank()] = parentStatex->rank();
+  auto allGather = childComm->bootstrap_->allGather(
+      gathered.data(), sizeof(int), childStatex->rank(), childStatex->nRanks());
+  COMMCHECK_TEST(static_cast<commResult_t>(std::move(allGather).get()));
+  EXPECT_EQ(parentRanks, gathered);
+}
+
+TEST_F(CtranCommSplitTest, LocalNvlSplitSupportsWindowRegistration) {
+  std::shared_ptr<CtranComm> childComm;
+  COMMCHECK_TEST(ctranCommSplitLocalNvl(parentComm_.get(), &childComm));
+
+  constexpr size_t kBufferBytes = 8192;
+  void* buffer = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buffer, kBufferBytes));
+  auto bufferGuard = folly::makeGuard([&]() {
+    if (buffer != nullptr) {
+      cudaFree(buffer);
+    }
+  });
+
+  ctran::CtranWin* win = nullptr;
+  COMMCHECK_TEST(
+      ctran::ctranWinRegister(buffer, kBufferBytes, childComm.get(), &win));
+  auto winGuard = folly::makeGuard([&]() {
+    if (win != nullptr) {
+      ctran::ctranWinFree(win);
+    }
+  });
+
+  ASSERT_NE(nullptr, win);
+  EXPECT_TRUE(win->comm->isSplitShare());
+  EXPECT_EQ(parentComm_.get(), win->comm->resourceComm());
+  ASSERT_EQ(win->remWinInfo.size(), childComm->statex_->nRanks());
+  const int childRank = childComm->statex_->rank();
+  for (int rank = 0; rank < static_cast<int>(win->remWinInfo.size()); ++rank) {
+    EXPECT_NE(nullptr, win->remWinInfo[rank].dataAddr);
+    if (rank != childRank) {
+      EXPECT_NE(
+          CtranMapperBackend::UNSET, win->remWinInfo[rank].dataRkey.backend);
+    }
+  }
+
+  COMMCHECK_TEST(ctran::ctranWinFree(win));
+  win = nullptr;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <memory>
+#include <numeric>
 
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/CtranComm.h"
@@ -21,6 +22,130 @@
 using ctran::window::RemWinInfo;
 
 namespace ctran {
+namespace {
+
+commResult_t getWindowMapper(CtranComm* comm, CtranMapper** mapperOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || mapperOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or mapper output is null");
+  }
+
+  auto* resourceComm = comm->resourceComm();
+  if (!ctranInitialized(resourceComm) ||
+      resourceComm->ctran_->mapper == nullptr) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: window resource communicator has no initialized mapper");
+  }
+
+  *mapperOut = resourceComm->ctran_->mapper.get();
+  return commSuccess;
+}
+
+commResult_t getWindowResourceRanks(
+    CtranComm* comm,
+    std::vector<int>* ranksOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || ranksOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or rank output is null");
+  }
+
+  const int nRanks = comm->statex_->nRanks();
+  ranksOut->resize(nRanks);
+  if (!comm->isSplitShare()) {
+    std::iota(ranksOut->begin(), ranksOut->end(), 0);
+    return commSuccess;
+  }
+
+  const auto& resourceRanks = comm->parentRanks();
+  if (resourceRanks.size() != static_cast<size_t>(nRanks)) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window rank map size {} does not match nRanks {}",
+        resourceRanks.size(),
+        nRanks);
+  }
+
+  *ranksOut = resourceRanks;
+  return commSuccess;
+}
+
+commResult_t getWindowResourceRank(CtranComm* comm, int rank, int* rankOut) {
+  if (comm == nullptr || comm->statex_ == nullptr || rankOut == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: window communicator/statex or rank output is null");
+  }
+  if (rank < 0 || rank >= comm->statex_->nRanks()) {
+    FB_ERRORRETURN(
+        commInvalidArgument, "CTRAN-WINDOW: rank {} is out of range", rank);
+  }
+  if (!comm->isSplitShare()) {
+    *rankOut = rank;
+    return commSuccess;
+  }
+
+  const auto& resourceRanks = comm->parentRanks();
+  if (resourceRanks.size() != static_cast<size_t>(comm->statex_->nRanks())) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window rank map size {} does not match nRanks {}",
+        resourceRanks.size(),
+        comm->statex_->nRanks());
+  }
+  *rankOut = resourceRanks[rank];
+  return commSuccess;
+}
+
+commResult_t windowBarrier(CtranComm* comm, CtranMapper* mapper) {
+  if (comm == nullptr || comm->statex_ == nullptr || mapper == nullptr) {
+    FB_ERRORRETURN(
+        commInvalidArgument,
+        "CTRAN-WINDOW: cannot run window barrier without comm/statex/mapper");
+  }
+  if (!comm->isSplitShare()) {
+    return mapper->barrier();
+  }
+
+  std::vector<int> ranks;
+  FB_COMMCHECK(getWindowResourceRanks(comm, &ranks));
+  if (ranks.size() <= 1) {
+    return commSuccess;
+  }
+
+  const int myResourceRank = comm->resourceComm()->statex_->rank();
+  bool foundSelf = false;
+  for (const int rank : ranks) {
+    if (rank == myResourceRank) {
+      foundSelf = true;
+      break;
+    }
+  }
+  if (!foundSelf) {
+    FB_ERRORRETURN(
+        commInternalError,
+        "CTRAN-WINDOW: split-share window ranks do not contain resource rank {}",
+        myResourceRank);
+  }
+
+  std::vector<CtranMapperRequest> reqs((ranks.size() - 1) * 2);
+  int reqIdx = 0;
+  for (const int peerRank : ranks) {
+    if (peerRank == myResourceRank) {
+      continue;
+    }
+    FB_COMMCHECK(mapper->irecvCtrl(peerRank, &reqs[reqIdx++]));
+    FB_COMMCHECK(mapper->isendCtrl(peerRank, &reqs[reqIdx++]));
+  }
+  for (auto& req : reqs) {
+    FB_COMMCHECK(mapper->waitRequest(&req));
+  }
+  return commSuccess;
+}
+
+} // namespace
 
 // Defined here (not in header) so that unique_ptr<HostWindow> destructor
 // sees the complete HostWindow type.
@@ -48,7 +173,8 @@ commResult_t CtranWin::exchange() {
 
   remWinInfo.resize(nRanks);
 
-  auto mapper = comm->ctran_->mapper.get();
+  CtranMapper* mapper = nullptr;
+  FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
   // Registration via ctran mapper.
   FB_COMMCHECK(mapper->regMem(
@@ -104,30 +230,50 @@ commResult_t CtranWin::exchange() {
       nRanks);
   std::vector<struct CtranMapperRemoteAccessKey> remoteUserBufAccessKeys(
       nRanks);
+  std::vector<int> exchangeRanks;
+  FB_COMMCHECK(getWindowResourceRanks(comm, &exchangeRanks));
+  if (comm->isSplitShare()) {
+    const auto resourceNRanks = comm->resourceComm()->statex_->nRanks();
+    remoteBaseBufs.resize(resourceNRanks);
+    remoteUserBufs.resize(resourceNRanks);
+    remoteBaseBufAccessKeys.resize(resourceNRanks);
+    remoteUserBufAccessKeys.resize(resourceNRanks);
+  }
 
   FB_COMMCHECK(mapper->allGatherCtrl(
-      winBasePtr, baseRegHdl, remoteBaseBufs, remoteBaseBufAccessKeys));
+      winBasePtr,
+      baseRegHdl,
+      exchangeRanks,
+      remoteBaseBufs,
+      remoteBaseBufAccessKeys));
 
   if (!allocDataBuf_) {
     // if data buffer is provided by user, extra round of handler exchange is
     // needed
     FB_COMMCHECK(mapper->allGatherCtrl(
-        winDataPtr, dataRegHdl, remoteUserBufs, remoteUserBufAccessKeys));
+        winDataPtr,
+        dataRegHdl,
+        exchangeRanks,
+        remoteUserBufs,
+        remoteUserBufAccessKeys));
   }
 
   for (auto r = 0; r < nRanks; r++) {
+    const int exchangeRank = exchangeRanks[r];
     remWinInfo[r].dataBytes = allRankSizes[r];
     if (allocDataBuf_) {
-      remWinInfo[r].dataAddr = remoteBaseBufs[r];
-      remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[r];
+      remWinInfo[r].dataAddr = remoteBaseBufs[exchangeRank];
+      remWinInfo[r].dataRkey = remoteBaseBufAccessKeys[exchangeRank];
       remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(
-          reinterpret_cast<size_t>(remoteBaseBufs[r]) + allRankSizes[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
+          reinterpret_cast<size_t>(remoteBaseBufs[exchangeRank]) +
+          allRankSizes[r]);
+      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     } else {
-      remWinInfo[r].dataAddr = remoteUserBufs[r];
-      remWinInfo[r].dataRkey = remoteUserBufAccessKeys[r];
-      remWinInfo[r].signalAddr = reinterpret_cast<uint64_t*>(remoteBaseBufs[r]);
-      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[r];
+      remWinInfo[r].dataAddr = remoteUserBufs[exchangeRank];
+      remWinInfo[r].dataRkey = remoteUserBufAccessKeys[exchangeRank];
+      remWinInfo[r].signalAddr =
+          reinterpret_cast<uint64_t*>(remoteBaseBufs[exchangeRank]);
+      remWinInfo[r].signalRkey = remoteBaseBufAccessKeys[exchangeRank];
     }
   }
   CLOGF_SUBSYS(
@@ -152,12 +298,12 @@ commResult_t CtranWin::exchange() {
 
   // A barrier among ranks after importing handles to prevent accessing window
   // memory space while other ranks are still importing.
-  FB_COMMCHECK(mapper->barrier());
+  FB_COMMCHECK(windowBarrier(comm, mapper));
   return commSuccess;
 }
 
 bool CtranWin::allGatherPSupported(CtranComm* comm) {
-  if (!ctranInitialized(comm)) {
+  if (comm == nullptr || comm->isSplitShare() || !ctranInitialized(comm)) {
     return false;
   }
   auto statex = comm->statex_.get();
@@ -242,7 +388,8 @@ commResult_t CtranWin::free(bool skipBarrier) {
   if (statex == nullptr) {
     FB_ERRORRETURN(commInternalError, "Empty communicator statex.");
   }
-  auto mapper = comm->ctran_->mapper.get();
+  CtranMapper* mapper = nullptr;
+  FB_COMMCHECK(getWindowMapper(comm, &mapper));
   CtranMapperEpochRAII epochRAII(mapper);
 
   CLOGF_SUBSYS(
@@ -261,7 +408,7 @@ commResult_t CtranWin::free(bool skipBarrier) {
   // ensure the host process waits for CUDA streams where put/wait operations
   // are launched.
   if (!skipBarrier) {
-    FB_COMMCHECK(mapper->barrier());
+    FB_COMMCHECK(windowBarrier(comm, mapper));
   }
 
   auto nRanks = statex->nRanks();
@@ -320,8 +467,14 @@ commResult_t CtranWin::free(bool skipBarrier) {
 }
 
 bool CtranWin::nvlEnabled(int rank) const {
+  CtranMapper* mapper = nullptr;
+  int resourceRank = -1;
+  if (getWindowMapper(comm, &mapper) != commSuccess ||
+      getWindowResourceRank(comm, rank, &resourceRank) != commSuccess) {
+    return false;
+  }
   return isGpuMem() &&
-      comm->ctran_->mapper->hasBackend(rank, CtranMapperBackend::NVL);
+      mapper->hasBackend(resourceRank, CtranMapperBackend::NVL);
 }
 
 #if defined(ENABLE_PRIMS)


### PR DESCRIPTION
Summary:

Consume the `splitShare` local-NVL window from D105884518; exchanges the cross-node rail IB rkeys lazily on the first graph replay.

`winPersistBuffReg` splits a local-NVL `CtranComm` and persists the recvbuff window registration for that clique; `allGatherWinInit` leaves the cross-node rail entries UNSET. The first graph replay exec calls `ensureRailKeysExchanged` (a null-check + in-line `allGatherCtrl` + `railBarrier`) to fill them; later replays find them set and skip. At replay all ranks are in lockstep, so the in-line exchange is quick and is never gated by a straggler cuMemImport during capture.

A/B on GB300 256-GPU DORA_BENCH_NIGHTLY (clique8, no cvars): this lazy variant captures in 56.8s, with a first replay (4.97s) and bit-identical loss (replays=0, no SDC). Simpler and at-or-below the deferred design on capture.

Differential Revision: D110056096
