### PR TITLE
Guard stream-capture mode inside IpcRegCache import

### DIFF
--- a/comms/ctran/mapper/CtranMapper.cc
+++ b/comms/ctran/mapper/CtranMapper.cc
@@ -734,9 +734,13 @@ commResult_t CtranMapper::deregRemReg(struct CtranMapperRemoteAccessKey* rkey) {
       FB_CHECKABORT(
           ctranNvl != nullptr,
           "Unexpected rkey with NVL backend but ctranNvl is not initialized");
-      FB_COMMCHECK(
-          ctran::IpcRegCache::getInstance()->releaseRemReg(
-              rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+      auto ipcRegCache = ctran::IpcRegCache::getInstance();
+      FB_CHECKABORT(
+          ipcRegCache != nullptr, "Failed to get IpcRegCache instance");
+      FB_COMMCHECK(ipcRegCache->releaseRemReg(
+          rkey->nvlKey.peerId, rkey->nvlKey.basePtr, rkey->nvlKey.uid));
+      // actual release of deferred deregistrations
+      ipcRegCache->cleanupInvalidImports();
       break;
     }
     default:
@@ -930,6 +934,27 @@ bool CtranMapper::hasBackend() {
   return true;
 }
 
+std::vector<bool> CtranMapper::getBackends() {
+  std::vector<bool> backends(CtranMapperBackend::NUM_BACKENDS, false);
+  const int rank = comm->statex_->rank();
+  const int nRanks = comm->statex_->nRanks();
+  backends.at(CtranMapperBackend::IB) =
+      hasBackend(rank, CtranMapperBackend::IB);
+  backends.at(CtranMapperBackend::SOCKET) =
+      hasBackend(rank, CtranMapperBackend::SOCKET);
+  backends.at(CtranMapperBackend::TCPDM) =
+      hasBackend(rank, CtranMapperBackend::TCPDM);
+  for (int peer = 0; peer < nRanks; peer++) {
+    if (peer == rank) {
+      continue;
+    }
+    if (hasBackend(peer, CtranMapperBackend::NVL)) {
+      backends.at(CtranMapperBackend::NVL) = true;
+    }
+  }
+  return backends;
+}
+
 CtranIb* CtranMapper::ctranIbPtr() {
   return ctranIb.get();
 }
@@ -996,7 +1021,9 @@ commResult_t CtranMapper::intraAllGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const auto& statex = comm->statex_;
   const int nLocalRanks = statex->nLocalRanks();
 
@@ -1006,7 +1033,30 @@ commResult_t CtranMapper::intraAllGatherCtrl(
   }
 
   return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
+}
+
+commResult_t CtranMapper::intraAllGatherCtrl(
+    const void* buf,
+    void* hdl,
+    std::vector<void*>& remoteBufs,
+    std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+    std::vector<ctran::ScopedIpcRegHdl>& remoteIpcRegHdls) {
+  return this->intraAllGatherCtrl(
+      buf,
+      hdl,
+      remoteBufs,
+      remoteAccessKeys,
+      CtranMapperBackend::NVL,
+      /*recordExport=*/false,
+      &remoteIpcRegHdls);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1014,14 +1064,23 @@ commResult_t CtranMapper::allGatherCtrl(
     void* hdl,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const int nRanks = comm->statex_->nRanks();
   std::vector<int> ranks(nRanks);
   for (int i = 0; i < nRanks; i++) {
     ranks[i] = i;
   }
-  return this->allGatherCtrl(
-      buf, hdl, ranks, remoteBufs, remoteAccessKeys, backend);
+  return this->allGatherCtrlImpl(
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
 }
 
 commResult_t CtranMapper::allGatherCtrl(
@@ -1030,8 +1089,37 @@ commResult_t CtranMapper::allGatherCtrl(
     const std::vector<int>& ranks,
     std::vector<void*>& remoteBufs,
     std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-    CtranMapperBackend backend) {
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
+  return this->allGatherCtrlImpl(
+      buf,
+      hdl,
+      ranks,
+      remoteBufs,
+      remoteAccessKeys,
+      backend,
+      recordExport,
+      outIpcHdls);
+}
+
+commResult_t CtranMapper::allGatherCtrlImpl(
+    const void* buf,
+    void* hdl,
+    const std::vector<int>& ranks,
+    std::vector<void*>& remoteBufs,
+    std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+    CtranMapperBackend backend,
+    bool recordExport,
+    std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls) {
   const int rank = comm->statex_->rank();
+
+  // outIpcHdls is indexed by local rank in the import loop below; size it here
+  // at the point of use so every caller is safe -- including the ranks overload
+  // that does not pre-size it.
+  if (outIpcHdls != nullptr) {
+    outIpcHdls->resize(comm->statex_->nLocalRanks());
+  }
 
   // Skip if rank is not in the ranks list
   if (std::find(ranks.begin(), ranks.end(), rank) == ranks.end()) {
@@ -1089,8 +1177,9 @@ commResult_t CtranMapper::allGatherCtrl(
             hdl,
             nvlSendMsg,
             &nvlExtraSegments,
-            peerBackends[i]));
-      } else if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+            peerBackends[i],
+            recordExport));
+      } else if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         // exportMem not called for this peer, record explicitly
         exportRegCache_.wlock()->record(regElem, peerList[i]);
       }
@@ -1220,12 +1309,18 @@ commResult_t CtranMapper::allGatherCtrl(
         }
       }
       if (!hasPending) {
+        ctran::ScopedIpcRegHdl importedHdl;
         FB_COMMCHECK(this->importMem(
             peerList[i],
             recvMsgs[i],
             &remoteBufs[peerList[i]],
             &remoteAccessKeys[peerList[i]],
-            allRecvExtraSegments[i]));
+            allRecvExtraSegments[i],
+            outIpcHdls != nullptr ? &importedHdl : nullptr));
+        if (outIpcHdls != nullptr && importedHdl) {
+          const auto peerLocalRank = comm->statex_->localRank(peerList[i]);
+          (*outIpcHdls)[peerLocalRank] = std::move(importedHdl);
+        }
         peerImported[i] = true;
         numPeersImported++;
       }

--- a/comms/ctran/mapper/CtranMapper.h
+++ b/comms/ctran/mapper/CtranMapper.h
@@ -42,6 +42,10 @@ namespace ncclx::colltrace {
 class MapperTrace;
 }
 
+namespace ctran {
+class ScopedIpcRegHdl;
+}
+
 class CtranMapperImpl;
 
 const std::string getReqTypeStr(CtranMapperRequest::ReqType type);
