### PR TITLE
fix dangling Synchronized LockedPtr reference in VcState (#3090)

### DIFF
--- a/comms/ctran/backends/ib/VcState.h
+++ b/comms/ctran/backends/ib/VcState.h
@@ -153,9 +153,15 @@ class VcState {
       return it->second;
     };
 
+    // Hold the read lock in a named local so the guarded VcStateMaps outlives
+    // the pointer passed to getVcFrom(). A default-constructed (null) LockedPtr
+    // is used when the lock is skipped, so the lock is only taken when needed.
+    auto lockedVcStateMaps = PerfConfig::skipVcConnectionCheck
+        ? decltype(vcStateMaps_.rlock()){}
+        : vcStateMaps_.rlock();
     auto vcstatemaps = PerfConfig::skipVcConnectionCheck
         ? vcStateMapsPtr_
-        : &(*vcStateMaps_.rlock());
+        : &(*lockedVcStateMaps);
     return getVcFrom(vcstatemaps);
   }
 


### PR DESCRIPTION
Summary:

The `[[clang::lifetimebound]]` annotation added to `folly::Synchronized`'s
`LockedPtr::operator*`/`operator->` in D110034222 surfaces a real use-after-scope
bug in `CtranIbVcState::getVcByQp`. The code computed
`&(*vcStateMaps_.rlock())` inside a ternary, taking the address of the guarded
`VcStateMaps` through a `LockedPtr` temporary destroyed at the end of the
full-expression, then passed that dangling pointer to `getVcFrom()`. Hoist the
read lock into a named `LockedPtr` local so the guarded maps outlive the call. A
default-constructed (null) LockedPtr is used on the lock-skipped branch so the
lock is only acquired when actually needed.

Surfaced by the [[clang::lifetimebound]] annotation on folly::Synchronized's
LockedPtr in D110034222.

Reviewed By: r-barnes

Differential Revision: D110325961


