### PR TITLE
Add MultimemHandler for CUDA multicast allocations (#3017)

### DIFF
--- a/comms/prims/memory/CuMemAllocation.h
+++ b/comms/prims/memory/CuMemAllocation.h
@@ -30,6 +30,9 @@ using CUdeviceptr = unsigned long long;
 struct CUmemAllocationProp {
   unsigned char _padding[1];
 };
+struct CUmemAccessDesc {
+  unsigned char _padding[1];
+};
 #endif
 
 /**

--- a/comms/prims/memory/CuMemMapping.cc
+++ b/comms/prims/memory/CuMemMapping.cc
@@ -4,6 +4,7 @@
 
 #include "comms/prims/core/Checks.h"
 #include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMulticastAllocation.h"
 
 #if !defined(__HIP_PLATFORM_AMD__)
 #include "comms/prims/platform/CudaDriverLazy.h"
@@ -60,6 +61,19 @@ CuMemMapping CuMemMapping::overAllocation(
   const CUdevice cuDev = alloc->device();
   const CUmemGenericAllocationHandle handle = alloc->handle();
   return CuMemMapping(cuDev, handle, size, granularity, std::move(alloc));
+}
+
+CuMemMapping CuMemMapping::overMulticast(
+    std::shared_ptr<CuMulticastAllocation> overlay,
+    std::size_t size,
+    std::size_t granularity) {
+  if (!overlay) {
+    throw std::runtime_error(
+        "CuMemMapping::overMulticast: overlay must be non-null");
+  }
+  const CUdevice cuDev = overlay->device();
+  const CUmemGenericAllocationHandle handle = overlay->handle();
+  return CuMemMapping(cuDev, handle, size, granularity, std::move(overlay));
 }
 
 CuMemMapping::~CuMemMapping() {

--- a/comms/prims/memory/CuMemMapping.h
+++ b/comms/prims/memory/CuMemMapping.h
@@ -21,6 +21,7 @@
 namespace comms::prims {
 
 class CuMemAllocation;
+class CuMulticastAllocation;
 
 // RAII virtual-address mapping over a physical / multicast allocation.
 //
@@ -49,6 +50,14 @@ class CuMemMapping {
   // mapping co-owns `alloc`.
   static CuMemMapping overAllocation(
       std::shared_ptr<CuMemAllocation> alloc,
+      std::size_t size,
+      std::size_t granularity);
+
+  // Map `overlay`'s multicast handle into a fresh VA of `size` bytes aligned to
+  // `granularity`, granting RW access on the device registered with the
+  // multicast object. The returned mapping co-owns `overlay`.
+  static CuMemMapping overMulticast(
+      std::shared_ptr<CuMulticastAllocation> overlay,
       std::size_t size,
       std::size_t granularity);
 

--- a/comms/prims/memory/CuMulticastAllocation.cc
+++ b/comms/prims/memory/CuMulticastAllocation.cc
@@ -1,0 +1,181 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/CuMulticastAllocation.h"
+
+#include "comms/prims/core/Checks.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <glog/logging.h>
+
+#include <stdexcept>
+
+namespace comms::prims {
+
+CuMulticastAllocation::CuMulticastAllocation(
+    CUmemGenericAllocationHandle handle,
+    std::size_t size)
+    : handle_(handle), size_(size) {}
+
+CuMulticastAllocation CuMulticastAllocation::create(
+    const CUmulticastObjectProp& prop) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)prop;
+  throw std::runtime_error("CuMulticastAllocation::create requires CUDA 12.3+");
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    throw std::runtime_error(
+        "CuMulticastAllocation::create: CUDA driver not available");
+  }
+  CUmemGenericAllocationHandle handle = 0;
+  checkCuError(
+      pfn_cuMulticastCreate(&handle, &prop), "cuMulticastCreate failed");
+  return CuMulticastAllocation(handle, prop.size);
+#endif
+}
+
+CuMulticastAllocation CuMulticastAllocation::adopt(
+    CUmemGenericAllocationHandle handle,
+    std::size_t size) {
+  return CuMulticastAllocation(handle, size);
+}
+
+CuMulticastAllocation::~CuMulticastAllocation() {
+  release();
+}
+
+CuMulticastAllocation::CuMulticastAllocation(
+    CuMulticastAllocation&& other) noexcept
+    : handle_(other.handle_),
+      device_(other.device_),
+      size_(other.size_),
+      boundSize_(other.boundSize_),
+      boundMcOffset_(other.boundMcOffset_),
+      deviceAdded_(other.deviceAdded_),
+      bound_(other.bound_) {
+  other.handle_ = 0;
+  other.bound_ = false;
+  other.deviceAdded_ = false;
+}
+
+CuMulticastAllocation& CuMulticastAllocation::operator=(
+    CuMulticastAllocation&& other) noexcept {
+  if (this != &other) {
+    release();
+    handle_ = other.handle_;
+    device_ = other.device_;
+    size_ = other.size_;
+    boundSize_ = other.boundSize_;
+    boundMcOffset_ = other.boundMcOffset_;
+    deviceAdded_ = other.deviceAdded_;
+    bound_ = other.bound_;
+    other.handle_ = 0;
+    other.bound_ = false;
+    other.deviceAdded_ = false;
+  }
+  return *this;
+}
+
+void CuMulticastAllocation::addDevice(CUdevice cuDev) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  // Single-device: the destructor unbinds exactly one device (`device_`), so
+  // a second addDevice() call would leak the earlier device's binding.
+  if (deviceAdded_) {
+    throw std::runtime_error(
+        "CuMulticastAllocation::addDevice: device already added; "
+        "single-device per object is the only supported mode");
+  }
+  checkCuError(
+      pfn_cuMulticastAddDevice(handle_, cuDev), "cuMulticastAddDevice failed");
+  device_ = cuDev;
+  deviceAdded_ = true;
+#else
+  (void)cuDev;
+  throw std::runtime_error("CuMulticastAllocation requires CUDA 12.3+");
+#endif
+}
+
+void CuMulticastAllocation::bindMem(
+    CUmemGenericAllocationHandle physHandle,
+    std::size_t mcOffset,
+    std::size_t physOffset,
+    std::size_t size) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  // Single-bind: the destructor unbinds exactly one (mcOffset, size) range;
+  // a second bindMem() call would leak the earlier binding.
+  if (bound_) {
+    throw std::runtime_error(
+        "CuMulticastAllocation::bindMem: already bound; "
+        "single-bind per object is the only supported mode");
+  }
+  checkCuError(
+      pfn_cuMulticastBindMem(
+          handle_, mcOffset, physHandle, physOffset, size, 0),
+      "cuMulticastBindMem failed");
+  bound_ = true;
+  boundSize_ = size;
+  boundMcOffset_ = mcOffset;
+#else
+  (void)physHandle;
+  (void)mcOffset;
+  (void)physOffset;
+  (void)size;
+  throw std::runtime_error("CuMulticastAllocation requires CUDA 12.3+");
+#endif
+}
+
+void CuMulticastAllocation::release() noexcept {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (handle_ == 0) {
+    return;
+  }
+  // Destructors can't throw, so the unwind-without-context paths below are
+  // best-effort: log when we have to skip cleanup so the leaked multicast
+  // handle is visible rather than silent.
+  if (cuda_driver_lazy_init() != 0) {
+    LOG(ERROR)
+        << "CuMulticastAllocation::release: CUDA driver lazy init failed; "
+           "leaking multicast handle=0x"
+        << std::hex << handle_ << std::dec;
+    handle_ = 0;
+    return;
+  }
+  CUcontext ctx = nullptr;
+  if (pfn_cuCtxGetCurrent == nullptr ||
+      pfn_cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+    LOG(ERROR) << "CuMulticastAllocation::release: no current CUDA context; "
+                  "leaking multicast handle=0x"
+               << std::hex << handle_ << std::dec;
+    handle_ = 0;
+    return;
+  }
+
+  // Unbind the local device's binding before releasing the multicast handle.
+  // The earlier no-context / no-driver branches log on failure so leaked
+  // resources are observable; mirror that here so a driver-level unbind or
+  // release failure isn't silently swallowed.
+  if (bound_ && deviceAdded_ && pfn_cuMulticastUnbind != nullptr) {
+    const CUresult unbindRc =
+        pfn_cuMulticastUnbind(handle_, device_, boundMcOffset_, boundSize_);
+    if (unbindRc != CUDA_SUCCESS) {
+      LOG(ERROR) << "CuMulticastAllocation::release: cuMulticastUnbind failed "
+                    "(CUresult="
+                 << static_cast<int>(unbindRc) << ", handle=0x" << std::hex
+                 << handle_ << std::dec << ")";
+    }
+    bound_ = false;
+  }
+  const CUresult releaseRc = pfn_cuMemRelease(handle_);
+  if (releaseRc != CUDA_SUCCESS) {
+    LOG(ERROR) << "CuMulticastAllocation::release: cuMemRelease failed "
+                  "(CUresult="
+               << static_cast<int>(releaseRc) << ", handle=0x" << std::hex
+               << handle_ << std::dec << "); leaking multicast handle";
+  }
+  handle_ = 0;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/CuMulticastAllocation.h
+++ b/comms/prims/memory/CuMulticastAllocation.h
@@ -1,0 +1,131 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. Multicast
+// is NVIDIA-only; on AMD the impl bodies throw and `CuMemAllocation.h`
+// provides the stub `CUdevice` / `CUmemGenericAllocationHandle` typedefs the
+// always-declared API references.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+
+namespace comms::prims {
+
+#if defined(__HIP_PLATFORM_AMD__)
+// Stub the multicast-only CUDA driver-API type so the always-declared API
+// surface (create(prop)) compiles on AMD. The create() body throws on AMD.
+struct CUmulticastObjectProp {
+  unsigned char _padding[1];
+};
+#endif
+
+/**
+ * CuMulticastAllocation - RAII owner of one CUDA multicast object handle (a
+ * `CUmemGenericAllocationHandle` returned by cuMulticastCreate, or imported on
+ * peers).
+ *
+ * It owns only the multicast object handle. Mapping the multicast VA is
+ * CuMemMapping's job; binding a physical allocation into the object is done via
+ * bindMem(). Like CuMemAllocation, it is meant to be co-owned via
+ * std::shared_ptr so a CuMemMapping can keep the multicast object alive for as
+ * long as its VA mapping exists.
+ *
+ * Two ways to obtain one:
+ *  - create(prop): cuMulticastCreate (team rank 0).
+ *  - adopt(handle, size): take ownership of an imported multicast handle
+ * (peers, after NvlMemExchange::importShareableHandle).
+ *
+ * The destructor cuMulticastUnbind()s the local binding (if bindMem ran) then
+ * cuMemRelease()s the handle. Drop the multicast VA mapping (CuMemMapping)
+ * BEFORE destroying this object. Not copyable; movable. Requires CUDA 12.3+.
+ */
+class CuMulticastAllocation {
+ public:
+  /** cuMulticastCreate a multicast object from `prop` (team rank 0). */
+  static CuMulticastAllocation create(const CUmulticastObjectProp& prop);
+
+  /**
+   * Take ownership of an imported multicast object handle (peers). `size` is
+   * the multicast object size (used for unbind at teardown).
+   */
+  static CuMulticastAllocation adopt(
+      CUmemGenericAllocationHandle handle,
+      std::size_t size);
+
+  ~CuMulticastAllocation();
+
+  CuMulticastAllocation(CuMulticastAllocation&& other) noexcept;
+  CuMulticastAllocation& operator=(CuMulticastAllocation&& other) noexcept;
+
+  CuMulticastAllocation(const CuMulticastAllocation&) = delete;
+  CuMulticastAllocation& operator=(const CuMulticastAllocation&) = delete;
+
+  /**
+   * cuMulticastAddDevice: register `cuDev` with the multicast object.
+   *
+   * Single-device only: the destructor unbinds exactly one device (`device_`),
+   * so calling addDevice() more than once on the same object would leak the
+   * earlier devices' bindings. Subsequent calls throw to surface the misuse
+   * rather than silently overwriting `device_`.
+   */
+  void addDevice(CUdevice cuDev);
+
+  /**
+   * cuMulticastBindMem: bind `physHandle` into the multicast object at
+   * `mcOffset` (physical offset `physOffset`) for `size` bytes. Records the
+   * binding so the destructor unbinds it.
+   *
+   * Single-bind only: the destructor unbinds exactly one (mcOffset, size)
+   * range. Calling bindMem() more than once on the same object would leak
+   * every binding except the last; subsequent calls throw to surface the
+   * misuse rather than silently overwriting the recorded range.
+   */
+  void bindMem(
+      CUmemGenericAllocationHandle physHandle,
+      std::size_t mcOffset,
+      std::size_t physOffset,
+      std::size_t size);
+
+  CUmemGenericAllocationHandle handle() const {
+    return handle_;
+  }
+
+  /** The local device registered via addDevice() (0 before addDevice). */
+  CUdevice device() const {
+    return device_;
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+ private:
+  CuMulticastAllocation(CUmemGenericAllocationHandle handle, std::size_t size);
+
+  void release() noexcept;
+
+  CUmemGenericAllocationHandle handle_{0};
+  CUdevice device_{0};
+  // `size_` is the multicast OBJECT size (from cuMulticastCreate / passed to
+  // adopt) and is the value the public `size()` accessor returns. `boundSize_`
+  // + `boundMcOffset_` are the (size, mcOffset) actually passed to bindMem();
+  // they're only meaningful when `bound_` is true and are what the destructor
+  // passes to cuMulticastUnbind. They are distinct from `size_` because
+  // adopt() never binds (peers import the handle but typically don't rebind),
+  // and they may differ if bindMem is called with a partial range.
+  std::size_t size_{0};
+  std::size_t boundSize_{0};
+  std::size_t boundMcOffset_{0};
+  bool deviceAdded_{false};
+  bool bound_{false};
+};
+
+} // namespace comms::prims

--- a/comms/prims/memory/MultimemHandler.cc
+++ b/comms/prims/memory/MultimemHandler.cc
@@ -1,0 +1,700 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/memory/MultimemHandler.h"
+
+#include "comms/prims/core/Checks.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMulticastAllocation.h"
+#include "comms/prims/memory/NvlMemExchange.h"
+
+#if !defined(__HIP_PLATFORM_AMD__)
+#include "comms/prims/platform/CudaDriverLazy.h"
+#endif
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include <unistd.h>
+
+namespace comms::prims {
+
+namespace {
+
+constexpr int kCachedMultimemSupportDevices = 8;
+
+bool isPowerOfTwo(std::size_t x) {
+  return x != 0 && (x & (x - 1)) == 0;
+}
+
+enum class MultimemSupportCacheState : uint8_t {
+  kUnknown,
+  kUnsupported,
+  kSupported,
+};
+
+const char* handleTypeName(MultimemHandler::HandleType handleType) {
+  switch (handleType) {
+    case ShareableHandleType::kUnsupported:
+      return "unsupported";
+    case ShareableHandleType::kFabric:
+      return "fabric";
+    case ShareableHandleType::kPosixFd:
+      return "posix_fd";
+  }
+  return "unknown";
+}
+
+bool multicastDriverApisAvailable() {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  return false;
+#else
+  return pfn_cuMulticastCreate != nullptr &&
+      pfn_cuMulticastAddDevice != nullptr &&
+      pfn_cuMulticastBindMem != nullptr && pfn_cuMulticastUnbind != nullptr &&
+      pfn_cuMulticastGetGranularity != nullptr;
+#endif
+}
+
+bool multicastSupported(CUdevice cuDev) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  int multicastSupported = 0;
+  auto err = pfn_cuDeviceGetAttribute(
+      &multicastSupported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, cuDev);
+  return err == CUDA_SUCCESS && multicastSupported != 0;
+#endif
+}
+
+// Builds the local-backing / multicast allocation prop for a single chosen
+// shareable handle type, reusing the shared makeVmmAllocationProp() helper.
+CUmemAllocationProp makeLocalAllocationProp(
+    CUdevice cuDev,
+    MultimemHandler::HandleType handleType) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  return makeVmmAllocationProp(
+      cuDev, static_cast<unsigned int>(toCudaHandleType(handleType)));
+#else
+  (void)handleType;
+  (void)cuDev;
+  return CUmemAllocationProp{};
+#endif
+}
+
+// Single O(n) pass that validates `nvlRankToCommRank` (non-empty, no negative
+// ranks, no duplicates, `commRank` present) and returns this rank's NVL-local
+// index. Throws std::runtime_error on any violation.
+int32_t computeNvlRankAndValidate(
+    int32_t commRank,
+    const std::vector<int>& nvlRankToCommRank) {
+  if (nvlRankToCommRank.empty()) {
+    throw std::runtime_error(
+        "MultimemHandler: nvlRankToCommRank must be non-empty");
+  }
+  std::unordered_set<int> seen;
+  seen.reserve(nvlRankToCommRank.size());
+  int32_t nvlRank = -1;
+  for (std::size_t i = 0; i < nvlRankToCommRank.size(); ++i) {
+    const int rank = nvlRankToCommRank[i];
+    if (rank < 0) {
+      throw std::runtime_error(
+          "MultimemHandler: nvlRankToCommRank contains a negative rank");
+    }
+    if (!seen.insert(rank).second) {
+      throw std::runtime_error(
+          "MultimemHandler: nvlRankToCommRank contains duplicate ranks");
+    }
+    if (rank == commRank) {
+      nvlRank = static_cast<int32_t>(i);
+    }
+  }
+  if (nvlRank < 0) {
+    throw std::runtime_error(
+        "MultimemHandler: commRank must appear in nvlRankToCommRank");
+  }
+  return nvlRank;
+}
+
+// Selects the shareable handle type for multicast on `cudaDevice`. Layers the
+// multicast-specific requirements (multicast driver APIs + multicast device
+// attribute) on top of the shared selectShareableHandleType() probe.
+MultimemHandler::HandleType selectMultimemHandleTypeImpl(int cudaDevice) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cudaDevice;
+  return ShareableHandleType::kUnsupported;
+#else
+  if (cudaDevice < 0) {
+    return ShareableHandleType::kUnsupported;
+  }
+  if (cuda_driver_lazy_init() != 0) {
+    return ShareableHandleType::kUnsupported;
+  }
+  if (!multicastDriverApisAvailable()) {
+    return ShareableHandleType::kUnsupported;
+  }
+
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    return ShareableHandleType::kUnsupported;
+  }
+
+  if (!multicastSupported(cuDev)) {
+    return ShareableHandleType::kUnsupported;
+  }
+
+  return selectShareableHandleType(cudaDevice);
+#endif
+}
+
+} // namespace
+
+std::shared_ptr<CuMemAllocation> MultimemHandler::requireBacking(
+    std::shared_ptr<CuMemAllocation> backing) {
+  if (!backing) {
+    throw std::runtime_error(
+        "MultimemHandler: backing CuMemAllocation must be non-null");
+  }
+  return backing;
+}
+
+MultimemHandler::MultimemHandler(
+    std::shared_ptr<CuMemAllocation> backing,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int32_t commRank,
+    std::vector<int> nvlRankToCommRank,
+    int cudaDevice)
+    : bootstrap_(std::move(bootstrap)),
+      commRank_(commRank),
+      nvlRank_(computeNvlRankAndValidate(commRank, nvlRankToCommRank)),
+      nvlRanks_(static_cast<int32_t>(nvlRankToCommRank.size())),
+      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
+      cudaDevice_(cudaDevice),
+      requestedSize_(requireBacking(backing)->size()),
+      backing_(std::move(backing)) {
+  if (requestedSize_ == 0) {
+    throw std::runtime_error("MultimemHandler: backing size must be non-zero");
+  }
+  if (!bootstrap_) {
+    throw std::runtime_error("MultimemHandler: bootstrap must be non-null");
+  }
+  handleType_ = selectMultimemHandleTypeImpl(cudaDevice_);
+  if (handleType_ == HandleType::kUnsupported) {
+    throw std::runtime_error(
+        "MultimemHandler: multicast multimem is not supported. Requires CUDA "
+        "12.3+, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, and fabric or POSIX "
+        "FD allocation handles.");
+  }
+}
+
+MultimemHandler::~MultimemHandler() {
+  cleanup();
+}
+
+bool MultimemHandler::isMultimemSupported(int cudaDevice) {
+  if (cudaDevice < 0) {
+    return false;
+  }
+
+  static std::array<
+      std::atomic<MultimemSupportCacheState>,
+      kCachedMultimemSupportDevices>
+      cachedResults{};
+  if (cudaDevice >= kCachedMultimemSupportDevices) {
+    return selectMultimemHandleTypeImpl(cudaDevice) != HandleType::kUnsupported;
+  }
+
+  auto& cachedResult = cachedResults[static_cast<std::size_t>(cudaDevice)];
+  const auto cachedState = cachedResult.load(std::memory_order_acquire);
+  if (cachedState != MultimemSupportCacheState::kUnknown) {
+    return cachedState == MultimemSupportCacheState::kSupported;
+  }
+
+  const bool supported =
+      selectMultimemHandleTypeImpl(cudaDevice) != HandleType::kUnsupported;
+  cachedResult.store(
+      supported ? MultimemSupportCacheState::kSupported
+                : MultimemSupportCacheState::kUnsupported,
+      std::memory_order_release);
+  return supported;
+}
+
+std::size_t MultimemHandler::backingGranularity(int cudaDevice, int nvlRanks) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cudaDevice;
+  (void)nvlRanks;
+  return 0;
+#else
+  const HandleType handleType = selectMultimemHandleTypeImpl(cudaDevice);
+  if (handleType == HandleType::kUnsupported) {
+    return 0;
+  }
+
+  CUdevice cuDev = 0;
+  if (pfn_cuDeviceGet(&cuDev, cudaDevice) != CUDA_SUCCESS) {
+    return 0;
+  }
+
+  auto localProp = makeLocalAllocationProp(cuDev, handleType);
+  std::size_t localGranularity = 0;
+  checkCuError(
+      pfn_cuMemGetAllocationGranularity(
+          &localGranularity, &localProp, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED),
+      "cuMemGetAllocationGranularity failed");
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks);
+  multicastProp.size = localGranularity;
+  multicastProp.handleTypes = toCudaHandleType(handleType);
+  multicastProp.flags = 0;
+
+  std::size_t multicastGranularity = 0;
+  checkCuError(
+      pfn_cuMulticastGetGranularity(
+          &multicastGranularity,
+          &multicastProp,
+          CU_MULTICAST_GRANULARITY_RECOMMENDED),
+      "cuMulticastGetGranularity failed");
+
+  if (!isPowerOfTwo(localGranularity)) {
+    throw std::runtime_error(
+        "MultimemHandler: local allocation granularity is not a power of two");
+  }
+  if (!isPowerOfTwo(multicastGranularity)) {
+    throw std::runtime_error(
+        "MultimemHandler: multicast granularity is not a power of two");
+  }
+
+  return std::max(localGranularity, multicastGranularity);
+#endif
+}
+
+void MultimemHandler::exchange() {
+  if (exchanged_) {
+    return;
+  }
+  // A previous exchange() attempt threw and cleanup() tore down `backing_`
+  // / `overlay_` / `multicastMapping_`. Re-entering the body would
+  // dereference the now-null `backing_` in computeAllocationLayout() /
+  // bindLocalMemoryToMulticast(). Make this a terminal state: retry
+  // requires constructing a fresh MultimemHandler over the same
+  // (caller-owned) backing.
+  if (failed_) {
+    throw std::runtime_error(
+        "MultimemHandler::exchange: this handler is in a terminal failed "
+        "state after a prior exchange() attempt threw. cleanup() released "
+        "the multicast object and the shared backing reference; construct "
+        "a new MultimemHandler with the same backing to retry.");
+  }
+
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  throw std::runtime_error("MultimemHandler requires CUDA 12.3+");
+#else
+  const char* failedPhase = "initializeDevice";
+  const char* completedPhase = "none";
+
+  try {
+    // Multicast setup is host-synchronous locally, but it still has ordering
+    // requirements across ranks:
+    //
+    // 1. initializeDevice() resolves cudaDevice_ to a CUdevice. The caller
+    //    must have already made cudaDevice_ current; this handler does not
+    //    call cudaSetDevice().
+    //
+    // 2. computeAllocationLayout() takes the shared backing's size (which the
+    //    caller sized to the multicast granularity) and queries the multicast
+    //    granularity for the VA mapping.
+    //
+    // 3. create/export/exchange/import shares only the multicast object
+    //    handle. Team rank 0 owns object creation, exports either a fabric
+    //    handle or a POSIX FD for it, all ranks exchange metadata, and the
+    //    other ranks import rank 0's object before joining the multicast team.
+    //
+    // 4. addLocalDeviceToMulticast() registers this rank's device with the
+    //    shared object. CUDA requires every participating device to be added
+    //    before memory can be bound to the multicast object.
+    //
+    // 5. The pre-bind barrier is a control-plane robustness barrier. It
+    //    serializes object create/import + addDevice across ranks before any
+    //    rank calls cuMulticastBindMem, so a slow / aborting rank can't race
+    //    into bind while peers are still importing — that mismatch is a known
+    //    way to wedge the driver. It is not a GPU stream synchronization.
+    //
+    // 6. bindLocalMemoryToMulticast() attaches this rank's shared backing
+    //    allocation at offset 0 in the multicast object. After all ranks bind
+    //    the same range, multimem stores to that range can be replicated by
+    //    NVSwitch. The caller is responsible for zeroing the backing.
+    //
+    // 7. mapMulticastMemory() reserves and maps this rank's multicast VA, then
+    //    grants device access. Kernels use this VA for multimem instructions.
+    //
+    // 8. The post-map barrier is the "ready to use" contract for exchange():
+    //    no rank returns and launches a kernel using multimem while another
+    //    rank is still binding or mapping the multicast VA.
+    cuDev_ = initializeDevice();
+    deviceInitialized_ = true;
+    completedPhase = failedPhase;
+
+    // Every rank independently selects handleType_ in the constructor; verify
+    // they all picked the same one before rank 0 creates the multicast object
+    // (which embeds handleType_). A silent mismatch would surface as a
+    // confusing export/import failure on the next phase; fail fast with a clear
+    // message.
+    failedPhase = "agreeOnHandleType";
+    agreeOnHandleType();
+    completedPhase = failedPhase;
+
+    failedPhase = "computeAllocationLayout";
+    const auto layout = computeAllocationLayout();
+    allocatedSize_ = layout.allocatedSize;
+    completedPhase = failedPhase;
+
+    failedPhase = "createMulticastHandle";
+    createMulticastHandle(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    ShareableHandle multicastHandle = {};
+    if (nvlRank_ == 0) {
+      failedPhase = "exportMulticastHandle";
+      multicastHandle = exportMulticastHandle();
+      completedPhase = failedPhase;
+    }
+    failedPhase = "exchangeMulticastHandle";
+    multicastHandle = exchangeMulticastHandle(multicastHandle);
+    completedPhase = failedPhase;
+
+    // nvlRank_ is the rank inside this NVLink multicast team. Team rank 0
+    // already owns the CUDA multicast handle it created; every other team rank
+    // imports rank 0's exchanged multicast handle.
+    if (nvlRank_ != 0) {
+      failedPhase = "importMulticastHandle";
+      importMulticastHandle(multicastHandle);
+      completedPhase = failedPhase;
+    }
+
+    // Every participating rank, including rank 0, must add its local device to
+    // the shared multicast object before any rank binds memory to the object.
+    failedPhase = "addLocalDeviceToMulticast";
+    addLocalDeviceToMulticast(cuDev_);
+    completedPhase = failedPhase;
+
+    // Keep all ranks out of the driver's blocking cuMulticastBindMem path
+    // until every rank has joined the multicast object. A slow / aborting
+    // rank that calls bind while peers are still in addDevice/import is a
+    // known way to wedge the driver; the barrier serializes the two phases.
+    failedPhase = "synchronizeRanks:pre-bind";
+    synchronizeRanks("pre-bind");
+    completedPhase = failedPhase;
+
+    failedPhase = "bindLocalMemoryToMulticast";
+    bindLocalMemoryToMulticast(layout.allocatedSize);
+    completedPhase = failedPhase;
+
+    failedPhase = "mapMulticastMemory";
+    mapMulticastMemory(layout);
+    completedPhase = failedPhase;
+
+    // exchange() returns ready-to-use pointers. This barrier prevents an early
+    // rank from launching kernels against the multicast VA while another rank
+    // is still binding or mapping that VA.
+    failedPhase = "synchronizeRanks:post-map";
+    synchronizeRanks("post-map");
+    completedPhase = failedPhase;
+
+    exchanged_ = true;
+  } catch (const std::exception& ex) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message = std::string("MultimemHandler::exchange failed: ") +
+        ex.what() + "\n" + state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    // Mark terminal BEFORE cleanup() so that even if cleanup itself throws
+    // somehow, the handler is still observably in the failed state for
+    // any subsequent exchange() call.
+    failed_ = true;
+    cleanup();
+    throw std::runtime_error(message);
+  } catch (...) {
+    const auto state = describeState(failedPhase, completedPhase);
+    std::string message =
+        std::string(
+            "MultimemHandler::exchange failed with unknown exception\n") +
+        state;
+    std::fprintf(stderr, "%s\n", message.c_str());
+    failed_ = true;
+    cleanup();
+    throw std::runtime_error(message);
+  }
+#endif
+}
+
+void* MultimemHandler::getMultimemDeviceMemPtr() const {
+  if (!exchanged_ || !multicastMapping_) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before using multimem ptr");
+  }
+  // NOLINTNEXTLINE(performance-no-int-to-ptr): CUdeviceptr is an integer type
+  return reinterpret_cast<void*>(multicastMapping_->devicePtr());
+}
+
+std::size_t MultimemHandler::getAllocatedSize() const {
+  if (!exchanged_) {
+    throw std::runtime_error(
+        "MultimemHandler: exchange() must complete before reading allocated size");
+  }
+  return allocatedSize_;
+}
+
+CUdevice MultimemHandler::initializeDevice() const {
+  CUdevice cuDev = 0;
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  checkCuError(pfn_cuDeviceGet(&cuDev, cudaDevice_), "cuDeviceGet failed");
+#endif
+  return cuDev;
+}
+
+MultimemHandler::AllocationLayout MultimemHandler::computeAllocationLayout()
+    const {
+  AllocationLayout layout;
+
+  layout.granularity =
+      MultimemHandler::backingGranularity(cudaDevice_, nvlRanks_);
+  // backingGranularity() returns 0 on the unsupported / failed-probe path
+  // (no CUDA 12.3+, no multicast device attribute, or cuDeviceGet failure).
+  // Computing `allocatedSize % 0` below would be UB / SIGFPE; surface a
+  // legible error instead so the calling phase ("computeAllocationLayout")
+  // gets attributed cleanly.
+  if (layout.granularity == 0) {
+    throw std::runtime_error(
+        "MultimemHandler::computeAllocationLayout: multicast unsupported on "
+        "this device / toolkit (backingGranularity returned 0)");
+  }
+
+  // The shared backing already exists. Use its size verbatim, but verify it can
+  // be bound into the multicast object.
+  layout.allocatedSize = backing_->size();
+  if (layout.allocatedSize % layout.granularity != 0) {
+    throw std::runtime_error(
+        fmt::format(
+            "shared CuMemAllocation size {} is not multicast-granularity aligned {}",
+            layout.allocatedSize,
+            layout.granularity));
+  }
+  return layout;
+}
+
+void MultimemHandler::createMulticastHandle(std::size_t allocatedSize) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (nvlRank_ != 0) {
+    return;
+  }
+
+  CUmulticastObjectProp multicastProp = {};
+  multicastProp.numDevices = static_cast<unsigned int>(nvlRanks_);
+  multicastProp.size = allocatedSize;
+  multicastProp.handleTypes = toCudaHandleType(handleType_);
+  multicastProp.flags = 0;
+
+  overlay_ = std::make_shared<CuMulticastAllocation>(
+      CuMulticastAllocation::create(multicastProp));
+#else
+  (void)allocatedSize;
+#endif
+}
+
+ShareableHandle MultimemHandler::exportMulticastHandle() {
+  ShareableHandle handle = {};
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (nvlRank_ == 0) {
+    handle = exportShareableHandle(overlay_->handle(), handleType_);
+    // Retain the exported POSIX FD on rank 0 until cleanup so peers can
+    // duplicate it during import.
+    if (handle.type == HandleType::kPosixFd) {
+      multicastExportedFd_ = handle.fd;
+    }
+  }
+#endif
+  return handle;
+}
+
+ShareableHandle MultimemHandler::exchangeMulticastHandle(
+    ShareableHandle handle) {
+  std::vector<ShareableHandle> allHandles(nvlRanks_, ShareableHandle{});
+  allHandles[nvlRank_] = handle;
+
+  auto result = bootstrap_
+                    ->allGatherNvlDomain(
+                        allHandles.data(),
+                        sizeof(ShareableHandle),
+                        nvlRank_,
+                        nvlRanks_,
+                        nvlRankToCommRank_)
+                    .get();
+  if (result != 0) {
+    throw std::runtime_error(
+        "MultimemHandler::exchangeMulticastHandle allGatherNvlDomain failed");
+  }
+  return allHandles[0];
+}
+
+void MultimemHandler::importMulticastHandle(const ShareableHandle& handle) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  overlay_ =
+      std::make_shared<CuMulticastAllocation>(CuMulticastAllocation::adopt(
+          importShareableHandle(handle), allocatedSize_));
+#else
+  (void)handle;
+#endif
+}
+
+void MultimemHandler::addLocalDeviceToMulticast(CUdevice cuDev) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  overlay_->addDevice(cuDev);
+#else
+  (void)cuDev;
+#endif
+}
+
+void MultimemHandler::bindLocalMemoryToMulticast(std::size_t allocatedSize) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  // Bind this rank's shared backing allocation at offset 0 in the multicast
+  // object. CuMulticastAllocation records the binding so its destructor
+  // unbinds.
+  overlay_->bindMem(
+      backing_->handle(), /*mcOffset=*/0, /*physOffset=*/0, allocatedSize);
+#else
+  (void)allocatedSize;
+#endif
+}
+
+void MultimemHandler::mapMulticastMemory(const AllocationLayout& layout) {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  // The multicast VA mapping co-owns overlay_ (the multicast object), so the
+  // multicast handle stays alive at least as long as this VA mapping.
+  // `CuMemMapping::overMulticast` reads the CUdevice from `overlay_` and
+  // builds its own access descriptor internally -- no per-phase wiring of
+  // device state needed here.
+  multicastMapping_ =
+      std::make_unique<CuMemMapping>(CuMemMapping::overMulticast(
+          overlay_, layout.allocatedSize, layout.granularity));
+#endif
+}
+
+void MultimemHandler::synchronizeRanks(const char* phase) {
+  auto barrierResult =
+      bootstrap_->barrierNvlDomain(nvlRank_, nvlRanks_, nvlRankToCommRank_)
+          .get();
+  if (barrierResult != 0) {
+    throw std::runtime_error(
+        std::string("MultimemHandler::synchronizeRanks failed during ") +
+        phase);
+  }
+}
+
+void MultimemHandler::agreeOnHandleType() {
+  std::vector<int> selections(static_cast<std::size_t>(nvlRanks_), 0);
+  selections[static_cast<std::size_t>(nvlRank_)] =
+      static_cast<int>(handleType_);
+  // Use the NVL-domain allGather (not the global one): nvlRank_/nvlRanks_ are
+  // the NVLink-team indices, and the bootstrap's plain allGather expects
+  // global comm ranks. Mirrors exchangeMulticastHandle's allGatherNvlDomain
+  // call. A mismatched scope would either corrupt the buffer (if the global
+  // rank count exceeded nvlRanks_) or skip the agreement check entirely (if
+  // peers outside the NVL team contributed zeros).
+  auto gatherResult = bootstrap_
+                          ->allGatherNvlDomain(
+                              selections.data(),
+                              sizeof(int),
+                              nvlRank_,
+                              nvlRanks_,
+                              nvlRankToCommRank_)
+                          .get();
+  if (gatherResult != 0) {
+    throw std::runtime_error(
+        "MultimemHandler::agreeOnHandleType allGatherNvlDomain failed");
+  }
+  for (int32_t r = 0; r < nvlRanks_; ++r) {
+    const auto peerType = static_cast<HandleType>(selections[r]);
+    if (peerType != handleType_) {
+      throw std::runtime_error(
+          fmt::format(
+              "MultimemHandler: ranks disagree on multicast handle type "
+              "(this rank nvl={} chose {}, peer nvl={} chose {}); all ranks "
+              "must select the same fabric / POSIX FD handle type",
+              nvlRank_,
+              handleTypeName(handleType_),
+              r,
+              handleTypeName(peerType)));
+    }
+  }
+}
+
+std::string MultimemHandler::describeState(
+    const char* failedPhase,
+    const char* completedPhase) const {
+  const CUmemGenericAllocationHandle localAllocHandle =
+      backing_ ? backing_->handle() : 0;
+  const CUmemGenericAllocationHandle multicastHandle =
+      overlay_ ? overlay_->handle() : 0;
+  const CUdeviceptr multicastPtr =
+      multicastMapping_ ? multicastMapping_->devicePtr() : 0;
+  return fmt::format(
+      "MultimemHandler state: failedPhase={} completedPhase={} commRank={} "
+      "nvlRank={} nvlRanks={} cudaDevice={} requestedSize={} allocatedSize={} "
+      "handleType={} multicastExportedFd={} rankMap=[{}] "
+      "flags={{exchanged={},failed={},deviceInitialized={},backing={},"
+      "overlay={},multicastMapping={}}} "
+      "handles={{cuDev={},multicastPtr=0x{:x},localAllocHandle=0x{:x},"
+      "multicastHandle=0x{:x}}}",
+      failedPhase != nullptr ? failedPhase : "unknown",
+      completedPhase != nullptr ? completedPhase : "unknown",
+      commRank_,
+      nvlRank_,
+      nvlRanks_,
+      cudaDevice_,
+      requestedSize_,
+      allocatedSize_,
+      handleTypeName(handleType_),
+      multicastExportedFd_,
+      fmt::join(nvlRankToCommRank_, ","),
+      exchanged_,
+      failed_,
+      deviceInitialized_,
+      static_cast<bool>(backing_),
+      static_cast<bool>(overlay_),
+      static_cast<bool>(multicastMapping_),
+      cuDev_,
+      multicastPtr,
+      localAllocHandle,
+      multicastHandle);
+}
+
+void MultimemHandler::cleanup() {
+#if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
+  if (multicastExportedFd_ >= 0) {
+    close(multicastExportedFd_);
+    multicastExportedFd_ = -1;
+  }
+
+  // Tear down the multicast VA mapping before dropping the multicast object
+  // (whose destructor unbinds + releases), then drop the shared backing. The
+  // VA mapping co-owns overlay_, so even out-of-order resets keep the
+  // unmap-before-unbind ordering; reset explicitly for clarity.
+  multicastMapping_.reset();
+  overlay_.reset();
+  backing_.reset();
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/memory/MultimemHandler.h
+++ b/comms/prims/memory/MultimemHandler.h
@@ -1,0 +1,217 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. Multimem is
+// NVIDIA-only; on AMD impl bodies throw and the stub `CUdevice` /
+// `CUmemGenericAllocationHandle` / `CUdeviceptr` typedefs come from
+// `CuMemAllocation.h`.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMemMapping.h"
+#include "comms/prims/memory/CuMulticastAllocation.h"
+#include "comms/prims/memory/NvlMemExchange.h"
+
+namespace comms::prims {
+
+/**
+ * MultimemHandler - the NVSwitch multicast overlay over a shared physical
+ * allocation.
+ *
+ * Addressing model:
+ *
+ * A CUDA multicast object replicates writes into every team rank's local
+ * backing allocation at the same object offset. This handler owns that
+ * multicast overlay and a single device pointer:
+ *
+ * - multimem pointer: multicast VA mapped to the shared multicast object.
+ *   Device code writes this pointer with `multimem.st.*` or `multimem.red.*`
+ *   instructions when it wants NVSwitch to replicate the write across all team
+ *   ranks. A multimem store to `getMultimemDeviceMemPtr() + x` becomes a local
+ *   write visible at offset `x` in every rank's backing allocation.
+ *
+ * This handler does NOT own or serve a unicast (local) pointer. The local
+ * backing is a shared `CuMemAllocation` provided by the caller (typically a
+ * GpuMemHandler, which owns the unicast VA and is responsible for zeroing it);
+ * this handler only binds that physical allocation into the multicast object
+ * and maps the multicast VA. The `CuMemAllocation` is co-owned via shared_ptr,
+ * so it stays alive as long as either the caller or this handler is alive.
+ *
+ * Pointer values are process-local CUDA virtual addresses. Do not compare the
+ * numeric multimem pointer value across MPI ranks or encode protocols that
+ * require it to match. The portable invariant is that the ranks map the same
+ * multicast object and interpret offsets within that object identically.
+ *
+ * `bootstrap` is the global communicator bootstrap. `commRank` is this
+ * process's rank in that global communicator. `nvlRankToCommRank` maps each
+ * NVLink-local rank to its global communicator rank. The handler derives its
+ * NVLink-local rank from the map, then exchange() uses the bootstrap's
+ * NVLink-domain collectives. Callers do not need to pre-wrap the bootstrap in
+ * an NVLink-local adapter.
+ *
+ * The multicast object handle is shared with fabric handles when the driver
+ * supports them, and falls back to POSIX file descriptors for single-host H100
+ * NVLS. POSIX FD sharing is intra-host only; the descriptor number itself is
+ * process-local, so peers duplicate rank 0's FD before importing it.
+ *
+ * The caller must set the current CUDA device to `cudaDevice` before using this
+ * handler. MultimemHandler uses `cudaDevice` to query driver properties and
+ * describe allocations, but it does not call cudaSetDevice().
+ */
+class MultimemHandler {
+ public:
+  /**
+   * Binds an existing physical VMM allocation into a new multicast object.
+   *
+   * `backing` is the shared physical allocation (typically a GpuMemHandler's,
+   * obtained via GpuMemHandler::allocation()) that this handler binds into the
+   * multicast object. `backing->size()` becomes this handler's allocated size,
+   * so the caller must have sized `backing` to a multiple of max(local
+   * allocation granularity, multicast granularity) -- see backingGranularity().
+   *
+   * Throws std::runtime_error if `backing` is null.
+   */
+  MultimemHandler(
+      std::shared_ptr<CuMemAllocation> backing,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int32_t commRank,
+      std::vector<int> nvlRankToCommRank,
+      int cudaDevice);
+
+  ~MultimemHandler();
+
+  MultimemHandler(const MultimemHandler&) = delete;
+  MultimemHandler& operator=(const MultimemHandler&) = delete;
+  MultimemHandler(MultimemHandler&&) = delete;
+  MultimemHandler& operator=(MultimemHandler&&) = delete;
+
+  /**
+   * Collective operation over all ranks in the multicast team.
+   *
+   * Creates the multicast object (team rank 0), exchanges its handle, binds
+   * each rank's shared backing allocation to the multicast object, and maps the
+   * multicast VA. Returns only after every rank has completed setup, so the
+   * multicast pointer is ready for device use.
+   */
+  void exchange();
+
+  /**
+   * Returns this rank's multicast VA. Device code uses this pointer with
+   * `multimem.*` instructions to broadcast writes to every rank in the
+   * multicast team.
+   */
+  void* getMultimemDeviceMemPtr() const;
+
+  std::size_t getAllocatedSize() const;
+
+  /**
+   * Returns this handler's shared physical backing allocation.
+   */
+  std::shared_ptr<CuMemAllocation> backing() const {
+    return backing_;
+  }
+
+  /**
+   * Returns whether the current process can create CUDA multicast allocations
+   * on `cudaDevice`. The caller is expected to have already made `cudaDevice`
+   * current; this helper does not switch devices.
+   */
+  static bool isMultimemSupported(int cudaDevice);
+
+  /**
+   * Returns max(local allocation granularity, multicast granularity) for the
+   * handle type that would be selected on `cudaDevice` for a multicast team of
+   * `nvlRanks` devices, both queried with the RECOMMENDED granularity. A
+   * caller can use this as the `alignFloor` when allocating its physical
+   * backing so that the resulting allocation is sized to be bindable into a
+   * multicast object.
+   *
+   * Returns 0 if multimem is not supported on `cudaDevice`.
+   */
+  static std::size_t backingGranularity(int cudaDevice, int nvlRanks);
+
+  // The shareable-handle type used to share the multicast object handle.
+  // Aliased to ShareableHandleType so the shared export/import helpers can be
+  // reused.
+  using HandleType = ShareableHandleType;
+
+ private:
+  struct AllocationLayout {
+    std::size_t allocatedSize{0};
+    std::size_t granularity{0};
+  };
+
+  // Throws std::runtime_error if `backing` is null, otherwise returns it. Used
+  // in the constructor's initializer list so the throw happens before const
+  // members are initialized.
+  static std::shared_ptr<CuMemAllocation> requireBacking(
+      std::shared_ptr<CuMemAllocation> backing);
+
+  CUdevice initializeDevice() const;
+  AllocationLayout computeAllocationLayout() const;
+  void createMulticastHandle(std::size_t allocatedSize);
+  ShareableHandle exportMulticastHandle();
+  ShareableHandle exchangeMulticastHandle(ShareableHandle handle);
+  void importMulticastHandle(const ShareableHandle& handle);
+  void addLocalDeviceToMulticast(CUdevice cuDev);
+  void bindLocalMemoryToMulticast(std::size_t allocatedSize);
+  void mapMulticastMemory(const AllocationLayout& layout);
+  void synchronizeRanks(const char* phase);
+  // AllGather handleType_ across the NVL team and throw if not every rank
+  // selected the same one. Called from exchange() before rank 0 creates the
+  // multicast object so a per-rank selection drift (e.g. one rank without IMEX
+  // chose POSIX FD while peers chose fabric) is reported as a clear error
+  // instead of a confusing export/import failure later.
+  void agreeOnHandleType();
+  std::string describeState(const char* failedPhase, const char* completedPhase)
+      const;
+  void cleanup();
+
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  const int32_t commRank_{-1};
+  const int32_t nvlRank_{-1};
+  const int32_t nvlRanks_{-1};
+  const std::vector<int> nvlRankToCommRank_;
+  const int cudaDevice_{-1};
+  const std::size_t requestedSize_{0};
+  HandleType handleType_{HandleType::kUnsupported};
+
+  bool exchanged_{false};
+  // Set true by the catch arms in exchange() before cleanup() runs. Once
+  // tripped, every subsequent exchange() call throws immediately rather
+  // than re-entering the multi-phase setup. The handler is one-shot: a
+  // failed exchange tears down `backing_` / `overlay_` / `multicastMapping_`
+  // via cleanup(), so a naive retry would crash on `backing_->size()` /
+  // `backing_->handle()` deref. To retry, the caller must construct a new
+  // MultimemHandler with the same (still caller-owned) backing.
+  bool failed_{false};
+  bool deviceInitialized_{false};
+  // Rank 0 keeps the exported POSIX FD open until peers have duplicated it.
+  int multicastExportedFd_{-1};
+
+  CUdevice cuDev_{0};
+  std::size_t allocatedSize_{0};
+
+  // The shared physical backing (a GpuMemHandler's, or any CuMemAllocation),
+  // co-owned so it outlives this handler's multicast binding. The multicast
+  // object (overlay_) binds backing_->handle() and replicates writes into it;
+  // the multicast VA mapping (multicastMapping_) co-owns overlay_.
+  std::shared_ptr<CuMemAllocation> backing_;
+  std::shared_ptr<CuMulticastAllocation> overlay_;
+  std::unique_ptr<CuMemMapping> multicastMapping_;
+};
+
+} // namespace comms::prims

--- a/comms/prims/platform/CudaDriverLazy.cc
+++ b/comms/prims/platform/CudaDriverLazy.cc
@@ -33,6 +33,24 @@ PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange = nullptr;
 PFN_cuMemGetHandleForAddressRange_v11070 pfn_cuMemGetHandleForAddressRange =
     nullptr;
 
+// Gated on CUDA 12.3+ to match the runtime multimem feature requirement
+// (see header comment); the PFN typedefs themselves date to 12.1 but the
+// feature isn't usable below 12.3.
+#if CUDART_VERSION >= 12030
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate = nullptr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice = nullptr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem = nullptr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr = nullptr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind = nullptr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity = nullptr;
+#endif
+
 namespace {
 
 std::once_flag init_flag;
@@ -58,6 +76,20 @@ int load_sym(const char* name, void** ptr, int version) {
     return -1;
   }
   return 0;
+}
+
+void load_optional_sym(const char* name, void** ptr, int version) {
+  cudaDriverEntryPointQueryResult status = cudaDriverEntryPointSymbolNotFound;
+#if CUDART_VERSION >= 13000
+  auto res = cudaGetDriverEntryPointByVersion(
+      name, ptr, version, cudaEnableDefault, &status);
+#else
+  (void)version;
+  auto res = cudaGetDriverEntryPoint(name, ptr, cudaEnableDefault, &status);
+#endif
+  if (res != cudaSuccess || status != cudaDriverEntryPointSuccess) {
+    *ptr = nullptr;
+  }
 }
 
 void do_init() {
@@ -86,6 +118,24 @@ void do_init() {
   LOAD(cuMemRetainAllocationHandle, 11000);
   LOAD(cuMemGetAddressRange, 3020);
   LOAD(cuMemGetHandleForAddressRange, 11070);
+
+  // Multicast / multimem driver entry points. Aligned with the runtime
+  // feature gate (CUDART_VERSION >= 12030) used by
+  // `MultimemHandler::selectMultimemHandleTypeImpl` -- the PFN typedefs
+  // exist since 12.1 but the multimem feature is only usable on 12.3+.
+#if CUDART_VERSION >= 12030
+#define LOAD_OPTIONAL(symbol, version) \
+  load_optional_sym(#symbol, reinterpret_cast<void**>(&pfn_##symbol), version)
+
+  LOAD_OPTIONAL(cuMulticastCreate, 12010);
+  LOAD_OPTIONAL(cuMulticastAddDevice, 12010);
+  LOAD_OPTIONAL(cuMulticastBindMem, 12010);
+  LOAD_OPTIONAL(cuMulticastBindAddr, 12010);
+  LOAD_OPTIONAL(cuMulticastUnbind, 12010);
+  LOAD_OPTIONAL(cuMulticastGetGranularity, 12010);
+
+#undef LOAD_OPTIONAL
+#endif
 
 #undef LOAD
 

--- a/comms/prims/platform/CudaDriverLazy.h
+++ b/comms/prims/platform/CudaDriverLazy.h
@@ -75,6 +75,31 @@ extern PFN_cuMemGetAddressRange_v3020 pfn_cuMemGetAddressRange;
 extern PFN_cuMemGetHandleForAddressRange_v11070
     pfn_cuMemGetHandleForAddressRange;
 
+// NVSwitch multicast / multimem. The PFN typedefs were introduced in CUDA
+// 12.1 (hence the `_v12010` suffix), but the multimem feature is only
+// usable on CUDA 12.3+ (it needs `CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED`
+// + functioning driver-side multicast). Gate the lazy-loaded symbols on
+// 12.3 so the header / loader can't end up half-populated on an
+// unsupported toolkit. The runtime feature gate in
+// `MultimemHandler::selectMultimemHandleTypeImpl` uses the same threshold,
+// keeping the two layers aligned. NOLINTs match the convention for the
+// other pfn_cu* globals above: these are runtime-resolved driver function
+// pointers that the lazy loader writes via void**, so they cannot be const.
+#if CUDART_VERSION >= 12030
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastCreate_v12010 pfn_cuMulticastCreate;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastAddDevice_v12010 pfn_cuMulticastAddDevice;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastBindMem_v12010 pfn_cuMulticastBindMem;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastBindAddr_v12010 pfn_cuMulticastBindAddr;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastUnbind_v12010 pfn_cuMulticastUnbind;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern PFN_cuMulticastGetGranularity_v12010 pfn_cuMulticastGetGranularity;
+#endif
+
 } // namespace comms::prims
 
 #endif // !defined(__HIP_PLATFORM_AMD__)

--- a/comms/prims/tests/CuMulticastAllocationTest.cc
+++ b/comms/prims/tests/CuMulticastAllocationTest.cc
@@ -1,0 +1,305 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/CuMulticastAllocation.h"
+#include "comms/prims/memory/MultimemHandler.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+
+namespace comms::prims::tests {
+namespace {
+
+// Skip the test cleanly if multicast / CUDA 12.3+ is unavailable on this host.
+// Returns the CUdevice for device 0 on success.
+bool multicastDevice(CUdevice& cuDev) {
+#if CUDART_VERSION < 12030
+  (void)cuDev;
+  return false;
+#else
+  if (cuda_driver_lazy_init() != 0) {
+    return false;
+  }
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+    return false;
+  }
+  if (cudaSetDevice(0) != cudaSuccess) {
+    return false;
+  }
+  if (!MultimemHandler::isMultimemSupported(0)) {
+    return false;
+  }
+  return pfn_cuDeviceGet(&cuDev, 0) == CUDA_SUCCESS;
+#endif
+}
+
+unsigned int posixFdMask() {
+  return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+}
+
+// Builds a `numDevices`-team multicast prop sized to the recommended multicast
+// granularity. Returns a prop with `size == 0` if the driver rejects the
+// granularity query (the caller should skip in that case).
+CUmulticastObjectProp makeProp(unsigned int numDevices, unsigned int mask) {
+  CUmulticastObjectProp prop = {};
+#if CUDART_VERSION >= 12030
+  prop.numDevices = numDevices;
+  prop.handleTypes = mask;
+  prop.flags = 0;
+  std::size_t gran = 0;
+  if (pfn_cuMulticastGetGranularity(
+          &gran, &prop, CU_MULTICAST_GRANULARITY_RECOMMENDED) == CUDA_SUCCESS &&
+      gran > 0) {
+    prop.size = gran;
+  }
+#else
+  (void)numDevices;
+  (void)mask;
+#endif
+  return prop;
+}
+
+} // namespace
+
+TEST(CuMulticastAllocationTest, CreateProducesUsableHandle) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/2, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query failed";
+  }
+
+  auto alloc = CuMulticastAllocation::create(prop);
+
+  EXPECT_NE(alloc.handle(), 0u);
+  EXPECT_EQ(alloc.size(), prop.size);
+  // device() is 0 until addDevice runs.
+  EXPECT_EQ(alloc.device(), CUdevice{0});
+}
+
+TEST(CuMulticastAllocationTest, AddDeviceRecordsLocalDevice) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/2, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query failed";
+  }
+
+  auto alloc = CuMulticastAllocation::create(prop);
+  alloc.addDevice(cuDev);
+
+  EXPECT_EQ(alloc.device(), cuDev);
+}
+
+// Aspirational single-process exercise of the bind / unbind lifecycle. The
+// CUDA driver currently makes this untestable from a single process:
+//   - numDevices=1 is rejected outright with "invalid argument".
+//   - numDevices>=2 with only the local device added causes bindMem to BLOCK
+//     waiting for the missing peer device(s) to be added, hanging the test.
+// So this test reliably hits its GTEST_SKIP path on every host we run on
+// today. It's left in the file as a documented placeholder: if the driver
+// ever relaxes either constraint, the test starts exercising the bind/unbind
+// destructor path automatically. Until then, the bind/unbind round-trip is
+// covered indirectly by MultimemHandler's ppn>=3 success-path tests.
+TEST(CuMulticastAllocationTest, BindMemUnbindsOnDestruction) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/1, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query rejected numDevices=1";
+  }
+
+  const std::size_t backingFloor =
+      MultimemHandler::backingGranularity(/*cudaDevice=*/0, /*nvlRanks=*/1);
+  ASSERT_GT(backingFloor, 0u);
+  auto backing =
+      CuMemAllocation::create(cuDev, prop.size, posixFdMask(), backingFloor);
+  ASSERT_NE(backing->handle(), 0u);
+
+  std::unique_ptr<CuMulticastAllocation> alloc;
+  try {
+    alloc = std::make_unique<CuMulticastAllocation>(
+        CuMulticastAllocation::create(prop));
+  } catch (const std::runtime_error& ex) {
+    GTEST_SKIP() << "cuMulticastCreate rejected numDevices=1 on this driver: "
+                 << ex.what();
+  }
+
+  alloc->addDevice(cuDev);
+  alloc->bindMem(
+      backing->handle(),
+      /*mcOffset=*/0,
+      /*physOffset=*/0,
+      prop.size);
+  EXPECT_EQ(alloc->size(), prop.size);
+
+  // Destruct the multicast allocation first, then the backing. The destructor
+  // should cuMulticastUnbind + cuMemRelease; the subsequent backing release
+  // would surface a driver error if unbind didn't happen.
+  alloc.reset();
+}
+
+// A second addDevice() on the same object must throw. The destructor only
+// unbinds the single recorded `device_`, so silently overwriting it would
+// leak the earlier device's binding. The check fires before any driver call,
+// so it's observable on any host that supports the initial create+addDevice
+// (no `numDevices=1` constraint).
+TEST(CuMulticastAllocationTest, RejectsDuplicateAddDevice) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/2, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query failed";
+  }
+
+  auto alloc = CuMulticastAllocation::create(prop);
+  alloc.addDevice(cuDev);
+  EXPECT_EQ(alloc.device(), cuDev);
+
+  try {
+    alloc.addDevice(cuDev);
+    FAIL() << "expected std::runtime_error on duplicate addDevice";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("device already added"), std::string::npos)
+        << ex.what();
+  }
+  // device_ must still match the original successful addDevice; a guard that
+  // ran the driver call before throwing would have overwritten it.
+  EXPECT_EQ(alloc.device(), cuDev);
+}
+
+// A second bindMem() on the same object must throw. The destructor unbinds
+// exactly one (mcOffset, size) range, so silently overwriting it would leak
+// the earlier binding. Uses the same single-process bind path as
+// `BindMemUnbindsOnDestruction` above and will skip on hosts where the driver
+// rejects single-process bind setup (which is currently every host); the
+// guard itself is also covered as a code-review item with the matching throw
+// site in `CuMulticastAllocation::bindMem`.
+TEST(CuMulticastAllocationTest, RejectsDuplicateBindMem) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/1, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query rejected numDevices=1";
+  }
+
+  const std::size_t backingFloor =
+      MultimemHandler::backingGranularity(/*cudaDevice=*/0, /*nvlRanks=*/1);
+  ASSERT_GT(backingFloor, 0u);
+  auto backing =
+      CuMemAllocation::create(cuDev, prop.size, posixFdMask(), backingFloor);
+  ASSERT_NE(backing->handle(), 0u);
+
+  std::unique_ptr<CuMulticastAllocation> alloc;
+  try {
+    alloc = std::make_unique<CuMulticastAllocation>(
+        CuMulticastAllocation::create(prop));
+  } catch (const std::runtime_error& ex) {
+    GTEST_SKIP() << "cuMulticastCreate rejected numDevices=1 on this driver: "
+                 << ex.what();
+  }
+
+  alloc->addDevice(cuDev);
+  alloc->bindMem(
+      backing->handle(),
+      /*mcOffset=*/0,
+      /*physOffset=*/0,
+      prop.size);
+
+  try {
+    alloc->bindMem(
+        backing->handle(),
+        /*mcOffset=*/0,
+        /*physOffset=*/0,
+        prop.size);
+    FAIL() << "expected std::runtime_error on duplicate bindMem";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(std::string(ex.what()).find("already bound"), std::string::npos)
+        << ex.what();
+  }
+}
+
+TEST(CuMulticastAllocationTest, MoveConstructorTransfersOwnership) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/2, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query failed";
+  }
+
+  auto src = CuMulticastAllocation::create(prop);
+  const auto srcHandle = src.handle();
+  CuMulticastAllocation dst(std::move(src));
+
+  EXPECT_EQ(dst.handle(), srcHandle);
+  EXPECT_EQ(dst.size(), prop.size);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(src.handle(), 0u);
+}
+
+// Move-assignment must release the destination's prior handle BEFORE adopting
+// the source's. If it didn't, the prior handle would leak (no release) and
+// later code that observes the FD count or cuMemRelease semantics would catch
+// it; this test asserts the visible post-state -- handle and size correctly
+// transferred, source inert.
+TEST(CuMulticastAllocationTest, MoveAssignmentReleasesPriorHandleAndTransfers) {
+  CUdevice cuDev = 0;
+  if (!multicastDevice(cuDev)) {
+    GTEST_SKIP() << "multicast / CUDA 12.3+ unavailable";
+  }
+  auto prop = makeProp(/*numDevices=*/2, posixFdMask());
+  if (prop.size == 0) {
+    GTEST_SKIP() << "multicast granularity query failed";
+  }
+
+  auto a = CuMulticastAllocation::create(prop);
+  auto b = CuMulticastAllocation::create(prop);
+  const auto bHandle = b.handle();
+
+  a = std::move(b);
+
+  EXPECT_EQ(a.handle(), bHandle);
+  EXPECT_EQ(a.size(), prop.size);
+  // NOLINTNEXTLINE(bugprone-use-after-move): intentionally checking moved-from
+  EXPECT_EQ(b.handle(), 0u);
+}
+
+// adopt(0, 0) constructs a zero-handle object. The destructor's release()
+// must early-return on `handle_ == 0` and NOT call into the CUDA driver --
+// this is the "I'm holding a moved-from / never-imported handle" case. A
+// regression that called cuMemRelease(0) would surface as a CUDA error on
+// destruction.
+TEST(CuMulticastAllocationTest, AdoptWithZeroHandleHasInertDestruction) {
+  auto inert = CuMulticastAllocation::adopt(/*handle=*/0, /*size=*/0);
+  EXPECT_EQ(inert.handle(), 0u);
+  EXPECT_EQ(inert.size(), 0u);
+  // Destructor at scope exit must not call cuMemRelease on handle=0.
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/MultimemHandlerTest.cc
+++ b/comms/prims/tests/MultimemHandlerTest.cc
@@ -1,0 +1,761 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+#include <folly/init/Init.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "caffe2/torch/csrc/distributed/c10d/Store.hpp"
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/prims/memory/CuMemAllocation.h"
+#include "comms/prims/memory/MultimemHandler.h"
+#include "comms/prims/platform/CudaDriverLazy.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TcpStoreBootstrap.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims::tests {
+
+class MultimemHandlerTestFixture : public ::testing::Test,
+                                   public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::vector<int> reverseRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = size - 1 - rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+bool allRanksMultimemSupported(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> supported(static_cast<std::size_t>(nRanks));
+  supported[static_cast<std::size_t>(rank)] =
+      MultimemHandler::isMultimemSupported(cudaDevice) ? 1 : 0;
+  auto supportRc =
+      bootstrap->allGather(supported.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(supportRc, 0);
+  if (supportRc != 0) {
+    return false;
+  }
+  bool allRanksSupported = true;
+  for (const auto value : supported) {
+    allRanksSupported = allRanksSupported && value != 0;
+  }
+  return allRanksSupported;
+}
+
+// Creates a physical backing CuMemAllocation sized to be bindable into a
+// multicast object for a team of `nRanks` devices on `cudaDevice`.
+std::shared_ptr<CuMemAllocation>
+makeMulticastBacking(int cudaDevice, int nRanks, std::size_t size) {
+  EXPECT_EQ(cuda_driver_lazy_init(), 0);
+  CUdevice cuDev = 0;
+  EXPECT_EQ(pfn_cuDeviceGet(&cuDev, cudaDevice), CUDA_SUCCESS);
+  const std::size_t gran =
+      MultimemHandler::backingGranularity(cudaDevice, nRanks);
+  EXPECT_GT(gran, 0u);
+  // Request fabric + POSIX FD; create() drops fabric and falls back to POSIX FD
+  // on a single host without IMEX.
+  const unsigned int mask =
+      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR | CU_MEM_HANDLE_TYPE_FABRIC;
+  return CuMemAllocation::create(cuDev, size, mask, gran);
+}
+
+// Non-std exception type used to drive the `catch (...)` arm in
+// `MultimemHandler::exchange`. Lives outside any class so the gmock action
+// lambdas can throw it directly. Deliberately does NOT derive from
+// std::exception -- that's the entire point of having this type: it lets us
+// verify the production `catch (...)` fallback fires when a peer / driver /
+// other layer throws something exotic.
+struct NonStdSimulatedFault {};
+
+using meta::comms::testing::MockBootstrap;
+using StrictMockBootstrap = ::testing::StrictMock<MockBootstrap>;
+
+// Builds a StrictMockBootstrap that, by default, forwards every IBootstrap
+// API to `real`. Individual tests override specific methods (or specific call
+// ordinals) via `EXPECT_CALL(...).WillOnce(...)` to inject failures. StrictMock
+// ensures that if a future change to `MultimemHandler` adds a new bootstrap
+// call we don't account for, the test fails immediately with an "uninteresting
+// mock function call" message -- locking down the bootstrap API surface that
+// `MultimemHandler` is allowed to touch.
+std::shared_ptr<StrictMockBootstrap> makeDelegatingMock(
+    const std::shared_ptr<meta::comms::IBootstrap>& real) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+
+  ON_CALL(*mock, allGather(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int rank, int nRanks) {
+        return real->allGather(buf, len, rank, nRanks);
+      });
+  ON_CALL(*mock, barrier(_, _)).WillByDefault([real](int rank, int nRanks) {
+    return real->barrier(rank, nRanks);
+  });
+  ON_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+      .WillByDefault([real](
+                         void* buf,
+                         int len,
+                         int r,
+                         int n,
+                         const std::vector<int>& rankMap) {
+        return real->allGatherNvlDomain(buf, len, r, n, rankMap);
+      });
+  ON_CALL(*mock, barrierNvlDomain(_, _, _))
+      .WillByDefault([real](int r, int n, const std::vector<int>& rankMap) {
+        return real->barrierNvlDomain(r, n, rankMap);
+      });
+  ON_CALL(*mock, send(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->send(buf, len, peer, tag);
+      });
+  ON_CALL(*mock, recv(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->recv(buf, len, peer, tag);
+      });
+
+  return mock;
+}
+
+// Identifies one of the four bootstrap call sites inside
+// `MultimemHandler::exchange`. `ordinal` is the 0-based occurrence of the
+// chosen `Api` within a single `exchange()` invocation:
+//   (kAllGatherNvlDomain, 0) -> agreeOnHandleType
+//   (kAllGatherNvlDomain, 1) -> exchangeMulticastHandle
+//   (kBarrierNvlDomain,   0) -> synchronizeRanks("pre-bind")
+//   (kBarrierNvlDomain,   1) -> synchronizeRanks("post-map")
+struct FailureCase {
+  // Short, gtest-name-safe label used in the parameterized test name.
+  const char* name;
+  enum class Api { kAllGatherNvlDomain, kBarrierNvlDomain } api;
+  int ordinal;
+};
+
+enum class FailureMode {
+  // Bootstrap method returns SemiFuture<int>(-1). MultimemHandler's per-phase
+  // code observes a non-zero result and throws std::runtime_error.
+  kReturnNonZero,
+  // Bootstrap method throws std::runtime_error synchronously at the call site
+  // (simulating a bootstrap-internal failure that didn't get translated into
+  // a return code). Caught by `catch (const std::exception&)`.
+  kSyncThrowsStd,
+  // Bootstrap method throws a non-std exception synchronously. Caught by the
+  // `catch (...)` fallback branch in exchange().
+  kSyncThrowsNonStd,
+};
+
+constexpr FailureCase kAllFailureCases[] = {
+    {"agreeOnHandleType", FailureCase::Api::kAllGatherNvlDomain, 0},
+    {"exchangeMulticastHandle", FailureCase::Api::kAllGatherNvlDomain, 1},
+    {"preBindBarrier", FailureCase::Api::kBarrierNvlDomain, 0},
+    {"postMapBarrier", FailureCase::Api::kBarrierNvlDomain, 1},
+};
+
+constexpr FailureMode kAllFailureModes[] = {
+    FailureMode::kReturnNonZero,
+    FailureMode::kSyncThrowsStd,
+    FailureMode::kSyncThrowsNonStd,
+};
+
+const char* describeMode(FailureMode mode) {
+  switch (mode) {
+    case FailureMode::kReturnNonZero:
+      return "ReturnNonZero";
+    case FailureMode::kSyncThrowsStd:
+      return "SyncThrowsStd";
+    case FailureMode::kSyncThrowsNonStd:
+      return "SyncThrowsNonStd";
+  }
+  return "Unknown";
+}
+
+// Returns the gmock action that implements the chosen failure mode for an
+// allGatherNvlDomain invocation. Captured by reference where used.
+auto allGatherFailureAction(FailureMode mode) {
+  return [mode](void*, int, int, int, const std::vector<int>&)
+             -> folly::SemiFuture<int> {
+    switch (mode) {
+      case FailureMode::kReturnNonZero:
+        return folly::makeSemiFuture(-1);
+      case FailureMode::kSyncThrowsStd:
+        throw std::runtime_error("simulated allGatherNvlDomain failure");
+      case FailureMode::kSyncThrowsNonStd:
+        // NonStdSimulatedFault deliberately does NOT derive from
+        // std::exception -- the whole purpose is to exercise the
+        // production `catch (...)` fallback in MultimemHandler::exchange().
+        // NOLINTNEXTLINE(facebook-hte-ThrowNonStdExceptionIssue)
+        throw NonStdSimulatedFault{};
+    }
+    return folly::makeSemiFuture(-1);
+  };
+}
+
+auto barrierFailureAction(FailureMode mode) {
+  return [mode](int, int, const std::vector<int>&) -> folly::SemiFuture<int> {
+    switch (mode) {
+      case FailureMode::kReturnNonZero:
+        return folly::makeSemiFuture(-1);
+      case FailureMode::kSyncThrowsStd:
+        throw std::runtime_error("simulated barrierNvlDomain failure");
+      case FailureMode::kSyncThrowsNonStd:
+        // See allGatherFailureAction above for the NOLINT rationale.
+        // NOLINTNEXTLINE(facebook-hte-ThrowNonStdExceptionIssue)
+        throw NonStdSimulatedFault{};
+    }
+    return folly::makeSemiFuture(-1);
+  };
+}
+
+// Programs the StrictMockBootstrap so the targeted (api, ordinal) call hits
+// `mode`, while every preceding ordinal of the same API delegates to `real`.
+// Other APIs are left to their ON_CALL defaults. Uses an InSequence so the
+// "succeed N-1 times then fail" pattern is unambiguous.
+//
+// `injectOnThisRank` lets the caller turn injection off for asymmetric tests.
+// When false, no EXPECT_CALL overrides are added; the makeDelegatingMock()
+// ON_CALL defaults stay in effect and this rank fully delegates to `real`. In
+// asymmetric scenarios, surviving ranks surface their failure via the bootstrap
+// store's timeout instead of via the injected error.
+void programFailureInjection(
+    StrictMockBootstrap& mock,
+    const std::shared_ptr<meta::comms::IBootstrap>& real,
+    const FailureCase& fail,
+    FailureMode mode,
+    bool injectOnThisRank = true) {
+  using ::testing::_;
+  using ::testing::AnyNumber;
+  using ::testing::InSequence;
+
+  // Local delegation lambdas, captured per-API. Defined once and reused for
+  // every EXPECT_CALL / ON_CALL action below so the closures aren't repeated
+  // 5+ times inline.
+  auto delegateAllGatherNvl =
+      [real](
+          void* buf, int len, int r, int n, const std::vector<int>& rankMap) {
+        return real->allGatherNvlDomain(buf, len, r, n, rankMap);
+      };
+  auto delegateBarrierNvl = [real](
+                                int r, int n, const std::vector<int>& rankMap) {
+    return real->barrierNvlDomain(r, n, rankMap);
+  };
+
+  if (!injectOnThisRank) {
+    // StrictMock treats any unmatched call as a test failure ("uninteresting
+    // mock function call"). Provide baseline AnyNumber expectations for the
+    // two NVL-domain APIs MultimemHandler::exchange() uses, all delegating to
+    // `real`. This lets the surviving rank actually run through exchange()
+    // with the real bootstrap and surface its failure via the lowered store
+    // timeout.
+    EXPECT_CALL(mock, allGatherNvlDomain(_, _, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(delegateAllGatherNvl);
+    EXPECT_CALL(mock, barrierNvlDomain(_, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(delegateBarrierNvl);
+    return;
+  }
+
+  // Allow the non-targeted API to be called by exchange() any number of times,
+  // always delegating to `real`. (For an allGatherNvlDomain failure, this lets
+  // any incidental barrierNvlDomain calls succeed, and vice versa.) Without
+  // this, StrictMock would flag those calls as uninteresting.
+  if (fail.api == FailureCase::Api::kAllGatherNvlDomain) {
+    EXPECT_CALL(mock, barrierNvlDomain(_, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(delegateBarrierNvl);
+  } else {
+    EXPECT_CALL(mock, allGatherNvlDomain(_, _, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(delegateAllGatherNvl);
+  }
+
+  InSequence s;
+  if (fail.api == FailureCase::Api::kAllGatherNvlDomain) {
+    for (int i = 0; i < fail.ordinal; ++i) {
+      EXPECT_CALL(mock, allGatherNvlDomain(_, _, _, _, _))
+          .WillOnce(delegateAllGatherNvl);
+    }
+    EXPECT_CALL(mock, allGatherNvlDomain(_, _, _, _, _))
+        .WillOnce(allGatherFailureAction(mode));
+  } else {
+    for (int i = 0; i < fail.ordinal; ++i) {
+      EXPECT_CALL(mock, barrierNvlDomain(_, _, _)).WillOnce(delegateBarrierNvl);
+    }
+    EXPECT_CALL(mock, barrierNvlDomain(_, _, _))
+        .WillOnce(barrierFailureAction(mode));
+  }
+}
+
+// Identifies which ranks should have their mock inject the failure for a
+// given parameterized case. Asymmetric patterns rely on the surviving ranks
+// hitting the bootstrap store's timeout (which we shorten via
+// ScopedShortTimeoutBootstrap) instead of an injected error.
+enum class RankPattern {
+  kAllRanks,
+  kRank0Only,
+  kAllExceptRank0,
+};
+
+constexpr RankPattern kAllRankPatterns[] = {
+    RankPattern::kAllRanks,
+    RankPattern::kRank0Only,
+    RankPattern::kAllExceptRank0,
+};
+
+const char* describePattern(RankPattern p) {
+  switch (p) {
+    case RankPattern::kAllRanks:
+      return "AllRanks";
+    case RankPattern::kRank0Only:
+      return "Rank0Only";
+    case RankPattern::kAllExceptRank0:
+      return "AllExceptRank0";
+  }
+  return "Unknown";
+}
+
+bool shouldInject(RankPattern p, int globalRank) {
+  switch (p) {
+    case RankPattern::kAllRanks:
+      return true;
+    case RankPattern::kRank0Only:
+      return globalRank == 0;
+    case RankPattern::kAllExceptRank0:
+      return globalRank != 0;
+  }
+  return false;
+}
+
+// Wraps the DistEnvironmentBase's global TCPStore in a fresh PrefixStore with
+// a shortened timeout, then constructs a TcpStoreBootstrap directly over it.
+// Restoring the timeout in the destructor matters: PrefixStore::setTimeout
+// forwards to the underlying global store, so leaving it lowered would shrink
+// every subsequent bootstrap's timeout in the same process.
+//
+// Returns an empty wrapper (operator bool == false) if the dist env is not in
+// TCPStore mode (e.g. MPI-only test runs); the caller should GTEST_SKIP in
+// that case.
+class ScopedShortTimeoutBootstrap {
+ public:
+  ScopedShortTimeoutBootstrap(
+      const std::string& /*prefix-unused, createPrefixStore stamps its own*/,
+      std::chrono::milliseconds timeout) {
+    if (!meta::comms::isDistTcpStoreMode()) {
+      return;
+    }
+    store_ = meta::comms::createPrefixStore();
+    if (!store_) {
+      return;
+    }
+    savedTimeout_ = store_->getTimeout();
+    store_->setTimeout(timeout);
+    auto [lr, gr, nr, ls] = meta::comms::getDistRankInfo();
+    bootstrap_ = std::make_shared<meta::comms::TcpStoreBootstrap>(
+        store_, gr, nr, lr, ls);
+  }
+  ~ScopedShortTimeoutBootstrap() {
+    if (store_) {
+      store_->setTimeout(savedTimeout_);
+    }
+  }
+  ScopedShortTimeoutBootstrap(const ScopedShortTimeoutBootstrap&) = delete;
+  ScopedShortTimeoutBootstrap& operator=(const ScopedShortTimeoutBootstrap&) =
+      delete;
+
+  explicit operator bool() const {
+    return bootstrap_ != nullptr;
+  }
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap() const {
+    return bootstrap_;
+  }
+
+ private:
+  c10::intrusive_ptr<c10d::Store> store_;
+  std::chrono::milliseconds savedTimeout_{0};
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+};
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSetsUpStableMappings) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  auto backing = makeMulticastBacking(localRank, numRanks, kRequestedBytes);
+  MultimemHandler handler(
+      backing, bootstrap, globalRank, identityRankMap(numRanks), localRank);
+  EXPECT_THROW(handler.getMultimemDeviceMemPtr(), std::runtime_error);
+
+  handler.exchange();
+
+  auto* multimemPtr = handler.getMultimemDeviceMemPtr();
+  EXPECT_NE(multimemPtr, nullptr);
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+  EXPECT_EQ(handler.backing(), backing);
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  std::vector<std::uintptr_t> multimemAddrs(static_cast<std::size_t>(numRanks));
+  multimemAddrs[static_cast<std::size_t>(globalRank)] =
+      reinterpret_cast<std::uintptr_t>(multimemPtr);
+  auto rc = bootstrap
+                ->allGather(
+                    multimemAddrs.data(),
+                    sizeof(std::uintptr_t),
+                    globalRank,
+                    numRanks)
+                .get();
+  ASSERT_EQ(rc, 0);
+  for (int rank = 0; rank < numRanks; ++rank) {
+    EXPECT_NE(multimemAddrs[static_cast<std::size_t>(rank)], 0);
+  }
+
+  handler.exchange();
+  EXPECT_EQ(multimemPtr, handler.getMultimemDeviceMemPtr());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, ExchangeSupportsNonIdentityRankMap) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("multimem_handler_non_identity_rank_map_test");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  constexpr std::size_t kRequestedBytes = 4096;
+  auto backing = makeMulticastBacking(localRank, numRanks, kRequestedBytes);
+  MultimemHandler handler(
+      backing, bootstrap, globalRank, reverseRankMap(numRanks), localRank);
+  handler.exchange();
+
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+  EXPECT_EQ(handler.backing(), backing);
+  EXPECT_GE(handler.getAllocatedSize(), kRequestedBytes);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(MultimemHandlerTestFixture, SharingRejectsNullBacking) {
+  auto bootstrap = makeBootstrap("multimem_null_backing_test");
+  // A null backing must fail fast.
+  EXPECT_THROW(
+      MultimemHandler(
+          nullptr, bootstrap, globalRank, identityRankMap(numRanks), localRank),
+      std::runtime_error);
+}
+
+// Locks down the ctor's "bootstrap must be non-null" branch on a GPU host
+// (where `handleType_ != kUnsupported`, so the unsupported-device branch
+// doesn't preempt this check). A valid backing + valid rank map + null
+// bootstrap must throw.
+TEST_F(MultimemHandlerTestFixture, ConstructorRejectsNullBootstrap) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto realBootstrap = makeBootstrap("multimem_ctor_reject_null_bootstrap");
+  if (!allRanksMultimemSupported(
+          realBootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+  EXPECT_THROW(
+      MultimemHandler(
+          backing,
+          /*bootstrap=*/nullptr,
+          globalRank,
+          identityRankMap(numRanks),
+          localRank),
+      std::runtime_error);
+}
+
+// On a GPU host where normal multimem support succeeds, passing
+// `cudaDevice = -1` still triggers `selectMultimemHandleTypeImpl ==
+// kUnsupported` and the ctor must throw. Rules out a false negative from the
+// no-GPU validation host (where every device id looks unsupported regardless
+// of branch coverage).
+TEST_F(
+    MultimemHandlerTestFixture,
+    ConstructorRejectsUnsupportedDeviceOnGpuHost) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto realBootstrap = makeBootstrap("multimem_ctor_reject_unsupported_dev");
+  if (!allRanksMultimemSupported(
+          realBootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  // Use the real (multimem-capable) device to build a usable backing -- we
+  // never reach exchange(), the ctor should reject `cudaDevice = -1` first.
+  auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+  EXPECT_THROW(
+      MultimemHandler(
+          backing,
+          realBootstrap,
+          globalRank,
+          identityRankMap(numRanks),
+          /*cudaDevice=*/-1),
+      std::runtime_error);
+}
+
+// Locks down the bootstrap API surface used by `MultimemHandler::exchange()`:
+//   - allGatherNvlDomain: exactly 2 calls per exchange (agreeOnHandleType,
+//     then exchangeMulticastHandle).
+//   - barrierNvlDomain:   exactly 2 calls per exchange (pre-bind, post-map).
+//   - allGather/barrier/send/recv: never called by MultimemHandler itself.
+// StrictMock + exact `.Times(...)` makes any future regression (an extra
+// barrier inserted, a stray allGather, a missing pre-bind sync) fail this
+// test with a clear "actually called N times, expected M" diff -- before the
+// regression has a chance to surface as a wedged exchange in production.
+// Also re-asserts the "exchange() is idempotent after success" contract by
+// invoking it a second time and verifying the call counters don't increment.
+TEST_F(MultimemHandlerTestFixture, SuccessPathCoversAllBootstrapApis) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  auto realBootstrap = makeBootstrap("multimem_success_api_coverage");
+  if (!allRanksMultimemSupported(
+          realBootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+  }
+
+  using ::testing::_;
+  auto mock = makeDelegatingMock(realBootstrap);
+
+  EXPECT_CALL(*mock, allGatherNvlDomain(_, _, _, _, _)).Times(2);
+  EXPECT_CALL(*mock, barrierNvlDomain(_, _, _)).Times(2);
+  EXPECT_CALL(*mock, allGather(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock, barrier(_, _)).Times(0);
+  EXPECT_CALL(*mock, send(_, _, _, _)).Times(0);
+  EXPECT_CALL(*mock, recv(_, _, _, _)).Times(0);
+
+  auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+  MultimemHandler handler(
+      backing,
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      globalRank,
+      identityRankMap(numRanks),
+      localRank);
+  handler.exchange();
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+
+  // Second call must early-return without touching the bootstrap; the exact
+  // .Times(2) expectations above would fail otherwise.
+  handler.exchange();
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+
+  ASSERT_EQ(realBootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// Parameterized failure-injection suite. The product is
+//   {4 phases of exchange()} x {3 failure modes} = 12 cases.
+//
+// For each case:
+//   - A real bootstrap is created with a per-case prefix so prior keys cannot
+//     leak between cases.
+//   - A StrictMockBootstrap is built that delegates every call to the real
+//     bootstrap, then the (api, ordinal) call site under test is overridden
+//     to fail with the chosen mode (return -1, throw std::runtime_error, or
+//     throw a non-std exception).
+//   - All ranks inject the same failure at the same ordinal, so every rank's
+//     exchange() throws together -- avoiding the asymmetric-failure deadlock
+//     scenario that would require a peer-side timeout to remain deterministic.
+//
+// Assertions per case:
+//   1. exchange() throws std::runtime_error.
+//   2. The message tags the right failedPhase (`failedPhase=<name>`), which
+//      proves `describeState` ran with the right phase label.
+//   3. The message contains the phase-specific substring (e.g. "pre-bind").
+//   4. For kSyncThrowsNonStd: the message contains the `catch (...)` prefix
+//      "MultimemHandler::exchange failed with unknown exception", confirming
+//      the unknown-exception fallback is reached. For std-throw / non-zero
+//      cases, the message uses the "MultimemHandler::exchange failed: " prefix.
+//   5. After the throw, both getters still throw "exchange() must complete",
+//      proving the partial-init state was not committed.
+//   6. The realBootstrap is still healthy: a subsequent barrier() returns 0.
+//      Proves cleanup() didn't leave any bootstrap state poisoned.
+//   7. Constructing a fresh handler over the *same* `backing` shared_ptr with
+//      a fresh bootstrap (different prefix) lets exchange() complete cleanly.
+//      Proves cleanup() released only the handler-owned multicast state and
+//      left the caller-owned physical backing intact and bindable.
+class MultimemHandlerFailureInjectionTest
+    : public ::testing::TestWithParam<
+          std::tuple<FailureCase, FailureMode, RankPattern>>,
+      public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+TEST_P(MultimemHandlerFailureInjectionTest, ExchangeReportsAndCleansUp) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "CUDA multimem transport is only useful for 3+ ranks";
+  }
+  const FailureCase& failCase = std::get<0>(GetParam());
+  const FailureMode failMode = std::get<1>(GetParam());
+  const RankPattern rankPattern = std::get<2>(GetParam());
+  const std::string casePrefix = std::string("multimem_fail_") + failCase.name +
+      "_" + describeMode(failMode) + "_" + describePattern(rankPattern);
+
+  // Asymmetric patterns require the bootstrap store's wait() to time out for
+  // surviving ranks; the underlying TCPStore supports that, MPI does not.
+  // Symmetric (kAllRanks) cases never reach a timeout because every rank
+  // throws synchronously, so we can use the normal bootstrap there.
+  const bool isAsymmetric = (rankPattern != RankPattern::kAllRanks);
+  if (isAsymmetric && !meta::comms::isDistTcpStoreMode()) {
+    GTEST_SKIP() << "asymmetric failure tests require TCPStore env";
+  }
+
+  {
+    std::optional<ScopedShortTimeoutBootstrap> shortBs;
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap;
+    if (isAsymmetric) {
+      shortBs.emplace(casePrefix, std::chrono::milliseconds(5000));
+      bootstrap = shortBs->bootstrap();
+      ASSERT_TRUE(bootstrap)
+          << "ScopedShortTimeoutBootstrap returned null in TCPStore mode";
+    } else {
+      bootstrap = makeBootstrap(casePrefix);
+    }
+
+    if (!allRanksMultimemSupported(
+            bootstrap, globalRank, numRanks, localRank)) {
+      GTEST_SKIP() << "CUDA multimem/NVLS multicast is not supported";
+    }
+
+    auto backing = makeMulticastBacking(localRank, numRanks, 4096);
+
+    {
+      auto mock = makeDelegatingMock(bootstrap);
+      programFailureInjection(
+          *mock,
+          bootstrap,
+          failCase,
+          failMode,
+          /*injectOnThisRank=*/shouldInject(rankPattern, globalRank));
+
+      MultimemHandler handler(
+          backing,
+          std::shared_ptr<meta::comms::IBootstrap>(mock),
+          globalRank,
+          identityRankMap(numRanks),
+          localRank);
+
+      // We assert behaviour, not message text: exchange must throw, and the
+      // post-failure handler must refuse to vend the (never-set) multicast
+      // pointer / allocated size. For asymmetric patterns, surviving ranks
+      // throw via the bootstrap store timeout instead of via the injected
+      // error; the outer `EXPECT_THROW` covers both surfaces uniformly.
+      EXPECT_THROW(handler.exchange(), std::runtime_error);
+      EXPECT_THROW((void)handler.getMultimemDeviceMemPtr(), std::runtime_error);
+      EXPECT_THROW((void)handler.getAllocatedSize(), std::runtime_error);
+    }
+
+    // Sanity: bootstrap is still callable after the failed exchange.
+    // Symmetric only -- asymmetric cases legitimately leave the failure-time
+    // bootstrap with stale keys / abandoned waits from the rank that didn't
+    // participate in the call where its peer aborted, so a follow-up barrier
+    // on the same bootstrap is allowed to time out. The recovery exchange
+    // below proves the *system* is still usable via a fresh bootstrap, which
+    // is the load-bearing assertion.
+    if (rankPattern == RankPattern::kAllRanks) {
+      ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+    }
+  } // ScopedShortTimeoutBootstrap (if any) destructed here -> timeout restored
+
+  // Recovery: the shared backing must still be bindable. A fresh handler over
+  // the same `backing` with a fresh, normal-timeout bootstrap should reach a
+  // clean steady state. Uses a different prefix so the bootstrap store has no
+  // overlap with the failed exchange's keys.
+  auto recoveryBootstrap = makeBootstrap(casePrefix + "_recovery");
+  MultimemHandler recovery(
+      makeMulticastBacking(localRank, numRanks, 4096),
+      recoveryBootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      localRank);
+  recovery.exchange();
+  EXPECT_NE(recovery.getMultimemDeviceMemPtr(), nullptr);
+  EXPECT_GE(recovery.getAllocatedSize(), 4096u);
+  ASSERT_EQ(recoveryBootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllPhasesAllModesAllPatterns,
+    MultimemHandlerFailureInjectionTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(kAllFailureCases),
+        ::testing::ValuesIn(kAllFailureModes),
+        ::testing::ValuesIn(kAllRankPatterns)),
+    [](const ::testing::TestParamInfo<
+        std::tuple<FailureCase, FailureMode, RankPattern>>& info) {
+      // Structured bindings here would put a bare `,` in the macro arg list
+      // and confuse the preprocessor; use std::get instead.
+      const FailureCase& failCase = std::get<0>(info.param);
+      const FailureMode failMode = std::get<1>(info.param);
+      const RankPattern pattern = std::get<2>(info.param);
+      return std::string(failCase.name) + "_" + describeMode(failMode) + "_" +
+          describePattern(pattern);
+    });
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/MultimemHandlerValidationTest.cc
+++ b/comms/prims/tests/MultimemHandlerValidationTest.cc
@@ -1,0 +1,143 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/MultimemHandler.h"
+
+namespace comms::prims::tests {
+
+namespace {
+
+class FakeBootstrap : public meta::comms::IBootstrap {
+ public:
+  folly::SemiFuture<int> allGather(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> send(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> recv(void*, int, int, int) override {
+    return folly::makeSemiFuture(0);
+  }
+};
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap() {
+  return std::make_shared<FakeBootstrap>();
+}
+
+template <typename Fn>
+void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
+  try {
+    std::forward<Fn>(fn)();
+    FAIL() << "expected std::runtime_error containing " << expected;
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected), std::string::npos)
+        << ex.what();
+  }
+}
+
+} // namespace
+
+// The rank-map validation runs in the constructor initializer list (before the
+// backing / GPU checks), so these cases throw with a null backing and need no
+// GPU.
+TEST(MultimemHandlerValidationTest, RejectsEmptyRankMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, makeBootstrap(), 0, {}, 0); },
+      "nvlRankToCommRank must be non-empty");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsMissingCommRank) {
+  expectRuntimeErrorContains(
+      [] {
+        MultimemHandler handler(nullptr, makeBootstrap(), 7, {0, 1, 2}, 0);
+      },
+      "commRank must appear in nvlRankToCommRank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNegativeRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, makeBootstrap(), 0, {0, -1}, 0); },
+      "contains a negative rank");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsDuplicateRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, makeBootstrap(), 0, {0, 0}, 0); },
+      "contains duplicate ranks");
+}
+
+TEST(MultimemHandlerValidationTest, RejectsNullBacking) {
+  // A valid rank map but a null backing throws at requireBacking, still before
+  // any GPU access.
+  expectRuntimeErrorContains(
+      [] { MultimemHandler handler(nullptr, makeBootstrap(), 0, {0}, 0); },
+      "backing CuMemAllocation must be non-null");
+}
+
+TEST(MultimemHandlerValidationTest, NegativeCudaDeviceIsUnsupported) {
+  EXPECT_FALSE(MultimemHandler::isMultimemSupported(-1));
+}
+
+// Locks down both branches of `isMultimemSupported`:
+//   1. The cache fast-path (`cachedState != kUnknown`): repeated calls for the
+//      same in-range device must agree with the first call.
+//   2. The slow-path used when `cudaDevice >= kCachedMultimemSupportDevices`
+//      (which is 8): repeated calls for the same out-of-cache device id must
+//      also agree (the slow path has no cache so the agreement is purely a
+//      selector-determinism property).
+// A regression that flips the cache semantics (wrong memory order, off-by-one
+// in `kCachedMultimemSupportDevices`, or a stale-cache bug) trips the
+// fast-path assertion; a non-deterministic selector trips the slow-path
+// assertion. The concrete bool is host-dependent (a no-GPU CI host returns
+// `false` for everything; a 1-GPU devserver returns `true` for device 0 but
+// `false` for device 8 because the device doesn't exist) -- we assert only
+// per-device stability, not cross-device equality.
+TEST(MultimemHandlerValidationTest, IsMultimemSupportedCacheStableAcrossCalls) {
+  const bool firstDevice0 = MultimemHandler::isMultimemSupported(0);
+  EXPECT_EQ(MultimemHandler::isMultimemSupported(0), firstDevice0);
+  EXPECT_EQ(MultimemHandler::isMultimemSupported(0), firstDevice0);
+
+  const bool device7 = MultimemHandler::isMultimemSupported(7);
+  EXPECT_EQ(MultimemHandler::isMultimemSupported(7), device7);
+
+  // Device 8 falls outside the cache; the slow-path's selector must agree
+  // with itself on repeated calls (regardless of whether device 8 exists).
+  const bool firstDevice8 = MultimemHandler::isMultimemSupported(8);
+  EXPECT_EQ(MultimemHandler::isMultimemSupported(8), firstDevice8);
+  EXPECT_EQ(MultimemHandler::isMultimemSupported(8), firstDevice8);
+}
+
+// `backingGranularity` has its own "unsupported -> return 0" early-exit that
+// is independent of `isMultimemSupported`'s cache. Pairs with the existing
+// `NegativeCudaDeviceIsUnsupported` to lock down both static entry points and
+// confirms `nvlRanks` is irrelevant when the device is unsupported. A future
+// refactor that accidentally divides by `nvlRanks` before the supported check
+// would surface here.
+TEST(MultimemHandlerValidationTest, BackingGranularityZeroOnUnsupportedDevice) {
+  EXPECT_EQ(MultimemHandler::backingGranularity(-1, 8), 0u);
+  EXPECT_EQ(MultimemHandler::backingGranularity(-1, 1), 0u);
+  // On a no-GPU host device 0 is also unsupported (no driver / no multicast
+  // attribute); the in-range branch is exercised on a GPU host's success
+  // path via `MultimemHandlerTest`.
+  if (!MultimemHandler::isMultimemSupported(0)) {
+    EXPECT_EQ(MultimemHandler::backingGranularity(0, 8), 0u);
+  }
+}
+
+} // namespace comms::prims::tests


### PR DESCRIPTION
Summary:

Add `MultimemHandler`, a thin multicast layer composed on top of a `GpuMemHandler` (direct ctor creates one; sharing ctor takes a `shared_ptr<GpuMemHandler>`). It owns only the CUDA multicast object + its `CuMemMapping`, binds the GpuMemHandler's physical handle into the multicast object, and delegates the unicast view to the backing GpuMemHandler. Adds the lazy multicast driver symbols (pfn_cuMulticast*) to `CudaDriverLazy`. Works on single-host H100 (POSIX-FD) and GB200/MNNVL (fabric).

Reviewed By: saifhhasan

Differential Revision: D105264759


