### PR TITLE
Add reduction numerical version comparator (#3022)

### DIFF
--- a/comms/ncclx/meta/tests/AllReduceNumericalTest.cc
+++ b/comms/ncclx/meta/tests/AllReduceNumericalTest.cc
@@ -157,6 +157,13 @@ class AllReduceNumericalTest
         stream_);
     ASSERT_EQ(result, ncclSuccess);
     CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    ncclx::test::numerics::printActualOutputBytes(
+        actualDevice,
+        param.count,
+        stream_,
+        globalRank,
+        "AllReduce",
+        param.name());
 
     const size_t mismatches = ncclx::test::numerics::countMismatches(
         actualDevice, reference, stream_, globalRank, param.name());

--- a/comms/ncclx/meta/tests/ReduceNumericalTest.cc
+++ b/comms/ncclx/meta/tests/ReduceNumericalTest.cc
@@ -148,6 +148,13 @@ class ReduceNumericalTest
     CUDACHECK_TEST(cudaStreamSynchronize(stream_));
 
     if (globalRank == kRoot) {
+      ncclx::test::numerics::printActualOutputBytes(
+          actualDevice,
+          param.count,
+          stream_,
+          globalRank,
+          "Reduce",
+          param.name());
       const size_t mismatches = ncclx::test::numerics::countMismatches(
           actualDevice, reference, stream_, globalRank, param.name());
       EXPECT_EQ(mismatches, 0) << param.name() << " rank=" << globalRank;

--- a/comms/ncclx/meta/tests/ReduceScatterNumericalTest.cc
+++ b/comms/ncclx/meta/tests/ReduceScatterNumericalTest.cc
@@ -158,6 +158,13 @@ class ReduceScatterNumericalTest
         stream_);
     ASSERT_EQ(result, ncclSuccess);
     CUDACHECK_TEST(cudaStreamSynchronize(stream_));
+    ncclx::test::numerics::printActualOutputBytes(
+        actualDevice,
+        param.count,
+        stream_,
+        globalRank,
+        "ReduceScatter",
+        param.name());
 
     const size_t mismatches = ncclx::test::numerics::countMismatches(
         actualDevice, reference, stream_, globalRank, param.name());

--- a/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
+++ b/comms/ncclx/meta/tests/ReductionNumericalTestUtils.h
@@ -9,6 +9,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <random>
 #include <string>
 #include <type_traits>
@@ -34,6 +36,8 @@ constexpr double kBfloat16Atol = 3e-2;
 
 // Arbitrary fixed seed for reproducible random test inputs.
 constexpr uint32_t kReductionInputSeed = 12345;
