### PR TITLE
Fix ROCm/AMD (rcclx) build breakage in NvlMemExchange/MultimemHandler

### DIFF
--- a/comms/prims/memory/MultimemHandler.cc
+++ b/comms/prims/memory/MultimemHandler.cc
@@ -20,11 +20,13 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <unistd.h>
 
@@ -643,12 +645,25 @@ void MultimemHandler::agreeOnHandleType() {
 std::string MultimemHandler::describeState(
     const char* failedPhase,
     const char* completedPhase) const {
-  const CUmemGenericAllocationHandle localAllocHandle =
-      backing_ ? backing_->handle() : 0;
-  const CUmemGenericAllocationHandle multicastHandle =
-      overlay_ ? overlay_->handle() : 0;
-  const CUdeviceptr multicastPtr =
-      multicastMapping_ ? multicastMapping_->devicePtr() : 0;
+  // Capture the handle / pointer values as plain integers for logging. The
+  // driver typedefs are integer-valued on NVIDIA, but HIPify rewrites some of
+  // them to opaque `hip*` POINTER types on the AMD build (and does so
+  // inconsistently across the sibling allocation classes), so normalize each
+  // value to `unsigned long long` whether it comes back as an integer or a
+  // pointer.
+  const auto toU64 = [](auto handle) -> unsigned long long {
+    if constexpr (std::is_pointer_v<decltype(handle)>) {
+      return reinterpret_cast<std::uintptr_t>(handle);
+    } else {
+      return static_cast<unsigned long long>(handle);
+    }
+  };
+  const unsigned long long localAllocHandle =
+      backing_ ? toU64(backing_->handle()) : 0ULL;
+  const unsigned long long multicastHandle =
+      overlay_ ? toU64(overlay_->handle()) : 0ULL;
+  const unsigned long long multicastPtr =
+      multicastMapping_ ? toU64(multicastMapping_->devicePtr()) : 0ULL;
   return fmt::format(
       "MultimemHandler state: failedPhase={} completedPhase={} commRank={} "
       "nvlRank={} nvlRanks={} cudaDevice={} requestedSize={} allocatedSize={} "

--- a/comms/prims/memory/NvlMemExchange.h
+++ b/comms/prims/memory/NvlMemExchange.h
@@ -2,8 +2,18 @@
 
 #pragma once
 
+// `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD the
+// concrete VMM driver-API calls are unavailable and the impl bodies throw;
+// `CuMemAllocation.h` (included transitively via `CuMemMapping.h`) declares the
+// matching AMD stub typedefs for `CUdevice` / `CUmemGenericAllocationHandle` /
+// `CUdeviceptr`, and the `CUmemAllocationHandleType` stub below covers the one
+// type unique to this header. Mirrors CuMemAllocation.h / MultimemHandler.h.
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
 #include <cuda.h>
 #include <cuda_runtime.h>
+#endif
 
 #include <sys/types.h>
 #include <cstddef>
@@ -14,6 +24,15 @@
 #include "comms/prims/memory/CuMemMapping.h"
 
 namespace comms::prims {
+
+#if defined(__HIP_PLATFORM_AMD__)
+// Stub the one CUDA driver-API type unique to this header (the shared
+// `CUdevice` / `CUmemGenericAllocationHandle` stubs come from CuMemAllocation.h
+// via CuMemMapping.h). Concrete VMM/multicast driver-API calls are NVIDIA-only
+// and live behind `#if !defined(__HIP_PLATFORM_AMD__)` in the .cc. The real
+// CUDA type is an enum (int-backed), so an unsigned-int alias matches its ABI.
+using CUmemAllocationHandleType = unsigned int;
+#endif
 
 #if CUDART_VERSION >= 12030
 using FabricHandle = CUmemFabricHandle;


### PR DESCRIPTION
Summary:
Recent changes in the NvlMemExchange / MultimemHandler area broke the
rcclx (flagship_rocm) conda build. MultimemHandler is NVIDIA-only, but its
sources are still swept into the ROCm/hipify build, so the header/diagnostic
paths that are compiled on all platforms must stay AMD-clean. Three issues
were failing the AMD compile:

- NvlMemExchange.h included <cuda.h>/<cuda_runtime.h> unconditionally, so it
  failed with "cuda.h file not found" on the AMD toolchain. Guard the include
  behind __HIP_PLATFORM_AMD__ (falling back to <hip/hip_runtime.h>), mirroring
  the sibling headers (CuMemAllocation.h / CuMemMapping.h / MultimemHandler.h /
  GpuMemHandler.h). Also add the AMD stub for CUmemAllocationHandleType (the
  one driver-API type unique to this header; the CUdevice /
  CUmemGenericAllocationHandle / CUdeviceptr stubs already come from
  CuMemAllocation.h via CuMemMapping.h).

- MultimemHandler::describeState() used fmt::join without <fmt/ranges.h>
  ("no member named join in namespace fmt"). Add the include.

- describeState() declared its logging locals with the CU* driver typedefs.
  HIPify rewrites those to opaque hip* POINTER types on the AMD build, and does
  so inconsistently across the sibling allocation classes (one handle getter
  comes back as a pointer, the others as integers), so a plain cast to an
  integer was rejected. Normalize each handle/pointer value to unsigned long
  long via an if-constexpr helper that reinterpret_casts pointers and
  static_casts integers. No behavior change on NVIDIA (all integers).

Differential Revision: D110380727


