### PR TITLE
Gate the comms/prims dependency behind ENABLE_PRIMS (default OFF) (#3075)

### DIFF
--- a/build_rcclx.sh
+++ b/build_rcclx.sh
@@ -408,11 +408,19 @@ esac
 
 
 function build_rccl {
+  # Opt in to compiling comms/prims into librccl only when ENABLE_PRIMS is set
+  # to a truthy value in the environment. Default (unset) keeps prims out of the
+  # build, shielding librccl from comms/prims churn.
+  local prims_flag=""
+  case "${ENABLE_PRIMS:-}" in
+    1 | ON | on | true | TRUE | yes | YES) prims_flag="--enable-prims" ;;
+  esac
   ./install.sh \
     --prefix "$BUILDDIR" \
     --amdgpu_targets "$AMDGPU_TARGETS" \
     --disable-colltrace \
-    --disable-msccl-kernel
+    --disable-msccl-kernel \
+    ${prims_flag}
 }
 
 build_rccl

--- a/comms/ctran/algos/CtranAlgo.cc
+++ b/comms/ctran/algos/CtranAlgo.cc
@@ -10,13 +10,17 @@
 #include "comms/ctran/utils/Alloc.h"
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/TmpBufSegManager.h"
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/nvl/NvlChannelState.cuh"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+#endif // defined(ENABLE_PRIMS)
 
 #include "comms/utils/cvars/nccl_cvars.h"
 #include "comms/utils/logger/LogUtils.h"
 
+#if defined(ENABLE_PRIMS)
 using comms::prims::NvlChannelState;
