### PR TITLE
Key NCCL bootstrap store on comm name instead of a process-wide counter (#3093)

### DIFF
--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -6,6 +6,10 @@
 
 #include <c10/core/DeviceGuard.h> // @manual=//caffe2:c10
 
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+
 namespace torch::comms {
 
 namespace {
@@ -588,6 +592,188 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
       std::move(work),
       std::vector<at::Tensor>{},
       /*hostBlocking=*/!opts.asyncOp);
+}
+
+void BackendWrapper::monitoredBarrier(
+    const c10d::BarrierOptions& opts,
+    bool waitAllRanks) {
+  // Reimplements c10d::ProcessGroupGloo::monitoredBarrier on TorchComms.
+  //
+  // The native gloo version posts async send/recv and then wait(timeout)s on
+  // each work to find stragglers. That form is unavailable here: WorkWrapper::
+  // wait() rejects any finite timeout ("wait timeout not supported"). Instead
+  // we run the same coordinator protocol with SYNCHRONOUS, per-op-timeout P2P
+  // on the underlying comm: a synchronous gloo recv with a finite timeout
+  // throws a catchable exception on timeout (TorchCommGloo::recv ->
+  // gloo UnboundBuffer::waitRecv(timeout)) and does NOT poison the comm
+  // (TorchCommGloo::checkAndAbortIfTimedOutOrError is a no-op), so rank 0 can
+  // keep probing the remaining ranks after one times out.
+  //
+  // Only meaningful for the gloo (CPU) backend; the dist.monitored_barrier
+  // entry point already restricts callers to gloo groups.
+  const int rank = getRank();
+  const int worldSize = getSize();
+
+  const std::chrono::milliseconds timeout =
+      (opts.timeout != kUnsetTimeout) ? opts.timeout : options_->timeout;
+
+  // Phase-1 (worker -> rank 0) and phase-2 (rank 0 -> worker) tags, generated
+  // per call. Identical on every rank because monitoredBarrier is collective
+  // and all ranks advance this PG's counter in lockstep (the counter is a
+  // per-BackendWrapper member, so concurrent barriers on other PGs cannot
+  // desync it across ranks).
+  const uint32_t tagBase = monitoredBarrierTagCounter_.fetch_add(2);
+  // Mask into the non-negative int range: c10d/gloo tags are ints, and the
+  // counter would otherwise wrap past INT_MAX in a long-lived process and
+  // produce negative tags. The mask is deterministic, so every rank still
+  // derives identical tags; fetch_add(2) keeps the two tags distinct
+  // (even/odd) and the low-30-bit mask never merges them.
+  constexpr uint32_t kTagMask = 0x3FFFFFFFu;
+  const int tagToZero = static_cast<int>(tagBase & kTagMask);
+  const int tagFromZero = static_cast<int>((tagBase + 1) & kTagMask);
+
+  auto makeCommTensor = [&]() {
+    auto t =
+        at::empty({1}, at::TensorOptions().dtype(at::kLong).device(at::kCPU));
+    t.fill_(rank);
+    return t;
+  };
+
+  // Workers report in to rank 0, then block until rank 0 acks. Only rank 0
+  // enforces the timeout, so a dead/slow rank is named by rank 0 instead of
+  // every worker timing out and hiding the culprit.
+  if (rank != 0) {
+    try {
+      auto outTensor = makeCommTensor();
+      SendOptions sopts;
+      sopts.tag = tagToZero; // blocking: timeout stays kNoTimeout
+      comm_->send(outTensor, 0, /*async_op=*/false, sopts);
+
+      auto inTensor = makeCommTensor();
+      RecvOptions ropts;
+      ropts.tag = tagFromZero; // blocking
+      comm_->recv(inTensor, 0, /*async_op=*/false, ropts);
+    } catch (const std::exception& e) {
+      TORCH_CHECK(
+          false,
+          "Rank ",
+          rank,
+          " successfully reached monitoredBarrier, but received errors while "
+          "waiting for send/recv from rank 0. Please check rank 0 logs for the "
+          "faulty rank.\n Original exception: \n",
+          e.what());
+    }
+    return;
+  }
+
+  // Rank 0 is the coordinator.
+  //
+  // Fast-fail (waitAllRanks == false) matches native
+  // ProcessGroupGloo::monitoredBarrier: on the first straggler rank 0 raises
+  // immediately (below) and never reaches the ack loop, so workers that already
+  // checked in stay blocked in their ack recv (kNoTimeout) until the process is
+  // torn down. This is intentional -- a failed monitoredBarrier is not a clean
+  // barrier exit. waitAllRanks == true instead probes every worker and reports
+  // all stragglers before raising.
+  const auto startTime = std::chrono::steady_clock::now();
+  auto remainingTime = [&]() -> std::chrono::milliseconds {
+    if (waitAllRanks) {
+      // Give every worker the full timeout: spending it all on worker n must
+      // not starve probing of workers n+1.. (see the native gloo impl).
+      return timeout;
+    }
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - startTime);
+    return timeout - elapsed;
+  };
+
+  auto joinInts = [](const std::vector<int>& v) {
+    std::string s;
+    for (size_t i = 0; i < v.size(); ++i) {
+      if (i > 0) {
+        s += ", ";
+      }
+      s += std::to_string(v[i]);
+    }
+    return s;
+  };
+
+  std::vector<int> processedRanks;
+  processedRanks.reserve(static_cast<size_t>(worldSize - 1));
+  for (int srcRank = 1; srcRank < worldSize; ++srcRank) {
+    const auto remaining = remainingTime();
+    if (!waitAllRanks && remaining.count() <= 0) {
+      TORCH_CHECK(
+          false,
+          "Rank 0 timed out in monitoredBarrier after ",
+          timeout.count(),
+          " ms. Successfully processed ranks: ",
+          joinInts(processedRanks));
+    }
+    try {
+      // Fresh buffer per rank: a timed-out recv leaves a pending registration
+      // on the gloo transport, so reusing the tensor could race a late message
+      // into memory in use by the next probe.
+      auto inTensor = makeCommTensor();
+      RecvOptions ropts;
+      ropts.tag = tagToZero;
+      ropts.timeout = (remaining.count() > 0) ? remaining : timeout;
+      comm_->recv(inTensor, srcRank, /*async_op=*/false, ropts);
+      processedRanks.push_back(srcRank);
+    } catch (const std::exception& e) {
+      if (!waitAllRanks) {
+        TORCH_CHECK(
+            false,
+            "[Rank 0]: Rank ",
+            srcRank,
+            " failed to pass monitoredBarrier in ",
+            timeout.count(),
+            " ms\n Original exception: \n",
+            e.what());
+      }
+      // waitAllRanks: keep going and collect every failure below.
+    }
+  }
+
+  if (waitAllRanks &&
+      processedRanks.size() != static_cast<size_t>(worldSize - 1)) {
+    std::vector<int> failedRanks;
+    for (int i = 1; i < worldSize; ++i) {
+      if (std::find(processedRanks.begin(), processedRanks.end(), i) ==
+          processedRanks.end()) {
+        failedRanks.push_back(i);
+      }
+    }
+    TORCH_CHECK(
+        false,
+        "[Rank 0]: Ranks ",
+        joinInts(failedRanks),
+        " failed to pass monitoredBarrier in ",
+        timeout.count(),
+        " ms");
+  }
+
+  // Every worker checked in: ack each so all ranks leave the barrier together
+  // (a true barrier -- all exit or none do). Ack every remaining worker even if
+  // one send throws: a worker that died between check-in and ack must not leave
+  // the healthy workers blocked forever in their ack recv. Collect failures and
+  // raise only after every other worker has been acked.
+  std::vector<int> ackFailedRanks;
+  for (int dstRank = 1; dstRank < worldSize; ++dstRank) {
+    try {
+      auto outTensor = makeCommTensor();
+      SendOptions sopts;
+      sopts.tag = tagFromZero;
+      comm_->send(outTensor, dstRank, /*async_op=*/false, sopts);
+    } catch (const std::exception&) {
+      ackFailedRanks.push_back(dstRank);
+    }
+  }
+  TORCH_CHECK(
+      ackFailedRanks.empty(),
+      "[Rank 0]: failed to ack ranks ",
+      joinInts(ackFailedRanks),
+      " in monitoredBarrier; these ranks may remain blocked");
 }
 
 c10::intrusive_ptr<c10d::Work>

