### PR TITLE
Add ScopedIpcRegHdl with deferred remote IPC import release (#3064)

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -734,9 +734,13 @@ commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
       FB_CHECKABORT(
           ctranNvl != nullptr,
           "Unexpected rkey with NVL backend but ctranNvl is not initialized");
-      FB_COMMCHECK(
-          ctran::IpcRegCache::getInstance()->releaseRemReg(
-              rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+      auto ipcRegCache = ctran::IpcRegCache::getInstance();
+      FB_CHECKABORT(
+          ipcRegCache != nullptr, "Failed to get IpcRegCache instance");
+      FB_COMMCHECK(ipcRegCache->releaseRemReg(
+          rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+      // actual release of deferred deregistrations
+      ipcRegCache->cleanupInvalidImports();
       break;
     }
     default:
@@ -930,6 +934,27 @@ bool CtranMapper::hasBackend() {
   return true;
 }
 
+std::vector<bool> CtranMapper::getBackends() {
+  std::vector<bool> backends(CtranMapperBackend::NUM_BACKENDS, false);
+  const int rank = comm->statex_->rank();
+  const int nRanks = comm->statex_->nRanks();
+  backends.at(CtranMapperBackend::IB) =
+      hasBackend(rank, CtranMapperBackend::IB);
+  backends.at(CtranMapperBackend::SOCKET) =
+      hasBackend(rank, CtranMapperBackend::SOCKET);
+  backends.at(CtranMapperBackend::TCPDM) =
+      hasBackend(rank, CtranMapperBackend::TCPDM);
+  for (int peer = 0; peer < nRanks; peer++) {
+    if (peer == rank) {
+      continue;
+    }
+    if (hasBackend(peer, CtranMapperBackend::NVL)) {
+      backends.at(CtranMapperBackend::NVL) = true;
+    }
+  }
+  return backends;
+}
+
 CtranIb* CtranMapper::ctranIbPtr() {
   return ctranIb.get();
 }
@@ -996,7 +1021,9 @@ commResult_t CtranMapper::intraAllGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const auto& statex = comm->statex_;
   const int nLocalRanks = statex->nLocalRanks();
 
@@ -1006,7 +1033,30 @@ commResult_t CtranMapper::intraAllGatherCtrl(
   }
 
   return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
+}
+
+commResult_t CtranMapper::intraAllGatherCtrl(
+    const void* buf,
+    void* hdl,
+    std::vector<void*>& remoteBufs,
+    std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+    std::vector<ctran::ScopedIpcRegHdl>& remoteIpcRegHdls) {
+  return this->intraAllGatherCtrl(
+      buf,
+      hdl,
+      remoteBufs,
+      remoteAccessKeys,
+      CtranMapperBackend::NVL,
+      /*recordExport=*/false,
+      &remoteIpcRegHdls);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1014,14 +1064,23 @@ commResult_t CtranMapper::allGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const int nRanks = comm->statex_->nRanks();
   std::vector<int> ranks(nRanks);
   for (int i = 0; i < nRanks; i++) {
     ranks[i] = i;
   }
-  return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+  return this->allGatherCtrlImpl(
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1030,8 +1089,37 @@ commResult_t CtranMapper::allGatherCtrl(
     const std::vector<int>& ranks,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
+  return this->allGatherCtrlImpl(
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
+}
+
+commResult_t CtranMapper::allGatherCtrlImpl(
+    const void* buf,
+    void* hdl,
+    const std::vector<int>& ranks,
+    std::vector<void*>& remoteBufs,
+    std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const int rank = comm->statex_->rank();
+
+  // outIpcHdls is indexed by local rank in the import loop below; size it here
+  // at the point of use so every caller is safe -- including the ranks overload
+  // that does not pre-size it.
+  if (outIpcHdls != nullptr) {
+    outIpcHdls->resize(comm->statex_->nLocalRanks());
+  }
 
   // Skip if rank is not in the ranks list
   if (std::find(ranks.begin(), ranks.end(), rank) == ranks.end()) {
@@ -1089,8 +1177,9 @@ commResult_t CtranMapper::allGatherCtrl(
             hdl,
             nvlSendMsg,
             &nvlExtraSegments,
-            peerBackends[i]));
-      } else if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+            peerBackends[i],
+            recordExport));
+      } else if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         // exportMem not called for this peer, record explicitly
         exportRegCache_.wlock()->record(regElem, peerList[i]);
       }
@@ -1220,12 +1309,18 @@ commResult_t CtranMapper::allGatherCtrl(
         }
       }
       if (!hasPending) {
+        ctran::ScopedIpcRegHdl importedHdl;
         FB_COMMCHECK(this->importMem(
             peerList[i],
             recvMsgs[i],
             &remoteBufs[peerList[i]],
             &remoteAccessKeys[peerList[i]],
-            allRecvExtraSegments[i]));
+            allRecvExtraSegments[i],
+            outIpcHdls != nullptr ? &importedHdl : nullptr));
+        if (outIpcHdls != nullptr && importedHdl) {
+          const auto peerLocalRank = comm->statex_->localRank(peerList[i]);
+          (*outIpcHdls)[peerLocalRank] = std::move(importedHdl);
+        }
         peerImported[i] = true;
         numPeersImported++;
       }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -42,6 +42,10 @@ namespace ncclx::colltrace {
 class MapperTrace;
 }
 
+namespace ctran {
+class ScopedIpcRegHdl;
+}
+
 class CtranMapperImpl;
 
 const std::string getReqTypeStr(CtranMapperRequest::ReqType type);
