### PR TITLE
Fix dynamo integration for PyTorch 2.14 getattro_impl/register_custom_class renames

### DIFF
--- a/comms/torchcomms/__init__.py
+++ b/comms/torchcomms/__init__.py
@@ -16,7 +16,12 @@ from torchcomms.functional import (
 )
 
 if is_torch_compile_supported():
-    from torch._opaque_base import OpaqueBaseMeta
+    try:
+        # PyTorch 2.14+ renamed torch._opaque_base to torch._custom_class_base
+        # (pytorch/pytorch#188456)
+        from torch._custom_class_base import OpaqueBaseMeta
+    except ImportError:
+        from torch._opaque_base import OpaqueBaseMeta
 
     # make the metaclass available to the pybind module
     sys.modules["torchcomms._opaque_meta"] = type(

--- a/comms/torchcomms/functional/collectives.py
+++ b/comms/torchcomms/functional/collectives.py
@@ -180,13 +180,16 @@ if lib is not None:  # noqa: C901
         )
 
     # Collective Registrations
-    from torch._library.opaque_object import MemberType, register_opaque_type
-    from torchcomms.functional.param_parsing import ParamKind, ParamSpec
+    from torch._library.opaque_object import MemberType
+    from torchcomms.functional.param_parsing import (
+        ParamKind,
+        ParamSpec,
+        register_opaque_reference_type,
+    )
 
     # Register TorchComm as opaque type with constant methods
