### PR TITLE
add ReduceScatter + AllGather traits to CollectiveTestSuite<Traits> (#3098)

### DIFF
--- a/comms/ctran/tests/AllGatherTestSuiteBase.h
+++ b/comms/ctran/tests/AllGatherTestSuiteBase.h
@@ -1,0 +1,94 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/AllGather/AllGatherImpl.h"
+#include "comms/ctran/tests/CollectiveTestSuite.h"
+
+// AllGather layout + verification traits for the generic CollectiveTestSuite
+// harness, plus the per-collective fixture-base alias leaves derive from. Each
+// AllGather algo leaf derives `AllGatherTestSuiteBase` and overrides the algo
+// dispatch hooks.
+struct AllGatherTraits {
+  using Algo = enum NCCL_ALLGATHER_ALGO;
+  static constexpr bool kHasOp = false;
+
+  static std::string algoName(Algo algo) {
+    return allGatherAlgoName(algo);
+  }
+
+  static bool support(CtranComm* comm, Algo algo) {
+    return ctranAllGatherSupport(comm, algo);
+  }
+
+  static BufferPlan plan(
+      size_t count,
+      int nranks,
+      int rank,
+      bool inPlace,
+      size_t offsetBytes,
+      size_t typeBytes) {
+    const size_t sendBytes = count * typeBytes;
+    const size_t recvBytes = sendBytes * static_cast<size_t>(nranks);
+    BufferPlan p;
+    p.recvAllocBytes = recvBytes + offsetBytes;
+    p.recvUserOffsetBytes = offsetBytes;
+    p.sendInitElems = count;
+    p.resultElems = count * static_cast<size_t>(nranks);
+    if (inPlace) {
+      p.sendAliasesRecv = true;
+      p.sendUserOffsetBytes =
+          offsetBytes + static_cast<size_t>(rank) * sendBytes;
+    } else {
+      p.sendAllocBytes = sendBytes + offsetBytes;
+      p.sendUserOffsetBytes = offsetBytes;
+    }
+    return p;
+  }
+
+  static void buildExpected(
+      void* expected,
+      commDataType_t datatype,
+      size_t count,
+      int nranks,
+      int /*rank*/,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitGatherExpectedTyped(
+            static_cast<float*>(expected), count, nranks, /*rep=*/0, stream);
+        return;
+      case commFloat16:
+        launchInitGatherExpectedTyped(
+            static_cast<__half*>(expected), count, nranks, /*rep=*/0, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static void checkResult(
+      const void* got,
+      const void* expected,
+      commDataType_t datatype,
+      size_t resultElems,
+      int /*nranks*/,
+      cudaStream_t stream,
+      size_t count,
+      int rank,
+      bool inPlace,
+      int repeat) {
+    // AG is a pure copy - checksum-based bitwise-equality suffices.
+    uint64_t actualChecksum = ctran::testsuite::computeRawBitsChecksumForType(
+        got, datatype, resultElems, stream);
+    uint64_t expectedChecksum = ctran::testsuite::computeRawBitsChecksumForType(
+        expected, datatype, resultElems, stream);
+    ASSERT_EQ(actualChecksum, expectedChecksum)
+        << "AG output checksum mismatch: sendcount=" << count
+        << " rank=" << rank << " datatype=" << commDataTypeToString(datatype)
+        << " inPlace=" << inPlace << " repeat=" << repeat;
+  }
+};
+
+using AllGatherTestSuiteBase = CollectiveTestSuite<AllGatherTraits>;

--- a/comms/ctran/tests/AllReduceTestSuiteBase.h
+++ b/comms/ctran/tests/AllReduceTestSuiteBase.h
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/AllReduce/AllReduceImpl.h"
+#include "comms/ctran/tests/CollectiveTestSuite.h"
+
+// AllReduce layout + verification traits for the generic CollectiveTestSuite
+// harness, plus the per-collective fixture-base alias leaves derive from. Each
+// AllReduce algo leaf (`AllReduce<Algo>TestSuite.cc`) derives
+// `AllReduceTestSuiteBase` and overrides the algo dispatch hooks.
+struct AllReduceTraits {
+  using Algo = enum NCCL_ALLREDUCE_ALGO;
+  static constexpr bool kHasOp = true;
+
+  static std::string algoName(Algo algo) {
+    return allReduceAlgoName(algo);
+  }
+
+  static bool support(CtranComm* comm, Algo algo) {
+    return ctranAllReduceSupport(comm, algo);
+  }
+
+  static BufferPlan plan(
+      size_t count,
+      int /*nranks*/,
+      int /*rank*/,
+      bool inPlace,
+      size_t offsetBytes,
+      size_t typeBytes) {
+    const size_t bytes = count * typeBytes;
+    BufferPlan p;
+    p.sendAllocBytes = bytes + offsetBytes;
+    p.sendUserOffsetBytes = offsetBytes;
+    p.sendInitElems = count;
+    p.resultElems = count;
+    if (inPlace) {
+      p.recvAliasesSend = true;
+      p.recvUserOffsetBytes = offsetBytes; // recv == send.
+    } else {
+      p.recvAllocBytes = bytes + offsetBytes;
+      p.recvUserOffsetBytes = offsetBytes;
+    }
+    return p;
+  }
+
+  static void buildExpected(
+      void* expected,
+      commDataType_t datatype,
+      size_t count,
+      int nranks,
+      int /*rank*/,
+      cudaStream_t stream) {
+    switch (datatype) {
+      case commFloat32:
+        launchInitExpectedKernel(
+            static_cast<float*>(expected), count, nranks, /*rep=*/0, stream);
+        return;
+      case commFloat16:
+        launchInitExpectedKernel(
+            static_cast<__half*>(expected), count, nranks, /*rep=*/0, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static void checkResult(
+      const void* got,
+      const void* expected,
+      commDataType_t datatype,
+      size_t resultElems,
+      int nranks,
+      cudaStream_t stream,
+      size_t count,
+      int rank,
+      bool inPlace,
+      int repeat) {
+    double maxDelta = ctran::testsuite::computeMaxDeltaForType(
+        got, expected, datatype, resultElems, stream);
+    double threshold = ctran::testsuite::thresholdForDatatype(datatype, nranks);
+    ASSERT_LT(maxDelta, threshold)
+        << "maxDelta=" << maxDelta << " threshold=" << threshold
+        << " count=" << count << " rank=" << rank
+        << " datatype=" << commDataTypeToString(datatype)
+        << " inPlace=" << inPlace << " repeat=" << repeat;
+  }
+};
+
+using AllReduceTestSuiteBase = CollectiveTestSuite<AllReduceTraits>;

--- a/comms/ctran/tests/AllReduceTreeTestSuite.cc
+++ b/comms/ctran/tests/AllReduceTreeTestSuite.cc
@@ -1,0 +1,67 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// AllReduce tree (ctree) correctness leaf on the shared
+// CollectiveTestSuite<AllReduceTraits> harness. All parameterization (the
+// consolidated size sweep, byte-offset sweep, 512 MiB large payload, and the
+// NCCL_CTRAN_MAX_NBLOCKS block-cap sweep) plus main() come from the shared
+// REGISTER_COLLECTIVE_TESTS / COLLECTIVE_TEST_MAIN macros in
+// CollectiveTestSuite.h; this leaf only binds the tree algo dispatch and its
+// topology-specific env.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <optional>
+
+#include "comms/ctran/tests/AllReduceTestSuiteBase.h"
+
+class AllReduceTreeTestSuite : public AllReduceTestSuiteBase {
+ protected:
+  commResult_t run(
+      enum NCCL_ALLREDUCE_ALGO algo,
+      const void* send,
+      void* recv,
+      size_t count,
+      commDataType_t datatype,
+      commRedOp_t op,
+      CtranComm* comm,
+      cudaStream_t stream,
+      std::optional<std::chrono::milliseconds> timeout) override {
+    (void)algo;
+    return ctranAllReduceTree(
+        send, recv, count, datatype, op, comm, stream, timeout);
+  }
+
+  bool algo_supports(commDataType_t /*dt*/, commRedOp_t op) const override {
+    return op == commSum;
+  }
+
+  ctran::CtranEnvs envOverrides() const override {
+    auto envs = AllReduceTestSuiteBase::envOverrides();
+    envs.emplace_back("NCCL_ALLREDUCE_ALGO", "ctree");
+    envs.emplace_back("NCCL_CTRAN_IBGDA_SENDRECV_ENABLE", "1");
+    envs.emplace_back("NCCL_CTRAN_IBGDA_DATA_BUFFER_SIZE", "33554432");
+    envs.emplace_back("NCCL_CTRAN_IB_MAX_GROUPS", "16");
+#if defined(CTRAN_ALLREDUCE_TEST_IB_ONLY)
+    envs.emplace_back("NCCL_COMM_STATE_DEBUG_TOPO", "nolocal");
+    envs.emplace_back("NCCL_IGNORE_TOPO_LOAD_FAILURE", "1");
+    envs.emplace_back("NCCL_P2P_DISABLE", "1");
+#endif
+    return envs;
+  }
+};
+
+#if defined(CTRAN_ALLREDUCE_TEST_NVL_ONLY) || \
+    defined(CTRAN_ALLREDUCE_TEST_IB_ONLY) ||  \
+    defined(CTRAN_ALLREDUCE_TEST_HYBRID)
+REGISTER_COLLECTIVE_TESTS(
+    AllReduceTreeTestSuite,
+    AllReduceTraits,
+    NCCL_ALLREDUCE_ALGO::ctree,
+    allReduceTreeDataTypes)
+#else
+#error "Define one CTRAN AllReduce topology: NVL_ONLY, IB_ONLY, or HYBRID"
+#endif
+
+COLLECTIVE_TEST_MAIN()

--- a/comms/ctran/tests/CollectiveTestSuite.h
+++ b/comms/ctran/tests/CollectiveTestSuite.h
@@ -1,0 +1,729 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cfloat>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "comms/ctran/Ctran.h"
+#include "comms/ctran/CtranComm.h"
+#include "comms/ctran/tests/CollectiveTestSuiteKernels.cuh"
+#include "comms/ctran/tests/CtranDistTestUtils.h"
+#include "comms/ctran/tests/CtranUtUtils.h"
+#include "comms/ctran/utils/Alloc.h"
+#include "comms/testinfra/TestUtils.h"
+#include "comms/testinfra/TestXPlatUtils.h"
+#include "comms/utils/commSpecs.h"
+#include "comms/utils/cvars/nccl_cvars.h"
+
+namespace ctran::testsuite {
+
+// Device-buffer RAII shared by the templated harness (user buffers, via
+// makeDeviceBuffer) and the compare/checksum helpers below (aligned scratch).
+// Free functions/type so both a class member and these non-members use one
+// buffer type. `commCuMemAlloc` backing (copy path); no nccl APIs.
+inline void* allocateDeviceBuffer(size_t bytes) {
+  void* ptr = nullptr;
+  COMMCHECK_TEST(
+      ctran::utils::commCuMemAlloc(
+          &ptr,
+          nullptr,
+          ctran::utils::getCuMemAllocHandleType(),
+          bytes,
+          nullptr,
+          "CollectiveTestSuite"));
+  return ptr;
+}
+
+inline void releaseDeviceBuffer(void* ptr) {
+  COMMCHECK_TEST(ctran::utils::commCuMemFree(ptr));
+}
+
+struct DeviceBufferDeleter {
+  void operator()(void* ptr) const {
+    if (ptr != nullptr) {
+      releaseDeviceBuffer(ptr);
+    }
+  }
+};
+using DeviceBuffer = std::unique_ptr<void, DeviceBufferDeleter>;
+
+// Host-side `commDataType_t` dispatch helpers shared by more than one Traits
+// struct (and, for the checksum, by the harness determinism check). They wrap
+// the algo-agnostic kernels in CollectiveTestSuiteKernels.cuh; they use gtest,
+// so they are defined here in the host-only header, not the nvcc-compiled
+// `.cuh`. Per-collective expected builders are folded into each Traits'
+// buildExpected().
+
+// Return whether `ptr` can be safely accessed as `datatype` elements.
+inline bool isAlignedForDatatype(const void* ptr, commDataType_t datatype) {
+  const auto alignment = commTypeSize(datatype);
+  return alignment != 0 && reinterpret_cast<uintptr_t>(ptr) % alignment == 0;
+}
+
+// max |actual - expected| over `count` elements, for floating-point dtypes.
+inline double computeMaxDeltaForType(
+    const void* actual,
+    const void* expected,
+    commDataType_t datatype,
+    size_t count,
+    cudaStream_t stream) {
+  if (!isAlignedForDatatype(actual, datatype)) {
+    // Unaligned inputs cannot use typed CUDA loads. Stage through an aligned
+    // scratch buffer, then compare. The recursive call syncs the stream before
+    // returning, so the RAII free on scope exit is ordered after the read.
+    const size_t bytes = count * commTypeSize(datatype);
+    DeviceBuffer alignedActual(allocateDeviceBuffer(bytes));
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        alignedActual.get(), actual, bytes, cudaMemcpyDeviceToDevice, stream));
+    return computeMaxDeltaForType(
+        alignedActual.get(), expected, datatype, count, stream);
+  }
+  switch (datatype) {
+    case commFloat32:
+      return computeMaxDelta(
+          static_cast<const float*>(actual),
+          static_cast<const float*>(expected),
+          count,
+          stream);
+    case commFloat16:
+      return computeMaxDelta(
+          static_cast<const __half*>(actual),
+          static_cast<const __half*>(expected),
+          count,
+          stream);
+    default:
+      ADD_FAILURE() << "computeMaxDeltaForType: unsupported datatype "
+                    << datatype;
+      return DBL_MAX;
+  }
+}
+
+// deterministic raw-bits digest over `count` elements.
+inline uint64_t computeRawBitsChecksumForType(
+    const void* data,
+    commDataType_t datatype,
+    size_t count,
+    cudaStream_t stream) {
+  if (!isAlignedForDatatype(data, datatype)) {
+    // Unaligned inputs cannot use typed CUDA loads. Stage through an aligned
+    // scratch buffer, then digest. The recursive call syncs the stream before
+    // returning, so the RAII free on scope exit is ordered after the read.
+    const size_t bytes = count * commTypeSize(datatype);
+    DeviceBuffer alignedData(allocateDeviceBuffer(bytes));
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        alignedData.get(), data, bytes, cudaMemcpyDeviceToDevice, stream));
+    return computeRawBitsChecksumForType(
+        alignedData.get(), datatype, count, stream);
+  }
+  switch (datatype) {
+    case commFloat32:
+      return computeRawBitsChecksum(
+          static_cast<const float*>(data), count, stream);
+    case commFloat16:
+      return computeRawBitsChecksum(
+          static_cast<const __half*>(data), count, stream);
+    default:
+      ADD_FAILURE() << "unsupported datatype " << datatype;
+      return 0;
+  }
+}
+
+// per-dtype absolute-error tolerance, scaled by nranks (floating-point only).
+inline double thresholdForDatatype(commDataType_t datatype, int nranks) {
+  const int rankScale = std::max(1, nranks - 1);
+  switch (datatype) {
+    case commFloat32:
+      return 1e-5 * rankScale;
+    case commFloat16:
+      // FP16 accumulation error grows with rank count, but keep the bound
+      // tight enough to catch small bit-corruption regressions.
+      return 1e-3 * rankScale;
+    default:
+      return 0.0;
+  }
+}
+
+} // namespace ctran::testsuite
+
+// Per-collective buffer layout for one correctness iteration. `plan()` on each
+// Traits struct derives every field from (count, nranks, rank, inPlace,
+// offsetBytes, typeBytes); the shared harness below consumes it verbatim.
+struct BufferPlan {
+  size_t sendAllocBytes{0};
+  size_t recvAllocBytes{0}; // 0 when in-place (recv aliases send).
+  size_t sendUserOffsetBytes{0};
+  size_t recvUserOffsetBytes{0};
+  bool recvAliasesSend{false};
+  bool sendAliasesRecv{false};
+  size_t sendInitElems{0};
+  size_t resultElems{0};
+};
+
+/**
+ * Traits-templated distributed CTRAN collective correctness fixture. One shared
+ * harness (buffer alloc, guard fill, determinism loop, guard-byte verify,
+ * GPE-leak verify) parameterized over a collective's layout + verification
+ * semantics via `Traits`. Leaf fixtures override the algo dispatch hooks and
+ * invoke REGISTER_COLLECTIVE_TESTS to emit their gtest suites.
+ */
+template <class Traits>
+class CollectiveTestSuite : public ctran::CtranDistTestFixture,
+                            public CtranBaseTest {
+ public:
+  using Algo = typename Traits::Algo;
+  using DeviceBuffer = ctran::testsuite::DeviceBuffer;
+
+  CollectiveTestSuite() = default;
+
+  /** Identical-input repeats used to check bitwise deterministic output. */
+  static constexpr int kDeterminismRepeats = 4;
+
+  void SetUp() override {
+    ctran::CtranDistTestFixture::SetUp(envOverrides());
+    ctranComm = makeCtranComm();
+  }
+
+  void TearDown() override {
+    ctran::CtranDistTestFixture::TearDown();
+    ncclCvarInit();
+  }
+
+  void runCorrectnessTest(
+      Algo algo,
+      commDataType_t datatype,
+      size_t count,
+      bool inPlace,
+      size_t bufferOffsetBytes = 0) {
+    if (!algo_supports(datatype, commSum)) {
+      GTEST_SKIP() << "algo " << Traits::algoName(algo)
+                   << " does not support datatype "
+                   << commDataTypeToString(datatype);
+    }
+    if (!Traits::support(ctranComm.get(), algo)) {
+      GTEST_SKIP() << "support returns false for algo "
+                   << Traits::algoName(algo);
+    }
+    if (count == 0) {
+      auto res =
+          run(algo,
+              nullptr,
+              nullptr,
+              0,
+              datatype,
+              commSum,
+              ctranComm.get(),
+              testStream,
+              std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+      return;
+    }
+
+    constexpr uint8_t kGuardPattern = 0xA5;
+    const size_t typeBytes = commTypeSize(datatype);
+    const BufferPlan p = Traits::plan(
+        count, numRanks, globalRank, inPlace, bufferOffsetBytes, typeBytes);
+
+    // Send-alloc buffer. When the recv buffer is the primary output (AG), the
+    // send buffer may instead alias into recv (in-place) - handled below.
+    DeviceBuffer sendAlloc = nullptr;
+    if (p.sendAllocBytes > 0) {
+      sendAlloc = makeDeviceBuffer(p.sendAllocBytes);
+      CUDACHECK_TEST(
+          cudaMemset(sendAlloc.get(), kGuardPattern, p.sendAllocBytes));
+    }
+    DeviceBuffer recvAlloc = nullptr;
+    if (p.recvAllocBytes > 0) {
+      recvAlloc = makeDeviceBuffer(p.recvAllocBytes);
+      CUDACHECK_TEST(
+          cudaMemset(recvAlloc.get(), kGuardPattern, p.recvAllocBytes));
+    }
+
+    // Resolve the primary (non-aliasing) allocation for each of send/recv, then
+    // derive user pointers. recvAliasesSend (RS/AR in-place) and
+    // sendAliasesRecv (AG in-place) fold one buffer onto the other. Offset only
+    // a non-null base: a zero-byte allocation returns nullptr, and
+    // `nullptr + offset` would be UB for a nonzero offset (a future traits with
+    // sendAllocBytes/recvAllocBytes == 0), so keep the null through.
+    auto userPtr = [](void* base, std::size_t offset) -> void* {
+      return base == nullptr ? nullptr : static_cast<char*>(base) + offset;
+    };
+    void* sendPtr = nullptr;
+    void* recvPtr = nullptr;
+    if (p.sendAliasesRecv) {
+      // AG in-place: recv is primary; send aliases into recv.
+      recvPtr = userPtr(recvAlloc.get(), p.recvUserOffsetBytes);
+      sendPtr = userPtr(recvAlloc.get(), p.sendUserOffsetBytes);
+    } else if (p.recvAliasesSend) {
+      // RS/AR in-place: send is primary; recv aliases into send.
+      sendPtr = userPtr(sendAlloc.get(), p.sendUserOffsetBytes);
+      recvPtr = userPtr(sendAlloc.get(), p.recvUserOffsetBytes);
+    } else {
+      // Out-of-place: independent send + recv allocations.
+      sendPtr = userPtr(sendAlloc.get(), p.sendUserOffsetBytes);
+      recvPtr = userPtr(recvAlloc.get(), p.recvUserOffsetBytes);
+    }
+
+    DeviceBuffer expectedBuf = makeDeviceBuffer(p.resultElems * typeBytes);
+    Traits::buildExpected(
+        expectedBuf.get(), datatype, count, numRanks, globalRank, testStream);
+
+    // Unaligned send pointers cannot be filled with typed CUDA stores; stage
+    // the init through an aligned scratch buffer. Aligned pointers (and empty
+    // send payloads, which init as a no-op) skip this.
+    DeviceBuffer sendStaging =
+        (p.sendInitElems == 0 ||
+         ctran::testsuite::isAlignedForDatatype(sendPtr, datatype))
+        ? nullptr
+        : makeDeviceBuffer(p.sendInitElems * typeBytes);
+
+    std::array<uint64_t, kDeterminismRepeats> checksums{};
+    for (int repeat = 0; repeat < kDeterminismRepeats; ++repeat) {
+      launchInitData(
+          sendPtr,
+          datatype,
+          p.sendInitElems,
+          globalRank,
+          /*rep=*/0,
+          testStream,
+          sendStaging.get());
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      commResult_t res =
+          run(algo,
+              sendPtr,
+              recvPtr,
+              count,
+              datatype,
+              commSum,
+              ctranComm.get(),
+              testStream,
+              std::nullopt);
+      EXPECT_EQ(res, commSuccess);
+      CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+
+      Traits::checkResult(
+          recvPtr,
+          expectedBuf.get(),
+          datatype,
+          p.resultElems,
+          numRanks,
+          testStream,
+          count,
+          globalRank,
+          inPlace,
+          repeat);
+
+      checksums[repeat] = ctran::testsuite::computeRawBitsChecksumForType(
+          recvPtr, datatype, p.resultElems, testStream);
+    }
+
+    CUDACHECK_TEST(cudaStreamSynchronize(testStream));
+    // Verify the guard region before AND after the user payload on each real
+    // allocation. The leading region is [0, userOffset); the trailing region is
+    // [userOffset + payloadBytes, allocBytes) - non-empty only if a plan()
+    // over-allocates a tail past the payload (none do today, but this keeps
+    // coverage complete if one ever does).
+    if (sendAlloc != nullptr) {
+      expectDeviceBytePattern(
+          sendAlloc.get(), p.sendUserOffsetBytes, kGuardPattern);
+      const size_t sendUsed =
+          p.sendUserOffsetBytes + p.sendInitElems * typeBytes;
+      if (p.sendAllocBytes > sendUsed) {
+        expectDeviceBytePattern(
+            static_cast<char*>(sendAlloc.get()) + sendUsed,
+            p.sendAllocBytes - sendUsed,
+            kGuardPattern);
+      }
+    }
+    if (recvAlloc != nullptr) {
+      expectDeviceBytePattern(
+          recvAlloc.get(), p.recvUserOffsetBytes, kGuardPattern);
+      const size_t recvUsed = p.recvUserOffsetBytes + p.resultElems * typeBytes;
+      if (p.recvAllocBytes > recvUsed) {
+        expectDeviceBytePattern(
+            static_cast<char*>(recvAlloc.get()) + recvUsed,
+            p.recvAllocBytes - recvUsed,
+            kGuardPattern);
+      }
+    }
+    for (int repeat = 1; repeat < kDeterminismRepeats; ++repeat) {
+      ASSERT_EQ(checksums[0], checksums[repeat])
+          << "non-deterministic output for count=" << count
+          << " rank=" << globalRank
+          << " datatype=" << commDataTypeToString(datatype)
+          << " inPlace=" << inPlace << " repeat=" << repeat;
+    }
+    verifyGpeLeak(ctranComm->ctran_.get());
+  }
+
+  void runCorrectnessSweep(
+      Algo algo,
+      commDataType_t datatype,
+      const std::vector<size_t>& counts,
+      bool inPlace,
+      size_t bufferOffsetBytes = 0) {
+    for (size_t count : counts) {
+      runCorrectnessTest(algo, datatype, count, inPlace, bufferOffsetBytes);
+    }
+  }
+
+ protected:
+  /** Dispatch one collective call for the algorithm under test. AG leaves
+   * ignore the op arg. */
+  virtual commResult_t run(
+      Algo algo,
+      const void* send,
+      void* recv,
+      size_t count,
+      commDataType_t datatype,
+      commRedOp_t op,
+      CtranComm* comm,
+      cudaStream_t stream,
+      std::optional<std::chrono::milliseconds> timeout) = 0;
+
+  virtual bool algo_supports(commDataType_t /*dt*/, commRedOp_t /*op*/) const {
+    return true;
+  }
+
+  virtual ctran::CtranEnvs envOverrides() const {
+    ctran::CtranEnvs envs{
+        {"NCCL_CTRAN_USE_PIPES", "1"},
+        // Keep setup cost bounded across the parameterized sweep.
+        {"NCCL_CTRAN_MAX_NBLOCKS", "8"},
+    };
+#ifdef CTRAN_TEST_SOCKET_ONLY_BACKEND
+    envs.emplace_back("NCCL_CTRAN_BACKENDS", "socket, nvl");
+#endif
+    return envs;
+  }
+
+  // User buffer, `commCuMemAlloc`-backed (copy path). Wraps the free
+  // ctran::testsuite::allocateDeviceBuffer in the shared DeviceBuffer RAII.
+  static DeviceBuffer makeDeviceBuffer(size_t bytes) {
+    return DeviceBuffer(ctran::testsuite::allocateDeviceBuffer(bytes));
+  }
+
+  // Initialize an aligned `datatype` buffer directly through typed CUDA stores.
+  static void launchInitDataAligned(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int rank,
+      int rep,
+      cudaStream_t stream) {
+    ASSERT_TRUE(ctran::testsuite::isAlignedForDatatype(buf, datatype));
+    switch (datatype) {
+      case commFloat32:
+        launchInitDataKernel(
+            static_cast<float*>(buf), count, rank, rep, stream);
+        return;
+      case commFloat16:
+        launchInitDataKernel(
+            static_cast<__half*>(buf), count, rank, rep, stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  // Initialize a possibly unaligned buffer with deterministic test data.
+  //
+  // Unaligned offset tests cannot use typed CUDA stores for setup. Stage
+  // through an aligned scratch buffer so only the collective call receives the
+  // unaligned payload pointer.
+  static void launchInitData(
+      void* buf,
+      commDataType_t datatype,
+      size_t count,
+      int rank,
+      int rep,
+      cudaStream_t stream,
+      void* alignedScratch = nullptr) {
+    if (count == 0) {
+      return;
+    }
+    if (ctran::testsuite::isAlignedForDatatype(buf, datatype)) {
+      launchInitDataAligned(buf, datatype, count, rank, rep, stream);
+      return;
+    }
+    ASSERT_NE(alignedScratch, nullptr);
+    const size_t bytes = count * commTypeSize(datatype);
+    launchInitDataAligned(alignedScratch, datatype, count, rank, rep, stream);
+    CUDACHECK_TEST(cudaMemcpyAsync(
+        buf, alignedScratch, bytes, cudaMemcpyDeviceToDevice, stream));
+  }
+
+  // ASSERT that `bytes` bytes at `ptr` all equal `expected` (guard-byte check).
+  static void
+  expectDeviceBytePattern(const void* ptr, size_t bytes, uint8_t expected) {
+    if (bytes == 0) {
+      return;
+    }
+    std::vector<uint8_t> host(bytes);
+    CUDACHECK_TEST(cudaMemcpy(host.data(), ptr, bytes, cudaMemcpyDeviceToHost));
+    for (size_t i = 0; i < bytes; ++i) {
+      ASSERT_EQ(host[i], expected) << "guard byte mismatch at offset " << i;
+    }
+  }
+
+  cudaStream_t testStream{0};
+  std::unique_ptr<CtranComm> ctranComm{nullptr};
+};
+
+// -----------------------------------------------------------------------------
+// Shared sweep builders + helpers used by REGISTER_COLLECTIVE_TESTS. These are
+// generic across every collective; a leaf only supplies its Traits, algo value,
+// and dtype list. The consolidated size sweep folds in the former mixed-order
+// sequence, the full correctness sweep, the 100B offset payload, and (at
+// offset 0) a 512 MiB large payload.
+// -----------------------------------------------------------------------------
+inline void collectiveAppendUniqueCount(
+    std::vector<size_t>& counts,
+    size_t count) {
+  if (std::find(counts.begin(), counts.end(), count) == counts.end()) {
+    counts.push_back(count);
+  }
+}
+
+inline std::vector<size_t> makeCollectiveElementCounts(
+    commDataType_t datatype,
+    bool includeZeroCount,
+    bool includeLargePayload) {
+  std::vector<size_t> counts;
+  const size_t elemBytes = commTypeSize(datatype);
+  for (size_t count : {
+           // Preserve the previous mixed-order sequence first.
+           size_t{1},
+           size_t{1048576 + 7},
+           size_t{7},
+           size_t{65536},
+           size_t{16},
+           size_t{1048576 - 7},
+           // Complete the previous correctness sweep.
+           size_t{0},
+           size_t{64},
+           size_t{256},
+           size_t{1024},
+           size_t{4096},
+           size_t{16384},
+           size_t{262144},
+           size_t{1048576},
+           size_t{4194304},
+           size_t{4194304 - 13},
+           size_t{4194304 + 13},
+       }) {
+    if (count == 0 && !includeZeroCount) {
+      continue;
+    }
+    collectiveAppendUniqueCount(counts, count);
+  }
+  // Preserve the previous 100-byte offset-test payload.
+  collectiveAppendUniqueCount(counts, 100 / elemBytes);
+  if (includeLargePayload) {
+    collectiveAppendUniqueCount(counts, (512 * 1024 * 1024) / elemBytes);
+  }
+  return counts;
+}
+
+// Byte offsets that exercise unaligned user-buffer starts: 0, one element, and
+// 15 bytes when that is a whole number of elements for this dtype.
+inline std::vector<size_t> collectiveBufferOffsetBytes(
+    commDataType_t datatype) {
+  constexpr size_t kByteOffsetCoverageBytes = 15;
+  const size_t elemBytes = commTypeSize(datatype);
+  std::vector<size_t> offsets;
+  auto appendUnique = [&](size_t offset) {
+    if (std::find(offsets.begin(), offsets.end(), offset) == offsets.end()) {
+      offsets.push_back(offset);
+    }
+  };
+  appendUnique(0);
+  appendUnique(elemBytes);
+  if (kByteOffsetCoverageBytes % elemBytes == 0) {
+    appendUnique(kByteOffsetCoverageBytes);
+  }
+  return offsets;
+}
+
+// NCCL_CTRAN_MAX_NBLOCKS caps swept for block-cap correctness coverage. The
+// block cap is a shared cnvlmm knob, so every collective gets this coverage.
+inline const std::vector<int>& collectiveMaxBlockCaps() {
+  static const std::vector<int> caps{1, 2, 3, 4, 5, 6, 7, 8};
+  return caps;
+}
+
+// Set (or replace) an env override in place.
+inline void collectiveSetEnvOverride(
+    ctran::CtranEnvs& envs,
+    const std::string& key,
+    const std::string& value) {
+  for (auto& env : envs) {
+    if (env.first == key) {
+      env.second = value;
+      return;
+    }
+  }
+  envs.emplace_back(key, value);
+}
+
+inline std::string collectiveDataTypeName(commDataType_t datatype) {
+  switch (datatype) {
+    case commFloat32:
+      return "FP32";
+    case commFloat16:
+      return "FP16";
+    default:
+      return "UnsupportedType";
+  }
+}
+
+// dtype lists reused by leaf fixtures.
+// cnvlmmDataTypes() is consumed by the RS/AG/AR cnvlmm leaf fixtures added
+// later in this stack (first use in D110902873); defined here so the shared
+// list lives with the harness rather than being duplicated per leaf.
+inline const std::vector<commDataType_t>& cnvlmmDataTypes() {
+  static const std::vector<commDataType_t> datatypes{commFloat32, commFloat16};
+  return datatypes;
+}
+
+inline const std::vector<commDataType_t>& allReduceTreeDataTypes() {
+  static const std::vector<commDataType_t> datatypes{commFloat32, commFloat16};
+  return datatypes;
+}
+
+// One (algo, datatype, inPlace, block-cap) point for the block-cap sweep.
+template <class Algo>
+struct CollectiveBlockCapParam {
+  Algo algo;
+  commDataType_t datatype;
+  bool inPlace;
+  int maxBlockCap;
+};
+
+template <class Algo>
+std::vector<CollectiveBlockCapParam<Algo>> makeCollectiveBlockCapParams(
+    Algo algo,
+    const std::vector<commDataType_t>& datatypes) {
+  std::vector<CollectiveBlockCapParam<Algo>> params;
+  for (commDataType_t datatype : datatypes) {
+    for (int maxBlockCap : collectiveMaxBlockCaps()) {
+      params.push_back(
+          CollectiveBlockCapParam<Algo>{
+              algo, datatype, /*inPlace=*/false, maxBlockCap});
+      params.push_back(
+          CollectiveBlockCapParam<Algo>{
+              algo, datatype, /*inPlace=*/true, maxBlockCap});
+    }
+  }
+  return params;
+}
+
+template <class Traits>
+std::string collectiveSweepTestName(
+    const testing::TestParamInfo<
+        std::tuple<typename Traits::Algo, commDataType_t, bool>>& info) {
+  auto [algo, datatype, inPlace] = info.param;
+  return Traits::algoName(algo) + "_" + collectiveDataTypeName(datatype) +
+      "_Sweep_" + (inPlace ? "InPlace" : "OutOfPlace");
+}
+
+template <class Traits>
+std::string collectiveBlockCapTestName(
+    const testing::TestParamInfo<
+        CollectiveBlockCapParam<typename Traits::Algo>>& info) {
+  const auto& param = info.param;
+  return Traits::algoName(param.algo) + "_" +
+      collectiveDataTypeName(param.datatype) + "_Sweep_" +
+      (param.inPlace ? "InPlace" : "OutOfPlace") + "_MaxBlocks" +
+      std::to_string(param.maxBlockCap);
+}
+
+// Emit the consolidated correctness sweep + block-cap sweep suites bound to a
+// concrete `Fixture` (must derive CollectiveTestSuite<Traits>). `AlgoEnum` is
+// the single algo value under test; `DataTypesFn` supplies the dtype list. Each
+// correctness case sweeps every buffer offset x element count internally; each
+// block-cap case pins NCCL_CTRAN_MAX_NBLOCKS and sweeps element counts.
+#define REGISTER_COLLECTIVE_TESTS(Fixture, TraitsType, AlgoEnum, DataTypesFn) \
+  using Fixture##SweepParam =                                                 \
+      std::tuple<TraitsType::Algo, commDataType_t, bool>;                     \
+  using Fixture##BlockCapParam = CollectiveBlockCapParam<TraitsType::Algo>;   \
+  class Fixture##CorrectnessTest                                              \
+      : public Fixture,                                                       \
+        public ::testing::WithParamInterface<Fixture##SweepParam> {};         \
+  class Fixture##BlockCapCorrectnessTest                                      \
+      : public Fixture,                                                       \
+        public ::testing::WithParamInterface<Fixture##BlockCapParam> {        \
+   protected:                                                                 \
+    ctran::CtranEnvs envOverrides() const override {                          \
+      auto envs = Fixture::envOverrides();                                    \
+      collectiveSetEnvOverride(                                               \
+          envs,                                                               \
+          "NCCL_CTRAN_MAX_NBLOCKS",                                           \
+          std::to_string(this->GetParam().maxBlockCap));                      \
+      return envs;                                                            \
+    }                                                                         \
+  };                                                                          \
+  TEST_P(Fixture##CorrectnessTest, Correctness) {                             \
+    auto [algo, datatype, inPlace] = GetParam();                              \
+    for (size_t offsetBytes : collectiveBufferOffsetBytes(datatype)) {        \
+      runCorrectnessSweep(                                                    \
+          algo,                                                               \
+          datatype,                                                           \
+          makeCollectiveElementCounts(                                        \
+              datatype,                                                       \
+              /*includeZeroCount=*/offsetBytes == 0,                          \
+              /*includeLargePayload=*/offsetBytes == 0),                      \
+          inPlace,                                                            \
+          offsetBytes);                                                       \
+    }                                                                         \
+  }                                                                           \
+  TEST_P(Fixture##BlockCapCorrectnessTest, Correctness) {                     \
+    const auto& param = GetParam();                                           \
+    runCorrectnessSweep(                                                      \
+        param.algo,                                                           \
+        param.datatype,                                                       \
+        makeCollectiveElementCounts(                                          \
+            param.datatype,                                                   \
+            /*includeZeroCount=*/true,                                        \
+            /*includeLargePayload=*/true),                                    \
+        param.inPlace);                                                       \
+  }                                                                           \
+  INSTANTIATE_TEST_SUITE_P(                                                   \
+      Fixture,                                                                \
+      Fixture##CorrectnessTest,                                               \
+      ::testing::Combine(                                                     \
+          ::testing::Values(AlgoEnum),                                        \
+          ::testing::ValuesIn(DataTypesFn()),                                 \
+          ::testing::Bool()),                                                 \
+      collectiveSweepTestName<TraitsType>);                                   \
+  INSTANTIATE_TEST_SUITE_P(                                                   \
+      Fixture,                                                                \
+      Fixture##BlockCapCorrectnessTest,                                       \
+      ::testing::ValuesIn(                                                    \
+          makeCollectiveBlockCapParams(AlgoEnum, DataTypesFn())),             \
+      collectiveBlockCapTestName<TraitsType>);
+
+// Standard distributed test main() shared by every collective leaf. folly::Init
+// is required for now so the cnvlmm/prims singletons initialize; it will be
+// dropped when the folly dependency is removed.
+#define COLLECTIVE_TEST_MAIN()                                            \
+  int main(int argc, char* argv[]) {                                      \
+    ::testing::InitGoogleTest(&argc, argv);                               \
+    ::testing::AddGlobalTestEnvironment(new ctran::CtranDistEnvironment); \
+    folly::Init init(&argc, &argv);                                       \
+    return RUN_ALL_TESTS();                                               \
+  }

--- a/comms/ctran/tests/CollectiveTestSuiteKernels.cu
+++ b/comms/ctran/tests/CollectiveTestSuiteKernels.cu
@@ -1,0 +1,323 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "comms/ctran/tests/CollectiveTestSuiteKernels.cuh"
+
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+namespace {
+
+void checkCuda(
+    cudaError_t result,
+    const char* expr,
+    const char* file,
+    int line) {
+  if (result != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "Failed: Cuda error %s:%d '%s' while running %s\n",
+        file,
+        line,
+        cudaGetErrorString(result),
+        expr);
+    std::abort();
+  }
+}
+
+#define COLLECTIVE_TEST_SUITE_CUDA_CHECK(cmd) \
+  checkCuda((cmd), #cmd, __FILE__, __LINE__)
+
+struct CudaFreeDeleter {
+  void operator()(void* ptr) const {
+    if (ptr != nullptr) {
+      COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaFree(ptr));
+    }
+  }
+};
+
+template <typename T>
+std::unique_ptr<T, CudaFreeDeleter> makeDeviceScratch(size_t count) {
+  T* ptr = nullptr;
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaMalloc(&ptr, count * sizeof(T)));
+  return std::unique_ptr<T, CudaFreeDeleter>(ptr);
+}
+
+} // namespace
+
+template <typename T>
+struct TestValueOps;
+
+template <>
+struct TestValueOps<float> {
+  using Word = uint32_t;
+  __device__ __forceinline__ static float fromFloat(float value) {
+    return value;
+  }
+  __device__ __forceinline__ static double toDouble(float value) {
+    return static_cast<double>(value);
+  }
+};
+
+template <>
+struct TestValueOps<__half> {
+  using Word = uint16_t;
+  __device__ __forceinline__ static __half fromFloat(float value) {
+    return __float2half(value);
+  }
+  __device__ __forceinline__ static double toDouble(__half value) {
+    return static_cast<double>(__half2float(value));
+  }
+};
+
+// Per-element value: 1.0f / (1.0f + (rep + rank + i) % 256)
+// This produces different values per element and per rank.
+__device__ static float elementValue(int rank, int rep, size_t i) {
+  return 1.0f / (1.0f + static_cast<float>((rep + rank + i) % 256));
+}
+
+template <typename T>
+__global__ void initDataKernel(T* buf, size_t count, int rank, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    buf[idx] = TestValueOps<T>::fromFloat(elementValue(rank, rep, idx));
+  }
+}
+
+template <typename T>
+__global__ void initExpectedKernel(T* buf, size_t count, int nranks, int rep) {
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < count) {
+    float sum = 0.0f;
+    for (int r = 0; r < nranks; r++) {
+      sum += elementValue(r, rep, idx);
+    }
+    buf[idx] = TestValueOps<T>::fromFloat(sum);
+  }
+}
+
+// Each block computes the max abs delta over its assigned elements, then
+// writes the per-block maximum into blockMaxes[blockIdx.x].
+template <typename T>
+__global__ void deltaKernel(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    double* blockMaxes) {
+  extern __shared__ double sdata[];
+
+  size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  double localMax = 0.0;
+  if (idx < count) {
+    localMax = fabs(
+        TestValueOps<T>::toDouble(actual[idx]) -
+        TestValueOps<T>::toDouble(expected[idx]));
+  }
+
+  sdata[threadIdx.x] = localMax;
+  __syncthreads();
+
+  for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (threadIdx.x < s) {
+      sdata[threadIdx.x] = fmax(sdata[threadIdx.x], sdata[threadIdx.x + s]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    blockMaxes[blockIdx.x] = sdata[0];
+  }
+}
+
+__device__ __forceinline__ uint64_t mixChecksum(uint64_t acc, uint64_t value) {
+  acc ^= value + 0x9e3779b97f4a7c15ULL + (acc << 6) + (acc >> 2);
+  return acc * 0x100000001b3ULL;
+}
+
+template <typename T>
+__global__ void
+rawBitsChecksumKernel(const T* data, size_t count, uint64_t* result) {
+  constexpr int kBlockSize = 256;
+  __shared__ uint64_t partials[kBlockSize];
+
+  using Word = typename TestValueOps<T>::Word;
+  const Word* words = reinterpret_cast<const Word*>(data);
+  uint64_t local = 0xcbf29ce484222325ULL ^
+      (static_cast<uint64_t>(threadIdx.x) << 32) ^ count ^
+      (static_cast<uint64_t>(sizeof(T)) << 56);
+  for (size_t i = threadIdx.x; i < count; i += blockDim.x) {
+    const uint64_t taggedValue =
+        (static_cast<uint64_t>(words[i]) << 32) ^ static_cast<uint64_t>(i);
+    local = mixChecksum(local, taggedValue);
+  }
+
+  partials[threadIdx.x] = local;
+  __syncthreads();
+
+  for (int stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      partials[threadIdx.x] =
+          mixChecksum(partials[threadIdx.x], partials[threadIdx.x + stride]);
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    *result = partials[0];
+  }
+}
+
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initDataKernel<<<numBlocks, kBlockSize, 0, stream>>>(buf, count, rank, rep);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+  initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, count, nranks, rep);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+template <typename T>
+double computeMaxDeltaTyped(
+    const T* actual,
+    const T* expected,
+    size_t count,
+    cudaStream_t stream) {
+  if (count == 0) {
+    return 0.0;
+  }
+
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
+
+  auto dBlockMaxes = makeDeviceScratch<double>(numBlocks);
+
+  size_t sharedBytes = kBlockSize * sizeof(double);
+  deltaKernel<<<numBlocks, kBlockSize, sharedBytes, stream>>>(
+      actual, expected, count, dBlockMaxes.get());
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+
+  std::vector<double> hBlockMaxes(numBlocks);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaMemcpyAsync(
+      hBlockMaxes.data(),
+      dBlockMaxes.get(),
+      numBlocks * sizeof(double),
+      cudaMemcpyDeviceToHost,
+      stream));
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  double maxDelta = 0.0;
+  for (int i = 0; i < numBlocks; i++) {
+    maxDelta = std::fmax(maxDelta, hBlockMaxes[i]);
+  }
+
+  return maxDelta;
+}
+
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream) {
+  return computeMaxDeltaTyped(actual, expected, count, stream);
+}
+
+template <typename T>
+uint64_t
+computeRawBitsChecksumTyped(const T* data, size_t count, cudaStream_t stream) {
+  if (count == 0) {
+    return 0;
+  }
+
+  auto dChecksum = makeDeviceScratch<uint64_t>(1);
+
+  constexpr int kBlockSize = 256;
+  rawBitsChecksumKernel<<<1, kBlockSize, 0, stream>>>(
+      data, count, dChecksum.get());
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+
+  uint64_t hChecksum = 0;
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaMemcpyAsync(
+      &hChecksum,
+      dChecksum.get(),
+      sizeof(uint64_t),
+      cudaMemcpyDeviceToHost,
+      stream));
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+  return hChecksum;
+}
+
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}
+
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream) {
+  return computeRawBitsChecksumTyped(data, count, stream);
+}

