### PR TITLE
PCIe Relaxed Ordering on bulk-data MRs in the shared MultiPeerIbTransport base (#3015)

### DIFF
--- a/comms/prims/platform/DocaHostUtils.h
+++ b/comms/prims/platform/DocaHostUtils.h
@@ -51,6 +51,18 @@ struct DmaBufExport {
   DmaBufAlignment alignment; // alignment info for ibv_reg_dmabuf_mr
 };
 
+// Mapping requested when exporting a GPU allocation as a DMA-BUF fd.
+enum class DmaBufExportKind {
+  // Standard mapping (cuMemGetHandleForAddressRange flags = 0).
+  Default,
+  // BAR1 PCIe mapping (CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE) so the fd
+  // can back an mlx5dv_reg_dmabuf_mr with MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT
+  // (NCCL's NCCL_IB_DATA_DIRECT / GDAKI path): the NIC writes straight to GPU
+  // HBM over PCIe BAR1 instead of bouncing through Grace's C2C path. Requires
+  // CUDA >= 12.8; on older toolkits it is unavailable (returns std::nullopt).
+  Pcie,
+};
+
 // Export a GPU buffer as DMA-BUF with proper page alignment.
 //
 // Handles the full flow for cudaMalloc buffers on Grace/aarch64:
@@ -58,14 +70,32 @@ struct DmaBufExport {
 //   2. compute_dmabuf_alignment → align base/size to host page size
 //   3. cuMemGetHandleForAddressRange → export as DMA-BUF fd
 //
-// This is the plain CUDA-driver DMA-BUF export — doca_gpu_dmabuf_fd is a thin
-// wrapper over the same cuMemGetHandleForAddressRange call — so no DOCA context
-// is needed. Returns std::nullopt on failure (caller can fall back to
-// ibv_reg_mr). The returned DmaBufExport contains the fd and alignment info
-// needed for ibv_reg_dmabuf_mr (dmabufOffset as offset, ptr as iova).
+// `kind` selects the mapping: Default is the plain CUDA-driver DMA-BUF export
+// (C2C) — doca_gpu_dmabuf_fd is a thin wrapper over the same
+// cuMemGetHandleForAddressRange call, so no DOCA context is needed; Pcie
+// requests the BAR1 PCIe mapping for mlx5 Data-Direct (see DmaBufExportKind).
+// Returns std::nullopt on failure (the caller may fall back to ibv_reg_mr, or
+// treat Data-Direct as mandatory and fail hard). The returned DmaBufExport
+// contains the fd and alignment info needed for ibv_reg_dmabuf_mr (dmabufOffset
+// as offset, ptr as iova).
 inline std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
     void* ptr,
-    size_t size) {
+    size_t size,
+    DmaBufExportKind kind = DmaBufExportKind::Default) {
+  // Resolve the cuMemGetHandleForAddressRange mapping flag. The PCIe
+  // (Data-Direct) mapping requires CUDA >= 12.8; on older toolkits it cannot be
+  // expressed, so report it as unavailable.
+  unsigned long long handleFlags = 0;
+  if (kind == DmaBufExportKind::Pcie) {
+#if CUDA_VERSION >= 12080
+    handleFlags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+#else
+    (void)ptr;
+    (void)size;
+    return std::nullopt;
+#endif
+  }
+
   if (cuda_driver_lazy_init() != 0 || pfn_cuMemGetAddressRange == nullptr ||
       pfn_cuMemGetHandleForAddressRange == nullptr) {
     LOG(WARNING)
@@ -93,10 +123,11 @@ inline std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
       reinterpret_cast<CUdeviceptr>(alignment.alignedBase),
       alignment.alignedSize,
       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      0);
+      handleFlags);
   if (fdRes != CUDA_SUCCESS || fd < 0) {
     LOG(WARNING) << "export_gpu_dmabuf_aligned: cuMemGetHandleForAddressRange"
-                 << " failed err=" << fdRes << " ptr=" << ptr
+                 << " failed err=" << fdRes << " ptr=" << ptr << " kind="
+                 << (kind == DmaBufExportKind::Pcie ? "pcie" : "default")
                  << " alignedBase=" << alignment.alignedBase
                  << " alignedSize=" << alignment.alignedSize;
     return std::nullopt;

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include "comms/prims/transport/MultiPeerIbTransport.h"
+
+namespace comms::prims {
+namespace {
+
+// The Data-Direct config knob (NCCL_IB_DATA_DIRECT 0/1/2, tunneled into
+// MultipeerIbTransportConfig::enableDataDirect) must reach registerBuffer's
+// per-NIC registration decision: registerBuffer() takes the Data-Direct
+// (BAR1) registration path exactly when dataDirectActiveForNic() holds. These
+// pure checks pin that config -> registration tunnel without needing a NIC.
+// enableDataDirect is the single shared comms::prims::DataDirectMode, also used
+// by NIC discovery.
+
+// Default config requests Data-Direct (Only = NCCL's default of 1).
+TEST(MultiPeerIbTransportConfigTest, DataDirectDefaultsToOnly) {
+  MultipeerIbTransportConfig config;
+  EXPECT_EQ(config.enableDataDirect, DataDirectMode::Only);
+}
+
+// Any non-Disabled mode (Only or Both) + a DD-capable NIC -> registerBuffer
+// uses the Data-Direct path.
+TEST(MultiPeerIbTransportConfigTest, DataDirectActiveOnCapableNic) {
+  MultipeerIbTransportConfig config;
+  config.enableDataDirect = DataDirectMode::Only;
+  EXPECT_TRUE(dataDirectActiveForNic(config, /*nicIsDataDirect=*/true));
+  config.enableDataDirect = DataDirectMode::Both;
+  EXPECT_TRUE(dataDirectActiveForNic(config, /*nicIsDataDirect=*/true));
+}
+
+// Non-Disabled but a non-DD NIC -> no Data-Direct path; registerBuffer falls
+// back to the regular DMA-BUF / reg_mr path (e.g. H100).
+TEST(MultiPeerIbTransportConfigTest, DataDirectInactiveOnNonCapableNic) {
+  MultipeerIbTransportConfig config;
+  config.enableDataDirect = DataDirectMode::Only;
+  EXPECT_FALSE(dataDirectActiveForNic(config, /*nicIsDataDirect=*/false));
+}
+
+// Disabled -> never use Data-Direct, even on a DD-capable NIC.
+TEST(MultiPeerIbTransportConfigTest, DataDirectDisabledNeverActivates) {
+  MultipeerIbTransportConfig config;
+  config.enableDataDirect = DataDirectMode::Disabled;
+  EXPECT_FALSE(dataDirectActiveForNic(config, /*nicIsDataDirect=*/true));
+  EXPECT_FALSE(dataDirectActiveForNic(config, /*nicIsDataDirect=*/false));
+}
+
+// The key automatic behavior: with a default-constructed config (no caller
+// opt-in), registerBuffer must AUTOMATICALLY select the Data-Direct path on a
+// DD-capable NIC and only on a DD-capable NIC. dataDirectActiveForNic() is the
+// exact predicate registerBuffer gates the DD registration path on, so this
+// asserts the auto-select decision end to end for the default configuration.
+TEST(
+    MultiPeerIbTransportConfigTest,
+    RegisterBufferAutoSelectsDataDirectByDefault) {
+  MultipeerIbTransportConfig defaultConfig; // no explicit enableDataDirect
+
+  // DD-capable NIC: auto-selected, no configuration needed.
+  EXPECT_TRUE(dataDirectActiveForNic(defaultConfig, /*nicIsDataDirect=*/true));
+  // Non-DD NIC: not selected (transparent fallback to the regular path).
+  EXPECT_FALSE(
+      dataDirectActiveForNic(defaultConfig, /*nicIsDataDirect=*/false));
+}
+
+} // namespace
+} // namespace comms::prims

--- a/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
+++ b/comms/prims/tests/MultiPeerIbTransportConfigTest.cc
@@ -64,5 +64,67 @@ TEST(
       dataDirectActiveForNic(defaultConfig, /*nicIsDataDirect=*/false));
 }
 
+// The PCIe Relaxed Ordering knob (NCCL_IB_PCI_RELAXED_ORDERING, tunneled into
+// enablePciRelaxedOrdering) reaches registerBuffer's access-flag decision via
+// relaxedOrderingActiveForNic(): the IBV_ACCESS_RELAXED_ORDERING flag is set
+// exactly when this holds. Crucially, it is also gated on NIC capability
+// (probed during openNics), so on a NIC whose driver rejects the flag both
+// Auto and Enabled fall back to strict ordering instead of failing
+// registration. These pure checks pin that gating without needing a NIC.
+
+// Default config requests Relaxed Ordering (Auto), matching NCCL's default.
+TEST(MultiPeerIbTransportConfigTest, RelaxedOrderingDefaultsToAuto) {
+  MultipeerIbTransportConfig config;
+  EXPECT_EQ(
+      config.enablePciRelaxedOrdering,
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Auto);
+}
+
+// Auto + RO-capable NIC -> registerBuffer sets the Relaxed Ordering flag.
+TEST(MultiPeerIbTransportConfigTest, RelaxedOrderingAutoActiveOnCapableNic) {
+  MultipeerIbTransportConfig config;
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Auto;
+  EXPECT_TRUE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/true));
+}
+
+// Auto but the NIC's driver rejects the flag -> fall back to strict ordering
+// (no throw). This is the case the review flagged.
+TEST(
+    MultiPeerIbTransportConfigTest,
+    RelaxedOrderingAutoFallsBackOnIncapableNic) {
+  MultipeerIbTransportConfig config;
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Auto;
+  EXPECT_FALSE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/false));
+}
+
+// Even an explicit Enabled request falls back when the NIC can't do RO, so
+// transport setup never breaks on an unsupporting driver (a warning is logged).
+TEST(
+    MultiPeerIbTransportConfigTest,
+    RelaxedOrderingEnabledFallsBackOnIncapableNic) {
+  MultipeerIbTransportConfig config;
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Enabled;
+  EXPECT_TRUE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/true));
+  EXPECT_FALSE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/false));
+}
+
+// Disabled -> never set the flag, even on a capable NIC.
+TEST(MultiPeerIbTransportConfigTest, RelaxedOrderingDisabledNeverActive) {
+  MultipeerIbTransportConfig config;
+  config.enablePciRelaxedOrdering =
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Disabled;
+  EXPECT_FALSE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/true));
+  EXPECT_FALSE(
+      relaxedOrderingActiveForNic(config, /*nicRelaxedOrderingCapable=*/false));
+}
+
 } // namespace
 } // namespace comms::prims

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -113,6 +113,41 @@ bool nicSupportsDataDirect(
 #endif
 }
 
