### PR TITLE
Add smem reduce path for direct IB reduce-scatter

### DIFF
--- a/comms/prims/benchmarks/CopyOpReduceBench.cc
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cc
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <glog/logging.h>
+
+#include "comms/prims/benchmarks/CopyOpReduceBench.cuh"
+#include "comms/testinfra/BenchUtils.h"
+
+namespace comms::prims::benchmark {
+namespace {
+
+void runPolicy(
+    unsigned int iters,
+    CopyOpReducePolicy policy,
+    std::size_t nbytes,
+    folly::UserCounters& counters) {
+  folly::BenchmarkSuspender suspender;
+  suspender.dismiss();
+  const auto timing =
+      runCopyOpReduceBenchmark(policy, nbytes, static_cast<int>(iters));
+  suspender.rehire();
+  counters["deviceTimeUs"] =
+      folly::UserMetric(timing.timeUs, folly::UserMetric::Type::METRIC);
+  counters["payloadGBps"] =
+      folly::UserMetric(timing.payloadGBps, folly::UserMetric::Type::METRIC);
+  counters["memoryGBps"] =
+      folly::UserMetric(timing.memoryGBps, folly::UserMetric::Type::METRIC);
+}
+
+void tileReduceStaged(
+    unsigned int iters,
+    std::size_t nbytes,
+    folly::UserCounters& counters) {
+  runPolicy(iters, CopyOpReducePolicy::TileReduceStaged, nbytes, counters);
+}
+
+void cpAsyncSmemReduce(
+    unsigned int iters,
+    std::size_t nbytes,
+    folly::UserCounters& counters) {
+  runPolicy(iters, CopyOpReducePolicy::CpAsyncSmemReduce, nbytes, counters);
+}
+
+#define REGISTER_SIZES(function)                     \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 32768);  \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 131072); \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 524288); \
+  BENCHMARK_SINGLE_PARAM_COUNTERS(function, 2097152)
+
+REGISTER_SIZES(tileReduceStaged);
+REGISTER_SIZES(cpAsyncSmemReduce);
+
+} // namespace
+} // namespace comms::prims::benchmark
+
+int main(int argc, char** argv) {
+  CHECK_GE(bench_utils::getNumCudaDevices(), 1);
+  CHECK_EQ(cudaSetDevice(0), cudaSuccess);
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+  CHECK_EQ(cudaDeviceReset(), cudaSuccess);
+  return 0;
+}