@@ -452,13 +456,45 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t intraAllGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
+  /* Blocking allgather control messages among all local ranks, importing the
+   * intra-node NVL peers self-managed (recordExport=false) and returning them
+   * as scoped RAII owners the caller releases on teardown.
+   *
+   * The two output kinds have different shapes and purposes:
+   *   - remoteBufs / remoteAccessKeys: for rank-based lookup. The caller must
+   *     pre-size them to nRanks (they are indexed by global rank); this fills
+   *     only the local-peer slots at their global-rank indices (self is left
+   *     UNSET, non-local ranks untouched). IB/other keys are returned here too.
+   *   - remoteIpcRegHdls: resource-ownership handles for the imported NVL
+   *     peers, with size of nLocalRanks. For localRank that cannot be imported
+   *     (including self), an empty handle is inserted as placeholder. The
+   *     caller releases the imports via RAII.
+   */
+  commResult_t intraAllGatherCtrl(
+      const void* buf,
+      void* hdl,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      std::vector<ctran::ScopedIpcRegHdl>& remoteIpcRegHdls);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -474,6 +510,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t allGatherCtrl(
       const void* buf,
@@ -481,7 +526,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<int>& ranks,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -497,13 +544,24 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t allGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.
@@ -949,6 +1007,12 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   bool hasBackend(int rank, CtranMapperBackend specified);
 
+  /* Get the set of transport backends this rank uses to reach all peer ranks,
+   * indexed by CtranMapperBackend. Entry true if this rank uses that backend to
+   * any peer. The returned vector has size CtranMapperBackend::NUM_BACKENDS.
+   */
+  std::vector<bool> getBackends();
+
   /* Some backends, notably NVL and TCPDM, require notifiers on the receiver
    * side. This method indicates whether the notifier is needed for
    * the specified peer rank.
@@ -1064,6 +1128,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
  private:
+  commResult_t allGatherCtrlImpl(
+      const void* buf,
+      void* hdl,
+      const std::vector<int>& ranks,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      CtranMapperBackend backend,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
   [[noreturn]] inline void throwCommAbortException(
       const std::string& abortContext) {
     auto commAbort = comm->getAbort();
@@ -1252,7 +1326,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       void* hdl,
       ControlMsg& msg,
       std::vector<ctran::utils::CtranIpcSegDesc>* extraSegments,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET) {
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true) {
     auto regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
     // TODO: Enforce that a communicator can only export memory it registered
     // itself except the memory registered by globalRegister. Currently any comm
@@ -1287,8 +1362,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         }
       }
 
-      // Record the exported remote rank to notify at deregistration
-      if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+      // Record the exported remote rank to notify at deregistration.
+      if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         exportRegCache_.wlock()->record(regElem, rank);
       }
 
@@ -1323,7 +1398,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const ControlMsg& msg,
       void** buf,
       CtranMapperRemoteAccessKey* remKey,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {}) {
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      ctran::ScopedIpcRegHdl* outHdl = nullptr) {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
@@ -1354,7 +1430,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
                 buf,
                 &(remKey->nvlKey),
                 &this->logMetaData_,
-                extraSegments));
+                extraSegments,
+                outHdl));
         break;
       }
       default:

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -126,6 +126,84 @@ TEST_P(CtranDistMapperBackendParam, intraAllGatherCtrl) {
   NCCLCHECK_TEST(ncclMemFree(buf));
 }
 
+// Verify that intraAllGatherCtrl with recordExport=false does NOT populate the
+// export tracking cache, so its self-managed NVL imports are not
+// double-released by the export-notify path at deregistration.
+TEST_F(CtranDistMapperTest, intraAllGatherCtrlNoRecordExport) {
+  void* buf = nullptr;
+  void* handle = nullptr;
+  constexpr size_t bufSize = 8192;
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+
+  for (int localRank = 0; localRank < statex->nLocalRanks(); localRank++) {
+    const int peer = statex->localRankToRank(localRank);
+    if (!mapper->hasBackend(peer, CtranMapperBackend::NVL)) {
+      GTEST_SKIP() << "NVL backend is not available for localRank " << localRank
+                   << " (rank " << peer << ")";
+    }
+  }
+
+  NCCLCHECK_TEST(ncclMemAlloc(&buf, bufSize));
+  COMMCHECK_TEST(comm_->ctran_->commRegister(buf, bufSize, &handle));
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  COMMCHECK_TEST(mapper->searchRegHandle(buf, bufSize, &sendHdl, &localReg));
+  ASSERT_NE(sendHdl, nullptr);
+  ASSERT_EQ(localReg, false);
+
+  std::vector<void*> remoteBufs(statex->nRanks(), nullptr);
+  std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(
+      statex->nRanks());
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+    ASSERT_EQ(
+        mapper->intraAllGatherCtrl(
+            buf,
+            sendHdl,
+            remoteBufs,
+            remoteAccessKeys,
+            CtranMapperBackend::NVL,
+            /*recordExport=*/false),
+        commSuccess);
+  }
+
+  ASSERT_TRUE(mapper->dumpExportRegCache().empty());
+
+  const int nodeId = statex->node();
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer == statex->rank()) {
+      ASSERT_EQ(remoteBufs[peer], buf);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    } else if (statex->node(peer) == nodeId) {
+      ASSERT_NE(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::NVL);
+    } else {
+      ASSERT_EQ(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    }
+  }
+
+  // Self-managed imports: release the remote NVL registrations explicitly.
+  barrierNvlDomain(comm_.get());
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (remoteAccessKeys[peer].backend == CtranMapperBackend::NVL) {
+      ASSERT_EQ(mapper->deregRemReg(&remoteAccessKeys[peer]), commSuccess);
+    }
+  }
+  barrierNvlDomain(comm_.get());
+
+  COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
+  NCCLCHECK_TEST(ncclMemFree(buf));
+}
+
 TEST_P(CtranDistMapperBackendParam, allGatherCtrl) {
   auto& [backend] = GetParam();
 #ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -91,6 +91,58 @@ void ctran::IpcRegCache::init() {
 ctran::IpcRegCache::~IpcRegCache() {
   stopAsyncSocket();
   clearAllRemReg();
+  cleanupInvalidImports();
+}
+
+void ctran::ScopedIpcRegHdl::reset() noexcept {
+  if (ipcRegCache_ == nullptr) {
+    return;
+  }
+
+  // Deferred release: safe on any thread (SW-only), the actual CUDA unmap is
+  // drained later by IpcRegCache::cleanupInvalidImports(). Ignore the result —
+  // a destructor must not throw or propagate errors.
+  FB_COMMCHECKIGNORE(
+      ipcRegCache_->releaseRemReg(peerId_, basePtr_, uid_, /*exportCount=*/1));
+
+  ipcRegCache_ = nullptr;
+  peerId_.clear();
+  basePtr_ = nullptr;
+  uid_ = 0;
+  refCount_ = 0;
+}
+
+ctran::ScopedIpcRegHdl& ctran::ScopedIpcRegHdl::operator=(
+    ScopedIpcRegHdl&& other) noexcept {
+  if (this != &other) {
+    reset();
+    ipcRegCache_ = other.ipcRegCache_;
+    peerId_ = std::move(other.peerId_);
+    basePtr_ = other.basePtr_;
+    uid_ = other.uid_;
+    refCount_ = other.refCount_;
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+    other.refCount_ = 0;
+  }
+  return *this;
+}
+
+ctran::ScopedIpcRegHdl::~ScopedIpcRegHdl() {
+  reset();
+}
+
+std::string ctran::ScopedIpcRegHdl::toString() const {
+  if (ipcRegCache_ == nullptr) {
+    return "[ScopedIpcRegHdl] empty";
+  }
+  return fmt::format(
+      "[ScopedIpcRegHdl] peerId: {}, basePtr: {}, uid: {}, refCount: {}",
+      peerId_,
+      basePtr_,
+      uid_,
+      refCount_);
 }
 
 commResult_t ctran::IpcRegCache::importMem(
@@ -100,10 +152,21 @@ commResult_t ctran::IpcRegCache::importMem(
     void** buf,
     struct ctran::regcache::IpcRemHandle* remKey,
     const struct CommLogData* logMetaData,
-    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments,
+    ctran::ScopedIpcRegHdl* outHdl) {
+  // Reclaim any imports released deferentially before this user-thread entry.
+  cleanupInvalidImports();
+
   void* basePtr = nullptr;
+  int refCount = 0;
   FB_COMMCHECK(importRemMemImpl(
-      peerId, ipcDesc, cudaDev, logMetaData, &basePtr, extraSegments));
+      peerId,
+      ipcDesc,
+      cudaDev,
+      logMetaData,
+      &basePtr,
+      extraSegments,
+      &refCount));
 
   // import from baseAddr of a remote segment, return buf at offset from
   // baseAddr
@@ -119,6 +182,14 @@ commResult_t ctran::IpcRegCache::importMem(
       (void*)basePtr,
       ipcDesc.offset,
       ipcDesc.uid);
+
+  // The single ref this import added is now owned by *outHdl: its destructor's
+  // deferred releaseRemReg drops it. Callers passing nullptr manage the ref
+  // themselves via releaseRemReg.
+  if (outHdl != nullptr) {
+    *outHdl =
+        ScopedIpcRegHdl(this, peerId, remKey->basePtr, remKey->uid, refCount);
+  }
   return commSuccess;
 }
 
@@ -128,7 +199,8 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
     int cudaDev,
     const struct CommLogData* logMetaData,
     void** mappedBase,
-    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments,
+    int* outRefCount) {
   auto lockedMap = ipcRemRegMap_.wlock();
   uint64_t base = reinterpret_cast<uint64_t>(ipcDesc.desc.base);
   IpcRemRegKey key{base, ipcDesc.uid};
@@ -138,15 +210,19 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
   if (peerIt != lockedMap->end()) {
     auto keyIt = peerIt->second.find(key);
     if (keyIt != peerIt->second.end()) {
-      keyIt->second->refCount.fetch_add(1, std::memory_order_relaxed);
+      const int newRefCount =
+          keyIt->second->refCount.fetch_add(1, std::memory_order_relaxed) + 1;
       *mappedBase = keyIt->second->ipcRemMem.getBase();
+      if (outRefCount != nullptr) {
+        *outRefCount = newRefCount;
+      }
       CLOGF_TRACE(
           COLL,
           "CTRAN-REGCACHE: IPC remote registration cache hit peer:base:uid=<{}:{}:{}>, refCount now {}",
           peerId,
           reinterpret_cast<void*>(base),
           ipcDesc.uid,
-          keyIt->second->refCount.load(std::memory_order_relaxed));
+          newRefCount);
       return commSuccess;
     }
   }
@@ -173,6 +249,9 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
       ipcDesc.uid,
       reg->toString());
 
+  if (outRefCount != nullptr) {
+    *outRefCount = 1;
+  }
   *mappedBase = reg->ipcRemMem.getBase();
   (*lockedMap)[peerId][key] = std::move(reg);
 
@@ -188,8 +267,9 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   uint64_t base = reinterpret_cast<uint64_t>(basePtr);
   IpcRemRegKey key{base, uid};
 
-  if (lockedMap->find(peerId) == lockedMap->end() ||
-      (*lockedMap)[peerId].find(key) == (*lockedMap)[peerId].end()) {
+  auto peerIt = lockedMap->find(peerId);
+  if (peerIt == lockedMap->end() ||
+      peerIt->second.find(key) == peerIt->second.end()) {
     CLOGF(
         ERR,
         "CTRAN-REGCACHE: Unknown IPC remote memory registration from peer {} base {} uid {}",
@@ -199,7 +279,8 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
     return ErrorStackTraceUtil::log(commInternalError);
   }
 
-  auto& elem = (*lockedMap)[peerId][key];
+  auto keyIt = peerIt->second.find(key);
+  auto& elem = keyIt->second;
   int prevCount =
       elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
 
@@ -213,7 +294,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         uid,
         prevCount,
         exportCount);
-    // Fall through to erase — the entry is invalid regardless
+    // Fall through to invalidate — the entry is invalid regardless
   } else if (prevCount > exportCount) {
     CLOGF_TRACE(
         COLL,
@@ -234,20 +315,23 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
       uid,
       elem->toString());
 
-  try {
-    (*lockedMap)[peerId].erase(key);
-  } catch (std::exception& e) {
-    CLOGF(
-        WARN,
-        "CTRAN-REGCACHE: failed to remove IPC remote registration from cache peer:base:uid=<{}:{}:{}>, error {}",
-        peerId,
-        basePtr,
-        uid,
-        e.what());
-    return ErrorStackTraceUtil::log(commInternalError);
-  }
+  // Move refcount==0 elem out of the live map. Actual unmap runs in
+  // cleanupInvalidImports().
+  invalidImports_.wlock()->push_back(std::move(elem));
+  peerIt->second.erase(keyIt);
 
   return commSuccess;
+}
+
+void ctran::IpcRegCache::cleanupInvalidImports() {
+  std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>> pending;
+  {
+    auto lockedInvalid = invalidImports_.wlock();
+    pending.swap(*lockedInvalid);
+  }
+
+  // Destruct the moved-out elems outside the lock; ~IpcRemRegElem performs the
+  // CUDA unmap. Safe when pending is empty and when called repeatedly.
 }
 
 void ctran::IpcRegCache::clearAllRemReg() {
@@ -273,6 +357,21 @@ size_t ctran::IpcRegCache::getNumRemReg(const std::string& peerId) const {
     return it->second.size();
   }
   return 0;
+}
+
+int ctran::IpcRegCache::maxRemRegRefCount() const {
+  auto lockedMap = ipcRemRegMap_.rlock();
+
+  int maxRefCount = 0;
+  for (const auto& [peerId, regs] : *lockedMap) {
+    for (const auto& [key, elem] : regs) {
+      const int refCount = elem->refCount.load(std::memory_order_relaxed);
+      if (refCount > maxRefCount) {
+        maxRefCount = refCount;
+      }
+    }
+  }
+  return maxRefCount;
 }
 
 commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