-    register_opaque_type(
+    register_opaque_reference_type(
         TorchComm,
-        typ="reference",
         members={
             "get_rank": MemberType.USE_REAL,
             "get_size": MemberType.USE_REAL,
@@ -196,9 +199,8 @@ if lib is not None:  # noqa: C901
     )
 
     # Register TorchCommWindow as opaque type with constant methods
-    register_opaque_type(
+    register_opaque_reference_type(
         TorchCommWindow,
-        typ="reference",
         members={
             "get_size": MemberType.USE_REAL,
             "dtype": MemberType.USE_REAL,

--- a/comms/torchcomms/functional/dynamo.py
+++ b/comms/torchcomms/functional/dynamo.py
@@ -337,6 +337,10 @@ class AsyncWorkVariable(VariableTracker):
             return AsyncWorkWaitMethod(self)
         raise AttributeError(f"AsyncWorkVariable has no attribute {name}")
 
+    # PyTorch 2.14+ dispatches attribute access to getattro_impl instead of
+    # var_getattr (pytorch/pytorch#186013); support both.
+    getattro_impl = var_getattr
+
     def call_method(
         self,
         tx: "InstructionTranslator",
@@ -624,8 +628,15 @@ def _patch_var_getattr() -> None:
     from torch._dynamo.source import AttrSource
     from torch._dynamo.variables.script_object import TorchScriptObjectVariable
 
+    # PyTorch 2.14+ renamed var_getattr to getattro_impl
+    # (pytorch/pytorch#186013); patch whichever the installed version has.
+    if hasattr(TorchScriptObjectVariable, "getattro_impl"):
+        getattr_method_name = "getattro_impl"
+    else:
+        getattr_method_name = "var_getattr"
+
     # Store the original method
-    original_var_getattr = TorchScriptObjectVariable.var_getattr
+    original_var_getattr = getattr(TorchScriptObjectVariable, getattr_method_name)
 
     def patched_var_getattr(
         self: TorchScriptObjectVariable,
@@ -668,10 +679,10 @@ def _patch_var_getattr() -> None:
         return original_var_getattr(self, tx, name)
 
     # Apply the patch
-    TorchScriptObjectVariable.var_getattr = patched_var_getattr  # type: ignore[method-assign]
+    setattr(TorchScriptObjectVariable, getattr_method_name, patched_var_getattr)
 
     logger.info(
-        f"Patched TorchScriptObjectVariable.var_getattr for {len(_METHOD_TO_OP)} collective methods"
+        f"Patched TorchScriptObjectVariable.{getattr_method_name} for {len(_METHOD_TO_OP)} collective methods"
     )
 
 

--- a/comms/torchcomms/functional/param_parsing.py
+++ b/comms/torchcomms/functional/param_parsing.py
@@ -54,6 +54,21 @@ class ParamSpec:
 _TYPE_NAME_TO_CLASS: dict[str, type] = {}
 
 
+def register_opaque_reference_type(cls: Any, **kwargs: Any) -> None:
+    """Register a class as a reference/symbolic opaque type with dynamo.
+
+    Compatibility wrapper: PyTorch 2.14+ renamed register_opaque_type to
+    register_custom_class and typ="reference" to typ="symbolic"
+    (pytorch/pytorch#188456); use whichever the installed version has.
+    """
+    import torch._library.opaque_object as _opaque_object
+
+    if hasattr(_opaque_object, "register_custom_class"):
+        _opaque_object.register_custom_class(cls, typ="symbolic", **kwargs)
+    else:
+        _opaque_object.register_opaque_type(cls, typ="reference", **kwargs)
+
+
 @dataclass
 class ParsedArgs:
     """Parsed arguments for collective operations.
@@ -336,11 +351,7 @@ class CollectiveParamSchema:
         Returns:
             A CollectiveParamSchema ready for use
         """
-        from torch._library.opaque_object import (
-            get_opaque_type_name,
-            is_opaque_type,
-            register_opaque_type,
-        )
+        from torch._library.opaque_object import get_opaque_type_name, is_opaque_type
 
         def _get_schema_type(torch_type: Any) -> str | None:
             """Return the schema type string for known torch types."""
@@ -380,7 +391,7 @@ class CollectiveParamSchema:
 
         # Register the class as opaque type
         if not is_opaque_type(target_class):
-            register_opaque_type(target_class, typ="reference")
+            register_opaque_reference_type(target_class)
         opaque_type_name = get_opaque_type_name(target_class)
         _TYPE_NAME_TO_CLASS[opaque_type_name] = target_class
 
@@ -400,7 +411,7 @@ class CollectiveParamSchema:
                 )
             elif isinstance(spec.torch_type, type):
                 if not is_opaque_type(spec.torch_type):
-                    register_opaque_type(spec.torch_type, typ="reference")
+                    register_opaque_reference_type(spec.torch_type)
                 type_name = get_opaque_type_name(spec.torch_type)
                 _TYPE_NAME_TO_CLASS[type_name] = spec.torch_type
                 processed_specs.append(
@@ -423,7 +434,7 @@ class CollectiveParamSchema:
                         inner_type = non_none_args[0]
                         if isinstance(inner_type, type):
                             if not is_opaque_type(inner_type):
-                                register_opaque_type(inner_type, typ="reference")
+                                register_opaque_reference_type(inner_type)
                             type_name = get_opaque_type_name(inner_type)
                             _TYPE_NAME_TO_CLASS[type_name] = inner_type
                             processed_specs.append(


### PR DESCRIPTION
## Summary

Fixes the nightly-torch `run_py_tests` CI failures that started July 2 (e.g. [this run](https://github.com/meta-pytorch/torchcomms/actions/runs/28801175858/job/85414539133)): `test_wait_proxy_propagation.py` fails with `AttributeError: type object 'TorchScriptObjectVariable' has no attribute 'var_getattr'`, and consequently `UnsafeScriptObjectError: Attempted to access unregistered member on an OpaqueObject` when tracing `all_reduce`.

Root cause is a set of upstream PyTorch renames landing in 2.14 nightlies:
- `TorchScriptObjectVariable.var_getattr` → `getattro_impl` (pytorch/pytorch#186013) — attribute access now dispatches through `generic_getattr` → `getattro_impl`, so our monkeypatch target no longer exists.
- `register_opaque_type(typ="reference")` → `register_custom_class(typ="symbolic")` (pytorch/pytorch#188456) — currently a deprecation warning, will break when the alias is removed.
- `torch._opaque_base` → `torch._custom_class_base` — deprecation warning on import.

## Changes

All changes are backwards compatible with stable torch (2.12):

- `functional/dynamo.py`: `_patch_var_getattr()` patches `getattro_impl` when present, else `var_getattr`; the wrapper body is unchanged and delegates to the captured original, preserving upstream error semantics for unhandled attributes. Also aliases `AsyncWorkVariable.getattro_impl = var_getattr` so `work.wait` resolves under the new dispatch.
- `functional/param_parsing.py`: new `register_opaque_reference_type()` compat wrapper choosing `register_custom_class(typ="symbolic")` vs `register_opaque_type(typ="reference")`; call sites updated.
- `functional/collectives.py`: `TorchComm`/`TorchCommWindow` registrations use the wrapper.
- `__init__.py`: import `OpaqueBaseMeta` from `torch._custom_class_base` with fallback to `torch._opaque_base`.

## Test plan

Built from source with `USE_NCCLX=OFF USE_TRANSPORT=OFF` (matching the failing CI flavor) in two separate venvs:

| | torch 2.14.0.dev20260706+cu130 (nightly) | torch 2.12.1+cu130 (stable) |
|---|---|---|
| `tests/unit/py` (incl. the 2 previously failing tests) | 88 passed, 4 skipped | 88 passed, 4 skipped |
| hooks + unit test dirs per `run_tests_unit_py.sh` (nccl, gloo) | pass | — |
| standalone `torch.compile(fullgraph=True)` of `all_reduce(async_op=True)` + `work.wait()` | pass | pass |
| deprecation warnings on import | none (previously 10+) | none |

`lintrunner` clean on changed files. Without the fix, the nightly venv reproduces the CI failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)