### PR TITLE
Add ScopedRegHdl for scoped local registration (#3063)

### DIFF
--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -593,7 +593,8 @@ void ctran::RegCache::resetExternalRegMemFn() {
 
 ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
     const void* ptr,
-    const size_t len) {
+    const size_t len,
+    bool acquireRef) {
   ctran::regcache::RegElem* regHdl = nullptr;
 
   auto regElemsMaps = regElemsMaps_.rlock();
@@ -616,6 +617,10 @@ ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
       // Lookup hit
       regHdl = searchRegElem.get();
       searchRegElem->lookupHit_++;
+      if (acquireRef) {
+        // Atomic increment: safe under the shared read lock.
+        regHdl->inUseCnt.fetch_add(1, std::memory_order_relaxed);
+      }
       break;
     }
   }
@@ -918,7 +923,8 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
     std::vector<ctran::regcache::Segment*>& segments,
     const std::vector<bool>& backends,
     bool ncclManaged,
-    ctran::regcache::RegElem** regHdl) {
+    ctran::regcache::RegElem** regHdl,
+    bool acquireRef) {
   // Create a new registration element for the segments
   auto newRegElem = std::make_unique<ctran::regcache::RegElem>(
       ptr, len, cudaDev, segments, ncclManaged);
@@ -932,6 +938,12 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
   auto regElemsMaps = regElemsMaps_.wlock();
   auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
   auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
+
+  // If the caller is a scoped acquire, add its use-side reference while holding
+  // the map lock.
+  if (acquireRef) {
+    regHdlPtr->inUseCnt.fetch_add(1, std::memory_order_relaxed);
+  }
 
   regHdlToElemMap.emplace(regHdlPtr, std::move(newRegElem));
   // Correlate the regElem with all associated segments to deregister it
@@ -954,6 +966,30 @@ commResult_t ctran::RegCache::regRangeCached(
     bool& didRegister,
     ctran::regcache::RegElem** regHdl,
     bool ncclManaged) {
+  return regRangeCachedImpl(
+      ptr,
+      len,
+      cudaDev,
+      useDesc,
+      logMetaData,
+      backends,
+      didRegister,
+      regHdl,
+      ncclManaged,
+      false /* acquireRef */);
+}
+
+commResult_t ctran::RegCache::regRangeCachedImpl(
+    const void* ptr,
+    const size_t len,
+    const int cudaDev,
+    const std::string& useDesc,
+    const struct CommLogData& logMetaData,
+    const std::vector<bool>& backends,
+    bool& didRegister,
+    ctran::regcache::RegElem** regHdl,
+    bool ncclManaged,
+    bool acquireRef) {
   auto dur = CtranMapperTimer();
   SetCudaDevRAII setCudaDev(cudaDev);
   auto timerBegin = std::chrono::steady_clock::now();
@@ -962,7 +998,7 @@ commResult_t ctran::RegCache::regRangeCached(
     // FAST PATH: find whether range has already been registered in
     // regElemsMaps. regElemsMaps should not be wlocked while performing
     // expensive registration/deregistration.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     // Lookup hit
     if (*regHdl) {
       return commSuccess;
@@ -983,7 +1019,7 @@ commResult_t ctran::RegCache::regRangeCached(
 
     // While holding the global lock, let's check again no one else has
     // registered the range.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     if (*regHdl) {
       return commSuccess;
     }
@@ -1032,7 +1068,8 @@ commResult_t ctran::RegCache::regRangeCached(
           segments,
           backends,
           ncclManaged,
-          regHdl));
+          regHdl,
+          acquireRef));
       didRegister = true;
     } else {
       // - WORST PATH: if any one is not found, return nullptr to trigger
@@ -1059,19 +1096,6 @@ commResult_t ctran::RegCache::regRangeCached(
 
   profiler.wlock()->record(ctran::regcache::EventType::kRegMemEvent, dur);
   return commSuccess;
-}
-
-bool ctran::regcache::Segment::askFree() {
-  auto stat = stateMnger.wlock();
-  stat->refCount--;
-  FB_CHECKABORT(
-      stat->refCount >= 0,
-      "Unexpected negative refCount {} in segment {} [{}]",
-      stat->refCount,
-      (void*)this,
-      toString(stat->refCount).c_str());
-
-  return stat->refCount == 0;
 }
 
 ctran::regcache::Segment* ctran::RegCache::getSegment(void* segHdl) {
@@ -1122,6 +1146,8 @@ commResult_t ctran::RegCache::freeSegment(
     std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems,
     bool forceFree) {
   ctran::regcache::Segment* segment = nullptr;
+  bool foundInuseReg = false;
+
   {
     // Global lock:
     // Lock both segmentsAvl and regElemsMaps since we may need remove segment
@@ -1146,11 +1172,21 @@ commResult_t ctran::RegCache::freeSegment(
     }
 
     ncclManaged = segment->ncclManaged;
+    auto segmentState = segment->stateMnger.wlock();
+
+    // Segment cache invariant
+    FB_CHECKABORT(
+        segmentState->refCount > 0,
+        "Unexpected non-positive refCount {} in segment {} [{}]",
+        segmentState->refCount,
+        (void*)segment,
+        segment->toString(segmentState->refCount).c_str());
 
     // Ask for free. False if still in use, then no-op and return.
     // When forceFree is true (e.g. globalDeregister), skip the refCount check
     // because the underlying physical memory is about to be freed.
-    if (!forceFree && !segment->askFree()) {
+    if (!forceFree && segmentState->refCount > 1) {
+      segmentState->refCount--;
       return commSuccess;
     }
 
@@ -1170,15 +1206,53 @@ commResult_t ctran::RegCache::freeSegment(
           continue;
         }
 
+        // Check the registration's ref. Any remaining count means live
+        // ScopedRegHdl owners, which violates the lifetime contract because the
+        // segment/memory is being freed underneath them.
+        // forceFree would just report error and continue to free the segment
+        const auto inUseCnt =
+            regIt->second->inUseCnt.load(std::memory_order_acquire);
+        if (inUseCnt > 0) {
+          // Intentionally error logging as this is invalid usage to free buffer
+          // before releasing all registrations.
+          CLOGF(
+              ERR,
+              "freeSegment: RegElem [buf {} len {}] still has {} live ScopedRegHdl owner(s)",
+              regIt->second->buf,
+              regIt->second->len,
+              inUseCnt);
+          if (!forceFree) {
+            foundInuseReg = true;
+            break;
+          }
+        }
+
         // Remove regElem from global cache and to be deregistered
         regElems.push_back(std::move(regIt->second));
         regHdlToElemMap.erase(regIt);
+      }
+
+      if (!forceFree && foundInuseReg) {
+        // If found in-use regElem, we cannot free the segment, revert all
+        // regElems and return error.
+        // FIXME: deregMem doesn't proper handle retry logic, so the error is
+        // not retry-able from callsite. We should delete per-mapper deregMem
+        // path given it is no longer used in prod. The only in-use path to call
+        // freeSegment is via globalDeregister with forceFree. Current
+        // foundInuseReg logic is a best effort to keep clean state inside
+        // regcache.
+        for (auto& regElem : regElems) {
+          regHdlToElemMap.emplace(regElem.get(), std::move(regElem));
+        }
+        regElems.clear();
+        return commInvalidUsage;
       }
 
       segToRegElemsMap.erase(segIt);
     }
 
     // - Remove segment from cache
+    segmentState->refCount = 0;
     FB_COMMCHECK(segmentsAvl->remove(segment->avlHdl_));
     CLOGF_TRACE(
         ALLOC,
@@ -1214,6 +1288,167 @@ commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   FB_COMMCHECK(regElem->doDeregister(externalDeregMemFn_));
   profiler.wlock()->record(ctran::regcache::EventType::kDeregMemEvent, dur);
   return commSuccess;
+}
+
+void ctran::RegCache::releaseScopedRegHdl(
+    ctran::regcache::RegElem* regHdl,
+    const uint64_t regId) {
+  // Pure SW-only release: drop the scope's use count (atomic decrement). Never
+  // deregisters, deletes, or touches CUDA, so it is safe to run from a CUDA
+  // graph-destroy callback. RegElem lifetime is controlled by allocator hooks
+  // and explicit deregistration, not by this counter.
+  //
+  // A read lock is enough: we only look up the map, we never modify it. The
+  // rlock excludes freeSegment's wlock, so the found RegElem cannot be freed
+  // underneath the decrement.
+  if (regHdl == nullptr) {
+    return;
+  }
+
+  auto regElemsMaps = regElemsMaps_.rlock();
+  // NOTE: regHdl may be a dangling pointer here if a buffer-release path
+  // (freeSegment/globalDeregister) already force-freed the RegElem while this
+  // scope was still live. It is therefore used ONLY as a map key below and is
+  // NEVER dereferenced. Beyond the not-found case, we also compare the captured
+  // regId against the found RegElem's id: the heap may reuse a force-freed
+  // RegElem's address for an unrelated RegElem (ABA), and the id check rejects
+  // that so we never decrement an unrelated registration's inUseCnt. Either
+  // case safely no-ops.
+  auto it = regElemsMaps->regHdlToElemMap.find(regHdl);
+  if (it == regElemsMaps->regHdlToElemMap.end() ||
+      it->second->regId_ != regId) {
+    CLOGF(
+        WARN,
+        "releaseScopedRegHdl: regElem {} not found or its address was reused (may have been force-freed by a buffer-release path)",
+        (void*)regHdl);
+    return;
+  }
+
+  const auto prev =
+      it->second->inUseCnt.fetch_sub(1, std::memory_order_acq_rel);
+  const auto after = prev - 1;
+  FB_CHECKABORT(
+      after >= 0,
+      "scoped release drove inUseCnt below zero for RegElem {} (cnt {})",
+      (void*)regHdl,
+      after);
+}
+
+commResult_t ctran::RegCache::acquireScopedRegister(
+    const void* buf,
+    size_t len,
+    int cudaDev,
+    const std::vector<bool>& backends,
+    ctran::ScopedRegHdl& scopedRegHdl) {
+  if (buf == nullptr || len == 0) {
+    CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
+    return commInvalidUsage;
+  }
+
+  // Acquire one RegElem ref. The buffer's segment must already be cached by the
+  // allocator; regRangeCachedImpl returns nullptr otherwise.
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData scopedLogData{};
+  scopedLogData.commDesc = "scopedRegister";
+  const auto regResult = regRangeCachedImpl(
+      buf,
+      len,
+      cudaDev,
+      "scopedRegister",
+      scopedLogData,
+      backends,
+      didRegister,
+      &regHdl,
+      true /* ncclManaged */,
+      true /* acquireRef */);
+
+  if (regResult != commSuccess || regHdl == nullptr) {
+    CLOGF(
+        ERR,
+        "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
+        "segment. Scoped registration requires the buffer's memory to be pre-registered "
+        "by the allocator (globalRegister / CCA memory hook) before use. Ensure the "
+        "allocator registers memory after allocation and deregisters before free.",
+        (void*)buf,
+        len);
+    return commInvalidUsage;
+  }
+
+  scopedRegHdl.regCache_ = this;
+  scopedRegHdl.regHdl_ = regHdl;
+  scopedRegHdl.regId_ = regHdl->regId_;
+  scopedRegHdl.buf_ = regHdl->buf;
+  scopedRegHdl.len_ = regHdl->len;
+  return commSuccess;
+}
+
+ctran::ScopedRegHdl::ScopedRegHdl(ctran::ScopedRegHdl&& other) noexcept
+    : regCache_(other.regCache_),
+      regHdl_(other.regHdl_),
+      regId_(other.regId_),
+      buf_(other.buf_),
+      len_(other.len_) {
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+}
+
+ctran::ScopedRegHdl& ctran::ScopedRegHdl::operator=(
+    ctran::ScopedRegHdl&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  // Release the current handle before taking over the other.
+  if (regCache_ != nullptr) {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  }
+  regCache_ = other.regCache_;
+  regHdl_ = other.regHdl_;
+  regId_ = other.regId_;
+  buf_ = other.buf_;
+  len_ = other.len_;
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+  return *this;
+}
+
+ctran::ScopedRegHdl::~ScopedRegHdl() {
+  if (regCache_ == nullptr) {
+    return;
+  }
+  // Best-effort SW-only cleanup; never throw out of the destructor.
+  try {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
+  }
+  regCache_ = nullptr;
+  regHdl_ = nullptr;
+}
+
+ctran::regcache::RegElem* ctran::ScopedRegHdl::get() const {
+  return regHdl_;
+}
+
+ctran::ScopedRegHdl::operator bool() const {
+  return regCache_ != nullptr && regHdl_ != nullptr;
+}
+
+std::string ctran::ScopedRegHdl::toString() const {
+  if (regCache_ == nullptr || regHdl_ == nullptr) {
+    return "ScopedRegHdl{empty}";
+  }
+  return fmt::format(
+      "ScopedRegHdl{{regHdl: {}, buf: {}, len: {}}}",
+      (void*)regHdl_,
+      buf_,
+      len_);
 }
 
 commResult_t ctran::RegCache::regRange(
@@ -1302,6 +1537,30 @@ commResult_t ctran::RegCache::regDynamic(
   return commSuccess;
 }
 
+namespace {
+// Remove regHdl from every segToRegElemsMap entry for its segments, erasing
+// any entry whose vector becomes empty.
+void removeRegElemFromSegCorrelations(
+    ctran::regcache::RegElem* regHdl,
+    const std::vector<ctran::regcache::Segment*>& segments,
+    std::unordered_map<
+        ctran::regcache::Segment*,
+        std::vector<ctran::regcache::RegElem*>>& segToRegElemsMap) {
+  for (auto seg : segments) {
+    auto segIt = segToRegElemsMap.find(seg);
+    if (segIt != segToRegElemsMap.end()) {
+      auto& regElemsVec = segIt->second;
+      regElemsVec.erase(
+          std::remove(regElemsVec.begin(), regElemsVec.end(), regHdl),
+          regElemsVec.end());
+      if (regElemsVec.empty()) {
+        segToRegElemsMap.erase(segIt);
+      }
+    }
+  }
+}
+} // namespace
+
 commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
   std::unique_ptr<ctran::regcache::RegElem> regElem = nullptr;
   // Global lock to update regElemsMaps_.
@@ -1315,6 +1574,27 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
+
+    const auto inUseCnt = it->second->inUseCnt.load(std::memory_order_acquire);
+    if (inUseCnt > 0) {
+      // The caller may already have performed mapper-side remote release, so
+      // this error is not a retry contract. Keep regcache state intact and let
+      // higher-level failure cleanup or allocator force-free reclaim memory.
+      CLOGF(
+          ERR,
+          "deregRange: RegElem {} still has {} live use-side owner(s)",
+          (void*)regHdl,
+          inUseCnt);
+      return commInvalidUsage;
+    }
+
+    // Remove the regElem from every segment correlation entry so no dangling
+    // pointer remains after ownership moves out of the live map. Dynamic
+    // RegElems carry no segments_, so this only matters for the cached
+    // cached path.
+    removeRegElemFromSegCorrelations(
+        regHdl, regHdl->segments_, regElemsMaps->segToRegElemsMap);
+
     // Remove regElem from global cache and return ownership to caller for any
     // remote registration release
     regElem = std::move(it->second);
@@ -1552,7 +1832,6 @@ commResult_t ctran::RegCache::deregAll() {
   {
     auto regElemsMaps = regCache->regElemsMaps_.wlock();
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
-    auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
 
     // Iterate through all regElems and collect non-dynamic ones for
     // deregistration
@@ -1567,19 +1846,8 @@ commResult_t ctran::RegCache::deregAll() {
       }
 
       // Remove from segToRegElemsMap
-      for (auto seg : regElem->segments_) {
-        auto segIt = segToRegElemsMap.find(seg);
-        if (segIt != segToRegElemsMap.end()) {
-          auto& regElemsVec = segIt->second;
-          regElemsVec.erase(
-              std::remove(
-                  regElemsVec.begin(), regElemsVec.end(), regElem.get()),
-              regElemsVec.end());
-          if (regElemsVec.empty()) {
-            segToRegElemsMap.erase(segIt);
-          }
-        }
-      }
+      removeRegElemFromSegCorrelations(
+          regElem.get(), regElem->segments_, regElemsMaps->segToRegElemsMap);
 
       // Transfer ownership to toDeregister vector and remove from map
       toDeregister.push_back(std::move(regElem));

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -3,7 +3,10 @@
 
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <atomic>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <unordered_map>
 
@@ -86,8 +89,6 @@ struct Segment {
  protected:
   void* avlHdl_{nullptr};
 
-  bool askFree();
-
   std::string toString(const int64_t refCount) const {
     std::stringstream ss;
     ss << "range: " << range.toString() << ", cudaDev:" << cudaDev
@@ -157,6 +158,31 @@ struct RegElem {
         ncclManaged_(ncclManaged) {
     type_ = segments.at(0)->getType();
   };
+
+  // Number of live use-side owners for this RegElem. This does not control the
+  // RegElem's lifetime: allocator hooks own that lifecycle by creating and
+  // deleting the registration around buffer allocation/free. inUseCnt starts at
+  // 0, and each live ScopedRegHdl adds one use-side reference.
+  //
+  // The preexisting RegElem consumers (searchRegHandle / searchIbRegHandle /
+  // getRegHandle) do NOT update inUseCnt. They rely on the allocator-hook
+  // contract: any lookup issued after the buffer's allocation hook
+  // (globalRegister) and before its free hook (globalDeregister) is safe.
+  // Consequently inUseCnt can only detect scoped-use contract violations; it
+  // cannot protect borrowed lookup users that have no matching release call.
+  //
+  // Atomic so a scoped acquire can increment it under the shared read lock.
+  std::atomic<int64_t> inUseCnt{0};
+
+  // Process-unique monotonic id assigned at construction. Used to validate a
+  // ScopedRegHdl's identity so that a reused heap address (a new RegElem
+  // occupying a force-freed RegElem's old address) is not mistaken for the
+  // original registration. The counter is a function-local static (NOT a global
+  // variable), so it satisfies facebook-avoid-non-const-global-variables.
+  const uint64_t regId_{[] {
+    static std::atomic<uint64_t> counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+  }()};
 
   std::size_t numSegments() const {
     return segments_.size();
@@ -267,6 +293,35 @@ class Profiler {
 
 } // namespace regcache
 
+// Move-only RAII owner of a scoped local registration acquired via
+// RegCache::acquireScopedRegister(). It owns one RegElem use-side reference
+// tracked in RegElem::inUseCnt; it does not cache or ref-count segments. The
+// registration lifetime itself is controlled by allocator hooks / explicit
+// deregistration. The destructor performs a pure SW-only decrement
+// (graph-destroy safe): it never touches CUDA and never deregisters.
+class ScopedRegHdl {
+ public:
+  ScopedRegHdl() = default;
+  ScopedRegHdl(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl& operator=(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl(const ScopedRegHdl&) = delete;
+  ScopedRegHdl& operator=(const ScopedRegHdl&) = delete;
+  ~ScopedRegHdl();
+
+  regcache::RegElem* get() const;
+  explicit operator bool() const;
+  std::string toString() const;
+
+ private:
+  friend class RegCache;
+
+  RegCache* regCache_{nullptr};
+  regcache::RegElem* regHdl_{nullptr};
+  uint64_t regId_{0};
+  const void* buf_{nullptr};
+  size_t len_{0};
+};
+
 /**
  * Singleton class to hold the IB network resources that are reused by all
  * communicators in the lifetime of program.
@@ -303,6 +358,20 @@ class RegCache {
       size_t len,
       bool skipRemRelease = false,
       int deviceId = -1);
+
+  // Acquire a scoped local registration for [buf, buf + len). The buffer's
+  // underlying segment MUST already be cached by the allocator (globalRegister
+  // / CCA memory hook); this API does not cache segments. On success it takes
+  // one RegElem use-side reference (counted in RegElem::inUseCnt) and the
+  // returned ScopedRegHdl owns that use, releasing it SW-only in its
+  // destructor. If the buffer is not backed by a cached segment,
+  // commInvalidUsage is returned and the ScopedRegHdl stays empty.
+  commResult_t acquireScopedRegister(
+      const void* buf,
+      size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      ScopedRegHdl& scopedRegHdl);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying
@@ -356,26 +425,6 @@ class RegCache {
       regcache::RegElem** regHdl,
       bool ncclManaged = false);
 
-  // Thread-safe function to directly register a buffer range without consulting
-  // the reusable segment/regElem cache. It registers every pinned physical
-  // range covering [ptr, ptr + len) as one dynamic RegElem, does not allow
-  // lookup reuse, and must be deregistered via deregRange().
-  // input:
-  //   - ptr: the pointer to the buffer to be registered
-  //   - len: the length of the buffer
-  //   - cudaDev: the cuda device id of the buffer
-  // output:
-  //   - regHdl: the direct registration handle
-  commResult_t regRange(
-      const void* ptr,
-      const size_t len,
-      int cudaDev,
-      const std::vector<bool>& backends,
-      regcache::RegElem** regHdl,
-      bool ncclManaged = false,
-      const struct CommLogData* logMetaData = nullptr,
-      const std::string& useDesc = "dynamicRegMem");
-
   // Thread-safe functions to dynamically register a segment. Compatibility
   // wrapper around regRange() for existing callers. Always records the
   // registration under "dynamicRegMem" so dynamic and window registrations stay
@@ -388,15 +437,10 @@ class RegCache {
       regcache::RegElem** regHdl,
       const struct CommLogData* logMetaData = nullptr);
 
-  // Thread-safe function to deregister a direct range registration.
-  // Unlike freeSegment(), it always deregisters since only the calling
-  // communicator uses it.
-  // input:
-  //   - regHdl: the direct registration handle
-  commResult_t deregRange(regcache::RegElem* regHdl);
-
   // Thread-safe function to deregister a dynamic registration. Compatibility
-  // wrapper around deregRange() for existing callers.
+  // wrapper around deregRange() for existing callers. Dynamic registrations do
+  // not acquire inUseCnt; deregistration fails with commInvalidUsage if any
+  // scoped-use owner is unexpectedly still live.
   // input:
   //   - regHdl: the dynamic registration handle
   commResult_t deregDynamic(regcache::RegElem* regHdl);
@@ -544,6 +588,8 @@ class RegCache {
   folly::Synchronized<regcache::Profiler> profiler;
 
  private:
+  friend class ScopedRegHdl;
+
   // Hold a reference to CtranIbSingleton to ensure proper destruction order.
   // By holding this shared_ptr, we guarantee CtranIbSingleton stays alive
   // as long as RegCache exists, preventing use-after-free during
@@ -587,7 +633,11 @@ class RegCache {
   void asyncRegThreadFn(int cudaDev);
 
   // Thread-safe function to search given <ptr, len> range in regElem cache.
-  regcache::RegElem* searchRegElem(const void* ptr, const size_t len);
+  // If acquireRef is true, atomically increments the found RegElem's inUseCnt
+  // on a lookup hit (safe under the shared read lock because inUseCnt is
+  // atomic).
+  regcache::RegElem*
+  searchRegElem(const void* ptr, const size_t len, bool acquireRef = false);
 
   // Helper function to perform backend registration for a set of segments.
   // Creates a RegElem, registers with backends, and updates regElemsMaps.
@@ -603,9 +653,53 @@ class RegCache {
       std::vector<regcache::Segment*>& segments,
       const std::vector<bool>& backends,
       bool ncclManaged,
-      regcache::RegElem** regHdl);
+      regcache::RegElem** regHdl,
+      bool acquireRef = false);
+
+  // Internal implementation for regRangeCached(). acquireRef is intentionally
+  // private so only acquireScopedRegister() can create an RAII-owned use-side
+  // reference.
+  commResult_t regRangeCachedImpl(
+      const void* ptr,
+      const size_t len,
+      const int cudaDev,
+      const std::string& useDesc,
+      const struct CommLogData& logMetaData,
+      const std::vector<bool>& backends,
+      bool& didRegister,
+      regcache::RegElem** regHdl,
+      bool ncclManaged = false,
+      bool acquireRef = false);
+
+  // Thread-safe function to directly register a buffer range without consulting
+  // the reusable segment/regElem cache. It registers every pinned physical
+  // range covering [ptr, ptr + len) as one dynamic RegElem, does not allow
+  // lookup reuse, and must be deregistered via deregRange().
+  // input:
+  //   - ptr: the pointer to the buffer to be registered
+  //   - len: the length of the buffer
+  //   - cudaDev: the cuda device id of the buffer
+  // output:
+  //   - regHdl: the direct registration handle
+  commResult_t regRange(
+      const void* ptr,
+      const size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      regcache::RegElem** regHdl,
+      bool ncclManaged = false,
+      const struct CommLogData* logMetaData = nullptr,
+      const std::string& useDesc = "dynamicRegMem");
+
+  // Thread-safe function to deregister a direct range registration.
+  commResult_t deregRange(regcache::RegElem* regHdl);
 
   commResult_t deregElem(regcache::RegElem* regElem);
+
+  // SW-only scoped-ref release used by ~ScopedRegHdl; graph-destroy safe. The
+  // regId identifies the RegElem captured at acquire time so a reused heap
+  // address is rejected. See .cc for details.
+  void releaseScopedRegHdl(regcache::RegElem* regHdl, const uint64_t regId);
 };
 
 static inline void CHECK_VALID_REGCACHE(std::shared_ptr<RegCache> regCache) {

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -109,6 +109,7 @@ RegElem
   isDynamic_ : bool         -- true for one-time uncached registrations
   type_      : DevMemType   -- memory type of the registered range
   ncclManaged_: bool        -- whether NCCL allocated this buffer
+  inUseCnt    : atomic<int64_t>  -- live scoped-use count; does not control RegElem lifetime (see Scoped Registration)
 ```
 
 ### RegCache (class)
@@ -202,8 +203,11 @@ freeSegment(segHdl, forceFree=false) -> freed, regElems
   1. Acquire both segmentsAvl_ and regElemsMaps_ locks
   2. Lookup Segment from AVL handle
      - Not found -> return (freed=false, commSuccess)
-  3. If !forceFree: askFree() -> decrement refCount
-     - refCount > 0 -> return (freed=false, commSuccess)
+  3. If !forceFree: lock SegmentStateMnger
+     - refCount > 1 -> decrement and return (freed=false, commSuccess)
+     - refCount == 1 -> validate associated RegElems have inUseCnt == 0
+       before setting refCount to 0
+     - inUseCnt > 0 -> return commInvalidUsage without changing refCount
   4. Collect all RegElems via segToRegElemsMap
   5. Transfer ownership from regHdlToElemMap to output vector
   6. Remove Segment from AVL tree
@@ -328,6 +332,76 @@ cleanup:
   -> cudaFree
 ```
 
+## Scoped Registration
+
+Ctran's persistent collectives (persistent AllGatherP, "AGP") and window
+collectives hold a registration for the lifetime of an operation, request, or
+window — not the lifetime of the underlying memory — and must release it safely,
+including from a CUDA graph-destroy callback where no CUDA calls are allowed.
+Move-only RAII owners provide this on top of the existing cache without
+disturbing the allocator (CCA) hook or the existing, non-refcounted lookup APIs.
+
+`globalRegister` / `globalDeregister` are the allocator-hook APIs. They are keyed
+on BUFFER (memory) lifetime — the allocator calls them around a buffer's
+allocation and free — and `globalDeregister` force-frees the cached segment and
+all of its registrations. They are therefore NOT suitable for scoped
+registration inside Ctran: a persistent collective or window has an operation /
+request / window lifetime, not a memory lifetime, and calling `globalDeregister`
+from that code would tear down allocator-owned state that other consumers may
+still need. Ctran-internal scopes must use `acquireScopedRegister` /
+`ScopedRegHdl` (below) instead; `globalRegister` / `globalDeregister` must be
+called ONLY from the allocator side (the CCA memory hook), never from collective
+or window code.
+
+### Local registration: `ScopedRegHdl`
+
+Use tracking (`RegElem::inUseCnt`):
+
+- `RegElem` lifetime is controlled by allocator hooks and explicit teardown, not
+  by `inUseCnt`. A cached registration starts with `inUseCnt = 0` when it is
+  created via `globalRegister` / the CCA hook or by first scoped use of an
+  already-cached segment.
+- `RegCache::acquireScopedRegister(buf, len, cudaDev, backends, &hdl)` resolves
+  the cached `RegElem`, increments `inUseCnt`, and returns a move-only
+  `ScopedRegHdl` owning that one use-side reference.
+- Dynamic registrations (`regDynamic` / internal `regRange`) do not acquire
+  `inUseCnt`. The explicit `deregDynamic` / internal `deregRange` call deletes
+  the RegElem only if `inUseCnt == 0`; a non-zero `inUseCnt` there is invalid
+  usage and returns `commInvalidUsage`.
+- `~ScopedRegHdl` performs a pure software decrement (`releaseScopedRegHdl`)
+  under the `regElemsMaps_` read lock — no deregistration, no delete, no CUDA —
+  so it is safe to run from a graph-destroy callback.
+- If `deregRange` or non-force `freeSegment` attempts to delete a registration
+  while `inUseCnt > 0`, it returns `commInvalidUsage`. The allocator hook
+  (`globalDeregister` -> force `freeSegment`) must not block memory free; it
+  logs and force-frees the registration because freeing the buffer while scoped
+  use is still live is already invalid usage. These errors are not retry
+  contracts: mapper-side release may already have partially run, and regcache
+  only preserves enough local state for whole-cache failure cleanup or
+  allocator force-free to reclaim memory.
+
+Compatibility with the allocator (CCA) hook:
+
+- The allocator hook owns memory lifetime: `globalRegister` caches the segment
+  and may create the `RegElem`; `globalDeregister` force-frees cached segments
+  and associated backend registrations right before the memory is freed.
+- `acquireScopedRegister` REQUIRES the buffer's segment to already be
+  allocator-cached and returns `commInvalidUsage` otherwise — it never caches or
+  frees segments. A scoped acquire/release only adjusts `inUseCnt`, so it can
+  neither race nor double-free allocator-owned state; the allocator remains the
+  owner of the registration's lifetime. If a buffer is freed while scoped use is
+  still live, force `freeSegment` logs a contract-violation warning and tears
+  down anyway (the memory is going away).
+
+Compatibility with the existing (non-refcounted) lookup APIs:
+
+- `searchRegHandle` / `searchIbRegHandle` / `getRegHandle` return a borrowed
+  `RegElem*` WITHOUT touching `inUseCnt`. These are the established production
+  callers (e.g. collective-time handle lookup) and are intentionally left
+  uncounted because there is no matching release API. Their safety still comes
+  from the allocator-hook contract: the buffer allocation must outlive borrowed
+  lookup use.
+
 ## Component Interactions
 
 ### CtranMapper (per-communicator)
@@ -340,7 +414,7 @@ notifications.
 CtranMapper
   regMem()          -> RegCache::cacheSegment [+ regRange]
   deregMem()        -> RegCache::getRegElems -> remReleaseMem per elem
-                       -> RegCache::freeSegment (decrement refCount)
+                       -> RegCache::freeSegment (decrement segment refCount)
   searchRegHandle() -> RegCache::regRange [or regDynamic as fallback]
   remReleaseMem()   -> send IPC release to remote peers via AsyncSocket
 ```

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1660,6 +1660,471 @@ TEST_F(RegCacheTest, ExternalRegMemFailureIsHandledGracefully) {
   CUDACHECK_TEST(cudaFree(buf));
 }
 
+// inUseCnt tracks only scoped use-side owners. globalRegister caches and
+// eager-registers but does not count as in-use; scoped acquire bumps inUseCnt
+// to 1 and scoped release decrements it back to 0. Registration lifecycle
+// remains controlled by globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSingleAcquireRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Allocator pre-caches the segment and eager-registers (scoped acquire
+  // requires the segment to be pre-cached).
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(static_cast<bool>(scopedRegHdl));
+    EXPECT_NE(scopedRegHdl.get(), nullptr);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release is a pure SW decrement of inUseCnt; the registration and its
+  // segment remain live because allocator hooks own their lifecycle.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // Only globalDeregister tears down the allocator-owned registration/segment.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Nested scoped acquires on the same buffer add use-side refs (0 -> 1 -> 2);
+// releasing them decrements back to zero. Dereg happens only via
+// globalDeregister, never through scope release.
+TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  auto outer = std::make_unique<ctran::ScopedRegHdl>();
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, *outer),
+      commSuccess);
+  auto* regElem = outer->get();
+  ASSERT_NE(regElem, nullptr);
+  // outer = 1 live use-side owner
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+  {
+    ctran::ScopedRegHdl inner;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, inner),
+        commSuccess);
+    // Both handles refer to the same reused registration; inUseCnt 1 + 1 = 2.
+    EXPECT_EQ(inner.get(), regElem);
+    EXPECT_EQ(regElem->inUseCnt.load(), 2);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Inner released one use-side owner (back to 1); registration stays live.
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Releasing the last scoped handle returns to zero; still live.
+  outer.reset();
+  EXPECT_EQ(regElem->inUseCnt.load(), 0);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Only globalDeregister tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Sequential acquire/release cycles each go inUseCnt 0 -> 1 -> 0; the
+// registration persists across cycles and is torn down only by
+// globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSequentialAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  for (int i = 0; i < 2; i++) {
+    {
+      ctran::ScopedRegHdl scopedRegHdl;
+      EXPECT_EQ(
+          regCache->acquireScopedRegister(
+              buf, bufSize, cudaDev, backends, scopedRegHdl),
+          commSuccess);
+      auto* regElem = scopedRegHdl.get();
+      ASSERT_NE(regElem, nullptr);
+      EXPECT_EQ(regElem->inUseCnt.load(), 1);
+      EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    }
+    // Scope released back to zero; still registered and reusable.
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// After globalRegister(forceReg) + scoped acquire/release, both the
+// registration and its segment are preserved because allocator hooks own their
+// lifecycle. globalDeregister then removes them.
+TEST_F(RegCacheTest, ScopedRegisterPreservesGlobalRegistration) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Global forceReg caches the segment and eager-registers the RegElem.
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release drops only the use-side count; both the registration AND the
+  // segment remain.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // globalDeregister force-frees the remaining allocator-owned state.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: scoped acquire on a buffer whose segment was NOT cached by the
+// allocator returns commInvalidUsage and leaves the ScopedRegHdl empty.
+TEST_F(RegCacheTest, ScopedRegisterUncachedSegmentReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  ctran::ScopedRegHdl scopedRegHdl;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, scopedRegHdl),
+      commInvalidUsage);
+
+  // The handle must stay empty since nothing was acquired.
+  EXPECT_FALSE(static_cast<bool>(scopedRegHdl));
+  EXPECT_EQ(scopedRegHdl.get(), nullptr);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: globalDeregister while a scoped registration is still alive
+// violates the lifetime contract. It emits a clear error and force-frees the
+// RegElem; the still-live ScopedRegHdl must then destruct without crashing (it
+// safely no-ops because its RegElem is already gone).
+TEST_F(RegCacheTest, GlobalDeregisterWhileScopedAliveReportsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+    // Force-free the buffer while the scoped handle is still alive. freeSegment
+    // sees the remaining scoped owner, logs the contract-violation warning, and
+    // tears down anyway because the allocator is freeing the memory.
+    EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+    EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regCache->getSegments().size(), 0);
+
+    // The scoped handle destructs here: its RegElem was already force-freed, so
+    // releaseScopedRegHdl safely no-ops with a WARN (no UAF/abort).
+  }
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Non-allocator teardown must not delete a registration while scoped users are
+// still live. It returns commInvalidUsage without consuming the segment ref;
+// the same free succeeds after the scoped owner releases inUseCnt back to zero.
+TEST_F(RegCacheTest, FreeSegmentWhileScopedAliveReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  ASSERT_EQ(segHdls.size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+    EXPECT_EQ(
+        regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+        commInvalidUsage);
+    EXPECT_FALSE(freed);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  }
+
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Read-only search/get callsites (acquireRef=false, the default) do not take a
+// scoped ref, so they require no matching release.
+TEST_F(RegCacheTest, RegRangeCachedNoAcquireRefNeedsNoRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache and eagerly register with the default acquireRef=false path.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  // A borrowed lookup is read-only: freeSegment tears down without any scoped
+  // release because inUseCnt was never incremented.
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// When acquireScopedRegister is the first to register a cached-but-unregistered
+// buffer, it creates the RegElem via the create path and records one scoped
+// use. Releasing the scope returns inUseCnt to zero (still registered); only
+// globalDeregister tears it down.
+TEST_F(RegCacheTest, ScopedRegisterFirstAcquireCreatesRegElem) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment WITHOUT eager-registering, so no RegElem pre-exists.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    // Scoped acquire is the first to register: it creates the RegElem.
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scope release drops inUseCnt back to zero; still registered.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // globalDeregister tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// ScopedRegHdl move construction transfers ownership without changing inUseCnt
+// (no use added or dropped). Move assignment releases the target's current use
+// first, then takes over the source. Self-assignment is a no-op. A moved-from
+// handle is empty and destructs as a no-op.
+TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::ScopedRegHdl a;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, a),
+      commSuccess);
+  auto* regElem = a.get();
+  ASSERT_NE(regElem, nullptr);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+  // Move construction: b takes a's use, inUseCnt unchanged, a becomes empty.
+  ctran::ScopedRegHdl b(std::move(a));
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_FALSE(static_cast<bool>(a));
+  EXPECT_EQ(a.get(), nullptr);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Self-move-assignment is a no-op (guarded); ref unchanged.
+  ctran::ScopedRegHdl& bRef = b;
+  b = std::move(bRef);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Acquire a second independent use into c (inUseCnt 1 -> 2).
+  ctran::ScopedRegHdl c;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, c),
+      commSuccess);
+  EXPECT_EQ(regElem->inUseCnt.load(), 2);
+
+  // Move-assign b into c: c releases its own use first (2 -> 1), then takes b.
+  c = std::move(b);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_FALSE(static_cast<bool>(b));
+  EXPECT_EQ(c.get(), regElem);
+
+  // c destructs at scope end (1 -> 0); a and b are empty no-ops.
+  {
+    ctran::ScopedRegHdl consume(std::move(c));
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  }
+  EXPECT_EQ(regElem->inUseCnt.load(), 0);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Dynamic registration does not use inUseCnt as a lifecycle gate; deregDynamic
+// explicitly tears it down.
+TEST_F(RegCacheTest, DynamicRegisterDoesNotAcquireInUseCnt) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  EXPECT_EQ(
+      regCache->regDynamic(buf, bufSize, cudaDev, backends, &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+  EXPECT_EQ(regHdl->inUseCnt.load(), 0);
+
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(RegCacheTest, DynamicDeregisterFailsWithLiveInUseCnt) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  EXPECT_EQ(
+      regCache->regDynamic(buf, bufSize, cudaDev, backends, &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  regHdl->inUseCnt.store(1);
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commInvalidUsage);
+
+  regHdl->inUseCnt.store(0);
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);


### PR DESCRIPTION
Summary:

Introduce a move-only `ScopedRegHdl` RAII type and a lifetime refcount on `RegElem` so graph / window / persistent-AGP code can hold a scoped local registration whose release is graph-destroy safe. This is a standalone RegCache primitive; it adds no AGP/window callsite migration (those land in later commits).
- `RegElem::refCount` (atomic, starts at 1): a `RegElem` is created when the buffer is actually registered, and that registration holds one reference; each live `ScopedRegHdl` adds one more. Preexisting consumers (`searchRegHandle` / `searchIbRegHandle` / `getRegHandle`) do NOT rely on refCount — they rely on the allocator-hook contract that any lookup made after the buffer's allocation hook (`globalRegister`) and before its free hook (`globalDeregister`) is safe. So a scoped reference never triggers a deregistration; the RegElem is deregistered only when the allocator's free hook (`globalDeregister` -> `freeSegment`) runs, `deregRange` drops the last reference, or the RegCache shuts down. refCount is accessed with `fetch_add`/`fetch_sub`, matching `IpcRegCache`.
- `RegCache::acquireScopedRegister(buf, len, cudaDev, backends, &scopedRegHdl)`: increments `refCount` and returns a `ScopedRegHdl` owning that one extra reference. It requires the buffer's segment to already be allocator-cached (CCA hook / `globalRegister`) and returns `commInvalidUsage` otherwise; it does not cache or ref-count segments. If it is the first registration of a cached buffer, it creates the RegElem (refCount 1) and takes the scoped reference (refCount 2).
- `ScopedRegHdl`: move-only owner of exactly one RegElem reference. Its destructor performs a pure SW atomic decrement (`releaseScopedRegHdl`) under the `regElemsMaps_` read lock; it never deregisters, deletes, or touches CUDA, so it is safe to run from a CUDA graph-destroy callback, and a scoped release can never drop the last reference.
- `regRangeCached(... acquireRef)` / `searchRegElem(... acquireRef)` / `deregRange(... releaseRef)` thread the scoped acquire/release through the existing register/search/dereg paths. `freeSegment` emits a contract-violation ERR if a buffer is torn down while a scoped reference is still live.
- Document the model in `regcache/docs/design.md` (new "Scoped Registration" section, local part).

Reviewed By: YulunW

Differential Revision: D110827409


