### PR TITLE
Batch sendrecv reuse credits (#3068)

### DIFF
--- a/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
+++ b/comms/prims/benchmarks/IbgdaSendRecvBenchmark.cc
@@ -116,7 +116,27 @@ struct BenchmarkSize {
   std::size_t nbytes;
 };
 
-constexpr std::array<BenchmarkSize, 13> kBenchmarkSizes{{
+constexpr std::array<BenchmarkSize, 33> kBenchmarkSizes{{
+    {"1B", 1ULL},
+    {"2B", 2ULL},
+    {"4B", 4ULL},
+    {"8B", 8ULL},
+    {"16B", 16ULL},
+    {"32B", 32ULL},
+    {"64B", 64ULL},
+    {"128B", 128ULL},
+    {"256B", 256ULL},
+    {"512B", 512ULL},
+    {"1KB", 1ULL << 10},
+    {"2KB", 2ULL << 10},
+    {"4KB", 4ULL << 10},
+    {"8KB", 8ULL << 10},
+    {"16KB", 16ULL << 10},
+    {"32KB", 32ULL << 10},
+    {"64KB", 64ULL << 10},
+    {"128KB", 128ULL << 10},
+    {"256KB", 256ULL << 10},
+    {"512KB", 512ULL << 10},
     {"1MB", 1ULL << 20},
     {"2MB", 2ULL << 20},
     {"4MB", 4ULL << 20},

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cc
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cc
@@ -1530,6 +1530,184 @@ TEST_F(
   }
 }
 
+TEST_F(MultipeerIbgdaTransportTestFixture, SendRecvReuseCreditCadence) {
+  if (numRanks != 2) {
+    GTEST_SKIP() << "Skipping test: requires exactly 2 ranks, got " << numRanks;
+  }
+  if (!test::supportsProgressSendRecv()) {
+    GTEST_SKIP() << "progress send/recv is not supported for this build";
+  }
+
+  constexpr std::size_t dataBufferSize = 64 * 1024;
+  constexpr int pipelineDepth = 2;
+  constexpr std::size_t protocolBytes = 16;
+  constexpr int numBlocks = 1;
+  constexpr std::size_t perBlockSlot = dataBufferSize / numBlocks;
+  constexpr std::size_t nicDoneCreditQuantum =
+      detail::ib_send_recv_nic_done_credit_quantum(perBlockSlot, pipelineDepth);
+  constexpr std::size_t slotFreeCreditQuantum =
+      detail::ib_send_recv_slot_free_credit_quantum(
+          perBlockSlot, pipelineDepth);
+  static_assert(nicDoneCreditQuantum == slotFreeCreditQuantum);
+  constexpr std::size_t testCreditQuantum = nicDoneCreditQuantum;
+  static_assert(testCreditQuantum % protocolBytes == 0);
+  constexpr std::size_t largeBytes = testCreditQuantum * 2;
+  static_assert(largeBytes <= perBlockSlot);
+  constexpr std::size_t largeNonQuantumBytes = perBlockSlot - protocolBytes;
+  static_assert(largeNonQuantumBytes % protocolBytes == 0);
+  static_assert(largeNonQuantumBytes % testCreditQuantum != 0);
+
+  constexpr int blockSize = 128;
+  constexpr int iterationsBeforeCredit =
+      static_cast<int>(testCreditQuantum / protocolBytes) - 1;
+  constexpr int iterationsAtCredit =
+      static_cast<int>(testCreditQuantum / protocolBytes);
+  constexpr uint8_t testPattern = 0x7B;
+  const int peerRank = (globalRank == 0) ? 1 : 0;
+
+  struct ReuseCreditCase {
+    const char* name;
+    std::size_t nbytes;
+    int iterations;
+    uint64_t expectedNicDoneCredit;
+    uint64_t expectedSlotFreeCredit;
+    uint64_t expectedDataReady;
+  };
+
+  const std::array<ReuseCreditCase, 4> cases{{
+      {
+          "tiny_before_quantum",
+          1,
+          iterationsBeforeCredit,
+          0,
+          0,
+          static_cast<uint64_t>(iterationsBeforeCredit) * protocolBytes,
+      },
+      {
+          "tiny_at_quantum",
+          1,
+          iterationsAtCredit,
+          nicDoneCreditQuantum,
+          slotFreeCreditQuantum,
+          testCreditQuantum,
+      },
+      {
+          "large_quantum_aligned",
+          largeBytes,
+          1,
+          largeBytes,
+          largeBytes,
+          largeBytes,
+      },
+      {
+          "large_non_quantum_single_chunk",
+          largeNonQuantumBytes,
+          1,
+          largeNonQuantumBytes,
+          largeNonQuantumBytes,
+          largeNonQuantumBytes,
+      },
+  }};
+
+  auto runCase = [&](const ReuseCreditCase& testCase, bool useProgress) {
+    SCOPED_TRACE(
+        ::testing::Message()
+        << testCase.name << (useProgress ? " progress" : " blocking"));
+    MultipeerIbgdaTransportConfig config{
+        .cudaDevice = localRank,
+        .dataBufferSize = dataBufferSize,
+        .sendRecv =
+            MultipeerIbgdaTransportConfig::SendRecvConfig{
+                .maxGroups = numBlocks,
+                .pipelineDepth = pipelineDepth,
+            },
+    };
+
+    auto bootstrap = std::make_shared<meta::comms::MpiBootstrap>();
+    auto transport = std::make_unique<MultipeerIbgdaTransport>(
+        globalRank, numRanks, bootstrap, config);
+    transport->exchange();
+
+    P2pIbgdaTransportDevice* peerTransportPtr =
+        transport->getP2pTransportDevice(peerRank);
+    DeviceBuffer buffer(testCase.nbytes);
+    DeviceBuffer outputBuffer(3 * sizeof(uint64_t));
+    auto* d_output = static_cast<uint64_t*>(outputBuffer.get());
+    CUDACHECK_TEST(cudaMemset(d_output, 0, 3 * sizeof(uint64_t)));
+
+    const bool isSender = globalRank == 0;
+    if (isSender) {
+      test::fillBufferWithPattern(
+          buffer.get(), testCase.nbytes, testPattern, numBlocks, blockSize);
+    } else {
+      CUDACHECK_TEST(cudaMemset(buffer.get(), 0, testCase.nbytes));
+    }
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    test::testSendRecvReuseCredits(
+        peerTransportPtr,
+        buffer.get(),
+        testCase.nbytes,
+        numBlocks,
+        testCase.iterations,
+        isSender,
+        useProgress,
+        testCase.expectedNicDoneCredit,
+        testCase.expectedSlotFreeCredit,
+        d_output,
+        numBlocks,
+        blockSize);
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+
+    std::array<uint64_t, 3> output{};
+    CUDACHECK_TEST(cudaMemcpy(
+        output.data(),
+        d_output,
+        output.size() * sizeof(uint64_t),
+        cudaMemcpyDeviceToHost));
+
+    if (isSender) {
+      EXPECT_EQ(output[0], testCase.expectedNicDoneCredit)
+          << "NIC_DONE credit mismatch";
+      EXPECT_EQ(output[2], testCase.expectedSlotFreeCredit)
+          << "SLOT_FREE credit mismatch";
+    } else {
+      EXPECT_EQ(output[1], testCase.expectedDataReady)
+          << "DATA_READY credit mismatch";
+
+      DeviceBuffer errorCountBuf(sizeof(int));
+      auto* d_errorCount = static_cast<int*>(errorCountBuf.get());
+      CUDACHECK_TEST(cudaMemset(d_errorCount, 0, sizeof(int)));
+      test::verifyBufferPattern(
+          buffer.get(),
+          testCase.nbytes,
+          testPattern,
+          d_errorCount,
+          numBlocks,
+          blockSize);
+      CUDACHECK_TEST(cudaDeviceSynchronize());
+
+      int h_errorCount = 0;
+      CUDACHECK_TEST(cudaMemcpy(
+          &h_errorCount, d_errorCount, sizeof(int), cudaMemcpyDeviceToHost));
+      EXPECT_EQ(h_errorCount, 0)
+          << "tiny progress send/recv transfer corrupted";
+    }
+    MPI_CHECK(MPI_Barrier(MPI_COMM_WORLD));
+  };
+
+  try {
+    for (const auto& testCase : cases) {
+      runCase(testCase, /*useProgress=*/false);
+      runCase(testCase, /*useProgress=*/true);
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
 // =============================================================================
 // Reset Signal Test - Tests resetting signals for reuse
 // =============================================================================

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cu
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cu
@@ -402,6 +402,73 @@ __global__ void progressReservationKernel(
         sendRecvState.state[sendRecvState.maxGroups + group.group_id].nextStep;
   }
 }
+
+__global__ void sendRecvReuseCreditKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    int iterations,
+    bool send,
+    bool useProgress,
+    uint64_t waitExpectedNicDoneCredit,
+    uint64_t waitExpectedSlotFreeCredit,
+    uint64_t* output) {
+  auto group = make_block_group();
+  Timeout timeout(kDefaultDeviceTimeoutCycles);
+  timeout.start();
+
+  for (int i = 0; i < iterations; ++i) {
+    if (useProgress) {
+      if (send) {
+        transport->init_send_progress(group, nbytes, activeBlocks);
+        while (transport->progress_send_once(
+                   group, buffer, nbytes, activeBlocks, 0, timeout) !=
+               IbgdaSendRecvProgressStatus::Done) {
+        }
+      } else {
+        transport->init_recv_progress(group, nbytes, activeBlocks);
+        while (transport->progress_recv_once(
+                   group, buffer, nbytes, activeBlocks, 0, timeout) !=
+               IbgdaSendRecvProgressStatus::Done) {
+        }
+      }
+    } else {
+      if (send) {
+        transport->send(group, buffer, nbytes, activeBlocks, 0, timeout);
+      } else {
+        transport->recv(group, buffer, nbytes, activeBlocks, 0, timeout);
+      }
+    }
+  }
+
+  const auto& state = transport->send_recv_state();
+  const auto groupId = static_cast<int>(group.group_id);
+  if (send && waitExpectedNicDoneCredit != 0) {
+    transport->wait_counter(
+        group,
+        state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)),
+        waitExpectedNicDoneCredit,
+        timeout);
+  }
+  if (send && waitExpectedSlotFreeCredit != 0) {
+    transport->wait_signal(
+        group,
+        state.localSignalBuf.subBuffer(
+            (state.maxGroups + groupId) * sizeof(uint64_t)),
+        waitExpectedSlotFreeCredit,
+        timeout);
+  }
+
+  if (group.is_leader()) {
+    output[0] = transport->read_counter(
+        state.localCounterBuf.subBuffer(groupId * sizeof(uint64_t)));
+    output[1] = transport->read_signal(
+        state.localSignalBuf.subBuffer(groupId * sizeof(uint64_t)));
+    output[2] = transport->read_signal(state.localSignalBuf.subBuffer(
+        (state.maxGroups + groupId) * sizeof(uint64_t)));
+  }
+}
 #endif
 
 void testProgressSendRecv(
@@ -426,6 +493,55 @@ void testProgressSendRecv(
 #else
   progressSendRecvKernel<<<numBlocks, blockSize>>>(
       transport, buffer, nbytes, activeBlocks, maxSignalBytes, send);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("Kernel launch failed: ") + cudaGetErrorString(err));
+  }
+  // The caller synchronizes immediately after this helper so runtime kernel
+  // failures are reported through the test's CUDA check rather than as skips.
+#endif
+}
+
+void testSendRecvReuseCredits(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    int iterations,
+    bool send,
+    bool useProgress,
+    uint64_t waitExpectedNicDoneCredit,
+    uint64_t waitExpectedSlotFreeCredit,
+    uint64_t* output,
+    int numBlocks,
+    int blockSize) {
+#ifdef __HIP_PLATFORM_AMD__
+  (void)transport;
+  (void)buffer;
+  (void)nbytes;
+  (void)activeBlocks;
+  (void)iterations;
+  (void)send;
+  (void)useProgress;
+  (void)waitExpectedNicDoneCredit;
+  (void)waitExpectedSlotFreeCredit;
+  (void)output;
+  (void)numBlocks;
+  (void)blockSize;
+  throw std::runtime_error("progress send/recv is NVIDIA-only");
+#else
+  sendRecvReuseCreditKernel<<<numBlocks, blockSize>>>(
+      transport,
+      buffer,
+      nbytes,
+      activeBlocks,
+      iterations,
+      send,
+      useProgress,
+      waitExpectedNicDoneCredit,
+      waitExpectedSlotFreeCredit,
+      output);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     throw std::runtime_error(

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.cuh
@@ -94,6 +94,18 @@ __global__ void progressReservationKernel(
     std::size_t sendBytes,
     std::size_t recvBytes,
     int activeBlocks);
+
+__global__ void sendRecvReuseCreditKernel(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    int iterations,
+    bool send,
+    bool useProgress,
+    uint64_t waitExpectedNicDoneCredit,
+    uint64_t waitExpectedSlotFreeCredit,
+    uint64_t* output);
 #endif
 
 __global__ void

--- a/comms/prims/tests/MultipeerIbgdaTransportTest.h
+++ b/comms/prims/tests/MultipeerIbgdaTransportTest.h
@@ -162,6 +162,24 @@ void testProgressReservations(
     int blockSize);
 
 /**
+ * Test kernel: run repeated blocking or progress send/recv calls and snapshot
+ * sendrecv protocol counters.
+ */
+void testSendRecvReuseCredits(
+    P2pIbgdaTransportDevice* transport,
+    void* buffer,
+    std::size_t nbytes,
+    int activeBlocks,
+    int iterations,
+    bool send,
+    bool useProgress,
+    uint64_t waitExpectedNicDoneCredit,
+    uint64_t waitExpectedSlotFreeCredit,
+    uint64_t* output,
+    int numBlocks,
+    int blockSize);
+
+/**
  * Fill a device buffer with a pattern based on index
  */
 void fillBufferWithPattern(

--- a/comms/prims/tests/RecvForwardChainTest.cc
+++ b/comms/prims/tests/RecvForwardChainTest.cc
@@ -6,6 +6,7 @@
 #include <folly/init/Init.h>
 #include <folly/logging/xlog.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -349,6 +350,99 @@ TEST_F(RecvForwardChainTest, MultiSection) {
       }
       EXPECT_EQ(errors, 0) << "Rank " << globalRank << ": " << errors
                            << " byte mismatches in multi-section transfer";
+    }
+  } catch (const std::exception& e) {
+    GTEST_SKIP() << "IBGDA transport not available: " << e.what();
+  }
+}
+
+TEST_F(RecvForwardChainTest, ForwardAdvancesReuseCreditStep) {
+  if (worldSize < 3) {
+    XLOGF(
+        INFO, "Skipping: requires >= 3 ranks for a send->forward->recv chain");
+    return;
+  }
+
+  constexpr int kNumBlocks = 1;
+  constexpr std::size_t kSlotSize = 512 * 1024;
+  constexpr std::size_t kProtocolBytes = 16;
+
+  struct ForwardCreditCase {
+    const char* name;
+    std::size_t nbytes;
+  };
+
+  const std::array<ForwardCreditCase, 3> cases{{
+      {"tiny", 1},
+      {"large", kSlotSize},
+      {"large_non_quantum", kSlotSize + kProtocolBytes},
+  }};
+
+  auto runCase = [&](const ForwardCreditCase& testCase) {
+    SCOPED_TRACE(testCase.name);
+
+    auto transport = create_transport(kSlotSize, kNumBlocks);
+
+    DeviceBuffer sendBuf(testCase.nbytes);
+    DeviceBuffer recvBuf(testCase.nbytes);
+    CUDACHECK_TEST(cudaMemset(sendBuf.get(), 0x3C, testCase.nbytes));
+    CUDACHECK_TEST(cudaMemset(recvBuf.get(), 0, testCase.nbytes));
+
+    DeviceBuffer outBuf(4 * sizeof(int64_t));
+    CUDACHECK_TEST(cudaMemset(outBuf.get(), 0, 4 * sizeof(int64_t)));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    std::vector<P2pIbgdaTransportDevice*> peerTransports(worldSize, nullptr);
+    for (int rank = 0; rank < worldSize; ++rank) {
+      if (rank != globalRank) {
+        peerTransports[rank] = transport->getP2pTransportDevice(rank);
+      }
+    }
+    DeviceBuffer dTransports(worldSize * sizeof(P2pIbgdaTransportDevice*));
+    CUDACHECK_TEST(cudaMemcpy(
+        dTransports.get(),
+        peerTransports.data(),
+        worldSize * sizeof(P2pIbgdaTransportDevice*),
+        cudaMemcpyHostToDevice));
+
+    bootstrap->barrierAll();
+
+    test::launch_recv_forward_reuse_credit_step(
+        static_cast<P2pIbgdaTransportDevice**>(dTransports.get()),
+        static_cast<const char*>(sendBuf.get()),
+        static_cast<char*>(recvBuf.get()),
+        testCase.nbytes,
+        globalRank,
+        worldSize,
+        kNumBlocks,
+        static_cast<int64_t*>(outBuf.get()),
+        stream_);
+
+    cudaError_t err = cudaStreamSynchronize(stream_);
+    ASSERT_EQ(err, cudaSuccess) << "Kernel failed: " << cudaGetErrorString(err);
+
+    bootstrap->barrierAll();
+
+    if (globalRank != 0 && globalRank != worldSize - 1) {
+      std::array<int64_t, 4> out{};
+      CUDACHECK_TEST(cudaMemcpy(
+          out.data(),
+          outBuf.get(),
+          4 * sizeof(int64_t),
+          cudaMemcpyDeviceToHost));
+
+      EXPECT_GT(out[1], 0) << "recv-slot nextStep should be > 0";
+      EXPECT_GT(out[3], 0) << "fwd-slot nextStep should be > 0";
+      EXPECT_EQ(out[0], out[1]) << "recv-slot reuseCreditStep (" << out[0]
+                                << ") != nextStep (" << out[1] << ")";
+      EXPECT_EQ(out[2], out[3]) << "fwd-slot reuseCreditStep (" << out[2]
+                                << ") != nextStep (" << out[3] << ")";
+    }
+  };
+
+  try {
+    for (const auto& testCase : cases) {
+      runCase(testCase);
     }
   } catch (const std::exception& e) {
     GTEST_SKIP() << "IBGDA transport not available: " << e.what();

--- a/comms/prims/tests/RecvForwardChainTest.cu
+++ b/comms/prims/tests/RecvForwardChainTest.cu
@@ -2,6 +2,8 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdint>
+
 #include "comms/prims/core/CopyOp.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/transport/ibgda/P2pIbgdaTransportDevice.cuh"
@@ -16,7 +18,8 @@ __global__ void recv_forward_chain_kernel(
     std::size_t nbytes,
     int my_rank,
     int world_size,
-    bool use_dst) {
+    bool use_dst,
+    int64_t* out) {
   auto group = make_block_group();
   const auto num_blocks = gridDim.x;
 
@@ -41,6 +44,15 @@ __global__ void recv_forward_chain_kernel(
     P2pIbgdaTransportDevice& next = *transports[next_rank];
     char* dst = use_dst ? (recv_buf + my_off) : nullptr;
     prev.forward(group, dst, next, my_bytes, num_blocks);
+    if (out != nullptr && group.is_leader()) {
+      const auto& prevState = prev.send_recv_state();
+      const auto& nextState = next.send_recv_state();
+      out[0] =
+          prevState.state[prevState.maxGroups + group.group_id].reuseCreditStep;
+      out[1] = prevState.state[prevState.maxGroups + group.group_id].nextStep;
+      out[2] = nextState.state[group.group_id].reuseCreditStep;
+      out[3] = nextState.state[group.group_id].nextStep;
+    }
   }
 }
 
@@ -60,7 +72,8 @@ void launch_recv_forward_chain(
       nbytes,
       my_rank,
       world_size,
-      /*use_dst=*/true);
+      /*use_dst=*/true,
+      /*out=*/nullptr);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
@@ -85,11 +98,39 @@ void launch_recv_forward_chain_no_dst(
       nbytes,
       my_rank,
       world_size,
-      /*use_dst=*/false);
+      /*use_dst=*/false,
+      /*out=*/nullptr);
   cudaError_t err = cudaGetLastError();
   if (err != cudaSuccess) {
     printf(
         "recv_forward_chain_no_dst kernel launch failed: %s\n",
+        cudaGetErrorString(err));
+  }
+}
+
+void launch_recv_forward_reuse_credit_step(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    int64_t* out,
+    cudaStream_t stream) {
+  recv_forward_chain_kernel<<<num_blocks, 128, 0, stream>>>(
+      transports,
+      send_buf,
+      recv_buf,
+      nbytes,
+      my_rank,
+      world_size,
+      /*use_dst=*/false,
+      out);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf(
+        "recv_forward_reuse_credit_step kernel launch failed: %s\n",
         cudaGetErrorString(err));
   }
 }

