### PR TITLE
Add `NvlBootstrapAdapter` nested NVL-domain forwarding (#3097)

### DIFF
--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -152,6 +152,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -160,6 +160,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/prims/bootstrap/NvlBootstrapAdapter.h
+++ b/comms/prims/bootstrap/NvlBootstrapAdapter.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -51,6 +52,30 @@ class NvlBootstrapAdapter : public meta::comms::IBootstrap {
     return underlying_->barrierNvlDomain(rank, nranks, localRankToCommRank_);
   }
 
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return underlying_->allGatherNvlDomain(
+        buf,
+        len,
+        nvlLocalRank,
+        nvlNranks,
+        translateLocalRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return underlying_->barrierNvlDomain(
+        nvlLocalRank,
+        nvlNranks,
+        translateLocalRanks(std::move(nvlRankToCommRank)));
+  }
+
   folly::SemiFuture<int> send(void* buf, int len, int peer, int tag) override {
     return underlying_->send(buf, len, localRankToCommRank_[peer], tag);
   }
@@ -60,6 +85,13 @@ class NvlBootstrapAdapter : public meta::comms::IBootstrap {
   }
 
  private:
+  std::vector<int> translateLocalRanks(std::vector<int> localRanks) const {
+    for (auto& rank : localRanks) {
+      rank = localRankToCommRank_.at(static_cast<std::size_t>(rank));
+    }
+    return localRanks;
+  }
+
   std::shared_ptr<meta::comms::IBootstrap> underlying_;
   std::vector<int> localRankToCommRank_;
 };

