### PR TITLE
Add recordExport option to allgather ctrl

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -1000,7 +1000,8 @@ commResult_t CtranMapper::intraAllGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport) {
   const auto& statex = comm->statex_;
   const int nLocalRanks = statex->nLocalRanks();
 
@@ -1010,7 +1011,7 @@ commResult_t CtranMapper::intraAllGatherCtrl(
   }
 
   return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend, recordExport);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1018,14 +1019,15 @@ commResult_t CtranMapper::allGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport) {
   const int nRanks = comm->statex_->nRanks();
   std::vector<int> ranks(nRanks);
   for (int i = 0; i < nRanks; i++) {
     ranks[i] = i;
   }
-  return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+  return this->allGatherCtrlImpl(
+      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend, recordExport);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1034,7 +1036,20 @@ commResult_t CtranMapper::allGatherCtrl(
     const std::vector<int>& ranks,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport) {
+  return this->allGatherCtrlImpl(
+      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend, recordExport);
+}
+
+commResult_t CtranMapper::allGatherCtrlImpl(
+    const void* buf,
+    void* hdl,
+    const std::vector<int>& ranks,
+    std::vector<void*>& remoteBufs,
+    std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+    CtranMapperBackend backend,
+    bool recordExport) {
   const int rank = comm->statex_->rank();
 
   // Skip if rank is not in the ranks list
@@ -1093,8 +1108,9 @@ commResult_t CtranMapper::allGatherCtrl(
             hdl,
             nvlSendMsg,
             &nvlExtraSegments,
-            peerBackends[i]));
-      } else if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+            peerBackends[i],
+            recordExport));
+      } else if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         // exportMem not called for this peer, record explicitly
         exportRegCache_.wlock()->record(regElem, peerList[i]);
       }

--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -734,9 +734,13 @@ commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
       FB_CHECKABORT(
           ctranNvl != nullptr,
           "Unexpected rkey with NVL backend but ctranNvl is not initialized");