--- a/comms/ctran/tests/CollectiveTestSuiteKernels.cu
+++ b/comms/ctran/tests/CollectiveTestSuiteKernels.cu
@@ -100,6 +100,23 @@ __global__ void initExpectedKernel(T* buf, size_t count, int nranks, int rep) {
   }
 }
 
+template <typename T>
+__global__ void initScatterExpectedKernel(
+    T* buf,
+    size_t recvcount,
+    int nranks,
+    int rep,
+    size_t baseIdx) {
+  size_t i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i < recvcount) {
+    float sum = 0.0f;
+    for (int r = 0; r < nranks; ++r) {
+      sum += elementValue(r, rep, baseIdx + i);
+    }
+    buf[i] = TestValueOps<T>::fromFloat(sum);
+  }
+}
+
 // Each block computes the max abs delta over its assigned elements, then
 // writes the per-block maximum into blockMaxes[blockIdx.x].
 template <typename T>
@@ -230,6 +247,40 @@ void launchInitExpectedKernel(
   int numBlocks = static_cast<int>((count + kBlockSize - 1) / kBlockSize);
   initExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
       buf, count, nranks, rep);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitScatterExpectedKernel(
+    float* buf,
+    size_t recvcount,
+    int nranks,
+    int rep,
+    size_t baseIdx,
+    cudaStream_t stream) {
+  if (recvcount == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((recvcount + kBlockSize - 1) / kBlockSize);
+  initScatterExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, recvcount, nranks, rep, baseIdx);
+  COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
+}
+
+void launchInitScatterExpectedKernel(
+    __half* buf,
+    size_t recvcount,
+    int nranks,
+    int rep,
+    size_t baseIdx,
+    cudaStream_t stream) {
+  if (recvcount == 0) {
+    return;
+  }
+  constexpr int kBlockSize = 256;
+  int numBlocks = static_cast<int>((recvcount + kBlockSize - 1) / kBlockSize);
+  initScatterExpectedKernel<<<numBlocks, kBlockSize, 0, stream>>>(
+      buf, recvcount, nranks, rep, baseIdx);
   COLLECTIVE_TEST_SUITE_CUDA_CHECK(cudaPeekAtLastError());
 }
 

