### PR TITLE
bump OSS NCCLX third-party pin to v2026.06.29.00 (#3039)

### DIFF
--- a/build_ncclx.sh
+++ b/build_ncclx.sh
@@ -159,7 +159,7 @@ function build_third_party {
   if [ "$CLEAN_THIRD_PARTY" == 1 ]; then
     rm -f "${CONDA_PREFIX}"/*.cmake 2>/dev/null || true
   fi
-  local third_party_tag="v2026.01.19.00"
+  local third_party_tag="v2026.06.29.00"
 
   mkdir -p /tmp/third-party
   pushd /tmp/third-party
@@ -379,6 +379,7 @@ pushd "${NCCL_HOME}"
 function build_nccl {
   make VERBOSE=1 -j$(nproc) \
     src.build \
+    CXXSTD="-std=c++20" \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \
     CUDA_HOME="$CUDA_HOME" \
@@ -396,6 +397,7 @@ function build_nccl {
 function build_and_install_nccl {
 make VERBOSE=1 -j$(nproc) \
     src.install \
+    CXXSTD="-std=c++20" \
     BUILDDIR="$BUILDDIR" \
     NVCC_GENCODE="$NVCC_GENCODE" \
     CUDA_HOME="$CUDA_HOME" \


### PR DESCRIPTION
Summary:

**What:** Bump the torchcomms OSS NCCLX third-party tag in `build_ncclx.sh` from `v2026.01.19.00` to `v2026.06.29.00` (folly/fbthrift/fizz/mvfst/wangle), and force `-std=c++20` for the NCCLX fork make build (`src.build`/`src.install`).

**Why:** The newer folly cut brings `AsyncSocket` to parity with zero-copy TX (`SEND_ZC`), needed to migrate ncclx onto native `AsyncSocket`. It also reimplements `folly::is_constant_evaluated_or` in `folly/lang/Bits.h` with a C++20 `consteval` constructor; NCCLX CTran device (`.cu`) kernels transitively include `Bits.h` (via `commSpecs.h` -> `folly/Hash.h`), so the device compile must be C++20 — otherwise the device sub-make inherits the `common.mk` `-std=c++17` default and fails to parse `consteval`. Stacked below D110369964 so the pin lands and mirrors first.

Reviewed By: rmahidhar

Differential Revision: D110492769