--- a/comms/torchcomms/BackendWrapper.cpp
+++ b/comms/torchcomms/BackendWrapper.cpp
@@ -68,8 +68,11 @@ std::vector<uint64_t> toVecUint64(const std::vector<int64_t>& vec) {
 
 WorkWrapper::WorkWrapper(
     c10::intrusive_ptr<TorchWork> work,
-    std::vector<at::Tensor> outputTensors)
-    : work_(std::move(work)), outputTensors_(std::move(outputTensors)) {
+    std::vector<at::Tensor> outputTensors,
+    bool hostBlocking)
+    : work_(std::move(work)),
+      outputTensors_(std::move(outputTensors)),
+      hostBlocking_(hostBlocking) {
   std::vector<c10::Device> devices;
   // CPU needs to wait for the TorchWork to complete before marking Future
   // as completed
@@ -111,6 +114,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
   }
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -124,6 +130,9 @@ bool WorkWrapper::wait(std::chrono::milliseconds timeout) {
 void WorkWrapper::synchronize() {
   try {
     work_->wait();
+    if (hostBlocking_) {
+      work_->hostSynchronize();
+    }
   } catch (...) {
     finish(std::current_exception());
     throw;
@@ -565,7 +574,20 @@ c10::intrusive_ptr<c10d::Work> BackendWrapper::barrier(
   } else {
     bopts.timeout = options_->timeout;
   }
-  return c10::make_intrusive<WorkWrapper>(comm_->barrier(opts.asyncOp, bopts));
+  // Mirror stock ProcessGroupNCCL: a synchronous barrier host-blocks the CPU
+  // thread until the collective (and prior stream work) completes, so callers
+  // relying on the barrier to flush async device work -- e.g. clearing IPC
+  // buffers on the stream before the first all_reduce -- do not race it and
+  // deadlock. The host block lives entirely at this c10d layer: WorkWrapper
+  // calls work_->hostSynchronize() after wait(), so the native TorchComm
+  // barrier and TorchWork::wait() keep uniform semantics with every other
+  // collective. Async barriers keep the non-blocking, stream-ordered behavior
+  // via the work.
+  auto work = comm_->barrier(opts.asyncOp, bopts);
+  return c10::make_intrusive<WorkWrapper>(
+      std::move(work),
+      std::vector<at::Tensor>{},
+      /*hostBlocking=*/!opts.asyncOp);
 }
 
 c10::intrusive_ptr<c10d::Work>

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -19,7 +19,8 @@ class WorkWrapper : public c10d::Work {
  public:
   explicit WorkWrapper(
       c10::intrusive_ptr<TorchWork> work,
-      std::vector<at::Tensor> outputTensors = {});
+      std::vector<at::Tensor> outputTensors = {},
+      bool hostBlocking = false);
   ~WorkWrapper() override = default;
 
   void synchronize() override;
@@ -32,6 +33,9 @@ class WorkWrapper : public c10d::Work {
   c10::intrusive_ptr<TorchWork> work_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   std::vector<at::Tensor> outputTensors_;
+  // When set (synchronous barrier), wait()/synchronize() also host-block via
+  // work_->hostSynchronize() after the stream-ordered wait().
+  bool hostBlocking_;
 };
 
 using c10d::kUnsetTimeout;

--- a/comms/torchcomms/BackendWrapper.hpp
+++ b/comms/torchcomms/BackendWrapper.hpp
@@ -11,6 +11,7 @@
 #include "comms/torchcomms/TorchCommTypes.hpp"
 #include "comms/torchcomms/TorchWork.hpp"
 
+#include <atomic>
 #include <optional>
 
 namespace torch::comms {
@@ -119,6 +120,12 @@ class BackendWrapper : public c10d::Backend {
       const c10d::AllToAllOptions& opts = c10d::AllToAllOptions()) override;
   c10::intrusive_ptr<c10d::Work> barrier(
       const c10d::BarrierOptions& opts = c10d::BarrierOptions()) override;
+  // Health-checking barrier used by torch.distributed.monitored_barrier. Only
+  // meaningful on the gloo (CPU) backend; reimplements
+  // c10d::ProcessGroupGloo::monitoredBarrier on top of TorchComms P2P.
+  void monitoredBarrier(
+      const c10d::BarrierOptions& opts = c10d::BarrierOptions(),
+      bool waitAllRanks = false) override;
   c10::intrusive_ptr<c10d::Work>
   send(std::vector<at::Tensor>& tensors, int dstRank, int tag) override;
   c10::intrusive_ptr<c10d::Work>
@@ -189,6 +196,15 @@ class BackendWrapper : public c10d::Backend {
   // immediately. c10d's coalescing manager serializes per-PG, so a single
   // slot suffices.
   std::optional<BatchSendRecv> coalescing_batch_;
+
+  // Per-call tag sequence for monitoredBarrier's check-in/ack P2P. Kept
+  // per-BackendWrapper (not process-global) so each ProcessGroup owns its own
+  // counter: monitoredBarrier is collective per PG, so every rank advances
+  // this instance's counter in lockstep and derives identical tags. A shared
+  // process-global counter could instead be advanced a different number of
+  // times per rank when unrelated PGs run concurrent barriers, yielding
+  // mismatched send/recv tags across ranks.
+  std::atomic<uint32_t> monitoredBarrierTagCounter_{0};
 };
 
 } // namespace torch::comms

--- a/comms/torchcomms/TorchWork.hpp
+++ b/comms/torchcomms/TorchWork.hpp
@@ -52,6 +52,13 @@ class TorchWork : public c10::intrusive_ptr_target {
     return std::chrono::milliseconds::max();
   }
 
+  // Block the calling CPU thread until the device work behind this object has
+  // completed (in addition to the stream-ordered wait()). Invoked by the c10d
+  // WorkWrapper for synchronous barriers to mirror stock ProcessGroupNCCL,
+  // whose barrier host-blocks the CPU thread. No-op by default; backends whose
+  // wait() is already host-blocking (e.g. CPU/gloo) need not override it.
+  virtual void hostSynchronize() {}
+
   // Fault Tolerance API
 
   /**

--- a/comms/torchcomms/device/cuda/CudaApi.hpp
+++ b/comms/torchcomms/device/cuda/CudaApi.hpp
@@ -4,6 +4,8 @@
 
 #include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
 #include <glog/logging.h>
+#include <sstream>
+#include <stdexcept>
 
 namespace torch::comms {
 
@@ -236,5 +238,28 @@ class DefaultCudaApi : public CudaApi {
 };
 
 bool deviceSupportsMulticast(int device_idx);
+
+// Block the host until all work on the device's current stream has completed.
+// Skips the sync while the stream is capturing a CUDA graph:
+// cudaStreamSynchronize is illegal during capture, and the captured work is
+// replayed on-device where a host sync is meaningless. Shared by the NCCL/NCCLX
+// synchronous-barrier host block that WorkWrapper::wait() invokes via
+// TorchWork::hostSynchronize().
+inline void syncCurrentStreamIfNotCapturing(
+    CudaApi* cuda_api,
+    int device_index) {
+  cudaStream_t current_stream = cuda_api->getCurrentCUDAStream(device_index);
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  CUDA_CHECK(
+      cuda_api,
+      cuda_api->streamIsCapturing(current_stream, &capture_status),
+      "Failed to query stream capture status in host-blocking wait");
+  if (capture_status == cudaStreamCaptureStatusNone) {
+    CUDA_CHECK(
+        cuda_api,
+        cuda_api->streamSynchronize(current_stream),
+        "CUDA stream synchronize in host-blocking wait failed");
+  }
+}
 
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/CMakeLists.txt
+++ b/comms/torchcomms/nccl/CMakeLists.txt
@@ -72,3 +72,7 @@ endif()
 install(TARGETS torchcomms_comms_nccl
     LIBRARY DESTINATION .
 )
+
+if (BUILD_TESTS)
+    add_subdirectory(comms/torchcomms/nccl/tests/unit/cpp)
+endif()

--- a/comms/torchcomms/nccl/TorchCommNCCLBootstrap.cpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLBootstrap.cpp
@@ -13,9 +13,6 @@
 
 namespace torch::comms {
 
-// Initialize the static counter
-int TorchCommNCCLBootstrap::counter_ = 0;
-
 const std::string kUniqueidXchgMethodAuto = "auto";
 const std::string kUniqueidXchgMethodTCPStore = "tcpstore";
 const std::string kUniqueidXchgMethodDefault = kUniqueidXchgMethodAuto;
@@ -87,24 +84,26 @@ TorchCommNCCLBootstrap::~TorchCommNCCLBootstrap() noexcept {
   }
 }
 
-std::string TorchCommNCCLBootstrap::getNCCLStoreKey() {
-  std::string key = fmt::format("{}{}", getNCCLStoreKeyPrefix(), counter_);
-  counter_++;
-  return key;
+std::string TorchCommNCCLBootstrap::getNCCLStoreKey(std::string_view name) {
+  // Key the bootstrap on the comm's name, which is identical across all ranks
+  // that participate in the comm and unique per comm (store_ is also uniquely
+  // prefixed per comm). A previous implementation used a process-wide counter
+  // incremented once per bootstrap; that counter diverges across ranks when
+  // comms have asymmetric membership (members-only or subset groups skip
+  // non-member ranks), so a later comm spanning diverged ranks would have rank
+  // 0 set one key while other ranks wait on a different key -> bootstrap hang.
+  return fmt::format("{}{}", getNCCLStoreKeyPrefix(), name);
 }
 
 std::string TorchCommNCCLBootstrap::getNCCLStoreKeyPrefix() {
   return "nccl_storekey_";
 };
 
-int TorchCommNCCLBootstrap::getNCCLStoreKeyCounter() {
-  return counter_;
-}
-
-ncclUniqueId TorchCommNCCLBootstrap::exchangeUniqueIdStore() {
+ncclUniqueId TorchCommNCCLBootstrap::exchangeUniqueIdStore(
+    std::string_view name) {
   ncclUniqueId uniqueId;
 
-  auto key = getNCCLStoreKey();
+  auto key = getNCCLStoreKey(name);
   if (rank_ == 0) {
     // Generate unique ID on rank 0
     ncclResult_t ncclErr = nccl_api_->getUniqueId(&uniqueId);
@@ -137,7 +136,7 @@ ncclUniqueId TorchCommNCCLBootstrap::exchangeUniqueIdTCPStore(
   store_ = createPrefixStore(std::string(name), timeout_);
   created_internal_store_ = true;
 
-  return exchangeUniqueIdStore();
+  return exchangeUniqueIdStore(name);
 }
 
 bool TorchCommNCCLBootstrap::isTCPStoreEnabled() {
@@ -146,7 +145,7 @@ bool TorchCommNCCLBootstrap::isTCPStoreEnabled() {
 
 ncclUniqueId TorchCommNCCLBootstrap::exchangeUniqueId(std::string_view name) {
   if (store_ != nullptr) {
-    return exchangeUniqueIdStore();
+    return exchangeUniqueIdStore(name);
   }
 
   bool is_tcp_store_enabled = isTCPStoreEnabled();

--- a/comms/torchcomms/nccl/TorchCommNCCLBootstrap.hpp
+++ b/comms/torchcomms/nccl/TorchCommNCCLBootstrap.hpp
@@ -39,9 +39,8 @@ class TorchCommNCCLBootstrap {
   ncclComm_t createNcclComm(
       const std::string& name,
       const CommOptions& options = {});
-  static std::string getNCCLStoreKey();
+  static std::string getNCCLStoreKey(std::string_view name);
   static std::string getNCCLStoreKeyPrefix();
-  static int getNCCLStoreKeyCounter();
 
   int getRank() {
     return rank_;
@@ -55,14 +54,13 @@ class TorchCommNCCLBootstrap {
 
  private:
   ncclUniqueId exchangeUniqueId(std::string_view name);
-  ncclUniqueId exchangeUniqueIdStore();
+  ncclUniqueId exchangeUniqueIdStore(std::string_view name);
   ncclUniqueId exchangeUniqueIdTCPStore(std::string_view name);
   bool isTCPStoreEnabled();
   void cleanupTCPStore(ncclComm_t nccl_comm);
 
  private:
   const std::chrono::milliseconds timeout_;
-  static int counter_;
 
   c10::intrusive_ptr<c10d::Store> store_;
   bool created_internal_store_;

--- a/comms/torchcomms/nccl/TorchWorkNCCL.cpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.cpp
@@ -196,4 +196,8 @@ void TorchWorkNCCL::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCL::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/nccl/TorchWorkNCCL.hpp
+++ b/comms/torchcomms/nccl/TorchWorkNCCL.hpp
@@ -53,6 +53,10 @@ class TorchWorkNCCL : public TorchWork {
     return timeout_ms_;
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/nccl/tests/unit/cpp/CMakeLists.txt
+++ b/comms/torchcomms/nccl/tests/unit/cpp/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Backend test dirs are pulled in via include() of the backend CMakeLists before
+# the shared tests/unit/cpp subdirectory that normally fetches GoogleTest, so
+# fetch it here if it has not been made available yet. FetchContent dedups by
+# name, so this is a no-op when the shared dir already fetched it.
+if(NOT TARGET GTest::gmock)
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG v1.14.0
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif()
+
+enable_testing()
+
+# The bootstrap drives NCCL/CUDA only through injected NcclApi/CudaApi
+# interfaces (both mocked here), so the test runs on CPU without a GPU. It
+# compiles TorchCommNCCLBootstrap.cpp directly (the nccl backend ships as a
+# Python MODULE, not a linkable library) and links libtorchcomms for the shared
+# store/utility symbols. NCCL_INCLUDE is inherited from the parent nccl
+# CMakeLists (headers only; no libnccl symbols are referenced).
+add_executable(TorchCommNCCLBootstrapTest
+    TorchCommNCCLBootstrapTest.cpp
+    ${ROOT}/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.cpp
+    ${ROOT}/comms/torchcomms/nccl/TorchCommNCCLBootstrap.cpp
+)
+target_include_directories(TorchCommNCCLBootstrapTest PRIVATE
+    ${ROOT}
+    ${NCCL_INCLUDE}
+    ${CONDA_INCLUDE}
+)
+target_compile_features(TorchCommNCCLBootstrapTest PRIVATE cxx_std_20)
+target_link_libraries(TorchCommNCCLBootstrapTest PRIVATE
+    torchcomms
+    ${TORCH_LIBRARIES}
+    GTest::gtest_main
+    GTest::gmock
+)
+target_link_options(TorchCommNCCLBootstrapTest PRIVATE
+    "LINKER:--allow-shlib-undefined"
+)
+
+include(GoogleTest)
+add_test(NAME TorchCommNCCLBootstrapTest COMMAND TorchCommNCCLBootstrapTest)

--- a/comms/torchcomms/nccl/tests/unit/cpp/TorchCommNCCLBootstrapTest.cpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/TorchCommNCCLBootstrapTest.cpp
@@ -1,0 +1,280 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+#include <ATen/ATen.h>
+#include <c10/core/Device.h>
+#include <torch/csrc/distributed/c10d/HashStore.hpp> // @manual=//caffe2:torch-cpp
+
+#include "comms/torchcomms/nccl/TorchCommNCCLBootstrap.hpp"
+#include "comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp"
+#include "comms/torchcomms/nccl/tests/unit/cpp/mocks/NcclMock.hpp"
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace torch::comms::test {
+
+constexpr std::chrono::seconds kTimeout{60};
+
+class TorchCommNCCLBootstrapTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    store_ = c10::make_intrusive<c10d::HashStore>();
+
+    // Use a CPU device so the constructor does not need a real GPU; all CUDA
+    // calls are mocked.
+    device_ = at::Device(at::DeviceType::CPU, 0);
+
+    nccl_mock_ = std::make_shared<NiceMock<NcclMock>>();
+    cuda_mock_ = std::make_shared<NiceMock<CudaMock>>();
+    cuda_mock_->setupDefaultBehaviors();
+  }
+
+  void TearDown() override {
+    unsetenv("TORCHCOMM_RANK");
+    unsetenv("TORCHCOMM_SIZE");
+    unsetenv("MASTER_ADDR");
+    unsetenv("MASTER_PORT");
+  }
+
+  void setupRankAndSize(int rank, int size) {
+    setenv("TORCHCOMM_RANK", std::to_string(rank).c_str(), 1);
+    setenv("TORCHCOMM_SIZE", std::to_string(size).c_str(), 1);
+  }
+
+  std::unique_ptr<TorchCommNCCLBootstrap> createBootstrap(
+      c10::intrusive_ptr<c10d::Store> store = nullptr) {
+    if (!store) {
+      store = store_;
+    }
+    return std::make_unique<TorchCommNCCLBootstrap>(
+        store, device_, nccl_mock_, cuda_mock_, kTimeout);
+  }
+
+  static ncclUniqueId makeUniqueId(int fill) {
+    ncclUniqueId id{};
+    // NOLINTNEXTLINE(facebook-hte-BadMemset)
+    memset(&id, fill, sizeof(id));
+    return id;
+  }
+
+  c10::intrusive_ptr<c10d::Store> store_;
+  at::Device device_{at::DeviceType::CPU, 0};
+  std::shared_ptr<NiceMock<NcclMock>> nccl_mock_;
+  std::shared_ptr<NiceMock<CudaMock>> cuda_mock_;
+};
+
+// The bedrock contract: the store key is a *pure function of the comm name*.
+// Feed it the same name and you always get the same key back; feed it two
+// different names and the keys never alias. No hidden per-call or per-rank
+// state (the old process-wide counter) is allowed to leak in -- killing that
+// leak is the entire reason this change exists.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    GetNCCLStoreKey_SameName_IsDeterministicAndNameScoped) {
+  EXPECT_EQ(TorchCommNCCLBootstrap::getNCCLStoreKeyPrefix(), "nccl_storekey_");
+
+  const std::string key_a1 = TorchCommNCCLBootstrap::getNCCLStoreKey("tp");
+  const std::string key_a2 = TorchCommNCCLBootstrap::getNCCLStoreKey("tp");
+  EXPECT_EQ(key_a1, key_a2);
+  EXPECT_EQ(key_a1, "nccl_storekey_tp");
+
+  EXPECT_NE(
+      TorchCommNCCLBootstrap::getNCCLStoreKey("tp"),
+      TorchCommNCCLBootstrap::getNCCLStoreKey("dp"));
+}
+
+// Fail-fast guardrail: with no TORCHCOMM_RANK / TORCHCOMM_SIZE in the
+// environment, the bootstrap has no idea which rank it is or how big the world
+// is. It must refuse to construct rather than silently invent defaults and wire
+// up a bogus communicator.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    Constructor_EnvironmentVariablesMissing_Throws) {
+  EXPECT_THROW(createBootstrap(), std::runtime_error);
+}
+
+// Rank 0 plays the publisher in the rendezvous: it mints the NCCL unique ID
+// and drops it in the store under nccl_storekey_<name> for everyone else to
+// pick up. This exercises the publish half -- the right bytes must land under
+// the key derived from the comm's name.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    CreateNcclComm_Rank0_StoresUniqueIdUnderNameKey) {
+  setupRankAndSize(0, 2);
+  auto bootstrap = createBootstrap();
+
+  const ncclUniqueId expected_id = makeUniqueId(0x42);
+
+  EXPECT_CALL(*nccl_mock_, getUniqueId(_))
+      .WillOnce(DoAll(SetArgPointee<0>(expected_id), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, 2, _, 0, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
+          Return(ncclSuccess)));
+
+  ncclComm_t comm = bootstrap->createNcclComm("mycomm");
+  EXPECT_NE(comm, nullptr);
+
+  auto stored = store_->get("nccl_storekey_mycomm");
+  ASSERT_EQ(stored.size(), sizeof(ncclUniqueId));
+  ncclUniqueId stored_id{};
+  memcpy(&stored_id, stored.data(), sizeof(stored_id));
+  EXPECT_EQ(memcmp(&stored_id, &expected_id, sizeof(ncclUniqueId)), 0);
+}
+
+// The mirror image: a non-zero rank is a subscriber. Rank 0 has already
+// published, so this rank must locate and read the unique ID back from that
+// same name-derived key. This exercises the read half of the rendezvous.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    CreateNcclComm_NonRank0_ReadsUniqueIdFromNameKey) {
+  setupRankAndSize(1, 2);
+
+  // Pre-populate the store as if rank 0 had already published under the
+  // name-scoped key.
+  const ncclUniqueId expected_id = makeUniqueId(0x42);
+  std::vector<uint8_t> id_vec(sizeof(ncclUniqueId));
+  memcpy(id_vec.data(), &expected_id, sizeof(expected_id));
+  store_->set("nccl_storekey_mycomm", id_vec);
+
+  auto bootstrap = createBootstrap();
+  EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, 2, _, 1, _))
+      .WillOnce(DoAll(
+          SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
+          Return(ncclSuccess)));
+
+  EXPECT_NE(bootstrap->createNcclComm("mycomm"), nullptr);
+}
+
+// The headline test -- a direct reenactment of the bug this change fixes.
+// Picture two ranks that lived different lives: rank 0 joined a couple of
+// earlier members-only groups, rank 1 sat those out. Later they meet in a
+// shared comm. The store key for that shared comm must not remember any of that
+// history -- both ranks derive it purely from the name and rendezvous cleanly.
+// Under the old process-wide counter their keys drifted apart and the bootstrap
+// deadlocked; keyed on the name, it just works.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    CreateNcclComm_RanksWithDivergentCommHistory_AgreeOnKey) {
+  const ncclUniqueId id = makeUniqueId(0x42);
+
+  EXPECT_CALL(*nccl_mock_, getUniqueId(_))
+      .WillRepeatedly(DoAll(SetArgPointee<0>(id), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, _, _, _, _))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
+          Return(ncclSuccess)));
+
+  // Rank 0 participates in two earlier comms and the later shared "pp" comm.
+  setupRankAndSize(0, 2);
+  auto rank0 = createBootstrap();
+  EXPECT_NO_THROW(rank0->createNcclComm("dp"));
+  EXPECT_NO_THROW(rank0->createNcclComm("tp"));
+  EXPECT_NO_THROW(rank0->createNcclComm("pp"));
+
+  // Rank 1 skipped the earlier comms and only joins "pp"; it must read the key
+  // rank 0 wrote for "pp", which is name-scoped and independent of comm count.
+  setupRankAndSize(1, 2);
+  auto rank1 = createBootstrap();
+  EXPECT_NO_THROW(rank1->createNcclComm("pp"));
+
+  auto stored = store_->get("nccl_storekey_pp");
+  EXPECT_EQ(stored.size(), sizeof(ncclUniqueId));
+}
+
+// Sad-path hygiene: if NCCL can't even mint a unique ID, the bootstrap has
+// nothing to broadcast. It must abort with a clear, wrapped error instead of
+// marching on and publishing garbage to the store.
+TEST_F(TorchCommNCCLBootstrapTest, CreateNcclComm_GetUniqueIdFailure_Throws) {
+  setupRankAndSize(0, 2);
+  auto bootstrap = createBootstrap();
+
+  EXPECT_CALL(*nccl_mock_, getUniqueId(_))
+      .WillOnce(Return(ncclInvalidArgument));
+  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
+      .WillOnce(Return("Invalid argument"));
+
+  EXPECT_THROW(
+      {
+        try {
+          bootstrap->createNcclComm("mycomm");
+        } catch (const std::runtime_error& e) {
+          EXPECT_TRUE(
+              std::string(e.what()).find("Failed to get NCCL unique ID") !=
+              std::string::npos);
+          throw;
+        }
+      },
+      std::runtime_error);
+}
+
+// Sad-path hygiene, one step later: the ID exchange succeeds but the actual
+// communicator init fails. That failure has to surface (wrapped) to the caller
+// rather than handing back a half-built comm that detonates mid-collective.
+TEST_F(
+    TorchCommNCCLBootstrapTest,
+    CreateNcclComm_InitRankConfigFailure_Throws) {
+  setupRankAndSize(0, 2);
+  auto bootstrap = createBootstrap();
+
+  const ncclUniqueId expected_id = makeUniqueId(0x42);
+
+  EXPECT_CALL(*nccl_mock_, getUniqueId(_))
+      .WillOnce(DoAll(SetArgPointee<0>(expected_id), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, 2, _, 0, _))
+      .WillOnce(Return(ncclInvalidArgument));
+  EXPECT_CALL(*nccl_mock_, getErrorString(ncclInvalidArgument))
+      .WillOnce(Return("Invalid argument"));
+
+  EXPECT_THROW(
+      {
+        try {
+          bootstrap->createNcclComm("mycomm");
+        } catch (const std::runtime_error& e) {
+          EXPECT_TRUE(
+              std::string(e.what()).find(
+                  "Failed to initialize NCCL communicator") !=
+              std::string::npos);
+          throw;
+        }
+      },
+      std::runtime_error);
+}
+
+// Corruption guard: a non-zero rank reads the unique ID straight out of the
+// store. If what comes back isn't a full ncclUniqueId (truncated or garbage),
+// the bootstrap must reject it outright rather than memcpy nonsense into an
+// ncclUniqueId and hang the whole job on a malformed handshake.
+TEST_F(TorchCommNCCLBootstrapTest, CreateNcclComm_InvalidStoreDataSize_Throws) {
+  setupRankAndSize(1, 2);
+
+  // Store data of the wrong size under the name-scoped key.
+  std::vector<uint8_t> invalid_vec(10);
+  store_->set("nccl_storekey_mycomm", invalid_vec);
+
+  auto bootstrap = createBootstrap();
+
+  EXPECT_THROW(
+      {
+        try {
+          bootstrap->createNcclComm("mycomm");
+        } catch (const std::runtime_error& e) {
+          EXPECT_TRUE(
+              std::string(e.what()).find("Invalid NCCL unique ID size") !=
+              std::string::npos);
+          throw;
+        }
+      },
+      std::runtime_error);
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.cpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "CudaMock.hpp"
+#include <cstdlib>
+#include <limits>
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+namespace torch::comms::test {
+
+void CudaMock::setupDefaultBehaviors() {
+  // Device management - return success by default
+  ON_CALL(*this, setDevice(_)).WillByDefault(Return(cudaSuccess));
+  ON_CALL(*this, getDevice(_))
+      .WillByDefault(DoAll(SetArgPointee<0>(0), Return(cudaSuccess)));
+
+  ON_CALL(*this, getDeviceCount(_))
+      .WillByDefault(DoAll(SetArgPointee<0>(1), Return(cudaSuccess)));
+
+  ON_CALL(*this, getDeviceProperties(_, _))
+      .WillByDefault(
+          DoAll(SetArgPointee<0>(cudaDeviceProp{}), Return(cudaSuccess)));
+
+  ON_CALL(*this, memGetInfo(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(std::numeric_limits<int>::max()),
+          SetArgPointee<1>(std::numeric_limits<int>::max()),
+          Return(cudaSuccess)));
+
+  // Stream management - return success by default
+  ON_CALL(*this, getStreamPriorityRange(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(10), SetArgPointee<1>(-10), Return(cudaSuccess)));
+
+  ON_CALL(*this, streamCreateWithPriority(_, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaStream_t>(0x1)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, streamDestroy(_)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, streamWaitEvent(_, _, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, getCurrentCUDAStream(_))
+      .WillByDefault(Return(reinterpret_cast<cudaStream_t>(0x1)));
+
+  ON_CALL(*this, streamIsCapturing(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<1>(cudaStreamCaptureStatusNone), Return(cudaSuccess)));
+
+  ON_CALL(*this, streamGetCaptureInfo(_, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<1>(cudaStreamCaptureStatusNone),
+          SetArgPointee<2>(0ULL),
+          Return(cudaSuccess)));
+
+  // CUDA Graph and User Object management - return success by default
+  ON_CALL(*this, userObjectCreate(_, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaUserObject_t>(0x3000)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, graphRetainUserObject(_, _, _, _))
+      .WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, userObjectRelease(_, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, launchHostFunc(_, _, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, streamGetCaptureInfo_v2(_, _, _, _, _, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<1>(cudaStreamCaptureStatusNone),
+          SetArgPointee<2>(0ULL),
+          SetArgPointee<3>(reinterpret_cast<cudaGraph_t>(0x4000)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, threadExchangeStreamCaptureMode(_))
+      .WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, hostAlloc(_, _, _))
+      .WillByDefault([](void** pHost, size_t size, unsigned int /*flags*/) {
+        *pHost = std::calloc(1, size);
+        return cudaSuccess;
+      });
+
+  ON_CALL(*this, hostFree(_)).WillByDefault([](void* ptr) {
+    std::free(ptr);
+    return cudaSuccess;
+  });
+
+  // Memory management - return success by default
+  ON_CALL(*this, malloc(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(reinterpret_cast<void*>(0x1000)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, free(_)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, memcpy(_, _, _, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, memcpyAsync(_, _, _, _, _)).WillByDefault(Return(cudaSuccess));
+
+  // Event management - return success by default
+  ON_CALL(*this, eventCreate(_))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0x2000)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, eventCreateWithFlags(_, _))
+      .WillByDefault(DoAll(
+          SetArgPointee<0>(reinterpret_cast<cudaEvent_t>(0x4000)),
+          Return(cudaSuccess)));
+
+  ON_CALL(*this, eventDestroy(_)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, eventRecord(_, _)).WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, eventRecordWithFlags(_, _, _))
+      .WillByDefault(Return(cudaSuccess));
+
+  ON_CALL(*this, eventQuery(_)).WillByDefault(Return(cudaSuccess));
+
+  // Error handling - return default error strings
+  ON_CALL(*this, getErrorString(_)).WillByDefault(Return("mock error string"));
+}
+
+void CudaMock::reset() {
+  // Clear all expectations and call counts
+  ::testing::Mock::VerifyAndClearExpectations(this);
+
+  // Re-setup default behaviors after reset
+  setupDefaultBehaviors();
+}
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/mocks/CudaMock.hpp
@@ -1,0 +1,180 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+#include <gmock/gmock.h>
+#include "comms/torchcomms/device/cuda/CudaApi.hpp"
+
+namespace torch::comms::test {
+
+/**
+ * Mock implementation of CudaApi using Google Mock.
+ * This class provides mock implementations of all CUDA API operations
+ * for testing purposes without requiring actual CUDA hardware.
+ */
+class CudaMock : public CudaApi {
+ public:
+  ~CudaMock() override = default;
+
+  // Device management
+  MOCK_METHOD(cudaError_t, setDevice, (int device), (override));
+  MOCK_METHOD(cudaError_t, getDevice, (int* device), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      getDeviceProperties,
+      (cudaDeviceProp * prop, int device),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      memGetInfo,
+      (size_t* free, size_t* total),
+      (override));
+  MOCK_METHOD(cudaError_t, getDeviceCount, (int* count), (override));
+
+  // Stream management
+  MOCK_METHOD(
+      cudaError_t,
+      getStreamPriorityRange,
+      (int* leastPriority, int* greatestPriority),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamCreateWithPriority,
+      (cudaStream_t * pStream, unsigned int flags, int priority),
+      (override));
+  MOCK_METHOD(cudaError_t, streamDestroy, (cudaStream_t stream), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamWaitEvent,
+      (cudaStream_t stream, cudaEvent_t event, unsigned int flags),
+      (override));
+  MOCK_METHOD(
+      cudaStream_t,
+      getCurrentCUDAStream,
+      (int device_index),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamSynchronize,
+      (cudaStream_t stream),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamIsCapturing,
+      (cudaStream_t stream, cudaStreamCaptureStatus* pCaptureStatus),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamGetCaptureInfo,
+      (cudaStream_t stream,
+       cudaStreamCaptureStatus* pCaptureStatus,
+       unsigned long long* pId),
+      (override));
+
+  // CUDA Graph and User Object management
+  MOCK_METHOD(
+      cudaError_t,
+      userObjectCreate,
+      (cudaUserObject_t * object_out,
+       void* ptr,
+       cudaHostFn_t destroy,
+       unsigned int initialRefcount,
+       unsigned int flags),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      graphRetainUserObject,
+      (cudaGraph_t graph,
+       cudaUserObject_t object,
+       unsigned int count,
+       unsigned int flags),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      userObjectRelease,
+      (cudaUserObject_t object, unsigned int count),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      launchHostFunc,
+      (cudaStream_t stream, cudaHostFn_t fn, void* userData),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      streamGetCaptureInfo_v2,
+      (cudaStream_t stream,
+       cudaStreamCaptureStatus* captureStatus_out,
+       unsigned long long* id_out,
+       cudaGraph_t* graph_out,
+       const cudaGraphNode_t** dependencies_out,
+       size_t* numDependencies_out),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      threadExchangeStreamCaptureMode,
+      (enum cudaStreamCaptureMode * mode),
+      (override));
+
+  MOCK_METHOD(
+      cudaError_t,
+      hostAlloc,
+      (void** pHost, size_t size, unsigned int flags),
+      (override));
+  MOCK_METHOD(cudaError_t, hostFree, (void* ptr), (override));
+
+  // Memory management
+  MOCK_METHOD(cudaError_t, malloc, (void** devPtr, size_t size), (override));
+  MOCK_METHOD(cudaError_t, free, (void* devPtr), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      memcpy,
+      (void* dst, const void* src, size_t count, cudaMemcpyKind kind),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      memcpyAsync,
+      (void* dst,
+       const void* src,
+       size_t count,
+       cudaMemcpyKind kind,
+       cudaStream_t stream),
+      (override));
+
+  // Event management
+  MOCK_METHOD(cudaError_t, eventCreate, (cudaEvent_t * event), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventCreateWithFlags,
+      (cudaEvent_t * event, unsigned int flags),
+      (override));
+  MOCK_METHOD(cudaError_t, eventDestroy, (cudaEvent_t event), (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventRecord,
+      (cudaEvent_t event, cudaStream_t stream),
+      (override));
+  MOCK_METHOD(
+      cudaError_t,
+      eventRecordWithFlags,
+      (cudaEvent_t event, cudaStream_t stream, unsigned int flags),
+      (override));
+  MOCK_METHOD(cudaError_t, eventQuery, (cudaEvent_t event), (override));
+
+  // Error handling
+  MOCK_METHOD(const char*, getErrorString, (cudaError_t error), (override));
+
+  /**
+   * Set up default behaviors for common CUDA operations.
+   * This method configures the mock to return success for most operations
+   * and provides reasonable default values for queries.
+   */
+  void setupDefaultBehaviors();
+
+  /**
+   * Reset all mock expectations and call counts.
+   */
+  void reset();
+};
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/nccl/tests/unit/cpp/mocks/NcclMock.hpp
+++ b/comms/torchcomms/nccl/tests/unit/cpp/mocks/NcclMock.hpp
@@ -1,0 +1,303 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_runtime.h> // @manual=third-party//cuda:cuda-lazy
+#include <gmock/gmock.h>
+
+#include "comms/torchcomms/nccl/NcclApi.hpp"
+
+namespace torch::comms::test {
+
+/**
+ * Mock implementation of NcclApi using Google Mock.
+ * This class provides mock implementations of all NCCL API operations
+ * for testing purposes without requiring actual NCCL hardware/setup.
+ */
+class NcclMock : public NcclApi {
+ public:
+  ~NcclMock() override = default;
+
+  // Error handling
+  MOCK_METHOD(const char*, getErrorString, (ncclResult_t result), (override));
+  MOCK_METHOD(std::string, getLastError, (ncclComm_t comm), (override));
+
+  // Unique ID generation
+  MOCK_METHOD(ncclResult_t, getUniqueId, (ncclUniqueId * uniqueId), (override));
+
+  // Communicator management
+  MOCK_METHOD(
+      ncclResult_t,
+      commInitRankConfig,
+      (ncclComm_t * comm,
+       int nranks,
+       ncclUniqueId commId,
+       int rank,
+       ncclConfig_t* config),
+      (override));
+
+  MOCK_METHOD(ncclResult_t, commDestroy, (ncclComm_t comm), (override));
+
+  MOCK_METHOD(ncclResult_t, commAbort, (ncclComm_t comm), (override));
+
+  MOCK_METHOD(ncclResult_t, commRevoke, (ncclComm_t comm), (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commGetAsyncError,
+      (ncclComm_t comm, ncclResult_t* asyncError),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commSplit,
+      (ncclComm_t comm,
+       int color,
+       int key,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commShrink,
+      (ncclComm_t comm,
+       int* excludeRanksList,
+       int excludeRanksCount,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config,
+       int shrinkFlags),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commGetUniqueId,
+      (ncclComm_t comm, ncclUniqueId* uniqueId),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commGrow,
+      (ncclComm_t comm,
+       int nRanks,
+       const ncclUniqueId* uniqueId,
+       int rank,
+       ncclComm_t* newcomm,
+       ncclConfig_t* config),
+      (override));
+
+  // Memory registration
+  MOCK_METHOD(
+      ncclResult_t,
+      commRegister,
+      (ncclComm_t comm, void* buffer, size_t size, void** handle),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commDeregister,
+      (ncclComm_t comm, void* handle),
+      (override));
+
+  // Point-to-point operations
+  MOCK_METHOD(
+      ncclResult_t,
+      send,
+      (const void* sendbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       int peer,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      recv,
+      (void* recvbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       int peer,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  // Collective operations
+  MOCK_METHOD(
+      ncclResult_t,
+      broadcast,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       int root,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      bcast,
+      (void* buff,
+       size_t count,
+       ncclDataType_t datatype,
+       int root,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allReduce,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       ncclRedOp_t op,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      reduce,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       ncclRedOp_t op,
+       int root,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allGather,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t sendcount,
+       ncclDataType_t datatype,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      reduceScatter,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t recvcount,
+       ncclDataType_t datatype,
+       ncclRedOp_t op,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      allToAll,
+      (const void* sendbuff,
+       void* recvbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  // Group operations
+  MOCK_METHOD(ncclResult_t, groupStart, (), (override));
+  MOCK_METHOD(ncclResult_t, groupEnd, (), (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commUserRank,
+      (const ncclComm_t comm, int* userRank),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      commCount,
+      (const ncclComm_t comm, int* count),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      redOpCreatePreMulSum,
+      (ncclRedOp_t * op,
+       void* scalar,
+       ncclDataType_t datatype,
+       ncclScalarResidence_t residence,
+       ncclComm_t comm),
+      (override));
+  MOCK_METHOD(
+      ncclResult_t,
+      redOpDestroy,
+      (ncclRedOp_t op, ncclComm_t comm),
+      (override));
+
+  MOCK_METHOD(ncclResult_t, memAlloc, (void** buff, size_t size), (override));
+  MOCK_METHOD(ncclResult_t, memFree, (void* buff), (override));
+
+  // Window / one-sided RMA operations
+  MOCK_METHOD(
+      ncclResult_t,
+      commWindowRegister,
+      (ncclComm_t comm,
+       void* buffer,
+       size_t size,
+       ncclWindow_t* win,
+       int winFlags),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      commWindowDeregister,
+      (ncclComm_t comm, ncclWindow_t win),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      winGetUserPtr,
+      (ncclComm_t comm, ncclWindow_t win, void** outUserPtr),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      putSignal,
+      (const void* localbuff,
+       size_t count,
+       ncclDataType_t datatype,
+       int peer,
+       ncclWindow_t peerWin,
+       size_t peerWinOffset,
+       int sigIdx,
+       int ctx,
+       unsigned int flags,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      signal,
+      (int peer,
+       int sigIdx,
+       int ctx,
+       unsigned int flags,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+
+  MOCK_METHOD(
+      ncclResult_t,
+      waitSignal,
+      (int peer,
+       int sigIdx,
+       int ctx,
+       int opCnt,
+       ncclComm_t comm,
+       cudaStream_t stream),
+      (override));
+};
+
+} // namespace torch::comms::test

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.cpp
@@ -16,9 +16,6 @@
 
 namespace torch::comms {
 
-// Initialize the static counter
-int TorchCommNCCLXBootstrap::counter_ = 0;
-
 namespace {
 
 const std::string kUniqueidXchgMethodAuto = "auto";
@@ -115,19 +112,20 @@ TorchCommNCCLXBootstrap::~TorchCommNCCLXBootstrap() noexcept {
   }
 }
 
-std::string TorchCommNCCLXBootstrap::getNCCLXStoreKey() {
-  std::string key = fmt::format("{}{}", getNCCLXStoreKeyPrefix(), counter_);
-  counter_++;
-  return key;
+std::string TorchCommNCCLXBootstrap::getNCCLXStoreKey(std::string_view name) {
+  // Key the bootstrap on the comm's name, which is identical across all ranks
+  // that participate in the comm and unique per comm (store_ is also uniquely
+  // prefixed per comm). A previous implementation used a process-wide counter
+  // incremented once per bootstrap; that counter diverges across ranks when
+  // comms have asymmetric membership (members-only or subset groups skip
+  // non-member ranks), so a later comm spanning diverged ranks would have rank
+  // 0 set one key while other ranks wait on a different key -> bootstrap hang.
+  return fmt::format("{}{}", getNCCLXStoreKeyPrefix(), name);
 }
 
 std::string TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix() {
   return "ncclx_storekey_";
 };
-
-int TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter() {
-  return counter_;
-}
 
 void TorchCommNCCLXBootstrap::createStore(std::string_view name) {
   if (store_ == nullptr) {
@@ -146,10 +144,10 @@ void TorchCommNCCLXBootstrap::createStore(std::string_view name) {
   }
 }
 
-ncclUniqueId TorchCommNCCLXBootstrap::exchangeUniqueId() {
+ncclUniqueId TorchCommNCCLXBootstrap::exchangeUniqueId(std::string_view name) {
   ncclUniqueId uniqueId;
 
-  auto key = getNCCLXStoreKey();
+  auto key = getNCCLXStoreKey(name);
   if (rank_ == 0) {
     // Generate unique ID on rank 0
     ncclResult_t ncclErr = nccl_api_->getUniqueId(&uniqueId);
@@ -372,10 +370,10 @@ ncclComm_t TorchCommNCCLXBootstrap::createNcclComm(
   if (useFastInit(hints)) {
     uniqueId = ncclUniqueId{};
   } else {
-    uniqueId = exchangeUniqueId();
+    uniqueId = exchangeUniqueId(name);
   }
 #else
-  uniqueId = exchangeUniqueId();
+  uniqueId = exchangeUniqueId(name);
 #endif
 
   ncclResult_t ncclErr = nccl_api_->commInitRankConfig(

--- a/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
+++ b/comms/torchcomms/ncclx/TorchCommNCCLXBootstrap.hpp
@@ -37,9 +37,8 @@ class TorchCommNCCLXBootstrap {
   ncclComm_t createNcclComm(
       const std::string& name,
       const CommOptions& options = {});
-  static std::string getNCCLXStoreKey();
+  static std::string getNCCLXStoreKey(std::string_view name);
   static std::string getNCCLXStoreKeyPrefix();
-  static int getNCCLXStoreKeyCounter();
 
   int getRank() {
     return rank_;
@@ -52,7 +51,7 @@ class TorchCommNCCLXBootstrap {
   }
 
  private:
-  ncclUniqueId exchangeUniqueId();
+  ncclUniqueId exchangeUniqueId(std::string_view name);
   void createStore(std::string_view name);
 #ifdef NCCLX_CONFIG_SUPPORTED
   bool useFastInit(const ncclx::Hints& hints);
@@ -61,7 +60,6 @@ class TorchCommNCCLXBootstrap {
 
  private:
   const std::chrono::milliseconds timeout_;
-  static int counter_;
 
   c10::intrusive_ptr<c10d::Store> store_;
   bool created_internal_store_;

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.cpp
@@ -306,4 +306,8 @@ void TorchWorkNCCLX::wait() {
 
   runWaitPostHooks();
 }
+
+void TorchWorkNCCLX::hostSynchronize() {
+  syncCurrentStreamIfNotCapturing(comm_->getCudaApi(), comm_->device_.index());
+}
 } // namespace torch::comms

--- a/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
+++ b/comms/torchcomms/ncclx/TorchWorkNCCLX.hpp
@@ -68,6 +68,10 @@ class TorchWorkNCCLX : public TorchWork {
     cpuTensors_ = std::move(tensors);
   }
 
+  // Host-block the current stream for a synchronous barrier. See
+  // TorchWork::hostSynchronize(); invoked by WorkWrapper::wait().
+  void hostSynchronize() override;
+
  protected:
   void recordStart(std::string_view coll_name);
   void recordEnd();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXBootstrapTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXBootstrapTest.cpp
@@ -35,11 +35,6 @@ class TorchCommNCCLXBootstrapTest : public ::testing::Test {
     // Create fresh mocks for each test
     nccl_mock_ = std::make_shared<NiceMock<NcclxMock>>();
     cuda_mock_ = std::make_shared<NiceMock<CudaMock>>();
-
-    // Reset the static counter to a known state
-    // We'll access it through the public interface
-    TorchCommNCCLXBootstrap::getNCCLXStoreKey(); // This increments counter
-    initial_counter_ = TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter();
   }
 
   void TearDown() override {
@@ -68,28 +63,25 @@ class TorchCommNCCLXBootstrapTest : public ::testing::Test {
   at::Device device_{at::DeviceType::CPU, 0};
   std::shared_ptr<NiceMock<NcclxMock>> nccl_mock_;
   std::shared_ptr<NiceMock<CudaMock>> cuda_mock_;
-  int initial_counter_{-1};
 };
 
+// The bedrock contract: the store key is a *pure function of the comm name*.
+// Feed it the same name and you always get the same key back; feed it two
+// different names and the keys never alias. No hidden per-call or per-rank
+// state (the old process-wide counter) is allowed to leak in -- killing that
+// leak is the entire reason this change exists.
 TEST_F(TorchCommNCCLXBootstrapTest, StaticMethodsStoreKeyGeneration) {
-  // Test that store key generation works correctly with counter
-  std::string prefix = TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix();
-  EXPECT_EQ(prefix, "ncclx_storekey_");
+  EXPECT_EQ(
+      TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix(), "ncclx_storekey_");
 
-  int counter_before = TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter();
-  std::string key1 = TorchCommNCCLXBootstrap::getNCCLXStoreKey();
-  int counter_after = TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter();
+  const std::string key_a1 = TorchCommNCCLXBootstrap::getNCCLXStoreKey("tp");
+  const std::string key_a2 = TorchCommNCCLXBootstrap::getNCCLXStoreKey("tp");
+  EXPECT_EQ(key_a1, key_a2);
+  EXPECT_EQ(key_a1, "ncclx_storekey_tp");
 
-  EXPECT_EQ(counter_after, counter_before + 1);
-  EXPECT_EQ(key1, prefix + std::to_string(counter_before));
-
-  // Test that subsequent calls increment the counter
-  std::string key2 = TorchCommNCCLXBootstrap::getNCCLXStoreKey();
-  int final_counter = TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter();
-
-  EXPECT_EQ(final_counter, counter_after + 1);
-  EXPECT_EQ(key2, prefix + std::to_string(counter_after));
-  EXPECT_NE(key1, key2);
+  EXPECT_NE(
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("tp"),
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("dp"));
 }
 
 TEST_F(TorchCommNCCLXBootstrapTest, GetRankAndSizeFromEnvironment) {
@@ -104,8 +96,8 @@ TEST_F(TorchCommNCCLXBootstrapTest, GetRankAndSizeFromEnvironment) {
   std::vector<uint8_t> id_vec(sizeof(ncclUniqueId));
   memcpy(id_vec.data(), &expected_id, sizeof(expected_id));
 
-  std::string store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix() +
-      std::to_string(TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter());
+  std::string store_key =
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_comm");
   store_->set(store_key, id_vec);
 
   // Set up mock expectations
@@ -144,8 +136,8 @@ TEST_F(TorchCommNCCLXBootstrapTest, ExchangeUniqueIdRank0) {
   EXPECT_NE(comm, nullptr);
 
   // Verify the unique ID was stored
-  std::string store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix() +
-      std::to_string(initial_counter_);
+  std::string store_key =
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_comm");
   auto stored_vec = store_->get(store_key);
   ncclUniqueId stored_id;
   memcpy(&stored_id, stored_vec.data(), sizeof(stored_id));
@@ -163,8 +155,8 @@ TEST_F(TorchCommNCCLXBootstrapTest, ExchangeUniqueIdNonRank0) {
   std::vector<uint8_t> id_vec(sizeof(ncclUniqueId));
   memcpy(id_vec.data(), &expected_id, sizeof(expected_id));
 
-  std::string store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix() +
-      std::to_string(TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter());
+  std::string store_key =
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_comm");
   store_->set(store_key, id_vec);
 
   auto bootstrap = createBootstrap();
@@ -176,6 +168,42 @@ TEST_F(TorchCommNCCLXBootstrapTest, ExchangeUniqueIdNonRank0) {
 
   ncclComm_t comm = bootstrap->createNcclComm("test_comm");
   EXPECT_NE(comm, nullptr);
+}
+
+// The headline test -- a direct reenactment of the bug this change fixes.
+// Picture two ranks that lived different lives: rank 0 joined a couple of
+// earlier members-only groups, rank 1 sat those out. Later they meet in a
+// shared comm. The store key for that shared comm must not remember any of that
+// history -- both ranks derive it purely from the name and rendezvous cleanly.
+// Under the old process-wide counter their keys drifted apart and the bootstrap
+// deadlocked; keyed on the name, it just works.
+TEST_F(TorchCommNCCLXBootstrapTest, RanksWithDivergentCommHistoryAgreeOnKey) {
+  ncclUniqueId id{};
+  // NOLINTNEXTLINE(facebook-hte-BadMemset)
+  memset(&id, 0x42, sizeof(id));
+
+  EXPECT_CALL(*nccl_mock_, getUniqueId(_))
+      .WillRepeatedly(DoAll(SetArgPointee<0>(id), Return(ncclSuccess)));
+  EXPECT_CALL(*nccl_mock_, commInitRankConfig(_, _, _, _, _))
+      .WillRepeatedly(DoAll(
+          SetArgPointee<0>(reinterpret_cast<ncclComm_t>(0x3000)),
+          Return(ncclSuccess)));
+
+  // Rank 0 participates in two earlier comms and the later shared "pp" comm.
+  setupRankAndSize(0, 2);
+  auto rank0 = createBootstrap();
+  EXPECT_NO_THROW(rank0->createNcclComm("dp"));
+  EXPECT_NO_THROW(rank0->createNcclComm("tp"));
+  EXPECT_NO_THROW(rank0->createNcclComm("pp"));
+
+  // Rank 1 skipped the earlier comms and only joins "pp"; it must read the key
+  // rank 0 wrote for "pp", which is name-scoped and independent of comm count.
+  setupRankAndSize(1, 2);
+  auto rank1 = createBootstrap();
+  EXPECT_NO_THROW(rank1->createNcclComm("pp"));
+
+  auto stored = store_->get(TorchCommNCCLXBootstrap::getNCCLXStoreKey("pp"));
+  EXPECT_EQ(stored.size(), sizeof(ncclUniqueId));
 }
 
 TEST_F(TorchCommNCCLXBootstrapTest, CreateNcclCommGetUniqueIdFailure) {
@@ -245,8 +273,8 @@ TEST_F(TorchCommNCCLXBootstrapTest, ExchangeUniqueIdInvalidStoreData) {
   // Store invalid data (wrong size)
   std::vector<uint8_t> invalid_vec(
       10); // Wrong size, should be sizeof(ncclUniqueId)
-  std::string store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKeyPrefix() +
-      std::to_string(TorchCommNCCLXBootstrap::getNCCLXStoreKeyCounter());
+  std::string store_key =
+      TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_comm");
   store_->set(store_key, invalid_vec);
 
   auto bootstrap = createBootstrap();

--- a/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
+++ b/comms/torchcomms/ncclx/tests/unit/cpp/TorchCommNCCLXTest.cpp
@@ -125,11 +125,7 @@ TEST_F(TorchCommNCCLXTest, InitializationRank0GetUniqueId) {
 
   EXPECT_NO_THROW(comm->init(*device_, "test_name", default_options_));
 
-  auto bootstrap = new TorchCommNCCLXBootstrap(
-      store_, *device_, nccl_mock_, cuda_mock_, std::chrono::seconds(60));
-  auto store_key = bootstrap->getNCCLXStoreKeyPrefix() +
-      std::to_string(bootstrap->getNCCLXStoreKeyCounter() - 1);
-  delete bootstrap;
+  auto store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_name");
 
   // Verify the unique ID was stored in the store
   auto stored_vec = store_->get(store_key);
@@ -145,11 +141,7 @@ TEST_F(TorchCommNCCLXTest, InitializationNonRank0ReadUniqueId) {
   // get it from store
   setupRankAndSize(1, 2); // rank 1, size 2
 
-  auto bootstrap = new TorchCommNCCLXBootstrap(
-      store_, *device_, nccl_mock_, cuda_mock_, std::chrono::seconds(60));
-  auto store_key = bootstrap->getNCCLXStoreKeyPrefix() +
-      std::to_string(bootstrap->getNCCLXStoreKeyCounter());
-  delete bootstrap;
+  auto store_key = TorchCommNCCLXBootstrap::getNCCLXStoreKey("test_name");
 
   // Pre-populate store with unique ID (as if rank 0 already stored it)
   ncclUniqueId expected_id{};

--- a/comms/torchcomms/tests/integration/py/BarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/BarrierTest.py
@@ -6,6 +6,8 @@ import os
 import unittest
 
 import torch
+from torch.distributed import BarrierOptions
+from torchcomms.device_mesh import _create_torchcomm_process_group
 from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
     TorchCommTestWrapper,
 )
@@ -96,6 +98,56 @@ class BarrierTest(unittest.TestCase):
                 graph.replay()
 
                 # No explicit verification needed for barrier, just ensure it completes
+
+    def _sync_barrier_blocks_host_on_stream(self):
+        """A synchronous c10d barrier must block the host until prior work on the
+        current stream has completed.
+
+        This mirrors stock ProcessGroupNCCL, whose barrier host-blocks the CPU
+        thread. It is a regression test for a trtllm flashinfer one-shot Lamport
+        all_reduce deadlock: that code clears its IPC buffers asynchronously on
+        the stream and then issues a synchronous barrier before the first
+        all_reduce, relying on the barrier to flush that clear. If the barrier
+        only inserts a stream-ordered wait (no host sync), the first all_reduce
+        races the clear and both ranks spin forever. The host block is applied by
+        BackendWrapper (the c10d layer), so the barrier is driven through a c10d
+        ProcessGroup rather than the native torchcomm.barrier().
+        """
+        pg = _create_torchcomm_process_group(self.torchcomm, "barrier_host_block_pg")
+        with torch.cuda.device(self.device):
+            stream = torch.cuda.current_stream()
+
+            # Enqueue a long-running kernel on the current stream so the host
+            # would observe an unfinished stream if the barrier did not
+            # synchronize it.
+            torch.cuda._sleep(1_000_000_000)
+            self.assertFalse(
+                stream.query(),
+                "precondition: enqueued work should leave the stream busy",
+            )
+
+            # Synchronous c10d barrier + wait() must block the host until the
+            # stream is drained.
+            opts = BarrierOptions()
+            opts.asyncOp = False
+            opts.device = self.device
+            work = pg.barrier(opts=opts)
+            work.wait()
+
+            self.assertTrue(
+                stream.query(),
+                "synchronous barrier must block the host until prior stream work completes",
+            )
+        print(f"[Rank {self.rank}] sync barrier blocked host until stream drained")
+
+    @unittest.skipIf(
+        os.getenv("TEST_BACKEND") not in ("nccl", "ncclx"),
+        "Host-blocking synchronous barrier is validated for the GPU backends "
+        "(nccl, ncclx)",
+    )
+    def test_sync_barrier_blocks_host_on_stream(self):
+        """Synchronous barrier + wait() must block the host until prior stream work done."""
+        self._sync_barrier_blocks_host_on_stream()
 
     def test_sync_barrier(self):
         """Test synchronous barrier with work object."""

--- a/comms/torchcomms/tests/integration/py/MonitoredBarrierTest.py
+++ b/comms/torchcomms/tests/integration/py/MonitoredBarrierTest.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# pyre-unsafe
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Test BackendWrapper::monitoredBarrier (the gloo health-checking barrier).
+
+torch.distributed.monitored_barrier is only implemented for the gloo backend.
+Under TorchComms the gloo ProcessGroup is backed by BackendWrapper, which now
+reimplements ProcessGroupGloo::monitoredBarrier on top of TorchComms P2P: rank 0
+acts as the coordinator, collecting a check-in from every other rank within the
+timeout and raising a RuntimeError that names the rank(s) that failed to report.
+
+This test wraps a real "gloo" TorchComm in a c10d ProcessGroup and drives
+``pg.monitored_barrier`` directly (the same entry point dist.monitored_barrier
+dispatches to), covering the all-pass path plus straggler detection in both the
+wait_all_ranks (report every straggler) and fast-fail (report the first) modes.
+
+monitored_barrier is gloo-only, so this test skips on any other backend rather
+than failing (the Buck target is also restricted to ``backends = ["gloo"]``).
+"""
+
+import datetime
+import os
+import time
+import unittest
+
+import torch
+import torch.distributed as dist
+import torchcomms
+from torchcomms import new_comm
+from torchcomms.device_mesh import _create_torchcomm_process_group
+from torchcomms.tests.integration.helpers.TorchCommTestHelpers import (
+    create_store,
+    get_rank_and_size,
+)
+
+
+def _make_wrapped_gloo_pg(
+    name: str,
+) -> tuple[torchcomms.TorchComm, dist.ProcessGroup]:
+    """Build a gloo TorchComm wrapped in a c10d ProcessGroup.
+
+    Reuses ``device_mesh._create_torchcomm_process_group`` for the wrap +
+    register so this test does not duplicate the _BackendWrapper /
+    _register_backend boilerplate. The comm carries its own store-bootstrapped
+    gloo context (used by monitoredBarrier's P2P); the ProcessGroup uses a
+    throwaway HashStore internally.
+
+    The comm is created on CPU on purpose: monitoredBarrier is a CPU-only gloo
+    op, and c10d dispatches pg.monitored_barrier to whichever backend is
+    registered for the CPU device. _create_torchcomm_process_group registers the
+    wrapper under comm.get_device(), so on a GPU host a cuda comm would leave the
+    CPU device unbacked and monitored_barrier would raise "No backend type
+    associated with device type cpu".
+    """
+    backend = os.environ["TEST_BACKEND"]
+    comm = new_comm(backend, torch.device("cpu"), store=create_store(), name=name)
+    pg = _create_torchcomm_process_group(comm, name)
+    return comm, pg
+
+
+class MonitoredBarrierTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.environ.get("TEST_BACKEND") != "gloo":
+            self.skipTest("monitored_barrier is only implemented for the gloo backend")
+        self.rank, self.num_ranks = get_rank_and_size()
+
+    def test_all_ranks_pass(self) -> None:
+        """When every rank checks in, monitoredBarrier returns without error."""
+        comm, pg = _make_wrapped_gloo_pg("mb_all_pass")
+        passed = False
+        try:
+            # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at runtime
+            # (bound from c10d) but is missing from the type stub.
+            pg.monitored_barrier(
+                timeout=datetime.timedelta(seconds=30),
+                wait_all_ranks=True,
+            )
+            passed = True
+        finally:
+            comm.finalize()
+        self.assertTrue(passed)
+
+    def test_straggler_detection(self) -> None:
+        """wait_all_ranks: rank 0 names every rank that fails to reach the barrier."""
+        if self.num_ranks < 2:
+            self.skipTest("straggler detection requires at least 2 ranks")
+
+        comm: torchcomms.TorchComm | None = None
+        timeout = datetime.timedelta(seconds=1)
+        try:
+            comm, pg = _make_wrapped_gloo_pg("mb_straggler")
+            if self.rank == 0:
+                # Every other rank deliberately never checks in, so rank 0 must
+                # time out on each and report all of them.
+                with self.assertRaises(RuntimeError) as ctx:
+                    # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at
+                    # runtime (bound from c10d) but is missing from the stub.
+                    pg.monitored_barrier(timeout=timeout, wait_all_ranks=True)
+                message = str(ctx.exception)
+                self.assertIn("monitoredBarrier", message)
+                # Match the distinctive "Ranks <list> failed" segment rather
+                # than bare rank ids: small ids like "1" would also match the
+                # timeout value ("1000 ms") or the "[Rank 0]" prefix, so a
+                # malformed/empty straggler list could still pass.
+                expected_ranks = ", ".join(str(r) for r in range(1, self.num_ranks))
+                self.assertIn(f"Ranks {expected_ranks} failed", message)
+            else:
+                # Stay alive (keeping the gloo context up) long enough for rank
+                # 0 to time out on us, then exit. wait_all_ranks spends the full
+                # timeout per rank sequentially, so allow num_ranks * timeout.
+                time.sleep(timeout.total_seconds() * self.num_ranks + 5)
+        finally:
+            if comm is not None:
+                comm.finalize()
+
+    def test_straggler_detection_fast_fail(self) -> None:
+        """Fast-fail (wait_all_ranks=False): rank 0 raises on the first straggler."""
+        if self.num_ranks < 2:
+            self.skipTest("straggler detection requires at least 2 ranks")
+
+        comm: torchcomms.TorchComm | None = None
+        timeout = datetime.timedelta(seconds=1)
+        try:
+            comm, pg = _make_wrapped_gloo_pg("mb_straggler_fast_fail")
+            if self.rank == 0:
+                # No worker checks in. In fast-fail mode rank 0 stops at the
+                # first straggler (rank 1) and raises without probing the rest.
+                with self.assertRaises(RuntimeError) as ctx:
+                    # pyre-fixme[16]: ProcessGroup.monitored_barrier exists at
+                    # runtime (bound from c10d) but is missing from the stub.
+                    pg.monitored_barrier(timeout=timeout, wait_all_ranks=False)
+                message = str(ctx.exception)
+                self.assertIn("monitoredBarrier", message)
+                # Fast-fail reports the first straggler only. Match the full
+                # "Rank 1 failed" phrase, not a bare id that could also match
+                # the timeout value or the "[Rank 0]" prefix.
+                self.assertIn("Rank 1 failed", message)
+            else:
+                # rank 0 bails after ~one timeout (it stops at rank 1), but keep
+                # the context up a bit longer to avoid tearing down mid-probe.
+                time.sleep(timeout.total_seconds() * self.num_ranks + 5)
+        finally:
+            if comm is not None:
+                comm.finalize()


### PR DESCRIPTION
Summary:

The NCCL bootstrap store key was built from a process-wide static counter
(counter_) incremented once per bootstrap -- but only on ranks that actually
participate in a comm. With members-only / subset comms, non-member ranks skip
the bootstrap, so counter_ diverges across ranks. A later comm spanning those
diverged ranks then has rank 0 write nccl_storekey_<c0> while other ranks wait
on nccl_storekey_<cN>, deadlocking the bootstrap exchange.

Key the bootstrap on the comm name instead. The name is identical across a
comm's members and unique per comm (store_ is already uniquely prefixed per
comm), so the exchange key matches on every rank regardless of prior
members-only comm creation. Removes counter_ / getNCCLStoreKeyCounter and
threads the name through exchangeUniqueId / exchangeUniqueIdStore /
exchangeUniqueIdTCPStore.

Differential Revision: D110791951


