### PR TITLE
Disable inductor simple_overlap pass when torchcomms compile support is active

### DIFF
--- a/comms/torchcomms/functional/inductor_lowering.py
+++ b/comms/torchcomms/functional/inductor_lowering.py
@@ -13,6 +13,27 @@ try:  # noqa: C901
     from torch._inductor import ir
     from torch._inductor.lowering import register_lowering
 
+    def _disable_unsafe_reordering_passes() -> None:
+        """Disable inductor passes that reorder torchcomms ops.
+
+        Inductor's simple_overlap pass (on by default since PyTorch 2.14
+        nightly dev20260625, pytorch/pytorch#184240) hoists collectives above
+        any node it doesn't recognize as a collective. torchcomms ops rely on
+        with_effects tokens for ordering, but the effect-chain StarDeps are
+        dropped on the scheduler floor due to a buffer-vs-operation name
+        mismatch in the with_effects lowering, so the pass freely reorders
+        blocking send/recv pairs and deadlocks ranks. Disable it until the
+        upstream fix lands.
+        """
+        from torch._inductor import config as inductor_config
+
+        dist_opts = getattr(inductor_config, "aten_distributed_optimizations", None)
+        if getattr(dist_opts, "enable_simple_overlap", None):
+            dist_opts.enable_simple_overlap = False
+            logger.info(
+                "Disabled inductor simple_overlap pass (unsafe with torchcomms ops)"
+            )
+
     def register_torchcomms_lowerings():
         from torchcomms.functional import collectives
 
@@ -20,6 +41,8 @@ try:  # noqa: C901
         if collectives is None:
             logger.warning("torchcomms.functional.collectives not available")
             return
+
+        _disable_unsafe_reordering_passes()
 
         try:
             from torchcomms.functional.registry import _REGISTERED_COLLECTIVES


### PR DESCRIPTION
## Summary

Fixes the nightly-torch `run_py_tests` CI hangs: every `Build and test torchcomms` run on main with torch nightly ≥ `2.14.0.dev20260625` stalls in `FullgraphCompileTest::test_fullgraph_compile_send_recv` until the 120-minute workflow timeout kills the job (e.g. [this run](https://github.com/meta-pytorch/torchcomms/actions/runs/28838385146/job/85532160748)).

## Root cause

PyTorch nightly `dev20260625` enabled inductor's `simple_overlap` scheduler pass by default (pytorch/pytorch#184240). The pass moves collectives earlier / waits later via adjacent swaps. Its safety guards are (a) data dependencies and (b) an `isinstance(node, ir._CollectiveKernel)` check to never reorder collectives across each other.

Neither guard protects torchcomms ops:

- torchcomms relies on `with_effects` effect tokens for ordering. Inductor's `with_effects` lowering records the effect chain into `V.graph.additional_star_deps` **keyed by buffer name** (`bufN`), but the scheduler looks entries up **by operation name** (`opN`) — so every effect-chain StarDep is silently dropped and there are no scheduler-visible ordering edges between torchcomms ops. (Upstream fix: https://github.com/pytorch/pytorch/pull/189209.)
- `torchcomm_send`/`torchcomm_barrier` (no tensor output) lower to plain `FallbackKernel`s rather than `_CollectiveKernel`, so the collective-ordering guard doesn't see them either.

Result: in the compiled `test_fullgraph_compile_send_recv` graph, the pass hoists the blocking `recv` above the `send`/`barrier` on every rank. The test alternates send/recv order by rank parity precisely to avoid deadlock; after the reorder all 4 ranks block in `recv` forever. Verified locally on 4×H100 with `torch==2.14.0.dev20260706+cu130`: py-spy shows all ranks in `torchcomm_recv`, and the generated `output_code.py` has `recv → barrier → send` on every rank.

## Change

Disable `enable_simple_overlap` when torchcomms registers its inductor lowerings (i.e. only when `TORCHCOMMS_PATCH_FOR_COMPILE=1` compile support is active), until the upstream key-mismatch fix lands. Guarded with `getattr` so stable torch (2.12, which has no such config) is unaffected.

## Test Plan

4×H100, `torch==2.14.0.dev20260706+cu130` (repros the CI hang exactly without this change):

- `test_fullgraph_compile_send_recv` + `_multiple`: pass in 15s (previously deadlocked indefinitely)
- full `FullgraphCompileTest.py` via torchrun 4 ranks: 22 passed, 1 skipped, 210 subtests passed in 97s
- verified generated code preserves `barrier → send/recv` program order on all ranks
- `lintrunner` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
