### PR TITLE
Implement monitoredBarrier for gloo groups under TorchComms (#3087)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -6,6 +6,10 @@
 
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+
 namespace torch::comms {
 
 namespace {
@@ -588,6 +592,188 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
       std::move(work),
       std::vector<at::Tensor>{},
       /*hostBlocking=*/!opts.asyncOp);
+}
+
+void BackendWrapper::monitoredBarrier(
+    const c10d::BarrierOptions& opts,
+    bool waitAllRanks) {
+  // Reimplements c10d::ProcessGroupGloo::monitoredBarrier on TorchComms.
+  //
+  // The native gloo version posts async send/recv and then wait(timeout)s on
+  // each work to find stragglers. That form is unavailable here: WorkWrapper::
+  // wait() rejects any finite timeout ("wait timeout not supported"). Instead
+  // we run the same coordinator protocol with SYNCHRONOUS, per-op-timeout P2P
+  // on the underlying comm: a synchronous gloo recv with a finite timeout
+  // throws a catchable exception on timeout (TorchCommGloo::recv ->
+  // gloo UnboundBuffer::waitRecv(timeout)) and does NOT poison the comm
+  // (TorchCommGloo::checkAndAbortIfTimedOutOrError is a no-op), so rank 0 can
+  // keep probing the remaining ranks after one times out.
+  //
+  // Only meaningful for the gloo (CPU) backend; the dist.monitored_barrier
+  // entry point already restricts callers to gloo groups.
+  const int rank = getRank();
+  const int worldSize = getSize();
+
+  const std::chrono::milliseconds timeout =
+      (opts.timeout != kUnsetTimeout) ? opts.timeout : options_->timeout;
+
+  // Phase-1 (worker -> rank 0) and phase-2 (rank 0 -> worker) tags, generated
+  // per call. Identical on every rank because monitoredBarrier is collective
+  // and all ranks advance this PG's counter in lockstep (the counter is a
+  // per-BackendWrapper member, so concurrent barriers on other PGs cannot
+  // desync it across ranks).
+  const uint32_t tagBase = monitoredBarrierTagCounter_.fetch_add(2);
+  // Mask into the non-negative int range: c10d/gloo tags are ints, and the
+  // counter would otherwise wrap past INT_MAX in a long-lived process and
+  // produce negative tags. The mask is deterministic, so every rank still
+  // derives identical tags; fetch_add(2) keeps the two tags distinct
+  // (even/odd) and the low-30-bit mask never merges them.
+  constexpr uint32_t kTagMask = 0x3FFFFFFFu;
+  const int tagToZero = static_cast<int>(tagBase & kTagMask);
+  const int tagFromZero = static_cast<int>((tagBase + 1) & kTagMask);
+
+  auto makeCommTensor = [&]() {
+    auto t =
+        at::empty({1}, at::TensorOptions().dtype(at::kLong).device(at::kCPU));
+    t.fill_(rank);
+    return t;
+  };
+
+  // Workers report in to rank 0, then block until rank 0 acks. Only rank 0
+  // enforces the timeout, so a dead/slow rank is named by rank 0 instead of
+  // every worker timing out and hiding the culprit.
+  if (rank != 0) {
+    try {
+      auto outTensor = makeCommTensor();
+      SendOptions sopts;
+      sopts.tag = tagToZero; // blocking: timeout stays kNoTimeout
+      comm_->send(outTensor, 0, /*async_op=*/false, sopts);
+
+      auto inTensor = makeCommTensor();
+      RecvOptions ropts;
+      ropts.tag = tagFromZero; // blocking
+      comm_->recv(inTensor, 0, /*async_op=*/false, ropts);
+    } catch (const std::exception& e) {
+      TORCH_CHECK(
+          false,
+          "Rank ",
+          rank,
+          " successfully reached monitoredBarrier, but received errors while "
+          "waiting for send/recv from rank 0. Please check rank 0 logs for the "
+          "faulty rank.\n Original exception: \n",
+          e.what());
+    }
+    return;
+  }
+
+  // Rank 0 is the coordinator.
+  //
+  // Fast-fail (waitAllRanks == false) matches native
+  // ProcessGroupGloo::monitoredBarrier: on the first straggler rank 0 raises
+  // immediately (below) and never reaches the ack loop, so workers that already
+  // checked in stay blocked in their ack recv (kNoTimeout) until the process is
+  // torn down. This is intentional -- a failed monitoredBarrier is not a clean
+  // barrier exit. waitAllRanks == true instead probes every worker and reports
+  // all stragglers before raising.
+  const auto startTime = std::chrono::steady_clock::now();
+  auto remainingTime = [&]() -> std::chrono::milliseconds {
+    if (waitAllRanks) {
+      // Give every worker the full timeout: spending it all on worker n must
+      // not starve probing of workers n+1.. (see the native gloo impl).
+      return timeout;
+    }
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - startTime);
+    return timeout - elapsed;
+  };
+
+  auto joinInts = [](const std::vector<int>& v) {
+    std::string s;
+    for (size_t i = 0; i < v.size(); ++i) {
+      if (i > 0) {
+        s += ", ";
+      }
+      s += std::to_string(v[i]);
+    }
+    return s;
+  };
+
+  std::vector<int> processedRanks;
+  processedRanks.reserve(static_cast<size_t>(worldSize - 1));
+  for (int srcRank = 1; srcRank < worldSize; ++srcRank) {
+    const auto remaining = remainingTime();
+    if (!waitAllRanks && remaining.count() <= 0) {
+      TORCH_CHECK(
+          false,
+          "Rank 0 timed out in monitoredBarrier after ",
+          timeout.count(),
+          " ms. Successfully processed ranks: ",
+          joinInts(processedRanks));
+    }
+    try {
+      // Fresh buffer per rank: a timed-out recv leaves a pending registration
+      // on the gloo transport, so reusing the tensor could race a late message
+      // into memory in use by the next probe.
+      auto inTensor = makeCommTensor();
+      RecvOptions ropts;
+      ropts.tag = tagToZero;
+      ropts.timeout = (remaining.count() > 0) ? remaining : timeout;
+      comm_->recv(inTensor, srcRank, /*async_op=*/false, ropts);
+      processedRanks.push_back(srcRank);
+    } catch (const std::exception& e) {
+      if (!waitAllRanks) {
+        TORCH_CHECK(
+            false,
+            "[Rank 0]: Rank ",
+            srcRank,
+            " failed to pass monitoredBarrier in ",
+            timeout.count(),
+            " ms\n Original exception: \n",
+            e.what());
+      }
+      // waitAllRanks: keep going and collect every failure below.
+    }
+  }
+
+  if (waitAllRanks &&
+      processedRanks.size() != static_cast<size_t>(worldSize - 1)) {
+    std::vector<int> failedRanks;
+    for (int i = 1; i < worldSize; ++i) {
+      if (std::find(processedRanks.begin(), processedRanks.end(), i) ==
+          processedRanks.end()) {
+        failedRanks.push_back(i);
+      }
+    }
+    TORCH_CHECK(
+        false,
+        "[Rank 0]: Ranks ",
+        joinInts(failedRanks),
+        " failed to pass monitoredBarrier in ",
+        timeout.count(),
+        " ms");
+  }
+
+  // Every worker checked in: ack each so all ranks leave the barrier together
+  // (a true barrier -- all exit or none do). Ack every remaining worker even if
+  // one send throws: a worker that died between check-in and ack must not leave
+  // the healthy workers blocked forever in their ack recv. Collect failures and
+  // raise only after every other worker has been acked.
+  std::vector<int> ackFailedRanks;
+  for (int dstRank = 1; dstRank < worldSize; ++dstRank) {
+    try {
+      auto outTensor = makeCommTensor();
+      SendOptions sopts;
+      sopts.tag = tagFromZero;
+      comm_->send(outTensor, dstRank, /*async_op=*/false, sopts);
+    } catch (const std::exception&) {
+      ackFailedRanks.push_back(dstRank);
+    }
+  }
+  TORCH_CHECK(
+      ackFailedRanks.empty(),
+      "[Rank 0]: failed to ack ranks ",
+      joinInts(ackFailedRanks),
+      " in monitoredBarrier; these ranks may remain blocked");
 }
 
 c10::intrusive_ptr<c10d::Work>

