### PR TITLE
Fix dynamo integration for PyTorch 2.14 CustomClassObjectVariable rename

### DIFF
--- a/comms/torchcomms/functional/dynamo.py
+++ b/comms/torchcomms/functional/dynamo.py
@@ -22,9 +22,17 @@ from torch._dynamo.variables.base import VariableTracker
 from torch._dynamo.variables.constant import ConstantVariable
 from torch._dynamo.variables.lists import ListVariable
 
+# PyTorch 2.14+ renamed TorchScriptObjectVariable to CustomClassObjectVariable
+# (pytorch/pytorch#188460) with no back-compat alias; support both.
+try:
+    from torch._dynamo.variables.script_object import (
+        CustomClassObjectVariable as TorchScriptObjectVariable,
+    )
+except ImportError:
+    from torch._dynamo.variables.script_object import TorchScriptObjectVariable
+
 if TYPE_CHECKING:
     from torch._dynamo.symbolic_convert import InstructionTranslator
-    from torch._dynamo.variables.script_object import TorchScriptObjectVariable
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +71,6 @@ class TorchCommMethodVariable(VariableTracker):
         # Directly call the torch op - no tracing through patched method
         from torch._dynamo.variables import TensorVariable
         from torch._dynamo.variables.builder import wrap_fx_proxy
-        from torch._dynamo.variables.script_object import TorchScriptObjectVariable
 
         op_name = self.op_info["op_name"]
         schema = self.op_info["param_schema"]
@@ -626,7 +633,6 @@ def _patch_var_getattr() -> None:
     register_opaque_type with members=MemberType.USE_REAL.
     """
     from torch._dynamo.source import AttrSource
-    from torch._dynamo.variables.script_object import TorchScriptObjectVariable
 
     # PyTorch 2.14+ renamed var_getattr to getattro_impl
     # (pytorch/pytorch#186013); patch whichever the installed version has.

--- a/comms/torchcomms/functional/param_parsing.py
+++ b/comms/torchcomms/functional/param_parsing.py
@@ -69,6 +69,20 @@ def register_opaque_reference_type(cls: Any, **kwargs: Any) -> None:
         _opaque_object.register_opaque_type(cls, typ="reference", **kwargs)
 
 
+def is_opaque_reference_type_registered(cls: Any) -> bool:
+    """Check whether a class is registered as an opaque/custom class type.
+
+    Compatibility wrapper: PyTorch 2.14+ renamed is_opaque_type to
+    is_custom_class (pytorch/pytorch#188461); the old name still exists but
+    emits a deprecation warning. Use whichever the installed version has.
+    """
+    import torch._library.opaque_object as _opaque_object
+
+    if hasattr(_opaque_object, "is_custom_class"):
+        return _opaque_object.is_custom_class(cls)
+    return _opaque_object.is_opaque_type(cls)
+
+
 @dataclass
 class ParsedArgs:
     """Parsed arguments for collective operations.
@@ -351,7 +365,7 @@ class CollectiveParamSchema:
         Returns:
             A CollectiveParamSchema ready for use
         """
-        from torch._library.opaque_object import get_opaque_type_name, is_opaque_type
+        from torch._library.opaque_object import get_opaque_type_name
 
         def _get_schema_type(torch_type: Any) -> str | None:
             """Return the schema type string for known torch types."""
@@ -390,7 +404,7 @@ class CollectiveParamSchema:
             return None
 
         # Register the class as opaque type
-        if not is_opaque_type(target_class):
+        if not is_opaque_reference_type_registered(target_class):
             register_opaque_reference_type(target_class)
         opaque_type_name = get_opaque_type_name(target_class)
         _TYPE_NAME_TO_CLASS[opaque_type_name] = target_class
@@ -410,7 +424,7 @@ class CollectiveParamSchema:
                     )
                 )
             elif isinstance(spec.torch_type, type):
-                if not is_opaque_type(spec.torch_type):
+                if not is_opaque_reference_type_registered(spec.torch_type):
                     register_opaque_reference_type(spec.torch_type)
                 type_name = get_opaque_type_name(spec.torch_type)
                 _TYPE_NAME_TO_CLASS[type_name] = spec.torch_type
@@ -433,7 +447,7 @@ class CollectiveParamSchema:
                     if len(non_none_args) == 1 and type(None) in args:
                         inner_type = non_none_args[0]
                         if isinstance(inner_type, type):
-                            if not is_opaque_type(inner_type):
+                            if not is_opaque_reference_type_registered(inner_type):
                                 register_opaque_reference_type(inner_type)
                             type_name = get_opaque_type_name(inner_type)
                             _TYPE_NAME_TO_CLASS[type_name] = inner_type


### PR DESCRIPTION
## Summary

PyTorch nightly dev20260707 renamed `TorchScriptObjectVariable` to `CustomClassObjectVariable` (pytorch/pytorch#188460) with no back-compat alias, so `functional/dynamo.py` fails at import on current nightlies: `test_wait_proxy_propagation` fails with `ImportError` and collective tracing breaks with `UnsafeScriptObjectError` (see [this failing run](https://github.com/meta-pytorch/torchcomms/actions/runs/28957706860/job/85930627629)). This is the trailing half of the same upstream ghstack that #3060 addressed (`getattro_impl`/`register_custom_class`); these renames landed 5 days later and only hit nightlies after that fix was tested.

## Changes

All backwards compatible with stable torch:

- `functional/dynamo.py`: import `CustomClassObjectVariable` with a try/except fallback to `TorchScriptObjectVariable` at module scope, replacing the three scattered function-local imports.
- `functional/param_parsing.py`: new `is_opaque_reference_type_registered()` compat wrapper choosing `is_custom_class` vs the deprecated `is_opaque_type` (renamed in pytorch/pytorch#188461, currently a warning shim that will be removed); call sites updated. Also silences the `is_opaque_type` deprecation warning spam visible in the failing CI logs.

## Test Plan

torch==2.14.0.dev20260707+cu130 (nightly, repros the CI failures without this change):
- `tests/unit/py`: 88 passed, 4 skipped (incl. the 2 previously failing `test_wait_proxy_propagation` tests)
- `FullgraphCompileTest.py` via torchrun 4 ranks (gloo/cpu): 22 passed, 1 skipped
- importing `torchcomms.functional.collectives` emits 0 opaque_object deprecation warnings (previously 40+)

torch==2.13.0+cu126 (stable, exercises all fallback branches: no `CustomClassObjectVariable`, no `is_custom_class`, no `register_custom_class`, no `getattro_impl`):
- `tests/unit/py`: 85 passed, 4 skipped, 3 pre-existing `test_backend_wrapper` monitoredBarrier failures that also fail without this change
- `FullgraphCompileTest.py` via torchrun 4 ranks (gloo/cpu): pass

lintrunner (UFMT/CLANGFORMAT) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)