### PR TITLE
Preserve lazy connect across grouped tasks (#3084)

### DIFF
--- a/comms/ncclx/meta/tests/LazyConnectTest.cc
+++ b/comms/ncclx/meta/tests/LazyConnectTest.cc
@@ -7,6 +7,7 @@
 #include <folly/init/Init.h>
 #include "comms/ncclx/meta/tests/NcclCommUtils.h"
 #include "comms/ncclx/meta/tests/NcclxBaseTest.h"
+#include "comms/ncclx/meta/transport/transportConnect.h"
 #include "comms/testinfra/TestUtils.h"
 
 #include "comm.h"
@@ -149,6 +150,26 @@ class NcclxLazyConnectTestFixture
     }
   }
 };
+
+TEST(
+    NcclxLazyConnectTest,
+    GroupedCollectiveNeedsAlgoConnectAfterChannelsReady) {
+  ncclComm comm{};
+  comm.nChannels = 32;
+  comm.nChannelsReady = comm.nChannels;
+  comm.planner.nTasksColl = 2;
+  comm.algoConnectedChannels[NCCL_ALGO_RING] = comm.nChannels;
+  comm.algoConnectedChannels[NCCL_ALGO_TREE] = 0;
+
+  ncclTaskColl task{};
+  task.algorithm = NCCL_ALGO_TREE;
+
+  EXPECT_TRUE(ncclx::algoNeedConnect(&comm, &task));
+  EXPECT_EQ(comm.planner.nMaxChannelsNeedInit, comm.nChannels);
+  EXPECT_EQ(
+      comm.planner.algoMaxChannelsNeedConnect.at(NCCL_ALGO_TREE),
+      comm.nChannels);
+}
 
 TEST_P(NcclxLazyConnectTestFixture, InitOnly) {
   rootComm = createRootComm();

--- a/comms/ncclx/v2_29/src/enqueue.cc
+++ b/comms/ncclx/v2_29/src/enqueue.cc
@@ -519,8 +519,9 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
     // number of channels need to be setup later in ncclCollPreconnectFunc for
     // collectives. Otherwise, fallback to baseline runtime connection logic
     if (comm->lazySetupChannels && ncclx::algoCanLazySetupChannel(comm, task)) {
-      *needConnect = ncclx::algoNeedConnect(comm, task);
-      algoNeedConnect[task->algorithm] |= *needConnect;
+      const bool taskNeedConnect = ncclx::algoNeedConnect(comm, task);
+      *needConnect |= taskNeedConnect;
+      algoNeedConnect[task->algorithm] |= taskNeedConnect;
     } else if (
         comm->runtimeConn && comm->initAlgoChannels[task->algorithm] == false) {
       if (task->algorithm == NCCL_ALGO_NVLS_TREE && comm->initAlgoChannels[NCCL_ALGO_NVLS] == false && regNeedConnect == true) {

--- a/comms/ncclx/v2_29/src/group.cc
+++ b/comms/ncclx/v2_29/src/group.cc
@@ -205,7 +205,7 @@ static ncclResult_t ncclCollPreconnect(struct ncclComm* comm, bool* algoNeedConn
 ncclResult_t ncclPrepareTasksAndCollPreconnectFunc(struct ncclAsyncJob* job_) {
   struct ncclPrepareTasksAndCollPreconnectJob* job = (ncclPrepareTasksAndCollPreconnectJob*)job_;
   struct ncclComm* comm = job->comm;
-  bool needConnect;
+  bool needConnect = false;
   bool algoNeedConnect[NCCL_NUM_ALGORITHMS];
   memset(algoNeedConnect, 0, sizeof(bool)*NCCL_NUM_ALGORITHMS);
   CUDACHECK(cudaSetDevice(comm->cudaDev));

--- a/comms/ncclx/v2_30/src/enqueue.cc
+++ b/comms/ncclx/v2_30/src/enqueue.cc
@@ -520,8 +520,9 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
     // number of channels need to be setup later in ncclCollPreconnectFunc for
     // collectives. Otherwise, fallback to baseline runtime connection logic
     if (comm->lazySetupChannels && ncclx::algoCanLazySetupChannel(comm, task)) {
-      *needConnect = ncclx::algoNeedConnect(comm, task);
-      algoNeedConnect[task->algorithm] |= *needConnect;
+      const bool taskNeedConnect = ncclx::algoNeedConnect(comm, task);
+      *needConnect |= taskNeedConnect;
+      algoNeedConnect[task->algorithm] |= taskNeedConnect;
     } else if (
         comm->runtimeConn && comm->initAlgoChannels[task->algorithm] == false) {
       if (task->algorithm == NCCL_ALGO_NVLS_TREE && comm->initAlgoChannels[NCCL_ALGO_NVLS] == false && regNeedConnect == true) {

--- a/comms/ncclx/v2_30/src/group.cc
+++ b/comms/ncclx/v2_30/src/group.cc
@@ -207,7 +207,7 @@ static ncclResult_t ncclCollPreconnect(struct ncclComm* comm, bool* algoNeedConn
 ncclResult_t ncclPrepareTasksAndCollPreconnectFunc(struct ncclAsyncJob* job_) {
   struct ncclPrepareTasksAndCollPreconnectJob* job = (ncclPrepareTasksAndCollPreconnectJob*)job_;
   struct ncclComm* comm = job->comm;
-  bool needConnect;
+  bool needConnect = false;
   bool algoNeedConnect[NCCL_NUM_ALGORITHMS];
   memset(algoNeedConnect, 0, sizeof(bool)*NCCL_NUM_ALGORITHMS);
   CUDACHECK(cudaSetDevice(comm->cudaDev));


### PR DESCRIPTION
Summary:

D110344951 fixes the aggregated-collective predicate, but the enqueue loop still overwrites the group-level `needConnect` flag for each task. A later task that does not need connection can suppress preconnect requested by an earlier task, leaving `TREE` connectors unset even though channel metadata is ready. OR the per-task result into `needConnect`, initialize the async accumulator, and add a regression for the channel-ready/RING-connected/TREE-missing planner state.

Reviewed By: riklas

Differential Revision: D111071969


