### PR TITLE
Disable inductor simple_overlap pass when torchcomms lowerings are registered

### DIFF
--- a/comms/torchcomms/functional/inductor_lowering.py
+++ b/comms/torchcomms/functional/inductor_lowering.py
@@ -13,6 +13,32 @@ try:  # noqa: C901
     from torch._inductor import ir
     from torch._inductor.lowering import register_lowering
 
+    def _disable_unsafe_reordering_passes() -> None:
+        """Disable inductor scheduler passes that reorder torchcomms comm ops.
+
+        PyTorch 2.14 nightly enables the simple_overlap scheduler pass by
+        default (pytorch/pytorch#184235, #184240). Its "no collective
+        reordering" guard only recognizes ir._CollectiveKernel nodes, but
+        torchcomms lowers ops without mutable tensor params (e.g. sync send,
+        barrier) as plain FallbackKernels, so the pass hoists recv above the
+        send/barrier that precede it and deadlocks blocking P2P patterns.
+        Disable it whenever torchcomms ops can appear in compiled graphs.
+        See pytorch/pytorch#189454.
+        """
+        try:
+            from torch._inductor import config as inductor_config
+
+            dist_opts = getattr(inductor_config, "aten_distributed_optimizations", None)
+            if dist_opts is not None and hasattr(dist_opts, "enable_simple_overlap"):
+                if dist_opts.enable_simple_overlap:
+                    dist_opts.enable_simple_overlap = False
+                    logger.info(
+                        "Disabled inductor simple_overlap pass (unsafe with "
+                        "torchcomms P2P ops)"
+                    )
+        except Exception as e:
+            logger.warning(f"Failed to disable simple_overlap pass: {e}")
+
     def register_torchcomms_lowerings():
         from torchcomms.functional import collectives
 
@@ -20,6 +46,8 @@ try:  # noqa: C901
         if collectives is None:
             logger.warning("torchcomms.functional.collectives not available")
             return
+
+        _disable_unsafe_reordering_passes()
 
         try:
             from torchcomms.functional.registry import _REGISTERED_COLLECTIVES


### PR DESCRIPTION
## Summary

All nightly-torch `run_py_tests` CI jobs on main have been timing out (cancelled at the 120-min limit) since June 25, hanging in `FullgraphCompileTest::test_fullgraph_compile_send_recv` — e.g. [this run](https://github.com/meta-pytorch/torchcomms/actions/runs/28993999992/job/86043550731).

Root cause: PyTorch nightly `dev20260625` enabled the `simple_overlap` inductor scheduler pass by default (pytorch/pytorch#184235, pytorch/pytorch#184240). Its "no collective reordering" guard only recognizes `ir._CollectiveKernel` nodes, but torchcomms lowers ops without mutable tensor params (sync `send`, `barrier`) as plain `FallbackKernel`s. The pass hoists compiled `recv` (a `_CollectiveKernel`) above the `send`/`barrier` that precede it:

```
SIMPLE_OVERLAP nodes: [op0 FallbackKernel torchcomm_barrier, op1 FallbackKernel torchcomm_send,
                       op2 _CollectiveKernel torchcomm_recv, op3 ComputedBuffer]
SIMPLE_OVERLAP swapping op2 above op1 (torchcomm_send)
SIMPLE_OVERLAP swapping op2 above op0 (torchcomm_barrier)
```

This destroys the even-send-first/odd-recv-first deadlock-avoidance ordering: generated code on every rank posts a blocking `recv` first, so all ranks hang forever.

Fix: disable the pass from `register_torchcomms_lowerings()` whenever torchcomms ops can appear in compiled graphs. Guarded with `hasattr` so stable torch (which lacks the knob) is unaffected. Upstream issue: pytorch/pytorch#189454. Longer-term we could lower sync send/barrier as `_CollectiveKernel` (or emit ordering deps between comm ops) so reordering passes treat them as fences, and re-enable overlap.

## Test Plan

torch==2.14.0.dev20260708+cu130 (nightly, 4xH100, NCCL — repros the CI hang without this change):
- `FullgraphCompileTest.py -k send_recv`: hangs indefinitely before, passes in 10s after
- Full `FullgraphCompileTest.py` via torchrun 4 ranks: 22 passed, 1 skipped, 210 subtests passed in 89s
- `tests/unit/py`: 88 passed, 4 skipped
- Verified torchcomms import flips `aten_distributed_optimizations.enable_simple_overlap` True → False

torch 2.12 stable: config section exists but knob doesn't; `hasattr` guard makes this a no-op.

lintrunner (UFMT) clean.