### PR TITLE
Replace bytes by bytesPerRank filter in meta NCCL tuner to support cleaner AG/RS tuning

### DIFF
--- a/comms/ncclx/meta/tuner/ConfigParse.h
+++ b/comms/ncclx/meta/tuner/ConfigParse.h
@@ -140,12 +140,13 @@ inline bool isFieldSet(
 
 // Builds a TuningConfig from the already-trimmed CSV/JSON column strings. Order
 // of fields:
-//   collType,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,
+//   collType,bytesPerRank,algorithm,protocol,channels,nNodes,nLocalRanks,
 //   numPipeOps,regBuff,chunkSize
-// bytes / nNodes / nLocalRanks are Int64Range expressions (interval, exact, or
-// "*" wildcard). numPipeOps, regBuff and chunkSize are optional; absent fields
-// are passed as empty strings and fall back to their wildcard / no-override
-// defaults. Returns nullopt when any column fails to parse (an Int64Range that
+// bytesPerRank / nNodes / nLocalRanks are Int64Range expressions (interval,
+// exact, or "*" wildcard). channels, numPipeOps, regBuff and chunkSize are
+// optional; absent fields are passed as empty strings (or omitted entirely)
+// and fall back to their wildcard / no-override defaults. Returns nullopt when
+// any column fails to parse (an Int64Range that
 // does not parse, an unknown collective/algorithm/protocol token, or a numeric
 // column that is present but not a valid integer), so the caller can log an
 // ERROR and reject the rule.
@@ -157,10 +158,11 @@ inline std::optional<TuningConfig> buildConfig(
     return field.empty() ? Int64Range{} : parseInt64Range(field);
   };
 
-  const std::optional<Int64Range> bytes = parseRangeField(fields[1]);
+  const std::optional<Int64Range> bytesPerRank = parseRangeField(fields[1]);
   const std::optional<Int64Range> nNodes = parseRangeField(fields[5]);
   const std::optional<Int64Range> nLocalRanks = parseRangeField(fields[6]);
-  if (!bytes.has_value() || !nNodes.has_value() || !nLocalRanks.has_value()) {
+  if (!bytesPerRank.has_value() || !nNodes.has_value() ||
+      !nLocalRanks.has_value()) {
     return std::nullopt;
   }
 
@@ -192,7 +194,7 @@ inline std::optional<TuningConfig> buildConfig(
 
   TuningConfig config{};
   config.collType = *collType;
-  config.bytes = *bytes;
+  config.bytesPerRank = *bytesPerRank;
   config.algorithm = *algorithm;
   config.protocol = *protocol;
   config.nChannels = *channels;

--- a/comms/ncclx/meta/tuner/CsvConfigParse.h
+++ b/comms/ncclx/meta/tuner/CsvConfigParse.h
@@ -12,7 +12,8 @@ namespace ncclx::tuner {
 // Minimum number of CSV columns required to form a valid rule (up to
 // nLocalRanks).
 inline constexpr size_t kMinCsvFields = 7;
-// Maximum number of CSV columns honored (numPipeOps, regBuff, chunkSize add 3).
+// Maximum number of CSV columns honored: the 7 required columns plus the
+// optional trailing numPipeOps, regBuff, and chunkSize (3 more).
 inline constexpr size_t kMaxCsvFields = 10;
 
 // Splits a CSV line into trimmed fields, honoring interval brackets: a comma

--- a/comms/ncclx/meta/tuner/JsonConfigParse.h
+++ b/comms/ncclx/meta/tuner/JsonConfigParse.h
@@ -40,11 +40,11 @@ inline std::string jsonIntStr(const folly::dynamic& object, const char* key) {
   return std::to_string(value->asInt());
 }
 
-// bytes / nNodes / nLocalRanks may be a JSON integer (exact), the string "*"
-// (wildcard), OR an interval string (e.g. "[0,1048576]", "(1,)"). Render
-// either form to the string the Int64Range parser consumes. An omitted key
-// maps to an empty string, which buildConfig treats as the wildcard (matches
-// any) -- identical to an omitted CSV column.
+// bytesPerRank / nNodes / nLocalRanks may be a JSON integer (exact), the
+// string "*" (wildcard), OR an interval string (e.g. "[0,1048576]", "(1,)").
+// Render either form to the string the Int64Range parser consumes. An omitted
+// key maps to an empty string, which buildConfig treats as the wildcard
+// (matches any) -- identical to an omitted CSV column.
 inline std::string jsonRangeStr(const folly::dynamic& object, const char* key) {
   const auto* value = object.get_ptr(key);
   if (value == nullptr) {
@@ -75,7 +75,7 @@ inline std::optional<TuningConfig> parseJsonRule(const folly::dynamic& rule) {
     // Reuse the CSV column builder so JSON and CSV always parse to identical
     // TuningConfig values for an equivalent table.
     const std::string collType = jsonStringOr(*filterObj, "collective", "");
-    const std::string bytes = jsonRangeStr(*filterObj, "bytes");
+    const std::string bytesPerRank = jsonRangeStr(*filterObj, "bytesPerRank");
     const std::string algorithm = jsonStringOr(*configObj, "algorithm", "");
     const std::string protocol = jsonStringOr(*configObj, "protocol", "");
     const std::string channels = jsonIntStr(*configObj, "channels");
@@ -85,9 +85,11 @@ inline std::optional<TuningConfig> parseJsonRule(const folly::dynamic& rule) {
     const std::string regBuff = jsonIntStr(*filterObj, "regBuff");
     const std::string chunkSize = jsonIntStr(*configObj, "chunkSize");
 
+    // Kept in lock-step with buildConfig's index order; bytesPerRank is the
+    // size field at index 1 (where total bytes used to be).
     const std::vector<std::string_view> fields{
         collType,
-        bytes,
+        bytesPerRank,
         algorithm,
         protocol,
         channels,

--- a/comms/ncclx/meta/tuner/MetaTuner.cc
+++ b/comms/ncclx/meta/tuner/MetaTuner.cc
@@ -31,10 +31,11 @@ namespace ncclx::tuner {
 
 std::string TuningConfig::toString() const {
   return fmt::format(
-      "collType={}, bytes={}, algorithm={}, protocol={}, nChannels={}, "
-      "nNodes={}, nLocalRanks={}, numPipeOps={}, regBuff={}, chunkSize={}",
+      "collType={}, bytesPerRank={}, algorithm={}, protocol={}, "
+      "nChannels={}, nNodes={}, nLocalRanks={}, numPipeOps={}, regBuff={}, "
+      "chunkSize={}",
       static_cast<int>(collType),
-      bytes.toString(),
+      bytesPerRank.toString(),
       algorithm,
       protocol,
       nChannels,
@@ -160,10 +161,11 @@ ncclResult_t loadConfigCsv(
 #ifdef NCCLX_TUNER_WITH_FOLLY_JSON
 // JSON parser, only compiled when folly is available. Parses a top-level
 // object with a "rules" array. Each rule is split into two nested objects:
-//   "filter" -- match conditions: collective, bytes, nNodes, nLocalRanks,
-//               numPipeOps, regBuff. Only "collective" is required; an omitted
-//               filter field means wildcard/any (bytes/nNodes/nLocalRanks -> *,
-//               numPipeOps/regBuff -> -1).
+//   "filter" -- match conditions: collective, bytesPerRank, nNodes,
+//               nLocalRanks, numPipeOps, regBuff. Only "collective" is
+//               required; an omitted filter field means wildcard/any
+//               (bytesPerRank/nNodes/nLocalRanks -> *, numPipeOps/regBuff ->
+//               -1).
 //   "config" -- overrides applied on match: algorithm, protocol, channels,
 //               chunkSize. "algorithm"/"protocol" are required; "channels" and
 //               "chunkSize" are optional and omitting them means "no override"
@@ -295,9 +297,17 @@ inline bool matchesCollective(
     const int nLocalRanks,
     const int regBuff,
     const ncclDebugLogger_t logFunction) {
+  // bytesPerRank matches nBytes / nRanks, where nRanks = nNodes * nLocalRanks
+  // (both from MetaTunerContext). Guard a zero/negative product so the division
+  // is always safe. A wildcard bytesPerRank matches any size.
+  int64_t nRanks =
+      static_cast<int64_t>(nNodes) * static_cast<int64_t>(nLocalRanks);
+  if (nRanks <= 0) {
+    nRanks = 1;
+  }
+  const int64_t perRank = static_cast<int64_t>(nBytes) / nRanks;
   auto matched = config.collType == collType &&
-      config.bytes.matches(static_cast<int64_t>(nBytes)) &&
-      config.nNodes.matches(nNodes) &&
+      config.bytesPerRank.matches(perRank) && config.nNodes.matches(nNodes) &&
       config.nLocalRanks.matches(nLocalRanks) &&
       (config.numPipeOps == -1 || config.numPipeOps == numPipeOps) &&
       (config.regBuff == -1 || config.regBuff == regBuff);
@@ -307,11 +317,12 @@ inline bool matchesCollective(
         NCCL_LOG_INFO,
         fmt::format(
             "NCCLX TUNER: rule did not match collective. rule: [{}]. actual: "
-            "collType={}, nBytes={}, nNodes={}, nLocalRanks={}, numPipeOps={}, "
-            "regBuff={}",
+            "collType={}, nBytes={}, bytesPerRank={}, nNodes={}, "
+            "nLocalRanks={}, numPipeOps={}, regBuff={}",
             config.toString(),
             static_cast<int>(collType),
             nBytes,
+            perRank,
             nNodes,
             nLocalRanks,
             numPipeOps,
@@ -411,10 +422,10 @@ ncclResult_t metaTunerGetCollInfo(
         context->logFunction,
         NCCL_LOG_INFO,
         fmt::format(
-            "NCCLX TUNER: matched rule for collType={} nBytes={} (bytes={} nNodes={} nLocalRanks={}) -> algo={} proto={} channels={}",
+            "NCCLX TUNER: matched rule for collType={} nBytes={} (bytesPerRank={} nNodes={} nLocalRanks={}) -> algo={} proto={} channels={}",
             static_cast<int>(collType),
             nBytes,
-            config.bytes.toString(),
+            config.bytesPerRank.toString(),
             config.nNodes.toString(),
             config.nLocalRanks.toString(),
             config.algorithm,

--- a/comms/ncclx/meta/tuner/MetaTuner.h
+++ b/comms/ncclx/meta/tuner/MetaTuner.h
@@ -16,13 +16,18 @@ namespace ncclx::tuner {
 
 // One tuning rule parsed from a CSV row or JSON object. A rule overrides NCCL
 // core algorithm/protocol selection (and optionally nChannels / chunkSize) for
-// collectives whose attributes AND-match every populated field. The bytes,
-// nNodes and nLocalRanks fields are Int64Range matchers (an interval, an exact
-// value, or the "-1" wildcard that matches any value); numPipeOps / regBuff are
-// exact-or-(-1) int matches; chunkSize == 0 means "no override".
+// collectives whose attributes AND-match every populated field. The
+// bytesPerRank, nNodes and nLocalRanks fields are Int64Range matchers (an
+// interval, an exact value, or the "*" wildcard that matches any value);
+// numPipeOps / regBuff are exact-or-(-1) int matches; chunkSize == 0 means "no
+// override". bytesPerRank matches nBytes / nRanks (nRanks = nNodes *
+// nLocalRanks, taken from the comm). For AllGather/ReduceScatter the tuner
+// nBytes is the rank-scaled total, so nBytes / nRanks is the per-rank shard;
+// for AllReduce nBytes is the full buffer, so it is buffer / nRanks (see
+// matchesCollective).
 struct TuningConfig {
   ncclFunc_t collType;
-  Int64Range bytes;
+  Int64Range bytesPerRank;
   int algorithm;
   int protocol;
   int nChannels;

--- a/comms/ncclx/meta/tuner/README.md
+++ b/comms/ncclx/meta/tuner/README.md
@@ -45,7 +45,7 @@ returns success.
 A rule matches a collective when every populated field AND-matches. The first
 matching rule wins, so rule order encodes priority.
 
-### Interval grammar (`bytes`, `nNodes`, `nLocalRanks`)
+### Interval grammar (`bytesPerRank`, `nNodes`, `nLocalRanks`)
 
 These three fields are `Int64Range` matchers and share a single value grammar
 (leading/trailing whitespace tolerated; `[` `]` inclusive, `(` `)` exclusive; an
@@ -71,12 +71,13 @@ single rule is logged at ERROR and skipped while remaining valid rules load.
 ### CSV (zero-dependency, always available)
 
 ```
-collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
+collective,bytesPerRank,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
 ```
 
 - `collective`: `allreduce` / `broadcast` / `reduce` / `allgather` /
   `reducescatter`
-- `bytes`: message-size Int64Range (interval / exact / `*` wildcard)
+- `bytesPerRank`: per-rank-size Int64Range (`nBytes / nRanks`, interval / exact /
+  `*` wildcard); see "Per-rank size filter"
 - `algorithm`: `tree` / `ring` / `collnet_direct` / `collnet_chain` / `nvls` /
   `nvls_tree` / `pat`
 - `protocol`: `ll` / `ll128` / `simple`
@@ -89,10 +90,37 @@ collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBu
   interval and do NOT separate columns (so `[0,1048576]` is one field)
 - Lines beginning with `#` and blank lines are ignored
 
-Example (2 nodes, 8 ranks/node, 1MB-256MB allreduce forced to ring + ll128):
+### Per-rank size filter (`bytesPerRank`)
+
+`bytesPerRank` matches the **per-rank shard** `nBytes / nRanks`
+(`nRanks = nNodes * nLocalRanks`, taken from the comm — so it is correct even when
+`nNodes` / `nLocalRanks` are left wildcard). Because the LL128→Simple crossover is
+~constant in per-rank bytes (but scales with rank count in total bytes), one
+`bytesPerRank` rule can span every rank count — collapsing a per-topology rule
+explosion into a few rules.
+
+- Best suited to **allgather / reducescatter**: NCCL passes those the rank-scaled
+  total `nBytes = nRanks × count × eltsize`, so `nBytes / nRanks` is exactly the
+  per-rank shard. For **allreduce**, `nBytes` is the full buffer (not rank-scaled),
+  so `bytesPerRank` is `buffer / nRanks` — keep that in mind when writing allreduce
+  rules.
+- All populated fields are AND-matched: setting only `bytesPerRank` matches on
+  per-rank size across all topologies; pinning `nNodes` / `nLocalRanks` too narrows
+  it to a specific topology.
+- `gen --per-rank` in the `nccl-tuner-from-sweep` skill emits these rules.
+
+Example (per-rank): force ring + ll128 for any allgather whose per-rank shard is
+8–16 MiB, on any topology (`nNodes` / `nLocalRanks` left wildcard):
 
 ```
-allreduce,[1048576,268435456],ring,ll128,-1,2,8,-1,-1,0
+allgather,[8388608,16777216],ring,ll128,-1,*,*
+```
+
+Example (2 nodes, 8 ranks/node, 1–256 MiB per-rank allreduce forced to ring +
+ll128):
+
+```
+allreduce,[1048576,268435456],ring,ll128,-1,2,8
 ```
 
 ### JSON (folly-enabled build only)
@@ -104,21 +132,21 @@ and `config` holds the overrides applied on a match.
 {
   "rules": [
     {
-      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "filter": { "collective": "allgather", "bytesPerRank": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
       "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
     }
   ]
 }
 ```
 
-- `filter` — match conditions: `collective`, `bytes`, `nNodes`, `nLocalRanks`,
-  `numPipeOps`, `regBuff`. Only `collective` is required; omitting any other
-  filter field means wildcard / any.
+- `filter` — match conditions: `collective`, `bytesPerRank`, `nNodes`,
+  `nLocalRanks`, `numPipeOps`, `regBuff`. Only `collective` is required; omitting
+  any other filter field means wildcard / any.
 - `config` — overrides: `algorithm`, `protocol`, `channels`, `chunkSize`.
   `algorithm` and `protocol` are required; `channels` and `chunkSize` are
   optional and omitting them means "no override".
-- `bytes` / `nNodes` / `nLocalRanks` may be a JSON integer (`N` exact), the
-  string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`, `"(1,)"`).
+- `bytesPerRank` / `nNodes` / `nLocalRanks` may be a JSON integer (`N` exact),
+  the string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`, `"(1,)"`).
 - JSON and an equivalent CSV still parse to identical `TuningConfig` values;
   `rules` array order = priority. The flat (un-nested) form is no longer
   accepted.

--- a/comms/ncclx/meta/tuner/docs/design.md
+++ b/comms/ncclx/meta/tuner/docs/design.md
@@ -10,7 +10,7 @@ force a binary/conda rebuild, and a `dlopen` plugin adds packaging surface.
 
 The built-in tuner solves this by compiling a CSV/JSON-driven tuner directly into
 `libnccl.so`. It overrides core `algorithm × protocol` selection, `nChannels`,
-and (on tuner API v6 only) `chunkSize`, keyed by `(collective, message-size
+and (on tuner API v6 only) `chunkSize`, keyed by `(collective, per-rank size
 range, topology, numPipeOps, regBuff)`. The topology key is `(nNodes,
 nLocalRanks)` where `nLocalRanks = nRanks / nNodes` is ranks per node. The override table lives in a runtime
 config file (kept in the L4x job's fbpkg, decoupled from the binary), so a tuning
@@ -70,10 +70,11 @@ comm init (src/init.cc, guarded by comm->tuner != NULL)
 
 per collective (src/enqueue.cc, guarded by comm->tuner != NULL)
   -> kMetaTuner.getCollInfo(ctx, collType, nBytes, ...) // metaTunerGetCollInfo
-       AND-match each rule on collType/bytes/nNodes/nLocalRanks/
+       AND-match each rule on collType/bytesPerRank/nNodes/nLocalRanks/
                                 numPipeOps/regBuff
-       (bytes/nNodes/nLocalRanks are Int64Range matchers with `*` = wildcard;
-        numPipeOps/regBuff are exact-or-(-1))
+       (bytesPerRank/nNodes/nLocalRanks are Int64Range matchers with
+        `*` = wildcard; bytesPerRank matches nBytes/nRanks, nRanks =
+        nNodes*nLocalRanks; numPipeOps/regBuff are exact-or-(-1))
        first match: costTable[algo][proto] = 0.0 (skip if NCCL_ALGO_PROTO_IGNORE)
                     if nChannels != -1, override *nChannels
 
@@ -93,7 +94,7 @@ All tuner logic lives in `meta/tuner/`, shared across NCCLX versions:
 |------|------|
 | `meta/tuner/MetaTuner.h` | `TuningConfig` rule struct; `metaTunerEnabled()`, `tryLoadMetaTuner(comm)`, `extern const ncclTuner_t kMetaTuner` |
 | `meta/tuner/MetaTuner.cc` | CSV + JSON parsers, the tuner callbacks (`init`/`getCollInfo`/`finalize`/`getChunkSize`), and `kMetaTuner` definition |
-| `meta/tuner/Int64Range.{h,cc}` | Self-contained `Int64Range` interval matcher (`bytes`/`nNodes`/`nLocalRanks`) and `parseInt64Range`; no NCCL/folly dependency |
+| `meta/tuner/Int64Range.{h,cc}` | Self-contained `Int64Range` interval matcher (`bytesPerRank`/`nNodes`/`nLocalRanks`) and `parseInt64Range`; no NCCL/folly dependency |
 | `meta/tuner/tests/MetaTunerTest.cpp` | Unit tests (CSV/JSON parsing, match semantics, version gating) |
 | `meta/tuner/tests/Int64RangeTest.cpp` | `int64_range_ut` (an `ncclx_meta_unittest` that links the nccl-internal lib) for `Int64Range` parse/match edge cases; no GPU |
 | `meta/tuner/tests/example_tuner_config.{csv,json}` | Example configs |
@@ -152,7 +153,7 @@ and `loadConfigJson` (the folly path and the no-folly stub).
 
 Both `getCollInfo` and `getChunkSize` iterate rules in file order and return on
 the first AND-match. A wildcard field matches any value: `*` for the
-`bytes`/`nNodes`/`nLocalRanks` (`Int64Range`) fields, `-1` for `numPipeOps`/`regBuff`.
+`bytesPerRank`/`nNodes`/`nLocalRanks` (`Int64Range`) fields, `-1` for `numPipeOps`/`regBuff`.
 `getCollInfo` never forces an `algo×proto` combo that core marked
 `NCCL_ALGO_PROTO_IGNORE`.
 
@@ -182,9 +183,9 @@ not force an API/ABI churn.
 A rule matches a collective when every populated field AND-matches. The first
 matching rule wins, so rule order encodes priority.
 
-### Interval grammar (`bytes`, `nNodes`, `nLocalRanks`)
+### Interval grammar (`bytesPerRank`, `nNodes`, `nLocalRanks`)
 
-`bytes`, `nNodes`, and `nLocalRanks` are `Int64Range` matchers backed by
+`bytesPerRank`, `nNodes`, and `nLocalRanks` are `Int64Range` matchers backed by
 `meta/tuner/Int64Range.{h,cc}` (a self-contained `int64_t` interval type with no
 NCCL/folly dependency, so it covers GB-scale byte values and is unit-tested by
 the `int64_range_ut` `ncclx_meta_unittest` target). They share one value grammar
@@ -210,14 +211,42 @@ offending value / line) and **fails comm init**. With
 `NCCLX_TUNER_IGNORE_CONFIG_ERRORS=1` it is logged and skipped while the remaining
 valid rules still load (see "Per-comm-init parsing").
 
+### Per-rank size filter (`bytesPerRank`)
+
+`bytesPerRank` is the single size field. It matches the **per-rank shard**
+`nBytes / nRanks`, where `nRanks = nNodes * nLocalRanks` (both captured in
+`metaTunerInit` from the comm, so `nRanks` always reflects the real topology even
+when a rule leaves `nNodes` / `nLocalRanks` as the `*` wildcard). A guard sets
+`nRanks = 1` if the product is non-positive, so the division is always safe, and
+a wildcard `bytesPerRank` matches any size.
+
+Why per-rank: for a fixed per-rank workload, the LL128→Simple crossover is roughly
+**constant in per-rank bytes** but scales linearly in *total* bytes with rank
+count. Keying on `bytesPerRank` lets **one** rule span every rank count,
+collapsing the per-topology rule explosion (e.g. the GB200 config goes from 20
+total-byte rules to ~4 per-rank rules; see the `nccl-tuner-from-sweep` skill's
+`gen --per-rank`).
+
+Best suited to **AllGather / ReduceScatter**: NCCL passes those collectives
+`nBytes = nRanks × count × eltsize` (the rank-scaled total), so `nBytes / nRanks`
+is exactly the per-rank shard. For **AllReduce** `nBytes` is already the full
+buffer (not scaled by ranks), so `bytesPerRank` is `buffer / nRanks` — author
+AllReduce rules with that in mind.
+
+Combining fields: every populated filter is **AND-matched**, so `bytesPerRank`
+intersects with any other set field. Setting only `bytesPerRank` (the common
+case) matches purely on per-rank size across all topologies; additionally pinning
+`nNodes` / `nLocalRanks` narrows the rule to a specific topology.
+
 ### CSV (zero-dependency, always available)
 
 ```
-collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
+collective,bytesPerRank,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
 ```
 
 - `collective`: `allreduce` / `broadcast` / `reduce` / `allgather` / `reducescatter`
-- `bytes`: message-size Int64Range (interval / exact / `*` wildcard)
+- `bytesPerRank`: per-rank-size Int64Range (`nBytes / nRanks`, interval / exact /
+  `*` wildcard); see "Per-rank size filter"
 - `algorithm`: `tree` / `ring` / `collnet_direct` / `collnet_chain` / `nvls` / `nvls_tree` / `pat`
 - `protocol`: `ll` / `ll128` / `simple`
 - `channels`: `-1` keeps the NCCL default; any other value overrides `*nChannels`
@@ -226,7 +255,7 @@ collective,bytes,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBu
 - `numPipeOps` / `regBuff`: exact int, `-1` is a wildcard
 - `chunkSize` (bytes): `0` means no override
 - `numPipeOps`, `regBuff`, `chunkSize` columns are optional (in that order); at
-  least the first 7 columns (through `nLocalRanks`) are required
+  least the first 7 columns (through `nLocalRanks`) are required.
 - The CSV split is **bracket-aware**: it tracks `()`/`[]` nesting and only splits
   on commas at depth 0, so an interval like `[0,1048576]` or `(1,)` stays a
   single column
@@ -247,7 +276,7 @@ and `config` holds the overrides applied on a match.
 {
   "rules": [
     {
-      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "filter": { "collective": "allgather", "bytesPerRank": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
       "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
     }
   ]
@@ -260,14 +289,15 @@ overrides `channels`. Rules that should apply regardless of topology simply omit
 `nNodes` / `nLocalRanks` from `filter` (an omitted filter field is the `*`
 wildcard).
 
-- `filter` holds the match conditions: `collective`, `bytes`, `nNodes`,
-  `nLocalRanks`, `numPipeOps`, `regBuff`. Only `collective` is required; omitting
-  any other filter field means wildcard / any.
+- `filter` holds the match conditions: `collective`, `bytesPerRank`, `nNodes`,
+  `nLocalRanks`, `numPipeOps`, `regBuff`. Only `collective` is required;
+  omitting any other filter field means wildcard / any.
 - `config` holds the overrides: `algorithm`, `protocol`, `channels`,
   `chunkSize`. `algorithm` and `protocol` are required; `channels` and
   `chunkSize` are optional and omitting them means "no override".
-- `bytes` / `nNodes` / `nLocalRanks` may be a JSON integer (`N` exact), the
-  string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`, `"(1,)"`); a
+- `bytesPerRank` / `nNodes` / `nLocalRanks` may be a JSON integer (`N`
+  exact), the string `"*"` (wildcard), OR an interval string (`"[0,1048576]"`,
+  `"(1,)"`); a
   bad interval string, an unknown enum, or a bad value type (`"channels": [4]`
   / `"abc"`) is a config error, handled per the policy in "Per-comm-init
   parsing" (default: fail comm init; with the ignore cvar: log + skip the rule),
@@ -314,7 +344,7 @@ identical, with version differences handled by compile macros:
   yields a clear error and empty table.
 - `getCollInfo` semantics: size-range match zeroes `table[algo][proto]`; topology
   filter (`nNodes`/`nLocalRanks`); interval matching (open-ended / endpoint
-  inclusivity / wildcard) on `bytes`/`nNodes`/`nLocalRanks`; bracket-aware CSV
+  inclusivity / wildcard) on `bytesPerRank`/`nNodes`/`nLocalRanks`; bracket-aware CSV
   split; bad-interval rule skipped; row-order priority; `nChannels` override;
   `NCCL_ALGO_PROTO_IGNORE` protection; missing/empty file leaves outputs
   untouched.

--- a/comms/ncclx/meta/tuner/tests/MetaTunerSelectDistTest.cc
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerSelectDistTest.cc
@@ -149,12 +149,13 @@ class MetaTunerSelectDistTest : public NcclxBaseTestFixture {
   }
 
   // Build a tuner CSV rule for one collective covering a broad size range.
-  // Format (MetaTuner CSV): collective,bytes,algo,proto,nChannels,nNodes,
-  // nLocalRanks. The size range is emitted as the closed bytes interval
-  // [minBytes,maxBytes]. A channels of -1 means "keep the NCCL default";
-  // nNodes/nLocalRanks default to -1, emitted as the "*" wildcard (match any).
-  // nNodes/nLocalRanks accept any Int64Range expression string via the
-  // makeRangeRule overload below.
+  // Format (MetaTuner CSV):
+  // collective,bytesPerRank,algo,proto,nChannels,nNodes, nLocalRanks. The size
+  // range is emitted as the closed per-rank interval [minBytes,maxBytes]
+  // (bytesPerRank = nBytes / nRanks). A channels of -1 means "keep the NCCL
+  // default"; nNodes/nLocalRanks default to -1, emitted as the
+  // "*" wildcard (match any). nNodes/nLocalRanks accept any Int64Range
+  // expression string via the makeRangeRule overload below.
   static std::string makeRule(
       Collective coll,
       const std::string& algo,
@@ -174,21 +175,21 @@ class MetaTunerSelectDistTest : public NcclxBaseTestFixture {
         nLocalRanks == -1 ? std::string("*") : std::to_string(nLocalRanks));
   }
 
-  // Like makeRule, but bytes / nNodes / nLocalRanks are arbitrary Int64Range
-  // expression strings (e.g. "(1,)", "[0,1048576]"), exercising interval
-  // matching end-to-end.
+  // Like makeRule, but bytesPerRank / nNodes / nLocalRanks are arbitrary
+  // Int64Range expression strings (e.g. "(1,)", "[0,1048576]"), exercising
+  // interval matching end-to-end.
   static std::string makeRangeRule(
       Collective coll,
       const std::string& algo,
       const std::string& proto,
       int channels,
-      const std::string& bytes,
+      const std::string& bytesPerRank,
       const std::string& nNodes,
       const std::string& nLocalRanks) {
     return fmt::format(
         "{},{},{},{},{},{},{}\n",
         tunerName(coll),
-        bytes,
+        bytesPerRank,
         algo,
         proto,
         channels,
@@ -472,7 +473,7 @@ TEST_F(MetaTunerSelectDistTest, NodesRangeKeyMatchesMultiNode) {
         "tree",
         "ll",
         /*channels=*/-1,
-        /*bytes=*/"*",
+        /*bytesPerRank=*/"*",
         /*nNodes=*/"(1,)",
         /*nLocalRanks=*/"*"));
     ncclx::test::NcclCommRAII commGuard(
@@ -496,7 +497,7 @@ TEST_F(MetaTunerSelectDistTest, NodesRangeKeyMatchesMultiNode) {
         "tree",
         "ll",
         /*channels=*/-1,
-        /*bytes=*/"*",
+        /*bytesPerRank=*/"*",
         /*nNodes=*/"(1,)",
         /*nLocalRanks=*/"*"));
     ncclx::test::NcclCommRAII ruleGuard(
@@ -509,10 +510,11 @@ TEST_F(MetaTunerSelectDistTest, NodesRangeKeyMatchesMultiNode) {
   }
 }
 
-// Size+topology-keyed matching: a rule keyed by BOTH a [0, 1 MiB] size range
-// AND the actual topology forces tree+LL. An in-range AllReduce (16 KiB) uses
-// LL_TREE; an out-of-range AllReduce (8 MiB > 1 MiB max) does not match the
-// rule, so the forced LL_TREE is absent (NCCL default applies).
+// Size+topology-keyed matching: a rule keyed by BOTH a [0, 1 MiB] per-rank size
+// range AND the actual topology forces tree+LL. An in-range AllReduce (16 KiB
+// total, 2 KiB per rank) uses LL_TREE; an out-of-range AllReduce (2 MiB per
+// rank > 1 MiB max) does not match the rule, so the forced LL_TREE is absent
+// (NCCL default applies).
 TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyInRange) {
   TunerConfigFile config(makeRule(
       Collective::kAllReduce,
@@ -527,20 +529,22 @@ TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyInRange) {
       globalRank, numRanks, localRank, bootstrap_.get());
   ncclComm_t comm = commGuard.get();
   assertTopology(comm);
-  // 4096 floats = 16 KiB, inside [0, 1 MiB].
+  // 4096 floats = 16 KiB total -> 2 KiB per rank, inside [0, 1 MiB].
   runCollective(comm, Collective::kAllReduce, 4096);
   algoStats_.verifyExact(comm, "AllReduce", "LL_TREE");
 }
 
 // Size+topology-keyed matching, out-of-range case ("unchanged vs default"
-// model): a rule with a [0, 1 MiB] size range does NOT match an 8 MiB
-// AllReduce, so the tuner ignores it. Create a no-tuner comm and run an 8 MiB
-// AllReduce on it, then create a comm carrying the out-of-range rule and run
-// the SAME 8 MiB AllReduce on it. verifyEqual asserts both comms selected the
-// same set of algorithms, proving the non-matching rule changed nothing.
+// model): a rule with a [0, 1 MiB] per-rank size range does NOT match a 16 MiB
+// AllReduce (2 MiB per rank), so the tuner ignores it. Create a no-tuner comm
+// and run a 16 MiB AllReduce on it, then create a comm carrying the
+// out-of-range rule and run the SAME 16 MiB AllReduce on it. verifyEqual
+// asserts both comms selected the same set of algorithms, proving the
+// non-matching rule changed nothing.
 TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyOutOfRange) {
-  // 2097152 floats = 8 MiB, above the rule's 1 MiB max_bytes.
-  constexpr size_t kOutOfRangeCount = 2097152;
+  // 4194304 floats = 16 MiB total -> 2 MiB per rank (16 MiB / 8 ranks), above
+  // the rule's 1 MiB per-rank max.
+  constexpr size_t kOutOfRangeCount = 4194304;
 
   // No-tuner comm: no TunerConfigFile in scope, so the tuner is disabled and
   // NCCL uses its default selection.
@@ -550,9 +554,9 @@ TEST_F(MetaTunerSelectDistTest, SizeAndTopologyKeyOutOfRange) {
   assertTopology(noTunerComm);
   runCollective(noTunerComm, Collective::kAllReduce, kOutOfRangeCount);
 
-  // Rule comm: a rule covering only [0, 1 MiB] forcing tree+LL does not match
-  // the 8 MiB run, so the tuner ignores it. Keep both comms alive until
-  // verifyEqual reads their AlgoStats.
+  // Rule comm: a rule covering only [0, 1 MiB] per-rank forcing tree+LL does
+  // not match the 16 MiB run (2 MiB per rank), so the tuner ignores it. Keep
+  // both comms alive until verifyEqual reads their AlgoStats.
   TunerConfigFile config(makeRule(
       Collective::kAllReduce,
       "tree",

--- a/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
+++ b/comms/ncclx/meta/tuner/tests/MetaTunerTest.cpp
@@ -124,11 +124,13 @@ TEST_F(MetaTunerTest, EnabledWhenCvarSet) {
 }
 
 // Case 2: size-range match sets the targeted entry to 0.0, others unchanged;
-// out-of-range leaves the whole table unchanged.
+// out-of-range leaves the whole table unchanged. nRanks=1 so bytesPerRank ==
+// nBytes here, isolating the Int64Range match from the per-rank division (the
+// division itself is covered by BytesPerRankFilter).
 TEST_F(MetaTunerTest, SizeRangeMatch) {
   const TunerConfigFile config(
       ".csv", "allreduce,[1024,4096],ring,ll128,-1,*,*\n");
-  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  void* context = initTuner(/* nRanks */ 1, /* nNodes */ 1);
 
   CostTable inRange;
   int nChannels = 1;
@@ -270,12 +272,14 @@ bool ruleMatched(
   return table.at(NCCL_ALGO_RING, NCCL_PROTO_LL128) == 0.0F;
 }
 
-// Int64Range bytes matching: a half-open interval [1024,4096) matches its lower
-// endpoint, an interior value, and excludes its upper endpoint and below-range.
+// Int64Range bytesPerRank matching: a half-open interval [1024,4096) matches
+// its lower endpoint, an interior value, and excludes its upper endpoint and
+// below-range. nRanks=1 so bytesPerRank == nBytes (per-rank division covered by
+// BytesPerRankFilter).
 TEST_F(MetaTunerTest, BytesIntervalEndpoints) {
   const TunerConfigFile config(
       ".csv", "allreduce,[1024,4096),ring,ll128,-1,*,*\n");
-  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  void* context = initTuner(/* nRanks */ 1, /* nNodes */ 1);
 
   EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 1023));
   EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1024));
@@ -285,10 +289,12 @@ TEST_F(MetaTunerTest, BytesIntervalEndpoints) {
   kMetaTuner.finalize(context);
 }
 
-// Open-ended bytes interval (1024,) matches everything strictly above 1024.
+// Open-ended bytesPerRank interval (1024,) matches everything strictly above
+// 1024. nRanks=1 so bytesPerRank == nBytes (per-rank division covered by
+// BytesPerRankFilter).
 TEST_F(MetaTunerTest, BytesOpenEndedAbove) {
   const TunerConfigFile config(".csv", "allreduce,(1024,),ring,ll128,-1,*,*\n");
-  void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  void* context = initTuner(/* nRanks */ 1, /* nNodes */ 1);
 
   EXPECT_FALSE(ruleMatched(context, ncclFuncAllReduce, 1024));
   EXPECT_TRUE(ruleMatched(context, ncclFuncAllReduce, 1025));
@@ -297,7 +303,7 @@ TEST_F(MetaTunerTest, BytesOpenEndedAbove) {
   kMetaTuner.finalize(context);
 }
 
-// Wildcard bytes (*) matches any size.
+// Wildcard bytesPerRank (*) matches any size.
 TEST_F(MetaTunerTest, BytesWildcardMatchesAll) {
   const TunerConfigFile config(".csv", "allreduce,*,ring,ll128,-1,*,*\n");
   void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
@@ -336,8 +342,68 @@ TEST_F(MetaTunerTest, LocalRanksRangeKeyed) {
   kMetaTuner.finalize(outOfRange);
 }
 
-// Bracket-aware CSV split: commas inside the bytes interval do not split the
-// column, so a row with [0,4096] and topology fields parses into the right
+// bytesPerRank filter: a single rule keyed on bytesPerRank=[8MiB,16MiB] (every
+// other field wildcard) matches a collective iff nBytes/nRanks is in range --
+// across DIFFERENT topologies that share a per-rank size. nRanks = nNodes *
+// nLocalRanks, so one per-rank rule spans rank counts where a total-bytes rule
+// would need one rule per topology (the whole point of bytesPerRank).
+TEST_F(MetaTunerTest, BytesPerRankFilter) {
+  constexpr size_t kMiB = 1024 * 1024;
+  const TunerConfigFile config(
+      ".csv", "allgather,[8388608,16777216],ring,ll128,-1,*,*\n");
+
+  // Topology A: 8 ranks / 1 node -> nRanks = 8.
+  void* topoA = initTuner(/* nRanks */ 8, /* nNodes */ 1);
+  // Topology B: 16 ranks / 2 nodes -> nRanks = 16.
+  void* topoB = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+
+  // Same per-rank size (10 MiB, in [8,16]) on both topologies -> both match,
+  // even though the total bytes differ -- one rule spans both rank counts.
+  EXPECT_TRUE(ruleMatched(topoA, ncclFuncAllGather, 10 * kMiB * 8));
+  EXPECT_TRUE(ruleMatched(topoB, ncclFuncAllGather, 10 * kMiB * 16));
+
+  // Endpoint inclusivity: per-rank == 8 MiB (lower bound) matches; below
+  // misses.
+  EXPECT_TRUE(ruleMatched(topoA, ncclFuncAllGather, 8 * kMiB * 8));
+  EXPECT_FALSE(ruleMatched(topoA, ncclFuncAllGather, 4 * kMiB * 8));
+  // Above the upper bound misses too (32 MiB/rank).
+  EXPECT_FALSE(ruleMatched(topoB, ncclFuncAllGather, 32 * kMiB * 16));
+
+  // The discriminating case: ONE total size (80 MiB) maps to 10 MiB/rank on
+  // topoA (8 ranks, in range -> match) but 5 MiB/rank on topoB (16 ranks, below
+  // range -> no match). A total-bytes rule could not tell these apart.
+  EXPECT_TRUE(ruleMatched(topoA, ncclFuncAllGather, 80 * kMiB));
+  EXPECT_FALSE(ruleMatched(topoB, ncclFuncAllGather, 80 * kMiB));
+
+  kMetaTuner.finalize(topoA);
+  kMetaTuner.finalize(topoB);
+}
+
+// Per-rank rules generated with nLocalRanks=(1,) must NOT match nolocal /
+// IB-only comms (nLocalRanks==1), which use PAT/Simple rather than ring/ll128,
+// even when the per-rank size is in range. Guards the gen --per-rank nolocal
+// carve-out: a wildcard nLocalRanks would otherwise force ll128 on nolocal.
+TEST_F(MetaTunerTest, PerRankExcludesNolocal) {
+  constexpr size_t kMiB = 1024 * 1024;
+  const TunerConfigFile config(
+      ".csv", "allgather,[8388608,16777216],ring,ll128,-1,(1,),(1,)\n");
+
+  // NVLink topology (16 ranks / 2 nodes -> nLocalRanks=8 > 1): per-rank 10 MiB
+  // is in range and nLocalRanks=(1,) is satisfied -> match.
+  void* nvlink = initTuner(/* nRanks */ 16, /* nNodes */ 2);
+  EXPECT_TRUE(ruleMatched(nvlink, ncclFuncAllGather, 10 * kMiB * 16));
+  kMetaTuner.finalize(nvlink);
+
+  // nolocal topology (8 ranks / 8 nodes -> nLocalRanks=1): same per-rank size
+  // (10 MiB, in range) and nNodes>1, but nLocalRanks=(1,) excludes it -> no
+  // match.
+  void* nolocal = initTuner(/* nRanks */ 8, /* nNodes */ 8);
+  EXPECT_FALSE(ruleMatched(nolocal, ncclFuncAllGather, 10 * kMiB * 8));
+  kMetaTuner.finalize(nolocal);
+}
+
+// Bracket-aware CSV split: commas inside the bytesPerRank interval do not split
+// the column, so a row with [0,4096] and topology fields parses into the right
 // columns. The rule matches the topology it targets and not another.
 TEST_F(MetaTunerTest, BracketAwareCsvSplit) {
   const TunerConfigFile config(
@@ -345,7 +411,8 @@ TEST_F(MetaTunerTest, BracketAwareCsvSplit) {
 
   void* matching = initTuner(/* nRanks */ 16, /* nNodes */ 2);
   EXPECT_TRUE(ruleMatched(matching, ncclFuncAllReduce, 1024));
-  EXPECT_FALSE(ruleMatched(matching, ncclFuncAllReduce, 8192)); // above bytes
+  // nBytes/nRanks = 131072/16 = 8192 > 4096 -> above the per-rank range.
+  EXPECT_FALSE(ruleMatched(matching, ncclFuncAllReduce, 131072));
   kMetaTuner.finalize(matching);
 
   void* wrongTopo = initTuner(/* nRanks */ 8, /* nNodes */ 1);
@@ -812,25 +879,30 @@ TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
     const TunerConfigFile csv(
         ".csv",
         "allreduce,[0,4096],ring,ll128,4,1,8,-1,-1,65536\n"
-        "allgather,[0,2048],tree,simple,-1,*,*,-1,-1,0\n");
+        "allgather,[0,2048],tree,simple,-1,*,*,-1,-1,0\n"
+        "reducescatter,[8388608,16777216],ring,ll128,-1,*,*\n");
     csvContext = initTuner(/* nRanks */ 8, /* nNodes */ 1);
   }
 
   void* jsonContext = nullptr;
   {
-    // The allreduce row exercises a JSON integer `bytes` field interpreted as
-    // an exact value via the int|string path; the allgather row omits `bytes`
-    // (defaults to the * wildcard). The CSV authors the equivalent intervals.
+    // The allreduce row exercises a JSON `bytesPerRank` interval string with a
+    // pinned topology; the allgather row omits `bytesPerRank` (defaults to the
+    // * wildcard). The reducescatter row keys purely on `bytesPerRank`. The CSV
+    // authors the equivalent rules.
     const TunerConfigFile json(
         ".json",
         R"({
           "rules": [
-            {"filter": {"collective": "allreduce", "bytes": "[0,4096]",
+            {"filter": {"collective": "allreduce", "bytesPerRank": "[0,4096]",
                         "nNodes": 1, "nLocalRanks": 8},
              "config": {"algorithm": "ring", "protocol": "ll128",
                         "channels": 4, "chunkSize": 65536}},
-            {"filter": {"collective": "allgather", "bytes": "[0,2048]"},
-             "config": {"algorithm": "tree", "protocol": "simple"}}
+            {"filter": {"collective": "allgather", "bytesPerRank": "[0,2048]"},
+             "config": {"algorithm": "tree", "protocol": "simple"}},
+            {"filter": {"collective": "reducescatter",
+                        "bytesPerRank": "[8388608,16777216]"},
+             "config": {"algorithm": "ring", "protocol": "ll128"}}
           ]
         })");
     jsonContext = initTuner(/* nRanks */ 8, /* nNodes */ 1);
@@ -860,6 +932,27 @@ TEST_F(MetaTunerTest, JsonParsingEquivalentToCsv) {
   EXPECT_EQ(csvRow1, (RuleProbe{0.0F, -1}));
 #endif
 
+  // Row 2 keys on bytesPerRank=[8MiB,16MiB]; at nRanks=8 a 80 MiB total is
+  // 10 MiB/rank (in range), so CSV and JSON must force ring/ll128 identically.
+  const RuleProbe csvRow2 = probeRule(
+      csvContext,
+      ncclFuncReduceScatter,
+      80 * 1024 * 1024,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128);
+  const RuleProbe jsonRow2 = probeRule(
+      jsonContext,
+      ncclFuncReduceScatter,
+      80 * 1024 * 1024,
+      NCCL_ALGO_RING,
+      NCCL_PROTO_LL128);
+  EXPECT_EQ(csvRow2, jsonRow2);
+#ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
+  EXPECT_EQ(csvRow2, (RuleProbe{0.0F, -1, 0}));
+#else
+  EXPECT_EQ(csvRow2, (RuleProbe{0.0F, -1}));
+#endif
+
   kMetaTuner.finalize(jsonContext);
   kMetaTuner.finalize(csvContext);
 }
@@ -877,7 +970,7 @@ TEST_F(MetaTunerTest, JsonUnsupportedInNoFollyBuild) {
     const EnvRAII<bool> ignoreGuard(NCCLX_TUNER_IGNORE_CONFIG_ERRORS, true);
     const TunerConfigFile json(
         ".json",
-        R"({"rules": [{"filter": {"collective": "allreduce", "bytes": "[0,4096]"},
+        R"({"rules": [{"filter": {"collective": "allreduce", "bytesPerRank": "[0,4096]"},
             "config": {"algorithm": "ring", "protocol": "ll128"}}]})");
     void* context = initTuner(/* nRanks */ 8, /* nNodes */ 1);
 
@@ -947,12 +1040,13 @@ TEST_F(MetaTunerTest, ExampleCsvConfigLoads) {
   EXPECT_EQ(smallTable.at(NCCL_ALGO_RING, NCCL_PROTO_LL128), 0.0F);
 
 #ifdef NCCLX_TUNER_HAS_GETCHUNKSIZE
-  // Large allreduce: ring/simple carries a 524288-byte chunkSize override.
+  // Large allreduce: per-rank shard above 1 MiB (16 MiB total / 8 ranks =
+  // 2 MiB/rank) -> ring/simple carries a 524288-byte chunkSize override.
   size_t chunkSize = 16384;
   kMetaTuner.getChunkSize(
       context,
       ncclFuncAllReduce,
-      /* nBytes */ 2097152,
+      /* nBytes */ 16777216,
       NCCL_ALGO_RING,
       NCCL_PROTO_SIMPLE,
       /* nChannels */ 1,

--- a/comms/ncclx/meta/tuner/tests/example_tuner_config.json
+++ b/comms/ncclx/meta/tuner/tests/example_tuner_config.json
@@ -1,20 +1,24 @@
 {
   "rules": [
     {
-      "filter": { "collective": "allreduce", "bytes": "[0,1048576]" },
+      "filter": { "collective": "allreduce", "bytesPerRank": "[0,1048576]" },
       "config": { "algorithm": "ring", "protocol": "ll128" }
     },
     {
-      "filter": { "collective": "allgather", "bytes": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
+      "filter": { "collective": "allgather", "bytesPerRank": "[0,2097152]", "nNodes": 2, "nLocalRanks": 8 },
       "config": { "algorithm": "tree", "protocol": "simple", "channels": 4 }
     },
     {
-      "filter": { "collective": "allreduce", "bytes": "(1048576,)" },
+      "filter": { "collective": "allreduce", "bytesPerRank": "(1048576,)" },
       "config": { "algorithm": "ring", "protocol": "simple", "chunkSize": 524288 }
     },
     {
-      "filter": { "collective": "reducescatter", "bytes": "(1048576,)", "nNodes": "(1,)" },
+      "filter": { "collective": "reducescatter", "bytesPerRank": "(1048576,)", "nNodes": "(1,)" },
       "config": { "algorithm": "ring", "protocol": "simple" }
+    },
+    {
+      "filter": { "collective": "allgather", "bytesPerRank": "[8388608,16777216]" },
+      "config": { "algorithm": "ring", "protocol": "ll128" }
     }
   ]
 }


### PR DESCRIPTION
Summary:
The meta NCCL built-in tuner (compiled into libnccl.so, driven by a CSV/JSON
config at NCCLX_TUNER_CONFIG_FILE) previously keyed each rule's size match on the
*total* message size (`bytes`). This diff replaces that single size field with a
*per-rank* key, `bytesPerRank = nBytes / nRanks` (nRanks = nNodes * nLocalRanks,
taken from the comm).

Why: for AllGather/ReduceScatter the LL128->Simple crossover is ~constant in
per-rank bytes but scales with rank count in total bytes. Keying on per-rank size
lets a single rule span every rank count, collapsing a per-topology rule
explosion into a few rules — cleaner AG/RS tuning.

What changed:
- Size field renamed `bytes` -> `bytesPerRank` at CSV column index 1 and JSON
  `filter.bytesPerRank`; same Int64Range grammar (`*` / exact / interval).
  Column count is unchanged:
  collective,bytesPerRank,algorithm,protocol,channels,nNodes,nLocalRanks,numPipeOps,regBuff,chunkSize
- matchesCollective() now computes perRank = nBytes / nRanks (guards nRanks >= 1
  so the division is always safe) and matches config.bytesPerRank against it.
- For AllGather/ReduceScatter, nBytes is the rank-scaled total, so nBytes/nRanks
  is the true per-rank shard. For AllReduce, nBytes is the full buffer, so the
  value is buffer/nRanks (documented caveat).
- numPipeOps / regBuff / chunkSize / nNodes / nLocalRanks matching, the wildcard
  and interval grammar, first-match-wins ordering, and the config-error policy
  are all unchanged.
- Updated: TuningConfig struct, CSV + JSON parsers, toString()/log lines,
  example_tuner_config.{csv,json}, README.md, docs/design.md, and the unit +
  distributed tests.

Note for config authors: the size column is now interpreted as per-rank, so
existing rules that expressed a total-bytes range must be re-expressed per rank.

Reviewed By: minsii

Differential Revision: D110247007


