### PR TITLE
Intra-node XGMI P2P transport (CudaApi IPC + handles + transport + MultiTransport wiring) (#3031)

### DIFF
--- a/comms/uniflow/MultiTransport.cpp
+++ b/comms/uniflow/MultiTransport.cpp
@@ -10,6 +10,8 @@
 #include "comms/uniflow/transport/rdma/RdmaTransport.h"
 #ifndef __HIP_PLATFORM_AMD__
 #include "comms/uniflow/transport/nvlink/NVLinkTransport.h"
+#else
+#include "comms/uniflow/transport/p2p/P2pTransport.h"
 #endif
 
 #include <cstring>
@@ -76,7 +78,9 @@ Status MultiTransportFactory::supported(TransportType type) {
       return NVLinkTransportFactory::supported();
 #else
     case TransportType::NVLink:
-      return Err(ErrCode::NotImplemented, "nvlink is not supported on AMD");
+      // On AMD the NVLink tier is served by the P2P (XGMI) transport, whose
+      // supported() encodes the all-XGMI arch gate.
+      return P2pTransportFactory::supported();
 #endif
     case TransportType::TCP:
       return Err(ErrCode::NotImplemented, "tcp transport is not implemented");
@@ -145,6 +149,22 @@ MultiTransportFactory::MultiTransportFactory(
     auto nvlink = std::make_shared<NVLinkTransportFactory>(
         deviceId, eventBaseThread_->getEventBase());
     factories_.emplace_back(std::move(nvlink));
+  }
+#else
+  // AMD: the NVLink tier is served by the P2P (XGMI) transport. Its supported()
+  // owns the all-XGMI arch gate (selectTransport is presence-driven; see §5.6).
+  if (deviceId_ >= 0) {
+    auto p2pSupported = P2pTransportFactory::supported();
+    if (!p2pSupported.hasError()) {
+      auto p2p = std::make_shared<P2pTransportFactory>(
+          deviceId, eventBaseThread_->getEventBase());
+      factories_.emplace_back(std::move(p2p));
+    } else {
+      UNIFLOW_LOG_INFO(
+          "P2P transport disabled for device {}: {}",
+          deviceId_,
+          p2pSupported.error().message());
+    }
   }
 #endif
 

--- a/comms/uniflow/Segment.h
+++ b/comms/uniflow/Segment.h
@@ -242,6 +242,7 @@ class RemoteRegisteredSegment : public SegmentBase<RemoteRegisteredSegment> {
     friend class MultiTransport;
     friend class NVLinkTransport;
     friend class RdmaTransport;
+    friend class P2pTransport;
 
    private:
     std::span<const std::unique_ptr<RemoteRegistrationHandle>> handles_;

--- a/comms/uniflow/drivers/cuda/CudaApi.cpp
+++ b/comms/uniflow/drivers/cuda/CudaApi.cpp
@@ -2,6 +2,7 @@
 
 #include "comms/uniflow/drivers/cuda/CudaApi.h"
 
+#include <algorithm>
 #include <string>
 
 // Checks a CUDA runtime call and returns Err on failure, recording the
@@ -68,6 +69,22 @@ Status CudaApi::getDevicePCIBusId(char* pciBusId, int len, int device) {
   CUDA_CHECK(
       cudaDeviceGetPCIBusId(pciBusId, len, device), ErrCode::DriverError);
   return Ok();
+}
+
+Result<std::string> CudaApi::getDeviceArch(int device) {
+  cudaDeviceProp prop{};
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, device), ErrCode::DriverError);
+#if defined(__HIP_PLATFORM_AMD__)
+  // AMD: gfx arch, e.g. "gfx942" (may carry feature flags like
+  // "gfx942:sramecc+:xnack-"); callers prefix-match the gfxNNNN base.
+  return std::string(prop.gcnArchName);
+#else
+  // NVIDIA: cudaDeviceProp has no gcnArchName; report the SM version. NVIDIA
+  // compute capabilities use a single-digit minor by convention, so the
+  // canonical "sm_<major><minor>" form (e.g. sm_90, sm_120) is unambiguous; if
+  // a multi-digit minor ever ships this concatenation would need a separator.
+  return "sm_" + std::to_string(prop.major) + std::to_string(prop.minor);
+#endif
 }
 
 // --- Host memory ---
@@ -191,6 +208,65 @@ Result<bool> CudaApi::eventQuery(cudaEvent_t event) {
 Status CudaApi::eventDestroy(cudaEvent_t event) {
   CUDA_CHECK(cudaEventDestroy(event), ErrCode::DriverError);
   return Ok();
+}
+
+// --- IPC (cross-process device memory sharing) ---
+
+static_assert(
+    sizeof(cudaIpcMemHandle_t) == CudaApi::kIpcMemHandleSize,
+    "IpcMemHandle byte size must match cudaIpcMemHandle_t/hipIpcMemHandle_t");
+
+Result<CudaApi::IpcMemHandle> CudaApi::ipcGetMemHandle(void* devPtr) {
+  cudaIpcMemHandle_t handle{};
+  CUDA_CHECK(cudaIpcGetMemHandle(&handle, devPtr), ErrCode::DriverError);
+  IpcMemHandle out{};
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&handle);
+  std::copy_n(bytes, kIpcMemHandleSize, out.begin());
+  return out;
+}
+
+Result<void*> CudaApi::ipcOpenMemHandle(const IpcMemHandle& handle) {
+  cudaIpcMemHandle_t raw{};
+  std::copy_n(
+      handle.begin(), kIpcMemHandleSize, reinterpret_cast<uint8_t*>(&raw));
+  void* ptr = nullptr;
+  CUDA_CHECK(
+      cudaIpcOpenMemHandle(&ptr, raw, cudaIpcMemLazyEnablePeerAccess),
+      ErrCode::DriverError);
+  return ptr;
+}
+
+Status CudaApi::ipcCloseMemHandle(void* devPtr) {
+  CUDA_CHECK(cudaIpcCloseMemHandle(devPtr), ErrCode::DriverError);
+  return Ok();
+}
+
+Result<CudaApi::MemRange> CudaApi::getMemAddressRange(void* devPtr) {
+#if defined(__HIP_PLATFORM_AMD__)
+  // AMD: HIP runtime address-range API (libamdhip64; no driver lib). Lets a
+  // sub-allocation segment be IPC-exported at its allocation base with the
+  // right offset. cuMemGetAddressRange hipifies to hipMemGetAddressRange; this
+  // branch compiles only on AMD.
+  CUdeviceptr base = 0;
+  size_t size = 0;
+  auto err =
+      cuMemGetAddressRange(&base, &size, reinterpret_cast<CUdeviceptr>(devPtr));
+  // Driver-API success sentinel (CUDA_SUCCESS, not the runtime cudaSuccess) to
+  // match cuMemGetAddressRange; both hipify to hipSuccess on AMD. The manual
+  // check is intentional: on failure we gracefully fall back to
+  // whole-allocation rather than propagating an error (do not switch to
+  // CUDA_CHECK).
+  if (err != CUDA_SUCCESS) {
+    // Range unavailable (e.g. non-VMM / host memory): fall back to
+    // whole-allocation (base == ptr, offset 0), preserving prior behavior.
+    return MemRange{devPtr, 0};
+  }
+  return MemRange{reinterpret_cast<void*>(base), size};
+#else
+  // NVIDIA: runtime-only, no driver dependency. Report the pointer as its own
+  // base -> whole-allocation / offset 0, identical to the pre-existing path.
+  return MemRange{devPtr, 0};
+#endif
 }
 
 // --- CudaDeviceGuard ---

--- a/comms/uniflow/drivers/cuda/CudaApi.h
+++ b/comms/uniflow/drivers/cuda/CudaApi.h
@@ -4,6 +4,9 @@
 
 #include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
 
+#include <array>
+#include <string>
+
 #include "comms/uniflow/Result.h"
 
 namespace uniflow {
@@ -28,6 +31,11 @@ class CudaApi {
   virtual Result<int> getDeviceCount();
 
   virtual Status getDevicePCIBusId(char* pciBusId, int len, int device);
+
+  /// Return the device architecture string. On AMD this is the gfx arch (e.g.
+  /// "gfx942", possibly with feature flags appended); on NVIDIA it is
+  /// "sm_<major><minor>".
+  virtual Result<std::string> getDeviceArch(int device);
 
   // --- Host memory ---
 
@@ -81,6 +89,36 @@ class CudaApi {
   virtual Result<bool> eventQuery(cudaEvent_t event);
 
   virtual Status eventDestroy(cudaEvent_t event);
+
+  // --- IPC (cross-process device memory sharing) ---
+
+  /// Opaque IPC handle bytes. `cudaIpcMemHandle_t` / `hipIpcMemHandle_t` is a
+  /// fixed 64-byte POD (`HIP_IPC_HANDLE_SIZE`); exposing it as a neutral byte
+  /// array lets callers above the driver seam serialize/exchange handles
+  /// without naming a vendor type (so they need no hipification).
+  static constexpr size_t kIpcMemHandleSize = 64;
+  using IpcMemHandle = std::array<uint8_t, kIpcMemHandleSize>;
+
+  /// Export an IPC handle for a device allocation (cudaIpcGetMemHandle).
+  virtual Result<IpcMemHandle> ipcGetMemHandle(void* devPtr);
+
+  /// Open a peer's IPC handle, returning a device pointer mapped into this
+  /// process (cudaIpcOpenMemHandle, lazy peer-access enable).
+  virtual Result<void*> ipcOpenMemHandle(const IpcMemHandle& handle);
+
+  /// Close a device pointer previously opened via ipcOpenMemHandle.
+  virtual Status ipcCloseMemHandle(void* devPtr);
+
+  /// Allocation base + size for a device pointer. Lets a segment that is a
+  /// sub-range of a larger allocation be IPC-exported at its allocation base
+  /// with the correct offset recorded. AMD uses the HIP runtime address-range
+  /// API; NVIDIA is a runtime-only no-op that reports the pointer as its own
+  /// base (whole-allocation / offset 0), leaving the NVIDIA path unchanged.
+  struct MemRange {
+    void* base{nullptr};
+    size_t size{0};
+  };
+  virtual Result<MemRange> getMemAddressRange(void* devPtr);
 };
 
 /// RAII guard that saves the current CUDA device on construction and

--- a/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
+++ b/comms/uniflow/drivers/cuda/mock/MockCudaApi.h
@@ -78,6 +78,31 @@ class MockCudaApi : public CudaApi {
       (override));
   MOCK_METHOD(Result<bool>, eventQuery, (cudaEvent_t event), (override));
   MOCK_METHOD(Status, eventDestroy, (cudaEvent_t event), (override));
+
+  MOCK_METHOD(Result<std::string>, getDeviceArch, (int device), (override));
+
+  MOCK_METHOD(
+      Result<IpcMemHandle>,
+      ipcGetMemHandle,
+      (void* devPtr),
+      (override));
+  MOCK_METHOD(
+      Result<void*>,
+      ipcOpenMemHandle,
+      (const IpcMemHandle& handle),
+      (override));
+  MOCK_METHOD(Status, ipcCloseMemHandle, (void* devPtr), (override));
+
+  MOCK_METHOD(Result<MemRange>, getMemAddressRange, (void* devPtr), (override));
+
+  MockCudaApi() {
+    // Default: report the pointer as its own allocation base (whole-allocation,
+    // offset 0), so tests that do not exercise sub-allocation keep the prior
+    // behavior without stubbing this call.
+    ON_CALL(*this, getMemAddressRange(testing::_))
+        .WillByDefault(
+            [](void* p) -> Result<MemRange> { return MemRange{p, 0}; });
+  }
 };
 
 } // namespace uniflow

--- a/comms/uniflow/drivers/cuda/tests/CudaApiTest.cpp
+++ b/comms/uniflow/drivers/cuda/tests/CudaApiTest.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace uniflow {
+namespace {
+
+// The IPC / arch wrappers are thin pass-throughs to the runtime, so the real
+// coverage is a GPU round-trip. Skip when no device is present so the target
+// still builds/links and passes on CPU-only hosts, and runs for real on GPU CI.
+bool hasGpu(CudaApi& api) {
+  auto count = api.getDeviceCount();
+  return count.hasValue() && count.value() > 0;
+}
+
+// Pins the neutral wire size to the driver ABI. The same invariant is enforced
+// at compile time in CudaApi.cpp; this gives a CPU-runnable guard too.
+TEST(CudaApiTest, IpcMemHandleSizeMatchesAbi) {
+  static_assert(CudaApi::kIpcMemHandleSize == 64);
+  EXPECT_EQ(sizeof(CudaApi::IpcMemHandle), CudaApi::kIpcMemHandleSize);
+}
+
+TEST(CudaApiTest, GetDeviceArchReturnsNonEmpty) {
+  CudaApi api;
+  if (!hasGpu(api)) {
+    GTEST_SKIP() << "no GPU available";
+  }
+  ASSERT_FALSE(api.setDevice(0).hasError());
+
+  auto arch = api.getDeviceArch(0);
+  ASSERT_FALSE(arch.hasError());
+  EXPECT_FALSE(arch.value().empty());
+}
+
+TEST(CudaApiTest, IpcGetMemHandleReturnsNonZeroHandle) {
+  CudaApi api;
+  if (!hasGpu(api)) {
+    GTEST_SKIP() << "no GPU available";
+  }
+  ASSERT_FALSE(api.setDevice(0).hasError());
+
+  void* devPtr = nullptr;
+  ASSERT_EQ(cudaMalloc(&devPtr, 4096), cudaSuccess);
+  // Free the device buffer regardless of how the assertions below exit, so a
+  // failed assertion does not leak the GPU allocation.
+  std::unique_ptr<void, void (*)(void*)> devGuard(devPtr, [](void* p) {
+    if (p != nullptr) {
+      (void)cudaFree(p);
+    }
+  });
+
+  auto handle = api.ipcGetMemHandle(devPtr);
+  ASSERT_FALSE(handle.hasError());
+  // A valid exported IPC handle is not all-zero.
+  const CudaApi::IpcMemHandle zero{};
+  EXPECT_NE(handle.value(), zero);
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/tests/integration/MultiTransportCrossHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportCrossHostTest.cpp
@@ -256,6 +256,7 @@ struct CudaBuffer {
 
 // RAII wrapper for cuMem VMM GPU memory allocation.
 // Uses cuMemCreate with CU_MEM_HANDLE_TYPE_FABRIC for MNNVL.
+#ifndef __HIP_PLATFORM_AMD__
 class VmmAllocation {
  public:
   VmmAllocation() = default;
@@ -333,6 +334,32 @@ class VmmAllocation {
   bool reserved_{false};
   bool mapped_{false};
 };
+#else
+// AMD: VMM fabric (MNNVL) allocation has no HIP equivalent until MI450 (no
+// CU_MEM_HANDLE_TYPE_FABRIC). Provide a stub so the test compiles; alloc()
+// always fails, so the Fabric-parameterized cases skip at runtime.
+class VmmAllocation {
+ public:
+  VmmAllocation() = default;
+
+  Status alloc(CudaDriverApi&, int, size_t) {
+    return Err(
+        ErrCode::NotImplemented,
+        "Fabric (MNNVL) VMM allocation is not supported on AMD");
+  }
+
+  VmmAllocation(const VmmAllocation&) = delete;
+  VmmAllocation& operator=(const VmmAllocation&) = delete;
+
+  void* ptr() const {
+    return nullptr;
+  }
+
+  size_t size() const {
+    return 0;
+  }
+};
+#endif
 
 // --- Same-device transfer tests (parameterized by mem type + alloc type) ---
 

--- a/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
+++ b/comms/uniflow/tests/integration/MultiTransportSingleHostTest.cpp
@@ -166,9 +166,18 @@ TEST_F(MultiTransportFactoryTest, ConstructorGpuCreatesNvlinkAndRdma) {
   MultiTransportFactory factory(0);
   ASSERT_GE(factoryCount(factory), 1u);
 #if defined(__HIP_PLATFORM_AMD__)
-  // NVLink is NVIDIA-only and is compiled out on AMD, so the GPU factory
-  // provides RDMA as the GPU transport (see MultiTransport.cpp).
-  EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  // On AMD the NVLink tier is served by the P2P (XGMI) transport, registered
+  // only on all-XGMI nodes (gfx942/gfx950/gfx1250); otherwise the GPU factory
+  // falls back to RDMA. Gate the expectation on the same condition the
+  // constructor uses (see MultiTransport.cpp).
+  if (!MultiTransportFactory::supported(TransportType::NVLink).hasError()) {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);
+    if (factoryCount(factory) > 1) {
+      EXPECT_EQ(factoryTransportType(factory, 1), TransportType::RDMA);
+    }
+  } else {
+    EXPECT_EQ(factoryTransportType(factory, 0), TransportType::RDMA);
+  }
 #else
   // GPU mode: NVLink factory first, then RDMA if PIX NICs exist.
   EXPECT_EQ(factoryTransportType(factory, 0), TransportType::NVLink);

--- a/comms/uniflow/transport/p2p/P2pRegistrationHandle.cpp
+++ b/comms/uniflow/transport/p2p/P2pRegistrationHandle.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/transport/p2p/P2pRegistrationHandle.h"
+
+#include <algorithm>
+
+#include "comms/uniflow/logging/Logger.h"
+
+namespace uniflow {
+
+P2pRegistrationHandle::P2pRegistrationHandle(
+    const CudaApi::IpcMemHandle& ipcHandle,
+    int32_t ownerPid,
+    uint64_t base,
+    uint64_t offset,
+    uint64_t size)
+    : payload_{ownerPid, base, offset, size, ipcHandle} {}
+
+std::vector<uint8_t> P2pRegistrationHandle::serialize() const {
+  std::vector<uint8_t> buf(kSerializedSize);
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&payload_);
+  std::copy_n(bytes, kSerializedSize, buf.begin());
+  return buf;
+}
+
+Result<P2pRegistrationHandle::Payload> P2pRegistrationHandle::deserialize(
+    std::span<const uint8_t> bytes) {
+  if (bytes.size() != kSerializedSize) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "P2pRegistrationHandle: serialized payload has wrong size");
+  }
+  Payload payload{};
+  std::copy_n(
+      bytes.begin(), kSerializedSize, reinterpret_cast<uint8_t*>(&payload));
+  return payload;
+}
+
+P2pRemoteRegistrationHandle::P2pRemoteRegistrationHandle(
+    void* mappedBase,
+    uint64_t offset,
+    size_t size,
+    bool ownedByIpc,
+    std::shared_ptr<CudaApi> cudaApi)
+    : mappedBase_(mappedBase),
+      offset_(offset),
+      size_(size),
+      ownedByIpc_(ownedByIpc),
+      cudaApi_(std::move(cudaApi)) {
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
+  }
+}
+
+void P2pRemoteRegistrationHandle::closeMapping() noexcept {
+  if (ownedByIpc_ && mappedBase_ != nullptr) {
+    auto st = cudaApi_->ipcCloseMemHandle(mappedBase_);
+    if (st.hasError()) {
+      // Best-effort cleanup: log and continue. Throwing here would escape a
+      // noexcept context (destructor / move-assignment) and call
+      // std::terminate.
+      UNIFLOW_LOG_ERROR(
+          "P2P: ipcCloseMemHandle failed: {}", st.error().message());
+    }
+  }
+  mappedBase_ = nullptr;
+  ownedByIpc_ = false;
+}
+
+P2pRemoteRegistrationHandle::~P2pRemoteRegistrationHandle() {
+  closeMapping();
+}
+
+P2pRemoteRegistrationHandle::P2pRemoteRegistrationHandle(
+    P2pRemoteRegistrationHandle&& other) noexcept
+    : mappedBase_(other.mappedBase_),
+      offset_(other.offset_),
+      size_(other.size_),
+      ownedByIpc_(other.ownedByIpc_),
+      cudaApi_(std::move(other.cudaApi_)) {
+  // Null out the source so its destructor does not also close the mapping.
+  other.mappedBase_ = nullptr;
+  other.ownedByIpc_ = false;
+}
+
+P2pRemoteRegistrationHandle& P2pRemoteRegistrationHandle::operator=(
+    P2pRemoteRegistrationHandle&& other) noexcept {
+  if (this != &other) {
+    // Release any mapping we currently own before taking over the source's.
+    closeMapping();
+    mappedBase_ = other.mappedBase_;
+    offset_ = other.offset_;
+    size_ = other.size_;
+    ownedByIpc_ = other.ownedByIpc_;
+    cudaApi_ = std::move(other.cudaApi_);
+    other.mappedBase_ = nullptr;
+    other.ownedByIpc_ = false;
+  }
+  return *this;
+}
+
+void* UNIFLOW_NULLABLE P2pRemoteRegistrationHandle::mappedPtr() const noexcept {
+  if (mappedBase_ == nullptr) {
+    // Moved-from or invalid handle: avoid UB pointer arithmetic.
+    return nullptr;
+  }
+  return static_cast<uint8_t*>(mappedBase_) + offset_;
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/P2pRegistrationHandle.h
+++ b/comms/uniflow/transport/p2p/P2pRegistrationHandle.h
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/transport/TransportType.h"
+
+/// Nullable-return annotation, equivalent to folly's FOLLY_NULLABLE. Defined
+/// locally because comms/uniflow is a strict-OSS library and cannot depend on
+/// folly (see OSS_DEPS_ALLOWLIST in comms/strict_oss_defs.bzl).
+#ifndef UNIFLOW_NULLABLE
+#if defined(__clang__)
+#define UNIFLOW_NULLABLE _Nullable
+#else
+#define UNIFLOW_NULLABLE
+#endif
+#endif
+
+namespace uniflow {
+
+/// Local registration handle for the AMD intra-node XGMI P2P transport.
+///
+/// Wraps a HIP IPC handle (CudaApi::IpcMemHandle) plus the metadata a peer
+/// needs to map and address the exporter's device allocation. The exported
+/// handle is pure bytes and the backing allocation is owned by the Segment, so
+/// this handle holds no GPU resource and its destructor is trivial.
+///
+/// All vendor contact is confined to the CudaApi seam (neutral types only), so
+/// this lives in a plain, non-hipified library.
+class P2pRegistrationHandle : public RegistrationHandle {
+ public:
+  /// Packed wire format (byte-copy serialized, like the NVLink handles).
+  struct __attribute__((packed)) Payload {
+    int32_t ownerPid{0};
+    uint64_t base{0}; // exporter allocation base address (same-pid fast path)
+    uint64_t offset{0}; // segment offset within the allocation
+    uint64_t size{0}; // segment length in bytes
+    CudaApi::IpcMemHandle ipcHandle{}; // 64-byte opaque HIP IPC handle
+  };
+  static constexpr size_t kSerializedSize =
+      sizeof(int32_t) + 3 * sizeof(uint64_t) + CudaApi::kIpcMemHandleSize;
+  static_assert(sizeof(Payload) == kSerializedSize);
+
+  P2pRegistrationHandle(
+      const CudaApi::IpcMemHandle& ipcHandle,
+      int32_t ownerPid,
+      uint64_t base,
+      uint64_t offset,
+      uint64_t size);
+
+  ~P2pRegistrationHandle() override = default;
+
+  TransportType transportType() const noexcept override {
+    // Shared intra-node GPU-interconnect tier (XGMI on AMD, NVLink on NVIDIA).
+    return TransportType::NVLink;
+  }
+
+  std::vector<uint8_t> serialize() const override;
+
+  /// Parse a serialized payload. Errors if @p bytes has the wrong length.
+  static Result<Payload> deserialize(std::span<const uint8_t> bytes);
+
+ private:
+  Payload payload_{};
+};
+
+/// Remote registration handle: a peer's allocation mapped into this process.
+///
+/// Cross-process imports come from hipIpcOpenMemHandle and are closed on
+/// destruction; same-process imports reuse the exporter's pointer directly (no
+/// IPC open, nothing to close).
+class P2pRemoteRegistrationHandle : public RemoteRegistrationHandle {
+ public:
+  /// @param mappedBase device pointer to the allocation base in this process.
+  /// @param offset     byte offset added to @p mappedBase for the segment ptr.
+  /// @param size       segment length in bytes.
+  /// @param ownedByIpc true when @p mappedBase came from ipcOpenMemHandle and
+  ///                   must be closed via ipcCloseMemHandle on destruction.
+  P2pRemoteRegistrationHandle(
+      void* mappedBase,
+      uint64_t offset,
+      size_t size,
+      bool ownedByIpc,
+      std::shared_ptr<CudaApi> cudaApi);
+
+  ~P2pRemoteRegistrationHandle() override;
+
+  // Owns the IPC mapping when ownedByIpc_; non-copyable. Moves transfer the
+  // mapping and null out the source so only one instance ever closes it.
+  P2pRemoteRegistrationHandle(const P2pRemoteRegistrationHandle&) = delete;
+  P2pRemoteRegistrationHandle& operator=(const P2pRemoteRegistrationHandle&) =
+      delete;
+  P2pRemoteRegistrationHandle(P2pRemoteRegistrationHandle&& other) noexcept;
+  P2pRemoteRegistrationHandle& operator=(
+      P2pRemoteRegistrationHandle&& other) noexcept;
+
+  TransportType transportType() const noexcept override {
+    return TransportType::NVLink;
+  }
+
+  /// Usable device pointer for the segment (mappedBase + offset). Returns
+  /// nullptr for a moved-from / invalid handle, so callers must null-check
+  /// before doing pointer arithmetic on the result.
+  void* UNIFLOW_NULLABLE mappedPtr() const noexcept;
+
+  size_t mappedSize() const noexcept {
+    return size_;
+  }
+
+ private:
+  // Closes the IPC mapping if this handle owns one, logging (not throwing) on
+  // failure, then nulls the owned state. Safe to call from the destructor and
+  // move-assignment (both noexcept).
+  void closeMapping() noexcept;
+
+  void* mappedBase_{nullptr};
+  uint64_t offset_{0};
+  size_t size_{0};
+  bool ownedByIpc_{false};
+  std::shared_ptr<CudaApi> cudaApi_;
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/P2pTransport.cpp
+++ b/comms/uniflow/transport/p2p/P2pTransport.cpp
@@ -1,0 +1,555 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/transport/p2p/P2pTransport.h"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <string_view>
+
+#include "comms/uniflow/logging/Logger.h"
+
+namespace uniflow {
+namespace {
+
+// Device ids cross the wire as a raw host-order int32 (matching
+// NVLinkTransport). Encode/decode are centralized here so bind()/getTopology()
+// and connect()/canConnect() cannot drift on size or range validation.
+std::vector<uint8_t> encodeDeviceId(int32_t deviceId) {
+  std::vector<uint8_t> bytes(sizeof(deviceId));
+  const auto* src = reinterpret_cast<const uint8_t*>(&deviceId);
+  std::copy_n(src, sizeof(deviceId), bytes.begin());
+  return bytes;
+}
+
+// Parses a device id, rejecting both a wrong-sized buffer and a negative id.
+Result<int32_t> decodeDeviceId(
+    std::span<const uint8_t> bytes,
+    std::string_view context) {
+  if (bytes.size() != sizeof(int32_t)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        std::string(context) + ": expected " + std::to_string(sizeof(int32_t)) +
+            " bytes, got " + std::to_string(bytes.size()));
+  }
+  int32_t deviceId = -1;
+  std::copy_n(
+      bytes.data(), sizeof(deviceId), reinterpret_cast<uint8_t*>(&deviceId));
+  if (deviceId < 0) {
+    return Err(
+        ErrCode::InvalidArgument,
+        std::string(context) + ": invalid device id " +
+            std::to_string(deviceId));
+  }
+  return deviceId;
+}
+
+// TODO(D110509654): the event-completion machinery below (poll -> re-dispatch
+// on the EventBase) is structurally shared with NVLinkTransport::transfer, but
+// the two are not interchangeable today: NVLink fulfills promises via
+// CHECK_SET_PROMISE (no noexcept guard, no drain on error) and has a
+// memcpyBatchAsync fast path this transport lacks. Converge them in the unified
+// intra-node transport rather than extracting a helper that would have to
+// preserve both error semantics.
+
+// Fulfill a completion promise without escaping a noexcept context. set_value
+// can throw std::future_error if the promise was already satisfied / has no
+// shared state (a logic-bug invariant violation); swallow it rather than
+// terminating the noexcept caller (an EventBase task).
+void setValueNoThrow(std::promise<Status>& promise, Status status) noexcept {
+  try {
+    promise.set_value(std::move(status));
+  } catch (const std::exception& e) {
+    UNIFLOW_LOG_ERROR("P2P transfer: set_value failed: {}", e.what());
+  }
+}
+
+// Error-path cleanup for transfer(): drain any copies already enqueued (so the
+// caller can safely release the buffers -- the GPU is no longer touching them),
+// destroy the completion event if one was created, then report the failure on
+// the promise. @p event may be nullptr when no event exists yet.
+void drainAndFail(
+    CudaApi& cudaApi,
+    std::promise<Status>& promise,
+    cudaStream_t stream,
+    cudaEvent_t event,
+    Status status) noexcept {
+  (void)cudaApi.streamSynchronize(stream);
+  if (event != nullptr) {
+    (void)cudaApi.eventDestroy(event);
+  }
+  setValueNoThrow(promise, std::move(status));
+}
+
+// Drive a recorded event to completion without blocking the EventBase worker:
+// poll eventQuery, and while the event is still in-flight re-dispatch onto @p
+// evb so the worker thread is freed between polls. On successful completion,
+// destroy the event and fulfill @p promise with Ok. On a query error the state
+// of the in-flight copies is unknown, so drain @p stream (via drainAndFail)
+// before reporting, so no D2D copy is still touching the caller's buffers when
+// the error is observed. Takes ownership of @p event and @p promise. noexcept:
+// runs as an EventBase task.
+void pollEventToCompletion(
+    EventBase* evb,
+    std::shared_ptr<CudaApi> cudaApi,
+    cudaEvent_t event,
+    cudaStream_t stream,
+    std::promise<Status> promise) noexcept {
+  auto poll = [evb,
+               cudaApi = std::move(cudaApi),
+               event,
+               stream,
+               promise = std::move(promise)](auto& self) mutable noexcept {
+    auto res = cudaApi->eventQuery(event);
+    if (res.hasError()) {
+      drainAndFail(*cudaApi, promise, stream, event, std::move(res).error());
+      return;
+    }
+    if (res.value()) {
+      (void)cudaApi->eventDestroy(event);
+      setValueNoThrow(promise, Ok());
+      return;
+    }
+    evb->dispatch([self = std::move(self)]() mutable noexcept { self(self); });
+  };
+  poll(poll);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// P2pTransport
+// ---------------------------------------------------------------------------
+
+P2pTransport::P2pTransport(
+    int deviceId,
+    EventBase* evb,
+    std::shared_ptr<CudaApi> cudaApi)
+    : deviceId_(deviceId),
+      deviceName_("cuda:" + std::to_string(deviceId)),
+      evb_(evb),
+      cudaApi_(std::move(cudaApi)) {
+  CHECK_THROW_EXCEPTION(evb_ != nullptr, std::invalid_argument);
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
+  }
+}
+
+TransportInfo P2pTransport::bind() {
+  auto bytes = encodeDeviceId(deviceId_);
+  TransportInfo info(bytes.size());
+  std::copy_n(bytes.begin(), bytes.size(), info.data());
+  // Advance the initial Disconnected state to Initialized. A transport that is
+  // already Connected is left untouched so bind() never regresses it back to
+  // Initialized (which would leave peerDeviceId_ stale).
+  if (state_ == TransportState::Disconnected) {
+    state_ = TransportState::Initialized;
+  }
+  return info;
+}
+
+Status P2pTransport::connect(std::span<const uint8_t> remoteInfo) {
+  if (state_ != TransportState::Initialized) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "P2P connect: transport must be bound and not already connected");
+  }
+  auto parsedPeer = decodeDeviceId(remoteInfo, "P2P connect");
+  CHECK_RETURN(parsedPeer);
+  const int32_t peer = parsedPeer.value();
+
+  // Enable this device to access the peer device (no-op for same device or if
+  // already enabled). Covers same-process cross-device P2P; cross-process
+  // imports also lazily enable peer access via ipcOpenMemHandle. Commit
+  // peerDeviceId_ / Connected only after this succeeds, so a failure leaves the
+  // transport in its prior (Initialized) state.
+  if (peer != deviceId_) {
+    CudaDeviceGuard guard(*cudaApi_, deviceId_);
+    auto st = cudaApi_->deviceEnablePeerAccess(peer);
+    if (st.hasError()) {
+      return st;
+    }
+  }
+
+  peerDeviceId_ = peer;
+  state_ = TransportState::Connected;
+  UNIFLOW_LOG_INFO(
+      "connect: device {} connected to peer device {}",
+      deviceId_,
+      peerDeviceId_);
+  return Ok();
+}
+
+std::future<Status> P2pTransport::transfer(
+    std::vector<CopyOp> ops,
+    void* stream) {
+  std::promise<Status> promise;
+  auto future = promise.get_future();
+
+  evb_->dispatch([evb = evb_,
+                  cudaApi = cudaApi_,
+                  deviceId = deviceId_,
+                  promise = std::move(promise),
+                  ops = std::move(ops),
+                  stream =
+                      static_cast<cudaStream_t>(stream)]() mutable noexcept {
+    CudaDeviceGuard deviceGuard(*cudaApi, deviceId);
+
+    for (auto& op : ops) {
+      auto st = cudaApi->memcpyAsync(
+          op.dst, op.src, op.size, cudaMemcpyDeviceToDevice, stream);
+      if (st.hasError()) {
+        drainAndFail(
+            *cudaApi, promise, stream, /*event=*/nullptr, std::move(st));
+        return;
+      }
+    }
+
+    // Completion via a recorded event, polled and re-dispatched on the
+    // EventBase (same model as NVLinkTransport).
+    cudaEvent_t event = nullptr;
+    auto createSt = cudaApi->eventCreate(&event);
+    if (createSt.hasError()) {
+      drainAndFail(
+          *cudaApi, promise, stream, /*event=*/nullptr, std::move(createSt));
+      return;
+    }
+
+    auto recordSt = cudaApi->eventRecord(event, stream);
+    if (recordSt.hasError()) {
+      drainAndFail(*cudaApi, promise, stream, event, std::move(recordSt));
+      return;
+    }
+
+    // Event recorded after the last copy; hand off to the poller, which frees
+    // this worker between polls and fulfills the promise on completion.
+    // Last use of the captured cudaApi in this lambda: move to avoid copying
+    // the shared_ptr (pollEventToCompletion takes ownership by value).
+    pollEventToCompletion(
+        evb, std::move(cudaApi), event, stream, std::move(promise));
+  });
+
+  return future;
+}
+
+Result<const P2pRemoteRegistrationHandle*> P2pTransport::findRemoteHandle(
+    const RemoteRegisteredSegment::Span& span) const {
+  // dynamic_cast (not static_cast): the NVLink interconnect tier is shared, so
+  // a handle reporting TransportType::NVLink is not guaranteed to be a P2P
+  // handle.
+  for (const auto& h : span.handles_) {
+    if (auto* p = dynamic_cast<const P2pRemoteRegistrationHandle*>(h.get())) {
+      return p;
+    }
+  }
+  return Err(
+      ErrCode::InvalidArgument, "P2P: no P2P remote registration handle found");
+}
+
+Result<std::vector<P2pTransport::CopyOp>> P2pTransport::buildCopyOps(
+    std::span<const TransferRequest> requests,
+    Dir dir) const {
+  std::vector<CopyOp> ops;
+  ops.reserve(requests.size());
+  for (auto& req : requests) {
+    if (req.local.size() != req.remote.size()) {
+      return Err(
+          ErrCode::InvalidArgument,
+          "P2P: local and remote buffer sizes must match");
+    }
+    auto remoteHandle = findRemoteHandle(req.remote);
+    CHECK_RETURN(remoteHandle);
+
+    // mappedPtr() is nullable (moved-from / invalid handle). Reject it here
+    // rather than feeding nullptr + offset into a device-to-device memcpy.
+    auto* mappedBase = static_cast<uint8_t*>(remoteHandle.value()->mappedPtr());
+    if (mappedBase == nullptr) {
+      return Err(ErrCode::InvalidArgument, "P2P: null mapped pointer");
+    }
+    auto* remotePtr = mappedBase + req.remote.nvlinkOffset_;
+
+    if (dir == Dir::Put) {
+      ops.emplace_back(CopyOp{remotePtr, req.local.data(), req.local.size()});
+    } else {
+      ops.emplace_back(
+          CopyOp{req.local.mutable_data(), remotePtr, req.remote.size()});
+    }
+  }
+  return ops;
+}
+
+std::future<Status> P2pTransport::put(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "P2P put: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto ops = buildCopyOps(requests, Dir::Put);
+  if (!ops) {
+    return make_ready_future<Status>(std::move(ops).error());
+  }
+
+  return transfer(std::move(ops).value(), options.stream.value_or(nullptr));
+}
+
+std::future<Status> P2pTransport::get(
+    std::span<const TransferRequest> requests,
+    const RequestOptions& options) {
+  if (state_ != TransportState::Connected) {
+    return make_ready_future<Status>(
+        Err(ErrCode::NotConnected, "P2P get: not connected"));
+  }
+  if (requests.empty()) {
+    return make_ready_future<Status>(Ok());
+  }
+
+  auto ops = buildCopyOps(requests, Dir::Get);
+  if (!ops) {
+    return make_ready_future<Status>(std::move(ops).error());
+  }
+
+  return transfer(std::move(ops).value(), options.stream.value_or(nullptr));
+}
+
+std::future<Status> P2pTransport::send(
+    RegisteredSegment::Span /*src*/,
+    const RequestOptions& /*options*/) {
+  return make_ready_future<Status>(Err(ErrCode::NotImplemented, "P2P send"));
+}
+
+std::future<Status> P2pTransport::send(
+    Segment::Span /*src*/,
+    const RequestOptions& /*options*/) {
+  return make_ready_future<Status>(Err(ErrCode::NotImplemented, "P2P send"));
+}
+
+std::future<Status> P2pTransport::recv(
+    RegisteredSegment::Span /*dst*/,
+    const RequestOptions& /*options*/) {
+  return make_ready_future<Status>(Err(ErrCode::NotImplemented, "P2P recv"));
+}
+
+std::future<Status> P2pTransport::recv(
+    Segment::Span /*dst*/,
+    const RequestOptions& /*options*/) {
+  return make_ready_future<Status>(Err(ErrCode::NotImplemented, "P2P recv"));
+}
+
+void P2pTransport::shutdown() {
+  // Marks the transport Disconnected so no new transfers are accepted.
+  // Transfers already in flight are NOT cancelled -- queued GPU copies cannot
+  // be aborted mid-flight; their futures still complete via the event poller
+  // (pollEventToCompletion).
+  // Callers needing a hard stop must wait on outstanding futures before calling
+  // this.
+  //
+  // Single-threaded-owned: like NVLinkTransport, this only transitions state_
+  // and does not reset peerDeviceId_ (peerDeviceId_ is set once in connect()
+  // and is never read on the transfer path), so there is no synchronization.
+  UNIFLOW_LOG_INFO("shutdown: device {}", deviceId_);
+  state_ = TransportState::Disconnected;
+}
+
+// ---------------------------------------------------------------------------
+// P2pTransportFactory
+// ---------------------------------------------------------------------------
+
+Status P2pTransportFactory::supported(std::shared_ptr<CudaApi> cudaApi) {
+  if (!cudaApi) {
+    cudaApi = std::make_shared<CudaApi>();
+  }
+  auto count = cudaApi->getDeviceCount();
+  CHECK_RETURN(count);
+  if (count.value() == 0) {
+    return Err(ErrCode::ResourceExhausted, "P2P: no GPU devices found");
+  }
+
+#if defined(__HIP_PLATFORM_AMD__)
+  // All supported AMD parts (MI300 gfx942, MI350 gfx950, MI450 gfx1250) are
+  // all-to-all XGMI intra-node. Gate on this arch family so a non-XGMI part
+  // never lets MultiTransport's presence-driven selectTransport prefer a slow
+  // PCIe-P2P link over RDMA (hipDeviceCanAccessPeer conflates the two). See
+  // comms/uniflow/amd/AMD_SUPPORT_DESIGN.md §5.6.
+  //
+  // Match an exact gfx token, allowing a feature-flag suffix after ':'
+  // (e.g. "gfx942:sramecc+:xnack-") but not a longer digit run ("gfx12500").
+  static constexpr std::array<std::string_view, 3> kAllowedArch = {
+      "gfx942", "gfx950", "gfx1250"};
+  auto matchesAllowed = [](std::string_view arch) {
+    for (const auto& base : kAllowedArch) {
+      if (arch.size() >= base.size() && arch.substr(0, base.size()) == base &&
+          (arch.size() == base.size() || arch[base.size()] == ':')) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  for (int dev = 0; dev < count.value(); ++dev) {
+    auto arch = cudaApi->getDeviceArch(dev);
+    if (arch.hasError()) {
+      UNIFLOW_LOG_WARN(
+          "P2P arch gate: getDeviceArch({}) failed ({}); disabling P2P",
+          dev,
+          arch.error().message());
+      return Err(
+          ErrCode::NotImplemented,
+          "P2P (XGMI) transport not supported: device arch query failed");
+    }
+    if (!matchesAllowed(arch.value())) {
+      UNIFLOW_LOG_INFO(
+          "P2P arch gate: device {} arch '{}' not in the all-XGMI family; "
+          "disabling P2P for this node",
+          dev,
+          arch.value());
+      return Err(
+          ErrCode::NotImplemented,
+          "P2P (XGMI) transport not supported: not an all-XGMI node");
+    }
+  }
+#endif
+
+  return Ok();
+}
+
+P2pTransportFactory::P2pTransportFactory(
+    int deviceId,
+    EventBase* evb,
+    std::shared_ptr<CudaApi> cudaApi)
+    : TransportFactory(TransportType::NVLink),
+      deviceId_(deviceId),
+      evb_(evb),
+      cudaApi_(std::move(cudaApi)) {
+  CHECK_THROW_EXCEPTION(evb_ != nullptr, std::invalid_argument);
+  if (!cudaApi_) {
+    cudaApi_ = std::make_shared<CudaApi>();
+  }
+}
+
+Result<std::unique_ptr<RegistrationHandle>>
+P2pTransportFactory::registerSegment(Segment& segment) {
+  if (segment.memType() != MemoryType::VRAM) {
+    return Err(
+        ErrCode::InvalidArgument, "P2P registerSegment: segment must be VRAM");
+  }
+
+  CudaDeviceGuard deviceGuard(*cudaApi_, deviceId_);
+
+  // Export the IPC handle at the *allocation base*, recording the segment's
+  // offset within it. A segment may be a sub-range of a larger allocation (e.g.
+  // a caching-allocator pool slice); the IPC handle maps to the allocation
+  // base, so the peer opens the base and adds this offset. getMemAddressRange
+  // returns the real base on AMD; on NVIDIA (and on any query failure) it
+  // reports the pointer as its own base -> whole-allocation behavior (offset
+  // 0), identical to the pre-existing path.
+  void* segPtr = segment.mutable_data();
+  void* allocBase = segPtr;
+  auto range = cudaApi_->getMemAddressRange(segPtr);
+  if (!range.hasError() && range.value().base != nullptr) {
+    allocBase = range.value().base;
+  }
+
+  auto handle = cudaApi_->ipcGetMemHandle(allocBase);
+  CHECK_RETURN(handle);
+
+  const auto offset = reinterpret_cast<uintptr_t>(segPtr) -
+      reinterpret_cast<uintptr_t>(allocBase);
+  return std::make_unique<P2pRegistrationHandle>(
+      handle.value(),
+      static_cast<int32_t>(::getpid()),
+      reinterpret_cast<uint64_t>(allocBase),
+      static_cast<uint64_t>(offset),
+      static_cast<uint64_t>(segment.len()));
+}
+
+Result<std::unique_ptr<RemoteRegistrationHandle>>
+P2pTransportFactory::importSegment(
+    size_t segmentLength,
+    std::span<const uint8_t> payload) {
+  auto parsed = P2pRegistrationHandle::deserialize(payload);
+  CHECK_RETURN(parsed);
+  const auto& p = parsed.value();
+
+  if (segmentLength != static_cast<size_t>(p.size)) {
+    return Err(
+        ErrCode::InvalidArgument,
+        "P2P importSegment: segment length mismatch (expected " +
+            std::to_string(segmentLength) + ", payload " +
+            std::to_string(p.size) + ")");
+  }
+
+  // p.offset, p.size, and p.base all come off the wire and drive raw pointer
+  // math (mappedBase + offset, then a size-byte D2D copy). p.size is pinned to
+  // segmentLength above; guard offset against wraparound here. Full bounds
+  // checking is not possible: ipcOpenMemHandle does not report the mapping
+  // size, and p.base is the exporter's VA. These values come from a cooperating
+  // peer rank on the same node, not an untrusted source.
+  if (p.offset > std::numeric_limits<uint64_t>::max() - p.size) {
+    return Err(
+        ErrCode::InvalidArgument, "P2P importSegment: offset + size overflow");
+  }
+
+  CudaDeviceGuard deviceGuard(*cudaApi_, deviceId_);
+
+  if (p.ownerPid == static_cast<int32_t>(::getpid())) {
+    // Same-process import: reuse the exporter's pointer directly. Opening an
+    // IPC handle exported by the same process is unsupported; peer access is
+    // enabled by the transport's connect().
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    auto* base = reinterpret_cast<void*>(p.base);
+    return std::make_unique<P2pRemoteRegistrationHandle>(
+        base,
+        p.offset,
+        static_cast<size_t>(p.size),
+        /*ownedByIpc=*/false,
+        cudaApi_);
+  }
+
+  auto mapped = cudaApi_->ipcOpenMemHandle(p.ipcHandle);
+  CHECK_RETURN(mapped);
+  return std::make_unique<P2pRemoteRegistrationHandle>(
+      mapped.value(),
+      p.offset,
+      static_cast<size_t>(p.size),
+      /*ownedByIpc=*/true,
+      cudaApi_);
+}
+
+Result<std::unique_ptr<Transport>> P2pTransportFactory::createTransport(
+    std::span<const uint8_t> peerTopology) {
+  CHECK_EXPR(canConnect(peerTopology));
+  return std::make_unique<P2pTransport>(deviceId_, evb_, cudaApi_);
+}
+
+std::vector<uint8_t> P2pTransportFactory::getTopology() {
+  return encodeDeviceId(deviceId_);
+}
+
+Status P2pTransportFactory::canConnect(std::span<const uint8_t> peerTopology) {
+  auto parsedPeer = decodeDeviceId(peerTopology, "P2P canConnect");
+  CHECK_RETURN(parsedPeer);
+  const int32_t peerDev = parsedPeer.value();
+
+  // Same device is trivially reachable; no peer-access check needed.
+  if (peerDev == deviceId_) {
+    return Ok();
+  }
+
+  auto canAccess = cudaApi_->deviceCanAccessPeer(deviceId_, peerDev);
+  CHECK_RETURN(canAccess);
+  if (!canAccess.value()) {
+    return Err(
+        ErrCode::TopologyDisconnect,
+        "P2P: P2P access not supported between devices");
+  }
+  return Ok();
+}
+
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/P2pTransport.h
+++ b/comms/uniflow/transport/p2p/P2pTransport.h
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "comms/uniflow/Result.h"
+#include "comms/uniflow/Segment.h"
+#include "comms/uniflow/drivers/cuda/CudaApi.h"
+#include "comms/uniflow/executor/EventBase.h"
+#include "comms/uniflow/transport/Transport.h"
+#include "comms/uniflow/transport/p2p/P2pRegistrationHandle.h"
+
+namespace uniflow {
+
+/// Intra-node GPU P2P transport (XGMI on AMD; also works on NVIDIA P2P).
+///
+/// Shares the NVLink interconnect tier (`TransportType::NVLink`). Memory is
+/// shared via HIP IPC handles (P2pRegistrationHandle); transfers are
+/// device-to-device copies over the GPU interconnect. GPU contact uses the
+/// vendor-typed CudaApi seam; the translation unit is hipified on AMD
+/// (mirroring transport/rdma and the planned unified intra-node transport).
+///
+/// Threading: a transport instance is single-threaded-owned. The lifecycle
+/// methods (bind/connect/shutdown) and state(), peerDeviceId_ access are not
+/// synchronized and must all be driven by one owner thread; only the GPU copy
+/// work submitted by transfer() runs off-thread (on the EventBase and the
+/// driver completion callback), and it never touches the lifecycle state. This
+/// matches NVLinkTransport's ownership model.
+class P2pTransport : public Transport {
+ public:
+  P2pTransport(
+      int deviceId,
+      EventBase* evb,
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  const std::string& name() const noexcept override {
+    return deviceName_;
+  }
+
+  TransportType transportType() const noexcept override {
+    return TransportType::NVLink;
+  }
+
+  TransportState state() const noexcept override {
+    return state_;
+  }
+
+  TransportInfo bind() override;
+  Status connect(std::span<const uint8_t> remoteInfo) override;
+
+  std::future<Status> put(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> get(
+      std::span<const TransferRequest> requests,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      RegisteredSegment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> send(
+      Segment::Span src,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      RegisteredSegment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  std::future<Status> recv(
+      Segment::Span dst,
+      const RequestOptions& options = {}) override;
+
+  void shutdown() override;
+
+ private:
+  struct CopyOp {
+    void* dst{nullptr};
+    const void* src{nullptr};
+    size_t size{};
+  };
+
+  /// Copy direction for buildCopyOps: Put writes to the remote segment, Get
+  /// reads from it.
+  enum class Dir { Put, Get };
+
+  std::future<Status> transfer(std::vector<CopyOp> ops, void* stream);
+
+  /// Validate @p requests and build the copy batch for direction @p dir. Shared
+  /// by put()/get(), which differ only in copy direction.
+  Result<std::vector<CopyOp>> buildCopyOps(
+      std::span<const TransferRequest> requests,
+      Dir dir) const;
+
+  Result<const P2pRemoteRegistrationHandle*> findRemoteHandle(
+      const RemoteRegisteredSegment::Span& span) const;
+
+  int deviceId_{-1};
+  int peerDeviceId_{-1};
+  std::string deviceName_;
+  TransportState state_{TransportState::Disconnected};
+  EventBase* evb_{nullptr};
+  std::shared_ptr<CudaApi> cudaApi_;
+};
+
+/// Factory for the intra-node P2P transport. Registration exports a HIP IPC
+/// handle; import opens it (cross-process) or reuses the exporter pointer
+/// (same-process).
+class P2pTransportFactory : public TransportFactory {
+ public:
+  /// Available when at least one GPU is present and, on AMD, when every device
+  /// belongs to the all-to-all XGMI arch family (gfx942/gfx950/gfx1250). The
+  /// arch gate lives here rather than in the caller so this factory fully
+  /// describes its own support contract: MultiTransport's presence-driven
+  /// selectTransport must never prefer a slow PCIe-P2P link over RDMA. On
+  /// NVIDIA the gate does not apply and only the device count is checked.
+  static Status supported(std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  P2pTransportFactory(
+      int deviceId,
+      EventBase* evb,
+      std::shared_ptr<CudaApi> cudaApi = nullptr);
+
+  ~P2pTransportFactory() override = default;
+
+  Result<std::unique_ptr<RegistrationHandle>> registerSegment(
+      Segment& segment) override;
+
+  Result<std::unique_ptr<RemoteRegistrationHandle>> importSegment(
+      size_t segmentLength,
+      std::span<const uint8_t> payload) override;
+
+  Result<std::unique_ptr<Transport>> createTransport(
+      std::span<const uint8_t> peerTopology) override;
+
+  std::vector<uint8_t> getTopology() override;
+
+ private:
+  Status canConnect(std::span<const uint8_t> peerTopology) override;
+
+  int deviceId_{-1};
+  EventBase* evb_{nullptr};
+  std::shared_ptr<CudaApi> cudaApi_;
+};
+
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/tests/P2pRegistrationHandleTest.cpp
+++ b/comms/uniflow/transport/p2p/tests/P2pRegistrationHandleTest.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/transport/p2p/P2pRegistrationHandle.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+
+namespace uniflow {
+namespace {
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+CudaApi::IpcMemHandle makePatternHandle() {
+  // Distinct nonzero bytes so a round-trip can't pass by accident (e.g. zeros).
+  CudaApi::IpcMemHandle h{};
+  std::iota(h.begin(), h.end(), uint8_t{1});
+  return h;
+}
+
+TEST(P2pRegistrationHandleTest, SerializeRoundTripPreservesFields) {
+  const auto ipc = makePatternHandle();
+  P2pRegistrationHandle handle(
+      ipc, /*ownerPid=*/4321, /*base=*/0x1000, /*offset=*/256, /*size=*/4096);
+
+  const auto bytes = handle.serialize();
+  ASSERT_EQ(bytes.size(), P2pRegistrationHandle::kSerializedSize);
+
+  auto parsed = P2pRegistrationHandle::deserialize(bytes);
+  ASSERT_FALSE(parsed.hasError());
+  const auto& p = parsed.value();
+  EXPECT_EQ(p.ownerPid, 4321);
+  EXPECT_EQ(p.base, 0x1000u);
+  EXPECT_EQ(p.offset, 256u);
+  EXPECT_EQ(p.size, 4096u);
+  EXPECT_EQ(p.ipcHandle, ipc);
+}
+
+TEST(P2pRegistrationHandleTest, DeserializeRejectsWrongSize) {
+  const std::vector<uint8_t> tooShort(
+      P2pRegistrationHandle::kSerializedSize - 1, 0);
+  EXPECT_TRUE(P2pRegistrationHandle::deserialize(tooShort).hasError());
+}
+
+TEST(P2pRegistrationHandleTest, UsesNvlinkInterconnectTier) {
+  P2pRegistrationHandle handle(makePatternHandle(), 1, 0, 0, 0);
+  EXPECT_EQ(handle.transportType(), TransportType::NVLink);
+}
+
+TEST(P2pRemoteRegistrationHandleTest, MappedPtrAddsOffsetToBase) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  alignas(64) uint8_t backing[512];
+  P2pRemoteRegistrationHandle remote(
+      backing, /*offset=*/128, /*size=*/64, /*ownedByIpc=*/false, mock);
+
+  EXPECT_EQ(remote.mappedPtr(), backing + 128);
+  EXPECT_EQ(remote.mappedSize(), 64u);
+}
+
+TEST(P2pRemoteRegistrationHandleTest, CrossPidImportClosesIpcHandleOnDestroy) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int sentinel = 0;
+  void* base = &sentinel;
+  EXPECT_CALL(*mock, ipcCloseMemHandle(base)).WillOnce(Return(Ok()));
+  {
+    P2pRemoteRegistrationHandle remote(
+        base, /*offset=*/0, /*size=*/64, /*ownedByIpc=*/true, mock);
+  }
+}
+
+TEST(P2pRemoteRegistrationHandleTest, SamePidImportDoesNotCloseIpcHandle) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int sentinel = 0;
+  EXPECT_CALL(*mock, ipcCloseMemHandle(_)).Times(0);
+  {
+    P2pRemoteRegistrationHandle remote(
+        &sentinel, /*offset=*/0, /*size=*/64, /*ownedByIpc=*/false, mock);
+  }
+}
+
+TEST(P2pRemoteRegistrationHandleTest, MoveConstructClosesExactlyOnce) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int sentinel = 0;
+  void* base = &sentinel;
+  // Across both src (moved-from) and dst destruction, close must happen once.
+  EXPECT_CALL(*mock, ipcCloseMemHandle(base)).Times(1).WillOnce(Return(Ok()));
+  {
+    P2pRemoteRegistrationHandle src(
+        base, /*offset=*/16, /*size=*/64, /*ownedByIpc=*/true, mock);
+    P2pRemoteRegistrationHandle dst(std::move(src));
+    EXPECT_EQ(dst.mappedPtr(), static_cast<uint8_t*>(base) + 16);
+    // src is moved-from; its destructor must not close the mapping.
+  }
+}
+
+TEST(P2pRemoteRegistrationHandleTest, MoveAssignClosesPriorAndSourceOnce) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  int a = 0;
+  int b = 0;
+  void* baseA = &a; // destination's prior mapping
+  void* baseB = &b; // source's mapping
+  EXPECT_CALL(*mock, ipcCloseMemHandle(baseA)).Times(1).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock, ipcCloseMemHandle(baseB)).Times(1).WillOnce(Return(Ok()));
+  {
+    P2pRemoteRegistrationHandle dst(
+        baseA, /*offset=*/0, /*size=*/64, /*ownedByIpc=*/true, mock);
+    P2pRemoteRegistrationHandle src(
+        baseB, /*offset=*/0, /*size=*/64, /*ownedByIpc=*/true, mock);
+
+    // Closes baseA (dst's prior mapping); dst takes over baseB; src is nulled.
+    dst = std::move(src);
+    EXPECT_EQ(dst.mappedPtr(), baseB);
+    // On scope exit: dst closes baseB once; src (moved-from) closes nothing.
+  }
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
+++ b/comms/uniflow/transport/p2p/tests/P2pTransportTest.cpp
@@ -1,0 +1,536 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/uniflow/transport/p2p/P2pTransport.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <vector>
+
+#include "comms/uniflow/drivers/cuda/mock/MockCudaApi.h"
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/p2p/P2pRegistrationHandle.h"
+
+namespace uniflow {
+
+// Helper that leverages the `friend class SegmentTest` declarations in
+// RegisteredSegment / RemoteRegisteredSegment to build them (with handles) from
+// tests, since production construction APIs are not yet available.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegisteredSegment(
+      void* buf,
+      size_t len,
+      MemoryType memType,
+      int deviceId) {
+    return RegisteredSegment(buf, len, memType, deviceId);
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+CudaApi::IpcMemHandle makePatternHandle() {
+  CudaApi::IpcMemHandle h{};
+  std::iota(h.begin(), h.end(), uint8_t{7});
+  return h;
+}
+
+// bind()/getTopology() serialize a device id as a raw host-order int32; mirror
+// that here so the wire shape lives in one place in the tests too.
+std::vector<uint8_t> makeDeviceIdBytes(int32_t deviceId) {
+  std::vector<uint8_t> bytes(sizeof(deviceId));
+  std::copy_n(
+      reinterpret_cast<const uint8_t*>(&deviceId),
+      sizeof(deviceId),
+      bytes.data());
+  return bytes;
+}
+
+class P2pTransportFactoryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock_ = std::make_shared<NiceMock<MockCudaApi>>();
+    // CudaDeviceGuard (used by register/import) needs these to succeed.
+    ON_CALL(*mock_, getDevice()).WillByDefault(Return(Result<int>(0)));
+    ON_CALL(*mock_, setDevice(_)).WillByDefault(Return(Ok()));
+  }
+
+  P2pTransportFactory makeFactory() {
+    return P2pTransportFactory(/*deviceId=*/0, ebt_.getEventBase(), mock_);
+  }
+
+  ScopedEventBaseThread ebt_;
+  std::shared_ptr<NiceMock<MockCudaApi>> mock_;
+};
+
+TEST_F(P2pTransportFactoryTest, SupportedReflectsDeviceCount) {
+  EXPECT_CALL(*mock_, getDeviceCount()).WillOnce(Return(Result<int>(2)));
+  EXPECT_FALSE(P2pTransportFactory::supported(mock_).hasError());
+
+  EXPECT_CALL(*mock_, getDeviceCount()).WillOnce(Return(Result<int>(0)));
+  EXPECT_TRUE(P2pTransportFactory::supported(mock_).hasError());
+}
+
+TEST_F(P2pTransportFactoryTest, RegisterSegmentRejectsNonVram) {
+  auto factory = makeFactory();
+  int dummy = 0;
+  Segment segment(&dummy, sizeof(dummy), MemoryType::DRAM, /*deviceId=*/0);
+  EXPECT_TRUE(factory.registerSegment(segment).hasError());
+}
+
+TEST_F(P2pTransportFactoryTest, RegisterSegmentExportsIpcHandle) {
+  const auto ipc = makePatternHandle();
+  EXPECT_CALL(*mock_, ipcGetMemHandle(_)).WillOnce(Return(ipc));
+
+  auto factory = makeFactory();
+  int buf = 0;
+  Segment segment(&buf, sizeof(buf), MemoryType::VRAM, /*deviceId=*/0);
+
+  auto handle = factory.registerSegment(segment);
+  ASSERT_FALSE(handle.hasError());
+
+  // Inspect the serialized payload to confirm the exported fields.
+  auto parsed = P2pRegistrationHandle::deserialize(handle.value()->serialize());
+  ASSERT_FALSE(parsed.hasError());
+  EXPECT_EQ(parsed.value().ipcHandle, ipc);
+  EXPECT_EQ(parsed.value().ownerPid, static_cast<int32_t>(::getpid()));
+  EXPECT_EQ(parsed.value().base, reinterpret_cast<uint64_t>(&buf));
+  EXPECT_EQ(parsed.value().offset, 0u);
+  EXPECT_EQ(parsed.value().size, sizeof(buf));
+}
+
+TEST_F(P2pTransportFactoryTest, RegisterSegmentSubAllocationRecordsOffset) {
+  const auto ipc = makePatternHandle();
+  // A segment that starts 64 bytes into a larger allocation. getMemAddressRange
+  // reports the true allocation base (AMD behavior); the IPC handle must be
+  // exported at that base and the segment's offset recorded.
+  uint8_t alloc[256] = {};
+  void* allocBase = alloc;
+  void* segPtr = alloc + 64;
+
+  EXPECT_CALL(*mock_, getMemAddressRange(segPtr))
+      .WillOnce(Return(
+          Result<CudaApi::MemRange>(
+              CudaApi::MemRange{allocBase, sizeof(alloc)})));
+  EXPECT_CALL(*mock_, ipcGetMemHandle(allocBase)).WillOnce(Return(ipc));
+
+  auto factory = makeFactory();
+  Segment segment(segPtr, 128, MemoryType::VRAM, /*deviceId=*/0);
+
+  auto handle = factory.registerSegment(segment);
+  ASSERT_FALSE(handle.hasError());
+
+  auto parsed = P2pRegistrationHandle::deserialize(handle.value()->serialize());
+  ASSERT_FALSE(parsed.hasError());
+  EXPECT_EQ(parsed.value().ipcHandle, ipc);
+  EXPECT_EQ(parsed.value().base, reinterpret_cast<uint64_t>(allocBase));
+  EXPECT_EQ(parsed.value().offset, 64u);
+  EXPECT_EQ(parsed.value().size, 128u);
+}
+
+TEST_F(P2pTransportFactoryTest, ImportSamePidReusesBaseWithoutIpcOpen) {
+  int peerBuf = 0;
+  P2pRegistrationHandle local(
+      makePatternHandle(),
+      /*ownerPid=*/static_cast<int32_t>(::getpid()),
+      /*base=*/reinterpret_cast<uint64_t>(&peerBuf),
+      /*offset=*/64,
+      /*size=*/256);
+  const auto payload = local.serialize();
+
+  EXPECT_CALL(*mock_, ipcOpenMemHandle(_)).Times(0);
+
+  auto factory = makeFactory();
+  auto imported = factory.importSegment(256, payload);
+  ASSERT_FALSE(imported.hasError());
+
+  auto* remote =
+      static_cast<P2pRemoteRegistrationHandle*>(imported.value().get());
+  EXPECT_EQ(remote->mappedPtr(), reinterpret_cast<uint8_t*>(&peerBuf) + 64);
+}
+
+TEST_F(P2pTransportFactoryTest, ImportCrossPidOpensIpcHandle) {
+  int sentinel = 0;
+  void* opened = &sentinel;
+  P2pRegistrationHandle local(
+      makePatternHandle(),
+      /*ownerPid=*/static_cast<int32_t>(::getpid()) + 1, // different process
+      /*base=*/0xdead,
+      /*offset=*/32,
+      /*size=*/128);
+  const auto payload = local.serialize();
+
+  EXPECT_CALL(*mock_, ipcOpenMemHandle(_))
+      .WillOnce(Return(Result<void*>(opened)));
+
+  auto factory = makeFactory();
+  auto imported = factory.importSegment(128, payload);
+  ASSERT_FALSE(imported.hasError());
+
+  auto* remote =
+      static_cast<P2pRemoteRegistrationHandle*>(imported.value().get());
+  EXPECT_EQ(remote->mappedPtr(), static_cast<uint8_t*>(opened) + 32);
+}
+
+TEST_F(P2pTransportFactoryTest, CreateTransportRejectsWhenNoPeerAccess) {
+  EXPECT_CALL(*mock_, deviceCanAccessPeer(0, 1))
+      .WillOnce(Return(Result<bool>(false)));
+
+  auto factory = makeFactory();
+  const auto topo = makeDeviceIdBytes(1);
+
+  EXPECT_TRUE(factory.createTransport(topo).hasError());
+}
+
+TEST_F(P2pTransportFactoryTest, CreateTransportSucceedsWithPeerAccess) {
+  EXPECT_CALL(*mock_, deviceCanAccessPeer(0, 1))
+      .WillOnce(Return(Result<bool>(true)));
+
+  auto factory = makeFactory();
+  const auto topo = makeDeviceIdBytes(1);
+
+  EXPECT_FALSE(factory.createTransport(topo).hasError());
+}
+
+TEST_F(P2pTransportFactoryTest, CreateTransportRejectsNegativePeerDevice) {
+  // canConnect must reject a negative peer id up front rather than passing it
+  // to deviceCanAccessPeer and surfacing an opaque driver error.
+  EXPECT_CALL(*mock_, deviceCanAccessPeer(_, _)).Times(0);
+
+  auto factory = makeFactory();
+  const auto topo = makeDeviceIdBytes(-1);
+
+  auto result = factory.createTransport(topo);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST_F(P2pTransportFactoryTest, CreateTransportRejectsWrongSizedTopology) {
+  EXPECT_CALL(*mock_, deviceCanAccessPeer(_, _)).Times(0);
+
+  auto factory = makeFactory();
+  const std::vector<uint8_t> tooShort(sizeof(int32_t) - 1, 0);
+
+  auto result = factory.createTransport(tooShort);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST(P2pTransportTest, ConnectEnablesPeerAccessForDifferentDevice) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
+  ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+
+  const auto info = makeDeviceIdBytes(1);
+
+  transport.bind();
+  EXPECT_FALSE(transport.connect(info).hasError());
+  EXPECT_EQ(transport.state(), TransportState::Connected);
+}
+
+TEST(P2pTransportTest, ConnectRejectsNegativePeerDevice) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
+  ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(_)).Times(0);
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+
+  const auto info = makeDeviceIdBytes(-1);
+
+  transport.bind();
+  EXPECT_TRUE(transport.connect(info).hasError());
+  EXPECT_NE(transport.state(), TransportState::Connected);
+}
+
+TEST_F(P2pTransportFactoryTest, ImportRejectsSegmentLengthMismatch) {
+  P2pRegistrationHandle local(
+      makePatternHandle(),
+      /*ownerPid=*/static_cast<int32_t>(::getpid()),
+      /*base=*/0x1000,
+      /*offset=*/0,
+      /*size=*/256);
+  const auto payload = local.serialize();
+
+  auto factory = makeFactory();
+  // Requested segment length (64) disagrees with the payload's size (256).
+  EXPECT_TRUE(factory.importSegment(64, payload).hasError());
+}
+
+TEST_F(P2pTransportFactoryTest, ImportRejectsOffsetPlusSizeOverflow) {
+  // offset + size must not wrap; both come straight off the wire and drive raw
+  // pointer math.
+  constexpr uint64_t kSize = 256;
+  P2pRegistrationHandle local(
+      makePatternHandle(),
+      /*ownerPid=*/static_cast<int32_t>(::getpid()),
+      /*base=*/0x1000,
+      /*offset=*/std::numeric_limits<uint64_t>::max() - kSize + 1,
+      /*size=*/kSize);
+  const auto payload = local.serialize();
+
+  EXPECT_CALL(*mock_, ipcOpenMemHandle(_)).Times(0);
+
+  auto factory = makeFactory();
+  auto result = factory.importSegment(kSize, payload);
+  ASSERT_TRUE(result.hasError());
+  EXPECT_EQ(result.error().code(), ErrCode::InvalidArgument);
+}
+
+TEST(P2pTransportTest, ConnectRequiresBindFirst) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+
+  const auto info = makeDeviceIdBytes(1);
+
+  // No bind() -> still Disconnected -> connect must be rejected.
+  EXPECT_TRUE(transport.connect(info).hasError());
+  EXPECT_NE(transport.state(), TransportState::Connected);
+}
+
+TEST(P2pTransportTest, BindDoesNotRegressConnectedState) {
+  auto mock = std::make_shared<NiceMock<MockCudaApi>>();
+  ON_CALL(*mock, getDevice()).WillByDefault(Return(Result<int>(0)));
+  ON_CALL(*mock, setDevice(_)).WillByDefault(Return(Ok()));
+  EXPECT_CALL(*mock, deviceEnablePeerAccess(1)).WillOnce(Return(Ok()));
+
+  ScopedEventBaseThread ebt;
+  P2pTransport transport(/*deviceId=*/0, ebt.getEventBase(), mock);
+  transport.bind();
+
+  const auto info = makeDeviceIdBytes(1);
+  ASSERT_FALSE(transport.connect(info).hasError());
+  ASSERT_EQ(transport.state(), TransportState::Connected);
+
+  // bind() again must not regress a Connected transport to Initialized.
+  transport.bind();
+  EXPECT_EQ(transport.state(), TransportState::Connected);
+}
+
+// Fixture exercising the put/get transfer path: memcpy submission plus the
+// vendor-typed event-completion seam (eventCreate/eventRecord/eventQuery/
+// eventDestroy), mocked directly on MockCudaApi.
+class P2pTransportPutGetTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock_ = std::make_shared<NiceMock<MockCudaApi>>();
+    ON_CALL(*mock_, getDevice()).WillByDefault(Return(Result<int>(0)));
+    ON_CALL(*mock_, setDevice(_)).WillByDefault(Return(Ok()));
+    ON_CALL(*mock_, deviceEnablePeerAccess(_)).WillByDefault(Return(Ok()));
+    transport_ = std::make_unique<P2pTransport>(
+        /*deviceId=*/0, ebt_.getEventBase(), mock_);
+
+    // The remote handle maps to remoteBuf_; use a distinct fake VA as the
+    // segment pointer so a bug that copies to the segment ptr instead of
+    // mappedPtr() would fail. ownedByIpc=false keeps the destructor trivial.
+    remoteSeg_ = SegmentTest::makeRemote(
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        reinterpret_cast<void*>(0xDEAD0000),
+        sizeof(remoteBuf_),
+        std::make_unique<P2pRemoteRegistrationHandle>(
+            remoteBuf_,
+            /*offset=*/0,
+            sizeof(remoteBuf_),
+            /*ownedByIpc=*/false,
+            mock_));
+  }
+
+  void connectTransport() {
+    const auto info = makeDeviceIdBytes(1);
+    transport_->bind();
+    ASSERT_FALSE(transport_->connect(info).hasError());
+  }
+
+  ScopedEventBaseThread ebt_;
+  std::shared_ptr<NiceMock<MockCudaApi>> mock_;
+  std::unique_ptr<P2pTransport> transport_;
+  uint8_t localBuf_[128]{};
+  uint8_t remoteBuf_[128]{};
+  RegisteredSegment localSeg_{SegmentTest::makeRegisteredSegment(
+      localBuf_,
+      sizeof(localBuf_),
+      MemoryType::VRAM,
+      /*deviceId=*/0)};
+  std::optional<RemoteRegisteredSegment> remoteSeg_;
+};
+
+TEST_F(P2pTransportPutGetTest, PutCompletesViaEventPoll) {
+  connectTransport();
+
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x42);
+
+  // put: dst = remote (mappedPtr()), src = local, default stream (nullptr).
+  EXPECT_CALL(
+      *mock_,
+      memcpyAsync(
+          remoteBuf_,
+          localBuf_,
+          sizeof(localBuf_),
+          cudaMemcpyDeviceToDevice,
+          nullptr))
+      .WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventCreate(_))
+      .WillOnce(DoAll(SetArgPointee<0>(fakeEvent), Return(Ok())));
+  EXPECT_CALL(*mock_, eventRecord(fakeEvent, _)).WillOnce(Return(Ok()));
+  // Not-ready first, then complete: exercises the EventBase re-dispatch poll.
+  EXPECT_CALL(*mock_, eventQuery(fakeEvent))
+      .WillOnce(Return(Result<bool>(false)))
+      .WillOnce(Return(Result<bool>(true)));
+  EXPECT_CALL(*mock_, eventDestroy(fakeEvent)).WillOnce(Return(Ok()));
+
+  TransferRequest req{localSeg_.span(), remoteSeg_->span()};
+  auto future = transport_->put(std::span(&req, 1));
+  EXPECT_TRUE(future.get().hasValue());
+}
+
+TEST_F(P2pTransportPutGetTest, GetCompletesViaEvent) {
+  connectTransport();
+
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x43);
+
+  // get: dst = local, src = remote (mappedPtr()).
+  EXPECT_CALL(
+      *mock_,
+      memcpyAsync(
+          localBuf_,
+          remoteBuf_,
+          sizeof(localBuf_),
+          cudaMemcpyDeviceToDevice,
+          nullptr))
+      .WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventCreate(_))
+      .WillOnce(DoAll(SetArgPointee<0>(fakeEvent), Return(Ok())));
+  EXPECT_CALL(*mock_, eventRecord(fakeEvent, _)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventQuery(fakeEvent))
+      .WillOnce(Return(Result<bool>(true)));
+  EXPECT_CALL(*mock_, eventDestroy(fakeEvent)).WillOnce(Return(Ok()));
+
+  TransferRequest req{localSeg_.span(), remoteSeg_->span()};
+  auto future = transport_->get(std::span(&req, 1));
+  EXPECT_TRUE(future.get().hasValue());
+}
+
+TEST_F(P2pTransportPutGetTest, PutMemcpyErrorDrainsAndFails) {
+  connectTransport();
+
+  EXPECT_CALL(
+      *mock_,
+      memcpyAsync(
+          remoteBuf_,
+          localBuf_,
+          sizeof(localBuf_),
+          cudaMemcpyDeviceToDevice,
+          nullptr))
+      .WillOnce(Return(Err(ErrCode::DriverError, "memcpy failed")));
+  // On failure the stream is drained so buffers are safe to release, and no
+  // completion event is created.
+  EXPECT_CALL(*mock_, streamSynchronize(nullptr)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventCreate(_)).Times(0);
+
+  TransferRequest req{localSeg_.span(), remoteSeg_->span()};
+  auto future = transport_->put(std::span(&req, 1));
+  auto status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
+TEST_F(P2pTransportPutGetTest, PutQueryEventErrorDrainsAndFails) {
+  connectTransport();
+
+  // NOLINTNEXTLINE(performance-no-int-to-ptr)
+  cudaEvent_t fakeEvent = reinterpret_cast<cudaEvent_t>(0x44);
+
+  EXPECT_CALL(
+      *mock_,
+      memcpyAsync(
+          remoteBuf_,
+          localBuf_,
+          sizeof(localBuf_),
+          cudaMemcpyDeviceToDevice,
+          nullptr))
+      .WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventCreate(_))
+      .WillOnce(DoAll(SetArgPointee<0>(fakeEvent), Return(Ok())));
+  EXPECT_CALL(*mock_, eventRecord(fakeEvent, _)).WillOnce(Return(Ok()));
+  // A hard query failure leaves the in-flight copies in an unknown state, so
+  // the stream is drained (buffers safe to release) and the event destroyed
+  // before the error surfaces on the promise.
+  EXPECT_CALL(*mock_, eventQuery(fakeEvent))
+      .WillOnce(Return(Err(ErrCode::DriverError, "queryEvent failed")));
+  EXPECT_CALL(*mock_, streamSynchronize(nullptr)).WillOnce(Return(Ok()));
+  EXPECT_CALL(*mock_, eventDestroy(fakeEvent)).WillOnce(Return(Ok()));
+
+  TransferRequest req{localSeg_.span(), remoteSeg_->span()};
+  auto future = transport_->put(std::span(&req, 1));
+  auto status = future.get();
+  ASSERT_TRUE(status.hasError());
+  EXPECT_EQ(status.error().code(), ErrCode::DriverError);
+}
+
+// A moved-from remote handle yields a null mappedPtr(). Both put() and get()
+// must reject it instead of doing nullptr + offset pointer math and handing the
+// result to a device-to-device memcpy.
+TEST_F(P2pTransportPutGetTest, RejectsNullMappedPointer) {
+  connectTransport();
+
+  auto handle = std::make_unique<P2pRemoteRegistrationHandle>(
+      remoteBuf_,
+      /*offset=*/0,
+      sizeof(remoteBuf_),
+      /*ownedByIpc=*/false,
+      mock_);
+  // Move out of the handle so mappedPtr() reports null.
+  P2pRemoteRegistrationHandle drained(std::move(*handle));
+  ASSERT_EQ(handle->mappedPtr(), nullptr);
+
+  auto movedFromSeg = SegmentTest::makeRemote(
+      // NOLINTNEXTLINE(performance-no-int-to-ptr)
+      reinterpret_cast<void*>(0xDEAD0000),
+      sizeof(remoteBuf_),
+      std::move(handle));
+
+  EXPECT_CALL(*mock_, memcpyAsync(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(*mock_, eventCreate(_)).Times(0);
+
+  TransferRequest req{localSeg_.span(), movedFromSeg.span()};
+
+  auto putStatus = transport_->put(std::span(&req, 1)).get();
+  ASSERT_TRUE(putStatus.hasError());
+  EXPECT_EQ(putStatus.error().code(), ErrCode::InvalidArgument);
+
+  auto getStatus = transport_->get(std::span(&req, 1)).get();
+  ASSERT_TRUE(getStatus.hasError());
+  EXPECT_EQ(getStatus.error().code(), ErrCode::InvalidArgument);
+}
+
+} // namespace
+} // namespace uniflow

--- a/comms/uniflow/transport/p2p/tests/integration/P2pSingleHostTest.cpp
+++ b/comms/uniflow/transport/p2p/tests/integration/P2pSingleHostTest.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/// Single-host integration test for the intra-node P2P (XGMI) transport.
+/// Requires >= 2 GPUs; uses two P2pTransportFactory instances on devices 0 and
+/// 1 within one process (the same-process import path), exercising the IPC
+/// export + device-to-device data plane on real hardware. Runs on AMD GPU CI.
+
+#include "comms/uniflow/executor/ScopedEventBaseThread.h"
+#include "comms/uniflow/transport/p2p/P2pTransport.h"
+
+#include <cuda_runtime_api.h> // @manual=third-party//cuda:cuda-lazy
+
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace uniflow {
+
+/// Friend wrapper to assemble RegisteredSegment / RemoteRegisteredSegment with
+/// handles. The name must be exactly "SegmentTest" to match Segment.h.
+class SegmentTest {
+ public:
+  static RegisteredSegment makeRegistered(
+      Segment& segment,
+      std::unique_ptr<RegistrationHandle> handle) {
+    RegisteredSegment reg(segment);
+    reg.handles_.push_back(std::move(handle));
+    return reg;
+  }
+
+  static RemoteRegisteredSegment makeRemote(
+      void* buf,
+      size_t len,
+      std::unique_ptr<RemoteRegistrationHandle> handle) {
+    RemoteRegisteredSegment remote(buf, len);
+    remote.handles_.push_back(std::move(handle));
+    return remote;
+  }
+};
+
+namespace {
+
+// ASSERT-based check so a failed CUDA setup call produces a clean test failure
+// rather than a silently-ignored error code.
+#define ASSERT_CUDA(expr) ASSERT_EQ((expr), cudaSuccess) << #expr
+
+int gpuCount() {
+  int count = 0;
+  if (cudaGetDeviceCount(&count) != cudaSuccess) {
+    return 0;
+  }
+  return count;
+}
+
+struct CudaBuffer {
+  void* ptr{nullptr};
+  size_t size{0};
+
+  CudaBuffer(size_t n, int device) : size(n) {
+    // On a setDevice failure, skip the malloc so ptr stays null and the
+    // caller's ASSERT_NE(ptr, nullptr) fails cleanly at the allocation site,
+    // rather than silently allocating on the wrong device.
+    if (cudaSetDevice(device) != cudaSuccess) {
+      return;
+    }
+    if (cudaMalloc(&ptr, n) != cudaSuccess) {
+      ptr = nullptr;
+    }
+  }
+  ~CudaBuffer() {
+    if (ptr != nullptr) {
+      // Best-effort cleanup; explicitly discard the nodiscard error code.
+      (void)cudaFree(ptr);
+    }
+  }
+  CudaBuffer(const CudaBuffer&) = delete;
+  CudaBuffer& operator=(const CudaBuffer&) = delete;
+};
+
+class P2pSingleHostTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    evbThread_ = std::make_unique<ScopedEventBaseThread>();
+  }
+  void TearDown() override {
+    evbThread_.reset();
+  }
+
+  struct ConnectedPair {
+    std::unique_ptr<P2pTransportFactory> factory0;
+    std::unique_ptr<P2pTransportFactory> factory1;
+    std::unique_ptr<Transport> transport0;
+    std::unique_ptr<Transport> transport1;
+  };
+
+  void connectPair(ConnectedPair& pair) {
+    auto* evb = evbThread_->getEventBase();
+    pair.factory0 = std::make_unique<P2pTransportFactory>(0, evb);
+    pair.factory1 = std::make_unique<P2pTransportFactory>(1, evb);
+
+    auto topo0 = pair.factory0->getTopology();
+    auto topo1 = pair.factory1->getTopology();
+
+    auto r0 = pair.factory0->createTransport(topo1);
+    auto r1 = pair.factory1->createTransport(topo0);
+    ASSERT_TRUE(r0.hasValue()) << r0.error().message();
+    ASSERT_TRUE(r1.hasValue()) << r1.error().message();
+    pair.transport0 = std::move(r0.value());
+    pair.transport1 = std::move(r1.value());
+
+    auto info0 = pair.transport0->bind();
+    auto info1 = pair.transport1->bind();
+    ASSERT_FALSE(pair.transport0->connect(info1).hasError());
+    ASSERT_FALSE(pair.transport1->connect(info0).hasError());
+  }
+
+  std::unique_ptr<ScopedEventBaseThread> evbThread_;
+};
+
+TEST_F(P2pSingleHostTest, TwoTransportsConnect) {
+  if (gpuCount() < 2) {
+    GTEST_SKIP() << "need >= 2 GPUs, found " << gpuCount();
+  }
+  auto pair = ConnectedPair{};
+  ASSERT_NO_FATAL_FAILURE(connectPair(pair));
+  EXPECT_EQ(pair.transport0->state(), TransportState::Connected);
+  EXPECT_EQ(pair.transport1->state(), TransportState::Connected);
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+TEST_F(P2pSingleHostTest, GpuPut) {
+  if (gpuCount() < 2) {
+    GTEST_SKIP() << "need >= 2 GPUs, found " << gpuCount();
+  }
+  constexpr size_t kSize = 1 << 20; // 1 MiB
+  ConnectedPair pair;
+  ASSERT_NO_FATAL_FAILURE(connectPair(pair));
+
+  CudaBuffer sendGpu(kSize, 0);
+  CudaBuffer recvGpu(kSize, 1);
+  ASSERT_NE(sendGpu.ptr, nullptr);
+  ASSERT_NE(recvGpu.ptr, nullptr);
+
+  std::vector<char> staging(kSize, static_cast<char>(0xC5));
+  ASSERT_CUDA(cudaSetDevice(0));
+  ASSERT_CUDA(
+      cudaMemcpy(sendGpu.ptr, staging.data(), kSize, cudaMemcpyHostToDevice));
+  ASSERT_CUDA(cudaSetDevice(1));
+  ASSERT_CUDA(cudaMemset(recvGpu.ptr, 0, kSize));
+  ASSERT_CUDA(cudaDeviceSynchronize());
+
+  Segment sendSeg(sendGpu.ptr, kSize, MemoryType::VRAM, 0);
+  Segment recvSeg(recvGpu.ptr, kSize, MemoryType::VRAM, 1);
+
+  auto sendReg = pair.factory0->registerSegment(sendSeg);
+  ASSERT_TRUE(sendReg.hasValue()) << sendReg.error().message();
+  auto recvReg = pair.factory1->registerSegment(recvSeg);
+  ASSERT_TRUE(recvReg.hasValue()) << recvReg.error().message();
+
+  auto recvPayload = recvReg.value()->serialize();
+  auto remoteHandle = pair.factory0->importSegment(kSize, recvPayload);
+  ASSERT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+
+  auto localReg =
+      SegmentTest::makeRegistered(sendSeg, std::move(sendReg.value()));
+  auto remoteReg = SegmentTest::makeRemote(
+      recvGpu.ptr, kSize, std::move(remoteHandle.value()));
+
+  std::vector<TransferRequest> reqs;
+  reqs.push_back(
+      TransferRequest{
+          .local = localReg.span(size_t{0}, kSize),
+          .remote = remoteReg.span(size_t{0}, kSize),
+      });
+
+  auto putStatus = pair.transport0->put(reqs, {}).get();
+  ASSERT_FALSE(putStatus.hasError()) << putStatus.error().message();
+
+  std::vector<char> verify(kSize, 0);
+  ASSERT_CUDA(cudaSetDevice(1));
+  ASSERT_CUDA(
+      cudaMemcpy(verify.data(), recvGpu.ptr, kSize, cudaMemcpyDeviceToHost));
+  const std::vector<char> expected(kSize, static_cast<char>(0xC5));
+  EXPECT_EQ(verify, expected);
+
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+TEST_F(P2pSingleHostTest, GpuGet) {
+  if (gpuCount() < 2) {
+    GTEST_SKIP() << "need >= 2 GPUs, found " << gpuCount();
+  }
+  constexpr size_t kSize = 1 << 20; // 1 MiB
+  ConnectedPair pair;
+  ASSERT_NO_FATAL_FAILURE(connectPair(pair));
+
+  CudaBuffer localGpu(kSize, 0);
+  CudaBuffer remoteGpu(kSize, 1);
+  ASSERT_NE(localGpu.ptr, nullptr);
+  ASSERT_NE(remoteGpu.ptr, nullptr);
+
+  ASSERT_CUDA(cudaSetDevice(0));
+  ASSERT_CUDA(cudaMemset(localGpu.ptr, 0, kSize));
+  std::vector<char> staging(kSize, static_cast<char>(0xD7));
+  ASSERT_CUDA(cudaSetDevice(1));
+  ASSERT_CUDA(
+      cudaMemcpy(remoteGpu.ptr, staging.data(), kSize, cudaMemcpyHostToDevice));
+  ASSERT_CUDA(cudaDeviceSynchronize());
+
+  Segment localSeg(localGpu.ptr, kSize, MemoryType::VRAM, 0);
+  Segment remoteSeg(remoteGpu.ptr, kSize, MemoryType::VRAM, 1);
+
+  auto localReg = pair.factory0->registerSegment(localSeg);
+  ASSERT_TRUE(localReg.hasValue()) << localReg.error().message();
+  auto remoteRegResult = pair.factory1->registerSegment(remoteSeg);
+  ASSERT_TRUE(remoteRegResult.hasValue()) << remoteRegResult.error().message();
+
+  auto remotePayload = remoteRegResult.value()->serialize();
+  auto remoteHandle = pair.factory0->importSegment(kSize, remotePayload);
+  ASSERT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+
+  auto localRegSeg =
+      SegmentTest::makeRegistered(localSeg, std::move(localReg.value()));
+  auto remoteReg = SegmentTest::makeRemote(
+      remoteGpu.ptr, kSize, std::move(remoteHandle.value()));
+
+  std::vector<TransferRequest> reqs;
+  reqs.push_back(
+      TransferRequest{
+          .local = localRegSeg.span(size_t{0}, kSize),
+          .remote = remoteReg.span(size_t{0}, kSize),
+      });
+
+  auto getStatus = pair.transport0->get(reqs, {}).get();
+  ASSERT_FALSE(getStatus.hasError()) << getStatus.error().message();
+
+  std::vector<char> verify(kSize, 0);
+  ASSERT_CUDA(cudaSetDevice(0));
+  ASSERT_CUDA(
+      cudaMemcpy(verify.data(), localGpu.ptr, kSize, cudaMemcpyDeviceToHost));
+  const std::vector<char> expected(kSize, static_cast<char>(0xD7));
+  EXPECT_EQ(verify, expected);
+
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+// Registers a segment that is a SUB-RANGE of a larger allocation and verifies a
+// put lands at base+offset (AMD: getMemAddressRange reports the real allocation
+// base, and the recorded offset is applied on import). Proves the pre-offset
+// region is untouched, i.e. data did not land at the allocation base.
+TEST_F(P2pSingleHostTest, GpuPutSubAllocation) {
+  if (gpuCount() < 2) {
+    GTEST_SKIP() << "need >= 2 GPUs, found " << gpuCount();
+  }
+  constexpr size_t kSize = 1 << 20; // 1 MiB segment
+  constexpr size_t kOffset = 1
+      << 20; // segment starts 1 MiB into the allocation
+  constexpr size_t kAlloc = kSize + kOffset; // 2 MiB allocation
+  ConnectedPair pair;
+  ASSERT_NO_FATAL_FAILURE(connectPair(pair));
+
+  CudaBuffer sendGpu(kSize, 0);
+  CudaBuffer recvGpu(
+      kAlloc, 1); // larger allocation; the segment is a sub-range
+  ASSERT_NE(sendGpu.ptr, nullptr);
+  ASSERT_NE(recvGpu.ptr, nullptr);
+
+  std::vector<char> staging(kSize, static_cast<char>(0xA9));
+  ASSERT_CUDA(cudaSetDevice(0));
+  ASSERT_CUDA(
+      cudaMemcpy(sendGpu.ptr, staging.data(), kSize, cudaMemcpyHostToDevice));
+  ASSERT_CUDA(cudaSetDevice(1));
+  ASSERT_CUDA(cudaMemset(recvGpu.ptr, 0, kAlloc)); // zero the whole allocation
+  ASSERT_CUDA(cudaDeviceSynchronize());
+
+  void* recvSubPtr = static_cast<uint8_t*>(recvGpu.ptr) + kOffset;
+  Segment sendSeg(sendGpu.ptr, kSize, MemoryType::VRAM, 0);
+  Segment recvSeg(recvSubPtr, kSize, MemoryType::VRAM, 1);
+
+  auto sendReg = pair.factory0->registerSegment(sendSeg);
+  ASSERT_TRUE(sendReg.hasValue()) << sendReg.error().message();
+  auto recvReg = pair.factory1->registerSegment(recvSeg);
+  ASSERT_TRUE(recvReg.hasValue()) << recvReg.error().message();
+
+  auto recvPayload = recvReg.value()->serialize();
+  auto remoteHandle = pair.factory0->importSegment(kSize, recvPayload);
+  ASSERT_TRUE(remoteHandle.hasValue()) << remoteHandle.error().message();
+
+  auto localReg =
+      SegmentTest::makeRegistered(sendSeg, std::move(sendReg.value()));
+  auto remoteReg = SegmentTest::makeRemote(
+      recvSubPtr, kSize, std::move(remoteHandle.value()));
+
+  std::vector<TransferRequest> reqs;
+  reqs.push_back(
+      TransferRequest{
+          .local = localReg.span(size_t{0}, kSize),
+          .remote = remoteReg.span(size_t{0}, kSize),
+      });
+
+  auto putStatus = pair.transport0->put(reqs, {}).get();
+  ASSERT_FALSE(putStatus.hasError()) << putStatus.error().message();
+
+  // Read back the whole allocation: [0, kOffset) must remain zero (data did NOT
+  // land at the allocation base) and [kOffset, kOffset+kSize) holds the
+  // pattern.
+  std::vector<char> verify(kAlloc, 0);
+  ASSERT_CUDA(cudaSetDevice(1));
+  ASSERT_CUDA(
+      cudaMemcpy(verify.data(), recvGpu.ptr, kAlloc, cudaMemcpyDeviceToHost));
+  const std::vector<char> zeros(kOffset, 0);
+  const std::vector<char> pattern(kSize, static_cast<char>(0xA9));
+  EXPECT_EQ(std::vector<char>(verify.begin(), verify.begin() + kOffset), zeros);
+  EXPECT_EQ(std::vector<char>(verify.begin() + kOffset, verify.end()), pattern);
+
+  pair.transport0->shutdown();
+  pair.transport1->shutdown();
+}
+
+} // namespace
+} // namespace uniflow


### PR DESCRIPTION
Summary:

Adds an intra-node GPU-to-GPU P2P transport for AMD (XGMI; also works on NVIDIA
P2P), implementing comms/uniflow/amd/AMD_SUPPORT_DESIGN.md (Seam-3 IPC backend,
sections 5.2.1 / 5.3.1 / 5.6). Squashed from a 4-part stack into one diff
(absorbs the now-abandoned D110137112, D110138863, D110141845).

The transfer path uses the vendor-typed CudaApi seam (cudaEvent_t/cudaStream_t;
cuda* -> hip* via hipify on AMD), and P2pTransport.cpp is compiled through hipify
with the amdclang toolchain on AMD -- mirroring transport/rdma and the planned
unified intra-node transport (D110509654). IPC registration handles stay a
neutral 64-byte byte array purely for wire serialization, so
P2pRegistrationHandle remains a plain oss_cpp_library. No consumer requires a
non-hipified build of the intra-node transport (the only consumer,
MultiTransport, already links the hipified rdma-transport on AMD), so the earlier
neutral CudaApi event/memcpy/stream wrappers were removed rather than carried to
unification.

Components:
1. CudaApi primitives (drivers/cuda): cross-platform IPC handle export/import via
   a neutral 64-byte IpcMemHandle (cudaIpc*/hipIpc*, kept as bytes purely for
   wire serialization); getDeviceArch (gfx* on AMD, sm_* on NVIDIA); and
   getMemAddressRange, which returns a device pointer's allocation base+size
   (AMD: HIP runtime address-range API; NVIDIA: runtime-only no-op that reports
   the pointer as its own base, so CudaApi stays driver-free there). A
   static_assert pins IpcMemHandle == HIP_IPC_HANDLE_SIZE (64). Mirrored in
   MockCudaApi.
2. P2P registration handles (transport/p2p): P2pRegistrationHandle (packed
   92-byte wire payload {ownerPid, base, offset, size, IPC handle};
   serialize/deserialize) and P2pRemoteRegistrationHandle (maps a peer
   allocation; closes the IPC mapping only for cross-process imports;
   Rule-of-Five with a noexcept-safe close).
3. P2pTransport + P2pTransportFactory: shares the NVLink interconnect tier
   (TransportType::NVLink) so MultiTransport::selectTransport (presence-driven)
   selects it for VRAM->VRAM with no selection-logic change. registerSegment
   exports the IPC handle at the allocation base and records the segment's offset
   within it (via getMemAddressRange), so a segment that is a sub-range of a
   larger allocation (e.g. a caching-allocator pool slice) imports at the correct
   address; on NVIDIA the range lookup is a runtime-only no-op, preserving the
   prior whole-allocation behavior. importSegment opens the handle cross-process
   or reuses the exporter pointer same-process; put/get build their copy batch
   through one direction-parameterized buildCopyOps() and submit a memcpyAsync
   device-to-device batch completed via a recorded CUDA event polled on the
   EventBase (self-re-dispatching, non-blocking); on error the stream is drained
   before failing so buffers are safe to release. bind/connect/shutdown follow a
   strict state machine, with device ids encoded/decoded through a single
   validated codec.
4. Arch gate + MultiTransport wiring: P2pTransportFactory::supported() owns the
   all-XGMI gate -- on AMD it requires every device to be gfx942 / gfx950 /
   gfx1250, because selectTransport is presence-driven and
   hipDeviceCanAccessPeer conflates XGMI with slower PCIe-P2P. Defining it in
   the factory keeps the support contract in one place and self-describing, so a
   direct consumer cannot be handed P2P on a node where MultiTransport would
   refuse it. MultiTransport just calls supported() from both its constructor
   and supported(NVLink), falling back to RDMA on failure. The gate is
   #ifdef'd to AMD; NVIDIA path unchanged.

Why a separate transport/p2p instead of adding an IpcHandle mode to
transport/nvlink now:

- The IPC mechanism itself is cross-platform (cudaIpc*/hipIpc*), so in principle
  it could be a third NVLinkTransport MemSharingMode next to Fabric and PosixFd.
  That single-transport shape IS the documented end state. But folding it in now
  is high-cost, low-reward:
  * transport/nvlink is NVIDIA-only and heavily coupled to CUDA Driver VMM
    (cuMem*, CUmemGenericAllocationHandle, CUmemFabricHandle) and NVML.
    Compiling it on AMD just to reach the IPC mode would force hipifying the
    whole folder, which re-opens the cuda-driver-api symbol-translation blocker
    we deliberately isolated (CU_STREAM_WRITE_VALUE_DEFAULT, cuGetErrorName
    arity, untranslated cuStreamWriteValue64), plus #ifdef-ing out
    Fabric/VMM/NVML on AMD (no CUmemFabricHandle until MI450; VMM immature on
    MI300/MI350; NVML stubbed). That is the #ifdef-soup the design's decision
    tree rejects for major divergences.
  * On NVIDIA, IPC is only the legacy fallback (prod uses VMM PosixFd + Fabric),
    so an IPC mode benefits AMD, not NVIDIA -- no reason to churn the NVIDIA
    production transport now.
  * Modifying the NVIDIA production transport carries blast radius this AMD
    intra-node MVP does not need.
- Convergence is therefore sequenced to MI450, where AMD needs VMM + fabric
  handles (the hipified twin of NVLink's VMM + CUmemFabricHandle path) and
  reuses ~90% of the nvlink logic. At that point NVLinkTransport is hipified
  once and evolves in place into a unified P2pTransport with modes {Fabric,
  PosixFd, IpcHandle}; the transport/p2p handles fold in as the IpcHandle
  backend (they are modeled on NVLinkFdRegistrationHandle precisely so they
  merge cleanly). The nvlink logic relocates into the unified transport -- it is
  not deleted, and the folder/name retires only after the merge is proven.

Follow-ups folded into this diff:
- P2pTransport matches NVLinkTransport's single-threaded-ownership model:
  state_ is a plain (non-atomic) TransportState and shutdown() only transitions
  state_ without resetting peerDeviceId_ (peerDeviceId_ is set once in connect()
  and is never read on the transfer path). Resolves a review comment about a
  potential data race in shutdown().
- Sub-allocation IPC support (resolves a review comment on registerSegment
  hard-coding offset 0): registerSegment now discovers the allocation base via
  the new CudaApi::getMemAddressRange seam and records offset = data() - base,
  exporting the IPC handle at the base so a sub-range of a larger allocation
  imports correctly. On AMD this uses the HIP runtime address-range API; on
  NVIDIA getMemAddressRange is a runtime-only no-op (whole-allocation, offset 0),
  so the NVIDIA path is unchanged and CudaApi gains no driver dependency. A
  whole-allocation segment yields offset 0 -- byte-identical to the previous
  hard-coded handle.
- Integration test fixes (tests/integration): MultiTransportSingleHostTest now
  expects the P2P (NVLink) tier at factory[0] on all-XGMI AMD nodes (RDMA
  fallback otherwise), gated on supported(NVLink) to match the constructor's
  arch gate. MultiTransportCrossHostTest guards the NVIDIA-only Fabric/MNNVL
  VmmAllocation behind #ifndef __HIP_PLATFORM_AMD__ (no CU_MEM_HANDLE_TYPE_FABRIC
  on AMD until MI450) with an AMD stub, so it compiles on AMD and the Fabric
  cases skip at runtime.

Review round on V24 (all six inline comments addressed):
- Land-blocking CLANGTIDY facebook-hte-NullableReturn on mappedPtr(): annotated
  nullable on both the declaration and the definition. Uses a local
  UNIFLOW_NULLABLE macro (_Nullable under clang, empty otherwise) rather than
  folly's FOLLY_NULLABLE, because comms/uniflow is a strict-OSS library whose
  OSS_DEPS_ALLOWLIST (comms/strict_oss_defs.bzl) excludes folly -- taking the
  lint bot's suggested FOLLY_NULLABLE patch verbatim would have broken the
  p2p-registration-handle_oss_dep_guard and the GitHub export.
- mappedPtr() is now null-checked before pointer arithmetic, so a moved-from
  handle yields InvalidArgument instead of feeding nullptr + offset into a
  device-to-device memcpy. The check lives in buildCopyOps, so it cannot drift
  between put() and get().
- put()/get() de-duplicated into buildCopyOps(requests, Dir): they had shared the
  not-connected guard, empty short-circuit, size check, findRemoteHandle, and
  mappedPtr() + nvlinkOffset_ math, differing only in copy direction.
- Device id <-> bytes conversion centralized into encodeDeviceId/decodeDeviceId,
  replacing hand-rolled reinterpret_cast + copy_n at four sites (bind, connect,
  getTopology, canConnect). decodeDeviceId validates size AND rejects negative
  ids, which closes a real gap: canConnect previously passed an unvalidated
  negative peer id to deviceCanAccessPeer and surfaced an opaque DriverError
  instead of InvalidArgument.
- The all-XGMI gate moved out of MultiTransport into
  P2pTransportFactory::supported() (see component 4). This removes the
  duplicated gate at two MultiTransport call sites, each of which had been
  constructing its own CudaApi, and closes the over-reporting gap where the
  factory claimed support on a non-XGMI node.
- importSegment now guards offset + size against wraparound before the ownerPid
  branch. Note the limitation, documented inline: offset and size cannot be fully
  bounds-checked because ipcOpenMemHandle does not report the mapping size and
  p.base is the exporter's VA. These values arrive from a cooperating peer rank
  on the same node, not an untrusted source.
- Not taken: extracting the event-completion machinery
  (setValueNoThrow/drainAndFail/pollEventToCompletion) into a helper shared with
  NVLinkTransport. The two are not actually interchangeable -- NVLink fulfills
  promises via CHECK_SET_PROMISE with no noexcept guard and no drain-on-error,
  and has a memcpyBatchAsync fast path this transport lacks -- so a shared helper
  would either change NVIDIA production error semantics or need to preserve both.
  Deferred to the unified intra-node transport and recorded as an explicit
  TODO(D110509654) at the site.

Differential Revision: D110133969


