### PR TITLE
comms/ctran: use FB_CUDACHECKIGNORE for cleanup cudaSetDevice calls

### DIFF
--- a/comms/ctran/tests/CtranTestUtils.cc
+++ b/comms/ctran/tests/CtranTestUtils.cc
@@ -185,17 +185,17 @@ commResult_t commMemFreeDisjoint(
   CUdevice ptrDev = 0;
 
   if (ptr == NULL) {
-    (void)cudaSetDevice(saveDevice);
+    FB_CUDACHECKIGNORE(cudaSetDevice(saveDevice));
     return ErrorStackTraceUtil::log(commInvalidArgument);
   }
 
   if (ctran::utils::commCudaLibraryInit() != commSuccess) {
-    (void)cudaSetDevice(saveDevice);
+    FB_CUDACHECKIGNORE(cudaSetDevice(saveDevice));
     return ErrorStackTraceUtil::log(commSystemError);
   }
 
   if (!ctran::utils::getCuMemSysSupported()) {
-    (void)cudaSetDevice(saveDevice);
+    FB_CUDACHECKIGNORE(cudaSetDevice(saveDevice));
     return ErrorStackTraceUtil::log(commSystemError);
   }
 
@@ -235,7 +235,7 @@ commResult_t commMemFreeDisjoint(
     curPtr = ctran::utils::addDevicePtr(curPtr, alignedSizes[i]);
   }
   FB_CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, vaSize));
-  CUDACHECK_TEST(cudaSetDevice(saveDevice));
+  FB_CUDACHECKIGNORE(cudaSetDevice(saveDevice));
   return ret;
 }
 


### PR DESCRIPTION
Summary: Clang 21 errors when a `[[nodiscard]]` return value is silently discarded. A device-memory free helper restores the current CUDA device on error paths and at function exit via bare `cudaSetDevice` calls. These are switched to a best-effort check macro that logs a warning on failure instead of silently ignoring the result, matching the idiom already used elsewhere in the same file.

Differential Revision: D109170076


