### PR TITLE
Generalize make_multiwarp_group + add PRIMS_DEVICE_CHECK_MSG (#3069)

### DIFF
--- a/comms/prims/core/DeviceCheck.cuh
+++ b/comms/prims/core/DeviceCheck.cuh
@@ -82,4 +82,43 @@ namespace comms::prims {
 #define PIPES_DEVICE_CHECK_MSG(expr, msg) ((void)0)
 #endif
 
+/**
+ * PRIMS_DEVICE_CHECK_MSG: Device-side assertion with a printf-style message.
+ *
+ * Like PIPES_DEVICE_CHECK but takes a printf format string plus arguments, so
+ * runtime values (sizes, ids, limits, ...) can be printed alongside the failing
+ * expression. On device: prints the diagnostic and calls __trap(); on host:
+ * evaluates to a no-op.
+ *
+ * Usage:
+ *   PRIMS_DEVICE_CHECK_MSG(
+ *       group_size % kWarpSize == 0,
+ *       "group_size (%u) must be a multiple of %u", group_size, kWarpSize);
+ */
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define PRIMS_DEVICE_CHECK_MSG(expr, fmt, ...)    \
+  do {                                            \
+    if (!(expr)) {                                \
+      printf(                                     \
+          "PRIMS_DEVICE_CHECK: %s (" fmt          \
+          ") in %s at %s:%d "                     \
+          "block=(%u,%u,%u) thread=(%u,%u,%u)\n", \
+          #expr,                                  \
+          ##__VA_ARGS__,                          \
+          __func__,                               \
+          __FILE__,                               \
+          __LINE__,                               \
+          blockIdx.x,                             \
+          blockIdx.y,                             \
+          blockIdx.z,                             \
+          threadIdx.x,                            \
+          threadIdx.y,                            \
+          threadIdx.z);                           \
+      __trap();                                   \
+    }                                             \
+  } while (0)
+#else
+#define PRIMS_DEVICE_CHECK_MSG(expr, fmt, ...) ((void)0)
+#endif
+
 } // namespace comms::prims

--- a/comms/prims/core/ThreadGroup.cuh
+++ b/comms/prims/core/ThreadGroup.cuh
@@ -8,6 +8,7 @@
 
 #include "comms/common/AtomicUtils.cuh"
 #include "comms/common/DeviceConstants.cuh"
+#include "comms/prims/core/DeviceCheck.cuh"
 #include "comms/prims/memory/DeviceSpan.cuh"
 #include "comms/prims/transport/amd/HipHostCompat.h"
 
@@ -122,15 +123,13 @@ struct ThreadGroup {
 #endif
         break;
       case SyncScope::MULTIWARP: {
-        // Multiwarp = 4 warps = 128 threads
 #if defined(__CUDA_ARCH__)
-        // Uses CUDA named barriers for synchronization within a multiwarp
+        // Uses CUDA named barriers for synchronization within this contiguous
+        // group. `group_size` is configurable for make_multiwarp_group().
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t barrierId = tid / kMultiwarpSize;
-        asm volatile("bar.sync %0, %1;"
-                     :
-                     : "r"(barrierId), "r"(kMultiwarpSize));
+        uint32_t barrierId = tid / group_size;
+        asm volatile("bar.sync %0, %1;" : : "r"(barrierId), "r"(group_size));
 #else
         // AMD: no named barriers, fall back to block-level sync
         __syncthreads();
@@ -271,7 +270,7 @@ struct ThreadGroup {
         __shared__ uint64_t __tg_broadcast_scratch[kMaxMultiwarpsPerBlock];
         uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
             threadIdx.z * blockDim.x * blockDim.y;
-        uint32_t scratch_idx = tid / kMultiwarpSize;
+        uint32_t scratch_idx = tid / group_size;
         if (is_leader()) {
           __tg_broadcast_scratch[scratch_idx] = static_cast<uint64_t>(val);
         }
@@ -938,20 +937,23 @@ __device__ inline ThreadGroup make_block_group() {
 }
 
 /**
- * make_multiwarp_group - Create a ThreadGroup where 4 warps (128 threads)
- *                        work together as a single multiwarp
+ * make_multiwarp_group - Create a ThreadGroup where multiple warps work
+ *                        together as one group
  *
  * Use case: For Hopper GPU tensor core operations (wgmma instructions) that
  * operate at multiwarp granularity, or when you need synchronization
  * granularity between a single warp and the entire block.
  *
  * REQUIREMENTS:
- * - Block size must be a multiple of 128 (multiwarp size)
- * - Maximum 16 multiwarps per block (hardware named barrier limit)
+ * - group_size must be a multiple of WARP_SIZE
+ * - Block size must be a multiple of group_size
+ * - Maximum 16 MULTIWARP groups per block (hardware named barrier limit)
  *
  * Example with 4 blocks × 512 threads:
- *   - total_groups = 16 (4 multiwarps per block × 4 blocks)
- *   - group_size = 128
+ *   - make_multiwarp_group() gives total_groups = 16
+ *     (4 default 128-thread multiwarps per block × 4 blocks)
+ *   - make_multiwarp_group(256) gives total_groups = 8
+ *     (2 256-thread groups per block × 4 blocks)
  *   - Each multiwarp can execute wgmma instructions or other
  *     multiwarp-level operations
  *
@@ -960,29 +962,47 @@ __device__ inline ThreadGroup make_block_group() {
  * - Allows asynchronous multiwarp-level matrix multiply-accumulate
  * - Better synchronization granularity for producer-consumer patterns
  */
-// TODO: Add support for configurable multiwarp size, 4/8/16.. warps as a
-// multiwarp.
-__device__ inline ThreadGroup make_multiwarp_group() {
+__device__ inline ThreadGroup make_multiwarp_group(
+    uint32_t group_size = kMultiwarpSize) {
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
   uint32_t threads_per_block = blockDim.x * blockDim.y * blockDim.z;
   uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
       threadIdx.z * blockDim.x * blockDim.y;
 
-  uint32_t multiwarps_per_block = threads_per_block / kMultiwarpSize;
-  uint32_t multiwarp_id_in_block = tid / kMultiwarpSize;
+  PRIMS_DEVICE_CHECK_MSG(
+      group_size >= kWarpSize && group_size % kWarpSize == 0,
+      "make_multiwarp_group: group_size (%u) must be >= %u and a multiple of %u",
+      group_size,
+      kWarpSize,
+      kWarpSize);
+  PRIMS_DEVICE_CHECK_MSG(
+      threads_per_block % group_size == 0,
+      "make_multiwarp_group: threads_per_block (%u) must be divisible by group_size (%u)",
+      threads_per_block,
+      group_size);
+
+  uint32_t multiwarps_per_block = threads_per_block / group_size;
+  PRIMS_DEVICE_CHECK_MSG(
+      group_size <= kWarpSize || multiwarps_per_block <= kMaxMultiwarpsPerBlock,
+      "make_multiwarp_group: groups per block (%u) exceeds named-barrier limit (%u)",
+      multiwarps_per_block,
+      kMaxMultiwarpsPerBlock);
+
+  uint32_t multiwarp_id_in_block = tid / group_size;
   uint32_t global_multiwarp_id =
       blockIdx.x * multiwarps_per_block + multiwarp_id_in_block;
   uint32_t total_multiwarps = gridDim.x * multiwarps_per_block;
 
-  uint32_t thread_id_in_multiwarp = tid % kMultiwarpSize;
+  uint32_t thread_id_in_multiwarp = tid % group_size;
 
   return ThreadGroup{
       .thread_id_in_group = thread_id_in_multiwarp,
-      .group_size = kMultiwarpSize,
+      .group_size = group_size,
       .group_id = global_multiwarp_id,
       .block_id = blockIdx.x,
       .total_groups = total_multiwarps,
-      .scope = SyncScope::MULTIWARP};
+      .scope =
+          group_size == kWarpSize ? SyncScope::WARP : SyncScope::MULTIWARP};
 #else
   return ThreadGroup{};
 #endif

--- a/comms/prims/tests/ThreadGroupTest.cc
+++ b/comms/prims/tests/ThreadGroupTest.cc
@@ -1986,6 +1986,142 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.testName;
     });
 
+struct ConfigurableMultiwarpTestParams {
+  int numBlocks;
+  int blockSize;
+  uint32_t groupSize;
+  std::string testName;
+};
+
+class ThreadGroupConfigurableMultiwarpTest
+    : public ThreadGroupTestFixture,
+      public ::testing::WithParamInterface<ConfigurableMultiwarpTestParams> {};
+
+TEST_P(ThreadGroupConfigurableMultiwarpTest, CreatesExpectedGroups) {
+  const auto& params = GetParam();
+  const uint32_t totalThreads = params.numBlocks * params.blockSize;
+
+  DeviceBuffer groupIdsBuffer(totalThreads * sizeof(uint32_t));
+  DeviceBuffer threadIdsBuffer(totalThreads * sizeof(uint32_t));
+  DeviceBuffer groupSizesBuffer(totalThreads * sizeof(uint32_t));
+  DeviceBuffer totalGroupsBuffer(totalThreads * sizeof(uint32_t));
+  DeviceBuffer scopesBuffer(totalThreads * sizeof(uint32_t));
+  DeviceBuffer errorCountBuffer(sizeof(uint32_t));
+
+  auto groupIds_d = static_cast<uint32_t*>(groupIdsBuffer.get());
+  auto threadIds_d = static_cast<uint32_t*>(threadIdsBuffer.get());
+  auto groupSizes_d = static_cast<uint32_t*>(groupSizesBuffer.get());
+  auto totalGroups_d = static_cast<uint32_t*>(totalGroupsBuffer.get());
+  auto scopes_d = static_cast<uint32_t*>(scopesBuffer.get());
+  auto errorCount_d = static_cast<uint32_t*>(errorCountBuffer.get());
+
+  CUDACHECK_TEST(cudaMemset(groupIds_d, 0, totalThreads * sizeof(uint32_t)));
+  CUDACHECK_TEST(cudaMemset(threadIds_d, 0, totalThreads * sizeof(uint32_t)));
+  CUDACHECK_TEST(cudaMemset(groupSizes_d, 0, totalThreads * sizeof(uint32_t)));
+  CUDACHECK_TEST(cudaMemset(totalGroups_d, 0, totalThreads * sizeof(uint32_t)));
+  CUDACHECK_TEST(cudaMemset(scopes_d, 0, totalThreads * sizeof(uint32_t)));
+  CUDACHECK_TEST(cudaMemset(errorCount_d, 0, sizeof(uint32_t)));
+
+  test::testConfigurableMultiwarpGroup(
+      groupIds_d,
+      threadIds_d,
+      groupSizes_d,
+      totalGroups_d,
+      scopes_d,
+      params.groupSize,
+      errorCount_d,
+      params.numBlocks,
+      params.blockSize);
+  CUDACHECK_TEST(cudaDeviceSynchronize());
+
+  uint32_t errorCount_h = 0;
+  CUDACHECK_TEST(cudaMemcpy(
+      &errorCount_h, errorCount_d, sizeof(uint32_t), cudaMemcpyDeviceToHost));
+  EXPECT_EQ(errorCount_h, 0);
+
+  std::vector<uint32_t> groupIds_h(totalThreads);
+  std::vector<uint32_t> threadIds_h(totalThreads);
+  std::vector<uint32_t> groupSizes_h(totalThreads);
+  std::vector<uint32_t> totalGroups_h(totalThreads);
+  std::vector<uint32_t> scopes_h(totalThreads);
+  CUDACHECK_TEST(cudaMemcpy(
+      groupIds_h.data(),
+      groupIds_d,
+      totalThreads * sizeof(uint32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      threadIds_h.data(),
+      threadIds_d,
+      totalThreads * sizeof(uint32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      groupSizes_h.data(),
+      groupSizes_d,
+      totalThreads * sizeof(uint32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      totalGroups_h.data(),
+      totalGroups_d,
+      totalThreads * sizeof(uint32_t),
+      cudaMemcpyDeviceToHost));
+  CUDACHECK_TEST(cudaMemcpy(
+      scopes_h.data(),
+      scopes_d,
+      totalThreads * sizeof(uint32_t),
+      cudaMemcpyDeviceToHost));
+
+  const uint32_t groupsPerBlock = params.blockSize / params.groupSize;
+  const uint32_t expectedTotalGroups = params.numBlocks * groupsPerBlock;
+  const uint32_t expectedScope = static_cast<uint32_t>(
+      params.groupSize == kWarpSize ? SyncScope::WARP : SyncScope::MULTIWARP);
+
+  for (uint32_t globalTid = 0; globalTid < totalThreads; globalTid++) {
+    const uint32_t tid = globalTid % params.blockSize;
+    const uint32_t blockId = globalTid / params.blockSize;
+    const uint32_t expectedGroupId =
+        blockId * groupsPerBlock + tid / params.groupSize;
+
+    EXPECT_EQ(groupIds_h[globalTid], expectedGroupId);
+    EXPECT_EQ(threadIds_h[globalTid], tid % params.groupSize);
+    EXPECT_EQ(groupSizes_h[globalTid], params.groupSize);
+    EXPECT_EQ(totalGroups_h[globalTid], expectedTotalGroups);
+    EXPECT_EQ(scopes_h[globalTid], expectedScope);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ConfigurableMultiwarpConfigs,
+    ThreadGroupConfigurableMultiwarpTest,
+    ::testing::Values(
+        ConfigurableMultiwarpTestParams{
+            .numBlocks = 3,
+            .blockSize = 256,
+            .groupSize = 32,
+            .testName = "WarpSizedGroups"},
+        ConfigurableMultiwarpTestParams{
+            .numBlocks = 2,
+            .blockSize = 256,
+            .groupSize = 64,
+            .testName = "TwoWarpGroups"},
+        ConfigurableMultiwarpTestParams{
+            .numBlocks = 4,
+            .blockSize = 512,
+            .groupSize = 128,
+            .testName = "FourWarpGroups"},
+        ConfigurableMultiwarpTestParams{
+            .numBlocks = 3,
+            .blockSize = 512,
+            .groupSize = 256,
+            .testName = "EightWarpGroups"},
+        ConfigurableMultiwarpTestParams{
+            .numBlocks = 2,
+            .blockSize = 1024,
+            .groupSize = 512,
+            .testName = "SixteenWarpGroups"}),
+    [](const ::testing::TestParamInfo<ConfigurableMultiwarpTestParams>& info) {
+      return info.param.testName;
+    });
+
 // =============================================================================
 // Block Cluster Tests (Hopper SM90+ cluster synchronization)
 // =============================================================================

--- a/comms/prims/tests/ThreadGroupTest.cu
+++ b/comms/prims/tests/ThreadGroupTest.cu
@@ -571,6 +571,63 @@ void testMultiwarpGroup(
   PIPES_KERNEL_LAUNCH_CHECK();
 }
 
+__global__ void testConfigurableMultiwarpGroupKernel(
+    uint32_t* groupIds,
+    uint32_t* threadIdsInGroup,
+    uint32_t* groupSizes,
+    uint32_t* totalGroups,
+    uint32_t* scopes,
+    uint32_t groupSize,
+    uint32_t* errorCount) {
+  auto group = make_multiwarp_group(groupSize);
+
+  const uint32_t tid = threadIdx.x + threadIdx.y * blockDim.x +
+      threadIdx.z * blockDim.x * blockDim.y;
+  const uint32_t threadsPerBlock = blockDim.x * blockDim.y * blockDim.z;
+  const uint32_t globalTid = blockIdx.x * threadsPerBlock + tid;
+  const uint32_t groupsPerBlock = threadsPerBlock / groupSize;
+  const uint32_t expectedGroupId =
+      blockIdx.x * groupsPerBlock + tid / groupSize;
+  const uint32_t expectedTotalGroups = gridDim.x * groupsPerBlock;
+  const SyncScope expectedScope =
+      groupSize == kWarpSize ? SyncScope::WARP : SyncScope::MULTIWARP;
+
+  groupIds[globalTid] = group.group_id;
+  threadIdsInGroup[globalTid] = group.thread_id_in_group;
+  groupSizes[globalTid] = group.group_size;
+  totalGroups[globalTid] = group.total_groups;
+  scopes[globalTid] = static_cast<uint32_t>(group.scope);
+
+  if (group.group_id != expectedGroupId ||
+      group.thread_id_in_group != tid % groupSize ||
+      group.group_size != groupSize ||
+      group.total_groups != expectedTotalGroups ||
+      group.block_id != blockIdx.x || group.scope != expectedScope) {
+    atomicAdd(errorCount, 1);
+  }
+}
+
+void testConfigurableMultiwarpGroup(
+    uint32_t* groupIds_d,
+    uint32_t* threadIdsInGroup_d,
+    uint32_t* groupSizes_d,
+    uint32_t* totalGroups_d,
+    uint32_t* scopes_d,
+    uint32_t groupSize,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize) {
+  testConfigurableMultiwarpGroupKernel<<<numBlocks, blockSize>>>(
+      groupIds_d,
+      threadIdsInGroup_d,
+      groupSizes_d,
+      totalGroups_d,
+      scopes_d,
+      groupSize,
+      errorCount_d);
+  PIPES_KERNEL_LAUNCH_CHECK();
+}
+
 // Test multiwarp synchronization using named barriers
 // This test verifies that all 128 threads in a multiwarp synchronize correctly.
 // Each thread writes a value, then after sync, verifies all threads wrote.

--- a/comms/prims/tests/ThreadGroupTest.cuh
+++ b/comms/prims/tests/ThreadGroupTest.cuh
@@ -145,6 +145,17 @@ void testMultiwarpGroup(
     int numBlocks,
     int blockSize);
 
+void testConfigurableMultiwarpGroup(
+    uint32_t* groupIds_d,
+    uint32_t* threadIdsInGroup_d,
+    uint32_t* groupSizes_d,
+    uint32_t* totalGroups_d,
+    uint32_t* scopes_d,
+    uint32_t groupSize,
+    uint32_t* errorCount_d,
+    int numBlocks,
+    int blockSize);
+
 // Tests multiwarp synchronization using named barriers
 // Verifies:
 // - All 128 threads in a multiwarp synchronize correctly


### PR DESCRIPTION
Summary:

Split out of D110094643 (NvlChannelState) per reviewer request so the ThreadGroup change lands as its own reviewable base diff. Generalizes ThreadGroup::make_multiwarp_group() to accept a runtime group_size (default kMultiwarpSize), preserving the 128-thread default while enabling variable-size multiwarp groups (e.g. the bidirectional-CTA send/recv split); bar.sync/broadcast use group_size. Adds a variadic PRIMS_DEVICE_CHECK_MSG(expr, fmt, ...) device-check macro and uses it for make_multiwarp_group validation (replacing printf+__trap).

Reviewed By: saifhhasan

Differential Revision: D110784194