+// A NIC supports PCIe Relaxed Ordering iff its driver accepts
+// IBV_ACCESS_RELAXED_ORDERING on a registration. Probe once by registering a
+// tiny host buffer with the flag (the same shape NCCL uses): if the driver
+// rejects it, applying the flag to the real (GPU) data MRs would fail every
+// registration and throw, breaking transport setup. RO is a TLP attribute
+// negotiated via the access flag, independent of the buffer's memory type, so a
+// host probe is a valid proxy for flag acceptance. registerBuffer() gates the
+// flag on this so an unsupporting NIC falls back to strict ordering.
+bool nicSupportsRelaxedOrdering(ibverbx::ibv_pd* pd) {
+  // Precondition: pd is an allocated protection domain (openNics throws on a
+  // failed alloc before reaching here). Guard defensively so a future caller
+  // that probes before allocation degrades to "not RO-capable" rather than
+  // dereferencing null inside the driver.
+  DCHECK(pd != nullptr) << "nicSupportsRelaxedOrdering called with null pd";
+  if (pd == nullptr) {
+    return false;
+  }
+  const auto& symbols = ibverbx::ibvSymbols;
+  if (symbols.ibv_internal_reg_mr == nullptr ||
+      symbols.ibv_internal_dereg_mr == nullptr) {
+    return false;
+  }
+  alignas(64) char probe[64] = {};
+  ibverbx::ibv_mr* mr = symbols.ibv_internal_reg_mr(
+      pd,
+      probe,
+      sizeof(probe),
+      ibverbx::IBV_ACCESS_LOCAL_WRITE | ibverbx::IBV_ACCESS_RELAXED_ORDERING);
+  if (mr == nullptr) {
+    return false;
+  }
+  symbols.ibv_internal_dereg_mr(mr);
+  return true;
+}
+
 #ifdef __HIP_PLATFORM_AMD__
 using SlotGpuError = hipError_t;
 constexpr SlotGpuError kSlotGpuSuccess = hipSuccess;
