### PR TITLE
Intranode dispatch/combine over NVLink

### DIFF
--- a/comms/prims/collectives/moe_ep/cpp/Buffer.cc
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.cc
@@ -1,0 +1,851 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/Buffer.h"
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <folly/futures/Future.h>
+#include <torch/csrc/utils/pybind.h>
+
+// `meta::comms::DeviceBuffer` is referenced by `MultiPeerNvlTransport.h`
+// private members. Bring it into scope before that header (transitively
+// pulled in by GpuMemHandler.h consumers).
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/collectives/moe_ep/cpp/intranode/Runtime.h"
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+#include "comms/prims/memory/GpuMemHandler.h"
+
+namespace comms::prims::moe_ep {
+
+namespace py = pybind11;
+
+namespace {
+
+void checkCuda(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+/**
+ * Trivial bootstrap that just remembers the rank and group size; collective
+ * operations are no-ops (return 0). Sufficient for the local-rank-only path
+ * inside `IntranodeRuntime` because `GpuMemHandler` falls back to a
+ * single-rank fast path when nRanks == 1, and `MultiPeerNvlTransport`'s
+ * `exchange()` does its own metadata gather.
+ *
+ * For multi-rank mode, a real `PreExchangedBootstrap` (per Q2/Q6 in the
+ * design) gets plumbed through `Buffer::sync()` in a follow-up commit.
+ * Until then, this stub is enough for single-rank smoke tests; multi-rank
+ * intranode_dispatch will be exercised once D5's PreExchangedBootstrap
+ * lands.
+ */
+class StubBootstrap : public meta::comms::IBootstrap {
+ public:
+  StubBootstrap(int rank, int nRanks) : rank_(rank), nRanks_(nRanks) {}
+
+  folly::SemiFuture<int>
+  allGather(void* /*buf*/, int /*len*/, int /*rank*/, int /*nranks*/) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrier(int /*rank*/, int /*nranks*/) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int>
+  send(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int>
+  recv(void* /*buf*/, int /*len*/, int /*peer*/, int /*tag*/) override {
+    return folly::makeSemiFuture(0);
+  }
+
+ private:
+  const int rank_;
+  const int nRanks_;
+};
+
+} // namespace
+
+Buffer::Buffer(
+    int rank,
+    int numRanks,
+    std::int64_t numNvlBytes,
+    std::int64_t numRdmaBytes,
+    bool lowLatencyMode,
+    bool explicitlyDestroy,
+    bool enableShrink,
+    bool useFabric)
+    : rank_(rank),
+      numRanks_(numRanks),
+      numNvlBytes_(numNvlBytes),
+      numRdmaBytes_(numRdmaBytes),
+      lowLatencyMode_(lowLatencyMode),
+      explicitlyDestroy_(explicitlyDestroy),
+      enableShrink_(enableShrink),
+      useFabric_(useFabric) {
+  if (rank_ < 0 || rank_ >= numRanks_) {
+    throw std::invalid_argument("Buffer: rank out of bounds");
+  }
+  if (numRanks_ <= 0 || numRanks_ > NUM_MAX_NVL_PEERS) {
+    // Phase 1 is intranode-only; Phase 3 (D5) adds multi-NVL-peer handling.
+    throw std::invalid_argument(
+        "Buffer: numRanks must be in (0, NUM_MAX_NVL_PEERS] for Phase 1");
+  }
+
+  checkCuda(cudaGetDevice(&deviceId_), "Buffer: cudaGetDevice failed");
+
+  // Allocate the local NVL data buffer EARLY (in ctor, not sync) so
+  // `get_local_ipc_handle()` returns a real IPC handle BEFORE Python's
+  // `dist.all_gather_object(local_ipc_handle)`. Without this, all peers
+  // gather zero-filled placeholders and `cudaIpcOpenMemHandle` fails at
+  // sync-time with "invalid argument".
+  //
+  // Layout:
+  //   [0 .. numNvlBytes_)              data region (per_rank/per_expert
+  //                                    prefix matrices, dispatch/combine
+  //                                    chunked send/recv slots)
+  //   [numNvlBytes_ .. +barrierBytes)  barrier signal slots — separate region
+  //                                    so notify_dispatch's prefix-matrix
+  //                                    writes don't clobber barrier counters
+  //                                    (which would deadlock barrier_device).
+  //
+  // On AMD use the uncached allocator path so the buffer is BNXT
+  // dma-buf-compatible; matches `GpuMemHandler::kCudaIpcUncached`.
+  const std::size_t barrierBytes =
+      static_cast<std::size_t>(kernels::NUM_MAX_FIFO_SLOTS) * sizeof(int);
+  const std::size_t totalBytes =
+      static_cast<std::size_t>(numNvlBytes_) + barrierBytes;
+#ifdef __HIP_PLATFORM_AMD__
+  checkCuda(
+      hipExtMallocWithFlags(
+          &localIpcBuffer_, totalBytes, hipDeviceMallocUncached),
+      "Buffer: hipExtMallocWithFlags(uncached) failed");
+#else
+  checkCuda(
+      cudaMalloc(&localIpcBuffer_, totalBytes),
+      "Buffer: cudaMalloc(local NVL buffer) failed");
+#endif
+  // Defer `cudaIpcGetMemHandle` to `get_local_ipc_handle()` (lazy). On
+  // ROCm/HIP, calling `hipIpcGetMemHandle` from the ctor — *before* PyTorch
+  // does its first `dist.all_gather_object` — triggers a downstream
+  // `hipErrorPeerAccessAlreadyEnabled` from PyTorch's caching allocator the
+  // next time a CPU→GPU `Tensor.to(device)` runs. The handle is only ever
+  // read by `get_local_ipc_handle()` so making it lazy is harmless.
+  // Zero only the barrier region. Use the NULL (default) stream — async, so
+  // the ctor returns immediately; the device runtime serializes against
+  // subsequent kernel launches.
+  if (barrierBytes > 0) {
+    void* barrierPtr =
+        static_cast<std::uint8_t*>(localIpcBuffer_) + numNvlBytes_;
+    checkCuda(
+        cudaMemsetAsync(barrierPtr, 0, barrierBytes, /*stream=*/nullptr),
+        "Buffer: cudaMemsetAsync(barrier region) failed");
+  }
+}
+
+Buffer::~Buffer() {
+  // intranode_ destructor handles workspace cleanup. Close peer IPC handles
+  // BEFORE freeing the local buffer (peer handles must be closed while their
+  // backing allocations are still live across the IPC; the local buffer free
+  // is independent).
+  for (int i = 0; i < static_cast<int>(peerIpcBuffers_.size()); ++i) {
+    if (i == rank_) {
+      continue;
+    }
+    if (peerIpcBuffers_[i] != nullptr) {
+      (void)cudaIpcCloseMemHandle(peerIpcBuffers_[i]);
+    }
+  }
+  peerIpcBuffers_.clear();
+  if (localIpcBuffer_ != nullptr) {
+    (void)cudaFree(localIpcBuffer_);
+    localIpcBuffer_ = nullptr;
+  }
+}
+
+int Buffer::get_num_rdma_ranks() const noexcept {
+  // Phase 1: intranode-only → exactly 1 RDMA rank (this node).
+  return 1;
+}
+
+int Buffer::get_rdma_rank() const noexcept {
+  return 0;
+}
+
+int Buffer::get_root_rdma_rank(bool /*global*/) const noexcept {
+  return 0;
+}
+
+py::bytearray Buffer::get_local_ipc_handle() const {
+  // Lazily compute the IPC handle on first access — see Buffer ctor for why
+  // we don't do this eagerly. The handle is cached after the first call
+  // because `cudaIpcGetMemHandle` is not idempotent across all HIP versions
+  // and the Python wrapper calls this once anyway.
+  if (!localIpcHandleReady_) {
+    if (localIpcBuffer_ == nullptr) {
+      throw std::runtime_error(
+          "Buffer::get_local_ipc_handle: local buffer not allocated");
+    }
+    checkCuda(
+        cudaIpcGetMemHandle(&localIpcHandle_, localIpcBuffer_),
+        "Buffer::get_local_ipc_handle: cudaIpcGetMemHandle failed");
+    localIpcHandleReady_ = true;
+  }
+  return py::bytearray(
+      reinterpret_cast<const char*>(&localIpcHandle_), sizeof(localIpcHandle_));
+}
+
+py::bytearray Buffer::get_local_nvshmem_unique_id() const {
+  // Pipes uses IBootstrap for QP exchange, not NVSHMEM unique IDs.
+  // Return a fixed dummy bytearray; the test code only forwards it back
+  // to `runtime.sync()` and we ignore it.
+  static constexpr std::size_t kNvshmemUniqueIdSize = 128;
+  return py::bytearray(nullptr, kNvshmemUniqueIdSize);
+}
+
+void Buffer::sync(
+    const std::vector<int>& deviceIds,
+    const std::vector<std::optional<py::bytearray>>& ipcHandles,
+    const std::optional<py::bytearray>& /*rootUniqueId*/) {
+  if (static_cast<int>(deviceIds.size()) != numRanks_) {
+    throw std::runtime_error(
+        "Buffer::sync: deviceIds length doesn't match numRanks");
+  }
+  if (deviceIds[rank_] != deviceId_) {
+    throw std::runtime_error(
+        "Buffer::sync: local device ID mismatch (Python vs C++)");
+  }
+  if (static_cast<int>(ipcHandles.size()) != numRanks_) {
+    throw std::runtime_error(
+        "Buffer::sync: ipcHandles length doesn't match numRanks");
+  }
+
+  // Open each peer's IPC handle and build the peer-pointer table. Entry
+  // `rank_` is the local buffer; other entries come from
+  // `cudaIpcOpenMemHandle(peer_i_handle)`. The opened pointers are owned by
+  // this Buffer and closed in the destructor.
+  peerIpcBuffers_.assign(numRanks_, nullptr);
+  for (int i = 0; i < numRanks_; ++i) {
+    if (i == rank_) {
+      peerIpcBuffers_[i] = localIpcBuffer_;
+      continue;
+    }
+    if (!ipcHandles[i].has_value()) {
+      throw std::runtime_error(
+          "Buffer::sync: missing IPC handle for peer " + std::to_string(i));
+    }
+    // Copy the bytearray contents into a `cudaIpcMemHandle_t` for the open
+    // call. `bytearray` exposes its bytes via `PyBytes_AsString`-style API
+    // through pybind's casting; using `std::string` round-trip preserves the
+    // raw bytes including embedded nulls.
+    const std::string handleBytes = std::string(*ipcHandles[i]);
+    if (handleBytes.size() != sizeof(cudaIpcMemHandle_t)) {
+      throw std::runtime_error(
+          "Buffer::sync: peer " + std::to_string(i) +
+          " IPC handle size mismatch (got " +
+          std::to_string(handleBytes.size()) + ", expected " +
+          std::to_string(sizeof(cudaIpcMemHandle_t)) + ")");
+    }
+    cudaIpcMemHandle_t peerHandle{};
+    std::memcpy(&peerHandle, handleBytes.data(), sizeof(peerHandle));
+    void* peerPtr = nullptr;
+    checkCuda(
+        cudaIpcOpenMemHandle(
+            &peerPtr, peerHandle, cudaIpcMemLazyEnablePeerAccess),
+        "Buffer::sync: cudaIpcOpenMemHandle failed");
+    peerIpcBuffers_[i] = peerPtr;
+  }
+
+  // Construct intranode runtime via the pre-allocated-buffer ctor: skips
+  // GpuMemHandler/transport entirely since Python already gathered IPC
+  // handles for us.
+  intranode_ = std::make_unique<IntranodeRuntime>(
+      rank_,
+      numRanks_,
+      static_cast<std::size_t>(numNvlBytes_),
+      localIpcBuffer_,
+      localIpcHandle_,
+      peerIpcBuffers_);
+
+  // Full device sync after sync() ensures the host-to-device pointer-table
+  // memcpys + barrier-region memset are visible to all subsequent kernels
+  // (which may run on a stream different from the one used in setup).
+  checkCuda(cudaDeviceSynchronize(), "Buffer::sync: cudaDeviceSynchronize");
+
+  available_ = true;
+}
+
+void Buffer::destroy() {
+  if (destroyed_) {
+    return;
+  }
+  intranode_.reset();
+  destroyed_ = true;
+  available_ = false;
+}
+
+std::tuple<
+    torch::Tensor,
+    std::optional<torch::Tensor>,
+    torch::Tensor,
+    torch::Tensor,
+    std::optional<EventHandle>>
+Buffer::get_dispatch_layout(
+    const torch::Tensor& topkIdx,
+    int numExperts,
+    const std::optional<EventHandle>& /*previousEvent*/,
+    bool asyncFinish,
+    bool /*allocateOnCommStream*/) {
+  if (!available_) {
+    throw std::runtime_error("Buffer::get_dispatch_layout: not synced yet");
+  }
+
+  TORCH_CHECK(topkIdx.dim() == 2, "topk_idx must be 2D");
+  TORCH_CHECK(
+      topkIdx.scalar_type() == torch::kInt64,
+      "topk_idx must be torch.int64 (== topk_idx_t)");
+  const int numTokens = topkIdx.size(0);
+  const int numTopk = topkIdx.size(1);
+
+  auto opts =
+      torch::TensorOptions().dtype(torch::kInt32).device(topkIdx.device());
+  auto numTokensPerRank = torch::empty({numRanks_}, opts);
+  auto numTokensPerExpert = torch::empty({numExperts}, opts);
+  auto isTokenInRank = torch::empty(
+      {numTokens, numRanks_},
+      torch::TensorOptions().dtype(torch::kBool).device(topkIdx.device()));
+
+  // Phase 1 intranode → no per-RDMA-rank tensor.
+  std::optional<torch::Tensor> numTokensPerRdmaRank = std::nullopt;
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  kernels::get_dispatch_layout(
+      topkIdx.data_ptr<std::int64_t>(),
+      numTokensPerRank.data_ptr<int>(),
+      /*num_tokens_per_rdma_rank=*/nullptr,
+      numTokensPerExpert.data_ptr<int>(),
+      isTokenInRank.data_ptr<bool>(),
+      numTokens,
+      numTopk,
+      numRanks_,
+      numExperts,
+      stream);
+
+  std::optional<EventHandle> event;
+  if (asyncFinish) {
+    event = EventHandle();
+  }
+  return std::make_tuple(
+      numTokensPerRank,
+      numTokensPerRdmaRank,
+      numTokensPerExpert,
+      isTokenInRank,
+      event);
+}
+
+py::tuple Buffer::intranode_dispatch(
+    const py::object& xObj,
+    const py::object& handleObj,
+    const std::optional<torch::Tensor>& numTokensPerRank,
+    const std::optional<torch::Tensor>& isTokenInRank,
+    const std::optional<torch::Tensor>& numTokensPerExpert,
+    const std::optional<torch::Tensor>& topkIdx,
+    const std::optional<torch::Tensor>& topkWeights,
+    int expertAlignment,
+    int numWorstTokens,
+    const Config& config,
+    const std::optional<EventHandle>& /*previousEvent*/,
+    bool asyncFinish,
+    bool /*allocateOnCommStream*/) {
+  if (!available_) {
+    throw std::runtime_error("Buffer::intranode_dispatch: not synced yet");
+  }
+  // Cached-dispatch path is selected when the caller passes a non-None handle
+  // (a dict from a prior dispatch). The handle holds the cached prefix
+  // matrices + recv metadata, so we can skip notify_dispatch's count exchange
+  // and call cached_notify_dispatch for state refresh.
+  const bool isCached =
+      !handleObj.is_none() && py::isinstance<py::dict>(handleObj);
+  if (!isCached &&
+      (!numTokensPerRank.has_value() || !isTokenInRank.has_value() ||
+       !numTokensPerExpert.has_value())) {
+    throw std::runtime_error(
+        "Buffer::intranode_dispatch: "
+        "non-cached mode requires num_tokens_per_rank, is_token_in_rank, "
+        "and num_tokens_per_expert");
+  }
+  if (isCached && !isTokenInRank.has_value()) {
+    throw std::runtime_error(
+        "Buffer::intranode_dispatch: cached mode requires is_token_in_rank "
+        "(thread it through from the cached handle)");
+  }
+
+  // FP8 path: x is a (data, scales) tuple. Both BF16/FP32 (Tensor input) and
+  // FP8 (tuple input) flow through the same kernel; scales are nullptr for
+  // non-FP8. Use PyTuple_Check + try-cast because pybind11's `isinstance<>`
+  // doesn't reliably recognize plain Python tuples or PyTorch tensors across
+  // toolchain versions.
+  torch::Tensor x;
+  std::optional<torch::Tensor> xScales;
+  bool isFp8 = false;
+  if (PyTuple_Check(xObj.ptr())) {
+    auto xTuple = xObj.cast<py::tuple>();
+    TORCH_CHECK(
+        xTuple.size() == 2, "x tuple must be (data, scales) of length 2");
+    x = xTuple[0].cast<torch::Tensor>();
+    xScales = xTuple[1].cast<torch::Tensor>();
+    isFp8 = true;
+    // FP8 scale path is deferred: the kernel derives num_scales from
+    // scale_hidden_stride (Dispatch.cu), which collapses to 1 for contiguous
+    // scales and silently under-fills the recv-scale buffer. Reject the
+    // (data, scales) tuple until the FP8-enablement diff threads num_scales.
+    TORCH_CHECK(
+        !isFp8,
+        "intranode_dispatch: FP8 (x=(data, scales)) is not supported yet; the "
+        "scale path is deferred to a follow-up diff. Pass a bf16/fp16 tensor.");
+  } else {
+    // Tensor path — fall back on cast-or-throw to bypass unreliable
+    // pybind11::isinstance<torch::Tensor>.
+    x = xObj.cast<torch::Tensor>();
+  }
+  TORCH_CHECK(x.dim() == 2 && x.is_contiguous(), "x must be 2D contiguous");
+  TORCH_CHECK(
+      (x.size(1) * x.element_size()) % sizeof(int4) == 0,
+      "hidden * elem_size must be int4-aligned");
+  TORCH_CHECK(
+      isTokenInRank->scalar_type() == torch::kBool, "is_token_in_rank bool");
+  if (!isCached) {
+    TORCH_CHECK(
+        numTokensPerRank->scalar_type() == torch::kInt32 &&
+            numTokensPerRank->size(0) == numRanks_,
+        "num_tokens_per_rank shape/dtype mismatch");
+    TORCH_CHECK(
+        numTokensPerExpert->scalar_type() == torch::kInt32 &&
+            numTokensPerExpert->size(0) % numRanks_ == 0,
+        "num_tokens_per_expert shape/dtype mismatch");
+  }
+
+  const int numTokens = static_cast<int>(x.size(0));
+  const int hidden = static_cast<int>(x.size(1));
+  // num_experts is unused on the cached path (no per-expert routing). Pull
+  // it from numTokensPerExpert for non-cached, default to 0 for cached.
+  const int numExperts =
+      isCached ? 0 : static_cast<int>(numTokensPerExpert->size(0));
+  const int numLocalExperts = isCached ? 0 : numExperts / numRanks_;
+
+  // FP8 scale validation. x_scales is 2D, dim0 == num_tokens,
+  // dim1 == num_scales (typically hidden / 128). Scales must be float32 or
+  // int (containers for casted FP8 scale exponents).
+  float* xScalesPtr = nullptr;
+  int numScales = 0;
+  int scaleTokenStride = 0;
+  int scaleHiddenStride = 0;
+  if (xScales.has_value()) {
+    TORCH_CHECK(
+        xScales->scalar_type() == torch::kFloat32 ||
+            xScales->scalar_type() == torch::kInt,
+        "x_scales must be float32 or int32");
+    TORCH_CHECK(xScales->dim() == 2, "x_scales must be 2D");
+    TORCH_CHECK(
+        xScales->size(0) == numTokens,
+        "x_scales.size(0) must equal num_tokens");
+    numScales = static_cast<int>(xScales->size(1));
+    xScalesPtr = static_cast<float*>(xScales->data_ptr());
+    scaleTokenStride = static_cast<int>(xScales->stride(0));
+    scaleHiddenStride = static_cast<int>(xScales->stride(1));
+  }
+
+  int numTopk = 0;
+  std::int64_t* topkIdxPtr = nullptr;
+  float* topkWeightsPtr = nullptr;
+  if (topkIdx.has_value()) {
+    TORCH_CHECK(topkWeights.has_value(), "topk_idx + topk_weights must agree");
+    numTopk = static_cast<int>(topkIdx->size(1));
+    TORCH_CHECK(numExperts > 0, "non-zero num_experts required for topk");
+    TORCH_CHECK(
+        topkIdx->dim() == 2 && topkIdx->is_contiguous() &&
+            topkIdx->scalar_type() == torch::kInt64,
+        "topk_idx must be 2D int64 contiguous");
+    TORCH_CHECK(
+        topkWeights->dim() == 2 && topkWeights->is_contiguous() &&
+            topkWeights->scalar_type() == torch::kFloat32,
+        "topk_weights must be 2D float32 contiguous");
+    topkIdxPtr = topkIdx->data_ptr<std::int64_t>();
+    topkWeightsPtr = topkWeights->data_ptr<float>();
+  }
+
+  TORCH_CHECK(config.num_sms % 2 == 0, "config.num_sms must be even");
+  const int numChannels = config.num_sms / 2;
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  torch::Tensor rankPrefixMatrix;
+  torch::Tensor channelPrefixMatrix;
+  torch::Tensor recvSrcIdx;
+  torch::Tensor recvChannelPrefixMatrix;
+  torch::Tensor sendHead;
+  int numRecvTokens = 0;
+  std::vector<int> numRecvTokensPerExpertList;
+  const int numMemsetInt = numChannels * numRanks_ * 4;
+
+  if (isCached) {
+    // Pull cached metadata from the handle dict (Python wrapper packs it for
+    // us). cached_notify_dispatch refreshes the barrier + memsets per-channel
+    // state (2 internal barriers, so move FIFO by 2). Skip the CPU sync —
+    // numRecvTokens comes from the handle.
+    auto handleDict = handleObj.cast<py::dict>();
+    rankPrefixMatrix = handleDict["rank_prefix_matrix"].cast<torch::Tensor>();
+    channelPrefixMatrix =
+        handleDict["channel_prefix_matrix"].cast<torch::Tensor>();
+    recvSrcIdx = handleDict["recv_src_idx"].cast<torch::Tensor>();
+    recvChannelPrefixMatrix =
+        handleDict["recv_channel_prefix_matrix"].cast<torch::Tensor>();
+    sendHead = handleDict["send_head"].cast<torch::Tensor>();
+    numRecvTokens = handleDict["num_recv_tokens"].cast<int>();
+
+    kernels::cached_notify_dispatch(
+        rankPrefixMatrix.data_ptr<int>(),
+        numMemsetInt,
+        intranode_->getPeerDataPtrsDevice(),
+        intranode_->getBarrierSignalPtrsDevice(),
+        rank_,
+        numRanks_,
+        stream,
+        intranode_->head());
+    intranode_->moveFifoSlots(2);
+    // Cached test path doesn't use per-expert counts (no topk). Leave
+    // numRecvTokensPerExpertList empty.
+  } else {
+    // Reset host counters before the notify_dispatch kernel writes them.
+    *intranode_->getMoeRecvCounterHost() = -1;
+    for (int i = 0; i < numLocalExperts; ++i) {
+      intranode_->getMoeRecvExpertCounterHost()[i] = -1;
+    }
+
+    rankPrefixMatrix = torch::empty(
+        {numRanks_, numRanks_},
+        torch::TensorOptions().dtype(torch::kInt32).device(x.device()));
+    channelPrefixMatrix = torch::empty(
+        {numRanks_, numChannels},
+        torch::TensorOptions().dtype(torch::kInt32).device(x.device()));
+
+    kernels::notify_dispatch(
+        numTokensPerRank->data_ptr<int>(),
+        intranode_->getMoeRecvCounterDevice(),
+        numRanks_,
+        numTokensPerExpert->data_ptr<int>(),
+        intranode_->getMoeRecvExpertCounterDevice(),
+        numExperts,
+        numTokens,
+        isTokenInRank->data_ptr<bool>(),
+        channelPrefixMatrix.data_ptr<int>(),
+        rankPrefixMatrix.data_ptr<int>(),
+        numMemsetInt,
+        expertAlignment,
+        intranode_->getPeerDataPtrsDevice(),
+        intranode_->getBarrierSignalPtrsDevice(),
+        intranode_->head(),
+        rank_,
+        stream,
+        numChannels);
+    intranode_->moveFifoSlots(3);
+
+    if (numWorstTokens > 0) {
+      numRecvTokens = numWorstTokens;
+      TORCH_CHECK(
+          topkIdx.has_value(), "num_worst_tokens > 0 requires topk_idx");
+    } else {
+      // Block until notify_dispatch flushes the per-rank/per-expert counters.
+      cudaStreamSynchronize(stream);
+      numRecvTokens = *intranode_->getMoeRecvCounterHost();
+      TORCH_CHECK(
+          numRecvTokens >= 0, "notify_dispatch did not publish counter");
+
+      numRecvTokensPerExpertList.resize(numLocalExperts);
+      for (int i = 0; i < numLocalExperts; ++i) {
+        numRecvTokensPerExpertList[i] =
+            intranode_->getMoeRecvExpertCounterHost()[i];
+      }
+    }
+
+    // Allocate fresh recv state — kernel writes recvSrcIdx,
+    // recvChannelPrefixMatrix, and sendHead in non-cached mode.
+    recvSrcIdx = torch::empty(
+        {numRecvTokens},
+        torch::TensorOptions().dtype(torch::kInt32).device(x.device()));
+    recvChannelPrefixMatrix = torch::empty(
+        {numRanks_, numChannels},
+        torch::TensorOptions().dtype(torch::kInt32).device(x.device()));
+    sendHead = torch::empty(
+        {numTokens, numRanks_},
+        torch::TensorOptions().dtype(torch::kInt32).device(x.device()));
+  }
+
+  auto recvX = torch::empty({numRecvTokens, hidden}, x.options());
+  std::optional<torch::Tensor> recvXScales;
+  float* recvXScalesPtr = nullptr;
+  if (xScales.has_value()) {
+    recvXScales = torch::empty({numRecvTokens, numScales}, xScales->options());
+    recvXScalesPtr = static_cast<float*>(recvXScales->data_ptr());
+  }
+
+  std::optional<torch::Tensor> recvTopkIdx;
+  std::optional<torch::Tensor> recvTopkWeights;
+  std::int64_t* recvTopkIdxPtr = nullptr;
+  float* recvTopkWeightsPtr = nullptr;
+  if (topkIdx.has_value()) {
+    recvTopkIdx = torch::empty({numRecvTokens, numTopk}, topkIdx->options());
+    recvTopkWeights =
+        torch::empty({numRecvTokens, numTopk}, topkWeights->options());
+    recvTopkIdxPtr = recvTopkIdx->data_ptr<std::int64_t>();
+    recvTopkWeightsPtr = recvTopkWeights->data_ptr<float>();
+  }
+
+  const int hiddenInt4 =
+      static_cast<int>(hidden * recvX.element_size() / sizeof(int4));
+
+  // num_nvl_bytes must hold the exact per-rank NVL layout the dispatch kernel
+  // writes (Dispatch.cu): R×R rank-prefix + per (channel, rank) 4 ring ints +
+  // recv slots of data/src-idx/topk-idx/topk-weights/scales. Undersize ->
+  // OOB peer-mapped writes, so fail loudly here instead.
+  {
+    const std::size_t cr = static_cast<std::size_t>(numChannels) * numRanks_;
+    const std::size_t recv =
+        static_cast<std::size_t>(config.num_max_nvl_chunked_recv_tokens);
+    const std::size_t requiredNvlBytes =
+        static_cast<std::size_t>(numRanks_) * numRanks_ * sizeof(int) +
+        cr * 4UL * sizeof(int) +
+        cr * recv * static_cast<std::size_t>(hidden) * recvX.element_size() +
+        cr * recv * sizeof(int) +
+        cr * recv * static_cast<std::size_t>(numTopk) * sizeof(std::int64_t) +
+        cr * recv * static_cast<std::size_t>(numTopk) * sizeof(float) +
+        cr * recv * static_cast<std::size_t>(numScales) * sizeof(float);
+    TORCH_CHECK(
+        requiredNvlBytes <= static_cast<std::size_t>(numNvlBytes_),
+        "intranode_dispatch: num_nvl_bytes (",
+        numNvlBytes_,
+        ") is too small for the NVL layout; need >= ",
+        requiredNvlBytes,
+        " bytes. Size the Buffer with "
+        "Config.get_nvl_buffer_size_hint(hidden_bytes, num_ranks).");
+  }
+
+  kernels::intranode_dispatch(
+      recvX.data_ptr(),
+      recvXScalesPtr,
+      recvTopkIdxPtr,
+      recvTopkWeightsPtr,
+      recvSrcIdx.data_ptr<int>(),
+      recvChannelPrefixMatrix.data_ptr<int>(),
+      sendHead.data_ptr<int>(),
+      x.data_ptr(),
+      xScalesPtr,
+      topkIdxPtr,
+      topkWeightsPtr,
+      isTokenInRank->data_ptr<bool>(),
+      channelPrefixMatrix.data_ptr<int>(),
+      numTokens,
+      numWorstTokens,
+      hiddenInt4,
+      numTopk,
+      numExperts,
+      scaleTokenStride,
+      scaleHiddenStride,
+      intranode_->getPeerDataPtrsDevice(),
+      rank_,
+      numRanks_,
+      stream,
+      config.num_sms,
+      config.num_max_nvl_chunked_send_tokens,
+      config.num_max_nvl_chunked_recv_tokens);
+
+  // The Python wrapper expects:
+  //   (recv_x, recv_x_scales, recv_topk_idx, recv_topk_weights,
+  //    num_recv_tokens_per_expert_list, handle, event)
+  // where `handle` is opaque (we use a dict containing the cached buffers).
+  // For FP8 (tuple input), recv_x is returned as a (data, scales) tuple;
+  // we wrap recv_x + recv_x_scales into a tuple here.
+  py::dict handle;
+  handle["rank_prefix_matrix"] = rankPrefixMatrix;
+  handle["channel_prefix_matrix"] = channelPrefixMatrix;
+  handle["recv_channel_prefix_matrix"] = recvChannelPrefixMatrix;
+  handle["recv_src_idx"] = recvSrcIdx;
+  handle["send_head"] = sendHead;
+  handle["num_recv_tokens"] = numRecvTokens;
+
+  py::object recvXObj;
+  if (isFp8) {
+    recvXObj = py::make_tuple(recvX, *recvXScales);
+  } else {
+    recvXObj = py::cast(recvX);
+  }
+
+  std::optional<EventHandle> event;
+  if (asyncFinish) {
+    event = EventHandle();
+  }
+
+  return py::make_tuple(
+      recvXObj,
+      recvXScales.has_value() ? py::cast(*recvXScales) : py::none(),
+      recvTopkIdx.has_value() ? py::cast(*recvTopkIdx) : py::none(),
+      recvTopkWeights.has_value() ? py::cast(*recvTopkWeights) : py::none(),
+      numRecvTokensPerExpertList,
+      handle,
+      event.has_value() ? py::cast(*event) : py::none());
+}
+
+std::tuple<
+    torch::Tensor,
+    std::optional<torch::Tensor>,
+    std::optional<EventHandle>>
+Buffer::intranode_combine(
+    const torch::Tensor& x,
+    const std::optional<torch::Tensor>& topkWeights,
+    const std::optional<torch::Tensor>& bias0,
+    const std::optional<torch::Tensor>& bias1,
+    const py::object& handle,
+    const Config& config,
+    const std::optional<EventHandle>& /*previousEvent*/,
+    bool asyncFinish,
+    bool /*allocateOnCommStream*/) {
+  if (!available_) {
+    throw std::runtime_error("Buffer::intranode_combine: not synced yet");
+  }
+  TORCH_CHECK(
+      x.dim() == 2 && x.is_contiguous() && x.scalar_type() == torch::kBFloat16,
+      "Phase 1 combine requires bf16 contiguous 2D x");
+  TORCH_CHECK(config.num_sms % 2 == 0, "config.num_sms must be even");
+
+  if (!py::isinstance<py::dict>(handle)) {
+    throw std::runtime_error(
+        "Buffer::intranode_combine: handle must be the dict returned by "
+        "intranode_dispatch");
+  }
+  auto handleDict = handle.cast<py::dict>();
+  auto rankPrefixMatrix =
+      handleDict["rank_prefix_matrix"].cast<torch::Tensor>();
+  auto channelPrefixMatrix =
+      handleDict["channel_prefix_matrix"].cast<torch::Tensor>();
+  auto recvSrcIdx = handleDict["recv_src_idx"].cast<torch::Tensor>();
+  auto sendHead = handleDict["send_head"].cast<torch::Tensor>();
+
+  const int numTokens = static_cast<int>(x.size(0));
+  const int hidden = static_cast<int>(x.size(1));
+  const int numRecvTokens = static_cast<int>(sendHead.size(0));
+
+  int numTopk = 0;
+  float* topkWeightsPtr = nullptr;
+  std::optional<torch::Tensor> recvTopkWeights;
+  if (topkWeights.has_value()) {
+    TORCH_CHECK(
+        topkWeights->dim() == 2 && topkWeights->is_contiguous() &&
+            topkWeights->scalar_type() == torch::kFloat32,
+        "topk_weights must be 2D float32 contiguous");
+    numTopk = static_cast<int>(topkWeights->size(1));
+    topkWeightsPtr = topkWeights->data_ptr<float>();
+    recvTopkWeights =
+        torch::empty({numRecvTokens, numTopk}, topkWeights->options());
+  }
+
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  auto recvX = torch::empty({numRecvTokens, hidden}, x.options());
+
+  // cached_notify_combine zeroes the per-channel buffers and fills in
+  // placeholder `send_head` entries (`-last_head - 1`) for tokens this
+  // rank didn't route to a given destination — so the combine kernel
+  // can identify which buffer slots actually contain data.
+  const int numChannels = config.num_sms / 2;
+  // memset region: 2 * num_channels * num_ranks for head/tail per
+  // (channel, rank).
+  const int numMemsetInt = 2 * numChannels * numRanks_;
+  kernels::cached_notify_combine(
+      intranode_->getPeerDataPtrsDevice(),
+      sendHead.data_ptr<int>(),
+      numChannels,
+      numRecvTokens,
+      numMemsetInt,
+      intranode_->getBarrierSignalPtrsDevice(),
+      rank_,
+      numRanks_,
+      stream,
+      intranode_->head());
+  intranode_->moveFifoSlots(2);
+
+  // num_nvl_bytes must hold the combine NVL layout (Combine.cu): per (channel,
+  // rank) head+tail ints + recv slots of data/src-idx/topk-weights. A subset
+  // of the dispatch layout; same fail-loud guard as dispatch.
+  {
+    const std::size_t cr = static_cast<std::size_t>(numChannels) * numRanks_;
+    const std::size_t recv =
+        static_cast<std::size_t>(config.num_max_nvl_chunked_recv_tokens);
+    const std::size_t requiredNvlBytes = cr * 2UL * sizeof(int) +
+        cr * recv * static_cast<std::size_t>(hidden) * recvX.element_size() +
+        cr * recv * sizeof(int) +
+        cr * recv * static_cast<std::size_t>(numTopk) * sizeof(float);
+    TORCH_CHECK(
+        requiredNvlBytes <= static_cast<std::size_t>(numNvlBytes_),
+        "intranode_combine: num_nvl_bytes (",
+        numNvlBytes_,
+        ") is too small for the NVL layout; need >= ",
+        requiredNvlBytes,
+        " bytes. Size the Buffer with "
+        "Config.get_nvl_buffer_size_hint(hidden_bytes, num_ranks).");
+  }
+
+  kernels::intranode_combine(
+      recvX.data_ptr(),
+      recvTopkWeights.has_value() ? recvTopkWeights->data_ptr<float>()
+                                  : nullptr,
+      x.data_ptr(),
+      topkWeightsPtr,
+      bias0.has_value() ? bias0->data_ptr() : nullptr,
+      bias1.has_value() ? bias1->data_ptr() : nullptr,
+      recvSrcIdx.data_ptr<int>(),
+      rankPrefixMatrix.data_ptr<int>(),
+      channelPrefixMatrix.data_ptr<int>(),
+      sendHead.data_ptr<int>(),
+      numTokens,
+      numRecvTokens,
+      hidden,
+      numTopk,
+      intranode_->getPeerDataPtrsDevice(),
+      rank_,
+      numRanks_,
+      stream,
+      config.num_sms,
+      config.num_max_nvl_chunked_send_tokens,
+      config.num_max_nvl_chunked_recv_tokens);
+
+  std::optional<EventHandle> event;
+  if (asyncFinish) {
+    event = EventHandle();
+  }
+  return std::make_tuple(recvX, recvTopkWeights, event);
+}
+
+void Buffer::notImplemented(const char* methodName) const {
+  throw std::runtime_error(
+      std::string("Buffer::") + methodName +
+      " is not yet implemented in this commit (D3 work-in-progress)");
+}
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/Buffer.h
+++ b/comms/prims/collectives/moe_ep/cpp/Buffer.h
@@ -1,0 +1,190 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+#include <torch/types.h>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/EventHandle.h"
+
+namespace comms::prims::moe_ep {
+
+class IntranodeRuntime;
+
+/**
+ * Buffer — pybind-facing C++ class backing
+ * `comms.prims.collectives.moe_ep.moe_ep.Buffer`.
+ *
+ * Phase 1 (D3): intranode dispatch / combine over NVLink. Phase 2 (D4)
+ * adds low_latency_*; Phase 3 (D5) adds internode_*.
+ *
+ * The Python `Buffer.__init__` constructs this with cosmetic args, then
+ * gathers `device_ids` + `ipc_handles` Python-side and feeds them back
+ * via `sync()`. The IPC handles are cosmetic on our backend — the
+ * underlying `GpuMemHandler` (mode `kCudaIpcUncached`) does its own
+ * IBootstrap-driven exchange in the runtime ctor.
+ */
+class Buffer {
+ public:
+  Buffer(
+      int rank,
+      int numRanks,
+      std::int64_t numNvlBytes,
+      std::int64_t numRdmaBytes,
+      bool lowLatencyMode,
+      bool explicitlyDestroy,
+      bool enableShrink,
+      bool useFabric);
+
+  ~Buffer();
+
+  Buffer(const Buffer&) = delete;
+  Buffer& operator=(const Buffer&) = delete;
+  Buffer(Buffer&&) = delete;
+  Buffer& operator=(Buffer&&) = delete;
+
+  // ---- Topology accessors ----
+  bool is_available() const noexcept {
+    return available_;
+  }
+  int get_num_rdma_ranks() const noexcept;
+  int get_rdma_rank() const noexcept;
+  int get_root_rdma_rank(bool global) const noexcept;
+  int get_local_device_id() const noexcept {
+    return deviceId_;
+  }
+
+  // ---- IPC / NVSHMEM bootstrap ----
+  pybind11::bytearray get_local_ipc_handle() const;
+  pybind11::bytearray get_local_nvshmem_unique_id() const;
+  /**
+   * Finalize bootstrap. Python supplies the gathered `device_ids` +
+   * `ipc_handles` from `dist.all_gather_object` calls, plus an optional
+   * `root_unique_id` for RDMA. On our backend the IPC exchange is owned by
+   * `GpuMemHandler` (kCudaIpcUncached) inside the runtime ctor, so the
+   * `ipc_handles` arg is cosmetic.
+   */
+  void sync(
+      const std::vector<int>& deviceIds,
+      const std::vector<std::optional<pybind11::bytearray>>& ipcHandles,
+      const std::optional<pybind11::bytearray>& rootUniqueId);
+
+  void destroy();
+
+  // ---- Layout ----
+  /**
+   * `get_dispatch_layout` — pure-compute kernel returning per-rank /
+   * per-expert / per-RDMA-rank token counts. See cpp/kernels/Layout.cu.
+   *
+   * Returns: (num_tokens_per_rank, num_tokens_per_rdma_rank,
+   *           num_tokens_per_expert, is_token_in_rank, event)
+   */
+  std::tuple<
+      torch::Tensor,
+      std::optional<torch::Tensor>,
+      torch::Tensor,
+      torch::Tensor,
+      std::optional<EventHandle>>
+  get_dispatch_layout(
+      const torch::Tensor& topkIdx,
+      int numExperts,
+      const std::optional<EventHandle>& previousEvent,
+      bool asyncFinish,
+      bool allocateOnCommStream);
+
+  // ---- Intranode dispatch / combine (Phase 1) ----
+  /**
+   * Returns a 6-tuple:
+   *   (recv_x, recv_topk_idx, recv_topk_weights,
+   * recv_num_tokens_per_expert_list, handle, event)
+   */
+  pybind11::tuple intranode_dispatch(
+      const pybind11::object& x, // Tensor or (Tensor, Tensor) for FP8
+      const pybind11::object& handle,
+      const std::optional<torch::Tensor>& numTokensPerRank,
+      const std::optional<torch::Tensor>& isTokenInRank,
+      const std::optional<torch::Tensor>& numTokensPerExpert,
+      const std::optional<torch::Tensor>& topkIdx,
+      const std::optional<torch::Tensor>& topkWeights,
+      int expertAlignment,
+      int numWorstTokens,
+      const Config& config,
+      const std::optional<EventHandle>& previousEvent,
+      bool asyncFinish,
+      bool allocateOnCommStream);
+
+  /**
+   * Returns (combined_x, combined_topk_weights, event).
+   */
+  std::tuple<
+      torch::Tensor,
+      std::optional<torch::Tensor>,
+      std::optional<EventHandle>>
+  intranode_combine(
+      const torch::Tensor& x,
+      const std::optional<torch::Tensor>& topkWeights,
+      const std::optional<torch::Tensor>& bias0,
+      const std::optional<torch::Tensor>& bias1,
+      const pybind11::object& handle,
+      const Config& config,
+      const std::optional<EventHandle>& previousEvent,
+      bool asyncFinish,
+      bool allocateOnCommStream);
+
+  // ---- Internode (Phase 3 — D5) + Low-latency (Phase 2 — D4) ----
+  // These are bound through the same pybind module (so the Python `Buffer`
+  // class's full method surface stays addressable), but throw at runtime
+  // until the matching kernels land. Concrete signatures + bindings live
+  // in PyBindings.cpp.
+  [[noreturn]] void notImplemented(const char* methodName) const;
+
+ private:
+  std::shared_ptr<meta::comms::IBootstrap> bootstrap_;
+  const int rank_;
+  const int numRanks_;
+  const std::int64_t numNvlBytes_;
+  const std::int64_t numRdmaBytes_;
+  const bool lowLatencyMode_;
+  const bool explicitlyDestroy_;
+  const bool enableShrink_;
+  const bool useFabric_;
+
+  int deviceId_{-1};
+  bool available_{false};
+  bool destroyed_{false};
+
+  // Local NVL data buffer + IPC handle. Allocated in the Buffer ctor (not
+  // sync) so that `get_local_ipc_handle()` returns a real handle BEFORE
+  // the Python `dist.all_gather_object(local_ipc_handle)` happens. Without
+  // this, the gathered handles are all zeros and `cudaIpcOpenMemHandle`
+  // fails at sync time.
+  void* localIpcBuffer_{nullptr};
+  mutable cudaIpcMemHandle_t localIpcHandle_{};
+  mutable bool localIpcHandleReady_{false};
+
+  // Peer-mapped device pointers opened by `cudaIpcOpenMemHandle` in `sync()`
+  // from the IPC handles Python gathered via `dist.all_gather_object`. Entry
+  // `rank_` is `localIpcBuffer_`; entry `i != rank_` is the local-process
+  // pointer to peer `i`'s NVL data buffer. Closed in the destructor.
+  std::vector<void*> peerIpcBuffers_;
+
+  // Owned only after `sync()` for Phase 1 (intranode-only).
+  std::unique_ptr<IntranodeRuntime> intranode_;
+  // LowLatencyRuntime / InternodeRuntime land in D4 / D5.
+};
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/PyBindings.cc
+++ b/comms/prims/collectives/moe_ep/cpp/PyBindings.cc
@@ -1,0 +1,182 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/csrc/utils/pybind.h>
+
+#include "comms/prims/collectives/moe_ep/cpp/Buffer.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/EventHandle.h"
+
+namespace py = pybind11;
+using namespace comms::prims::moe_ep;
+
+PYBIND11_MODULE(_cpp, m) {
+  m.doc() = "Python bindings for comms.prims.collectives.moe_ep MoE EP runtime";
+
+  // ---------------------------------------------------------------------------
+  // Module-level constants.
+  // ---------------------------------------------------------------------------
+  m.attr("NUM_WORKSPACE_BYTES") = py::int_(NUM_WORKSPACE_BYTES);
+  m.attr("NUM_MAX_NVL_PEERS") = py::int_(NUM_MAX_NVL_PEERS);
+  m.attr("NUM_BUFFER_ALIGNMENT_BYTES") = py::int_(NUM_BUFFER_ALIGNMENT_BYTES);
+  // topk_idx_t == int64 — Python side uses this to assert dtype.
+  m.attr("topk_idx_t") = py::module_::import("torch").attr("int64");
+
+  // Module attrs / free fns expected by the test files.
+  // - `AITER_MOE`: hardcoded `False` per design plan §2.4 (line 166).
+  // - `is_sm90_compiled()`: returns False on AMD (matches USE_ROCM
+  //   behavior); on NVIDIA we conservatively return False until a
+  //   proper compute-cap probe lands.
+  m.attr("AITER_MOE") = py::bool_(false);
+  m.def("is_sm90_compiled", []() { return false; });
+
+  // Low-latency RDMA buffer size estimator. Phase 2 (D4) lands the LL
+  // kernels; this helper is bound now because the Python `Buffer` ctor
+  // calls it during construction even when low_latency_mode=False (paths
+  // that compute hint sizes for diagnostic output).
+  //
+  // Per-rank send + recv buffers sized by max-dispatch tokens × hidden bytes ×
+  // num_experts / num_ranks × 2 (send + recv) + signal slots.
+  m.def(
+      "get_low_latency_rdma_size_hint",
+      [](int num_max_dispatch_tokens_per_rank,
+         int hidden,
+         int num_ranks,
+         int num_experts) {
+        constexpr int kBytesPerToken = 2; // bf16
+        const int num_local_experts = num_experts / num_ranks;
+        const std::size_t per_token_bytes =
+            static_cast<std::size_t>(hidden) * kBytesPerToken;
+        // 2× for send + recv, num_ranks peers, num_local_experts slots.
+        const std::size_t data =
+            static_cast<std::size_t>(num_max_dispatch_tokens_per_rank) *
+            per_token_bytes * num_ranks * num_local_experts * 2UL;
+        // Plus a small per-(peer × local_expert) signal/state region.
+        const std::size_t signal =
+            static_cast<std::size_t>(num_ranks) * num_local_experts * 64UL;
+        return data + signal + (32UL * 1024UL * 1024UL);
+      },
+      py::arg("num_max_dispatch_tokens_per_rank"),
+      py::arg("hidden"),
+      py::arg("num_ranks"),
+      py::arg("num_experts"));
+
+  // ---------------------------------------------------------------------------
+  // Config — POD with five tunables.
+  // ---------------------------------------------------------------------------
+  py::class_<Config>(m, "Config")
+      .def(
+          py::init<int, int, int, int, int>(),
+          py::arg("num_sms"),
+          py::arg("num_max_nvl_chunked_send_tokens"),
+          py::arg("num_max_nvl_chunked_recv_tokens"),
+          py::arg("num_max_rdma_chunked_send_tokens") = 6,
+          py::arg("num_max_rdma_chunked_recv_tokens") = 128)
+      .def_readwrite("num_sms", &Config::num_sms)
+      .def_readwrite(
+          "num_max_nvl_chunked_send_tokens",
+          &Config::num_max_nvl_chunked_send_tokens)
+      .def_readwrite(
+          "num_max_nvl_chunked_recv_tokens",
+          &Config::num_max_nvl_chunked_recv_tokens)
+      .def_readwrite(
+          "num_max_rdma_chunked_send_tokens",
+          &Config::num_max_rdma_chunked_send_tokens)
+      .def_readwrite(
+          "num_max_rdma_chunked_recv_tokens",
+          &Config::num_max_rdma_chunked_recv_tokens)
+      .def(
+          "get_nvl_buffer_size_hint",
+          &Config::getNvlBufferSizeHint,
+          py::arg("hidden_bytes"),
+          py::arg("num_ranks"))
+      .def("get_rdma_buffer_size_hint", &Config::getRdmaBufferSizeHint);
+
+  // ---------------------------------------------------------------------------
+  // EventHandle — RAII shared_ptr cudaEvent_t, exposes current_stream_wait()
+  // for the Python `EventOverlap` wrapper.
+  // ---------------------------------------------------------------------------
+  py::class_<EventHandle>(m, "EventHandle")
+      .def(py::init<>())
+      .def("current_stream_wait", &EventHandle::current_stream_wait);
+
+  // ---------------------------------------------------------------------------
+  // Buffer — pybind-facing class. Constructor + topology + IPC bootstrap +
+  // layout/dispatch/combine. Phase 2/3 entry points are bound below but
+  // throw `notImplemented` until D4 / D5 wire in their kernels.
+  // ---------------------------------------------------------------------------
+  py::class_<Buffer>(m, "Buffer")
+      .def(
+          py::init<
+              int,
+              int,
+              std::int64_t,
+              std::int64_t,
+              bool,
+              bool,
+              bool,
+              bool>(),
+          py::arg("rank"),
+          py::arg("num_ranks"),
+          py::arg("num_nvl_bytes"),
+          py::arg("num_rdma_bytes"),
+          py::arg("low_latency_mode") = false,
+          py::arg("explicitly_destroy") = false,
+          py::arg("enable_shrink") = false,
+          py::arg("use_fabric") = false)
+      // ---- Topology ----
+      .def("is_available", &Buffer::is_available)
+      .def("get_num_rdma_ranks", &Buffer::get_num_rdma_ranks)
+      .def("get_rdma_rank", &Buffer::get_rdma_rank)
+      .def("get_root_rdma_rank", &Buffer::get_root_rdma_rank)
+      .def("get_local_device_id", &Buffer::get_local_device_id)
+      // ---- IPC / NVSHMEM bootstrap ----
+      .def("get_local_ipc_handle", &Buffer::get_local_ipc_handle)
+      .def("get_local_nvshmem_unique_id", &Buffer::get_local_nvshmem_unique_id)
+      .def(
+          "sync",
+          &Buffer::sync,
+          py::arg("device_ids"),
+          py::arg("ipc_handles"),
+          py::arg("root_unique_id"))
+      .def("destroy", &Buffer::destroy)
+      // ---- Layout ----
+      .def(
+          "get_dispatch_layout",
+          &Buffer::get_dispatch_layout,
+          py::arg("topk_idx"),
+          py::arg("num_experts"),
+          py::arg("previous_event") = std::nullopt,
+          py::arg("async_finish") = false,
+          py::arg("allocate_on_comm_stream") = false)
+      // ---- Phase 1 (intranode dispatch / combine) ----
+      .def(
+          "intranode_dispatch",
+          &Buffer::intranode_dispatch,
+          py::arg("x"),
+          py::arg("handle"),
+          py::arg("num_tokens_per_rank") = std::nullopt,
+          py::arg("is_token_in_rank") = std::nullopt,
+          py::arg("num_tokens_per_expert") = std::nullopt,
+          py::arg("topk_idx") = std::nullopt,
+          py::arg("topk_weights") = std::nullopt,
+          py::arg("expert_alignment") = 1,
+          py::arg("num_worst_tokens") = 0,
+          py::arg("config"),
+          py::arg("previous_event") = std::nullopt,
+          py::arg("async_finish") = false,
+          py::arg("allocate_on_comm_stream") = false)
+      .def(
+          "intranode_combine",
+          &Buffer::intranode_combine,
+          py::arg("x"),
+          py::arg("topk_weights") = std::nullopt,
+          py::arg("bias_0") = std::nullopt,
+          py::arg("bias_1") = std::nullopt,
+          py::arg("handle"),
+          py::arg("config"),
+          py::arg("previous_event") = std::nullopt,
+          py::arg("async_finish") = false,
+          py::arg("allocate_on_comm_stream") = false);
+}

--- a/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.cc
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.cc
@@ -1,0 +1,374 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/intranode/Runtime.h"
+
+#include <stdexcept>
+#include <string>
+
+// Heavy includes that the public IntranodeRuntime.h forward-declares.
+// Must come before any use of GpuMemHandler / MultiPeerNvlTransport types.
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h"
+#else
+#include "comms/utils/CudaRAII.h"
+#endif
+
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+#include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
+
+namespace comms::prims::moe_ep {
+
+namespace {
+
+void checkCuda(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+} // namespace
+
+IntranodeRuntime::IntranodeRuntime(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int rank,
+    int numRanks,
+    std::size_t numNvlBytes)
+    : rank_(rank), numRanks_(numRanks), numNvlBytes_(numNvlBytes) {
+  if (numRanks_ <= 0 || numRanks_ > NUM_MAX_NVL_PEERS) {
+    throw std::invalid_argument(
+        "IntranodeRuntime: numRanks must be in (0, NUM_MAX_NVL_PEERS]");
+  }
+  if (rank_ < 0 || rank_ >= numRanks_) {
+    throw std::invalid_argument("IntranodeRuntime: rank out of bounds");
+  }
+
+  // 1. NVL data buffer via GpuMemHandler (kCudaIpcUncached for BNXT
+  //    dma-buf compatibility — see N1 in the design plan).
+  memHandler_ = std::make_unique<comms::prims::GpuMemHandler>(
+      bootstrap,
+      rank_,
+      numRanks_,
+      numNvlBytes_,
+      comms::prims::MemSharingMode::kCudaIpcUncached);
+  memHandler_->exchangeMemPtrs();
+
+  // 2. Pipes NVL transport — per-peer P2P state, signal slots, barrier
+  //    slots. The actual `dataBufferSize` here is for the transport's own
+  //    state buffers (chunked-send pipelining) — not the dispatch/combine
+  //    data block (which lives in `memHandler_`).
+  comms::prims::MultiPeerNvlTransportConfig nvlConfig{
+      .dataBufferSize = 1024UL * 1024UL, // 1 MiB transport state
+      .chunkSize = 1024,
+      .pipelineDepth = 4,
+      // numSignalSlots is dimensioned by callers; for Phase 1 dispatch +
+      // combine we need ~num_channels*num_peers*2 slots. With num_sms=64,
+      // num_channels=32 and 7 peers → ~448 slots. Bump to 1024 to avoid
+      // re-tuning per config.
+      .p2pSignalCount = 1024,
+      .p2pBarrierCount = 64,
+  };
+  transport_ = std::make_unique<comms::prims::MultiPeerNvlTransport>(
+      rank_, numRanks_, bootstrap, nvlConfig);
+  transport_->exchange();
+
+  // 3. Persistent workspace.
+  checkCuda(
+      cudaMalloc(&workspace_, NUM_WORKSPACE_BYTES),
+      "IntranodeRuntime: cudaMalloc(workspace) failed");
+  checkCuda(
+      cudaMemset(workspace_, 0, NUM_WORKSPACE_BYTES),
+      "IntranodeRuntime: cudaMemset(workspace) failed");
+
+  // 4. Per-runtime atomic counters (4 bytes each; only AMD strictly needs
+  //    them, but we always allocate so the kernel signatures don't need
+  //    AMD/NVIDIA gating).
+  checkCuda(
+      cudaMalloc(&dispatchGlobalAtomicCounter_, sizeof(int)),
+      "IntranodeRuntime: cudaMalloc(dispatchGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMemset(dispatchGlobalAtomicCounter_, 0, sizeof(int)),
+      "IntranodeRuntime: cudaMemset(dispatchGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMalloc(&combineGlobalAtomicCounter_, sizeof(int)),
+      "IntranodeRuntime: cudaMalloc(combineGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMemset(combineGlobalAtomicCounter_, 0, sizeof(int)),
+      "IntranodeRuntime: cudaMemset(combineGlobalAtomicCounter) failed");
+
+  // 5. Communication stream.
+  checkCuda(
+      cudaStreamCreate(&commStream_),
+      "IntranodeRuntime: cudaStreamCreate(comm) failed");
+
+  // 6. Peer-mapped pointer table. Fill the
+  //    host-side staging vector with each peer's NVL data buffer pointer
+  //    (self entry == local) and copy to the device-resident pointer array
+  //    that kernels consume.
+  std::vector<void*> peerPtrsHost(numRanks_, nullptr);
+  for (int i = 0; i < numRanks_; ++i) {
+    peerPtrsHost[i] = (i == rank_) ? memHandler_->getLocalDeviceMemPtr()
+                                   : memHandler_->getPeerDeviceMemPtr(i);
+  }
+  checkCuda(
+      cudaMalloc(&peerDataPtrsDevice_, numRanks_ * sizeof(void*)),
+      "IntranodeRuntime: cudaMalloc(peerDataPtrsDevice) failed");
+  checkCuda(
+      cudaMemcpy(
+          peerDataPtrsDevice_,
+          peerPtrsHost.data(),
+          numRanks_ * sizeof(void*),
+          cudaMemcpyHostToDevice),
+      "IntranodeRuntime: cudaMemcpy(peerDataPtrsDevice) failed");
+
+  // 7. Barrier-signal pointer table — carved out of the workspace so each
+  //    rank's int* slot lives in the peer-mapped IPC region. With `numRanks`
+  //    barrier slots × `NUM_MAX_FIFO_SLOTS` rotating positions, each
+  //    barrier costs `numRanks * sizeof(int)` of workspace.
+  //
+  //    On a single-rank smoke setup peer pointers point back at us, so the
+  //    star-pattern barrier degenerates to a same-buffer ping (still
+  //    correct; just no cross-rank semantics).
+  std::vector<int*> barrierPtrsHost(numRanks_, nullptr);
+  for (int i = 0; i < numRanks_; ++i) {
+    // First slice of each peer's data buffer (offset 0) is reserved for the
+    // FIFO barrier slots. The dispatch / combine kernels
+    // start their own region after `kNumRanks * kNumRanks * sizeof(int)`,
+    // so reusing the same region is a TODO for production multi-rank: in
+    // Phase 1 we colocate barrier slots with the rank prefix matrix because
+    // notify_dispatch zeros them via the memset stride (num_memset_int).
+    barrierPtrsHost[i] = reinterpret_cast<int*>(peerPtrsHost[i]);
+  }
+  checkCuda(
+      cudaMalloc(&barrierSignalPtrsDevice_, numRanks_ * sizeof(int*)),
+      "IntranodeRuntime: cudaMalloc(barrierSignalPtrsDevice) failed");
+  checkCuda(
+      cudaMemcpy(
+          barrierSignalPtrsDevice_,
+          barrierPtrsHost.data(),
+          numRanks_ * sizeof(int*),
+          cudaMemcpyHostToDevice),
+      "IntranodeRuntime: cudaMemcpy(barrierSignalPtrsDevice) failed");
+
+  // 8. Host-pinned MoE recv counters. notify_dispatch's block 0 writes the
+  //    aggregated count back into `*moe_recv_counter_mapped`; the host loop
+  //    in Buffer::intranode_dispatch polls `moeRecvCounterHost_`.
+  void* hostPtr = nullptr;
+  void* devicePtr = nullptr;
+  checkCuda(
+      cudaHostAlloc(&hostPtr, sizeof(int), cudaHostAllocMapped),
+      "IntranodeRuntime: cudaHostAlloc(moeRecvCounter) failed");
+  moeRecvCounterHost_ = static_cast<int*>(hostPtr);
+  checkCuda(
+      cudaHostGetDevicePointer(&devicePtr, hostPtr, 0),
+      "IntranodeRuntime: cudaHostGetDevicePointer(moeRecvCounter) failed");
+  moeRecvCounterDevice_ = static_cast<int*>(devicePtr);
+  *moeRecvCounterHost_ = -1;
+
+  const std::size_t expertCounterBytes =
+      kernels::NUM_MAX_LOCAL_EXPERTS * sizeof(int);
+  hostPtr = nullptr;
+  devicePtr = nullptr;
+  checkCuda(
+      cudaHostAlloc(&hostPtr, expertCounterBytes, cudaHostAllocMapped),
+      "IntranodeRuntime: cudaHostAlloc(moeRecvExpertCounter) failed");
+  moeRecvExpertCounterHost_ = static_cast<int*>(hostPtr);
+  checkCuda(
+      cudaHostGetDevicePointer(&devicePtr, hostPtr, 0),
+      "IntranodeRuntime: cudaHostGetDevicePointer(moeRecvExpertCounter) failed");
+  moeRecvExpertCounterDevice_ = static_cast<int*>(devicePtr);
+}
+
+IntranodeRuntime::IntranodeRuntime(
+    int rank,
+    int numRanks,
+    std::size_t numNvlBytes,
+    void* localBuffer,
+    const cudaIpcMemHandle_t& /*localHandle*/,
+    std::vector<void*> peerDataPtrs)
+    : rank_(rank), numRanks_(numRanks), numNvlBytes_(numNvlBytes) {
+  if (numRanks_ <= 0 || numRanks_ > NUM_MAX_NVL_PEERS) {
+    throw std::invalid_argument(
+        "IntranodeRuntime: numRanks must be in (0, NUM_MAX_NVL_PEERS]");
+  }
+  if (rank_ < 0 || rank_ >= numRanks_) {
+    throw std::invalid_argument("IntranodeRuntime: rank out of bounds");
+  }
+  if (static_cast<int>(peerDataPtrs.size()) != numRanks_) {
+    throw std::invalid_argument(
+        "IntranodeRuntime: peerDataPtrs size must equal numRanks");
+  }
+  if (localBuffer == nullptr) {
+    throw std::invalid_argument("IntranodeRuntime: localBuffer is null");
+  }
+  if (peerDataPtrs[rank_] != localBuffer) {
+    throw std::invalid_argument(
+        "IntranodeRuntime: peerDataPtrs[rank] must equal localBuffer");
+  }
+
+  // Skip steps 1 + 2: memHandler_ and transport_ stay nullptr. Caller already
+  // allocated the local NVL buffer and exchanged peer pointers Python-side.
+  localBufferPtr_ = localBuffer;
+  peerDataPtrsHost_ = peerDataPtrs;
+
+  // 3. Persistent workspace.
+  checkCuda(
+      cudaMalloc(&workspace_, NUM_WORKSPACE_BYTES),
+      "IntranodeRuntime: cudaMalloc(workspace) failed");
+  checkCuda(
+      cudaMemset(workspace_, 0, NUM_WORKSPACE_BYTES),
+      "IntranodeRuntime: cudaMemset(workspace) failed");
+
+  // 4. Per-runtime atomic counters.
+  checkCuda(
+      cudaMalloc(&dispatchGlobalAtomicCounter_, sizeof(int)),
+      "IntranodeRuntime: cudaMalloc(dispatchGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMemset(dispatchGlobalAtomicCounter_, 0, sizeof(int)),
+      "IntranodeRuntime: cudaMemset(dispatchGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMalloc(&combineGlobalAtomicCounter_, sizeof(int)),
+      "IntranodeRuntime: cudaMalloc(combineGlobalAtomicCounter) failed");
+  checkCuda(
+      cudaMemset(combineGlobalAtomicCounter_, 0, sizeof(int)),
+      "IntranodeRuntime: cudaMemset(combineGlobalAtomicCounter) failed");
+
+  // 5. Communication stream.
+  checkCuda(
+      cudaStreamCreate(&commStream_),
+      "IntranodeRuntime: cudaStreamCreate(comm) failed");
+
+  // 6. Peer-mapped pointer table — copy caller-supplied peerDataPtrs
+  //    (entry rank == localBuffer; others are cudaIpcOpenMemHandle results)
+  //    to the device-resident pointer array that kernels consume.
+  checkCuda(
+      cudaMalloc(&peerDataPtrsDevice_, numRanks_ * sizeof(void*)),
+      "IntranodeRuntime: cudaMalloc(peerDataPtrsDevice) failed");
+  checkCuda(
+      cudaMemcpy(
+          peerDataPtrsDevice_,
+          peerDataPtrsHost_.data(),
+          numRanks_ * sizeof(void*),
+          cudaMemcpyHostToDevice),
+      "IntranodeRuntime: cudaMemcpy(peerDataPtrsDevice) failed");
+
+  // 7. Barrier-signal pointer table — barrier slots live in a DEDICATED
+  //    region AFTER `numNvlBytes_` of each peer's data buffer. Putting them
+  //    at offset 0 collides with notify_dispatch's per-rank/per-expert
+  //    prefix matrix writes — the barrier_device spin-wait then never sees
+  //    the completion signal and the kernel hangs until GPU watchdog fires.
+  //
+  //    The Buffer ctor pre-allocates `numNvlBytes_ + NUM_MAX_FIFO_SLOTS *
+  //    sizeof(int)` for each peer's IPC region so this offset is valid.
+  std::vector<int*> barrierPtrsHost(numRanks_, nullptr);
+  for (int i = 0; i < numRanks_; ++i) {
+    barrierPtrsHost[i] = reinterpret_cast<int*>(
+        reinterpret_cast<std::uint8_t*>(peerDataPtrsHost_[i]) + numNvlBytes_);
+  }
+  checkCuda(
+      cudaMalloc(&barrierSignalPtrsDevice_, numRanks_ * sizeof(int*)),
+      "IntranodeRuntime: cudaMalloc(barrierSignalPtrsDevice) failed");
+  checkCuda(
+      cudaMemcpy(
+          barrierSignalPtrsDevice_,
+          barrierPtrsHost.data(),
+          numRanks_ * sizeof(int*),
+          cudaMemcpyHostToDevice),
+      "IntranodeRuntime: cudaMemcpy(barrierSignalPtrsDevice) failed");
+
+  // 8. Host-pinned MoE recv counters.
+  void* hostPtr = nullptr;
+  void* devicePtr = nullptr;
+  checkCuda(
+      cudaHostAlloc(&hostPtr, sizeof(int), cudaHostAllocMapped),
+      "IntranodeRuntime: cudaHostAlloc(moeRecvCounter) failed");
+  moeRecvCounterHost_ = static_cast<int*>(hostPtr);
+  checkCuda(
+      cudaHostGetDevicePointer(&devicePtr, hostPtr, 0),
+      "IntranodeRuntime: cudaHostGetDevicePointer(moeRecvCounter) failed");
+  moeRecvCounterDevice_ = static_cast<int*>(devicePtr);
+  *moeRecvCounterHost_ = -1;
+
+  const std::size_t expertCounterBytes =
+      kernels::NUM_MAX_LOCAL_EXPERTS * sizeof(int);
+  hostPtr = nullptr;
+  devicePtr = nullptr;
+  checkCuda(
+      cudaHostAlloc(&hostPtr, expertCounterBytes, cudaHostAllocMapped),
+      "IntranodeRuntime: cudaHostAlloc(moeRecvExpertCounter) failed");
+  moeRecvExpertCounterHost_ = static_cast<int*>(hostPtr);
+  checkCuda(
+      cudaHostGetDevicePointer(&devicePtr, hostPtr, 0),
+      "IntranodeRuntime: cudaHostGetDevicePointer(moeRecvExpertCounter) failed");
+  moeRecvExpertCounterDevice_ = static_cast<int*>(devicePtr);
+}
+
+IntranodeRuntime::~IntranodeRuntime() {
+  if (moeRecvExpertCounterHost_ != nullptr) {
+    (void)cudaFreeHost(moeRecvExpertCounterHost_);
+  }
+  if (moeRecvCounterHost_ != nullptr) {
+    (void)cudaFreeHost(moeRecvCounterHost_);
+  }
+  if (barrierSignalPtrsDevice_ != nullptr) {
+    (void)cudaFree(barrierSignalPtrsDevice_);
+  }
+  if (peerDataPtrsDevice_ != nullptr) {
+    (void)cudaFree(peerDataPtrsDevice_);
+  }
+  if (commStream_ != nullptr) {
+    (void)cudaStreamDestroy(commStream_);
+  }
+  if (combineGlobalAtomicCounter_ != nullptr) {
+    (void)cudaFree(combineGlobalAtomicCounter_);
+  }
+  if (dispatchGlobalAtomicCounter_ != nullptr) {
+    (void)cudaFree(dispatchGlobalAtomicCounter_);
+  }
+  if (workspace_ != nullptr) {
+    (void)cudaFree(workspace_);
+  }
+  // memHandler_ + transport_ destructors handle their own cleanup.
+}
+
+void IntranodeRuntime::moveFifoSlots(int n) {
+  // Rotate `head` by `n * numRanks_`
+  // (each barrier consumes one slot per peer) modulo NUM_MAX_FIFO_SLOTS.
+  head_ = (head_ + n * numRanks_) % kernels::NUM_MAX_FIFO_SLOTS;
+}
+
+void* IntranodeRuntime::getLocalDataPtr() const {
+  if (memHandler_ == nullptr) {
+    return localBufferPtr_;
+  }
+  return memHandler_->getLocalDeviceMemPtr();
+}
+
+void* IntranodeRuntime::getPeerDataPtr(int peerRank) const {
+  if (memHandler_ == nullptr) {
+    if (peerRank < 0 || peerRank >= numRanks_) {
+      throw std::out_of_range(
+          "IntranodeRuntime::getPeerDataPtr: peerRank out of bounds");
+    }
+    return peerDataPtrsHost_[peerRank];
+  }
+  return memHandler_->getPeerDeviceMemPtr(peerRank);
+}
+
+comms::prims::MultiPeerNvlTransport& IntranodeRuntime::transport() {
+  return *transport_;
+}
+
+const comms::prims::MultiPeerNvlTransport& IntranodeRuntime::transport() const {
+  return *transport_;
+}
+
+comms::prims::GpuMemHandler& IntranodeRuntime::memHandler() {
+  return *memHandler_;
+}
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.h
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/Runtime.h
@@ -1,0 +1,205 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+// Forward declarations to avoid pulling MultiPeerNvlTransport.h /
+// GpuMemHandler.h (and their `meta::comms::DeviceBuffer` reference) into
+// every consumer's translation unit. The .cc file owns the heavy includes.
+namespace meta::comms {
+class IBootstrap;
+} // namespace meta::comms
+
+namespace comms::prims {
+class GpuMemHandler;
+class MultiPeerNvlTransport;
+} // namespace comms::prims
+
+namespace comms::prims::moe_ep {
+
+/**
+ * IntranodeRuntime — host-side runtime for Phase 1 (intranode dispatch /
+ * combine over NVLink).
+ *
+ * Owns:
+ *  - `comms::prims::GpuMemHandler` (mode `kCudaIpcUncached`) for the
+ *    NVL data buffer + barrier/ptr-table block.
+ *  - `comms::prims::MultiPeerNvlTransport` for the per-peer NVL P2P state +
+ *    signal/barrier slots that the dispatch/combine kernels use.
+ *  - Persistent workspace (`NUM_WORKSPACE_BYTES` = 32 MiB) for atomic
+ *    counters and per-expert state.
+ *
+ * One IntranodeRuntime per `Buffer` instance. Constructed from `Buffer::sync`
+ * after device IDs + IPC handles have been gathered Python-side.
+ */
+class IntranodeRuntime {
+ public:
+  IntranodeRuntime(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int rank,
+      int numRanks,
+      std::size_t numNvlBytes);
+
+  /**
+   * Pre-allocated-buffer ctor — used by `Buffer::sync` when the local NVL
+   * buffer was already allocated by the `Buffer` ctor and the per-peer
+   * IPC handles were gathered Python-side via `dist.all_gather_object`.
+   * Skips `GpuMemHandler` entirely because we already have everything it
+   * would have produced.
+   *
+   * `peerDataPtrs` is a host-side vector of size `numRanks` where entry
+   * `i` is the local-process pointer to peer `i`'s NVL data buffer
+   * (entry `rank` == `localBuffer`; other entries come from
+   * `cudaIpcOpenMemHandle`). The runtime takes ownership of opening the
+   * peer handles before this ctor is called and closing them in its
+   * destructor.
+   */
+  IntranodeRuntime(
+      int rank,
+      int numRanks,
+      std::size_t numNvlBytes,
+      void* localBuffer,
+      const cudaIpcMemHandle_t& localHandle,
+      std::vector<void*> peerDataPtrs);
+
+  ~IntranodeRuntime();
+
+  // Non-copyable, non-movable.
+  IntranodeRuntime(const IntranodeRuntime&) = delete;
+  IntranodeRuntime& operator=(const IntranodeRuntime&) = delete;
+  IntranodeRuntime(IntranodeRuntime&&) = delete;
+  IntranodeRuntime& operator=(IntranodeRuntime&&) = delete;
+
+  /** Local rank within the group [0, numRanks). */
+  int rank() const noexcept {
+    return rank_;
+  }
+
+  /** Total number of ranks (== num NVL peers in intranode-only mode). */
+  int numRanks() const noexcept {
+    return numRanks_;
+  }
+
+  /** Local pointer to the NVL data buffer (data + barrier slots + per-peer
+   *  ptr table; layout owned by callers, computed as offsets on this base
+   *  pointer). */
+  void* getLocalDataPtr() const;
+
+  /** Per-peer remote pointer for the NVL data buffer (peer-mapped via IPC). */
+  void* getPeerDataPtr(int peerRank) const;
+
+  /** Persistent workspace pointer — `NUM_WORKSPACE_BYTES` (32 MiB) of
+   *  GPU-uncached memory for atomic counters + per-expert state. */
+  void* getWorkspacePtr() const noexcept {
+    return workspace_;
+  }
+
+  /** Per-runtime atomic counter used by combine's grid_barrier (AMD path).
+   *  4-byte device buffer. */
+  int* getDispatchGlobalAtomicCounter() const noexcept {
+    return dispatchGlobalAtomicCounter_;
+  }
+  int* getCombineGlobalAtomicCounter() const noexcept {
+    return combineGlobalAtomicCounter_;
+  }
+
+  /** Communication stream used by the runtime's kernel launches. */
+  cudaStream_t commStream() const noexcept {
+    return commStream_;
+  }
+
+  /** Underlying NVLink multi-peer transport (per-peer signal/barrier slots
+   *  + state buffers). Defined in the .cc to keep the heavy include out of
+   *  consumers' translation units. */
+  comms::prims::MultiPeerNvlTransport& transport();
+  const comms::prims::MultiPeerNvlTransport& transport() const;
+
+  /** GpuMemHandler that owns the kCudaIpcUncached data buffer. */
+  comms::prims::GpuMemHandler& memHandler();
+
+  /** `void**` device array of size `numRanks` with peer-mapped NVL data
+   *  buffer pointers (entry `i` = `getPeerDataPtr(i)`; entry == self points
+   *  to local). Passed to the dispatch / combine kernels as `buffer_ptrs`. */
+  void** getPeerDataPtrsDevice() const noexcept {
+    return peerDataPtrsDevice_;
+  }
+
+  /** `int**` device array of size `numRanks` with peer-mapped barrier-signal
+   *  pointers (carved out of the workspace). Passed to `notify_dispatch` /
+   *  `cached_notify_dispatch` / `cached_notify_combine` as `task_fifo_ptrs`. */
+  int** getBarrierSignalPtrsDevice() const noexcept {
+    return barrierSignalPtrsDevice_;
+  }
+
+  /** Host-pinned `volatile int*` mapped into device address space. The
+   *  notify_dispatch kernel writes the local rank's recv-token count here;
+   *  Buffer::intranode_dispatch reads it from the host side to size the
+   *  output tensors. */
+  int* getMoeRecvCounterHost() const noexcept {
+    return moeRecvCounterHost_;
+  }
+  int* getMoeRecvCounterDevice() const noexcept {
+    return moeRecvCounterDevice_;
+  }
+  int* getMoeRecvExpertCounterHost() const noexcept {
+    return moeRecvExpertCounterHost_;
+  }
+  int* getMoeRecvExpertCounterDevice() const noexcept {
+    return moeRecvExpertCounterDevice_;
+  }
+
+  /** Rotating FIFO head used by notify_dispatch / cached_notify_dispatch /
+   *  cached_notify_combine to avoid stomping on prior barrier slots. */
+  int head() const noexcept {
+    return head_;
+  }
+  void moveFifoSlots(int n);
+
+ private:
+  const int rank_;
+  const int numRanks_;
+  const std::size_t numNvlBytes_;
+
+  std::unique_ptr<comms::prims::MultiPeerNvlTransport> transport_;
+  std::unique_ptr<comms::prims::GpuMemHandler> memHandler_;
+
+  // Persistent workspace — NUM_WORKSPACE_BYTES (see KernelConfigs.cuh).
+  void* workspace_{nullptr};
+  int* dispatchGlobalAtomicCounter_{nullptr};
+  int* combineGlobalAtomicCounter_{nullptr};
+
+  cudaStream_t commStream_{nullptr};
+
+  // Peer-mapped pointer arrays (allocated on the device, populated from
+  // `memHandler_->getPeerDeviceMemPtr(i)` in the ctor).
+  void** peerDataPtrsDevice_{nullptr};
+  int** barrierSignalPtrsDevice_{nullptr};
+
+  // Host-pinned counters whose device shadow is the kernel-visible one.
+  int* moeRecvCounterHost_{nullptr};
+  int* moeRecvCounterDevice_{nullptr};
+  int* moeRecvExpertCounterHost_{nullptr};
+  int* moeRecvExpertCounterDevice_{nullptr};
+
+  // Rotating barrier head — bumped after every notify_*.
+  int head_{0};
+
+  // Fallback storage when memHandler_ is null (pre-allocated-buffer ctor
+  // path). getLocalDataPtr() / getPeerDataPtr() consult these instead of
+  // memHandler_ when the runtime was constructed with caller-owned buffers.
+  void* localBufferPtr_{nullptr};
+  std::vector<void*> peerDataPtrsHost_;
+};
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cu
@@ -1,0 +1,453 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cuh"
+
+#include <climits>
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/EpBuffer.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh"
+
+// Symmetric counterpart to dispatch:
+//   - Sender SMs (even) iterate over local tokens, push payload + weights
+//     to peer's recv-buffer.
+//   - Receiver SMs (odd) split into one head-updater warp + N reducer warps;
+//     each reducer warp picks up tokens, sums payload across topk source
+//     ranks (with optional bias_0 / bias_1), and writes into recv_x.
+
+namespace comms::prims::moe_ep::kernels {
+
+namespace {
+
+template <typename DType, int kNumRanks, int kNumThreads>
+__global__ void __launch_bounds__(kNumThreads, 1) intranode_combine_kernel(
+    DType* recv_x,
+    float* recv_topk_weights,
+    const DType* x,
+    const float* topk_weights,
+    const DType* bias_0,
+    const DType* bias_1,
+    const int* src_idx,
+    const int* rank_prefix_matrix,
+    const int* channel_prefix_matrix,
+    int* send_head,
+    int num_tokens,
+    int num_recv_tokens,
+    int hidden,
+    int num_topk,
+    void** buffer_ptrs,
+    int rank,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens) {
+  const int num_sms = static_cast<int>(gridDim.x);
+  const int thread_id = static_cast<int>(threadIdx.x);
+  const int lane_id = thread_id % kWarpSize;
+  const int sm_id = static_cast<int>(blockIdx.x);
+  const int num_channels = num_sms / 2;
+  const bool is_sender = sm_id % 2 == 0;
+  const int responsible_channel = sm_id / 2;
+
+  EP_DEVICE_ASSERT(num_topk <= kWarpSize);
+
+  constexpr int kDtypePerInt4 = sizeof(int4) / sizeof(DType);
+  const int hidden_int4 = hidden * sizeof(DType) / sizeof(int4);
+  const int4* x_int4 = reinterpret_cast<const int4*>(x);
+  const int4* bias_0_int4 = reinterpret_cast<const int4*>(bias_0);
+  const int4* bias_1_int4 = reinterpret_cast<const int4*>(bias_1);
+  int4* recv_int4 = reinterpret_cast<int4*>(recv_x);
+
+  if (is_sender) {
+    // ------------------- SENDER PATH -------------------
+    constexpr int num_send_warps = kNumThreads / kWarpSize;
+    constexpr int num_send_warps_per_rank = num_send_warps / kNumRanks;
+    const int send_rank_id =
+        (responsible_channel + thread_id / kWarpSize) % kNumRanks;
+    const int send_warp_id_in_rank = thread_id / kWarpSize / kNumRanks;
+
+    void* ptr = reinterpret_cast<void*>(
+        reinterpret_cast<int8_t*>(buffer_ptrs[send_rank_id]));
+    const int num_channels_total = num_channels * kNumRanks;
+    const int channel_rank_offset = responsible_channel * kNumRanks + rank;
+
+    auto channel_head_idx =
+        Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+    auto channel_tail_idx =
+        Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+    auto channel_x_buffers = Buffer<int4>(
+        ptr,
+        num_channels_total * num_recv_buffer_tokens * hidden_int4,
+        channel_rank_offset * num_recv_buffer_tokens * hidden_int4);
+    auto channel_src_idx_buffers = Buffer<int>(
+        ptr,
+        num_channels_total * num_recv_buffer_tokens,
+        channel_rank_offset * num_recv_buffer_tokens);
+    auto channel_topk_weights_buffers = Buffer<float>(
+        ptr,
+        num_channels_total * num_recv_buffer_tokens * num_topk,
+        channel_rank_offset * num_recv_buffer_tokens * num_topk);
+
+    const int rank_offset = send_rank_id > 0
+        ? rank_prefix_matrix[(send_rank_id - 1) * kNumRanks + rank]
+        : 0;
+    const int num_rank_tokens =
+        rank_prefix_matrix[send_rank_id * kNumRanks + rank] - rank_offset;
+    const int channel_offset = channel_prefix_matrix
+        [send_rank_id * num_channels + responsible_channel];
+    const int num_channel_tokens =
+        (responsible_channel == num_channels - 1
+             ? num_rank_tokens
+             : channel_prefix_matrix
+                   [send_rank_id * num_channels + responsible_channel + 1]) -
+        channel_offset;
+    const int token_start_idx = rank_offset + channel_offset;
+    const int token_end_idx = token_start_idx + num_channel_tokens;
+
+    int current_channel_tail_idx = 0;
+    for (int64_t token_idx = token_start_idx; token_idx < token_end_idx;) {
+      long long start_time = wall_clock64_compat();
+      const int num_round_tokens =
+          min(num_max_send_tokens, token_end_idx - static_cast<int>(token_idx));
+      while (lane_id == 0) {
+        int num_used_slots = current_channel_tail_idx -
+            ld_volatile_global(channel_head_idx.buffer());
+        if (num_recv_buffer_tokens - num_used_slots >= num_round_tokens) {
+          break;
+        }
+        long long now = wall_clock64_compat();
+        long long elapsed = now > start_time ? (now - start_time) : 0;
+        if (elapsed > NUM_TIMEOUT_CYCLES) {
+          printf(
+              "moe_ep combine sender timeout, rank %d channel %d\n",
+              rank,
+              responsible_channel);
+          trap_kernel();
+        }
+      }
+      syncwarp();
+
+#pragma unroll
+      for (int i = send_warp_id_in_rank; i < num_round_tokens;
+           i += num_send_warps_per_rank) {
+        const int dst_slot_idx =
+            (current_channel_tail_idx + i) % num_recv_buffer_tokens;
+        int4* shifted_x_buffers =
+            channel_x_buffers.buffer() + dst_slot_idx * hidden_int4;
+        const int4* shifted_x = x_int4 + (token_idx + i) * hidden_int4;
+        // x_int4 here is recv_x from the prior dispatch (xGMI-written by
+        // peers), so reads need cache-bypass on AMD too. Use ld_nc_global on
+        // both NVIDIA and AMD.
+        MOE_EP_UNROLLED_WARP_COPY(
+            kIntranodeUnrollFactor,
+            lane_id,
+            hidden_int4,
+            shifted_x_buffers,
+            shifted_x,
+            ld_nc_global,
+            st_na_global);
+
+        if (lane_id == 0) {
+          channel_src_idx_buffers[dst_slot_idx] =
+              ld_nc_global(src_idx + token_idx + i);
+        }
+        if (num_topk > 0 && lane_id < num_topk) {
+          channel_topk_weights_buffers[dst_slot_idx * num_topk + lane_id] =
+              ld_nc_global(topk_weights + (token_idx + i) * num_topk + lane_id);
+        }
+      }
+      token_idx += num_round_tokens;
+      current_channel_tail_idx += num_round_tokens;
+
+      __syncthreads();
+      // AMD: the payload writes are non-temporal; this explicit system fence
+      // flushes them to HBM before the tail publish (see Dispatch.cu).
+#ifdef __HIP_PLATFORM_AMD__
+      memory_fence();
+#endif
+      if (lane_id == 0 && send_warp_id_in_rank == 0) {
+        // Release-store the tail to pair with the receiver's acquire-load on
+        // both platforms; a relaxed handshake races on stale payload across
+        // xGMI (see Dispatch.cu).
+        st_release_sys_global(
+            channel_tail_idx.buffer(), current_channel_tail_idx);
+      }
+    }
+  } else {
+    // ------------------- RECEIVER PATH -------------------
+    constexpr int num_recv_warps = kNumThreads / kWarpSize;
+    const int recv_warp_id = thread_id / kWarpSize;
+    EP_DEVICE_ASSERT(kNumRanks <= kWarpSize && kNumThreads > kWarpSize);
+    EP_DEVICE_ASSERT(thread_id >= 0 && kNumThreads % kWarpSize == 0);
+
+    __shared__ volatile int warp_channel_head_idx[num_recv_warps][kNumRanks];
+    __shared__ volatile int channel_tail_idx[kNumRanks];
+    __shared__ volatile bool warp_retired[num_recv_warps];
+    if (thread_id < num_recv_warps) {
+      warp_retired[thread_id] = false;
+    }
+    if (lane_id < kNumRanks) {
+      warp_channel_head_idx[recv_warp_id][lane_id] = 0;
+    }
+    if (thread_id < kNumRanks) {
+      channel_tail_idx[thread_id] = 0;
+    }
+    __syncthreads();
+
+    if (thread_id < kWarpSize) {
+      int* channel_head_idx_ptr = reinterpret_cast<int*>(buffer_ptrs[rank]) +
+          responsible_channel * kNumRanks + lane_id;
+      int* channel_tail_idx_ptr =
+          channel_head_idx_ptr + num_channels * kNumRanks;
+
+      int last_head = 0;
+      while (lane_id < kNumRanks) {
+        bool retired = true;
+#pragma unroll
+        for (int i = 1; i < num_recv_warps; ++i) {
+          retired = retired && warp_retired[i];
+        }
+        if (retired) {
+          break;
+        }
+
+        // Acquire-load the tail to pair with the sender's release-store on both
+        // platforms: the acquire orders the payload reads after it and makes
+        // the producer's payload visible across xGMI (a relaxed load races on
+        // stale payload — see Dispatch.cu).
+        channel_tail_idx[lane_id] = ld_acquire_sys_global(channel_tail_idx_ptr);
+
+        int min_head = INT_MAX;
+#pragma unroll
+        for (int i = 1; i < num_recv_warps; ++i) {
+          if (!warp_retired[i]) {
+            min_head = min(min_head, warp_channel_head_idx[i][lane_id]);
+          }
+        }
+        if (min_head != INT_MAX && min_head > last_head) {
+          last_head = min_head;
+          st_relaxed_sys_global(channel_head_idx_ptr, last_head);
+        }
+      }
+    } else {
+      Buffer<int4> channel_x_buffers[kNumRanks];
+      Buffer<float> channel_topk_weights_buffers[kNumRanks];
+
+#pragma unroll
+      for (int i = 0; i < kNumRanks; ++i) {
+        const int channel_rank_offset = responsible_channel * kNumRanks + i;
+        const int num_channels_total = num_channels * kNumRanks;
+        void* ptr = reinterpret_cast<void*>(
+            reinterpret_cast<int8_t*>(buffer_ptrs[rank]) +
+            2 * num_channels * kNumRanks * sizeof(int));
+
+        channel_x_buffers[i] = Buffer<int4>(
+            ptr,
+            num_channels_total * num_recv_buffer_tokens * hidden_int4,
+            channel_rank_offset * num_recv_buffer_tokens * hidden_int4);
+        ptr = reinterpret_cast<void*>(
+            reinterpret_cast<int8_t*>(ptr) +
+            num_channels_total * num_recv_buffer_tokens * sizeof(int));
+        channel_topk_weights_buffers[i] = Buffer<float>(
+            ptr,
+            num_channels_total * num_recv_buffer_tokens * num_topk,
+            channel_rank_offset * num_recv_buffer_tokens * num_topk);
+      }
+
+      int token_start_idx = 0, token_end_idx = 0;
+      get_channel_task_range(
+          num_recv_tokens,
+          num_channels,
+          responsible_channel,
+          token_start_idx,
+          token_end_idx);
+
+      for (int64_t token_idx = token_start_idx + recv_warp_id - 1;
+           token_idx < token_end_idx;
+           token_idx += num_recv_warps - 1) {
+        int expected_head = -1;
+        if (lane_id < kNumRanks) {
+          expected_head =
+              ld_nc_global(send_head + token_idx * kNumRanks + lane_id);
+        }
+
+        long long start_time = wall_clock64_compat();
+        // Spin until every contributing rank has produced this token.
+        while (true) {
+          bool wait =
+              (channel_tail_idx[lane_id] <= expected_head &&
+               expected_head >= 0);
+#ifdef __HIP_PLATFORM_AMD__
+          uint64_t pred = __ballot(wait);
+          if ((pred & kFullWarpMask) == 0) {
+            break;
+          }
+#else
+          if (!__any_sync(kFullWarpMask, wait)) {
+            break;
+          }
+#endif
+          long long now = wall_clock64_compat();
+          long long elapsed = now > start_time ? (now - start_time) : 0;
+          if (elapsed > NUM_TIMEOUT_CYCLES) {
+            printf(
+                "moe_ep combine receiver timeout rank %d channel %d expect %d\n",
+                rank,
+                responsible_channel,
+                expected_head);
+            trap_kernel();
+          }
+        }
+        syncwarp();
+
+        // Broadcast each lane's expected_head to its corresponding rank
+        // index, then collect (rank, slot) pairs.
+        int num_topk_ranks = 0;
+        int topk_ranks[kNumRanks];
+        int slot_indices[kNumRanks];
+#pragma unroll
+        for (int i = 0; i < kNumRanks; ++i) {
+          int expected_head_i = shfl_sync_compat(expected_head, i);
+          if (expected_head_i >= 0) {
+            slot_indices[num_topk_ranks] =
+                expected_head_i % num_recv_buffer_tokens;
+            topk_ranks[num_topk_ranks++] = i;
+          }
+        }
+
+        // Reduce hidden vector across topk source ranks.
+#pragma unroll
+        for (int i = lane_id; i < hidden_int4; i += kWarpSize) {
+          int4 bias_0_value_int4 = bias_0_int4 != nullptr
+              ? bias_0_int4[token_idx * hidden_int4 + i]
+              : make_int4(0, 0, 0, 0);
+          int4 bias_1_value_int4 = bias_1_int4 != nullptr
+              ? bias_1_int4[token_idx * hidden_int4 + i]
+              : make_int4(0, 0, 0, 0);
+
+          int4 recv_value_int4[kNumRanks];
+#pragma unroll
+          for (int j = 0; j < num_topk_ranks; ++j) {
+            recv_value_int4[j] = ld_nc_global(
+                channel_x_buffers[topk_ranks[j]].buffer() +
+                slot_indices[j] * hidden_int4 + i);
+          }
+
+          float values[kDtypePerInt4];
+          const DType* bias_0_values =
+              reinterpret_cast<const DType*>(&bias_0_value_int4);
+          const DType* bias_1_values =
+              reinterpret_cast<const DType*>(&bias_1_value_int4);
+#pragma unroll
+          for (int j = 0; j < kDtypePerInt4; ++j) {
+            values[j] = static_cast<float>(bias_0_values[j]) +
+                static_cast<float>(bias_1_values[j]);
+          }
+
+#pragma unroll
+          for (int j = 0; j < num_topk_ranks; ++j) {
+            const DType* recv_dtypes =
+                reinterpret_cast<const DType*>(&recv_value_int4[j]);
+#pragma unroll
+            for (int k = 0; k < kDtypePerInt4; ++k) {
+              values[k] += static_cast<float>(recv_dtypes[k]);
+            }
+          }
+
+          int4 out_int4;
+          DType* out_dtypes = reinterpret_cast<DType*>(&out_int4);
+#pragma unroll
+          for (int j = 0; j < kDtypePerInt4; ++j) {
+            out_dtypes[j] = static_cast<DType>(values[j]);
+          }
+          recv_int4[token_idx * hidden_int4 + i] = out_int4;
+        }
+
+        if (lane_id < num_topk) {
+          float value = 0;
+#pragma unroll
+          for (int i = 0; i < num_topk_ranks; ++i) {
+            value += ld_nc_global(
+                channel_topk_weights_buffers[topk_ranks[i]].buffer() +
+                slot_indices[i] * num_topk + lane_id);
+          }
+          recv_topk_weights[token_idx * num_topk + lane_id] = value;
+        }
+
+        if (lane_id < kNumRanks) {
+          warp_channel_head_idx[recv_warp_id][lane_id] =
+              (expected_head < 0) ? -expected_head - 1 : expected_head + 1;
+        }
+      }
+
+      syncwarp();
+      if (lane_id == 0) {
+        warp_retired[recv_warp_id] = true;
+      }
+    }
+  }
+}
+
+} // namespace
+
+void intranode_combine(
+    void* recv_x,
+    float* recv_topk_weights,
+    const void* x,
+    const float* topk_weights,
+    const void* bias_0,
+    const void* bias_1,
+    const int* src_idx,
+    const int* rank_prefix_matrix,
+    const int* channel_prefix_matrix,
+    int* send_head,
+    int num_tokens,
+    int num_recv_tokens,
+    int hidden,
+    int num_topk,
+    void** buffer_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int num_sms,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens) {
+  // Wave-size-dependent thread budget: 1024 for 64-wide waves, else 768.
+  constexpr int kNumThreads = (kWarpSize == 64 ? 1024 : 768);
+
+  EP_HOST_ASSERT(num_sms % 2 == 0);
+  EP_HOST_ASSERT(kNumThreads >= num_ranks * kWarpSize);
+  SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
+
+  // For Phase 1 we only support bf16. FP32 + the DType switch land in a
+  // follow-up patch.
+  using DType = gpu_bfloat16_t;
+
+#define INTRANODE_COMBINE_CASE(ranks)                        \
+  LAUNCH_KERNEL_NON_COOPERATIVE(                             \
+      &cfg,                                                  \
+      (intranode_combine_kernel<DType, ranks, kNumThreads>), \
+      reinterpret_cast<DType*>(recv_x),                      \
+      recv_topk_weights,                                     \
+      reinterpret_cast<const DType*>(x),                     \
+      topk_weights,                                          \
+      reinterpret_cast<const DType*>(bias_0),                \
+      reinterpret_cast<const DType*>(bias_1),                \
+      src_idx,                                               \
+      rank_prefix_matrix,                                    \
+      channel_prefix_matrix,                                 \
+      send_head,                                             \
+      num_tokens,                                            \
+      num_recv_tokens,                                       \
+      hidden,                                                \
+      num_topk,                                              \
+      buffer_ptrs,                                           \
+      rank,                                                  \
+      num_max_send_tokens,                                   \
+      num_recv_buffer_tokens)
+
+  SWITCH_RANKS(INTRANODE_COMBINE_CASE);
+#undef INTRANODE_COMBINE_CASE
+}
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Combine.cuh
@@ -1,0 +1,44 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+namespace comms::prims::moe_ep::kernels {
+
+/**
+ * Intranode combine — reduces per-rank dispatched tokens back to original
+ * source ranks.
+ *
+ * Real kernel + launch wrapper in a follow-up sub-commit.
+ */
+void intranode_combine(
+    void* recv_x,
+    float* recv_topk_weights,
+    const void* x,
+    const float* topk_weights,
+    const void* bias_0,
+    const void* bias_1,
+    const int* src_idx,
+    const int* rank_prefix_matrix,
+    const int* channel_prefix_matrix,
+    int* send_head,
+    int num_tokens,
+    int num_recv_tokens,
+    int hidden,
+    int num_topk,
+    void** buffer_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int num_sms,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens);
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cu
@@ -1,0 +1,537 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh"
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/EpBuffer.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh"
+
+// `dispatch` (lines 204-528).
+//
+// Pipeline:
+//   - Even-numbered SMs are senders, odd-numbered SMs are receivers.
+//   - Sender / receiver pairs are partitioned by (channel, dst_rank): each
+//     channel is `kNumRanks` warp-groups deep on the sender side; each
+//     channel × dst_rank gets its own per-peer FIFO slot.
+//   - Sender writes payloads to peer's recv-buffer region using
+//     `MOE_EP_UNROLLED_WARP_COPY` (NVLink → IPC-mapped peer pointer).
+//   - Receiver spins on `channel_tail_idx`, then `__syncthreads`-coordinates
+//     with sender warps to drain into local `recv_x` etc.
+//
+// Layout of the per-rank workspace (offsets into `buffer_ptrs[rank]`):
+//   `rank_prefix_matrix`  : kNumRanks * kNumRanks * sizeof(int)
+//   `channel_start_offset`: num_channels * kNumRanks * sizeof(int)
+//   `channel_end_offset`  : num_channels * kNumRanks * sizeof(int)
+//   `channel_head_idx`    : num_channels * kNumRanks * sizeof(int)
+//   `channel_tail_idx`    : num_channels * kNumRanks * sizeof(int)
+//   `channel_x_buffers`   : num_channels * kNumRanks * num_recv_buffer_tokens
+//                            * hidden_int4 * sizeof(int4)
+//   `channel_src_idx_buffers`     : * sizeof(int)
+//   `channel_topk_idx_buffers`    : * num_topk * sizeof(topk_idx_t)
+//   `channel_topk_weights_buffers`: * num_topk * sizeof(float)
+//   `channel_x_scales_buffers`    : * num_scales * sizeof(float)
+
+namespace comms::prims::moe_ep::kernels {
+
+namespace {
+
+template <int kNumRanks, int kNumThreads>
+__global__ void __launch_bounds__(kNumThreads, 1) intranode_dispatch_kernel(
+    int4* recv_x,
+    float* recv_x_scales,
+    int* recv_src_idx,
+    topk_idx_t* recv_topk_idx,
+    float* recv_topk_weights,
+    int* recv_channel_offset,
+    int* send_head,
+    const int4* x,
+    const float* x_scales,
+    const topk_idx_t* topk_idx,
+    const float* topk_weights,
+    const bool* is_token_in_rank,
+    const int* channel_prefix_matrix,
+    int num_tokens,
+    int num_worst_tokens,
+    int hidden_int4,
+    int num_topk,
+    int num_experts,
+    int num_scales,
+    int scale_token_stride,
+    int scale_hidden_stride,
+    void** buffer_ptrs,
+    int rank,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens) {
+  const int num_sms = static_cast<int>(gridDim.x);
+  const int sm_id = static_cast<int>(blockIdx.x);
+  const int thread_id = static_cast<int>(threadIdx.x);
+  const bool is_sender = sm_id % 2 == 0;
+  EP_DEVICE_ASSERT(num_sms % 2 == 0);
+
+  // Threads per (channel × dst_rank) pair.
+  const int num_threads_per_rank = kNumThreads / kNumRanks;
+  const int num_channels = num_sms / 2;
+  const int responsible_rank = thread_id / num_threads_per_rank;
+  const int responsible_channel = sm_id / 2;
+
+  const int num_experts_per_rank = num_experts / kNumRanks;
+  EP_DEVICE_ASSERT(num_experts_per_rank > 0 || num_topk == 0);
+  EP_DEVICE_ASSERT(num_topk <= kWarpSize);
+  EP_DEVICE_ASSERT((topk_idx == nullptr) == (topk_weights == nullptr));
+  EP_DEVICE_ASSERT(
+      (recv_topk_idx == nullptr) == (recv_topk_weights == nullptr));
+
+  // Buffer cursor advances over the workspace as the layout helpers slice
+  // sub-regions out of it.
+  void* ptr = reinterpret_cast<void*>(
+      reinterpret_cast<int8_t*>(
+          buffer_ptrs[is_sender ? responsible_rank : rank]) +
+      kNumRanks * kNumRanks * sizeof(int));
+  const int target_rank = is_sender ? rank : responsible_rank;
+  const int num_channels_total = num_channels * kNumRanks;
+  const int channel_rank_offset = responsible_channel * kNumRanks + target_rank;
+
+  auto channel_start_offset =
+      Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+  auto channel_end_offset =
+      Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+  auto channel_head_idx =
+      Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+  auto channel_tail_idx =
+      Buffer<int>(ptr, num_channels_total, channel_rank_offset);
+
+  auto channel_x_buffers = Buffer<int4>(
+      ptr,
+      num_channels_total * num_recv_buffer_tokens * hidden_int4,
+      channel_rank_offset * num_recv_buffer_tokens * hidden_int4);
+  auto channel_src_idx_buffers = Buffer<int>(
+      ptr,
+      num_channels_total * num_recv_buffer_tokens,
+      channel_rank_offset * num_recv_buffer_tokens);
+  auto channel_topk_idx_buffers = Buffer<topk_idx_t>(
+      ptr,
+      num_channels_total * num_recv_buffer_tokens * num_topk,
+      channel_rank_offset * num_recv_buffer_tokens * num_topk);
+  auto channel_topk_weights_buffers = Buffer<float>(
+      ptr,
+      num_channels_total * num_recv_buffer_tokens * num_topk,
+      channel_rank_offset * num_recv_buffer_tokens * num_topk);
+  auto channel_x_scales_buffers = Buffer<float>(
+      ptr,
+      num_channels_total * num_recv_buffer_tokens * num_scales,
+      channel_rank_offset * num_recv_buffer_tokens * num_scales);
+
+  if (is_sender) {
+    // ------------------- SENDER PATH -------------------
+    constexpr int num_send_warps = kNumThreads / kWarpSize;
+    constexpr int num_send_warps_per_rank = num_send_warps / kNumRanks;
+    const int send_thread_id = thread_id;
+    const int send_lane_id = send_thread_id % kWarpSize;
+    const int send_warp_id_in_rank =
+        (send_thread_id % num_threads_per_rank) / kWarpSize;
+    EP_DEVICE_ASSERT(kNumRanks <= kWarpSize);
+    EP_DEVICE_ASSERT(num_send_warps % kNumRanks == 0);
+
+    // Encode the start / end offsets as `-value - 1` so we can distinguish
+    // "not yet written" (value == 0) from "wrote zero tokens".
+    if (send_lane_id == 0 && send_warp_id_in_rank == 0) {
+      int value = responsible_channel > 0
+          ? channel_prefix_matrix
+                [responsible_rank * num_channels + responsible_channel - 1]
+          : 0;
+      st_relaxed_sys_global(channel_start_offset.buffer(), -value - 1);
+      value = channel_prefix_matrix
+          [responsible_rank * num_channels + responsible_channel];
+      st_relaxed_sys_global(channel_end_offset.buffer(), -value - 1);
+    }
+    syncwarp();
+
+    int token_start_idx = 0, token_end_idx = 0;
+    get_channel_task_range(
+        num_tokens,
+        num_channels,
+        responsible_channel,
+        token_start_idx,
+        token_end_idx);
+
+    int cached_channel_tail_idx = 0;
+    for (int64_t token_idx = token_start_idx; token_idx < token_end_idx;) {
+      // Wait for receiver to free up at least `num_max_send_tokens` slots.
+      long long start_time = wall_clock64_compat();
+      while (send_lane_id == 0) {
+        int num_used_slots = cached_channel_tail_idx -
+            ld_volatile_global(channel_head_idx.buffer());
+        if (num_recv_buffer_tokens - num_used_slots >= num_max_send_tokens) {
+          break;
+        }
+        long long now = wall_clock64_compat();
+        long long elapsed = now > start_time ? (now - start_time) : 0;
+        if (elapsed > NUM_TIMEOUT_CYCLES) {
+          printf(
+              "moe_ep dispatch sender timeout, rank %d, channel %d\n",
+              rank,
+              responsible_channel);
+          trap_kernel();
+        }
+      }
+      syncwarp();
+
+      int chunk_token_idx = 0;
+      while (chunk_token_idx < num_max_send_tokens &&
+             token_idx < token_end_idx) {
+        // Save send_head so combine knows which slot this token ended up in
+        // (or -1 if not routed to this dst_rank).
+        if (send_lane_id == 0 &&
+            token_idx % num_send_warps_per_rank == send_warp_id_in_rank) {
+          send_head[token_idx * kNumRanks + responsible_rank] =
+              is_token_in_rank[token_idx * kNumRanks + responsible_rank]
+              ? cached_channel_tail_idx
+              : -1;
+        }
+
+        if (!is_token_in_rank[token_idx * kNumRanks + responsible_rank]) {
+          token_idx++;
+          continue;
+        }
+
+        const int dst_slot_idx =
+            (cached_channel_tail_idx++) % num_recv_buffer_tokens;
+        if (cached_channel_tail_idx % num_send_warps_per_rank ==
+            send_warp_id_in_rank) {
+          // Payload copy (hidden_int4 × 16B each) — NVLink to peer.
+          // Sender reads its own LOCAL `x` buffer; use cached __ldg.
+          // Cache-bypass loads (ld_nc_global) on local data collapse
+          // throughput on AMD.
+          int4* shifted_dst =
+              channel_x_buffers.buffer() + dst_slot_idx * hidden_int4;
+          const int4* shifted_src = x + token_idx * hidden_int4;
+          MOE_EP_UNROLLED_WARP_COPY(
+              kIntranodeUnrollFactor,
+              send_lane_id,
+              hidden_int4,
+              shifted_dst,
+              shifted_src,
+              ld_cached_global,
+              st_na_global);
+
+          if (send_lane_id == 0) {
+            channel_src_idx_buffers[dst_slot_idx] = static_cast<int>(token_idx);
+          }
+
+          // topk_idx + topk_weights — one lane per topk slot.
+          if (send_lane_id < num_topk) {
+            const int recv_expert_begin =
+                responsible_rank * num_experts_per_rank;
+            const int recv_expert_end =
+                (responsible_rank + 1) * num_experts_per_rank;
+            topk_idx_t idx_value =
+                topk_idx[token_idx * num_topk + send_lane_id];
+            idx_value =
+                (idx_value >= recv_expert_begin && idx_value < recv_expert_end)
+                ? idx_value - recv_expert_begin
+                : -1;
+            channel_topk_idx_buffers[dst_slot_idx * num_topk + send_lane_id] =
+                idx_value;
+
+            float weight_value =
+                topk_weights[token_idx * num_topk + send_lane_id];
+            weight_value = (idx_value >= 0) ? weight_value : 0.0f;
+            channel_topk_weights_buffers
+                [dst_slot_idx * num_topk + send_lane_id] = weight_value;
+          }
+
+          // x_scales (FP8 path; degenerates to no-op when num_scales == 0).
+#pragma unroll
+          for (int i = send_lane_id; i < num_scales; i += kWarpSize) {
+            channel_x_scales_buffers[dst_slot_idx * num_scales + i] =
+                x_scales[token_idx * num_scales + i];
+          }
+        }
+
+        chunk_token_idx++;
+        token_idx++;
+      }
+
+      // All sender warps for this dst_rank converge before publishing tail.
+      __syncthreads();
+      // AMD/xGMI: the payload `st_na_global` writes (UNROLLED_WARP_COPY above)
+      // are non-temporal and not ordered against the tail publish below, so an
+      // explicit system fence flushes them to HBM before the tail becomes
+      // visible. The tail itself is then RELEASE-stored to pair with the
+      // receiver's acquire-load.
+#ifdef __HIP_PLATFORM_AMD__
+      memory_fence();
+#endif
+      if (send_warp_id_in_rank == 0 && send_lane_id == 0) {
+        // Release/acquire on both platforms. A relaxed tail store/load
+        // handshake races on AMD: a relaxed read establishes no ordering, so
+        // the receiver can observe the advanced tail but read stale/unwritten
+        // payload across xGMI → illegal access under async execution. The
+        // release store (plus the fence above for the non-temporal payload)
+        // carries the happens-before to the receiver's ld_acquire_sys_global.
+        st_release_sys_global(
+            channel_tail_idx.buffer(), cached_channel_tail_idx);
+      }
+    }
+  } else {
+    // ------------------- RECEIVER PATH -------------------
+    constexpr int num_recv_warps = kNumThreads / kWarpSize;
+    constexpr int num_recv_warps_per_rank = num_recv_warps / kNumRanks;
+    const int recv_thread_id = thread_id;
+    const int recv_lane_id = recv_thread_id % kWarpSize;
+    const int recv_thread_id_in_rank = recv_thread_id % num_threads_per_rank;
+    const int recv_warp_id_in_rank = recv_thread_id_in_rank / kWarpSize;
+    EP_DEVICE_ASSERT(kNumRanks <= kWarpSize);
+    EP_DEVICE_ASSERT(num_recv_warps % kNumRanks == 0);
+
+    int* rank_prefix_matrix = reinterpret_cast<int*>(buffer_ptrs[rank]);
+    int rank_offset = responsible_rank > 0
+        ? rank_prefix_matrix[(responsible_rank - 1) * kNumRanks + rank]
+        : 0;
+
+    int total_offset = 0, num_tokens_to_recv = 0;
+    // Wait for the sender to publish this channel's start/end offsets. Guard
+    // both spins with the same timeout/trap as the sibling loops below so a
+    // stuck/failed sender traps with a diagnostic instead of hanging the GPU
+    // unrecoverably. The offsets are published before any data movement, so a
+    // healthy sender never approaches NUM_TIMEOUT_CYCLES.
+    long long offset_wait_start = wall_clock64_compat();
+    while (recv_lane_id == 0 &&
+           (total_offset = ld_volatile_global(channel_start_offset.buffer())) ==
+               0) {
+      long long now = wall_clock64_compat();
+      if ((now > offset_wait_start ? now - offset_wait_start : 0) >
+          NUM_TIMEOUT_CYCLES) {
+        printf(
+            "moe_ep dispatch receiver start-offset timeout rank %d channel %d\n",
+            rank,
+            responsible_channel);
+        trap_kernel();
+      }
+    }
+    offset_wait_start = wall_clock64_compat();
+    while (recv_lane_id == 0 &&
+           (num_tokens_to_recv =
+                ld_volatile_global(channel_end_offset.buffer())) == 0) {
+      long long now = wall_clock64_compat();
+      if ((now > offset_wait_start ? now - offset_wait_start : 0) >
+          NUM_TIMEOUT_CYCLES) {
+        printf(
+            "moe_ep dispatch receiver end-offset timeout rank %d channel %d\n",
+            rank,
+            responsible_channel);
+        trap_kernel();
+      }
+    }
+    if (recv_lane_id == 0) {
+      total_offset = -total_offset - 1;
+      num_tokens_to_recv = -num_tokens_to_recv - 1;
+      if (recv_warp_id_in_rank == 0) {
+        recv_channel_offset
+            [responsible_rank * num_channels + responsible_channel] =
+                total_offset;
+      }
+      num_tokens_to_recv -= total_offset;
+    }
+    total_offset = shfl_sync_compat(total_offset, 0);
+    total_offset += rank_offset;
+    num_tokens_to_recv = shfl_sync_compat(num_tokens_to_recv, 0);
+
+    __shared__ volatile int shared_channel_tail_idx[kNumRanks];
+
+    long long start_time = wall_clock64_compat();
+    int cached_channel_head_idx = 0, cached_channel_tail_idx = 0;
+    while (num_tokens_to_recv > 0) {
+      while (recv_thread_id_in_rank == 0) {
+        // Acquire-load the tail to pair with the sender's release-store: the
+        // acquire both orders the subsequent payload reads after this load and
+        // makes the producer's payload writes visible across xGMI. A relaxed
+        // load would establish neither, racing on stale payload.
+        cached_channel_tail_idx =
+            ld_acquire_sys_global(channel_tail_idx.buffer());
+        if (cached_channel_head_idx != cached_channel_tail_idx) {
+          shared_channel_tail_idx[responsible_rank] = cached_channel_tail_idx;
+          break;
+        }
+        long long now = wall_clock64_compat();
+        long long elapsed = now > start_time ? (now - start_time) : 0;
+        if (elapsed > NUM_TIMEOUT_CYCLES) {
+          printf(
+              "moe_ep dispatch receiver timeout rank %d channel %d remain %d\n",
+              rank,
+              responsible_channel,
+              num_tokens_to_recv);
+          trap_kernel();
+        }
+      }
+
+      __syncthreads();
+      cached_channel_tail_idx = shared_channel_tail_idx[responsible_rank];
+
+      const int num_recv_tokens =
+          cached_channel_tail_idx - cached_channel_head_idx;
+      for (int chunk_idx = recv_warp_id_in_rank; chunk_idx < num_recv_tokens;
+           chunk_idx += num_recv_warps_per_rank) {
+        const int token_idx_in_buffer =
+            (cached_channel_head_idx + chunk_idx) % num_recv_buffer_tokens;
+        const int4* shifted_buffer =
+            channel_x_buffers.buffer() + token_idx_in_buffer * hidden_int4;
+        int4* shifted_recv = recv_x +
+            static_cast<int64_t>(total_offset + chunk_idx) * hidden_int4;
+        MOE_EP_UNROLLED_WARP_COPY(
+            kIntranodeUnrollFactor,
+            recv_lane_id,
+            hidden_int4,
+            shifted_recv,
+            shifted_buffer,
+            ld_nc_global,
+            st_na_global);
+      }
+
+#pragma unroll 4
+      for (int chunk_idx = cached_channel_head_idx + recv_thread_id_in_rank;
+           chunk_idx < cached_channel_tail_idx;
+           chunk_idx += kWarpSize * num_recv_warps_per_rank) {
+        recv_src_idx[total_offset + chunk_idx - cached_channel_head_idx] =
+            ld_nc_global(
+                channel_src_idx_buffers.buffer() +
+                chunk_idx % num_recv_buffer_tokens);
+      }
+
+#pragma unroll 4
+      for (int idx = recv_thread_id_in_rank; idx < num_recv_tokens * num_topk;
+           idx += kWarpSize * num_recv_warps_per_rank) {
+        const int chunk_idx = idx / num_topk;
+        const int token_topk_idx = idx % num_topk;
+        const int token_idx_in_buffer =
+            (cached_channel_head_idx + chunk_idx) % num_recv_buffer_tokens;
+        const int64_t recv_idx =
+            static_cast<int64_t>(total_offset + chunk_idx) * num_topk +
+            token_topk_idx;
+        const int buffer_idx = token_idx_in_buffer * num_topk + token_topk_idx;
+        recv_topk_idx[recv_idx] =
+            ld_nc_global(channel_topk_idx_buffers.buffer() + buffer_idx);
+        recv_topk_weights[recv_idx] =
+            ld_nc_global(channel_topk_weights_buffers.buffer() + buffer_idx);
+      }
+
+#pragma unroll 4
+      for (int i = recv_thread_id_in_rank; i < num_recv_tokens * num_scales;
+           i += kWarpSize * num_recv_warps_per_rank) {
+        const int chunk_idx = i / num_scales;
+        const int scales_idx = i % num_scales;
+        const int token_idx_in_buffer =
+            (cached_channel_head_idx + chunk_idx) % num_recv_buffer_tokens;
+        recv_x_scales
+            [static_cast<int64_t>(total_offset + chunk_idx) * num_scales +
+             scales_idx] =
+                ld_nc_global(
+                    channel_x_scales_buffers.buffer() +
+                    token_idx_in_buffer * num_scales + scales_idx);
+      }
+
+      cached_channel_head_idx += num_recv_tokens;
+      total_offset += num_recv_tokens;
+      __syncthreads();
+
+      if (recv_warp_id_in_rank == num_recv_warps_per_rank - 1 &&
+          recv_lane_id == 0) {
+        st_relaxed_sys_global(
+            channel_head_idx.buffer(), cached_channel_head_idx);
+      }
+
+      num_tokens_to_recv -= num_recv_tokens;
+    }
+  }
+
+  // Clean unused recv_topk_idx slots to -1.
+  if (num_worst_tokens > 0) {
+    int* rank_prefix_matrix = static_cast<int*>(buffer_ptrs[rank]);
+    const int num_recv_tokens =
+        rank_prefix_matrix[(kNumRanks - 1) * kNumRanks + rank];
+    const int clean_start = num_recv_tokens * num_topk + sm_id * kNumThreads;
+    const int clean_end = num_worst_tokens * num_topk;
+    const int clean_stride = num_sms * kNumThreads;
+#pragma unroll
+    for (int i = clean_start + thread_id; i < clean_end; i += clean_stride) {
+      recv_topk_idx[i] = -1;
+    }
+  }
+}
+
+} // namespace
+
+void intranode_dispatch(
+    void* recv_x,
+    float* recv_x_scales,
+    std::int64_t* recv_topk_idx,
+    float* recv_topk_weights,
+    int* recv_src_idx,
+    int* recv_channel_offset,
+    int* send_head,
+    const void* x,
+    const float* x_scales,
+    const std::int64_t* topk_idx,
+    const float* topk_weights,
+    const bool* is_token_in_rank,
+    const int* channel_prefix_matrix,
+    int num_tokens,
+    int num_worst_tokens,
+    int hidden_int4,
+    int num_topk,
+    int num_experts,
+    int scale_token_stride,
+    int scale_hidden_stride,
+    void** buffer_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int num_sms,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens) {
+  constexpr int kNumThreads = (kWarpSize == 64 ? 1024 : 512);
+
+  EP_HOST_ASSERT(num_sms % 2 == 0);
+  SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
+
+  const int num_scales = (scale_token_stride > 0 || scale_hidden_stride > 0)
+      ? scale_hidden_stride
+      : 0;
+
+#define INTRANODE_DISPATCH_CASE(ranks)                 \
+  LAUNCH_KERNEL_NON_COOPERATIVE(                       \
+      &cfg,                                            \
+      (intranode_dispatch_kernel<ranks, kNumThreads>), \
+      reinterpret_cast<int4*>(recv_x),                 \
+      recv_x_scales,                                   \
+      recv_src_idx,                                    \
+      recv_topk_idx,                                   \
+      recv_topk_weights,                               \
+      recv_channel_offset,                             \
+      send_head,                                       \
+      reinterpret_cast<const int4*>(x),                \
+      x_scales,                                        \
+      topk_idx,                                        \
+      topk_weights,                                    \
+      is_token_in_rank,                                \
+      channel_prefix_matrix,                           \
+      num_tokens,                                      \
+      num_worst_tokens,                                \
+      hidden_int4,                                     \
+      num_topk,                                        \
+      num_experts,                                     \
+      num_scales,                                      \
+      scale_token_stride,                              \
+      scale_hidden_stride,                             \
+      buffer_ptrs,                                     \
+      rank,                                            \
+      num_max_send_tokens,                             \
+      num_recv_buffer_tokens)
+
+  SWITCH_RANKS(INTRANODE_DISPATCH_CASE);
+#undef INTRANODE_DISPATCH_CASE
+}
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Dispatch.cuh
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+namespace comms::prims::moe_ep::kernels {
+
+/**
+ * Intranode dispatch — chunked NVLink pipelined send across ≤
+ * NUM_MAX_NVL_PEERS peers.
+ *
+ * Per-rank workspace layout — see the comment block at the top of
+ * IntranodeDispatch.cu.
+ *
+ * `topk_idx` / `recv_topk_idx` are int64 (`topk_idx_t`).
+ */
+void intranode_dispatch(
+    void* recv_x,
+    float* recv_x_scales,
+    std::int64_t* recv_topk_idx,
+    float* recv_topk_weights,
+    int* recv_src_idx,
+    int* recv_channel_offset,
+    int* send_head,
+    const void* x,
+    const float* x_scales,
+    const std::int64_t* topk_idx,
+    const float* topk_weights,
+    const bool* is_token_in_rank,
+    const int* channel_prefix_matrix,
+    int num_tokens,
+    int num_worst_tokens,
+    int hidden_int4,
+    int num_topk,
+    int num_experts,
+    int scale_token_stride,
+    int scale_hidden_stride,
+    void** buffer_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int num_sms,
+    int num_max_send_tokens,
+    int num_recv_buffer_tokens);
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cu
@@ -1,0 +1,220 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// (~150 LOC, no transport involved). Pure compute kernel that derives
+// per-rank / per-expert token counts from `topk_idx`. Used as the first
+// step of every dispatch operation.
+
+// HipHostCompat aliases `__trap()` -> `abort()` in HIP device-compile pass
+// (HIP doesn't expose `__trap()` in host pass like nvcc does). Pulled in
+// before the kernel that uses MOE_EP_DEVICE_ASSERT.
+#ifdef __HIP_PLATFORM_AMD__
+#include "comms/prims/transport/amd/HipHostCompat.h" // @manual
+#endif
+
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace comms::prims::moe_ep::kernels {
+
+namespace {
+
+// Trap on bad inputs from the kernel. `__trap()` is only valid in the
+// device-compile pass (CUDA: `__CUDA_ARCH__`; HIP: `__HIP_DEVICE_COMPILE__`).
+// In host pass we still emit a no-op so the kernel signature compiles.
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define MOE_EP_DEVICE_ASSERT(cond) \
+  do {                             \
+    if (!(cond)) {                 \
+      __trap();                    \
+    }                              \
+  } while (0)
+#else
+#define MOE_EP_DEVICE_ASSERT(cond) ((void)0)
+#endif
+
+template <int kNumThreads, int kNumExpertsPerSM, int kNumRanksPerSM>
+__global__ void getDispatchLayoutKernel(
+    const topk_idx_t* __restrict__ topk_idx,
+    int* __restrict__ num_tokens_per_rank,
+    int* __restrict__ num_tokens_per_rdma_rank,
+    int* __restrict__ num_tokens_per_expert,
+    bool* __restrict__ is_token_in_rank,
+    int num_tokens,
+    int num_topk,
+    int num_ranks,
+    int num_experts) {
+  const int sm_id = static_cast<int>(blockIdx.x);
+  const int thread_id = static_cast<int>(threadIdx.x);
+
+  // First (num_experts / kNumExpertsPerSM) SMs handle the per-expert count.
+  __shared__ int per_expert_partial[kNumThreads][kNumExpertsPerSM];
+  const int expert_begin_idx = sm_id * kNumExpertsPerSM;
+  const int expert_end_idx =
+      min(expert_begin_idx + kNumExpertsPerSM, num_experts);
+
+  if (expert_begin_idx < expert_end_idx) {
+#pragma unroll
+    for (int i = 0; i < kNumExpertsPerSM; ++i) {
+      per_expert_partial[thread_id][i] = 0;
+    }
+    for (int i = thread_id; i < num_tokens; i += kNumThreads) {
+      const auto* shifted = topk_idx + i * num_topk;
+#pragma unroll 4
+      for (int j = 0; j < num_topk; ++j) {
+        const int expert_idx = static_cast<int>(shifted[j]);
+        if (expert_idx >= expert_begin_idx && expert_idx < expert_end_idx) {
+          ++per_expert_partial[thread_id][expert_idx - expert_begin_idx];
+        }
+      }
+    }
+    __syncthreads();
+
+    static_assert(kNumExpertsPerSM <= kNumThreads, "Too many experts per SM");
+    if (expert_begin_idx + thread_id < expert_end_idx) {
+      int sum = 0;
+#pragma unroll
+      for (int i = 0; i < kNumThreads; ++i) {
+        sum += per_expert_partial[i][thread_id];
+      }
+      num_tokens_per_expert[expert_begin_idx + thread_id] = sum;
+    }
+    return;
+  }
+
+  if (num_tokens_per_rdma_rank != nullptr) {
+    MOE_EP_DEVICE_ASSERT(
+        num_ranks % NUM_MAX_NVL_PEERS == 0 && num_ranks > NUM_MAX_NVL_PEERS);
+  }
+
+  // Remaining SMs handle per-rank + per-RDMA-rank counts.
+  constexpr int kNumRDMARanksPerSM = kNumRanksPerSM / NUM_MAX_NVL_PEERS;
+  __shared__ int per_rank_partial[kNumThreads][kNumRanksPerSM];
+  __shared__ int per_rdma_partial[kNumThreads][kNumRDMARanksPerSM];
+
+  const int sm_begin_for_rank =
+      (num_experts + kNumExpertsPerSM - 1) / kNumExpertsPerSM;
+  const int rank_begin_idx = (sm_id - sm_begin_for_rank) * kNumRanksPerSM;
+  const int rank_end_idx = min(rank_begin_idx + kNumRanksPerSM, num_ranks);
+  const int rdma_rank_begin_idx = rank_begin_idx / NUM_MAX_NVL_PEERS;
+  const int rdma_rank_end_idx = rank_end_idx / NUM_MAX_NVL_PEERS;
+
+  if (rank_begin_idx < rank_end_idx) {
+    const int num_expert_per_rank = num_experts / num_ranks;
+    const int expert_begin = rank_begin_idx * num_expert_per_rank;
+    const int expert_end = rank_end_idx * num_expert_per_rank;
+
+#pragma unroll
+    for (int i = 0; i < kNumRanksPerSM; ++i) {
+      per_rank_partial[thread_id][i] = 0;
+    }
+#pragma unroll
+    for (int i = 0; i < kNumRDMARanksPerSM; ++i) {
+      per_rdma_partial[thread_id][i] = 0;
+    }
+
+    for (int i = thread_id; i < num_tokens; i += kNumThreads) {
+      const auto* shifted = topk_idx + i * num_topk;
+      int is_in_rank[kNumRanksPerSM] = {0};
+      int is_in_rdma_rank[kNumRDMARanksPerSM] = {0};
+#pragma unroll 4
+      for (int j = 0; j < num_topk; ++j) {
+        const int expert_idx = static_cast<int>(shifted[j]);
+        if (expert_idx >= expert_begin && expert_idx < expert_end) {
+          const int rank_idx =
+              expert_idx / num_expert_per_rank - rank_begin_idx;
+          is_in_rank[rank_idx]++;
+          is_in_rdma_rank[rank_idx / NUM_MAX_NVL_PEERS]++;
+        }
+      }
+
+      bool* shifted_is_token_in_rank = is_token_in_rank + i * num_ranks;
+#pragma unroll 4
+      for (int j = 0; j + rank_begin_idx < rank_end_idx; ++j) {
+        shifted_is_token_in_rank[j + rank_begin_idx] = (is_in_rank[j] > 0);
+        per_rank_partial[thread_id][j] += (is_in_rank[j] > 0);
+      }
+#pragma unroll 4
+      for (int j = 0; j + rdma_rank_begin_idx < rdma_rank_end_idx; ++j) {
+        per_rdma_partial[thread_id][j] += (is_in_rdma_rank[j] > 0);
+      }
+    }
+    __syncthreads();
+
+    static_assert(kNumRanksPerSM <= kNumThreads, "Too many ranks per SM");
+    if (rank_begin_idx + thread_id < rank_end_idx) {
+      int sum = 0;
+#pragma unroll
+      for (int i = 0; i < kNumThreads; ++i) {
+        sum += per_rank_partial[i][thread_id];
+      }
+      num_tokens_per_rank[rank_begin_idx + thread_id] = sum;
+    }
+
+    if (num_tokens_per_rdma_rank != nullptr &&
+        rdma_rank_begin_idx + thread_id < rdma_rank_end_idx) {
+      int sum = 0;
+#pragma unroll
+      for (int i = 0; i < kNumThreads; ++i) {
+        sum += per_rdma_partial[i][thread_id];
+      }
+      num_tokens_per_rdma_rank[rdma_rank_begin_idx + thread_id] = sum;
+    }
+  }
+}
+
+} // namespace
+
+void get_dispatch_layout(
+    const topk_idx_t* topk_idx,
+    int* num_tokens_per_rank,
+    int* num_tokens_per_rdma_rank,
+    int* num_tokens_per_expert,
+    bool* is_token_in_rank,
+    int num_tokens,
+    int num_topk,
+    int num_ranks,
+    int num_experts,
+    cudaStream_t stream) {
+  constexpr int kNumThreads = 256;
+  constexpr int kNumExpertsPerSM = 4;
+  constexpr int kNumRanksPerSM = 8;
+  static_assert(
+      kNumRanksPerSM % NUM_MAX_NVL_PEERS == 0,
+      "kNumRanksPerSM must be divisible by NUM_MAX_NVL_PEERS");
+
+  const int num_sms =
+      ((num_experts + kNumExpertsPerSM - 1) / kNumExpertsPerSM) +
+      (num_ranks + kNumRanksPerSM - 1) / kNumRanksPerSM;
+
+  void* args[] = {
+      reinterpret_cast<void*>(const_cast<topk_idx_t**>(&topk_idx)),
+      reinterpret_cast<void*>(&num_tokens_per_rank),
+      reinterpret_cast<void*>(&num_tokens_per_rdma_rank),
+      reinterpret_cast<void*>(&num_tokens_per_expert),
+      reinterpret_cast<void*>(&is_token_in_rank),
+      reinterpret_cast<void*>(&num_tokens),
+      reinterpret_cast<void*>(&num_topk),
+      reinterpret_cast<void*>(&num_ranks),
+      reinterpret_cast<void*>(&num_experts),
+  };
+  auto err = cudaLaunchKernel(
+      reinterpret_cast<const void*>(&getDispatchLayoutKernel<
+                                    kNumThreads,
+                                    kNumExpertsPerSM,
+                                    kNumRanksPerSM>),
+      dim3(num_sms),
+      dim3(kNumThreads),
+      args,
+      0,
+      stream);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("get_dispatch_layout: cudaLaunchKernel failed: ") +
+        cudaGetErrorString(err));
+  }
+}
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Layout.cuh
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime_api.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+namespace comms::prims::moe_ep::kernels {
+
+// Top-k index type (TOPK_IDX_BITS=64).
+using topk_idx_t = int64_t;
+
+/**
+ * get_dispatch_layout — pure compute kernel that derives per-rank /
+ * per-expert / per-RDMA-rank token counts from `topk_idx`.
+ *
+ * No transport involvement; pure local compute.
+ *
+ * @param topk_idx                Per-token expert indices, [num_tokens,
+ * num_topk].
+ * @param num_tokens_per_rank     Output [num_ranks].
+ * @param num_tokens_per_rdma_rank Output [num_rdma_ranks] — may be `nullptr`
+ *                                 in intranode-only mode.
+ * @param num_tokens_per_expert   Output [num_experts].
+ * @param is_token_in_rank        Output [num_tokens, num_ranks] bool.
+ * @param num_tokens              Number of input tokens.
+ * @param num_topk                Top-k count per token.
+ * @param num_ranks               Total ranks (== num_nvl_peers in intranode).
+ * @param num_experts             Total experts (must be divisible by
+ * num_ranks).
+ * @param stream                  CUDA / HIP stream.
+ */
+void get_dispatch_layout(
+    const topk_idx_t* topk_idx,
+    int* num_tokens_per_rank,
+    int* num_tokens_per_rdma_rank,
+    int* num_tokens_per_expert,
+    bool* is_token_in_rank,
+    int num_tokens,
+    int num_topk,
+    int num_ranks,
+    int num_experts,
+    cudaStream_t stream);
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cu
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cu
@@ -1,0 +1,449 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cuh"
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh"
+
+// `notify_dispatch` (lines 11-150).
+//
+// Performs three tasks:
+//
+//  1. Per-rank exchange — every rank writes its `num_tokens_per_rank[i]` count
+//     for every other rank `i` into a per-peer slot in the shared NVLink
+//     buffer. After a barrier, every rank has the full N×N count matrix.
+//  2. Per-channel prefix matrix — for each (dst_rank, channel) pair, count
+//     how many tokens this rank routes to that destination on that channel
+//     and write a prefix sum.
+//  3. Memset — zero out the channel-state region of the buffer so the
+//     subsequent dispatch kernel sees clean state.
+//
+// Synchronization: a star-pattern atomicAdd_system / atomicSub_system on
+// per-peer FIFO slots. `task_fifo_ptrs` here is
+// `barrier_signal_ptrs[rank]` (peer-mapped int* pointers from the runtime's
+// barrier slot region). The `head` rotates through `NUM_MAX_FIFO_SLOTS` so
+// concurrent kernel invocations don't trample each other.
+
+namespace comms::prims::moe_ep::kernels {
+
+namespace {
+
+// Helper — warp-vote pattern. ALL threads in
+// the warp must execute, so the implicit warp sync inside the vote keeps
+// lanes converged. Lanes >= kNumRanks always vote "false" (finished).
+template <int kNumRanks>
+__device__ __forceinline__ bool not_finished_inline(int* task, int expected) {
+  const int lane_id = static_cast<int>(threadIdx.x) % kWarpSize;
+  bool result = false;
+  if (lane_id < kNumRanks) {
+    result = ld_volatile_global(task + lane_id) != expected;
+  }
+#ifdef __HIP_PLATFORM_AMD__
+  return __any(result);
+#else
+  return __any_sync(kFullWarpMask, result);
+#endif
+}
+
+// Star-pattern barrier. Each
+// rank atomically increments its own slot in every peer's FIFO and
+// atomically decrements every peer's slot in its own FIFO. After both
+// sides have done so, the local FIFO entries for every peer should sum
+// back to zero, at which point all ranks have reached the barrier.
+//
+// Spin loop uses `__any_sync` warp-vote so all kNumRanks lanes converge
+// when ALL slots are 0. Without that, lanes exit independently and the
+// warp can desync mid-spin — possible source of cross-rank atomic ordering
+// hazards under AMD's wave64.
+template <int kNumRanks>
+__device__ __forceinline__ void
+barrier_device_inline(int** task_fifo_ptrs, int head, int rank) {
+  const int thread_id = static_cast<int>(threadIdx.x);
+  EP_DEVICE_ASSERT(kNumRanks <= kWarpSize);
+
+  if (thread_id < kNumRanks) {
+    atomicAdd_system(task_fifo_ptrs[rank] + head + thread_id, FINISHED_SUM_TAG);
+    memory_fence();
+    atomicSub_system(task_fifo_ptrs[thread_id] + head + rank, FINISHED_SUM_TAG);
+  }
+
+  long long start = wall_clock64_compat();
+  while (not_finished_inline<kNumRanks>(task_fifo_ptrs[rank] + head, 0)) {
+    long long now = wall_clock64_compat();
+    long long elapsed = now > start ? (now - start) : 0;
+    if (elapsed > NUM_TIMEOUT_CYCLES && thread_id == 0) {
+      printf("moe_ep notify_dispatch barrier timeout (rank=%d)\n", rank);
+      trap_kernel();
+    }
+  }
+}
+
+template <int kNumRanks>
+__device__ __forceinline__ void move_fifo_slots_inline(int& head) {
+  head = (head + kNumRanks) % NUM_MAX_FIFO_SLOTS;
+}
+
+template <int kNumRanks>
+__global__ void notify_dispatch_kernel(
+    const int* num_tokens_per_rank,
+    int* moe_recv_counter_mapped,
+    const int* num_tokens_per_expert,
+    int* moe_recv_expert_counter_mapped,
+    int num_experts,
+    int num_tokens,
+    int num_channels,
+    const bool* is_token_in_rank,
+    int* channel_prefix_matrix,
+    int* rank_prefix_matrix_copy,
+    int num_memset_int,
+    int expert_alignment,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int head,
+    int rank) {
+  const int sm_id = static_cast<int>(blockIdx.x);
+  const int thread_id = static_cast<int>(threadIdx.x);
+  const int num_threads = static_cast<int>(blockDim.x);
+  const int lane_id = thread_id % kWarpSize;
+  const int warp_id = thread_id / kWarpSize;
+  const int num_warps = num_threads / kWarpSize;
+
+  if (sm_id == 0) {
+    // Block 0: cross-rank count exchange via peer-mapped buffer.
+    barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+    move_fifo_slots_inline<kNumRanks>(head);
+    __syncthreads();
+
+    int* per_rank_buffer = nullptr;
+    int* per_expert_buffer = nullptr;
+    if (thread_id < kNumRanks) {
+      per_rank_buffer = reinterpret_cast<int*>(buffer_ptrs[thread_id]);
+      per_expert_buffer = per_rank_buffer + kNumRanks * kNumRanks;
+    }
+
+    // Per-rank counts: write `num_tokens_per_rank[i]` into peer i's row,
+    // column = our rank.
+    const int num_experts_per_rank = num_experts / kNumRanks;
+    if (thread_id < kNumRanks) {
+      per_rank_buffer[rank * kNumRanks + thread_id] =
+          num_tokens_per_rank[thread_id];
+      // These peer per-expert writes are consumed only after the
+      // __syncthreads() at the end of this block AND the cross-rank
+      // barrier_device_inline() below; a sync inside this
+      // `if (thread_id < kNumRanks)` block would be a divergent barrier.
+      // patternlint-disable-next-line cuda-smem-reduction-missing-final-sync
+#pragma unroll
+      for (int i = 0; i < num_experts_per_rank; ++i) {
+        per_expert_buffer[rank * num_experts_per_rank + i] =
+            num_tokens_per_expert[thread_id * num_experts_per_rank + i];
+      }
+    }
+    __syncthreads();
+
+    // Wait for all ranks to finish writing.
+    barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+    move_fifo_slots_inline<kNumRanks>(head);
+    __syncthreads();
+
+    // Compute prefix sum over per-rank counts and write back the local
+    // total to CPU-mapped memory.
+    int* local_per_rank_buffer = reinterpret_cast<int*>(buffer_ptrs[rank]);
+    if (thread_id < kNumRanks) {
+#pragma unroll
+      for (int i = 1; i < kNumRanks; ++i) {
+        local_per_rank_buffer[i * kNumRanks + thread_id] +=
+            local_per_rank_buffer[(i - 1) * kNumRanks + thread_id];
+      }
+      if (thread_id == rank) {
+        *moe_recv_counter_mapped =
+            local_per_rank_buffer[(kNumRanks - 1) * kNumRanks + rank];
+      }
+    }
+
+    // Per-expert sums + alignment.
+    int* local_per_expert_buffer =
+        local_per_rank_buffer + kNumRanks * kNumRanks;
+    if (thread_id < num_experts_per_rank) {
+      int sum = 0;
+#pragma unroll
+      for (int i = 0; i < kNumRanks; ++i) {
+        sum += local_per_expert_buffer[i * num_experts_per_rank + thread_id];
+      }
+      sum = (sum + expert_alignment - 1) / expert_alignment * expert_alignment;
+      moe_recv_expert_counter_mapped[thread_id] = sum;
+    }
+    __syncthreads();
+
+    // Copy rank prefix matrix to host-readable tensor (bypasses the per-peer
+    // shared region).
+#pragma unroll
+    for (int i = thread_id; i < kNumRanks * kNumRanks; i += num_threads) {
+      rank_prefix_matrix_copy[i] = local_per_rank_buffer[i];
+    }
+
+    // Zero out the channel-state region of the local buffer for the
+    // subsequent dispatch kernel.
+#pragma unroll
+    for (int i = thread_id; i < num_memset_int; i += num_threads) {
+      local_per_expert_buffer[i] = 0;
+    }
+
+    memory_fence();
+    __syncthreads();
+    barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+  } else {
+    // Blocks 1..N: per-channel × per-rank token counts.
+    const int dst_rank = sm_id - 1;
+    for (int channel_id = warp_id; channel_id < num_channels;
+         channel_id += num_warps) {
+      int token_start_idx = 0, token_end_idx = 0;
+      get_channel_task_range(
+          num_tokens, num_channels, channel_id, token_start_idx, token_end_idx);
+
+      int count = 0;
+      for (int64_t i = token_start_idx + lane_id; i < token_end_idx;
+           i += kWarpSize) {
+        count += is_token_in_rank[i * kNumRanks + dst_rank];
+      }
+      count = warp_reduce_sum(count);
+      if (lane_id == 0) {
+        channel_prefix_matrix[dst_rank * num_channels + channel_id] = count;
+      }
+    }
+    __syncthreads();
+
+    // Block-local prefix sum across channels (single thread is fine; the
+    // matrix has at most ~32 channels).
+    if (thread_id == 0) {
+#pragma unroll
+      for (int i = 1; i < num_channels; ++i) {
+        channel_prefix_matrix[dst_rank * num_channels + i] +=
+            channel_prefix_matrix[dst_rank * num_channels + i - 1];
+      }
+    }
+  }
+}
+
+} // namespace
+
+// cached_notify_dispatch — handle-reuse path. Skips the count exchange and
+// just (a) memcpys the cached rank_prefix_matrix back into the local
+// buffer's prefix region (b) zeroes out `num_memset_int` ints of the
+// channel-state region. Used when callers reuse a `handle` from a prior
+// dispatch.
+template <int kNumRanks>
+__global__ void cached_notify_dispatch_kernel(
+    const int* rank_prefix_matrix,
+    int num_memset_int,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int head,
+    int rank) {
+  barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+  move_fifo_slots_inline<kNumRanks>(head);
+  __syncthreads();
+
+  const int thread_id = static_cast<int>(threadIdx.x);
+  const int num_threads = static_cast<int>(blockDim.x);
+  int* ptr = reinterpret_cast<int*>(buffer_ptrs[rank]);
+#pragma unroll
+  for (int i = thread_id; i < kNumRanks * kNumRanks; i += num_threads) {
+    ptr[i] = rank_prefix_matrix[i];
+  }
+#pragma unroll
+  for (int i = thread_id; i < num_memset_int; i += num_threads) {
+    ptr[kNumRanks * kNumRanks + i] = 0;
+  }
+  memory_fence();
+  __syncthreads();
+  barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+}
+
+// cached_notify_combine — symmetric prep for combine. Barrier, zero out a
+// fixed prefix of the local buffer, then run a per-channel pass that walks
+// `send_head` backwards to fill in placeholder entries (`-last_head - 1`)
+// for tokens that didn't route to a given destination.
+template <int kNumRanks>
+__global__ void cached_notify_combine_kernel(
+    void** buffer_ptrs,
+    int* send_head,
+    int num_channels,
+    int num_recv_tokens,
+    int num_memset_int,
+    int** task_fifo_ptrs,
+    int head,
+    int rank) {
+  const int sm_id = static_cast<int>(blockIdx.x);
+  if (sm_id == 0) {
+    barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+    move_fifo_slots_inline<kNumRanks>(head);
+    __syncthreads();
+
+    const int thread_id = static_cast<int>(threadIdx.x);
+    const int num_threads = static_cast<int>(blockDim.x);
+    int* ptr = reinterpret_cast<int*>(buffer_ptrs[rank]);
+#pragma unroll
+    for (int i = thread_id; i < num_memset_int; i += num_threads) {
+      ptr[i] = 0;
+    }
+    memory_fence();
+    __syncthreads();
+    barrier_device_inline<kNumRanks>(task_fifo_ptrs, head, rank);
+  } else {
+    const int channel_id = sm_id - 1;
+    const int thread_id = static_cast<int>(threadIdx.x);
+    const int rank_id = thread_id / kWarpSize;
+    const int lane_id = get_lane_id();
+    if (rank_id >= kNumRanks) {
+      return;
+    }
+
+    int token_start_idx = 0, token_end_idx = 0;
+    get_channel_task_range(
+        num_recv_tokens,
+        num_channels,
+        channel_id,
+        token_start_idx,
+        token_end_idx);
+
+    int last_head = 1 << 25; // sentinel: heuristic large value
+    for (int token_idx_tail = token_end_idx - 1;
+         token_idx_tail >= token_start_idx;
+         token_idx_tail -= kWarpSize) {
+      const int token_idx = token_idx_tail - lane_id;
+      int expected_head = 0;
+      int current_head = (token_idx >= token_start_idx)
+          ? send_head[token_idx * kNumRanks + rank_id]
+          : -1;
+      const int loop_n = min(kWarpSize, token_idx_tail - token_start_idx + 1);
+      for (int i = 0; i < loop_n; ++i) {
+        const int h = shfl_sync_compat(current_head, i);
+        if (h < 0) {
+          if (lane_id == i) {
+            expected_head = -last_head - 1;
+          }
+        } else {
+          last_head = h;
+        }
+      }
+      if (current_head < 0 && token_idx >= token_start_idx) {
+        send_head[token_idx * kNumRanks + rank_id] = expected_head;
+      }
+    }
+  }
+}
+
+void notify_dispatch(
+    const int* num_tokens_per_rank,
+    int* moe_recv_counter_mapped,
+    int num_ranks,
+    const int* num_tokens_per_expert,
+    int* moe_recv_expert_counter_mapped,
+    int num_experts,
+    int num_tokens,
+    const bool* is_token_in_rank,
+    int* channel_prefix_matrix,
+    int* rank_prefix_matrix_copy,
+    int num_memset_int,
+    int expert_alignment,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int head,
+    int rank,
+    cudaStream_t stream,
+    int num_channels) {
+  constexpr int kNumThreads = 128;
+  EP_HOST_ASSERT(num_experts % num_ranks == 0);
+  EP_HOST_ASSERT(num_experts / num_ranks <= kNumThreads);
+  EP_HOST_ASSERT(num_ranks <= kNumThreads);
+
+  SETUP_LAUNCH_CONFIG(1 + num_ranks, kNumThreads, stream);
+
+#define NOTIFY_DISPATCH_LAUNCH_CASE(ranks) \
+  LAUNCH_KERNEL_NON_COOPERATIVE(           \
+      &cfg,                                \
+      notify_dispatch_kernel<ranks>,       \
+      num_tokens_per_rank,                 \
+      moe_recv_counter_mapped,             \
+      num_tokens_per_expert,               \
+      moe_recv_expert_counter_mapped,      \
+      num_experts,                         \
+      num_tokens,                          \
+      num_channels,                        \
+      is_token_in_rank,                    \
+      channel_prefix_matrix,               \
+      rank_prefix_matrix_copy,             \
+      num_memset_int,                      \
+      expert_alignment,                    \
+      buffer_ptrs,                         \
+      task_fifo_ptrs,                      \
+      head,                                \
+      rank)
+
+  SWITCH_RANKS(NOTIFY_DISPATCH_LAUNCH_CASE);
+#undef NOTIFY_DISPATCH_LAUNCH_CASE
+}
+
+void cached_notify_dispatch(
+    const int* rank_prefix_matrix,
+    int num_memset_int,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int head) {
+  SETUP_LAUNCH_CONFIG(1, 128, stream);
+
+#define CACHED_NOTIFY_DISPATCH_LAUNCH_CASE(ranks) \
+  LAUNCH_KERNEL_NON_COOPERATIVE(                  \
+      &cfg,                                       \
+      cached_notify_dispatch_kernel<ranks>,       \
+      rank_prefix_matrix,                         \
+      num_memset_int,                             \
+      buffer_ptrs,                                \
+      task_fifo_ptrs,                             \
+      head,                                       \
+      rank)
+
+  SWITCH_RANKS(CACHED_NOTIFY_DISPATCH_LAUNCH_CASE);
+#undef CACHED_NOTIFY_DISPATCH_LAUNCH_CASE
+}
+
+void cached_notify_combine(
+    void** buffer_ptrs,
+    int* send_head,
+    int num_channels,
+    int num_recv_tokens,
+    int num_memset_int,
+    int** task_fifo_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int head) {
+  // num_threads = max(128, 64 * num_ranks).
+  const int num_threads = num_ranks * 64 > 128 ? num_ranks * 64 : 128;
+  EP_HOST_ASSERT(num_threads <= 1024);
+  SETUP_LAUNCH_CONFIG(1 + num_channels, num_threads, stream);
+
+#define CACHED_NOTIFY_COMBINE_LAUNCH_CASE(ranks) \
+  LAUNCH_KERNEL_NON_COOPERATIVE(                 \
+      &cfg,                                      \
+      cached_notify_combine_kernel<ranks>,       \
+      buffer_ptrs,                               \
+      send_head,                                 \
+      num_channels,                              \
+      num_recv_tokens,                           \
+      num_memset_int,                            \
+      task_fifo_ptrs,                            \
+      head,                                      \
+      rank)
+
+  SWITCH_RANKS(CACHED_NOTIFY_COMBINE_LAUNCH_CASE);
+#undef CACHED_NOTIFY_COMBINE_LAUNCH_CASE
+}
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/intranode/kernels/Notify.cuh
@@ -1,0 +1,76 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+namespace comms::prims::moe_ep::kernels {
+
+/**
+ * Notify pre-dispatch — exchanges per-rank counts via NVL transport and
+ * stages the channel head/tail/queue offsets that subsequent dispatch
+ * reads.
+ *
+ * Real implementation lands in a follow-up sub-commit alongside
+ * IntranodeDispatch.cu — this header keeps the BUCK target buildable.
+ */
+void notify_dispatch(
+    const int* num_tokens_per_rank,
+    int* moe_recv_counter_mapped,
+    int num_ranks,
+    const int* num_tokens_per_expert,
+    int* moe_recv_expert_counter_mapped,
+    int num_experts,
+    int num_tokens,
+    const bool* is_token_in_rank,
+    int* channel_prefix_matrix,
+    int* rank_prefix_matrix_copy,
+    int num_memset_int,
+    int expert_alignment,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int head,
+    int rank,
+    cudaStream_t stream,
+    int num_channels);
+
+/**
+ * `cached_notify_dispatch` — handle-reuse path. Called when the user passes
+ * a `handle` from a prior dispatch back into the next one; skips the count
+ * exchange and just refreshes the local prefix-matrix region + zeroes the
+ * channel state.
+ */
+void cached_notify_dispatch(
+    const int* rank_prefix_matrix,
+    int num_memset_int,
+    void** buffer_ptrs,
+    int** task_fifo_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int head = 0);
+
+/**
+ * `cached_notify_combine` — symmetric to cached_notify_dispatch. Barrier +
+ * memset + per-channel `send_head` placeholder fill so combine sees
+ * already-routed token slots in the right shape.
+ */
+void cached_notify_combine(
+    void** buffer_ptrs,
+    int* send_head,
+    int num_channels,
+    int num_recv_tokens,
+    int num_memset_int,
+    int** task_fifo_ptrs,
+    int rank,
+    int num_ranks,
+    cudaStream_t stream,
+    int head = 0);
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/shared/Config.h
+++ b/comms/prims/collectives/moe_ep/cpp/shared/Config.h
@@ -1,0 +1,103 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace comms::prims::moe_ep {
+
+/**
+ * Config — tuning knobs for the dispatch / combine kernels.
+ *
+ * The Python `comms.prims.collectives.moe_ep.Config(...)` ctor signature is:
+ *
+ *   Config(num_sms,
+ *          num_max_nvl_chunked_send_tokens,
+ *          num_max_nvl_chunked_recv_tokens,
+ *          num_max_rdma_chunked_send_tokens=6,
+ *          num_max_rdma_chunked_recv_tokens=128)
+ *
+ * Bound through `PyBindings.cpp`.
+ */
+struct Config {
+  int num_sms{20};
+  int num_max_nvl_chunked_send_tokens{6};
+  int num_max_nvl_chunked_recv_tokens{256};
+  int num_max_rdma_chunked_send_tokens{6};
+  int num_max_rdma_chunked_recv_tokens{128};
+
+  Config() = default;
+  Config(
+      int num_sms,
+      int num_max_nvl_chunked_send_tokens,
+      int num_max_nvl_chunked_recv_tokens,
+      int num_max_rdma_chunked_send_tokens = 6,
+      int num_max_rdma_chunked_recv_tokens = 128)
+      : num_sms(num_sms),
+        num_max_nvl_chunked_send_tokens(num_max_nvl_chunked_send_tokens),
+        num_max_nvl_chunked_recv_tokens(num_max_nvl_chunked_recv_tokens),
+        num_max_rdma_chunked_send_tokens(num_max_rdma_chunked_send_tokens),
+        num_max_rdma_chunked_recv_tokens(num_max_rdma_chunked_recv_tokens) {}
+
+  /** NVLink staging-buffer size hint for `Buffer.__init__` `num_nvl_bytes`.
+   *
+   *  Mirrors the exact per-rank NVL layout the dispatch kernel slices out of
+   *  this region (intranode/kernels/Dispatch.cu): an R×R rank-prefix region,
+   *  then per (channel, nvl-rank) 4 ring-metadata ints and
+   *  `num_max_nvl_chunked_recv_tokens` slots of payload + src-idx + topk-idx +
+   *  topk-weights + scales. `num_channels = num_sms/2`: dropping it (as the
+   *  prior hint did) undersizes by ~10-32x and corrupts memory. Worst-case
+   *  topk/scales (128) give headroom; the Buffer.cc dispatch/combine host
+   *  guards re-check the exact size with the real topk/scales.
+   */
+  std::size_t getNvlBufferSizeHint(std::size_t hidden_bytes, int num_ranks)
+      const noexcept {
+    constexpr std::size_t kNumMaxTopK = 128;
+    constexpr std::size_t kNumMaxScales = 128;
+    // NUM_MAX_NVL_PEERS (== 8) is declared after this struct, so use the
+    // literal here (matches the original hint).
+    const std::size_t num_nvl_ranks =
+        static_cast<std::size_t>(num_ranks < 8 ? num_ranks : 8);
+    const std::size_t num_channels = static_cast<std::size_t>(num_sms / 2);
+    const std::size_t recv =
+        static_cast<std::size_t>(num_max_nvl_chunked_recv_tokens);
+    const std::size_t cr = num_channels * num_nvl_ranks;
+    std::size_t n = num_nvl_ranks * num_nvl_ranks * sizeof(int);
+    n += cr * 4UL * sizeof(int);
+    n += cr * recv * hidden_bytes;
+    n += cr * recv * sizeof(int);
+    n += cr * recv * kNumMaxTopK * sizeof(std::int64_t);
+    n += cr * recv * kNumMaxTopK * sizeof(float);
+    n += cr * recv * kNumMaxScales * sizeof(float);
+    n = ((n + 127UL) / 128UL) * 128UL; // NUM_BUFFER_ALIGNMENT_BYTES
+    return n;
+  }
+
+  /** RDMA staging-buffer size hint for `Buffer.__init__` `num_rdma_bytes`. */
+  std::size_t getRdmaBufferSizeHint() const noexcept {
+    constexpr std::size_t kMaxHiddenBytes = 8UL * 1024UL * 2UL;
+    return static_cast<std::size_t>(num_max_rdma_chunked_recv_tokens) *
+        kMaxHiddenBytes * 8UL +
+        (32UL * 1024UL * 1024UL);
+  }
+};
+
+/**
+ * NUM_WORKSPACE_BYTES — persistent scratch used by every kernel for atomic
+ * counters and per-expert state.
+ */
+inline constexpr std::size_t NUM_WORKSPACE_BYTES = 32UL * 1024UL * 1024UL;
+
+/**
+ * NUM_MAX_NVL_PEERS — ≤8 NVL peers per node (typical 8-GPU MI300X / H100
+ * NVL8 layout).
+ */
+inline constexpr int NUM_MAX_NVL_PEERS = 8;
+
+/**
+ * NUM_BUFFER_ALIGNMENT_BYTES — all buffer offsets are aligned to this.
+ */
+inline constexpr std::size_t NUM_BUFFER_ALIGNMENT_BYTES = 128;
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/shared/EventHandle.cc
+++ b/comms/prims/collectives/moe_ep/cpp/shared/EventHandle.cc
@@ -1,0 +1,48 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/EventHandle.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace comms::prims::moe_ep {
+
+namespace {
+
+void check(cudaError_t err, const char* msg) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(msg) + ": " + cudaGetErrorString(err));
+  }
+}
+
+} // namespace
+
+EventHandle::Impl::Impl() {
+  cudaStream_t stream = nullptr; // current stream
+  check(cudaEventCreate(&raw), "cudaEventCreate failed");
+  check(cudaEventRecord(raw, stream), "cudaEventRecord failed");
+}
+
+EventHandle::Impl::~Impl() {
+  if (raw != nullptr) {
+    // Best-effort cleanup; never throw from a destructor.
+    (void)cudaEventDestroy(raw);
+  }
+}
+
+EventHandle::EventHandle() : event_(std::make_shared<Impl>()) {}
+
+EventHandle::EventHandle(cudaEvent_t event)
+    : event_(std::make_shared<Impl>(event)) {}
+
+void EventHandle::current_stream_wait() const {
+  if (!event_) {
+    return;
+  }
+  cudaStream_t stream = nullptr; // current stream
+  check(
+      cudaStreamWaitEvent(stream, event_->raw, /*flags=*/0),
+      "cudaStreamWaitEvent failed");
+}
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/shared/EventHandle.h
+++ b/comms/prims/collectives/moe_ep/cpp/shared/EventHandle.h
@@ -1,0 +1,62 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <memory>
+
+// AMD vs NVIDIA include divergence — same pattern as
+// MultipeerIbgdaTransport.cc. HIPify rewrites cuda* symbols to hip* in the
+// source after compilation branches; the include path determines which type
+// defs are visible.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+namespace comms::prims::moe_ep {
+
+/**
+ * EventHandle — RAII wrapper around a `cudaEvent_t` (HIPified to
+ * `hipEvent_t` on AMD), recorded on the current stream at construction.
+ *
+ * Bound through pybind as `_cpp.EventHandle`. The Python `EventOverlap`
+ * wraps it and exposes `current_stream_wait()` so callers can synchronize
+ * the default stream against the captured event without touching CUDA APIs.
+ *
+ * Shared ownership semantics — the Python `Buffer.dispatch / combine` code
+ * passes `EventHandle` instances around (they're returned in the result
+ * tuple AND captured by `previous_event=` arguments). Implemented as a
+ * shared_ptr so multiple wrappers can share a single underlying CUDA event
+ * and the destruction is one-shot.
+ */
+class EventHandle {
+ public:
+  /** Capture an event on the current stream. */
+  EventHandle();
+
+  /** Adopt an existing event (used internally by the runtime when launch
+   *  paths construct the event manually). */
+  explicit EventHandle(cudaEvent_t event);
+
+  /** Make `torch.cuda.current_stream()` wait on the captured event. */
+  void current_stream_wait() const;
+
+  /** Underlying event handle (for runtime passthrough). */
+  cudaEvent_t event() const noexcept {
+    return event_ ? event_->raw : nullptr;
+  }
+
+ private:
+  struct Impl {
+    cudaEvent_t raw{nullptr};
+    Impl();
+    explicit Impl(cudaEvent_t event) : raw(event) {}
+    ~Impl();
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+  };
+  std::shared_ptr<Impl> event_;
+};
+
+} // namespace comms::prims::moe_ep

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/EpBuffer.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/EpBuffer.cuh
@@ -1,0 +1,194 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+//
+// Three small device-only RAII helpers used to slice the flat workspace
+// passed to dispatch / combine kernels into typed sub-buffers + per-channel
+// + per-rank stripes. They:
+//   - take a `void*&` cursor by reference and bump it forward by `total_bytes`
+//   - cast the slice to a typed pointer so kernels can index without manual
+//     pointer arithmetic
+//   - support the three layouts dispatch / combine need:
+//       Buffer        — flat per-rank scratch
+//       AsymBuffer    — per-channel × per-rank scratch (asymmetric — sender
+//                       writes to recv_ptr, recv reads from send_ptr; same
+//                       memory)
+//       SymBuffer     — per-channel × per-rank send + recv scratch (when
+//                       decoupled, send and recv are different memory
+//                       regions; when not, they alias and direction is
+//                       determined by the kernel)
+
+namespace comms::prims::moe_ep::kernels {
+
+template <typename DType>
+struct Buffer {
+ private:
+  std::uint8_t* ptr;
+
+ public:
+  int total_bytes;
+
+  __device__ __forceinline__ Buffer() : ptr(nullptr), total_bytes(0) {}
+
+  __device__ __forceinline__
+  Buffer(void*& gbl_ptr, int num_elems, int offset = 0) {
+    total_bytes = num_elems * sizeof(DType);
+    ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + offset * sizeof(DType);
+    gbl_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + total_bytes;
+  }
+
+  __device__ __forceinline__ Buffer advance_also(void*& gbl_ptr) {
+    gbl_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + total_bytes;
+    return *this;
+  }
+
+  __device__ __forceinline__ DType* buffer() {
+    return reinterpret_cast<DType*>(ptr);
+  }
+
+  __device__ __forceinline__ DType& operator[](int idx) {
+    return buffer()[idx];
+  }
+};
+
+template <typename DType, int kNumRanks = 1>
+struct AsymBuffer {
+ private:
+  std::uint8_t* ptrs[kNumRanks];
+  int num_bytes;
+
+ public:
+  int total_bytes;
+
+  // Single-rank ctor — used in dispatch's per-channel local-receiver buffer.
+  __device__ __forceinline__ AsymBuffer(
+      void*& gbl_ptr,
+      int num_elems,
+      int num_ranks,
+      int sm_id = 0,
+      int num_sms = 1,
+      int offset = 0) {
+    static_assert(kNumRanks == 1, "Single-rank ctor requires kNumRanks == 1");
+    num_bytes = num_elems * sizeof(DType);
+
+    const int per_channel_bytes = num_bytes * num_ranks;
+    total_bytes = per_channel_bytes * num_sms;
+    ptrs[0] = reinterpret_cast<std::uint8_t*>(gbl_ptr) +
+        per_channel_bytes * sm_id + num_bytes * offset;
+    gbl_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + total_bytes;
+  }
+
+  // Multi-rank ctor — used in dispatch's per-channel sender buffer (one
+  // per peer NVLink target).
+  __device__ __forceinline__ AsymBuffer(
+      void** gbl_ptrs,
+      int num_elems,
+      int num_ranks,
+      int sm_id = 0,
+      int num_sms = 1,
+      int offset = 0) {
+    static_assert(kNumRanks > 1, "Multi-rank ctor requires kNumRanks > 1");
+    num_bytes = num_elems * sizeof(DType);
+
+    const int per_channel_bytes = num_bytes * num_ranks;
+    total_bytes = per_channel_bytes * num_sms;
+#pragma unroll
+    for (int i = 0; i < kNumRanks; ++i) {
+      ptrs[i] = reinterpret_cast<std::uint8_t*>(gbl_ptrs[i]) +
+          per_channel_bytes * sm_id + num_bytes * offset;
+      gbl_ptrs[i] = reinterpret_cast<std::uint8_t*>(gbl_ptrs[i]) + total_bytes;
+    }
+  }
+
+  __device__ __forceinline__ void advance(int shift) {
+#pragma unroll
+    for (int i = 0; i < kNumRanks; ++i) {
+      ptrs[i] = ptrs[i] + shift * sizeof(DType);
+    }
+  }
+
+  __device__ __forceinline__ AsymBuffer advance_also(void*& gbl_ptr) {
+    gbl_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + total_bytes;
+    return *this;
+  }
+
+  template <int kNumAlsoRanks>
+  __device__ __forceinline__ AsymBuffer advance_also(void** gbl_ptrs) {
+#pragma unroll
+    for (int i = 0; i < kNumAlsoRanks; ++i) {
+      gbl_ptrs[i] = reinterpret_cast<std::uint8_t*>(gbl_ptrs[i]) + total_bytes;
+    }
+    return *this;
+  }
+
+  __device__ __forceinline__ DType* buffer(int idx = 0) {
+    static_assert(kNumRanks == 1, "`buffer` is only available for single rank");
+    return reinterpret_cast<DType*>(ptrs[0] + num_bytes * idx);
+  }
+
+  __device__ __forceinline__ DType* buffer_by(int rank_idx, int idx = 0) {
+    static_assert(
+        kNumRanks > 1, "`buffer_by` is only available for multi-rank");
+    return reinterpret_cast<DType*>(ptrs[rank_idx] + num_bytes * idx);
+  }
+};
+
+template <typename DType, bool kDecoupled = true>
+struct SymBuffer {
+ private:
+  // NOTE: for non-decoupled case `recv_ptr` is unused.
+  std::uint8_t* send_ptr;
+  std::uint8_t* recv_ptr;
+  int num_bytes;
+
+ public:
+  int total_bytes;
+
+  __device__ __forceinline__ SymBuffer(
+      void*& gbl_ptr,
+      int num_elems,
+      int num_ranks,
+      int sm_id = 0,
+      int num_sms = 1) {
+    num_bytes = num_elems * sizeof(DType);
+
+    const int per_channel_bytes = num_bytes * num_ranks;
+    total_bytes =
+        per_channel_bytes * num_sms * (static_cast<int>(kDecoupled) + 1);
+    send_ptr =
+        reinterpret_cast<std::uint8_t*>(gbl_ptr) + per_channel_bytes * sm_id;
+    recv_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) +
+        per_channel_bytes * (sm_id + num_sms);
+    gbl_ptr = reinterpret_cast<std::uint8_t*>(gbl_ptr) + total_bytes;
+  }
+
+  __device__ __forceinline__ DType* send_buffer(int idx = 0) {
+    static_assert(
+        kDecoupled, "`send_buffer` is only available for the decoupled case");
+    return reinterpret_cast<DType*>(send_ptr + num_bytes * idx);
+  }
+
+  __device__ __forceinline__ DType* recv_buffer(int idx = 0) {
+    static_assert(
+        kDecoupled, "`recv_buffer` is only available for the decoupled case");
+    return reinterpret_cast<DType*>(recv_ptr + num_bytes * idx);
+  }
+
+  __device__ __forceinline__ DType* buffer(int idx = 0) {
+    static_assert(
+        !kDecoupled, "`buffer` is only available for the non-decoupled case");
+    return reinterpret_cast<DType*>(send_ptr + num_bytes * idx);
+  }
+};
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh
@@ -1,0 +1,108 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <string>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+//
+// Provides the `EPException` host-side exception type plus three macros used
+// across the dispatch / combine kernels:
+//   - `EP_STATIC_ASSERT(cond, reason)` — compile-time assert (alias of
+//     `static_assert`)
+//   - `EP_HOST_ASSERT(cond)` — runtime check on host code; throws EPException
+//   - `EP_DEVICE_ASSERT(cond)` — device-side check; printf + trap on failure
+//   - `CUDA_CHECK(cmd)` — wrap a CUDA call and throw on non-success
+
+namespace comms::prims::moe_ep::kernels {
+
+class EPException : public std::exception {
+ public:
+  EPException(
+      const char* name,
+      const char* file,
+      int line,
+      const std::string& error) {
+    message_ = std::string("Failed: ") + name + " error " + file + ":" +
+        std::to_string(line) + " '" + error + "'";
+  }
+
+  const char* what() const noexcept override {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
+
+} // namespace comms::prims::moe_ep::kernels
+
+#ifndef EP_STATIC_ASSERT
+#define EP_STATIC_ASSERT(cond, reason) static_assert(cond, reason)
+#endif
+
+#ifndef CUDA_CHECK
+#define CUDA_CHECK(cmd)                                       \
+  do {                                                        \
+    cudaError_t e = (cmd);                                    \
+    if (e != cudaSuccess) {                                   \
+      throw ::comms::prims::moe_ep::kernels::EPException(     \
+          "CUDA", __FILE__, __LINE__, cudaGetErrorString(e)); \
+    }                                                         \
+  } while (0)
+#endif
+
+#ifndef EP_HOST_ASSERT
+#define EP_HOST_ASSERT(cond)                              \
+  do {                                                    \
+    if (!(cond)) {                                        \
+      throw ::comms::prims::moe_ep::kernels::EPException( \
+          "Assertion", __FILE__, __LINE__, #cond);        \
+    }                                                     \
+  } while (0)
+#endif
+
+#ifndef EP_DEVICE_ASSERT
+// Device-side: only emit `printf`+`__trap()` when actually compiling the
+// device pass. The host pass uses `abort()` so the macro stays well-formed
+// in cross-platform contexts.
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#ifdef __HIP_PLATFORM_AMD__
+#define EP_DEVICE_ASSERT(cond)                        \
+  do {                                                \
+    if (!(cond)) {                                    \
+      printf(                                         \
+          "Assertion failed: %s:%d, condition: %s\n", \
+          __FILE__,                                   \
+          __LINE__,                                   \
+          #cond);                                     \
+      abort();                                        \
+    }                                                 \
+  } while (0)
+#else
+#define EP_DEVICE_ASSERT(cond)                        \
+  do {                                                \
+    if (!(cond)) {                                    \
+      printf(                                         \
+          "Assertion failed: %s:%d, condition: %s\n", \
+          __FILE__,                                   \
+          __LINE__,                                   \
+          #cond);                                     \
+      asm("trap;");                                   \
+    }                                                 \
+  } while (0)
+#endif
+#else
+// Host pass: no-op so the macro can appear unconditionally inside `__device__`
+// + `__host__` annotated helpers without breaking the host compile.
+#define EP_DEVICE_ASSERT(cond) ((void)0)
+#endif
+#endif

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh
@@ -1,0 +1,73 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+// Device-side constants used across the dispatch / combine kernels.
+//
+// subset that actually shows up in the kernel bodies. The host-side constants
+// (NUM_WORKSPACE_BYTES, NUM_MAX_NVL_PEERS, NUM_BUFFER_ALIGNMENT_BYTES) live
+// in `cpp/Config.h` so host code can use them without pulling in CUDA/HIP
+// headers.
+//
+// NVSHMEM / rocshmem includes are intentionally omitted — pipes'
+// MultiPeerNvlTransport replaces NVSHMEM for NVLink signaling, and pipes'
+// MultipeerIbgdaTransport replaces NVSHMEM for RDMA.
+
+namespace comms::prims::moe_ep::kernels {
+
+// Maximum number of FIFO slots used by the `task_fifo_ptrs` barrier. We
+// don't use task_fifo (we use pipes' barrier_sync instead), but the kernels
+// still reserve workspace for them in the layout helpers.
+inline constexpr int NUM_MAX_FIFO_SLOTS = 32768;
+
+inline constexpr int NUM_MAX_LOCAL_EXPERTS = 1024;
+
+// Tag value used by combine's grid_barrier to mark "I am done."
+inline constexpr int FINISHED_SUM_TAG = 1024;
+
+// CPU-side timeout: 100 seconds before throwing.
+inline constexpr int NUM_CPU_TIMEOUT_SECS = 100;
+
+// GPU-side spin-loop timeout. NVIDIA: ~100s on 2 GHz `clock64`. AMD's
+// `__builtin_amdgcn_s_memrealtime` ticks at ~100 MHz (15x slower), so use a
+// proportionally smaller bound so the timeout actually fires within the
+// test harness window.
+#ifdef __HIP_PLATFORM_AMD__
+inline constexpr long long NUM_TIMEOUT_CYCLES = 3000000000ll; // ~30s @ 100MHz
+#else
+inline constexpr long long NUM_TIMEOUT_CYCLES = 200000000000ll;
+#endif
+
+inline constexpr int NUM_WAIT_NANOSECONDS = 500;
+
+#ifdef __HIP_PLATFORM_AMD__
+// On AMD, additional cycle budget per spin iteration since AMD wave size
+// (64) doubles the iteration cost vs NVIDIA warp (32).
+inline constexpr int NUM_WAIT_CYCLES_TIMES_64 = 16;
+#endif
+
+// Warp / wave size — 32 on NVIDIA, 64 on AMD.
+#ifdef __HIP_PLATFORM_AMD__
+inline constexpr int kWarpSize = 64;
+inline constexpr int kEmulatedWarpSize = kWarpSize / 2; // 32
+inline constexpr std::uint64_t kFullWarpMask = 0xffffffffffffffffULL;
+inline constexpr std::uint64_t kFirstHalfMask = 0x00000000ffffffffULL;
+inline constexpr std::uint64_t kSecondHalfMask = 0xffffffff00000000ULL;
+#else
+inline constexpr int kWarpSize = 32;
+inline constexpr int kEmulatedWarpSize = kWarpSize;
+inline constexpr std::uint32_t kFullWarpMask = 0xffffffffU;
+#endif
+
+// Topk index dtype — we standardize on int64 (TOPK_IDX_BITS=64).
+using topk_idx_t = std::int64_t;
+
+} // namespace comms::prims::moe_ep::kernels

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelUtils.cuh
@@ -1,0 +1,369 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_runtime.h>
+#endif
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/KernelConfigs.cuh"
+
+// Helpers used by intranode dispatch / combine kernels.
+//
+// Pipes-specific notes:
+//
+//  - A `barrier_device<kNumRanks>(task_fifo_ptrs, head, rank)` star-pattern
+//    atomic-add/sub barrier needs N peer-mapped FIFO arrays plus a rotating
+//    `head` counter. We replace it everywhere with a thin `barrier_all_peers`
+//    wrapper that calls into pipes' `MultiPeerNvlTransport::barrier_sync`
+//    (one-line free function from D2). The kernel keeps the same call shape so
+//    the body of `notify_dispatch` etc. doesn't have to change otherwise.
+
+namespace comms::prims::moe_ep::kernels {
+
+// ---------------------------------------------------------------------------
+// Math / layout helpers (pure-compute, no comm).
+// ---------------------------------------------------------------------------
+
+template <typename DType>
+__host__ __device__ __forceinline__ DType cell_div(DType a, DType b) {
+  return (a + b - 1) / b;
+}
+
+template <typename DType>
+__host__ __device__ __forceinline__ DType align(DType a, DType b) {
+  return cell_div<DType>(a, b) * b;
+}
+
+__device__ __forceinline__ void get_channel_task_range(
+    int num_tokens,
+    int num_sms,
+    int sm_id,
+    int& token_start_idx,
+    int& token_end_idx) {
+  int num_tokens_per_sm = cell_div(num_tokens, num_sms);
+  token_start_idx = min(num_tokens_per_sm * sm_id, num_tokens);
+  token_end_idx = min(token_start_idx + num_tokens_per_sm, num_tokens);
+}
+
+// ---------------------------------------------------------------------------
+// Memory-fence wrappers — bridge NVIDIA inline PTX vs HIP threadfence calls.
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ void memory_fence() {
+#ifdef __HIP_PLATFORM_AMD__
+  __threadfence_system();
+#else
+  asm volatile("fence.acq_rel.sys;" : : : "memory");
+#endif
+}
+
+__device__ __forceinline__ void memory_fence_gpu() {
+#ifdef __HIP_PLATFORM_AMD__
+  __threadfence();
+#else
+  asm volatile("fence.acq_rel.gpu;" : : : "memory");
+#endif
+}
+
+__device__ __forceinline__ void memory_fence_cta() {
+#ifdef __HIP_PLATFORM_AMD__
+  __threadfence_block();
+#else
+  asm volatile("fence.acq_rel.cta;" : : : "memory");
+#endif
+}
+
+__device__ __forceinline__ void trap_kernel() {
+#ifdef __HIP_PLATFORM_AMD__
+  abort();
+#else
+  asm("trap;");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Warp shuffle primitives — one wrapper for both NVIDIA and HIP.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+__device__ __forceinline__ T shfl_xor_sync_compat(T val, int lane_mask) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __shfl_xor(val, lane_mask, kWarpSize);
+#else
+  return __shfl_xor_sync(kFullWarpMask, val, lane_mask, kWarpSize);
+#endif
+}
+
+__device__ __forceinline__ int warp_reduce_sum(int value) {
+  if constexpr (kWarpSize == 64) {
+    value += shfl_xor_sync_compat<int>(value, 32);
+  }
+  value += shfl_xor_sync_compat<int>(value, 16);
+  value += shfl_xor_sync_compat<int>(value, 8);
+  value += shfl_xor_sync_compat<int>(value, 4);
+  value += shfl_xor_sync_compat<int>(value, 2);
+  value += shfl_xor_sync_compat<int>(value, 1);
+  return value;
+}
+
+__device__ __forceinline__ int get_lane_id() {
+#ifdef __HIP_PLATFORM_AMD__
+  return threadIdx.x % kWarpSize;
+#else
+  int lane_id;
+  asm("mov.s32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Loads / stores with explicit memory ordering, used by the channel-state
+// communication in dispatch / combine.
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ void st_relaxed_sys_global(int* ptr, int val) {
+#ifdef __HIP_PLATFORM_AMD__
+  __hip_atomic_store(ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  asm volatile("st.relaxed.sys.global.s32 [%0], %1;"
+               :
+               : "l"(ptr), "r"(val)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ void st_release_sys_global(int* ptr, int val) {
+#ifdef __HIP_PLATFORM_AMD__
+  __hip_atomic_store(ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  asm volatile("st.release.sys.global.s32 [%0], %1;"
+               :
+               : "l"(ptr), "r"(val)
+               : "memory");
+#endif
+}
+
+__device__ __forceinline__ int ld_relaxed_sys_global(const int* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __hip_atomic_load(ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  int ret;
+  asm volatile("ld.relaxed.sys.global.s32 %0, [%1];" : "=r"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ int ld_acquire_sys_global(const int* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __hip_atomic_load(ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  int ret;
+  asm volatile("ld.acquire.sys.global.s32 %0, [%1];" : "=r"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ int ld_volatile_global(const volatile int* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return *ptr;
+#else
+  int ret;
+  asm volatile("ld.volatile.global.s32 %0, [%1];" : "=r"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ int atomic_add_release_global(int* ptr, int value) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __hip_atomic_fetch_add(
+      ptr, value, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  int ret;
+  asm volatile("atom.add.release.gpu.global.s32 %0, [%1], %2;"
+               : "=r"(ret)
+               : "l"(ptr), "r"(value));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ long long wall_clock64_compat() {
+#ifdef __HIP_PLATFORM_AMD__
+  return static_cast<long long>(__builtin_amdgcn_s_memrealtime());
+#else
+  long long t;
+  asm volatile("mov.u64 %0, %%clock64;" : "=l"(t));
+  return t;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Warp shuffle / sync wrappers (extended).
+// ---------------------------------------------------------------------------
+
+__device__ __forceinline__ void syncwarp() {
+#ifdef __HIP_PLATFORM_AMD__
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
+  __builtin_amdgcn_wave_barrier();
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+#else
+  __syncwarp();
+#endif
+}
+
+template <typename T>
+__device__ __forceinline__ T shfl_sync_compat(T val, int src_lane) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __shfl(val, src_lane, kWarpSize);
+#else
+  return __shfl_sync(kFullWarpMask, val, src_lane, kWarpSize);
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// WARP_COPY unroll factor. AMD uses 2 vs NVIDIA's 4 because AMD's 64-lane
+// warp already issues twice the data per stride; mismatched factors trigger
+// AMD memory-pipe stalls / data races.
+// ---------------------------------------------------------------------------
+#ifdef __HIP_PLATFORM_AMD__
+constexpr int kIntranodeUnrollFactor = 2;
+#else
+constexpr int kIntranodeUnrollFactor = 4;
+#endif
+
+// ---------------------------------------------------------------------------
+// Non-coalescing / no-allocate global loads + stores for the data-path copies.
+// ---------------------------------------------------------------------------
+
+// On AMD: cross-GPU IPC reads use __builtin_nontemporal_load to bypass L2.
+// Required because xGMI peer writes don't invalidate the local L2.
+__device__ __forceinline__ int ld_nc_global(const int* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __builtin_nontemporal_load(ptr);
+#else
+  int ret;
+  asm volatile("ld.global.nc.s32 %0, [%1];" : "=r"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ int4 ld_nc_global(const int4* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  // No 16B nontemporal_load; emit 4×int32.
+  const int* p = reinterpret_cast<const int*>(ptr);
+  int4 ret;
+  ret.x = __builtin_nontemporal_load(p + 0);
+  ret.y = __builtin_nontemporal_load(p + 1);
+  ret.z = __builtin_nontemporal_load(p + 2);
+  ret.w = __builtin_nontemporal_load(p + 3);
+  return ret;
+#else
+  int4 ret;
+  asm volatile("ld.global.nc.v4.s32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(ret.x), "=r"(ret.y), "=r"(ret.z), "=r"(ret.w)
+               : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ int64_t ld_nc_global(const int64_t* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __builtin_nontemporal_load(ptr);
+#else
+  int64_t ret;
+  asm volatile("ld.global.nc.s64 %0, [%1];" : "=l"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ float ld_nc_global(const float* ptr) {
+#ifdef __HIP_PLATFORM_AMD__
+  return __builtin_nontemporal_load(ptr);
+#else
+  float ret;
+  asm volatile("ld.global.nc.f32 %0, [%1];" : "=f"(ret) : "l"(ptr));
+  return ret;
+#endif
+}
+
+__device__ __forceinline__ void st_na_global(int* ptr, int val) {
+#ifdef __HIP_PLATFORM_AMD__
+  *ptr = val;
+#else
+  asm volatile("st.global.s32 [%0], %1;" : : "l"(ptr), "r"(val) : "memory");
+#endif
+}
+
+__device__ __forceinline__ void st_na_global(int4* ptr, int4 val) {
+#ifdef __HIP_PLATFORM_AMD__
+  *ptr = val;
+#else
+  asm volatile("st.global.v4.s32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(ptr), "r"(val.x), "r"(val.y), "r"(val.z), "r"(val.w)
+               : "memory");
+#endif
+}
+
+// Cached read for LOCAL data (sender's own input). On AMD, plain `__ldg`
+// suffices — local L1/L2 are coherent with the producer (CPU/torch). Using
+// `ld_nc_global` (cache-bypass) here would force every read to round-trip
+// to HBM and degrade dispatch sender throughput by 10-100x.
+__device__ __forceinline__ int4 ld_cached_global(const int4* ptr) {
+  return __ldg(ptr);
+}
+__device__ __forceinline__ int ld_cached_global(const int* ptr) {
+  return __ldg(ptr);
+}
+__device__ __forceinline__ float ld_cached_global(const float* ptr) {
+  return __ldg(ptr);
+}
+__device__ __forceinline__ int64_t ld_cached_global(const int64_t* ptr) {
+  return __ldg(ptr);
+}
+
+} // namespace comms::prims::moe_ep::kernels
+
+// ---------------------------------------------------------------------------
+// UNROLLED_WARP_COPY — bulk warp-cooperative memcpy with N-way unrolling.
+//
+// Used by the data-path of dispatch / combine to copy `hidden_int4`-sized
+// payloads from peer or local memory. LANE_ID is `threadIdx.x % kWarpSize`, N
+// is the count, DST + SRC are typed pointers, LD_FUNC / ST_FUNC are the load /
+// store primitives to use.
+// ---------------------------------------------------------------------------
+
+#ifndef MOE_EP_UNROLLED_WARP_COPY
+#define MOE_EP_UNROLLED_WARP_COPY(                                           \
+    UNROLL_FACTOR, LANE_ID, N, DST, SRC, LD_FUNC, ST_FUNC)                   \
+  do {                                                                       \
+    constexpr int _kLoopStride =                                             \
+        ::comms::prims::moe_ep::kernels::kWarpSize * (UNROLL_FACTOR);        \
+    typename std::remove_reference<decltype(LD_FUNC((SRC) + 0))>::type       \
+        _unrolled_values[(UNROLL_FACTOR)];                                   \
+    auto _src = (SRC);                                                       \
+    auto _dst = (DST);                                                       \
+    for (int _i = (LANE_ID); _i < ((N) / _kLoopStride) * _kLoopStride;       \
+         _i += _kLoopStride) {                                               \
+      _Pragma("unroll") for (int _j = 0; _j < (UNROLL_FACTOR); ++_j) {       \
+        _unrolled_values[_j] = LD_FUNC(                                      \
+            _src + _i + _j * ::comms::prims::moe_ep::kernels::kWarpSize);    \
+      }                                                                      \
+      _Pragma("unroll") for (int _j = 0; _j < (UNROLL_FACTOR); ++_j) {       \
+        ST_FUNC(                                                             \
+            _dst + _i + _j * ::comms::prims::moe_ep::kernels::kWarpSize,     \
+            _unrolled_values[_j]);                                           \
+      }                                                                      \
+    }                                                                        \
+    for (int _i = ((N) / _kLoopStride) * _kLoopStride + (LANE_ID); _i < (N); \
+         _i += ::comms::prims::moe_ep::kernels::kWarpSize) {                 \
+      ST_FUNC(_dst + _i, LD_FUNC(_src + _i));                                \
+    }                                                                        \
+  } while (0)
+#endif

--- a/comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh
+++ b/comms/prims/collectives/moe_ep/cpp/shared/kernels/Launch.cuh
@@ -1,0 +1,146 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <utility>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_runtime.h>
+#else
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#endif
+
+#include "comms/prims/collectives/moe_ep/cpp/shared/Config.h"
+#include "comms/prims/collectives/moe_ep/cpp/shared/kernels/Exception.cuh"
+
+//
+// Provides launch-config helpers + dispatch-by-num-ranks switch macros.
+//
+// Two notable simplifications:
+//
+//  1) `LAUNCH_KERNEL_NON_COOPERATIVE` collapses to a plain triple-bracket
+//     launch on both NVIDIA and AMD, avoiding `cudaLaunchKernelEx` and its
+//     cooperative-launch attributes. We don't use cooperative launches in
+//     Phase 1 (notify_dispatch is the only place
+//     that touches `task_fifo_ptrs`, and we replace that with pipes
+//     `barrier_all` which doesn't require cooperative launch).
+//
+//  2) `SWITCH_RANKS` is restricted to the values D3 actually instantiates
+//     (2 / 4 / 8). D5 (internode) extends with rdma-rank variants.
+
+namespace comms::prims::moe_ep::kernels {
+
+#ifdef __HIP_PLATFORM_AMD__
+#define MOE_EP_GPU_R_16BF HIP_R_16BF
+#define MOE_EP_GPU_R_32F HIP_R_32F
+using gpu_bfloat16_t = hip_bfloat16;
+#else
+#define MOE_EP_GPU_R_16BF CUDA_R_16BF
+#define MOE_EP_GPU_R_32F CUDA_R_32F
+using gpu_bfloat16_t = nv_bfloat16;
+#endif
+
+// Light-weight launch config that works on both NVIDIA and AMD without
+// needing cudaLaunchKernelEx / cooperative launch.
+struct LaunchConfig {
+  dim3 num_sms;
+  dim3 num_threads;
+  unsigned int shared_mem_bytes{0};
+  cudaStream_t stream{nullptr};
+};
+
+} // namespace comms::prims::moe_ep::kernels
+
+#ifndef SETUP_LAUNCH_CONFIG
+#define SETUP_LAUNCH_CONFIG(num_sms, num_threads, stream) \
+  ::comms::prims::moe_ep::kernels::LaunchConfig cfg = {   \
+      static_cast<dim3>(num_sms),                         \
+      static_cast<dim3>(num_threads),                     \
+      0u,                                                 \
+      (stream)}
+#endif
+
+#ifndef LAUNCH_KERNEL_NON_COOPERATIVE
+#define LAUNCH_KERNEL_NON_COOPERATIVE(cfg_ptr, kernel, ...) \
+  do {                                                      \
+    auto* _cfg = (cfg_ptr);                                 \
+    (kernel)<<<                                             \
+        _cfg->num_sms,                                      \
+        _cfg->num_threads,                                  \
+        _cfg->shared_mem_bytes,                             \
+        _cfg->stream>>>(__VA_ARGS__);                       \
+  } while (0)
+#endif
+
+#ifndef SWITCH_RANKS
+#define SWITCH_RANKS(case_macro)                                     \
+  switch (num_ranks) {                                               \
+    case 2:                                                          \
+      case_macro(2);                                                 \
+      break;                                                         \
+    case 4:                                                          \
+      case_macro(4);                                                 \
+      break;                                                         \
+    case 8:                                                          \
+      case_macro(8);                                                 \
+      break;                                                         \
+    default:                                                         \
+      EP_HOST_ASSERT(false && "Unsupported num_ranks (need 2/4/8)"); \
+  }
+#endif
+
+#ifndef SWITCH_RANKS_WITH_DTYPE
+#define SWITCH_RANKS_WITH_DTYPE(dtype, case_macro)                   \
+  switch (num_ranks) {                                               \
+    case 2:                                                          \
+      case_macro(dtype, 2);                                          \
+      break;                                                         \
+    case 4:                                                          \
+      case_macro(dtype, 4);                                          \
+      break;                                                         \
+    case 8:                                                          \
+      case_macro(dtype, 8);                                          \
+      break;                                                         \
+    default:                                                         \
+      EP_HOST_ASSERT(false && "Unsupported num_ranks (need 2/4/8)"); \
+  }
+#endif
+
+#ifndef SWITCH_TYPES
+#define SWITCH_TYPES(case_macro)                                    \
+  switch (type) {                                                   \
+    case MOE_EP_GPU_R_16BF:                                         \
+      case_macro(::comms::prims::moe_ep::kernels::gpu_bfloat16_t);  \
+      break;                                                        \
+    case MOE_EP_GPU_R_32F:                                          \
+      case_macro(float);                                            \
+      break;                                                        \
+    default:                                                        \
+      EP_HOST_ASSERT(false && "Unsupported dtype (need bf16/f32)"); \
+  }
+#endif
+
+#ifndef SWITCH_HIDDEN
+#define SWITCH_HIDDEN(case_macro)                    \
+  switch (hidden) {                                  \
+    case 2048:                                       \
+      case_macro(2048);                              \
+      break;                                         \
+    case 2560:                                       \
+      case_macro(2560);                              \
+      break;                                         \
+    case 4096:                                       \
+      case_macro(4096);                              \
+      break;                                         \
+    case 5120:                                       \
+      case_macro(5120);                              \
+      break;                                         \
+    case 7168:                                       \
+      case_macro(7168);                              \
+      break;                                         \
+    default:                                         \
+      EP_HOST_ASSERT(false && "Unsupported hidden"); \
+  }
+#endif

--- a/comms/prims/collectives/moe_ep/moe_ep/__init__.py
+++ b/comms/prims/collectives/moe_ep/moe_ep/__init__.py
@@ -1,0 +1,38 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""
+Pipes MoE expert-parallel (EP) communication API.
+
+Public Python surface for the pipes-based dispatch / combine kernels under
+`comms/prims/collectives/moe_ep/`. Exports `Buffer`, `EventOverlap`, `Config`, and the
+`topk_idx_t` torch dtype.
+"""
+
+from __future__ import annotations
+
+# pyre-ignore[21]: cpp_python_extension at runtime
+from comms.prims.collectives.moe_ep import _cpp  # @manual
+from comms.prims.collectives.moe_ep.moe_ep.buffer import Buffer
+from comms.prims.collectives.moe_ep.moe_ep.utils import EventOverlap
+
+# Tuning-knob struct re-exported from the C++ extension. Ctor:
+#   Config(num_sms,
+#          num_max_nvl_chunked_send_tokens,
+#          num_max_nvl_chunked_recv_tokens,
+#          num_max_rdma_chunked_send_tokens=6,
+#          num_max_rdma_chunked_recv_tokens=128)
+Config = _cpp.Config  # type: ignore[misc]
+
+# `torch.dtype` indicating the wire format of `topk_idx` tensors. Tests cast
+# `topk_idx.to(comms.prims.collectives.moe_ep.moe_ep.topk_idx_t)`. We standardize on
+# torch.int64 (TOPK_IDX_BITS=64).
+topk_idx_t = _cpp.topk_idx_t  # type: ignore[misc]
+
+__all__ = [
+    "Buffer",
+    "EventOverlap",
+    "Config",
+    "topk_idx_t",
+]

--- a/comms/prims/collectives/moe_ep/moe_ep/buffer.py
+++ b/comms/prims/collectives/moe_ep/moe_ep/buffer.py
@@ -1,0 +1,581 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""
+Python `Buffer` wrapper for the pipes MoE expert-parallel runtime.
+
+The C++ runtime backing `Buffer` lives in `comms.prims.collectives.moe_ep._cpp`. For
+Phase 1 (intranode, NVLink only) we only implement the dispatch / combine
+methods exercised by `tests/test_intranode.py`; LL / internode methods are
+stubbed and raise `NotImplementedError` until the follow-up diffs land.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Callable
+
+import torch
+import torch.distributed as dist
+
+# pyre-ignore[21]: cpp_python_extension at runtime
+from comms.prims.collectives.moe_ep import _cpp  # @manual
+from comms.prims.collectives.moe_ep.moe_ep.utils import (
+    check_nvlink_connections,
+    EventHandle,
+    EventOverlap,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+Config = _cpp.Config  # type: ignore[misc]
+
+
+_PEER_ACCESS_PREWARMED: bool = False
+
+
+def _prewarm_peer_access(num_ranks: int) -> None:
+    """Pre-enable peer access between every (cur_dev, peer) pair so PyTorch's
+    HIP allocator's later `hipDeviceEnablePeerAccess` returns
+    `hipErrorPeerAccessAlreadyEnabled` cleanly (PyTorch's caching allocator
+    silently swallows that error). Idempotent — runs at most once per process.
+    """
+    global _PEER_ACCESS_PREWARMED
+    if _PEER_ACCESS_PREWARMED:
+        return
+    if not torch.cuda.is_available():
+        return
+    cur = torch.cuda.current_device()
+    n_devices = torch.cuda.device_count()
+    n = min(num_ranks, n_devices)
+    for peer in range(n):
+        if peer == cur:
+            continue
+        if not torch.cuda.can_device_access_peer(cur, peer):
+            continue
+        try:
+            torch.cuda._lazy_init()
+            # Trigger BOTH directions: peer→cur (.to copy) and cur→peer
+            # (an explicit CUDAGuard + write). Both directions must be
+            # enabled before the dispatch kernel issues cross-rank atomics
+            # and DMA transfers; PyTorch's caching allocator otherwise
+            # tries to enable them lazily during the first kernel and
+            # blows up with `hipErrorPeerAccessAlreadyEnabled` when NCCL
+            # has already set them up.
+            with torch.cuda.device(cur):
+                _ = torch.zeros(1, device=f"cuda:{peer}").to(f"cuda:{cur}")
+                _ = torch.zeros(1, device=f"cuda:{cur}").to(f"cuda:{peer}")
+        except Exception as e:  # noqa: BLE001
+            logger.debug("prewarm peer (%d <-> %d) failed: %s", cur, peer, e)
+    _PEER_ACCESS_PREWARMED = True
+
+
+class Buffer:
+    """
+    Core expert-parallel (EP) communication buffer for Mixture of Experts.
+
+    Supports:
+    - **High-throughput intranode** all-to-all (dispatch + combine, NVLink) — D3
+    - **Low-latency** all-to-all (dispatch + combine, RDMA) — D4
+    - **High-throughput internode** all-to-all (dispatch + combine, RDMA + NVLink) — D5
+
+    Mirrors the `Buffer` API surface that the canonical `test_intranode.py`
+    / `test_low_latency.py` / `test_internode.py` scripts in
+    `comms/prims/collectives/moe_ep/tests/` exercise.
+    """
+
+    num_sms: int = 20
+
+    rank: int
+    group: dist.ProcessGroup | None
+    group_size: int
+    _internode_ready: bool = False
+
+    def __init__(
+        self,
+        group: dist.ProcessGroup | None,
+        num_nvl_bytes: int = 0,
+        num_rdma_bytes: int = 0,
+        low_latency_mode: bool = False,
+        num_qps_per_rank: int = 24,
+        allow_nvlink_for_low_latency_mode: bool = True,
+        allow_mnnvl: bool = False,
+        use_fabric: bool = False,
+        explicitly_destroy: bool = False,
+        enable_shrink: bool = False,
+        # `comm: mpi4py.MPI.Comm | None` — accept Any to avoid hard mpi4py
+        # dependency at import time.
+        comm: object | None = None,
+    ) -> None:
+        if allow_mnnvl:
+            raise NotImplementedError("allow_mnnvl=True is a v1 non-goal")
+        if use_fabric:
+            raise NotImplementedError("use_fabric=True is a v1 non-goal")
+        if enable_shrink:
+            raise NotImplementedError(
+                "enable_shrink=True is a v1 non-goal (shrink-test family)"
+            )
+
+        check_nvlink_connections(group) if group is not None else None
+
+        all_gather_object: Callable[[object], list[object]]
+        if group is not None:
+            self.rank = group.rank()
+            self.group = group
+            self.group_size = group.size()
+
+            def _all_gather_object_group(obj: object) -> list[object]:
+                # pyre-ignore[9]: None pre-fill, overwritten by all_gather_object
+                object_list: list[object] = [None] * self.group_size
+                dist.all_gather_object(object_list, obj, group)
+                return object_list
+
+            all_gather_object = _all_gather_object_group
+        elif comm is not None:
+            # mpi4py path
+            self.rank = comm.Get_rank()  # pyre-ignore[16]
+            # pyre-ignore[8]: mpi4py comm fallback (not a ProcessGroup)
+            self.group = comm
+            self.group_size = comm.Get_size()  # pyre-ignore[16]
+
+            def _all_gather_object_mpi(obj: object) -> list[object]:
+                return list(comm.allgather(obj))  # pyre-ignore[16]
+
+            all_gather_object = _all_gather_object_mpi
+        else:
+            raise ValueError("Either 'group' or 'comm' must be provided.")
+
+        self.num_nvl_bytes = num_nvl_bytes
+        self.num_rdma_bytes = num_rdma_bytes
+        self.low_latency_mode = low_latency_mode
+        self.explicitly_destroy = explicitly_destroy
+        self.enable_shrink = enable_shrink
+        # Cached layout from the most recent non-cached dispatch, reused on
+        # subsequent cached calls (handle != None). See `dispatch()` for the
+        # rationale.
+        self._last_num_tokens_per_rank: torch.Tensor | None = None
+        self._last_is_token_in_rank: torch.Tensor | None = None
+        self._last_num_tokens_per_expert: torch.Tensor | None = None
+        self.runtime = _cpp.Buffer(  # type: ignore[attr-defined]
+            self.rank,
+            self.group_size,
+            num_nvl_bytes,
+            num_rdma_bytes,
+            low_latency_mode,
+            explicitly_destroy,
+            enable_shrink,
+            use_fabric,
+        )
+
+        # On AMD, PyTorch's distributed `_object_to_tensor` path fails on the
+        # first `dist.all_gather_object(...)` after our `_cpp.Buffer`
+        # ctor with `hipErrorPeerAccessAlreadyEnabled`. The error originates
+        # in `torch.ByteTensor(byte_storage).to(device)` because PyTorch's
+        # caching allocator tries to enable peer access between the rank's
+        # GPU and other GPUs that NCCL/RCCL has already set up. Pre-warm
+        # peer access between every pair *before* the first collective so
+        # PyTorch sees the access already exists and short-circuits — this
+        # is benign on NVIDIA (idempotent) and avoids the AMD failure.
+        _prewarm_peer_access(self.group_size)
+
+        # Synchronize device IDs
+        local_device_id = self.runtime.get_local_device_id()
+        device_ids = all_gather_object(local_device_id)
+
+        # Synchronize IPC handles
+        local_ipc_handle = self.runtime.get_local_ipc_handle()
+        ipc_handles = all_gather_object(local_ipc_handle)
+
+        # NVSHMEM unique-id exchange — RDMA / LL only (Phase 2/3). For
+        # Phase 1 (intranode-only), get_num_rdma_ranks() returns 1 and
+        # low_latency_mode is False, so we skip this branch entirely.
+        root_unique_id: object | None = None
+        if self.runtime.get_num_rdma_ranks() > 1 or low_latency_mode:
+            if num_qps_per_rank <= 0:
+                raise ValueError("num_qps_per_rank must be > 0 for RDMA mode")
+
+            # The pipes IBGDA transport doesn't use NVSHMEM env vars; the
+            # equivalent settings live on `MultipeerIbgdaTransportConfig`,
+            # set inside the C++ runtime when constructing the IBGDA
+            # transport in Phase 2/3 (D4 / D5).
+
+            if (low_latency_mode and self.rank == 0) or (
+                not low_latency_mode and self.runtime.get_rdma_rank() == 0
+            ):
+                root_unique_id = self.runtime.get_local_nvshmem_unique_id()
+            nvshmem_unique_ids = all_gather_object(root_unique_id)
+            root_unique_id = nvshmem_unique_ids[
+                0 if low_latency_mode else self.runtime.get_root_rdma_rank(True)
+            ]
+
+        # Finalize — give the C++ runtime the gathered metadata.
+        self.runtime.sync(device_ids, ipc_handles, root_unique_id)
+        if not self.runtime.is_available():
+            raise RuntimeError("Buffer.sync() failed: runtime not available")
+
+    def destroy(self) -> None:
+        """Destroy the C++ runtime. Requires `explicitly_destroy=True`."""
+        if not self.explicitly_destroy:
+            raise RuntimeError(
+                "destroy() requires `explicitly_destroy=True` at construction"
+            )
+        self.runtime.destroy()
+        # pyre-ignore[8]: deliberately invalidate
+        self.runtime = None
+
+    @staticmethod
+    def is_sm90_compiled() -> bool:
+        # pyre-ignore[16]
+        return _cpp.is_sm90_compiled()
+
+    @staticmethod
+    def set_num_sms(new_num_sms: int) -> None:
+        if new_num_sms % 2 != 0:
+            raise ValueError("num_sms must be even (sender/receiver block pairs)")
+        Buffer.num_sms = new_num_sms
+
+    @staticmethod
+    def capture() -> EventOverlap:
+        return EventOverlap(EventHandle())
+
+    @staticmethod
+    def get_low_latency_rdma_size_hint(
+        num_max_dispatch_tokens_per_rank: int,
+        hidden: int,
+        num_ranks: int,
+        num_experts: int,
+    ) -> int:
+        # pyre-ignore[16]
+        return _cpp.get_low_latency_rdma_size_hint(
+            num_max_dispatch_tokens_per_rank, hidden, num_ranks, num_experts
+        )
+
+    @staticmethod
+    def get_dispatch_config(num_ranks: int) -> object:  # Config
+        # Tuned dispatch configs per EP rank count.
+        config_map: dict[int, object] = {
+            2: Config(Buffer.num_sms, 24, 256, 6, 128),
+            4: Config(Buffer.num_sms, 6, 256, 6, 128),
+            8: Config(Buffer.num_sms, 6, 256, 6, 128),
+            16: Config(Buffer.num_sms, 36, 288, 20, 128),
+            24: Config(Buffer.num_sms, 32, 288, 8, 128),
+            32: Config(Buffer.num_sms, 32, 288, 8, 128),
+            48: Config(Buffer.num_sms, 32, 288, 8, 128),
+            64: Config(Buffer.num_sms, 32, 288, 8, 128),
+            96: Config(Buffer.num_sms, 20, 480, 12, 128),
+            128: Config(Buffer.num_sms, 20, 560, 12, 128),
+            144: Config(Buffer.num_sms, 32, 720, 12, 128),
+            160: Config(Buffer.num_sms, 28, 720, 12, 128),
+        }
+        if num_ranks not in config_map:
+            raise ValueError(f"Unsupported number of EP ranks: {num_ranks}")
+        return config_map[num_ranks]
+
+    @staticmethod
+    def get_combine_config(num_ranks: int) -> object:  # Config
+        config_map: dict[int, object] = {
+            2: Config(Buffer.num_sms, 10, 256, 6, 128),
+            4: Config(Buffer.num_sms, 9, 256, 6, 128),
+            8: Config(Buffer.num_sms, 4, 256, 6, 128),
+            16: Config(Buffer.num_sms, 4, 288, 12, 128),
+            24: Config(Buffer.num_sms, 1, 288, 8, 128),
+            32: Config(Buffer.num_sms, 1, 288, 8, 128),
+            48: Config(Buffer.num_sms, 1, 288, 8, 128),
+            64: Config(Buffer.num_sms, 1, 288, 8, 128),
+            72: Config(Buffer.num_sms, 1, 288, 8, 128),
+            96: Config(Buffer.num_sms, 1, 480, 8, 128),
+            128: Config(Buffer.num_sms, 1, 560, 8, 128),
+            144: Config(Buffer.num_sms, 2, 720, 8, 128),
+            160: Config(Buffer.num_sms, 2, 720, 8, 128),
+        }
+        if num_ranks not in config_map:
+            raise ValueError(f"Unsupported number of EP ranks: {num_ranks}")
+        return config_map[num_ranks]
+
+    def get_dispatch_layout(
+        self,
+        topk_idx: torch.Tensor,
+        num_experts: int,
+        previous_event: EventOverlap | None = None,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor,
+        torch.Tensor,
+        EventOverlap,
+    ]:
+        """Compute the per-rank / per-expert layout from `topk_idx`."""
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            event,
+        ) = self.runtime.get_dispatch_layout(
+            topk_idx,
+            num_experts,
+            getattr(previous_event, "event", None),
+            async_finish,
+            allocate_on_comm_stream,
+        )
+        return (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            EventOverlap(event),
+        )
+
+    def dispatch(
+        self,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        handle: tuple[Any, ...] | None = None,
+        num_tokens_per_rank: torch.Tensor | None = None,
+        num_tokens_per_rdma_rank: torch.Tensor | None = None,
+        is_token_in_rank: torch.Tensor | None = None,
+        num_tokens_per_expert: torch.Tensor | None = None,
+        topk_idx: torch.Tensor | None = None,
+        topk_weights: torch.Tensor | None = None,
+        expert_alignment: int = 1,
+        num_worst_tokens: int = 0,
+        config: object | None = None,
+        previous_event: EventOverlap | None = None,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> tuple[Any, ...]:
+        """Dispatch tokens to per-expert ranks. Phase 1: intranode (NVLink)."""
+        # Route to internode_dispatch when crossing nodes (Phase 3).
+        if self.runtime.get_num_rdma_ranks() > 1:
+            return self.internode_dispatch(
+                x,
+                handle,
+                num_tokens_per_rank,
+                num_tokens_per_rdma_rank,
+                is_token_in_rank,
+                num_tokens_per_expert,
+                topk_idx,
+                topk_weights,
+                expert_alignment,
+                config,
+                previous_event,
+                async_finish,
+                allocate_on_comm_stream,
+            )
+        # Intranode call — implemented in C++ runtime via PyBindings.
+        # C++ returns a 7-tuple:
+        #   (recv_x_obj, recv_x_scales, recv_topk_idx, recv_topk_weights,
+        #    num_recv_tokens_per_expert_list, handle_dict, event)
+        # where `recv_x_obj` is already (data, scales) for FP8 and a Tensor
+        # otherwise, and `handle_dict` is a py::dict with the cached
+        # buffers. Reshape to the 6-tuple layout so callers (and
+        # `test_intranode.py`) can unpack:
+        #   (recv_x, recv_topk_idx, recv_topk_weights,
+        #    num_recv_tokens_per_expert_list, handle, event)
+        # with `handle = (rank_prefix_matrix, channel_prefix_matrix,
+        #                 recv_channel_prefix_matrix, recv_src_idx,
+        #                 is_token_in_rank, send_head)`.
+        #
+        # Cached-dispatch path (handle is not None): the C++ runtime currently
+        # always re-runs notify_dispatch (the cached_notify_dispatch fast path
+        # is disabled until kernel-side debug). To make the call valid we
+        # need num_tokens_per_rank / is_token_in_rank / num_tokens_per_expert
+        # — when the caller doesn't pass them (the cached test path), we
+        # reuse the values from the most recent non-cached call. They're
+        # invariant across cached calls on the same input `x`.
+        # When the caller passes a 6-tuple handle (from a prior dispatch's
+        # `out_handle`), repack into the dict shape that C++ expects so
+        # `py::isinstance<py::dict>` returns True and the cached path is
+        # taken. Otherwise stash kwargs for future cached calls.
+        handle_for_cpp = handle
+        if handle is not None:
+            if isinstance(handle, tuple) and len(handle) == 6:
+                (
+                    rank_prefix_matrix,
+                    channel_prefix_matrix,
+                    recv_channel_prefix_matrix,
+                    recv_src_idx,
+                    h_is_token_in_rank,
+                    send_head,
+                ) = handle
+                handle_for_cpp = {
+                    "rank_prefix_matrix": rank_prefix_matrix,
+                    "channel_prefix_matrix": channel_prefix_matrix,
+                    "recv_channel_prefix_matrix": recv_channel_prefix_matrix,
+                    "recv_src_idx": recv_src_idx,
+                    "send_head": send_head,
+                    "num_recv_tokens": int(recv_src_idx.size(0)),
+                }
+                if is_token_in_rank is None:
+                    is_token_in_rank = h_is_token_in_rank
+            if num_tokens_per_rank is None:
+                num_tokens_per_rank = self._last_num_tokens_per_rank
+            if is_token_in_rank is None:
+                is_token_in_rank = self._last_is_token_in_rank
+            if num_tokens_per_expert is None:
+                num_tokens_per_expert = self._last_num_tokens_per_expert
+        else:
+            # Stash for the next cached call.
+            self._last_num_tokens_per_rank = num_tokens_per_rank
+            self._last_is_token_in_rank = is_token_in_rank
+            self._last_num_tokens_per_expert = num_tokens_per_expert
+        (
+            recv_x_obj,
+            _recv_x_scales,  # already merged into `recv_x_obj` for FP8
+            recv_topk_idx,
+            recv_topk_weights,
+            num_recv_tokens_per_expert_list,
+            handle_dict,
+            event,
+        ) = self.runtime.intranode_dispatch(
+            x,
+            handle_for_cpp,
+            num_tokens_per_rank,
+            is_token_in_rank,
+            num_tokens_per_expert,
+            topk_idx,
+            topk_weights,
+            expert_alignment,
+            num_worst_tokens,
+            config or Buffer.get_dispatch_config(self.group_size),
+            getattr(previous_event, "event", None),
+            async_finish,
+            allocate_on_comm_stream,
+        )
+        out_handle = (
+            handle_dict["rank_prefix_matrix"],
+            handle_dict["channel_prefix_matrix"],
+            handle_dict["recv_channel_prefix_matrix"],
+            handle_dict["recv_src_idx"],
+            is_token_in_rank,
+            handle_dict["send_head"],
+        )
+        return (
+            recv_x_obj,
+            recv_topk_idx,
+            recv_topk_weights,
+            num_recv_tokens_per_expert_list,
+            out_handle,
+            EventOverlap(event),
+        )
+
+    def combine(
+        self,
+        x: torch.Tensor,
+        handle: tuple[Any, ...],
+        topk_weights: torch.Tensor | None = None,
+        bias: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None = None,
+        config: object | None = None,
+        previous_event: EventOverlap | None = None,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, EventOverlap]:
+        """Combine reduces dispatched tokens. Phase 1: intranode (NVLink)."""
+        if self.runtime.get_num_rdma_ranks() > 1:
+            return self.internode_combine(
+                x,
+                handle,
+                topk_weights,
+                bias,
+                config,
+                previous_event,
+                async_finish,
+                allocate_on_comm_stream,
+            )
+        bias_0, bias_1 = self._unpack_bias(bias)
+        # Unpack the 6-tuple handle returned by `dispatch` and
+        # re-pack into the dict-shaped handle our C++ `intranode_combine`
+        # consumes (only the cached tensors it actually reads need to be
+        # present; `is_token_in_rank` is dispatch-side bookkeeping).
+        #
+        # CRITICAL: combine uses `recv_channel_prefix_matrix`
+        # (position 2) NOT `channel_prefix_matrix` (position 1).
+        # The channel_prefix_matrix (pos 1) describes the SENDER's per-channel
+        # distribution; recv_channel_prefix_matrix (pos 2) describes the
+        # RECEIVER's. Combine needs the receiver's view.
+        (
+            rank_prefix_matrix,
+            _channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            recv_src_idx,
+            _is_token_in_rank,
+            send_head,
+        ) = handle
+        handle_dict = {
+            "rank_prefix_matrix": rank_prefix_matrix,
+            "channel_prefix_matrix": recv_channel_prefix_matrix,
+            "recv_channel_prefix_matrix": recv_channel_prefix_matrix,
+            "recv_src_idx": recv_src_idx,
+            "send_head": send_head,
+        }
+        combined_x, combined_topk_weights, event = self.runtime.intranode_combine(
+            x,
+            topk_weights,
+            bias_0,
+            bias_1,
+            handle_dict,
+            config or Buffer.get_combine_config(self.group_size),
+            getattr(previous_event, "event", None),
+            async_finish,
+            allocate_on_comm_stream,
+        )
+        return combined_x, combined_topk_weights, EventOverlap(event)
+
+    @staticmethod
+    def _unpack_bias(
+        bias: torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if bias is None:
+            return None, None
+        if isinstance(bias, torch.Tensor):
+            return bias, None
+        if isinstance(bias, tuple) and len(bias) == 2:
+            return bias[0], bias[1]
+        raise TypeError(
+            "bias must be Tensor, (Tensor, Tensor), or None — got "
+            f"{type(bias).__name__}"
+        )
+
+    def internode_dispatch(self, *args: object, **kwargs: object) -> tuple[Any, ...]:
+        """Phase 3 (D5) — internode dispatch (RDMA + NVLink)."""
+        raise NotImplementedError(
+            "internode_dispatch lands in D5 of the design plan stack"
+        )
+
+    def internode_combine(self, *args: object, **kwargs: object) -> tuple[Any, ...]:
+        """Phase 3 (D5) — internode combine (RDMA + NVLink)."""
+        raise NotImplementedError(
+            "internode_combine lands in D5 of the design plan stack"
+        )
+
+    def low_latency_dispatch(self, *args: object, **kwargs: object) -> tuple[Any, ...]:
+        """Phase 2 (D4) — low-latency dispatch (IBGDA)."""
+        raise NotImplementedError(
+            "low_latency_dispatch lands in D4 of the design plan stack"
+        )
+
+    def low_latency_combine(self, *args: object, **kwargs: object) -> tuple[Any, ...]:
+        """Phase 2 (D4) — low-latency combine (IBGDA)."""
+        raise NotImplementedError(
+            "low_latency_combine lands in D4 of the design plan stack"
+        )
+
+    def clean_low_latency_buffer(
+        self,
+        num_max_dispatch_tokens_per_rank: int,
+        hidden: int,
+        num_experts: int,
+    ) -> None:
+        """Phase 2 (D4) — zero the LL buffer regions."""
+        raise NotImplementedError(
+            "clean_low_latency_buffer lands in D4 of the design plan stack"
+        )
+
+    def get_next_low_latency_combine_buffer(
+        self, handle: tuple[Any, ...]
+    ) -> torch.Tensor:
+        """Phase 2 (D4) — `zero_copy=True` combine path."""
+        raise NotImplementedError("get_next_low_latency_combine_buffer lands in D4")

--- a/comms/prims/collectives/moe_ep/moe_ep/utils.py
+++ b/comms/prims/collectives/moe_ep/moe_ep/utils.py
@@ -1,0 +1,123 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+"""
+Python-side utilities for the pipes MoE expert-parallel runtime.
+
+EventOverlap is the public RAII wrapper around `EventHandle` from the C++
+extension. It's used as `previous_event=` argument and as a return value from
+`Buffer.dispatch` / `Buffer.combine` / `Buffer.get_dispatch_layout` /
+`Buffer.capture()`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+# pyre-ignore[21]: cpp_python_extension at runtime; static analyzer doesn't see it
+from comms.prims.collectives.moe_ep import _cpp  # @manual
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Re-export EventHandle so callers can `from .utils import EventHandle`
+EventHandle = _cpp.EventHandle  # type: ignore[misc]
+
+
+class EventOverlap:
+    """
+    Wrapper class to manage CUDA events for kernel-overlap convenience.
+
+    Attributes:
+        event: the captured CUDA event (or None for a no-op).
+        extra_tensors: tuple of tensors held alive for the event's lifetime
+            (simulates `Tensor.record_stream` in a way that's CUDA-graph
+            compatible).
+    """
+
+    def __init__(
+        self,
+        event: EventHandle | None = None,  # type: ignore[valid-type]
+        extra_tensors: tuple[torch.Tensor, ...] | None = None,
+    ) -> None:
+        self.event: EventHandle | None = event  # type: ignore[valid-type]
+        # Use extra tensors to achieve stream-record-like semantics; plain
+        # `tensor.record_stream` is incompatible with CUDA graph capture.
+        self.extra_tensors = extra_tensors
+
+    def current_stream_wait(self) -> None:
+        """Make `torch.cuda.current_stream()` wait for `self.event`."""
+        if self.event is None:
+            raise RuntimeError("EventOverlap.current_stream_wait called with no event")
+        self.event.current_stream_wait()
+
+    def __enter__(self) -> Any:
+        """Context-manager entry; the corresponding `__exit__` calls
+        `current_stream_wait()` so the body runs while the event is in
+        flight and the next op on the current stream waits for it."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if self.event is not None:
+            self.event.current_stream_wait()
+
+
+def check_nvlink_connections(group: dist.ProcessGroup) -> None:
+    """
+    Verify that every pair of GPUs in `group` is connected via NVLink.
+
+    Some PCIe-only GPU SKUs (e.g. some A100 PCIE) only have pairwise NVLink,
+    so we hard-cap the group size at 2 in that case. This is only meaningful
+    on NVIDIA — AMD MI300X uses XGMI and doesn't expose NVML.
+    """
+    device_name = torch.cuda.get_device_name()
+    if "PCIE" not in device_name:
+        return
+
+    if group.size() > 2:
+        raise RuntimeError(
+            "PCIe GPUs only have pairwise NVLink connections; "
+            f"group size {group.size()} > 2 is not supported"
+        )
+
+    try:
+        # pyre-ignore[21]: optional third-party
+        import pynvml  # @manual
+    except ImportError:
+        logger.warning("pynvml not available; skipping NVLink connectivity check")
+        return
+
+    pynvml.nvmlInit()
+    try:
+        devices = (
+            os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
+            .strip(",")
+            .split(",")
+        )
+        physical_device_idx = int(devices[torch.cuda.current_device()])
+        physical_device_indices = [0] * group.size()
+        dist.all_gather_object(physical_device_indices, physical_device_idx, group)
+
+        handles = [
+            pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_indices
+        ]
+        for i, handle in enumerate(handles):
+            for j, peer_handle in enumerate(handles):
+                if i >= j:
+                    continue
+                status = pynvml.nvmlDeviceGetP2PStatus(
+                    handle, peer_handle, pynvml.NVML_P2P_CAPS_INDEX_NVLINK
+                )
+                if status != pynvml.NVML_P2P_STATUS_OK:
+                    raise RuntimeError(
+                        f"GPU {physical_device_indices[i]} and "
+                        f"GPU {physical_device_indices[j]} are not connected "
+                        "via NVLink"
+                    )
+    finally:
+        pynvml.nvmlShutdown()

--- a/comms/prims/collectives/moe_ep/tests/test_intranode.py
+++ b/comms/prims/collectives/moe_ep/tests/test_intranode.py
@@ -1,0 +1,503 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-ignore-all-errors
+
+# Intranode EP dispatch/combine test. The moe_ep adaptations are: the
+# `deep_ep`/`deep_ep_cpp` import shims (this module runs directly as
+# `:test_intranode`), the `upstream_utils` import path, a lazy
+# `test_low_latency` import (it ships in a later diff), and one `x_e4m3 = None`
+# line that disables FP8 cases until the kernel FP8-scales path is wired.
+
+import argparse
+import sys
+import time
+
+# Install the import shims BEFORE the first `import deep_ep` / `import deep_ep_cpp`
+# so the test body below runs unchanged.
+import comms.prims.collectives.moe_ep._cpp as _moe_ep_cpp  # noqa: E402
+import comms.prims.collectives.moe_ep.moe_ep as _moe_ep  # noqa: E402
+
+sys.modules["deep_ep"] = _moe_ep
+sys.modules["deep_ep_cpp"] = _moe_ep_cpp
+
+# Bind `deep_ep` / `deep_ep_cpp` to the in-house moe_ep modules (installed in
+# sys.modules above) so the upstream-style test body runs against our impl
+# without importing — and thus depending on — the external deeplearning/deep_ep.
+deep_ep = _moe_ep
+deep_ep_cpp = _moe_ep_cpp
+import torch  # noqa: E402
+import torch.distributed as dist  # noqa: E402
+from comms.prims.collectives.moe_ep.tests.upstream_utils import (  # noqa: E402
+    bench,
+    calc_diff,
+    init_dist,
+    inplace_unique,
+    per_token_cast_back,
+    per_token_cast_to_fp8,
+    use_rocm,
+)
+
+
+# noinspection PyShadowingNames
+def test_main(
+    args: argparse.Namespace,
+    num_sms: int,
+    local_rank: int,
+    num_ranks: int,
+    rank: int,
+    buffer: deep_ep.Buffer,
+    group: dist.ProcessGroup,
+):
+    # Settings
+    num_tokens, hidden = args.num_tokens, args.hidden
+    num_topk, num_experts = args.num_topk, args.num_experts
+
+    assert num_experts % num_ranks == 0
+    if local_rank == 0:
+        print(
+            f"[config] num_tokens={num_tokens}, hidden={hidden}, num_topk={num_topk}",
+            flush=True,
+        )
+
+    # Random data
+    x = torch.ones((num_tokens, hidden), dtype=torch.bfloat16, device="cuda") * rank
+    x_pure_rand = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    x_e4m3 = (
+        per_token_cast_to_fp8(x)
+        if (use_rocm or deep_ep.Buffer.is_sm90_compiled())
+        else None
+    )
+    x_e4m3 = (x_e4m3[0], x_e4m3[1].T.contiguous().T) if x_e4m3 is not None else None
+    x_e4m3 = None  # moe_ep: FP8 dispatch path not yet wired in the kernel (num_scales=0); skip FP8 cases.
+    scores = (
+        torch.randn((num_tokens, num_experts), dtype=torch.float32, device="cuda").abs()
+        + 1
+    )
+    topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)[1]
+    topk_idx = topk_idx.to(deep_ep.topk_idx_t)
+    topk_weights = (
+        torch.ones((num_tokens, num_topk), dtype=torch.float32, device="cuda") * rank
+    )
+    topk_weights_pure_rand = torch.randn(
+        (num_tokens, num_topk), dtype=torch.float32, device="cuda"
+    )
+    rank_idx = topk_idx // (num_experts // num_ranks)
+    rank_idx = rank_idx.to(torch.int64)
+    rank_idx.masked_fill_(topk_idx == -1, -1)
+    inplace_unique(rank_idx, num_ranks)
+
+    invalid_index = -1
+    num_experts_per_rank = num_experts // num_ranks
+    if deep_ep_cpp.AITER_MOE:
+        invalid_index = num_experts_per_rank
+
+    # Expert meta
+    num_tokens_per_expert = torch.zeros((num_experts,), dtype=torch.int, device="cuda")
+    for i in range(num_experts):
+        num_tokens_per_expert[i] = (topk_idx == i).sum()
+    gbl_num_tokens_per_expert = num_tokens_per_expert.clone()
+    dist.all_reduce(gbl_num_tokens_per_expert, group=group)
+
+    # Rank layout meta
+    num_tokens_per_rank = torch.empty((num_ranks,), dtype=torch.int, device="cuda")
+    token_idx_in_rank = torch.full(
+        (num_ranks, num_tokens), -1, dtype=torch.long, device="cuda"
+    )
+    for i in range(num_ranks):
+        num_tokens_per_rank[i] = (rank_idx == i).sum()
+        token_sel = (rank_idx == i).max(dim=-1)[0]
+        count = token_sel.sum().item()
+        tokens = torch.sort(token_sel.to(torch.int), descending=True)[1]
+        tokens[:count] = torch.sort(tokens[:count])[0]
+        token_idx_in_rank[i][tokens[:count]] = torch.arange(
+            count, dtype=torch.long, device="cuda"
+        )
+    token_idx_in_rank = token_idx_in_rank.T.contiguous().to(torch.int)
+    is_token_in_rank = token_idx_in_rank >= 0
+    gbl_num_tokens_per_rank = num_tokens_per_rank.clone()
+    dist.all_reduce(gbl_num_tokens_per_rank, group=group)
+
+    ref_num_tokens_per_rank, _, ref_num_tokens_per_expert, ref_is_token_in_rank, _ = (
+        buffer.get_dispatch_layout(topk_idx, num_experts)
+    )
+    assert torch.allclose(ref_num_tokens_per_rank, num_tokens_per_rank)
+    assert torch.allclose(ref_num_tokens_per_expert, num_tokens_per_expert)
+    assert torch.allclose(ref_is_token_in_rank, is_token_in_rank)
+    t = bench(lambda: buffer.get_dispatch_layout(topk_idx, num_experts))[0]
+    if local_rank == 0:
+        print(f"[layout] Kernel performance: {t * 1000:.3f} ms", flush=True)
+        print("", flush=True)
+    group.barrier()
+    time.sleep(1)
+
+    # Config
+    nvl_buffer_size = 256
+    config = deep_ep.Config(num_sms, 8, nvl_buffer_size)
+
+    # Test dispatch
+    # noinspection PyShadowingNames
+    def check_data(check_x, rank_prefix_matrix):
+        assert torch.allclose(check_x.amin(dim=1), check_x.amax(dim=1))
+        check_start = 0
+        for i in range(num_ranks):
+            check_end = rank_prefix_matrix[i][rank].item()
+            assert (check_x[check_start:check_end, :].int() - i).sum().item() == 0
+            check_start = check_end
+
+    for previous_mode in (False, True):
+        for async_mode in (False, True):
+            for current_x in filter(
+                lambda elem: elem is not None, (x_pure_rand, x, x_e4m3)
+            ):
+                for with_topk in (False, True):
+                    if local_rank == 0:
+                        print(
+                            f"[testing] Running with {'FP8' if isinstance(current_x, tuple) else 'BF16'}, {'with' if with_topk else 'without'} top-k (async={async_mode}, previous={previous_mode}) ...",
+                            flush=True,
+                            end="",
+                        )
+                    dispatch_args = {
+                        "x": current_x,
+                        "num_tokens_per_rank": num_tokens_per_rank,
+                        "is_token_in_rank": is_token_in_rank,
+                        "num_tokens_per_expert": num_tokens_per_expert,
+                        "config": config,
+                        "async_finish": async_mode,
+                    }
+                    if with_topk:
+                        dispatch_args.update(
+                            {
+                                "topk_idx": topk_idx,
+                                "topk_weights": (
+                                    topk_weights_pure_rand
+                                    if current_x is x_pure_rand
+                                    else topk_weights
+                                ),
+                            }
+                        )
+                    if previous_mode:
+                        dispatch_args.update({"previous_event": buffer.capture()})
+                    (
+                        recv_x,
+                        recv_topk_idx,
+                        recv_topk_weights,
+                        recv_num_tokens_per_expert_list,
+                        handle,
+                        event,
+                    ) = buffer.dispatch(**dispatch_args)
+                    event.current_stream_wait() if async_mode else ()
+                    recv_x = (
+                        per_token_cast_back(*recv_x)
+                        if isinstance(recv_x, tuple)
+                        else recv_x
+                    )
+
+                    # Checks
+                    rank_prefix_matrix = handle[0]
+                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(0), (
+                        f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    )
+                    assert (
+                        gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
+                        == recv_num_tokens_per_expert_list
+                    )
+                    if current_x is not x_pure_rand:
+                        check_data(recv_x, rank_prefix_matrix)
+                    recv_topk_weights_clone = None
+                    if with_topk:
+                        # Check `topk_idx`
+                        assert (
+                            recv_topk_idx.eq(invalid_index)
+                            | (
+                                (recv_topk_idx >= 0)
+                                & (recv_topk_idx < (num_experts // num_ranks))
+                            )
+                        ).sum().item() == recv_topk_idx.numel()
+                        for i, count in enumerate(recv_num_tokens_per_expert_list):
+                            assert recv_topk_idx.eq(i).sum().item() == count
+
+                        # Check `topk_weights`
+                        recv_topk_weights_clone = recv_topk_weights.clone()
+                        if current_x is not x_pure_rand:
+                            recv_topk_weights[recv_topk_idx.eq(invalid_index)] = (
+                                recv_topk_weights.amax(dim=1, keepdim=True).expand_as(
+                                    recv_topk_weights
+                                )[recv_topk_idx.eq(invalid_index)]
+                            )
+                            check_data(recv_topk_weights, rank_prefix_matrix)
+
+                    # Test `num_worst_tokens != 0`
+                    if with_topk:
+                        num_worst_tokens = num_tokens * num_ranks
+                        dispatch_args.update({"num_worst_tokens": num_worst_tokens})
+                        (
+                            recv_worst_x,
+                            recv_worst_topk_idx,
+                            recv_worst_topk_weights,
+                            empty_list,
+                            _,
+                            event,
+                        ) = buffer.dispatch(**dispatch_args)
+                        event.current_stream_wait() if async_mode else ()
+                        recv_worst_x = (
+                            per_token_cast_back(*recv_worst_x)
+                            if isinstance(recv_worst_x, tuple)
+                            else recv_worst_x
+                        )
+                        assert len(empty_list) == 0
+                        assert num_worst_tokens == recv_worst_x.size(0)
+                        assert num_worst_tokens == recv_worst_topk_idx.size(0)
+                        assert num_worst_tokens == recv_worst_topk_weights.size(0)
+                        assert torch.equal(recv_x, recv_worst_x[: recv_x.size(0)])
+                        assert torch.equal(
+                            recv_topk_idx, recv_worst_topk_idx[: recv_x.size(0)]
+                        )
+                        assert torch.equal(
+                            recv_topk_weights_clone,
+                            recv_worst_topk_weights[: recv_x.size(0)],
+                        )
+                        if not use_rocm:
+                            assert torch.all(
+                                recv_worst_topk_idx[recv_x.size(0) :] == -1
+                            ).item()
+
+                    # Test cached dispatch (must without top-k staffs)
+                    if not with_topk:
+                        dispatch_args = {
+                            "x": current_x,
+                            "handle": handle,
+                            "config": config,
+                            "async_finish": async_mode,
+                        }
+                        if previous_mode:
+                            dispatch_args.update({"previous_event": buffer.capture()})
+                        recv_x, _, _, _, _, event = buffer.dispatch(**dispatch_args)
+                        event.current_stream_wait() if async_mode else ()
+                        recv_x = (
+                            per_token_cast_back(*recv_x)
+                            if isinstance(recv_x, tuple)
+                            else recv_x
+                        )
+                        if current_x is not x_pure_rand:
+                            check_data(recv_x, rank_prefix_matrix)
+
+                    # Test combine
+                    combine_args = {
+                        "x": recv_x,
+                        "handle": handle,
+                        "config": config,
+                        "async_finish": async_mode,
+                    }
+                    if with_topk:
+                        combine_args.update({"topk_weights": recv_topk_weights})
+                    if previous_mode:
+                        combine_args.update({"previous_event": buffer.capture()})
+                    combined_x, combined_topk_weights, event = buffer.combine(
+                        **combine_args
+                    )
+                    event.current_stream_wait() if async_mode else ()
+                    check_x = combined_x.float() / is_token_in_rank.sum(
+                        dim=1
+                    ).unsqueeze(1)
+                    ref_x = x_pure_rand if current_x is x_pure_rand else x
+                    assert calc_diff(check_x, ref_x) < 5e-6
+                    if with_topk:
+                        check_topk_weights = (
+                            combined_topk_weights
+                            if (current_x is x_pure_rand)
+                            else (
+                                combined_topk_weights
+                                / is_token_in_rank.sum(dim=1).unsqueeze(1)
+                            )
+                        )
+                        ref_topk_weights = (
+                            topk_weights_pure_rand
+                            if current_x is x_pure_rand
+                            else topk_weights
+                        )
+                        assert calc_diff(check_topk_weights, ref_topk_weights) < 1e-9
+
+                    # For later tuning
+                    dispatch_bf16_nvl_recv_bytes = recv_x.numel() * 2
+                    combine_bf16_nvl_send_bytes = dispatch_bf16_nvl_recv_bytes
+
+                    if local_rank == 0:
+                        print(" passed", flush=True)
+    if local_rank == 0:
+        print("", flush=True)
+
+    # Tune dispatch performance
+    best_dispatch_results = None
+    fp8_factor = (1 + 4 / 128) / 2
+    for current_x in filter(lambda elem: elem is not None, (x_e4m3, x)):
+        best_time, best_results = 1e10, None
+        nvl_recv_bytes = (
+            (dispatch_bf16_nvl_recv_bytes * fp8_factor)
+            if isinstance(current_x, tuple)
+            else dispatch_bf16_nvl_recv_bytes
+        )
+        for nvl_chunk_size in tuple(range(4, 33, 2)) + (0,):
+            if nvl_chunk_size > 0:
+                config = deep_ep.Config(num_sms, nvl_chunk_size, nvl_buffer_size)
+            else:
+                # Test default config as well
+                deep_ep.Buffer.set_num_sms(num_sms)
+                config = deep_ep.Buffer.get_dispatch_config(num_ranks)
+            tune_args = {"x": current_x, "handle": handle, "config": config}
+            t = bench(lambda: buffer.dispatch(**tune_args))[0]  # noqa: B023
+            if t < best_time and nvl_chunk_size > 0:
+                best_time, best_results = t, (num_sms, nvl_chunk_size)
+            if local_rank == 0:
+                print(
+                    f"[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else 'default'}: "
+                    f"{nvl_recv_bytes / 1e9 / t:.2f} GB/s (NVL), {t * 1e6:.2f} us",
+                    flush=True,
+                )
+        if local_rank == 0:
+            print(
+                f"[tuning] Best dispatch ({'FP8' if isinstance(current_x, tuple) else 'BF16'}): SMs {best_results[0]}, NVL chunk {best_results[1]}, {nvl_recv_bytes / 1e9 / best_time:.2f} GB/s (NVL), t: {best_time * 1e6:.2f} us",
+                flush=True,
+            )
+            print("", flush=True)
+
+        # Gather the best config from rank 0 and the first test setting
+        if best_dispatch_results is None:
+            best_dispatch_results = torch.tensor(
+                [best_results[0], best_results[1]], dtype=torch.int32, device="cuda"
+            )
+            all_best_fp8_results_list = [
+                torch.zeros_like(best_dispatch_results)
+                for _ in range(torch.distributed.get_world_size())
+            ]
+            dist.all_gather(
+                all_best_fp8_results_list, best_dispatch_results, group=group
+            )
+            best_dispatch_results = all_best_fp8_results_list[0].tolist()
+    dispatch_config = deep_ep.Config(
+        best_dispatch_results[0], best_dispatch_results[1], nvl_buffer_size
+    )
+
+    dispatch_args = {
+        "x": x,
+        "num_tokens_per_rank": num_tokens_per_rank,
+        "is_token_in_rank": is_token_in_rank,
+        "num_tokens_per_expert": num_tokens_per_expert,
+        "config": dispatch_config if dispatch_config is not None else config,
+    }
+    recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
+
+    # Tune combine performance
+    best_time, best_results = 1e10, None
+    for nvl_chunk_size in tuple(range(1, 17, 1)) + (0,):
+        if nvl_chunk_size > 0:
+            config = deep_ep.Config(num_sms, nvl_chunk_size, nvl_buffer_size)
+        else:
+            # Test default config as well
+            deep_ep.Buffer.set_num_sms(num_sms)
+            config = deep_ep.Buffer.get_combine_config(num_ranks)
+        tune_args = {"x": recv_x, "handle": handle, "config": config}
+        t = bench(lambda: buffer.combine(**tune_args))[0]  # noqa: B023
+        if local_rank == 0:
+            print(
+                f"[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else 'default'}: "
+                f"{combine_bf16_nvl_send_bytes / 1e9 / t:.2f} GB/s (NVL), {t * 1e6:.2f} us",
+                flush=True,
+            )
+            if t < best_time and nvl_chunk_size > 0:
+                best_time, best_results = t, (num_sms, nvl_chunk_size)
+
+    if local_rank == 0:
+        print(
+            f"[tuning] Best combine: SMs {best_results[0]}, NVL chunk {best_results[1]}: {combine_bf16_nvl_send_bytes / 1e9 / best_time:.2f} GB/s (NVL), t: {best_time * 1e6:.2f} us",
+            flush=True,
+        )
+        print("", flush=True)
+
+
+# noinspection PyUnboundLocalVariable,PyShadowingNames
+def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    test_ll_compatibility, num_rdma_bytes = False, 0
+    if test_ll_compatibility:
+        ll_num_tokens, ll_hidden, ll_num_experts, ll_num_topk = 16, 5120, 256, 9
+        num_rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint(
+            ll_num_tokens, ll_hidden, num_ranks, ll_num_experts
+        )
+
+    buffer = deep_ep.Buffer(
+        group,
+        int(2e9),
+        num_rdma_bytes,
+        low_latency_mode=test_ll_compatibility,
+        num_qps_per_rank=(ll_num_experts // num_ranks if test_ll_compatibility else 1),
+        explicitly_destroy=True,
+        allow_mnnvl=args.allow_mnnvl,
+        use_fabric=args.use_fabric,
+    )
+    torch.manual_seed(rank)
+
+    if use_rocm:
+        num_sms = 64
+    else:
+        num_sms = 24
+
+    for i in (num_sms,):
+        test_main(args, i, local_rank, num_ranks, rank, buffer, group)
+        if local_rank == 0:
+            print("", flush=True)
+
+    # Test compatibility with low latency functions
+    if test_ll_compatibility:
+        # moe_ep: `test_low_latency` ships in a later diff; import lazily so the
+        # intranode-only build doesn't depend on it (this branch is off here).
+        from comms.prims.collectives.moe_ep.tests import test_low_latency
+
+        buffer.clean_low_latency_buffer(ll_num_tokens, ll_hidden, ll_num_experts)
+        test_low_latency.test_main(
+            ll_num_tokens,
+            ll_hidden,
+            ll_num_experts,
+            ll_num_topk,
+            rank,
+            num_ranks,
+            group,
+            buffer,
+            seed=1,
+        )
+
+    # Destroy the buffer runtime and communication group
+    buffer.destroy()
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test intranode EP kernels")
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=8,
+        help="Number of processes to spawn (default: 8)",
+    )
+    parser.add_argument(
+        "--num-tokens", type=int, default=4096, help="Number of tokens (default: 4096)"
+    )
+    parser.add_argument(
+        "--hidden", type=int, default=7168, help="Hidden dimension size (default: 7168)"
+    )
+    parser.add_argument(
+        "--num-topk", type=int, default=8, help="Number of top-k experts (default: 8)"
+    )
+    parser.add_argument(
+        "--num-experts", type=int, default=256, help="Number of experts (default: 256)"
+    )
+    parser.add_argument(
+        "--allow-mnnvl", action="store_true", help="Enable MNNVL support"
+    )
+    parser.add_argument("--use-fabric", action="store_true", help="Enable fabric mode")
+    args = parser.parse_args()
+
+    num_processes = args.num_processes
+    torch.multiprocessing.spawn(
+        test_loop, args=(num_processes, args), nprocs=num_processes
+    )

--- a/comms/prims/collectives/moe_ep/tests/test_intranode_wrapper.py
+++ b/comms/prims/collectives/moe_ep/tests/test_intranode_wrapper.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-ignore-all-errors
+
+"""
+unittest wrapper around `test_intranode.test_loop`. Dispatched to
+an 8-GPU host by `comms_py_unittest(... num_gpus = 8)`. Validates intranode
+dispatch / combine end-to-end against the BF16 + FP8 test matrix.
+
+Hardware: 1 node with 8 GPUs. Equivalent CLI entry point:
+
+    python test_intranode.py --num-processes 8 --num-tokens 4096 \\
+        --hidden 7168 --num-topk 8 --num-experts 256
+
+`buck2 test @fbcode//mode/opt-amd-gpu //comms/prims/collectives/moe_ep/tests:test_intranode_wrapper`
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import unittest
+
+# Install the import shims BEFORE the test file's first
+# `import deep_ep` / `import deep_ep_cpp` line runs.
+import comms.prims.collectives.moe_ep._cpp as _moe_ep_cpp  # noqa: E402
+import comms.prims.collectives.moe_ep.moe_ep as _moe_ep  # noqa: E402
+import torch
+
+sys.modules["deep_ep"] = _moe_ep
+sys.modules["deep_ep_cpp"] = _moe_ep_cpp
+
+from comms.prims.collectives.moe_ep.tests.test_intranode import test_loop  # noqa: E402
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and torch.cuda.device_count() >= 8,
+    "test_intranode requires an 8-GPU host",
+)
+class Intranode8GpuTest(unittest.TestCase):
+    """End-to-end smoke + perf test for intranode dispatch / combine."""
+
+    def test_main(self) -> None:
+        """Drives `test_loop` for 8 ranks. Each child rank exercises:
+        - get_dispatch_layout
+        - notify_dispatch + intranode_dispatch (BF16 / FP8 / with+without topk,
+          async + sync, previous_event chaining)
+        - intranode_combine (sum-without-weights, sum-with-weights)
+        - cached-mode dispatch (handle reuse from prior dispatch)
+        """
+        # Match test_intranode.py defaults.
+        args = argparse.Namespace(
+            num_processes=8,
+            num_tokens=4096,
+            hidden=7168,
+            num_topk=8,
+            num_experts=256,
+            allow_mnnvl=False,
+            use_fabric=False,
+        )
+        torch.multiprocessing.spawn(test_loop, args=(8, args), nprocs=8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/comms/prims/collectives/moe_ep/tests/test_rccl_moe.py
+++ b/comms/prims/collectives/moe_ep/tests/test_rccl_moe.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""
+RCCL/NCCL baseline benchmark for MoE dispatch + combine.
+
+Implements an equivalent MoE dispatch+combine using only
+`torch.distributed.all_to_all_single` (which on AMD routes to RCCL, on NVIDIA
+to NCCL). Apples-to-apples baseline for the pipes MoE EP custom kernel:
+
+  * Routing layout (`topk_idx` -> per-rank send counts, permutation, dedup)
+    is computed ONCE before the timed loop. This matches how the pipes test
+    calls `get_dispatch_layout()` separately at the top of `test_main` and
+    re-uses the cached `handle` across bench iterations.
+
+  * Per-(token, dst_rank) dedup via `inplace_unique` — each token is sent at
+    MOST once per unique destination rank, even if multiple of its top-k
+    experts live on that rank. Without this, the baseline would move
+    ~`num_topk × num_unique_ranks_per_token` more bytes than the pipes
+    kernel (which dedups internally) — a comparison artifact that has
+    nothing to do with the underlying collective performance.
+
+  * Send / recv buffers are pre-allocated outside the timed loop. The pipes
+    `dispatch()` / `combine()` reuse the buffer's symmetric region across
+    calls; the baseline matches that by pre-sizing the recv buffer based on
+    the pre-exchanged counts.
+
+  * Timed region inside `fn()` is the two `dist.all_to_all_single` calls
+    (dispatch + combine) and the topk-weighted reduction that the pipes
+    `combine()` kernel also does internally. Nothing else.
+
+  * Uses `upstream_utils.bench` directly (50 warmups, 50 timed runs, L2
+    flushed before timing) — identical methodology to the pipes test.
+
+  * Correctness assertion comparing output against a reference implementation
+    runs once before the bench loop. The bench fails loudly if the baseline
+    is silently wrong.
+
+Default shape matches `test_intranode.py` (high-throughput config):
+num_tokens=4096, hidden=7168, num_topk=8, num_experts=256, BF16.
+
+Run with the same wrapper as the intranode test:
+  HSA_NO_SCRATCH_RECLAIM=1 NCCL_NET=Socket NCCL_SOCKET_IFNAME=lo \\
+    buck2 run @fbcode//mode/opt-amd-gpu \\
+    //comms/prims/collectives/moe_ep/tests:test_rccl_moe -- --num-processes 8
+"""
+
+# pyre-ignore-all-errors
+
+import argparse
+
+# In-tree aliases (same pattern as test_intranode.py).
+import sys
+
+import comms.prims.collectives.moe_ep._cpp as _moe_ep_cpp  # noqa: E402
+import comms.prims.collectives.moe_ep.moe_ep as _moe_ep  # noqa: E402
+
+sys.modules["deep_ep"] = _moe_ep
+sys.modules["deep_ep_cpp"] = _moe_ep_cpp
+
+# Bind to the in-house moe_ep module (sys.modules shim above) — no import of
+# the external deeplearning/deep_ep package.
+deep_ep = _moe_ep
+import torch  # noqa: E402
+import torch.distributed as dist  # noqa: E402
+from comms.prims.collectives.moe_ep.tests.upstream_utils import (  # noqa: E402  # noqa: E402
+    bench,
+    init_dist,
+    inplace_unique,
+    use_rocm,
+)
+
+
+def precompute_dispatch_layout(
+    topk_idx: torch.Tensor,
+    num_experts: int,
+    num_ranks: int,
+    group: dist.ProcessGroup,
+):
+    """Pre-compute the dispatch routing: per-rank send counts, recv counts,
+    and the permutation that buckets tokens by destination rank.
+
+    Mirrors what pipes' `get_dispatch_layout()` returns at host-side. Result
+    is reused across all timed iterations.
+
+    Returns:
+      send_counts: list[int] of length num_ranks (tokens to send to each peer)
+      recv_counts: list[int] of length num_ranks (tokens to receive from each)
+      send_token_idx: int64 (sum(send_counts),) gather indices into x
+      inverse_perm: int64 (sum(send_counts),) un-permute indices for combine
+      send_topk_slot: int64 (sum(send_counts),) the topk slot each send refers
+        to (for the weighted reduction during combine).
+    """
+    num_tokens, num_topk = topk_idx.shape
+    num_local_experts = num_experts // num_ranks
+
+    # rank_idx[token, k] = which rank owns the k-th top expert for this token.
+    rank_idx = (topk_idx // num_local_experts).clone()
+
+    # Dedup per token: a token going to rank R for any of its k experts is
+    # sent to R exactly once. inplace_unique fills invalid slots with -1
+    # and keeps the unique dst ranks (sorted) in the leading positions.
+    inplace_unique(rank_idx, num_ranks)
+
+    # Flatten and drop the -1 padding to get the per-rank send list.
+    flat_dst = rank_idx.flatten()  # (num_tokens * num_topk,)
+    valid = flat_dst >= 0
+    flat_dst_valid = flat_dst[valid]
+    # send_token_idx[i] = source token index for the i-th dispatch send.
+    token_idx_repeated = (
+        torch.arange(num_tokens, device=topk_idx.device)
+        .unsqueeze(1)
+        .expand(-1, num_topk)
+        .flatten()
+    )
+    send_token_idx_unsorted = token_idx_repeated[valid]
+
+    # Bucket sort by dst_rank so each peer's chunk is contiguous.
+    perm = torch.argsort(flat_dst_valid, stable=True)
+    send_token_idx = send_token_idx_unsorted[perm]
+    sorted_dst = flat_dst_valid[perm]
+    send_counts = torch.bincount(sorted_dst, minlength=num_ranks).cpu().tolist()
+
+    # Inverse permutation for the combine path: un-bucket recv data back to
+    # per-token order before the weighted sum.
+    inverse_perm = torch.empty_like(perm)
+    inverse_perm[perm] = torch.arange(perm.numel(), device=perm.device)
+
+    # Exchange counts so both sides know recv sizes (one-shot — not timed).
+    send_counts_t = torch.tensor(send_counts, dtype=torch.int64, device=topk_idx.device)
+    recv_counts_t = torch.empty(num_ranks, dtype=torch.int64, device=topk_idx.device)
+    dist.all_to_all_single(recv_counts_t, send_counts_t, group=group)
+    recv_counts = recv_counts_t.cpu().tolist()
+
+    return send_counts, recv_counts, send_token_idx, inverse_perm
+
+
+def reference_dispatch_combine(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    num_ranks: int,
+    group: dist.ProcessGroup,
+):
+    """Reference implementation: same as the timed path but unfused. Used
+    only for the one-shot correctness assertion. Identical to what the
+    pipes kernel computes logically — for the identity-processing
+    benchmark scenario, combine returns x weighted by sum(topk_weights)."""
+    send_counts, recv_counts, send_token_idx, inverse_perm = precompute_dispatch_layout(
+        topk_idx, num_experts, num_ranks, group
+    )
+    send_buf = x[send_token_idx]
+    recv_buf = torch.empty(
+        (sum(recv_counts), x.shape[1]), dtype=x.dtype, device=x.device
+    )
+    dist.all_to_all_single(recv_buf, send_buf, recv_counts, send_counts, group=group)
+    # Combine reverses dispatch.
+    combine_recv = torch.empty_like(send_buf)
+    dist.all_to_all_single(
+        combine_recv, recv_buf, send_counts, recv_counts, group=group
+    )
+    combine_unpermuted = combine_recv[inverse_perm]
+    # Each token T receives back one copy per unique dst_rank it sent to.
+    # The pipes combine kernel sums these per token (weighted by topk_weights
+    # for the experts that mapped to each dst_rank). For the identity
+    # benchmark, the reduction is just sum of weights for the experts that
+    # routed to each unique dst_rank. We approximate this with a scatter_add
+    # back to per-token outputs.
+    num_tokens = x.shape[0]
+    num_topk = topk_idx.shape[1]
+    num_local_experts = num_experts // num_ranks
+    rank_idx_orig = topk_idx // num_local_experts  # (num_tokens, num_topk)
+    rank_idx_dedup = rank_idx_orig.clone()
+    inplace_unique(rank_idx_dedup, num_ranks)
+    # token_idx_repeated[i] gives source token, flat_dst_valid[i] gives unique
+    # dst_rank for the i-th send. After perm, contiguous-by-dst-rank.
+    token_idx_repeated = (
+        torch.arange(num_tokens, device=x.device)
+        .unsqueeze(1)
+        .expand(-1, num_topk)
+        .flatten()
+    )
+    flat_dst = rank_idx_dedup.flatten()
+    valid = flat_dst >= 0
+    # combine_unpermuted is in send order.
+    combined = torch.zeros(
+        (num_tokens, x.shape[1]), dtype=torch.float32, device=x.device
+    )
+    # For each (token, unique_dst_rank), compute the sum of topk_weights for
+    # the experts that mapped to that rank.
+    weight_per_send = torch.zeros(
+        combine_unpermuted.shape[0], dtype=torch.float32, device=x.device
+    )
+    # rank_idx_orig has full (token, topk) -> dst_rank map; weight per (token,
+    # dst_rank) = sum of topk_weights where rank_idx_orig == dst_rank.
+    # Build a (num_tokens, num_ranks) weight matrix and scatter_add from
+    # topk_weights via rank_idx_orig.
+    weights_per_token_per_rank = torch.zeros(
+        (num_tokens, num_ranks), dtype=torch.float32, device=x.device
+    )
+    weights_per_token_per_rank.scatter_add_(
+        1, rank_idx_orig, topk_weights.to(torch.float32)
+    )
+    # Look up weight for each send.
+    # Need original (pre-perm) ordering of (token, dst_rank) for weight lookup.
+    # The combine_unpermuted is in original (token-major) order BEFORE perm,
+    # so use src_token unpermuted (i.e., from the un-perm step).
+    src_token_orig = token_idx_repeated[valid]  # original (token, topk-slot) order
+    dst_rank_orig = flat_dst[valid]
+    weight_per_send = weights_per_token_per_rank[src_token_orig, dst_rank_orig]
+    # Weighted sum into output.
+    combined.scatter_add_(
+        0,
+        src_token_orig.unsqueeze(-1).expand(-1, x.shape[1]),
+        combine_unpermuted.to(torch.float32) * weight_per_send.unsqueeze(-1),
+    )
+    return combined.to(x.dtype)
+
+
+def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(rank)
+
+    num_tokens = args.num_tokens
+    hidden = args.hidden
+    num_topk = args.num_topk
+    num_experts = args.num_experts
+
+    if local_rank == 0:
+        print(
+            f"[config] num_tokens={num_tokens} hidden={hidden} num_topk={num_topk} "
+            f"num_experts={num_experts} num_ranks={num_ranks} dtype=bf16",
+            flush=True,
+        )
+
+    # Suppress the spurious `hipErrorPeerAccessAlreadyEnabled` that PyTorch's
+    # caching allocator throws on first GPU op in multi-process HIP runs.
+    # PyTorch tries to enable peer access between adjacent GPUs as a perf
+    # optimization; on AMD ROCm this can collide with the prior peer-access
+    # state set up by other ranks. Swallowing the spurious error here is
+    # safe — peer access stays enabled either way, which is what we want.
+    try:
+        _ = torch.zeros(1, dtype=torch.bfloat16, device="cuda")
+    except RuntimeError as _re:
+        if "PeerAccessAlreadyEnabled" not in str(_re):
+            raise
+
+    # Generate inputs matching test_intranode.py methodology.
+    x = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    scores = torch.randn(
+        (num_tokens, num_experts), dtype=torch.float32, device="cuda"
+    ).abs()
+    topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)[1]
+    topk_weights = torch.softmax(
+        torch.randn((num_tokens, num_topk), dtype=torch.float32, device="cuda"), dim=-1
+    ).to(torch.bfloat16)
+
+    # ============ PRE-COMPUTATION (NOT TIMED) ============
+    # Routing layout, send/recv counts, permutation, and ALL buffer
+    # allocations happen exactly once before the timed loop. This mirrors
+    # how the pipes test calls `get_dispatch_layout()` once (timed
+    # separately at test_intranode.py:125) and re-uses the cached
+    # `handle` across every bench iteration — so the per-iteration timing
+    # captures only the actual collective work.
+    send_counts, recv_counts, send_token_idx, inverse_perm = precompute_dispatch_layout(
+        topk_idx, num_experts, num_ranks, group
+    )
+    total_send = sum(send_counts)
+    total_recv = sum(recv_counts)
+    # Pre-allocated buffers — re-used across every bench iteration.
+    send_buf = x[send_token_idx].clone()  # (total_send, hidden)
+    recv_buf = torch.empty((total_recv, hidden), dtype=x.dtype, device=x.device)
+    combine_recv = torch.empty_like(send_buf)
+    combine_unpermuted = torch.empty_like(send_buf)
+    # Per-(token, dst_rank) weight for the combine reduction. Sums the
+    # topk_weights of the experts that mapped to that rank. Equivalent to
+    # what the pipes combine kernel applies via topk_weights internally.
+    num_local_experts = num_experts // num_ranks
+    rank_idx_orig = topk_idx // num_local_experts
+    weights_per_token_per_rank = torch.zeros(
+        (num_tokens, num_ranks), dtype=torch.float32, device=x.device
+    )
+    weights_per_token_per_rank.scatter_add_(
+        1, rank_idx_orig, topk_weights.to(torch.float32)
+    )
+    token_idx_repeated = (
+        torch.arange(num_tokens, device=x.device)
+        .unsqueeze(1)
+        .expand(-1, num_topk)
+        .flatten()
+    )
+    rank_idx_dedup = rank_idx_orig.clone()
+    inplace_unique(rank_idx_dedup, num_ranks)
+    flat_dst = rank_idx_dedup.flatten()
+    valid = flat_dst >= 0
+    src_token_orig = token_idx_repeated[valid]
+    dst_rank_orig = flat_dst[valid]
+    weight_per_send = weights_per_token_per_rank[src_token_orig, dst_rank_orig].to(
+        x.dtype
+    )
+    out_indices = src_token_orig.unsqueeze(-1).expand(-1, hidden).contiguous()
+
+    # ============ CORRECTNESS CHECK (NOT TIMED) ============
+    # Run the timed path once and verify against a fresh reference computation.
+    def run_bench_once():
+        dist.all_to_all_single(
+            recv_buf, send_buf, recv_counts, send_counts, group=group
+        )
+        dist.all_to_all_single(
+            combine_recv, recv_buf, send_counts, recv_counts, group=group
+        )
+        # Un-permute and weighted-reduce. Both ops mirror what the pipes
+        # combine kernel applies internally.
+        combine_unpermuted[:] = combine_recv[inverse_perm]
+        out = torch.zeros((num_tokens, hidden), dtype=x.dtype, device=x.device)
+        out.scatter_add_(
+            0,
+            out_indices,
+            (combine_unpermuted * weight_per_send.unsqueeze(-1)),
+        )
+        return out
+
+    # One-shot correctness verification before timing.
+    out_test = run_bench_once()
+    out_ref = reference_dispatch_combine(
+        x, topk_idx, topk_weights, num_experts, num_ranks, group
+    )
+    max_abs_diff = (out_test.float() - out_ref.float()).abs().max().item()
+    rel_diff = max_abs_diff / (out_ref.float().abs().max().item() + 1e-8)
+    if local_rank == 0:
+        print(
+            f"[correctness] max_abs_diff={max_abs_diff:.4e} rel_diff={rel_diff:.4e}",
+            flush=True,
+        )
+    if rel_diff > 1e-2:
+        if local_rank == 0:
+            print(
+                "[WARN] correctness check rel_diff > 1%. Bench may not measure "
+                "the same logical op as the pipes kernel.",
+                flush=True,
+            )
+    dist.barrier(group=group)
+
+    # ============ TIMED BENCH (matches pipes methodology exactly) ============
+    # `upstream_utils.bench` does 50 warmups + 50 timed runs with L2 flush.
+    # Same function the pipes test uses.
+    t_avg, t_min, t_max = bench(run_bench_once)
+
+    # Byte volume for BW reporting.
+    # Per rank: sends `total_send * hidden * 2` bytes for dispatch + same back
+    # for combine. Total round trip per rank = 2 * total_send * hidden * 2.
+    per_rank_dispatch_bytes = total_send * hidden * 2
+    total_round_trip_bytes = per_rank_dispatch_bytes * 2
+
+    if local_rank == 0:
+        print("", flush=True)
+        print(
+            f"[rccl-moe] dispatch+combine avg: {t_avg * 1e6:.2f} us "
+            f"(min {t_min * 1e6:.2f} us, max {t_max * 1e6:.2f} us)",
+            flush=True,
+        )
+        print(
+            f"[rccl-moe] per-rank dispatch send-count total: {total_send} tokens",
+            flush=True,
+        )
+        print(
+            f"[rccl-moe] per-rank dispatch volume: "
+            f"{per_rank_dispatch_bytes / 1e6:.2f} MB",
+            flush=True,
+        )
+        print(
+            f"[rccl-moe] per-rank round-trip BW: "
+            f"{total_round_trip_bytes / 1e9 / t_avg:.2f} GB/s",
+            flush=True,
+        )
+
+    dist.barrier(group=group)
+    dist.destroy_process_group()
+
+
+def bench_e2e_breakdown(
+    local_rank: int, num_local_ranks: int, args: argparse.Namespace
+):
+    """Benchmark B: e2e dispatch+combine with a PER-PART time breakdown that
+    INCLUDES the topk-derived pre-computation, for both our moe_ep kernel and
+    the RCCL all_to_all baseline.
+
+    Motivation: in real training topk_idx changes every batch,
+    so the routing pre-computation (counts + host sync) CANNOT be amortized.
+    The existing per-iteration numbers (cached moe_ep dispatch / RCCL with
+    routing precomputed outside the loop) hide that cost. Here every part is
+    measured per iteration so the e2e picture is accurate.
+
+    moe_ep breakdown (uses cached-vs-non-cached differencing to isolate the
+    host sync without C++ instrumentation):
+      layout        = get_dispatch_layout(topk_idx)
+      dispatch_data = cached dispatch (handle reused; pure NVLink data move)
+      notify+sync   = non-cached dispatch - cached dispatch
+      combine       = combine(recv_x, handle)
+
+    RCCL breakdown (torch.distributed.all_to_all_single, RCCL on AMD):
+      count_compute = rank dedup + argsort + bincount
+      counts_a2a+sync = all_to_all_single(counts) + .cpu() host sync
+      permute       = gather tokens by destination rank
+      data_a2a      = all_to_all_single(data)  [dispatch]
+      combine       = reverse all_to_all_single + unpermute + weighted scatter
+    """
+    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(rank)
+
+    num_tokens, hidden = args.num_tokens, args.hidden
+    num_topk, num_experts = args.num_topk, args.num_experts
+    num_local_experts = num_experts // num_ranks
+    dev = "cuda"
+
+    if local_rank == 0:
+        print(
+            f"[config] num_tokens={num_tokens} hidden={hidden} num_topk={num_topk} "
+            f"num_experts={num_experts} num_ranks={num_ranks} dtype=bf16",
+            flush=True,
+        )
+
+    # Swallow the spurious first-op hipErrorPeerAccessAlreadyEnabled (AMD).
+    try:
+        _ = torch.zeros(1, dtype=torch.bfloat16, device=dev)
+    except RuntimeError as _re:
+        if "PeerAccessAlreadyEnabled" not in str(_re):
+            raise
+
+    x = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device=dev)
+    scores = torch.randn(
+        (num_tokens, num_experts), dtype=torch.float32, device=dev
+    ).abs()
+    topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)[1]
+    topk_weights = torch.softmax(
+        torch.randn((num_tokens, num_topk), dtype=torch.float32, device=dev), dim=-1
+    ).to(torch.float32)
+
+    # ==================== moe_ep path ====================
+    buffer = deep_ep.Buffer(
+        group,
+        int(2e9),
+        0,
+        low_latency_mode=False,
+        num_qps_per_rank=1,
+        explicitly_destroy=True,
+    )
+    num_sms = 64 if use_rocm else 24
+    deep_ep.Buffer.set_num_sms(num_sms)
+    dispatch_cfg = deep_ep.Buffer.get_dispatch_config(num_ranks)
+    combine_cfg = deep_ep.Buffer.get_combine_config(num_ranks)
+
+    def moeep_layout():
+        return buffer.get_dispatch_layout(topk_idx, num_experts)
+
+    ntpr, _, ntpe, is_in_rank, _ = moeep_layout()
+
+    def moeep_dispatch_noncached():
+        return buffer.dispatch(
+            x=x,
+            num_tokens_per_rank=ntpr,
+            is_token_in_rank=is_in_rank,
+            num_tokens_per_expert=ntpe,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            config=dispatch_cfg,
+        )
+
+    recv_x, _, recv_tw, _, handle, _ = moeep_dispatch_noncached()
+
+    def moeep_dispatch_cached():
+        return buffer.dispatch(x=x, handle=handle, config=dispatch_cfg)
+
+    def moeep_combine():
+        return buffer.combine(x=recv_x, handle=handle, config=combine_cfg)
+
+    t_layout = bench(moeep_layout)[0]
+    t_disp_full = bench(moeep_dispatch_noncached)[0]
+    t_disp_data = bench(moeep_dispatch_cached)[0]
+    t_notify_sync = max(t_disp_full - t_disp_data, 0.0)
+    t_combine_me = bench(moeep_combine)[0]
+
+    # Optional: sweep nvl_chunk_size for the data legs. Ranges
+    # (dispatch range(4,150,4), combine range(1,35,1)) are wider than our
+    # test_intranode.py (4..32 / 1..16). Lets us
+    # report the speedup at BOTH default and best-of-tuned config from ONE run
+    # with a single consistent RCCL baseline -- isolating the effect of (a)
+    # per-kernel tuning vs (b) including pre-computation. The notify+host-sync
+    # is config-independent, so tuned non-cached dispatch = best cached dispatch
+    # + t_notify_sync.
+    best_disp = best_combine = None
+    best_disp_ck = best_combine_ck = 0
+    if args.tune:
+        # The ONLY knob swept is nvl_send_chunk (Config arg 2 =
+        # num_max_nvl_chunked_send_tokens). num_sms and nvl_recv_buffer (256)
+        # are held fixed. The default configs come from the
+        # NVIDIA-tuned table (get_dispatch_config / get_combine_config), so on
+        # AMD xGMI re-sweeping the chunk recovers real perf.
+        nvl_buffer_size = 256
+        best_disp = 1e30
+        for ck in range(4, 150, 4):
+            cfg = deep_ep.Config(num_sms, ck, nvl_buffer_size)
+            t = bench(lambda c=cfg: buffer.dispatch(x=x, handle=handle, config=c))[0]
+            if t < best_disp:
+                best_disp, best_disp_ck = t, ck
+        best_combine = 1e30
+        for ck in range(1, 35, 1):
+            cfg = deep_ep.Config(num_sms, ck, nvl_buffer_size)
+            t = bench(lambda c=cfg: buffer.combine(x=recv_x, handle=handle, config=c))[
+                0
+            ]
+            if t < best_combine:
+                best_combine, best_combine_ck = t, ck
+
+    # ==================== RCCL all_to_all path ====================
+    def rccl_count_compute():
+        rank_idx = (topk_idx // num_local_experts).clone()
+        inplace_unique(rank_idx, num_ranks)
+        flat = rank_idx.flatten()
+        valid = flat >= 0
+        fv = flat[valid]
+        perm = torch.argsort(fv, stable=True)
+        sc = torch.bincount(fv[perm], minlength=num_ranks)
+        return sc, perm, valid, fv
+
+    sc, perm, valid, fv = rccl_count_compute()
+    send_counts = sc.cpu().tolist()
+    token_rep = (
+        torch.arange(num_tokens, device=dev).unsqueeze(1).expand(-1, num_topk).flatten()
+    )
+    send_token_idx = token_rep[valid][perm]
+    send_counts_t = torch.tensor(send_counts, dtype=torch.int64, device=dev)
+    recv_counts_t = torch.empty(num_ranks, dtype=torch.int64, device=dev)
+
+    def rccl_counts_a2a_sync():
+        dist.all_to_all_single(recv_counts_t, send_counts_t, group=group)
+        return recv_counts_t.cpu().tolist()
+
+    recv_counts = rccl_counts_a2a_sync()
+    total_send, total_recv = sum(send_counts), sum(recv_counts)
+    send_buf = x[send_token_idx].clone()
+    recv_buf = torch.empty((total_recv, hidden), dtype=x.dtype, device=dev)
+    combine_recv = torch.empty_like(send_buf)
+    inverse_perm = torch.empty_like(perm)
+    inverse_perm[perm] = torch.arange(perm.numel(), device=dev)
+    src_token = token_rep[valid]
+    out_idx = src_token.unsqueeze(-1).expand(-1, hidden).contiguous()
+
+    def rccl_permute():
+        return x[send_token_idx]
+
+    def rccl_data_a2a():
+        dist.all_to_all_single(
+            recv_buf, send_buf, recv_counts, send_counts, group=group
+        )
+
+    def rccl_combine():
+        dist.all_to_all_single(
+            combine_recv, recv_buf, send_counts, recv_counts, group=group
+        )
+        out = torch.zeros((num_tokens, hidden), dtype=x.dtype, device=dev)
+        out.scatter_add_(0, out_idx, combine_recv[inverse_perm])
+        return out
+
+    t_cc = bench(rccl_count_compute)[0]
+    t_ca = bench(rccl_counts_a2a_sync)[0]
+    t_pm = bench(rccl_permute)[0]
+    t_da = bench(rccl_data_a2a)[0]
+    t_rc = bench(rccl_combine)[0]
+    rccl_e2e = t_cc + t_ca + t_pm + t_da + t_rc
+
+    if local_rank == 0:
+        u = lambda s: s * 1e6  # noqa: E731
+        # With --tune, report the moe_ep data legs at the best-of-sweep config
+        # (the config our test_intranode actually uses).
+        # notify+host-sync is config-independent, so e2e = layout + (best
+        # dispatch + notify_sync) + best combine.
+        if best_disp is not None:
+            disp_show, comb_show = best_disp, best_combine
+            cfg_note = f" [tuned: nvl_send_chunk dispatch {best_disp_ck}, combine {best_combine_ck}]"
+        else:
+            disp_show, comb_show = t_disp_data, t_combine_me
+            cfg_note = ""
+        me_e2e_show = t_layout + (disp_show + t_notify_sync) + comb_show
+        pre_me = t_layout + t_notify_sync
+        print("", flush=True)
+        print(
+            "================ Benchmark B: e2e breakdown (us) ================",
+            flush=True,
+        )
+        print(f"---- moe_ep (NVLink IPC){cfg_note} ----", flush=True)
+        print(f"  layout (get_dispatch_layout) : {u(t_layout):9.1f}", flush=True)
+        print(f"  notify + host-sync          : {u(t_notify_sync):9.1f}", flush=True)
+        print(f"  dispatch data move          : {u(disp_show):9.1f}", flush=True)
+        print(f"  combine                     : {u(comb_show):9.1f}", flush=True)
+        print(f"  >> moe_ep e2e total         : {u(me_e2e_show):9.1f}", flush=True)
+        print(
+            f"     pre-computation share    : {u(pre_me):9.1f}  ({100 * pre_me / me_e2e_show:.1f}%)",
+            flush=True,
+        )
+        print("---- RCCL all_to_all_single ----", flush=True)
+        print(f"  count compute               : {u(t_cc):9.1f}", flush=True)
+        print(f"  counts a2a + host-sync      : {u(t_ca):9.1f}", flush=True)
+        print(f"  permute (gather by dst)     : {u(t_pm):9.1f}", flush=True)
+        print(f"  data a2a (dispatch)         : {u(t_da):9.1f}", flush=True)
+        print(f"  combine (a2a + scatter)     : {u(t_rc):9.1f}", flush=True)
+        print(f"  >> RCCL e2e total           : {u(rccl_e2e):9.1f}", flush=True)
+        pre_rccl = t_cc + t_ca + t_pm
+        print(
+            f"     pre-computation share    : {u(pre_rccl):9.1f}  ({100 * pre_rccl / rccl_e2e:.1f}%)",
+            flush=True,
+        )
+        print("---- comparison ----", flush=True)
+        print(
+            f"  e2e speedup (RCCL/moe_ep)   : {rccl_e2e / me_e2e_show:.2f}x", flush=True
+        )
+        print(
+            f"  per-rank send/recv tokens   : {total_send} / {total_recv}", flush=True
+        )
+        # Per-rank BW. Identical topk routing => identical byte volume for both
+        # paths: dispatch moves total_send rows out, combine moves total_recv
+        # rows back. e2e effective = round-trip bytes / e2e total (incl. the
+        # pre-computation that is not itself inter-rank traffic).
+        gbps = lambda b, t: (b / 1e9) / t  # noqa: E731
+        bd = total_send * hidden * 2  # dispatch send bytes/rank (bf16)
+        bc = total_recv * hidden * 2  # combine send bytes/rank (bf16)
+        print(
+            f"     dispatch {bd / 1e6:.0f} MB/rank, combine {bc / 1e6:.0f} MB/rank",
+            flush=True,
+        )
+        print("---- per-rank BW (GB/s) ----", flush=True)
+        print(f"  {'leg':<16}{'moe_ep':>10}{'RCCL':>10}", flush=True)
+        print(
+            f"  {'dispatch data':<16}{gbps(bd, disp_show):>10.1f}{gbps(bd, t_da):>10.1f}",
+            flush=True,
+        )
+        print(
+            f"  {'combine':<16}{gbps(bc, comb_show):>10.1f}{gbps(bc, t_rc):>10.1f}",
+            flush=True,
+        )
+        print(
+            f"  {'e2e effective':<16}{gbps(bd + bc, me_e2e_show):>10.1f}{gbps(bd + bc, rccl_e2e):>10.1f}",
+            flush=True,
+        )
+        print(
+            "================================================================",
+            flush=True,
+        )
+
+    buffer.destroy()
+    dist.barrier(group=group)
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="RCCL/NCCL baseline for MoE dispatch+combine"
+    )
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=8,
+        help="Number of processes to spawn (default: 8)",
+    )
+    parser.add_argument(
+        "--num-tokens", type=int, default=4096, help="Number of tokens (default: 4096)"
+    )
+    parser.add_argument(
+        "--hidden", type=int, default=7168, help="Hidden dimension (default: 7168)"
+    )
+    parser.add_argument(
+        "--num-topk", type=int, default=8, help="Top-k experts per token (default: 8)"
+    )
+    parser.add_argument(
+        "--num-experts",
+        type=int,
+        default=256,
+        help="Total number of experts (default: 256)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("breakdown", "rccl-only"),
+        default="breakdown",
+        help="breakdown: Benchmark B e2e moe_ep-vs-RCCL with per-part timing "
+        "(includes pre-computation). rccl-only: legacy RCCL data-move bench.",
+    )
+    parser.add_argument(
+        "--tune",
+        action="store_true",
+        help="Also sweep nvl_chunk_size for the moe_ep data legs and print a "
+        "config x precompute 2x2 of the speedup (same RCCL baseline). Shows that "
+        "including pre-computation RAISES moe_ep's lead at fixed config.",
+    )
+    args = parser.parse_args()
+
+    entry = bench_e2e_breakdown if args.mode == "breakdown" else test_loop
+    torch.multiprocessing.spawn(
+        entry, args=(args.num_processes, args), nprocs=args.num_processes
+    )

--- a/comms/prims/collectives/moe_ep/tests/upstream_utils.py
+++ b/comms/prims/collectives/moe_ep/tests/upstream_utils.py
@@ -1,0 +1,294 @@
+import inspect
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+use_rocm = torch.version.hip is not None
+
+
+def get_rocm_gfx():
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return None
+    props = torch.cuda.get_device_properties(0)
+    return getattr(props, "gcnArchName", None)
+
+
+def init_dist(local_rank: int, num_local_ranks: int, backend: str = "nccl"):
+    # NOTES: you may rewrite this function with your own cluster settings
+    ip = os.getenv("MASTER_ADDR", "127.0.0.1")
+    port = int(os.getenv("MASTER_PORT", "8361"))
+    num_nodes = int(os.getenv("WORLD_SIZE", 1))
+    node_rank = int(os.getenv("RANK", 0))
+
+    sig = inspect.signature(dist.init_process_group)
+    params: dict[str, Any] = {
+        "backend": backend,
+        "init_method": f"tcp://{ip}:{port}",
+        "world_size": num_nodes * num_local_ranks,
+        "rank": node_rank * num_local_ranks + local_rank,
+    }
+    if "device_id" in sig.parameters:
+        # noinspection PyTypeChecker
+        params["device_id"] = torch.device(f"cuda:{local_rank}")
+    dist.init_process_group(**params)
+
+    torch.set_default_dtype(torch.bfloat16)
+    torch.set_default_device("cuda")
+    torch.cuda.set_device(local_rank)
+
+    return (
+        dist.get_rank(),
+        dist.get_world_size(),
+        dist.new_group(list(range(num_local_ranks * num_nodes))),
+    )
+
+
+def calc_diff(x: torch.Tensor, y: torch.Tensor):
+    x, y = x.double() + 1, y.double() + 1
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return (1 - sim).item()
+
+
+def align_up(x, y):
+    return (x + y - 1) // y * y
+
+
+def per_token_cast_to_fp8(x: torch.Tensor):
+    assert x.dim() == 2
+    m, n = x.shape
+    aligned_n = align_up(n, 128)
+    x_padded = torch.nn.functional.pad(x, (0, aligned_n - n), mode="constant", value=0)
+    x_padded_view = x_padded.view(m, -1, 128)
+    fp8_max = 448
+    fp8_dtype = torch.float8_e4m3fn
+    gfx = get_rocm_gfx()
+    if gfx is not None and "gfx942" in gfx:
+        fp8_max = 240
+        fp8_dtype = torch.float8_e4m3fnuz
+    x_amax = x_padded_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
+    # pyre-ignore[6]: int / Tensor dispatches to Tensor.__rtruediv__ at runtime
+    return (x_padded_view * (fp8_max / x_amax.unsqueeze(2))).to(fp8_dtype).view(
+        m, aligned_n
+    )[:, :n].contiguous(), (x_amax / fp8_max).view(m, -1)
+
+
+def per_token_cast_back(x_fp8: torch.Tensor, x_scales: torch.Tensor):
+    if x_fp8.numel() == 0:
+        return x_fp8.to(torch.bfloat16)
+
+    assert x_fp8.dim() == 2
+    m, n = x_fp8.shape
+    aligned_n = align_up(n, 128)
+    x_fp8_padded = torch.nn.functional.pad(
+        x_fp8, (0, aligned_n - n), mode="constant", value=0
+    )
+    if x_scales.dtype == torch.int:
+        x_scales = x_scales.view(dtype=torch.uint8).to(torch.int) << 23
+        x_scales = x_scales.view(dtype=torch.float)
+    x_fp32_padded = x_fp8_padded.to(torch.float32).view(x_fp8.size(0), -1, 128)
+    x_scales = x_scales.view(x_fp8.size(0), -1, 1)
+    return (
+        (x_fp32_padded * x_scales)
+        .view(x_fp8_padded.shape)
+        .to(torch.bfloat16)[:, :n]
+        .contiguous()
+    )
+
+
+def inplace_unique(x: torch.Tensor, num_slots: int):
+    assert x.dim() == 2
+    mask = x < 0
+    x_padded = x.masked_fill(mask, num_slots)
+    bin_count = torch.zeros((x.size(0), num_slots + 1), dtype=x.dtype, device=x.device)
+    bin_count.scatter_add_(1, x_padded, torch.ones_like(x_padded))
+    bin_count = bin_count[:, :num_slots]
+    sorted_bin_count, sorted_bin_idx = torch.sort(bin_count, dim=-1, descending=True)
+    sorted_bin_idx.masked_fill_(sorted_bin_count == 0, -1)
+    sorted_bin_idx = torch.sort(sorted_bin_idx, descending=True, dim=-1).values
+    x[:, :].fill_(-1)
+    valid_len = min(num_slots, x.size(1))
+    x[:, :valid_len] = sorted_bin_idx[:, :valid_len]
+
+
+def create_grouped_scores(
+    scores: torch.Tensor, group_idx: torch.Tensor, num_groups: int
+):
+    num_tokens, num_experts = scores.shape
+    scores = scores.view(num_tokens, num_groups, -1)
+    mask = torch.zeros((num_tokens, num_groups), dtype=torch.bool, device=scores.device)
+    mask = mask.scatter_(1, group_idx, True).unsqueeze(-1).expand_as(scores)
+    return (scores * mask).view(num_tokens, num_experts)
+
+
+def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
+    # Flush L2 cache with 256 MB data
+    torch.cuda.synchronize()
+    cache = torch.empty(int(256e6 // 4), dtype=torch.int, device="cuda")
+
+    # Warmup
+    for _ in range(num_warmups):
+        fn()
+
+    # Flush L2
+    cache.zero_()
+
+    # Testing
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_tests)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_tests)]
+    for i in range(num_tests):
+        # Record
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+        if post_fn is not None:
+            post_fn()
+    torch.cuda.synchronize()
+
+    times = np.array(
+        [s.elapsed_time(e) / 1e3 for s, e in zip(start_events, end_events)]
+    )[1:]
+    return np.average(times), np.min(times), np.max(times)
+
+
+class empty_suppress:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+
+class suppress_stdout_stderr:
+    def __enter__(self):
+        self.outnull_file = open(os.devnull, "w")
+        self.errnull_file = open(os.devnull, "w")
+
+        self.old_stdout_fileno_undup = sys.stdout.fileno()
+        self.old_stderr_fileno_undup = sys.stderr.fileno()
+
+        self.old_stdout_fileno = os.dup(sys.stdout.fileno())
+        self.old_stderr_fileno = os.dup(sys.stderr.fileno())
+
+        self.old_stdout = sys.stdout
+        self.old_stderr = sys.stderr
+
+        os.dup2(self.outnull_file.fileno(), self.old_stdout_fileno_undup)
+        os.dup2(self.errnull_file.fileno(), self.old_stderr_fileno_undup)
+
+        sys.stdout = self.outnull_file
+        sys.stderr = self.errnull_file
+        return self
+
+    def __exit__(self, *_):
+        sys.stdout = self.old_stdout
+        sys.stderr = self.old_stderr
+
+        os.dup2(self.old_stdout_fileno, self.old_stdout_fileno_undup)
+        os.dup2(self.old_stderr_fileno, self.old_stderr_fileno_undup)
+
+        os.close(self.old_stdout_fileno)
+        os.close(self.old_stderr_fileno)
+
+        self.outnull_file.close()
+        self.errnull_file.close()
+
+
+def bench_kineto(
+    fn,
+    kernel_names: Union[str, tuple],
+    num_tests: int = 30,
+    suppress_kineto_output: bool = False,
+    trace_path: Optional[str] = None,
+    barrier_comm_profiling: bool = False,
+    num_kernels_per_period: int = 1,
+):
+    # Profile
+    suppress = suppress_stdout_stderr if suppress_kineto_output else empty_suppress
+    with suppress():
+        schedule = torch.profiler.schedule(wait=1, warmup=0, active=1, repeat=1)
+        with torch.profiler.profile(
+            # pyre-ignore[16]: ProfilerActivity missing from torch.profiler stubs
+            activities=[torch.profiler.ProfilerActivity.CUDA],
+            schedule=schedule,
+        ) as prof:
+            for _ in range(2):
+                # NOTES: use a large kernel and a barrier to eliminate the unbalanced CPU launch overhead
+                if barrier_comm_profiling:
+                    lhs = torch.randn((8192, 8192), dtype=torch.float, device="cuda")
+                    rhs = torch.randn((8192, 8192), dtype=torch.float, device="cuda")
+                    lhs @ rhs
+                    dist.all_reduce(torch.ones(1, dtype=torch.float, device="cuda"))
+                for _ in range(num_tests):
+                    fn()
+                torch.cuda.synchronize()
+                prof.step()
+
+    # Parse the profiling table
+    assert isinstance(kernel_names, (str, tuple))
+    is_tuple = isinstance(kernel_names, tuple)
+    prof_lines = (
+        prof.key_averages()
+        .table(sort_by="cuda_time_total", max_name_column_width=100)
+        .split("\n")
+    )
+    kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
+    assert all([isinstance(name, str) for name in kernel_names])
+    for name in kernel_names:
+        assert sum([name in line for line in prof_lines]) == 1, (
+            f"Errors of the kernel {name} in the profiling table"
+        )
+
+    # Save chrome traces
+    if trace_path is not None:
+        prof.export_chrome_trace(trace_path)
+
+    # Return average kernel durations
+    units = {"ms": 1e3, "us": 1e6}
+    kernel_durations = []
+    for name in kernel_names:
+        for line in prof_lines:
+            if name in line:
+                time_str = line.split()[-2]
+                for unit, scale in units.items():
+                    if unit in time_str:
+                        kernel_durations.append(
+                            float(time_str.replace(unit, "")) / scale
+                        )
+                        break
+                break
+
+    # Expand the kernels by periods
+    if num_kernels_per_period > 1:
+        with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
+            prof.export_chrome_trace(tmp.name)
+            profile_data = json.loads(Path(tmp.name).read_text())
+
+        for i, kernel_name in enumerate(kernel_names):
+            events = [
+                event
+                for event in profile_data["traceEvents"]
+                if f"::{kernel_name}" in event["name"]
+            ]
+            events = sorted(events, key=lambda event: event["ts"])
+            durations = [event["dur"] / 1e6 for event in events]
+            assert len(durations) % num_kernels_per_period == 0
+            num_kernel_patterns = len(durations) // num_kernels_per_period
+            kernel_durations[i] = [
+                sum(durations[j::num_kernels_per_period]) / num_kernel_patterns
+                for j in range(num_kernels_per_period)
+            ]
+
+    # Return execution durations
+    return kernel_durations if is_tuple else kernel_durations[0]
+
+
+def hash_tensor(t: torch.Tensor):
+    return t.view(torch.int).sum().item()


### PR DESCRIPTION
Summary:
Adds a deep_ep-compatible MoE expert-parallel (EP) dispatch/combine implementation for the intranode case (single-node, NVLink only) built on the prims transport stack. Drop-in for the standard `deep_ep.Buffer` Python API.

**Layout**
- `comms/prims/collectives/moe_ep/moe_ep/` — Python package exposing `Buffer`, `EventOverlap`, `Config`, `topk_idx_t`. Intranode methods are implemented; LL / internode methods raise `NotImplementedError` until the follow-up diffs in this stack land.
- `comms/prims/collectives/moe_ep/cpp/` — host runtime (`IntranodeRuntime`, `Buffer`, pybind layer). Owns the IPC-uncached symmetric buffer (BNXT dma-buf compatible), `MultiPeerNvlTransport`, a 32 MiB persistent workspace, peer-mapped pointer tables, and pinned MoE recv counters. Buffer ctor pre-allocates the local IPC buffer so `get_local_ipc_handle()` can return a real handle before Python's `all_gather_object`.
- `comms/prims/collectives/moe_ep/cpp/intranode/kernels/` — device kernels: `Layout` (per-rank / per-expert token counts), `Notify` (cross-rank count exchange + prefix matrix + barriers), `Dispatch` / `Combine` (chunked NVLink pipeline; even SMs send, odd SMs receive; per-(channel, peer) FIFO slots).

**AMD + NVIDIA single source**
- `#ifdef __HIP_PLATFORM_AMD__` shims in `KernelUtils.cuh` and `Launch.cuh` cover warp-shuffle, fences, ordered loads/stores, `wall_clock64`, and trap-vs-abort divergences.
- `meta::comms::DeviceBuffer` resolves via `HipHostCompat.h` on AMD and `CudaRAII.h` on NVIDIA.

Builds clean on `mode/opt` (NVIDIA) and `mode/opt-amd-gpu` (AMD MI300X).

Reviewed By: srinathb-meta

Differential Revision: D104958307