-      FB_COMMCHECK(
-          ctran::IpcRegCache::getInstance()->releaseRemReg(
-              rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+      auto ipcRegCache = ctran::IpcRegCache::getInstance();
+      if (ipcRegCache) {
+        FB_COMMCHECK(ipcRegCache->releaseRemReg(
+            rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+        // actual release of deferred deregistrations
+        ipcRegCache->cleanupInvalidImports();
+      }
       break;
     }
     default:

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -452,13 +452,18 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
    */
   commResult_t intraAllGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -474,6 +479,10 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
    */
   commResult_t allGatherCtrl(
       const void* buf,
@@ -481,7 +490,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<int>& ranks,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -497,13 +507,18 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
    */
   commResult_t allGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.
@@ -1064,6 +1079,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
  private:
+  commResult_t allGatherCtrlImpl(
+      const void* buf,
+      void* hdl,
+      const std::vector<int>& ranks,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      CtranMapperBackend backend,
+      bool recordExport = true);
+
   [[noreturn]] inline void throwCommAbortException(
       const std::string& abortContext) {
     auto commAbort = comm->getAbort();
@@ -1252,7 +1276,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       void* hdl,
       ControlMsg& msg,
       std::vector<ctran::utils::CtranIpcSegDesc>* extraSegments,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET) {
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true) {
     auto regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
     // TODO: Enforce that a communicator can only export memory it registered
     // itself except the memory registered by globalRegister. Currently any comm
@@ -1287,8 +1312,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         }
       }
 
-      // Record the exported remote rank to notify at deregistration
-      if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+      // Record the exported remote rank to notify at deregistration.
+      if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         exportRegCache_.wlock()->record(regElem, rank);
       }
 

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -126,6 +126,83 @@ TEST_P(CtranDistMapperBackendParam, intraAllGatherCtrl) {
   NCCLCHECK_TEST(ncclMemFree(buf));
 }
 
+// Verify that intraAllGatherCtrl with recordExport=false does NOT populate the
+// export tracking cache, so its self-managed NVL imports are not
+// double-released by the export-notify path at deregistration.
+TEST_F(CtranDistMapperTest, intraAllGatherCtrlNoRecordExport) {
+  void* buf = nullptr;
+  void* handle = nullptr;
+  constexpr size_t bufSize = 8192;
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+
+  for (int localRank = 0; localRank < statex->nLocalRanks(); localRank++) {
+    const int peer = statex->localRankToRank(localRank);
+    if (!mapper->hasBackend(peer, CtranMapperBackend::NVL)) {
+      GTEST_SKIP() << "NVL backend is not available for local rank " << peer;
+    }
+  }
+
+  NCCLCHECK_TEST(ncclMemAlloc(&buf, bufSize));
+  COMMCHECK_TEST(comm_->ctran_->commRegister(buf, bufSize, &handle));
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  COMMCHECK_TEST(mapper->searchRegHandle(buf, bufSize, &sendHdl, &localReg));
+  ASSERT_NE(sendHdl, nullptr);
+  ASSERT_EQ(localReg, false);
+
+  std::vector<void*> remoteBufs(statex->nRanks(), nullptr);
+  std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(
+      statex->nRanks());
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+    ASSERT_EQ(
+        mapper->intraAllGatherCtrl(
+            buf,
+            sendHdl,
+            remoteBufs,
+            remoteAccessKeys,
+            CtranMapperBackend::NVL,
+            /*recordExport=*/false),
+        commSuccess);
+  }
+
+  ASSERT_TRUE(mapper->dumpExportRegCache().empty());
+
+  const int nodeId = statex->node();
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer == statex->rank()) {
+      ASSERT_EQ(remoteBufs[peer], buf);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    } else if (statex->node(peer) == nodeId) {
+      ASSERT_NE(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::NVL);
+    } else {
+      ASSERT_EQ(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    }
+  }
+
+  // Self-managed imports: release the remote NVL registrations explicitly.
+  barrierNvlDomain(comm_.get());
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (remoteAccessKeys[peer].backend == CtranMapperBackend::NVL) {
+      ASSERT_EQ(mapper->deregRemReg(&remoteAccessKeys[peer]), commSuccess);
+    }
+  }
+  barrierNvlDomain(comm_.get());
+
+  COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
+  NCCLCHECK_TEST(ncclMemFree(buf));
+}
+
 TEST_P(CtranDistMapperBackendParam, allGatherCtrl) {
   auto& [backend] = GetParam();
 #ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -91,6 +91,60 @@ void ctran::IpcRegCache::init() {
 ctran::IpcRegCache::~IpcRegCache() {
   stopAsyncSocket();
   clearAllRemReg();
+  cleanupInvalidImports();
+}
+
+ctran::ScopedIpcRegHdl ctran::IpcRegCache::makeScopedIpcRegHdl(
+    const ctran::regcache::IpcRemHandle& nvlKey) {
+  return ScopedIpcRegHdl(
+      this, std::string(nvlKey.peerId), nvlKey.basePtr, nvlKey.uid);
+}
+
+void ctran::ScopedIpcRegHdl::reset() noexcept {
+  if (ipcRegCache_ == nullptr) {
+    return;
+  }
+
+  // Deferred release: safe on any thread (SW-only), the actual CUDA unmap is
+  // drained later by IpcRegCache::cleanupInvalidImports(). Ignore the result —
+  // a destructor must not throw or propagate errors.
+  FB_COMMCHECKIGNORE(
+      ipcRegCache_->releaseRemReg(peerId_, basePtr_, uid_, /*exportCount=*/1));
+
+  ipcRegCache_ = nullptr;
+  peerId_.clear();
+  basePtr_ = nullptr;
+  uid_ = 0;
+}
+
+ctran::ScopedIpcRegHdl& ctran::ScopedIpcRegHdl::operator=(
+    ScopedIpcRegHdl&& other) noexcept {
+  if (this != &other) {
+    reset();
+    ipcRegCache_ = other.ipcRegCache_;
+    peerId_ = std::move(other.peerId_);
+    basePtr_ = other.basePtr_;
+    uid_ = other.uid_;
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+  }
+  return *this;
+}
+
+ctran::ScopedIpcRegHdl::~ScopedIpcRegHdl() {
+  reset();
+}
+
+std::string ctran::ScopedIpcRegHdl::toString() const {
+  if (ipcRegCache_ == nullptr) {
+    return "[ScopedIpcRegHdl] empty";
+  }
+  return fmt::format(
+      "[ScopedIpcRegHdl] peerId: {}, basePtr: {}, uid: {}",
+      peerId_,
+      basePtr_,
+      uid_);
 }
 
 commResult_t ctran::IpcRegCache::importMem(
@@ -101,6 +155,9 @@ commResult_t ctran::IpcRegCache::importMem(
     struct ctran::regcache::IpcRemHandle* remKey,
     const struct CommLogData* logMetaData,
     const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+  // Reclaim any imports released deferentially before this user-thread entry.
+  cleanupInvalidImports();
+
   void* basePtr = nullptr;
   FB_COMMCHECK(importRemMemImpl(
       peerId, ipcDesc, cudaDev, logMetaData, &basePtr, extraSegments));
@@ -188,8 +245,9 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   uint64_t base = reinterpret_cast<uint64_t>(basePtr);
   IpcRemRegKey key{base, uid};
 
-  if (lockedMap->find(peerId) == lockedMap->end() ||
-      (*lockedMap)[peerId].find(key) == (*lockedMap)[peerId].end()) {
+  auto peerIt = lockedMap->find(peerId);
+  if (peerIt == lockedMap->end() ||
+      peerIt->second.find(key) == peerIt->second.end()) {
     CLOGF(
         ERR,
         "CTRAN-REGCACHE: Unknown IPC remote memory registration from peer {} base {} uid {}",
@@ -199,7 +257,8 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
     return ErrorStackTraceUtil::log(commInternalError);
   }
 
-  auto& elem = (*lockedMap)[peerId][key];
+  auto keyIt = peerIt->second.find(key);
+  auto& elem = keyIt->second;
   int prevCount =
       elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
 
@@ -213,7 +272,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         uid,
         prevCount,
         exportCount);
-    // Fall through to erase — the entry is invalid regardless
+    // Fall through to invalidate — the entry is invalid regardless
   } else if (prevCount > exportCount) {
     CLOGF_TRACE(
         COLL,
@@ -234,20 +293,23 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
       uid,
       elem->toString());
 
-  try {
-    (*lockedMap)[peerId].erase(key);
-  } catch (std::exception& e) {
-    CLOGF(
-        WARN,
-        "CTRAN-REGCACHE: failed to remove IPC remote registration from cache peer:base:uid=<{}:{}:{}>, error {}",
-        peerId,
-        basePtr,
-        uid,
-        e.what());
-    return ErrorStackTraceUtil::log(commInternalError);
-  }
+  // Move refcount==0 elem out of the live map. Actual unmap runs in
+  // cleanupInvalidImports().
+  invalidImports_.wlock()->push_back(std::move(elem));
+  peerIt->second.erase(keyIt);
 
   return commSuccess;
+}
+
+void ctran::IpcRegCache::cleanupInvalidImports() {
+  std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>> pending;
+  {
+    auto lockedInvalid = invalidImports_.wlock();
+    pending.swap(*lockedInvalid);
+  }
+
+  // Destruct the moved-out elems outside the lock; ~IpcRemRegElem performs the
+  // CUDA unmap. Safe when pending is empty and when called repeatedly.
 }
 
 void ctran::IpcRegCache::clearAllRemReg() {
@@ -443,6 +505,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                 ipcReq.release.base,
                 ipcReq.release.uid,
                 ipcReq.release.exportCount));
+            cleanupInvalidImports();
             break;
           }
           case ctran::regcache::IpcReqType::kDesc: {

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -2,6 +2,9 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -17,6 +20,77 @@
 #include "comms/ctran/utils/Checks.h"
 
 namespace ctran {
+
+class IpcRegCache;
+class ScopedIpcRegHdl;
+
+// Move-only RAII owner of ONE remote NVL IPC import ref. It ADOPTS an existing
+// import ref (does not importMem, does not add a ref) and, on destruction,
+// drops that ref via a deferred releaseRemReg so it is safe to destroy from a
+// CUDA-callback context (e.g. graph destroy): the drop is pure SW; the parked
+// import is unmapped later by IpcRegCache::cleanupInvalidImports() on a user
+// thread.
+//
+// Lifecycle difference vs the local ScopedRegHdl: ScopedIpcRegHdl has NO
+// cache-held baseline ref. Its last release CAN drive the import refCount to 0
+// and retire the mapping (deferred: moved to invalidImports_, unmapped later by
+// cleanupInvalidImports()). A local ScopedRegHdl release never retires the
+// local registration because regcache always holds a baseline ref.
+class ScopedIpcRegHdl {
+ public:
+  ScopedIpcRegHdl() = default;
+
+  ScopedIpcRegHdl(ScopedIpcRegHdl&& other) noexcept
+      : ipcRegCache_(other.ipcRegCache_),
+        peerId_(std::move(other.peerId_)),
+        basePtr_(other.basePtr_),
+        uid_(other.uid_) {
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+  }
+
+  ScopedIpcRegHdl& operator=(ScopedIpcRegHdl&& other) noexcept;
+
+  ScopedIpcRegHdl(const ScopedIpcRegHdl&) = delete;
+  ScopedIpcRegHdl& operator=(const ScopedIpcRegHdl&) = delete;
+
+  ~ScopedIpcRegHdl();
+
+  // The IpcRegCache this handle will release into, or nullptr when the handle
+  // is empty or moved-from.
+  IpcRegCache* get() const {
+    return ipcRegCache_;
+  }
+
+  explicit operator bool() const {
+    return ipcRegCache_ != nullptr;
+  }
+
+  std::string toString() const;
+
+ private:
+  friend class IpcRegCache;
+
+  ScopedIpcRegHdl(
+      IpcRegCache* ipcRegCache,
+      std::string peerId,
+      void* basePtr,
+      uint32_t uid)
+      : ipcRegCache_(ipcRegCache),
+        peerId_(std::move(peerId)),
+        basePtr_(basePtr),
+        uid_(uid) {}
+
+  // Drop the held import ref (deferred release) and reset to the empty state.
+  // No-op when already empty/moved-from. Never throws.
+  void reset() noexcept;
+
+  IpcRegCache* ipcRegCache_{nullptr};
+  std::string peerId_;
+  void* basePtr_{nullptr};
+  uint32_t uid_{0};
+};
 
 // Class to manage IPC-based remote memory registrations for a single
 // communicator. Currently handles NVL (NVLink) remote memory imports from peer
@@ -120,14 +194,29 @@ class IpcRegCache {
     return commSuccess;
   }
 
-  // Release a specific remote registration for a given peer.
-  // exportCount specifies how many times the buffer was exported to this peer;
-  // the refcount is decremented by this amount.
+  // Release a specific remote registration for a given peer. Always deferred
+  // (SW-only): exportCount specifies how many times the buffer was exported to
+  // this peer; the refcount is decremented by this amount. When the refcount
+  // drops to zero the elem is moved out of the live map into invalidImports_
+  // WITHOUT touching CUDA. The backing CUDA unmap happens later, only when
+  // cleanupInvalidImports() is explicitly called on a user thread.
   commResult_t releaseRemReg(
       const std::string& peerId,
       void* basePtr,
       uint32_t uid,
       int32_t exportCount = 1);
+
+  // Convert preexisting IpcRemHandle callsites at mapper to a move-only RAII
+  // owner. This ADOPTS the existing ref (it does not importMem and does not add
+  // a ref); the returned ScopedIpcRegHdl drops the ref via a deferred
+  // releaseRemReg on destruction.
+  ScopedIpcRegHdl makeScopedIpcRegHdl(
+      const ctran::regcache::IpcRemHandle& nvlKey);
+
+  // Drain invalidImports_: destroy every refcount==0 elem pending CUDA unmap.
+  // Must be called on a user thread (performs CUDA APIs). Safe when empty and
+  // safe to call repeatedly.
+  void cleanupInvalidImports();
 
   // Get the number of existing remote registrations for a given peer
   size_t getNumRemReg(const std::string& peerId) const;
@@ -220,6 +309,14 @@ class IpcRegCache {
           std::unique_ptr<ctran::regcache::IpcRemRegElem>,
           folly::Hash>>;
   folly::Synchronized<IpcRemRegMap> ipcRemRegMap_;
+
+  // Elems whose refCount reached zero and left ipcRemRegMap_, still holding a
+  // live CUDA mapping. Destroying the unique_ptr performs the cuMemUnmap; that
+  // must happen on a user thread, so releaseRemReg parks the elem
+  // here and cleanupInvalidImports() drains it later outside the map lock.
+  folly::Synchronized<
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>>
+      invalidImports_;
 
   // Flag for one-time initialization
   std::once_flag initFlag_;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -593,7 +593,8 @@ void ctran::RegCache::resetExternalRegMemFn() {
 
 ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
     const void* ptr,
-    const size_t len) {
+    const size_t len,
+    bool acquireRef) {
   ctran::regcache::RegElem* regHdl = nullptr;
 
   auto regElemsMaps = regElemsMaps_.rlock();
@@ -616,6 +617,10 @@ ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
       // Lookup hit
       regHdl = searchRegElem.get();
       searchRegElem->lookupHit_++;
+      if (acquireRef) {
+        // Atomic increment: safe under the shared read lock.
+        regHdl->refCount.fetch_add(1, std::memory_order_relaxed);
+      }
       break;
     }
   }
@@ -918,7 +923,8 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
     std::vector<ctran::regcache::Segment*>& segments,
     const std::vector<bool>& backends,
     bool ncclManaged,
-    ctran::regcache::RegElem** regHdl) {
+    ctran::regcache::RegElem** regHdl,
+    bool acquireRef) {
   // Create a new registration element for the segments
   auto newRegElem = std::make_unique<ctran::regcache::RegElem>(
       ptr, len, cudaDev, segments, ncclManaged);
@@ -932,6 +938,12 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
   auto regElemsMaps = regElemsMaps_.wlock();
   auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
   auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
+
+  // The RegElem already holds the registration's ref (refCount starts at 1).
+  // If the caller is a scoped acquire, add its ref while holding the map lock.
+  if (acquireRef) {
+    regHdlPtr->refCount.fetch_add(1, std::memory_order_relaxed);
+  }
 
   regHdlToElemMap.emplace(regHdlPtr, std::move(newRegElem));
   // Correlate the regElem with all associated segments to deregister it
@@ -953,7 +965,8 @@ commResult_t ctran::RegCache::regRangeCached(
     const std::vector<bool>& backends,
     bool& didRegister,
     ctran::regcache::RegElem** regHdl,
-    bool ncclManaged) {
+    bool ncclManaged,
+    bool acquireRef) {
   auto dur = CtranMapperTimer();
   SetCudaDevRAII setCudaDev(cudaDev);
   auto timerBegin = std::chrono::steady_clock::now();
@@ -962,7 +975,7 @@ commResult_t ctran::RegCache::regRangeCached(
     // FAST PATH: find whether range has already been registered in
     // regElemsMaps. regElemsMaps should not be wlocked while performing
     // expensive registration/deregistration.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     // Lookup hit
     if (*regHdl) {
       return commSuccess;
@@ -983,7 +996,7 @@ commResult_t ctran::RegCache::regRangeCached(
 
     // While holding the global lock, let's check again no one else has
     // registered the range.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     if (*regHdl) {
       return commSuccess;
     }
@@ -1032,7 +1045,8 @@ commResult_t ctran::RegCache::regRangeCached(
           segments,
           backends,
           ncclManaged,
-          regHdl));
+          regHdl,
+          acquireRef));
       didRegister = true;
     } else {
       // - WORST PATH: if any one is not found, return nullptr to trigger
@@ -1170,6 +1184,21 @@ commResult_t ctran::RegCache::freeSegment(
           continue;
         }
 
+        // Remove the registration's ref. Any remaining count means live
+        // ScopedRegHdl owners, which violates the lifetime contract because the
+        // segment/memory is being freed underneath them.
+        const auto prev =
+            regIt->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+        const auto after = prev - 1;
+        if (after > 0) {
+          CLOGF(
+              ERR,
+              "freeSegment: tearing down RegElem [buf {} len {}] that still has {} live ScopedRegHdl owner(s). This violates the scoped-registration lifetime contract: the buffer memory must outlive all ScopedRegHdl scopes.",
+              regIt->second->buf,
+              regIt->second->len,
+              after);
+        }
+
         // Remove regElem from global cache and to be deregistered
         regElems.push_back(std::move(regIt->second));
         regHdlToElemMap.erase(regIt);
@@ -1214,6 +1243,145 @@ commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   FB_COMMCHECK(regElem->doDeregister(externalDeregMemFn_));
   profiler.wlock()->record(ctran::regcache::EventType::kDeregMemEvent, dur);
   return commSuccess;
+}
+
+void ctran::RegCache::releaseScopedRegHdl(ctran::regcache::RegElem* regHdl) {
+  // Pure SW-only release: drop the scope's ref (atomic decrement). Never
+  // deregisters, deletes, or touches CUDA, so it is safe to run from a CUDA
+  // graph-destroy callback. The registration's own ref (dropped only by
+  // freeSegment/deregRange on a user thread) keeps the RegElem alive, so a
+  // scoped release can never drive refCount to 0.
+  //
+  // A read lock is enough: we only look up the map, we never modify it. The
+  // rlock excludes freeSegment's wlock, so the found RegElem cannot be freed
+  // underneath the decrement.
+  if (regHdl == nullptr) {
+    return;
+  }
+
+  auto regElemsMaps = regElemsMaps_.rlock();
+  // NOTE: regHdl may be a dangling pointer here if a buffer-release path
+  // (freeSegment/globalDeregister) already force-freed the RegElem while this
+  // scope was still live. It is therefore used ONLY as a map key below and is
+  // NEVER dereferenced; a not-found lookup safely no-ops.
+  auto it = regElemsMaps->regHdlToElemMap.find(regHdl);
+  if (it == regElemsMaps->regHdlToElemMap.end()) {
+    CLOGF(
+        WARN,
+        "releaseScopedRegHdl: regElem {} not found (may have been force-freed by a buffer-release path)",
+        (void*)regHdl);
+    return;
+  }
+
+  const auto prev =
+      it->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+  const auto after = prev - 1;
+  FB_CHECKABORT(
+      after >= 1,
+      "scoped release drove refCount below the registration baseline for RegElem {} (cnt {})",
+      (void*)regHdl,
+      after);
+}
+
+commResult_t ctran::RegCache::acquireScopedRegister(
+    const void* buf,
+    size_t len,
+    int cudaDev,
+    const std::vector<bool>& backends,
+    ctran::ScopedRegHdl& scopedRegHdl) {
+  if (buf == nullptr || len == 0) {
+    CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
+    return commInvalidUsage;
+  }
+
+  // Acquire one RegElem ref. The buffer's segment must already be cached by the
+  // allocator; regRangeCached returns nullptr otherwise.
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData scopedLogData{};
+  scopedLogData.commDesc = "scopedRegister";
+  const auto regResult = regRangeCached(
+      buf,
+      len,
+      cudaDev,
+      "scopedRegister",
+      scopedLogData,
+      backends,
+      didRegister,
+      &regHdl,
+      true /* ncclManaged */,
+      true /* acquireRef */);
+
+  if (regResult != commSuccess || regHdl == nullptr) {
+    CLOGF(
+        ERR,
+        "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
+        "segment. Scoped registration requires the buffer's memory to be pre-registered "
+        "by the allocator (globalRegister / CCA memory hook) before use. Ensure the "
+        "allocator registers memory after allocation and deregisters before free.",
+        (void*)buf,
+        len);
+    return commInvalidUsage;
+  }
+
+  scopedRegHdl.regCache_ = this;
+  scopedRegHdl.regHdl_ = regHdl;
+  return commSuccess;
+}
+
+ctran::ScopedRegHdl::ScopedRegHdl(ctran::ScopedRegHdl&& other) noexcept
+    : regCache_(other.regCache_), regHdl_(other.regHdl_) {
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+}
+
+ctran::ScopedRegHdl& ctran::ScopedRegHdl::operator=(
+    ctran::ScopedRegHdl&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  // Release the current handle before taking over the other.
+  if (regCache_ != nullptr) {
+    regCache_->releaseScopedRegHdl(regHdl_);
+  }
+  regCache_ = other.regCache_;
+  regHdl_ = other.regHdl_;
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  return *this;
+}
+
+ctran::ScopedRegHdl::~ScopedRegHdl() {
+  if (regCache_ == nullptr) {
+    return;
+  }
+  // Best-effort SW-only cleanup; never throw out of the destructor.
+  try {
+    regCache_->releaseScopedRegHdl(regHdl_);
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
+  }
+  regCache_ = nullptr;
+  regHdl_ = nullptr;
+}
+
+ctran::regcache::RegElem* ctran::ScopedRegHdl::get() const {
+  return regHdl_;
+}
+
+ctran::ScopedRegHdl::operator bool() const {
+  return regCache_ != nullptr && regHdl_ != nullptr;
+}
+
+std::string ctran::ScopedRegHdl::toString() const {
+  if (regCache_ == nullptr || regHdl_ == nullptr) {
+    return "ScopedRegHdl{empty}";
+  }
+  return fmt::format(
+      "ScopedRegHdl{{regHdl: {}, buf: {}, len: {}}}",
+      (void*)regHdl_,
+      regHdl_->buf,
+      regHdl_->len);
 }
 
 commResult_t ctran::RegCache::regRange(
@@ -1302,7 +1470,33 @@ commResult_t ctran::RegCache::regDynamic(
   return commSuccess;
 }
 
-commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
+namespace {
+// Remove regHdl from every segToRegElemsMap entry for its segments, erasing
+// any entry whose vector becomes empty.
+void removeRegElemFromSegCorrelations(
+    ctran::regcache::RegElem* regHdl,
+    const std::vector<ctran::regcache::Segment*>& segments,
+    std::unordered_map<
+        ctran::regcache::Segment*,
+        std::vector<ctran::regcache::RegElem*>>& segToRegElemsMap) {
+  for (auto seg : segments) {
+    auto segIt = segToRegElemsMap.find(seg);
+    if (segIt != segToRegElemsMap.end()) {
+      auto& regElemsVec = segIt->second;
+      regElemsVec.erase(
+          std::remove(regElemsVec.begin(), regElemsVec.end(), regHdl),
+          regElemsVec.end());
+      if (regElemsVec.empty()) {
+        segToRegElemsMap.erase(segIt);
+      }
+    }
+  }
+}
+} // namespace
+
+commResult_t ctran::RegCache::deregRange(
+    ctran::regcache::RegElem* regHdl,
+    bool releaseRef) {
   std::unique_ptr<ctran::regcache::RegElem> regElem = nullptr;
   // Global lock to update regElemsMaps_.
   // Unlock before deregistration, avoid long holding time of the lock.
@@ -1315,6 +1509,30 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
+
+    // When releasing a scoped ref, decrement first and only tear down on the
+    // last reference. Other references keep the registration alive.
+    if (releaseRef) {
+      const auto prev =
+          it->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+      const auto after = prev - 1;
+      FB_CHECKABORT(
+          after >= 0,
+          "Unexpected negative refCount {} in RegElem {}",
+          after,
+          (void*)regHdl);
+      if (after > 0) {
+        return commSuccess;
+      }
+    }
+
+    // Remove the regElem from every segment correlation entry so no dangling
+    // pointer remains after ownership moves out of the live map. Dynamic
+    // RegElems carry no segments_, so this only matters for the cached
+    // (releaseRef) path.
+    removeRegElemFromSegCorrelations(
+        regHdl, regHdl->segments_, regElemsMaps->segToRegElemsMap);
+
     // Remove regElem from global cache and return ownership to caller for any
     // remote registration release
     regElem = std::move(it->second);
@@ -1552,7 +1770,6 @@ commResult_t ctran::RegCache::deregAll() {
   {
     auto regElemsMaps = regCache->regElemsMaps_.wlock();
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
-    auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
 
     // Iterate through all regElems and collect non-dynamic ones for
     // deregistration
@@ -1567,19 +1784,8 @@ commResult_t ctran::RegCache::deregAll() {
       }
 
       // Remove from segToRegElemsMap
-      for (auto seg : regElem->segments_) {
-        auto segIt = segToRegElemsMap.find(seg);
-        if (segIt != segToRegElemsMap.end()) {
-          auto& regElemsVec = segIt->second;
-          regElemsVec.erase(
-              std::remove(
-                  regElemsVec.begin(), regElemsVec.end(), regElem.get()),
-              regElemsVec.end());
-          if (regElemsVec.empty()) {
-            segToRegElemsMap.erase(segIt);
-          }
-        }
-      }
+      removeRegElemFromSegCorrelations(
+          regElem.get(), regElem->segments_, regElemsMaps->segToRegElemsMap);
 
       // Transfer ownership to toDeregister vector and remove from map
       toDeregister.push_back(std::move(regElem));

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -3,6 +3,7 @@
 
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <atomic>
 #include <memory>
 #include <queue>
 #include <unordered_map>
@@ -158,6 +159,22 @@ struct RegElem {
     type_ = segments.at(0)->getType();
   };
 
+  // Reference count controlling this RegElem's lifetime. A RegElem exists only
+  // once the buffer is actually registered, and that registration holds one
+  // reference, so refCount starts at 1. Each live ScopedRegHdl adds one more.
+  //
+  // The preexisting RegElem consumers (searchRegHandle / searchIbRegHandle /
+  // getRegHandle) do NOT rely on refCount. They rely on the allocator-hook
+  // contract: any lookup issued after the buffer's allocation hook
+  // (globalRegister) and before its free hook (globalDeregister) is safe.
+  // Consequently a ScopedRegHdl reference layered on top never triggers an
+  // actual deregistration, and a scoped release can never drop the last
+  // reference. Deregistration happens only when the allocator's free hook
+  // (globalDeregister) runs, or when the RegCache shuts down.
+  //
+  // Atomic so a scoped acquire can increment it under the shared read lock.
+  std::atomic<int64_t> refCount{1};
+
   std::size_t numSegments() const {
     return segments_.size();
   }
@@ -267,6 +284,35 @@ class Profiler {
 
 } // namespace regcache
 
+// Move-only RAII owner of a scoped local registration acquired via
+// RegCache::acquireScopedRegister(). It owns ONLY a RegElem reference (one live
+// ScopedRegHdl ref counted in RegElem::refCount); it does not cache or
+// ref-count segments. The registration itself holds a reference; a scoped
+// handle adds one on top and never triggers a deregistration. The destructor
+// performs a pure SW-only ref decrement (graph-destroy safe): it never touches
+// CUDA and never deregisters. A scoped release can never drop the last
+// reference, so the registration persists (cached and reusable) until the
+// allocator frees the segment via freeSegment/deregRange.
+class ScopedRegHdl {
+ public:
+  ScopedRegHdl() = default;
+  ScopedRegHdl(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl& operator=(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl(const ScopedRegHdl&) = delete;
+  ScopedRegHdl& operator=(const ScopedRegHdl&) = delete;
+  ~ScopedRegHdl();
+
+  regcache::RegElem* get() const;
+  explicit operator bool() const;
+  std::string toString() const;
+
+ private:
+  friend class RegCache;
+
+  RegCache* regCache_{nullptr};
+  regcache::RegElem* regHdl_{nullptr};
+};
+
 /**
  * Singleton class to hold the IB network resources that are reused by all
  * communicators in the lifetime of program.
@@ -303,6 +349,20 @@ class RegCache {
       size_t len,
       bool skipRemRelease = false,
       int deviceId = -1);
+
+  // Acquire a scoped local registration for [buf, buf + len). The buffer's
+  // underlying segment MUST already be cached by the allocator (globalRegister
+  // / CCA memory hook); this API does not cache segments. On success it takes
+  // one RegElem ref (counted in RegElem::refCount) and the returned
+  // ScopedRegHdl owns that ref, releasing it SW-only in its destructor. If the
+  // buffer is not backed by a cached segment, commInvalidUsage is returned and
+  // the ScopedRegHdl stays empty.
+  commResult_t acquireScopedRegister(
+      const void* buf,
+      size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      ScopedRegHdl& scopedRegHdl);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying
@@ -345,6 +405,9 @@ class RegCache {
   // output:
   //   - didRegister: whether regRangeCached registered regHdl, or just found it
   //   - regHdl: the registration handle
+  // If acquireRef is true, the returned RegElem's scoped refcount is
+  // incremented while holding the map lock (typically for a ScopedRegHdl, which
+  // releases it via its destructor).
   commResult_t regRangeCached(
       const void* ptr,
       const size_t len,
@@ -354,7 +417,8 @@ class RegCache {
       const std::vector<bool>& backends,
       bool& didRegister,
       regcache::RegElem** regHdl,
-      bool ncclManaged = false);
+      bool ncclManaged = false,
+      bool acquireRef = false);
 
   // Thread-safe function to directly register a buffer range without consulting
   // the reusable segment/regElem cache. It registers every pinned physical
@@ -393,7 +457,9 @@ class RegCache {
   // communicator uses it.
   // input:
   //   - regHdl: the direct registration handle
-  commResult_t deregRange(regcache::RegElem* regHdl);
+  //   - releaseRef: if true, decrement the RegElem's refcount first and only
+  //                 proceed to backend deregistration when it reaches 0.
+  commResult_t deregRange(regcache::RegElem* regHdl, bool releaseRef = false);
 
   // Thread-safe function to deregister a dynamic registration. Compatibility
   // wrapper around deregRange() for existing callers.
@@ -544,6 +610,8 @@ class RegCache {
   folly::Synchronized<regcache::Profiler> profiler;
 
  private:
+  friend class ScopedRegHdl;
+
   // Hold a reference to CtranIbSingleton to ensure proper destruction order.
   // By holding this shared_ptr, we guarantee CtranIbSingleton stays alive
   // as long as RegCache exists, preventing use-after-free during
@@ -587,7 +655,11 @@ class RegCache {
   void asyncRegThreadFn(int cudaDev);
 
   // Thread-safe function to search given <ptr, len> range in regElem cache.
-  regcache::RegElem* searchRegElem(const void* ptr, const size_t len);
+  // If acquireRef is true, atomically increments the found RegElem's refCount
+  // on a lookup hit (safe under the shared read lock because refCount is
+  // atomic).
+  regcache::RegElem*
+  searchRegElem(const void* ptr, const size_t len, bool acquireRef = false);
 
   // Helper function to perform backend registration for a set of segments.
   // Creates a RegElem, registers with backends, and updates regElemsMaps.
@@ -603,9 +675,14 @@ class RegCache {
       std::vector<regcache::Segment*>& segments,
       const std::vector<bool>& backends,
       bool ncclManaged,
-      regcache::RegElem** regHdl);
+      regcache::RegElem** regHdl,
+      bool acquireRef = false);
 
   commResult_t deregElem(regcache::RegElem* regElem);
+
+  // SW-only scoped-ref release used by ~ScopedRegHdl; graph-destroy safe. See
+  // .cc for details.
+  void releaseScopedRegHdl(regcache::RegElem* regHdl);
 };
 
 static inline void CHECK_VALID_REGCACHE(std::shared_ptr<RegCache> regCache) {

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -109,6 +109,7 @@ RegElem
   isDynamic_ : bool         -- true for one-time uncached registrations
   type_      : DevMemType   -- memory type of the registered range
   ncclManaged_: bool        -- whether NCCL allocated this buffer
+  refCount    : atomic<int64_t>  -- lifetime refcount; allocator holds one ref for lookup consumers (see Scoped Registration)
 ```
 
 ### RegCache (class)
@@ -327,6 +328,71 @@ cleanup:
   -> CtranMapper::deregMem (notify remote peers + freeSegment)
   -> cudaFree
 ```
+
+## Scoped Registration
+
+Ctran's persistent collectives (persistent AllGatherP, "AGP") and window
+collectives hold a registration for the lifetime of an operation, request, or
+window — not the lifetime of the underlying memory — and must release it safely,
+including from a CUDA graph-destroy callback where no CUDA calls are allowed.
+Move-only RAII owners provide this on top of the existing cache without
+disturbing the allocator (CCA) hook or the existing, non-refcounted lookup APIs.
+
+`globalRegister` / `globalDeregister` are the allocator-hook APIs. They are keyed
+on BUFFER (memory) lifetime — the allocator calls them around a buffer's
+allocation and free — and `globalDeregister` force-frees the cached segment and
+all of its registrations. They are therefore NOT suitable for scoped
+registration inside Ctran: a persistent collective or window has an operation /
+request / window lifetime, not a memory lifetime, and calling `globalDeregister`
+from that code would tear down allocator-owned state that other consumers may
+still need. Ctran-internal scopes must use `acquireScopedRegister` /
+`ScopedRegHdl` (below) instead; `globalRegister` / `globalDeregister` must be
+called ONLY from the allocator side (the CCA memory hook), never from collective
+or window code.
+
+### Local registration: `ScopedRegHdl`
+
+Lifecycle (`RegElem::refCount`):
+
+- The allocator owns one reference to each `RegElem`. It is created with
+  `refCount = 1` when the registration is first cached (via `globalRegister` /
+  the CCA hook); this one reference stands in for the allocator's non-refcounted
+  lookup consumers (`searchRegHandle` / `searchIbRegHandle` / `getRegHandle`),
+  which borrow the `RegElem*` without touching `refCount`.
+- `RegCache::acquireScopedRegister(buf, len, cudaDev, backends, &hdl)` resolves
+  the cached `RegElem`, increments `refCount`, and returns a move-only
+  `ScopedRegHdl` owning that one ADDITIONAL reference.
+- `~ScopedRegHdl` performs a pure software decrement (`releaseScopedRegHdl`)
+  under the `regElemsMaps_` read lock — no deregistration, no delete, no CUDA —
+  so it is safe to run from a graph-destroy callback.
+- The allocator's reference is dropped only by user-thread teardown paths
+  (`freeSegment`, invoked by `globalDeregister`, or `deregRange`). A scoped
+  release can therefore never drop the last reference: a `ScopedRegHdl` is never
+  the sole owner and never retires the registration.
+
+Compatibility with the allocator (CCA) hook:
+
+- The allocator hook owns memory lifetime: `globalRegister` caches the segment
+  and creates the `RegElem` with the allocator's one reference; `globalDeregister`
+  drops that reference (`freeSegment` → backend dereg) right before the memory is
+  freed.
+- `acquireScopedRegister` REQUIRES the buffer's segment to already be
+  allocator-cached and returns `commInvalidUsage` otherwise — it never caches or
+  frees segments. A scoped acquire/release only adjusts the extra reference, so
+  it can neither race nor double-free allocator-owned state; the allocator
+  remains the sole owner of the registration's lifetime. If a buffer is freed
+  while a scoped reference is still live, `freeSegment` logs a
+  contract-violation error and tears down anyway (the memory is going away).
+
+Compatibility with the existing (non-refcounted) lookup APIs:
+
+- `searchRegHandle` / `searchIbRegHandle` / `getRegHandle` return a borrowed
+  `RegElem*` WITHOUT touching `refCount`. These are the established production
+  callers (e.g. collective-time handle lookup) and are intentionally left
+  non-refcounted to avoid changing their behavior. The allocator's single
+  reference already covers these lookups; only `ScopedRegHdl` adds or removes
+  further references, so a scoped owner and these borrowed lookups safely share
+  the same cached `RegElem`.
 
 ## Component Interactions
 

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -394,6 +394,44 @@ Compatibility with the existing (non-refcounted) lookup APIs:
   further references, so a scoped owner and these borrowed lookups safely share
   the same cached `RegElem`.
 
+### Remote IPC import: `ScopedIpcRegHdl`
+
+Remote NVLink IPC imports live in `IpcRegCache`, separate from the local segment
+cache, and use a symmetric-but-different scoped owner.
+
+Lifecycle:
+
+- An imported `IpcRemRegElem` is refcounted (`refCount`). `releaseRemReg` ALWAYS
+  defers: it decrements the refcount and, on reaching zero, moves the elem out of
+  the live map into `invalidImports_`. This is pure software work (no CUDA), so
+  it is safe from a graph-destroy callback. Because rc==0 entries leave the live
+  map, a released import is never resurrected by a later import.
+- `cleanupInvalidImports()` performs the actual CUDA unmap of the parked
+  entries. It runs on user-thread entries (`importMem`, `~IpcRegCache`) and is
+  called explicitly by release callsites that want prompt teardown
+  (`CtranMapper::deregRemReg`, the async-socket `kRelease` handler).
+- `ScopedIpcRegHdl` is a move-only owner of one import reference, created via
+  `IpcRegCache::makeScopedIpcRegHdl(const IpcRemHandle& nvlKey)`. It ADOPTS an
+  existing import (identified by an NVL remote-access key's handle) — it does not
+  import and does not add a reference. `~ScopedIpcRegHdl` performs a deferred
+  `releaseRemReg`, so it is graph-destroy safe; the CUDA unmap drains later via
+  an explicit `cleanupInvalidImports()` at a user-thread teardown point (window
+  free, eager AGP destroy).
+
+Difference from local `ScopedRegHdl`, and compatibility:
+
+- `IpcRegCache` holds no reference of its own on an imported elem — the refcount
+  is owned entirely by importers, with no allocator-held reference like the local
+  one. So, unlike a local `ScopedRegHdl` (which can never retire its
+  registration), the LAST `ScopedIpcRegHdl` release DOES retire the import
+  (deferred).
+- `IpcRemRegElem` was already refcount-based for existing importers, and its
+  release can be triggered either by an explicit importer-side call
+  (`releaseRemReg` / `CtranMapper::deregRemReg`) or by the exporter's `kRelease`
+  notification over the async socket. `ScopedIpcRegHdl` layers cleanly on top of
+  this existing refcount — it introduces no new scheme and does not change the
+  C-style release/notify paths.
+
 ## Component Interactions
 
 ### CtranMapper (per-communicator)

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1660,6 +1660,425 @@ TEST_F(RegCacheTest, ExternalRegMemFailureIsHandledGracefully) {
   CUDACHECK_TEST(cudaFree(buf));
 }
 
+// Baseline-1 model: globalRegister caches + eager-registers (refcnt baseline
+// 1). A scoped acquire bumps it to 2; releasing the scope decrements back to 1
+// but NEVER dereg's (baseline keeps it alive). The registration persists and is
+// reusable after the scope ends; only globalDeregister tears it down.
+TEST_F(RegCacheTest, ScopedRegisterSingleAcquireRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Allocator pre-caches the segment and eager-registers (scoped acquire
+  // requires the segment to be pre-cached).
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(static_cast<bool>(scopedRegHdl));
+    EXPECT_NE(scopedRegHdl.get(), nullptr);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release is a pure SW decrement: the registration and its segment
+  // remain live (the regcache baseline ref keeps them).
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // Only globalDeregister tears down the allocator-owned registration/segment.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Nested scoped acquires on the same buffer add refs (baseline 1 -> 2 -> 3);
+// releasing them decrements back toward the baseline. Dereg happens only via
+// globalDeregister, never through scope release.
+TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  auto outer = std::make_unique<ctran::ScopedRegHdl>();
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, *outer),
+      commSuccess);
+  auto* regElem = outer->get();
+  ASSERT_NE(regElem, nullptr);
+  // baseline 1 + outer = 2
+  EXPECT_EQ(regElem->refCount.load(), 2);
+
+  {
+    ctran::ScopedRegHdl inner;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, inner),
+        commSuccess);
+    // Both handles refer to the same reused registration; refcnt 1 + 2 = 3.
+    EXPECT_EQ(inner.get(), regElem);
+    EXPECT_EQ(regElem->refCount.load(), 3);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Inner released one ref (back to 2); registration stays live.
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Releasing the last scoped handle returns to the baseline (1); still live.
+  outer.reset();
+  EXPECT_EQ(regElem->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Only globalDeregister removes the baseline ref and tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Sequential acquire/release cycles each go baseline 1 -> 2 -> 1; the
+// registration persists across cycles and is torn down only by
+// globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSequentialAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  for (int i = 0; i < 2; i++) {
+    {
+      ctran::ScopedRegHdl scopedRegHdl;
+      EXPECT_EQ(
+          regCache->acquireScopedRegister(
+              buf, bufSize, cudaDev, backends, scopedRegHdl),
+          commSuccess);
+      auto* regElem = scopedRegHdl.get();
+      ASSERT_NE(regElem, nullptr);
+      EXPECT_EQ(regElem->refCount.load(), 2);
+      EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    }
+    // Scope released back to baseline; still registered and reusable.
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// After globalRegister(forceReg) + scoped acquire/release, BOTH the
+// registration and its segment are preserved (baseline ref keeps them).
+// globalDeregister then removes them.
+TEST_F(RegCacheTest, ScopedRegisterPreservesGlobalRegistration) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Global forceReg caches the segment and eager-registers the RegElem.
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release drops only the scope's ref; both the registration AND the
+  // segment remain (baseline ref).
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // globalDeregister force-frees the remaining allocator-owned state.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: scoped acquire on a buffer whose segment was NOT cached by the
+// allocator returns commInvalidUsage and leaves the ScopedRegHdl empty.
+TEST_F(RegCacheTest, ScopedRegisterUncachedSegmentReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  ctran::ScopedRegHdl scopedRegHdl;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, scopedRegHdl),
+      commInvalidUsage);
+
+  // The handle must stay empty since nothing was acquired.
+  EXPECT_FALSE(static_cast<bool>(scopedRegHdl));
+  EXPECT_EQ(scopedRegHdl.get(), nullptr);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: globalDeregister while a scoped registration is still alive
+// violates the lifetime contract. It emits a clear error and force-frees the
+// RegElem; the still-live ScopedRegHdl must then destruct without crashing (it
+// safely no-ops because its RegElem is already gone).
+TEST_F(RegCacheTest, GlobalDeregisterWhileScopedAliveReportsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+    // Force-free the buffer while the scoped handle is still alive (refcnt 2:
+    // baseline + scope). freeSegment removes the baseline ref, sees a remaining
+    // scoped owner, logs the contract-violation ERR, and tears down anyway
+    // because the memory is being freed.
+    EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+    EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regCache->getSegments().size(), 0);
+
+    // The scoped handle destructs here: its RegElem was already force-freed, so
+    // releaseScopedRegHdl safely no-ops with a WARN (no UAF/abort).
+  }
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Read-only search/get callsites (acquireRef=false, the default) do not take a
+// scoped ref, so they require no matching release.
+TEST_F(RegCacheTest, RegRangeCachedNoAcquireRefNeedsNoRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache and eagerly register with the default acquireRef=false path.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  // A borrowed lookup is read-only: freeSegment tears down without any scoped
+  // release, i.e. refcnt was never incremented.
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// When acquireScopedRegister is the FIRST to register a cached-but-unregistered
+// buffer, it creates the RegElem via the create path. The registration holds
+// the baseline ref (1) and the scope adds one, so refCount ends at 2. Releasing
+// the scope returns to 1 (still registered); only globalDeregister tears it
+// down.
+TEST_F(RegCacheTest, ScopedRegisterFirstAcquireCreatesRegElem) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment WITHOUT eager-registering, so no RegElem pre-exists.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    // Scoped acquire is the first to register: it creates the RegElem.
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    // Registration baseline 1 + scoped 1 = 2.
+    EXPECT_EQ(regElem->refCount.load(), 2);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scope release drops the scoped ref back to the baseline; still registered.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // globalDeregister removes the baseline ref and tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// ScopedRegHdl move construction transfers ownership without changing refCount
+// (no ref added or dropped). Move assignment releases the target's current ref
+// first, then takes over the source. Self-assignment is a no-op. A moved-from
+// handle is empty and destructs as a no-op.
+TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::ScopedRegHdl a;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, a),
+      commSuccess);
+  auto* regElem = a.get();
+  ASSERT_NE(regElem, nullptr);
+  EXPECT_EQ(regElem->refCount.load(), 2); // baseline + a
+
+  // Move construction: b takes a's ref, refcnt unchanged, a becomes empty.
+  ctran::ScopedRegHdl b(std::move(a));
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_FALSE(static_cast<bool>(a));
+  EXPECT_EQ(a.get(), nullptr);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Self-move-assignment is a no-op (guarded); ref unchanged.
+  ctran::ScopedRegHdl& bRef = b;
+  b = std::move(bRef);
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Acquire a second independent ref into c (refcnt 2 -> 3).
+  ctran::ScopedRegHdl c;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, c),
+      commSuccess);
+  EXPECT_EQ(regElem->refCount.load(), 3);
+
+  // Move-assign b into c: c releases its own ref first (3 -> 2), then takes b.
+  c = std::move(b);
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_FALSE(static_cast<bool>(b));
+  EXPECT_EQ(c.get(), regElem);
+
+  // c destructs at scope end (2 -> 1); a and b are empty no-ops.
+  {
+    ctran::ScopedRegHdl consume(std::move(c));
+    EXPECT_EQ(regElem->refCount.load(), 2);
+  }
+  EXPECT_EQ(regElem->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// deregRange(releaseRef=true) is the user-thread teardown primitive: it
+// decrements refCount and only tears the RegElem down when the count reaches 0.
+// With refCount above baseline it returns early (registration stays live); the
+// final call (baseline) proceeds to backend deregistration.
+TEST_F(RegCacheTest, DeregRangeReleaseRefDecrementsThenTearsDown) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Bump the scoped ref via acquireRef=true (baseline 1 -> 2).
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl,
+          true /* ncclManaged */,
+          true /* acquireRef */),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+  EXPECT_EQ(regHdl->refCount.load(), 2);
+
+  // First releaseRef decrement: refcnt 2 -> 1, returns early, still registered.
+  EXPECT_EQ(regCache->deregRange(regHdl, true /* releaseRef */), commSuccess);
+  EXPECT_EQ(regHdl->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Second releaseRef decrement drops the baseline (1 -> 0) and tears down.
+  EXPECT_EQ(regCache->deregRange(regHdl, true /* releaseRef */), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -938,6 +938,7 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCount) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   // Cleanup
   ctran::IpcRegCache::deregMem(ipcRegElem);
@@ -1357,6 +1358,7 @@ TEST_F(RegCacheTest, ImportMemWithExtraSegments) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   ctran::IpcRegCache::deregMem(ipcRegElem);
   COMMCHECK_TEST(ctran::commMemFreeDisjoint(buf, segSizes));
@@ -2077,6 +2079,366 @@ TEST_F(RegCacheTest, DeregRangeReleaseRefDecrementsThenTearsDown) {
   EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
 
   CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Refcounted import: importing the same descriptor twice bumps the single
+// entry's refCount to 2; the first release keeps it live (getNumRemReg stays
+// 1); the second release drops it to 0, moving the elem out of the live map.
+// An explicit cleanupInvalidImports() then performs the CUDA unmap.
+TEST_F(RegCacheTest, IpcRemRegImmediateRelease) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_immediate_release_peer";
+
+  // Import twice: single map entry, refCount 2.
+  void* importedBuf1 = nullptr;
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_EQ(importedBuf1, importedBuf2);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // First release: refCount 2 -> 1, entry stays live.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Second release: refCount 1 -> 0, elem moved out of the live map. The
+  // deferred CUDA unmap is drained by the explicit cleanupInvalidImports().
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// Releasing to rc 0 removes the elem from the live map (getNumRemReg == 0) but
+// does not unmap yet (release is always deferred). A fresh importMem of the
+// same descriptor cannot resurrect the dead elem and instead creates a new live
+// mapping. cleanupInvalidImports() is safe to call afterwards.
+TEST_F(RegCacheTest, IpcRemRegDeferredReleaseNoResurrect) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_deferred_release_peer";
+
+  void* importedBuf1 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Deferred release to rc 0: leaves the live map but is not yet unmapped.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  // A fresh import of the same descriptor must create a NEW live entry rather
+  // than resurrecting the deferred-dead one. importMem also drains the pending
+  // unmap via cleanupInvalidImports().
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_NE(importedBuf2, nullptr);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Release the fresh entry and drain.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// ScopedIpcRegHdl adopts an existing import ref identified by an NVL
+// remote-access key via makeScopedIpcRegHdl. Adoption neither adds nor drops a
+// ref, so the live entry is unchanged while the handle is held. When the handle
+// leaves scope its deferred release drives refCount to 0, removing the entry
+// from the live map (getNumRemReg == 0); the actual unmap is drained later by
+// cleanupInvalidImports().
+TEST_F(RegCacheTest, ScopedIpcRegHdlAdoptViaConvertHelper) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_scoped_convert_peer";
+
+  void* importedBuf = nullptr;
+  ctran::regcache::IpcRemHandle remKey;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf, &remKey),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  {
+    // Adopt the existing ref: no ref is added or dropped by adoption.
+    auto scoped = ipcRegCache->makeScopedIpcRegHdl(remKey);
+    EXPECT_TRUE(static_cast<bool>(scoped));
+    EXPECT_EQ(scoped.get(), ipcRegCache.get());
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+  }
+
+  // Scope exit performed a deferred release to refCount 0: the entry is gone
+  // from the live map but the mapping is still parked in invalidImports_.
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  // Drain the deferred unmap on this user thread.
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// ScopedIpcRegHdl performs a deferred release on destruction: the entry leaves
+// the live map (getNumRemReg == 0) without unmapping, and a subsequent
+// cleanupInvalidImports() unmaps it and is idempotent.
+TEST_F(RegCacheTest, ScopedIpcRegHdlDeferredReleaseThenCleanup) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_scoped_deferred_peer";
+
+  void* importedBuf = nullptr;
+  ctran::regcache::IpcRemHandle remKey;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf, &remKey),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  {
+    auto scoped = ipcRegCache->makeScopedIpcRegHdl(remKey);
+    EXPECT_TRUE(static_cast<bool>(scoped));
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+  }
+
+  // Deferred release moved the elem out of the live map without unmapping.
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  // cleanupInvalidImports() drains the parked import; a second call is a safe
+  // no-op.
+  ipcRegCache->cleanupInvalidImports();
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// Moving a ScopedIpcRegHdl transfers ownership: the moved-from handle becomes
+// empty and its destructor is a no-op, so exactly ONE deferred release happens
+// when the destination handle leaves scope.
+TEST_F(RegCacheTest, ScopedIpcRegHdlMoveTransfersOwnership) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_scoped_move_peer";
+
+  void* importedBuf = nullptr;
+  ctran::regcache::IpcRemHandle remKey;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf, &remKey),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  {
+    auto scoped1 = ipcRegCache->makeScopedIpcRegHdl(remKey);
+    auto scoped2 = std::move(scoped1);
+
+    // Ownership transferred: source is empty (no-op destructor), dest is live.
+    EXPECT_FALSE(static_cast<bool>(scoped1));
+    EXPECT_TRUE(static_cast<bool>(scoped2));
+
+    // Move alone released nothing.
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+  }
+
+  // Exactly one deferred release fired (from scoped2); the moved-from scoped1
+  // did not double-release.
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// Two ScopedIpcRegHdl owners each adopt one of two refs on a single live entry
+// (imported twice, refCount 2). Destroying the first drops refCount 2 -> 1 and
+// keeps the entry live; destroying the second drops 1 -> 0 and retires it.
+TEST_F(RegCacheTest, ScopedIpcRegHdlTwoOwnerRefcount) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_scoped_two_owner_peer";
+
+  // Import twice: single live entry with refCount 2.
+  void* importedBuf1 = nullptr;
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  {
+    auto scopedOuter = ipcRegCache->makeScopedIpcRegHdl(remKey1);
+    {
+      auto scopedInner = ipcRegCache->makeScopedIpcRegHdl(remKey2);
+      EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+    }
+
+    // Inner drop: refCount 2 -> 1, entry stays live.
+    EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+  }
+
+  // Outer drop: refCount 1 -> 0, entry retired from the live map.
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// cleanupInvalidImports() on an empty invalidImports_ list is safe and
+// idempotent.
+TEST_F(RegCacheTest, IpcCleanupEmptyIsIdempotent) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  ipcRegCache->cleanupInvalidImports();
+  ipcRegCache->cleanupInvalidImports();
 }
 
 int main(int argc, char* argv[]) {

--- a/comms/ctran/utils/CtranAvlTree.cc
+++ b/comms/ctran/utils/CtranAvlTree.cc
@@ -55,9 +55,14 @@ commResult_t CtranAvlTree::remove(void* hdl) {
     return commInvalidUsage;
   }
 
-  // First try to remove from AVL tree
+  // First try to remove from AVL tree. Guard against a null root_: the tree may
+  // be empty while the element still lives in the fallback list_ (e.g. the only
+  // tree node was removed first). In that case removed stays false and control
+  // falls through to the list removal path below.
   bool removed = false;
-  this->root_ = this->root_->remove(e, &removed);
+  if (this->root_ != nullptr) {
+    this->root_ = this->root_->remove(e, &removed);
+  }
   if (removed) {
     delete e;
   } else {

--- a/comms/ctran/utils/tests/AvlTreeUT.cc
+++ b/comms/ctran/utils/tests/AvlTreeUT.cc
@@ -558,3 +558,54 @@ TEST_F(CtranUtilsAvlTreeTest, SearchRangeLeftSubtreePruning) {
   tree->remove(hdl2);
   tree->remove(hdl3);
 }
+
+// Regression test: when the only tree node is removed first, root_ becomes null
+// while an overlapping element still lives in the fallback list_. A subsequent
+// remove() of that list element must not dereference the null root_.
+// Range A goes into the AVL tree as the first/only node; range B overlaps A and
+// falls back to list_.
+TEST_F(CtranUtilsAvlTreeTest, RemoveTreeNodeBeforeOverlappingListNode) {
+  const uintptr_t base = 0x100000;
+  void* const valA = reinterpret_cast<void*>(0xA);
+  void* const valB = reinterpret_cast<void*>(0xB);
+
+  // Tree-then-list removal order
+  {
+    auto tree = std::make_unique<CtranAvlTree>();
+
+    void* const hdlA =
+        tree->insert(reinterpret_cast<void*>(base + 0x1000), 0x1000, valA);
+    void* const hdlB =
+        tree->insert(reinterpret_cast<void*>(base), 0x4000, valB);
+    ASSERT_NE(hdlA, nullptr);
+    ASSERT_NE(hdlB, nullptr);
+    ASSERT_EQ(tree->size(), 2);
+
+    // Remove the tree node first, emptying the internal AVL tree (root_ null)
+    ASSERT_EQ(tree->remove(hdlA), commSuccess);
+    ASSERT_EQ(tree->size(), 1);
+
+    // Remove the list node with a null root_; must not crash
+    ASSERT_EQ(tree->remove(hdlB), commSuccess);
+    ASSERT_EQ(tree->size(), 0);
+  }
+
+  // Reverse order: list-then-tree removal
+  {
+    auto tree = std::make_unique<CtranAvlTree>();
+
+    void* const hdlA =
+        tree->insert(reinterpret_cast<void*>(base + 0x1000), 0x1000, valA);
+    void* const hdlB =
+        tree->insert(reinterpret_cast<void*>(base), 0x4000, valB);
+    ASSERT_NE(hdlA, nullptr);
+    ASSERT_NE(hdlB, nullptr);
+    ASSERT_EQ(tree->size(), 2);
+
+    ASSERT_EQ(tree->remove(hdlB), commSuccess);
+    ASSERT_EQ(tree->size(), 1);
+
+    ASSERT_EQ(tree->remove(hdlA), commSuccess);
+    ASSERT_EQ(tree->size(), 0);
+  }
+}

--- a/comms/ctran/window/tests/CtranWinTests.cc
+++ b/comms/ctran/window/tests/CtranWinTests.cc
@@ -777,6 +777,68 @@ TEST_F(CtranWinTest, multiSegmentWindowRegister) {
   COMMCHECK_TEST(commMemFreeDisjoint(disjointBuf, segSizes));
 }
 
+TEST_F(CtranWinTest, RegisterOverRangeUserBufferNoLeak) {
+  // Reproduces a leak in ctranWinRegister: it constructs the CtranWin with a
+  // raw `new`, then FB_COMMCHECK(exchange()). If exchange() fails, the early
+  // return never deletes the window nor calls free(), so the window and any
+  // resources it already acquired leak. In particular exchange() first
+  // registers the internal signal buffer via regMem (caching one RegCache
+  // segment) and only afterwards registers the user data buffer; a failure in
+  // that later step leaks the already-cached signal-buffer segment.
+  //
+  // Trigger: register a genuine cumem device buffer with a size far larger
+  // than its actual mapped allocation. The user-buffer registration walks the
+  // range past the mapped VA (cuMemGetAddressRange) and returns an error,
+  // after the signal-buffer segment has already been cached. The buffer must
+  // be a real cumem allocation so getDevMemType returns kCumem and the range
+  // discovery takes the cumem path; a cudaMalloc/host over-range buffer does
+  // not reliably error there.
+  //
+  // With the RAII guard fix, the failed register frees the window (and its
+  // signal-buffer segment), so getSegments() returns to baseline.
+  if (!ncclIsCuMemSupported()) {
+    GTEST_SKIP() << "CuMem not supported, skip over-range user buffer test";
+  }
+
+  auto comm = makeCtranComm();
+  ASSERT_NE(comm, nullptr);
+
+  // Allocate a modest, real cumem device buffer. The registration below passes
+  // a size far beyond this, so pinRange walks past the mapped VA and errors.
+  const size_t allocBytes = 2 * 1024 * 1024; // 2MB
+  const MemAllocType bufType = MemAllocType::kMemCuMemAlloc;
+  void* cumemBuf = commMemAlloc(allocBytes, bufType, segments);
+  ASSERT_NE(cumemBuf, nullptr);
+
+  // Register with a size 1GB beyond the 2MB mapped allocation. This is safely
+  // past the cumem granularity-rounded mapped range, guaranteeing over-range.
+  const size_t oversizedBytes = allocBytes + (1UL << 30);
+
+  auto regCache = ctran::RegCache::getInstance();
+  const size_t segsBefore = regCache->getSegments().size();
+
+  CtranWin* win = nullptr;
+  meta::comms::Hints hints;
+  const auto res =
+      ctranWinRegister(cumemBuf, oversizedBytes, comm.get(), &win, hints);
+  EXPECT_NE(res, commSuccess);
+  EXPECT_EQ(win, nullptr);
+
+  EXPECT_EQ(regCache->getSegments().size(), segsBefore)
+      << "ctranWinRegister leaked a RegCache segment on exchange() failure";
+
+  // Free the ACTUAL allocated buffer (allocBytes, not the oversized size).
+  commMemFree(cumemBuf, allocBytes, bufType);
+  segments.erase(
+      std::remove_if(
+          segments.begin(),
+          segments.end(),
+          [cumemBuf](const TestMemSegment& seg) {
+            return seg.ptr == cumemBuf;
+          }),
+      segments.end());
+}
+
 INSTANTIATE_TEST_SUITE_P(
     CtranWinInstance,
     CtranWinTestParam,

--- a/comms/ctran/window/window.cc
+++ b/comms/ctran/window/window.cc
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <folly/ScopeGuard.h>
 #include <memory>
 #include <numeric>
 
@@ -545,6 +546,12 @@ commResult_t ctranWinAllocate(
       comm,
       size,
       locationRes == "cpu" ? DevMemType::kHostPinned : DevMemType::kCumem);
+  auto winGuard = folly::makeGuard([&newWin]() {
+    // On any early error return, release partial resources (SW + backend
+    // dereg, no barrier) and delete the window so it does not leak.
+    (void)newWin->free(/*skipBarrier=*/true);
+    delete newWin;
+  });
   newWin->setAtomicCapable(true);
   FB_COMMCHECK(newWin->allocate(nullptr));
   FB_COMMCHECK(newWin->exchange());
@@ -552,6 +559,7 @@ commResult_t ctranWinAllocate(
     *baseptr = newWin->winDataPtr;
   }
   *win = newWin;
+  winGuard.dismiss();
   return commSuccess;
 }
 
@@ -598,6 +606,12 @@ commResult_t ctranWinRegister(
       // if user buffer is on host CPU, allocate kHostPinned buffer for
       // signal otherwise is on GPU device, allocate kCumem buffer for signal
       userBufType);
+  auto winGuard = folly::makeGuard([&newWin]() {
+    // On any early error return, release partial resources (SW + backend
+    // dereg, no barrier) and delete the window so it does not leak.
+    (void)newWin->free(/*skipBarrier=*/true);
+    delete newWin;
+  });
   newWin->setAtomicCapable(
       reinterpret_cast<uintptr_t>(databuf) % sizeof(uint64_t) == 0 &&
       size % sizeof(uint64_t) == 0);
@@ -607,6 +621,7 @@ commResult_t ctranWinRegister(
   FB_COMMCHECK(newWin->exchange()); // register and exchange both signal
                                     // & data buffer
   *win = newWin;
+  winGuard.dismiss();
   return commSuccess;
 }
 


### PR DESCRIPTION
Summary: Add a `bool recordExport = true` parameter to the allgather control-exchange path (`intraAllGatherCtrl` / `allGatherCtrl` -> `allGatherCtrlImpl` -> `exportMem`). When `recordExport == false`, the local export is not recorded in `exportRegCache_`, so the exporter's `commDeregister` never sends an export-notify (`remReleaseMem` -> `notifyRemoteIpcRelease`) for it. This lets a caller that self-manages its NVL IPC imports (releasing them explicitly on the import rank via `releaseRemReg`) opt out of the export-notify, avoiding a double release of the same import (one from the explicit release, one from the exporter notification). The default `recordExport = true` preserves the existing export-notify behavior for all other callers. The import side is unchanged: `IpcRegCache::importMem` fills `remoteBufs`/`remoteAccessKeys` as before.

Differential Revision: D110829238


