### PR TITLE
Enable folly-JSON tuner config parsing in the conda NCCLX build (#3057)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -24,6 +24,15 @@ CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
 # Use header-only fmt to avoid runtime dependency on libfmt.so
 CXXFLAGS += -DFMT_HEADER_ONLY=1
 
+# Enable JSON parsing in the NCCLX built-in CSV/JSON tuner (meta/tuner) when
+# folly is available. The conda feedstock build sets NCCLX_TUNER_WITH_FOLLY_JSON=1
+# (folly is already linked there); a bare OSS `make` without folly leaves it off,
+# so meta/tuner compiles only its CSV parser -- matching def_build.bzl.
+NCCLX_TUNER_WITH_FOLLY_JSON ?= 0
+ifeq ($(NCCLX_TUNER_WITH_FOLLY_JSON),1)
+CXXFLAGS += -DNCCLX_TUNER_WITH_FOLLY_JSON
+endif
+
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM
 endif

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -24,6 +24,15 @@ CXXFLAGS += -DMOCK_SCUBA_DATA -DFOLLY_XLOG_STRIP_PREFIXES=\"${BASE_DIR}\"
 # Use header-only fmt to avoid runtime dependency on libfmt.so
 CXXFLAGS += -DFMT_HEADER_ONLY=1
 
+# Enable JSON parsing in the NCCLX built-in CSV/JSON tuner (meta/tuner) when
+# folly is available. The conda feedstock build sets NCCLX_TUNER_WITH_FOLLY_JSON=1
+# (folly is already linked there); a bare OSS `make` without folly leaves it off,
+# so meta/tuner compiles only its CSV parser -- matching def_build.bzl.
+NCCLX_TUNER_WITH_FOLLY_JSON ?= 0
+ifeq ($(NCCLX_TUNER_WITH_FOLLY_JSON),1)
+CXXFLAGS += -DNCCLX_TUNER_WITH_FOLLY_JSON
+endif
+
 ifeq ($(ENABLE_TCPDM),0)
 CXXFLAGS += -DCTRAN_DISABLE_TCPDM
 endif


### PR DESCRIPTION
Summary:

The NCCLX built-in tuner (meta/tuner) only compiles its folly::parseJson path
under -DNCCLX_TUNER_WITH_FOLLY_JSON. That macro is defined in the buck build
(v2_29/v2_30 def_build.bzl) but not in the conda/Makefile build, so conda NCCLX
compiles only the CSV parser and a .json NCCLX_TUNER_CONFIG_FILE fails comm init
with ncclInvalidUsage. folly (incl. folly/json) is already linked into the conda
build and its headers are on the include path, so enabling JSON is just defining
the macro.

- Add a gated NCCLX_TUNER_WITH_FOLLY_JSON make flag (default 0) to
  comms/ncclx/v2_29/src/Makefile and comms/ncclx/v2_30/src/Makefile that appends
  -DNCCLX_TUNER_WITH_FOLLY_JSON to CXXFLAGS when set to 1. A bare OSS make
  (no folly) stays CSV-only, matching def_build.bzl.
- Set NCCLX_TUNER_WITH_FOLLY_JSON=1 in the conda feedstock build.sh (make imports
  the env var and ?= keeps it), so the conda NCCLX compiles the JSON parser.

Reviewed By: minsii

Differential Revision: D110572933


