### PR TITLE
Fix lazy connect for aggregated collectives (#3030)

### DIFF
--- a/comms/ncclx/meta/transport/transportConnect.cc
+++ b/comms/ncclx/meta/transport/transportConnect.cc
@@ -222,14 +222,15 @@ bool algoCanLazySetupChannel(struct ncclComm* comm, struct ncclTaskColl* task) {
 
 bool algoNeedConnect(struct ncclComm* comm, struct ncclTaskColl* task) {
   if (comm->planner.nTasksColl > 1) {
-    /* FIXME: cannot support aggregated collectives now because it may use more
-     * channels at scheduling time, update nMaxChannelsNeedInit and
-     * algoMaxChannelsNeedConnect in planner to ensure all channels will be
-     * setup and the selected algorithm will be connected */
-    comm->planner.nMaxChannelsNeedInit = comm->nChannels;
+    /* Aggregated collectives may use more channels at scheduling time than any
+     * individual task requests, so ensure all channels are initialized and the
+     * selected algorithm is connected for the full channel set. */
+    const int nChannelsNeedConnect = comm->nChannels;
+    comm->planner.nMaxChannelsNeedInit = nChannelsNeedConnect;
     comm->planner.algoMaxChannelsNeedConnect.at(task->algorithm) =
-        comm->nChannels;
-    return comm->nChannelsReady < comm->nChannels;
+        nChannelsNeedConnect;
+    return comm->nChannelsReady < nChannelsNeedConnect ||
+        comm->algoConnectedChannels[task->algorithm] < nChannelsNeedConnect;
   }
   // update the maximal number of channels need to be initialized later
   if (task->nMaxChannels > comm->nChannelsReady) {


### PR DESCRIPTION
Summary:

Aggregated collectives force the planner to initialize and connect all channels because scheduling can use more channels than any individual task advertises. The existing lazy setup predicate only checked `nChannelsReady`, so it could skip `collPreconnect()` when channel metadata was ready but the selected algorithm's transports were not connected. That matches the induced Ring repro where `nChannelsReady == nChannels`, `algoConnectedChannels[RING] == 0`, then `SaveProxy` hit a missing transport during `allreduce_coalesced`.

This change makes the aggregated path request connect whenever either channel metadata or selected-algorithm transport connectivity is incomplete.

Reviewed By: dboyda

Differential Revision: D110344951