+#endif // defined(ENABLE_PRIMS)
 
 CtranAlgo::CtranAlgo(CtranComm* comm, ICtran* ctran)
     : comm_(comm), ctran_(ctran) {
@@ -80,11 +84,13 @@ CtranAlgo::~CtranAlgo() {
   // Note: No destructor calls needed since objects were constructed on CPU
   // and copied to device memory. The CPU objects were already destructed
   // when they went out of scope after cudaMemcpy.
+#if defined(ENABLE_PRIMS)
   if (nvlTransports_) {
     FB_COMMCHECKIGNORE(
         ctran::utils::commCudaFree(nvlTransports_, &this->comm_->logMetaData_));
     nvlTransports_ = nullptr;
   }
+#endif // defined(ENABLE_PRIMS)
 
   // Dot not throw exception in destructor to avoid early termination in stack
   // unwind. See discussion in
@@ -114,8 +120,19 @@ inline size_t alignUp(size_t value, size_t alignment) {
   return ((value + alignment - 1) / alignment) * alignment;
 }
 
+// NvlChannelState is a comms/prims type gated behind ENABLE_PRIMS. Pin its
+// size/alignment so the OFF build computes the same NVL shared-memory layout
+// without the prims header; the static_asserts (compiled only with prims)
+// catch drift.
+constexpr size_t kNvlChannelStateSize = 384;
+constexpr size_t kNvlChannelStateAlign = 128;
+#if defined(ENABLE_PRIMS)
+static_assert(sizeof(NvlChannelState) == kNvlChannelStateSize);
+static_assert(alignof(NvlChannelState) == kNvlChannelStateAlign);
+#endif // defined(ENABLE_PRIMS)
+
 inline size_t getPerPeerChannelStatesSize() {
-  return sizeof(NvlChannelState) * CTRAN_ALGO_MAX_THREAD_BLOCKS;
+  return kNvlChannelStateSize * CTRAN_ALGO_MAX_THREAD_BLOCKS;
 }
 
 inline size_t getChannelStatesBaseOffset(
@@ -123,7 +140,7 @@ inline size_t getChannelStatesBaseOffset(
     size_t nvlSharedDevbufSize) {
   return alignUp(
       (nLocalRanks - 1) * (sizeof(CtranAlgoDeviceSync) + nvlSharedDevbufSize),
-      alignof(NvlChannelState));
+      kNvlChannelStateAlign);
 }
 
 inline size_t getBcastBufOffset(int nLocalRanks, size_t nvlSharedDevbufSize) {
@@ -131,6 +148,7 @@ inline size_t getBcastBufOffset(int nLocalRanks, size_t nvlSharedDevbufSize) {
       (nLocalRanks - 1) * getPerPeerChannelStatesSize();
 }
 
+#if defined(ENABLE_PRIMS)
 NvlChannelState* partitionChannelStates(
     void* mappedDevShmPtr,
     int nLocalRanks,
@@ -143,6 +161,7 @@ NvlChannelState* partitionChannelStates(
       reinterpret_cast<char*>(channelStateBase_d) +
       pos * getPerPeerChannelStatesSize());
 }
+#endif // defined(ENABLE_PRIMS)
 
 // Helper to calculate sync and staging buffer pointers for a given peer
 std::tuple<CtranAlgoDeviceSync*, void*> partitionDevShm(
@@ -290,6 +309,7 @@ commResult_t CtranAlgo::initKernelResources() {
       sizeof(CtranAlgoDeviceState),
       cudaMemcpyHostToDevice));
 
+#if defined(ENABLE_PRIMS)
   // Pre-allocate P2pNvlTransportDevice array for all peers in device memory.
   FB_COMMCHECK(
       ctran::utils::commCudaMalloc(
@@ -348,6 +368,7 @@ commResult_t CtranAlgo::initKernelResources() {
         sizeof(comms::prims::P2pNvlTransportDevice),
         cudaMemcpyHostToDevice));
   }
+#endif // defined(ENABLE_PRIMS)
 
   this->isResInitialized_ = true;
 
@@ -416,12 +437,14 @@ CtranAlgo::SharedResource::SharedResource(CtranComm* comm) {
             cudaMemcpyHostToDevice),
         comm->logMetaData_);
 
+#if defined(ENABLE_PRIMS)
     void* channelStatePtr_d = reinterpret_cast<char*>(devShmPtr) +
         getChannelStatesBaseOffset(nLocalRanks, nvlSharedDevbufSize) +
         pos * getPerPeerChannelStatesSize();
     FB_CUDACHECKTHROW_EX(
         cudaMemset(channelStatePtr_d, 0, getPerPeerChannelStatesSize()),
         comm->logMetaData_);
+#endif // defined(ENABLE_PRIMS)
   }
 
   // Exchange IPC handle with all ranks in the NVL domain

--- a/comms/ctran/algos/CtranAlgo.h
+++ b/comms/ctran/algos/CtranAlgo.h
@@ -15,7 +15,15 @@
 #include "comms/ctran/mapper/CtranMapper.h"
 #include "comms/ctran/memory/memCacheAllocator.h"
 #include "comms/ctran/utils/CtranIpc.h"
+#if defined(ENABLE_PRIMS)
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
+#else
+// prims not compiled in; the member/getter are pointer-only, so a forward
+// declaration suffices (mirrors SendRecv/Types.h).
+namespace comms::prims {
+class P2pNvlTransportDevice;
+} // namespace comms::prims
+#endif // defined(ENABLE_PRIMS)
 #include "comms/utils/logger/Logger.h"
 
 #include <folly/Synchronized.h>

--- a/comms/ctran/algos/SendRecv/SendRecv.cc
+++ b/comms/ctran/algos/SendRecv/SendRecv.cc
@@ -4,6 +4,10 @@
 #include <deque>
 #include <optional>
 
+#if !defined(ENABLE_PRIMS)
+#include <mutex> // std::once_flag/std::call_once for the prims-off fallback warn
+#endif
+
 #include "comms/ctran/Ctran.h"
 #include "comms/ctran/algos/SendRecv/SendRecvImpl.h"
 #include "comms/ctran/gpe/CtranGpe.h"
@@ -41,8 +45,10 @@ std::unordered_map<KernelConfig::KernelType, void*> kernelFns = {
      reinterpret_cast<void*>(ncclKernelRecv</*UNPACK=*/true>)},
     {KernelConfig::KernelType::SENDRECV_UNPACK,
      reinterpret_cast<void*>(ncclKernelSendRecv</*UNPACK=*/true>)},
+#if defined(ENABLE_PRIMS)
     {KernelConfig::KernelType::SENDRECV_P2P,
      reinterpret_cast<void*>(ncclKernelSendRecvP2p)},
+#endif // defined(ENABLE_PRIMS)
 };
 
 static const auto myAlgo = NCCL_SENDRECV_ALGO::ctran;