--- a/comms/prims/benchmarks/CopyOpReduceBench.cu
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cu
@@ -1,0 +1,133 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/benchmarks/CopyOpReduceBench.cuh"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::prims::benchmark {
+namespace {
+
+constexpr int kBlockSize = 384;
+constexpr int kBlocks = 1;
+
+using StagedPolicy = TileReduceStaged<float, SumOp, 24576, kBlockSize>;
+using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 8192, kBlockSize, 2>;
+
+template <typename Policy>
+__global__ void reduceKernel(
+    float* output,
+    const float* staging,
+    const float* local,
+    std::size_t nbytes) {
+  auto group = make_block_group();
+  Policy::recv(
+      reinterpret_cast<char*>(output),
+      reinterpret_cast<const char*>(staging),
+      nbytes,
+      group,
+      0,
+      reinterpret_cast<const char*>(local));
+}
+
+void checkCuda(cudaError_t status, const char* operation) {
+  if (status != cudaSuccess) {
+    throw std::runtime_error(
+        std::string(operation) + ": " + cudaGetErrorString(status));
+  }
+}
+
+void launchPolicy(
+    CopyOpReducePolicy policy,
+    float* output,
+    const float* staging,
+    const float* local,
+    std::size_t nbytes,
+    std::size_t dynamicSmem) {
+  switch (policy) {
+    case CopyOpReducePolicy::TileReduceStaged:
+      reduceKernel<StagedPolicy>
+          <<<kBlocks, kBlockSize>>>(output, staging, local, nbytes);
+      return;
+    case CopyOpReducePolicy::CpAsyncSmemReduce:
+      reduceKernel<SmemPolicy><<<kBlocks, kBlockSize, dynamicSmem>>>(
+          output, staging, local, nbytes);
+      return;
+  }
+  throw std::invalid_argument("unknown CopyOp reduce policy");
+}
+
+std::size_t smemForPolicy(CopyOpReducePolicy policy) {
+  return policy == CopyOpReducePolicy::CpAsyncSmemReduce
+      ? SmemPolicy::smem_bytes()
+      : 0;
+}
+
+} // namespace
+
+CopyOpReduceTiming runCopyOpReduceBenchmark(
+    CopyOpReducePolicy policy,
+    std::size_t nbytes,
+    int iterations) {
+  const std::size_t allocationBytes = nbytes * kBlocks;
+  meta::comms::DeviceBuffer staging(allocationBytes);
+  meta::comms::DeviceBuffer local(allocationBytes);
+  meta::comms::DeviceBuffer output(allocationBytes);
+  checkCuda(
+      cudaMemset(staging.get(), 1, allocationBytes), "initialize staging");
+  checkCuda(cudaMemset(local.get(), 2, allocationBytes), "initialize local");
+
+  const std::size_t dynamicSmem = smemForPolicy(policy);
+  if (dynamicSmem > 0) {
+    checkCuda(
+        cudaFuncSetAttribute(
+            reduceKernel<SmemPolicy>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            static_cast<int>(dynamicSmem)),
+        "set dynamic shared memory");
+  }
+
+  auto* outputPtr = static_cast<float*>(output.get());
+  const auto* stagingPtr = static_cast<const float*>(staging.get());
+  const auto* localPtr = static_cast<const float*>(local.get());
+
+  cudaEvent_t start{};
+  cudaEvent_t stop{};
+  checkCuda(cudaEventCreate(&start), "create start event");
+  checkCuda(cudaEventCreate(&stop), "create stop event");
+
+  launchPolicy(policy, outputPtr, stagingPtr, localPtr, nbytes, dynamicSmem);
+  checkCuda(cudaGetLastError(), "warmup launch");
+  checkCuda(cudaDeviceSynchronize(), "warmup synchronize");
+
+  checkCuda(cudaEventRecord(start), "record start");
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    launchPolicy(policy, outputPtr, stagingPtr, localPtr, nbytes, dynamicSmem);
+    checkCuda(cudaGetLastError(), "benchmark launch");
+  }
+  checkCuda(cudaEventRecord(stop), "record stop");
+  checkCuda(cudaEventSynchronize(stop), "benchmark synchronize");
+
+  float elapsedMs = 0;
+  checkCuda(cudaEventElapsedTime(&elapsedMs, start, stop), "measure elapsed");
+  checkCuda(cudaEventDestroy(stop), "destroy stop event");
+  checkCuda(cudaEventDestroy(start), "destroy start event");
+
+  const float operations = static_cast<float>(iterations);
+  const float timeUs = elapsedMs * 1000.0f / operations;
+  const float payloadGBps =
+      static_cast<float>(allocationBytes) / 1000.0f / timeUs;
+  return CopyOpReduceTiming{
+      .timeUs = timeUs,
+      .payloadGBps = payloadGBps,
+      .memoryGBps = 3.0f * payloadGBps,
+  };
+}
+
+} // namespace comms::prims::benchmark

--- a/comms/prims/benchmarks/CopyOpReduceBench.cuh
+++ b/comms/prims/benchmarks/CopyOpReduceBench.cuh
@@ -1,0 +1,25 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::benchmark {
+
+enum class CopyOpReducePolicy {
+  TileReduceStaged,
+  CpAsyncSmemReduce,
+};
+
+struct CopyOpReduceTiming {
+  float timeUs;
+  float payloadGBps;
+  float memoryGBps;
+};
+
+CopyOpReduceTiming runCopyOpReduceBenchmark(
+    CopyOpReducePolicy policy,
+    std::size_t nbytes,
+    int iterations);
+
+} // namespace comms::prims::benchmark

--- a/comms/prims/collectives/ReduceScatterDirectIb.cu
+++ b/comms/prims/collectives/ReduceScatterDirectIb.cu
@@ -124,7 +124,7 @@ template __global__ void direct_reduce_scatter_ib_kernel<
     128,
     384,
     512,