+constexpr const char* kPrintActualOutputEnv =
+    "REDUCTION_NUMERICAL_PRINT_ACTUAL";
 
 struct AllCloseTolerance {
   double rtol{0.0};
@@ -90,6 +94,46 @@ std::vector<T> gatherInputs(
   CUDACHECK_TEST(cudaStreamSynchronize(stream));
   NCCLCHECK_TEST(ncclMemFree(gatheredDevice));
   return gathered;
+}
+
+inline bool shouldPrintActualOutput() {
+  return std::getenv(kPrintActualOutputEnv) != nullptr;
+}
+
+template <typename T>
+void printActualOutputBytes(
+    const T* deviceBuffer,
+    size_t count,
+    cudaStream_t stream,
+    int rank,
+    const std::string& collectiveName,
+    const std::string& caseName) {
+  if (!shouldPrintActualOutput()) {
+    return;
+  }
+
+  std::vector<T> observed(count);
+  CUDACHECK_TEST(cudaMemcpyAsync(
+      observed.data(),
+      deviceBuffer,
+      observed.size() * sizeof(T),
+      cudaMemcpyDefault,
+      stream));
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  const auto* bytes = reinterpret_cast<const unsigned char*>(observed.data());
+  const size_t byteCount = observed.size() * sizeof(T);
+  std::string hex;
+  hex.resize(byteCount * 2);
+  constexpr char kHexDigits[] = "0123456789abcdef";
+  for (size_t i = 0; i < byteCount; ++i) {
+    hex[2 * i] = kHexDigits[bytes[i] >> 4];
+    hex[2 * i + 1] = kHexDigits[bytes[i] & 0x0f];
+  }
+
+  std::cout << "REDUCTION_NUMERICAL_ACTUAL collective=" << collectiveName
+            << " case=" << caseName << " rank=" << rank << " bytes=" << hex
+            << std::endl;
 }
 
 template <typename T>

--- a/comms/ncclx/meta/tests/ReductionNumericalVersionCompare.py
+++ b/comms/ncclx/meta/tests/ReductionNumericalVersionCompare.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Compare reduction numerical outputs produced by two NCCLX versions.
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+OUTPUT_PREFIX = "REDUCTION_NUMERICAL_ACTUAL "
+MAX_FAILURE_LINES = 10
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run versioned reduction numerical binaries and compare "
+        "their actual NCCL outputs bitwise."
+    )
+    parser.add_argument("--launcher", required=True)
+    parser.add_argument("--old-version", required=True)
+    parser.add_argument("--new-version", required=True)
+    parser.add_argument("--ppn", type=int, default=8)
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    parser.add_argument("--gtest-filter")
+    parser.add_argument(
+        "--allow-numerical-test-failures",
+        action="store_true",
+        help=(
+            "Compare structured NCCL outputs even when the underlying "
+            "FP64-reference numerical test fails. The binary must still produce "
+            "structured outputs and show gtest failures; launcher failures and "
+            "timeouts remain hard failures."
+        ),
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        nargs=3,
+        metavar=("COLLECTIVE", "OLD_BINARY", "NEW_BINARY"),
+        required=True,
+        help="Collective name and the two versioned binaries to compare.",
+    )
+    return parser.parse_args()
+
+
+def run_binary(
+    launcher: str,
+    binary: str,
+    ppn: int,
+    timeout_seconds: int,
+    gtest_filter: str | None,
+    allow_numerical_test_failures: bool,
+) -> dict[str, str]:
+    launcher_path = str(Path(launcher).resolve())
+    binary_path = str(Path(binary).resolve())
+    binary_command = [binary_path]
+    if gtest_filter:
+        binary_command.append(f"--gtest_filter={gtest_filter}")
+
+    # The outer `timeout` bounds the whole per-binary run; give the TCPStore
+    # connect a strictly smaller budget (half) so a slow rendezvous still leaves
+    # time for the reduction workload and fails cleanly before the outer timeout
+    # SIGKILLs the process.
+    tcpstore_timeout_seconds = max(1, timeout_seconds // 2)
+    cmd = [
+        launcher_path,
+        "--ppn",
+        str(ppn),
+        "--env",
+        "REDUCTION_NUMERICAL_PRINT_ACTUAL=1",
+        "--env",
+        f"COMMS_TEST_TCPSTORE_TIMEOUT_SECONDS={tcpstore_timeout_seconds}",
+        "--",
+        "timeout",
+        str(timeout_seconds),
+        "bash",
+        "-c",
+        shlex.join(binary_command),
+    ]
+    print(f"Running {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    outputs = parse_actual_outputs(result.stdout)
+    if result.returncode != 0:
+        # `timeout` writes its diagnostics to stderr, so scan both streams for
+        # timeout markers when classifying the failure.
+        if allow_numerical_test_failures and is_numerical_test_failure(
+            result.returncode, f"{result.stdout}\n{result.stderr}", outputs
+        ):
+            print(
+                "FP64_REFERENCE_STATUS "
+                f"binary={binary_path} status=FAIL "
+                f"returncode={result.returncode} structured_outputs={len(outputs)}"
+            )
+            print_numerical_failure_summary(result.stdout)
+            return outputs
+        print(result.stdout, end="")
+        print(result.stderr, end="", file=sys.stderr)
+        result.check_returncode()
+    if not outputs:
+        raise RuntimeError(f"{binary_path} produced no structured numerical outputs")
+    print(
+        "FP64_REFERENCE_STATUS "
+        f"binary={binary_path} status=PASS structured_outputs={len(outputs)}"
+    )
+    return outputs
+
+
+REQUIRED_OUTPUT_FIELDS = ("collective", "case", "rank", "bytes")
+
+
+def parse_actual_outputs(stdout: str) -> dict[str, str]:
+    outputs: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if not line.startswith(OUTPUT_PREFIX):
+            continue
+        fields: dict[str, str] = {}
+        for token in line[len(OUTPUT_PREFIX) :].split():
+            if "=" not in token:
+                raise ValueError(
+                    f"malformed structured output token {token!r} in line: {line}"
+                )
+            name, value = token.split("=", 1)
+            fields[name] = value
+        missing = [name for name in REQUIRED_OUTPUT_FIELDS if name not in fields]
+        if missing:
+            raise ValueError(f"structured output line missing fields {missing}: {line}")
+        key = f"{fields['collective']}__{fields['case']}__rank_{fields['rank']}"
+        if key in outputs:
+            raise RuntimeError(f"duplicate numerical output record: {key}")
+        outputs[key] = fields["bytes"]
+    return outputs
+
+
+def is_numerical_test_failure(
+    returncode: int, output: str, outputs: dict[str, str]
+) -> bool:
+    # `output` should be the combined stdout+stderr so timeout markers (which
+    # `timeout` writes to stderr) are visible here alongside the gtest markers.
+    timeout_markers = (
+        "exit code: 124",
+        "timed out",
+        "Timed out",
+    )
+    if returncode == 124 or any(marker in output for marker in timeout_markers):
+        return False
+    # A numerical failure means the binary ran the reduction path (it emitted
+    # structured outputs) and gtest reported a failing assertion. Match the gtest
+    # marker with a whitespace-tolerant regex so the classification does not
+    # silently break if gtest changes the marker spacing.
+    gtest_failed = re.search(r"\[\s*FAILED\s*\]", output) is not None
+    return bool(outputs) and gtest_failed
+
+
+def print_numerical_failure_summary(stdout: str) -> None:
+    printed = 0
+    for line in stdout.splitlines():
+        if " reference=" not in line or " actual=" not in line:
+            continue
+        print(f"FP64_REFERENCE_FAILURE {line}")
+        printed += 1
+        if printed >= MAX_FAILURE_LINES:
+            print("FP64_REFERENCE_FAILURE ... truncated")
+            return
+
+
+def bfloat16_to_float(raw: bytes) -> float:
+    bits = struct.unpack("<H", raw)[0] << 16
+    return struct.unpack("<f", struct.pack("<I", bits))[0]
+
+
+def element_size(output_name: str) -> int:
+    if "_Float32_" in output_name:
+        return 4
+    if "_Bfloat16_" in output_name:
+        return 2
+    return 1
+
+
+def format_value(output_name: str, data: bytes, offset: int) -> str:
+    # offset must be aligned to the element size so the formatted value
+    # corresponds to a single element rather than bytes spanning two elements.
+    if "_Float32_" in output_name and offset + 4 <= len(data):
+        value = struct.unpack("<f", data[offset : offset + 4])[0]
+        return f"{value:.9g}"
+    if "_Bfloat16_" in output_name and offset + 2 <= len(data):
+        raw = data[offset : offset + 2]
+        return f"{bfloat16_to_float(raw):.9g} (bf16=0x{raw.hex()})"
+    # Fallback for unknown dtypes: annotate the byte count so a short slice near
+    # the buffer end is not mistaken for a full element.
+    raw = data[offset : offset + 8]
+    return f"0x{raw.hex()} ({len(raw)} bytes)"
+
+
+def element_index(output_name: str, offset: int) -> int:
+    return offset // element_size(output_name)
+
+
+def compare_output(
+    old_version: str, new_version: str, output_name: str, old_hex: str, new_hex: str
+) -> bool:
+    old_data = bytes.fromhex(old_hex)
+    new_data = bytes.fromhex(new_hex)
+    if old_data == new_data:
+        return True
+
+    if len(old_data) != len(new_data):
+        print(
+            f"BITWISE MISMATCH {output_name}: length differs "
+            f"{old_version}={len(old_data)} bytes {new_version}={len(new_data)} bytes"
+        )
+        return False
+
+    mismatch_offset = next(
+        i
+        for i, (old_byte, new_byte) in enumerate(zip(old_data, new_data))
+        if old_byte != new_byte
+    )
+    # Align to the element boundary so the formatted values correspond to the
+    # reported element_index; byte_offset still points at the differing byte.
+    index = element_index(output_name, mismatch_offset)
+    aligned_offset = index * element_size(output_name)
+    print(
+        "BITWISE MISMATCH "
+        f"{output_name}: byte_offset={mismatch_offset} "
+        f"element_index={index} "
+        f"{old_version}={format_value(output_name, old_data, aligned_offset)} "
+        f"{new_version}={format_value(output_name, new_data, aligned_offset)}"
+    )
+    return False
+
+
+def compare_outputs(
+    old_version: str,
+    new_version: str,
+    old_outputs: dict[str, str],
+    new_outputs: dict[str, str],
+) -> bool:
+    passed = True
+
+    missing = sorted(old_outputs.keys() - new_outputs.keys())
+    extra = sorted(new_outputs.keys() - old_outputs.keys())
+    for name in missing:
+        print(f"MISSING {new_version} output: {name}")
+        passed = False
+    for name in extra:
+        print(f"EXTRA {new_version} output: {name}")
+        passed = False
+
+    for name in sorted(old_outputs.keys() & new_outputs.keys()):
+        passed = (
+            compare_output(
+                old_version, new_version, name, old_outputs[name], new_outputs[name]
+            )
+            and passed
+        )
+    return passed
+
+
+def main() -> int:
+    args = parse_args()
+    all_passed = True
+    for collective, old_binary, new_binary in args.case:
+        print(
+            f"Comparing {collective}: {args.old_version} vs {args.new_version}",
+            flush=True,
+        )
+        old_outputs = run_binary(
+            args.launcher,
+            old_binary,
+            args.ppn,
+            args.timeout_seconds,
+            args.gtest_filter,
+            args.allow_numerical_test_failures,
+        )
+        new_outputs = run_binary(
+            args.launcher,
+            new_binary,
+            args.ppn,
+            args.timeout_seconds,
+            args.gtest_filter,
+            args.allow_numerical_test_failures,
+        )
+        comparison_passed = compare_outputs(
+            args.old_version, args.new_version, old_outputs, new_outputs
+        )
+        print(
+            "RELEASE_COMPARE_STATUS "
+            f"collective={collective} "
+            f"old_version={args.old_version} "
+            f"new_version={args.new_version} "
+            f"status={'PASS' if comparison_passed else 'FAIL'}"
+        )
+        all_passed = comparison_passed and all_passed
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary:

- Adds `ReductionNumericalVersionCompare.py`, a reduction-collective version comparator that launches versioned numerical binaries and compares structured NCCL output bytes from NCCL 2.29 against NCCL 2.30 on the same fixed topology.
- Separates the two validation dimensions in the output: `RELEASE_COMPARE_STATUS` reports release-to-release bitwise match, while `FP64_REFERENCE_STATUS` reports whether each underlying numerical binary passed its FP64-reference tolerance check.
- Adds `--gtest-filter` so topology targets can select the exact numerical cases under test, and `--allow-numerical-test-failures` so BF16 multi-node investigations can still compare 2.29 vs 2.30 bytes while preserving FP64-reference failure evidence.
- Keeps infrastructure failures strict: launcher failures, missing structured output, and timeout/connectivity markers remain hard failures even when numerical failures are allowed.
- Adds `COMMS_TEST_TCPSTORE_TIMEOUT_SECONDS` support in `DistEnvironmentBase.cc` so multi-host comparator targets can use an explicit TCPStore timeout instead of relying on the default.

Reviewed By: jspark1105

Differential Revision: D110224389


