### PR TITLE
Support configurable max NIC size to avoid cpu memory PFC issue on GB300

### DIFF
--- a/comms/ctran/backends/ib/CtranIb.cc
+++ b/comms/ctran/backends/ib/CtranIb.cc
@@ -369,7 +369,8 @@ CtranIb::CtranIb(
     std::optional<const SocketServerAddr*> qpServerAddr,
     std::shared_ptr<Abort> abortCtrl,
     std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
-    std::optional<int> maxNumCqe) {
+    std::optional<int> maxNumCqe,
+    std::optional<int> maxNumNic) {
   init(
       nullptr,
       rank,
@@ -381,7 +382,8 @@ CtranIb::CtranIb(
       qpServerAddr,
       abortCtrl,
       socketFactory,
-      maxNumCqe);
+      maxNumCqe,
+      maxNumNic);
 
   CLOGF_SUBSYS(
       INFO,
@@ -406,7 +408,8 @@ void CtranIb::init(
     std::optional<const SocketServerAddr*> qpServerAddr,
     std::shared_ptr<Abort> abortCtrl,
     std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory,
-    std::optional<int> maxNumCqe) {
+    std::optional<int> maxNumCqe,
+    std::optional<int> maxNumNic) {
   bool foundPort = false;
   this->comm = comm;
   this->rank = rank;
@@ -422,8 +425,12 @@ void CtranIb::init(
       .nRanks = comm ? comm->statex_->nRanks() : 1};
   this->enableLocalFlush_ = enableLocalFlush;
   this->bootstrapMode = bootstrapMode;
-  this->devices.resize(NCCL_CTRAN_IB_DEVICES_PER_RANK);
-  this->cqs.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
+  this->numNics = maxNumNic
+      ? std::min(*maxNumNic, NCCL_CTRAN_IB_DEVICES_PER_RANK)
+      : NCCL_CTRAN_IB_DEVICES_PER_RANK;
+  FB_CHECKTHROW_EX_LOGDATA(this->numNics > 0, ncclLogData, "numNics > 0");
+  this->devices.resize(this->numNics);
+  this->cqs.reserve(this->numNics);
   FB_COMMCHECKTHROW_EX(this->setPgToTrafficClassMap(), this->ncclLogData);
 
   auto s = CtranIbSingleton::getInstance();
@@ -479,7 +486,7 @@ void CtranIb::init(
         this->commDesc);
   }
 
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; ++device) {
+  for (int device = 0; device < numNics; ++device) {
     int singletonDevIdx =
         cudaDev * NCCL_CTRAN_IB_DEVICES_PER_RANK * NCCL_CTRAN_IB_DEVICE_STRIDE +
         device;
@@ -632,15 +639,14 @@ void CtranIb::init(
     CLOGF(ERR, msg);
     throw ctran::utils::Exception(msg, commInvalidArgument);
   }
-  vcLayout_ =
-      ctran::ib::VcLayout(NCCL_CTRAN_IB_DEVICES_PER_RANK, maxVcsPerPeer);
+  vcLayout_ = ctran::ib::VcLayout(numNics, maxVcsPerPeer);
   CLOGF_SUBSYS(
       INFO,
       INIT,
       "CTRAN-IB: VC layout: {} (numNics={}, NCCL_CTRAN_IB_MAX_QPS={}). "
       "Per-VC data-QP count is determined per connection class inside CtranIbVirtualConn.",
       vcLayout_.describe(),
-      NCCL_CTRAN_IB_DEVICES_PER_RANK,
+      numNics,
       NCCL_CTRAN_IB_MAX_QPS);
 
   // Optionally start internal bootstrap service.
@@ -961,12 +967,12 @@ commResult_t CtranIb::initRemoteTransStates(void) {
   // resources; We still need per-object lock here to ensure the internal
   // listenThread doesn't read garbage data
 
-  this->cqs.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
+  this->cqs.reserve(this->numNics);
 
   // create a new cq
   {
     std::unique_lock<std::mutex> lock(cqMutex);
-    for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+    for (int device = 0; device < numNics; device++) {
       auto createCqResult =
           devices[device].ibvDevice->createCq(maxCqe, nullptr, nullptr, 0);
       FOLLY_EXPECTED_CHECK(createCqResult);

--- a/comms/ctran/backends/ib/CtranIb.h
+++ b/comms/ctran/backends/ib/CtranIb.h
@@ -91,7 +91,8 @@ class CtranIb {
       std::shared_ptr<Abort> abortCtrl =
           ::ctran::utils::createAbort(/*enabled=*/false),
       std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
-      std::optional<int> maxNumCqe = std::nullopt);
+      std::optional<int> maxNumCqe = std::nullopt,
+      std::optional<int> maxNumNic = std::nullopt);
 
   ~CtranIb();
 
@@ -481,7 +482,7 @@ class CtranIb {
   // the per-VC mutex via CTRAN_IB_PER_OBJ_LOCK_GUARD.
 
   inline int getNumIbDevices() const {
-    return NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    return numNics;
   }
   inline int getMaxVcsPerPeer() const {
     return vcLayout_.maxVcsPerPeer;
@@ -566,6 +567,10 @@ class CtranIb {
     return maxCqe;
   }
 
+  int getNumNics() const {
+    return numNics;
+  }
+
  private:
   friend class CtranIbRequest;
   void init(
@@ -580,7 +585,8 @@ class CtranIb {
       std::shared_ptr<Abort> abortCtrl =
           ::ctran::utils::createAbort(/*enabled=*/false),
       std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
-      std::optional<int> maxNumCqe = std::nullopt);
+      std::optional<int> maxNumCqe = std::nullopt,
+      std::optional<int> maxNumNic = std::nullopt);
 
   commResult_t setPgToTrafficClassMap();
 
@@ -625,14 +631,11 @@ class CtranIb {
       int& deviceBegin,
       int& deviceEnd) {
     deviceBegin = 0;
-    deviceEnd = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+    deviceEnd = numNics;
     if (device.has_value()) {
-      if (*device < 0 || *device >= NCCL_CTRAN_IB_DEVICES_PER_RANK) {
+      if (*device < 0 || *device >= numNics) {
         CLOGF(
-            ERR,
-            "CTRAN-IB: invalid device {} (numNics={})",
-            *device,
-            NCCL_CTRAN_IB_DEVICES_PER_RANK);
+            ERR, "CTRAN-IB: invalid device {} (numNics={})", *device, numNics);
         return commInternalError;
       }
       deviceBegin = *device;
@@ -1110,6 +1113,7 @@ class CtranIb {
   std::mutex cqMutex;
 
   int maxCqe{-1};
+  int numNics{-1};
   std::vector<CtranIbDevice> devices; // IB device info
   std::vector<ibverbx::IbvCq> cqs;
   int cudaDev{-1};

--- a/comms/ctran/backends/ib/CtranIbLocalVc.cc
+++ b/comms/ctran/backends/ib/CtranIbLocalVc.cc
@@ -19,15 +19,15 @@ LocalVirtualConn::LocalVirtualConn(
     CommLogData commLogData)
     : devices_(devices), commLogData_(std::move(commLogData)) {
   FB_CHECKABORT(
-      devices_.size() == NCCL_CTRAN_IB_DEVICES_PER_RANK,
+      devices_.size() <= NCCL_CTRAN_IB_DEVICES_PER_RANK,
       "Invalid number of devices {} received in flush virtual connection compared to NCCL_CTRAN_IB_DEVICES_PER_RANK {}",
       devices_.size(),
       NCCL_CTRAN_IB_DEVICES_PER_RANK);
-  ibvMrs_.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
-  ibvQps_.reserve(NCCL_CTRAN_IB_DEVICES_PER_RANK);
-  sgs_.resize(NCCL_CTRAN_IB_DEVICES_PER_RANK);
+  ibvMrs_.reserve(devices_.size());
+  ibvQps_.reserve(devices_.size());
+  sgs_.resize(devices_.size());
 
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+  for (int device = 0; device < devices_.size(); device++) {
     auto maybeMr = devices_[device].ibvPd->regMr(
         &buf_, sizeof(int), ibverbx::IBV_ACCESS_LOCAL_WRITE);
     FOLLY_EXPECTED_CHECKTHROW_EX(maybeMr, commLogData_);
@@ -109,7 +109,7 @@ commResult_t LocalVirtualConn::iflush(
     const void* ibRegElem,
     CtranIbRequest* req) {
   auto mrs = reinterpret_cast<const std::vector<ibverbx::IbvMr>*>(ibRegElem);
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
+  for (int device = 0; device < devices_.size(); device++) {
     ibverbx::ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = 0;
@@ -133,9 +133,8 @@ commResult_t LocalVirtualConn::iflush(
 
   // Push one entry per device CQE. Only the last carries the actual req;
   // earlier entries are nullptr so processCqe drains them without completing.
-  for (int device = 0; device < NCCL_CTRAN_IB_DEVICES_PER_RANK; device++) {
-    outstandingReqs_.push_back(
-        device == NCCL_CTRAN_IB_DEVICES_PER_RANK - 1 ? req : nullptr);
+  for (int device = 0; device < devices_.size(); device++) {
+    outstandingReqs_.push_back(device == devices_.size() - 1 ? req : nullptr);
   }
 
   return commSuccess;

--- a/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
+++ b/comms/ctran/backends/ib/tests/CtranIbBootstrapTest.cc
@@ -126,7 +126,8 @@ std::unique_ptr<CtranIb> createCtranIb(
     AbortPtr abortCtrl,
     std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
     std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
-    std::optional<int> maxNumCqe = std::nullopt) {
+    std::optional<int> maxNumCqe = std::nullopt,
+    std::optional<int> maxNumNic = std::nullopt) {
   const uint64_t commHash = 0x12345678;
   const std::string commDesc = "test";
 
@@ -145,7 +146,8 @@ std::unique_ptr<CtranIb> createCtranIb(
       qpServerAddr,
       abortCtrl,
       socketFactory,
-      maxNumCqe);
+      maxNumCqe,
+      maxNumNic);
 }
 // Helper class to run two-rank tests with address exchange
 class TwoRankTestHelper {
@@ -246,7 +248,8 @@ class CtranIbBootstrapTestBase : public ::testing::Test {
       AbortPtr abortCtrl,
       std::optional<const SocketServerAddr*> qpServerAddr = std::nullopt,
       std::shared_ptr<ctran::bootstrap::ISocketFactory> socketFactory = nullptr,
-      std::optional<int> maxNumCqe = std::nullopt) {
+      std::optional<int> maxNumCqe = std::nullopt,
+      std::optional<int> maxNumNic = std::nullopt) {
     const uint64_t commHash = 0x12345678;
     const std::string commDesc = "test";
 
@@ -265,7 +268,8 @@ class CtranIbBootstrapTestBase : public ::testing::Test {
         qpServerAddr,
         abortCtrl,
         socketFactory,
-        maxNumCqe);
+        maxNumCqe,
+        maxNumNic);
   }
 };
 
@@ -1462,4 +1466,36 @@ TEST_F(CtranIbBootstrapCommonTest, MaxNumCqe) {
   unsetenv("NCCL_CTRAN_IB_MAX_NUM_CQE");
   ncclCvarInit();
   EXPECT_EQ(makeIb(2048)->getMaxCqe(), 2048);
+}
+
+// Test maxNumNic: NCCL_CTRAN_IB_DEVICES_PER_RANK fallback and per-transport
+// override. maxNumNic caps the number of NICs a transport initializes, so a
+// valid override never exceeds the device-count cvar.
+TEST_F(CtranIbBootstrapCommonTest, MaxNumNic) {
+  const int defaultNumNics = NCCL_CTRAN_IB_DEVICES_PER_RANK;
+
+  auto makeIb = [&](std::optional<int> maxNumNic = std::nullopt) {
+    auto abortCtrl = ctran::utils::createAbort(/*enabled=*/true);
+    return createCtranIb(
+        /*rank=*/0,
+        CtranIb::BootstrapMode::kDefaultServer,
+        abortCtrl,
+        std::nullopt,
+        nullptr,
+        std::nullopt /* maxNumCqe */,
+        maxNumNic);
+  };
+
+  // Default (nullopt) falls through to NCCL_CTRAN_IB_DEVICES_PER_RANK
+  EXPECT_EQ(makeIb()->getNumNics(), defaultNumNics);
+  EXPECT_EQ(makeIb(std::nullopt)->getNumNics(), defaultNumNics);
+
+  // Per-transport override caps NIC usage. Capping to a single NIC is always
+  // valid since default init already uses device 0.
+  EXPECT_EQ(makeIb(1)->getNumNics(), 1);
+
+  // Override equal to the cvar keeps all NICs; an override larger than the cvar
+  // is clamped down to NCCL_CTRAN_IB_DEVICES_PER_RANK.
+  EXPECT_EQ(makeIb(defaultNumNics)->getNumNics(), defaultNumNics);
+  EXPECT_EQ(makeIb(defaultNumNics + 100)->getNumNics(), defaultNumNics);
 }

--- a/comms/torchcomms/transport/RdmaTransport.cpp
+++ b/comms/torchcomms/transport/RdmaTransport.cpp
@@ -187,7 +187,8 @@ struct RdmaTransport::Work {
 RdmaTransport::RdmaTransport(
     int cudaDev,
     folly::EventBase* evb,
-    std::optional<int> maxNumCqe)
+    std::optional<int> maxNumCqe,
+    std::optional<int> maxNumNic)
     : cudaDev_(cudaDev), evb_(evb) {
   initEnvironment();
   // Create IB Instance
@@ -201,7 +202,8 @@ RdmaTransport::RdmaTransport(
       std::nullopt /* qpServerAddr */,
       ::ctran::utils::createAbort(/*enabled=*/false),
       nullptr /* socketFactory */,
-      maxNumCqe);
+      maxNumCqe,
+      maxNumNic);
 
   if (evb_) {
     // Optionally create progress timeout; skip it if the transport is never
@@ -285,6 +287,10 @@ bool RdmaTransport::connected() const {
 
 int RdmaTransport::getMaxCqe() const {
   return ib_->getMaxCqe();
+}
+
+int RdmaTransport::getNumNics() const {
+  return ib_->getNumNics();
 }
 
 folly::SemiFuture<commResult_t> RdmaTransport::write(

--- a/comms/torchcomms/transport/RdmaTransport.h
+++ b/comms/torchcomms/transport/RdmaTransport.h
@@ -332,7 +332,8 @@ class __attribute__((visibility("default"))) RdmaTransport {
   explicit RdmaTransport(
       int cudaDev,
       folly::EventBase* evb = nullptr,
-      std::optional<int> maxNumCqe = std::nullopt);
+      std::optional<int> maxNumCqe = std::nullopt,
+      std::optional<int> maxNumNic = std::nullopt);
 
   ~RdmaTransport();
 
@@ -370,6 +371,11 @@ class __attribute__((visibility("default"))) RdmaTransport {
    * Return the effective max CQ entries configured for this transport.
    */
   int getMaxCqe() const;
+
+  /*
+   * Return the effective number of NICs configured for this transport.
+   */
+  int getNumNics() const;
 
   /*
    * [Remote Op] Transfer data from local buffer to remote buffer on the peer

--- a/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
+++ b/comms/torchcomms/transport/tests/cpp/RdmaTransportTest.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <thread>
 
 #include <folly/futures/Future.h>
@@ -58,7 +59,8 @@ class RdmaTransportTest : public ::testing::Test {
   // Common thread function that handles both server and client logic for write
   void runRdmaTransportThreadWrite(
       bool isServer,
-      ThreadSyncObjects& syncObjects) {
+      ThreadSyncObjects& syncObjects,
+      std::optional<int> maxNumNic = std::nullopt) {
     const size_t bufferSize = 8192;
     const int cudaDev = isServer ? 0 : 1;
     // Set CUDA device
@@ -66,7 +68,10 @@ class RdmaTransportTest : public ::testing::Test {
 
     // Create RdmaTransport instance
     auto transport = std::make_unique<torch::comms::RdmaTransport>(
-        cudaDev, evbThread_->getEventBase());
+        cudaDev,
+        evbThread_->getEventBase(),
+        std::nullopt /* maxNumCqe */,
+        maxNumNic);
 
     // Bind and get URL
     std::string myUrl = transport->bind();
@@ -525,6 +530,52 @@ TEST_F(RdmaTransportTest, ServerClientDataTransferWrite) {
       [&]() { runRdmaTransportThreadWrite(false, clientSyncObjects); });
 
   // Wait for both threads to complete
+  serverThread.join();
+  clientThread.join();
+
+  // Verify the communication was successful
+  bool success = std::move(communicationFuture).get();
+  EXPECT_TRUE(success);
+}
+
+// Same bind -> connect -> write round-trip as above, but caps each transport to
+// a single NIC (maxNumNic=1). This mirrors the shard_service default
+// (kDefaultMaxNumNic=1) and guards the transfer path when maxNumNic <
+// NCCL_CTRAN_IB_DEVICES_PER_RANK.
+TEST_F(RdmaTransportTest, ServerClientDataTransferWriteMaxNumNic) {
+  // Promise/future pairs for exchanging URLs between threads
+  auto [urlPromise0, urlFuture0] = folly::makePromiseContract<std::string>();
+  auto [urlPromise1, urlFuture1] = folly::makePromiseContract<std::string>();
+  auto [memoryInfoPromise, memoryInfoFuture] =
+      folly::makePromiseContract<RdmaRemoteBuffer>();
+  auto [communicationResult, communicationFuture] =
+      folly::makePromiseContract<bool>();
+
+  // Setup synchronization objects for server (CUDA device 0)
+  ThreadSyncObjects serverSyncObjects{
+      std::move(urlPromise0),
+      std::move(urlFuture1),
+      folly::Promise<RdmaRemoteBuffer>(), // server doesn't export memory
+      std::move(memoryInfoFuture),
+      std::move(communicationResult)};
+
+  // Setup synchronization objects for client (CUDA device 1)
+  ThreadSyncObjects clientSyncObjects{
+      std::move(urlPromise1),
+      std::move(urlFuture0),
+      std::move(memoryInfoPromise),
+      folly::SemiFuture<RdmaRemoteBuffer>::makeEmpty(), // client doesn't import
+                                                        // memory
+      folly::Promise<bool>()}; // client doesn't set communication result
+
+  constexpr int kMaxNumNic = 1;
+  std::thread serverThread([&]() {
+    runRdmaTransportThreadWrite(true, serverSyncObjects, kMaxNumNic);
+  });
+  std::thread clientThread([&]() {
+    runRdmaTransportThreadWrite(false, clientSyncObjects, kMaxNumNic);
+  });
+
   serverThread.join();
   clientThread.join();
 


### PR DESCRIPTION
Summary:
# Why we need configurable # NIC cap

Problem: On GB300 platform, CX8 has directly link to GPU to saturate the 100 GB/s bandwidth, however, for CPU, socket direct links requires an additional purchase of PCIe Auxiliary Card Kit (See [Chapter 10 PCIe Auxiliary Card Kit](https://docs.nvidia.com/networking/display/nvidia-connectx-8-supernic-user-manual.pdf)). Without socket directly links, we can at most get ~55 GB/s bandiwdth for cpu buffer (the bottleneck is the PCIe link internally.) Therefore, if recv side is using CPU buffer, we should only use one port of physical NIC (one mlx5 device at PCIe tree), otherwise, the sender side will send the data too fast but recv side cannot consume it in time so that it will send back PFC pause through the whole traffic path (RTSW/FTSW), which might affect other jobs running in the same zone. 

# Make the # NIC configurable at CtranIb constructor:
  1. Per-transport maxNumNic parameter — allows callers (e.g., RdmaTransport, shard_service) to override the global cap per instance. Per-transport takes precedence over the env var `NCCL_CTRAN_IB_DEVICES_PER_RANK`.

Default behavior is unchanged: Default uses the `NCCL_CTRAN_IB_DEVICES_PER_RANK`, preserving backward compatibility. The cap only takes effect when explicitly configured.

Differential Revision: D110415974


