### PR TITLE
Consolidate MultiPeerTransport NVL exchange onto nvlMemExchange (#3038)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -143,7 +143,9 @@ ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -151,7 +151,9 @@ ifeq ($(ENABLE_PRIMS),1)
 LIBSRCFILES += ${BASE_DIR}/comms/prims/platform/CudaDriverLazy.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMemMapping.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc

--- a/comms/prims/memory/GpuMemHandler.cc
+++ b/comms/prims/memory/GpuMemHandler.cc
@@ -11,6 +11,8 @@
 #include <hip/hip_runtime.h>
 #else
 #include "comms/prims/platform/CudaDriverLazy.h"
+// The multicast overlay is NVIDIA-only; not composed on AMD.
+#include "comms/prims/memory/MultimemHandler.h"
 #endif
 
 #include "comms/prims/core/Checks.h"
@@ -182,6 +184,25 @@ MemSharingMode GpuMemHandler::detectBestMode() {
 #endif
 }
 
+bool GpuMemHandler::isMultimemSupported(int cudaDevice) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cudaDevice;
+  return false;
+#else
+  return MultimemHandler::isMultimemSupported(cudaDevice);
+#endif
+}
+
+std::size_t GpuMemHandler::backingGranularity(int cudaDevice, int nvlRanks) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+  (void)cudaDevice;
+  (void)nvlRanks;
+  return 0;
+#else
+  return MultimemHandler::backingGranularity(cudaDevice, nvlRanks);
+#endif
+}
+
 GpuMemHandler::GpuMemHandler(
     std::shared_ptr<meta::comms::IBootstrap> bootstrap,
     int32_t selfRank,
@@ -215,6 +236,11 @@ GpuMemHandler::GpuMemHandler(
 }
 
 GpuMemHandler::~GpuMemHandler() {
+#ifndef __HIP_PLATFORM_AMD__
+  // Tear down the multicast overlay (if any) before the unicast mapping and the
+  // shared physical allocation.
+  multimem_.reset();
+#endif
   if (isVmmMode()) {
     cleanupVmm();
   } else {
@@ -285,6 +311,81 @@ const cudaIpcMemHandle_t& GpuMemHandler::getLocalIpcHandle() const {
   }
   return cudaIpcLocalHandle_;
 }
+
+#ifndef __HIP_PLATFORM_AMD__
+void GpuMemHandler::exchangeMulticast(
+    int32_t commRank,
+    std::vector<int> nvlRankToCommRank,
+    int cudaDevice) {
+  // PRECONDITION: VMM allocation + unicast mapping must already exist (the
+  // constructor does this for kFabric/kPosixFd modes). The multicast object
+  // binds into this rank's physical handle and shares its VA with peers.
+  // Zeroing the backing before peers see it is the caller's responsibility —
+  // intentionally not done here so this method doesn't issue default-stream
+  // operations that could race with caller-managed compute streams.
+  if (!isVmmMode()) {
+    throw std::runtime_error(
+        "GpuMemHandler::exchangeMulticast requires a VMM handler mode "
+        "(kFabric or kPosixFd); cudaIpc has no physical handle to bind into "
+        "a multicast object");
+  }
+  if (!allocation_) {
+    throw std::runtime_error(
+        "GpuMemHandler::exchangeMulticast: VMM allocation is null "
+        "(allocation was never created or has been torn down)");
+  }
+
+  if (multimem_) {
+    // Re-entry must match the topology we already set up. Silently accepting
+    // a second call with different ranks/device would hide an incorrect setup
+    // and surface as a multicast collective desync at runtime.
+    if (commRank != multimemCommRank_ ||
+        nvlRankToCommRank != multimemNvlRankToCommRank_ ||
+        cudaDevice != multimemCudaDevice_) {
+      throw std::runtime_error(
+          "GpuMemHandler::exchangeMulticast: re-entered with different "
+          "(commRank, nvlRankToCommRank, cudaDevice) than the existing "
+          "multicast overlay; the overlay is bound to the first call's "
+          "topology");
+    }
+    return;
+  }
+
+  // Construct + exchange into a local unique_ptr first; only assign to
+  // multimem_ on success. Otherwise a failure in MultimemHandler::exchange()
+  // would leave multimem_ non-null but unexchanged, and the next call's
+  // `if (multimem_) { return; }` would silently no-op while
+  // getMultimemDeviceMemPtr() dereferenced an unexchanged overlay.
+  auto pending = std::make_unique<MultimemHandler>(
+      allocation_, bootstrap_, commRank, nvlRankToCommRank, cudaDevice);
+  pending->exchange();
+  multimem_ = std::move(pending);
+  multimemCommRank_ = commRank;
+  multimemNvlRankToCommRank_ = std::move(nvlRankToCommRank);
+  multimemCudaDevice_ = cudaDevice;
+}
+
+void* GpuMemHandler::getMultimemDeviceMemPtr() const {
+  if (!multimem_) {
+    throw std::runtime_error(
+        "GpuMemHandler: exchangeMulticast() must complete before using multimem ptr");
+  }
+  return multimem_->getMultimemDeviceMemPtr();
+}
+#else
+void GpuMemHandler::exchangeMulticast(
+    int32_t /*commRank*/,
+    std::vector<int> /*nvlRankToCommRank*/,
+    int /*cudaDevice*/) {
+  throw std::runtime_error(
+      "GpuMemHandler::exchangeMulticast: multicast is not supported on AMD");
+}
+
+void* GpuMemHandler::getMultimemDeviceMemPtr() const {
+  throw std::runtime_error(
+      "GpuMemHandler::getMultimemDeviceMemPtr: multicast is not supported on AMD");
+}
+#endif
 
 // ============================================================================
 // VMM Mode Implementation (kFabric / kPosixFd)

--- a/comms/prims/memory/GpuMemHandler.h
+++ b/comms/prims/memory/GpuMemHandler.h
@@ -29,6 +29,11 @@
 
 namespace comms::prims {
 
+// Forward-declared so GpuMemHandler.h stays lean for its many users; the
+// composed multicast overlay is an implementation detail (out-of-line dtor in
+// the .cc, which includes MultimemHandler.h).
+class MultimemHandler;
+
 /**
  * Memory sharing mode - determines which IPC mechanism to use.
  */
@@ -213,6 +218,40 @@ class GpuMemHandler {
   }
 
   /**
+   * Adds an NVSwitch multicast overlay over this handler's physical allocation.
+   *
+   * COLLECTIVE OPERATION over the NVLink-domain team described by
+   * `nvlRankToCommRank`. Creates a multicast object, binds this rank's physical
+   * allocation into it, and maps the multicast VA. After this call,
+   * getMultimemDeviceMemPtr() returns a pointer usable with `multimem.*`
+   * instructions, while getLocalDeviceMemPtr() continues to return the unicast
+   * VA onto the same physical backing.
+   *
+   * Zeroing the local backing before peers read through the multicast VA is the
+   * CALLER'S responsibility. This method intentionally issues no default-stream
+   * operations (no implicit `cudaMemset` / `cudaStreamSynchronize`) so it can't
+   * race with caller-managed compute streams; instead, the caller should
+   * `cudaMemsetAsync` the backing on the same stream it will use for the
+   * subsequent collective and synchronize there.
+   *
+   * The allocation must have been sized to backingGranularity() (pass it as the
+   * constructor's `alignFloor`). Throws in cudaIpc mode (no VMM handle).
+   *
+   * @param commRank This process's rank in the global communicator
+   * @param nvlRankToCommRank Maps each NVLink-local rank to its global rank
+   * @param cudaDevice CUDA device ordinal (already current)
+   */
+  void exchangeMulticast(
+      int32_t commRank,
+      std::vector<int> nvlRankToCommRank,
+      int cudaDevice);
+
+  /**
+   * Returns this rank's multicast VA. PRECONDITION: exchangeMulticast() done.
+   */
+  void* getMultimemDeviceMemPtr() const;
+
+  /**
    * Check if the current GPU supports fabric handles.
    *
    * @return true if Hopper+ GPU with CUDA 12.3+ and fabric support enabled
@@ -223,6 +262,20 @@ class GpuMemHandler {
    * Get the best available sharing mode for the current system.
    */
   static MemSharingMode detectBestMode();
+
+  /**
+   * Returns whether multicast/multimem is supported on `cudaDevice`. Delegates
+   * to MultimemHandler::isMultimemSupported.
+   */
+  static bool isMultimemSupported(int cudaDevice);
+
+  /**
+   * Returns the allocation alignment/size floor (alignFloor) required for a
+   * physical allocation to be bindable into a multicast object for a team of
+   * `nvlRanks` devices on `cudaDevice`. Delegates to
+   * MultimemHandler::backingGranularity. Returns 0 if multimem is unsupported.
+   */
+  static std::size_t backingGranularity(int cudaDevice, int nvlRanks);
 
  private:
   void init(size_t size, std::size_t alignFloor);
@@ -266,6 +319,17 @@ class GpuMemHandler {
   // exchangeMemPtrs(). For VMM modes the peer mappings co-own their imported
   // allocations; for cudaIpc only the peer pointers (owned by the IPC runtime).
   NvlPeerMem peers_;
+#ifndef __HIP_PLATFORM_AMD__
+  // Optional NVSwitch multicast overlay over allocation_, created lazily by
+  // exchangeMulticast(). NVIDIA-only; forward-declared, destroyed via the
+  // out-of-line dtor (which includes MultimemHandler.h).
+  std::unique_ptr<MultimemHandler> multimem_;
+  // Topology args recorded by the first successful exchangeMulticast() so a
+  // re-entry with mismatched args can be rejected instead of silently no-op'd.
+  int32_t multimemCommRank_{-1};
+  std::vector<int> multimemNvlRankToCommRank_;
+  int multimemCudaDevice_{-1};
+#endif
 
   // ---- CudaIpc mode state ----
   void* cudaIpcLocalPtr_{nullptr};

--- a/comms/prims/tests/GpuMemHandlerMulticastTest.cc
+++ b/comms/prims/tests/GpuMemHandlerMulticastTest.cc
@@ -1,0 +1,447 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Exercises GpuMemHandler::exchangeMulticast() boundary semantics over a real
+// NVL-domain bootstrap on a GPU host:
+//
+//   - Happy path on the auto-selected VMM mode (fabric on GB200-class hosts,
+//     POSIX FD on H100) and on the explicit kPosixFd mode, confirming that the
+//     pointer is non-null + stable across a matching re-entry.
+//   - Failed-exchange retry must not become a silent success: if the first
+//     exchangeMulticast throws, multimem_ stays null and a follow-up call must
+//     actually re-attempt (not hit the if-multimem_-return early-exit).
+//   - Re-entry with mismatched (commRank, nvlRankToCommRank, cudaDevice) must
+//     throw deterministically with a "re-entered with different" message rather
+//     than silently rebinding the existing overlay to a new topology.
+//
+// The AMD non-NVIDIA stubs (`exchangeMulticast` / `getMultimemDeviceMemPtr`
+// throwing "not supported on AMD") are verified by code inspection plus the
+// existing AMD conda CI compile run; they cannot easily be exercised here
+// because this target is `disable_amd_ci = True` (the rest of the GPU multicast
+// surface is NVIDIA-only).
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/memory/MultimemHandler.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims::tests {
+
+namespace {
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+// Mirrors the gate used by MultimemHandlerTest: if any rank reports the device
+// can't host a multimem object, skip on every rank. Avoids partial-team setup
+// where some ranks would throw inside exchange().
+bool allRanksMultimemSupported(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> supported(static_cast<std::size_t>(nRanks));
+  supported[static_cast<std::size_t>(rank)] =
+      MultimemHandler::isMultimemSupported(cudaDevice) ? 1 : 0;
+  auto rc =
+      bootstrap->allGather(supported.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(rc, 0);
+  if (rc != 0) {
+    return false;
+  }
+  for (const auto value : supported) {
+    if (value == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Picks the strongest VMM-capable sharing mode for the multicast tests:
+// kFabric on GB200 (and on H100 with IMEX), kPosixFd on H100 NVLS without
+// IMEX. Returns std::nullopt when detectBestMode() can only offer kCudaIpc;
+// cudaIpc has no physical handle for a multicast object to bind into, so the
+// test must skip in that case. Centralizing this avoids hardcoding kFabric
+// (which would fail on H100 NVLS) at every test site.
+std::optional<MemSharingMode> bestVmmModeForMulticast() {
+  const MemSharingMode mode = GpuMemHandler::detectBestMode();
+  if (mode == MemSharingMode::kFabric || mode == MemSharingMode::kPosixFd) {
+    return mode;
+  }
+  return std::nullopt;
+}
+
+// alignFloor for the constructor's VMM allocation must satisfy
+// max(local granularity, multicast granularity); MultimemHandler exposes that
+// via backingGranularity(). Falls back to 4096 only on the unsupported path,
+// which we never reach (the test skips first).
+std::size_t multicastBackingSize(int cudaDevice, int nvlRanks) {
+  const std::size_t gran =
+      MultimemHandler::backingGranularity(cudaDevice, nvlRanks);
+  return gran ? gran : 4096;
+}
+
+using meta::comms::testing::MockBootstrap;
+using StrictMockBootstrap = ::testing::StrictMock<MockBootstrap>;
+
+// Builds a StrictMock that, by default, forwards every IBootstrap API to
+// `real`. Tests override individual call ordinals via EXPECT_CALL to inject
+// failures without losing the default delegation. Same pattern as
+// MultimemHandlerTest's `makeDelegatingMock`.
+std::shared_ptr<StrictMockBootstrap> makeDelegatingMock(
+    const std::shared_ptr<meta::comms::IBootstrap>& real) {
+  using ::testing::_;
+  auto mock = std::make_shared<StrictMockBootstrap>();
+  ON_CALL(*mock, allGather(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int rank, int nRanks) {
+        return real->allGather(buf, len, rank, nRanks);
+      });
+  ON_CALL(*mock, barrier(_, _)).WillByDefault([real](int rank, int nRanks) {
+    return real->barrier(rank, nRanks);
+  });
+  ON_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+      .WillByDefault(
+          [real](void* buf, int len, int r, int n, const std::vector<int>& m) {
+            return real->allGatherNvlDomain(buf, len, r, n, m);
+          });
+  ON_CALL(*mock, barrierNvlDomain(_, _, _))
+      .WillByDefault([real](int r, int n, const std::vector<int>& m) {
+        return real->barrierNvlDomain(r, n, m);
+      });
+  ON_CALL(*mock, send(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->send(buf, len, peer, tag);
+      });
+  ON_CALL(*mock, recv(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->recv(buf, len, peer, tag);
+      });
+  return mock;
+}
+
+} // namespace
+
+class GpuMemHandlerMulticastTestFixture : public ::testing::Test,
+                                          public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+// Happy path on the auto-selected VMM mode. detectBestMode picks kFabric when
+// the driver + IMEX support fabric (GB200-class), otherwise kPosixFd (H100
+// single-host NVLS). Either route drives exchangeMulticast through the same
+// MultimemHandler integration, exercising the local pending->multimem_
+// commit-on-success path. We also verify pointer stability on a matching
+// re-entry (the early `if (multimem_) return` branch must not invalidate the
+// previously-vended pointer).
+TEST_F(GpuMemHandlerMulticastTestFixture, ExchangeMulticastHappyPathAutoMode) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto bootstrap = makeBootstrap("gpumem_multicast_happy_auto");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      bootstrap,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  EXPECT_THROW(handler.getMultimemDeviceMemPtr(), std::runtime_error);
+
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+  auto* mcPtr = handler.getMultimemDeviceMemPtr();
+  EXPECT_NE(mcPtr, nullptr);
+
+  // Matching re-entry: must hit the early `if (multimem_) return` and leave
+  // the existing overlay's pointer intact (no rebind, no throw).
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+  EXPECT_EQ(mcPtr, handler.getMultimemDeviceMemPtr());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// A failed exchangeMulticast must NOT make subsequent calls a silent no-op.
+//
+// The V1.6 fix in GpuMemHandler::exchangeMulticast constructs into a local
+// `pending` unique_ptr, calls pending->exchange(), then assigns multimem_ only
+// on success. The expected behavior chain:
+//   1. First call: inject a failure into the NVL-domain bootstrap → throws.
+//   2. multimem_ is still null (the local pending was destroyed by the throw).
+//   3. Second call: must construct a new pending, retry exchange(), and on
+//      success produce a valid pointer. It must NOT hit `if (multimem_) return`
+//      because that branch is reserved for previously-successful exchanges.
+//
+// Failure injection point: agreeOnHandleType (the first allGatherNvlDomain
+// inside MultimemHandler::exchange()) returns -1. exchangeMemPtrs() runs first
+// and only uses the non-NVL-domain `allGather` / `barrier` APIs, so the
+// injection does not corrupt the pre-multicast setup.
+TEST_F(
+    GpuMemHandlerMulticastTestFixture,
+    ExchangeMulticastFailedRetryIsNotSilentSuccess) {
+  using ::testing::_;
+  using ::testing::AnyNumber;
+  using ::testing::InSequence;
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto real = makeBootstrap("gpumem_multicast_failed_retry");
+  if (!allRanksMultimemSupported(real, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  auto mock = makeDelegatingMock(real);
+
+  // Drive the first NVL-domain allGather of the first exchangeMulticast call
+  // to fail with -1; every subsequent NVL-domain allGather delegates to `real`
+  // so the retry can succeed. barrierNvlDomain is allowed AnyNumber of times
+  // (always delegating); StrictMock would otherwise flag any incidental call
+  // as an uninteresting expectation.
+  {
+    InSequence s;
+    EXPECT_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+        .WillOnce([](void*, int, int, int, const std::vector<int>&) {
+          return folly::makeSemiFuture(-1);
+        });
+    EXPECT_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+        .Times(AnyNumber())
+        .WillRepeatedly(
+            [real](void* b, int l, int r, int n, const std::vector<int>& m) {
+              return real->allGatherNvlDomain(b, l, r, n, m);
+            });
+  }
+  EXPECT_CALL(*mock, barrierNvlDomain(_, _, _))
+      .Times(AnyNumber())
+      .WillRepeatedly([real](int r, int n, const std::vector<int>& m) {
+        return real->barrierNvlDomain(r, n, m);
+      });
+  // GpuMemHandler::exchangeMemPtrs (which runs before exchangeMulticast) uses
+  // the non-NVL-domain `allGather` and `barrier` APIs via NvlMemExchange. With
+  // StrictMock, ON_CALL alone does NOT authorize unexpected calls -- we need
+  // explicit EXPECT_CALL with AnyNumber so the pre-multicast setup doesn't
+  // trip the uninteresting-call check.
+  EXPECT_CALL(*mock, allGather(_, _, _, _))
+      .Times(AnyNumber())
+      .WillRepeatedly([real](void* buf, int len, int rank, int nRanks) {
+        return real->allGather(buf, len, rank, nRanks);
+      });
+  EXPECT_CALL(*mock, barrier(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(
+          [real](int rank, int nRanks) { return real->barrier(rank, nRanks); });
+
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      mock,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  EXPECT_THROW(
+      handler.exchangeMulticast(
+          globalRank, identityRankMap(numRanks), localRank),
+      std::runtime_error);
+  // Pointer must still throw - the failed exchange must not vend a stale ptr.
+  EXPECT_THROW(handler.getMultimemDeviceMemPtr(), std::runtime_error);
+
+  // Retry: must actually re-attempt, not silently return success. A non-null
+  // pointer here is the proof that the early `if (multimem_) return` branch
+  // was NOT hit (multimem_ was left null by the failed first attempt).
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+  EXPECT_NE(handler.getMultimemDeviceMemPtr(), nullptr);
+
+  ASSERT_EQ(real->barrier(globalRank, numRanks).get(), 0);
+}
+
+// After a successful exchangeMulticast, re-entry with a different commRank
+// must throw rather than silently no-op. Without the V1.6 mismatch check the
+// second call would just hit `if (multimem_) return` and the caller would
+// think they had bound the multicast object to a different topology.
+TEST_F(
+    GpuMemHandlerMulticastTestFixture,
+    ExchangeMulticastMismatchedReentryCommRankThrows) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto bootstrap = makeBootstrap("gpumem_multicast_mismatch_commrank");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      bootstrap,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+  try {
+    // The intra-rank validation runs BEFORE any bootstrap call, so passing a
+    // commRank not in the original team is observable locally without
+    // requiring cooperating peers to also call.
+    handler.exchangeMulticast(
+        /*commRank=*/globalRank + numRanks,
+        identityRankMap(numRanks),
+        localRank);
+    FAIL() << "expected std::runtime_error on commRank mismatch";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("re-entered with different"),
+        std::string::npos)
+        << ex.what();
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    GpuMemHandlerMulticastTestFixture,
+    ExchangeMulticastMismatchedReentryRankMapThrows) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto bootstrap = makeBootstrap("gpumem_multicast_mismatch_rankmap");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      bootstrap,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+
+  // Append an extra rank id to make the second map differ from the first.
+  // Local-only check, no bootstrap traffic.
+  std::vector<int> altMap = identityRankMap(numRanks);
+  altMap.push_back(numRanks);
+  try {
+    handler.exchangeMulticast(globalRank, altMap, localRank);
+    FAIL() << "expected std::runtime_error on nvlRankToCommRank mismatch";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("re-entered with different"),
+        std::string::npos)
+        << ex.what();
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+TEST_F(
+    GpuMemHandlerMulticastTestFixture,
+    ExchangeMulticastMismatchedReentryCudaDeviceThrows) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "multimem requires >=3 NVL ranks";
+  }
+  auto bootstrap = makeBootstrap("gpumem_multicast_mismatch_cudadev");
+  if (!allRanksMultimemSupported(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "multimem unsupported on this host";
+  }
+  const auto modeOpt = bestVmmModeForMulticast();
+  if (!modeOpt) {
+    GTEST_SKIP() << "multicast requires VMM mode (kFabric/kPosixFd); "
+                    "detectBestMode returned kCudaIpc";
+  }
+  const std::size_t allocSize = multicastBackingSize(localRank, numRanks);
+  GpuMemHandler handler(
+      bootstrap,
+      globalRank,
+      numRanks,
+      allocSize,
+      *modeOpt,
+      /*alignFloor=*/allocSize);
+  handler.exchangeMemPtrs();
+
+  handler.exchangeMulticast(globalRank, identityRankMap(numRanks), localRank);
+  try {
+    // -1 is guaranteed != localRank for every valid CUDA device ordinal; the
+    // local mismatch check fires before any device touch.
+    handler.exchangeMulticast(
+        globalRank, identityRankMap(numRanks), /*cudaDevice=*/-1);
+    FAIL() << "expected std::runtime_error on cudaDevice mismatch";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("re-entered with different"),
+        std::string::npos)
+        << ex.what();
+  }
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  folly::Init init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/MultiPeerTransportTest.cc
+++ b/comms/prims/tests/MultiPeerTransportTest.cc
@@ -270,7 +270,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferCudaMalloc) {
 
   MPI_Barrier(MPI_COMM_WORLD);
 
-  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, nbytes);
+  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
   verifyMappedPtrs(*transport, mappedPtrs, localBuf);
 
   transport->unmapNvlBuffers(mappedPtrs);
@@ -305,7 +305,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferMultipleRoundTrips) {
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, nbytes);
+    auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
     EXPECT_EQ(static_cast<int>(mappedPtrs.size()), transport->nvl_n_ranks());
     for (int rank = 0; rank < transport->nvl_n_ranks(); ++rank) {
       EXPECT_NE(mappedPtrs[rank], nullptr);
@@ -383,7 +383,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferFabric) {
 
   MPI_Barrier(MPI_COMM_WORLD);
 
-  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, requestedSize);
+  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
   verifyMappedPtrs(*transport, mappedPtrs, localBuf);
 
   transport->unmapNvlBuffers(mappedPtrs);
@@ -462,7 +462,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferPosixFd) {
 
   MPI_Barrier(MPI_COMM_WORLD);
 
-  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, requestedSize);
+  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
   verifyMappedPtrs(*transport, mappedPtrs, localBuf);
 
   transport->unmapNvlBuffers(mappedPtrs);
@@ -541,7 +541,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferPosixFd_MultipleRounds) {
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, requestedSize);
+    auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
     ASSERT_EQ(static_cast<int>(mappedPtrs.size()), transport->nvl_n_ranks());
     for (int rank = 0; rank < transport->nvl_n_ranks(); ++rank) {
       EXPECT_NE(mappedPtrs[rank], nullptr);
@@ -610,9 +610,7 @@ TEST_F(MultiPeerTransportTestFixture, ExchangeNvlBufferCuMemNone_Throws) {
 
   void* localBuf = reinterpret_cast<void*>(devPtr);
 
-  EXPECT_THROW(
-      transport->exchangeNvlBuffer(localBuf, requestedSize),
-      std::runtime_error);
+  EXPECT_THROW(transport->exchangeNvlBuffer(localBuf), std::runtime_error);
 
   cuMemUnmap(devPtr, allocSize);
   cuMemAddressFree(devPtr, allocSize);
@@ -701,7 +699,7 @@ TEST_F(MultiPeerTransportTestFixture, DisableIb_NvlBufferExchange) {
 
   MPI_Barrier(MPI_COMM_WORLD);
 
-  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf, nbytes);
+  auto mappedPtrs = transport->exchangeNvlBuffer(localBuf);
   verifyMappedPtrs(*transport, mappedPtrs, localBuf);
 
   transport->unmapNvlBuffers(mappedPtrs);

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -1,0 +1,641 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <folly/futures/Future.h>
+#include <folly/init/Init.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/common/bootstrap/tests/MockBootstrap.h"
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/memory/MultimemHandler.h"
+#include "comms/prims/tests/MultimemNvlTransportTest.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransport.h"
+#include "comms/testinfra/DistEnvironmentBase.h"
+#include "comms/testinfra/DistTestBase.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+
+namespace comms::prims::tests {
+
+namespace {
+
+std::shared_ptr<meta::comms::IBootstrap> makeBootstrap(
+    const std::string& prefix) {
+  return std::shared_ptr<meta::comms::IBootstrap>(
+      meta::comms::createBootstrap(prefix));
+}
+
+std::vector<int> identityRankMap(int size) {
+  std::vector<int> rankMap(static_cast<std::size_t>(size));
+  for (int rank = 0; rank < size; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+// Collective check: returns true iff every rank reports that multimem is
+// eligible on the given CUDA device. Tests use this to skip cleanly on
+// non-NVLS hosts without leaving stragglers blocked in downstream collectives.
+bool allRanksMultimemEligible(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int rank,
+    int nRanks,
+    int cudaDevice) {
+  std::vector<int> eligible(static_cast<std::size_t>(nRanks));
+  eligible[static_cast<std::size_t>(rank)] =
+      MultimemNvlTransport::isEligible(nRanks, cudaDevice) ? 1 : 0;
+  auto rc =
+      bootstrap->allGather(eligible.data(), sizeof(int), rank, nRanks).get();
+  EXPECT_EQ(rc, 0);
+  if (rc != 0) {
+    return false;
+  }
+  for (const int v : eligible) {
+    if (v == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+MultimemNvlTransportConfig makeConfig(
+    std::size_t dataBufferSize,
+    uint32_t userSignalCount = 1,
+    uint32_t internalSignalCount = 0) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = dataBufferSize;
+  config.userSignalCount = userSignalCount;
+  config.internalSignalCount = internalSignalCount;
+  return config;
+}
+
+using meta::comms::testing::MockBootstrap;
+using StrictMockBootstrap = ::testing::StrictMock<MockBootstrap>;
+
+// Builds a StrictMockBootstrap that, by default, forwards every IBootstrap
+// API to `real`. Individual tests override specific methods via EXPECT_CALL
+// to inject failures. StrictMock ensures that if MultimemNvlTransport (or
+// its GpuMemHandler/MultimemHandler) ever grows a new bootstrap dependency
+// we didn't account for, the test fails immediately with an "uninteresting
+// mock function call" error -- locking down the bootstrap API surface.
+std::shared_ptr<StrictMockBootstrap> makeDelegatingMock(
+    const std::shared_ptr<meta::comms::IBootstrap>& real) {
+  using ::testing::_;
+
+  auto mock = std::make_shared<StrictMockBootstrap>();
+
+  ON_CALL(*mock, allGather(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int rank, int nRanks) {
+        return real->allGather(buf, len, rank, nRanks);
+      });
+  ON_CALL(*mock, barrier(_, _)).WillByDefault([real](int rank, int nRanks) {
+    return real->barrier(rank, nRanks);
+  });
+  ON_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+      .WillByDefault([real](
+                         void* buf,
+                         int len,
+                         int r,
+                         int n,
+                         const std::vector<int>& rankMap) {
+        return real->allGatherNvlDomain(buf, len, r, n, rankMap);
+      });
+  ON_CALL(*mock, barrierNvlDomain(_, _, _))
+      .WillByDefault([real](int r, int n, const std::vector<int>& rankMap) {
+        return real->barrierNvlDomain(r, n, rankMap);
+      });
+  ON_CALL(*mock, send(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->send(buf, len, peer, tag);
+      });
+  ON_CALL(*mock, recv(_, _, _, _))
+      .WillByDefault([real](void* buf, int len, int peer, int tag) {
+        return real->recv(buf, len, peer, tag);
+      });
+
+  return mock;
+}
+
+} // namespace
+
+class MultimemNvlTransportTestFixture : public ::testing::Test,
+                                        public meta::comms::DistBaseTest {
+ protected:
+  void SetUp() override {
+    distSetUp();
+    CUDACHECK_TEST(cudaSetDevice(localRank));
+  }
+
+  void TearDown() override {
+    distTearDown();
+  }
+};
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    EligibilityRequiresSupportAndThreeRanks) {
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(1, localRank));
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(2, localRank));
+  EXPECT_EQ(
+      MultimemNvlTransport::isEligible(3, localRank),
+      MultimemHandler::isMultimemSupported(localRank));
+}
+
+// getDeviceTransport() must refuse to vend a handle before exchange() has
+// installed the multicast overlay. Tested per-rank (no bootstrap needed for
+// the throw path, so this runs even on hosts without NVLS).
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    GetDeviceTransportThrowsBeforeExchange) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_get_device_before_exchange");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(/*dataBufferSize=*/4096));
+  EXPECT_THROW((void)transport.getDeviceTransport(), std::runtime_error);
+}
+
+// Happy-path exchange() from the primary (global-bootstrap +
+// nvlRankToCommRank) constructor. Locks down the device handle shape:
+// non-null local/multimem base pointers, distinct pointers, dataBufferSize
+// echoed through, and user + internal signal spans sized to the requested
+// slot counts. Also verifies the multimem pointer is stable across
+// exchange() calls (idempotency) and that the two getAllocated* accessors
+// report the configured / SignalState-aligned sizes.
+TEST_F(MultimemNvlTransportTestFixture, ExchangeSetsUpDeviceHandle) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_exchange_happy_path");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kDataBytes = 8192;
+  constexpr uint32_t kUserSignals = 2;
+  constexpr uint32_t kInternalSignals = 3;
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(kDataBytes, kUserSignals, kInternalSignals));
+
+  transport.exchange();
+  auto handle = transport.getDeviceTransport();
+
+  EXPECT_NE(handle.localData, nullptr);
+  EXPECT_NE(handle.multimemData, nullptr);
+  EXPECT_NE(handle.localData, handle.multimemData)
+      << "unicast and multicast VAs should be distinct";
+  EXPECT_EQ(handle.dataBufferSize, kDataBytes);
+  EXPECT_EQ(handle.userLocalSignals.size(), kUserSignals);
+  EXPECT_EQ(handle.userMultimemSignals.size(), kUserSignals);
+  EXPECT_EQ(handle.internalLocalSignals.size(), kInternalSignals);
+  EXPECT_EQ(handle.internalMultimemSignals.size(), kInternalSignals);
+
+  EXPECT_EQ(transport.getAllocatedDataBufferSize(), kDataBytes);
+  EXPECT_EQ(
+      transport.getAllocatedSignalBufferSize(),
+      getSignalBufferSize(static_cast<int>(kUserSignals + kInternalSignals)));
+
+  // Idempotency: a second exchange() must be a no-op.
+  auto* firstMultimemBase = handle.multimemData;
+  transport.exchange();
+  auto handle2 = transport.getDeviceTransport();
+  EXPECT_EQ(handle2.multimemData, firstMultimemBase);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// The user and internal signal spans must be disjoint contiguous regions,
+// with the internal region starting immediately after the user region on
+// both the local and the multimem sides. This is what lets the transport
+// reserve internal slots for its own protocols without leaking into the
+// user-visible SignalState indices.
+TEST_F(MultimemNvlTransportTestFixture, UserAndInternalSignalSpansAreDisjoint) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_signal_span_layout");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr uint32_t kUserSignals = 4;
+  constexpr uint32_t kInternalSignals = 2;
+
+  MultimemNvlTransport transport(
+      bootstrap,
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(/*dataBufferSize=*/4096, kUserSignals, kInternalSignals));
+  transport.exchange();
+  auto handle = transport.getDeviceTransport();
+
+  // Internal region starts at userSignalCount elements past the user base,
+  // on both mirrors.
+  EXPECT_EQ(
+      handle.internalLocalSignals.data(),
+      handle.userLocalSignals.data() + kUserSignals);
+  EXPECT_EQ(
+      handle.internalMultimemSignals.data(),
+      handle.userMultimemSignals.data() + kUserSignals);
+
+  // User and internal regions do not overlap on either mirror.
+  EXPECT_LE(
+      handle.userLocalSignals.data() + handle.userLocalSignals.size(),
+      handle.internalLocalSignals.data());
+  EXPECT_LE(
+      handle.userMultimemSignals.data() + handle.userMultimemSignals.size(),
+      handle.internalMultimemSignals.data());
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// The compat constructor must also drive a real exchange to completion.
+// Uses NVL-local (rank, size) coordinates against the same underlying NVL
+// team.
+TEST_F(MultimemNvlTransportTestFixture, CompatCtorExchangeSucceeds) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_compat_ctor_exchange");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultimemNvlTransport transport(
+      /*nvlRank=*/globalRank,
+      /*nvlRanks=*/numRanks,
+      bootstrap,
+      makeConfig(/*dataBufferSize=*/4096));
+  ASSERT_NO_THROW(transport.exchange());
+  auto handle = transport.getDeviceTransport();
+  EXPECT_NE(handle.localData, nullptr);
+  EXPECT_NE(handle.multimemData, nullptr);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// Poison-on-failure: inject a bootstrap failure symmetrically on every rank
+// via a delegating StrictMock, verify exchange() throws, and verify a
+// second exchange() on the same object also throws (the poisoned-object
+// contract). The recovery path -- constructing a fresh MultimemNvlTransport
+// and exchange()-ing successfully -- is proven in ExchangeSetsUpDeviceHandle
+// (fresh transport per test) and by the underlying MultimemHandler failure
+// tests, so we intentionally do not repeat the fresh-object recovery here.
+TEST_F(MultimemNvlTransportTestFixture, ExchangePoisonsAfterFailure) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto real = makeBootstrap("mmnvl_exchange_poison");
+  if (!allRanksMultimemEligible(real, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  using ::testing::_;
+  using ::testing::AnyNumber;
+  auto mock = makeDelegatingMock(real);
+  // Inject failure on the very first NVL-domain allGather (agreeOnHandleType
+  // inside MultimemHandler::exchange). Every rank throws symmetrically so
+  // there's no need to shorten the store timeout.
+  EXPECT_CALL(*mock, allGatherNvlDomain(_, _, _, _, _))
+      .WillOnce([](void*, int, int, int, const std::vector<int>&) {
+        return folly::makeSemiFuture(-1);
+      });
+  EXPECT_CALL(*mock, barrierNvlDomain(_, _, _)).Times(AnyNumber());
+
+  MultimemNvlTransport transport(
+      std::shared_ptr<meta::comms::IBootstrap>(mock),
+      globalRank,
+      identityRankMap(numRanks),
+      makeConfig(/*dataBufferSize=*/4096));
+
+  EXPECT_THROW(transport.exchange(), std::runtime_error);
+
+  // Second call must throw the poisoned-object error without touching the
+  // bootstrap. The StrictMock has no further EXPECT_CALL, so any recovered
+  // bootstrap call would fail the test.
+  try {
+    transport.exchange();
+    FAIL() << "expected poisoned transport to throw on second exchange()";
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(
+        std::string(ex.what()).find("previous exchange() failed"),
+        std::string::npos)
+        << ex.what();
+  }
+
+  // getDeviceTransport must also refuse: the transport was never marked
+  // exchanged.
+  EXPECT_THROW((void)transport.getDeviceTransport(), std::runtime_error);
+
+  ASSERT_EQ(real->barrier(globalRank, numRanks).get(), 0);
+}
+
+// -----------------------------------------------------------------------------
+// Device signal API tests
+// -----------------------------------------------------------------------------
+// These tests launch the kernels declared in MultimemNvlTransportTest.cuh
+// against a fully-exchanged transport. Each verifies one behavior of the
+// device signal API end-to-end: multimem PTX store propagation, multimem
+// atomic-add accumulation, user/internal span isolation, wait_until, and
+// read_signal / read_internal_signal.
+
+namespace {
+
+// Device buffer for a single uint64_t output slot. Reset to a distinctive
+// sentinel between tests so a missing kernel write is obvious.
+struct DeviceUint64Slot {
+  DeviceUint64Slot() {
+    CUDACHECK_TEST(cudaMalloc(&ptr_, sizeof(uint64_t)));
+    reset(kSentinel);
+  }
+  ~DeviceUint64Slot() {
+    if (ptr_) {
+      (void)cudaFree(ptr_);
+    }
+  }
+  DeviceUint64Slot(const DeviceUint64Slot&) = delete;
+  DeviceUint64Slot& operator=(const DeviceUint64Slot&) = delete;
+  DeviceUint64Slot(DeviceUint64Slot&&) = delete;
+  DeviceUint64Slot& operator=(DeviceUint64Slot&&) = delete;
+
+  void reset(uint64_t v) {
+    CUDACHECK_TEST(
+        cudaMemcpy(ptr_, &v, sizeof(uint64_t), cudaMemcpyHostToDevice));
+  }
+  uint64_t read() const {
+    uint64_t v = 0;
+    CUDACHECK_TEST(
+        cudaMemcpy(&v, ptr_, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+    return v;
+  }
+  uint64_t* device_ptr() {
+    return ptr_;
+  }
+
+  static constexpr uint64_t kSentinel = 0xDEADBEEFCAFEBABEULL;
+
+ private:
+  uint64_t* ptr_{nullptr};
+};
+
+// Convenience: construct + exchange a transport with the given signal
+// counts. Skips the caller test if the NVL team isn't multimem-eligible.
+std::unique_ptr<MultimemNvlTransport> makeExchangedTransport(
+    const std::shared_ptr<meta::comms::IBootstrap>& bootstrap,
+    int globalRank,
+    int numRanks,
+    int localRank,
+    uint32_t userSignalCount,
+    uint32_t internalSignalCount) {
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    return nullptr;
+  }
+  auto config = makeConfig(
+      /*dataBufferSize=*/4096, userSignalCount, internalSignalCount);
+  auto transport = std::make_unique<MultimemNvlTransport>(
+      bootstrap, globalRank, identityRankMap(numRanks), config);
+  transport->exchange();
+  return transport;
+}
+
+} // namespace
+
+// signal(SET) from rank 0 must broadcast a value to every rank's local
+// signal state; every rank observes it through wait_signal_until +
+// read_signal.
+TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalSetBroadcasts) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_user_signal_set");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/0);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr uint64_t kSignalValue = 0xA5A50000ULL + 42;
+  auto handle = transport->getDeviceTransport();
+
+  if (globalRank == 0) {
+    test::launchSetUserSignal(handle, /*signalId=*/0, kSignalValue);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  DeviceUint64Slot out;
+  test::launchWaitAndReadUserSignal(
+      handle, /*signalId=*/0, CmpOp::CMP_EQ, kSignalValue, out.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  EXPECT_EQ(out.read(), kSignalValue);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// signal(ADD) from every rank must accumulate atomically through the
+// multimem VA. Every rank waits until the sum arrives, then reads it.
+TEST_F(MultimemNvlTransportTestFixture, DeviceUserSignalAddAccumulates) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_user_signal_add");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/0);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const uint64_t expected = static_cast<uint64_t>(numRanks);
+  auto handle = transport->getDeviceTransport();
+
+  test::launchAddUserSignal(handle, /*signalId=*/0, /*value=*/1);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceUint64Slot out;
+  test::launchWaitAndReadUserSignal(
+      handle, /*signalId=*/0, CmpOp::CMP_GE, expected, out.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  EXPECT_EQ(out.read(), expected);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// signal_internal(SET) from rank 0 must reach every rank's internal span
+// via wait_internal_signal_until + read_internal_signal, exercising the
+// internal-signal path independently of the user path.
+TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalSetBroadcasts) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_internal_signal_set");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/1);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr uint64_t kValue = 0xC0DECAFE00000010ULL;
+  auto handle = transport->getDeviceTransport();
+
+  if (globalRank == 0) {
+    test::launchSetInternalSignal(handle, /*signalId=*/0, kValue);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  DeviceUint64Slot out;
+  test::launchWaitAndReadInternalSignal(
+      handle, /*signalId=*/0, CmpOp::CMP_EQ, kValue, out.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  EXPECT_EQ(out.read(), kValue);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// signal_internal(ADD) accumulates on the internal span, disjoint from
+// whatever the user span may be doing.
+TEST_F(MultimemNvlTransportTestFixture, DeviceInternalSignalAddAccumulates) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_internal_signal_add");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/1);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  const uint64_t expected = static_cast<uint64_t>(numRanks);
+  auto handle = transport->getDeviceTransport();
+
+  test::launchAddInternalSignal(handle, /*signalId=*/0, /*value=*/1);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceUint64Slot out;
+  test::launchWaitAndReadInternalSignal(
+      handle, /*signalId=*/0, CmpOp::CMP_GE, expected, out.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  EXPECT_EQ(out.read(), expected);
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+// User vs. internal signal spans are isolated in device memory: writing
+// only the user slot must NOT be observable through the internal read
+// path, and vice versa. Uses the same signalId (0) in both spans on
+// purpose, so a bug that merged the two spans would surface as one write
+// leaking into the other reader.
+TEST_F(MultimemNvlTransportTestFixture, DeviceUserAndInternalSignalsIsolated) {
+  if (numRanks < 3) {
+    GTEST_SKIP() << "MultimemNvlTransport requires 3+ ranks";
+  }
+  auto bootstrap = makeBootstrap("mmnvl_device_user_internal_isolation");
+  auto transport = makeExchangedTransport(
+      bootstrap,
+      globalRank,
+      numRanks,
+      localRank,
+      /*userSignalCount=*/1,
+      /*internalSignalCount=*/1);
+  if (!transport) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  // Distinct values so any aliasing between spans is obvious.
+  constexpr uint64_t kUserValue = 0x11111111ULL;
+  constexpr uint64_t kInternalValue = 0x22222222ULL;
+  auto handle = transport->getDeviceTransport();
+
+  if (globalRank == 0) {
+    test::launchSetUserSignal(handle, /*signalId=*/0, kUserValue);
+    test::launchSetInternalSignal(handle, /*signalId=*/0, kInternalValue);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+  }
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+
+  // Each rank waits on both spans (broadcast from rank 0). Waiting on both
+  // before reading ensures a stale sentinel doesn't slip through.
+  DeviceUint64Slot userOut;
+  test::launchWaitAndReadUserSignal(
+      handle, /*signalId=*/0, CmpOp::CMP_EQ, kUserValue, userOut.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  DeviceUint64Slot internalOut;
+  test::launchWaitAndReadInternalSignal(
+      handle,
+      /*signalId=*/0,
+      CmpOp::CMP_EQ,
+      kInternalValue,
+      internalOut.device_ptr());
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  EXPECT_EQ(userOut.read(), kUserValue);
+  EXPECT_EQ(internalOut.read(), kInternalValue);
+
+  // Cross-check via the no-wait reader that reads both spans in one shot.
+  // Uses a 2-slot device buffer so the kernel writes out[0]=user and
+  // out[1]=internal in a single launch.
+  uint64_t* pairOut = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&pairOut, 2 * sizeof(uint64_t)));
+  test::launchReadUserAndInternal(
+      handle, /*userId=*/0, /*internalId=*/0, pairOut);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+  uint64_t hostPair[2] = {0, 0};
+  CUDACHECK_TEST(
+      cudaMemcpy(hostPair, pairOut, sizeof(hostPair), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(hostPair[0], kUserValue);
+  EXPECT_EQ(hostPair[1], kInternalValue);
+  CUDACHECK_TEST(cudaFree(pairOut));
+
+  ASSERT_EQ(bootstrap->barrier(globalRank, numRanks).get(), 0);
+}
+
+} // namespace comms::prims::tests
+
+int main(int argc, char* argv[]) {
+  // folly::Init consumes glog/gflags argv before other initializers see them.
+  folly::Init init(&argc, &argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new meta::comms::DistEnvironmentBase());
+  return RUN_ALL_TESTS();
+}

--- a/comms/prims/tests/MultimemNvlTransportTest.cu
+++ b/comms/prims/tests/MultimemNvlTransportTest.cu
@@ -1,0 +1,154 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/MultimemNvlTransportTest.cuh"
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/tests/Checks.h"
+
+namespace comms::prims::test {
+
+namespace {
+
+__global__ void setUserSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value) {
+  auto group = make_warp_group();
+  transport.signal(group, signalId, SignalOp::SIGNAL_SET, value);
+}
+
+__global__ void setInternalSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value) {
+  auto group = make_warp_group();
+  transport.signal_internal(group, signalId, SignalOp::SIGNAL_SET, value);
+}
+
+__global__ void addUserSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value) {
+  auto group = make_warp_group();
+  transport.signal(group, signalId, SignalOp::SIGNAL_ADD, value);
+}
+
+__global__ void addInternalSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value) {
+  auto group = make_warp_group();
+  transport.signal_internal(group, signalId, SignalOp::SIGNAL_ADD, value);
+}
+
+__global__ void waitAndReadUserSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  transport.wait_signal_until(group, signalId, op, expected);
+  if (group.is_leader()) {
+    *out = transport.read_signal(signalId);
+  }
+}
+
+__global__ void waitAndReadInternalSignalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out) {
+  auto group = make_warp_group();
+  transport.wait_internal_signal_until(group, signalId, op, expected);
+  if (group.is_leader()) {
+    *out = transport.read_internal_signal(signalId);
+  }
+}
+
+__global__ void readUserAndInternalKernel(
+    MultimemNvlTransportDevice transport,
+    uint64_t userId,
+    uint64_t internalId,
+    uint64_t* out) {
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    out[0] = transport.read_signal(userId);
+    out[1] = transport.read_internal_signal(internalId);
+  }
+}
+
+} // namespace
+
+void launchSetUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream) {
+  setUserSignalKernel<<<1, 32, 0, stream>>>(transport, signalId, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchSetInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream) {
+  setInternalSignalKernel<<<1, 32, 0, stream>>>(transport, signalId, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchAddUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream) {
+  addUserSignalKernel<<<1, 32, 0, stream>>>(transport, signalId, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchAddInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream) {
+  addInternalSignalKernel<<<1, 32, 0, stream>>>(transport, signalId, value);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchWaitAndReadUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out,
+    cudaStream_t stream) {
+  waitAndReadUserSignalKernel<<<1, 32, 0, stream>>>(
+      transport, signalId, op, expected, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchWaitAndReadInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out,
+    cudaStream_t stream) {
+  waitAndReadInternalSignalKernel<<<1, 32, 0, stream>>>(
+      transport, signalId, op, expected, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+void launchReadUserAndInternal(
+    MultimemNvlTransportDevice transport,
+    uint64_t userId,
+    uint64_t internalId,
+    uint64_t* out,
+    cudaStream_t stream) {
+  readUserAndInternalKernel<<<1, 32, 0, stream>>>(
+      transport, userId, internalId, out);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportTest.cuh
+++ b/comms/prims/tests/MultimemNvlTransportTest.cuh
@@ -1,0 +1,79 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims::test {
+
+// Each launch is one warp -> one ThreadGroup. The leader performs the
+// multimem PTX store; the remaining lanes sync alongside it. Callers must
+// cudaStreamSynchronize (or cudaDeviceSynchronize) before observing effects
+// on the host.
+
+// user_signal(signalId) <- value on this rank; broadcasts to every peer's
+// local backing via multimem.st.
+void launchSetUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+// internal_signal(signalId) <- value; identical shape, different span.
+void launchSetInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+// user_signal(signalId) += value via multimem.red.add.
+void launchAddUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+// internal_signal(signalId) += value via multimem.red.add.
+void launchAddInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    uint64_t value,
+    cudaStream_t stream = nullptr);
+
+// Wait via wait_signal_until until user_signal(signalId) satisfies (op
+// expected); then read the local user signal state and write it to *out.
+void launchWaitAndReadUserSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+// Same as above, but through wait_internal_signal_until +
+// read_internal_signal.
+void launchWaitAndReadInternalSignal(
+    MultimemNvlTransportDevice transport,
+    uint64_t signalId,
+    CmpOp op,
+    uint64_t expected,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+// Reads user + internal signals (no wait). out[0] receives read_signal(userId),
+// out[1] receives read_internal_signal(internalId). Used to prove the two
+// spans are isolated: touching one is not observable through the other.
+void launchReadUserAndInternal(
+    MultimemNvlTransportDevice transport,
+    uint64_t userId,
+    uint64_t internalId,
+    uint64_t* out,
+    cudaStream_t stream = nullptr);
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/MultimemNvlTransportValidationTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportValidationTest.cc
@@ -1,0 +1,153 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+
+#include <climits>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "comms/prims/transport/nvl/MultimemNvlTransport.h"
+
+namespace comms::prims::tests {
+
+namespace {
+
+template <typename Fn>
+void expectRuntimeErrorContains(Fn&& fn, const std::string& expected) {
+  try {
+    std::forward<Fn>(fn)();
+    FAIL() << "expected std::runtime_error containing " << expected;
+  } catch (const std::runtime_error& ex) {
+    EXPECT_NE(std::string(ex.what()).find(expected), std::string::npos)
+        << ex.what();
+  }
+}
+
+} // namespace
+
+// validateRankMap runs before any GPU access in the constructor; these cases
+// must reject bad topologies on CPU-only hosts.
+
+TEST(MultimemNvlTransportValidationTest, AcceptsValidRankMap) {
+  EXPECT_NO_THROW(MultimemNvlTransport::validateRankMap(2, {0, 1, 2, 3}));
+}
+
+TEST(MultimemNvlTransportValidationTest, RejectsEmptyRankMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemNvlTransport::validateRankMap(0, {}); },
+      "nvlRankToCommRank must be non-empty");
+}
+
+TEST(MultimemNvlTransportValidationTest, RejectsNegativeRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemNvlTransport::validateRankMap(0, {0, -1}); },
+      "contains a negative rank");
+}
+
+TEST(MultimemNvlTransportValidationTest, RejectsDuplicateRankInMap) {
+  expectRuntimeErrorContains(
+      [] { MultimemNvlTransport::validateRankMap(0, {0, 1, 0}); },
+      "contains duplicate ranks");
+}
+
+TEST(MultimemNvlTransportValidationTest, RejectsMissingCommRank) {
+  expectRuntimeErrorContains(
+      [] { MultimemNvlTransport::validateRankMap(7, {0, 1, 2}); },
+      "commRank must appear in nvlRankToCommRank");
+}
+
+TEST(MultimemNvlTransportValidationTest, IsEligibleRequiresMoreThanTwoRanks) {
+  // The cudaDevice check needs a valid device; pass -1 to force the
+  // isMultimemSupported branch to short-circuit to false. The point of this
+  // test is the nRanks gate.
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(2, -1));
+  EXPECT_FALSE(MultimemNvlTransport::isEligible(1, -1));
+}
+
+// Compat constructor: the identity-map path prechecks nvlRank bounds before
+// delegating so misuse surfaces as a targeted message instead of the generic
+// "commRank must appear in nvlRankToCommRank" from validateRankMap. The
+// precheck runs in the delegating-ctor argument list (before cudaGetDevice),
+// so it is exercisable on CPU-only hosts with a null bootstrap.
+
+TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsNegativeNvlRank) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = 1024;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*nvlRank=*/-1, /*nvlRanks=*/4, /*bootstrap=*/nullptr, config);
+      },
+      "nvlRank must be in [0, nvlRanks)");
+}
+
+TEST(MultimemNvlTransportValidationTest, CompatCtorRejectsOutOfRangeNvlRank) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = 1024;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*nvlRank=*/4, /*nvlRanks=*/4, /*bootstrap=*/nullptr, config);
+      },
+      "nvlRank must be in [0, nvlRanks)");
+}
+
+// Config-validation guards. All three run in the primary ctor body BEFORE
+// cudaGetDevice, so they are exercisable on CPU-only hosts with a null
+// bootstrap: none of the code paths past these throws is reached.
+
+TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroDataBufferSize) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = 0; // triggers the guard
+  config.userSignalCount = 1;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*bootstrap=*/nullptr,
+            /*commRank=*/0,
+            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
+            config);
+      },
+      "dataBufferSize must be non-zero");
+}
+
+TEST(MultimemNvlTransportValidationTest, PrimaryCtorRejectsZeroSignalCount) {
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = 1024;
+  config.userSignalCount = 0;
+  config.internalSignalCount = 0;
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*bootstrap=*/nullptr,
+            /*commRank=*/0,
+            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
+            config);
+      },
+      "at least one signal slot is required");
+}
+
+TEST(
+    MultimemNvlTransportValidationTest,
+    PrimaryCtorRejectsSignalCountOverflow) {
+  // Sum of two uint32_t maxes overflows the int32 clamp used downstream.
+  MultimemNvlTransportConfig config{};
+  config.dataBufferSize = 1024;
+  config.userSignalCount = std::numeric_limits<uint32_t>::max();
+  config.internalSignalCount = std::numeric_limits<uint32_t>::max();
+  expectRuntimeErrorContains(
+      [&] {
+        MultimemNvlTransport(
+            /*bootstrap=*/nullptr,
+            /*commRank=*/0,
+            /*nvlRankToCommRank=*/std::vector<int>{0, 1, 2, 3},
+            config);
+      },
+      "signalCount too large");
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -2,13 +2,9 @@
 
 #include "comms/prims/transport/MultiPeerTransport.h"
 
-#include <algorithm>
-#include <cerrno>
-#include <cstring>
 #include <stdexcept>
-
-#include <sys/syscall.h>
-#include <unistd.h>
+#include <utility>
+#include <vector>
 
 #ifdef __HIP_PLATFORM_AMD__
 // On AMD, HIPify renames `cuda*` runtime calls to `hip*`; pull in the HIP
@@ -25,6 +21,7 @@
 #include <glog/logging.h>
 
 #include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
+#include "comms/prims/memory/CuMemAllocation.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
 #include "comms/prims/transport/MultiPeerDeviceHandle.cuh"
 
@@ -474,305 +471,62 @@ MultiPeerTransport::NvlMemMode MultiPeerTransport::detectNvlMemMode(
 #endif
 }
 
-std::vector<void*> MultiPeerTransport::exchangeNvlBufferCudaIpc(
-    void* localPtr) {
-  cudaIpcMemHandle_t localHandle{};
-  CUDA_CHECK(cudaIpcGetMemHandle(&localHandle, localPtr));
-
-  std::vector<cudaIpcMemHandle_t> allHandles(nvlNRanks_);
-  allHandles[nvlLocalRank_] = localHandle;
-
-  auto result = nvlBootstrapAdapter_
-                    ->allGather(
-                        allHandles.data(),
-                        sizeof(cudaIpcMemHandle_t),
-                        nvlLocalRank_,
-                        nvlNRanks_)
-                    .get();
-  if (result != 0) {
-    throw std::runtime_error("exchangeNvlBufferCudaIpc: allGather failed");
-  }
-
-  std::vector<void*> mappedPtrs(nvlNRanks_, nullptr);
-  mappedPtrs[nvlLocalRank_] = localPtr;
-
-  for (int rank = 0; rank < nvlNRanks_; ++rank) {
-    if (rank == nvlLocalRank_) {
-      continue;
-    }
-    CUDA_CHECK(cudaIpcOpenMemHandle(
-        &mappedPtrs[rank], allHandles[rank], cudaIpcMemLazyEnablePeerAccess));
-  }
-
-  return mappedPtrs;
-}
-
-std::vector<void*> MultiPeerTransport::exchangeNvlBufferFabric(
-    void* localPtr,
-    std::size_t size) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("Fabric handles require CUDA 12.3+");
-#else
-  if (cuda_driver_lazy_init() != 0) {
-    throw std::runtime_error(
-        "exchangeNvlBufferFabric: CUDA driver not available");
-  }
-
-  // Retain allocation handle and export fabric handle
-  CUmemGenericAllocationHandle allocHandle;
-  CU_CHECK(pfn_cuMemRetainAllocationHandle(&allocHandle, localPtr));
-
-  FabricHandle localFabricHandle{};
-  CU_CHECK(pfn_cuMemExportToShareableHandle(
-      &localFabricHandle, allocHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
-  CU_CHECK(pfn_cuMemRelease(allocHandle));
-
-  // Get actual allocated size (may be larger due to granularity)
-  CUdeviceptr basePtr;
-  size_t allocatedSize = 0;
-  CU_CHECK(pfn_cuMemGetAddressRange(
-      &basePtr, &allocatedSize, (CUdeviceptr)localPtr));
-
-  // Exchange fabric handles + allocated sizes
-  struct ExchangeData {
-    FabricHandle handle;
-    size_t allocatedSize;
-  };
-
-  std::vector<ExchangeData> allData(nvlNRanks_);
-  allData[nvlLocalRank_].handle = localFabricHandle;
-  allData[nvlLocalRank_].allocatedSize = allocatedSize;
-
-  auto result =
-      nvlBootstrapAdapter_
-          ->allGather(
-              allData.data(), sizeof(ExchangeData), nvlLocalRank_, nvlNRanks_)
-          .get();
-  if (result != 0) {
-    throw std::runtime_error("exchangeNvlBufferFabric: allGather failed");
-  }
-
-  // Import peer fabric handles
-  int cudaDev = 0;
-  CUdevice cuDev;
-  CUDA_CHECK(cudaGetDevice(&cudaDev));
-  CU_CHECK(pfn_cuDeviceGet(&cuDev, cudaDev));
-
-  NvlExchangeRecord record;
-  record.mode = NvlMemMode::kFabric;
-  record.cuMemPeerPtrs.resize(nvlNRanks_, 0);
-  record.cuMemPeerAllocHandles.resize(nvlNRanks_, 0);
-  record.cuMemPeerSizes.resize(nvlNRanks_, 0);
-
-  std::vector<void*> mappedPtrs(nvlNRanks_, nullptr);
-  mappedPtrs[nvlLocalRank_] = localPtr;
-
-  for (int rank = 0; rank < nvlNRanks_; ++rank) {
-    if (rank == nvlLocalRank_) {
-      continue;
-    }
-
-    size_t peerAllocatedSize = allData[rank].allocatedSize;
-    record.cuMemPeerSizes[rank] = peerAllocatedSize;
-
-    CU_CHECK(pfn_cuMemImportFromShareableHandle(
-        &record.cuMemPeerAllocHandles[rank],
-        const_cast<void*>(static_cast<const void*>(&allData[rank].handle)),
-        CU_MEM_HANDLE_TYPE_FABRIC));
-
-    CUmemAllocationProp prop = {};
-    CU_CHECK(pfn_cuMemGetAllocationPropertiesFromHandle(
-        &prop, record.cuMemPeerAllocHandles[rank]));
-
-    size_t granularity = 0;
-    CU_CHECK(pfn_cuMemGetAllocationGranularity(
-        &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-
-    CU_CHECK(pfn_cuMemAddressReserve(
-        &record.cuMemPeerPtrs[rank], peerAllocatedSize, granularity, 0, 0));
-
-    CU_CHECK(pfn_cuMemMap(
-        record.cuMemPeerPtrs[rank],
-        peerAllocatedSize,
-        0,
-        record.cuMemPeerAllocHandles[rank],
-        0));
-
-    CUmemAccessDesc accessDesc = {};
-    accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    accessDesc.location.id = cuDev;
-    accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    CU_CHECK(pfn_cuMemSetAccess(
-        record.cuMemPeerPtrs[rank], peerAllocatedSize, &accessDesc, 1));
-
-    mappedPtrs[rank] = reinterpret_cast<void*>(record.cuMemPeerPtrs[rank]);
-  }
-
-  // Store record keyed by the local pointer for cleanup
-  nvlExchangeRecords_[localPtr] = std::move(record);
-
-  return mappedPtrs;
-#endif
-}
-
-std::vector<void*> MultiPeerTransport::exchangeNvlBufferPosixFd(
-    void* localPtr,
-    std::size_t size) {
-#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
-  throw std::runtime_error("POSIX FD cuMem handles require CUDA 12.3+");
-#else
-  if (cuda_driver_lazy_init() != 0) {
-    throw std::runtime_error(
-        "exchangeNvlBufferPosixFd: CUDA driver not available");
-  }
-
-  // Retain allocation handle and export as POSIX file descriptor
-  CUmemGenericAllocationHandle allocHandle;
-  CU_CHECK(pfn_cuMemRetainAllocationHandle(&allocHandle, localPtr));
-
-  int localFd = -1;
-  CU_CHECK(pfn_cuMemExportToShareableHandle(
-      &localFd, allocHandle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
-  CU_CHECK(pfn_cuMemRelease(allocHandle));
-
-  // Get actual allocated size (may be larger due to granularity)
-  CUdeviceptr basePtr;
-  size_t allocatedSize = 0;
-  CU_CHECK(pfn_cuMemGetAddressRange(
-      &basePtr, &allocatedSize, (CUdeviceptr)localPtr));
-
-  // Exchange {pid, fd, allocatedSize} with NVL peers.
-  // Peers will use pidfd_getfd to duplicate our fd into their fd table.
-  struct ExchangeData {
-    pid_t pid;
-    int fd;
-    size_t allocatedSize;
-  };
-
-  std::vector<ExchangeData> allData(nvlNRanks_);
-  allData[nvlLocalRank_] = {getpid(), localFd, allocatedSize};
-
-  auto result =
-      nvlBootstrapAdapter_
-          ->allGather(
-              allData.data(), sizeof(ExchangeData), nvlLocalRank_, nvlNRanks_)
-          .get();
-  if (result != 0) {
-    close(localFd);
-    throw std::runtime_error("exchangeNvlBufferPosixFd: allGather failed");
-  }
-
-  // Import peer handles via pidfd_open + pidfd_getfd (Linux 5.6+)
-  int cudaDev = 0;
-  CUdevice cuDev;
-  CUDA_CHECK(cudaGetDevice(&cudaDev));
-  CU_CHECK(pfn_cuDeviceGet(&cuDev, cudaDev));
-
-  NvlExchangeRecord record;
-  record.mode = NvlMemMode::kPosixFd;
-  record.localExportedFd = localFd;
-  record.cuMemPeerPtrs.resize(nvlNRanks_, 0);
-  record.cuMemPeerAllocHandles.resize(nvlNRanks_, 0);
-  record.cuMemPeerSizes.resize(nvlNRanks_, 0);
-
-  std::vector<void*> mappedPtrs(nvlNRanks_, nullptr);
-  mappedPtrs[nvlLocalRank_] = localPtr;
-
-  for (int rank = 0; rank < nvlNRanks_; ++rank) {
-    if (rank == nvlLocalRank_) {
-      continue;
-    }
-
-    // Duplicate the remote process's fd into this process
-    int pidfd = static_cast<int>(syscall(SYS_pidfd_open, allData[rank].pid, 0));
-    if (pidfd < 0) {
-      throw std::runtime_error(
-          "exchangeNvlBufferPosixFd: pidfd_open failed for rank " +
-          std::to_string(rank) + ": " + strerror(errno));
-    }
-
-    int importedFd =
-        static_cast<int>(syscall(SYS_pidfd_getfd, pidfd, allData[rank].fd, 0));
-    close(pidfd);
-    if (importedFd < 0) {
-      throw std::runtime_error(
-          "exchangeNvlBufferPosixFd: pidfd_getfd failed for rank " +
-          std::to_string(rank) + ": " + strerror(errno));
-    }
-
-    size_t peerAllocatedSize = allData[rank].allocatedSize;
-    record.cuMemPeerSizes[rank] = peerAllocatedSize;
-
-    CU_CHECK(pfn_cuMemImportFromShareableHandle(
-        &record.cuMemPeerAllocHandles[rank],
-        reinterpret_cast<void*>(static_cast<uintptr_t>(importedFd)),
-        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
-
-    // fd can be closed immediately after import
-    close(importedFd);
-
-    CUmemAllocationProp prop = {};
-    CU_CHECK(pfn_cuMemGetAllocationPropertiesFromHandle(
-        &prop, record.cuMemPeerAllocHandles[rank]));
-
-    size_t granularity = 0;
-    CU_CHECK(pfn_cuMemGetAllocationGranularity(
-        &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-
-    CU_CHECK(pfn_cuMemAddressReserve(
-        &record.cuMemPeerPtrs[rank], peerAllocatedSize, granularity, 0, 0));
-
-    CU_CHECK(pfn_cuMemMap(
-        record.cuMemPeerPtrs[rank],
-        peerAllocatedSize,
-        0,
-        record.cuMemPeerAllocHandles[rank],
-        0));
-
-    CUmemAccessDesc accessDesc = {};
-    accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    accessDesc.location.id = cuDev;
-    accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
-    CU_CHECK(pfn_cuMemSetAccess(
-        record.cuMemPeerPtrs[rank], peerAllocatedSize, &accessDesc, 1));
-
-    mappedPtrs[rank] = reinterpret_cast<void*>(record.cuMemPeerPtrs[rank]);
-  }
-
-  nvlExchangeRecords_[localPtr] = std::move(record);
-
-  return mappedPtrs;
-#endif
-}
-
-std::vector<void*> MultiPeerTransport::exchangeNvlBuffer(
-    void* localPtr,
-    std::size_t size) {
+std::vector<void*> MultiPeerTransport::exchangeNvlBuffer(void* localPtr) {
   if (!nvlBootstrapAdapter_ || nvlNRanks_ <= 1) {
     throw std::runtime_error(
         "exchangeNvlBuffer: NVL transport not available or single rank");
   }
 
   NvlMemMode mode = detectNvlMemMode(localPtr);
-  if (mode == NvlMemMode::kFabric) {
-    return exchangeNvlBufferFabric(localPtr, size);
+
+  if (mode == NvlMemMode::kFabric || mode == NvlMemMode::kPosixFd) {
+#if defined(__HIP_PLATFORM_AMD__) || CUDART_VERSION < 12030
+    throw std::runtime_error("exchangeNvlBuffer: VMM path requires CUDA 12.3+");
+#else
+    if (cuda_driver_lazy_init() != 0) {
+      throw std::runtime_error("exchangeNvlBuffer: CUDA driver not available");
+    }
+
+    int cudaDev = 0;
+    CUdevice cuDev;
+    CUDA_CHECK(cudaGetDevice(&cudaDev));
+    CU_CHECK(pfn_cuDeviceGet(&cuDev, cudaDev));
+
+    // Retain the external VMM allocation's physical handle via
+    // CuMemAllocation::retain -- its destructor releases the retain reference
+    // on both the success path and any exception unwind from
+    // nvlMemExchangeVmm (allGather / import / map failures), preventing a
+    // silent driver-refcount leak. The factory also queries the buffer's
+    // real allocated size via cuMemGetAddressRange -- nvlMemExchangeVmm
+    // needs a granularity-multiple size for peer-side cuMemAddressReserve.
+    auto phys = CuMemAllocation::retain(localPtr);
+
+    auto pm = nvlMemExchangeVmm(
+        *nvlBootstrapAdapter_,
+        nvlLocalRank_,
+        nvlNRanks_,
+        cuDev,
+        phys->handle(),
+        localPtr,
+        phys->size(),
+        /*preferFabric=*/mode == NvlMemMode::kFabric);
+
+    std::vector<void*> mappedPtrs = pm.peerPtrs;
+    nvlExchangeRecords_[localPtr] = NvlExchangeRecord{mode, std::move(pm)};
+    return mappedPtrs;
+#endif
   }
-  if (mode == NvlMemMode::kPosixFd) {
-    return exchangeNvlBufferPosixFd(localPtr, size);
-  }
 
-  auto mappedPtrs = exchangeNvlBufferCudaIpc(localPtr);
-
-  // Store a cudaIpc record for cleanup dispatch
-  NvlExchangeRecord record;
-  record.mode = NvlMemMode::kCudaIpc;
-  nvlExchangeRecords_[localPtr] = std::move(record);
-
+  auto pm = nvlMemExchangeCudaIpc(
+      *nvlBootstrapAdapter_, nvlLocalRank_, nvlNRanks_, localPtr);
+  std::vector<void*> mappedPtrs = pm.peerPtrs;
+  nvlExchangeRecords_[localPtr] =
+      NvlExchangeRecord{NvlMemMode::kCudaIpc, std::move(pm)};
   return mappedPtrs;
 }
 
 void MultiPeerTransport::unmapNvlBuffers(const std::vector<void*>& mappedPtrs) {
-  // Find the exchange record by the self entry (localPtr)
+  // Find the exchange record by the self entry (localPtr).
   void* localPtr = (nvlLocalRank_ >= 0 &&
                     nvlLocalRank_ < static_cast<int>(mappedPtrs.size()))
       ? mappedPtrs[nvlLocalRank_]
@@ -780,43 +534,31 @@ void MultiPeerTransport::unmapNvlBuffers(const std::vector<void*>& mappedPtrs) {
 
   auto it =
       localPtr ? nvlExchangeRecords_.find(localPtr) : nvlExchangeRecords_.end();
+  if (it == nvlExchangeRecords_.end()) {
+    return;
+  }
 
-  bool isCuMem =
-      (it != nvlExchangeRecords_.end() &&
-       (it->second.mode == NvlMemMode::kFabric ||
-        it->second.mode == NvlMemMode::kPosixFd));
-
-  if (isCuMem) {
+  auto& record = it->second;
+  if (record.mode == NvlMemMode::kFabric ||
+      record.mode == NvlMemMode::kPosixFd) {
 #if !defined(__HIP_PLATFORM_AMD__) && CUDART_VERSION >= 12030
-    if (cuda_driver_lazy_init() != 0) {
-      return;
-    }
-
-    auto& record = it->second;
-    for (int rank = 0; rank < static_cast<int>(mappedPtrs.size()); ++rank) {
-      if (rank == nvlLocalRank_) {
-        continue;
-      }
-      if (record.cuMemPeerPtrs[rank] != 0) {
-        pfn_cuMemUnmap(record.cuMemPeerPtrs[rank], record.cuMemPeerSizes[rank]);
-        pfn_cuMemAddressFree(
-            record.cuMemPeerPtrs[rank], record.cuMemPeerSizes[rank]);
-      }
-      if (record.cuMemPeerAllocHandles[rank] != 0) {
-        pfn_cuMemRelease(record.cuMemPeerAllocHandles[rank]);
-      }
-    }
-    if (record.localExportedFd >= 0) {
-      close(record.localExportedFd);
+    if (cuda_driver_lazy_init() == 0) {
+      // Tear down the peer VAs. Each CuMemMapping co-owns its imported peer
+      // CuMemAllocation (via keepAlive), so clearing the mappings runs
+      // cuMemUnmap + cuMemAddressFree and then releases the imported physical
+      // handle -- the unmap-VA-then-release-handle ordering is preserved
+      // without separate handle bookkeeping.
+      record.mem.vmmMappings.clear();
     }
 #endif
   } else {
-    // cudaIpc path
-    for (int rank = 0; rank < static_cast<int>(mappedPtrs.size()); ++rank) {
-      if (rank == nvlLocalRank_ || mappedPtrs[rank] == nullptr) {
+    // cudaIpc path: close every non-self peer handle.
+    for (int rank = 0; rank < static_cast<int>(record.mem.peerPtrs.size());
+         ++rank) {
+      if (rank == nvlLocalRank_ || record.mem.peerPtrs[rank] == nullptr) {
         continue;
       }
-      cudaError_t err = cudaIpcCloseMemHandle(mappedPtrs[rank]);
+      cudaError_t err = cudaIpcCloseMemHandle(record.mem.peerPtrs[rank]);
       if (err != cudaSuccess) {
         fprintf(
             stderr,
@@ -828,9 +570,7 @@ void MultiPeerTransport::unmapNvlBuffers(const std::vector<void*>& mappedPtrs) {
     }
   }
 
-  if (it != nvlExchangeRecords_.end()) {
-    nvlExchangeRecords_.erase(it);
-  }
+  nvlExchangeRecords_.erase(it);
 }
 
 void MultiPeerTransport::build_device_handle() {

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -11,9 +11,8 @@
 // `<cuda.h>` (driver API) and `<cuda_runtime.h>` are NVIDIA-only. On AMD,
 // `comms/prims/memory/GpuMemHandler.h` (included below) brings in the HIP
 // runtime headers under `#ifdef __HIP_PLATFORM_AMD__` and provides the
-// stand-in types needed for the `CUdeviceptr` /
-// `CUmemGenericAllocationHandle` member fields used by the
-// `NvlExchangeRecord`.
+// stand-in types needed for the CUDA driver types referenced via
+// `NvlMemExchange.h` (`NvlPeerMem`).
 #ifndef __HIP_PLATFORM_AMD__
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -21,6 +20,7 @@
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/memory/NvlMemExchange.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
 #include "comms/prims/transport/IbTransportConfig.h"
 #include "comms/prims/transport/Transport.cuh"
@@ -268,13 +268,15 @@ class MultiPeerTransport {
    * - cuMem with CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR (no fabric):
    *   POSIX FD path via pidfd_getfd (Linux 5.6+, intra-host only)
    *
-   * @param localPtr GPU pointer (cudaMalloc or ncclMemAlloc)
-   * @param size Size of the buffer in bytes
+   * @param localPtr GPU pointer (cudaMalloc or ncclMemAlloc). The actual
+   *                 buffer length is derived from the allocation itself
+   *                 (via `cuMemGetAddressRange` on the VMM path) -- callers
+   *                 do not need to pass a size.
    * @return Vector of mapped peer pointers (size = nvlNRanks_), indexed by
    *         NVL local rank. Self entry is the original localPtr. Other entries
    *         are IPC-mapped pointers to peer buffers.
    */
-  std::vector<void*> exchangeNvlBuffer(void* localPtr, std::size_t size);
+  std::vector<void*> exchangeNvlBuffer(void* localPtr);
 
   /**
    * Unmap NVL IPC-mapped peer buffers obtained from exchangeNvlBuffer().
@@ -324,23 +326,17 @@ class MultiPeerTransport {
   enum class NvlMemMode { kCudaIpc, kFabric, kPosixFd };
   NvlMemMode detectNvlMemMode(void* ptr) const;
 
-  // Handle exchange helpers
-  std::vector<void*> exchangeNvlBufferCudaIpc(void* localPtr);
-  std::vector<void*> exchangeNvlBufferFabric(void* localPtr, std::size_t size);
-  std::vector<void*> exchangeNvlBufferPosixFd(void* localPtr, std::size_t size);
-
-  // Track NVL exchange state for proper cleanup in unmapNvlBuffers
+  // Track NVL exchange state for proper cleanup in unmapNvlBuffers. The
+  // NvlPeerMem owns the peer memory state produced by the NvlMemExchange
+  // helpers: for VMM modes its `vmmMappings` (RAII peer VAs) and
+  // `vmmPeerHandles` (imported handles released via cuMemRelease), and for
+  // cudaIpc mode the peer pointers in `peerPtrs` (closed via
+  // cudaIpcCloseMemHandle).
   struct NvlExchangeRecord {
-    NvlMemMode mode;
-    // cuMem state for cleanup (used by kFabric and kPosixFd paths):
-    std::vector<CUdeviceptr> cuMemPeerPtrs;
-    std::vector<CUmemGenericAllocationHandle> cuMemPeerAllocHandles;
-    std::vector<size_t> cuMemPeerSizes;
-    // POSIX FD exported by this rank — kept open until unmap so that peers
-    // can complete pidfd_getfd imports before the fd is closed.
-    int localExportedFd{-1};
+    NvlMemMode mode{NvlMemMode::kCudaIpc};
+    NvlPeerMem mem;
   };
-  // Keyed by the mappedPtrs vector's data pointer (first element address)
+  // Keyed by the self (local) pointer, i.e. mappedPtrs[nvlLocalRank_].
   std::unordered_map<void*, NvlExchangeRecord> nvlExchangeRecords_;
 };
 

--- a/comms/prims/transport/nvl/MultimemNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.cc
@@ -1,0 +1,237 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/transport/nvl/MultimemNvlTransport.h"
+
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include "comms/common/BitOps.cuh"
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/utils/checks.h"
+
+namespace comms::prims {
+
+namespace {
+
+int getCurrentCudaDevice() {
+  int cudaDevice = 0;
+  const auto err = cudaGetDevice(&cudaDevice);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("cudaGetDevice failed: ") + cudaGetErrorString(err));
+  }
+  return cudaDevice;
+}
+
+std::vector<int> identityRankMap(int nRanks) {
+  if (nRanks <= 0) {
+    return {};
+  }
+  std::vector<int> rankMap(static_cast<std::size_t>(nRanks));
+  for (int rank = 0; rank < nRanks; ++rank) {
+    rankMap[static_cast<std::size_t>(rank)] = rank;
+  }
+  return rankMap;
+}
+
+} // namespace
+
+void MultimemNvlTransport::validateRankMap(
+    int commRank,
+    const std::vector<int>& nvlRankToCommRank) {
+  if (nvlRankToCommRank.empty()) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: nvlRankToCommRank must be non-empty");
+  }
+  // Single pass: reject negative ranks, duplicates, and require commRank to be
+  // present.
+  std::unordered_set<int> seen;
+  seen.reserve(nvlRankToCommRank.size());
+  bool sawCommRank = false;
+  for (const int peerCommRank : nvlRankToCommRank) {
+    if (peerCommRank < 0) {
+      throw std::runtime_error(
+          "MultimemNvlTransport: nvlRankToCommRank contains a negative rank");
+    }
+    if (!seen.insert(peerCommRank).second) {
+      throw std::runtime_error(
+          "MultimemNvlTransport: nvlRankToCommRank contains duplicate ranks");
+    }
+    if (peerCommRank == commRank) {
+      sawCommRank = true;
+    }
+  }
+  if (!sawCommRank) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: commRank must appear in nvlRankToCommRank");
+  }
+}
+
+MultimemNvlTransport::MultimemNvlTransport(
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    int commRank,
+    std::vector<int> nvlRankToCommRank,
+    const MultimemNvlTransportConfig& config)
+    : commRank_(commRank),
+      nvlRanks_(static_cast<int>(nvlRankToCommRank.size())),
+      nvlRankToCommRank_(std::move(nvlRankToCommRank)),
+      config_(config) {
+  // Topology validation runs BEFORE cudaGetDevice so the rank-map preconditions
+  // are exercisable on CPU-only hosts (see MultimemNvlTransportValidationTest).
+  validateRankMap(commRank_, nvlRankToCommRank_);
+
+  if (config_.dataBufferSize == 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: dataBufferSize must be non-zero");
+  }
+  const uint64_t totalSignalCount =
+      static_cast<uint64_t>(config_.userSignalCount) +
+      static_cast<uint64_t>(config_.internalSignalCount);
+  if (totalSignalCount == 0) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: at least one signal slot is required");
+  }
+  if (totalSignalCount >
+      static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+    throw std::runtime_error("MultimemNvlTransport: signalCount too large");
+  }
+
+  // commRank presence in the map is already verified by validateRankMap.
+  int nvlRank = -1;
+  for (int rank = 0; rank < nvlRanks_; ++rank) {
+    if (nvlRankToCommRank_[static_cast<std::size_t>(rank)] == commRank_) {
+      nvlRank = rank;
+      break;
+    }
+  }
+
+  cudaDevice_ = getCurrentCudaDevice();
+
+  signalRegionOffset_ =
+      comms::bitops::alignUp(config_.dataBufferSize, alignof(SignalState));
+  const std::size_t signalRegionBytes =
+      getSignalBufferSize(static_cast<int>(totalSignalCount));
+  const std::size_t combinedSize = signalRegionOffset_ + signalRegionBytes;
+
+  // The GpuMemHandler owns the unicast backing; exchange() adds the multicast
+  // overlay over it. Size the allocation to the multicast granularity
+  // (alignFloor) so it is bindable into a multicast object. Only multicast is
+  // used (no P2P exchangeMemPtrs), so the selfRank/nRanks coordinates here are
+  // the NVL-team rank and size.
+  const std::size_t alignFloor =
+      GpuMemHandler::backingGranularity(cudaDevice_, nvlRanks_);
+  combinedHandler_ = std::make_unique<GpuMemHandler>(
+      std::move(bootstrap),
+      nvlRank,
+      nvlRanks_,
+      combinedSize,
+      GpuMemHandler::detectBestMode(),
+      alignFloor);
+
+  // Zero the signal region so every rank starts from SignalState{0}. Neither
+  // GpuMemHandler nor MultimemHandler zero the backing ("the caller is
+  // responsible for zeroing the backing"), and the device arrival-counter
+  // barrier reads its counter/epoch slots assuming they are zero-initialized.
+  // Write through the local unicast VA -- the multicast overlay does not exist
+  // until exchange() -- and synchronize so the zero is materialized before
+  // exchange()'s post-map barrier lets any peer signal into this region. This
+  // mirrors MultiPeerNvlTransport, which zeroes its signal buffer at
+  // construction.
+  auto* localSignalRegion =
+      static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr()) +
+      signalRegionOffset_;
+  CUDA_CHECK(cudaMemset(localSignalRegion, 0, signalRegionBytes));
+  CUDA_CHECK(cudaStreamSynchronize(/*stream=*/0));
+}
+
+MultimemNvlTransport::MultimemNvlTransport(
+    int nvlRank,
+    int nvlRanks,
+    std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+    const MultimemNvlTransportConfig& config)
+    : MultimemNvlTransport(
+          std::move(bootstrap),
+          nvlRank,
+          [&]() {
+            // Precheck the identity-map contract before delegating so a
+            // misuse (out-of-range nvlRank) surfaces as a targeted message
+            // instead of the generic "commRank must appear in
+            // nvlRankToCommRank" error from validateRankMap.
+            if (nvlRank < 0 || nvlRank >= nvlRanks) {
+              throw std::runtime_error(
+                  "MultimemNvlTransport: nvlRank must be in [0, nvlRanks)");
+            }
+            return identityRankMap(nvlRanks);
+          }(),
+          config) {}
+
+void MultimemNvlTransport::exchange() {
+  if (exchanged_) {
+    return;
+  }
+  if (broken_) {
+    throw std::runtime_error(
+        "MultimemNvlTransport::exchange: previous exchange() failed; "
+        "rebuild the transport to retry (same-object retry is unsafe after "
+        "a partial multicast setup)");
+  }
+  try {
+    combinedHandler_->exchangeMulticast(
+        commRank_, nvlRankToCommRank_, cudaDevice_);
+  } catch (...) {
+    broken_ = true;
+    throw;
+  }
+  exchanged_ = true;
+}
+
+MultimemNvlTransportDevice MultimemNvlTransport::getDeviceTransport() const {
+  if (!exchanged_) {
+    throw std::runtime_error(
+        "MultimemNvlTransport: exchange() must complete before device use");
+  }
+
+  auto* localBase =
+      static_cast<char*>(combinedHandler_->getLocalDeviceMemPtr());
+  auto* multimemBase =
+      static_cast<char*>(combinedHandler_->getMultimemDeviceMemPtr());
+  auto* localSignals =
+      reinterpret_cast<SignalState*>(localBase + signalRegionOffset_);
+  auto* multimemSignals =
+      reinterpret_cast<SignalState*>(multimemBase + signalRegionOffset_);
+  const auto userSignalCount = config_.userSignalCount;
+  const auto internalSignalCount = config_.internalSignalCount;
+
+  return MultimemNvlTransportDevice{
+      .localData = localBase,
+      .multimemData = multimemBase,
+      .userLocalSignals =
+          DeviceSpan<SignalState>(localSignals, userSignalCount),
+      .userMultimemSignals =
+          DeviceSpan<SignalState>(multimemSignals, userSignalCount),
+      .internalLocalSignals = DeviceSpan<SignalState>(
+          localSignals + userSignalCount, internalSignalCount),
+      .internalMultimemSignals = DeviceSpan<SignalState>(
+          multimemSignals + userSignalCount, internalSignalCount),
+      .dataBufferSize = config_.dataBufferSize,
+  };
+}
+
+std::size_t MultimemNvlTransport::getAllocatedDataBufferSize() const {
+  return config_.dataBufferSize;
+}
+
+std::size_t MultimemNvlTransport::getAllocatedSignalBufferSize() const {
+  // Report the usable signal region size (SignalState-aligned bytes for the
+  // configured user + internal slot counts), not the padded backing tail. The
+  // GpuMemHandler rounds the physical allocation up to the multicast backing
+  // granularity, so combinedHandler_->getAllocatedSize() - signalRegionOffset_
+  // would include trailing padding that is not addressable as SignalState.
+  return getSignalBufferSize(
+      static_cast<int>(config_.userSignalCount + config_.internalSignalCount));
+}
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransport.h
+++ b/comms/prims/transport/nvl/MultimemNvlTransport.h
@@ -1,0 +1,127 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "comms/common/bootstrap/IBootstrap.h"
+#include "comms/prims/memory/GpuMemHandler.h"
+#include "comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh"
+
+namespace comms::prims {
+
+struct MultimemNvlTransportConfig {
+  // Size in bytes of the multicast staging data window.
+  std::size_t dataBufferSize{0};
+
+  // Signal slots exposed through signal(), read_signal(), and
+  // wait_signal_until().
+  uint32_t userSignalCount{1};
+
+  // Signal slots reserved for transport-internal protocols. These are not
+  // addressable through the public signal API.
+  uint32_t internalSignalCount{0};
+};
+
+/**
+ * Host-side owner for a copy-based NVL multimem transport.
+ *
+ * This transport is group-scoped rather than peer-scoped: every rank in the
+ * NVL team maps the same multicast object and a private local backing VA.
+ * Writers use `multimemData` to broadcast into every rank's `localData` at the
+ * same offset; readers consume from their local backing memory after observing
+ * a signal. The numeric `multimemData` pointer is a process-local CUDA VA and
+ * is not part of the cross-rank protocol.
+ *
+ * The caller must set the current CUDA device before construction. The
+ * transport records that device ordinal and passes it to MultimemHandler; it
+ * does not switch CUDA devices internally.
+ *
+ * `bootstrap` is the global communicator bootstrap. `commRank` is this
+ * process's rank in that global communicator. `nvlRankToCommRank` maps each
+ * NVLink-local rank to its global communicator rank; the transport uses
+ * NVLink-domain bootstrap collectives internally.
+ */
+class MultimemNvlTransport {
+ public:
+  MultimemNvlTransport(
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      int commRank,
+      std::vector<int> nvlRankToCommRank,
+      const MultimemNvlTransportConfig& config);
+
+  // Compatibility constructor for callers that already wrapped `bootstrap` in
+  // an NVLink-local adapter. Prefer the global-bootstrap constructor above for
+  // new code.
+  MultimemNvlTransport(
+      int nvlRank,
+      int nvlRanks,
+      std::shared_ptr<meta::comms::IBootstrap> bootstrap,
+      const MultimemNvlTransportConfig& config);
+
+  ~MultimemNvlTransport() = default;
+
+  MultimemNvlTransport(const MultimemNvlTransport&) = delete;
+  MultimemNvlTransport& operator=(const MultimemNvlTransport&) = delete;
+  MultimemNvlTransport(MultimemNvlTransport&&) = delete;
+  MultimemNvlTransport& operator=(MultimemNvlTransport&&) = delete;
+
+  // Runs the host-side multicast exchange and marks the transport ready for
+  // device-side use. Throws on failure. After a failed call, the transport is
+  // poisoned: subsequent exchange() calls will throw immediately rather than
+  // retry, since cuMulticastCreate / cuMemImport / bind failures can leave
+  // partial driver state that is unsafe to re-exchange on the same object.
+  void exchange();
+
+  MultimemNvlTransportDevice getDeviceTransport() const;
+
+  std::size_t getAllocatedDataBufferSize() const;
+  std::size_t getAllocatedSignalBufferSize() const;
+
+  // Mirrors NCCL/NVLS enablement: multicast must be supported on cudaDevice
+  // and useful only for teams larger than two ranks. The caller should already
+  // have made cudaDevice current.
+  static bool isEligible(int nRanks, int cudaDevice) {
+    return nRanks > 2 && GpuMemHandler::isMultimemSupported(cudaDevice);
+  }
+
+  // Throws std::runtime_error if `nvlRankToCommRank` is empty, contains a
+  // negative rank, contains duplicates, or does not contain `commRank`. Exposed
+  // as a static so unit tests can exercise the rank-map preconditions without
+  // requiring a CUDA device (the constructor calls cudaGetDevice).
+  static void validateRankMap(
+      int commRank,
+      const std::vector<int>& nvlRankToCommRank);
+
+ private:
+  const int commRank_{-1};
+  const int nvlRanks_{-1};
+  const std::vector<int> nvlRankToCommRank_;
+  // Recorded after the rank-map validation in the constructor body so a bad
+  // topology fails before cudaGetDevice is consulted (lets tests cover the
+  // rank-map preconditions on CPU-only hosts).
+  int cudaDevice_{-1};
+  const MultimemNvlTransportConfig config_;
+  bool exchanged_{false};
+  // Set when exchange() throws; subsequent calls throw instead of silently
+  // retrying. Multicast object create/import/bind failures can leave partial
+  // driver state, so a same-object retry is unsafe — callers must rebuild the
+  // transport to recover.
+  bool broken_{false};
+
+  // Single GpuMemHandler whose physical allocation contains both the data
+  // window and the signal slots back-to-back. Layout: [data | pad-to-128B |
+  // signals]. The handler provides the unicast local VA (getLocalDeviceMemPtr)
+  // and, via its multicast overlay (exchangeMulticast), the multicast VA
+  // (getMultimemDeviceMemPtr) -- one cuMulticastCreate / one set of binds / one
+  // MC VA range over one shared physical backing.
+  std::unique_ptr<GpuMemHandler> combinedHandler_;
+  // Offset of the signal region within combinedHandler_'s allocation. Equals
+  // dataBufferSize rounded up to SignalState's 128-byte alignment.
+  std::size_t signalRegionOffset_{0};
+};
+
+} // namespace comms::prims

--- a/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
+++ b/comms/prims/transport/nvl/MultimemNvlTransportDevice.cuh
@@ -1,0 +1,186 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/common/AtomicUtils.cuh"
+#include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Timeout.cuh"
+#include "comms/prims/memory/DeviceSpan.cuh"
+
+namespace comms::prims {
+
+namespace detail {
+
+__device__ __forceinline__ void multimem_store_release_sys_u64(
+    uint64_t* dst,
+    uint64_t v) {
+  (void)dst;
+  (void)v;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.st.release.sys.global.u64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  // A plain store on a multimem VA would only update this rank's backing and
+  // silently diverge from multicast semantics. Host-side isEligible() /
+  // isMultimemSupported() gates prevent this path from ever being taken with
+  // a multimem pointer, but trap so any accidental pre-SM90 use is loud.
+  __trap();
+#endif
+}
+
+__device__ __forceinline__ void multimem_red_release_sys_add_u64(
+    uint64_t* dst,
+    uint64_t v) {
+  (void)dst;
+  (void)v;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("multimem.red.release.sys.global.add.u64 [%0], %1;"
+               :
+               : "l"(dst), "l"(v)
+               : "memory");
+#elif defined(__CUDA_ARCH__)
+  __trap();
+#endif
+}
+
+} // namespace detail
+
+/**
+ * Device-side handle for one multicast staging window.
+ *
+ * `multimemData` and multimem signal spans are multicast VAs. Writes into the
+ * multicast pointer preserve multicast semantics; `localData` and local signal
+ * spans are this rank's backing memory after multicast replication. Callers
+ * that want to broadcast into the multicast VA should obtain
+ * `multimem_data_ptr()` and use PTX `multimem.st.*` intrinsics (or a helper
+ * built on top, e.g. the one in `MultimemNvlStaging.cuh`).
+ */
+struct MultimemNvlTransportDevice {
+  char* localData{nullptr};
+  char* multimemData{nullptr};
+  DeviceSpan<SignalState> userLocalSignals{};
+  DeviceSpan<SignalState> userMultimemSignals{};
+  DeviceSpan<SignalState> internalLocalSignals{};
+  DeviceSpan<SignalState> internalMultimemSignals{};
+  std::size_t dataBufferSize{0};
+
+  __device__ __forceinline__ char* local_data_ptr(std::size_t offset) const {
+    return localData + offset;
+  }
+
+  __device__ __forceinline__ char* multimem_data_ptr(std::size_t offset) const {
+    return multimemData + offset;
+  }
+
+  __device__ __forceinline__ void signal(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      SignalOp op,
+      uint64_t value) const {
+    signal_at(group, user_multimem_signal_ptr(signal_id), op, value);
+  }
+
+  __device__ __forceinline__ uint64_t read_signal(uint64_t signal_id) const {
+    return user_local_signal_ptr(signal_id)->load();
+  }
+
+  __device__ __forceinline__ void wait_signal_until(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      CmpOp op,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    user_local_signal_ptr(signal_id)->wait_until(group, op, expected, timeout);
+  }
+
+  __device__ __forceinline__ void signal_internal(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      SignalOp op,
+      uint64_t value) const {
+    signal_at(group, internal_multimem_signal_ptr(signal_id), op, value);
+  }
+
+  __device__ __forceinline__ uint64_t
+  read_internal_signal(uint64_t signal_id) const {
+    return internal_local_signal_ptr(signal_id)->load();
+  }
+
+  __device__ __forceinline__ void wait_internal_signal_until(
+      ThreadGroup& group,
+      uint64_t signal_id,
+      CmpOp op,
+      uint64_t expected,
+      const Timeout& timeout = Timeout()) const {
+    internal_local_signal_ptr(signal_id)->wait_until(
+        group, op, expected, timeout);
+  }
+
+ private:
+  __device__ __forceinline__ SignalState* signal_ptr(
+      DeviceSpan<SignalState> signals,
+      uint64_t signal_id,
+      [[maybe_unused]] const char* kind) const {
+#if defined(__CUDA_ARCH__)
+    if (signal_id >= signals.size()) {
+      printf(
+          "MultimemNvlTransportDevice: %s signal_id=%llu out of range "
+          "(count=%u)\n",
+          kind,
+          static_cast<unsigned long long>(signal_id),
+          static_cast<unsigned>(signals.size()));
+      __trap();
+    }
+#endif
+    return signals.data() + signal_id;
+  }
+
+  __device__ __forceinline__ SignalState* user_local_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr(userLocalSignals, signal_id, "user local");
+  }
+
+  __device__ __forceinline__ SignalState* user_multimem_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr(userMultimemSignals, signal_id, "user multimem");
+  }
+
+  __device__ __forceinline__ SignalState* internal_local_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr(internalLocalSignals, signal_id, "internal local");
+  }
+
+  __device__ __forceinline__ SignalState* internal_multimem_signal_ptr(
+      uint64_t signal_id) const {
+    return signal_ptr(internalMultimemSignals, signal_id, "internal multimem");
+  }
+
+  __device__ __forceinline__ void signal_at(
+      ThreadGroup& group,
+      SignalState* signal,
+      SignalOp op,
+      uint64_t value) const {
+    comms::device::fence_acq_rel_sys();
+    group.sync();
+    if (group.is_leader()) {
+      switch (op) {
+        case SignalOp::SIGNAL_SET:
+          detail::multimem_store_release_sys_u64(&signal->signal_, value);
+          break;
+        case SignalOp::SIGNAL_ADD:
+          detail::multimem_red_release_sys_add_u64(&signal->signal_, value);
+          break;
+      }
+    }
+  }
+};
+
+} // namespace comms::prims

--- a/comms/prims/window/HostWindow.cc
+++ b/comms/prims/window/HostWindow.cc
@@ -358,7 +358,7 @@ void HostWindow::registerAndExchangeBuffer(void* ptr, std::size_t size) {
 
   // NVL side: IPC exchange
   if (nNvlPeers > 0) {
-    exchangedNvlMappedPtrs_ = transport_.exchangeNvlBuffer(ptr, size);
+    exchangedNvlMappedPtrs_ = transport_.exchangeNvlBuffer(ptr);
 
     // Upload NVL peer pointers to device for offset-based put/put_signal.
     // exchangedNvlMappedPtrs_ is indexed by NVL local rank; extract peers


### PR DESCRIPTION
Summary:

`MultiPeerTransport::exchangeNvlBuffer` now delegates to the shared `nvlMemExchangeVmm` / `nvlMemExchangeCudaIpc` helpers in `NvlMemExchange`, removing ~270 lines of duplicated fabric / POSIX-FD / cudaIpc export -> all-gather -> import -> map code. `detectNvlMemMode` (which inspects an existing external buffer's handle types) is retained and selects the VMM `preferFabric` flag or the cudaIpc path. `unmapNvlBuffers` drops the RAII `CuMemMapping`s + releases peer handles (VMM) or closes the cudaIpc handles. This is the follow-up that makes the `nvlMemExchange*` helpers genuinely shared between `GpuMemHandler` and `MultiPeerTransport`.

VMM handle ownership uses `CuMemAllocation::retain(localPtr)` -- the retained physical-handle reference is released by its destructor on both the success path and any exception unwind through `nvlMemExchangeVmm` (which can throw from its allGather / import / map steps). This closes an exception-safety hole where a raw `cuMemRetainAllocationHandle` + `cuMemRelease` pair would leak the retained ref on any failed exchange. The factory also fetches the buffer's real allocated size via `cuMemGetAddressRange`, so callers no longer need to pass a size:

- `exchangeNvlBuffer(void*, std::size_t)` -> `exchangeNvlBuffer(void*)`. The `size` argument was already unused by both the VMM branch (uses `phys->size()`) and the cudaIpc branch (uses only `localPtr`); removing it prevents callers from being misled into thinking their `size` affects behavior.
- Prod call site (`HostWindow.cc`) and 7 test call sites in `MultiPeerTransportTest.cc` updated to drop the `size` arg.

One behavior change: for the POSIX-FD path the exporter's fd is now closed right after the post-import barrier inside `nvlMemExchangeVmm` (the barrier guarantees peers have duplicated it) rather than being held until `unmapNvlBuffers` — functionally safer, no semantic change for callers.

Reviewed By: saifhhasan

Differential Revision: D107654365