--- a/comms/prims/tests/RecvForwardChainTest.h
+++ b/comms/prims/tests/RecvForwardChainTest.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace comms::prims {
 class P2pIbgdaTransportDevice;
@@ -47,6 +48,23 @@ void launch_recv_forward_chain_no_dst(
     int my_rank,
     int world_size,
     int num_blocks,
+    cudaStream_t stream);
+
+/**
+ * Forward-only chain launch that records each intermediate rank's
+ * post-forward() reuse-credit cursors. The group leader writes four int64_t
+ * values into out: recv-slot reuseCreditStep, recv-slot nextStep, fwd-slot
+ * reuseCreditStep, fwd-slot nextStep.
+ */
+void launch_recv_forward_reuse_credit_step(
+    P2pIbgdaTransportDevice** transports,
+    const char* send_buf,
+    char* recv_buf,
+    std::size_t nbytes,
+    int my_rank,
+    int world_size,
+    int num_blocks,
+    int64_t* out,
     cudaStream_t stream);
 
 } // namespace comms::prims::test

--- a/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
+++ b/comms/prims/transport/P2pIbTransportDeviceDecl.cuh
@@ -44,6 +44,36 @@ enum class IbgdaSendRecvProgressStatus : uint8_t {
   Done,
 };
 
+namespace detail {
+__host__ __device__ constexpr std::size_t ib_send_recv_credit_quantum(
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  const std::size_t pipelineBytes =
+      perBlockSlot * static_cast<std::size_t>(pipelineDepth);
+  std::size_t quantum = pipelineBytes / 4;
+  if (quantum < 16ULL) {
+    quantum = 16ULL;
+  }
+  if (quantum > perBlockSlot) {
+    quantum = perBlockSlot;
+  }
+  quantum &= ~15ULL;
+  return quantum == 0 ? 16ULL : quantum;
+}
+
+__host__ __device__ constexpr std::size_t ib_send_recv_nic_done_credit_quantum(
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return ib_send_recv_credit_quantum(perBlockSlot, pipelineDepth);
+}
+
+__host__ __device__ constexpr std::size_t ib_send_recv_slot_free_credit_quantum(
+    std::size_t perBlockSlot,
+    int pipelineDepth) {
+  return ib_send_recv_credit_quantum(perBlockSlot, pipelineDepth);
+}
+} // namespace detail
+
 #if PIPES_IS_DEVICE_COMPILE
 __device__ __forceinline__ uint32_t trace_ibgda_step(std::size_t value) {
   constexpr std::size_t kMaxTraceStep = static_cast<std::size_t>(UINT32_MAX);
@@ -129,6 +159,7 @@ class IbSendRecvDevice {
     auto& slot = progress_state_slot(group, progressIndex);
     assert_progress_slot_idle(group, slot, "send");
     IbSendRecvState::ProgressSlot state{};
+    state.reuseCreditStep = slot.reuseCreditStep;
     state.activeStage = nbytes == 0
         ? detail::IbSendRecvProgressStage::Done
         : detail::IbSendRecvProgressStage::WaitNicDone;
@@ -186,6 +217,7 @@ class IbSendRecvDevice {
     auto& slot = progress_state_slot(group, progressIndex);
     assert_progress_slot_idle(group, slot, "recv");
     IbSendRecvState::ProgressSlot state{};
+    state.reuseCreditStep = slot.reuseCreditStep;
     state.activeStage = nbytes == 0
         ? detail::IbSendRecvProgressStage::Done
         : detail::IbSendRecvProgressStage::WaitDataReady;
@@ -220,8 +252,8 @@ class IbSendRecvDevice {
    * The send path first waits for NIC_DONE before reusing the local
    * send-staging range, then copies user data into send-staging through
    * `CopyOp::send`, waits for SLOT_FREE before reusing the peer's recv-staging
-   * range, and finally issues an RDMA put that piggybacks DATA_READY and
-   * records NIC_DONE in the local counter. Returning `Done` means the reserved
+   * range, and finally issues an RDMA put that piggybacks DATA_READY and may
+   * batch NIC_DONE into the local counter. Returning `Done` means the reserved
    * byte range has completed.
    *
    * `CopyOp` must expose `send(dst, src, bytes, group, dataOffset, args...)`.
@@ -356,7 +388,17 @@ class IbSendRecvDevice {
 
       __threadfence_system();
       group.sync();
+      IbgdaLocalBuffer counterBuf{};
+      uint64_t counterVal = 0;
       if (group.is_leader()) {
+        if (should_post_nic_done_credit(
+                chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+          counterVal =
+              reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
+          counterBuf = sendRecvState_.localCounterCompletionBuf.subBuffer(
+              progress_params.groupId * sizeof(uint64_t));
+          state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
+        }
         ThreadGroup solo{
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         transport.put(
@@ -367,9 +409,8 @@ class IbSendRecvDevice {
             sendRecvState_.remoteSignalBuf.subBuffer(
                 progress_params.groupId * sizeof(uint64_t)),
             chunk.bytes,
-            sendRecvState_.localCounterCompletionBuf.subBuffer(
-                progress_params.groupId * sizeof(uint64_t)),
-            chunk.bytes);
+            counterBuf,
+            counterVal);
       }
       group.sync();
 
@@ -416,8 +457,8 @@ class IbSendRecvDevice {
    *
    * When DATA_READY reaches the chunk's `streamEnd`, the recv path copies from
    * transport-owned recv-staging into the caller's destination through
-   * `CopyOp::recv`, then signals SLOT_FREE back to the sender. Returning `Done`
-   * means the reserved byte range has completed.
+   * `CopyOp::recv`, then may signal batched SLOT_FREE credit back to the
+   * sender. Returning `Done` means the reserved byte range has completed.
    *
    * `CopyOp` must expose `recv(dst, src, bytes, group, dataOffset, args...)`.
    * The default `Memcpy` copies bytes cooperatively across the supplied
@@ -506,13 +547,25 @@ class IbSendRecvDevice {
     }
     group.sync();
 
-    transport.signal(
-        group,
-        sendRecvState_.remoteSignalBuf.subBuffer(
-            (sendRecvState_.maxGroups + progress_params.groupId) *
-            sizeof(uint64_t)),
-        chunk.bytes,
-        IbDirection::Recv);
+    uint64_t slotFreeVal = 0;
+    if (group.is_leader()) {
+      if (should_post_slot_free_credit(
+              chunk.streamEnd, state.reuseCreditStep, progress_params)) {
+        slotFreeVal =
+            reuse_credit_value(chunk.streamEnd, state.reuseCreditStep);
+        state.reuseCreditStep = static_cast<int64_t>(chunk.streamEnd);
+      }
+    }
+    slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
+    if (slotFreeVal != 0) {
+      transport.signal(
+          group,
+          sendRecvState_.remoteSignalBuf.subBuffer(
+              (sendRecvState_.maxGroups + progress_params.groupId) *
+              sizeof(uint64_t)),
+          slotFreeVal,
+          IbDirection::Recv);
+    }
 
     state.activeNextByte += chunk.bytes;
     if (state.activeNextByte >= progress_params.protocolBytes) {
@@ -704,6 +757,15 @@ class IbSendRecvDevice {
       __threadfence_system();
       group.sync();
       if (group.is_leader()) {
+        IbgdaLocalBuffer counterBuf{};
+        uint64_t counterVal = 0;
+        if (should_post_nic_done_credit(
+                streamEnd, state.reuseCreditStep, perBlockSlot)) {
+          counterVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
+          counterBuf = sendRecvState_.localCounterCompletionBuf.subBuffer(
+              groupId * sizeof(uint64_t));
+          state.reuseCreditStep = static_cast<int64_t>(streamEnd);
+        }
         ThreadGroup solo{
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         transport.put(
@@ -714,9 +776,8 @@ class IbSendRecvDevice {
             sendRecvState_.remoteSignalBuf.subBuffer(
                 groupId * sizeof(uint64_t)),
             bytesThis,
-            sendRecvState_.localCounterCompletionBuf.subBuffer(
-                groupId * sizeof(uint64_t)),
-            bytesThis);
+            counterBuf,
+            counterVal);
       }
       group.sync();
       dataOff += bytesThis;
@@ -871,12 +932,23 @@ class IbSendRecvDevice {
 
       // (3) Signal SLOT_FREE to sender. Sender waits on the cumulative byte
       //     threshold before reusing remote recvStaging at the same offset.
-      transport.signal(
-          group,
-          sendRecvState_.remoteSignalBuf.subBuffer(
-              (maxGroups + groupId) * sizeof(uint64_t)),
-          bytesThis,
-          IbDirection::Recv);
+      uint64_t slotFreeVal = 0;
+      if (group.is_leader()) {
+        if (should_post_slot_free_credit(
+                streamEnd, state.reuseCreditStep, perBlockSlot)) {
+          slotFreeVal = reuse_credit_value(streamEnd, state.reuseCreditStep);
+          state.reuseCreditStep = static_cast<int64_t>(streamEnd);
+        }
+      }
+      slotFreeVal = group.broadcast<uint64_t>(slotFreeVal);
+      if (slotFreeVal != 0) {
+        transport.signal(
+            group,
+            sendRecvState_.remoteSignalBuf.subBuffer(
+                (maxGroups + groupId) * sizeof(uint64_t)),
+            slotFreeVal,
+            IbDirection::Recv);
+      }
       dataOff += bytesThis;
     }
 
@@ -1123,15 +1195,19 @@ class IbSendRecvDevice {
       }
       group.sync();
 
-      // (4) Signal SLOT_FREE to sender (this transport).
-      //     CRITICAL: must happen BEFORE waiting on fwd's SLOT_FREE (step 5)
-      //     to break circular ring dependency.
+      // (4) SLOT_FREE, posted unbatched every chunk. This must happen before
+      //     the step-5 wait to break circular ring dependency. Advance
+      //     reuseCreditStep so an interleaved recv() on this shared slot
+      //     computes reuse credit from a current cursor.
       transport.signal(
           group,
           sendRecvState_.remoteSignalBuf.subBuffer(
               (recvMaxGroups + groupId) * sizeof(uint64_t)),
           bytesThis,
           IbDirection::Recv);
+      if (group.is_leader()) {
+        recvSlotState.reuseCreditStep = static_cast<int64_t>(recvStreamEnd);
+      }
 
       // (5) Wait for fwd receiver's SLOT_FREE (backpressure on fwd's
       //     recvStaging).
@@ -1148,6 +1224,7 @@ class IbSendRecvDevice {
       __threadfence_system();
       group.sync();
       if (group.is_leader()) {
+        fwdSlotState.reuseCreditStep = static_cast<int64_t>(fwdStreamEnd);
         ThreadGroup solo{
             0, 1, group.group_id, group.block_id, 1, SyncScope::THREAD};
         fwdTransport.put(
@@ -1398,6 +1475,7 @@ class IbSendRecvDevice {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     if (group.is_leader()) {
       auto& slot = sendRecvState_.state[progressIndex];
+      slot.reuseCreditStep = state.reuseCreditStep;
       slot.activeNextByte = state.activeNextByte;
       slot.activeBaseStep = state.activeBaseStep;
       slot.activeStage = state.activeStage;
@@ -1497,6 +1575,68 @@ class IbSendRecvDevice {
     (void)opName;
     return {};
 #endif
+  }
+
+  __device__ __forceinline__ std::size_t nic_done_credit_quantum(
+      std::size_t perBlockSlot) const {
+    return detail::ib_send_recv_nic_done_credit_quantum(
+        perBlockSlot, sendRecvState_.pipelineDepth);
+  }
+
+  __device__ __forceinline__ std::size_t slot_free_credit_quantum(
+      std::size_t perBlockSlot) const {
+    return detail::ib_send_recv_slot_free_credit_quantum(
+        perBlockSlot, sendRecvState_.pipelineDepth);
+  }
+
+  __device__ __forceinline__ bool should_post_nic_done_credit(
+      uint64_t streamEnd,
+      int64_t reuseCreditStep,
+      const ProgressGeometry& geometry) const {
+    return should_post_nic_done_credit(
+        streamEnd, reuseCreditStep, geometry.perBlockSlot);
+  }
+
+  __device__ __forceinline__ bool should_post_nic_done_credit(
+      uint64_t streamEnd,
+      int64_t reuseCreditStep,
+      std::size_t perBlockSlot) const {
+    return should_post_credit_at_quantum(
+        streamEnd, reuseCreditStep, nic_done_credit_quantum(perBlockSlot));
+  }
+
+  __device__ __forceinline__ bool should_post_slot_free_credit(
+      uint64_t streamEnd,
+      int64_t reuseCreditStep,
+      const ProgressGeometry& geometry) const {
+    return should_post_slot_free_credit(
+        streamEnd, reuseCreditStep, geometry.perBlockSlot);
+  }
+
+  __device__ __forceinline__ bool should_post_slot_free_credit(
+      uint64_t streamEnd,
+      int64_t reuseCreditStep,
+      std::size_t perBlockSlot) const {
+    return should_post_credit_at_quantum(
+        streamEnd, reuseCreditStep, slot_free_credit_quantum(perBlockSlot));
+  }
+
+  __device__ __forceinline__ bool should_post_credit_at_quantum(
+      uint64_t streamEnd,
+      int64_t reuseCreditStep,
+      std::size_t creditQuantum) const {
+    const uint64_t posted = reuse_credit_posted_step(reuseCreditStep);
+    return streamEnd > posted && streamEnd - posted >= creditQuantum;
+  }
+
+  __device__ __forceinline__ uint64_t
+  reuse_credit_value(uint64_t streamEnd, int64_t reuseCreditStep) const {
+    return streamEnd - reuse_credit_posted_step(reuseCreditStep);
+  }
+
+  __device__ __forceinline__ static uint64_t reuse_credit_posted_step(
+      int64_t reuseCreditStep) {
+    return reuseCreditStep > 0 ? static_cast<uint64_t>(reuseCreditStep) : 0ULL;
   }
 
   /**

--- a/comms/prims/transport/ibgda/IbgdaBuffer.h
+++ b/comms/prims/transport/ibgda/IbgdaBuffer.h
@@ -480,11 +480,16 @@ struct IbSendRecvState {
    *
    * The state is indexed by direction and transport group. `nextStep` is the
    * shared byte-stream cursor used by blocking send/recv and async init.
-   * `activeBaseStep`, `activeNextByte`, and `activeStage` track the currently
-   * initialized async operation or a blocking call in progress, if any.
+   * `reuseCreditStep` is the persistent byte cursor for reuse credits: NIC_DONE
+   * on sender slots and SLOT_FREE on receiver slots. It may lag `nextStep`
+   * because those credits can be batched without delaying DATA_READY
+   * visibility. `activeBaseStep`, `activeNextByte`, and `activeStage` track the
+   * currently initialized async operation or a blocking call in progress, if
+   * any.
    */
   struct ProgressSlot {
     int64_t nextStep{0};
+    int64_t reuseCreditStep{0};
     std::size_t activeNextByte{0};
     int64_t activeBaseStep{0};
     detail::IbSendRecvProgressStage activeStage{


### PR DESCRIPTION
Summary:

Batch `NIC_DONE` and `SLOT_FREE` reuse-credit updates in the shared IB sendrecv protocol while keeping `DATA_READY` per chunk. Add a persistent progress-slot credit cursor and emit reuse credits at a cadence based on the per-lane staging window so tiny repeated sends avoid per-call counter and slot-free control work without weakening ring-reuse waits.

Reviewed By: siyengar

Differential Revision: D110846798