-    TileReduceStaged<float, SumOp, 24576, 384>>(
+    CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>>(
     const __grid_constant__ DirectReduceScatterIbArgs<float>,
     Timeout);
 
@@ -140,8 +140,8 @@ void launch_direct_reduce_scatter_ib_impl(
       128,
       384,
       512,
-      TileReduceStaged<float, SumOp, 24576, 384>>;
-  using ReduceOp = TileReduceStaged<float, SumOp, 24576, 384>;
+      CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>>;
+  using ReduceOp = CpAsyncSmemReduce<float, SumOp, 8192, 384, 2>;
   constexpr std::size_t dynamic_smem = ReduceOp::smem_bytes();
   if constexpr (dynamic_smem > 0) {
     PIPES_CUDA_CHECK(cudaFuncSetAttribute(

--- a/comms/prims/core/CopyOp.cuh
+++ b/comms/prims/core/CopyOp.cuh
@@ -6,6 +6,7 @@
 
 #include "comms/prims/core/CopyUtils.cuh"
 #include "comms/prims/core/MemcpyCopyOp.cuh"
+#include "comms/prims/core/SmemTile.cuh"
 #include "comms/prims/core/ThreadGroup.cuh"
 #include "comms/prims/core/Tile.cuh"
 
@@ -1067,5 +1068,121 @@ struct AnsCompress {
 };
 
 #endif // PIPES_ENABLE_ANS_COMPRESSION
+
+// cp.async shared-memory staged reduce.
+template <
+    typename T,
+    typename AccumOp,
+    int kTileElems,
+    int kBlockSize,
+    int kStages = 2>
+struct CpAsyncSmemReduce {
+  using SmemTile = CpAsyncSmemTile<T, kTileElems, kBlockSize, kStages>;
+
+  __host__ __device__ static constexpr std::size_t smem_bytes() {
+    return SmemTile::smem_bytes();
+  }
+
+  static constexpr bool kVariableSize = false;
+  static constexpr std::size_t kActivationThreshold = 0;
+  __host__ __device__ __forceinline__ static constexpr std::size_t
+  worst_case_chunk_stride(std::size_t chunkSize) {
+    return chunkSize;
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static std::size_t send(
+      char* staging,
+      const char* src,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t /*byte_offset*/,
+      Args...) {
+    memcpy_vectorized(staging, src, nbytes, group);
+    return nbytes;
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static std::size_t recv(
+      char* dst,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    T* dst_t = reinterpret_cast<T*>(dst);
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    const std::size_t nelems = nbytes / sizeof(T);
+    const int ntiles = SmemTile::num_tiles(nelems);
+    if (ntiles <= 0) {
+      return 0;
+    }
+    SmemTile::check_alignment(dst_t, "CpAsyncSmemReduce::recv dst");
+    SmemTile::check_alignment(staging_t, "CpAsyncSmemReduce::recv staging");
+    SmemTile::check_alignment(local_t, "CpAsyncSmemReduce::recv local");
+
+    char* smem = SmemTile::smem();
+    const int prime = min(SmemTile::prefetch_distance(), ntiles);
+    for (int t = 0; t < prime; ++t) {
+      SmemTile::enqueue_load(smem, t, staging_t, local_t, nelems, group);
+      SmemTile::commit();
+    }
+
+    for (int t = 0; t < ntiles; ++t) {
+      const int fetch = t + SmemTile::prefetch_distance();
+      if (fetch < ntiles) {
+        SmemTile::enqueue_load(smem, fetch, staging_t, local_t, nelems, group);
+        SmemTile::commit();
+      }
+
+      const int in_flight = min(SmemTile::prefetch_distance(), ntiles - 1 - t);
+      SmemTile::wait_prior(in_flight);
+      group.sync();
+
+      SmemTile::template reduce_store<AccumOp>(
+          dst_t, smem, t, staging_t, local_t, nelems, group);
+      group.sync();
+    }
+    SmemTile::wait_prior(0);
+#elif defined(__CUDA_ARCH__)
+    static_assert(
+        __CUDA_ARCH__ >= 800, "CpAsyncSmemReduce requires cp.async support");
+#endif
+    return nbytes;
+  }
+
+  template <typename... Args>
+  __device__ __forceinline__ static void forward(
+      char* /*dst*/,
+      char* fwd_staging,
+      const char* staging,
+      std::size_t nbytes,
+      ThreadGroup& group,
+      std::size_t byte_offset,
+      const char* local_input,
+      Args...) {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    const T* staging_t = reinterpret_cast<const T*>(staging);
+    T* fwd_t = reinterpret_cast<T*>(fwd_staging);
+    const T* local_t = reinterpret_cast<const T*>(local_input + byte_offset);
+    std::size_t nelems = nbytes / sizeof(T);
+    int ntiles = static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+
+    for (int t = 0; t < ntiles; t++) {
+      std::size_t valid =
+          min(static_cast<std::size_t>(kTileElems),
+              nelems - static_cast<std::size_t>(t) * kTileElems);
+      auto acc =
+          tile_load<T, kTileElems, kBlockSize>(staging_t, t, group, valid);
+      tile_load_accumulate<T, AccumOp, kTileElems, kBlockSize>(
+          acc, local_t, t, group, valid);
+      tile_store<T, kTileElems, kBlockSize>(fwd_t, t, acc, group, valid);
+    }
+#endif
+  }
+};
 
 } // namespace comms::prims

--- a/comms/prims/core/SmemTile.cuh
+++ b/comms/prims/core/SmemTile.cuh
@@ -1,0 +1,190 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__CUDA_ARCH__)
+#include <cuda_pipeline.h>
+#endif
+
+#include "comms/prims/core/ThreadGroup.cuh"
+#include "comms/prims/core/Tile.cuh"
+
+namespace comms::prims {
+
+template <typename T, int kTileElems, int kBlockSize, int kStages = 2>
+struct CpAsyncSmemTile {
+  static_assert(kStages >= 2, "cp.async pipeline needs at least 2 stages");
+
+  static constexpr int kEPV = VecOps<T>::kElemsPerVec;
+  static constexpr int kTileVecs = kTileElems / kEPV;
+  static_assert(
+      kTileElems % kEPV == 0,
+      "kTileElems must be a multiple of the 16B vector width");
+
+  __host__ __device__ static constexpr std::size_t smem_bytes() {
+    return static_cast<std::size_t>(kStages) * 2 *
+        static_cast<std::size_t>(kTileElems) * sizeof(T);
+  }
+
+  __device__ __forceinline__ static char* smem() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    extern __shared__ __align__(16) char cp_async_smem_reduce[];
+    return cp_async_smem_reduce;
+#else
+    return nullptr;
+#endif
+  }
+
+  __host__ __device__ static constexpr int prefetch_distance() {
+    return kStages - 1;
+  }
+
+  __host__ __device__ static constexpr int stage_for_tile(int tile) {
+    return tile % kStages;
+  }
+
+  __host__ __device__ static constexpr int num_tiles(std::size_t nelems) {
+    return static_cast<int>((nelems + kTileElems - 1) / kTileElems);
+  }
+
+  __device__ __forceinline__ static void check_alignment(
+      const void* ptr,
+      const char* name) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    if (reinterpret_cast<uintptr_t>(ptr) % alignof(uint4) != 0) {
+      printf(
+          "%s: ptr %p is not 16-byte aligned (required for uint4 vectorized access)\n",
+          name,
+          ptr);
+      __trap();
+    }
+#endif
+  }
+
+  __device__ __forceinline__ static void enqueue_load(
+      char* smem_base,
+      int tile,
+      const T* staging,
+      const T* local,
+      std::size_t nelems,
+      const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    Stage base = stage_base(smem_base, stage_for_tile(tile));
+    const int full_vecs = static_cast<int>(valid_elems(tile, nelems) / kEPV);
+    const std::size_t tile_vec_start =
+        static_cast<std::size_t>(tile) * kTileVecs;
+    enqueue_vector_load(
+        base.staging,
+        reinterpret_cast<const uint4*>(staging) + tile_vec_start,
+        full_vecs,
+        group);
+    enqueue_vector_load(
+        base.local,
+        reinterpret_cast<const uint4*>(local) + tile_vec_start,
+        full_vecs,
+        group);
+#endif
+  }
+
+  __device__ __forceinline__ static void commit() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    __pipeline_commit();
+#endif
+  }
+
+  __device__ __forceinline__ static void wait_prior(int in_flight) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    __pipeline_wait_prior(in_flight);
+#endif
+  }
+
+  template <typename Op>
+  __device__ __forceinline__ static void reduce_store(
+      T* dst,
+      char* smem_base,
+      int tile,
+      const T* staging,
+      const T* local,
+      std::size_t nelems,
+      const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    Stage base = stage_base(smem_base, stage_for_tile(tile));
+    const std::size_t valid = valid_elems(tile, nelems);
+    const int full_vecs = static_cast<int>(valid / kEPV);
+    const int rem = static_cast<int>(valid % kEPV);
+    const std::size_t global_tile_start =
+        static_cast<std::size_t>(tile) * kTileVecs;
+    uint4* dst_v = reinterpret_cast<uint4*>(dst);
+
+    for (int v = static_cast<int>(group.thread_id_in_group); v < full_vecs;
+         v += static_cast<int>(group.group_size)) {
+      uint4 acc = base.staging[v];
+      VecOps<T>::reduce(Op{}, acc, base.local[v]);
+      dst_v[global_tile_start + v] = acc;
+    }
+
+    if (rem > 0 && group.thread_id_in_group == 0) {
+      const std::size_t tile_start =
+          static_cast<std::size_t>(tile) * static_cast<std::size_t>(kTileElems);
+      const std::size_t rem_start = tile_start + full_vecs * kEPV;
+      for (int e = 0; e < rem; ++e) {
+        T acc = staging[rem_start + e];
+        VecOps<T>::reduce_scalar(Op{}, acc, local[rem_start + e]);
+        dst[rem_start + e] = acc;
+      }
+    }
+#elif defined(__CUDA_ARCH__)
+    static_assert(
+        __CUDA_ARCH__ >= 800, "CpAsyncSmemTile requires cp.async support");
+#endif
+  }
+
+ private:
+  struct Stage {
+    uint4* staging;
+    uint4* local;
+  };
+
+  __device__ __forceinline__ static Stage stage_base(
+      char* smem_base,
+      int stage) {
+    uint4* base = reinterpret_cast<uint4*>(smem_base);
+    uint4* stage_base = base + static_cast<std::size_t>(stage) * 2 * kTileVecs;
+    return Stage{
+        .staging = stage_base,
+        .local = stage_base + kTileVecs,
+    };
+  }
+
+  __host__ __device__ static constexpr std::size_t valid_elems(
+      int tile,
+      std::size_t nelems) {
+    const std::size_t tile_start =
+        static_cast<std::size_t>(tile) * static_cast<std::size_t>(kTileElems);
+    if (tile_start >= nelems) {
+      return 0;
+    }
+    const std::size_t remaining = nelems - tile_start;
+    return remaining < static_cast<std::size_t>(kTileElems)
+        ? remaining
+        : static_cast<std::size_t>(kTileElems);
+  }
+
+  __device__ __forceinline__ static void enqueue_vector_load(
+      uint4* __restrict__ dst,
+      const uint4* __restrict__ src,
+      int full_vecs,
+      const ThreadGroup& group) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+    for (int v = static_cast<int>(group.thread_id_in_group); v < full_vecs;
+         v += static_cast<int>(group.group_size)) {
+      __pipeline_memcpy_async(&dst[v], &src[v], sizeof(uint4));
+    }
+#endif
+  }
+};
+
+} // namespace comms::prims