@@ -452,13 +456,45 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t intraAllGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
+  /* Blocking allgather control messages among all local ranks, importing the
+   * intra-node NVL peers self-managed (recordExport=false) and returning them
+   * as scoped RAII owners the caller releases on teardown.
+   *
+   * The two output kinds have different shapes and purposes:
+   *   - remoteBufs / remoteAccessKeys: for rank-based lookup. The caller must
+   *     pre-size them to nRanks (they are indexed by global rank); this fills
+   *     only the local-peer slots at their global-rank indices (self is left
+   *     UNSET, non-local ranks untouched). IB/other keys are returned here too.
+   *   - remoteIpcRegHdls: resource-ownership handles for the imported NVL
+   *     peers, with size of nLocalRanks. For localRank that cannot be imported
+   *     (including self), an empty handle is inserted as placeholder. The
+   *     caller releases the imports via RAII.
+   */
+  commResult_t intraAllGatherCtrl(
+      const void* buf,
+      void* hdl,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      std::vector<ctran::ScopedIpcRegHdl>& remoteIpcRegHdls);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -474,6 +510,15 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t allGatherCtrl(
       const void* buf,
@@ -481,7 +526,9 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const std::vector<int>& ranks,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
 
   /* Blocking allgather control messages among ranks of the mapper associated
    * communicator specified in ranks. It returns after sent and received all
@@ -497,13 +544,24 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    *                 including the rank itself
    *   - remoteAccessKeys: the allgathered remote access keys from all local
    *                       ranks
+   *   - recordExport: whether to record NVL exports in exportRegCache_ so that
+   *                   remReleaseMem notifies peers to release imports at
+   *                   deregistration. Set false when the caller self-manages
+   *                   its imports (e.g., AGP) to avoid double-release.
+   *   - outIpcHdls: optional; if non-null, receives the imported NVL peers'
+   *                 scoped-ownership handles, sized to nLocalRanks and indexed
+   *                 by local rank (self and non-NVL peers are empty handles).
+   *                 The caller owns the imports and releases them via RAII
+   *                 (deferred releaseRemReg at handle destruction).
    */
   commResult_t allGatherCtrl(
       const void* buf,
       void* hdl,
       std::vector<void*>& remoteBufs,
       std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET);
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
 
   /* Convenient wrapper of isendCtrl/irecvCtrl to post a blocking barrier among
    * all local ranks of the mapper associated communicator.
@@ -949,6 +1007,12 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
    */
   bool hasBackend(int rank, CtranMapperBackend specified);
 
+  /* Get the set of transport backends this rank uses to reach all peer ranks,
+   * indexed by CtranMapperBackend. Entry true if this rank uses that backend to
+   * any peer. The returned vector has size CtranMapperBackend::NUM_BACKENDS.
+   */
+  std::vector<bool> getBackends();
+
   /* Some backends, notably NVL and TCPDM, require notifiers on the receiver
    * side. This method indicates whether the notifier is needed for
    * the specified peer rank.
@@ -1064,6 +1128,16 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
   }
 
  private:
+  commResult_t allGatherCtrlImpl(
+      const void* buf,
+      void* hdl,
+      const std::vector<int>& ranks,
+      std::vector<void*>& remoteBufs,
+      std::vector<struct CtranMapperRemoteAccessKey>& remoteAccessKeys,
+      CtranMapperBackend backend,
+      bool recordExport = true,
+      std::vector<ctran::ScopedIpcRegHdl>* outIpcHdls = nullptr);
+
   [[noreturn]] inline void throwCommAbortException(
       const std::string& abortContext) {
     auto commAbort = comm->getAbort();
@@ -1252,7 +1326,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       void* hdl,
       ControlMsg& msg,
       std::vector<ctran::utils::CtranIpcSegDesc>* extraSegments,
-      CtranMapperBackend backend = CtranMapperBackend::UNSET) {
+      CtranMapperBackend backend = CtranMapperBackend::UNSET,
+      bool recordExport = true) {
     auto regElem = reinterpret_cast<ctran::regcache::RegElem*>(hdl);
     // TODO: Enforce that a communicator can only export memory it registered
     // itself except the memory registered by globalRegister. Currently any comm
@@ -1287,8 +1362,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
         }
       }
 
-      // Record the exported remote rank to notify at deregistration
-      if (NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
+      // Record the exported remote rank to notify at deregistration.
+      if (recordExport && NCCL_CTRAN_IPC_REGCACHE_ENABLE_ASYNC_SOCKET) {
         exportRegCache_.wlock()->record(regElem, rank);
       }
 
@@ -1323,7 +1398,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
       const ControlMsg& msg,
       void** buf,
       CtranMapperRemoteAccessKey* remKey,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {}) {
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      ctran::ScopedIpcRegHdl* outHdl = nullptr) {
     switch (msg.type) {
       case ControlMsgType::IB_EXPORT_MEM:
         if (!this->ctranIb) {
@@ -1354,7 +1430,8 @@ class CtranMapper : public ctran::regcache::IpcExportClient {
                 buf,
                 &(remKey->nvlKey),
                 &this->logMetaData_,
-                extraSegments));
+                extraSegments,
+                outHdl));
         break;
       }
       default:

--- a/comms/ctran/mapper/tests/CtranDistMapperUT.cc
+++ b/comms/ctran/mapper/tests/CtranDistMapperUT.cc
@@ -126,6 +126,84 @@ TEST_P(CtranDistMapperBackendParam, intraAllGatherCtrl) {
   NCCLCHECK_TEST(ncclMemFree(buf));
 }
 
+// Verify that intraAllGatherCtrl with recordExport=false does NOT populate the
+// export tracking cache, so its self-managed NVL imports are not
+// double-released by the export-notify path at deregistration.
+TEST_F(CtranDistMapperTest, intraAllGatherCtrlNoRecordExport) {
+  void* buf = nullptr;
+  void* handle = nullptr;
+  constexpr size_t bufSize = 8192;
+  auto mapper = comm_->ctran_->mapper.get();
+  const auto& statex = comm_->statex_.get();
+
+  if (statex->nLocalRanks() < 2) {
+    GTEST_SKIP()
+        << "Test requires at least 2 localRanks on each node.  Skip test.";
+  }
+
+  for (int localRank = 0; localRank < statex->nLocalRanks(); localRank++) {
+    const int peer = statex->localRankToRank(localRank);
+    if (!mapper->hasBackend(peer, CtranMapperBackend::NVL)) {
+      GTEST_SKIP() << "NVL backend is not available for localRank " << localRank
+                   << " (rank " << peer << ")";
+    }
+  }
+
+  NCCLCHECK_TEST(ncclMemAlloc(&buf, bufSize));
+  COMMCHECK_TEST(comm_->ctran_->commRegister(buf, bufSize, &handle));
+
+  void* sendHdl = nullptr;
+  bool localReg = false;
+  COMMCHECK_TEST(mapper->searchRegHandle(buf, bufSize, &sendHdl, &localReg));
+  ASSERT_NE(sendHdl, nullptr);
+  ASSERT_EQ(localReg, false);
+
+  std::vector<void*> remoteBufs(statex->nRanks(), nullptr);
+  std::vector<struct CtranMapperRemoteAccessKey> remoteAccessKeys(
+      statex->nRanks());
+
+  {
+    CtranMapperEpochRAII epochRAII(mapper);
+    ASSERT_EQ(
+        mapper->intraAllGatherCtrl(
+            buf,
+            sendHdl,
+            remoteBufs,
+            remoteAccessKeys,
+            CtranMapperBackend::NVL,
+            /*recordExport=*/false),
+        commSuccess);
+  }
+
+  ASSERT_TRUE(mapper->dumpExportRegCache().empty());
+
+  const int nodeId = statex->node();
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (peer == statex->rank()) {
+      ASSERT_EQ(remoteBufs[peer], buf);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    } else if (statex->node(peer) == nodeId) {
+      ASSERT_NE(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::NVL);
+    } else {
+      ASSERT_EQ(remoteBufs[peer], nullptr);
+      ASSERT_EQ(remoteAccessKeys[peer].backend, CtranMapperBackend::UNSET);
+    }
+  }
+
+  // Self-managed imports: release the remote NVL registrations explicitly.
+  barrierNvlDomain(comm_.get());
+  for (int peer = 0; peer < statex->nRanks(); peer++) {
+    if (remoteAccessKeys[peer].backend == CtranMapperBackend::NVL) {
+      ASSERT_EQ(mapper->deregRemReg(&remoteAccessKeys[peer]), commSuccess);
+    }
+  }
+  barrierNvlDomain(comm_.get());
+
+  COMMCHECK_TEST(comm_->ctran_->commDeregister(handle));
+  NCCLCHECK_TEST(ncclMemFree(buf));
+}
+
 TEST_P(CtranDistMapperBackendParam, allGatherCtrl) {
   auto& [backend] = GetParam();
 #ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -7,6 +7,7 @@
 #include "comms/ctran/utils/Checks.h"
 #include "comms/ctran/utils/Debug.h"
 #include "comms/ctran/utils/Utils.h"
+#include "comms/utils/CudaRAII.h"
 #include "comms/utils/cvars/nccl_cvars.h"
 
 // Initialize static unique ID counter
@@ -154,6 +155,15 @@ commResult_t ctran::IpcRegCache::importMem(
     const struct CommLogData* logMetaData,
     const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments,
     ctran::ScopedIpcRegHdl* outHdl) {
+  // Importing a remote NVL buffer issues host CUDA driver calls
+  // (cuMemImportFromShareableHandle / cuMemMap / cuMemSetAccess, and cuMemUnmap
+  // via cleanupInvalidImports below). Relax this thread's stream-capture mode
+  // so IpcRegCache is self-guarding when a caller imports during CUDA graph
+  // capture (e.g. persistent AllGatherP); callers must not need their own
+  // guard.
+  meta::comms::StreamCaptureModeGuard captureGuard{
+      cudaStreamCaptureModeRelaxed};
+
   // Reclaim any imports released deferentially before this user-thread entry.
   cleanupInvalidImports();
 

--- a/comms/ctran/regcache/IpcRegCache.cc
+++ b/comms/ctran/regcache/IpcRegCache.cc
@@ -91,6 +91,58 @@ void ctran::IpcRegCache::init() {
 ctran::IpcRegCache::~IpcRegCache() {
   stopAsyncSocket();
   clearAllRemReg();
+  cleanupInvalidImports();
+}
+
+void ctran::ScopedIpcRegHdl::reset() noexcept {
+  if (ipcRegCache_ == nullptr) {
+    return;
+  }
+
+  // Deferred release: safe on any thread (SW-only), the actual CUDA unmap is
+  // drained later by IpcRegCache::cleanupInvalidImports(). Ignore the result —
+  // a destructor must not throw or propagate errors.
+  FB_COMMCHECKIGNORE(
+      ipcRegCache_->releaseRemReg(peerId_, basePtr_, uid_, /*exportCount=*/1));
+
+  ipcRegCache_ = nullptr;
+  peerId_.clear();
+  basePtr_ = nullptr;
+  uid_ = 0;
+  refCount_ = 0;
+}
+
+ctran::ScopedIpcRegHdl& ctran::ScopedIpcRegHdl::operator=(
+    ScopedIpcRegHdl&& other) noexcept {
+  if (this != &other) {
+    reset();
+    ipcRegCache_ = other.ipcRegCache_;
+    peerId_ = std::move(other.peerId_);
+    basePtr_ = other.basePtr_;
+    uid_ = other.uid_;
+    refCount_ = other.refCount_;
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+    other.refCount_ = 0;
+  }
+  return *this;
+}
+
+ctran::ScopedIpcRegHdl::~ScopedIpcRegHdl() {
+  reset();
+}
+
+std::string ctran::ScopedIpcRegHdl::toString() const {
+  if (ipcRegCache_ == nullptr) {
+    return "[ScopedIpcRegHdl] empty";
+  }
+  return fmt::format(
+      "[ScopedIpcRegHdl] peerId: {}, basePtr: {}, uid: {}, refCount: {}",
+      peerId_,
+      basePtr_,
+      uid_,
+      refCount_);
 }
 
 commResult_t ctran::IpcRegCache::importMem(
@@ -100,10 +152,21 @@ commResult_t ctran::IpcRegCache::importMem(
     void** buf,
     struct ctran::regcache::IpcRemHandle* remKey,
     const struct CommLogData* logMetaData,
-    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments,
+    ctran::ScopedIpcRegHdl* outHdl) {
+  // Reclaim any imports released deferentially before this user-thread entry.
+  cleanupInvalidImports();
+
   void* basePtr = nullptr;
+  int refCount = 0;
   FB_COMMCHECK(importRemMemImpl(
-      peerId, ipcDesc, cudaDev, logMetaData, &basePtr, extraSegments));
+      peerId,
+      ipcDesc,
+      cudaDev,
+      logMetaData,
+      &basePtr,
+      extraSegments,
+      &refCount));
 
   // import from baseAddr of a remote segment, return buf at offset from
   // baseAddr
@@ -119,6 +182,14 @@ commResult_t ctran::IpcRegCache::importMem(
       (void*)basePtr,
       ipcDesc.offset,
       ipcDesc.uid);
+
+  // The single ref this import added is now owned by *outHdl: its destructor's
+  // deferred releaseRemReg drops it. Callers passing nullptr manage the ref
+  // themselves via releaseRemReg.
+  if (outHdl != nullptr) {
+    *outHdl =
+        ScopedIpcRegHdl(this, peerId, remKey->basePtr, remKey->uid, refCount);
+  }
   return commSuccess;
 }
 
@@ -128,7 +199,8 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
     int cudaDev,
     const struct CommLogData* logMetaData,
     void** mappedBase,
-    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments) {
+    const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments,
+    int* outRefCount) {
   auto lockedMap = ipcRemRegMap_.wlock();
   uint64_t base = reinterpret_cast<uint64_t>(ipcDesc.desc.base);
   IpcRemRegKey key{base, ipcDesc.uid};
@@ -138,15 +210,19 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
   if (peerIt != lockedMap->end()) {
     auto keyIt = peerIt->second.find(key);
     if (keyIt != peerIt->second.end()) {
-      keyIt->second->refCount.fetch_add(1, std::memory_order_relaxed);
+      const int newRefCount =
+          keyIt->second->refCount.fetch_add(1, std::memory_order_relaxed) + 1;
       *mappedBase = keyIt->second->ipcRemMem.getBase();
+      if (outRefCount != nullptr) {
+        *outRefCount = newRefCount;
+      }
       CLOGF_TRACE(
           COLL,
           "CTRAN-REGCACHE: IPC remote registration cache hit peer:base:uid=<{}:{}:{}>, refCount now {}",
           peerId,
           reinterpret_cast<void*>(base),
           ipcDesc.uid,
-          keyIt->second->refCount.load(std::memory_order_relaxed));
+          newRefCount);
       return commSuccess;
     }
   }
@@ -173,6 +249,9 @@ commResult_t ctran::IpcRegCache::importRemMemImpl(
       ipcDesc.uid,
       reg->toString());
 
+  if (outRefCount != nullptr) {
+    *outRefCount = 1;
+  }
   *mappedBase = reg->ipcRemMem.getBase();
   (*lockedMap)[peerId][key] = std::move(reg);
 
@@ -188,8 +267,9 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
   uint64_t base = reinterpret_cast<uint64_t>(basePtr);
   IpcRemRegKey key{base, uid};
 
-  if (lockedMap->find(peerId) == lockedMap->end() ||
-      (*lockedMap)[peerId].find(key) == (*lockedMap)[peerId].end()) {
+  auto peerIt = lockedMap->find(peerId);
+  if (peerIt == lockedMap->end() ||
+      peerIt->second.find(key) == peerIt->second.end()) {
     CLOGF(
         ERR,
         "CTRAN-REGCACHE: Unknown IPC remote memory registration from peer {} base {} uid {}",
@@ -199,7 +279,8 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
     return ErrorStackTraceUtil::log(commInternalError);
   }
 
-  auto& elem = (*lockedMap)[peerId][key];
+  auto keyIt = peerIt->second.find(key);
+  auto& elem = keyIt->second;
   int prevCount =
       elem->refCount.fetch_sub(exportCount, std::memory_order_acq_rel);
 
@@ -213,7 +294,7 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
         uid,
         prevCount,
         exportCount);
-    // Fall through to erase — the entry is invalid regardless
+    // Fall through to invalidate — the entry is invalid regardless
   } else if (prevCount > exportCount) {
     CLOGF_TRACE(
         COLL,
@@ -234,20 +315,23 @@ commResult_t ctran::IpcRegCache::releaseRemReg(
       uid,
       elem->toString());
 
-  try {
-    (*lockedMap)[peerId].erase(key);
-  } catch (std::exception& e) {
-    CLOGF(
-        WARN,
-        "CTRAN-REGCACHE: failed to remove IPC remote registration from cache peer:base:uid=<{}:{}:{}>, error {}",
-        peerId,
-        basePtr,
-        uid,
-        e.what());
-    return ErrorStackTraceUtil::log(commInternalError);
-  }
+  // Move refcount==0 elem out of the live map. Actual unmap runs in
+  // cleanupInvalidImports().
+  invalidImports_.wlock()->push_back(std::move(elem));
+  peerIt->second.erase(keyIt);
 
   return commSuccess;
+}
+
+void ctran::IpcRegCache::cleanupInvalidImports() {
+  std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>> pending;
+  {
+    auto lockedInvalid = invalidImports_.wlock();
+    pending.swap(*lockedInvalid);
+  }
+
+  // Destruct the moved-out elems outside the lock; ~IpcRemRegElem performs the
+  // CUDA unmap. Safe when pending is empty and when called repeatedly.
 }
 
 void ctran::IpcRegCache::clearAllRemReg() {
@@ -273,6 +357,21 @@ size_t ctran::IpcRegCache::getNumRemReg(const std::string& peerId) const {
     return it->second.size();
   }
   return 0;
+}
+
+int ctran::IpcRegCache::maxRemRegRefCount() const {
+  auto lockedMap = ipcRemRegMap_.rlock();
+
+  int maxRefCount = 0;
+  for (const auto& [peerId, regs] : *lockedMap) {
+    for (const auto& [key, elem] : regs) {
+      const int refCount = elem->refCount.load(std::memory_order_relaxed);
+      if (refCount > maxRefCount) {
+        maxRefCount = refCount;
+      }
+    }
+  }
+  return maxRefCount;
 }
 
 commResult_t ctran::IpcRegCache::notifyRemoteIpcRelease(
@@ -443,6 +542,7 @@ commResult_t ctran::IpcRegCache::initAsyncSocket() {
                 ipcReq.release.base,
                 ipcReq.release.uid,
                 ipcReq.release.exportCount));
+            cleanupInvalidImports();
             break;
           }
           case ctran::regcache::IpcReqType::kDesc: {

--- a/comms/ctran/regcache/IpcRegCache.h
+++ b/comms/ctran/regcache/IpcRegCache.h
@@ -2,6 +2,9 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -17,6 +20,89 @@
 #include "comms/ctran/utils/Checks.h"
 
 namespace ctran {
+
+class IpcRegCache;
+class ScopedIpcRegHdl;
+
+// Move-only RAII owner of ONE remote NVL IPC import ref. It ADOPTS an existing
+// import ref (does not importMem, does not add a ref) and, on destruction,
+// drops that ref via a deferred releaseRemReg so it is safe to destroy from a
+// CUDA-callback context (e.g. graph destroy): the drop is pure SW; the parked
+// import is unmapped later by IpcRegCache::cleanupInvalidImports() on a user
+// thread.
+//
+// Lifecycle difference vs the local ScopedRegHdl: ScopedIpcRegHdl has NO
+// cache-held baseline ref. Its last release CAN drive the import refCount to 0
+// and retire the mapping (deferred: moved to invalidImports_, unmapped later by
+// cleanupInvalidImports()). A local ScopedRegHdl release never retires the
+// local registration because regcache always holds a baseline ref.
+class ScopedIpcRegHdl {
+ public:
+  ScopedIpcRegHdl() = default;
+
+  ScopedIpcRegHdl(ScopedIpcRegHdl&& other) noexcept
+      : ipcRegCache_(other.ipcRegCache_),
+        peerId_(std::move(other.peerId_)),
+        basePtr_(other.basePtr_),
+        uid_(other.uid_),
+        refCount_(other.refCount_) {
+    other.ipcRegCache_ = nullptr;
+    other.basePtr_ = nullptr;
+    other.uid_ = 0;
+    other.refCount_ = 0;
+  }
+
+  ScopedIpcRegHdl& operator=(ScopedIpcRegHdl&& other) noexcept;
+
+  ScopedIpcRegHdl(const ScopedIpcRegHdl&) = delete;
+  ScopedIpcRegHdl& operator=(const ScopedIpcRegHdl&) = delete;
+
+  ~ScopedIpcRegHdl();
+
+  // The IpcRegCache this handle will release into, or nullptr when the handle
+  // is empty or moved-from.
+  IpcRegCache* get() const {
+    return ipcRegCache_;
+  }
+
+  explicit operator bool() const {
+    return ipcRegCache_ != nullptr;
+  }
+
+  std::string toString() const;
+
+  // The import's refCount observed when this handle adopted it: >1 means the
+  // remote IPC import was already held by another owner (reused / cache hit),
+  // ==1 means this handle is the sole holder (freshly imported), 0 if unknown.
+  int refCount() const {
+    return refCount_;
+  }
+
+ private:
+  friend class IpcRegCache;
+
+  ScopedIpcRegHdl(
+      IpcRegCache* ipcRegCache,
+      std::string peerId,
+      void* basePtr,
+      uint32_t uid,
+      int refCount)
+      : ipcRegCache_(ipcRegCache),
+        peerId_(std::move(peerId)),
+        basePtr_(basePtr),
+        uid_(uid),
+        refCount_(refCount) {}
+
+  // Drop the held import ref (deferred release) and reset to the empty state.
+  // No-op when already empty/moved-from. Never throws.
+  void reset() noexcept;
+
+  IpcRegCache* ipcRegCache_{nullptr};
+  std::string peerId_;
+  void* basePtr_{nullptr};
+  uint32_t uid_{0};
+  int refCount_{0};
+};
 
 // Class to manage IPC-based remote memory registrations for a single
 // communicator. Currently handles NVL (NVLink) remote memory imports from peer
@@ -83,6 +169,9 @@ class IpcRegCache {
   // Output arguments:
   //   - buf: the local buffer mapped to the imported remote memory
   //   - remKey: the remoteAccessKey (rkey) of the remote buffer registration
+  //   - outHdl: (optional) when non-null, populated with a ScopedIpcRegHdl that
+  //             ADOPTS the ref this import added (its destructor drops that
+  //             ref)
   commResult_t importMem(
       const std::string& peerId,
       const ctran::regcache::IpcDesc& ipcDesc,
@@ -90,7 +179,8 @@ class IpcRegCache {
       void** buf,
       struct ctran::regcache::IpcRemHandle* remKey,
       const struct CommLogData* logMetaData = nullptr,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      ctran::ScopedIpcRegHdl* outHdl = nullptr);
 
   // Export local NVL memory registration for sharing with remote peers.
   // Input arguments:
@@ -120,17 +210,30 @@ class IpcRegCache {
     return commSuccess;
   }
 
-  // Release a specific remote registration for a given peer.
-  // exportCount specifies how many times the buffer was exported to this peer;
-  // the refcount is decremented by this amount.
+  // Release a specific remote registration for a given peer. Always deferred
+  // (SW-only): exportCount specifies how many times the buffer was exported to
+  // this peer; the refcount is decremented by this amount. When the refcount
+  // drops to zero the elem is moved out of the live map into invalidImports_
+  // WITHOUT touching CUDA. The backing CUDA unmap happens later, only when
+  // cleanupInvalidImports() is explicitly called on a user thread.
   commResult_t releaseRemReg(
       const std::string& peerId,
       void* basePtr,
       uint32_t uid,
       int32_t exportCount = 1);
 
+  // Drain invalidImports_: destroy every refcount==0 elem pending CUDA unmap.
+  // Must be called on a user thread (performs CUDA APIs). Safe when empty and
+  // safe to call repeatedly.
+  void cleanupInvalidImports();
+
   // Get the number of existing remote registrations for a given peer
   size_t getNumRemReg(const std::string& peerId) const;
+
+  // Max refCount among live remote IPC imports (0 if none). For
+  // test/observability: refCount > 1 means an import was reused (shared) by
+  // multiple importers.
+  int maxRemRegRefCount() const;
 
   // Release all remote registrations.
   // Called during destruction to clean up any remaining cached registrations.
@@ -196,7 +299,8 @@ class IpcRegCache {
       int cudaDev,
       const struct CommLogData* logMetaData,
       void** mappedBase,
-      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {});
+      const std::vector<ctran::utils::CtranIpcSegDesc>& extraSegments = {},
+      int* outRefCount = nullptr);
 
   // Initialize the AsyncSocket infrastructure for this rank.
   // Must be called once per rank before notifyRemoteIpcRelease can be used.
@@ -220,6 +324,14 @@ class IpcRegCache {
           std::unique_ptr<ctran::regcache::IpcRemRegElem>,
           folly::Hash>>;
   folly::Synchronized<IpcRemRegMap> ipcRemRegMap_;
+
+  // Elems whose refCount reached zero and left ipcRemRegMap_, still holding a
+  // live CUDA mapping. Destroying the unique_ptr performs the cuMemUnmap; that
+  // must happen on a user thread, so releaseRemReg parks the elem
+  // here and cleanupInvalidImports() drains it later outside the map lock.
+  folly::Synchronized<
+      std::vector<std::unique_ptr<ctran::regcache::IpcRemRegElem>>>
+      invalidImports_;
 
   // Flag for one-time initialization
   std::once_flag initFlag_;

--- a/comms/ctran/regcache/RegCache.cc
+++ b/comms/ctran/regcache/RegCache.cc
@@ -593,7 +593,8 @@ void ctran::RegCache::resetExternalRegMemFn() {
 
 ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
     const void* ptr,
-    const size_t len) {
+    const size_t len,
+    bool acquireRef) {
   ctran::regcache::RegElem* regHdl = nullptr;
 
   auto regElemsMaps = regElemsMaps_.rlock();
@@ -616,6 +617,10 @@ ctran::regcache::RegElem* ctran::RegCache::searchRegElem(
       // Lookup hit
       regHdl = searchRegElem.get();
       searchRegElem->lookupHit_++;
+      if (acquireRef) {
+        // Atomic increment: safe under the shared read lock.
+        regHdl->refCount.fetch_add(1, std::memory_order_relaxed);
+      }
       break;
     }
   }
@@ -918,7 +923,8 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
     std::vector<ctran::regcache::Segment*>& segments,
     const std::vector<bool>& backends,
     bool ncclManaged,
-    ctran::regcache::RegElem** regHdl) {
+    ctran::regcache::RegElem** regHdl,
+    bool acquireRef) {
   // Create a new registration element for the segments
   auto newRegElem = std::make_unique<ctran::regcache::RegElem>(
       ptr, len, cudaDev, segments, ncclManaged);
@@ -932,6 +938,12 @@ commResult_t ctran::RegCache::registerSegmentsTogether(
   auto regElemsMaps = regElemsMaps_.wlock();
   auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
   auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
+
+  // The RegElem already holds the registration's ref (refCount starts at 1).
+  // If the caller is a scoped acquire, add its ref while holding the map lock.
+  if (acquireRef) {
+    regHdlPtr->refCount.fetch_add(1, std::memory_order_relaxed);
+  }
 
   regHdlToElemMap.emplace(regHdlPtr, std::move(newRegElem));
   // Correlate the regElem with all associated segments to deregister it
@@ -953,7 +965,8 @@ commResult_t ctran::RegCache::regRangeCached(
     const std::vector<bool>& backends,
     bool& didRegister,
     ctran::regcache::RegElem** regHdl,
-    bool ncclManaged) {
+    bool ncclManaged,
+    bool acquireRef) {
   auto dur = CtranMapperTimer();
   SetCudaDevRAII setCudaDev(cudaDev);
   auto timerBegin = std::chrono::steady_clock::now();
@@ -962,7 +975,7 @@ commResult_t ctran::RegCache::regRangeCached(
     // FAST PATH: find whether range has already been registered in
     // regElemsMaps. regElemsMaps should not be wlocked while performing
     // expensive registration/deregistration.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     // Lookup hit
     if (*regHdl) {
       return commSuccess;
@@ -983,7 +996,7 @@ commResult_t ctran::RegCache::regRangeCached(
 
     // While holding the global lock, let's check again no one else has
     // registered the range.
-    *regHdl = searchRegElem(ptr, len);
+    *regHdl = searchRegElem(ptr, len, acquireRef);
     if (*regHdl) {
       return commSuccess;
     }
@@ -1032,7 +1045,8 @@ commResult_t ctran::RegCache::regRangeCached(
           segments,
           backends,
           ncclManaged,
-          regHdl));
+          regHdl,
+          acquireRef));
       didRegister = true;
     } else {
       // - WORST PATH: if any one is not found, return nullptr to trigger
@@ -1170,6 +1184,21 @@ commResult_t ctran::RegCache::freeSegment(
           continue;
         }
 
+        // Remove the registration's ref. Any remaining count means live
+        // ScopedRegHdl owners, which violates the lifetime contract because the
+        // segment/memory is being freed underneath them.
+        const auto prev =
+            regIt->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+        const auto after = prev - 1;
+        if (after > 0) {
+          CLOGF(
+              ERR,
+              "freeSegment: tearing down RegElem [buf {} len {}] that still has {} live ScopedRegHdl owner(s). This violates the scoped-registration lifetime contract: the buffer memory must outlive all ScopedRegHdl scopes.",
+              regIt->second->buf,
+              regIt->second->len,
+              after);
+        }
+
         // Remove regElem from global cache and to be deregistered
         regElems.push_back(std::move(regIt->second));
         regHdlToElemMap.erase(regIt);
@@ -1214,6 +1243,168 @@ commResult_t ctran::RegCache::deregElem(ctran::regcache::RegElem* regElem) {
   FB_COMMCHECK(regElem->doDeregister(externalDeregMemFn_));
   profiler.wlock()->record(ctran::regcache::EventType::kDeregMemEvent, dur);
   return commSuccess;
+}
+
+void ctran::RegCache::releaseScopedRegHdl(
+    ctran::regcache::RegElem* regHdl,
+    const uint64_t regId) {
+  // Pure SW-only release: drop the scope's ref (atomic decrement). Never
+  // deregisters, deletes, or touches CUDA, so it is safe to run from a CUDA
+  // graph-destroy callback. The registration's own ref (dropped only by
+  // freeSegment/deregRange on a user thread) keeps the RegElem alive, so a
+  // scoped release can never drive refCount to 0.
+  //
+  // A read lock is enough: we only look up the map, we never modify it. The
+  // rlock excludes freeSegment's wlock, so the found RegElem cannot be freed
+  // underneath the decrement.
+  if (regHdl == nullptr) {
+    return;
+  }
+
+  auto regElemsMaps = regElemsMaps_.rlock();
+  // NOTE: regHdl may be a dangling pointer here if a buffer-release path
+  // (freeSegment/globalDeregister) already force-freed the RegElem while this
+  // scope was still live. It is therefore used ONLY as a map key below and is
+  // NEVER dereferenced. Beyond the not-found case, we also compare the captured
+  // regId against the found RegElem's id: the heap may reuse a force-freed
+  // RegElem's address for an unrelated RegElem (ABA), and the id check rejects
+  // that so we never decrement an unrelated registration's refCount. Either
+  // case safely no-ops.
+  auto it = regElemsMaps->regHdlToElemMap.find(regHdl);
+  if (it == regElemsMaps->regHdlToElemMap.end() ||
+      it->second->regId_ != regId) {
+    CLOGF(
+        WARN,
+        "releaseScopedRegHdl: regElem {} not found or its address was reused (may have been force-freed by a buffer-release path)",
+        (void*)regHdl);
+    return;
+  }
+
+  const auto prev =
+      it->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+  const auto after = prev - 1;
+  FB_CHECKABORT(
+      after >= 1,
+      "scoped release drove refCount below the registration baseline for RegElem {} (cnt {})",
+      (void*)regHdl,
+      after);
+}
+
+commResult_t ctran::RegCache::acquireScopedRegister(
+    const void* buf,
+    size_t len,
+    int cudaDev,
+    const std::vector<bool>& backends,
+    ctran::ScopedRegHdl& scopedRegHdl) {
+  if (buf == nullptr || len == 0) {
+    CLOGF(ERR, "acquireScopedRegister: invalid buf {} len {}", (void*)buf, len);
+    return commInvalidUsage;
+  }
+
+  // Acquire one RegElem ref. The buffer's segment must already be cached by the
+  // allocator; regRangeCached returns nullptr otherwise.
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData scopedLogData{};
+  scopedLogData.commDesc = "scopedRegister";
+  const auto regResult = regRangeCached(
+      buf,
+      len,
+      cudaDev,
+      "scopedRegister",
+      scopedLogData,
+      backends,
+      didRegister,
+      &regHdl,
+      true /* ncclManaged */,
+      true /* acquireRef */);
+
+  if (regResult != commSuccess || regHdl == nullptr) {
+    CLOGF(
+        ERR,
+        "acquireScopedRegister: buffer [buf {} len {}] is not backed by a cached "
+        "segment. Scoped registration requires the buffer's memory to be pre-registered "
+        "by the allocator (globalRegister / CCA memory hook) before use. Ensure the "
+        "allocator registers memory after allocation and deregisters before free.",
+        (void*)buf,
+        len);
+    return commInvalidUsage;
+  }
+
+  scopedRegHdl.regCache_ = this;
+  scopedRegHdl.regHdl_ = regHdl;
+  scopedRegHdl.regId_ = regHdl->regId_;
+  scopedRegHdl.buf_ = regHdl->buf;
+  scopedRegHdl.len_ = regHdl->len;
+  return commSuccess;
+}
+
+ctran::ScopedRegHdl::ScopedRegHdl(ctran::ScopedRegHdl&& other) noexcept
+    : regCache_(other.regCache_),
+      regHdl_(other.regHdl_),
+      regId_(other.regId_),
+      buf_(other.buf_),
+      len_(other.len_) {
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+}
+
+ctran::ScopedRegHdl& ctran::ScopedRegHdl::operator=(
+    ctran::ScopedRegHdl&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  // Release the current handle before taking over the other.
+  if (regCache_ != nullptr) {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  }
+  regCache_ = other.regCache_;
+  regHdl_ = other.regHdl_;
+  regId_ = other.regId_;
+  buf_ = other.buf_;
+  len_ = other.len_;
+  other.regCache_ = nullptr;
+  other.regHdl_ = nullptr;
+  other.regId_ = 0;
+  other.buf_ = nullptr;
+  other.len_ = 0;
+  return *this;
+}
+
+ctran::ScopedRegHdl::~ScopedRegHdl() {
+  if (regCache_ == nullptr) {
+    return;
+  }
+  // Best-effort SW-only cleanup; never throw out of the destructor.
+  try {
+    regCache_->releaseScopedRegHdl(regHdl_, regId_);
+  } catch (const std::exception& e) {
+    CLOGF(ERR, "~ScopedRegHdl: cleanup failed: {}", e.what());
+  }
+  regCache_ = nullptr;
+  regHdl_ = nullptr;
+}
+
+ctran::regcache::RegElem* ctran::ScopedRegHdl::get() const {
+  return regHdl_;
+}
+
+ctran::ScopedRegHdl::operator bool() const {
+  return regCache_ != nullptr && regHdl_ != nullptr;
+}
+
+std::string ctran::ScopedRegHdl::toString() const {
+  if (regCache_ == nullptr || regHdl_ == nullptr) {
+    return "ScopedRegHdl{empty}";
+  }
+  return fmt::format(
+      "ScopedRegHdl{{regHdl: {}, buf: {}, len: {}}}",
+      (void*)regHdl_,
+      buf_,
+      len_);
 }
 
 commResult_t ctran::RegCache::regRange(
@@ -1302,7 +1493,33 @@ commResult_t ctran::RegCache::regDynamic(
   return commSuccess;
 }
 
-commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
+namespace {
+// Remove regHdl from every segToRegElemsMap entry for its segments, erasing
+// any entry whose vector becomes empty.
+void removeRegElemFromSegCorrelations(
+    ctran::regcache::RegElem* regHdl,
+    const std::vector<ctran::regcache::Segment*>& segments,
+    std::unordered_map<
+        ctran::regcache::Segment*,
+        std::vector<ctran::regcache::RegElem*>>& segToRegElemsMap) {
+  for (auto seg : segments) {
+    auto segIt = segToRegElemsMap.find(seg);
+    if (segIt != segToRegElemsMap.end()) {
+      auto& regElemsVec = segIt->second;
+      regElemsVec.erase(
+          std::remove(regElemsVec.begin(), regElemsVec.end(), regHdl),
+          regElemsVec.end());
+      if (regElemsVec.empty()) {
+        segToRegElemsMap.erase(segIt);
+      }
+    }
+  }
+}
+} // namespace
+
+commResult_t ctran::RegCache::deregRange(
+    ctran::regcache::RegElem* regHdl,
+    bool releaseRef) {
   std::unique_ptr<ctran::regcache::RegElem> regElem = nullptr;
   // Global lock to update regElemsMaps_.
   // Unlock before deregistration, avoid long holding time of the lock.
@@ -1315,6 +1532,30 @@ commResult_t ctran::RegCache::deregRange(ctran::regcache::RegElem* regHdl) {
       CLOGF(ERR, "deregRange: regElem {} not found", (void*)regHdl);
       return commInvalidUsage;
     }
+
+    // When releasing a scoped ref, decrement first and only tear down on the
+    // last reference. Other references keep the registration alive.
+    if (releaseRef) {
+      const auto prev =
+          it->second->refCount.fetch_sub(1, std::memory_order_acq_rel);
+      const auto after = prev - 1;
+      FB_CHECKABORT(
+          after >= 0,
+          "Unexpected negative refCount {} in RegElem {}",
+          after,
+          (void*)regHdl);
+      if (after > 0) {
+        return commSuccess;
+      }
+    }
+
+    // Remove the regElem from every segment correlation entry so no dangling
+    // pointer remains after ownership moves out of the live map. Dynamic
+    // RegElems carry no segments_, so this only matters for the cached
+    // (releaseRef) path.
+    removeRegElemFromSegCorrelations(
+        regHdl, regHdl->segments_, regElemsMaps->segToRegElemsMap);
+
     // Remove regElem from global cache and return ownership to caller for any
     // remote registration release
     regElem = std::move(it->second);
@@ -1552,7 +1793,6 @@ commResult_t ctran::RegCache::deregAll() {
   {
     auto regElemsMaps = regCache->regElemsMaps_.wlock();
     auto& regHdlToElemMap = regElemsMaps->regHdlToElemMap;
-    auto& segToRegElemsMap = regElemsMaps->segToRegElemsMap;
 
     // Iterate through all regElems and collect non-dynamic ones for
     // deregistration
@@ -1567,19 +1807,8 @@ commResult_t ctran::RegCache::deregAll() {
       }
 
       // Remove from segToRegElemsMap
-      for (auto seg : regElem->segments_) {
-        auto segIt = segToRegElemsMap.find(seg);
-        if (segIt != segToRegElemsMap.end()) {
-          auto& regElemsVec = segIt->second;
-          regElemsVec.erase(
-              std::remove(
-                  regElemsVec.begin(), regElemsVec.end(), regElem.get()),
-              regElemsVec.end());
-          if (regElemsVec.empty()) {
-            segToRegElemsMap.erase(segIt);
-          }
-        }
-      }
+      removeRegElemFromSegCorrelations(
+          regElem.get(), regElem->segments_, regElemsMaps->segToRegElemsMap);
 
       // Transfer ownership to toDeregister vector and remove from map
       toDeregister.push_back(std::move(regElem));

--- a/comms/ctran/regcache/RegCache.h
+++ b/comms/ctran/regcache/RegCache.h
@@ -3,7 +3,10 @@
 
 #include <fmt/format.h>
 #include <folly/Synchronized.h>
+#include <atomic>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <unordered_map>
 
@@ -158,6 +161,32 @@ struct RegElem {
     type_ = segments.at(0)->getType();
   };
 
+  // Reference count controlling this RegElem's lifetime. A RegElem exists only
+  // once the buffer is actually registered, and that registration holds one
+  // reference, so refCount starts at 1. Each live ScopedRegHdl adds one more.
+  //
+  // The preexisting RegElem consumers (searchRegHandle / searchIbRegHandle /
+  // getRegHandle) do NOT rely on refCount. They rely on the allocator-hook
+  // contract: any lookup issued after the buffer's allocation hook
+  // (globalRegister) and before its free hook (globalDeregister) is safe.
+  // Consequently a ScopedRegHdl reference layered on top never triggers an
+  // actual deregistration, and a scoped release can never drop the last
+  // reference. Deregistration happens only when the allocator's free hook
+  // (globalDeregister) runs, or when the RegCache shuts down.
+  //
+  // Atomic so a scoped acquire can increment it under the shared read lock.
+  std::atomic<int64_t> refCount{1};
+
+  // Process-unique monotonic id assigned at construction. Used to validate a
+  // ScopedRegHdl's identity so that a reused heap address (a new RegElem
+  // occupying a force-freed RegElem's old address) is not mistaken for the
+  // original registration. The counter is a function-local static (NOT a global
+  // variable), so it satisfies facebook-avoid-non-const-global-variables.
+  const uint64_t regId_{[] {
+    static std::atomic<uint64_t> counter{1};
+    return counter.fetch_add(1, std::memory_order_relaxed);
+  }()};
+
   std::size_t numSegments() const {
     return segments_.size();
   }
@@ -267,6 +296,38 @@ class Profiler {
 
 } // namespace regcache
 
+// Move-only RAII owner of a scoped local registration acquired via
+// RegCache::acquireScopedRegister(). It owns ONLY a RegElem reference (one live
+// ScopedRegHdl ref counted in RegElem::refCount); it does not cache or
+// ref-count segments. The registration itself holds a reference; a scoped
+// handle adds one on top and never triggers a deregistration. The destructor
+// performs a pure SW-only ref decrement (graph-destroy safe): it never touches
+// CUDA and never deregisters. A scoped release can never drop the last
+// reference, so the registration persists (cached and reusable) until the
+// allocator frees the segment via freeSegment/deregRange.
+class ScopedRegHdl {
+ public:
+  ScopedRegHdl() = default;
+  ScopedRegHdl(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl& operator=(ScopedRegHdl&& other) noexcept;
+  ScopedRegHdl(const ScopedRegHdl&) = delete;
+  ScopedRegHdl& operator=(const ScopedRegHdl&) = delete;
+  ~ScopedRegHdl();
+
+  regcache::RegElem* get() const;
+  explicit operator bool() const;
+  std::string toString() const;
+
+ private:
+  friend class RegCache;
+
+  RegCache* regCache_{nullptr};
+  regcache::RegElem* regHdl_{nullptr};
+  uint64_t regId_{0};
+  const void* buf_{nullptr};
+  size_t len_{0};
+};
+
 /**
  * Singleton class to hold the IB network resources that are reused by all
  * communicators in the lifetime of program.
@@ -303,6 +364,20 @@ class RegCache {
       size_t len,
       bool skipRemRelease = false,
       int deviceId = -1);
+
+  // Acquire a scoped local registration for [buf, buf + len). The buffer's
+  // underlying segment MUST already be cached by the allocator (globalRegister
+  // / CCA memory hook); this API does not cache segments. On success it takes
+  // one RegElem ref (counted in RegElem::refCount) and the returned
+  // ScopedRegHdl owns that ref, releasing it SW-only in its destructor. If the
+  // buffer is not backed by a cached segment, commInvalidUsage is returned and
+  // the ScopedRegHdl stays empty.
+  commResult_t acquireScopedRegister(
+      const void* buf,
+      size_t len,
+      int cudaDev,
+      const std::vector<bool>& backends,
+      ScopedRegHdl& scopedRegHdl);
 
   // Thread-safe functions to cache a buffer range into the global cache.
   // This function uses pinRange to discover all physical segments underlying
@@ -345,6 +420,9 @@ class RegCache {
   // output:
   //   - didRegister: whether regRangeCached registered regHdl, or just found it
   //   - regHdl: the registration handle
+  // If acquireRef is true, the returned RegElem's scoped refcount is
+  // incremented while holding the map lock (typically for a ScopedRegHdl, which
+  // releases it via its destructor).
   commResult_t regRangeCached(
       const void* ptr,
       const size_t len,
@@ -354,7 +432,8 @@ class RegCache {
       const std::vector<bool>& backends,
       bool& didRegister,
       regcache::RegElem** regHdl,
-      bool ncclManaged = false);
+      bool ncclManaged = false,
+      bool acquireRef = false);
 
   // Thread-safe function to directly register a buffer range without consulting
   // the reusable segment/regElem cache. It registers every pinned physical
@@ -393,7 +472,9 @@ class RegCache {
   // communicator uses it.
   // input:
   //   - regHdl: the direct registration handle
-  commResult_t deregRange(regcache::RegElem* regHdl);
+  //   - releaseRef: if true, decrement the RegElem's refcount first and only
+  //                 proceed to backend deregistration when it reaches 0.
+  commResult_t deregRange(regcache::RegElem* regHdl, bool releaseRef = false);
 
   // Thread-safe function to deregister a dynamic registration. Compatibility
   // wrapper around deregRange() for existing callers.
@@ -544,6 +625,8 @@ class RegCache {
   folly::Synchronized<regcache::Profiler> profiler;
 
  private:
+  friend class ScopedRegHdl;
+
   // Hold a reference to CtranIbSingleton to ensure proper destruction order.
   // By holding this shared_ptr, we guarantee CtranIbSingleton stays alive
   // as long as RegCache exists, preventing use-after-free during
@@ -587,7 +670,11 @@ class RegCache {
   void asyncRegThreadFn(int cudaDev);
 
   // Thread-safe function to search given <ptr, len> range in regElem cache.
-  regcache::RegElem* searchRegElem(const void* ptr, const size_t len);
+  // If acquireRef is true, atomically increments the found RegElem's refCount
+  // on a lookup hit (safe under the shared read lock because refCount is
+  // atomic).
+  regcache::RegElem*
+  searchRegElem(const void* ptr, const size_t len, bool acquireRef = false);
 
   // Helper function to perform backend registration for a set of segments.
   // Creates a RegElem, registers with backends, and updates regElemsMaps.
@@ -603,9 +690,15 @@ class RegCache {
       std::vector<regcache::Segment*>& segments,
       const std::vector<bool>& backends,
       bool ncclManaged,
-      regcache::RegElem** regHdl);
+      regcache::RegElem** regHdl,
+      bool acquireRef = false);
 
   commResult_t deregElem(regcache::RegElem* regElem);
+
+  // SW-only scoped-ref release used by ~ScopedRegHdl; graph-destroy safe. The
+  // regId identifies the RegElem captured at acquire time so a reused heap
+  // address is rejected. See .cc for details.
+  void releaseScopedRegHdl(regcache::RegElem* regHdl, const uint64_t regId);
 };
 
 static inline void CHECK_VALID_REGCACHE(std::shared_ptr<RegCache> regCache) {

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -394,6 +394,44 @@ Compatibility with the existing (non-refcounted) lookup APIs:
   further references, so a scoped owner and these borrowed lookups safely share
   the same cached `RegElem`.
 
+### Remote IPC import: `ScopedIpcRegHdl`
+
+Remote NVLink IPC imports live in `IpcRegCache`, separate from the local segment
+cache, and use a symmetric-but-different scoped owner.
+
+Lifecycle:
+
+- An imported `IpcRemRegElem` is refcounted (`refCount`). `releaseRemReg` ALWAYS
+  defers: it decrements the refcount and, on reaching zero, moves the elem out of
+  the live map into `invalidImports_`. This is pure software work (no CUDA), so
+  it is safe from a graph-destroy callback. Because rc==0 entries leave the live
+  map, a released import is never resurrected by a later import.
+- `cleanupInvalidImports()` performs the actual CUDA unmap of the parked
+  entries. It runs on user-thread entries (`importMem`, `~IpcRegCache`) and is
+  called explicitly by release callsites that want prompt teardown
+  (`CtranMapper::deregRemReg`, the async-socket `kRelease` handler).
+- `ScopedIpcRegHdl` is a move-only owner of one import reference, produced
+  directly by `IpcRegCache::importMem` via its optional `outHdl` out-param: the
+  single reference the import adds is ADOPTED by the returned handle (no extra
+  reference is added). `~ScopedIpcRegHdl` performs a deferred `releaseRemReg`, so
+  it is graph-destroy safe; the CUDA unmap drains later via an explicit
+  `cleanupInvalidImports()` at a user-thread teardown point (window free, eager
+  AGP destroy).
+
+Difference from local `ScopedRegHdl`, and compatibility:
+
+- `IpcRegCache` holds no reference of its own on an imported elem — the refcount
+  is owned entirely by importers, with no allocator-held reference like the local
+  one. So, unlike a local `ScopedRegHdl` (which can never retire its
+  registration), the LAST `ScopedIpcRegHdl` release DOES retire the import
+  (deferred).
+- `IpcRemRegElem` was already refcount-based for existing importers, and its
+  release can be triggered either by an explicit importer-side call
+  (`releaseRemReg` / `CtranMapper::deregRemReg`) or by the exporter's `kRelease`
+  notification over the async socket. `ScopedIpcRegHdl` layers cleanly on top of
+  this existing refcount — it introduces no new scheme and does not change the
+  C-style release/notify paths.
+
 ## Component Interactions
 
 ### CtranMapper (per-communicator)

--- a/comms/ctran/regcache/docs/design.md
+++ b/comms/ctran/regcache/docs/design.md
@@ -109,6 +109,7 @@ RegElem
   isDynamic_ : bool         -- true for one-time uncached registrations
   type_      : DevMemType   -- memory type of the registered range
   ncclManaged_: bool        -- whether NCCL allocated this buffer
+  refCount    : atomic<int64_t>  -- lifetime refcount; allocator holds one ref for lookup consumers (see Scoped Registration)
 ```
 
 ### RegCache (class)
@@ -327,6 +328,71 @@ cleanup:
   -> CtranMapper::deregMem (notify remote peers + freeSegment)
   -> cudaFree
 ```
+
+## Scoped Registration
+
+Ctran's persistent collectives (persistent AllGatherP, "AGP") and window
+collectives hold a registration for the lifetime of an operation, request, or
+window — not the lifetime of the underlying memory — and must release it safely,
+including from a CUDA graph-destroy callback where no CUDA calls are allowed.
+Move-only RAII owners provide this on top of the existing cache without
+disturbing the allocator (CCA) hook or the existing, non-refcounted lookup APIs.
+
+`globalRegister` / `globalDeregister` are the allocator-hook APIs. They are keyed
+on BUFFER (memory) lifetime — the allocator calls them around a buffer's
+allocation and free — and `globalDeregister` force-frees the cached segment and
+all of its registrations. They are therefore NOT suitable for scoped
+registration inside Ctran: a persistent collective or window has an operation /
+request / window lifetime, not a memory lifetime, and calling `globalDeregister`
+from that code would tear down allocator-owned state that other consumers may
+still need. Ctran-internal scopes must use `acquireScopedRegister` /
+`ScopedRegHdl` (below) instead; `globalRegister` / `globalDeregister` must be
+called ONLY from the allocator side (the CCA memory hook), never from collective
+or window code.
+
+### Local registration: `ScopedRegHdl`
+
+Lifecycle (`RegElem::refCount`):
+
+- The allocator owns one reference to each `RegElem`. It is created with
+  `refCount = 1` when the registration is first cached (via `globalRegister` /
+  the CCA hook); this one reference stands in for the allocator's non-refcounted
+  lookup consumers (`searchRegHandle` / `searchIbRegHandle` / `getRegHandle`),
+  which borrow the `RegElem*` without touching `refCount`.
+- `RegCache::acquireScopedRegister(buf, len, cudaDev, backends, &hdl)` resolves
+  the cached `RegElem`, increments `refCount`, and returns a move-only
+  `ScopedRegHdl` owning that one ADDITIONAL reference.
+- `~ScopedRegHdl` performs a pure software decrement (`releaseScopedRegHdl`)
+  under the `regElemsMaps_` read lock — no deregistration, no delete, no CUDA —
+  so it is safe to run from a graph-destroy callback.
+- The allocator's reference is dropped only by user-thread teardown paths
+  (`freeSegment`, invoked by `globalDeregister`, or `deregRange`). A scoped
+  release can therefore never drop the last reference: a `ScopedRegHdl` is never
+  the sole owner and never retires the registration.
+
+Compatibility with the allocator (CCA) hook:
+
+- The allocator hook owns memory lifetime: `globalRegister` caches the segment
+  and creates the `RegElem` with the allocator's one reference; `globalDeregister`
+  drops that reference (`freeSegment` → backend dereg) right before the memory is
+  freed.
+- `acquireScopedRegister` REQUIRES the buffer's segment to already be
+  allocator-cached and returns `commInvalidUsage` otherwise — it never caches or
+  frees segments. A scoped acquire/release only adjusts the extra reference, so
+  it can neither race nor double-free allocator-owned state; the allocator
+  remains the sole owner of the registration's lifetime. If a buffer is freed
+  while a scoped reference is still live, `freeSegment` logs a
+  contract-violation error and tears down anyway (the memory is going away).
+
+Compatibility with the existing (non-refcounted) lookup APIs:
+
+- `searchRegHandle` / `searchIbRegHandle` / `getRegHandle` return a borrowed
+  `RegElem*` WITHOUT touching `refCount`. These are the established production
+  callers (e.g. collective-time handle lookup) and are intentionally left
+  non-refcounted to avoid changing their behavior. The allocator's single
+  reference already covers these lookups; only `ScopedRegHdl` adds or removes
+  further references, so a scoped owner and these borrowed lookups safely share
+  the same cached `RegElem`.
 
 ## Component Interactions
 

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -945,6 +945,75 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCount) {
   ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
 }
 
+// Verify that importing a remote NVL buffer works during CUDA graph stream
+// capture. importMem issues host CUDA driver calls
+// (cuMemImportFromShareableHandle / cuMemMap / cuMemSetAccess); the internal
+// StreamCaptureModeGuard must relax capture so these calls don't invalidate the
+// capture. Uses a single-process self-export + self-import (same pattern as
+// IpcRemRegElemRefCount). Without the guard this capture would fail with
+// cudaErrorStreamCaptureUnsupported.
+TEST_F(RegCacheTest, ImportMemDuringGraphCapture) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  // Allocate a cuMem buffer so IPC export is supported, then self-export to get
+  // an IpcDesc we can import back.
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  ASSERT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  ASSERT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_capture_peer";
+
+  cudaStream_t stream;
+  CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+  // ThreadLocal (strict) mode: without the internal StreamCaptureModeGuard in
+  // importMem, the host CUDA driver calls would invalidate this capture.
+  // Relaxed mode here would make the guard a no-op and defeat the test.
+  CUDACHECK_TEST(
+      cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal));
+
+  void* importedBuf = nullptr;
+  ctran::regcache::IpcRemHandle remKey;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf, &remKey),
+      commSuccess);
+  EXPECT_NE(importedBuf, nullptr);
+
+  // The capture must still be valid: end-capture succeeds and yields a graph.
+  cudaGraph_t graph = nullptr;
+  EXPECT_EQ(cudaStreamEndCapture(stream, &graph), cudaSuccess);
+  EXPECT_NE(graph, nullptr);
+
+  if (graph != nullptr) {
+    CUDACHECK_TEST(cudaGraphDestroy(graph));
+  }
+  CUDACHECK_TEST(cudaStreamDestroy(stream));
+
+  // Release the imported registration and drain the deferred unmap.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
+      commSuccess);
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
 // Test that releasing an IpcRemRegElem
 // returns an error (unknown registration).
 TEST_F(RegCacheTest, IpcRemRegElemReleaseUnknown) {

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -1660,6 +1660,425 @@ TEST_F(RegCacheTest, ExternalRegMemFailureIsHandledGracefully) {
   CUDACHECK_TEST(cudaFree(buf));
 }
 
+// Baseline-1 model: globalRegister caches + eager-registers (refcnt baseline
+// 1). A scoped acquire bumps it to 2; releasing the scope decrements back to 1
+// but NEVER dereg's (baseline keeps it alive). The registration persists and is
+// reusable after the scope ends; only globalDeregister tears it down.
+TEST_F(RegCacheTest, ScopedRegisterSingleAcquireRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Allocator pre-caches the segment and eager-registers (scoped acquire
+  // requires the segment to be pre-cached).
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(static_cast<bool>(scopedRegHdl));
+    EXPECT_NE(scopedRegHdl.get(), nullptr);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release is a pure SW decrement: the registration and its segment
+  // remain live (the regcache baseline ref keeps them).
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // Only globalDeregister tears down the allocator-owned registration/segment.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Nested scoped acquires on the same buffer add refs (baseline 1 -> 2 -> 3);
+// releasing them decrements back toward the baseline. Dereg happens only via
+// globalDeregister, never through scope release.
+TEST_F(RegCacheTest, ScopedRegisterNestedAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  auto outer = std::make_unique<ctran::ScopedRegHdl>();
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, *outer),
+      commSuccess);
+  auto* regElem = outer->get();
+  ASSERT_NE(regElem, nullptr);
+  // baseline 1 + outer = 2
+  EXPECT_EQ(regElem->refCount.load(), 2);
+
+  {
+    ctran::ScopedRegHdl inner;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, inner),
+        commSuccess);
+    // Both handles refer to the same reused registration; refcnt 1 + 2 = 3.
+    EXPECT_EQ(inner.get(), regElem);
+    EXPECT_EQ(regElem->refCount.load(), 3);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Inner released one ref (back to 2); registration stays live.
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Releasing the last scoped handle returns to the baseline (1); still live.
+  outer.reset();
+  EXPECT_EQ(regElem->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Only globalDeregister removes the baseline ref and tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Sequential acquire/release cycles each go baseline 1 -> 2 -> 1; the
+// registration persists across cycles and is torn down only by
+// globalDeregister.
+TEST_F(RegCacheTest, ScopedRegisterSequentialAcquire) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  for (int i = 0; i < 2; i++) {
+    {
+      ctran::ScopedRegHdl scopedRegHdl;
+      EXPECT_EQ(
+          regCache->acquireScopedRegister(
+              buf, bufSize, cudaDev, backends, scopedRegHdl),
+          commSuccess);
+      auto* regElem = scopedRegHdl.get();
+      ASSERT_NE(regElem, nullptr);
+      EXPECT_EQ(regElem->refCount.load(), 2);
+      EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+    }
+    // Scope released back to baseline; still registered and reusable.
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// After globalRegister(forceReg) + scoped acquire/release, BOTH the
+// registration and its segment are preserved (baseline ref keeps them).
+// globalDeregister then removes them.
+TEST_F(RegCacheTest, ScopedRegisterPreservesGlobalRegistration) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Global forceReg caches the segment and eager-registers the RegElem.
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scoped release drops only the scope's ref; both the registration AND the
+  // segment remain (baseline ref).
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 1);
+
+  // globalDeregister force-frees the remaining allocator-owned state.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  EXPECT_EQ(regCache->getSegments().size(), 0);
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: scoped acquire on a buffer whose segment was NOT cached by the
+// allocator returns commInvalidUsage and leaves the ScopedRegHdl empty.
+TEST_F(RegCacheTest, ScopedRegisterUncachedSegmentReturnsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  ctran::ScopedRegHdl scopedRegHdl;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(
+          buf, bufSize, cudaDev, backends, scopedRegHdl),
+      commInvalidUsage);
+
+  // The handle must stay empty since nothing was acquired.
+  EXPECT_FALSE(static_cast<bool>(scopedRegHdl));
+  EXPECT_EQ(scopedRegHdl.get(), nullptr);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// CONTRACT: globalDeregister while a scoped registration is still alive
+// violates the lifetime contract. It emits a clear error and force-frees the
+// RegElem; the still-live ScopedRegHdl must then destruct without crashing (it
+// safely no-ops because its RegElem is already gone).
+TEST_F(RegCacheTest, GlobalDeregisterWhileScopedAliveReportsError) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+    // Force-free the buffer while the scoped handle is still alive (refcnt 2:
+    // baseline + scope). freeSegment removes the baseline ref, sees a remaining
+    // scoped owner, logs the contract-violation ERR, and tears down anyway
+    // because the memory is being freed.
+    EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+    EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+    EXPECT_EQ(regCache->getSegments().size(), 0);
+
+    // The scoped handle destructs here: its RegElem was already force-freed, so
+    // releaseScopedRegHdl safely no-ops with a WARN (no UAF/abort).
+  }
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Read-only search/get callsites (acquireRef=false, the default) do not take a
+// scoped ref, so they require no matching release.
+TEST_F(RegCacheTest, RegRangeCachedNoAcquireRefNeedsNoRelease) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache and eagerly register with the default acquireRef=false path.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+
+  // A borrowed lookup is read-only: freeSegment tears down without any scoped
+  // release, i.e. refcnt was never incremented.
+  bool freed = false;
+  bool ncclManaged = false;
+  std::vector<std::unique_ptr<ctran::regcache::RegElem>> regElems;
+  EXPECT_EQ(
+      regCache->freeSegment(segHdls[0], freed, ncclManaged, regElems),
+      commSuccess);
+  EXPECT_TRUE(freed);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// When acquireScopedRegister is the FIRST to register a cached-but-unregistered
+// buffer, it creates the RegElem via the create path. The registration holds
+// the baseline ref (1) and the scope adds one, so refCount ends at 2. Releasing
+// the scope returns to 1 (still registered); only globalDeregister tears it
+// down.
+TEST_F(RegCacheTest, ScopedRegisterFirstAcquireCreatesRegElem) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  // Cache the segment WITHOUT eager-registering, so no RegElem pre-exists.
+  std::vector<ctran::regcache::Segment*> segments;
+  std::vector<void*> segHdls;
+  EXPECT_EQ(
+      regCache->cacheSegment(
+          buf, bufSize, cudaDev, false, 0, segments, segHdls),
+      commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+  {
+    ctran::ScopedRegHdl scopedRegHdl;
+    // Scoped acquire is the first to register: it creates the RegElem.
+    EXPECT_EQ(
+        regCache->acquireScopedRegister(
+            buf, bufSize, cudaDev, backends, scopedRegHdl),
+        commSuccess);
+    auto* regElem = scopedRegHdl.get();
+    ASSERT_NE(regElem, nullptr);
+    // Registration baseline 1 + scoped 1 = 2.
+    EXPECT_EQ(regElem->refCount.load(), 2);
+    EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+  }
+
+  // Scope release drops the scoped ref back to the baseline; still registered.
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // globalDeregister removes the baseline ref and tears it down.
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// ScopedRegHdl move construction transfers ownership without changing refCount
+// (no ref added or dropped). Move assignment releases the target's current ref
+// first, then takes over the source. Self-assignment is a no-op. A moved-from
+// handle is empty and destructs as a no-op.
+TEST_F(RegCacheTest, ScopedRegisterMoveSemantics) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  ctran::ScopedRegHdl a;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, a),
+      commSuccess);
+  auto* regElem = a.get();
+  ASSERT_NE(regElem, nullptr);
+  EXPECT_EQ(regElem->refCount.load(), 2); // baseline + a
+
+  // Move construction: b takes a's ref, refcnt unchanged, a becomes empty.
+  ctran::ScopedRegHdl b(std::move(a));
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_FALSE(static_cast<bool>(a));
+  EXPECT_EQ(a.get(), nullptr);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Self-move-assignment is a no-op (guarded); ref unchanged.
+  ctran::ScopedRegHdl& bRef = b;
+  b = std::move(bRef);
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_EQ(b.get(), regElem);
+
+  // Acquire a second independent ref into c (refcnt 2 -> 3).
+  ctran::ScopedRegHdl c;
+  EXPECT_EQ(
+      regCache->acquireScopedRegister(buf, bufSize, cudaDev, backends, c),
+      commSuccess);
+  EXPECT_EQ(regElem->refCount.load(), 3);
+
+  // Move-assign b into c: c releases its own ref first (3 -> 2), then takes b.
+  c = std::move(b);
+  EXPECT_EQ(regElem->refCount.load(), 2);
+  EXPECT_FALSE(static_cast<bool>(b));
+  EXPECT_EQ(c.get(), regElem);
+
+  // c destructs at scope end (2 -> 1); a and b are empty no-ops.
+  {
+    ctran::ScopedRegHdl consume(std::move(c));
+    EXPECT_EQ(regElem->refCount.load(), 2);
+  }
+  EXPECT_EQ(regElem->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  EXPECT_EQ(regCache->globalDeregister(buf, bufSize), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
+// deregRange(releaseRef=true) is the user-thread teardown primitive: it
+// decrements refCount and only tears the RegElem down when the count reaches 0.
+// With refCount above baseline it returns early (registration stays live); the
+// final call (baseline) proceeds to backend deregistration.
+TEST_F(RegCacheTest, DeregRangeReleaseRefDecrementsThenTearsDown) {
+  size_t bufSize = 8192;
+  void* buf = nullptr;
+  CUDACHECK_TEST(cudaMalloc(&buf, bufSize));
+
+  EXPECT_EQ(regCache->globalRegister(buf, bufSize, true), commSuccess);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  std::vector<bool> backends(CommBackend::NUM_BACKENDS, false); // IB only
+  backends[CommBackend::IB] = true;
+
+  // Bump the scoped ref via acquireRef=true (baseline 1 -> 2).
+  bool didRegister = false;
+  ctran::regcache::RegElem* regHdl = nullptr;
+  CommLogData logMetaData{};
+  EXPECT_EQ(
+      regCache->regRangeCached(
+          buf,
+          bufSize,
+          cudaDev,
+          "test",
+          logMetaData,
+          backends,
+          didRegister,
+          &regHdl,
+          true /* ncclManaged */,
+          true /* acquireRef */),
+      commSuccess);
+  ASSERT_NE(regHdl, nullptr);
+  EXPECT_EQ(regHdl->refCount.load(), 2);
+
+  // First releaseRef decrement: refcnt 2 -> 1, returns early, still registered.
+  EXPECT_EQ(regCache->deregRange(regHdl, true /* releaseRef */), commSuccess);
+  EXPECT_EQ(regHdl->refCount.load(), 1);
+  EXPECT_TRUE(regCache->isRegistered(buf, bufSize));
+
+  // Second releaseRef decrement drops the baseline (1 -> 0) and tears down.
+  EXPECT_EQ(regCache->deregRange(regHdl, true /* releaseRef */), commSuccess);
+  EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
+
+  CUDACHECK_TEST(cudaFree(buf));
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);

--- a/comms/ctran/regcache/tests/RegCacheUT.cc
+++ b/comms/ctran/regcache/tests/RegCacheUT.cc
@@ -938,6 +938,7 @@ TEST_F(RegCacheTest, IpcRemRegElemRefCount) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   // Cleanup
   ctran::IpcRegCache::deregMem(ipcRegElem);
@@ -1357,6 +1358,7 @@ TEST_F(RegCacheTest, ImportMemWithExtraSegments) {
       ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid),
       commSuccess);
   EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+  ipcRegCache->cleanupInvalidImports();
 
   ctran::IpcRegCache::deregMem(ipcRegElem);
   COMMCHECK_TEST(ctran::commMemFreeDisjoint(buf, segSizes));
@@ -2077,6 +2079,142 @@ TEST_F(RegCacheTest, DeregRangeReleaseRefDecrementsThenTearsDown) {
   EXPECT_FALSE(regCache->isRegistered(buf, bufSize));
 
   CUDACHECK_TEST(cudaFree(buf));
+}
+
+// Refcounted import: importing the same descriptor twice bumps the single
+// entry's refCount to 2; the first release keeps it live (getNumRemReg stays
+// 1); the second release drops it to 0, moving the elem out of the live map.
+// An explicit cleanupInvalidImports() then performs the CUDA unmap.
+TEST_F(RegCacheTest, IpcRemRegImmediateRelease) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_immediate_release_peer";
+
+  // Import twice: single map entry, refCount 2.
+  void* importedBuf1 = nullptr;
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_EQ(importedBuf1, importedBuf2);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // First release: refCount 2 -> 1, entry stays live.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Second release: refCount 1 -> 0, elem moved out of the live map. The
+  // deferred CUDA unmap is drained by the explicit cleanupInvalidImports().
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// Releasing to rc 0 removes the elem from the live map (getNumRemReg == 0) but
+// does not unmap yet (release is always deferred). A fresh importMem of the
+// same descriptor cannot resurrect the dead elem and instead creates a new live
+// mapping. cleanupInvalidImports() is safe to call afterwards.
+TEST_F(RegCacheTest, IpcRemRegDeferredReleaseNoResurrect) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  size_t bufSize = 4096;
+  std::vector<TestMemSegment> segments;
+  void* buf = ctran::commMemAlloc(bufSize, kMemCuMemAlloc, segments);
+  ASSERT_NE(buf, nullptr);
+
+  void* ipcRegElem = nullptr;
+  EXPECT_EQ(
+      ctran::IpcRegCache::regMem(buf, bufSize, cudaDev, &ipcRegElem),
+      commSuccess);
+  ASSERT_NE(ipcRegElem, nullptr);
+
+  ctran::regcache::IpcDesc ipcDesc;
+  std::vector<ctran::utils::CtranIpcSegDesc> extraSegments;
+  EXPECT_EQ(
+      ipcRegCache->exportMem(buf, ipcRegElem, ipcDesc, extraSegments),
+      commSuccess);
+
+  const std::string peerId = "test_deferred_release_peer";
+
+  void* importedBuf1 = nullptr;
+  ctran::regcache::IpcRemHandle remKey1;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf1, &remKey1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Deferred release to rc 0: leaves the live map but is not yet unmapped.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  // A fresh import of the same descriptor must create a NEW live entry rather
+  // than resurrecting the deferred-dead one. importMem also drains the pending
+  // unmap via cleanupInvalidImports().
+  void* importedBuf2 = nullptr;
+  ctran::regcache::IpcRemHandle remKey2;
+  EXPECT_EQ(
+      ipcRegCache->importMem(peerId, ipcDesc, cudaDev, &importedBuf2, &remKey2),
+      commSuccess);
+  EXPECT_NE(importedBuf2, nullptr);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 1);
+
+  // Release the fresh entry and drain.
+  EXPECT_EQ(
+      ipcRegCache->releaseRemReg(peerId, ipcDesc.desc.base, ipcDesc.uid, 1),
+      commSuccess);
+  EXPECT_EQ(ipcRegCache->getNumRemReg(peerId), 0);
+
+  ipcRegCache->cleanupInvalidImports();
+
+  ctran::IpcRegCache::deregMem(ipcRegElem);
+  ctran::commMemFree(buf, bufSize, kMemCuMemAlloc);
+}
+
+// cleanupInvalidImports() on an empty invalidImports_ list is safe and
+// idempotent.
+TEST_F(RegCacheTest, IpcCleanupEmptyIsIdempotent) {
+  auto ipcRegCache = ctran::IpcRegCache::getInstance();
+  ASSERT_NE(ipcRegCache, nullptr);
+  ipcRegCache->init();
+
+  ipcRegCache->cleanupInvalidImports();
+  ipcRegCache->cleanupInvalidImports();
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Summary: Make `IpcRegCache::importMem` self-guard the thread's CUDA stream-capture mode so callers can import a remote NVL buffer while a CUDA graph is being captured. Importing issues host CUDA driver calls -- `cuMemImportFromShareableHandle` / `cuMemMap` / `cuMemSetAccess` via the `IpcRemRegElem` constructor, plus `cuMemUnmap` via the `cleanupInvalidImports()` drain at the top of `importMem` -- which would otherwise invalidate an in-progress capture. A `meta::comms::StreamCaptureModeGuard{cudaStreamCaptureModeRelaxed}` as the first statement of `importMem` covers the whole function body and restores the prior mode on exit; it is a benign thread-local mode swap when the caller is not capturing. This lets a persistent collective (e.g. AllGatherP) register its NVL IPC imports during capture without wrapping the mapper callsite in its own guard.

Differential Revision: D110923466


