### PR TITLE
Add generic packet geometry

### DIFF
--- a/comms/prims/transport/llx/LlPacket.cuh
+++ b/comms/prims/transport/llx/LlPacket.cuh
@@ -1,0 +1,154 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/common/DeviceConstants.cuh"
+
+using comms::device::kWarpSize;
+
+namespace comms::prims {
+
+// =============================================================================
+// Packet<X, Y> — compile-time LL packet-geometry policy
+// =============================================================================
+//
+// A packet is the atomic data+flag unit of the LL/LL128 protocol: X (`kData`)
+// payload bytes + Y (`kFlag`) flag bytes, written/read as ONE hardware-atomic
+// transfer so the trailing flag is never visible before its data.
+//
+//   LlPacketGeometry    = Packet<4, 4>    -> 8 B packet
+//   Ll128PacketGeometry = Packet<120, 8>  -> 128 B packet
+//
+// Everything in the generic path (build_packet, ll_recv, the IBGDA wrapper,
+// buffer sizing) is templated on packet geometry. The legacy fixed
+// `Ll128Packet` / `ll128_*` symbols are untouched.
+template <int kDataBytes, int kFlagBytes>
+struct Packet {
+  static constexpr int kData = kDataBytes; // X — payload bytes / packet
+  static constexpr int kFlag = kFlagBytes; // Y — flag bytes / packet tail
+  static constexpr int kPacketBytes = kDataBytes + kFlagBytes;
+  static constexpr int kSlotBytes = 16; // one CUDA lane stores one 16 B slot
+  static constexpr int kThreadsPerPacket =
+      kPacketBytes <= kSlotBytes ? 1 : kPacketBytes / kSlotBytes;
+  static constexpr int kWordsPerSlot = kSlotBytes / sizeof(uint64_t);
+  static constexpr int kPacketsPerWarp = kWarpSize / kThreadsPerPacket;
+  static constexpr int kFlagLane =
+      kThreadsPerPacket - 1; // last lane owns flag tail
+  using Flag = std::conditional_t<kFlagBytes == 4, int32_t, int64_t>;
+
+  static_assert(
+      kPacketBytes % static_cast<int>(sizeof(uint64_t)) == 0,
+      "Packet size (kData+kFlag) must be a multiple of 8 B");
+  static_assert(
+      kPacketBytes == 8 || kPacketBytes == 128,
+      "Packet size (kData+kFlag) must be 8 B (universal) or 128 B (PIX-gated)");
+  static_assert(
+      kPacketBytes <= kSlotBytes ? (kSlotBytes % kPacketBytes == 0)
+                                 : (kPacketBytes % kSlotBytes == 0),
+      "Packet must tile a lane slot or be tiled by lane slots");
+
+  /// Number of packets needed for a message of `nbytes`.
+  __host__ __device__ static constexpr size_t num_packets(size_t nbytes) {
+    return nbytes == 0 ? 0 : (nbytes + kData - 1) / kData;
+  }
+
+  /// Valid payload bytes carried by packet `packetIdx` of a `totalBytes`
+  /// message.
+  __host__ __device__ static constexpr size_t payload_size(
+      size_t packetIdx,
+      size_t totalBytes) {
+    const size_t offset = packetIdx * static_cast<size_t>(kData);
+    if (offset >= totalBytes) {
+      return 0;
+    }
+    const size_t remaining = totalBytes - offset;
+    return remaining < static_cast<size_t>(kData) ? remaining
+                                                  : static_cast<size_t>(kData);
+  }
+
+  /// Registered buffer bytes needed to hold a `maxBytes` message (multiple of
+  /// `kPacketBytes`).
+  __host__ __device__ static constexpr size_t buffer_size(size_t maxBytes) {
+    return num_packets(maxBytes) * static_cast<size_t>(kPacketBytes);
+  }
+};
+
+using LlPacketGeometry = Packet<4, 4>; // 8 B packet
+using Ll128PacketGeometry = Packet<120, 8>; // 128 B packet — PIX-gated
+
+// =============================================================================
+// Device helpers (generic over packet geometry)
+// =============================================================================
+
+/// Pointer to lane `laneInPacket`'s slot within a packet.
+template <typename P>
+__device__ __forceinline__ volatile uint64_t* ll_slot_ptr(
+    void* pkt,
+    int laneInPacket) {
+  auto* base = reinterpret_cast<volatile uint64_t*>(pkt);
+  return base + laneInPacket * P::kWordsPerSlot;
+}
+
+template <typename P>
+__device__ __forceinline__ const volatile uint64_t* ll_slot_ptr(
+    const void* pkt,
+    int laneInPacket) {
+  auto* base = reinterpret_cast<const volatile uint64_t*>(pkt);
+  return base + laneInPacket * P::kWordsPerSlot;
+}
+
+/// Pointer to the packet's flag tail.
+template <typename P>
+__device__ __forceinline__ volatile typename P::Flag* ll_flag_ptr(void* pkt) {
+  auto* base = reinterpret_cast<volatile char*>(pkt);
+  return reinterpret_cast<volatile typename P::Flag*>(base + P::kData);
+}
+
+template <typename P>
+__device__ __forceinline__ const volatile typename P::Flag* ll_flag_ptr(
+    const void* pkt) {
+  auto* base = reinterpret_cast<const volatile char*>(pkt);
+  return reinterpret_cast<const volatile typename P::Flag*>(base + P::kData);
+}
+
+/// Volatile-load the flag.
+template <typename P>
+__device__ __forceinline__ typename P::Flag ll_load_flag(const void* pkt) {
+#ifdef __CUDA_ARCH__
+  if constexpr (P::kFlag == 8) {
+    return static_cast<typename P::Flag>(comms::device::ld_volatile_global(
+        reinterpret_cast<const volatile uint64_t*>(ll_flag_ptr<P>(pkt))));
+  } else {
+    return *ll_flag_ptr<P>(pkt);
+  }
+#else
+  (void)pkt;
+  return 0;
+#endif
+}
+
+/// Volatile-store the flag.
+template <typename P>
+__device__ __forceinline__ void ll_store_flag(
+    void* pkt,
+    typename P::Flag flag) {
+#ifdef __CUDA_ARCH__
+  if constexpr (P::kFlag == 8) {
+    comms::device::st_volatile_global(
+        reinterpret_cast<volatile uint64_t*>(ll_flag_ptr<P>(pkt)),
+        static_cast<uint64_t>(flag));
+  } else {
+    *ll_flag_ptr<P>(pkt) = flag;
+  }
+#else
+  (void)pkt;
+  (void)flag;
+#endif
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/llx/tests/LlPacketTest.cc
+++ b/comms/prims/transport/llx/tests/LlPacketTest.cc
@@ -1,0 +1,120 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+
+#include "comms/prims/transport/llx/LlPacket.cuh"
+#include "comms/prims/transport/llx/tests/LlPacketTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+using meta::comms::DeviceBuffer;
+
+namespace comms::prims {
+
+// ---- compile-time geometry: the two tiers and the atomicity invariant ----
+static_assert(
+    Ll128PacketGeometry::kData == 120 && Ll128PacketGeometry::kFlag == 8);
+static_assert(Ll128PacketGeometry::kPacketBytes % sizeof(uint64_t) == 0);
+static_assert(
+    Ll128PacketGeometry::kPacketBytes == 128 &&
+    Ll128PacketGeometry::kThreadsPerPacket == 8);
+static_assert(
+    Ll128PacketGeometry::kFlagLane == 7 &&
+    Ll128PacketGeometry::kPacketsPerWarp ==
+        comms::device::kWarpSize / Ll128PacketGeometry::kThreadsPerPacket);
+static_assert(LlPacketGeometry::kData == 4 && LlPacketGeometry::kFlag == 4);
+static_assert(LlPacketGeometry::kPacketBytes % sizeof(uint64_t) == 0);
+static_assert(
+    LlPacketGeometry::kPacketBytes == 8 &&
+    LlPacketGeometry::kThreadsPerPacket == 1);
+static_assert(
+    LlPacketGeometry::kFlagLane == 0 &&
+    LlPacketGeometry::kPacketsPerWarp ==
+        comms::device::kWarpSize / LlPacketGeometry::kThreadsPerPacket);
+
+class LlPacketTestFixture : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    CUDACHECK_TEST(cudaSetDevice(0));
+  }
+  void TearDown() override {
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+
+  uint32_t runKernel(void (*fn)(uint32_t*)) {
+    DeviceBuffer errBuf(sizeof(uint32_t));
+    auto* err_d = static_cast<uint32_t*>(errBuf.get());
+    CUDACHECK_TEST(cudaMemset(err_d, 0, sizeof(uint32_t)));
+    fn(err_d);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    uint32_t err_h = 0;
+    CUDACHECK_TEST(
+        cudaMemcpy(&err_h, err_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+    return err_h;
+  }
+};
+
+TEST_F(LlPacketTestFixture, DeviceGeometry) {
+  EXPECT_EQ(runKernel(test::test_ll_packet_geometry), 0u)
+      << "Packet geometry constants wrong";
+}
+
+TEST_F(LlPacketTestFixture, DeviceSlotAndFlag) {
+  DeviceBuffer p128(Ll128PacketGeometry::kPacketBytes);
+  DeviceBuffer p8(LlPacketGeometry::kPacketBytes);
+  CUDACHECK_TEST(cudaMemset(p128.get(), 0, Ll128PacketGeometry::kPacketBytes));
+  CUDACHECK_TEST(cudaMemset(p8.get(), 0, LlPacketGeometry::kPacketBytes));
+
+  DeviceBuffer errBuf(sizeof(uint32_t));
+  auto* err_d = static_cast<uint32_t*>(errBuf.get());
+  CUDACHECK_TEST(cudaMemset(err_d, 0, sizeof(uint32_t)));
+
+  test::test_ll_packet_slot_flag(p128.get(), p8.get(), err_d);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t err_h = 0;
+  CUDACHECK_TEST(
+      cudaMemcpy(&err_h, err_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(err_h, 0u) << "ll_slot_ptr / flag round-trip wrong";
+}
+
+TEST_F(LlPacketTestFixture, HostNumPackets) {
+  // LL128 (kData = 120) — matches legacy Ll128 math.
+  EXPECT_EQ(Ll128PacketGeometry::num_packets(0), 0u);
+  EXPECT_EQ(Ll128PacketGeometry::num_packets(1), 1u);
+  EXPECT_EQ(Ll128PacketGeometry::num_packets(120), 1u);
+  EXPECT_EQ(Ll128PacketGeometry::num_packets(121), 2u);
+  EXPECT_EQ(Ll128PacketGeometry::num_packets(65536), 547u);
+  // LL (kData = 4).
+  EXPECT_EQ(LlPacketGeometry::num_packets(0), 0u);
+  EXPECT_EQ(LlPacketGeometry::num_packets(1), 1u);
+  EXPECT_EQ(LlPacketGeometry::num_packets(4), 1u);
+  EXPECT_EQ(LlPacketGeometry::num_packets(5), 2u);
+  EXPECT_EQ(LlPacketGeometry::num_packets(64), 16u);
+}
+
+TEST_F(LlPacketTestFixture, HostPayloadSize) {
+  EXPECT_EQ(Ll128PacketGeometry::payload_size(0, 0), 0u);
+  EXPECT_EQ(Ll128PacketGeometry::payload_size(0, 121), 120u);
+  EXPECT_EQ(Ll128PacketGeometry::payload_size(1, 121), 1u);
+  EXPECT_EQ(Ll128PacketGeometry::payload_size(1, 120), 0u); // out of range
+
+  EXPECT_EQ(LlPacketGeometry::payload_size(0, 4), 4u);
+  EXPECT_EQ(LlPacketGeometry::payload_size(0, 5), 4u);
+  EXPECT_EQ(LlPacketGeometry::payload_size(1, 5), 1u);
+  EXPECT_EQ(LlPacketGeometry::payload_size(1, 4), 0u); // out of range
+}
+
+TEST_F(LlPacketTestFixture, HostBufferSize) {
+  EXPECT_EQ(Ll128PacketGeometry::buffer_size(0), 0u);
+  EXPECT_EQ(Ll128PacketGeometry::buffer_size(120), 128u);
+  EXPECT_EQ(Ll128PacketGeometry::buffer_size(121), 256u);
+
+  EXPECT_EQ(LlPacketGeometry::buffer_size(0), 0u);
+  EXPECT_EQ(LlPacketGeometry::buffer_size(4), 8u);
+  EXPECT_EQ(LlPacketGeometry::buffer_size(5), 16u);
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/llx/tests/LlPacketTest.cu
+++ b/comms/prims/transport/llx/tests/LlPacketTest.cu
@@ -1,0 +1,100 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+
+#include "comms/prims/tests/Checks.h"
+#include "comms/prims/transport/ll128/Ll128Packet.cuh"
+#include "comms/prims/transport/llx/LlPacket.cuh"
+
+namespace comms::prims::test {
+
+using namespace comms::prims;
+
+// =============================================================================
+// Packet geometry for both tiers
+// =============================================================================
+
+__global__ void test_ll_packet_geometry_kernel(uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // LL128 packet = 128 B, 8 threads, flag lane 7.
+    if (Ll128PacketGeometry::kPacketBytes != 128 ||
+        Ll128PacketGeometry::kThreadsPerPacket != 8 ||
+        Ll128PacketGeometry::kFlagLane != 7 ||
+        Ll128PacketGeometry::kData != 120 ||
+        Ll128PacketGeometry::kPacketsPerWarp !=
+            comms::device::kWarpSize / Ll128PacketGeometry::kThreadsPerPacket) {
+      atomicAdd(errorCount, 1);
+    }
+
+    // LL packet = 8 B: one 4 B data + 4 B flag.
+    if (LlPacketGeometry::kThreadsPerPacket != 1 ||
+        LlPacketGeometry::kFlagLane != 0 || LlPacketGeometry::kData != 4 ||
+        LlPacketGeometry::kFlag != 4 || LlPacketGeometry::kPacketBytes != 8 ||
+        LlPacketGeometry::kPacketsPerWarp !=
+            comms::device::kWarpSize / LlPacketGeometry::kThreadsPerPacket) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+}
+
+void test_ll_packet_geometry(uint32_t* errorCount_d) {
+  test_ll_packet_geometry_kernel<<<1, 1>>>(errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+// =============================================================================
+// Slot pointers + flag round-trip (both tiers)
+// =============================================================================
+
+// `pkt` is in GLOBAL memory — ll_load/store_flag use global volatile ops.
+template <typename P>
+__device__ void check_slot_flag(void* pkt, uint32_t* errorCount) {
+  auto* base = reinterpret_cast<volatile uint64_t*>(pkt);
+
+  // Each lane's slot points to data[lane * P::kWordsPerSlot].
+  for (int lane = 0; lane < P::kThreadsPerPacket; ++lane) {
+    if (ll_slot_ptr<P>(pkt, lane) != base + lane * P::kWordsPerSlot) {
+      atomicAdd(errorCount, 1);
+    }
+  }
+
+  auto* expectedFlag = reinterpret_cast<volatile typename P::Flag*>(
+      reinterpret_cast<volatile char*>(pkt) + P::kData);
+  if (ll_flag_ptr<P>(pkt) != expectedFlag) {
+    atomicAdd(errorCount, 1);
+  }
+
+  // Round-trip a few flag values.
+  ll_store_flag<P>(pkt, static_cast<typename P::Flag>(kLl128ReadyToWrite));
+  if (ll_load_flag<P>(pkt) !=
+      static_cast<typename P::Flag>(kLl128ReadyToWrite)) {
+    atomicAdd(errorCount, 1);
+  }
+  ll_store_flag<P>(pkt, static_cast<typename P::Flag>(1));
+  if (ll_load_flag<P>(pkt) != static_cast<typename P::Flag>(1)) {
+    atomicAdd(errorCount, 1);
+  }
+  ll_store_flag<P>(pkt, static_cast<typename P::Flag>(42));
+  if (ll_load_flag<P>(pkt) != static_cast<typename P::Flag>(42)) {
+    atomicAdd(errorCount, 1);
+  }
+}
+
+__global__ void
+test_ll_packet_slot_flag_kernel(void* p128, void* p8, uint32_t* errorCount) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    check_slot_flag<Ll128PacketGeometry>(p128, errorCount);
+    check_slot_flag<LlPacketGeometry>(p8, errorCount);
+  }
+}
+
+void test_ll_packet_slot_flag(
+    void* p128_d,
+    void* p8_d,
+    uint32_t* errorCount_d) {
+  test_ll_packet_slot_flag_kernel<<<1, 1>>>(p128_d, p8_d, errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/transport/llx/tests/LlPacketTest.cuh
+++ b/comms/prims/transport/llx/tests/LlPacketTest.cuh
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+namespace comms::prims::test {
+
+/// Device-side: packet geometry for both tiers (8 B / 128 B).
+void test_ll_packet_geometry(uint32_t* errorCount_d);
+
+/// Device-side: ll_slot_ptr addresses + ll_load/store_flag round-trip, both
+/// tiers. `p128_d` / `p8_d` are global device buffers (>= 128 B / 8 B) — flag
+/// I/O uses global volatile ops, which are illegal on shared memory.
+void test_ll_packet_slot_flag(void* p128_d, void* p8_d, uint32_t* errorCount_d);
+
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary:
Introduce the first LLX building block: a compile-time packet-geometry policy for low-latency data+flag packet formats.

This adds:
- `Packet<kData,kFlag>` with packet sizing helpers for packet count and registered buffer size.
- `LlPacketGeometry = Packet<4,4>` and `Ll128PacketGeometry = Packet<120,8>` aliases for the two planned IBGDA tiers.
- Pointer-based generic slot and flag helpers used by later pack/recv primitives.
- Focused `LlPacketTest` coverage for device geometry, slot/flag access, and host-side sizing math.

The change is additive under `comms/prims/transport/llx` and does not modify the existing NVLink LL128 path.

Differential Revision: D110090962