--- a/comms/ctran/tests/CollectiveTestSuiteKernels.cuh
+++ b/comms/ctran/tests/CollectiveTestSuiteKernels.cuh
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+#include <cstdint>
+
+#include "comms/utils/commSpecs.h"
+
+// Shared algo-agnostic per-element kernels for the collective TestSuite family:
+// deterministic initData, AR(sum) initExpected, float/int max-delta, and a
+// raw-bits checksum. Collective-specific expected builders (e.g. AG gather / RS
+// scatter shards) live with their collective's traits, not here.
+
+// -----------------------------------------------------------------------------
+// initData: each element = deterministic per-(rank, rep, idx) value.
+// -----------------------------------------------------------------------------
+void launchInitDataKernel(
+    float* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+void launchInitDataKernel(
+    __half* buf,
+    size_t count,
+    int rank,
+    int rep,
+    cudaStream_t stream);
+
+// -----------------------------------------------------------------------------
+// initExpected: expected[i] = sum over all ranks of initData(rank, rep, i).
+// This is the AR(sum) expected buffer.
+// -----------------------------------------------------------------------------
+void launchInitExpectedKernel(
+    float* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+void launchInitExpectedKernel(
+    __half* buf,
+    size_t count,
+    int nranks,
+    int rep,
+    cudaStream_t stream);
+
+// -----------------------------------------------------------------------------
+// delta: max |actual[i] - expected[i]|. Synchronous.
+// -----------------------------------------------------------------------------
+double computeMaxDelta(
+    const float* actual,
+    const float* expected,
+    size_t count,
+    cudaStream_t stream);
+double computeMaxDelta(
+    const __half* actual,
+    const __half* expected,
+    size_t count,
+    cudaStream_t stream);
+
+// -----------------------------------------------------------------------------
+// raw-bits checksum: deterministic per-buffer digest for determinism checks.
+// -----------------------------------------------------------------------------
+uint64_t
+computeRawBitsChecksum(const float* data, size_t count, cudaStream_t stream);
+uint64_t
+computeRawBitsChecksum(const __half* data, size_t count, cudaStream_t stream);

--- a/comms/ctran/tests/CollectiveTestSuiteKernels.cuh
+++ b/comms/ctran/tests/CollectiveTestSuiteKernels.cuh
@@ -48,6 +48,44 @@ void launchInitExpectedKernel(
     cudaStream_t stream);
 
 // -----------------------------------------------------------------------------
+// initScatterExpected (ReduceScatter): expected[i] = sum over all ranks of
+// initData(rank, rep, baseIdx + i). Each rank's expected recv buffer is the
+// reduction shard starting at baseIdx = myRank * recvcount.
+// -----------------------------------------------------------------------------
+void launchInitScatterExpectedKernel(
+    float* buf,
+    size_t recvcount,
+    int nranks,
+    int rep,
+    size_t baseIdx,
+    cudaStream_t stream);
+void launchInitScatterExpectedKernel(
+    __half* buf,
+    size_t recvcount,
+    int nranks,
+    int rep,
+    size_t baseIdx,
+    cudaStream_t stream);
+
+// -----------------------------------------------------------------------------
+// initGatherExpected (AllGather): expected[r*sendcount + i] = initData(r, rep,
+// i) for every r in [0, nranks). Pure host composition of launchInitDataKernel
+// over each rank's shard.
+// -----------------------------------------------------------------------------
+template <typename T>
+inline void launchInitGatherExpectedTyped(
+    T* dst,
+    size_t sendcount,
+    int nranks,
+    int rep,
+    cudaStream_t stream) {
+  for (int r = 0; r < nranks; ++r) {
+    launchInitDataKernel(
+        dst + static_cast<size_t>(r) * sendcount, sendcount, r, rep, stream);
+  }
+}
+
+// -----------------------------------------------------------------------------
 // delta: max |actual[i] - expected[i]|. Synchronous.
 // -----------------------------------------------------------------------------
 double computeMaxDelta(

--- a/comms/ctran/tests/ReduceScatterTestSuiteBase.h
+++ b/comms/ctran/tests/ReduceScatterTestSuiteBase.h
@@ -1,0 +1,104 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "comms/ctran/algos/ReduceScatter/ReduceScatterImpl.h"
+#include "comms/ctran/tests/CollectiveTestSuite.h"
+
+// ReduceScatter layout + verification traits for the generic
+// CollectiveTestSuite harness, plus the per-collective fixture-base alias
+// leaves derive from. Each ReduceScatter algo leaf derives
+// `ReduceScatterTestSuiteBase` and overrides the algo dispatch hooks.
+struct ReduceScatterTraits {
+  using Algo = enum NCCL_REDUCESCATTER_ALGO;
+  static constexpr bool kHasOp = true;
+
+  static std::string algoName(Algo algo) {
+    return reduceScatterAlgoName(algo);
+  }
+
+  static bool support(CtranComm* comm, Algo algo) {
+    return ctranReduceScatterSupport(comm, algo);
+  }
+
+  static BufferPlan plan(
+      size_t count,
+      int nranks,
+      int rank,
+      bool inPlace,
+      size_t offsetBytes,
+      size_t typeBytes) {
+    const size_t recvBytes = count * typeBytes;
+    const size_t sendBytes = recvBytes * static_cast<size_t>(nranks);
+    BufferPlan p;
+    p.sendAllocBytes = sendBytes + offsetBytes;
+    p.sendUserOffsetBytes = offsetBytes;
+    p.sendInitElems = count * static_cast<size_t>(nranks);
+    p.resultElems = count;
+    if (inPlace) {
+      p.recvAliasesSend = true;
+      p.recvUserOffsetBytes =
+          offsetBytes + static_cast<size_t>(rank) * recvBytes;
+    } else {
+      p.recvAllocBytes = recvBytes + offsetBytes;
+      p.recvUserOffsetBytes = offsetBytes;
+    }
+    return p;
+  }
+
+  static void buildExpected(
+      void* expected,
+      commDataType_t datatype,
+      size_t count,
+      int nranks,
+      int rank,
+      cudaStream_t stream) {
+    const size_t baseIdx = static_cast<size_t>(rank) * count;
+    switch (datatype) {
+      case commFloat32:
+        launchInitScatterExpectedKernel(
+            static_cast<float*>(expected),
+            count,
+            nranks,
+            /*rep=*/0,
+            baseIdx,
+            stream);
+        return;
+      case commFloat16:
+        launchInitScatterExpectedKernel(
+            static_cast<__half*>(expected),
+            count,
+            nranks,
+            /*rep=*/0,
+            baseIdx,
+            stream);
+        return;
+      default:
+        ADD_FAILURE() << "unsupported datatype " << datatype;
+        return;
+    }
+  }
+
+  static void checkResult(
+      const void* got,
+      const void* expected,
+      commDataType_t datatype,
+      size_t resultElems,
+      int nranks,
+      cudaStream_t stream,
+      size_t count,
+      int rank,
+      bool inPlace,
+      int repeat) {
+    double maxDelta = ctran::testsuite::computeMaxDeltaForType(
+        got, expected, datatype, resultElems, stream);
+    double threshold = ctran::testsuite::thresholdForDatatype(datatype, nranks);
+    ASSERT_LT(maxDelta, threshold)
+        << "RS maxDelta=" << maxDelta << " threshold=" << threshold
+        << " recvcount=" << count << " rank=" << rank
+        << " datatype=" << commDataTypeToString(datatype)
+        << " inPlace=" << inPlace << " repeat=" << repeat;
+  }
+};
+
+using ReduceScatterTestSuiteBase = CollectiveTestSuite<ReduceScatterTraits>;

--- a/comms/ncclx/v2_29/src/Makefile
+++ b/comms/ncclx/v2_29/src/Makefile
@@ -152,6 +152,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/ncclx/v2_30/src/Makefile
+++ b/comms/ncclx/v2_30/src/Makefile
@@ -160,6 +160,7 @@ LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/CuMulticastAllocation.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/GpuMemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/MultimemHandler.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/memory/NvlMemExchange.cc
+LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultimemNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/transport/MultiPeerTransport.cc
 LIBSRCFILES += ${BASE_DIR}/comms/prims/trace/PipesTrace.cc

--- a/comms/prims/bootstrap/NvlBootstrapAdapter.h
+++ b/comms/prims/bootstrap/NvlBootstrapAdapter.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -51,6 +52,30 @@ class NvlBootstrapAdapter : public meta::comms::IBootstrap {
     return underlying_->barrierNvlDomain(rank, nranks, localRankToCommRank_);
   }
 
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return underlying_->allGatherNvlDomain(
+        buf,
+        len,
+        nvlLocalRank,
+        nvlNranks,
+        translateLocalRanks(std::move(nvlRankToCommRank)));
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    return underlying_->barrierNvlDomain(
+        nvlLocalRank,
+        nvlNranks,
+        translateLocalRanks(std::move(nvlRankToCommRank)));
+  }
+
   folly::SemiFuture<int> send(void* buf, int len, int peer, int tag) override {
     return underlying_->send(buf, len, localRankToCommRank_[peer], tag);
   }
@@ -60,6 +85,13 @@ class NvlBootstrapAdapter : public meta::comms::IBootstrap {
   }
 
  private:
+  std::vector<int> translateLocalRanks(std::vector<int> localRanks) const {
+    for (auto& rank : localRanks) {
+      rank = localRankToCommRank_.at(static_cast<std::size_t>(rank));
+    }
+    return localRanks;
+  }
+
   std::shared_ptr<meta::comms::IBootstrap> underlying_;
   std::vector<int> localRankToCommRank_;
 };

--- a/comms/prims/bootstrap/tests/NvlBootstrapAdapterUnitTest.cc
+++ b/comms/prims/bootstrap/tests/NvlBootstrapAdapterUnitTest.cc
@@ -1,0 +1,196 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "comms/prims/bootstrap/NvlBootstrapAdapter.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace comms::prims::tests {
+
+namespace {
+
+class RecordingBootstrap final : public meta::comms::IBootstrap {
+ public:
+  folly::SemiFuture<int> allGather(void* /*buf*/, int, int, int) override {
+    return folly::makeSemiFuture(EINVAL);
+  }
+
+  folly::SemiFuture<int> barrier(int, int) override {
+    return folly::makeSemiFuture(EINVAL);
+  }
+
+  folly::SemiFuture<int> allGatherNvlDomain(
+      void* buf,
+      int len,
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    ++allGatherNvlDomainCalls;
+    lastAllGatherBuf = buf;
+    lastAllGatherLen = len;
+    lastAllGatherNvlLocalRank = nvlLocalRank;
+    lastAllGatherNvlNranks = nvlNranks;
+    lastAllGatherNvlRankToCommRank = std::move(nvlRankToCommRank);
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> barrierNvlDomain(
+      int nvlLocalRank,
+      int nvlNranks,
+      std::vector<int> nvlRankToCommRank) override {
+    ++barrierNvlDomainCalls;
+    lastBarrierNvlLocalRank = nvlLocalRank;
+    lastBarrierNvlNranks = nvlNranks;
+    lastBarrierNvlRankToCommRank = std::move(nvlRankToCommRank);
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> send(void* /*buf*/, int, int peer, int tag) override {
+    ++sendCalls;
+    lastSendPeer = peer;
+    lastSendTag = tag;
+    return folly::makeSemiFuture(0);
+  }
+
+  folly::SemiFuture<int> recv(void* /*buf*/, int, int peer, int tag) override {
+    ++recvCalls;
+    lastRecvPeer = peer;
+    lastRecvTag = tag;
+    return folly::makeSemiFuture(0);
+  }
+
+  int allGatherNvlDomainCalls{0};
+  void* lastAllGatherBuf{nullptr};
+  int lastAllGatherLen{-1};
+  int lastAllGatherNvlLocalRank{-1};
+  int lastAllGatherNvlNranks{-1};
+  std::vector<int> lastAllGatherNvlRankToCommRank;
+
+  int barrierNvlDomainCalls{0};
+  int lastBarrierNvlLocalRank{-1};
+  int lastBarrierNvlNranks{-1};
+  std::vector<int> lastBarrierNvlRankToCommRank;
+
+  int sendCalls{0};
+  int lastSendPeer{-1};
+  int lastSendTag{-1};
+
+  int recvCalls{0};
+  int lastRecvPeer{-1};
+  int lastRecvTag{-1};
+};
+
+} // namespace
+
+TEST(NvlBootstrapAdapterUnitTest, AllGatherUsesAdapterRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int buffer[4] = {};
+  EXPECT_EQ(adapter.allGather(buffer, sizeof(int), 2, 4).get(), 0);
+
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastAllGatherBuf, buffer);
+  EXPECT_EQ(underlying->lastAllGatherLen, sizeof(int));
+  EXPECT_EQ(underlying->lastAllGatherNvlLocalRank, 2);
+  EXPECT_EQ(underlying->lastAllGatherNvlNranks, 4);
+  EXPECT_EQ(
+      underlying->lastAllGatherNvlRankToCommRank,
+      (std::vector<int>{12, 7, 19, 3}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedAllGatherTranslatesLocalRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int buffer[3] = {};
+  EXPECT_EQ(
+      adapter
+          .allGatherNvlDomain(
+              buffer,
+              sizeof(int),
+              /*nvlLocalRank=*/1,
+              /*nvlNranks=*/3,
+              /*nvlRankToCommRank=*/{3, 0, 2})
+          .get(),
+      0);
+
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastAllGatherBuf, buffer);
+  EXPECT_EQ(underlying->lastAllGatherLen, sizeof(int));
+  EXPECT_EQ(underlying->lastAllGatherNvlLocalRank, 1);
+  EXPECT_EQ(underlying->lastAllGatherNvlNranks, 3);
+  EXPECT_EQ(
+      underlying->lastAllGatherNvlRankToCommRank,
+      (std::vector<int>{3, 12, 19}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedBarrierTranslatesLocalRankMap) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  EXPECT_EQ(
+      adapter
+          .barrierNvlDomain(
+              /*nvlLocalRank=*/2,
+              /*nvlNranks=*/3,
+              /*nvlRankToCommRank=*/{1, 3, 0})
+          .get(),
+      0);
+
+  EXPECT_EQ(underlying->barrierNvlDomainCalls, 1);
+  EXPECT_EQ(underlying->lastBarrierNvlLocalRank, 2);
+  EXPECT_EQ(underlying->lastBarrierNvlNranks, 3);
+  EXPECT_EQ(
+      underlying->lastBarrierNvlRankToCommRank, (std::vector<int>{7, 3, 12}));
+}
+
+TEST(NvlBootstrapAdapterUnitTest, NestedRankMapRejectsOutOfRangeLocalRank) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7});
+
+  int buffer[1] = {};
+  EXPECT_THROW(
+      adapter.allGatherNvlDomain(
+          buffer,
+          sizeof(int),
+          /*nvlLocalRank=*/0,
+          /*nvlNranks=*/1,
+          /*nvlRankToCommRank=*/{2}),
+      std::out_of_range);
+  EXPECT_EQ(underlying->allGatherNvlDomainCalls, 0);
+
+  EXPECT_THROW(
+      adapter.barrierNvlDomain(
+          /*nvlLocalRank=*/0,
+          /*nvlNranks=*/1,
+          /*nvlRankToCommRank=*/{2}),
+      std::out_of_range);
+  EXPECT_EQ(underlying->barrierNvlDomainCalls, 0);
+}
+
+TEST(NvlBootstrapAdapterUnitTest, SendRecvTranslatePeerRank) {
+  auto underlying = std::make_shared<RecordingBootstrap>();
+  NvlBootstrapAdapter adapter(underlying, {12, 7, 19, 3});
+
+  int value = 0;
+  EXPECT_EQ(
+      adapter.send(&value, sizeof(value), /*peer=*/2, /*tag=*/33).get(), 0);
+  EXPECT_EQ(underlying->sendCalls, 1);
+  EXPECT_EQ(underlying->lastSendPeer, 19);
+  EXPECT_EQ(underlying->lastSendTag, 33);
+
+  EXPECT_EQ(
+      adapter.recv(&value, sizeof(value), /*peer=*/3, /*tag=*/44).get(), 0);
+  EXPECT_EQ(underlying->recvCalls, 1);
+  EXPECT_EQ(underlying->lastRecvPeer, 3);
+  EXPECT_EQ(underlying->lastRecvTag, 44);
+}
+
+} // namespace comms::prims::tests