@@ -399,10 +434,17 @@ void MultiPeerIbTransportBase::allocateSendRecvBuffersEager(
   sendRecvSignalBulk_ = allocateBulk(signalPerPeer, "signal bulk");
   sendRecvStateBulk_ = allocateBulk(statePerPeer, "state bulk");
 
+  // Staging is bulk data: opt into Relaxed Ordering. Signal/counter stay strict
+  // so a flag write can't be reordered ahead of the data on the shared route.
+  // (Data-Direct, when active, applies to all of these automatically.)
   auto sendStagingBulkReg = registerBuffer(
-      sendRecvSendStagingBulk_->get(), stagingPerPeer * numPeers);
+      sendRecvSendStagingBulk_->get(),
+      stagingPerPeer * numPeers,
+      /*relaxedOrdering=*/true);
   sendRecvRecvStagingBulkReg_ = registerBuffer(
-      sendRecvRecvStagingBulk_->get(), stagingPerPeer * numPeers);
+      sendRecvRecvStagingBulk_->get(),
+      stagingPerPeer * numPeers,
+      /*relaxedOrdering=*/true);
   sendRecvSignalBulkReg_ =
       registerBuffer(sendRecvSignalBulk_->get(), signalPerPeer * numPeers);
 
@@ -745,6 +787,27 @@ void MultiPeerIbTransportBase::openNics() {
             << nics_[0].deviceName << " for GPU device " << config_.cudaDevice;
   }
 
+  // Data-Direct active per NIC = requested (config Auto) AND capable. RO mode
+  // string for logging by enum value (Disabled/Enabled/Auto) so autodetection
+  // vs explicit opt-in stays distinguishable. Computed once before the bring-up
+  // loop so each NIC can log its resolved status inline.
+  const bool ddEnabled = config_.enableDataDirect != DataDirectMode::Disabled;
+  const char* roMode = "auto";
+  switch (config_.enablePciRelaxedOrdering) {
+    case MultipeerIbTransportConfig::PciRelaxedOrderingMode::Disabled:
+      roMode = "disabled";
+      break;
+    case MultipeerIbTransportConfig::PciRelaxedOrderingMode::Enabled:
+      roMode = "enabled";
+      break;
+    case MultipeerIbTransportConfig::PciRelaxedOrderingMode::Auto:
+      roMode = "auto";
+      break;
+  }
+  // RO must be uniform across NICs (the MR cache keys on one effective-ordering
+  // bool per allocation); AND in each NIC's capability as it is brought up.
+  relaxedOrderingCapable_ = numNics_ > 0;
+
   // Open + setup each NIC: find by name, open ctx, alloc PD, query GID + port.
   for (int n = 0; n < numNics_; ++n) {
     int nicIdx = -1;
@@ -773,6 +836,13 @@ void MultiPeerIbTransportBase::openNics() {
       throw std::runtime_error(
           "Failed to allocate protection domain on NIC " + nics_[n].deviceName);
     }
+
+    // Probe PCIe Relaxed Ordering support once per NIC. registerBuffer() gates
+    // IBV_ACCESS_RELAXED_ORDERING on this; on a driver that rejects the flag,
+    // applying it would fail every data-MR registration and break setup, so an
+    // unsupporting NIC falls back to strict ordering instead.
+    nics_[n].relaxedOrderingCapable =
+        nicSupportsRelaxedOrdering(nics_[n].ibvPd);
 
     // Detect Data-Direct capability for the explicit gpuNicMap path.
     // registerBuffer() auto-selects the Data-Direct (BAR1) path when
@@ -843,17 +913,36 @@ void MultiPeerIbTransportBase::openNics() {
                    << " differs from NIC 0 active_mtu=" << localMtu_
                    << "; using NIC 0's MTU for negotiation";
     }
-  }
 
-  // Per-NIC Data-Direct status, covering both the gpuNicMap and auto-discovery
-  // paths. enable is a request (config); capability is autodetected; DD is
-  // active only when both hold.
-  const bool ddEnabled = config_.enableDataDirect != DataDirectMode::Disabled;
-  for (int n = 0; n < numNics_; ++n) {
+    // NIC fully brought up: fold its RO capability into the cross-NIC aggregate
+    // and log its resolved Data-Direct / Relaxed-Ordering status inline.
+    relaxedOrderingCapable_ =
+        relaxedOrderingCapable_ && nics_[n].relaxedOrderingCapable;
     LOG(INFO) << "MultiPeerIbTransport: NIC " << n << " ("
               << nics_[n].deviceName << ") Data-Direct enabled=" << ddEnabled
               << " nicCapable=" << nics_[n].isDataDirect << " -> "
-              << ((ddEnabled && nics_[n].isDataDirect) ? "ACTIVE" : "inactive");
+              << ((ddEnabled && nics_[n].isDataDirect) ? "ACTIVE" : "inactive")
+              << "; relaxedOrdering=" << roMode
+              << " nicCapable=" << nics_[n].relaxedOrderingCapable;
+  }
+
+  // PCIe Relaxed Ordering is applied only when every NIC accepts the flag
+  // (aggregated above). Surface an explicit Enabled request that can't be met
+  // (it falls back to strict ordering rather than throwing); otherwise just
+  // record the resolved setting: config, capability, and the ordering in
+  // effect.
+  const bool useRelaxedOrdering =
+      relaxedOrderingActiveForNic(config_, relaxedOrderingCapable_);
+  if (config_.enablePciRelaxedOrdering ==
+          MultipeerIbTransportConfig::PciRelaxedOrderingMode::Enabled &&
+      !relaxedOrderingCapable_) {
+    LOG(WARNING) << "MultiPeerIbTransport: PCIe Relaxed Ordering requested "
+                    "(Enabled) but not supported on all NICs; falling back to "
+                    "strict ordering on data MRs";
+  } else {
+    LOG(INFO) << "MultiPeerIbTransport: PCIe Relaxed Ordering config=" << roMode
+              << " allNicsCapable=" << relaxedOrderingCapable_ << " -> "
+              << (useRelaxedOrdering ? "ACTIVE" : "strict");
   }
 
   // Success: SCOPE_EXIT frees the device list; SCOPE_FAIL is skipped, so the
