### PR TITLE
add synchronize to sync barrier (#3086)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -68,8 +68,11 @@ std::vector<uint64_t> toVecUint64(const std::vector<int64_t>& vec) {
 
 WorkWrapper::WorkWrapper(
     c10::intrusive_ptr<TorchWork> work,
-    std::vector<at::Tensor> outputTensors)
-    : work_(std::move(work)), outputTensors_(std::move(outputTensors)) {
+    std::vector<at::Tensor> outputTensors,
+    bool hostBlocking)
+    : work_(std::move(work)),
+      outputTensors_(std::move(outputTensors)),
+      hostBlocking_(hostBlocking) {
   std::vector<c10::Device> devices;
   // CPU needs to wait for the TorchWork to complete before marking Future
   // as completed
@@ -111,6 +114,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
   }
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -124,6 +130,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
 void WorkWrapper::synchronize() {
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -565,7 +574,20 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   } else {
     bopts.timeout = options_->timeout;
   }
-  return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
+  // Mirror stock ProcessGroupNCCL: a synchronous barrier host-blocks the CPU
+  // thread until the collective (and prior stream work) completes, so callers
+  // relying on the barrier to flush async device work -- e.g. clearing IPC
+  // buffers on the stream before the first all_reduce -- do not race it and
+  // deadlock. The host block lives entirely at this c10d layer: WorkWrapper
+  // calls work_->hostSynchronize() after wait(), so the native TorchComm
+  // barrier and TorchWork::wait() keep uniform semantics with every other
+  // collective. Async barriers keep the non-blocking, stream-ordered behavior
+  // via the work.
+  auto work = comm_->barrier(opts.asyncOp, bopts);
+  return c10::make_intrusive<WorkWrapper>(
+      std::move(work),
+      std::vector<at::Tensor>{},
+      /*hostBlocking=*/!opts.asyncOp);
 }
 
 c10::intrusive_ptr<c10d::Work>

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -19,7 +19,8 @@ class WorkWrapper : public c10d::Work {
  public:
   explicit WorkWrapper(
       c10::intrusive_ptr<TorchWork> work,
-      std::vector<at::Tensor> outputTensors = {});
+      std::vector<at::Tensor> outputTensors = {},
+      bool hostBlocking = false);
   ~WorkWrapper() override = default;
 
   void synchronize() override;
@@ -32,6 +33,9 @@ class WorkWrapper : public c10d::Work {
   c10::intrusive_ptr<TorchWork> work_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   std::vector<at::Tensor> outputTensors_;
+  // When set (synchronous barrier), wait()/synchronize() also host-block via
+  // work_->hostSynchronize() after the stream-ordered wait().
+  bool hostBlocking_;
 };
 
 using c10d::kUnsetTimeout;

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -52,6 +52,13 @@ class TorchWork : public c10::intrusive_ptr_target {
     return std::chrono::milliseconds::max();
   }
 
