### PR TITLE
Enable BackendWrapperShutdownTest mixed backend for XCCL

### DIFF
--- a/.github/scripts/xpu_test.sh
+++ b/.github/scripts/xpu_test.sh
@@ -17,7 +17,7 @@ conda install conda-forge::glog=0.4.0 conda-forge::gflags=2.2.2 conda-forge::fmt
 export USE_XCCL=ON
 export USE_NCCL=OFF
 export USE_NCCLX=OFF
-export USE_GLOO=OFF
+export USE_GLOO=ON
 export USE_TRANSPORT=OFF
 export USE_SYSTEM_LIBS=1
 ulimit -n 65535 # Increase the open file descriptor limit to avoid oneCCL/Level Zero
@@ -27,7 +27,7 @@ python3 -m pip install --pre torch --index-url https://download.pytorch.org/whl/
 
 #Build and run XCCL C++ unit tests (mock-based, no XPU hardware required)
 cd torchcomms
-cmake -B build -G Ninja -DBUILD_TESTS=ON -DUSE_XCCL=ON -DUSE_NCCL=OFF -DUSE_NCCLX=OFF -DUSE_GLOO=OFF -DUSE_TRANSPORT=OFF
+cmake -B build -G Ninja -DBUILD_TESTS=ON -DUSE_XCCL=ON -DUSE_NCCL=OFF -DUSE_NCCLX=OFF -DUSE_GLOO=ON -DUSE_TRANSPORT=OFF
 cmake --build build
 ctest --test-dir build --output-on-failure -R "TorchCommXCCLTest|TorchWorkXCCLQueueTest|TorchCommXCCLBootstrapTest|HintParsingTest"
 cd ..

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -162,8 +162,8 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         shuts down both sub-backends, which share one ``TorchComm``.
         Without idempotent ``shutdown``, the second call raises
         ``TorchCommNCCL already finalized``."""
-        if os.environ["TEST_BACKEND"] != "nccl":
-            self.skipTest("mixed backend test is nccl-specific")
+        if os.environ["TEST_BACKEND"] not in ["nccl", "xccl"]:
+            self.skipTest("mixed backend test is nccl/xccl-specific")
         if _torch_predates_pr_182057():
             self.skipTest(
                 f"torch {torch.__version__} predates pytorch/pytorch#182057 "
@@ -174,26 +174,29 @@ class TestBackendWrapperShutdown(unittest.TestCase):
 
         rank, world_size = get_rank_and_size()
         local_rank = _local_rank()
-        torch.cuda.set_device(local_rank)
+        torch.accelerator.set_device_index(local_rank)
         dist.config.use_torchcomms = True
         store_name = "mixed_backend_destroy_idempotent"
+        backend_str = os.environ["TEST_BACKEND"]
+        device_str = "cuda" if backend_str == "nccl" else "xpu"
+        local_device_str = f"{device_str}:{local_rank}"
         dist.init_process_group(
-            backend="cpu:gloo,cuda:nccl",
+            backend=f"cpu:gloo,{device_str}:{backend_str}",
             store=_create_store_on_free_port(store_name),
             rank=rank,
             world_size=world_size,
-            device_id=torch.device(f"cuda:{local_rank}"),
+            device_id=torch.device(local_device_str),
         )
         try:
-            torch.set_default_device(f"cuda:{local_rank}")
+            torch.set_default_device(local_device_str)
             cpu_tensor = torch.ones(4, dtype=torch.float32, device="cpu")
-            cuda_tensor = torch.ones(
-                4, dtype=torch.float32, device=f"cuda:{local_rank}"
+            gpu_tensor = torch.ones(
+                4, dtype=torch.float32, device=local_device_str
             )
             dist.all_reduce(cpu_tensor)
-            dist.all_reduce(cuda_tensor)
+            dist.all_reduce(gpu_tensor)
             self.assertEqual(cpu_tensor[0].item(), float(world_size))
-            self.assertEqual(cuda_tensor[0].item(), float(world_size))
+            self.assertEqual(gpu_tensor[0].item(), float(world_size))
         finally:
             # Must not raise even though both sub-backends share the comm.
             dist.destroy_process_group()

--- a/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
+++ b/comms/torchcomms/tests/integration/py/BackendWrapperShutdownTest.py
@@ -190,9 +190,7 @@ class TestBackendWrapperShutdown(unittest.TestCase):
         try:
             torch.set_default_device(local_device_str)
             cpu_tensor = torch.ones(4, dtype=torch.float32, device="cpu")
-            gpu_tensor = torch.ones(
-                4, dtype=torch.float32, device=local_device_str
-            )
+            gpu_tensor = torch.ones(4, dtype=torch.float32, device=local_device_str)
             dist.all_reduce(cpu_tensor)
             dist.all_reduce(gpu_tensor)
             self.assertEqual(cpu_tensor[0].item(), float(world_size))


### PR DESCRIPTION
Extends the mixed-backend idempotent shutdown test to also run on Intel XPU (XCCL), previously restricted to NCCL only.

Changes in BackendWrapperShutdownTest.py:
* Broaden the skip guard to run for both nccl and xccl backends instead of nccl only.
* Replace CUDA-specific calls and naming.
* Derive the device type (cuda vs xpu) and backend pair (cpu:gloo,{device}:{backend}) dynamically from TEST_BACKEND, so the process group and device_id are built for the correct accelerator.

No behavioral change for NCCL; the test now exercises the same idempotent destroy_process_group() path on XPU.