### PR TITLE
Exclude MultimemHandler from the ROCm/rcclx build (#3053)

### DIFF
--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -907,6 +907,12 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "NvlMemExchange\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemAllocation\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CuMemMapping\\.")
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "CudaDriverLazy\\.")
+# Exclude MultimemHandler — it is NVIDIA-only (NVSwitch multicast) and owns a
+# std::unique_ptr<CuMemMapping>, so its TU emits an out-of-line reference to
+# CuMemMapping::~CuMemMapping(), whose definition lives in the excluded
+# CuMemMapping.cc. Leaving it in compiles clean but leaves that symbol
+# undefined in librccl at load time. No other compiled source references it.
+list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultimemHandler\\.")
 # Exclude MultiPeerNvlTransport — it depends on GpuMemHandler.h which is excluded.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")
 # Exclude comms/prims/transport/amd/ — the AMD GDA (GPUDirect Async) verbs backend


### PR DESCRIPTION
Summary:

The conda rcclx (flagship_rocm) build was failing at load time when torch
imports librccl.so.1:

  ImportError: .../librccl.so.1: undefined symbol:
  _ZN5comms5prims12CuMemMappingD1Ev
  (comms::prims::CuMemMapping::~CuMemMapping())

D110380727 fixed the AMD *compile* errors in the NvlMemExchange /
MultimemHandler area, which advanced the build far enough to expose a
pre-existing packaging gap.

The rcclx CMake build excludes the NVIDIA-only VMM/driver-API sources
(GpuMemHandler / NvlMemExchange / CuMemAllocation / CuMemMapping /
CudaDriverLazy) from PIPES_SOURCES because they need the CUDA driver API
that is unavailable on ROCm. MultimemHandler is also NVIDIA-only (NVSwitch
multicast) and owns a std::unique_ptr<CuMemMapping>, so its translation
unit emits an out-of-line reference to CuMemMapping::~CuMemMapping() whose
definition lives in the excluded CuMemMapping.cc. It was left in the build,
so it compiled clean but left that symbol undefined in librccl at load
time.

Exclude MultimemHandler.cc alongside its siblings. The only other consumers
of MultimemHandler are BUCK targets (not part of this CMake build) and
comms/prims/tests/* (already excluded), so nothing else in the compiled
sweep references it and no new undefined symbols are introduced.

Differential Revision: D110658541