@@ -443,6 +542,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                 ipcReq.release.base,
                 ipcReq.release.uid,
                 ipcReq.release.exportCount));
+            cleanupInvalidImports();
             break;
           }
           case ctran::regcache::IpcReqType::kDesc: {

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -2,6 +2,9 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -17,6 +20,91 @@
 #include "comms/ctran/utils/Checks.h"
 
 namespace ctran {
+
+class IpcRegCache;
+class ScopedIpcRegHdl;
+
+// Move-only RAII owner of ONE remote NVL IPC import ref. It ADOPTS an existing
+// import ref (does not importMem, does not add a ref) and, on destruction,
+// drops that ref via a deferred releaseRemReg so it is safe to destroy from a
+// CUDA-callback context (e.g. graph destroy): the drop is pure SW; the parked
+// import is unmapped later by IpcRegCache::cleanupInvalidImports() on a user
+// thread.
+//
+// Lifecycle difference vs the local ScopedRegHdl: ScopedIpcRegHdl owns a real
+// import ref. Its last release CAN drive the import refCount to 0 and retire
+// the mapping (deferred: moved to invalidImports_, unmapped later by
+// cleanupInvalidImports()). A local ScopedRegHdl release only drops a
+// RegElem::inUseCnt use-side owner; it never retires the local registration
+// because local registration lifetime is controlled by allocator hooks or
+// explicit teardown.
+class ScopedIpcRegHdl {
+ public:
+  ScopedIpcRegHdl() = default;
+
+  ScopedIpcRegHdl(ScopedIpcRegHdl&& other) noexcept
+      : ipcRegCache_(other.ipcRegCache_),
+        peerId_(std::move(other.peerId_)),
+        basePtr_(other.basePtr_),
+        uid_(other.uid_),
+        refCount_(other.refCount_) {
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+    other.refCount_ = 0;
+  }
+
+  ScopedIpcRegHdl& operator=(ScopedIpcRegHdl&& other) noexcept;
+
+  ScopedIpcRegHdl(const ScopedIpcRegHdl&) = delete;
+  ScopedIpcRegHdl& operator=(const ScopedIpcRegHdl&) = delete;
+
+  ~ScopedIpcRegHdl();
+
+  // The IpcRegCache this handle will release into, or nullptr when the handle
+  // is empty or moved-from.
+  IpcRegCache* get() const {
+    return ipcRegCache_;
+  }
+
+  explicit operator bool() const {
+    return ipcRegCache_ != nullptr;
+  }
+
+  std::string toString() const;
+
+  // The import's refCount observed when this handle adopted it: >1 means the
+  // remote IPC import was already held by another owner (reused / cache hit),
+  // ==1 means this handle is the sole holder (freshly imported), 0 if unknown.
+  int refCount() const {
+    return refCount_;
+  }
+
+ private:
+  friend class IpcRegCache;
+
+  ScopedIpcRegHdl(
+      IpcRegCache* ipcRegCache,
+      std::string peerId,
+      void* basePtr,
+      uint32_t uid,
+      int refCount)
+      : ipcRegCache_(ipcRegCache),
+        peerId_(std::move(peerId)),
+        basePtr_(basePtr),
+        uid_(uid),
+        refCount_(refCount) {}
+
+  // Drop the held import ref (deferred release) and reset to the empty state.
+  // No-op when already empty/moved-from. Never throws.
+  void reset() noexcept;
+
+  IpcRegCache* ipcRegCache_{nullptr};
+  std::string peerId_;
+  void* basePtr_{nullptr};
+  uint32_t uid_{0};
+  int refCount_{0};
+};
 
 // Class to manage IPC-based remote memory registrations for a single
 // communicator. Currently handles NVL (NVLink) remote memory imports from peer
@@ -83,6 +171,9 @@ class IpcRegCache {
   // Output arguments:
   //   - buf: the local buffer mapped to the imported remote memory
   //   - remKey: the remoteAccessKey (rkey) of the remote buffer registration
+  //   - outHdl: (optional) when non-null, populated with a ScopedIpcRegHdl that
+  //             ADOPTS the ref this import added (its destructor drops that
+  //             ref)
   commResult_t importMem(
       const std::string& peerId,
       const ctran::regcache::IpcDesc& ipcDesc,
@@ -90,7 +181,8 @@ class IpcRegCache {
       void** buf,
       struct ctran::regcache::IpcRemHandle* remKey,
       const struct CommLogData* logMetaData = nullptr,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      ctran::ScopedIpcRegHdl* outHdl = nullptr);
 
   // Export local NVL memory registration for sharing with remote peers.
   // Input arguments:
@@ -120,17 +212,30 @@ class IpcRegCache {
     return commSuccess;
   }
 
-  // Release a specific remote registration for a given peer.
-  // exportCount specifies how many times the buffer was exported to this peer;
-  // the refcount is decremented by this amount.
+  // Release a specific remote registration for a given peer. Always deferred
+  // (SW-only): exportCount specifies how many times the buffer was exported to
+  // this peer; the refcount is decremented by this amount. When the refcount
+  // drops to zero the elem is moved out of the live map into invalidImports_
+  // WITHOUT touching CUDA. The backing CUDA unmap happens later, only when
+  // cleanupInvalidImports() is explicitly called on a user thread.
   commResult_t releaseRemReg(
       const std::string& peerId,
       void* basePtr,
       uint32_t uid,
       int32_t exportCount = 1);
 
+  // Drain invalidImports_: destroy every refcount==0 elem pending CUDA unmap.
+  // Must be called on a user thread (performs CUDA APIs). Safe when empty and
+  // safe to call repeatedly.
+  void cleanupInvalidImports();
+
   // Get the number of existing remote registrations for a given peer
   size_t getNumRemReg(const std::string& peerId) const;
+
+  // Max refCount among live remote IPC imports (0 if none). For
+  // test/observability: refCount > 1 means an import was reused (shared) by
+  // multiple importers.
+  int maxRemRegRefCount() const;
 
   // Release all remote registrations.
   // Called during destruction to clean up any remaining cached registrations.
@@ -196,7 +301,8 @@ class IpcRegCache {
       int cudaDev,
       const struct CommLogData* logMetaData,
       void** mappedBase,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      int* outRefCount = nullptr);
 
   // Initialize the AsyncSocket infrastructure for this rank.
   // Must be called once per rank before notifyRemoteIpcRelease can be used.
@@ -220,6 +326,14 @@ class IpcRegCache {
           std::unique_ptr<ctran::regcache::IpcRemRegElem>,
           folly::Hash>>;
   folly::Synchronized<IpcRemRegMap> ipcRemRegMap_;
+
+  // Elems whose refCount reached zero and left ipcRemRegMap_, still holding a
+  // live CUDA mapping. Destroying the unique_ptr performs the cuMemUnmap; that
+  // must happen on a user thread, so releaseRemReg parks the elem
+  // here and cleanupInvalidImports() drains it later outside the map lock.
+  folly::Synchronized<
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>>
+      invalidImports_;
 
   // Flag for one-time initialization
   std::once_flag initFlag_;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -593,7 +593,8 @@ void ctran::RegCache::resetExternalRegMemFn() {
 
 ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
     const void* ptr,
-    const size_t len) {
+    const size_t len,
+    bool acquireRef) {
   ctran::regcache::RegElem* regHdl = nullptr;
 
   auto regElemsMaps = regElemsMaps_.rlock();
@@ -616,6 +617,10 @@ ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
       // Lookup hit
       regHdl = searchRegElem.get();
       searchRegElem->lookupHit_++;
+      if (acquireRef) {
+        // Atomic increment: safe under the shared read lock.
+        regHdl->inUseCnt.fetch_add(1, std::memory_order_relaxed);
+      }
       break;
     }
   }
@@ -918,7 +923,8 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
     std::vector<ctran::regcache::Segment*>& segments,
     const std::vector<bool>& backends,
     bool ncclManaged,
-    ctran::regcache::RegElem** regHdl) {
+    ctran::regcache::RegElem** regHdl,
+    bool acquireRef) {
   // Create a new registration element for the segments
   auto newRegElem = std::make_unique<ctran::regcache::RegElem>(
       ptr, len, cudaDev, segments, ncclManaged);
@@ -932,6 +938,12 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
   auto regElemsMaps = regElemsMaps_.wlock();
   auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
   auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
+
+  // If the caller is a scoped acquire, add its use-side reference while holding
+  // the map lock.
+  if (acquireRef) {
+    regHdlPtr->inUseCnt.fetch_add(1, std::memory_order_relaxed);
+  }
 
   regHdlToElemMap.emplace(regHdlPtr, std::move(newRegElem));
   // Correlate the regElem with all associated segments to deregister it
@@ -954,6 +966,30 @@ commResult_t ctran::RegCache::regRangeCached(
     bool& didRegister,
     ctran::regcache::RegElem** regHdl,
     bool ncclManaged) {
+  return regRangeCachedImpl(
+      ptr,
+      len,
+      cudaDev,
+      useDesc,
+      logMetaData,
+      backends,
+      didRegister,
+      regHdl,
+      ncclManaged,
+      false /* acquireRef */);
+}
+
+commResult_t ctran::RegCache::regRangeCachedImpl(
+    const void* ptr,
+    const size_t len,
+    const int cudaDev,
+    const std::string& useDesc,
+    const struct CommLogData& logMetaData,
+    const std::vector<bool>& backends,
+    bool& didRegister,
+    ctran::regcache::RegElem** regHdl,
+    bool ncclManaged,
+    bool acquireRef) {
   auto dur = CtranMapperTimer();
   SetCudaDevRAII setCudaDev(cudaDev);
   auto timerBegin = std::chrono::steady_clock::now();
@@ -962,7 +998,7 @@ commResult_t ctran::RegCache::regRangeCached(
     // FAST PATH: find whether range has already been registered in
     // regElemsMaps. regElemsMaps should not be wlocked while performing
     // expensive registration/deregistration.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     // Lookup hit
     if (*regHdl) {
       return commSuccess;
@@ -983,7 +1019,7 @@ commResult_t ctran::RegCache::regRangeCached(
 
     // While holding the global lock, let's check again no one else has
     // registered the range.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     if (*regHdl) {
       return commSuccess;
     }
@@ -1032,7 +1068,8 @@ commResult_t ctran::RegCache::regRangeCached(
           segments,
           backends,
           ncclManaged,
-          regHdl));
+          regHdl,
+          acquireRef));
       didRegister = true;
     } else {
       // - WORST PATH: if any one is not found, return nullptr to trigger
@@ -1059,19 +1096,6 @@ commResult_t ctran::RegCache::regRangeCached(
 
   profiler.wlock()->record(ctran::regcache::EventType::kRegMemEvent, dur);
   return commSuccess;
-}
-
-bool ctran::regcache::Segment::askFree() {
-  auto stat = stateMnger.wlock();
-  stat->refCount--;
-  FB_CHECKABORT(
-      stat->refCount >= 0,
-      "Unexpected negative refCount {} in segment {} [{}]",
-      stat->refCount,
-      (void*)this,
-      toString(stat->refCount).c_str());
-
-  return stat->refCount == 0;
 }
 
 ctran::regcache::Segment* ctran::RegCache::getSegment(void* segHdl) {
@@ -1122,6 +1146,8 @@ commResult_t ctran::RegCache::freeSegment(
     std::vector<std::unique_ptr<ctran::regcache::RegElem>>& regElems,
     bool forceFree) {
   ctran::regcache::Segment* segment = nullptr;
+  bool foundInuseReg = false;
+
   {
     // Global lock:
     // Lock both segmentsAvl and regElemsMaps since we may need remove segment
@@ -1146,11 +1172,21 @@ commResult_t ctran::RegCache::freeSegment(
     }
 
     ncclManaged = segment->ncclManaged;
+    auto segmentState = segment->stateMnger.wlock();
+
+    // Segment cache invariant
+    FB_CHECKABORT(
+        segmentState->refCount > 0,
+        "Unexpected non-positive refCount {} in segment {} [{}]",
+        segmentState->refCount,
+        (void*)segment,
+        segment->toString(segmentState->refCount).c_str());
 
     // Ask for free. False if still in use, then no-op and return.
     // When forceFree is true (e.g. globalDeregister), skip the refCount check
     // because the underlying physical memory is about to be freed.
-    if (!forceFree && !segment->askFree()) {
+    if (!forceFree && segmentState->refCount > 1) {
+      segmentState->refCount--;
       return commSuccess;
     }
 
@@ -1170,15 +1206,53 @@ commResult_t ctran::RegCache::freeSegment(
           continue;
         }
 
+        // Check the registration's ref. Any remaining count means live
+        // ScopedRegHdl owners, which violates the lifetime contract because the
+        // segment/memory is being freed underneath them.
+        // forceFree would just report error and continue to free the segment
+        const auto inUseCnt =
+            regIt->second->inUseCnt.load(std::memory_order_acquire);
+        if (inUseCnt > 0) {
+          // Intentionally error logging as this is invalid usage to free buffer
+          // before releasing all registrations.
+          CLOGF(
+              ERR,
+              "freeSegment: RegElem [buf {} len {}] still has {} live ScopedRegHdl owner(s)",
+              regIt->second->buf,
+              regIt->second->len,
+              inUseCnt);
+          if (!forceFree) {
+            foundInuseReg = true;
+            break;
+          }
+        }
+
         // Remove regElem from global cache and to be deregistered
         regElems.push_back(std::move(regIt->second));
         regHdlToElemMap.erase(regIt);
+      }
+
+      if (!forceFree && foundInuseReg) {
+        // If found in-use regElem, we cannot free the segment, revert all
+        // regElems and return error.
+        // FIXME: deregMem doesn't proper handle retry logic, so the error is
+        // not retry-able from callsite. We should delete per-mapper deregMem
+        // path given it is no longer used in prod. The only in-use path to call
+        // freeSegment is via globalDeregister with forceFree. Current
+        // foundInuseReg logic is a best effort to keep clean state inside
+        // regcache.
+        for (auto& regElem : regElems) {
+          regHdlToElemMap.emplace(regElem.get(), std::move(regElem));
+        }
+        regElems.clear();
+        return commInvalidUsage;
       }
 
       segToRegElemsMap.erase(segIt);
     }
 
     // - Remove segment from cache
+    segmentState->refCount = 0;
     FB_COMMCHECK(segmentsAvl->remove(segment->avlHdl_));
     CLOGF_TRACE(
         ALLOC,
@@ -1214,6 +1288,167 @@ commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   FB_COMMCHECK(regElem->doDeregister(externalDeregMemFn_));
   profiler.wlock()->record(ctran::regcache::EventType::kDeregMemEvent, dur);
   return commSuccess;
+}
+
+void ctran::RegCache::releaseScopedRegHdl(
+    ctran::regcache::RegElem* regHdl,
+    const uint64_t regId) {
+  // Pure SW-only release: drop the scope's use count (atomic decrement). Never
+  // deregisters, deletes, or touches CUDA, so it is safe to run from a CUDA
+  // graph-destroy callback. RegElem lifetime is controlled by allocator hooks
+  // and explicit deregistration, not by this counter.
+  //
+  // A read lock is enough: we only look up the map, we never modify it. The
+  // rlock excludes freeSegment's wlock, so the found RegElem cannot be freed
+  // underneath the decrement.
+  if (regHdl == nullptr) {
+    return;
+  }
+
+  auto regElemsMaps = regElemsMaps_.rlock();
+  // NOTE: regHdl may be a dangling pointer here if a buffer-release path
+  // (freeSegment/globalDeregister) already force-freed the RegElem while this
+  // scope was still live. It is therefore used ONLY as a map key below and is
+  // NEVER dereferenced. Beyond the not-found case, we also compare the captured
+  // regId against the found RegElem's id: the heap may reuse a force-freed
+  // RegElem's address for an unrelated RegElem (ABA), and the id check rejects
+  // that so we never decrement an unrelated registration's inUseCnt. Either
+  // case safely no-ops.
+  auto it = regElemsMaps->regHdlToElemMap.find(regHdl);
+  if (it == regElemsMaps->regHdlToElemMap.end() ||
+      it->second->regId_ != regId) {
+    CLOGF(
+        WARN,
+        "releaseScopedRegHdl: regElem {} not found or its address was reused (may have been force-freed by a buffer-release path)",
+        (void*)regHdl);
+    return;
+  }
+
+  const auto prev =
+      it->second->inUseCnt.fetch_sub(1, std::memory_order_acq_rel);
+  const auto after = prev - 1;
+  FB_CHECKABORT(
+      after >= 0,
+      "scoped release drove inUseCnt below zero for RegElem {} (cnt {})",
+      (void*)regHdl,
+      after);
+}
+
+commResult_t ctran::RegCache::acquireScopedRegister(
+    const void* buf,
+    size_t len,
+    int cudaDev,
+    const std::vector<bool>& backends,
+    ctran::ScopedRegHdl& scopedRegHdl) {
+  if (buf == nullptr || len == 0) {
+    CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
+    return commInvalidUsage;
+  }
+
+  // Acquire one RegElem ref. The buffer's segment must already be cached by the
+  // allocator; regRangeCachedImpl returns nullptr otherwise.
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData scopedLogData{};
+  scopedLogData.commDesc = "scopedRegister";
+  const auto regResult = regRangeCachedImpl(
+      buf,
+      len,
+      cudaDev,
+      "scopedRegister",
+      scopedLogData,
+      backends,
+      didRegister,
+      &regHdl,
+      true /* ncclManaged */,
+      true /* acquireRef */);
+
+  if (regResult != commSuccess || regHdl == nullptr) {
+    CLOGF(
+        ERR,
+        "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
+        "segment. Scoped registration requires the buffer's memory to be pre-registered "
+        "by the allocator (globalRegister / CCA memory hook) before use. Ensure the "
+        "allocator registers memory after allocation and deregisters before free.",
+        (void*)buf,
+        len);
+    return commInvalidUsage;
+  }
+
+  scopedRegHdl.regCache_ = this;
+  scopedRegHdl.regHdl_ = regHdl;
+  scopedRegHdl.regId_ = regHdl->regId_;
+  scopedRegHdl.buf_ = regHdl->buf;
+  scopedRegHdl.len_ = regHdl->len;
+  return commSuccess;
+}
+
+ctran::ScopedRegHdl::ScopedRegHdl(ctran::ScopedRegHdl&& other) noexcept
+    : regCache_(other.regCache_),
+      regHdl_(other.regHdl_),
+      regId_(other.regId_),
+      buf_(other.buf_),
+      len_(other.len_) {
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+}
+
+ctran::ScopedRegHdl& ctran::ScopedRegHdl::operator=(
+    ctran::ScopedRegHdl&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  // Release the current handle before taking over the other.
+  if (regCache_ != nullptr) {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  }
+  regCache_ = other.regCache_;
+  regHdl_ = other.regHdl_;
+  regId_ = other.regId_;
+  buf_ = other.buf_;
+  len_ = other.len_;
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+  return *this;
+}
+
+ctran::ScopedRegHdl::~ScopedRegHdl() {
+  if (regCache_ == nullptr) {
+    return;
+  }
+  // Best-effort SW-only cleanup; never throw out of the destructor.
+  try {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
+  }
+  regCache_ = nullptr;
+  regHdl_ = nullptr;
+}
+
+ctran::regcache::RegElem* ctran::ScopedRegHdl::get() const {
+  return regHdl_;
+}
+
+ctran::ScopedRegHdl::operator bool() const {
+  return regCache_ != nullptr && regHdl_ != nullptr;
+}
+
+std::string ctran::ScopedRegHdl::toString() const {
+  if (regCache_ == nullptr || regHdl_ == nullptr) {
+    return "ScopedRegHdl{empty}";
+  }
+  return fmt::format(
+      "ScopedRegHdl{{regHdl: {}, buf: {}, len: {}}}",
+      (void*)regHdl_,
+      buf_,
+      len_);
 }
 
 commResult_t ctran::RegCache::regRange(
@@ -1302,6 +1537,30 @@ commResult_t ctran::RegCache::regDynamic(
   return commSuccess;
 }
 
+namespace {
+// Remove regHdl from every segToRegElemsMap entry for its segments, erasing
+// any entry whose vector becomes empty.
+void removeRegElemFromSegCorrelations(
+    ctran::regcache::RegElem* regHdl,
+    const std::vector<ctran::regcache::Segment*>& segments,
+    std::unordered_map<
+        ctran::regcache::Segment*,
+        std::vector<ctran::regcache::RegElem*>>& segToRegElemsMap) {
+  for (auto seg : segments) {
+    auto segIt = segToRegElemsMap.find(seg);
+    if (segIt != segToRegElemsMap.end()) {
+      auto& regElemsVec = segIt->second;
+      regElemsVec.erase(
+          std::remove(regElemsVec.begin(), regElemsVec.end(), regHdl),
+          regElemsVec.end());
+      if (regElemsVec.empty()) {
+        segToRegElemsMap.erase(segIt);
+      }
+    }
+  }
+}
+} // namespace
+
 commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
   std::unique_ptr<ctran::regcache::RegElem> regElem = nullptr;
   // Global lock to update regElemsMaps_.
@@ -1315,6 +1574,27 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
+
+    const auto inUseCnt = it->second->inUseCnt.load(std::memory_order_acquire);
+    if (inUseCnt > 0) {
+      // The caller may already have performed mapper-side remote release, so
+      // this error is not a retry contract. Keep regcache state intact and let
+      // higher-level failure cleanup or allocator force-free reclaim memory.
+      CLOGF(
+          ERR,
+          "deregRange: RegElem {} still has {} live use-side owner(s)",
+          (void*)regHdl,
+          inUseCnt);
+      return commInvalidUsage;
+    }
+
+    // Remove the regElem from every segment correlation entry so no dangling
+    // pointer remains after ownership moves out of the live map. Dynamic
+    // RegElems carry no segments_, so this only matters for the cached
+    // cached path.
+    removeRegElemFromSegCorrelations(
+        regHdl, regHdl->segments_, regElemsMaps->segToRegElemsMap);
+
     // Remove regElem from global cache and return ownership to caller for any
     // remote registration release
     regElem = std::move(it->second);
@@ -1552,7 +1832,6 @@ commResult_t ctran::RegCache::deregAll() {
   {
     auto regElemsMaps = regCache->regElemsMaps_.wlock();
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
-    auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
 
     // Iterate through all regElems and collect non-dynamic ones for
     // deregistration
@@ -1567,19 +1846,8 @@ commResult_t ctran::RegCache::deregAll() {
       }
 
       // Remove from segToRegElemsMap
-      for (auto seg : regElem->segments_) {
-        auto segIt = segToRegElemsMap.find(seg);
-        if (segIt != segToRegElemsMap.end()) {
-          auto& regElemsVec = segIt->second;
-          regElemsVec.erase(
-              std::remove(
-                  regElemsVec.begin(), regElemsVec.end(), regElem.get()),
-              regElemsVec.end());
-          if (regElemsVec.empty()) {
-            segToRegElemsMap.erase(segIt);
-          }
-        }
-      }
+      removeRegElemFromSegCorrelations(
+          regElem.get(), regElem->segments_, regElemsMaps->segToRegElemsMap);
 
       // Transfer ownership to toDeregister vector and remove from map
       toDeregister.push_back(std::move(regElem));

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -3,7 +3,10 @@
 
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <atomic>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <unordered_map>
 
@@ -86,8 +89,6 @@ struct Segment {
  protected:
   void* avlHdl_{nullptr};
 
-  bool askFree();
-
   std::string toString(const int64_t refCount) const {
     std::stringstream ss;
     ss << "range: " << range.toString() << ", cudaDev:" << cudaDev
@@ -157,6 +158,31 @@ struct RegElem {
         ncclManaged_(ncclManaged) {
     type_ = segments.at(0)->getType();
   };
+
+  // Number of live use-side owners for this RegElem. This does not control the
+  // RegElem's lifetime: allocator hooks own that lifecycle by creating and
+  // deleting the registration around buffer allocation/free. inUseCnt starts at
+  // 0, and each live ScopedRegHdl adds one use-side reference.
+  //
+  // The preexisting RegElem consumers (searchRegHandle / searchIbRegHandle /
+  // getRegHandle) do NOT update inUseCnt. They rely on the allocator-hook
+  // contract: any lookup issued after the buffer's allocation hook
+  // (globalRegister) and before its free hook (globalDeregister) is safe.
+  // Consequently inUseCnt can only detect scoped-use contract violations; it
+  // cannot protect borrowed lookup users that have no matching release call.
+  //
+  // Atomic so a scoped acquire can increment it under the shared read lock.
+  std::atomic<int64_t> inUseCnt{0};
+
+  // Process-unique monotonic id assigned at construction. Used to validate a
+  // ScopedRegHdl's identity so that a reused heap address (a new RegElem
+  // occupying a force-freed RegElem's old address) is not mistaken for the
+  // original registration. The counter is a function-local static (NOT a global
+  // variable), so it satisfies facebook-avoid-non-const-global-variables.
+  const uint64_t regId_{[] {
+    static std::atomic<uint64_t> counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+  }()};
 
   std::size_t numSegments() const {
     return segments_.size();
@@ -267,6 +293,35 @@ class Profiler {
 
 } // namespace regcache
 
+// Move-only RAII owner of a scoped local registration acquired via
+// RegCache::acquireScopedRegister(). It owns one RegElem use-side reference
+// tracked in RegElem::inUseCnt; it does not cache or ref-count segments. The
+// registration lifetime itself is controlled by allocator hooks / explicit
+// deregistration. The destructor performs a pure SW-only decrement
+// (graph-destroy safe): it never touches CUDA and never deregisters.
+class ScopedRegHdl {
+ public:
+  ScopedRegHdl() = default;
+  ScopedRegHdl(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl& operator=(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl(const ScopedRegHdl&) = delete;
+  ScopedRegHdl& operator=(const ScopedRegHdl&) = delete;
+  ~ScopedRegHdl();
+
+  regcache::RegElem* get() const;
+  explicit operator bool() const;
+  std::string toString() const;
+
+ private:
+  friend class RegCache;
+
+  RegCache* regCache_{nullptr};
+  regcache::RegElem* regHdl_{nullptr};
+  uint64_t regId_{0};
+  const void* buf_{nullptr};
+  size_t len_{0};
+};
+
 /**
  * Singleton class to hold the IB network resources that are reused by all
  * communicators in the lifetime of program.
@@ -303,6 +358,20 @@ class RegCache {
       size_t len,
       bool skipRemRelease = false,
       int deviceId = -1);
+
+  // Acquire a scoped local registration for [buf, buf + len). The buffer's
+  // underlying segment MUST already be cached by the allocator (globalRegister
+  // / CCA memory hook); this API does not cache segments. On success it takes
+  // one RegElem use-side reference (counted in RegElem::inUseCnt) and the
+  // returned ScopedRegHdl owns that use, releasing it SW-only in its
+  // destructor. If the buffer is not backed by a cached segment,
+  // commInvalidUsage is returned and the ScopedRegHdl stays empty.
+  commResult_t acquireScopedRegister(
+      const void* buf,
+      size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      ScopedRegHdl& scopedRegHdl);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying
@@ -356,26 +425,6 @@ class RegCache {
       regcache::RegElem** regHdl,
       bool ncclManaged = false);
 
-  // Thread-safe function to directly register a buffer range without consulting
-  // the reusable segment/regElem cache. It registers every pinned physical
-  // range covering [ptr, ptr + len) as one dynamic RegElem, does not allow
-  // lookup reuse, and must be deregistered via deregRange().
-  // input:
-  //   - ptr: the pointer to the buffer to be registered
-  //   - len: the length of the buffer
-  //   - cudaDev: the cuda device id of the buffer
-  // output:
-  //   - regHdl: the direct registration handle
-  commResult_t regRange(
-      const void* ptr,
-      const size_t len,
-      int cudaDev,
-      const std::vector<bool>& backends,
-      regcache::RegElem** regHdl,
-      bool ncclManaged = false,
-      const struct CommLogData* logMetaData = nullptr,
-      const std::string& useDesc = "dynamicRegMem");
-
   // Thread-safe functions to dynamically register a segment. Compatibility
   // wrapper around regRange() for existing callers. Always records the
   // registration under "dynamicRegMem" so dynamic and window registrations stay
@@ -388,15 +437,10 @@ class RegCache {
       regcache::RegElem** regHdl,
       const struct CommLogData* logMetaData = nullptr);
 
-  // Thread-safe function to deregister a direct range registration.
-  // Unlike freeSegment(), it always deregisters since only the calling
-  // communicator uses it.
-  // input:
-  //   - regHdl: the direct registration handle
-  commResult_t deregRange(regcache::RegElem* regHdl);
-
   // Thread-safe function to deregister a dynamic registration. Compatibility
-  // wrapper around deregRange() for existing callers.
+  // wrapper around deregRange() for existing callers. Dynamic registrations do
+  // not acquire inUseCnt; deregistration fails with commInvalidUsage if any
+  // scoped-use owner is unexpectedly still live.
   // input:
   //   - regHdl: the dynamic registration handle
   commResult_t deregDynamic(regcache::RegElem* regHdl);
@@ -544,6 +588,8 @@ class RegCache {
   folly::Synchronized<regcache::Profiler> profiler;
 
  private:
+  friend class ScopedRegHdl;
+
   // Hold a reference to CtranIbSingleton to ensure proper destruction order.
   // By holding this shared_ptr, we guarantee CtranIbSingleton stays alive
   // as long as RegCache exists, preventing use-after-free during
@@ -587,7 +633,11 @@ class RegCache {
   void asyncRegThreadFn(int cudaDev);
 
   // Thread-safe function to search given <ptr, len> range in regElem cache.
-  regcache::RegElem* searchRegElem(const void* ptr, const size_t len);
+  // If acquireRef is true, atomically increments the found RegElem's inUseCnt
+  // on a lookup hit (safe under the shared read lock because inUseCnt is
+  // atomic).
+  regcache::RegElem*
+  searchRegElem(const void* ptr, const size_t len, bool acquireRef = false);
 
   // Helper function to perform backend registration for a set of segments.
   // Creates a RegElem, registers with backends, and updates regElemsMaps.
@@ -603,9 +653,53 @@ class RegCache {
       std::vector<regcache::Segment*>& segments,
       const std::vector<bool>& backends,
       bool ncclManaged,
-      regcache::RegElem** regHdl);
+      regcache::RegElem** regHdl,
+      bool acquireRef = false);
+
+  // Internal implementation for regRangeCached(). acquireRef is intentionally
+  // private so only acquireScopedRegister() can create an RAII-owned use-side
+  // reference.
+  commResult_t regRangeCachedImpl(
+      const void* ptr,
+      const size_t len,
+      const int cudaDev,
+      const std::string& useDesc,
+      const struct CommLogData& logMetaData,
+      const std::vector<bool>& backends,
+      bool& didRegister,
+      regcache::RegElem** regHdl,
+      bool ncclManaged = false,
+      bool acquireRef = false);
+
+  // Thread-safe function to directly register a buffer range without consulting
+  // the reusable segment/regElem cache. It registers every pinned physical
+  // range covering [ptr, ptr + len) as one dynamic RegElem, does not allow
+  // lookup reuse, and must be deregistered via deregRange().
+  // input:
+  //   - ptr: the pointer to the buffer to be registered
+  //   - len: the length of the buffer
+  //   - cudaDev: the cuda device id of the buffer
+  // output:
+  //   - regHdl: the direct registration handle
+  commResult_t regRange(
+      const void* ptr,
+      const size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      regcache::RegElem** regHdl,
+      bool ncclManaged = false,
+      const struct CommLogData* logMetaData = nullptr,
+      const std::string& useDesc = "dynamicRegMem");
+
+  // Thread-safe function to deregister a direct range registration.
+  commResult_t deregRange(regcache::RegElem* regHdl);
 
   commResult_t deregElem(regcache::RegElem* regElem);
+
+  // SW-only scoped-ref release used by ~ScopedRegHdl; graph-destroy safe. The
+  // regId identifies the RegElem captured at acquire time so a reused heap
+  // address is rejected. See .cc for details.
+  void releaseScopedRegHdl(regcache::RegElem* regHdl, const uint64_t regId);
 };
 
 static inline void CHECK_VALID_REGCACHE(std::shared_ptr<RegCache> regCache) {

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -109,6 +109,7 @@ RegElem
   isDynamic_ : bool         -- true for one-time uncached registrations
   type_      : DevMemType   -- memory type of the registered range
   ncclManaged_: bool        -- whether NCCL allocated this buffer
+  inUseCnt    : atomic<int64_t>  -- live scoped-use count; does not control RegElem lifetime (see Scoped Registration)
 ```
 
 ### RegCache (class)
@@ -202,8 +203,11 @@ freeSegment(segHdl, forceFree=false) -> freed, regElems
   1. Acquire both segmentsAvl_ and regElemsMaps_ locks
   2. Lookup Segment from AVL handle
      - Not found -> return (freed=false, commSuccess)
-  3. If !forceFree: askFree() -> decrement refCount
-     - refCount > 0 -> return (freed=false, commSuccess)
+  3. If !forceFree: lock SegmentStateMnger
+     - refCount > 1 -> decrement and return (freed=false, commSuccess)
+     - refCount == 1 -> validate associated RegElems have inUseCnt == 0
+       before setting refCount to 0
+     - inUseCnt > 0 -> return commInvalidUsage without changing refCount
   4. Collect all RegElems via segToRegElemsMap
   5. Transfer ownership from regHdlToElemMap to output vector
   6. Remove Segment from AVL tree
@@ -328,6 +332,76 @@ cleanup:
   -> cudaFree
 ```
 
+## Scoped Registration
+
+Ctran's persistent collectives (persistent AllGatherP, "AGP") and window
+collectives hold a registration for the lifetime of an operation, request, or
+window — not the lifetime of the underlying memory — and must release it safely,
+including from a CUDA graph-destroy callback where no CUDA calls are allowed.
+Move-only RAII owners provide this on top of the existing cache without
+disturbing the allocator (CCA) hook or the existing, non-refcounted lookup APIs.
+
+`globalRegister` / `globalDeregister` are the allocator-hook APIs. They are keyed
+on BUFFER (memory) lifetime — the allocator calls them around a buffer's
+allocation and free — and `globalDeregister` force-frees the cached segment and
+all of its registrations. They are therefore NOT suitable for scoped
+registration inside Ctran: a persistent collective or window has an operation /
+request / window lifetime, not a memory lifetime, and calling `globalDeregister`
+from that code would tear down allocator-owned state that other consumers may
+still need. Ctran-internal scopes must use `acquireScopedRegister` /
+`ScopedRegHdl` (below) instead; `globalRegister` / `globalDeregister` must be
+called ONLY from the allocator side (the CCA memory hook), never from collective
+or window code.
+
+### Local registration: `ScopedRegHdl`
+
+Use tracking (`RegElem::inUseCnt`):
+
+- `RegElem` lifetime is controlled by allocator hooks and explicit teardown, not
+  by `inUseCnt`. A cached registration starts with `inUseCnt = 0` when it is
+  created via `globalRegister` / the CCA hook or by first scoped use of an
+  already-cached segment.
+- `RegCache::acquireScopedRegister(buf, len, cudaDev, backends, &hdl)` resolves
+  the cached `RegElem`, increments `inUseCnt`, and returns a move-only
+  `ScopedRegHdl` owning that one use-side reference.
+- Dynamic registrations (`regDynamic` / internal `regRange`) do not acquire
+  `inUseCnt`. The explicit `deregDynamic` / internal `deregRange` call deletes
+  the RegElem only if `inUseCnt == 0`; a non-zero `inUseCnt` there is invalid
+  usage and returns `commInvalidUsage`.
+- `~ScopedRegHdl` performs a pure software decrement (`releaseScopedRegHdl`)
+  under the `regElemsMaps_` read lock — no deregistration, no delete, no CUDA —
+  so it is safe to run from a graph-destroy callback.
+- If `deregRange` or non-force `freeSegment` attempts to delete a registration
+  while `inUseCnt > 0`, it returns `commInvalidUsage`. The allocator hook
+  (`globalDeregister` -> force `freeSegment`) must not block memory free; it
+  logs and force-frees the registration because freeing the buffer while scoped
+  use is still live is already invalid usage. These errors are not retry
+  contracts: mapper-side release may already have partially run, and regcache
+  only preserves enough local state for whole-cache failure cleanup or
+  allocator force-free to reclaim memory.
+
+Compatibility with the allocator (CCA) hook:
+
+- The allocator hook owns memory lifetime: `globalRegister` caches the segment
+  and may create the `RegElem`; `globalDeregister` force-frees cached segments
+  and associated backend registrations right before the memory is freed.
+- `acquireScopedRegister` REQUIRES the buffer's segment to already be
+  allocator-cached and returns `commInvalidUsage` otherwise — it never caches or
+  frees segments. A scoped acquire/release only adjusts `inUseCnt`, so it can
+  neither race nor double-free allocator-owned state; the allocator remains the
+  owner of the registration's lifetime. If a buffer is freed while scoped use is
+  still live, force `freeSegment` logs a contract-violation warning and tears
+  down anyway (the memory is going away).
+
+Compatibility with the existing (non-refcounted) lookup APIs:
+
+- `searchRegHandle` / `searchIbRegHandle` / `getRegHandle` return a borrowed
+  `RegElem*` WITHOUT touching `inUseCnt`. These are the established production
+  callers (e.g. collective-time handle lookup) and are intentionally left
+  uncounted because there is no matching release API. Their safety still comes
+  from the allocator-hook contract: the buffer allocation must outlive borrowed
+  lookup use.
+
 ## Component Interactions
 
 ### CtranMapper (per-communicator)
@@ -340,7 +414,7 @@ notifications.
 CtranMapper
   regMem()          -> RegCache::cacheSegment [+ regRange]
   deregMem()        -> RegCache::getRegElems -> remReleaseMem per elem
-                       -> RegCache::freeSegment (decrement refCount)
+                       -> RegCache::freeSegment (decrement segment refCount)
   searchRegHandle() -> RegCache::regRange [or regDynamic as fallback]
   remReleaseMem()   -> send IPC release to remote peers via AsyncSocket
 ```

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -402,6 +402,44 @@ Compatibility with the existing (non-refcounted) lookup APIs:
   from the allocator-hook contract: the buffer allocation must outlive borrowed
   lookup use.
 
+### Remote IPC import: `ScopedIpcRegHdl`
+
+Remote NVLink IPC imports live in `IpcRegCache`, separate from the local segment
+cache, and use a symmetric-but-different scoped owner.
+
+Lifecycle:
+
+- An imported `IpcRemRegElem` is refcounted (`refCount`). `releaseRemReg` ALWAYS
+  defers: it decrements the refcount and, on reaching zero, moves the elem out of
+  the live map into `invalidImports_`. This is pure software work (no CUDA), so
+  it is safe from a graph-destroy callback. Because rc==0 entries leave the live
+  map, a released import is never resurrected by a later import.
+- `cleanupInvalidImports()` performs the actual CUDA unmap of the parked
+  entries. It runs on user-thread entries (`importMem`, `~IpcRegCache`) and is
+  called explicitly by release callsites that want prompt teardown
+  (`CtranMapper::deregRemReg`, the async-socket `kRelease` handler).
+- `ScopedIpcRegHdl` is a move-only owner of one import reference, produced
+  directly by `IpcRegCache::importMem` via its optional `outHdl` out-param: the
+  single reference the import adds is ADOPTED by the returned handle (no extra
+  reference is added). `~ScopedIpcRegHdl` performs a deferred `releaseRemReg`, so
+  it is graph-destroy safe; the CUDA unmap drains later via an explicit
+  `cleanupInvalidImports()` at a user-thread teardown point (window free, eager
+  AGP destroy).
+
+Difference from local `ScopedRegHdl`, and compatibility:
+
+- `ScopedIpcRegHdl` owns a real import ref. Its last release CAN retire the
+  import (deferred). Local `ScopedRegHdl` only owns a `RegElem::inUseCnt`
+  use-side reference; releasing it never retires the local registration because
+  local registration lifetime is controlled by allocator hooks or explicit
+  teardown.
+- `IpcRemRegElem` was already refcount-based for existing importers, and its
+  release can be triggered either by an explicit importer-side call
+  (`releaseRemReg` / `CtranMapper::deregRemReg`) or by the exporter's `kRelease`
+  notification over the async socket. `ScopedIpcRegHdl` layers cleanly on top of
+  this existing refcount — it introduces no new scheme and does not change the
+  C-style release/notify paths.
+
 ## Component Interactions
 
 ### CtranMapper (per-communicator)

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -938,6 +938,7 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCount) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   // Cleanup
   ctran::IpcRegCache::deregMem(ipcRegElem);
@@ -1357,6 +1358,7 @@ TEST_F(RegCacheTest, ImportMemWithExtraSegments) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   ctran::IpcRegCache::deregMem(ipcRegElem);
   COMMCHECK_TEST(ctran::commMemFreeDisjoint(buf, segSizes));
@@ -2123,6 +2125,142 @@ TEST_F(RegCacheTest, DynamicDeregisterFailsWithLiveInUseCnt) {
   EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
 
   CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Refcounted import: importing the same descriptor twice bumps the single
+// entry's refCount to 2; the first release keeps it live (getNumRemReg stays
+// 1); the second release drops it to 0, moving the elem out of the live map.
+// An explicit cleanupInvalidImports() then performs the CUDA unmap.
+TEST_F(RegCacheTest, IpcRemRegImmediateRelease) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_immediate_release_peer";
+
+  // Import twice: single map entry, refCount 2.
+  void* importedBuf1 = nullptr;
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_EQ(importedBuf1, importedBuf2);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // First release: refCount 2 -> 1, entry stays live.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Second release: refCount 1 -> 0, elem moved out of the live map. The
+  // deferred CUDA unmap is drained by the explicit cleanupInvalidImports().
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// Releasing to rc 0 removes the elem from the live map (getNumRemReg == 0) but
+// does not unmap yet (release is always deferred). A fresh importMem of the
+// same descriptor cannot resurrect the dead elem and instead creates a new live
+// mapping. cleanupInvalidImports() is safe to call afterwards.
+TEST_F(RegCacheTest, IpcRemRegDeferredReleaseNoResurrect) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_deferred_release_peer";
+
+  void* importedBuf1 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Deferred release to rc 0: leaves the live map but is not yet unmapped.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  // A fresh import of the same descriptor must create a NEW live entry rather
+  // than resurrecting the deferred-dead one. importMem also drains the pending
+  // unmap via cleanupInvalidImports().
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_NE(importedBuf2, nullptr);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Release the fresh entry and drain.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// cleanupInvalidImports() on an empty invalidImports_ list is safe and
+// idempotent.
+TEST_F(RegCacheTest, IpcCleanupEmptyIsIdempotent) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  ipcRegCache->cleanupInvalidImports();
+  ipcRegCache->cleanupInvalidImports();
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1660,6 +1660,471 @@ TEST_F(RegCacheTest, ExternalRegMemFailureIsHandledGracefully) {
   CUDACHECK_TEST(cudaFree(buf));
 }
 
+// inUseCnt tracks only scoped use-side owners. globalRegister caches and
+// eager-registers but does not count as in-use; scoped acquire bumps inUseCnt
+// to 1 and scoped release decrements it back to 0. Registration lifecycle
+// remains controlled by globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSingleAcquireRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Allocator pre-caches the segment and eager-registers (scoped acquire
+  // requires the segment to be pre-cached).
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(static_cast<bool>(scopedRegHdl));
+    EXPECT_NE(scopedRegHdl.get(), nullptr);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release is a pure SW decrement of inUseCnt; the registration and its
+  // segment remain live because allocator hooks own their lifecycle.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // Only globalDeregister tears down the allocator-owned registration/segment.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Nested scoped acquires on the same buffer add use-side refs (0 -> 1 -> 2);
+// releasing them decrements back to zero. Dereg happens only via
+// globalDeregister, never through scope release.
+TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  auto outer = std::make_unique<ctran::ScopedRegHdl>();
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, *outer),
+      commSuccess);
+  auto* regElem = outer->get();
+  ASSERT_NE(regElem, nullptr);
+  // outer = 1 live use-side owner
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+  {
+    ctran::ScopedRegHdl inner;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, inner),
+        commSuccess);
+    // Both handles refer to the same reused registration; inUseCnt 1 + 1 = 2.
+    EXPECT_EQ(inner.get(), regElem);
+    EXPECT_EQ(regElem->inUseCnt.load(), 2);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Inner released one use-side owner (back to 1); registration stays live.
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Releasing the last scoped handle returns to zero; still live.
+  outer.reset();
+  EXPECT_EQ(regElem->inUseCnt.load(), 0);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Only globalDeregister tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Sequential acquire/release cycles each go inUseCnt 0 -> 1 -> 0; the
+// registration persists across cycles and is torn down only by
+// globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSequentialAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  for (int i = 0; i < 2; i++) {
+    {
+      ctran::ScopedRegHdl scopedRegHdl;
+      EXPECT_EQ(
+          regCache->acquireScopedRegister(
+              buf, bufSize, cudaDev, backends, scopedRegHdl),
+          commSuccess);
+      auto* regElem = scopedRegHdl.get();
+      ASSERT_NE(regElem, nullptr);
+      EXPECT_EQ(regElem->inUseCnt.load(), 1);
+      EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    }
+    // Scope released back to zero; still registered and reusable.
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// After globalRegister(forceReg) + scoped acquire/release, both the
+// registration and its segment are preserved because allocator hooks own their
+// lifecycle. globalDeregister then removes them.
+TEST_F(RegCacheTest, ScopedRegisterPreservesGlobalRegistration) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Global forceReg caches the segment and eager-registers the RegElem.
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release drops only the use-side count; both the registration AND the
+  // segment remain.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // globalDeregister force-frees the remaining allocator-owned state.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: scoped acquire on a buffer whose segment was NOT cached by the
+// allocator returns commInvalidUsage and leaves the ScopedRegHdl empty.
+TEST_F(RegCacheTest, ScopedRegisterUncachedSegmentReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  ctran::ScopedRegHdl scopedRegHdl;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, scopedRegHdl),
+      commInvalidUsage);
+
+  // The handle must stay empty since nothing was acquired.
+  EXPECT_FALSE(static_cast<bool>(scopedRegHdl));
+  EXPECT_EQ(scopedRegHdl.get(), nullptr);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: globalDeregister while a scoped registration is still alive
+// violates the lifetime contract. It emits a clear error and force-frees the
+// RegElem; the still-live ScopedRegHdl must then destruct without crashing (it
+// safely no-ops because its RegElem is already gone).
+TEST_F(RegCacheTest, GlobalDeregisterWhileScopedAliveReportsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+    // Force-free the buffer while the scoped handle is still alive. freeSegment
+    // sees the remaining scoped owner, logs the contract-violation warning, and
+    // tears down anyway because the allocator is freeing the memory.
+    EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+    EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regCache->getSegments().size(), 0);
+
+    // The scoped handle destructs here: its RegElem was already force-freed, so
+    // releaseScopedRegHdl safely no-ops with a WARN (no UAF/abort).
+  }
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Non-allocator teardown must not delete a registration while scoped users are
+// still live. It returns commInvalidUsage without consuming the segment ref;
+// the same free succeeds after the scoped owner releases inUseCnt back to zero.
+TEST_F(RegCacheTest, FreeSegmentWhileScopedAliveReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  ASSERT_EQ(segHdls.size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+    EXPECT_EQ(
+        regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+        commInvalidUsage);
+    EXPECT_FALSE(freed);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  }
+
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Read-only search/get callsites (acquireRef=false, the default) do not take a
+// scoped ref, so they require no matching release.
+TEST_F(RegCacheTest, RegRangeCachedNoAcquireRefNeedsNoRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache and eagerly register with the default acquireRef=false path.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  // A borrowed lookup is read-only: freeSegment tears down without any scoped
+  // release because inUseCnt was never incremented.
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// When acquireScopedRegister is the first to register a cached-but-unregistered
+// buffer, it creates the RegElem via the create path and records one scoped
+// use. Releasing the scope returns inUseCnt to zero (still registered); only
+// globalDeregister tears it down.
+TEST_F(RegCacheTest, ScopedRegisterFirstAcquireCreatesRegElem) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment WITHOUT eager-registering, so no RegElem pre-exists.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    // Scoped acquire is the first to register: it creates the RegElem.
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scope release drops inUseCnt back to zero; still registered.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // globalDeregister tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// ScopedRegHdl move construction transfers ownership without changing inUseCnt
+// (no use added or dropped). Move assignment releases the target's current use
+// first, then takes over the source. Self-assignment is a no-op. A moved-from
+// handle is empty and destructs as a no-op.
+TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::ScopedRegHdl a;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, a),
+      commSuccess);
+  auto* regElem = a.get();
+  ASSERT_NE(regElem, nullptr);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+
+  // Move construction: b takes a's use, inUseCnt unchanged, a becomes empty.
+  ctran::ScopedRegHdl b(std::move(a));
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_FALSE(static_cast<bool>(a));
+  EXPECT_EQ(a.get(), nullptr);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Self-move-assignment is a no-op (guarded); ref unchanged.
+  ctran::ScopedRegHdl& bRef = b;
+  b = std::move(bRef);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Acquire a second independent use into c (inUseCnt 1 -> 2).
+  ctran::ScopedRegHdl c;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, c),
+      commSuccess);
+  EXPECT_EQ(regElem->inUseCnt.load(), 2);
+
+  // Move-assign b into c: c releases its own use first (2 -> 1), then takes b.
+  c = std::move(b);
+  EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  EXPECT_FALSE(static_cast<bool>(b));
+  EXPECT_EQ(c.get(), regElem);
+
+  // c destructs at scope end (1 -> 0); a and b are empty no-ops.
+  {
+    ctran::ScopedRegHdl consume(std::move(c));
+    EXPECT_EQ(regElem->inUseCnt.load(), 1);
+  }
+  EXPECT_EQ(regElem->inUseCnt.load(), 0);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Dynamic registration does not use inUseCnt as a lifecycle gate; deregDynamic
+// explicitly tears it down.
+TEST_F(RegCacheTest, DynamicRegisterDoesNotAcquireInUseCnt) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  EXPECT_EQ(
+      regCache->regDynamic(buf, bufSize, cudaDev, backends, &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+  EXPECT_EQ(regHdl->inUseCnt.load(), 0);
+
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+TEST_F(RegCacheTest, DynamicDeregisterFailsWithLiveInUseCnt) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::regcache::RegElem* regHdl = nullptr;
+  EXPECT_EQ(
+      regCache->regDynamic(buf, bufSize, cudaDev, backends, &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  regHdl->inUseCnt.store(1);
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commInvalidUsage);
+
+  regHdl->inUseCnt.store(0);
+  EXPECT_EQ(regCache->deregDynamic(regHdl), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);


### PR DESCRIPTION
Summary:

Add the move-only ScopedIpcRegHdl RAII owner for remote NVL IPC imports and the scoped-import allgather-ctrl mapper API, generalize the registration-backend helper, and harden releaseRemReg observability.
- ScopedIpcRegHdl (regcache): move-only owner of one remote NVL IPC import ref; destruction issues a deferred releaseRemReg (SW-only, safe from CUDA-callback contexts), with the actual unmap drained later by cleanupInvalidImports(). Carries a refCount_ snapshot (refCount() getter, shown in toString()).
- IpcRegCache::importMem gains an optional outHdl that produces the adopting ScopedIpcRegHdl directly (carrying the import refCount, no extra lookup); the standalone makeScopedIpcRegHdl is removed.
- CtranMapper::getBackends() returns the backend mask from this rank to all peer ranks (self IB/SOCKET/TCPDM + NVL-if-any-peer), replacing per-caller helpers.
- intraAllGatherCtrl/allGatherCtrl gain an optional outIpcHdls output: the imported intra-node NVL peers as scoped RAII owners, sized to nLocalRanks and indexed by local rank (self and non-NVL peers left empty). The resize is centralized in allGatherCtrlImpl at the point of use so every overload -- including the ranks overload -- sizes outIpcHdls before it is indexed; this fixes an out-of-bounds write on the ranks-overload path (previously only the base and full-comm overloads pre-sized it).
- deregRemReg aborts (FB_CHECKABORT) if the IpcRegCache singleton is unexpectedly null when releasing an NVL rkey.
- Add IpcRegCache::maxRemRegRefCount() (test-only) reporting the max live remote-import refCount, for observability and regression assertions.

Reviewed By: YulunW

Differential Revision: D110828809