@@ -55,6 +61,24 @@ bool ctranSendRecvSupport(
   if (!ctranInitialized(comm)) {
     return false;
   }
+
+#if !defined(ENABLE_PRIMS)
+  // ctp2p/ctgraph are prims-backed and not compiled in; decline so the caller
+  // falls back to baseline send/recv.
+  if (algo == NCCL_SENDRECV_ALGO::ctp2p ||
+      algo == NCCL_SENDRECV_ALGO::ctgraph) {
+    static std::once_flag warnedOnce;
+    std::call_once(warnedOnce, []() {
+      CLOGF_SUBSYS(
+          WARN,
+          COLL,
+          "CTRAN SendRecv: ctp2p/ctgraph requires comms::prims device transports "
+          "(ENABLE_PRIMS), which are not compiled in this build; falling back to "
+          "baseline send/recv.");
+    });
+    return false;
+  }
+#endif // !defined(ENABLE_PRIMS)
 
   const auto statex = comm->statex_.get();
 

--- a/comms/ctran/algos/SendRecv/SendRecvImpl.cc
+++ b/comms/ctran/algos/SendRecv/SendRecvImpl.cc
@@ -44,10 +44,12 @@ KernelConfig::KernelType getKernelType(
     bool hasTcpDmRecv,
     enum NCCL_SENDRECV_ALGO algo) {
   KernelConfig::KernelType kernelType = KernelConfig::KernelType::SENDRECV;
+#if defined(ENABLE_PRIMS)
   if (algo == NCCL_SENDRECV_ALGO::ctp2p) {
     kernelType = KernelConfig::KernelType::SENDRECV_P2P;
     return kernelType;
   }
+#endif // defined(ENABLE_PRIMS)
   if (hasSend && hasRecv) {
     if (hasTcpDmRecv) {
       kernelType = KernelConfig::KernelType::SENDRECV_UNPACK;

--- a/comms/ctran/algos/SendRecv/SendRecvP2p.cu
+++ b/comms/ctran/algos/SendRecv/SendRecvP2p.cu
@@ -1,5 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+// This entire translation unit is the comms::prims-backed NVLink P2P sendrecv
+// kernel. It is compiled only when prims is enabled; otherwise it becomes an
+// empty TU (mirrors AllToAll/DeviceAllToAllvPipes.cu,
+// AllReduce/AllReduceIbTree.cu).
+#if defined(ENABLE_PRIMS)
+
 #include <stdio.h>
 #include <cstddef>
 #include "comms/ctran/algos/CtranAlgoDev.h"
@@ -108,3 +114,5 @@ __global__ __launch_bounds__(512, 1) void ncclKernelSendRecvP2p(
     ctran::device::KernelWaitGpeTerminate(flag);
   }
 }
+
+#endif // defined(ENABLE_PRIMS)

--- a/comms/rcclx/develop/projects/rccl/CMakeLists.txt
+++ b/comms/rcclx/develop/projects/rccl/CMakeLists.txt
@@ -44,6 +44,7 @@ option(TRACE                                   "Enable additional tracing"      
 option(FAULT_INJECTION                         "Enable fault injection"                        ON)
 option(QUIET_WARNINGS                          "Supress compiler warnings"                     OFF)
 option(ENABLE_ROCSHMEM                         "Enable rocSHMEM support in RCCL"               OFF)
+option(ENABLE_PRIMS                            "Compile comms/prims (pipes) into RCCLX"        OFF)
 
 # Third-party dependency paths
 #==================================================================================================
@@ -855,7 +856,9 @@ if (NOT DEFINED ENABLE_TCPDM OR NOT ENABLE_TCPDM)
     list(FILTER CTRAN_SOURCES EXCLUDE REGEX "comms/ctran/backends/tcpdevmem/.*")
 endif()
 
-# Automatically collect all pipes source files.
+# comms/prims (pipes) sources, gated on ENABLE_PRIMS (default OFF) so the
+# AMD/ROCm build is isolated from comms/prims churn.
+if(ENABLE_PRIMS)
 file(GLOB_RECURSE PIPES_SOURCES_ABS
     "${FBCODE_DIR}/comms/prims/*.cc"
     "${FBCODE_DIR}/comms/prims/*.cu"
@@ -920,6 +923,10 @@ list(FILTER PIPES_SOURCES EXCLUDE REGEX "MultiPeerNvlTransport\\.")
 # MultipeerIbgdaTransport, and depends on mlx5dv/bnxt direct-verbs headers
 # (infiniband/mlx5dv.h, BnxtReDv.h) not available in this build.
 list(FILTER PIPES_SOURCES EXCLUDE REGEX "comms/prims/transport/amd/.*")
+else()
+# ENABLE_PRIMS off: compile no comms/prims sources into librccl.
+set(PIPES_SOURCES "")
+endif()
 
 # Run this command to get RCCLX_LIB_FILES:
 # find comms/rcclx/develop/meta -type f ! -path "*/tests/*" -path "*/lib/*" \( -name "*.cc" -o -name "*.h" -o -name "*.hpp" \) | sort
@@ -1422,7 +1429,10 @@ target_include_directories(rccl PRIVATE ${HIPIFY_DIR}/comms/ctran)
 # headers (HipDeviceCompat.h, nic/NicConfig.h) are included by compiled
 # transport/ibrc code via bare paths, so put the original source dir on the
 # include path. See the EXCLUDE for comms/prims/transport/amd/.* above.
+# Only needed when comms/prims sources are compiled in (ENABLE_PRIMS).
+if(ENABLE_PRIMS)
 target_include_directories(rccl PRIVATE ${FBCODE_DIR}/comms/prims/transport/amd)
+endif()
 
 if(DEMANGLE_DIR)
   target_include_directories(rccl PRIVATE ${DEMANGLE_DIR})
@@ -1471,6 +1481,9 @@ if(ENABLE_WARP_SPEED)
 endif()
 if(ENABLE_ROCSHMEM)
   target_compile_definitions(rccl PRIVATE ENABLE_ROCSHMEM)
+endif()
+if(ENABLE_PRIMS)
+  target_compile_definitions(rccl PRIVATE ENABLE_PRIMS)
 endif()
 
 # ==== rocSHMEM integration (optional) ====

--- a/comms/rcclx/develop/projects/rccl/install.sh
+++ b/comms/rcclx/develop/projects/rccl/install.sh
@@ -42,6 +42,7 @@ generate_sym_kernels=false
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
 quiet_warnings=false
 build_rocshmem_support=false
+enable_prims=false
 
 # #################################################
 # helper functions
@@ -84,6 +85,7 @@ function display_help()
     echo "       --generate-sym-kernels  Generate symmetric memory kernels"
     echo "    -q|--quiet-warnings        Suppress majority of compiler warnings (not recommended)"
     echo "       --rocshmem              Build with rocSHMEM support"
+    echo "       --enable-prims          Compile comms/prims (pipes) into RCCLX (default: off)"
 }
 
 # #################################################
@@ -93,7 +95,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,dependencies,debug,dump-asm,enable-code-coverage,enable_backtrace,disable-colltrace,disable-msccl-kernel,enable-mscclpp,fast,help,install,jobs:,kernel-resource-use,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,log-trace,openmp-test-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,force-reduce-pipeline,generate-sym-kernels,quiet-warnings,disable-warp-speed,verbose,rocshmem -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,dependencies,debug,dump-asm,enable-code-coverage,enable_backtrace,disable-colltrace,disable-msccl-kernel,enable-mscclpp,fast,help,install,jobs:,kernel-resource-use,local_gpu_only,amdgpu_targets:,no_clean,npkit-enable,log-trace,openmp-test-enable,roctx-enable,package_build,prefix:,rm-legacy-include-dir,run_tests_all,run_tests_quick,static,tests_build,time-trace,force-reduce-pipeline,generate-sym-kernels,quiet-warnings,disable-warp-speed,verbose,rocshmem,enable-prims -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -143,6 +145,7 @@ while true; do
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
     -q | --quiet-warnings)           quiet_warnings=true;                                                                              shift ;;
          --rocshmem)                 build_rocshmem_support=true;                                                                      shift ;;
+         --enable-prims)             enable_prims=true;                                                                                shift ;;
     --) shift ; break ;;
     *)  echo "Unexpected command line parameter received; aborting";
         exit 1