+  // Block the calling CPU thread until the device work behind this object has
+  // completed (in addition to the stream-ordered wait()). Invoked by the c10d
+  // WorkWrapper for synchronous barriers to mirror stock ProcessGroupNCCL,
+  // whose barrier host-blocks the CPU thread. No-op by default; backends whose
+  // wait() is already host-blocking (e.g. CPU/gloo) need not override it.
+  virtual void hostSynchronize() {}
+
   // Fault Tolerance API
 
   /**

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -4,6 +4,8 @@
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 #include <glog/logging.h>
+#include <sstream>
+#include <stdexcept>
 
 namespace torch::comms {
 
@@ -236,5 +238,28 @@ class DefaultCudaApi : public CudaApi {
 };
 
 bool deviceSupportsMulticast(int device_idx);
+
+// Block the host until all work on the device's current stream has completed.
+// Skips the sync while the stream is capturing a CUDA graph:
+// cudaStreamSynchronize is illegal during capture, and the captured work is
+// replayed on-device where a host sync is meaningless. Shared by the NCCL/NCCLX
+// synchronous-barrier host block that WorkWrapper::wait() invokes via
+// TorchWork::hostSynchronize().
+inline void syncCurrentStreamIfNotCapturing(
+    CudaApi* cuda_api,
+    int device_index) {
+  cudaStream_t current_stream = cuda_api->getCurrentCUDAStream(device_index);
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  CUDA_CHECK(
+      cuda_api,
+      cuda_api->streamIsCapturing(current_stream, &capture_status),
+      "Failed to query stream capture status in host-blocking wait");
+  if (capture_status == cudaStreamCaptureStatusNone) {
+    CUDA_CHECK(
+        cuda_api,
+        cuda_api->streamSynchronize(current_stream),
+        "CUDA stream synchronize in host-blocking wait failed");
+  }
+}
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchWorkNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.cpp
@@ -196,4 +196,8 @@ void TorchWorkNCCL::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCL::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchWorkNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.hpp
@@ -53,6 +53,10 @@ class TorchWorkNCCL : public TorchWork {
     return timeout_ms_;
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -306,4 +306,8 @@ void TorchWorkNCCLX::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCLX::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
@@ -68,6 +68,10 @@ class TorchWorkNCCLX : public TorchWork {
     cpuTensors_ = std::move(tensors);
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/tests/integration/py/BarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/BarrierTest.py
@@ -6,6 +6,8 @@ import os
 import unittest
 
 import torch
+from torch.distributed import BarrierOptions
+from torchcomms.device_mesh import _create_torchcomm_process_group
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
     TorchCommTestWrapper,
 )
@@ -96,6 +98,56 @@ class BarrierTest(unittest.TestCase):
                 graph.replay()
 
                 # No explicit verification needed for barrier, just ensure it completes
+
+    def _sync_barrier_blocks_host_on_stream(self):
+        """A synchronous c10d barrier must block the host until prior work on the
+        current stream has completed.
+
+        This mirrors stock ProcessGroupNCCL, whose barrier host-blocks the CPU
+        thread. It is a regression test for a trtllm flashinfer one-shot Lamport
+        all_reduce deadlock: that code clears its IPC buffers asynchronously on
+        the stream and then issues a synchronous barrier before the first
+        all_reduce, relying on the barrier to flush that clear. If the barrier
+        only inserts a stream-ordered wait (no host sync), the first all_reduce
+        races the clear and both ranks spin forever. The host block is applied by
+        BackendWrapper (the c10d layer), so the barrier is driven through a c10d
+        ProcessGroup rather than the native torchcomm.barrier().
+        """
+        pg = _create_torchcomm_process_group(self.torchcomm, "barrier_host_block_pg")
+        with torch.cuda.device(self.device):
+            stream = torch.cuda.current_stream()
+
+            # Enqueue a long-running kernel on the current stream so the host
+            # would observe an unfinished stream if the barrier did not
+            # synchronize it.
+            torch.cuda._sleep(1_000_000_000)
+            self.assertFalse(
+                stream.query(),
+                "precondition: enqueued work should leave the stream busy",
+            )
+
+            # Synchronous c10d barrier + wait() must block the host until the
+            # stream is drained.
+            opts = BarrierOptions()
+            opts.asyncOp = False
+            opts.device = self.device
+            work = pg.barrier(opts=opts)
+            work.wait()
+
+            self.assertTrue(
+                stream.query(),
+                "synchronous barrier must block the host until prior stream work completes",
+            )
+        print(f"[Rank {self.rank}] sync barrier blocked host until stream drained")
+
+    @unittest.skipIf(
+        os.getenv("TEST_BACKEND") not in ("nccl", "ncclx"),
+        "Host-blocking synchronous barrier is validated for the GPU backends "
+        "(nccl, ncclx)",
+    )
+    def test_sync_barrier_blocks_host_on_stream(self):
+        """Synchronous barrier + wait() must block the host until prior stream work done."""
+        self._sync_barrier_blocks_host_on_stream()
 
     def test_sync_barrier(self):
         """Test synchronous barrier with work object."""


### PR DESCRIPTION
Summary:

Aligns synchronous barriers in `TorchCommNCCL` with `ProcessGroupNCCL::barrier()` by introducing a device-wide synchronization when the barrier collective is synchronous. This prevents race conditions and deadlocks in workflows that rely on the barrier to flush asynchronous device work on other streams before proceeding, while preserving stream-ordered behavior for asynchronous operations and safely skipping the host sync during CUDA graph captures.

Differential Revision: D109866902