--- a/comms/prims/core/Tile.cuh
+++ b/comms/prims/core/Tile.cuh
@@ -93,6 +93,10 @@
 #include <cstdint>
 #include <type_traits>
 
+#if defined(__CUDA_ARCH__)
+#include <cuda_pipeline.h>
+#endif
+
 #include "comms/prims/core/ThreadGroup.cuh"
 
 namespace comms::prims {

--- a/comms/prims/docs/DirectIbReduceScatter.md
+++ b/comms/prims/docs/DirectIbReduceScatter.md
@@ -39,11 +39,14 @@ The current kernel uses:
 - 512 threads per CTA.
 - 128 send threads and 384 receive/reduce threads.
 - One CTA per IB channel.
-- `TileReduceStaged` for receive-side reduction.
+- `CpAsyncSmemReduce` for receive-side reduction.
 
-The receive group reduces incoming staged IB data into the output tile using a
-register/tile-staged reduce policy. Shared-memory async staging is a follow-up
-optimization layer on top of this baseline.
+The receive group stages incoming IB data and the local output tile through
+dynamic shared memory with `cp.async` before reducing. The parent diff keeps the
+register/tile-staged `TileReduceStaged` policy as the baseline; this layer
+reduces receive-side register pressure and improves the large-message path.
+For the current `float` kernel, the smem policy requests 128KB of dynamic shared
+memory per CTA.
 
 ## Transport Setup
 

--- a/comms/prims/tests/CopyOpReduceTest.cc
+++ b/comms/prims/tests/CopyOpReduceTest.cc
@@ -1,0 +1,130 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "comms/prims/tests/CopyOpReduceTest.cuh"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/CudaRAII.h"
+
+namespace comms::prims::test {
+namespace {
+
+constexpr std::size_t kGuardElems = 4;
+constexpr std::size_t kOffsetElems = 4;
+constexpr float kGuardValue = -9876.5f;
+
+struct PolicyParam {
+  CopyOpReducePolicy policy;
+  const char* name;
+};
+
+class CopyOpReduceTest : public ::testing::TestWithParam<PolicyParam> {};
+
+TEST_P(CopyOpReduceTest, ProducesExpectedSumAndPreservesGuards) {
+  cudaDeviceProp properties{};
+  CUDACHECK_TEST(cudaGetDeviceProperties(&properties, 0));
+  if (GetParam().policy == CopyOpReducePolicy::CpAsyncSmemReduce &&
+      properties.major < 8) {
+    GTEST_SKIP() << "cp.async requires SM80 or newer";
+  }
+
+  const std::vector<std::size_t> elementCounts = {
+      3,
+      8191,
+      8192,
+      8195,
+      3 * 8192 + 5,
+      512 * 1024 / sizeof(float),
+  };
+
+  for (const std::size_t nelems : elementCounts) {
+    std::vector<float> staging(nelems);
+    std::vector<float> local(kOffsetElems + nelems);
+    for (std::size_t i = 0; i < nelems; ++i) {
+      staging[i] = 0.25f * static_cast<float>(i % 29) - 3.5f;
+      local[kOffsetElems + i] = -0.125f * static_cast<float>(i % 17) + 2.25f;
+    }
+    const std::vector<float> originalStaging = staging;
+    const std::vector<float> originalLocal = local;
+    std::vector<float> output(kGuardElems + nelems + kGuardElems, kGuardValue);
+
+    meta::comms::DeviceBuffer stagingDevice(nelems * sizeof(float));
+    meta::comms::DeviceBuffer localDevice(local.size() * sizeof(float));
+    meta::comms::DeviceBuffer outputDevice(output.size() * sizeof(float));
+    CUDACHECK_TEST(cudaMemcpy(
+        stagingDevice.get(),
+        staging.data(),
+        nelems * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        localDevice.get(),
+        local.data(),
+        local.size() * sizeof(float),
+        cudaMemcpyHostToDevice));
+    CUDACHECK_TEST(cudaMemcpy(
+        outputDevice.get(),
+        output.data(),
+        output.size() * sizeof(float),
+        cudaMemcpyHostToDevice));
+
+    launchCopyOpReduce(
+        GetParam().policy,
+        static_cast<float*>(outputDevice.get()) + kGuardElems,
+        static_cast<const float*>(stagingDevice.get()),
+        static_cast<const float*>(localDevice.get()),
+        kOffsetElems * sizeof(float),
+        nelems * sizeof(float));
+    CUDACHECK_TEST(cudaDeviceSynchronize());
+
+    CUDACHECK_TEST(cudaMemcpy(
+        output.data(),
+        outputDevice.get(),
+        output.size() * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    for (std::size_t i = 0; i < nelems; ++i) {
+      EXPECT_FLOAT_EQ(
+          output[kGuardElems + i], staging[i] + local[kOffsetElems + i])
+          << "policy=" << GetParam().name << " nelems=" << nelems
+          << " index=" << i;
+    }
+    for (std::size_t i = 0; i < kGuardElems; ++i) {
+      EXPECT_EQ(output[i], kGuardValue);
+      EXPECT_EQ(output[kGuardElems + nelems + i], kGuardValue);
+    }
+
+    CUDACHECK_TEST(cudaMemcpy(
+        staging.data(),
+        stagingDevice.get(),
+        nelems * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    CUDACHECK_TEST(cudaMemcpy(
+        local.data(),
+        localDevice.get(),
+        local.size() * sizeof(float),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(staging, originalStaging);
+    EXPECT_EQ(local, originalLocal);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Policies,
+    CopyOpReduceTest,
+    ::testing::Values(
+        PolicyParam{CopyOpReducePolicy::TileReduce, "TileReduce"},
+        PolicyParam{CopyOpReducePolicy::TileReduceStaged, "TileReduceStaged"},
+        PolicyParam{
+            CopyOpReducePolicy::CpAsyncSmemReduce,
+            "CpAsyncSmemReduce"}),
+    [](const ::testing::TestParamInfo<PolicyParam>& info) {
+      return std::string(info.param.name);
+    });
+
+} // namespace
+} // namespace comms::prims::test

--- a/comms/prims/tests/CopyOpReduceTest.cu
+++ b/comms/prims/tests/CopyOpReduceTest.cu
@@ -1,0 +1,87 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/tests/CopyOpReduceTest.cuh"
+
+#include <cuda_runtime.h>
+
+#include <stdexcept>
+
+#include "comms/prims/core/CopyOp.cuh"
+#include "comms/prims/core/ThreadGroup.cuh"
+
+namespace comms::prims::test {
+namespace {
+
+constexpr int kBlockSize = 384;
+using TilePolicy = TileReduce<float, SumOp, 24576, kBlockSize>;
+using StagedPolicy = TileReduceStaged<float, SumOp, 24576, kBlockSize>;
+using SmemPolicy = CpAsyncSmemReduce<float, SumOp, 8192, kBlockSize, 2>;
+
+template <typename Policy>
+__global__ void reduceKernel(
+    float* output,
+    const float* staging,
+    const float* localInput,
+    std::size_t byteOffset,
+    std::size_t nbytes) {
+  auto group = make_block_group();
+  Policy::recv(
+      reinterpret_cast<char*>(output),
+      reinterpret_cast<const char*>(staging),
+      nbytes,
+      group,
+      byteOffset,
+      reinterpret_cast<const char*>(localInput));
+}
+
+template <typename Policy>
+void launch(
+    float* output,
+    const float* staging,
+    const float* localInput,
+    std::size_t byteOffset,
+    std::size_t nbytes,
+    std::size_t dynamicSmem = 0) {
+  if (dynamicSmem > 0) {
+    const auto status = cudaFuncSetAttribute(
+        reduceKernel<Policy>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(dynamicSmem));
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+  reduceKernel<Policy><<<1, kBlockSize, dynamicSmem>>>(
+      output, staging, localInput, byteOffset, nbytes);
+}
+
+} // namespace
+
+void launchCopyOpReduce(
+    CopyOpReducePolicy policy,
+    float* output,
+    const float* staging,
+    const float* localInput,
+    std::size_t byteOffset,
+    std::size_t nbytes) {
+  switch (policy) {
+    case CopyOpReducePolicy::TileReduce:
+      launch<TilePolicy>(output, staging, localInput, byteOffset, nbytes);
+      return;
+    case CopyOpReducePolicy::TileReduceStaged:
+      launch<StagedPolicy>(output, staging, localInput, byteOffset, nbytes);
+      return;
+    case CopyOpReducePolicy::CpAsyncSmemReduce:
+      launch<SmemPolicy>(
+          output,
+          staging,
+          localInput,
+          byteOffset,
+          nbytes,
+          SmemPolicy::smem_bytes());
+      return;
+  }
+  throw std::invalid_argument("unknown CopyOp reduce policy");
+}
+
+} // namespace comms::prims::test

--- a/comms/prims/tests/CopyOpReduceTest.cuh
+++ b/comms/prims/tests/CopyOpReduceTest.cuh
@@ -1,0 +1,23 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstddef>
+
+namespace comms::prims::test {
+
+enum class CopyOpReducePolicy {
+  TileReduce,
+  TileReduceStaged,
+  CpAsyncSmemReduce,
+};
+
+void launchCopyOpReduce(
+    CopyOpReducePolicy policy,
+    float* output,
+    const float* staging,
+    const float* localInput,
+    std::size_t byteOffset,
+    std::size_t nbytes);
+
+} // namespace comms::prims::test


### PR DESCRIPTION
Summary: Add a `CpAsyncSmemReduce` copy policy for direct IB reduce-scatter and switch the GB300 direct IB kernel from the parent diff's `TileReduceStaged` receive path to a cp.async shared-memory staged receive/reduce path. This is an optimization-only child of `D110544920`: the collective shape, fixed-channel transport use, and public launcher surface stay the same; this diff changes the receive-side reduction policy, explicitly constrains that policy to cp.async-capable device compilation, and documents the optimization layer.

Reviewed By: saifhhasan

Differential Revision: D110824468