@@ -862,18 +951,45 @@ void MultiPeerIbTransportBase::openNics() {
 
 IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
     void* ptr,
-    std::size_t size) {
+    std::size_t size,
+    bool relaxedOrdering) {
   if (ptr == nullptr || size == 0) {
     throw std::invalid_argument("Invalid buffer pointer or size");
   }
 
+  // Resolve the effective Relaxed Ordering once, up front: the caller's request
+  // gated by config (NCCL_IB_PCI_RELAXED_ORDERING) AND by NIC capability probed
+  // during openNics. Gating on capability means a NIC whose driver rejects
+  // IBV_ACCESS_RELAXED_ORDERING falls back to strict ordering here rather than
+  // failing every data-MR registration below. This is the actual MR access
+  // flag, so it is part of the cache identity (key) below and is reused for the
+  // access flags — keeping the two from drifting apart.
+  const bool useRelaxedOrdering = relaxedOrdering &&
+      relaxedOrderingActiveForNic(config_, relaxedOrderingCapable_);
+
   // Fast path: containment lookup — if [ptr, ptr+size) falls entirely within an
-  // existing registration, return the cached per-NIC lkeys with no driver call.
+  // existing registration with the same effective ordering, return the cached
+  // per-NIC lkeys with no driver call.
   const auto addr = reinterpret_cast<uintptr_t>(ptr);
   auto it = registeredBuffers_.upper_bound(addr);
   if (it != registeredBuffers_.begin()) {
     --it;
     if (addr + size <= it->first + it->second.allocSize) {
+      // The cache holds one MR set per allocation; its access flags (including
+      // Relaxed Ordering) are fixed at registration, so the effective ordering
+      // is part of the cache key. A containment hit resolving to different
+      // ordering would silently get the wrong semantics.
+      if (it->second.relaxedOrdering != useRelaxedOrdering) {
+        throw std::runtime_error(
+            fmt::format(
+                "registerBuffer: ptr={} is contained in an existing registration "
+                "(allocBase=0x{:x}) registered with relaxedOrdering={} but "
+                "requested relaxedOrdering={}",
+                ptr,
+                it->first,
+                it->second.relaxedOrdering,
+                useRelaxedOrdering));
+      }
       it->second.refs++;
       VLOG(1) << "MultiPeerIbTransport: cache hit for ptr=" << ptr
               << " allocBase=0x" << std::hex << it->first << std::dec
@@ -912,6 +1028,13 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
       ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
       ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
+  // PCIe Relaxed Ordering (resolved above as useRelaxedOrdering): on bulk data
+  // MRs only, let NIC<->HBM DMA TLPs pipeline instead of strict-ordering to
+  // ~half rate. Signal/counter MRs stay strict so a strict flag write cannot be
+  // reordered ahead of the data on the shared route.
+  if (useRelaxedOrdering) {
+    accessFlags |= ibverbx::IBV_ACCESS_RELAXED_ORDERING;
+  }
   // mlx5 Data-Direct (config.enableDataDirect): on a DD-capable NIC, register
   // through the data-direct (BAR1) PCIe path for ~2x NIC<->HBM write BW on
   // GB300 (NCCL's GDAKI path). Applied to every MR registered here so data and
@@ -921,6 +1044,7 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   CachedMr cached;
   cached.allocSize = allocSize;
   cached.refs = 1;
+  cached.relaxedOrdering = useRelaxedOrdering;
 
   // Per NIC, register the MR in priority order, each path falling through to
   // the next on failure:

--- a/comms/prims/transport/MultiPeerIbTransport.cc
+++ b/comms/prims/transport/MultiPeerIbTransport.cc
@@ -14,10 +14,12 @@
 
 #include <fmt/core.h>
 #include <folly/ScopeGuard.h>
+#include <folly/String.h>
 #include <glog/logging.h>
 
 #include "comms/ctran/ibverbx/Ibverbx.h"
 #include "comms/ctran/ibverbx/IbverbxSymbols.h"
+#include "comms/ctran/ibverbx/Mlx5core.h"
 #include "comms/prims/transport/rdma/NicDiscovery.h"
 // GPU DMA-BUF export for MR registration. Generic (no DOCA context): on NVIDIA
 // it is cuMemGetHandleForAddressRange via DocaHostUtils (with the CUDA driver
@@ -42,6 +44,74 @@ namespace comms::prims {
 
 namespace {
 constexpr int kDefaultGidIndex = 3; // Default RoCE GID index
+
+// A NIC is Data-Direct-capable iff all three hold: (1) the mlx5dv provider
+// supports the device, (2) the mlx5 Data-Direct DMA-BUF verb is usable, and
+// (3) the driver exposes a data-direct sysfs path for its context. This mirrors
+// the gate NIC discovery (augmentWithDataDirect) and NCCL
+// (ncclMlx5dvDmaBufCapable + the sysfs check) use, so the explicit gpuNicMap
+// path -- which has no discovery candidate to read capability from -- matches
+// the auto-discovery path rather than relying on the sysfs check alone. Always
+// false on AMD (no mlx5 Data-Direct).
+bool nicSupportsDataDirect(
+    [[maybe_unused]] ibverbx::ibv_device* device,
+    [[maybe_unused]] ibverbx::ibv_context* ctx,
+    [[maybe_unused]] ibverbx::ibv_pd* pd) {
+#ifdef __HIP_PLATFORM_AMD__
+  return false;
+#else
+  // Precondition: an opened device/context/PD. Guard so a future caller that
+  // probes before opening degrades to "not DD-capable" rather than
+  // dereferencing null inside the mlx5 driver. DCHECK surfaces misuse in
+  // debug/test builds; release falls back safely.
+  DCHECK(device != nullptr && ctx != nullptr && pd != nullptr)
+      << "nicSupportsDataDirect called with null device/ctx/pd";
+  if (device == nullptr || ctx == nullptr || pd == nullptr) {
+    return false;
+  }
+  const auto& symbols = ibverbx::ibvSymbols;
+
+  // (1) mlx5dv provider supports this device.
+  if (symbols.mlx5dv_internal_is_supported == nullptr ||
+      !symbols.mlx5dv_internal_is_supported(device)) {
+    return false;
+  }
+
+  // (2) The mlx5 Data-Direct DMA-BUF verb is usable. Probe with an invalid fd:
+  // the driver rejects an unsupported verb with EOPNOTSUPP/EPROTONOSUPPORT,
+  // while any other errno (e.g. EBADF) means the verb exists and would have
+  // proceeded. This is the predictor NCCL uses (ncclMlx5dvDmaBufCapable) and is
+  // the relevant one, since DD registration goes through this exact verb.
+  if (symbols.mlx5dv_internal_reg_dmabuf_mr == nullptr) {
+    return false;
+  }
+  errno = 0;
+  ibverbx::ibv_mr* probeMr = symbols.mlx5dv_internal_reg_dmabuf_mr(
+      pd,
+      /*offset=*/0,
+      /*length=*/0,
+      /*iova=*/0,
+      /*fd=*/-1,
+      /*access=*/0,
+      ibverbx::MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+  const bool dmabufUnsupported =
+      (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
+  if (probeMr != nullptr) {
+    symbols.ibv_internal_dereg_mr(probeMr);
+  }
+  if (dmabufUnsupported) {
+    return false;
+  }
+
+  // (3) Data-Direct sysfs path resolves (mlx5dv contract: rc == 0 on success).
+  if (symbols.mlx5dv_internal_get_data_direct_sysfs_path == nullptr) {
+    return false;
+  }
+  char ddSysfsPath[4096];
+  return symbols.mlx5dv_internal_get_data_direct_sysfs_path(
+             ctx, ddSysfsPath, sizeof(ddSysfsPath)) == 0;
+#endif
+}
 
 #ifdef __HIP_PLATFORM_AMD__
 using SlotGpuError = hipError_t;
@@ -169,14 +239,16 @@ MultiPeerIbTransportBase::MultiPeerIbTransportBase(
     n = static_cast<int>(it->second.size());
     source = "config.gpuNicMap";
   } else {
-    // On AMD, the `DataDirectMode::Only` default triggers `ibv_reg_dmabuf_mr`
-    // inside `augmentWithDataDirect()`, which is not exercised on AMD's
-    // libibverbs path here. Force `Disabled` to skip the DataDirect probe.
+    // Pass the configured Data-Direct mode through so discovery's DD probing
+    // honors config.enableDataDirect (Disabled here yields no DD candidates).
+    // On AMD, force Disabled: augmentWithDataDirect()'s ibv_reg_dmabuf_mr probe
+    // is not exercised on AMD's libibverbs path.
 #ifdef __HIP_PLATFORM_AMD__
     GpuNicDiscovery discovery(
         config_.cudaDevice, config_.ibHca, DataDirectMode::Disabled);
 #else
-    GpuNicDiscovery discovery(config_.cudaDevice, config_.ibHca);
+    GpuNicDiscovery discovery(
+        config_.cudaDevice, config_.ibHca, config_.enableDataDirect);
 #endif
     auto bestNics = discovery.getBestAffinityNics();
     if (bestNics.empty()) {
@@ -616,7 +688,9 @@ void MultiPeerIbTransportBase::openNics() {
   // Priority 1: Explicit GPU-to-NIC mapping from config (entries [0..numNics_)
   // used in order — first is preferred).
   auto it = config_.gpuNicMap.find(config_.cudaDevice);
-  if (it != config_.gpuNicMap.end() && !it->second.empty()) {
+  const bool usingGpuNicMap =
+      it != config_.gpuNicMap.end() && !it->second.empty();
+  if (usingGpuNicMap) {
     const auto& names = it->second;
     if (static_cast<int>(names.size()) < numNics_) {
       throw std::runtime_error(
@@ -639,14 +713,16 @@ void MultiPeerIbTransportBase::openNics() {
 
   // Priority 2: Auto-discovery (top-numNics_ candidates by NUMA affinity).
   if (nics_[0].deviceName.empty()) {
-    // On AMD, the `DataDirectMode::Only` default triggers `ibv_reg_dmabuf_mr`
-    // inside `augmentWithDataDirect()`, which is not exercised on AMD's
-    // libibverbs path here. Force `Disabled` to skip the DataDirect probe.
+    // Pass the configured Data-Direct mode through so discovery's DD probing
+    // honors config.enableDataDirect (Disabled here yields no DD candidates).
+    // On AMD, force Disabled: augmentWithDataDirect()'s ibv_reg_dmabuf_mr probe
+    // is not exercised on AMD's libibverbs path.
 #ifdef __HIP_PLATFORM_AMD__
     auto discovery = GpuNicDiscovery(
         config_.cudaDevice, config_.ibHca, DataDirectMode::Disabled);
 #else
-    auto discovery = GpuNicDiscovery(config_.cudaDevice, config_.ibHca);
+    auto discovery = GpuNicDiscovery(
+        config_.cudaDevice, config_.ibHca, config_.enableDataDirect);
 #endif
     const auto& candidates = discovery.getCandidates();
     if (static_cast<int>(candidates.size()) < numNics_) {
@@ -661,6 +737,9 @@ void MultiPeerIbTransportBase::openNics() {
     }
     for (int n = 0; n < numNics_; ++n) {
       nics_[n].deviceName = candidates[n].name;
+      // Discovery already probed Data-Direct capability for each candidate;
+      // read it cheaply (no extra sysfs probe needed on this path).
+      nics_[n].isDataDirect = candidates[n].isDataDirect;
     }
     VLOG(1) << "MultiPeerIbTransport: auto-discovered NIC "
             << nics_[0].deviceName << " for GPU device " << config_.cudaDevice;
@@ -693,6 +772,16 @@ void MultiPeerIbTransportBase::openNics() {
     if (!nics_[n].ibvPd) {
       throw std::runtime_error(
           "Failed to allocate protection domain on NIC " + nics_[n].deviceName);
+    }
+
+    // Detect Data-Direct capability for the explicit gpuNicMap path.
+    // registerBuffer() auto-selects the Data-Direct (BAR1) path when
+    // nics_[n].isDataDirect is set. The auto-discovery path sets that flag for
+    // free from the discovery candidate; the gpuNicMap path bypasses discovery,
+    // so run the same capability gate here on the just-opened device.
+    if (usingGpuNicMap) {
+      nics_[n].isDataDirect = nicSupportsDataDirect(
+          deviceList[nicIdx], nics_[n].ibvCtx, nics_[n].ibvPd);
     }
 
     if (symbols.ibv_internal_query_gid(
@@ -755,6 +844,18 @@ void MultiPeerIbTransportBase::openNics() {
                    << "; using NIC 0's MTU for negotiation";
     }
   }
+
+  // Per-NIC Data-Direct status, covering both the gpuNicMap and auto-discovery
+  // paths. enable is a request (config); capability is autodetected; DD is
+  // active only when both hold.
+  const bool ddEnabled = config_.enableDataDirect != DataDirectMode::Disabled;
+  for (int n = 0; n < numNics_; ++n) {
+    LOG(INFO) << "MultiPeerIbTransport: NIC " << n << " ("
+              << nics_[n].deviceName << ") Data-Direct enabled=" << ddEnabled
+              << " nicCapable=" << nics_[n].isDataDirect << " -> "
+              << ((ddEnabled && nics_[n].isDataDirect) ? "ACTIVE" : "inactive");
+  }
+
   // Success: SCOPE_EXIT frees the device list; SCOPE_FAIL is skipped, so the
   // opened ctx/PD are kept for the transport's lifetime.
 }
@@ -811,29 +912,98 @@ IbgdaLocalBuffer MultiPeerIbTransportBase::registerBuffer(
   int accessFlags = ibverbx::IBV_ACCESS_LOCAL_WRITE |
       ibverbx::IBV_ACCESS_REMOTE_WRITE | ibverbx::IBV_ACCESS_REMOTE_READ |
       ibverbx::IBV_ACCESS_REMOTE_ATOMIC;
+  // mlx5 Data-Direct (config.enableDataDirect): on a DD-capable NIC, register
+  // through the data-direct (BAR1) PCIe path for ~2x NIC<->HBM write BW on
+  // GB300 (NCCL's GDAKI path). Applied to every MR registered here so data and
+  // signal/counter share the same route on the same QP -- preserving
+  // data-before-flag ordering without a flush. Autodetected per NIC.
 
   CachedMr cached;
   cached.allocSize = allocSize;
   cached.refs = 1;
 
-  // Try DMABUF first per NIC, fall back to plain reg_mr per NIC. If any NIC's
-  // registration fails, deregister everything already registered and propagate.
+  // Per NIC, register the MR in priority order, each path falling through to
+  // the next on failure:
+  //   1. Data-Direct: PCIe-mapped (BAR1) dmabuf + mlx5dv DATA_DIRECT reg. Only
+  //      on a DD-capable NIC with DD enabled. The regular C2C dmabuf is NOT
+  //      used here -- DD needs its own PCIe-mapped dmabuf.
+  //   2. Regular DMABUF: default (C2C) dmabuf + ibv_reg_dmabuf_mr.
+  //   3. Plain ibv_reg_mr.
+  // If any NIC ultimately fails, deregister everything already done and throw.
   for (int n = 0; n < numNics_; ++n) {
     ibverbx::ibv_mr* mr = nullptr;
-    auto dmabuf = export_gpu_dmabuf_aligned(
-        reinterpret_cast<void*>(allocBase), allocSize);
-    if (dmabuf) {
-      if (symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
-        mr = symbols.ibv_internal_reg_dmabuf_mr(
-            nics_[n].ibvPd,
-            dmabuf->alignment.dmabufOffset,
-            allocSize,
-            static_cast<uint64_t>(allocBase),
-            dmabuf->fd,
-            accessFlags);
+    // 1. Data-Direct. When selected for this NIC it is mandatory: every MR on
+    //    the NIC must share the Data-Direct route so data and signal/counter
+    //    stay ordered on one QP without a flush (see the per-MR-uniformity note
+    //    above). A per-MR fallback would mix DD and non-DD MRs on the same QP
+    //    and break that ordering, so any Data-Direct failure here is fatal --
+    //    deregister the MRs done so far and throw, rather than silently
+    //    downgrading this one MR to the regular path.
+    if (dataDirectActiveForNic(config_, nics_[n].isDataDirect) &&
+        symbols.mlx5dv_internal_reg_dmabuf_mr != nullptr) {
+      auto ddDmabuf = export_gpu_dmabuf_aligned(
+          reinterpret_cast<void*>(allocBase),
+          allocSize,
+          DmaBufExportKind::Pcie);
+      if (!ddDmabuf) {
+        for (int j = 0; j < n; ++j) {
+          symbols.ibv_internal_dereg_mr(cached.mrs[j]);
+        }
+        throw std::runtime_error(
+            fmt::format(
+                "Data-Direct selected for NIC {} but PCIe DMA-BUF export failed "
+                "(allocSize={}); refusing to mix DD and non-DD MRs on one QP "
+                "(PCIe DMA-BUF export needs CUDA >= 12.8 and a capable driver)",
+                n,
+                allocSize));
       }
-      close(dmabuf->fd);
+      errno = 0;
+      mr = symbols.mlx5dv_internal_reg_dmabuf_mr(
+          nics_[n].ibvPd,
+          ddDmabuf->alignment.dmabufOffset,
+          allocSize,
+          static_cast<uint64_t>(allocBase),
+          ddDmabuf->fd,
+          accessFlags,
+          ibverbx::MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+      // Capture the registration errno before close(): a failing (or even
+      // successful) close() may clobber errno, which would mask the real
+      // mlx5dv_reg_dmabuf_mr failure reason in the message below.
+      const int regErrno = errno;
+      close(ddDmabuf->fd);
+      if (!mr) {
+        for (int j = 0; j < n; ++j) {
+          symbols.ibv_internal_dereg_mr(cached.mrs[j]);
+        }
+        throw std::runtime_error(
+            fmt::format(
+                "Data-Direct mlx5dv_reg_dmabuf_mr failed for NIC {} "
+                "(allocSize={} errno={} ({})); refusing to mix DD and non-DD "
+                "MRs on one QP",
+                n,
+                allocSize,
+                regErrno,
+                folly::errnoStr(regErrno)));
+      }
     }
+    // 2. Regular DMABUF (default C2C mapping).
+    if (!mr) {
+      auto dmabuf = export_gpu_dmabuf_aligned(
+          reinterpret_cast<void*>(allocBase), allocSize);
+      if (dmabuf) {
+        if (symbols.ibv_internal_reg_dmabuf_mr != nullptr) {
+          mr = symbols.ibv_internal_reg_dmabuf_mr(
+              nics_[n].ibvPd,
+              dmabuf->alignment.dmabufOffset,
+              allocSize,
+              static_cast<uint64_t>(allocBase),
+              dmabuf->fd,
+              accessFlags);
+        }
+        close(dmabuf->fd);
+      }
+    }
+    // 3. Plain reg_mr.
     if (!mr) {
       errno = 0;
       mr = symbols.ibv_internal_reg_mr(

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -122,6 +122,18 @@ struct MultipeerIbTransportConfig {
   // field.
   DataDirectMode enableDataDirect{DataDirectMode::Only};
 
+  // PCIe Relaxed Ordering on eligible (bulk data) MRs so NIC<->HBM DMA TLPs
+  // pipeline instead of strict-ordering to ~half rate (NCCL's
+  // NCCL_IB_PCI_RELAXED_ORDERING). Only applied to MRs the caller marks
+  // relaxed-ordering-eligible (data, not signal/counter). The caller should
+  // tunnel NCCL_IB_PCI_RELAXED_ORDERING into this field.
+  enum class PciRelaxedOrderingMode {
+    Disabled, // strict ordering on every MR
+    Enabled, // relaxed ordering on eligible MRs
+    Auto, // relaxed ordering on eligible MRs when supported (NCCL default)
+  };
+  PciRelaxedOrderingMode enablePciRelaxedOrdering{PciRelaxedOrderingMode::Auto};
+
   // InfiniBand Verbs Timeout for QP ACK timeout (4.096us * 2^timeout). Valid
   // 1-31; 0 or >=32 is infinite. Default 20 (similar to NCCL_IB_TIMEOUT).
   uint8_t timeout{20};
@@ -160,6 +172,20 @@ inline bool dataDirectActiveForNic(
     const MultipeerIbTransportConfig& config,
     bool nicIsDataDirect) {
   return config.enableDataDirect != DataDirectMode::Disabled && nicIsDataDirect;
+}
+
+// Whether PCIe Relaxed Ordering applies for a NIC: requested via config (not
+// Disabled) and the NIC accepts the IBV_ACCESS_RELAXED_ORDERING access flag
+// (probed during openNics). registerBuffer() sets the flag exactly when this
+// holds, so on a NIC whose driver rejects it both Auto and Enabled fall back to
+// strict ordering instead of failing registration. Free function so the
+// config -> registration gating is unit-testable without a NIC.
+inline bool relaxedOrderingActiveForNic(
+    const MultipeerIbTransportConfig& config,
+    bool nicRelaxedOrderingCapable) {
+  return config.enablePciRelaxedOrdering !=
+      MultipeerIbTransportConfig::PciRelaxedOrderingMode::Disabled &&
+      nicRelaxedOrderingCapable;
 }
 
 /**
@@ -344,7 +370,12 @@ class MultiPeerIbTransportBase {
    *
    * @return IbgdaLocalBuffer carrying one lkey per NIC.
    */
-  IbgdaLocalBuffer registerBuffer(void* ptr, std::size_t size);
+  // @param relaxedOrdering eligible for PCIe Relaxed Ordering (gated by
+  //   config.enablePciRelaxedOrdering). Only bulk data (staging) MRs pass true;
+  //   signal/counter MRs stay strict. Data-Direct is applied automatically on
+  //   DD-capable NICs regardless of this flag.
+  IbgdaLocalBuffer
+  registerBuffer(void* ptr, std::size_t size, bool relaxedOrdering = false);
 
   /** deregisterBuffer - Decrement refcount; deregister all per-NIC MRs at 0. */
   void deregisterBuffer(void* ptr);
@@ -497,6 +528,12 @@ class MultiPeerIbTransportBase {
     std::array<ibverbx::ibv_mr*, kMaxNicsPerGpu> mrs{};
     std::size_t allocSize{0};
     int refs{0};
+    // Effective PCIe Relaxed Ordering the MRs were registered with (the
+    // caller's request resolved against config). Part of the cache key: a
+    // containment hit must resolve to the same value, else the access-flag
+    // (ordering) semantics would silently differ from what the caller asked
+    // for.
+    bool relaxedOrdering{false};
   };
 
   const int myRank_{-1};
@@ -526,8 +563,19 @@ class MultiPeerIbTransportBase {
     // This NIC exposes a Data-Direct (`_dma`) variant, so data MRs can register
     // through the PCIe (BAR1) path. Copied from the discovery NicCandidate.
     bool isDataDirect{false};
+    // This NIC's driver accepts IBV_ACCESS_RELAXED_ORDERING (probed once during
+    // openNics). registerBuffer() applies Relaxed Ordering only when every NIC
+    // is capable, so an unsupporting NIC falls back to strict ordering instead
+    // of failing every data-MR registration.
+    bool relaxedOrderingCapable{false};
   };
   std::vector<NicResources> nics_;
+
+  // True iff every opened NIC accepts IBV_ACCESS_RELAXED_ORDERING (AND of
+  // nics_[n].relaxedOrderingCapable, computed once in openNics). The MR cache
+  // keys on a single effective-ordering bool per allocation, so Relaxed
+  // Ordering must be uniform across NICs; gating on this aggregate keeps it so.
+  bool relaxedOrderingCapable_{false};
 
   // Maps allocation base address -> cached MR covering the full allocation.
   // Ordered map enables O(log n) containment lookup via upper_bound.

--- a/comms/prims/transport/MultiPeerIbTransport.h
+++ b/comms/prims/transport/MultiPeerIbTransport.h
@@ -18,6 +18,7 @@
 #include "comms/ctran/ibverbx/Ibvcore.h"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/ibgda/IbgdaBuffer.h"
+#include "comms/prims/transport/rdma/DataDirectMode.h"
 
 namespace meta::comms {
 class DeviceBuffer;
@@ -111,6 +112,16 @@ struct MultipeerIbTransportConfig {
     return maxGroups * qpsPerBlockPerNic;
   }
 
+  // mlx5 Data-Direct: register MRs through the NIC's data-direct (BAR1) PCIe
+  // path for ~2x NIC<->HBM RDMA-write BW on GB300 (NCCL's NCCL_IB_DATA_DIRECT).
+  // The single shared comms::prims::DataDirectMode (see DataDirectMode.h) — the
+  // same enum NIC discovery uses — so this field both selects the discovery
+  // mode and gates the registration path. Disabled disables discovery's DD
+  // probing too; Only/Both take effect only on a DD-capable NIC (a no-op
+  // otherwise). The caller should tunnel NCCL_IB_DATA_DIRECT (0/1/2) into this
+  // field.
+  DataDirectMode enableDataDirect{DataDirectMode::Only};
+
   // InfiniBand Verbs Timeout for QP ACK timeout (4.096us * 2^timeout). Valid
   // 1-31; 0 or >=32 is infinite. Default 20 (similar to NCCL_IB_TIMEOUT).
   uint8_t timeout{20};
@@ -139,6 +150,17 @@ struct MultipeerIbTransportConfig {
   // Timeout (ms) for the bilateral exchange in materializePeer().
   uint32_t materializePeerTimeoutMs{30000};
 };
+
+// Whether Data-Direct MR registration applies for a NIC: Data-Direct is
+// requested via config (not Disabled) and the NIC is DD-capable.
+// registerBuffer() selects the Data-Direct registration path exactly when this
+// holds (and the mlx5dv symbol is available). Exposed as a free function so the
+// config -> registration tunnel can be unit-tested without a NIC.
+inline bool dataDirectActiveForNic(
+    const MultipeerIbTransportConfig& config,
+    bool nicIsDataDirect) {
+  return config.enableDataDirect != DataDirectMode::Disabled && nicIsDataDirect;
+}
 
 /**
  * Transport connection information for RDMA QP setup.
@@ -501,6 +523,9 @@ class MultiPeerIbTransportBase {
     ibverbx::ibv_pd* ibvPd{nullptr};
     ibverbx::ibv_gid localGid{};
     int linkLayer{0}; // ibverbx::IBV_LINK_LAYER_* (IB vs Ethernet/RoCE)
+    // This NIC exposes a Data-Direct (`_dma`) variant, so data MRs can register
+    // through the PCIe (BAR1) path. Copied from the discovery NicCandidate.
+    bool isDataDirect{false};
   };
   std::vector<NicResources> nics_;
 

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.cc
@@ -1956,9 +1956,14 @@ pipes_gda_error_t pipes_gda_gpu_verbs_destroy_qp_group_hl(
 
 namespace comms::prims {
 
-std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
-    void* ptr,
-    std::size_t size) {
+std::optional<DmaBufExport>
+export_gpu_dmabuf_aligned(void* ptr, std::size_t size, DmaBufExportKind kind) {
+  // mlx5 Data-Direct (BAR1 PCIe mapping) is NVIDIA-only; the AMD HSA export has
+  // no equivalent, so report Pcie as unavailable. (Data-Direct is also disabled
+  // in AMD NIC discovery, so this is never requested at runtime.)
+  if (kind == DmaBufExportKind::Pcie) {
+    return std::nullopt;
+  }
   // Skip dmabuf for non-GPU pointers. HSA's
   // `hsa_amd_portable_export_dmabuf` will export host-pinned
   // (`hipHostMalloc`) memory as a dmabuf, but the resulting fd

--- a/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
+++ b/comms/prims/transport/amd/pipes_gda/PipesGdaHost.h
@@ -393,9 +393,20 @@ struct DmaBufExport {
   DmaBufAlignment alignment;
 };
 
+// Mapping requested when exporting a GPU allocation as a DMA-BUF fd. mlx5
+// Data-Direct (Pcie / BAR1 PCIe-mapped DMA-BUF) is NVIDIA/GB300-only; on AMD
+// the Pcie kind is unsupported and export returns std::nullopt. (Data-Direct is
+// also disabled in NIC discovery on AMD, so Pcie is never requested at runtime;
+// the enum exists so the shared registerBuffer compiles under HIP.)
+enum class DmaBufExportKind {
+  Default,
+  Pcie,
+};
+
 std::optional<DmaBufExport> export_gpu_dmabuf_aligned(
     void* ptr,
-    std::size_t size);
+    std::size_t size,
+    DmaBufExportKind kind = DmaBufExportKind::Default);
 
 } // namespace comms::prims
 

--- a/comms/prims/transport/rdma/DataDirectMode.h
+++ b/comms/prims/transport/rdma/DataDirectMode.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+namespace comms::prims {
+
+// Single source of truth for the Data-Direct mode, shared by NIC discovery
+// (GpuNicDiscovery) and the IB transport config
+// (MultipeerIbTransportConfig::enableDataDirect). One knob drives two coupled
+// decisions: which NIC candidates discovery surfaces (and tags isDataDirect),
+// and whether registerBuffer takes the Data-Direct (BAR1 PCIe) registration
+// path on a DD-tagged NIC. Mirrors NCCL_IB_DATA_DIRECT (0/1/2).
+enum class DataDirectMode {
+  // 0: never discover or use Data-Direct.
+  Disabled = 0,
+  // 1 (NCCL default): discovery REPLACES a DD-capable NIC with its Data-Direct
+  // variant -- each physical NIC appears exactly once (non-DD NICs are
+  // unaffected) -- and the transport registers MRs through the Data-Direct
+  // (BAR1) path on it.
+  Only = 1,
+  // 2: discovery exposes BOTH the regular and the Data-Direct variant of a
+  // DD-capable NIC -- the SAME physical NIC over its two PCIe routes (Grace
+  // C2C and BAR1), not two different NICs. In NCCL this drives one NIC over
+  // both rails for more aggregate NIC<->HBM concurrency (each rail is a
+  // separate net device; the same buffer is registered on both). NOTE: this
+  // transport does NOT exploit that -- it selects one variant per NIC slot
+  // (the DD variant sorts first via getBestAffinityNics), so Both currently
+  // behaves identically to Only. It is kept only for NCCL_IB_DATA_DIRECT
+  // parity; true dual-rail would register each buffer on both routes and
+  // spread QP groups across them.
+  Both = 2,
+};
+
+} // namespace comms::prims

--- a/comms/prims/transport/rdma/NicDiscovery.h
+++ b/comms/prims/transport/rdma/NicDiscovery.h
@@ -7,19 +7,10 @@
 #include <utility>
 #include <vector>
 
+#include "comms/prims/transport/rdma/DataDirectMode.h"
 #include "comms/prims/transport/rdma/IbHcaParser.h"
 
 namespace comms::prims {
-
-/**
- * Data Direct NIC discovery mode.
- * Controls whether Data Direct DMA NICs are discovered alongside regular NICs.
- */
-enum class DataDirectMode {
-  Disabled = 0, // No Data Direct discovery
-  Only = 1, // Replace regular NICs with DD variants (non-DD NICs remain)
-  Both = 2, // Keep both regular and DD variants
-};
 
 /**
  * Path type hierarchy for topology-aware NIC selection.


### PR DESCRIPTION
Summary:

Opt bulk-data MRs into PCIe Relaxed Ordering so NIC<->HBM DMA TLPs pipeline instead of strict-ordering to roughly half rate. This is NCCL's `NCCL_IB_PCI_RELAXED_ORDERING`. Relaxed ordering is applied only to MRs the caller marks eligible (bulk staging data), never to signal/counter MRs — a strict flag write must not be reordered ahead of the data it announces on the shared route.

- `MultiPeerIbTransport.h`: adds `MultipeerIbTransportConfig::PciRelaxedOrderingMode` (`Disabled`/`Enabled`/`Auto`) + `enablePciRelaxedOrdering{Auto}`, and a `relaxedOrdering` parameter on `registerBuffer()` (default false). The caller tunnels `NCCL_IB_PCI_RELAXED_ORDERING` into the config field.
- `MultiPeerIbTransport.cc`: `registerBuffer()` sets `IBV_ACCESS_RELAXED_ORDERING` when the caller passes `relaxedOrdering=true` and the config is not `Disabled`; the send/recv staging bulks register relaxed-ordering-eligible while signal/counter stay strict. Per-NIC log now reports the relaxed-ordering state.

Stacked on the Data-Direct diff; Data-Direct (when active) already applies to all MRs, and relaxed ordering is orthogonal to it.

Reviewed By: goelayu

Differential Revision: D109917559