--- a/comms/prims/tests/MultimemNvlTransportTest.cc
+++ b/comms/prims/tests/MultimemNvlTransportTest.cc
@@ -14,10 +14,13 @@
 #include <utility>
 #include <vector>
 
+#include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/common/bootstrap/tests/MockBootstrap.h"
 #include "comms/prims/core/SignalState.cuh"
+#include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/memory/MultimemHandler.h"
 #include "comms/prims/tests/MultimemNvlTransportTest.cuh"
+#include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 #include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/testinfra/DistEnvironmentBase.h"
 #include "comms/testinfra/DistTestBase.h"
@@ -146,7 +149,63 @@ TEST_F(
   EXPECT_FALSE(MultimemNvlTransport::isEligible(2, localRank));
   EXPECT_EQ(
       MultimemNvlTransport::isEligible(3, localRank),
-      MultimemHandler::isMultimemSupported(localRank));
+      GpuMemHandler::isMultimemSupported(localRank));
+}
+
+TEST_F(MultimemNvlTransportTestFixture, MultiPeerMultimemDisabled) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_lazy_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 0,
+      .chunkSize = 0,
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      // This test exercises only the multimem path; disable the tile P2P
+      // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
+      .maxNumChannels = 0,
+      .enableMultimem = false,
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  EXPECT_FALSE(transport.hasMultimemNvlTransport());
+  EXPECT_NO_THROW(transport.exchange());
+  EXPECT_THROW(
+      static_cast<void>(transport.getMultimemNvlTransportDevice()),
+      std::runtime_error);
+}
+
+TEST_F(
+    MultimemNvlTransportTestFixture,
+    MultiPeerLazilyInitializesMultimemTransport) {
+  auto bootstrap = makeBootstrap("multimem_nvl_transport_multi_peer_test");
+  if (!allRanksMultimemEligible(bootstrap, globalRank, numRanks, localRank)) {
+    GTEST_SKIP() << "CUDA multimem/NVLS multicast is not eligible";
+  }
+
+  constexpr std::size_t kBytesPerRank = 4096;
+  MultiPeerNvlTransportConfig config{
+      .dataBufferSize = 0,
+      .chunkSize = 0,
+      .pipelineDepth = 0,
+      .p2pSignalCount = 1,
+      // This test exercises only the multimem path; disable the tile P2P
+      // channels (a nonzero maxNumChannels requires pipelineDepth >= 1).
+      .maxNumChannels = 0,
+      .enableMultimem = true,
+      .multimem =
+          MultimemNvlTransportConfig{
+              .dataBufferSize =
+                  kBytesPerRank * static_cast<std::size_t>(numRanks),
+              .userSignalCount = 1,
+              .internalSignalCount = 1,
+          },
+  };
+  MultiPeerNvlTransport transport(globalRank, numRanks, bootstrap, config);
+  EXPECT_TRUE(transport.hasMultimemNvlTransport());
+  ASSERT_NO_THROW(transport.exchange());
+  EXPECT_NO_THROW(transport.getMultimemNvlTransportDevice());
 }
 
 // getDeviceTransport() must refuse to vend a handle before exchange() has

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.cc
@@ -2,6 +2,7 @@
 
 #include "comms/prims/transport/nvl/MultiPeerNvlTransport.h"
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 
@@ -229,10 +230,13 @@ void MultiPeerNvlTransport::exchange() {
   if (channelStateHandler_) {
     channelStateHandler_->exchangeMemPtrs();
   }
-
   if (llBufferHandler_) {
     llBufferHandler_->exchangeMemPtrs();
   }
+
+  // Multimem NVL is intentionally not initialized here. Most collectives only
+  // need the peer-to-peer NVLink transport; multicast setup is deferred until
+  // getMultimemNvlTransportDevice() is called by a multimem collective.
 }
 
 P2pNvlTransportDevice MultiPeerNvlTransport::getP2pTransportDevice(
@@ -417,6 +421,93 @@ DeviceSpan<Transport> MultiPeerNvlTransport::getDeviceTransports() {
 
   return DeviceSpan<Transport>(
       static_cast<Transport*>(transportsDevice_->get()), nRanks_);
+}
+
+bool MultiPeerNvlTransport::hasMultimemNvlTransport() const {
+  if (!config_.enableMultimem ||
+      multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+    return false;
+  }
+
+  int cudaDevice = 0;
+  CUDA_CHECK(cudaGetDevice(&cudaDevice));
+  return MultimemNvlTransport::isEligible(nRanks_, cudaDevice);
+}
+
+MultimemNvlTransportDevice
+MultiPeerNvlTransport::getMultimemNvlTransportDevice() const {
+  initializeMultimemNvlTransport();
+  return multimemNvlTransport_->getDeviceTransport();
+}
+
+void MultiPeerNvlTransport::initializeMultimemNvlTransport() const {
+  // Serialize concurrent same-rank callers so at most one thread drives the
+  // collective (eligibility allGather + MultimemNvlTransport::exchange). If
+  // two threads on this rank both raced past the null-check, each would
+  // enter its own collective while other ranks only participate once,
+  // deadlocking the bootstrap. Second+ arrivals block here, then see the
+  // cached transport (or the poison bit) via the fast paths below.
+  std::lock_guard<std::mutex> lock(multimemInitMutex_);
+
+  if (multimemNvlTransport_) {
+    return;
+  }
+  if (!config_.enableMultimem) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem NVL transport is not enabled "
+        "(config.enableMultimem is false)");
+  }
+  if (multimemNvlUnavailable_.load(std::memory_order_acquire)) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem NVL transport is not available: " +
+        multimemNvlErrorMessage_);
+  }
+
+  int cudaDevice = 0;
+  CUDA_CHECK(cudaGetDevice(&cudaDevice));
+  std::vector<int> multimemEligible(nRanks_, 0);
+  multimemEligible[myRank_] =
+      MultimemNvlTransport::isEligible(nRanks_, cudaDevice) ? 1 : 0;
+  auto eligibilityResult =
+      bootstrap_
+          ->allGather(multimemEligible.data(), sizeof(int), myRank_, nRanks_)
+          .get();
+  // Note: allGather-failure is intentionally NOT latched into
+  // multimemNvlUnavailable_. It can be transient (bootstrap glitch, peer
+  // slow-start) and the caller may legitimately want to retry -- the outer
+  // mutex serializes concurrent retries so cross-rank collectives stay
+  // aligned. Eligibility failure, in contrast, is terminal on this comm.
+  if (eligibilityResult != 0) {
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: multimem eligibility allGather failed");
+  }
+  if (!std::all_of(
+          multimemEligible.begin(), multimemEligible.end(), [](int value) {
+            return value != 0;
+          })) {
+    multimemNvlErrorMessage_ =
+        "multimem NVL transport is not eligible on all ranks";
+    multimemNvlUnavailable_.store(true, std::memory_order_release);
+    throw std::runtime_error(
+        "MultiPeerNvlTransport: " + multimemNvlErrorMessage_);
+  }
+
+  auto multimemNvlTransport = std::make_unique<MultimemNvlTransport>(
+      myRank_, nRanks_, bootstrap_, config_.multimem);
+  // Unlike the eligibility allGather above, exchange() is a cross-rank
+  // collective that can partially succeed on peers before it throws locally; a
+  // retry would re-enter a collective the other ranks have already moved past,
+  // risking desync/hang. So an exchange() failure is terminal: latch the poison
+  // bit before rethrowing so future callers fall back instead of retrying.
+  try {
+    multimemNvlTransport->exchange();
+  } catch (const std::exception& e) {
+    multimemNvlErrorMessage_ =
+        std::string("multimem NVL transport exchange failed: ") + e.what();
+    multimemNvlUnavailable_.store(true, std::memory_order_release);
+    throw;
+  }
+  multimemNvlTransport_ = std::move(multimemNvlTransport);
 }
 
 void MultiPeerNvlTransport::initializeTransportsArray() {

--- a/comms/prims/transport/nvl/MultiPeerNvlTransport.h
+++ b/comms/prims/transport/nvl/MultiPeerNvlTransport.h
@@ -2,13 +2,17 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
 
 #include "comms/common/bootstrap/IBootstrap.h"
 #include "comms/prims/memory/GpuMemHandler.h"
 #include "comms/prims/transport/Transport.cuh"
+#include "comms/prims/transport/nvl/MultimemNvlTransport.h"
 #include "comms/prims/transport/nvl/P2pNvlTransportDevice.cuh"
 #include "comms/prims/transport/self/P2pSelfTransportDevice.cuh"
 // On AMD, `meta::comms::DeviceBuffer` is provided by
@@ -81,6 +85,15 @@ struct MultiPeerNvlTransportConfig {
   // keeps the default behavior: fabric handles when available, cudaIpc
   // otherwise.
   std::optional<MemSharingMode> memSharingMode;
+
+  // NVLS multicast: when true, the transport composes an internal
+  // MultimemNvlTransport (from `multimem` below) and reports it via
+  // hasMultimemNvlTransport(). The actual multicast setup runs lazily on the
+  // first getMultimemNvlTransportDevice() call, and only when the device
+  // supports multimem and the NVL team has more than two ranks. `multimem` is
+  // ignored unless `enableMultimem` is true.
+  bool enableMultimem{false};
+  MultimemNvlTransportConfig multimem;
 };
 
 /**
@@ -228,6 +241,10 @@ class MultiPeerNvlTransport {
    *    preallocated device array (allocated in constructor)
    * 3. Implicit barrier ensures all ranks complete before returning
    *
+   * Optional multimem NVL setup is not performed here; it is a separate
+   * collective operation triggered by getMultimemNvlTransportDevice() so
+   * non-multimem collectives do not pay the multicast allocation cost.
+   *
    * The type of handle (fabric or cudaIpc) depends on the automatically
    * detected memory sharing mode.
    *
@@ -306,6 +323,21 @@ class MultiPeerNvlTransport {
    */
   DeviceSpan<Transport> getDeviceTransports();
 
+  // Cheap local check for whether multimem NVL was configured and appears
+  // usable on this rank. This does not perform the collective multimem setup;
+  // the first getMultimemNvlTransportDevice() call initializes it lazily.
+  bool hasMultimemNvlTransport() const;
+
+  /**
+   * getMultimemNvlTransportDevice - Get the lazily initialized NVLS device
+   * transport.
+   *
+   * PRECONDITION: All ranks that may use this multimem collective must call
+   * this method in the same order. The first call performs a collective
+   * eligibility check, multicast memory setup, and exchange.
+   */
+  MultimemNvlTransportDevice getMultimemNvlTransportDevice() const;
+
   /**
    * Check if fabric-based transport is supported (H100+, CUDA 12.3+).
    *
@@ -335,6 +367,10 @@ class MultiPeerNvlTransport {
   // Initialize transports array on device (both P2P and SELF transports)
   void initializeTransportsArray();
 
+  // Lazily construct and exchange the multimem NVL transport. This is a
+  // collective operation across the MultiPeerNvlTransport ranks.
+  void initializeMultimemNvlTransport() const;
+
   // ==========================================================================
   // Member variables
   // ==========================================================================
@@ -356,6 +392,27 @@ class MultiPeerNvlTransport {
       barrierBufferHandler_; // nullptr when p2pBarrierCount == 0
   std::unique_ptr<GpuMemHandler>
       llBufferHandler_; // nullptr when llBufferSize == 0
+  mutable std::unique_ptr<MultimemNvlTransport> multimemNvlTransport_;
+  // Latched to true when we know multimem NVL cannot succeed on this comm:
+  // eligibility failed on some rank, or the multicast handle exchange() failed.
+  // Terminal -- subsequent calls throw the cached reason from
+  // `multimemNvlErrorMessage_` without re-attempting the collective. The
+  // eligibility allGather returning non-zero is intentionally NOT latched (it
+  // can be transient and is retry-safe) so callers can retry.
+  // `std::atomic` because `hasMultimemNvlTransport()` reads it on the fast path
+  // without holding `multimemInitMutex_`, while the init path stores under it.
+  mutable std::atomic<bool> multimemNvlUnavailable_{false};
+  // Preserved reason for the terminal-failure throw so debuggers see the
+  // original cause (e.g. "not eligible on all ranks") on every subsequent
+  // call, not a generic "not available".
+  mutable std::string multimemNvlErrorMessage_;
+  // Guards `initializeMultimemNvlTransport()` against concurrent callers on
+  // the same rank: only one thread performs the eligibility allGather +
+  // multimem exchange; other concurrent threads block and use the cached
+  // result. Without this, two same-rank threads could each drive an
+  // allGather while other ranks only participate once, deadlocking the
+  // collective.
+  mutable std::mutex multimemInitMutex_;
 
   // External data buffer pointers (set via setExternalDataBuffers()).
   // When set, exchange() skips data buffer allocation/exchange.


### PR DESCRIPTION
Summary:

Add `ReduceScatterTraits` and `AllGatherTraits` in their own per-collective base headers (`ReduceScatterTestSuiteBase.h`, `AllGatherTestSuiteBase.h`), mirroring `AllReduceTestSuiteBase.h` from D110821006, plus their collective-specific expected-buffer kernels in the shared kernels lib.

- Each new `<Coll>TestSuiteBase.h` includes the generic `CollectiveTestSuite.h` harness + its `<Coll>Impl.h`, defines the collective's `Traits`, and exposes `using <Coll>TestSuiteBase = CollectiveTestSuite<<Coll>Traits>;` for leaves to derive.
- `initScatterExpected` (RS reduction shard starting at `rank * recvcount`) and `initGatherExpected` (AG per-rank concat), with the `commDataType_t` dispatch wrappers (`fp32`/`fp16`).
- `ReduceScatterTraits::checkResult` uses the shared float-tolerance compare (`computeMaxDeltaForType` vs `thresholdForDatatype`); `AllGatherTraits` verifies via a raw-bits checksum equality. (`int32` exact-integer support is added by the int32 prep later in the stack.)
- Builds on the generalized harness from D110821006; the generic `CollectiveTestSuite.h` stays free of any collective-specific traits.

Differential Revision: D110902873


