### PR TITLE
Split fused AllReduce headers from legacy (#3074)

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceFusedImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedImpl.h
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+#include "comms/ctran/algos/CtranAlgo.h"
+#include "comms/utils/commSpecs.h"
+
+/**
+ * Run the Prims-backed tree AllReduce implementation.
+ *
+ * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
+ * It relies on Prims NVL and IBGDA transport staging for transient receives and
+ * does not allocate message-size-dependent AllReduce staging.
+ */
+commResult_t ctranAllReduceTree(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
+
+/**
+ * Run the Prims-backed hierarchical ring AllReduce implementation.
+ *
+ * Three phases: NVL ReduceScatter (Phase 1), inter-node IBGDA ring (Phase 2),
+ * NVL AllGather (Phase 3), reusing the shared NVL phases with the ring as the
+ * cross-node Phase 2. Implemented in a stacked diff; this declaration plus the
+ * dispatch wiring land first.
+ */
+commResult_t ctranAllReduceHierarchicalRing(
+    const void* sendbuff,
+    void* recvbuff,
+    size_t count,
+    commDataType_t datatype,
+    commRedOp_t redOp,
+    CtranComm* comm,
+    cudaStream_t stream,
+    std::optional<std::chrono::milliseconds> timeout = std::nullopt);

--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 
 #include "comms/ctran/algos/CtranAlgoDev.h" // CTRAN_MAX_NVL_PEERS
+#include "comms/ctran/algos/topo/TreeConstants.h" // kMaxTreeChildren
 #include "comms/utils/commSpecs.h" // commDataType_t, commRedOp_t
 
 namespace ctran::allreduce::common {
@@ -32,6 +33,21 @@ namespace ctran::allreduce::nvl::direct {
 struct ExtraArgs {};
 
 } // namespace ctran::allreduce::nvl::direct
+
+namespace ctran::allreduce {
+
+// Tree topology for one half of the dual tree pair.
+// Holds communicator ranks — transport dispatch uses the shared Transport
+// array.
+struct TreeTopology {
+  int parentRank{-1};
+  int childRanks[ctran::algos::topo::kMaxTreeChildren]{-1, -1, -1};
+  int numChildren{0};
+  bool isRoot{false};
+  bool isLeaf{false};
+};
+
+} // namespace ctran::allreduce
 
 #if defined(ENABLE_PRIMS)
 

--- a/comms/ctran/algos/AllReduce/AllReduceIbTree.cc
+++ b/comms/ctran/algos/AllReduce/AllReduceIbTree.cc
@@ -6,7 +6,6 @@
 #include "comms/ctran/CtranComm.h"
 #include "comms/ctran/algos/AllReduce/AllReduceFused.h"
 #include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
-#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/topo/CtranTreeBuilder.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"

--- a/comms/ctran/algos/AllReduce/AllReduceIbTree.cuh
+++ b/comms/ctran/algos/AllReduce/AllReduceIbTree.cuh
@@ -5,7 +5,6 @@
 #if defined(ENABLE_PRIMS)
 
 #include "comms/ctran/algos/AllReduce/AllReduceFusedTypes.h"
-#include "comms/ctran/algos/AllReduce/Types.h"
 #include "comms/ctran/algos/CtranAlgoDev.h"
 #include "comms/ctran/algos/topo/TreeConstants.h"
 #include "comms/utils/commSpecs.h"

--- a/comms/ctran/algos/AllReduce/AllReduceImpl.h
+++ b/comms/ctran/algos/AllReduce/AllReduceImpl.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 
+#include "comms/ctran/algos/AllReduce/AllReduceFusedImpl.h"
 #include "comms/ctran/algos/CtranAlgo.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
@@ -18,40 +19,6 @@ commResult_t ctranAllReduceDirect(
     cudaStream_t stream,
     std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 commResult_t ctranAllReduceRing(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    commDataType_t datatype,
-    commRedOp_t redOp,
-    CtranComm* comm,
-    cudaStream_t stream,
-    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-/**
- * Run the Prims-backed tree AllReduce implementation.
- *
- * The implementation supports `commSum` over `commFloat32` and `commFloat16`.
- * It relies on Prims NVL and IBGDA transport staging for transient receives and
- * does not allocate message-size-dependent AllReduce staging.
- */
-commResult_t ctranAllReduceTree(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    commDataType_t datatype,
-    commRedOp_t redOp,
-    CtranComm* comm,
-    cudaStream_t stream,
-    std::optional<std::chrono::milliseconds> timeout = std::nullopt);
-
-/**
- * Run the Prims-backed hierarchical ring AllReduce implementation.
- *
- * Three phases: NVL ReduceScatter (Phase 1), inter-node IBGDA ring (Phase 2),
- * NVL AllGather (Phase 3), reusing the shared NVL phases with the ring as the
- * cross-node Phase 2. Implemented in a stacked diff; this declaration plus the
- * dispatch wiring land first.
- */
-commResult_t ctranAllReduceHierarchicalRing(
     const void* sendbuff,
     void* recvbuff,
     size_t count,

--- a/comms/ctran/algos/AllReduce/Types.h
+++ b/comms/ctran/algos/AllReduce/Types.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "comms/ctran/algos/CtranAlgoDev.h"
-#include "comms/ctran/algos/topo/TreeConstants.h"
 #include "comms/utils/commSpecs.h"
 
 // Forward declaration
@@ -37,17 +36,6 @@ struct KernelArgs {
   // IPC imported ptr to each of the local peers' RecvBuff
   void* intraNodeRemoteRecvBuffs[CTRAN_MAX_NVL_PEERS];
   KernelElem* kernelElems[ALLREDUCE_MAX_KERNEL_ELEMS];
-};
-
-// Tree topology for one half of the dual tree pair.
-// Holds communicator ranks — transport dispatch uses the shared Transport
-// array.
-struct TreeTopology {
-  int parentRank{-1};
-  int childRanks[ctran::algos::topo::kMaxTreeChildren]{-1, -1, -1};
-  int numChildren{0};
-  bool isRoot{false};
-  bool isLeaf{false};
 };
 
 } // namespace ctran::allreduce


### PR DESCRIPTION
Summary:

Separate the fused AllReduce family (CTREE/NVL-Direct/HierarchicalRing, Prims-based) from the legacy family (Direct/Ring/ShM/IbRing, GPE + CtranMapper) at the header level, so the fused set can later be built as a standalone per-collective target (unblocks B.2) and migrated into MCCL. Behavior-preserving header reorganization — no runtime logic changes:
- Move the fused-only `ctran::allreduce::TreeTopology` from `Types.h` into `AllReduceFusedTypes.h` (the fused type home). `Types.h` pulls `CtranMapperTypes.h`/GPE ring types, so fused sources no longer need it.
- Extract the fused declarations (`ctranAllReduceTree`, `ctranAllReduceHierarchicalRing`) into a new `AllReduceFusedImpl.h`. `AllReduceImpl.h` re-includes it, so every existing caller is unchanged (umbrella header).
- Drop the now-redundant `Types.h` includes from `AllReduceIbTree.{cc,cuh}` — they get `TreeTopology` via `AllReduceFused.h` -> `AllReduceFusedTypes.h`.
- `AllReduce.cc` remains the shared runtime dispatcher (unchanged).

Note: `AllReduceIbTree.cc` still delegates nccl-tests sync comms to the legacy `ctranAllReduceDirect` — a runtime fallback, not a type coupling. That single link edge is addressed when the fused-only target is introduced (B.2).

Reviewed By: Scusemua, saifhhasan

Differential Revision: D110858813