--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -68,8 +68,11 @@ std::vector<uint64_t> toVecUint64(const std::vector<int64_t>& vec) {
 
 WorkWrapper::WorkWrapper(
     c10::intrusive_ptr<TorchWork> work,
-    std::vector<at::Tensor> outputTensors)
-    : work_(std::move(work)), outputTensors_(std::move(outputTensors)) {
+    std::vector<at::Tensor> outputTensors,
+    bool hostBlocking)
+    : work_(std::move(work)),
+      outputTensors_(std::move(outputTensors)),
+      hostBlocking_(hostBlocking) {
   std::vector<c10::Device> devices;
   // CPU needs to wait for the TorchWork to complete before marking Future
   // as completed
@@ -111,6 +114,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
   }
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -124,6 +130,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
 void WorkWrapper::synchronize() {
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -565,7 +574,20 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   } else {
     bopts.timeout = options_->timeout;
   }
-  return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
+  // Mirror stock ProcessGroupNCCL: a synchronous barrier host-blocks the CPU
+  // thread until the collective (and prior stream work) completes, so callers
+  // relying on the barrier to flush async device work -- e.g. clearing IPC
+  // buffers on the stream before the first all_reduce -- do not race it and
+  // deadlock. The host block lives entirely at this c10d layer: WorkWrapper
+  // calls work_->hostSynchronize() after wait(), so the native TorchComm
+  // barrier and TorchWork::wait() keep uniform semantics with every other
+  // collective. Async barriers keep the non-blocking, stream-ordered behavior
+  // via the work.
+  auto work = comm_->barrier(opts.asyncOp, bopts);
+  return c10::make_intrusive<WorkWrapper>(
+      std::move(work),
+      std::vector<at::Tensor>{},
+      /*hostBlocking=*/!opts.asyncOp);
 }
 
 c10::intrusive_ptr<c10d::Work>

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -19,7 +19,8 @@ class WorkWrapper : public c10d::Work {
  public:
   explicit WorkWrapper(
       c10::intrusive_ptr<TorchWork> work,
-      std::vector<at::Tensor> outputTensors = {});
+      std::vector<at::Tensor> outputTensors = {},
+      bool hostBlocking = false);
   ~WorkWrapper() override = default;
 
   void synchronize() override;