--- a/comms/prims/bootstrap/tests/NvlBootstrapAdapterUnitTest.cc
+++ b/comms/prims/bootstrap/tests/NvlBootstrapAdapterUnitTest.cc
@@ -1,0 +1,196 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace comms::prims::tests {
+
+namespace {
+
+class RecordingBootstrap final : public meta::comms::IBootstrap {
+ public:
+  folly::SemiFuture<int> allGather(void* /*buf*/, int, int, int) override {
+    return folly::makeSemiFuture(EINVAL);
+  }
+
+  folly::SemiFuture<int> barrier(int, int) override {
+    return folly::makeSemiFuture(EINVAL);
+  }
+
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    ++allGatherNvlDomainCalls;
+    lastAllGatherBuf = buf;
+    lastAllGatherLen = len;
+    lastAllGatherNvlLocalRank = nvlLocalRank;
+    lastAllGatherNvlNranks = nvlNranks;
+    lastAllGatherNvlRankToCommRank = std::move(nvlRankToCommRank);
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    ++barrierNvlDomainCalls;
+    lastBarrierNvlLocalRank = nvlLocalRank;
+    lastBarrierNvlNranks = nvlNranks;
+    lastBarrierNvlRankToCommRank = std::move(nvlRankToCommRank);
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> send(void* /*buf*/, int, int peer, int tag) override {
+    ++sendCalls;
+    lastSendPeer = peer;
+    lastSendTag = tag;
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> recv(void* /*buf*/, int, int peer, int tag) override {
+    ++recvCalls;
+    lastRecvPeer = peer;
+    lastRecvTag = tag;
+    return folly::makeSemiFuture(0);
+  }
+
+  int allGatherNvlDomainCalls{0};
+  void* lastAllGatherBuf{nullptr};
+  int lastAllGatherLen{-1};
+  int lastAllGatherNvlLocalRank{-1};
+  int lastAllGatherNvlNranks{-1};
+  std::vector<int> lastAllGatherNvlRankToCommRank;
+
+  int barrierNvlDomainCalls{0};
+  int lastBarrierNvlLocalRank{-1};
+  int lastBarrierNvlNranks{-1};
+  std::vector<int> lastBarrierNvlRankToCommRank;
+
+  int sendCalls{0};
+  int lastSendPeer{-1};
+  int lastSendTag{-1};
+
+  int recvCalls{0};
+  int lastRecvPeer{-1};
+  int lastRecvTag{-1};
+};
+
+} // namespace
+
+TEST(NvlBootstrapAdapterUnitTest, AllGatherUsesAdapterRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int buffer[4] = {};
+  EXPECT_EQ(adapter.allGather(buffer, sizeof(int), 2, 4).get(), 0);
+
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastAllGatherBuf, buffer);
+  EXPECT_EQ(underlying->lastAllGatherLen, sizeof(int));
+  EXPECT_EQ(underlying->lastAllGatherNvlLocalRank, 2);
+  EXPECT_EQ(underlying->lastAllGatherNvlNranks, 4);
+  EXPECT_EQ(
+      underlying->lastAllGatherNvlRankToCommRank,
+      (std::vector<int>{12, 7, 19, 3}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedAllGatherTranslatesLocalRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int buffer[3] = {};
+  EXPECT_EQ(
+      adapter
+          .allGatherNvlDomain(
+              buffer,
+              sizeof(int),
+              /*nvlLocalRank=*/1,
+              /*nvlNranks=*/3,
+              /*nvlRankToCommRank=*/{3, 0, 2})
+          .get(),
+      0);
+
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastAllGatherBuf, buffer);
+  EXPECT_EQ(underlying->lastAllGatherLen, sizeof(int));
+  EXPECT_EQ(underlying->lastAllGatherNvlLocalRank, 1);
+  EXPECT_EQ(underlying->lastAllGatherNvlNranks, 3);
+  EXPECT_EQ(
+      underlying->lastAllGatherNvlRankToCommRank,
+      (std::vector<int>{3, 12, 19}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedBarrierTranslatesLocalRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  EXPECT_EQ(
+      adapter
+          .barrierNvlDomain(
+              /*nvlLocalRank=*/2,
+              /*nvlNranks=*/3,
+              /*nvlRankToCommRank=*/{1, 3, 0})
+          .get(),
+      0);
+
+  EXPECT_EQ(underlying->barrierNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastBarrierNvlLocalRank, 2);
+  EXPECT_EQ(underlying->lastBarrierNvlNranks, 3);
+  EXPECT_EQ(
+      underlying->lastBarrierNvlRankToCommRank, (std::vector<int>{7, 3, 12}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedRankMapRejectsOutOfRangeLocalRank) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7});
+
+  int buffer[1] = {};
+  EXPECT_THROW(
+      adapter.allGatherNvlDomain(
+          buffer,
+          sizeof(int),
+          /*nvlLocalRank=*/0,
+          /*nvlNranks=*/1,
+          /*nvlRankToCommRank=*/{2}),
+      std::out_of_range);
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 0);
+
+  EXPECT_THROW(
+      adapter.barrierNvlDomain(
+          /*nvlLocalRank=*/0,
+          /*nvlNranks=*/1,
+          /*nvlRankToCommRank=*/{2}),
+      std::out_of_range);
+  EXPECT_EQ(underlying->barrierNvlDomainCalls, 0);
+}
+
+TEST(NvlBootstrapAdapterUnitTest, SendRecvTranslatePeerRank) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int value = 0;
+  EXPECT_EQ(
+      adapter.send(&value, sizeof(value), /*peer=*/2, /*tag=*/33).get(), 0);
+  EXPECT_EQ(underlying->sendCalls, 1);
+  EXPECT_EQ(underlying->lastSendPeer, 19);
+  EXPECT_EQ(underlying->lastSendTag, 33);
+
+  EXPECT_EQ(
+      adapter.recv(&value, sizeof(value), /*peer=*/3, /*tag=*/44).get(), 0);
+  EXPECT_EQ(underlying->recvCalls, 1);
+  EXPECT_EQ(underlying->lastRecvPeer, 3);
+  EXPECT_EQ(underlying->lastRecvTag, 44);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -14,10 +14,13 @@
 #include <utility>
 #include <vector>
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/common/bootstrap/tests/MockBootstrap.h"
 #include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
 #include "comms/testinfra/DistTestBase.h"
@@ -146,7 +149,60 @@ TEST_F(
   EXPECT_FALSE(MultimemNvlTransport::isEligible(2, localRank));
   EXPECT_EQ(
       MultimemNvlTransport::isEligible(3, localRank),
-      MultimemHandler::isMultimemSupported(localRank));
+      GpuMemHandler::isMultimemSupported(localRank));
+}
+
+TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
+  // No multimem-eligibility skip here: with enableMultimem=false this test
+  // exercises only the disabled-path API (hasMultimemNvlTransport() == false,
+  // getMultimemNvlTransportDevice() throws) and never touches the multimem
+  // setup, so it must run on non-NVLS hosts too (skipping would drop coverage).
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_lazy_test");
+
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      // Disable the tile P2P channels (a nonzero maxNumChannels requires
+      // pipelineDepth >= 1); this test checks only the disabled-path API.
+      .maxNumChannels = 0,
+      .enableMultimem = false,
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_NO_THROW(transport.exchange());
+  EXPECT_THROW(
+      static_cast<void>(transport.getMultimemNvlTransportDevice()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerLazilyInitializesMultimemTransport) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kBytesPerRank = 4096;
+  MultiPeerNvlTransportConfig config{
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      // This test exercises only the multimem path; disable the tile P2P
+      // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize =
+                  kBytesPerRank * static_cast<std::size_t>(numRanks),
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  EXPECT_TRUE(transport.hasMultimemNvlTransport());
+  ASSERT_NO_THROW(transport.exchange());
+  EXPECT_NO_THROW(transport.getMultimemNvlTransportDevice());
 }
 
 // getDeviceTransport() must refuse to vend a handle before exchange() has

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -2,6 +2,7 @@
 
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 
@@ -229,10 +230,13 @@ void MultiPeerNvlTransport::exchange() {
   if (channelStateHandler_) {
     channelStateHandler_->exchangeMemPtrs();
   }
-
   if (llBufferHandler_) {
     llBufferHandler_->exchangeMemPtrs();
   }
+
+  // Multimem NVL is intentionally not initialized here. Most collectives only
+  // need the peer-to-peer NVLink transport; multicast setup is deferred until
+  // getMultimemNvlTransportDevice() is called by a multimem collective.
 }
 
 P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
@@ -417,6 +421,97 @@ DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {
 
   return DeviceSpan<Transport>(
       static_cast<Transport*>(transportsDevice_->get()), nRanks_);
+}
+
+bool MultiPeerNvlTransport::hasMultimemNvlTransport() const {
+  if (!config_.enableMultimem ||
+      multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  int cudaDevice = 0;
+  CUDA_CHECK(cudaGetDevice(&cudaDevice));
+  return MultimemNvlTransport::isEligible(nRanks_, cudaDevice);
+}
+
+MultimemNvlTransportDevice
+MultiPeerNvlTransport::getMultimemNvlTransportDevice() const {
+  initializeMultimemNvlTransport();
+  return multimemNvlTransport_->getDeviceTransport();
+}
+
+void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
+  // Serialize concurrent same-rank callers so at most one thread drives the
+  // collective (eligibility allGather + MultimemNvlTransport::exchange). If
+  // two threads on this rank both raced past the null-check, each would
+  // enter its own collective while other ranks only participate once,
+  // deadlocking the bootstrap. Second+ arrivals block here, then see the
+  // cached transport (or the poison bit) via the fast paths below.
+  std::lock_guard<std::mutex> lock(multimemInitMutex_);
+
+  if (multimemNvlTransport_) {
+    return;
+  }
+  if (!config_.enableMultimem) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem NVL transport is not enabled "
+        "(config.enableMultimem is false)");
+  }
+  if (multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem NVL transport is not available: " +
+        multimemNvlErrorMessage_);
+  }
+
+  int cudaDevice = 0;
+  CUDA_CHECK(cudaGetDevice(&cudaDevice));
+  std::vector<int> multimemEligible(nRanks_, 0);
+  multimemEligible[myRank_] =
+      MultimemNvlTransport::isEligible(nRanks_, cudaDevice) ? 1 : 0;
+  auto eligibilityResult =
+      bootstrap_
+          ->allGather(multimemEligible.data(), sizeof(int), myRank_, nRanks_)
+          .get();
+  // Note: allGather-failure is intentionally NOT latched into
+  // multimemNvlUnavailable_. It can be transient (bootstrap glitch, peer
+  // slow-start) and the caller may legitimately want to retry -- the outer
+  // mutex serializes concurrent retries so cross-rank collectives stay
+  // aligned. Eligibility failure, in contrast, is terminal on this comm.
+  if (eligibilityResult != 0) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem eligibility allGather failed");
+  }
+  if (!std::all_of(
+          multimemEligible.begin(), multimemEligible.end(), [](int value) {
+            return value != 0;
+          })) {
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport is not eligible on all ranks";
+    multimemNvlUnavailable_.store(true, std::memory_order_release);
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
+  }
+
+  auto multimemNvlTransport = std::make_unique<MultimemNvlTransport>(
+      myRank_, nRanks_, bootstrap_, config_.multimem);
+  // Unlike the eligibility allGather above, exchange() is a cross-rank
+  // collective that can partially succeed on peers before it throws locally; a
+  // retry would re-enter a collective the other ranks have already moved past,
+  // risking desync/hang. So an exchange() failure is terminal: latch the poison
+  // bit before rethrowing so future callers fall back instead of retrying.
+  try {
+    multimemNvlTransport->exchange();
+  } catch (const std::exception& e) {
+    // Latch the poison bit BEFORE building the message: the string
+    // concatenation can throw (bad_alloc), and if the poison store were skipped
+    // a later caller would retry the already-partially-run collective and risk
+    // cross-rank desync.
+    multimemNvlUnavailable_.store(true, std::memory_order_release);
+    multimemNvlErrorMessage_ =
+        std::string("multimem NVL transport exchange failed: ") + e.what();
+    throw;
+  }
+  multimemNvlTransport_ = std::move(multimemNvlTransport);
 }
 
 void MultiPeerNvlTransport::initializeTransportsArray() {

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -2,13 +2,17 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/transport/Transport.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 #include "comms/prims/transport/self/P2pSelfTransportDevice.cuh"
 // On AMD, `meta::comms::DeviceBuffer` is provided by
@@ -81,6 +85,15 @@ struct MultiPeerNvlTransportConfig {
   // keeps the default behavior: fabric handles when available, cudaIpc
   // otherwise.
   std::optional<MemSharingMode> memSharingMode;
+
+  // NVLS multicast: when true, the transport composes an internal
+  // MultimemNvlTransport (from `multimem` below) and reports it via
+  // hasMultimemNvlTransport(). The actual multicast setup runs lazily on the
+  // first getMultimemNvlTransportDevice() call, and only when the device
+  // supports multimem and the NVL team has more than two ranks. `multimem` is
+  // ignored unless `enableMultimem` is true.
+  bool enableMultimem{false};
+  MultimemNvlTransportConfig multimem;
 };
 
 /**
@@ -228,6 +241,10 @@ class MultiPeerNvlTransport {
    *    preallocated device array (allocated in constructor)
    * 3. Implicit barrier ensures all ranks complete before returning
    *
+   * Optional multimem NVL setup is not performed here; it is a separate
+   * collective operation triggered by getMultimemNvlTransportDevice() so
+   * non-multimem collectives do not pay the multicast allocation cost.
+   *
    * The type of handle (fabric or cudaIpc) depends on the automatically
    * detected memory sharing mode.
    *
@@ -306,6 +323,21 @@ class MultiPeerNvlTransport {
    */
   DeviceSpan<Transport> getDeviceTransports();
 
+  // Cheap local check for whether multimem NVL was configured and appears
+  // usable on this rank. This does not perform the collective multimem setup;
+  // the first getMultimemNvlTransportDevice() call initializes it lazily.
+  bool hasMultimemNvlTransport() const;
+
+  /**
+   * getMultimemNvlTransportDevice - Get the lazily initialized NVLS device
+   * transport.
+   *
+   * PRECONDITION: All ranks that may use this multimem collective must call
+   * this method in the same order. The first call performs a collective
+   * eligibility check, multicast memory setup, and exchange.
+   */
+  MultimemNvlTransportDevice getMultimemNvlTransportDevice() const;
+
   /**
    * Check if fabric-based transport is supported (H100+, CUDA 12.3+).
    *
@@ -335,6 +367,10 @@ class MultiPeerNvlTransport {
   // Initialize transports array on device (both P2P and SELF transports)
   void initializeTransportsArray();
 
+  // Lazily construct and exchange the multimem NVL transport. This is a
+  // collective operation across the MultiPeerNvlTransport ranks.
+  void initializeMultimemNvlTransport() const;
+
   // ==========================================================================
   // Member variables
   // ==========================================================================
@@ -356,6 +392,27 @@ class MultiPeerNvlTransport {
       barrierBufferHandler_; // nullptr when p2pBarrierCount == 0
   std::unique_ptr<GpuMemHandler>
       llBufferHandler_; // nullptr when llBufferSize == 0
+  mutable std::unique_ptr<MultimemNvlTransport> multimemNvlTransport_;
+  // Latched to true when we know multimem NVL cannot succeed on this comm:
+  // eligibility failed on some rank, or the multicast handle exchange() failed.
+  // Terminal -- subsequent calls throw the cached reason from
+  // `multimemNvlErrorMessage_` without re-attempting the collective. The
+  // eligibility allGather returning non-zero is intentionally NOT latched (it
+  // can be transient and is retry-safe) so callers can retry.
+  // `std::atomic` because `hasMultimemNvlTransport()` reads it on the fast path
+  // without holding `multimemInitMutex_`, while the init path stores under it.
+  mutable std::atomic<bool> multimemNvlUnavailable_{false};
+  // Preserved reason for the terminal-failure throw so debuggers see the
+  // original cause (e.g. "not eligible on all ranks") on every subsequent
+  // call, not a generic "not available".
+  mutable std::string multimemNvlErrorMessage_;
+  // Guards `initializeMultimemNvlTransport()` against concurrent callers on
+  // the same rank: only one thread performs the eligibility allGather +
+  // multimem exchange; other concurrent threads block and use the cached
+  // result. Without this, two same-rank threads could each drive an
+  // allGather while other ranks only participate once, deadlocking the
+  // collective.
+  mutable std::mutex multimemInitMutex_;
 
   // External data buffer pointers (set via setExternalDataBuffers()).
   // When set, exchange() skips data buffer allocation/exchange.


### PR DESCRIPTION
Summary:

Add `allGatherNvlDomain` and `barrierNvlDomain` overrides to `NvlBootstrapAdapter` so an NVL-adapter that wraps another NVL-adapter (nested-domain forwarding) translates the caller-provided NVL-local rank map through its own local-to-comm mapping before delegating to the underlying bootstrap.

- Both new overrides apply `translateLocalRanks(nvlRankToCommRank)` -- a small helper that rewrites each entry via `localRankToCommRank_.at(...)` -- and forward the translated vector along with the caller's `(nvlLocalRank, nvlNranks)` to the underlying bootstrap.
- Without these overrides, calling `allGatherNvlDomain` / `barrierNvlDomain` on a nested adapter would leak the inner adapter's local-rank space out to the outer bootstrap, which interprets ranks in a different (outer) domain and either mis-routes or errors.
- Unit test `NvlBootstrapAdapterUnitTest` uses a `RecordingBootstrap` mock to lock down: (a) the translated rank map matches `localRankToCommRank_`-mapped values, (b) forwarded `(nvlLocalRank, nvlNranks)` are pass-through, (c) preexisting `allGather` / `barrier` / `send` / `recv` translation is unchanged.

Plumbing: BUCK adds a `cpp_unittest` target `nvl_bootstrap_adapter_unit_test` (CPU-only, no MPI, `network_access = network_access_utils.none()` -- the test is pure in-process against a mock so no Configerator / Manifold / HTTP / ODS access is needed). Sits alongside the existing GPU-distributed `nvl_bootstrap_adapter_test`.

Reviewed By: saifhhasan

Differential Revision: D110355090