@@ -338,6 +341,14 @@ if [[ "${build_rocshmem_support}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
 else
     cmake_common_options="${cmake_common_options} -DENABLE_ROCSHMEM=OFF"
+fi
+
+# Compile comms/prims (pipes) into RCCLX. Default OFF shields the AMD/ROCm build
+# from comms/prims churn; pass --enable-prims to opt in (e.g. for local eval).
+if [[ "${enable_prims}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DENABLE_PRIMS=ON"
+else
+    cmake_common_options="${cmake_common_options} -DENABLE_PRIMS=OFF"
 fi
 
 check_exit_code "$?"


### PR DESCRIPTION
Summary:

The RCCLX ROCm conda build unconditionally compiled prims transport code that never runs on AMD, so any upstream churn in that code broke the AMD build for no reason.

This gates the prims dependency behind an `ENABLE_PRIMS` CMake option (default OFF), aligning the conda build path with Buck which already excluded prims on AMD. When off, the prims-backed P2P sendrecv paths gracefully decline to baseline at runtime with a one-time warning. Opt in for local evaluation with `ENABLE_PRIMS=1 ./build_rcclx.sh` (or `./install.sh --enable-prims`).

Default OFF is a runtime no-op on AMD since no checked-in config selects the prims-backed algorithms.

Reviewed By: saifhhasan

Differential Revision: D110784208


