### PR TITLE
Make ClogHook registration init-agnostic (defer new_comm signature)

### DIFF
--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -82,7 +82,17 @@ class TorchWork : public c10::intrusive_ptr_target {
   using WorkHook = std::function<void()>;
 
   void registerWorkStartHook(WorkHook hook) {
-    start_hooks_.push_back(std::move(hook));
+    // If work already started (or finished), fire the hook immediately rather
+    // than enqueuing it (it would never fire otherwise). Mirrors
+    // registerWorkEndHook's terminal-state fallback. This handles backends
+    // (e.g. MCCL) whose ctor sets INPROGRESS before the post-hook registers
+    // the start hook; without this the start event is lost (clog has no "S").
+    // Any status other than NOT_STARTED means the start transition has fired.
+    if (status() != WorkStatus::NOT_STARTED) {
+      hook();
+    } else {
+      start_hooks_.push_back(std::move(hook));
+    }
   }
 
   void registerWorkEndHook(WorkHook hook) {

--- a/comms/torchcomms/hooks/clog/ClogHook.cpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.cpp
@@ -70,12 +70,25 @@ ClogHook::~ClogHook() = default;
 // -- Registration --
 
 void ClogHook::registerWithComm(std::shared_ptr<TorchComm> comm) {
-  log_file_.writeLine(buildNewCommSignature(
-      comm->getCommName(), comm->getRank(), comm->getSize()));
-  registerHooks(comm);
+  // The new_comm signature needs the comm's rank/size, which are only assigned
+  // once the comm is initialized. Comms are usually initialized at registration
+  // (the WORLD-init path), so write the signature up front, before any hook can
+  // fire. Dynamic-regime comms — e.g. PAFT's inter-replica MCCL comm, which is
+  // created uninitialized and only gets rank/size on its first reconfigure() —
+  // are registered before init; for those, defer the signature to the first
+  // pre-hook, which cannot fire until a collective runs (i.e. after init).
+  if (comm->getBackendImpl()->isInitialized()) {
+    log_file_.writeLine(buildNewCommSignature(
+        comm->getCommName(), comm->getRank(), comm->getSize()));
+    registerHooks(comm);
+  } else {
+    registerHooks(comm, std::make_shared<std::atomic<bool>>(true));
+  }
 }
 
-void ClogHook::registerHooks(std::shared_ptr<TorchComm> comm) {
+void ClogHook::registerHooks(
+    std::shared_ptr<TorchComm> comm,
+    std::shared_ptr<std::atomic<bool>> signature_pending) {
   for (const auto& reg : registrations_) {
     if (reg.comm.lock() == comm) {
       throw std::runtime_error(
@@ -88,8 +101,39 @@ void ClogHook::registerHooks(std::shared_ptr<TorchComm> comm) {
   auto self = shared_from_this();
 
   int device_index = comm->getDevice().index();
+  std::weak_ptr<TorchComm> comm_weak = comm;
+  // Serializes the deferred new_comm signature so it is written before any
+  // collective line for this comm, even if several pre-hooks fire concurrently
+  // on the first collective. Once the signature is written the atomic flag
+  // flips and pre-hooks skip the lock entirely (lock-free fast path), so the
+  // mutex is taken only during the brief pre-write window. Allocated only for
+  // the deferred (uninitialized) path; the eager path passes signature_pending
+  // == nullptr and never touches the lock.
+  auto sig_mutex = signature_pending ? std::make_shared<std::mutex>()
+                                     : std::shared_ptr<std::mutex>();
   auto pre_hook_handle = comm->registerPreHook(
-      [self, comm_name, device_index](size_t op_id, const PreHookArgs& args) {
+      [self, comm_name, device_index, signature_pending, sig_mutex, comm_weak](
+          size_t op_id, const PreHookArgs& args) {
+        // Deferred new_comm signature (dynamic-regime comm registered before
+        // init): the first pre-hook runs once a collective is issued, by which
+        // point rank/size are available. The acquire-load is a lock-free fast
+        // path — after the signature is written the flag reads false and every
+        // later pre-hook skips the lock. Until then the lock guarantees the
+        // signature precedes every collective line and is written once. The
+        // flag is cleared only after a successful write, so a failed lock()
+        // (comm already gone) leaves it to a later pre-hook rather than
+        // dropping it.
+        if (signature_pending &&
+            signature_pending->load(std::memory_order_acquire)) {
+          std::lock_guard<std::mutex> lock(*sig_mutex);
+          if (signature_pending->load(std::memory_order_relaxed)) {
+            if (auto c = comm_weak.lock()) {
+              self->log_file_.writeLine(buildNewCommSignature(
+                  c->getCommName(), c->getRank(), c->getSize()));
+              signature_pending->store(false, std::memory_order_release);
+            }
+          }
+        }
         self->onPreHook(comm_name, device_index, op_id, args);
       });
 

--- a/comms/torchcomms/hooks/clog/ClogHook.hpp
+++ b/comms/torchcomms/hooks/clog/ClogHook.hpp
@@ -155,7 +155,14 @@ class ClogHook : public std::enable_shared_from_this<ClogHook> {
   void registerWithComm(std::shared_ptr<TorchComm> comm);
 
  private:
-  void registerHooks(std::shared_ptr<TorchComm> comm);
+  // signature_pending: if non-null, the new_comm signature is deferred and the
+  // first pre-hook writes it under a per-registration lock (for comms
+  // registered before initialization, when rank/size aren't available yet),
+  // then flips the flag so later pre-hooks skip the lock (atomic fast path). If
+  // null, this path writes no deferred signature and takes no lock.
+  void registerHooks(
+      std::shared_ptr<TorchComm> comm,
+      std::shared_ptr<std::atomic<bool>> signature_pending = nullptr);
 
   // Pre-hook: log collective signature and enqueue event.
   void onPreHook(

--- a/comms/torchcomms/hooks/clog/tests/cpp/ClogHookRegistrationTest.cpp
+++ b/comms/torchcomms/hooks/clog/tests/cpp/ClogHookRegistrationTest.cpp
@@ -1,0 +1,148 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+// Unit tests for ClogHook::registerWithComm's init-agnostic new_comm signature.
+//
+// Uses the CPU-only TorchCommFake backend (loaded dynamically via
+// FAKE_TEST_BACKEND_LIB_PATH) so no GPU/MCCL is required. A comm created via
+// new_comm is initialized; finalize() flips it back to uninitialized to
+// exercise the dynamic-regime path (PAFT's inter-replica comm registers clog
+// before its first reconfigure()).
+
+#include <comms/torchcomms/TorchComm.hpp>
+#include <comms/torchcomms/fake/TorchCommFake.hpp>
+#include <comms/torchcomms/hooks/clog/ClogHook.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace torch::comms {
+
+namespace {
+constexpr const char* kBackendName = "fake_test";
+constexpr const char* kBackendEnvKey = "TORCHCOMMS_BACKEND_LIB_PATH_FAKE_TEST";
+
+std::vector<std::string> readLines(const std::string& path) {
+  std::vector<std::string> lines;
+  std::ifstream f(path);
+  std::string line;
+  while (std::getline(f, line)) {
+    if (!line.empty()) {
+      lines.push_back(line);
+    }
+  }
+  return lines;
+}
+
+size_t countContaining(
+    const std::vector<std::string>& lines,
+    const std::string& sub) {
+  size_t n = 0;
+  for (const auto& line : lines) {
+    if (line.find(sub) != std::string::npos) {
+      ++n;
+    }
+  }
+  return n;
+}
+} // namespace
+
+class ClogHookRegistrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* lib_path = std::getenv("FAKE_TEST_BACKEND_LIB_PATH");
+    ASSERT_NE(lib_path, nullptr) << "FAKE_TEST_BACKEND_LIB_PATH not set";
+    setenv(kBackendEnvKey, lib_path, 1);
+
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    log_path_ = (std::filesystem::temp_directory_path() /
+                 (std::string(info->test_suite_name()) + "_" +
+                  std::string(info->name()) + ".clog"))
+                    .string();
+    std::filesystem::remove(log_path_);
+  }
+
+  void TearDown() override {
+    unsetenv(kBackendEnvKey);
+    std::filesystem::remove(log_path_);
+  }
+
+  std::string log_path_;
+};
+
+// An initialized comm (the WORLD-init path) writes the new_comm signature
+// eagerly at registration, before any collective runs.
+TEST_F(
+    ClogHookRegistrationTest,
+    SignatureWrittenAtRegistrationWhenInitialized) {
+  auto comm = new_comm(kBackendName, at::Device(at::kCPU), "eager_comm", {});
+  ASSERT_NE(comm, nullptr);
+
+  auto hook =
+      std::make_shared<ClogHook>(log_path_, std::vector<std::string>{"ALL"});
+  hook->registerWithComm(comm);
+
+  EXPECT_EQ(
+      countContaining(readLines(log_path_), "new_comm|comm=eager_comm"), 1u);
+}
+
+// A comm registered before initialization (dynamic regime) must NOT throw and
+// must defer the new_comm signature to the first pre-hook, which fires once a
+// collective is issued.
+TEST_F(
+    ClogHookRegistrationTest,
+    SignatureDeferredUntilFirstCollectiveWhenUninitialized) {
+  auto comm = new_comm(kBackendName, at::Device(at::kCPU), "deferred_comm", {});
+  ASSERT_NE(comm, nullptr);
+
+  auto backend =
+      std::dynamic_pointer_cast<TorchCommFake>(comm->getBackendImpl());
+  ASSERT_NE(backend, nullptr);
+  backend->finalize(); // isInitialized() -> false
+  ASSERT_FALSE(backend->isInitialized());
+
+  auto hook =
+      std::make_shared<ClogHook>(log_path_, std::vector<std::string>{"ALL"});
+  hook->registerWithComm(comm);
+
+  // Deferred: no signature yet at registration time.
+  EXPECT_EQ(
+      countContaining(readLines(log_path_), "new_comm|comm=deferred_comm"), 0u);
+
+  // First collective fires the pre-hook, which flushes the deferred signature.
+  auto tensor = at::ones({2, 2}, at::kFloat);
+  comm->all_reduce(tensor, ReduceOp::SUM, /*async_op=*/false);
+
+  EXPECT_EQ(
+      countContaining(readLines(log_path_), "new_comm|comm=deferred_comm"), 1u);
+}
+
+// The deferred signature is emitted exactly once, even across many collectives.
+TEST_F(ClogHookRegistrationTest, DeferredSignatureWrittenExactlyOnce) {
+  auto comm = new_comm(kBackendName, at::Device(at::kCPU), "once_comm", {});
+  ASSERT_NE(comm, nullptr);
+
+  auto backend =
+      std::dynamic_pointer_cast<TorchCommFake>(comm->getBackendImpl());
+  ASSERT_NE(backend, nullptr);
+  backend->finalize();
+
+  auto hook =
+      std::make_shared<ClogHook>(log_path_, std::vector<std::string>{"ALL"});
+  hook->registerWithComm(comm);
+
+  auto tensor = at::ones({2, 2}, at::kFloat);
+  comm->all_reduce(tensor, ReduceOp::SUM, /*async_op=*/false);
+  comm->all_reduce(tensor, ReduceOp::SUM, /*async_op=*/false);
+  comm->all_reduce(tensor, ReduceOp::SUM, /*async_op=*/false);
+
+  EXPECT_EQ(
+      countContaining(readLines(log_path_), "new_comm|comm=once_comm"), 1u);
+}
+
+} // namespace torch::comms

--- a/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
+++ b/comms/torchcomms/tests/unit/cpp/TorchWorkTest.cpp
@@ -40,6 +40,19 @@ TEST(TorchWorkTest, StartHookFiredOnInProgress) {
   EXPECT_EQ(start_count, 1);
 }
 
+TEST(TorchWorkTest, StartHookFiredImmediatelyIfAlreadyInProgress) {
+  auto work = c10::make_intrusive<TestWork>();
+  work->setStatus(TorchWork::WorkStatus::INPROGRESS);
+
+  // A start hook registered after the work already transitioned to INPROGRESS
+  // must fire immediately (mirrors the end-hook fallback). This is the MCCL
+  // case: TorchWorkMCCL's ctor sets INPROGRESS before the clog post-hook
+  // registers the start hook, which otherwise drops the "S" clog event.
+  int start_count = 0;
+  work->registerWorkStartHook([&start_count]() { start_count++; });
+  EXPECT_EQ(start_count, 1);
+}
+
 TEST(TorchWorkTest, EndHookFiredOnCompleted) {
   auto work = c10::make_intrusive<TestWork>();
   int end_count = 0;


### PR DESCRIPTION
Summary:
`ClogHook::registerWithComm` wrote the `new_comm|...|rank=N|world_size=M` signature immediately, which calls `comm->getRank()/getSize()` and throws on a not-yet-initialized comm. This makes registration init-agnostic: already-initialized comms (the WORLD-init path and split comms) write the signature eagerly as before; a comm registered before init (e.g. a dynamic-regime MCCL comm) defers the signature to the first pre-hook, which can't fire until a collective runs (i.e. after init). Hook installation itself never depended on init. The deferral is opt-in via a nullable `signature_pending` flag, so the split path (`onPostHook` -> `registerHooks`) is unchanged.

This is the shared torchcomms layer of the MCCL clog registration work; the `genai/msl/comms` register-hook and the farm PAFT registration are stacked on top so the farm application layer stays separate while these lower layers remain common.

Reviewed By: saifhhasan

Differential Revision: D110781916


