### PR TITLE
Update reference to deprecated ROCm 6 to 7.0 in README.md

### DIFF
--- a/comms/rcclx/snapshots/README.md
+++ b/comms/rcclx/snapshots/README.md
@@ -164,8 +164,6 @@ After creating or updating snapshots:
 
 ```bash
 # Test stable builds for all ROCm versions
-buck2 build //comms/rcclx:rcclx-stable --modifier=rocm621
-buck2 build //comms/rcclx:rcclx-stable --modifier=rocm64
 buck2 build //comms/rcclx:rcclx-stable --modifier=rocm70
 
 # Test last-stable builds


### PR DESCRIPTION
Summary:
ROCm 6 is deprecated and build-time components will be removed shortly now that [buck reverse dependencies in fbsource is 99.99% on ROCm 7.0](https://fburl.com/scuba/rocm_usage/yrza2o0o), so usage of ROCm 6 should already be on ROCm 7.0.

This diff just updates lingering sources of ROCm 6 usage to have it properly use 7.0.

Useful Links:
- https://fb.workplace.com/groups/1033913261193230/permalink/1408760637041822/ (Feb 2026 announcement of ROCm 6 sunset)
- https://fb.workplace.com/groups/1033913261193230/permalink/1493904531860765/ (June 2026 reminder of ROCm 6 removal)

Differential Revision: D110535267


