### PR TITLE
Support AllGather rtptest benchmark

### DIFF
--- a/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
+++ b/comms/ctran/algos/AllGather/AllGatherHierarchicalRing.cc
@@ -232,16 +232,16 @@ commResult_t validateHierarchicalRingParams(CtranComm* comm, int numBlocks) {
   const auto& ibRing = (*rings)[0];
   const int prevGlobal = ibRing.prev_rank * nLocalRanks + localRank;
   const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
-  if (!mpt->has_ibgda(prevGlobal) || !mpt->has_ibgda(nextGlobal)) {
+  if (!mpt->is_ib_peer(prevGlobal) || !mpt->is_ib_peer(nextGlobal)) {
     CLOGF_SUBSYS(
         WARN,
         COLL,
-        "AllGather {} requires IBGDA prev/next transports; prev {} has_ibgda={} next {} has_ibgda={}",
+        "AllGather {} requires IB prev/next transports; prev {} type={} next {} type={}",
         allGatherAlgoName(myAlgo),
         prevGlobal,
-        mpt->has_ibgda(prevGlobal),
+        comms::prims::transport_type_name(mpt->get_transport_type(prevGlobal)),
         nextGlobal,
-        mpt->has_ibgda(nextGlobal));
+        comms::prims::transport_type_name(mpt->get_transport_type(nextGlobal)));
     return commInvalidArgument;
   }
 
@@ -387,8 +387,8 @@ commResult_t ctranAllGatherHierarchicalRing(
   const int nextGlobal = ibRing.next_rank * nLocalRanks + localRank;
   params.ib_ring.prev_rank = ibRing.prev_rank;
   params.ib_ring.next_rank = ibRing.next_rank;
-  params.ib_ring.prev = mpt->get_p2p_ibgda_transport_device(prevGlobal);
-  params.ib_ring.next = mpt->get_p2p_ibgda_transport_device(nextGlobal);
+  params.ib_ring.prev = mpt->get_p2p_ib_transport_device(prevGlobal);
+  params.ib_ring.next = mpt->get_p2p_ib_transport_device(nextGlobal);
 
   for (int peerLocal = 0; peerLocal < nLocalRanks; ++peerLocal) {
     if (peerLocal == localRank) {

--- a/comms/prims/benchmarks/IbgdaBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaBenchmark.cc
@@ -640,7 +640,7 @@ TEST_P(IbgdaBenchmarkFixture, ThreadScopeMultiBlockPutFlush) {
   printResultsTable("IBGDA ThreadScope MultiBlock Put+Flush", results);
 }
 
-TEST_F(IbgdaBenchmarkFixture, PutWaitCounter) {
+TEST_P(IbgdaBenchmarkFixture, PutWaitCounter) {
   // Measures raw RDMA Write latency (put + transport counter-slot wait).
   if (numRanks != 2) {
     XLOGF(INFO, "Skipping test: requires exactly 2 ranks, got {}", numRanks);

--- a/comms/prims/benchmarks/IbgdaSendRecv.cu
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cu
@@ -19,9 +19,9 @@ __device__ __forceinline__ std::size_t benchmark_align_protocol_bytes(
 }
 
 __device__ __forceinline__ std::size_t section_bytes(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     std::size_t totalBytes) {
-  return min(transport->send_recv_state().dataBufferSize, totalBytes);
+  return min(transport.send_recv_state().dataBufferSize, totalBytes);
 }
 
 __device__ __forceinline__ std::size_t
@@ -50,7 +50,7 @@ protocol_bytes_for_tiled_group_per_launch(
 } // namespace
 
 __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t totalBytes,
@@ -73,18 +73,18 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_kernel(
 
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
-      transport->send(
+      transport.send(
           sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
-      transport->recv(
+      transport.recv(
           sub, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
     }
   }
 }
 
 void launch_ibgda_send_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t nbytes,
@@ -102,7 +102,7 @@ void launch_ibgda_send_recv(
 
 #ifndef __HIP_PLATFORM_AMD__
 __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t totalBytes,
@@ -121,9 +121,9 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
 
     if (isSender) {
       TiledBuffer<char> tiles(src + offset, sectionBytes, sub);
-      transport->init_send_progress(
+      transport.init_send_progress(
           sub, tiles.bytes(), numBlocks, maxSignalBytes);
-      while (transport->progress_send_once(
+      while (transport.progress_send_once(
                  sub,
                  tiles.data(),
                  tiles.bytes(),
@@ -133,9 +133,9 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
       }
     } else {
       TiledBuffer<char> tiles(dst + offset, sectionBytes, sub);
-      transport->init_recv_progress(
+      transport.init_recv_progress(
           sub, tiles.bytes(), numBlocks, maxSignalBytes);
-      while (transport->progress_recv_once(
+      while (transport.progress_recv_once(
                  sub,
                  tiles.data(),
                  tiles.bytes(),
@@ -149,7 +149,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_recv_kernel(
 #endif
 
 void launch_ibgda_progress_send_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t nbytes,
@@ -180,7 +180,7 @@ void launch_ibgda_progress_send_recv(
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t firstBytes,
@@ -196,7 +196,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
 
   if (isSender) {
     TiledBuffer<char> first(src, firstBytes, sub);
-    transport->send(
+    transport.send(
         sub,
         first.data(),
         first.bytes(),
@@ -204,7 +204,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
         firstMaxSignalBytes,
         timeout);
     TiledBuffer<char> second(src + firstBytes, secondBytes, sub);
-    transport->send(
+    transport.send(
         sub,
         second.data(),
         second.bytes(),
@@ -213,7 +213,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
         timeout);
   } else {
     TiledBuffer<char> first(dst, firstBytes, sub);
-    transport->recv(
+    transport.recv(
         sub,
         first.data(),
         first.bytes(),
@@ -221,7 +221,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
         firstMaxSignalBytes,
         timeout);
     TiledBuffer<char> second(dst + firstBytes, secondBytes, sub);
-    transport->recv(
+    transport.recv(
         sub,
         second.data(),
         second.bytes(),
@@ -232,7 +232,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_recv_two_call_kernel(
 }
 
 void launch_ibgda_send_recv_two_call(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t firstBytes,
@@ -260,7 +260,7 @@ void launch_ibgda_send_recv_two_call(
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t totalBytes,
     int numBlocks,
@@ -273,13 +273,13 @@ __global__ void __launch_bounds__(512, 1) ibgda_send_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
-    transport->send(
+    transport.send(
         group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
   }
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
@@ -292,13 +292,13 @@ __global__ void __launch_bounds__(512, 1) ibgda_recv_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
-    transport->recv(
+    transport.recv(
         group, tiles.data(), tiles.bytes(), numBlocks, maxSignalBytes, timeout);
   }
 }
 
 void launch_ibgda_send(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t nbytes,
     int numBlocks,
@@ -314,7 +314,7 @@ void launch_ibgda_send(
 }
 
 void launch_ibgda_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t nbytes,
     int numBlocks,
@@ -427,7 +427,7 @@ void launch_ibgda_reset_send_recv(
 
 #ifndef __HIP_PLATFORM_AMD__
 __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t totalBytes,
     int numBlocks,
@@ -440,9 +440,9 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(src + s * sectionBytes, sectionBytes, group);
-    transport->init_send_progress(
+    transport.init_send_progress(
         group, tiles.bytes(), numBlocks, maxSignalBytes);
-    while (transport->progress_send_once(
+    while (transport.progress_send_once(
                group,
                tiles.data(),
                tiles.bytes(),
@@ -454,7 +454,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_send_kernel(
 }
 
 __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
@@ -467,9 +467,9 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
 
   for (std::size_t s = 0; s < totalSections; ++s) {
     TiledBuffer<char> tiles(dst + s * sectionBytes, sectionBytes, group);
-    transport->init_recv_progress(
+    transport.init_recv_progress(
         group, tiles.bytes(), numBlocks, maxSignalBytes);
-    while (transport->progress_recv_once(
+    while (transport.progress_recv_once(
                group,
                tiles.data(),
                tiles.bytes(),
@@ -482,7 +482,7 @@ __global__ void __launch_bounds__(512, 1) ibgda_progress_recv_kernel(
 #endif
 
 void launch_ibgda_progress_send(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t nbytes,
     int numBlocks,
@@ -511,7 +511,7 @@ void launch_ibgda_progress_send(
 }
 
 void launch_ibgda_progress_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t nbytes,
     int numBlocks,
@@ -540,17 +540,17 @@ void launch_ibgda_progress_recv(
 }
 
 __global__ void ibgda_snapshot_step_state_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     int64_t* dst,
     int count) {
   const auto idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < count) {
-    dst[idx] = transport->send_recv_state().state[idx].nextStep;
+    dst[idx] = transport.send_recv_state().state[idx].nextStep;
   }
 }
 
 void launch_ibgda_snapshot_step_state(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     int64_t* dst,
     int count,
     cudaStream_t stream) {

--- a/comms/prims/benchmarks/IbgdaSendRecv.cuh
+++ b/comms/prims/benchmarks/IbgdaSendRecv.cuh
@@ -4,12 +4,12 @@
 
 #include "comms/prims/core/TiledBuffer.cuh"
 #include "comms/prims/core/Timeout.cuh"
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 
 namespace comms::prims::benchmark {
 
 /**
- * Bidirectional tile sendrecv kernel for IBGDA transport.
+ * Bidirectional tile sendrecv kernel for IB transport.
  *
  * Grid: 2 * numBlocks (first half sends, second half receives).
  * Block: 512 threads.
@@ -21,7 +21,7 @@ namespace comms::prims::benchmark {
  * partitions data into per-block tiles. Each tile fits in one perBlockSlotSize.
  */
 __global__ void ibgda_send_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t totalBytes,
@@ -31,7 +31,7 @@ __global__ void ibgda_send_recv_kernel(
 
 #ifndef __HIP_PLATFORM_AMD__
 __global__ void ibgda_progress_send_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t totalBytes,
@@ -41,7 +41,7 @@ __global__ void ibgda_progress_send_recv_kernel(
 #endif
 
 __global__ void ibgda_send_recv_two_call_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t firstBytes,
@@ -56,7 +56,7 @@ __global__ void ibgda_send_recv_two_call_kernel(
  * Grid: numBlocks. Block: 512 threads.
  */
 __global__ void ibgda_send_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t totalBytes,
     int numBlocks,
@@ -68,7 +68,7 @@ __global__ void ibgda_send_kernel(
  * Grid: numBlocks. Block: 512 threads.
  */
 __global__ void ibgda_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t totalBytes,
     int numBlocks,
@@ -81,7 +81,7 @@ __global__ void ibgda_recv_kernel(
  * Grid: numBlocks. Block: 512 threads.
  */
 __global__ void ibgda_progress_send_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t totalBytes,
     int numBlocks,
@@ -93,7 +93,7 @@ __global__ void ibgda_progress_send_kernel(
  * Grid: numBlocks. Block: 512 threads.
  */
 __global__ void ibgda_progress_recv_kernel(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t totalBytes,
     int numBlocks,

--- a/comms/prims/benchmarks/IbgdaSendRecv.h
+++ b/comms/prims/benchmarks/IbgdaSendRecv.h
@@ -7,20 +7,17 @@
 #include <cstdint>
 
 #include "comms/prims/core/Timeout.cuh"
-
-namespace comms::prims {
-class P2pIbgdaTransportDevice;
-} // namespace comms::prims
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 
 namespace comms::prims::benchmark {
 
 /**
- * Launch bidirectional tile sendrecv kernel for IBGDA transport.
+ * Launch bidirectional tile sendrecv kernel for IB transport.
  *
  * Grid: 2 * numBlocks (first half sends, second half receives).
  * Block: 512 threads.
  *
- * @param transport  GPU-resident P2pIbgdaTransportDevice pointer
+ * @param transport  Backend-agnostic P2pIbTransportDevice handle
  * @param src        Source data buffer (device memory)
  * @param dst        Destination data buffer (device memory)
  * @param nbytes     Total bytes to transfer
@@ -30,7 +27,7 @@ namespace comms::prims::benchmark {
  * @param timeout    Optional timeout for wait operations
  */
 void launch_ibgda_send_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t nbytes,
@@ -40,13 +37,13 @@ void launch_ibgda_send_recv(
     Timeout timeout = Timeout());
 
 /**
- * Launch bidirectional progress-send/recv kernel for IBGDA transport.
+ * Launch bidirectional progress-send/recv kernel for IB transport.
  *
  * Uses the resumable init/progress API and loops until each initialized
  * transfer reaches Done.
  */
 void launch_ibgda_progress_send_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t nbytes,
@@ -60,7 +57,7 @@ void launch_ibgda_progress_send_recv(
  * send()/recv() calls with independent maxSignalBytes values.
  */
 void launch_ibgda_send_recv_two_call(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     char* dst,
     std::size_t firstBytes,
@@ -75,7 +72,7 @@ void launch_ibgda_send_recv_two_call(
  * Launch unidirectional tile send kernel. All blocks send.
  */
 void launch_ibgda_send(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t nbytes,
     int numBlocks,
@@ -87,7 +84,7 @@ void launch_ibgda_send(
  * Launch unidirectional tile recv kernel. All blocks receive.
  */
 void launch_ibgda_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t nbytes,
     int numBlocks,
@@ -120,7 +117,7 @@ void launch_ibgda_reset_send_recv(
  * Launch unidirectional progress send kernel. All blocks send.
  */
 void launch_ibgda_progress_send(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* src,
     std::size_t nbytes,
     int numBlocks,
@@ -132,7 +129,7 @@ void launch_ibgda_progress_send(
  * Launch unidirectional progress recv kernel. All blocks receive.
  */
 void launch_ibgda_progress_recv(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     char* dst,
     std::size_t nbytes,
     int numBlocks,
@@ -143,13 +140,13 @@ void launch_ibgda_progress_recv(
 /**
  * Snapshot the transport send/recv byte cursors into device memory.
  *
- * @param transport  GPU-resident P2pIbgdaTransportDevice pointer
+ * @param transport  Backend-agnostic P2pIbTransportDevice handle
  * @param dst        Device buffer receiving `count` int64_t values
  * @param count      Number of byte cursor entries to copy
  * @param stream     CUDA stream
  */
 void launch_ibgda_snapshot_step_state(
-    P2pIbgdaTransportDevice* transport,
+    P2pIbTransportDevice transport,
     int64_t* dst,
     int count,
     cudaStream_t stream);

--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -17,6 +17,7 @@
 
 #include "comms/prims/benchmarks/IbgdaSendRecv.h"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
+#include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
 #include "comms/testinfra/ITestBootstrap.h"
 #include "comms/testinfra/TcpStoreBootstrap.h"
 #include "comms/testinfra/mpi/MpiBootstrap.h"
@@ -46,6 +47,11 @@ enum class SendRecvApi {
 enum class SendRecvDirection {
   Bidirectional,
   Unidirectional,
+};
+
+enum class BenchmarkTransport {
+  Ibgda,
+  Ibrc,
 };
 
 bool isTcpEnvironment() {
@@ -116,23 +122,40 @@ struct BenchmarkSize {
   std::size_t nbytes;
 };
 
-constexpr std::array<BenchmarkSize, 13> kBenchmarkSizes{{
-    {"1MB", 1ULL << 20},
-    {"2MB", 2ULL << 20},
-    {"4MB", 4ULL << 20},
-    {"8MB", 8ULL << 20},
-    {"16MB", 16ULL << 20},
-    {"32MB", 32ULL << 20},
-    {"64MB", 64ULL << 20},
-    {"128MB", 128ULL << 20},
-    {"256MB", 256ULL << 20},
-    {"512MB", 512ULL << 20},
-    {"1GB", 1ULL << 30},
-    {"2GB", 2ULL << 30},
-    {"4GB", 4ULL << 30},
+constexpr std::array<BenchmarkSize, 23> kBenchmarkSizes{{
+    {"1KB", 1ULL << 10},     {"2KB", 2ULL << 10},     {"4KB", 4ULL << 10},
+    {"8KB", 8ULL << 10},     {"16KB", 16ULL << 10},   {"32KB", 32ULL << 10},
+    {"64KB", 64ULL << 10},   {"128KB", 128ULL << 10}, {"256KB", 256ULL << 10},
+    {"512KB", 512ULL << 10}, {"1MB", 1ULL << 20},     {"2MB", 2ULL << 20},
+    {"4MB", 4ULL << 20},     {"8MB", 8ULL << 20},     {"16MB", 16ULL << 20},
+    {"32MB", 32ULL << 20},   {"64MB", 64ULL << 20},   {"128MB", 128ULL << 20},
+    {"256MB", 256ULL << 20}, {"512MB", 512ULL << 20}, {"1GB", 1ULL << 30},
+    {"2GB", 2ULL << 30},     {"4GB", 4ULL << 30},
 }};
 
 constexpr std::size_t kMaxBenchmarkBytes = 4ULL << 30;
+constexpr std::array<BenchmarkTransport, 2> kBenchmarkTransports{
+    BenchmarkTransport::Ibgda,
+    BenchmarkTransport::Ibrc,
+};
+constexpr std::array<SendRecvApi, 2> kBenchmarkApis{
+    SendRecvApi::Blocking,
+    SendRecvApi::Progress,
+};
+constexpr std::array<SendRecvDirection, 2> kBenchmarkDirections{
+    SendRecvDirection::Bidirectional,
+    SendRecvDirection::Unidirectional,
+};
+
+const char* transportName(BenchmarkTransport transport) {
+  switch (transport) {
+    case BenchmarkTransport::Ibgda:
+      return "ibgda";
+    case BenchmarkTransport::Ibrc:
+      return "ibrc";
+  }
+  return "unknown";
+}
 
 const char* apiName(SendRecvApi api) {
   switch (api) {
@@ -155,10 +178,12 @@ const char* directionName(SendRecvDirection direction) {
 }
 
 std::string benchmarkName(
+    BenchmarkTransport transport,
     SendRecvApi api,
     SendRecvDirection direction,
     const char* sizeName) {
-  std::string name = "ibgdaSendRecv(";
+  std::string name = transportName(transport);
+  name += "SendRecv(";
   name += apiName(api);
   name += "_";
   name += directionName(direction);
@@ -181,7 +206,7 @@ class IbgdaSendRecvBenchmarkContext {
     localRank_ = bootstrap_->getLocalRank();
 
     CHECK_EQ(worldSize_, kWorldSize)
-        << "IBGDA send/recv benchmark requires exactly two ranks";
+        << "IB send/recv benchmark requires exactly two ranks";
     int deviceCount = 0;
     CHECK_EQ(cudaGetDeviceCount(&deviceCount), cudaSuccess);
     CHECK_GT(deviceCount, localRank_)
@@ -189,26 +214,11 @@ class IbgdaSendRecvBenchmarkContext {
     CHECK_EQ(cudaSetDevice(localRank_), cudaSuccess);
     CHECK_EQ(cudaStreamCreate(&stream_), cudaSuccess);
 
-    MultipeerIbgdaTransportConfig transportConfig{
-        .cudaDevice = localRank_,
-        .dataBufferSize = kSlotSize,
-        .sendRecv =
-            MultipeerIbgdaTransportConfig::SendRecvConfig{
-                .maxGroups = kNumBlocks,
-                .pipelineDepth = kPipelineDepth,
-            },
-    };
-    transport_ = std::make_unique<MultipeerIbgdaTransport>(
-        globalRank_, worldSize_, bootstrap_, transportConfig);
-    transport_->exchange();
-
     sendBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
     recvBuf_ = std::make_unique<DeviceBuffer>(maxBytes_);
     CHECK_EQ(cudaMemset(sendBuf_->get(), 0xAA, maxBytes_), cudaSuccess);
     CHECK_EQ(cudaMemset(recvBuf_->get(), 0, maxBytes_), cudaSuccess);
     CHECK_EQ(cudaDeviceSynchronize(), cudaSuccess);
-
-    deviceTransport_ = transport_->getP2pTransportDevice(1 - globalRank_);
   }
 
   ~IbgdaSendRecvBenchmarkContext() {
@@ -225,7 +235,8 @@ class IbgdaSendRecvBenchmarkContext {
     }
     recvBuf_.reset();
     sendBuf_.reset();
-    transport_.reset();
+    ibrcTransport_.reset();
+    ibgdaTransport_.reset();
     bootstrap_.reset();
   }
 
@@ -244,6 +255,10 @@ class IbgdaSendRecvBenchmarkContext {
       launchOperation(nbytes, api, direction);
       CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
     }
+  }
+
+  void barrierAll() {
+    bootstrap_->barrierAll();
   }
 
   float runLocalElapsed(
@@ -271,6 +286,45 @@ class IbgdaSendRecvBenchmarkContext {
     CHECK_EQ(cudaEventDestroy(stop), cudaSuccess);
 
     return elapsedMs;
+  }
+
+  void useTransport(BenchmarkTransport transport) {
+    if (transportInitialized_ && benchmarkTransport_ == transport) {
+      return;
+    }
+
+    CHECK_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+    bootstrap_->barrierAll();
+    ibrcTransport_.reset();
+    ibgdaTransport_.reset();
+    deviceTransport_ = P2pIbTransportDevice();
+
+    MultipeerIbgdaTransportConfig transportConfig{
+        .cudaDevice = localRank_,
+        .dataBufferSize = kSlotSize,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = kNumBlocks,
+                .pipelineDepth = kPipelineDepth,
+            },
+    };
+
+    benchmarkTransport_ = transport;
+    transportInitialized_ = true;
+    if (benchmarkTransport_ == BenchmarkTransport::Ibrc) {
+      ibrcTransport_ = std::make_unique<MultipeerIbrcTransport>(
+          globalRank_, worldSize_, bootstrap_, transportConfig);
+      ibrcTransport_->exchange();
+      deviceTransport_ = P2pIbTransportDevice(
+          ibrcTransport_->getP2pTransportDevice(1 - globalRank_));
+      return;
+    }
+
+    ibgdaTransport_ = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank_, worldSize_, bootstrap_, transportConfig);
+    ibgdaTransport_->exchange();
+    deviceTransport_ = P2pIbTransportDevice(
+        ibgdaTransport_->getP2pTransportDevice(1 - globalRank_));
   }
 
  private:
@@ -312,10 +366,13 @@ class IbgdaSendRecvBenchmarkContext {
   }
 
   std::shared_ptr<ITestBootstrap> bootstrap_;
-  std::unique_ptr<MultipeerIbgdaTransport> transport_;
+  std::unique_ptr<MultipeerIbgdaTransport> ibgdaTransport_;
+  std::unique_ptr<MultipeerIbrcTransport> ibrcTransport_;
   std::unique_ptr<DeviceBuffer> sendBuf_;
   std::unique_ptr<DeviceBuffer> recvBuf_;
-  P2pIbgdaTransportDevice* deviceTransport_{nullptr};
+  P2pIbTransportDevice deviceTransport_;
+  BenchmarkTransport benchmarkTransport_{BenchmarkTransport::Ibgda};
+  bool transportInitialized_{false};
   std::size_t maxBytes_{0};
   cudaStream_t stream_{};
   int globalRank_{0};
@@ -325,6 +382,7 @@ class IbgdaSendRecvBenchmarkContext {
 
 static unsigned int ibgdaSendRecv(
     IbgdaSendRecvBenchmarkContext& context,
+    BenchmarkTransport transport,
     uint32_t iters,
     std::size_t nbytes,
     SendRecvApi api,
@@ -333,7 +391,9 @@ static unsigned int ibgdaSendRecv(
   CHECK_GT(iters, 0);
 
   BENCHMARK_SUSPEND {
+    context.useTransport(transport);
     context.warmup(nbytes, api, direction);
+    context.barrierAll();
   }
 
   const float elapsedMs =
@@ -341,6 +401,7 @@ static unsigned int ibgdaSendRecv(
   folly::doNotOptimizeAway(elapsedMs);
 
   BENCHMARK_SUSPEND {
+    context.barrierAll();
     const double totalBytes =
         (direction == SendRecvDirection::Bidirectional ? 2.0 : 1.0) *
         static_cast<double>(nbytes) * iters;
@@ -358,34 +419,29 @@ static unsigned int ibgdaSendRecv(
 
 void registerBenchmark(
     IbgdaSendRecvBenchmarkContext& context,
+    BenchmarkTransport transport,
     const BenchmarkSize& size,
     SendRecvApi api,
     SendRecvDirection direction) {
   folly::addBenchmark(
       __FILE__,
-      benchmarkName(api, direction, size.name),
-      [&context, nbytes = size.nbytes, api, direction](
+      benchmarkName(transport, api, direction, size.name),
+      [&context, transport, nbytes = size.nbytes, api, direction](
           folly::UserCounters& counters, unsigned int iters) -> unsigned int {
-        return ibgdaSendRecv(context, iters, nbytes, api, direction, counters);
+        return ibgdaSendRecv(
+            context, transport, iters, nbytes, api, direction, counters);
       });
 }
 
 void registerBenchmarks(IbgdaSendRecvBenchmarkContext& context) {
   for (const auto& size : kBenchmarkSizes) {
-    registerBenchmark(
-        context, size, SendRecvApi::Blocking, SendRecvDirection::Bidirectional);
-    registerBenchmark(
-        context, size, SendRecvApi::Progress, SendRecvDirection::Bidirectional);
-    registerBenchmark(
-        context,
-        size,
-        SendRecvApi::Blocking,
-        SendRecvDirection::Unidirectional);
-    registerBenchmark(
-        context,
-        size,
-        SendRecvApi::Progress,
-        SendRecvDirection::Unidirectional);
+    for (auto transport : kBenchmarkTransports) {
+      for (auto api : kBenchmarkApis) {
+        for (auto direction : kBenchmarkDirections) {
+          registerBenchmark(context, transport, size, api, direction);
+        }
+      }
+    }
   }
 }
 

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -160,6 +160,50 @@ The benchmark was run with eight ranks total, two ranks per host on GPUs 0 and 1
 | 64M_16B_2R | 512MB | 2 | 52.04 | 51.52 | 0.99x | 10315.7 | 10421.1 |
 | 256M_32B_2R | 2GB | 2 | 48.87 | 49.52 | 1.01x | 43939.0 | 43366.6 |
 
+## CTRAN AllGather Benchmark
+
+Run date: 2026-07-01
+
+Benchmark target:
+
+```bash
+fbcode//comms/ctran/benchmarks:allgather_bench_4x1_binary
+```
+
+The benchmark was run with `cthierarchical_ring`, `NCCL_CTRAN_ENABLE=1`, `NCCL_CTRAN_USE_PIPES=1`, `NCCL_CTRAN_IBGDA_SENDRECV_ENABLE=1`, and `NCCL_CTRAN_PIPES_IB_MODE={ibgda,ibrc}`. Values are rank 0 CTRAN bandwidth in GB/s from the `Finished <size>: NCCL=... ctran=...` lines. The 2-node run used `rtptest2329.nha6.facebook.com` and `rtptest2344.nha6.facebook.com` with 4 ranks total, 2 ranks per host, and `NCCL_CTRAN_IB_DEVICES_PER_RANK=1`. The 4-node run used `rtptest2356.nha6.facebook.com`, `rtptest2357.nha6.facebook.com`, `rtptest2359.nha6.facebook.com`, and `rtptest2360.nha6.facebook.com` with 8 ranks total, 2 ranks per host, `NCCL_CTRAN_IB_DEVICES_PER_RANK=2`, and `NCCL_CTRAN_IB_DEVICE_STRIDE=0`.
+
+Full logs:
+
+| Run | Log |
+| --- | --- |
+| 2-node IBGDA | `/tmp/rtptest_gb200_allgather_ibgda_sweep.txt` |
+| 2-node IBRC | `/tmp/rtptest_gb200_allgather_ibrc_sweep.txt` |
+| 4-node IBGDA, two-NIC config | `/tmp/rtptest_gb200_4node_dualnic_allgather_ibgda_sweep.txt` |
+| 4-node IBRC, two-NIC config | `/tmp/rtptest_gb200_4node_dualnic_allgather_ibrc_sweep.txt` |
+
+| Size | 2-node IBGDA | 2-node IBRC | 4-node IBGDA | 4-node IBRC |
+| ---: | ---: | ---: | ---: | ---: |
+| 8KB | 0.075 | 0.071 | 0.028 | 0.027 |
+| 16KB | 0.151 | 0.149 | 0.052 | 0.053 |
+| 32KB | 0.300 | 0.304 | 0.110 | 0.107 |
+| 64KB | 0.620 | 0.586 | 0.223 | 0.211 |
+| 128KB | 1.14 | 1.14 | 0.453 | 0.443 |
+| 256KB | 2.37 | 2.39 | 0.881 | 0.844 |
+| 512KB | 4.73 | 4.63 | 1.74 | 1.65 |
+| 1MB | 8.72 | 8.65 | 3.57 | 3.45 |
+| 2MB | 15.23 | 15.01 | 6.23 | 6.12 |
+| 4MB | 25.98 | 25.66 | 11.34 | 10.94 |
+| 8MB | 34.37 | 36.82 | 17.82 | 18.72 |
+| 16MB | 46.12 | 47.39 | 25.80 | 26.84 |
+| 32MB | 50.81 | 53.00 | 33.65 | 35.87 |
+| 64MB | 58.60 | 58.33 | 40.84 | 41.62 |
+| 128MB | 60.61 | 60.34 | 44.41 | 45.35 |
+| 256MB | 62.87 | 62.80 | 45.69 | 47.02 |
+| 512MB | 64.51 | 61.33 | 45.22 | 46.02 |
+| 1GB | 64.07 | 63.77 | 46.96 | 48.40 |
+
+The 4-node two-NIC setting did not double the CTRAN bandwidth for this path. A follow-up run with `NCCL_CTRAN_IB_QP_INTERLEAVE_DEVICES_ENABLE=1` produced similar top-end results (`47.02 GB/s` for IBGDA and `48.25 GB/s` for IBRC at 1GB), which is consistent with `cthierarchical_ring` using the prims hierarchical fused send/recv path instead of the CTRAN-IB QP interleave path.
+
 ## Current Counter-Slot Results
 
 These results are from the 2026-06-24 rerun after pinning the IBRC progress thread. The initial filtered run covered `PutFlush`, `PutSignalWaitCounter`, `SignalOnly`, and `PutSignalComparison`. `PutWaitCounter` required a local benchmark test fix from `TEST_F` to `TEST_P` so the backend parameterization works; it was then rebuilt for `aarch64` and rerun separately on the same hosts.

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -20,6 +20,70 @@ python3 comms/testinfra/ncclx_test_launcher.py \
 
 The `rtptest2333`/`rtptest2349` pair was used because both hosts had CUDA ready (`cuInit=0`, two devices, no compute processes) and the MPI hostname smoke test passed. Before launching, the `2803:*` IPv6 address on `eth0` was temporarily removed on both hosts to avoid Open MPI advertising a peer address that did not match DNS. The `2803:*` addresses were restored after the run. The `rtptest2348`/`rtptest2350` pair was rejected because CUDA initialization returned `802`.
 
+## Send/Recv Benchmark
+
+Run date: 2026-07-01, with exact KB reruns on 2026-07-02
+
+Hosts: `rtptest2347.nha6.facebook.com`, `rtptest2348.nha6.facebook.com`
+
+Setup: one rank per host on GPU 0, using the rebased `aarch64` GB200 binary. Values are rank 0 P2P bandwidth in GB/s; bidirectional counts traffic in both directions. KB rows use exact 1000-iteration reruns.
+
+Blocking API:
+
+| Size | Bidir IBGDA | Bidir IBRC | Unidir IBGDA | Unidir IBRC |
+| ---: | ---: | ---: | ---: | ---: |
+| 1KB | 0.052 | 0.035 | 0.063 | 0.041 |
+| 2KB | 0.105 | 0.063 | 0.119 | 0.082 |
+| 4KB | 0.210 | 0.129 | 0.236 | 0.164 |
+| 8KB | 0.417 | 0.254 | 0.485 | 0.320 |
+| 16KB | 0.828 | 0.497 | 0.969 | 0.656 |
+| 32KB | 1.57 | 0.944 | 1.94 | 1.12 |
+| 64KB | 3.11 | 1.79 | 3.65 | 2.08 |
+| 128KB | 5.83 | 3.44 | 6.40 | 3.87 |
+| 256KB | 10.41 | 7.11 | 11.24 | 9.84 |
+| 512KB | 5.57 | 3.65 | 7.00 | 4.54 |
+| 1MB | 25.51 | 18.30 | 33.46 | 24.69 |
+| 2MB | 33.07 | 26.71 | 51.28 | 39.54 |
+| 4MB | 39.50 | 34.28 | 69.66 | 56.38 |
+| 8MB | 43.67 | 40.59 | 59.97 | 55.63 |
+| 16MB | 69.60 | 64.37 | 59.14 | 55.21 |
+| 32MB | 85.60 | 79.21 | 58.78 | 57.40 |
+| 64MB | 97.67 | 89.76 | 58.60 | 57.41 |
+| 128MB | 105.40 | 97.46 | 58.50 | 55.36 |
+| 256MB | 111.47 | 102.32 | 57.81 | 56.05 |
+| 512MB | 114.46 | 107.16 | 57.71 | 57.48 |
+| 1GB | 112.37 | 108.70 | 57.69 | 57.98 |
+| 2GB | 115.88 | 111.14 | 58.22 | 60.24 |
+| 4GB | 117.58 | 111.39 | 57.69 | 59.55 |
+
+Progress API:
+
+| Size | Bidir IBGDA | Bidir IBRC | Unidir IBGDA | Unidir IBRC |
+| ---: | ---: | ---: | ---: | ---: |
+| 1KB | 0.050 | 0.031 | 0.054 | 0.049 |
+| 2KB | 0.101 | 0.063 | 0.111 | 0.074 |
+| 4KB | 0.200 | 0.138 | 0.221 | 0.143 |
+| 8KB | 0.401 | 0.247 | 0.444 | 0.290 |
+| 16KB | 0.798 | 0.494 | 0.889 | 0.592 |
+| 32KB | 1.52 | 0.946 | 1.65 | 1.06 |
+| 64KB | 2.91 | 1.82 | 3.22 | 2.68 |
+| 128KB | 5.22 | 3.50 | 5.58 | 3.83 |
+| 256KB | 9.44 | 7.19 | 10.24 | 9.61 |
+| 512KB | 5.06 | 3.80 | 6.04 | 4.35 |
+| 1MB | 24.00 | 19.00 | 31.28 | 24.54 |
+| 2MB | 32.21 | 27.35 | 48.70 | 39.26 |
+| 4MB | 39.86 | 35.19 | 67.23 | 56.02 |
+| 8MB | 44.24 | 41.25 | 59.73 | 55.44 |
+| 16MB | 69.15 | 64.73 | 59.06 | 55.01 |
+| 32MB | 84.96 | 79.86 | 58.66 | 54.58 |
+| 64MB | 96.60 | 90.81 | 58.43 | 55.88 |
+| 128MB | 104.10 | 97.88 | 57.62 | 56.83 |
+| 256MB | 110.46 | 103.44 | 57.57 | 56.08 |
+| 512MB | 112.53 | 108.19 | 57.52 | 57.51 |
+| 1GB | 112.41 | 110.29 | 57.53 | 57.55 |
+| 2GB | 115.33 | 113.14 | 58.08 | 58.86 |
+| 4GB | 119.67 | 112.19 | 57.53 | 59.31 |
+
 ## Current Counter-Slot Results
 
 These results are from the 2026-06-24 rerun after pinning the IBRC progress thread. The initial filtered run covered `PutFlush`, `PutSignalWaitCounter`, `SignalOnly`, and `PutSignalComparison`. `PutWaitCounter` required a local benchmark test fix from `TEST_F` to `TEST_P` so the backend parameterization works; it was then rebuilt for `aarch64` and rerun separately on the same hosts.

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -84,6 +84,82 @@ Progress API:
 | 2GB | 115.33 | 113.14 | 58.08 | 58.86 |
 | 4GB | 119.67 | 112.19 | 57.53 | 59.31 |
 
+## Ring ReduceScatter Benchmark
+
+Run date: 2026-06-26
+
+Hosts used: `rtptest2329.nha6.facebook.com`, `rtptest2330.nha6.facebook.com`, `rtptest2344.nha6.facebook.com`, `rtptest2345.nha6.facebook.com`
+
+Benchmark target:
+
+```bash
+fbcode//comms/prims/collectives/benchmarks:ring_reduce_scatter_benchmark_binary
+```
+
+Run command:
+
+```bash
+RUN_ID=codex_4host_ppn1_b_20260626_115913 \
+  HOSTS=rtptest2329.nha6.facebook.com,rtptest2330.nha6.facebook.com,rtptest2344.nha6.facebook.com,rtptest2345.nha6.facebook.com \
+  NNODES=4 \
+  PPN=1 \
+  GPU_ID=0 \
+  /tmp/run_ibrc_reduce_scatter_benchmark.sh
+```
+
+Full log: `/tmp/ibrc_reduce_scatter_codex_4host_ppn1_b.log`
+
+The benchmark was run with four ranks total, one rank per host on GPU 0. Values are bandwidth in GB/s and latency in microseconds. The `Size` column is total bytes across the four ranks; `chunk_elements` is per-rank output elements.
+
+| Test | Size | Rings | IBGDA BW | IBRC BW | Speedup | IBGDA Latency (us) | IBRC Latency (us) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 256K_8B | 1MB | 1 | 9.00 | 5.81 | 0.64x | 116.4 | 180.5 |
+| 1M_16B | 4MB | 1 | 22.88 | 18.05 | 0.79x | 183.3 | 232.4 |
+| 4M_16B | 16MB | 1 | 43.88 | 40.34 | 0.92x | 382.3 | 415.9 |
+| 16M_16B | 64MB | 1 | 52.07 | 53.07 | 1.02x | 1288.9 | 1264.7 |
+| 64M_16B | 256MB | 1 | 60.61 | 61.78 | 1.02x | 4428.7 | 4344.7 |
+| 128M_16B | 512MB | 1 | 61.34 | 62.84 | 1.02x | 8752.1 | 8544.1 |
+| 256M_32B | 1GB | 1 | 62.95 | 62.86 | 1.00x | 17055.8 | 17081.4 |
+| 4M_16B_2R | 16MB | 2 | 40.42 | 37.01 | 0.92x | 415.0 | 453.3 |
+| 16M_16B_2R | 64MB | 2 | 55.37 | 52.38 | 0.95x | 1212.0 | 1281.2 |
+| 64M_16B_2R | 256MB | 2 | 59.11 | 58.34 | 0.99x | 4541.6 | 4601.6 |
+| 256M_32B_2R | 1GB | 2 | 57.01 | 58.16 | 1.02x | 18832.7 | 18462.8 |
+
+### 8 ranks, 4 nodes
+
+Run command:
+
+```bash
+/home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/70552be409c74e42/comms/testinfra/__ncclx_test_launcher__/ncclx_test_launcher.par \
+  --launcher mpi \
+  --nnode 4 \
+  --ppn 2 \
+  --interleave \
+  --hosts rtptest2329.nha6.facebook.com,rtptest2330.nha6.facebook.com,rtptest2344.nha6.facebook.com,rtptest2345.nha6.facebook.com \
+  --ifname eth0 \
+  --env 'NCCL_DEBUG=WARN;NCCL_IB_HCA=mlx5_0,mlx5_1,mlx5_3,mlx5_4' \
+  --gtest_filter RingReduceScatterBenchmarkFixture.IbrcVsIbgda \
+  --testname /home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/7923733aec21c17e/comms/prims/collectives/benchmarks/__ring_reduce_scatter_benchmark_binary__/ring_reduce_scatter_benchmark_binary
+```
+
+Full log: `/tmp/ibrc_reduce_scatter_codex_4node_8rank_interleave_retry.log`
+
+The benchmark was run with eight ranks total, two ranks per host on GPUs 0 and 1. `--interleave` is required for this host layout; the default `ppr:2:node` rank ordering reached the benchmark header but did not produce a result row. Values are bandwidth in GB/s and latency in microseconds. The `Size` column is total bytes across the eight ranks.
+
+| Test | Size | Rings | IBGDA BW | IBRC BW | Speedup | IBGDA Latency (us) | IBRC Latency (us) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 256K_8B | 2MB | 1 | 8.26 | 4.66 | 0.56x | 254.0 | 450.0 |
+| 1M_16B | 8MB | 1 | 23.48 | 14.04 | 0.60x | 357.3 | 597.6 |
+| 4M_16B | 32MB | 1 | 43.09 | 34.34 | 0.80x | 778.7 | 977.1 |
+| 16M_16B | 128MB | 1 | 48.85 | 47.73 | 0.98x | 2747.3 | 2811.9 |
+| 64M_16B | 512MB | 1 | 52.79 | 54.41 | 1.03x | 10170.8 | 9867.6 |
+| 128M_16B | 1GB | 1 | 53.04 | 54.85 | 1.03x | 20242.7 | 19575.8 |
+| 256M_32B | 2GB | 1 | 53.37 | 54.72 | 1.03x | 40235.5 | 39246.8 |
+| 4M_16B_2R | 32MB | 2 | 19.04 | 30.55 | 1.60x | 1762.0 | 1098.4 |
+| 16M_16B_2R | 128MB | 2 | 47.98 | 46.08 | 0.96x | 2797.1 | 2912.5 |
+| 64M_16B_2R | 512MB | 2 | 52.04 | 51.52 | 0.99x | 10315.7 | 10421.1 |
+| 256M_32B_2R | 2GB | 2 | 48.87 | 49.52 | 1.01x | 43939.0 | 43366.6 |
+
 ## Current Counter-Slot Results
 
 These results are from the 2026-06-24 rerun after pinning the IBRC progress thread. The initial filtered run covered `PutFlush`, `PutSignalWaitCounter`, `SignalOnly`, and `PutSignalComparison`. `PutWaitCounter` required a local benchmark test fix from `TEST_F` to `TEST_P` so the backend parameterization works; it was then rebuilt for `aarch64` and rerun separately on the same hosts.

--- a/comms/prims/benchmarks/IbrcBenchmarkResults.md
+++ b/comms/prims/benchmarks/IbrcBenchmarkResults.md
@@ -1,8 +1,8 @@
 # IBRC Benchmark Results
 
-Run date: 2026-06-16
+Run date: 2026-06-24
 
-Hosts used: `rtptest2330.nha6`, `rtptest2334.nha6`
+Hosts used: `rtptest2333.nha6.facebook.com`, `rtptest2349.nha6.facebook.com`
 
 Launcher:
 
@@ -11,102 +11,105 @@ python3 comms/testinfra/ncclx_test_launcher.py \
   --launcher mpi \
   --nnode 2 \
   --ppn 1 \
-  --hosts rtptest2330.nha6,rtptest2334.nha6 \
-  --ifname eth1 \
-  --env 'NCCL_DEBUG=WARN' \
-  --testname /home/zhiyongww/worktrees/IBRC/buck-out/v2/art/fbcode/065941cadf27ce30/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
+  --hosts rtptest2333.nha6.facebook.com,rtptest2349.nha6.facebook.com \
+  --ifname eth0 \
+  --env 'NCCL_DEBUG=WARN;NCCL_IB_HCA=mlx5_0,mlx5_1' \
+  --gtest_filter 'IbBackend/IbgdaBenchmarkFixture.PutSignalWaitCounter/*:IbBackend/IbgdaBenchmarkFixture.PutSignalComparison/*:IbBackend/IbgdaBenchmarkFixture.PutFlush/*:IbBackend/IbgdaBenchmarkFixture.SignalOnly/*' \
+  --testname /data/users/zhiyongww/fbsource/buck-out/v2/art/fbcode/5b4cba3f80737e3b/comms/prims/benchmarks/__ibgda_benchmark_binary__/ibgda_benchmark_binary
 ```
 
-The initially suggested hosts, `rtptest2347.nha6` and `rtptest2346.nha6`, were not usable for this run because CUDA context creation failed with `CUDA-capable device(s) is/are busy or unavailable`. The results below use the clean GB200 pair listed above.
+The `rtptest2333`/`rtptest2349` pair was used because both hosts had CUDA ready (`cuInit=0`, two devices, no compute processes) and the MPI hostname smoke test passed. Before launching, the `2803:*` IPv6 address on `eth0` was temporarily removed on both hosts to avoid Open MPI advertising a peer address that did not match DNS. The `2803:*` addresses were restored after the run. The `rtptest2348`/`rtptest2350` pair was rejected because CUDA initialization returned `802`.
 
 ## Current Counter-Slot Results
 
-These results are after switching the counter benchmarks from explicit counter buffers to the transport-owned counter-slot API. IBRC `PutWaitCounter`, `PutSignalWaitCounter`, and `PutSignalComparison` pass with this path.
+These results are from the 2026-06-24 rerun after pinning the IBRC progress thread. The initial filtered run covered `PutFlush`, `PutSignalWaitCounter`, `SignalOnly`, and `PutSignalComparison`. `PutWaitCounter` required a local benchmark test fix from `TEST_F` to `TEST_P` so the backend parameterization works; it was then rebuilt for `aarch64` and rerun separately on the same hosts.
 
 Current logs:
 
 | Run | Log |
 | --- | --- |
-| Expanded sweep through 1GB | `/tmp/ibrc_1gb_sweep.log` |
-| IBRC counter-slot retest | `/tmp/ibrc_counter_slot_tests.log` |
-| IBGDA counter-slot retest | `/tmp/ibgda_counter_slot_tests.log` |
+| 2026-06-24 filtered rerun on `rtptest2333`/`rtptest2349` | `/tmp/ibrc-benchmark-direct-2333-2349-no2803-20260624-151520.log` |
+| 2026-06-24 fixed `PutWaitCounter` rerun on `rtptest2333`/`rtptest2349` | `/tmp/ibrc-benchmark-putwait-fixed-2333-2349-no2803-20260624-160334.log` |
 
 Summary:
 
 | Benchmark | IBGDA | IBRC |
 | --- | ---: | ---: |
-| `PutFlush`, 1GB | 22202.67 us, 48.36 GB/s | 23039.32 us, 46.60 GB/s |
-| `PutWaitCounter`, 1GB | 22209.76 us, 48.35 GB/s | 22987.54 us, 46.71 GB/s |
-| `PutSignalWaitCounter`, 1GB | 22210.01 us, 48.34 GB/s | 22943.53 us, 46.80 GB/s |
-| `PutSignalComparison`, 16MB | 368.99 us | 704.07 us |
-| `MultiPeerCounterFanOut`, 64KB per peer | Not rerun in current retest | N/A: explicit shared-counter-buffer benchmark |
+| `PutFlush`, 1GB | 22197.61 us, 48.37 GB/s | 22203.10 us, 48.36 GB/s |
+| `PutWaitCounter`, 1GB | 22204.56 us, 48.36 GB/s | 22205.06 us, 48.36 GB/s |
+| `PutSignalWaitCounter`, 1GB | 22204.38 us, 48.36 GB/s | 22211.54 us, 48.34 GB/s |
+| `PutSignalComparison`, 16MB | 365.32 us | 374.78 us |
+| `SignalOnly`, average latency | 12.25 us | 30.33 us |
+| `MultiPeerCounterFanOut`, 64KB per peer | Not rerun in 2026-06-24 filtered run | N/A: explicit shared-counter-buffer benchmark |
 
 ## PutWaitCounter
 
+Rerun separately on 2026-06-24 using a locally rebuilt `aarch64` benchmark binary after fixing the test declaration to `TEST_P(IbgdaBenchmarkFixture, PutWaitCounter)`. The previous `TEST_F` declaration aborted before measuring because it called `GetParam()` outside a parameterized test.
+
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 21.27 | 0.00 | 38.28 | 0.00 |
-| 64B | 23.02 | 0.00 | 38.27 | 0.00 |
-| 256B | 23.07 | 0.01 | 38.26 | 0.01 |
-| 1KB | 23.17 | 0.04 | 38.25 | 0.03 |
-| 4KB | 23.48 | 0.17 | 38.31 | 0.11 |
-| 8KB | 23.71 | 0.35 | 38.29 | 0.21 |
-| 16KB | 23.95 | 0.68 | 42.00 | 0.39 |
-| 32KB | 24.43 | 1.34 | 43.70 | 0.75 |
-| 64KB | 25.10 | 2.61 | 44.16 | 1.48 |
-| 128KB | 27.32 | 4.80 | 49.02 | 2.67 |
-| 256KB | 30.02 | 8.73 | 52.46 | 5.00 |
-| 512KB | 35.44 | 14.79 | 65.69 | 7.98 |
-| 1MB | 46.23 | 22.68 | 86.75 | 12.09 |
-| 2MB | 67.83 | 30.92 | 129.09 | 16.25 |
-| 4MB | 110.97 | 37.80 | 216.09 | 19.41 |
-| 8MB | 197.30 | 42.52 | 384.12 | 21.84 |
-| 16MB | 369.71 | 45.38 | 695.64 | 24.12 |
-| 32MB | 714.95 | 46.93 | 1271.31 | 26.39 |
-| 64MB | 1405.48 | 47.75 | 2322.96 | 28.89 |
-| 128MB | 2787.44 | 48.15 | 3521.63 | 38.11 |
-| 256MB | 5572.73 | 48.17 | 6944.67 | 38.65 |
-| 512MB | 11118.86 | 48.28 | 13613.28 | 39.44 |
-| 1GB | 22209.76 | 48.35 | 22987.54 | 46.71 |
+| 8B | 15.63 | 0.00 | 19.88 | 0.00 |
+| 64B | 16.77 | 0.00 | 20.01 | 0.00 |
+| 256B | 17.75 | 0.01 | 19.63 | 0.01 |
+| 1KB | 17.94 | 0.06 | 20.10 | 0.05 |
+| 4KB | 18.03 | 0.23 | 19.99 | 0.20 |
+| 8KB | 18.30 | 0.45 | 20.14 | 0.41 |
+| 16KB | 18.53 | 0.88 | 20.31 | 0.81 |
+| 32KB | 19.06 | 1.72 | 22.65 | 1.45 |
+| 64KB | 19.75 | 3.32 | 22.76 | 2.88 |
+| 128KB | 21.97 | 5.97 | 22.99 | 5.70 |
+| 256KB | 24.66 | 10.63 | 27.89 | 9.40 |
+| 512KB | 30.06 | 17.44 | 33.58 | 15.61 |
+| 1MB | 40.80 | 25.70 | 42.43 | 24.71 |
+| 2MB | 62.35 | 33.64 | 66.19 | 31.68 |
+| 4MB | 105.49 | 39.76 | 109.14 | 38.43 |
+| 8MB | 191.77 | 43.74 | 195.05 | 43.01 |
+| 16MB | 364.31 | 46.05 | 368.27 | 45.56 |
+| 32MB | 709.46 | 47.30 | 713.38 | 47.04 |
+| 64MB | 1400.05 | 47.93 | 1403.72 | 47.81 |
+| 128MB | 2786.51 | 48.17 | 2785.43 | 48.19 |
+| 256MB | 5567.58 | 48.21 | 5568.85 | 48.20 |
+| 512MB | 11113.65 | 48.31 | 11114.50 | 48.30 |
+| 1GB | 22204.56 | 48.36 | 22205.06 | 48.36 |
 
 ## PutSignalWaitCounter
 
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 22.05 | 0.00 | 65.29 | 0.00 |
-| 64B | 23.09 | 0.00 | 65.33 | 0.00 |
-| 256B | 23.22 | 0.01 | 64.58 | 0.00 |
-| 1KB | 23.35 | 0.04 | 65.23 | 0.02 |
-| 4KB | 23.68 | 0.17 | 65.67 | 0.06 |
-| 8KB | 23.94 | 0.34 | 64.94 | 0.13 |
-| 16KB | 24.18 | 0.68 | 64.80 | 0.25 |
-| 32KB | 24.55 | 1.33 | 64.63 | 0.51 |
-| 64KB | 25.24 | 2.60 | 65.06 | 1.01 |
-| 128KB | 27.41 | 4.78 | 72.07 | 1.82 |
-| 256KB | 30.24 | 8.67 | 78.78 | 3.33 |
-| 512KB | 35.43 | 14.80 | 87.25 | 6.01 |
-| 1MB | 46.14 | 22.72 | 111.76 | 9.38 |
-| 2MB | 67.67 | 30.99 | 149.81 | 14.00 |
-| 4MB | 110.66 | 37.90 | 237.82 | 17.64 |
-| 8MB | 196.82 | 42.62 | 406.69 | 20.63 |
-| 16MB | 369.59 | 45.39 | 731.31 | 22.94 |
-| 32MB | 714.92 | 46.93 | 1281.58 | 26.18 |
-| 64MB | 1405.51 | 47.75 | 2324.56 | 28.87 |
-| 128MB | 2787.41 | 48.15 | 3527.65 | 38.05 |
-| 256MB | 5573.03 | 48.17 | 6940.11 | 38.68 |
-| 512MB | 11119.03 | 48.28 | 13555.27 | 39.61 |
-| 1GB | 22210.01 | 48.34 | 22943.53 | 46.80 |
+| 8B | 16.76 | 0.00 | 27.75 | 0.00 |
+| 64B | 18.90 | 0.00 | 27.74 | 0.00 |
+| 256B | 18.98 | 0.01 | 27.80 | 0.01 |
+| 1KB | 19.08 | 0.05 | 27.80 | 0.04 |
+| 4KB | 19.31 | 0.21 | 27.77 | 0.15 |
+| 8KB | 19.50 | 0.42 | 27.73 | 0.30 |
+| 16KB | 19.67 | 0.83 | 27.86 | 0.59 |
+| 32KB | 20.11 | 1.63 | 27.81 | 1.18 |
+| 64KB | 20.80 | 3.15 | 30.52 | 2.15 |
+| 128KB | 23.05 | 5.69 | 31.22 | 4.20 |
+| 256KB | 25.77 | 10.17 | 33.78 | 7.76 |
+| 512KB | 31.19 | 16.81 | 41.46 | 12.65 |
+| 1MB | 42.00 | 24.97 | 50.49 | 20.77 |
+| 2MB | 63.53 | 33.01 | 72.62 | 28.88 |
+| 4MB | 106.72 | 39.30 | 115.90 | 36.19 |
+| 8MB | 192.90 | 43.49 | 201.96 | 41.54 |
+| 16MB | 365.26 | 45.93 | 374.67 | 44.78 |
+| 32MB | 710.34 | 47.24 | 719.73 | 46.62 |
+| 64MB | 1400.89 | 47.90 | 1410.88 | 47.57 |
+| 128MB | 2786.67 | 48.16 | 2793.80 | 48.04 |
+| 256MB | 5567.98 | 48.21 | 5575.46 | 48.15 |
+| 512MB | 11113.82 | 48.31 | 11121.18 | 48.27 |
+| 1GB | 22204.38 | 48.36 | 22211.54 | 48.34 |
 
 ## PutSignalComparison
 
 | Size | IBGDA Counter Latency (us) | IBRC Counter Latency (us) |
 | --- | ---: | ---: |
-| 8B | 21.48 | 64.89 |
-| 64B | 22.26 | 64.81 |
-| 1KB | 22.54 | 64.01 |
-| 64KB | 24.50 | 65.44 |
-| 1MB | 45.78 | 111.09 |
-| 16MB | 368.99 | 704.07 |
+| 8B | 16.78 | 27.42 |
+| 64B | 18.80 | 27.46 |
+| 1KB | 18.94 | 27.38 |
+| 64KB | 20.83 | 31.11 |
+| 1MB | 41.94 | 50.80 |
+| 16MB | 365.32 | 374.78 |
 
 ## PutFlush Baseline
 
@@ -114,29 +117,29 @@ Summary:
 
 | Size | IBGDA Latency (us) | IBGDA BW (GB/s) | IBRC Latency (us) | IBRC BW (GB/s) |
 | --- | ---: | ---: | ---: | ---: |
-| 8B | 16.89 | 0.00 | 38.64 | 0.00 |
-| 64B | 17.17 | 0.00 | 39.58 | 0.00 |
-| 256B | 17.25 | 0.01 | 38.55 | 0.01 |
-| 1KB | 17.35 | 0.06 | 38.55 | 0.03 |
-| 4KB | 17.67 | 0.23 | 38.54 | 0.11 |
-| 8KB | 17.79 | 0.46 | 38.53 | 0.21 |
-| 16KB | 18.10 | 0.90 | 39.22 | 0.42 |
-| 32KB | 18.47 | 1.77 | 38.60 | 0.85 |
-| 64KB | 19.15 | 3.42 | 43.39 | 1.51 |
-| 128KB | 21.39 | 6.13 | 44.10 | 2.97 |
-| 256KB | 24.09 | 10.88 | 50.02 | 5.24 |
-| 512KB | 29.48 | 17.78 | 61.50 | 8.52 |
-| 1MB | 40.28 | 26.03 | 83.85 | 12.51 |
-| 2MB | 61.86 | 33.90 | 127.60 | 16.44 |
-| 4MB | 105.03 | 39.94 | 207.77 | 20.19 |
-| 8MB | 191.35 | 43.84 | 375.71 | 22.33 |
-| 16MB | 364.00 | 46.09 | 695.80 | 24.11 |
-| 32MB | 709.30 | 47.31 | 1280.02 | 26.21 |
-| 64MB | 1399.92 | 47.94 | 2269.87 | 29.57 |
-| 128MB | 2782.83 | 48.23 | 3535.06 | 37.97 |
-| 256MB | 5566.01 | 48.23 | 6928.67 | 38.74 |
-| 512MB | 11111.88 | 48.32 | 13582.13 | 39.53 |
-| 1GB | 22202.67 | 48.36 | 23039.32 | 46.60 |
+| 8B | 11.81 | 0.00 | 22.67 | 0.00 |
+| 64B | 11.83 | 0.01 | 20.11 | 0.00 |
+| 256B | 12.27 | 0.02 | 20.08 | 0.01 |
+| 1KB | 12.37 | 0.08 | 20.04 | 0.05 |
+| 4KB | 12.58 | 0.33 | 20.13 | 0.20 |
+| 8KB | 12.80 | 0.64 | 19.98 | 0.41 |
+| 16KB | 12.99 | 1.26 | 20.09 | 0.82 |
+| 32KB | 13.48 | 2.43 | 21.50 | 1.52 |
+| 64KB | 14.16 | 4.63 | 22.28 | 2.94 |
+| 128KB | 16.37 | 8.01 | 22.62 | 5.79 |
+| 256KB | 19.07 | 13.74 | 26.74 | 9.80 |
+| 512KB | 24.48 | 21.42 | 33.40 | 15.70 |
+| 1MB | 35.27 | 29.73 | 42.25 | 24.82 |
+| 2MB | 56.86 | 36.89 | 65.69 | 31.92 |
+| 4MB | 100.02 | 41.93 | 108.51 | 38.65 |
+| 8MB | 186.34 | 45.02 | 194.58 | 43.11 |
+| 16MB | 359.00 | 46.73 | 366.93 | 45.72 |
+| 32MB | 704.31 | 47.64 | 712.63 | 47.09 |
+| 64MB | 1394.93 | 48.11 | 1402.98 | 47.83 |
+| 128MB | 2777.88 | 48.32 | 2784.92 | 48.19 |
+| 256MB | 5561.42 | 48.27 | 5567.89 | 48.21 |
+| 512MB | 11107.01 | 48.34 | 11113.06 | 48.31 |
+| 1GB | 22197.61 | 48.37 | 22203.10 | 48.36 |
 
 ## SignalOnly Baseline
 
@@ -144,5 +147,5 @@ Summary:
 
 | Metric | IBGDA | IBRC |
 | --- | ---: | ---: |
-| Average latency (us) | 17.75 | 40.90 |
+| Average latency (us) | 12.25 | 30.33 |
 | Batch iterations | 1000 | 1000 |

--- a/comms/prims/collectives/AllGatherDirect.cu
+++ b/comms/prims/collectives/AllGatherDirect.cu
@@ -9,7 +9,7 @@
 #include "comms/prims/core/MemcpyCopyOp.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/TiledBuffer.cuh"
-#include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
+#include "comms/prims/transport/P2pIbTransportDevice.cuh"
 
 namespace comms::prims {
 
@@ -114,8 +114,8 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_fused_kernel(
   }
 
   const auto& topo = args.ib_ring;
-  auto& prev = *topo.prev;
-  auto& next = *topo.next;
+  auto prev = topo.prev;
+  auto next = topo.next;
   const std::size_t pipeline_window = next.pipeline_window(group.total_groups);
   PIPES_DEVICE_CHECK_MSG(
       pipeline_window != 0,
@@ -302,8 +302,8 @@ __launch_bounds__(kBlockSize, 1) void hierarchical_allgather_overlap_kernel(
       }
 
       const auto& topo = args.ib_ring;
-      auto& prev = *topo.prev;
-      auto& next = *topo.next;
+      auto prev = topo.prev;
+      auto next = topo.next;
       const int stride = (args.ib_rank - topo.prev_rank + W) % W;
       const std::size_t ib_window = next.pipeline_window(args.ib_num_blocks);
       PIPES_DEVICE_CHECK_MSG(

--- a/comms/prims/collectives/AllGatherDirectTypes.h
+++ b/comms/prims/collectives/AllGatherDirectTypes.h
@@ -7,11 +7,10 @@
 
 #include "comms/prims/collectives/DirectCollectiveTypes.h"
 #include "comms/prims/trace/PipesTraceTypes.h"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 
 namespace comms::prims {
-
-class P2pIbgdaTransportDevice;
 
 struct DirectAllgatherNvlArgs {
   int my_rank{0};
@@ -23,11 +22,11 @@ struct DirectAllgatherNvlArgs {
   char* recvbuf{nullptr};
 };
 
-struct HierarchicalAllgatherIbgdaRing {
+struct HierarchicalAllgatherIbRing {
   int prev_rank{0};
   int next_rank{0};
-  P2pIbgdaTransportDevice* prev{nullptr};
-  P2pIbgdaTransportDevice* next{nullptr};
+  P2pIbTransportDevice prev{};
+  P2pIbTransportDevice next{};
 };
 
 struct HierarchicalAllgatherFusedArgs {
@@ -40,7 +39,7 @@ struct HierarchicalAllgatherFusedArgs {
   std::size_t nvl_signaling_data_size{0};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
-  HierarchicalAllgatherIbgdaRing ib_ring{};
+  HierarchicalAllgatherIbRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
 };
 
@@ -60,7 +59,7 @@ struct HierarchicalAllgatherOverlapArgs {
   uint64_t* ready_counters{nullptr};
   const char* sendbuf{nullptr};
   char* recvbuf{nullptr};
-  HierarchicalAllgatherIbgdaRing ib_ring{};
+  HierarchicalAllgatherIbRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
   PipesTraceHandle trace{};
 };

--- a/comms/prims/collectives/AllGatherLauncher.h
+++ b/comms/prims/collectives/AllGatherLauncher.h
@@ -42,7 +42,7 @@ struct HierarchicalAllgatherLaunchParams {
   int ib_num_blocks{16};
   float timeout_ms{0.0f};
   cudaStream_t stream{nullptr};
-  HierarchicalAllgatherIbgdaRing ib_ring{};
+  HierarchicalAllgatherIbRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
 };
 
@@ -68,7 +68,7 @@ struct HierarchicalAllgatherOverlapLaunchParams {
   int nvl_num_blocks{16};
   float timeout_ms{0.0f};
   cudaStream_t stream{nullptr};
-  HierarchicalAllgatherIbgdaRing ib_ring{};
+  HierarchicalAllgatherIbRing ib_ring{};
   P2pNvlTransportDevice nvl_peers[kDirectNvlMaxRanks]{};
   PipesTraceHandle trace{};
 };

--- a/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/HierarchicalAllGatherBenchmark.cc
@@ -411,10 +411,10 @@ class HierarchicalAllGatherBenchmarkFixture
       const int next_global = ib_ring.next_rank * config.nvl_size + nvl_rank;
       launch_params.ib_ring.prev_rank = ib_ring.prev_rank;
       launch_params.ib_ring.next_rank = ib_ring.next_rank;
-      launch_params.ib_ring.prev =
-          ib_transport->getP2pTransportDevice(prev_global);
-      launch_params.ib_ring.next =
-          ib_transport->getP2pTransportDevice(next_global);
+      launch_params.ib_ring.prev = P2pIbTransportDevice(
+          ib_transport->getP2pTransportDevice(prev_global));
+      launch_params.ib_ring.next = P2pIbTransportDevice(
+          ib_transport->getP2pTransportDevice(next_global));
     }
 
     for (int peer = 0; peer < config.nvl_size; ++peer) {

--- a/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
+++ b/comms/prims/collectives/benchmarks/RingReduceScatterBenchmark.cc
@@ -163,6 +163,7 @@ class RingReduceScatterBenchmarkFixture
         cudaMemset(recv_buf.get(), 0, config.chunk_elements * sizeof(float)));
 
     const int maxGroups = config.num_blocks * config.num_rings;
+    constexpr int kMaxEagerExchangeQpsPerPeerPerNic = 128;
     MultipeerIbgdaTransportConfig transport_config{
         .cudaDevice = localRank,
         .dataBufferSize = config.data_buffer_size,
@@ -172,6 +173,8 @@ class RingReduceScatterBenchmarkFixture
                 .pipelineDepth = config.pipeline_depth,
             },
         .qpsPerBlockPerNic = config.num_qps,
+        .ibLazyConnect =
+            maxGroups * config.num_qps > kMaxEagerExchangeQpsPerPeerPerNic,
     };
 
     if (config.use_ibrc) {

--- a/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
+++ b/comms/prims/collectives/tests/HierarchicalAllGatherTest.cc
@@ -107,8 +107,10 @@ class HierarchicalAllGatherTest : public AllGatherTestBase {
     const int nextGlobal = ibRing.next_rank * kNvlSize + nvlRank;
     launchParams.ib_ring.prev_rank = ibRing.prev_rank;
     launchParams.ib_ring.next_rank = ibRing.next_rank;
-    launchParams.ib_ring.prev = ibTransport->getP2pTransportDevice(prevGlobal);
-    launchParams.ib_ring.next = ibTransport->getP2pTransportDevice(nextGlobal);
+    launchParams.ib_ring.prev =
+        P2pIbTransportDevice(ibTransport->getP2pTransportDevice(prevGlobal));
+    launchParams.ib_ring.next =
+        P2pIbTransportDevice(ibTransport->getP2pTransportDevice(nextGlobal));
 
     for (int peer = 0; peer < kNvlSize; ++peer) {
       if (peer == nvlRank) {

--- a/comms/prims/transport/MultiPeerTransport.cc
+++ b/comms/prims/transport/MultiPeerTransport.cc
@@ -263,6 +263,30 @@ P2pIbgdaTransportDevice* MultiPeerTransport::get_p2p_ibgda_transport_device(
   return ibgdaTransport_->getP2pTransportDevice(globalPeerRank);
 }
 
+P2pIbTransportDevice MultiPeerTransport::get_p2p_ib_transport_device(
+    int globalPeerRank) const {
+  const auto transportType = typePerRank_.at(globalPeerRank);
+  if (transportType == TransportType::P2P_IBGDA) {
+    if (!ibgdaTransport_) {
+      throw std::runtime_error(
+          "get_p2p_ib_transport_device: IBGDA transport not available");
+    }
+    return P2pIbTransportDevice(
+        ibgdaTransport_->getP2pTransportDevice(globalPeerRank));
+  }
+  if (transportType == TransportType::P2P_IBRC) {
+    if (!ibrcTransport_) {
+      throw std::runtime_error(
+          "get_p2p_ib_transport_device: IBRC transport not available");
+    }
+    return P2pIbTransportDevice(
+        ibrcTransport_->getP2pTransportDevice(globalPeerRank));
+  }
+  throw std::runtime_error(
+      "get_p2p_ib_transport_device: peer " + std::to_string(globalPeerRank) +
+      " is not an IB peer");
+}
+
 Transport* /*nullable*/ MultiPeerTransport::get_nvl_transports_array() const {
   if (!nvlTransport_) {
     return nullptr;

--- a/comms/prims/transport/MultiPeerTransport.h
+++ b/comms/prims/transport/MultiPeerTransport.h
@@ -23,6 +23,7 @@
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/topology/TopologyDiscovery.h"
 #include "comms/prims/transport/IbTransportConfig.h"
+#include "comms/prims/transport/P2pIbTransportDeviceDecl.cuh"
 #include "comms/prims/transport/Transport.cuh"
 #include "comms/prims/transport/ibgda/MultipeerIbgdaTransport.h"
 #include "comms/prims/transport/ibrc/MultipeerIbrcTransport.h"
@@ -109,6 +110,13 @@ class MultiPeerTransport {
   /** @return True if IBGDA is the preferred transport for peerRank. */
   bool is_ibgda_peer(int peerRank) const;
 
+  /** @return True if an IB transport is the preferred transport for peerRank.
+   */
+  bool is_ib_peer(int peerRank) const {
+    return typePerRank_[peerRank] == TransportType::P2P_IBGDA ||
+        typePerRank_[peerRank] == TransportType::P2P_IBRC;
+  }
+
   /** @return True if IBGDA transport is available for peerRank (all non-self).
    */
   bool has_ibgda(int peerRank) const {
@@ -193,6 +201,12 @@ class MultiPeerTransport {
    */
   P2pIbgdaTransportDevice* get_p2p_ibgda_transport_device(
       int globalPeerRank) const;
+
+  /**
+   * @param globalPeerRank Global rank of an IB peer.
+   * @return Generic IB transport handle backed by the configured IB backend.
+   */
+  P2pIbTransportDevice get_p2p_ib_transport_device(int globalPeerRank) const;
 
   /** @return A stateless P2pSelfTransportDevice handle. */
   P2pSelfTransportDevice get_p2p_self_transport_device() const;

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -510,6 +510,34 @@ __device__ __forceinline__ void P2pIbTransportDevice::send(
 }
 
 template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::sendWithTrace(
+    ThreadGroup& group,
+    const void* __restrict__ src,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->send<CopyOp>(
+        group, src, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->sendWithTrace<CopyOp>(
+        group,
+        src,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        trace,
+        self_rank,
+        args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
 __device__ __forceinline__ void P2pIbTransportDevice::recv(
     ThreadGroup& group,
     void* __restrict__ dst,
@@ -524,6 +552,34 @@ __device__ __forceinline__ void P2pIbTransportDevice::recv(
   } else {
     ibgda->recv<CopyOp>(
         group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::recvWithTrace(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->recv<CopyOp>(
+        group, dst, nbytes, active_blocks, max_signal_bytes, timeout, args...);
+  } else {
+    ibgda->recvWithTrace<CopyOp>(
+        group,
+        dst,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        trace,
+        self_rank,
+        args...);
   }
 }
 
@@ -556,6 +612,43 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
         active_blocks,
         max_signal_bytes,
         timeout,
+        args...);
+  }
+}
+
+template <typename CopyOp, typename... Args>
+__device__ __forceinline__ void P2pIbTransportDevice::forwardWithTrace(
+    ThreadGroup& group,
+    void* __restrict__ dst,
+    P2pIbTransportDevice& fwd,
+    std::size_t nbytes,
+    int active_blocks,
+    std::size_t max_signal_bytes,
+    const Timeout& timeout,
+    PipesTraceHandle trace,
+    uint8_t self_rank,
+    Args... args) {
+  if (type == P2pIbBackendType::IBRC) {
+    ibrc->forward<CopyOp>(
+        group,
+        dst,
+        *fwd.ibrc,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        args...);
+  } else {
+    ibgda->forwardWithTrace<CopyOp>(
+        group,
+        dst,
+        *fwd.ibgda,
+        nbytes,
+        active_blocks,
+        max_signal_bytes,
+        timeout,
+        trace,
+        self_rank,
         args...);
   }
 }

--- a/comms/prims/transport/P2pIbTransportDevice.cuh
+++ b/comms/prims/transport/P2pIbTransportDevice.cuh
@@ -560,6 +560,14 @@ __device__ __forceinline__ void P2pIbTransportDevice::forward(
   }
 }
 
+__host__ __device__ __forceinline__ const IbSendRecvState&
+P2pIbTransportDevice::send_recv_state() const {
+  if (type == P2pIbBackendType::IBRC) {
+    return ibrc->send_recv_state();
+  }
+  return ibgda->send_recv_state();
+}
+
 __device__ __forceinline__ std::size_t P2pIbTransportDevice::pipeline_window(
     int active_blocks) const {
   if (type == P2pIbBackendType::IBRC) {

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -1898,6 +1898,18 @@ struct P2pIbTransportDevice {
       Args... args);
 
   template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void sendWithTrace(
+      ThreadGroup& group,
+      const void* __restrict__ src,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
   __device__ __forceinline__ void recv(
       ThreadGroup& group,
       void* __restrict__ dst,
@@ -1905,6 +1917,18 @@ struct P2pIbTransportDevice {
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void recvWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
       Args... args);
 
   template <typename CopyOp = Memcpy, typename... Args>
@@ -1916,6 +1940,19 @@ struct P2pIbTransportDevice {
       int active_blocks = 0,
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
+      Args... args);
+
+  template <typename CopyOp = Memcpy, typename... Args>
+  __device__ __forceinline__ void forwardWithTrace(
+      ThreadGroup& group,
+      void* __restrict__ dst,
+      P2pIbTransportDevice& fwd,
+      std::size_t nbytes,
+      int active_blocks,
+      std::size_t max_signal_bytes,
+      const Timeout& timeout,
+      PipesTraceHandle trace,
+      uint8_t self_rank,
       Args... args);
 
   __host__ __device__ const IbSendRecvState& send_recv_state() const;

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -69,7 +69,7 @@ __device__ __forceinline__ void trace_ibgda_event(
  * `send`/`recv`/`forward`, the resumable `init_*_progress` /
  * `progress_*_once` pair, and all of their private helpers. The send/recv
  * algorithm is independent of the underlying transport: it only needs the
- * common explicit-buffer IB device ops `put` (fused signal+counter),
+ * common explicit-buffer IB device ops `put`,
  * `signal`, `wait_signal`, `wait_counter`, `read_signal`, and `read_counter`.
  *
  * Every public method takes the owning transport as a `Transport& transport`
@@ -1917,6 +1917,8 @@ struct P2pIbTransportDevice {
       std::size_t max_signal_bytes = 0,
       const Timeout& timeout = Timeout(),
       Args... args);
+
+  __host__ __device__ const IbSendRecvState& send_recv_state() const;
 
   // Per-block pipelined staging window — forwarded to the active backend.
   __device__ __forceinline__ std::size_t pipeline_window(


### PR DESCRIPTION
Summary: Update hierarchical AllGather to use the generic `P2pIbTransportDevice` wrapper instead of an IBGDA-only handle, allowing the same rtptest `cthierarchical_ring` path to run with `NCCL_CTRAN_PIPES_IB_MODE=ibrc` or `ibgda`. Record the GB200 rtptest AllGather comparison results in `IbrcBenchmarkResults.md`.

Differential Revision: D110510170


