### PR TITLE
Fix CtranWin leak when registration exchange fails

### DIFF
--- a/comms/ctran/utils/CtranAvlTree.cc
+++ b/comms/ctran/utils/CtranAvlTree.cc
@@ -55,9 +55,14 @@ commResult_t CtranAvlTree::remove(void* hdl) {
     return commInvalidUsage;
   }
 
-  // First try to remove from AVL tree
+  // First try to remove from AVL tree. Guard against a null root_: the tree may
+  // be empty while the element still lives in the fallback list_ (e.g. the only
+  // tree node was removed first). In that case removed stays false and control
+  // falls through to the list removal path below.
   bool removed = false;
-  this->root_ = this->root_->remove(e, &removed);
+  if (this->root_ != nullptr) {
+    this->root_ = this->root_->remove(e, &removed);
+  }
   if (removed) {
     delete e;
   } else {

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -558,3 +558,54 @@ TEST_F(CtranUtilsAvlTreeTest, SearchRangeLeftSubtreePruning) {
   tree->remove(hdl2);
   tree->remove(hdl3);
 }
+
+// Regression test: when the only tree node is removed first, root_ becomes null
+// while an overlapping element still lives in the fallback list_. A subsequent
+// remove() of that list element must not dereference the null root_.
+// Range A goes into the AVL tree as the first/only node; range B overlaps A and
+// falls back to list_.
+TEST_F(CtranUtilsAvlTreeTest, RemoveTreeNodeBeforeOverlappingListNode) {
+  const uintptr_t base = 0x100000;
+  void* const valA = reinterpret_cast<void*>(0xA);
+  void* const valB = reinterpret_cast<void*>(0xB);
+
+  // Tree-then-list removal order
+  {
+    auto tree = std::make_unique<CtranAvlTree>();
+
+    void* const hdlA =
+        tree->insert(reinterpret_cast<void*>(base + 0x1000), 0x1000, valA);
+    void* const hdlB =
+        tree->insert(reinterpret_cast<void*>(base), 0x4000, valB);
+    ASSERT_NE(hdlA, nullptr);
+    ASSERT_NE(hdlB, nullptr);
+    ASSERT_EQ(tree->size(), 2);
+
+    // Remove the tree node first, emptying the internal AVL tree (root_ null)
+    ASSERT_EQ(tree->remove(hdlA), commSuccess);
+    ASSERT_EQ(tree->size(), 1);
+
+    // Remove the list node with a null root_; must not crash
+    ASSERT_EQ(tree->remove(hdlB), commSuccess);
+    ASSERT_EQ(tree->size(), 0);
+  }
+
+  // Reverse order: list-then-tree removal
+  {
+    auto tree = std::make_unique<CtranAvlTree>();
+
+    void* const hdlA =
+        tree->insert(reinterpret_cast<void*>(base + 0x1000), 0x1000, valA);
+    void* const hdlB =
+        tree->insert(reinterpret_cast<void*>(base), 0x4000, valB);
+    ASSERT_NE(hdlA, nullptr);
+    ASSERT_NE(hdlB, nullptr);
+    ASSERT_EQ(tree->size(), 2);
+
+    ASSERT_EQ(tree->remove(hdlB), commSuccess);
+    ASSERT_EQ(tree->size(), 1);
+
+    ASSERT_EQ(tree->remove(hdlA), commSuccess);
+    ASSERT_EQ(tree->size(), 0);
+  }
+}

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -777,6 +777,68 @@ TEST_F(CtranWinTest, multiSegmentWindowRegister) {
   COMMCHECK_TEST(commMemFreeDisjoint(disjointBuf, segSizes));
 }
 
+TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
+  // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
+  // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early
+  // return never deletes the window nor calls free(), so the window and any
+  // resources it already acquired leak. In particular exchange() first
+  // registers the internal signal buffer via regMem (caching one RegCache
+  // segment) and only afterwards registers the user data buffer; a failure in
+  // that later step leaks the already-cached signal-buffer segment.
+  //
+  // Trigger: register a genuine cumem device buffer with a size far larger
+  // than its actual mapped allocation. The user-buffer registration walks the
+  // range past the mapped VA (cuMemGetAddressRange) and returns an error,
+  // after the signal-buffer segment has already been cached. The buffer must
+  // be a real cumem allocation so getDevMemType returns kCumem and the range
+  // discovery takes the cumem path; a cudaMalloc/host over-range buffer does
+  // not reliably error there.
+  //
+  // With the RAII guard fix, the failed register frees the window (and its
+  // signal-buffer segment), so getSegments() returns to baseline.
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip over-range user buffer test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  // Allocate a modest, real cumem device buffer. The registration below passes
+  // a size far beyond this, so pinRange walks past the mapped VA and errors.
+  const size_t allocBytes = 2 * 1024 * 1024; // 2MB
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* cumemBuf = commMemAlloc(allocBytes, bufType, segments);
+  ASSERT_NE(cumemBuf, nullptr);
+
+  // Register with a size 1GB beyond the 2MB mapped allocation. This is safely
+  // past the cumem granularity-rounded mapped range, guaranteeing over-range.
+  const size_t oversizedBytes = allocBytes + (1UL << 30);
+
+  auto regCache = ctran::RegCache::getInstance();
+  const size_t segsBefore = regCache->getSegments().size();
+
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  const auto res =
+      ctranWinRegister(cumemBuf, oversizedBytes, comm.get(), &win, hints);
+  EXPECT_NE(res, commSuccess);
+  EXPECT_EQ(win, nullptr);
+
+  EXPECT_EQ(regCache->getSegments().size(), segsBefore)
+      << "ctranWinRegister leaked a RegCache segment on exchange() failure";
+
+  // Free the ACTUAL allocated buffer (allocBytes, not the oversized size).
+  commMemFree(cumemBuf, allocBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [cumemBuf](const TestMemSegment& seg) {
+            return seg.ptr == cumemBuf;
+          }),
+      segments.end());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CtranWinInstance,
     CtranWinTestParam,

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <folly/ScopeGuard.h>
 #include <memory>
 #include <numeric>
 
