### PR TITLE
Unify CTREE AllReduce tile size at 60KB (#3065)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedCommon.cuh
@@ -178,7 +178,7 @@ struct IbReduceCopy {
     const T* staged = reinterpret_cast<const T*>(staging);
     const size_t nelems = nbytes / sizeof(T);
 
-    tileReduce<T, common::kIbTileElems, common::kBlockSize>(
+    tileReduce<T, common::TileElems<T>::k, common::kBlockSize>(
         accum, staged, nelems, group);
 #endif
   }

--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -11,10 +11,19 @@ namespace ctran::allreduce::common {
 
 /** CUDA threads per block used by the fused AllReduce kernels. */
 static constexpr int kBlockSize = 640;
-/** Elements processed by one NVL tile operation in the reduction helpers. */
-static constexpr int kNvlTileElems = 15360;
-/** Elements processed by one IB tile operation in the reduction helpers. */
-static constexpr int kIbTileElems = 5120;
+
+static constexpr size_t kTileBytesPerThread = 96;
+static constexpr size_t kTileBytes = kBlockSize * kTileBytesPerThread;
+
+template <typename T>
+struct TileElems {
+  static constexpr size_t kBytes = kTileBytes;
+
+  static_assert(kBytes > 0);
+  static_assert(kBytes % sizeof(T) == 0);
+
+  static constexpr int k = static_cast<int>(kBytes / sizeof(T));
+};
 
 } // namespace ctran::allreduce::common
 

--- a/comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceNvlDirect.cuh
@@ -61,7 +61,7 @@ struct NvlReduceCopy {
       }
       group.sync();
     }
-    common::tileReduce<T, common::kNvlTileElems, common::kBlockSize>(
+    common::tileReduce<T, common::TileElems<T>::k, common::kBlockSize>(
         out, staged, nelems, group);
 #endif
   }


### PR DESCRIPTION
Summary:

Unify fused AllReduce tile sizing across NVL and IB by deriving the tile from `kBlockSize * 96` bytes per thread. For `float`, both paths now use the same `60KB` / `15360` element tile, preserving the previously measured effective D110560271 tile size while removing topology-specific target-byte rounding.

Reviewed By: Scusemua

Differential Revision: D110560271


