### PR TITLE
Document unified AllReduce tile sizing

### DIFF
--- a/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
+++ b/comms/ctran/algos/AllReduce/AllReduceFusedTypes.h
@@ -13,9 +13,12 @@ namespace ctran::allreduce::common {
 /** CUDA threads per block used by the fused AllReduce kernels. */
 static constexpr int kBlockSize = 640;
 
+/** Bytes reduced per thread in one NVL or IB tile; 96B * 640 = 60KB. */
 static constexpr size_t kTileBytesPerThread = 96;
+/** Topology-agnostic tile byte width shared by NVL and IB reductions. */
 static constexpr size_t kTileBytes = kBlockSize * kTileBytesPerThread;
 
+/** Datatype-specific element count for the unified byte tile. */
 template <typename T>
 struct TileElems {
   static constexpr size_t kBytes = kTileBytes;

--- a/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
+++ b/comms/ctran/algos/AllReduce/docs/TreeAllReduce.md
@@ -93,12 +93,13 @@ totalBytes < numBlocks * 640 * 64
 
 `NCCL_CTRAN_MAX_NBLOCKS` controls the cap and defaults to `16`, which keeps the tree implementation below the NCCL Tree CTA count used on the current H100 and GB200/GB300 validation setups.
 
-The implementation uses phase-specific tile widths:
+The implementation uses one topology-agnostic tile width for both NVL and IB reductions:
 
-- `kNvlTileElems = 15360`
-- `kIbTileElems = 5120`
+```text
+kTileBytes = kBlockSize * kTileBytesPerThread = 640 * 96B = 60KB
+```
 
-Both are selected to satisfy Pipes tile divisibility constraints with `640`-thread blocks and the vector widths used by supported datatypes.
+`TileElems<T>` converts this byte width into a datatype-specific element count while preserving tile divisibility for the supported datatypes and the vector widths used by the reduction helpers.
 
 ## Staging and Memory Lifetime
 


### PR DESCRIPTION
Summary: Add the missing inline and markdown documentation for the unified fused AllReduce tile size introduced by `D110560271`. This explains `kTileBytesPerThread`, `kTileBytes`, and `TileElems<T>`, and updates `TreeAllReduce.md` to remove the obsolete `kNvlTileElems` / `kIbTileElems` text.

Differential Revision: D111285993


