### PR TITLE
Use TiledBuffer for CTREE tile splits (#3024)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
@@ -97,28 +97,6 @@ actualSegElems(size_t count, size_t segmentElems, int rank) {
 }
 
 /**
- * Tile view for one logical segment owned by the current num-block group.
- */
-struct SegmentTile {
-  size_t offsetBytes;
-  size_t bytes;
-};
-
-__device__ __forceinline__ SegmentTile
-segmentTileForBlock(size_t totalBytes, int numBlocks, int blockId) {
-  comms::prims::TiledBuffer<char> tile(nullptr, totalBytes, numBlocks);
-  return SegmentTile{
-      .offsetBytes = static_cast<size_t>(blockId) * tile.tile_elements,
-      .bytes = tile.tile_bytes(blockId),
-  };
-}
-
-__device__ __forceinline__ SegmentTile
-segmentTile(size_t totalBytes, const comms::prims::ThreadGroup& group) {
-  return segmentTileForBlock(totalBytes, group.total_groups, group.group_id);
-}
-
-/**
  * Return the largest owner tile participating in local NVL exchange.
  */
 template <typename T>
@@ -129,8 +107,10 @@ __device__ __forceinline__ size_t maxOwnerTileBytes(
   for (int owner = 0; owner < args.pMin; owner++) {
     const size_t ownerElems =
         actualSegElems(args.count, args.segmentElems, owner);
-    const auto ownerTile = segmentTile(ownerElems * sizeof(T), group);
-    maxBytes = ownerTile.bytes > maxBytes ? ownerTile.bytes : maxBytes;
+    const comms::prims::TiledBuffer<char> ownerTile(
+        nullptr, ownerElems * sizeof(T), group);
+    const size_t ownerTileBytes = ownerTile.bytes();
+    maxBytes = ownerTileBytes > maxBytes ? ownerTileBytes : maxBytes;
   }
   return maxBytes;
 }

--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "comms/ctran/algos/CtranAlgoDev.h" // CTRAN_MAX_NVL_PEERS
 #include "comms/utils/commSpecs.h" // commDataType_t, commRedOp_t
 
@@ -82,7 +84,6 @@ struct CommonKernArgs {
   int localRank;
   /** Number of logical data partitions processed by CUDA blocks per GPU. */
   int numBlocks;
-
   /** Collective datatype implemented by the kernel dispatch. */
   commDataType_t datatype;
   /** Reduction operation implemented by the kernel dispatch. */

--- a/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
+++ b/comms/ctran/algos/AllReduce/AllReduceIbTree.cu
@@ -18,7 +18,7 @@
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
 
 // Shared device utilities (tileReduce, IbReduceCopy, logicalDataGroup,
-// segmentTile, actualSegElems, pipelineStepBytes, ...) live in
+// actualSegElems, pipelineStepBytes, ...) live in
 // AllReduceFusedCommon.cuh (ctran::allreduce::common). The NVL phases live in
 // AllReduceNvlDirect.cuh (ctran::allreduce::nvl::direct) and the
 // phase-sequencing orchestrator in AllReduceFused.cuh
@@ -329,10 +329,9 @@ __device__ __noinline__ void phase2IbDualTree(
 
   const size_t actualElems = actualSegElems(
       args.common.count, args.common.segmentElems, args.common.localRank);
-  const auto tile = segmentTile(actualElems * sizeof(T), blockGroup);
-  const size_t tileOffsetElems = tile.offsetBytes / sizeof(T);
-  const size_t tileElems = tile.bytes / sizeof(T);
-
+  char* phase2Buf = static_cast<char*>(args.common.phase2Buf);
+  comms::prims::TiledBuffer<char> blockTile(
+      phase2Buf, actualElems * sizeof(T), blockGroup);
   // If the whole segment has at most one element per block, lane 1 would be
   // empty for every block. Compress transport group ids to a single lane for
   // that tiny-message shape; otherwise keep the stable two-lane mapping.
@@ -341,9 +340,12 @@ __device__ __noinline__ void phase2IbDualTree(
   const int activeIbLanesPerBlock =
       useSingleLane ? 1 : ctran::allreduce::tree::kTreeLanes;
 
-  const size_t halfElems0 = useSingleLane ? tileElems : (tileElems + 1) / 2;
-  const size_t halfElems1 = useSingleLane ? 0 : tileElems - halfElems0;
-  T* phase2Buf = static_cast<T*>(args.common.phase2Buf);
+  comms::prims::TiledBuffer<char> laneTiles(
+      blockTile.data(), blockTile.bytes(), ctran::allreduce::tree::kTreeLanes);
+  const size_t halfElems0 =
+      (useSingleLane ? blockTile.bytes() : laneTiles.tile_bytes(0)) / sizeof(T);
+  const size_t halfElems1 =
+      useSingleLane ? 0 : laneTiles.tile_bytes(1) / sizeof(T);
   const int activeIbGroups = args.common.numBlocks * activeIbLanesPerBlock;
 
   auto lane0Group = blockGroup;
@@ -356,13 +358,13 @@ __device__ __noinline__ void phase2IbDualTree(
   auto lane0 = makeTreeLaneState<T>(
       args,
       args.tree0,
-      phase2Buf + tileOffsetElems,
+      reinterpret_cast<T*>(laneTiles.tile_data(0)),
       halfElems0,
       activeIbGroups);
   auto lane1 = makeTreeLaneState<T>(
       args,
       args.tree1,
-      phase2Buf + tileOffsetElems + halfElems0,
+      reinterpret_cast<T*>(laneTiles.tile_data(1)),
       halfElems1,
       activeIbGroups);
 

--- a/comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh
@@ -98,21 +98,20 @@ __device__ __noinline__ void nvlDirectReduceScatter(
 
   comms::prims::Timeout timeout{};
 
-  // Every owner initializes its tile before receiving peer contributions. The
-  // tile view is derived from the group identity, so numBlocks=1 is just the
-  // degenerate full-segment tile.
-  common::SegmentTile myTile{};
+  const size_t myActualElems = localRank < pMin
+      ? common::actualSegElems(args.count, segmentElems, localRank)
+      : 0;
+  comms::prims::TiledBuffer<char> myPhase2Tile(
+      phase2Buf, myActualElems * sizeof(T), group);
   bool copiedLocalTile = false;
   if (localRank < pMin) {
-    const size_t myActualElems =
-        common::actualSegElems(args.count, segmentElems, localRank);
-    myTile = common::segmentTile(myActualElems * sizeof(T), group);
     const size_t mySegmentOffset =
         static_cast<size_t>(localRank) * segmentBytes;
-    const char* src = sendbuff + mySegmentOffset + myTile.offsetBytes;
-    char* dst = phase2Buf + myTile.offsetBytes;
-    if (myTile.bytes > 0 && dst != src) {
-      comms::prims::memcpy_vectorized(dst, src, myTile.bytes, group);
+    const comms::prims::TiledBuffer<const char> mySendTile(
+        sendbuff + mySegmentOffset, myActualElems * sizeof(T), group);
+    if (myPhase2Tile.bytes() > 0 && myPhase2Tile.data() != mySendTile.data()) {
+      comms::prims::memcpy_vectorized(
+          myPhase2Tile.data(), mySendTile.data(), myPhase2Tile.bytes(), group);
       copiedLocalTile = true;
     }
   }
@@ -134,7 +133,7 @@ __device__ __noinline__ void nvlDirectReduceScatter(
       "Phase 1 NVL reduce-scatter pipeline window is zero");
 
   const size_t maxTileBytes = common::maxOwnerTileBytes<T>(args, group);
-  char* myDst = phase2Buf + myTile.offsetBytes;
+  char* myDst = myPhase2Tile.data();
 
   for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
     for (int owner = 0; owner < pMin; owner++) {
@@ -144,29 +143,29 @@ __device__ __noinline__ void nvlDirectReduceScatter(
 
       const size_t ownerActualElems =
           common::actualSegElems(args.count, segmentElems, owner);
-      const auto ownerTile =
-          common::segmentTile(ownerActualElems * sizeof(T), group);
-      if (off >= ownerTile.bytes) {
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      const comms::prims::TiledBuffer<const char> ownerTile(
+          sendbuff + ownerSegmentOffset, ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes()) {
         continue;
       }
 
       const int ownerGlobalRank = args.localRankToGlobalRank[owner];
-      const size_t ownerSegmentOffset =
-          static_cast<size_t>(owner) * segmentBytes;
       const size_t window =
-          common::pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+          common::pipelineStepBytes(ownerTile.bytes(), off, pipelineWindow);
       args.transports[ownerGlobalRank].p2p_nvl.send(
           group,
-          sendbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          ownerTile.data() + off,
           window,
           group.total_groups,
           0,
           timeout);
     }
 
-    if (localRank < pMin && off < myTile.bytes) {
+    if (localRank < pMin && off < myPhase2Tile.bytes()) {
       const size_t window =
-          common::pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+          common::pipelineStepBytes(myPhase2Tile.bytes(), off, pipelineWindow);
       for (int peer = 0; peer < nLocalRanks; peer++) {
         if (peer == localRank) {
           continue;
@@ -220,19 +219,18 @@ __device__ __noinline__ void nvlDirectAllGather(
       pipelineWindow != 0, "Phase 3 NVL all-gather pipeline window is zero");
 
   const size_t maxTileBytes = common::maxOwnerTileBytes<T>(args, group);
-  common::SegmentTile myTile{};
-  if (localRank < pMin) {
-    const size_t myActualElems =
-        common::actualSegElems(args.count, segmentElems, localRank);
-    myTile = common::segmentTile(myActualElems * sizeof(T), group);
-  }
+  const size_t myActualElems = localRank < pMin
+      ? common::actualSegElems(args.count, segmentElems, localRank)
+      : 0;
+  const size_t mySegmentOffset =
+      localRank < pMin ? static_cast<size_t>(localRank) * segmentBytes : 0;
+  comms::prims::TiledBuffer<char> myRecvTile(
+      recvbuff + mySegmentOffset, myActualElems * sizeof(T), group);
 
   for (size_t off = 0; off < maxTileBytes; off += pipelineWindow) {
-    if (localRank < pMin && off < myTile.bytes) {
-      const size_t mySegmentOffset =
-          static_cast<size_t>(localRank) * segmentBytes;
+    if (localRank < pMin && off < myRecvTile.bytes()) {
       const size_t window =
-          common::pipelineStepBytes(myTile.bytes, off, pipelineWindow);
+          common::pipelineStepBytes(myRecvTile.bytes(), off, pipelineWindow);
       for (int peer = 0; peer < nLocalRanks; peer++) {
         if (peer == localRank) {
           continue;
@@ -240,7 +238,7 @@ __device__ __noinline__ void nvlDirectAllGather(
         const int peerGlobalRank = args.localRankToGlobalRank[peer];
         args.transports[peerGlobalRank].p2p_nvl.send(
             group,
-            recvbuff + mySegmentOffset + myTile.offsetBytes + off,
+            myRecvTile.data() + off,
             window,
             group.total_groups,
             0,
@@ -255,20 +253,20 @@ __device__ __noinline__ void nvlDirectAllGather(
 
       const size_t ownerActualElems =
           common::actualSegElems(args.count, segmentElems, owner);
-      const auto ownerTile =
-          common::segmentTile(ownerActualElems * sizeof(T), group);
-      if (off >= ownerTile.bytes) {
+      const size_t ownerSegmentOffset =
+          static_cast<size_t>(owner) * segmentBytes;
+      comms::prims::TiledBuffer<char> ownerTile(
+          recvbuff + ownerSegmentOffset, ownerActualElems * sizeof(T), group);
+      if (off >= ownerTile.bytes()) {
         continue;
       }
 
       const int ownerGlobalRank = args.localRankToGlobalRank[owner];
-      const size_t ownerSegmentOffset =
-          static_cast<size_t>(owner) * segmentBytes;
       const size_t window =
-          common::pipelineStepBytes(ownerTile.bytes, off, pipelineWindow);
+          common::pipelineStepBytes(ownerTile.bytes(), off, pipelineWindow);
       args.transports[ownerGlobalRank].p2p_nvl.recv(
           group,
-          recvbuff + ownerSegmentOffset + ownerTile.offsetBytes + off,
+          ownerTile.data() + off,
           window,
           group.total_groups,
           0,

--- a/comms/ctran/algos/AllReduce/tests/AllReduceFusedTiledBufferTest.cc
+++ b/comms/ctran/algos/AllReduce/tests/AllReduceFusedTiledBufferTest.cc
@@ -1,0 +1,103 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+
+#include "comms/prims/core/TiledBuffer.cuh"
+
+namespace {
+
+struct TileView {
+  std::size_t offsetBytes;
+  std::size_t bytes;
+  std::size_t strideBytes;
+};
+
+TileView
+tileView(char* base, std::size_t totalBytes, int numTiles, int tileId) {
+  comms::prims::TiledBuffer<char> tiles(base, totalBytes, numTiles);
+  return TileView{
+      .offsetBytes = static_cast<std::size_t>(tiles.tile_data(tileId) - base),
+      .bytes = tiles.tile_bytes(tileId),
+      .strideBytes = tiles.tile_elements,
+  };
+}
+
+TEST(AllReduceFusedTiledBuffer, BlockTileSplitUsesNativeTiledBufferStride) {
+  std::array<char, 1000> buffer{};
+  const auto tile0 = tileView(buffer.data(), buffer.size(), 3, 0);
+  const auto tile1 = tileView(buffer.data(), buffer.size(), 3, 1);
+  const auto tile2 = tileView(buffer.data(), buffer.size(), 3, 2);
+
+  EXPECT_EQ(tile0.strideBytes, 336);
+  EXPECT_EQ(tile0.offsetBytes, 0);
+  EXPECT_EQ(tile0.bytes, 336);
+  EXPECT_EQ(tile1.offsetBytes, 336);
+  EXPECT_EQ(tile1.bytes, 336);
+  EXPECT_EQ(tile2.offsetBytes, 672);
+  EXPECT_EQ(tile2.bytes, 328);
+}
+
+TEST(AllReduceFusedTiledBuffer, BlockTileSplitKeepsDegenerateCases) {
+  std::array<char, 1040> buffer{};
+  EXPECT_EQ(tileView(buffer.data(), 0, 8, 0).bytes, 0);
+  EXPECT_EQ(tileView(buffer.data(), 1025, 1, 0).offsetBytes, 0);
+  EXPECT_EQ(tileView(buffer.data(), 1025, 1, 0).bytes, 1025);
+  EXPECT_EQ(tileView(buffer.data(), 1000, 3, 3).offsetBytes, 1008);
+  EXPECT_EQ(tileView(buffer.data(), 1000, 3, 3).bytes, 0);
+}
+
+TEST(AllReduceFusedTiledBuffer, LaneSplitUsesNestedTiledBuffer) {
+  std::array<char, 1000> buffer{};
+  const auto blockTile = tileView(buffer.data(), buffer.size(), 3, 0);
+  const auto lane0 =
+      tileView(buffer.data() + blockTile.offsetBytes, blockTile.bytes, 2, 0);
+  const auto lane1 =
+      tileView(buffer.data() + blockTile.offsetBytes, blockTile.bytes, 2, 1);
+
+  EXPECT_EQ(blockTile.bytes, 336);
+  EXPECT_EQ(lane0.offsetBytes, 0);
+  EXPECT_EQ(lane0.bytes, 176);
+  EXPECT_EQ(lane1.offsetBytes, 176);
+  EXPECT_EQ(lane1.bytes, 160);
+  EXPECT_EQ(lane0.bytes + lane1.bytes, blockTile.bytes);
+}
+
+TEST(AllReduceFusedTiledBuffer, LaneSplitKeepsTailInSecondLane) {
+  std::array<char, 1000> buffer{};
+  const auto blockTail = tileView(buffer.data(), buffer.size(), 3, 2);
+  const auto lane0 =
+      tileView(buffer.data() + blockTail.offsetBytes, blockTail.bytes, 2, 0);
+  const auto lane1 =
+      tileView(buffer.data() + blockTail.offsetBytes, blockTail.bytes, 2, 1);
+
+  EXPECT_EQ(blockTail.bytes, 328);
+  EXPECT_EQ(lane0.bytes, 176);
+  EXPECT_EQ(lane1.bytes, 152);
+  EXPECT_EQ(lane0.bytes + lane1.bytes, blockTail.bytes);
+}
+
+TEST(AllReduceFusedTiledBuffer, CoversUnalignedNear64MiBPayload) {
+  constexpr std::size_t kUnaligned64MiBBytes =
+      64UL * 1024 * 1024 + sizeof(float);
+  constexpr int kNumPartitions = 8;
+  constexpr std::size_t kNativeTileAlignmentBytes = 16;
+
+  comms::prims::TiledBuffer<char> tiles(
+      nullptr, kUnaligned64MiBBytes, kNumPartitions);
+  const std::size_t unalignedPartitionBytes =
+      (kUnaligned64MiBBytes + kNumPartitions - 1) / kNumPartitions;
+
+  EXPECT_NE(tiles.tile_elements, unalignedPartitionBytes);
+  EXPECT_EQ(tiles.tile_elements % kNativeTileAlignmentBytes, 0);
+
+  std::size_t coveredBytes = 0;
+  for (int tileId = 0; tileId < kNumPartitions; ++tileId) {
+    coveredBytes += tiles.tile_bytes(tileId);
+  }
+  EXPECT_EQ(coveredBytes, kUnaligned64MiBBytes);
+}
+
+} // namespace

--- a/comms/ctran/benchmarks/AllReduceBenchmark.cc
+++ b/comms/ctran/benchmarks/AllReduceBenchmark.cc
@@ -49,10 +49,16 @@ struct BenchCase {
 std::vector<size_t> gBenchmarkSizes;
 std::vector<BenchCase> gBenchmarkCases;
 
+// 64 MiB plus one float exercises block/tree partitions with an uneven
+// TiledBuffer tail.
+static constexpr size_t kUnalignedPartitionBenchmarkBytes =
+    64UL * 1024 * 1024 + sizeof(float);
+
 std::vector<size_t> defaultBenchmarkSizes() {
   return {
       1024UL,
       8UL * 1024 * 1024,
+      kUnalignedPartitionBenchmarkBytes,
       1024UL * 1024 * 1024,
   };
 }
@@ -147,13 +153,13 @@ bool parseSizeList(
 }
 
 std::string formatSize(size_t bytes) {
-  if (bytes >= 1024UL * 1024 * 1024) {
+  if (bytes >= 1024UL * 1024 * 1024 && bytes % (1024UL * 1024 * 1024) == 0) {
     return std::to_string(bytes / (1024UL * 1024 * 1024)) + "G";
   }
-  if (bytes >= 1024UL * 1024) {
+  if (bytes >= 1024UL * 1024 && bytes % (1024UL * 1024) == 0) {
     return std::to_string(bytes / (1024UL * 1024)) + "M";
   }
-  if (bytes >= 1024UL) {
+  if (bytes >= 1024UL && bytes % 1024UL == 0) {
     return std::to_string(bytes / 1024UL) + "K";
   }
   return std::to_string(bytes) + "B";

--- a/comms/prims/core/TiledBuffer.cuh
+++ b/comms/prims/core/TiledBuffer.cuh
@@ -71,12 +71,13 @@ struct TiledBuffer {
   }
 
   /// Pointer to tile i's data (explicit indexing)
-  __device__ __forceinline__ T* __restrict__ tile_data(int tile_id) const {
+  __host__ __device__
+      __forceinline__ T* __restrict__ tile_data(int tile_id) const {
     return buf + tile_id * tile_elements;
   }
 
   /// Number of elements in tile i (last tile may be smaller)
-  __device__ __forceinline__ std::size_t tile_size(int tile_id) const {
+  __host__ __device__ __forceinline__ std::size_t tile_size(int tile_id) const {
     std::size_t offset = tile_id * tile_elements;
     if (offset >= num_elements) {
       return 0;
@@ -86,7 +87,8 @@ struct TiledBuffer {
   }
 
   /// Bytes in tile i
-  __device__ __forceinline__ std::size_t tile_bytes(int tile_id) const {
+  __host__ __device__ __forceinline__ std::size_t tile_bytes(
+      int tile_id) const {
     return tile_size(tile_id) * sizeof(T);
   }
 


### PR DESCRIPTION
Summary:

Rework CTREE fused AllReduce block and dual-tree lane partitioning to use the existing `comms/prims/core/TiledBuffer.cuh` primitive directly. NVL and IB phases now share the same block-owned segment tile view, and the IB dual-tree phase uses a second two-partition `TiledBuffer<char>` over the block tile for lane ownership. This removes the custom alignment helper so native `TiledBuffer` tiling is the source of truth.

Reviewed By: function47

Differential Revision: D110234428