@@ -32,6 +33,9 @@ class WorkWrapper : public c10d::Work {
   c10::intrusive_ptr<TorchWork> work_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   std::vector<at::Tensor> outputTensors_;
+  // When set (synchronous barrier), wait()/synchronize() also host-block via
+  // work_->hostSynchronize() after the stream-ordered wait().
+  bool hostBlocking_;
 };
 
 using c10d::kUnsetTimeout;

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -11,6 +11,7 @@
 #include "comms/torchcomms/TorchCommTypes.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
 
+#include <atomic>
 #include <optional>
 
 namespace torch::comms {
@@ -119,6 +120,12 @@ class BackendWrapper : public c10d::Backend {
       const c10d::AllToAllOptions& opts = c10d::AllToAllOptions()) override;
   c10::intrusive_ptr<c10d::Work> barrier(
       const c10d::BarrierOptions& opts = c10d::BarrierOptions()) override;
+  // Health-checking barrier used by torch.distributed.monitored_barrier. Only
+  // meaningful on the gloo (CPU) backend; reimplements
+  // c10d::ProcessGroupGloo::monitoredBarrier on top of TorchComms P2P.
+  void monitoredBarrier(
+      const c10d::BarrierOptions& opts = c10d::BarrierOptions(),
+      bool waitAllRanks = false) override;
   c10::intrusive_ptr<c10d::Work>
   send(std::vector<at::Tensor>& tensors, int dstRank, int tag) override;
   c10::intrusive_ptr<c10d::Work>
@@ -189,6 +196,15 @@ class BackendWrapper : public c10d::Backend {
   // immediately. c10d's coalescing manager serializes per-PG, so a single
   // slot suffices.
   std::optional<BatchSendRecv> coalescing_batch_;
+
+  // Per-call tag sequence for monitoredBarrier's check-in/ack P2P. Kept
+  // per-BackendWrapper (not process-global) so each ProcessGroup owns its own
+  // counter: monitoredBarrier is collective per PG, so every rank advances
+  // this instance's counter in lockstep and derives identical tags. A shared
+  // process-global counter could instead be advanced a different number of
+  // times per rank when unrelated PGs run concurrent barriers, yielding
+  // mismatched send/recv tags across ranks.
+  std::atomic<uint32_t> monitoredBarrierTagCounter_{0};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -52,6 +52,13 @@ class TorchWork : public c10::intrusive_ptr_target {
     return std::chrono::milliseconds::max();
   }
 
+  // Block the calling CPU thread until the device work behind this object has
+  // completed (in addition to the stream-ordered wait()). Invoked by the c10d
+  // WorkWrapper for synchronous barriers to mirror stock ProcessGroupNCCL,
+  // whose barrier host-blocks the CPU thread. No-op by default; backends whose
+  // wait() is already host-blocking (e.g. CPU/gloo) need not override it.
+  virtual void hostSynchronize() {}
+
   // Fault Tolerance API
 
   /**

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -4,6 +4,8 @@
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 #include <glog/logging.h>
+#include <sstream>
+#include <stdexcept>
 
 namespace torch::comms {
 
@@ -236,5 +238,28 @@ class DefaultCudaApi : public CudaApi {
 };
 
 bool deviceSupportsMulticast(int device_idx);
+
+// Block the host until all work on the device's current stream has completed.
+// Skips the sync while the stream is capturing a CUDA graph:
+// cudaStreamSynchronize is illegal during capture, and the captured work is
+// replayed on-device where a host sync is meaningless. Shared by the NCCL/NCCLX
+// synchronous-barrier host block that WorkWrapper::wait() invokes via
+// TorchWork::hostSynchronize().
+inline void syncCurrentStreamIfNotCapturing(
+    CudaApi* cuda_api,
+    int device_index) {
+  cudaStream_t current_stream = cuda_api->getCurrentCUDAStream(device_index);
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  CUDA_CHECK(
+      cuda_api,
+      cuda_api->streamIsCapturing(current_stream, &capture_status),
+      "Failed to query stream capture status in host-blocking wait");
+  if (capture_status == cudaStreamCaptureStatusNone) {
+    CUDA_CHECK(
+        cuda_api,
+        cuda_api->streamSynchronize(current_stream),
+        "CUDA stream synchronize in host-blocking wait failed");
+  }
+}
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchWorkNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.cpp
@@ -196,4 +196,8 @@ void TorchWorkNCCL::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCL::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchWorkNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.hpp
@@ -53,6 +53,10 @@ class TorchWorkNCCL : public TorchWork {
     return timeout_ms_;
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -306,4 +306,8 @@ void TorchWorkNCCLX::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCLX::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
@@ -68,6 +68,10 @@ class TorchWorkNCCLX : public TorchWork {
     cpuTensors_ = std::move(tensors);
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/tests/integration/py/BarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/BarrierTest.py
@@ -6,6 +6,8 @@ import os
 import unittest
 
 import torch
+from torch.distributed import BarrierOptions
+from torchcomms.device_mesh import _create_torchcomm_process_group
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
     TorchCommTestWrapper,
 )
@@ -96,6 +98,56 @@ class BarrierTest(unittest.TestCase):
                 graph.replay()
 
                 # No explicit verification needed for barrier, just ensure it completes
+
+    def _sync_barrier_blocks_host_on_stream(self):
+        """A synchronous c10d barrier must block the host until prior work on the
+        current stream has completed.
+
+        This mirrors stock ProcessGroupNCCL, whose barrier host-blocks the CPU
+        thread. It is a regression test for a trtllm flashinfer one-shot Lamport
+        all_reduce deadlock: that code clears its IPC buffers asynchronously on
+        the stream and then issues a synchronous barrier before the first
+        all_reduce, relying on the barrier to flush that clear. If the barrier
+        only inserts a stream-ordered wait (no host sync), the first all_reduce
+        races the clear and both ranks spin forever. The host block is applied by
+        BackendWrapper (the c10d layer), so the barrier is driven through a c10d
+        ProcessGroup rather than the native torchcomm.barrier().
+        """
+        pg = _create_torchcomm_process_group(self.torchcomm, "barrier_host_block_pg")
+        with torch.cuda.device(self.device):
+            stream = torch.cuda.current_stream()
+
+            # Enqueue a long-running kernel on the current stream so the host
+            # would observe an unfinished stream if the barrier did not
+            # synchronize it.
+            torch.cuda._sleep(1_000_000_000)
+            self.assertFalse(
+                stream.query(),
+                "precondition: enqueued work should leave the stream busy",
+            )
+
+            # Synchronous c10d barrier + wait() must block the host until the
+            # stream is drained.
+            opts = BarrierOptions()
+            opts.asyncOp = False
+            opts.device = self.device
+            work = pg.barrier(opts=opts)
+            work.wait()
+
+            self.assertTrue(
+                stream.query(),
+                "synchronous barrier must block the host until prior stream work completes",
+            )
+        print(f"[Rank {self.rank}] sync barrier blocked host until stream drained")
+
+    @unittest.skipIf(
+        os.getenv("TEST_BACKEND") not in ("nccl", "ncclx"),
+        "Host-blocking synchronous barrier is validated for the GPU backends "
+        "(nccl, ncclx)",
+    )
+    def test_sync_barrier_blocks_host_on_stream(self):
+        """Synchronous barrier + wait() must block the host until prior stream work done."""
+        self._sync_barrier_blocks_host_on_stream()
 
     def test_sync_barrier(self):
         """Test synchronous barrier with work object."""

--- a/comms/torchcomms/tests/integration/py/MonitoredBarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/MonitoredBarrierTest.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test BackendWrapper::monitoredBarrier (the gloo health-checking barrier).
+
+torch.distributed.monitored_barrier is only implemented for the gloo backend.
+Under TorchComms the gloo ProcessGroup is backed by BackendWrapper, which now
+reimplements ProcessGroupGloo::monitoredBarrier on top of TorchComms P2P: rank 0
+acts as the coordinator, collecting a check-in from every other rank within the
+timeout and raising a RuntimeError that names the rank(s) that failed to report.
+
+This test wraps a real "gloo" TorchComm in a c10d ProcessGroup and drives
+``pg.monitored_barrier`` directly (the same entry point dist.monitored_barrier
+dispatches to), covering the all-pass path plus straggler detection in both the
+wait_all_ranks (report every straggler) and fast-fail (report the first) modes.
+
+monitored_barrier is gloo-only, so this test skips on any other backend rather
+than failing (the Buck target is also restricted to ``backends = ["gloo"]``).
+"""
+
+import datetime
+import os
+import time
+import unittest
+
+import torch
+import torch.distributed as dist
+import torchcomms
+from torchcomms import new_comm
+from torchcomms.device_mesh import _create_torchcomm_process_group
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    create_store,
+    get_rank_and_size,
+)
+
+
+def _make_wrapped_gloo_pg(
+    name: str,
+) -> tuple[torchcomms.TorchComm, dist.ProcessGroup]:
+    """Build a gloo TorchComm wrapped in a c10d ProcessGroup.
+
+    Reuses ``device_mesh._create_torchcomm_process_group`` for the wrap +
+    register so this test does not duplicate the _BackendWrapper /
+    _register_backend boilerplate. The comm carries its own store-bootstrapped
+    gloo context (used by monitoredBarrier's P2P); the ProcessGroup uses a
+    throwaway HashStore internally.
+
+    The comm is created on CPU on purpose: monitoredBarrier is a CPU-only gloo
+    op, and c10d dispatches pg.monitored_barrier to whichever backend is
+    registered for the CPU device. _create_torchcomm_process_group registers the
+    wrapper under comm.get_device(), so on a GPU host a cuda comm would leave the
+    CPU device unbacked and monitored_barrier would raise "No backend type
+    associated with device type cpu".
+    """
+    backend = os.environ["TEST_BACKEND"]
+    comm = new_comm(backend, torch.device("cpu"), store=create_store(), name=name)
+    pg = _create_torchcomm_process_group(comm, name)
+    return comm, pg
+
+
+class MonitoredBarrierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.environ.get("TEST_BACKEND") != "gloo":
+            self.skipTest("monitored_barrier is only implemented for the gloo backend")
+        self.rank, self.num_ranks = get_rank_and_size()
+
+    def test_all_ranks_pass(self) -> None:
+        """When every rank checks in, monitoredBarrier returns without error."""
+        comm, pg = _make_wrapped_gloo_pg("mb_all_pass")
+        passed = False
+        try:
+            # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at runtime
+            # (bound from c10d) but is missing from the type stub.
+            pg.monitored_barrier(
+                timeout=datetime.timedelta(seconds=30),
+                wait_all_ranks=True,
+            )
+            passed = True
+        finally:
+            comm.finalize()
+        self.assertTrue(passed)
+
+    def test_straggler_detection(self) -> None:
+        """wait_all_ranks: rank 0 names every rank that fails to reach the barrier."""
+        if self.num_ranks < 2:
+            self.skipTest("straggler detection requires at least 2 ranks")
+
+        comm: torchcomms.TorchComm | None = None
+        timeout = datetime.timedelta(seconds=1)
+        try:
+            comm, pg = _make_wrapped_gloo_pg("mb_straggler")
+            if self.rank == 0:
+                # Every other rank deliberately never checks in, so rank 0 must
+                # time out on each and report all of them.
+                with self.assertRaises(RuntimeError) as ctx:
+                    # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at
+                    # runtime (bound from c10d) but is missing from the stub.
+                    pg.monitored_barrier(timeout=timeout, wait_all_ranks=True)
+                message = str(ctx.exception)
+                self.assertIn("monitoredBarrier", message)
+                # Match the distinctive "Ranks <list> failed" segment rather
+                # than bare rank ids: small ids like "1" would also match the
+                # timeout value ("1000 ms") or the "[Rank 0]" prefix, so a
+                # malformed/empty straggler list could still pass.
+                expected_ranks = ", ".join(str(r) for r in range(1, self.num_ranks))
+                self.assertIn(f"Ranks {expected_ranks} failed", message)
+            else:
+                # Stay alive (keeping the gloo context up) long enough for rank
+                # 0 to time out on us, then exit. wait_all_ranks spends the full
+                # timeout per rank sequentially, so allow num_ranks * timeout.
+                time.sleep(timeout.total_seconds() * self.num_ranks + 5)
+        finally:
+            if comm is not None:
+                comm.finalize()
+
+    def test_straggler_detection_fast_fail(self) -> None:
+        """Fast-fail (wait_all_ranks=False): rank 0 raises on the first straggler."""
+        if self.num_ranks < 2:
+            self.skipTest("straggler detection requires at least 2 ranks")
+
+        comm: torchcomms.TorchComm | None = None
+        timeout = datetime.timedelta(seconds=1)
+        try:
+            comm, pg = _make_wrapped_gloo_pg("mb_straggler_fast_fail")
+            if self.rank == 0:
+                # No worker checks in. In fast-fail mode rank 0 stops at the
+                # first straggler (rank 1) and raises without probing the rest.
+                with self.assertRaises(RuntimeError) as ctx:
+                    # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at
+                    # runtime (bound from c10d) but is missing from the stub.
+                    pg.monitored_barrier(timeout=timeout, wait_all_ranks=False)
+                message = str(ctx.exception)
+                self.assertIn("monitoredBarrier", message)
+                # Fast-fail reports the first straggler only. Match the full
+                # "Rank 1 failed" phrase, not a bare id that could also match
+                # the timeout value or the "[Rank 0]" prefix.
+                self.assertIn("Rank 1 failed", message)
+            else:
+                # rank 0 bails after ~one timeout (it stops at rank 1), but keep
+                # the context up a bit longer to avoid tearing down mid-probe.
+                time.sleep(timeout.total_seconds() * self.num_ranks + 5)
+        finally:
+            if comm is not None:
+                comm.finalize()


### PR DESCRIPTION
Summary:

torch.distributed.monitored_barrier is only implemented for the gloo backend.
Under TorchComms a gloo ProcessGroup is backed by BackendWrapper, which did not
implement monitoredBarrier, so monitored_barrier was unavailable on gloo groups
created through TorchComms.

Reimplement ProcessGroupGloo::monitoredBarrier on top of TorchComms P2P. Rank 0
is the coordinator: every other rank sends a check-in and blocks for an ack;
rank 0 receives from each worker and, on timeout, raises an error naming the
straggler(s). The native gloo version finds stragglers via Work::wait(timeout),
which is unavailable here (WorkWrapper::wait rejects finite timeouts), so instead
we use synchronous, per-op-timeout P2P on the underlying comm: a timed-out gloo
recv throws a catchable exception and does not poison the comm, letting rank 0
keep probing the remaining ranks. On success rank 0 acks every worker so all
ranks leave the barrier together. Per-call send/recv tags (advanced in lockstep
across ranks) keep concurrent barriers isolated. wait_all_ranks reports every
failing rank instead of stopping at the first.

Only meaningful for the gloo (CPU) backend; the dist.monitored_barrier entry
point already restricts callers to gloo groups.

Reviewed By: d4l3k

Differential Revision: D110791955