@@ -545,6 +546,12 @@ commResult_t ctranWinAllocate(
       comm,
       size,
       locationRes == "cpu" ? DevMemType::kHostPinned : DevMemType::kCumem);
+  auto winGuard = folly::makeGuard([&newWin]() {
+    // On any early error return, release partial resources (SW + backend
+    // dereg, no barrier) and delete the window so it does not leak.
+    (void)newWin->free(/*skipBarrier=*/true);
+    delete newWin;
+  });
   newWin->setAtomicCapable(true);
   FB_COMMCHECK(newWin->allocate(nullptr));
   FB_COMMCHECK(newWin->exchange());
@@ -552,6 +559,7 @@ commResult_t ctranWinAllocate(
     *baseptr = newWin->winDataPtr;
   }
   *win = newWin;
+  winGuard.dismiss();
   return commSuccess;
 }
 
@@ -598,6 +606,12 @@ commResult_t ctranWinRegister(
       // if user buffer is on host CPU, allocate kHostPinned buffer for
       // signal otherwise is on GPU device, allocate kCumem buffer for signal
       userBufType);
+  auto winGuard = folly::makeGuard([&newWin]() {
+    // On any early error return, release partial resources (SW + backend
+    // dereg, no barrier) and delete the window so it does not leak.
+    (void)newWin->free(/*skipBarrier=*/true);
+    delete newWin;
+  });
   newWin->setAtomicCapable(
       reinterpret_cast<uintptr_t>(databuf) % sizeof(uint64_t) == 0 &&
       size % sizeof(uint64_t) == 0);
@@ -607,6 +621,7 @@ commResult_t ctranWinRegister(
   FB_COMMCHECK(newWin->exchange()); // register and exchange both signal
                                     // & data buffer
   *win = newWin;
+  winGuard.dismiss();
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary:
`ctranWinRegister` and `ctranWinAllocate` construct a `CtranWin` with raw `new`, then `FB_COMMCHECK(newWin->allocate(...))` and `FB_COMMCHECK(newWin->exchange())`. On failure those macros return early, so `newWin` is never deleted and `free()` never runs — leaking the window object plus any resources `exchange()` had already acquired. In particular `exchange()` first registers the internal signal buffer via `mapper->regMem` (caching one RegCache segment) and only afterwards registers the user data buffer; a failure in that later step leaks the already-cached signal-buffer segment.
- Wrap `newWin`'s lifetime in a `folly::makeGuard` placed immediately after construction that calls `free(/*skipBarrier=*/true)` + `delete` on any early return, dismissed only after `*win = newWin` succeeds. `skipBarrier=true` avoids a collective hang since peers may not have reached the same failure point. `CtranWin::free` is null-safe on a partially-initialized window (all dereg/free paths are null/UNSET-guarded), so no double-free vs the success path (dismiss neutralizes the guard).
- Add regression test `RegisterOverRangeUserBufferNoLeak`: register a genuine cumem device buffer with a size far larger than its mapped allocation. The user-buffer registration walks the range past the mapped VA (`cuMemGetAddressRange`) and returns an error, after the base signal-buffer segment has already been cached — so the un-freed window leaks that segment. The test asserts `RegCache::getInstance()->getSegments().size()` returns to baseline after the failed register.

Differential Revision: D110820313


