### PR TITLE
Fire work end-hooks on teardown and start-hooks immediately (#3046)

### DIFF
--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -82,7 +82,17 @@ class TorchWork : public c10::intrusive_ptr_target {
   using WorkHook = std::function<void()>;
 
   void registerWorkStartHook(WorkHook hook) {
-    start_hooks_.push_back(std::move(hook));
+    // If work already started (or finished), fire the hook immediately rather
+    // than enqueuing it (it would never fire otherwise). Mirrors
+    // registerWorkEndHook's terminal-state fallback. This handles backends
+    // (e.g. MCCL) whose ctor sets INPROGRESS before the post-hook registers
+    // the start hook; without this the start event is lost (clog has no "S").
+    // Any status other than NOT_STARTED means the start transition has fired.
+    if (status() != WorkStatus::NOT_STARTED) {
+      hook();
+    } else {
+      start_hooks_.push_back(std::move(hook));
+    }
   }
 
   void registerWorkEndHook(WorkHook hook) {

--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -40,6 +40,19 @@ TEST(TorchWorkTest, StartHookFiredOnInProgress) {
   EXPECT_EQ(start_count, 1);
 }
 
+TEST(TorchWorkTest, StartHookFiredImmediatelyIfAlreadyInProgress) {
+  auto work = c10::make_intrusive<TestWork>();
+  work->setStatus(TorchWork::WorkStatus::INPROGRESS);
+
+  // A start hook registered after the work already transitioned to INPROGRESS
+  // must fire immediately (mirrors the end-hook fallback). This is the MCCL
+  // case: TorchWorkMCCL's ctor sets INPROGRESS before the clog post-hook
+  // registers the start hook, which otherwise drops the "S" clog event.
+  int start_count = 0;
+  work->registerWorkStartHook([&start_count]() { start_count++; });
+  EXPECT_EQ(start_count, 1);
+}
+
 TEST(TorchWorkTest, EndHookFiredOnCompleted) {
   auto work = c10::make_intrusive<TestWork>();
   int end_count = 0;


### PR DESCRIPTION
Summary:

Part 3 of 3 (independent of the graph-replay tracker). Fixes two eager-mode clog gaps where a collective's lifecycle hooks could fail to fire, leaving a bare `Q`/`S` with no matching `E` in the clog.

- `TorchWork::registerWorkStartHook()`: if the work has already started (or finished) when the start hook is registered, fire it immediately instead of enqueuing it (it would never fire otherwise). This mirrors `registerWorkEndHook`'s terminal-state fallback and handles backends (e.g. MCCL) whose constructor sets `INPROGRESS` before the post-hook registers the start hook — without it the start event (`S`) is lost.
- `TorchWorkMCCL::closeIncompleteOnTeardown()` + `~TorchWorkMCCLQueue()`: when the comm is torn down with a collective still in flight (e.g. PAFT fault recovery destroys the comm directly), force the still-pending work to a terminal `ERROR` while the queue still holds a strong ref, so its end hook (`E`) fires before destruction. After a clean `finalize()` the queues are already empty, so this is a no-op on the normal path. The queue gains explicit deleted copy/move members (rule of 5) now that it has a user-declared destructor.

Reviewed By: saifhhasan, dboyda

Differential Revision: D109956455


