### PR TITLE
Fix libnccl_static.a rename race that breaks OSS parallel builds (#3025)

### DIFF
--- a/comms/torchcomms/transport/cca_hook/CMakeLists.txt
+++ b/comms/torchcomms/transport/cca_hook/CMakeLists.txt
@@ -141,11 +141,12 @@ else()
         COMMAND "${ROOT}/rename_symbols.sh"
                 '$<TARGET_OBJECTS:torchcomms_transport_cca_hook>'
     )
-    add_custom_command(
-        TARGET torchcomms_transport_cca_hook
-        PRE_LINK
-        COMMAND "${ROOT}/rename_symbols.sh" "${NCCLX_STATIC_LIB}"
-    )
+    # libnccl_static.a is symbol-renamed by _comms_ncclx's PRE_LINK step.
+    # Depend on that target so the rename is done before this module links,
+    # rather than renaming the shared archive again here -- two modules
+    # rewriting it concurrently under `ninja -j` raced and intermittently
+    # failed the link with "cannot find libnccl_static.a".
+    add_dependencies(torchcomms_transport_cca_hook torchcomms_comms_ncclx)
 endif()
 
 if(CUDA_FOUND)


### PR DESCRIPTION
Summary:

The torchcomms OSS CMake build symbol-renames the bundled ncclx archive (`build/ncclx/lib/libnccl_static.a`) from `nccl*`/`pnccl*` to `torchcomms_*` so the symbols do not clash with PyTorch's bundled nccl. `_comms_ncclx` (`comms/torchcomms/ncclx/CMakeLists.txt`) does this in a `PRE_LINK` step that rewrites the archive in place via `rename_symbols.sh`. As long as it was the only writer this was fine.

D109222641 added the `_transport_cca_hook` extension, which copied that pattern and registered a second `PRE_LINK` rename of the same shared `libnccl_static.a`. Under `ninja -j` the two modules link concurrently, so both rewrite the shared archive at the same time; one module's linker can then open `libnccl_static.a` while the other's in-place rewrite has it momentarily missing, producing intermittent link failures:

```
ld: cannot find /.../build/ncclx/lib/libnccl_static.a: No such file or directory
collect2: error: ld returned 1 exit status
```

Fix (one file): stop `_transport_cca_hook` from re-renaming the shared archive. Remove the duplicate `PRE_LINK` rename of `libnccl_static.a` that D109222641 added, and instead `add_dependencies(torchcomms_transport_cca_hook torchcomms_comms_ncclx)` so the archive — already renamed by `_comms_ncclx`'s `PRE_LINK` step — is done before cca_hook links. Only one module ever rewrites the shared archive, so the race is gone. `_comms_ncclx` and `rename_symbols.sh` are unchanged, and cca_hook still renames its own object files in `PRE_LINK`.

Reviewed By: d4l3k

Differential Revision: D110235735


